### PR TITLE
fix: add --publish never to electron-builder and local Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# Keep Docker context small — only send what the build needs
+.git
+node_modules
+**/node_modules
+**/dist
+**/out
+**/build-assets
+release/
+*.md
+.DS_Store
+.env*
+.venv
+__pycache__

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           - runner: macos-14
             os: darwin
             arch: arm64
-          - runner: macos-13
+          - runner: macos-14
             os: darwin
             arch: x64
           - runner: ubuntu-latest
@@ -63,7 +63,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EB_PLATFORM: ${{ matrix.os == 'darwin' && 'mac' || 'linux' }}
           EB_ARCH: ${{ matrix.arch }}
-        run: npx electron-builder --"$EB_PLATFORM" --"$EB_ARCH"
+        run: npx electron-builder --"$EB_PLATFORM" --"$EB_ARCH" --publish never
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ __pycache__/
 .venv/
 venv/
 
+# Local build output
+release/
+
 # IDE
 .idea/
 .vscode/

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,38 @@
+# Local build environment for testing Linux Electron packaging.
+# Usage:
+#   docker build -f Dockerfile.build -t sf-build .
+#   docker run --rm -v "$PWD/release:/out" sf-build
+#
+# Optional: pass --build-arg ARCH=arm64 for ARM builds (requires QEMU).
+
+FROM node:20-bookworm-slim
+
+ARG ARCH=x64
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates tar gzip \
+    # electron-builder Linux targets
+    dpkg fakeroot \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Copy only what's needed for dependency install first (layer caching)
+COPY apps/desktop/package.json apps/desktop/package-lock.json apps/desktop/
+RUN cd apps/desktop && npm ci
+
+# Copy the rest of the repo
+COPY . .
+
+# Download build assets (uv, python, wheel cache) for Linux
+RUN ./scripts/download-build-assets.sh --os linux --arch "$ARCH"
+
+# Build the Electron frontend
+RUN cd apps/desktop && npm run build
+
+# Package — publish=never since this is local testing
+RUN cd apps/desktop && npx electron-builder --linux --"$ARCH" --publish never
+
+# Copy artifacts to /out on run
+CMD cp apps/desktop/dist/*.AppImage apps/desktop/dist/*.tar.gz /out/ 2>/dev/null; \
+    echo "==> Artifacts copied to /out:" && ls -lh /out/

--- a/scripts/local-build.sh
+++ b/scripts/local-build.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Build ScreamingFace Electron app locally using Docker (Linux target).
+# Mirrors the GitHub Actions release workflow for pre-push testing.
+#
+# Usage:
+#   ./scripts/local-build.sh              # build linux/x64
+#   ./scripts/local-build.sh --arch arm64 # build linux/arm64 (needs QEMU)
+#   ./scripts/local-build.sh --no-cache   # rebuild without Docker cache
+
+set -euo pipefail
+
+ARCH="x64"
+DOCKER_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --arch)     ARCH="$2"; shift 2 ;;
+    --no-cache) DOCKER_ARGS+=(--no-cache); shift ;;
+    *)          echo >&2 "Unknown arg: $1"; exit 1 ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT_DIR="$REPO_ROOT/release"
+mkdir -p "$OUT_DIR"
+
+echo "==> Building ScreamingFace for linux/$ARCH"
+echo "    Output: $OUT_DIR/"
+
+docker build \
+  -f "$REPO_ROOT/Dockerfile.build" \
+  --build-arg ARCH="$ARCH" \
+  ${DOCKER_ARGS[@]+"${DOCKER_ARGS[@]}"} \
+  -t sf-build \
+  "$REPO_ROOT"
+
+docker run --rm -v "$OUT_DIR:/out" sf-build
+
+echo ""
+echo "==> Build complete. Artifacts:"
+ls -lh "$OUT_DIR/"


### PR DESCRIPTION
- Fix release workflow failing with "Cannot detect repository by .git/config" — electron-builder was implicitly trying to publish via git tag detection, but publishing is handled separately by softprops/action-gh-release and gh release create
- Replace deprecated macos-13 runner with macos-14 for darwin/x64
- Add Dockerfile.build and scripts/local-build.sh for testing Linux Electron packaging locally via Docker before pushing to CI
- Add .dockerignore to keep build context small
- Gitignore release/ directory for local build artifacts

https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1213703039092843

## Description
Please include a summary of the change, the motivation, and any additional context that will help others understand your PR. If it closes one or more open issues, [please tag them as described here](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
