### PR TITLE
fix: resolve electron-builder CI packaging failure

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "description": "ScreamingFace desktop control plane",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/OpenMined/screamingface.git",
+    "directory": "apps/desktop"
+  },
   "main": "./out/main/index.js",
   "scripts": {
     "dev": "electron-vite dev",
@@ -110,6 +115,7 @@
     "win": {
       "target": "nsis"
     },
-    "artifactName": "ScreamingFace-${version}-${os}-${arch}.${ext}"
+    "artifactName": "ScreamingFace-${version}-${os}-${arch}.${ext}",
+    "publish": null
   }
 }


### PR DESCRIPTION
## Summary
- Added `repository` field to `apps/desktop/package.json` so electron-builder can detect the GitHub repo from a monorepo subdirectory
- Set `"publish": null` in the build config to disable auto-update info file generation, which was crashing with `TypeError: Cannot read properties of null (reading 'channel')` at `computeChannelNames`
- We distribute via `sf-installer`, not electron-builder's built-in publish/auto-updater, so this is not needed

## Test plan
- [ ] All 3 CI build jobs (darwin-arm64, darwin-x64, linux-x64) pass the "Package Electron app" step
- [ ] Release artifacts are uploaded successfully

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1213726131213980