### PR TITLE
feat: add Launch Claude button to claude-frontend config

### DIFF
--- a/apps/desktop/src/main/ipc/claude.ipc.ts
+++ b/apps/desktop/src/main/ipc/claude.ipc.ts
@@ -1,0 +1,12 @@
+import { ipcMain } from 'electron';
+import { execFile } from 'child_process';
+
+export function registerClaudeHandlers(): void {
+  ipcMain.handle('claude:launch', (_event, baseUrl: string) => {
+    const cmd = `export ANTHROPIC_BASE_URL=${baseUrl} && claude`;
+    execFile('osascript', [
+      '-e',
+      `tell application "Terminal" to do script "${cmd}"`,
+    ]);
+  });
+}

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -2,10 +2,12 @@ import { registerServerHandlers } from './server-process.ipc';
 import { registerVenvHandlers } from './venv-manager.ipc';
 import { registerPluginHandlers } from './plugin-manager.ipc';
 import { registerConfigHandlers } from './config.ipc';
+import { registerClaudeHandlers } from './claude.ipc';
 
 export function registerAllHandlers(): void {
   registerConfigHandlers();
   registerVenvHandlers();
   registerServerHandlers();
   registerPluginHandlers();
+  registerClaudeHandlers();
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -46,6 +46,9 @@ const api: ElectronAPI = {
     write: (config) => ipcRenderer.invoke('config:write', config),
     onChanged: (cb) => onEvent('config:changed', cb),
   },
+  claude: {
+    launch: (baseUrl) => ipcRenderer.invoke('claude:launch', baseUrl),
+  },
 };
 
 contextBridge.exposeInMainWorld('electronAPI', api);

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -74,6 +74,9 @@ export interface ElectronAPI {
     write: (config: Record<string, unknown>) => Promise<void>;
     onChanged: (callback: (config: Record<string, unknown>) => void) => () => void;
   };
+  claude: {
+    launch: (baseUrl: string) => Promise<void>;
+  };
 }
 
 declare global {

--- a/apps/desktop/src/renderer/src/views/SettingsView.tsx
+++ b/apps/desktop/src/renderer/src/views/SettingsView.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { ChevronDown, ChevronRight } from 'lucide-react';
+import { ChevronDown, ChevronRight, Terminal } from 'lucide-react';
 import validator from '@rjsf/validator-ajv8';
 import type { RJSFSchema } from '@rjsf/utils';
 import { useServerStatus } from '../hooks/use-server-status';
@@ -494,6 +494,26 @@ export function SettingsView() {
                           omitExtraData
                           uiSchema={{ 'ui:submitButtonOptions': { norender: true } }}
                         />
+                      )}
+                      {name === 'claude-frontend' && (
+                        <div className="mt-3 border-t border-border/50 pt-3">
+                          <button
+                            onClick={() => {
+                              const settings = {
+                                ...pluginLiveSettings[name],
+                                ...config.plugin_config[name],
+                              };
+                              const host = (settings.listen_host as string) || '127.0.0.1';
+                              const port = (settings.listen_port as number) || 9101;
+                              window.electronAPI.claude.launch(`http://${host}:${port}`);
+                            }}
+                            disabled={serverStatus !== 'ready'}
+                            className="flex items-center gap-1.5 rounded-md bg-chart-4/15 px-3 py-1.5 text-xs font-medium text-chart-4 transition-colors hover:bg-chart-4/25 disabled:opacity-40 disabled:pointer-events-none"
+                          >
+                            <Terminal size={14} />
+                            Launch Claude
+                          </button>
+                        </div>
                       )}
                     </div>
                   )}


### PR DESCRIPTION
## Summary
- Adds a "Launch Claude" button in the claude-frontend plugin's Settings config panel
- Opens macOS Terminal.app with `ANTHROPIC_BASE_URL` set to the proxy URL (e.g. `http://127.0.0.1:9101`)
- Button is only enabled when the SF server is running (proxy must be active)

## Changes
- New IPC handler (`claude.ipc.ts`) using `execFile('osascript', ...)` to open Terminal
- Preload bridge + types wired up for `electronAPI.claude.launch()`
- "Launch Claude" button rendered inside the claude-frontend expanded config section in SettingsView

## Test plan
- [ ] Start SF server with claude-frontend plugin enabled
- [ ] Go to Settings, expand claude-frontend config
- [ ] Click "Launch Claude" — verify Terminal.app opens with `claude` running
- [ ] Verify `ANTHROPIC_BASE_URL` is set in that terminal session
- [ ] Verify button is disabled when server is not running

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1213810888753492