### PR TITLE
feat: e2e testing pipeline, OTel tracing, configurable embedding, session edit

### DIFF
--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Lint (ruff format)
         run: uv run ruff format --check
 
-      - name: Run tests with coverage
+      - name: Run unit tests with coverage
         run: |
           uv run pytest \
             --tb=short \
@@ -47,14 +47,32 @@ jobs:
             --cov=screamingface \
             --cov-report=term-missing \
             --cov-report=xml:coverage.xml \
+            -m "not e2e and not e2e_live" \
             -v
 
-      - name: Test report
+      - name: Run e2e tests
+        run: |
+          uv run pytest tests/e2e/ \
+            --tb=short \
+            --junitxml=results-e2e.xml \
+            --timeout=120 \
+            -m "e2e" \
+            -v
+
+      - name: Unit test report
         uses: dorny/test-reporter@v2
         if: always()
         with:
-          name: Test Results
+          name: Unit Test Results
           path: apps/server/results.xml
+          reporter: java-junit
+
+      - name: E2E test report
+        uses: dorny/test-reporter@v2
+        if: always()
+        with:
+          name: E2E Test Results
+          path: apps/server/results-e2e.xml
           reporter: java-junit
 
       - name: Coverage report

--- a/apps/desktop/src/main/ipc/session.ipc.ts
+++ b/apps/desktop/src/main/ipc/session.ipc.ts
@@ -33,6 +33,17 @@ export function registerSessionHandlers(): void {
     sessionManager.removeSession(id);
   });
 
+  ipcMain.handle(
+    'session:update',
+    (_event, id: string, workingDir: string, pluginConfig?: Record<string, Record<string, unknown>>) => {
+      return sessionManager.updateSession(id, workingDir, pluginConfig);
+    },
+  );
+
+  ipcMain.handle('session:restart', (_event, id: string) => {
+    return sessionManager.restartSession(id);
+  });
+
   // Forward session state changes to all renderer windows
   sessionManager.on('sessionsChanged', (sessions) => {
     for (const win of BrowserWindow.getAllWindows()) {

--- a/apps/desktop/src/main/services/session-manager.ts
+++ b/apps/desktop/src/main/services/session-manager.ts
@@ -1,6 +1,6 @@
 import { ChildProcess, spawn, execFile } from 'child_process';
 import { join } from 'path';
-import { writeFileSync, readFileSync, unlinkSync, chmodSync, existsSync } from 'fs';
+import { writeFileSync, readFileSync, unlinkSync, chmodSync, existsSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 import net from 'net';
 import { randomUUID } from 'crypto';
@@ -36,6 +36,7 @@ interface ActiveSession {
   status: SessionStatus;
   createdAt: Date;
   workingDir: string;
+  pluginConfig: Record<string, Record<string, unknown>>;
   proxy: ChildProcess | null;
   proxyReady: ReadyEvent | null;
   scriptPath: string | null;
@@ -140,6 +141,11 @@ class SessionManager extends EventEmitter {
     const id = randomUUID();
     const port = await this.allocatePort();
 
+    // Ensure workingDir exists (e.g. /tmp/sf-<uuid> default)
+    if (!existsSync(workingDir)) {
+      mkdirSync(workingDir, { recursive: true });
+    }
+
     const session: ActiveSession = {
       id,
       type,
@@ -147,6 +153,7 @@ class SessionManager extends EventEmitter {
       status: 'starting',
       createdAt: new Date(),
       workingDir,
+      pluginConfig: pluginConfig || {},
       proxy: null,
       proxyReady: null,
       scriptPath: null,
@@ -437,6 +444,50 @@ end tell`;
     this.emitSessionsChanged();
   }
 
+  updateSession(
+    id: string,
+    workingDir: string,
+    pluginConfig?: Record<string, Record<string, unknown>>,
+  ): SessionInfo {
+    const session = this.sessions.get(id);
+    if (!session) throw new Error(`Session ${id} not found`);
+    if (session.status !== 'stopped' && session.status !== 'error') {
+      throw new Error('Can only edit stopped or error sessions');
+    }
+    session.workingDir = workingDir;
+    session.pluginConfig = pluginConfig || {};
+    if (!existsSync(workingDir)) {
+      mkdirSync(workingDir, { recursive: true });
+    }
+    this.emitSessionsChanged();
+    return this.toSessionInfo(session);
+  }
+
+  async restartSession(id: string): Promise<SessionInfo> {
+    const session = this.sessions.get(id);
+    if (!session) throw new Error(`Session ${id} not found`);
+    if (session.status !== 'stopped' && session.status !== 'error') {
+      throw new Error('Can only restart stopped or error sessions');
+    }
+    session.port = await this.allocatePort();
+    session.status = 'starting';
+    session.createdAt = new Date();
+    this.emitSessionsChanged();
+
+    try {
+      await this.spawnProxy(session, session.pluginConfig);
+      this.openTerminal(session);
+      session.status = 'running';
+      this.emitSessionsChanged();
+    } catch (err) {
+      session.status = 'error';
+      this.emitSessionsChanged();
+      throw err;
+    }
+
+    return this.toSessionInfo(session);
+  }
+
   private toSessionInfo(s: ActiveSession): SessionInfo {
     return {
       id: s.id,
@@ -445,6 +496,7 @@ end tell`;
       status: s.status,
       createdAt: s.createdAt.toISOString(),
       workingDir: s.workingDir,
+      pluginConfig: s.pluginConfig,
     };
   }
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -54,6 +54,9 @@ const api: ElectronAPI = {
     terminate: (id) => ipcRenderer.invoke('session:terminate', id),
     terminateAll: () => ipcRenderer.invoke('session:terminateAll'),
     remove: (id) => ipcRenderer.invoke('session:remove', id),
+    update: (id, workingDir, pluginConfig?) =>
+      ipcRenderer.invoke('session:update', id, workingDir, pluginConfig),
+    restart: (id) => ipcRenderer.invoke('session:restart', id),
     onSessionsChanged: (cb) => onEvent('session:sessionsChanged', cb),
     onLog: (cb) => {
       const handler = (_event: Electron.IpcRendererEvent, id: string, line: string): void => {

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -19,6 +19,7 @@ export interface SessionInfo {
   status: SessionStatus;
   createdAt: string;
   workingDir: string;
+  pluginConfig?: Record<string, Record<string, unknown>>;
 }
 
 export interface PluginManifest {
@@ -97,6 +98,12 @@ export interface ElectronAPI {
     terminate: (id: string) => Promise<void>;
     terminateAll: () => Promise<void>;
     remove: (id: string) => Promise<void>;
+    update: (
+      id: string,
+      workingDir: string,
+      pluginConfig?: Record<string, Record<string, unknown>>,
+    ) => Promise<SessionInfo>;
+    restart: (id: string) => Promise<SessionInfo>;
     onSessionsChanged: (callback: (sessions: SessionInfo[]) => void) => () => void;
     onLog: (callback: (id: string, line: string) => void) => () => void;
   };

--- a/apps/desktop/src/renderer/src/components/rjsf-theme.tsx
+++ b/apps/desktop/src/renderer/src/components/rjsf-theme.tsx
@@ -545,9 +545,33 @@ function SpecSelectorWidget(props: WidgetProps) {
   );
 }
 
+function TextareaWidget(props: WidgetProps) {
+  const { id, value, onChange, onBlur, onFocus, disabled, readonly, rawErrors, options } = props;
+  const hasError = rawErrors && rawErrors.length > 0;
+  const rows = (options?.rows as number) || 3;
+  return (
+    <textarea
+      id={id}
+      value={value ?? ''}
+      rows={rows}
+      disabled={disabled}
+      readOnly={readonly}
+      onChange={(e) => onChange(e.target.value)}
+      onBlur={(e) => onBlur(id, e.target.value)}
+      onFocus={(e) => onFocus(id, e.target.value)}
+      className={`w-full rounded-md border px-3 py-1.5 font-mono text-xs text-foreground focus:outline-none focus:ring-1 resize-y ${
+        hasError
+          ? 'border-destructive bg-destructive/5 focus:ring-destructive'
+          : 'border-input bg-background focus:ring-ring'
+      }`}
+    />
+  );
+}
+
 const widgets: RegistryWidgetsType = {
   CheckboxWidget: CheckboxWidget as ComponentType<WidgetProps>,
   SelectWidget: SelectWidget as ComponentType<WidgetProps>,
+  TextareaWidget: TextareaWidget as ComponentType<WidgetProps>,
   SpecSelectorWidget: SpecSelectorWidget as ComponentType<WidgetProps>,
 };
 

--- a/apps/desktop/src/renderer/src/components/session/NewSessionDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/session/NewSessionDialog.tsx
@@ -1,22 +1,28 @@
 import { useState, useEffect, useCallback } from 'react';
 import validator from '@rjsf/validator-ajv8';
 import type { RJSFSchema } from '@rjsf/utils';
-import { FolderOpen, X, Rocket } from 'lucide-react';
+import { FolderOpen, X, Rocket, Save } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ThemedForm } from '@/components/rjsf-theme';
 import { inlineRefs } from '@/components/rjsf-utils';
 import { useServerStatus } from '@/hooks/use-server-status';
-import type { SessionType } from '../../../../preload/types';
+import type { SessionInfo, SessionType } from '../../../../preload/types';
 
-/** Fields managed by session-manager or not applicable per-session — hidden from the user. */
-const HIDDEN_FRONTEND_FIELDS = [
+/** Fields managed by session-manager — removed entirely from the schema. */
+const REMOVED_FIELDS = [
   'listen_host',
   'listen_port',
   'session_service_url',
+  'backend_url',
+  'resolve_timeout',
 ];
+
+/** Fields to show first, in this order. */
+const TOP_FIELDS = ['embed_target', 'embed_mode', 'system_prompt'];
 
 interface Props {
   type: SessionType;
+  editSession?: SessionInfo;
   onLaunch: (
     type: SessionType,
     workingDir: string,
@@ -34,19 +40,36 @@ function typeLabel(type: SessionType): string {
   }
 }
 
-/** Build a uiSchema that hides specific fields. */
-function hideFields(fields: string[]): Record<string, unknown> {
-  const ui: Record<string, unknown> = {
-    'ui:submitButtonOptions': { norender: true },
-  };
-  for (const f of fields) {
-    ui[f] = { 'ui:widget': 'hidden' };
+/** Remove fields from JSON schema and reorder so TOP_FIELDS come first. */
+function cleanSchema(schema: RJSFSchema): RJSFSchema {
+  const props = { ...(schema.properties || {}) };
+  for (const f of REMOVED_FIELDS) {
+    delete props[f];
   }
-  return ui;
+
+  // Reorder: TOP_FIELDS first, then the rest in original order
+  const ordered: Record<string, unknown> = {};
+  for (const f of TOP_FIELDS) {
+    if (props[f]) {
+      ordered[f] = props[f];
+      delete props[f];
+    }
+  }
+  for (const [k, v] of Object.entries(props)) {
+    ordered[k] = v;
+  }
+
+  return { ...schema, properties: ordered };
 }
 
-export function NewSessionDialog({ type, onLaunch, onClose }: Props) {
-  const [workingDir, setWorkingDir] = useState<string | null>(null);
+export function NewSessionDialog({ type, editSession, onLaunch, onClose }: Props) {
+  const isEdit = !!editSession;
+
+  const [workingDir, setWorkingDir] = useState<string | null>(() => {
+    if (editSession) return editSession.workingDir;
+    const id = crypto.randomUUID().replace(/-/g, '').slice(0, 12);
+    return `/tmp/sf-${id}`;
+  });
 
   // Plugin schemas and form data
   const [frontendSchema, setFrontendSchema] = useState<RJSFSchema | null>(null);
@@ -79,11 +102,20 @@ export function NewSessionDialog({ type, onLaunch, onClose }: Props) {
       .then(([schemaRes, settingsRes]) => {
         const feSchema = schemaRes.ok ? schemaRes.json() : null;
         const feSettings = settingsRes.ok ? settingsRes.json() : null;
-        if (feSchema?.properties) setFrontendSchema(inlineRefs(feSchema));
-        if (feSettings) setFrontendData(feSettings as Record<string, unknown>);
+        if (feSchema?.properties) setFrontendSchema(cleanSchema(inlineRefs(feSchema)));
+
+        // For edit mode: merge saved config over server defaults
+        if (editSession?.pluginConfig?.['claude-frontend']) {
+          setFrontendData({
+            ...(feSettings || {}),
+            ...editSession.pluginConfig['claude-frontend'],
+          });
+        } else if (feSettings) {
+          setFrontendData(feSettings as Record<string, unknown>);
+        }
       })
       .finally(() => setLoading(false));
-  }, [serverUrl, serverFetch]);
+  }, [serverUrl, serverFetch, editSession]);
 
   const handlePickDir = async () => {
     const dir = await window.electronAPI.session.pickDir();
@@ -92,9 +124,9 @@ export function NewSessionDialog({ type, onLaunch, onClose }: Props) {
 
   const handleLaunch = () => {
     if (!workingDir) return;
-    // Strip fields that are managed by session-manager or not applicable per-session
+    // Strip fields that are managed by session-manager
     const cleanedFrontend = { ...frontendData };
-    for (const f of HIDDEN_FRONTEND_FIELDS) {
+    for (const f of REMOVED_FIELDS) {
       delete cleanedFrontend[f];
     }
     onLaunch(type, workingDir, {
@@ -110,7 +142,7 @@ export function NewSessionDialog({ type, onLaunch, onClose }: Props) {
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border px-6 py-4">
           <h2 className="text-base font-semibold text-foreground">
-            New {typeLabel(type)} Session
+            {isEdit ? 'Edit' : 'New'} {typeLabel(type)} Session
           </h2>
           <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
             <X className="h-4 w-4" />
@@ -164,8 +196,10 @@ export function NewSessionDialog({ type, onLaunch, onClose }: Props) {
                   }}
                   omitExtraData
                   uiSchema={{
-                    ...hideFields(HIDDEN_FRONTEND_FIELDS),
+                    'ui:submitButtonOptions': { norender: true },
+                    'ui:order': [...TOP_FIELDS, '*'],
                     active_spec: { 'ui:widget': 'SpecSelectorWidget' },
+                    system_prompt: { 'ui:widget': 'textarea', 'ui:options': { rows: 4 }, classNames: 'w-full' },
                   }}
                 />
               </div>
@@ -184,8 +218,17 @@ export function NewSessionDialog({ type, onLaunch, onClose }: Props) {
             onClick={handleLaunch}
             disabled={!canLaunch}
           >
-            <Rocket className="mr-1.5 h-3.5 w-3.5" />
-            Launch Session
+            {isEdit ? (
+              <>
+                <Save className="mr-1.5 h-3.5 w-3.5" />
+                Save &amp; Restart
+              </>
+            ) : (
+              <>
+                <Rocket className="mr-1.5 h-3.5 w-3.5" />
+                Launch Session
+              </>
+            )}
           </Button>
         </div>
       </div>

--- a/apps/desktop/src/renderer/src/hooks/use-sessions.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-sessions.ts
@@ -42,9 +42,33 @@ export function useSessions() {
     });
   }, []);
 
+  const updateSession = useCallback(
+    async (
+      id: string,
+      workingDir: string,
+      pluginConfig?: Record<string, Record<string, unknown>>,
+    ) => {
+      return window.electronAPI.session.update(id, workingDir, pluginConfig);
+    },
+    [],
+  );
+
+  const restartSession = useCallback(async (id: string) => {
+    return window.electronAPI.session.restart(id);
+  }, []);
+
   const clearLogs = useCallback((id: string) => {
     setLogs((prev) => ({ ...prev, [id]: [] }));
   }, []);
 
-  return { sessions, logs, createSession, terminateSession, removeSession, clearLogs };
+  return {
+    sessions,
+    logs,
+    createSession,
+    terminateSession,
+    removeSession,
+    updateSession,
+    restartSession,
+    clearLogs,
+  };
 }

--- a/apps/desktop/src/renderer/src/views/SessionsView.tsx
+++ b/apps/desktop/src/renderer/src/views/SessionsView.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect } from 'react';
-import { Plus, Square, X, Terminal, Circle, FolderOpen, ChevronDown, ChevronRight } from 'lucide-react';
+import { Plus, Square, X, Terminal, Circle, FolderOpen, ChevronDown, ChevronRight, Pencil, Play } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ServerLogs } from '@/components/server/ServerLogs';
 import { NewSessionDialog } from '@/components/session/NewSessionDialog';
 import { useSessions } from '@/hooks/use-sessions';
-import type { SessionStatus, SessionType } from '../../../preload/types';
+import type { SessionInfo, SessionStatus, SessionType } from '../../../preload/types';
 
 const SESSION_TYPES: { type: SessionType; label: string }[] = [
   { type: 'claude', label: 'Claude Code' },
@@ -55,8 +55,9 @@ function typeLabel(type: SessionType): string {
 }
 
 export function SessionsView() {
-  const { sessions, logs, createSession, terminateSession, removeSession, clearLogs } = useSessions();
+  const { sessions, logs, createSession, terminateSession, removeSession, updateSession, restartSession, clearLogs } = useSessions();
   const [dialogType, setDialogType] = useState<SessionType | null>(null);
+  const [editingSession, setEditingSession] = useState<SessionInfo | null>(null);
 
   const activeSessions = sessions.filter((s) => s.status !== 'stopped');
   const stoppedSessions = sessions.filter((s) => s.status === 'stopped');
@@ -66,18 +67,30 @@ export function SessionsView() {
     workingDir: string,
     pluginConfig: Record<string, Record<string, unknown>>,
   ) => {
+    if (editingSession) {
+      await updateSession(editingSession.id, workingDir, pluginConfig);
+      await restartSession(editingSession.id);
+      setEditingSession(null);
+    } else {
+      setDialogType(null);
+      await createSession(type, workingDir, pluginConfig);
+    }
+  };
+
+  const handleCloseDialog = () => {
     setDialogType(null);
-    await createSession(type, workingDir, pluginConfig);
+    setEditingSession(null);
   };
 
   return (
     <div className="flex h-full flex-col">
-      {/* New session dialog */}
-      {dialogType && (
+      {/* New / Edit session dialog */}
+      {(dialogType || editingSession) && (
         <NewSessionDialog
-          type={dialogType}
+          type={editingSession?.type || dialogType!}
+          editSession={editingSession ?? undefined}
           onLaunch={handleLaunch}
-          onClose={() => setDialogType(null)}
+          onClose={handleCloseDialog}
         />
       )}
 
@@ -151,6 +164,8 @@ export function SessionsView() {
                       logs={logs[s.id] || []}
                       onClearLogs={() => clearLogs(s.id)}
                       onRemove={() => removeSession(s.id)}
+                      onEdit={() => setEditingSession(s)}
+                      onRestart={() => restartSession(s.id)}
                     />
                   ))}
                 </div>
@@ -169,12 +184,16 @@ function SessionCard({
   onClearLogs,
   onStop,
   onRemove,
+  onEdit,
+  onRestart,
 }: {
   session: { id: string; type: SessionType; port: number; status: SessionStatus; workingDir: string; createdAt: string };
   logs: string[];
   onClearLogs: () => void;
   onStop?: () => void;
   onRemove?: () => void;
+  onEdit?: () => void;
+  onRestart?: () => void;
 }) {
   const [showLogs, setShowLogs] = useState(false);
 
@@ -231,6 +250,28 @@ function SessionCard({
             title="Stop session"
           >
             <Square className="h-3.5 w-3.5" />
+          </Button>
+        )}
+        {onEdit && (session.status === 'stopped' || session.status === 'error') && (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onEdit}
+            className="h-8 w-8 text-muted-foreground hover:text-foreground"
+            title="Edit settings"
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </Button>
+        )}
+        {onRestart && (session.status === 'stopped' || session.status === 'error') && (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onRestart}
+            className="h-8 w-8 text-green-400 hover:text-green-300"
+            title="Restart session"
+          >
+            <Play className="h-3.5 w-3.5" />
           </Button>
         )}
         {onRemove && (

--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -43,6 +43,10 @@ select = ["E", "F", "I", "UP"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "src/screamingface/plugins"]
+markers = [
+    "e2e: end-to-end test using subprocess server",
+    "e2e_live: e2e test requiring real Anthropic API key",
+]
 
 [dependency-groups]
 dev = [
@@ -58,4 +62,5 @@ dev = [
     "arize-phoenix>=8.0",
     "arize-phoenix-otel>=0.6",
     "pytest-cov>=7.1.0",
+    "pytest-timeout>=2.3",
 ]

--- a/apps/server/src/screamingface/plugins/claude_backend/routes.py
+++ b/apps/server/src/screamingface/plugins/claude_backend/routes.py
@@ -121,6 +121,23 @@ def create_router(settings: ClaudeBackendSettings, app: Any = None) -> APIRouter
         except Exception as exc:
             logger.warning("Claude url4 evaluation failed: %s", exc, exc_info=True)
             raise HTTPException(status_code=502, detail=f"Claude url4 evaluation failed: {exc}")
+
+        # Record result on the FastAPI auto-instrumented span
+        try:
+            from opentelemetry import trace
+
+            span = trace.get_current_span()
+            if span and span.is_recording():
+                span.set_attribute("sf.plugin", "claude-backend")
+                span.set_attribute("url4.expression", q[:500])
+                span.set_attribute("url4.result_length", len(result))
+                preview = result[:4000]
+                if len(result) > 4000:
+                    preview += f"\n... ({len(result) - 4000} more chars)"
+                span.set_attribute("url4.response_body", preview)
+        except ImportError:
+            pass
+
         return PlainTextResponse(content=result)
 
     async def _handle_profile(

--- a/apps/server/src/screamingface/plugins/claude_backend/runner.py
+++ b/apps/server/src/screamingface/plugins/claude_backend/runner.py
@@ -106,9 +106,66 @@ async def run_claude(
 ) -> tuple[int, str, str, float]:
     """Run the Claude CLI and return (exit_code, stdout, stderr, duration_seconds).
 
-    Uses asyncio.create_subprocess_exec (not shell) — args are passed as a list,
-    preventing shell injection.
+    When *cwd* is None, creates a temporary ``/tmp/sf-<uuid>`` directory so
+    Claude never picks up project context (CLAUDE.md, git, etc.).  The
+    directory is removed after the process exits.
     """
+    import shutil
+    import uuid
+
+    tmp_cwd: str | None = None
+    if cwd is None:
+        tmp_cwd = f"/tmp/sf-{uuid.uuid4().hex[:12]}"
+        os.makedirs(tmp_cwd, exist_ok=True)
+        cwd = tmp_cwd
+
+    env = dict(os.environ)
+    env["ANTHROPIC_BASE_URL"] = "https://api.anthropic.com"
+    start = time.monotonic()
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *args,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+            cwd=cwd,
+        )
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+            proc.communicate(prompt.encode()),
+            timeout=timeout,
+        )
+        duration = time.monotonic() - start
+        return (
+            proc.returncode or 0,
+            stdout_bytes.decode(),
+            stderr_bytes.decode(),
+            duration,
+        )
+    finally:
+        if tmp_cwd:
+            shutil.rmtree(tmp_cwd, ignore_errors=True)
+
+
+async def stream_claude(
+    args: list[str],
+    prompt: str,
+    timeout: float,
+    cwd: str | None = None,
+) -> AsyncGenerator[str, None]:
+    """Stream stdout lines from the Claude CLI, ending with a done event.
+
+    When *cwd* is None, creates a temporary ``/tmp/sf-<uuid>`` directory.
+    """
+    import shutil
+    import uuid
+
+    tmp_cwd: str | None = None
+    if cwd is None:
+        tmp_cwd = f"/tmp/sf-{uuid.uuid4().hex[:12]}"
+        os.makedirs(tmp_cwd, exist_ok=True)
+        cwd = tmp_cwd
+
     env = dict(os.environ)
     env["ANTHROPIC_BASE_URL"] = "https://api.anthropic.com"
     start = time.monotonic()
@@ -119,35 +176,6 @@ async def run_claude(
         stderr=asyncio.subprocess.PIPE,
         env=env,
         cwd=cwd,
-    )
-    stdout_bytes, stderr_bytes = await asyncio.wait_for(
-        proc.communicate(prompt.encode()),
-        timeout=timeout,
-    )
-    duration = time.monotonic() - start
-    return (
-        proc.returncode or 0,
-        stdout_bytes.decode(),
-        stderr_bytes.decode(),
-        duration,
-    )
-
-
-async def stream_claude(
-    args: list[str],
-    prompt: str,
-    timeout: float,
-) -> AsyncGenerator[str, None]:
-    """Stream stdout lines from the Claude CLI, ending with a done event."""
-    env = dict(os.environ)
-    env["ANTHROPIC_BASE_URL"] = "https://api.anthropic.com"
-    start = time.monotonic()
-    proc = await asyncio.create_subprocess_exec(
-        *args,
-        stdin=asyncio.subprocess.PIPE,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        env=env,
     )
     assert proc.stdin is not None
     assert proc.stdout is not None
@@ -181,3 +209,6 @@ async def stream_claude(
         )
         + "\n"
     )
+
+    if tmp_cwd:
+        shutil.rmtree(tmp_cwd, ignore_errors=True)

--- a/apps/server/src/screamingface/plugins/claude_frontend/plugin.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/plugin.py
@@ -119,14 +119,7 @@ class ClaudeFrontendPlugin(Plugin):
         return schema
 
     def preflight(self) -> tuple[bool, str]:
-        ok, reason = super().preflight()
-        if not ok:
-            return ok, reason
-        import shutil
-
-        if not shutil.which("claude"):
-            return False, "Claude Code CLI not found in PATH"
-        return True, ""
+        return super().preflight()
 
     def _collect_spec_names(self) -> list[str]:
         """Return the active spec as a single-element list, or empty."""

--- a/apps/server/src/screamingface/plugins/claude_frontend/plugin.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/plugin.py
@@ -12,7 +12,7 @@ import os
 import socket
 import threading
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import httpx
 import uvicorn
@@ -60,6 +60,30 @@ class ClaudeFrontendSettings(PluginSettings):
     resolve_timeout: float = Field(
         default=300.0,
         description="Max seconds to wait for url4 spec resolution on first request.",
+    )
+    embed_target: Literal["system", "user"] = Field(
+        default="user",
+        description=(
+            "Where to inject url4-resolved context: "
+            "'system' (prepend to system prompt) or 'user' (inject into user message)."
+        ),
+    )
+    embed_mode: Literal["concat", "replace"] = Field(
+        default="concat",
+        description=(
+            "How to embed in user message: "
+            "'concat' (original prompt + context) or 'replace' (context only). "
+            "Only used when embed_target is 'user'."
+        ),
+    )
+    system_prompt: str = Field(
+        default=(
+            "You are a helpful assistant. Answer the user's question based only on "
+            "the provided context. Be concise and factual."
+        ),
+        description=(
+            "System prompt prepended to the resolved context when embed_target is 'system'."
+        ),
     )
 
 

--- a/apps/server/src/screamingface/plugins/claude_frontend/proxy.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/proxy.py
@@ -326,6 +326,43 @@ def _replace_last_user_message(messages: list[dict[str, Any]], new_text: str) ->
         return
 
 
+def _inject_system_context(body: dict[str, Any], text: str) -> None:
+    """Inject *text* into the request body's system prompt.
+
+    Handles the three formats Anthropic accepts:
+    - None → create a new list with a single text block
+    - str  → concatenate with ``\\n\\n``
+    - list → append as a new text block
+    """
+    existing = body.get("system")
+    if existing is None:
+        body["system"] = [{"type": "text", "text": text}]
+    elif isinstance(existing, str):
+        body["system"] = existing + "\n\n" + text
+    elif isinstance(existing, list):
+        existing.append({"type": "text", "text": text})
+
+
+def _embed_context(
+    body: dict[str, Any],
+    resolved_context: str,
+    settings: ClaudeFrontendSettings,
+) -> None:
+    """Embed resolved url4 context into the request body per settings."""
+    if settings.embed_target == "user":
+        messages = body.get("messages", [])
+        last_user_text = _extract_last_user_text(messages)
+        if last_user_text:
+            if settings.embed_mode == "concat":
+                combined = f"{last_user_text}\n\n{resolved_context}"
+            else:  # replace
+                combined = resolved_context
+            _replace_last_user_message(messages, combined)
+    else:  # system
+        wrapped = f"{settings.system_prompt}\n\n{resolved_context}"
+        _inject_system_context(body, wrapped)
+
+
 def create_router(
     settings: ClaudeFrontendSettings,
     app: Any = None,
@@ -373,19 +410,33 @@ def create_router(
             msgs = body.get("messages", [])
             if msgs:
                 original_user_msg = msgs[-1].copy() if isinstance(msgs[-1], dict) else msgs[-1]
-            try:
-                results = await hooks.emit_async(
-                    "session.enrich_request",
-                    body=body,
-                    session_id=session_id,
-                    session_service_url=session_service_url,
+            tracer = _get_tracer()
+            enrich_ctx = (
+                tracer.start_as_current_span("session.enrich_request") if tracer else _nullcontext()
+            )
+            with enrich_ctx:
+                _set_span_attrs(
+                    {
+                        "session.id": session_id,
+                        "session.service_url": session_service_url,
+                    }
                 )
-                for result in results:
-                    if result is not None:
-                        body = result
-                        break
-            except Exception:
-                logger.warning("Session enrichment failed for %s", session_id, exc_info=True)
+                try:
+                    results = await hooks.emit_async(
+                        "session.enrich_request",
+                        body=body,
+                        session_id=session_id,
+                        session_service_url=session_service_url,
+                    )
+                    modified = False
+                    for result in results:
+                        if result is not None:
+                            body = result
+                            modified = True
+                            break
+                    _set_span_attrs({"session.modified": modified})
+                except Exception:
+                    logger.warning("Session enrichment failed for %s", session_id, exc_info=True)
 
         # --- URL4 context injection ---
         # If the active spec contains $prompt, substitute the user's last message
@@ -416,16 +467,36 @@ def create_router(
 
                         # Store user prompt as blob on the backend server
                         if backend_url:
-                            async with httpx.AsyncClient(
-                                timeout=httpx.Timeout(30.0), verify=False
-                            ) as dc:
-                                blob_resp = await dc.post(
-                                    f"{backend_url}/data",
-                                    content=last_user_text.encode("utf-8"),
-                                    headers={"content-type": "text/plain; charset=utf-8"},
+                            blob_url_target = f"{backend_url}/data"
+                            blob_span_ctx = (
+                                _start_client_span(tracer, "POST /data")
+                                if tracer
+                                else _nullcontext()
+                            )
+                            with blob_span_ctx:
+                                _set_span_attrs(
+                                    {
+                                        "http.method": "POST",
+                                        "http.url": blob_url_target,
+                                    }
                                 )
-                                blob_resp.raise_for_status()
-                                blob_key = blob_resp.json()["key"]
+                                async with httpx.AsyncClient(
+                                    timeout=httpx.Timeout(30.0), verify=False
+                                ) as dc:
+                                    blob_resp = await dc.post(
+                                        blob_url_target,
+                                        content=last_user_text.encode("utf-8"),
+                                        headers={"content-type": "text/plain; charset=utf-8"},
+                                    )
+                                    blob_resp.raise_for_status()
+                                    blob_key = blob_resp.json()["key"]
+                                _set_span_attrs(
+                                    {
+                                        "http.status_code": blob_resp.status_code,
+                                        "data.key": blob_key,
+                                        "data.size": len(last_user_text),
+                                    }
+                                )
                         else:
                             from screamingface.plugins.data_store.routes import store_blob
 
@@ -444,14 +515,36 @@ def create_router(
 
                         # Resolve the full expression via /ensemble endpoint
                         if backend_url:
-                            async with httpx.AsyncClient(
-                                timeout=httpx.Timeout(300.0), verify=False
-                            ) as ec:
-                                ens_resp = await ec.get(
-                                    f"{backend_url}/ensemble", params={"q": substituted}
+                            ens_url = f"{backend_url}/ensemble"
+                            ens_span_ctx = (
+                                _start_client_span(tracer, "GET /ensemble")
+                                if tracer
+                                else _nullcontext()
+                            )
+                            with ens_span_ctx:
+                                _set_span_attrs(
+                                    {
+                                        "http.method": "GET",
+                                        "http.url": ens_url,
+                                        "url4.expression": _truncate(substituted, 500),
+                                    }
                                 )
-                                ens_resp.raise_for_status()
-                                final_text = ens_resp.text
+                                async with httpx.AsyncClient(
+                                    timeout=httpx.Timeout(300.0), verify=False
+                                ) as ec:
+                                    ens_resp = await ec.get(ens_url, params={"q": substituted})
+                                    ens_resp.raise_for_status()
+                                    final_text = ens_resp.text
+                                body_preview = final_text[:4000]
+                                if len(final_text) > 4000:
+                                    body_preview += f"\n... ({len(final_text) - 4000} more chars)"
+                                _set_span_attrs(
+                                    {
+                                        "http.status_code": ens_resp.status_code,
+                                        "url4.result_length": len(final_text),
+                                        "url4.response_body": body_preview,
+                                    }
+                                )
                         else:
                             from screamingface.plugins.url4_executor.interpreter import (
                                 Url4Interpreter,
@@ -468,12 +561,13 @@ def create_router(
                             prompt_span.set_attribute("url4.status", "ok")
 
                         if final_text:
-                            combined = f"{last_user_text}\n\n{final_text}"
-                            _replace_last_user_message(messages, combined)
+                            _embed_context(body, final_text, settings)
                             logger.info(
-                                "$prompt: blob=%s resolved %d chars → appended to user message",
+                                "$prompt: blob=%s resolved %d chars → target=%s mode=%s",
                                 blob_key,
                                 len(final_text),
+                                settings.embed_target,
+                                settings.embed_mode,
                             )
                     except Exception as exc:
                         if prompt_span and prompt_span.is_recording():
@@ -541,20 +635,12 @@ def create_router(
                 }
                 return JSONResponse(content=error_response, status_code=200)
             if resolved_context:
-                wrapped = (
-                    "Please be accurate and keep this information "
-                    "constantly in your context:\n\n" + resolved_context
-                )
-                existing = body.get("system")
-                if existing is None:
-                    body["system"] = [{"type": "text", "text": wrapped}]
-                elif isinstance(existing, str):
-                    body["system"] = existing + "\n\n" + wrapped
-                elif isinstance(existing, list):
-                    existing.append({"type": "text", "text": wrapped})
+                _embed_context(body, resolved_context, settings)
                 logger.info(
-                    "Injected cached url4 context (%d chars) into system prompt",
+                    "Injected cached url4 context (%d chars) embed_target=%s embed_mode=%s",
                     len(resolved_context),
+                    settings.embed_target,
+                    settings.embed_mode,
                 )
 
         # Trace the FINAL request body (after all modifications) as child spans.
@@ -677,20 +763,34 @@ def create_router(
                         if session_id and session_service_url and hooks and original_user_msg:
                             response_data = _parse_sse_response(raw)
                             if response_data:
-                                try:
-                                    await hooks.emit_async(
-                                        "session.save_response",
-                                        session_id=session_id,
-                                        session_service_url=session_service_url,
-                                        user_message_body=original_user_msg,
-                                        response_body=response_data,
+                                save_tracer = _get_tracer()
+                                save_ctx = (
+                                    save_tracer.start_as_current_span("session.save_response")
+                                    if save_tracer
+                                    else _nullcontext()
+                                )
+                                with save_ctx:
+                                    _set_span_attrs(
+                                        {
+                                            "session.id": session_id,
+                                            "session.service_url": session_service_url,
+                                            "session.streaming": True,
+                                        }
                                     )
-                                except Exception:
-                                    logger.warning(
-                                        "Session save (stream) failed for %s",
-                                        session_id,
-                                        exc_info=True,
-                                    )
+                                    try:
+                                        await hooks.emit_async(
+                                            "session.save_response",
+                                            session_id=session_id,
+                                            session_service_url=session_service_url,
+                                            user_message_body=original_user_msg,
+                                            response_body=response_data,
+                                        )
+                                    except Exception:
+                                        logger.warning(
+                                            "Session save (stream) failed for %s",
+                                            session_id,
+                                            exc_info=True,
+                                        )
 
                     if upstream_span:
                         upstream_span.end()
@@ -731,16 +831,30 @@ def create_router(
             # --- Session save (non-streaming) ---
             response_data = resp.json()
             if session_id and session_service_url and hooks and original_user_msg:
-                try:
-                    await hooks.emit_async(
-                        "session.save_response",
-                        session_id=session_id,
-                        session_service_url=session_service_url,
-                        user_message_body=original_user_msg,
-                        response_body=response_data,
+                save_tracer = _get_tracer()
+                save_ctx = (
+                    save_tracer.start_as_current_span("session.save_response")
+                    if save_tracer
+                    else _nullcontext()
+                )
+                with save_ctx:
+                    _set_span_attrs(
+                        {
+                            "session.id": session_id,
+                            "session.service_url": session_service_url,
+                            "session.streaming": False,
+                        }
                     )
-                except Exception:
-                    logger.warning("Session save failed for %s", session_id, exc_info=True)
+                    try:
+                        await hooks.emit_async(
+                            "session.save_response",
+                            session_id=session_id,
+                            session_service_url=session_service_url,
+                            user_message_body=original_user_msg,
+                            response_body=response_data,
+                        )
+                    except Exception:
+                        logger.warning("Session save failed for %s", session_id, exc_info=True)
 
             return JSONResponse(content=response_data, status_code=resp.status_code)
 

--- a/apps/server/src/screamingface/plugins/claude_frontend/tests/test_claude_frontend_models.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/tests/test_claude_frontend_models.py
@@ -324,7 +324,10 @@ class _FakePlugin:
 
 @pytest.fixture
 def proxy_app_with_context() -> FastAPI:
-    settings = ClaudeFrontendSettings(upstream_url="https://api.anthropic.com")
+    settings = ClaudeFrontendSettings(
+        upstream_url="https://api.anthropic.com",
+        embed_target="system",
+    )
     app = FastAPI()
     router = create_router(settings, plugin=_FakePlugin("cached url4 docs"))
     app.include_router(router)
@@ -340,7 +343,11 @@ def proxy_app_no_context() -> FastAPI:
     return app
 
 
-_INJECT_PREFIX = "Please be accurate and keep this information constantly in your context:\n\n"
+_DEFAULT_SYS_PROMPT = (
+    "You are a helpful assistant. Answer the user's question based only on "
+    "the provided context. Be concise and factual."
+)
+_INJECT_PREFIX = _DEFAULT_SYS_PROMPT + "\n\n"
 
 
 class TestProxyContextInjection:

--- a/apps/server/src/screamingface/plugins/url4_executor/_tracing.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/_tracing.py
@@ -1,0 +1,49 @@
+"""Optional OTel tracing helpers for url4-executor.
+
+All functions are no-ops when opentelemetry is not installed.
+"""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from typing import Any
+
+_PLUGIN = "url4-executor"
+
+
+def _get_tracer():  # type: ignore[no-untyped-def]
+    try:
+        from opentelemetry import trace
+
+        return trace.get_tracer(f"screamingface.{_PLUGIN}")
+    except ImportError:
+        return None
+
+
+def traced(name: str, kind: str = "internal"):  # type: ignore[no-untyped-def]
+    """Return a span context manager, or nullcontext if OTel not available."""
+    tracer = _get_tracer()
+    if not tracer:
+        return nullcontext()
+    from opentelemetry.trace import SpanKind
+
+    kind_map = {
+        "internal": SpanKind.INTERNAL,
+        "client": SpanKind.CLIENT,
+        "server": SpanKind.SERVER,
+    }
+    return tracer.start_as_current_span(name, kind=kind_map.get(kind, SpanKind.INTERNAL))
+
+
+def set_span_attrs(attrs: dict[str, Any], span: Any = None) -> None:
+    """Set attributes on the current or provided span (no-op without OTel)."""
+    try:
+        from opentelemetry import trace
+
+        span = span or trace.get_current_span()
+        if span and span.is_recording():
+            span.set_attribute("sf.plugin", _PLUGIN)
+            for k, v in attrs.items():
+                span.set_attribute(k, v)
+    except ImportError:
+        pass

--- a/apps/server/src/screamingface/plugins/url4_executor/interpreter.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/interpreter.py
@@ -51,15 +51,52 @@ class Url4Interpreter:
 
     async def evaluate(self, expr: str) -> str:
         """Full evaluation pipeline."""
-        source_expr, raw_intent = split_intent(expr.strip())
+        from screamingface.plugins.url4_executor._tracing import set_span_attrs, traced
 
-        # Resolve sources (parallel fetch of URLs, concatenate text)
-        sources = await resolve_str(source_expr, self.app) if source_expr else ""
+        with traced("url4.evaluate"):
+            set_span_attrs(
+                {
+                    "url4.expression": expr[:500],
+                }
+            )
 
-        # Resolve intent (text / relative URL / absolute URL)
-        intent = await resolve_intent(raw_intent, self.app) if raw_intent else None
+            source_expr, raw_intent = split_intent(expr.strip())
+            set_span_attrs({"url4.has_intent": raw_intent is not None})
 
-        return await self.process(sources, intent)
+            # Resolve sources (parallel fetch of URLs, concatenate text)
+            with traced("url4.resolve_sources"):
+                sources = await resolve_str(source_expr, self.app) if source_expr else ""
+                src_preview = sources[:4000]
+                if len(sources) > 4000:
+                    src_preview += f"\n... ({len(sources) - 4000} more chars)"
+                set_span_attrs(
+                    {
+                        "url4.sources_length": len(sources),
+                        "url4.response_body": src_preview,
+                    }
+                )
+
+            # Resolve intent (text / relative URL / absolute URL)
+            with traced("url4.resolve_intent"):
+                intent = await resolve_intent(raw_intent, self.app) if raw_intent else None
+                set_span_attrs(
+                    {
+                        "url4.intent_length": len(intent) if intent else 0,
+                        "url4.response_body": intent[:4000] if intent else "",
+                    }
+                )
+
+            result = await self.process(sources, intent)
+            result_preview = result[:4000]
+            if len(result) > 4000:
+                result_preview += f"\n... ({len(result) - 4000} more chars)"
+            set_span_attrs(
+                {
+                    "url4.result_length": len(result),
+                    "url4.response_body": result_preview,
+                }
+            )
+            return result
 
     async def process(self, sources: str, intent: str | None) -> str:
         """Process resolved sources and intent. Override in subclasses.

--- a/apps/server/src/screamingface/plugins/url4_executor/routes.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/routes.py
@@ -57,6 +57,20 @@ def create_router(app=None) -> APIRouter:  # type: ignore[no-untyped-def]
             logger.warning("url4 evaluation failed: %s", exc, exc_info=True)
             raise HTTPException(status_code=502, detail=f"url4 evaluation failed: {exc}")
 
+        # Record result on the FastAPI auto-instrumented span
+        from screamingface.plugins.url4_executor._tracing import set_span_attrs
+
+        preview = result[:4000]
+        if len(result) > 4000:
+            preview += f"\n... ({len(result) - 4000} more chars)"
+        set_span_attrs(
+            {
+                "url4.expression": q[:500],
+                "url4.result_length": len(result),
+                "url4.response_body": preview,
+            }
+        )
+
         if ast:
             source_expr, intent = split_intent(q)
             tree = parse(source_expr) if source_expr else None

--- a/apps/server/src/screamingface/plugins/url4_executor/url4.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/url4.py
@@ -159,22 +159,52 @@ def _sanitize_url(url: str) -> str:
 
 async def _fetch_relative(app: Any, path: str) -> str:
     """Fetch a relative path via in-process ASGI transport (no network hop)."""
+    from screamingface.plugins.url4_executor._tracing import set_span_attrs, traced
+
     if not app:
         raise ValueError(f"Cannot resolve relative URL {path!r} without app context")
-    transport = httpx.ASGITransport(app=app)
-    async with httpx.AsyncClient(transport=transport, base_url="http://localhost") as client:
-        resp = await client.get(path)
-        resp.raise_for_status()
-        return resp.text
+    with traced("url4.fetch_relative", kind="client"):
+        set_span_attrs({"http.method": "GET", "url4.path": path})
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://localhost") as client:
+            resp = await client.get(path)
+            resp.raise_for_status()
+            body = resp.text
+            preview = body[:4000]
+            if len(body) > 4000:
+                preview += f"\n... ({len(body) - 4000} more chars)"
+            set_span_attrs(
+                {
+                    "http.status_code": resp.status_code,
+                    "url4.response_length": len(body),
+                    "url4.response_body": preview,
+                }
+            )
+            return body
 
 
 async def _fetch_url(url: str) -> str:
     """Fetch a URL via HTTP GET and return the response body as text."""
+    from screamingface.plugins.url4_executor._tracing import set_span_attrs, traced
+
     safe_url = _sanitize_url(url)
     logger.info("url4: fetching %s", safe_url[:200])
-    timeout = httpx.Timeout(connect=10.0, read=60.0, write=10.0, pool=10.0)
-    # verify=False for self-signed certs on localhost
-    async with httpx.AsyncClient(timeout=timeout, verify=False) as client:
-        resp = await client.get(safe_url)
-        resp.raise_for_status()
-        return resp.text
+    with traced("url4.fetch", kind="client"):
+        set_span_attrs({"http.method": "GET", "http.url": safe_url[:500]})
+        timeout = httpx.Timeout(connect=10.0, read=60.0, write=10.0, pool=10.0)
+        # verify=False for self-signed certs on localhost
+        async with httpx.AsyncClient(timeout=timeout, verify=False) as client:
+            resp = await client.get(safe_url)
+            resp.raise_for_status()
+            body = resp.text
+            preview = body[:4000]
+            if len(body) > 4000:
+                preview += f"\n... ({len(body) - 4000} more chars)"
+            set_span_attrs(
+                {
+                    "http.status_code": resp.status_code,
+                    "url4.response_length": len(body),
+                    "url4.response_body": preview,
+                }
+            )
+            return body

--- a/apps/server/tests/e2e/conftest.py
+++ b/apps/server/tests/e2e/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Generator
 
 import pytest
 
@@ -31,10 +32,10 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
 
 
 @pytest.fixture(scope="session")
-def otlp_collector() -> OTLPCollector:
+def otlp_collector() -> Generator[OTLPCollector, None, None]:
     collector = OTLPCollector()
     collector.start()
-    yield collector  # type: ignore[misc]
+    yield collector
     collector.stop()
 
 
@@ -127,11 +128,11 @@ def proxy_server_config(
 
 
 @pytest.fixture(scope="session")
-def sf_server(main_server_config: dict) -> ServerManager:
+def sf_server(main_server_config: dict) -> Generator[ServerManager, None, None]:
     """Main SF server (url4-executor, data-store). Started once per session."""
     mgr = ServerManager(main_server_config)
     mgr.start(timeout=30)
-    yield mgr  # type: ignore[misc]
+    yield mgr
     mgr.stop()
 
 
@@ -140,7 +141,7 @@ def proxy_server(
     proxy_server_config: dict,
     sf_server: ServerManager,  # noqa: ARG001 — ensure main server starts first
     proxy_server_port: int,
-) -> ServerManager:
+) -> Generator[ServerManager, None, None]:
     """Session proxy (claude-frontend → httpbin). Started once per session."""
     mgr = ServerManager(proxy_server_config, session_id="e2e-test")
     mgr.start(timeout=30)
@@ -148,7 +149,7 @@ def proxy_server(
     if not ServerManager.wait_for_port(proxy_server_port):
         mgr.stop()
         raise RuntimeError(f"Proxy not listening on port {proxy_server_port}")
-    yield mgr  # type: ignore[misc]
+    yield mgr
     mgr.stop()
 
 
@@ -166,9 +167,9 @@ def proxy_url(proxy_server_port: int) -> str:
 def claude_client(
     proxy_url: str,
     proxy_server: ServerManager,  # noqa: ARG001 — ensures servers are running
-) -> ClaudeCodeClient:
+) -> Generator[ClaudeCodeClient, None, None]:
     client = ClaudeCodeClient(proxy_url=proxy_url)
-    yield client  # type: ignore[misc]
+    yield client
     client.reset()
 
 

--- a/apps/server/tests/e2e/conftest.py
+++ b/apps/server/tests/e2e/conftest.py
@@ -1,0 +1,182 @@
+"""E2E test fixtures — server lifecycle, OTLP collector, Claude Code client."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tests.e2e.infrastructure.claude_code_client import ClaudeCodeClient
+from tests.e2e.infrastructure.otlp_collector import OTLPCollector
+from tests.e2e.infrastructure.server_manager import ServerManager
+
+# ---------------------------------------------------------------------------
+# Auto-skip e2e_live tests without API key
+# ---------------------------------------------------------------------------
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    has_api_key = bool(os.environ.get("ANTHROPIC_API_KEY"))
+    if has_api_key:
+        return
+    skip_marker = pytest.mark.skip(reason="ANTHROPIC_API_KEY not set")
+    for item in items:
+        if "e2e_live" in item.keywords:
+            item.add_marker(skip_marker)
+
+
+# ---------------------------------------------------------------------------
+# OTLP Collector (session-scoped)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def otlp_collector() -> OTLPCollector:
+    collector = OTLPCollector()
+    collector.start()
+    yield collector  # type: ignore[misc]
+    collector.stop()
+
+
+# ---------------------------------------------------------------------------
+# Server configs
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def main_server_port() -> int:
+    return ServerManager.find_free_port()
+
+
+@pytest.fixture(scope="session")
+def proxy_server_port() -> int:
+    return ServerManager.find_free_port()
+
+
+@pytest.fixture(scope="session")
+def main_server_config(otlp_collector: OTLPCollector, main_server_port: int) -> dict:
+    """Config for the main SF server (url4 resolution, data-store)."""
+    return {
+        "version": "0.1.0",
+        "server": {
+            "host": "127.0.0.1",
+            "port": main_server_port,
+            "ssl": False,
+            "reload": False,
+        },
+        "plugins": ["tracing", "url4-executor", "url4-specs", "data-store"],
+        "plugin_config": {
+            "tracing": {
+                "phoenix_launch": False,
+                "otlp_endpoint": otlp_collector.endpoint,
+            },
+        },
+    }
+
+
+@pytest.fixture(scope="session")
+def proxy_server_config(
+    otlp_collector: OTLPCollector,
+    main_server_port: int,
+    proxy_server_port: int,
+) -> dict:
+    """Config for the session proxy (claude-frontend → httpbin echo)."""
+    return {
+        "version": "0.1.0",
+        "server": {
+            "host": "127.0.0.1",
+            "port": main_server_port + 1,  # internal server port
+            "ssl": False,
+            "reload": False,
+        },
+        "plugins": [
+            "tracing",
+            "claude-frontend",
+            "url4-specs",
+            "url4-executor",
+            "data-store",
+        ],
+        "plugin_config": {
+            "tracing": {
+                "phoenix_launch": False,
+                "otlp_endpoint": otlp_collector.endpoint,
+            },
+            "claude-frontend": {
+                "active_spec": "test-prompt-spec",
+                "upstream_url": "https://httpbin.org/anything",
+                "listen_host": "127.0.0.1",
+                "listen_port": proxy_server_port,
+            },
+            "url4-specs": {
+                "specs": {
+                    "test-static-spec": {
+                        "expression": "(https://httpbin.org/robots.txt)!'Be helpful'",
+                    },
+                    "test-prompt-spec": {
+                        "expression": "(https://httpbin.org/robots.txt)!$prompt",
+                    },
+                },
+            },
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Server lifecycle (session-scoped)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def sf_server(main_server_config: dict) -> ServerManager:
+    """Main SF server (url4-executor, data-store). Started once per session."""
+    mgr = ServerManager(main_server_config)
+    mgr.start(timeout=30)
+    yield mgr  # type: ignore[misc]
+    mgr.stop()
+
+
+@pytest.fixture(scope="session")
+def proxy_server(
+    proxy_server_config: dict,
+    sf_server: ServerManager,  # noqa: ARG001 — ensure main server starts first
+    proxy_server_port: int,
+) -> ServerManager:
+    """Session proxy (claude-frontend → httpbin). Started once per session."""
+    mgr = ServerManager(proxy_server_config, session_id="e2e-test")
+    mgr.start(timeout=30)
+    # Wait for the proxy port to be listening
+    if not ServerManager.wait_for_port(proxy_server_port):
+        mgr.stop()
+        raise RuntimeError(f"Proxy not listening on port {proxy_server_port}")
+    yield mgr  # type: ignore[misc]
+    mgr.stop()
+
+
+@pytest.fixture(scope="session")
+def proxy_url(proxy_server_port: int) -> str:
+    return f"http://127.0.0.1:{proxy_server_port}"
+
+
+# ---------------------------------------------------------------------------
+# Claude Code client (per-test)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def claude_client(
+    proxy_url: str,
+    proxy_server: ServerManager,  # noqa: ARG001 — ensures servers are running
+) -> ClaudeCodeClient:
+    client = ClaudeCodeClient(proxy_url=proxy_url)
+    yield client  # type: ignore[misc]
+    client.reset()
+
+
+# ---------------------------------------------------------------------------
+# Span clearing (per-test, autouse)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_spans(otlp_collector: OTLPCollector) -> None:
+    otlp_collector.clear()

--- a/apps/server/tests/e2e/infrastructure/__init__.py
+++ b/apps/server/tests/e2e/infrastructure/__init__.py
@@ -1,0 +1,13 @@
+from .claude_code_client import ClaudeCodeClient, ProxyResponse
+from .log_collector import LogCollector
+from .otlp_collector import CollectedSpan, OTLPCollector
+from .server_manager import ServerManager
+
+__all__ = [
+    "ClaudeCodeClient",
+    "CollectedSpan",
+    "LogCollector",
+    "OTLPCollector",
+    "ProxyResponse",
+    "ServerManager",
+]

--- a/apps/server/tests/e2e/infrastructure/claude_code_client.py
+++ b/apps/server/tests/e2e/infrastructure/claude_code_client.py
@@ -1,0 +1,189 @@
+"""Claude Code client emulator for e2e proxy testing.
+
+Builds realistic Claude Code request payloads (multi-turn conversations,
+system-reminder injection, tool_use/tool_result cycles) and sends them
+to the claude-frontend proxy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+
+@dataclass
+class ProxyResponse:
+    """Response from the proxy, with helpers for httpbin echo mode."""
+
+    status_code: int
+    body: dict[str, Any]
+    headers: dict[str, str]
+
+    @property
+    def echoed_body(self) -> dict[str, Any]:
+        """The forwarded request body echoed back by httpbin ``/anything``."""
+        return self.body.get("json", {})
+
+    @property
+    def forwarded_system(self) -> str | list[dict[str, Any]] | None:
+        """System prompt from the echoed request body."""
+        return self.echoed_body.get("system")
+
+    @property
+    def forwarded_messages(self) -> list[dict[str, Any]]:
+        """Messages array from the echoed request body."""
+        return self.echoed_body.get("messages", [])
+
+    @property
+    def last_user_content(self) -> str | list[dict[str, Any]]:
+        """Content of the last user message in the echoed body."""
+        for msg in reversed(self.forwarded_messages):
+            if msg.get("role") == "user":
+                return msg.get("content", "")
+        return ""
+
+    @property
+    def last_user_text(self) -> str:
+        """Plain text of the last user message (handles both str and blocks)."""
+        content = self.last_user_content
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            texts = [
+                b.get("text", "")
+                for b in content
+                if isinstance(b, dict)
+                and b.get("type") == "text"
+                and not b.get("text", "").lstrip().startswith("<system-reminder>")
+            ]
+            return texts[-1] if texts else ""
+        return str(content)
+
+
+@dataclass
+class ClaudeCodeClient:
+    """Emulates Claude Code CLI requests to the proxy."""
+
+    proxy_url: str
+    api_key: str = "test-key"
+    model: str = "claude-sonnet-4-20250514"
+    max_tokens: int = 1024
+
+    _messages: list[dict[str, Any]] = field(default_factory=list, init=False)
+    _system_reminders: list[str] = field(default_factory=list, init=False)
+
+    def send_message(
+        self,
+        content: str | list[dict[str, Any]],
+        *,
+        system: str | list[dict[str, Any]] | None = None,
+        stream: bool = False,
+        tools: list[dict[str, Any]] | None = None,
+        extra_headers: dict[str, str] | None = None,
+        timeout: float = 30,
+        extra_body: dict[str, Any] | None = None,
+        track_history: bool = True,
+    ) -> ProxyResponse:
+        """Send a user message to the proxy.
+
+        If *track_history* is True (default), the message is appended to the
+        internal conversation history for multi-turn testing.
+        """
+        # Build user message content blocks
+        if isinstance(content, str):
+            user_content: str | list[dict[str, Any]] = content
+            if self._system_reminders:
+                blocks: list[dict[str, Any]] = [
+                    {"type": "text", "text": f"<system-reminder>\n{r}\n</system-reminder>"}
+                    for r in self._system_reminders
+                ]
+                blocks.append({"type": "text", "text": content})
+                user_content = blocks
+        else:
+            user_content = content
+            if self._system_reminders:
+                reminder_blocks = [
+                    {"type": "text", "text": f"<system-reminder>\n{r}\n</system-reminder>"}
+                    for r in self._system_reminders
+                ]
+                user_content = reminder_blocks + list(content)
+
+        user_msg = {"role": "user", "content": user_content}
+
+        messages = list(self._messages) + [user_msg]
+        body: dict[str, Any] = {
+            "model": self.model,
+            "max_tokens": self.max_tokens,
+            "messages": messages,
+        }
+        if system is not None:
+            body["system"] = system
+        if stream:
+            body["stream"] = True
+        if tools:
+            body["tools"] = tools
+        if extra_body:
+            body.update(extra_body)
+
+        headers = {"x-api-key": self.api_key}
+        if extra_headers:
+            headers.update(extra_headers)
+
+        resp = httpx.post(
+            f"{self.proxy_url}/v1/messages",
+            json=body,
+            headers=headers,
+            timeout=timeout,
+        )
+
+        if track_history:
+            self._messages.append(user_msg)
+
+        return ProxyResponse(
+            status_code=resp.status_code,
+            body=resp.json(),
+            headers=dict(resp.headers),
+        )
+
+    def send_tool_result(
+        self,
+        tool_use_id: str,
+        content: str | list[dict[str, Any]],
+        *,
+        is_error: bool = False,
+        system: str | list[dict[str, Any]] | None = None,
+        track_history: bool = True,
+    ) -> ProxyResponse:
+        """Send a tool_result message (continues a multi-turn conversation)."""
+        if isinstance(content, str):
+            tool_content: list[dict[str, Any]] = [
+                {"type": "tool_result", "tool_use_id": tool_use_id, "content": content}
+            ]
+        else:
+            tool_content = [{"type": "tool_result", "tool_use_id": tool_use_id, "content": content}]
+        if is_error:
+            tool_content[0]["is_error"] = True
+
+        return self.send_message(
+            tool_content,
+            system=system,
+            track_history=track_history,
+        )
+
+    def inject_assistant_response(self, content: list[dict[str, Any]]) -> None:
+        """Add an assistant response to history (for setting up multi-turn context)."""
+        self._messages.append({"role": "assistant", "content": content})
+
+    def add_system_reminder(self, text: str) -> None:
+        """Add a system-reminder block injected into subsequent user messages."""
+        self._system_reminders.append(text)
+
+    def clear_system_reminders(self) -> None:
+        self._system_reminders.clear()
+
+    def reset(self) -> None:
+        """Clear conversation history and system reminders."""
+        self._messages.clear()
+        self._system_reminders.clear()

--- a/apps/server/tests/e2e/infrastructure/log_collector.py
+++ b/apps/server/tests/e2e/infrastructure/log_collector.py
@@ -1,0 +1,69 @@
+"""Thread-safe subprocess log collector.
+
+Consolidates the LogCollector class previously duplicated across
+test_e2e_url4.py, test_e2e_claude_frontend.py, and test_prompt_e2e.py.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import threading
+import time
+
+
+class LogCollector:
+    """Reads subprocess stdout in a background thread and stores lines."""
+
+    def __init__(self, proc: subprocess.Popen) -> None:
+        self.lines: list[str] = []
+        self._lock = threading.Lock()
+        self._thread = threading.Thread(target=self._read, args=(proc,), daemon=True)
+        self._thread.start()
+
+    def _read(self, proc: subprocess.Popen) -> None:
+        assert proc.stdout is not None
+        for raw_line in proc.stdout:
+            line = raw_line.rstrip()
+            with self._lock:
+                self.lines.append(line)
+
+    def wait_for_ready(self, timeout: float = 30) -> dict | None:
+        """Block until the JSON ``{"event": "ready", ...}`` line appears."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            with self._lock:
+                for line in self.lines:
+                    if '"event"' in line and '"ready"' in line:
+                        try:
+                            return json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+            time.sleep(0.3)
+        return None
+
+    def wait_for_line(self, needle: str, timeout: float = 10) -> str | None:
+        """Block until a line containing *needle* appears."""
+        deadline = time.monotonic() + timeout
+        seen = 0
+        while time.monotonic() < deadline:
+            with self._lock:
+                for line in self.lines[seen:]:
+                    if needle in line:
+                        return line
+                seen = len(self.lines)
+            time.sleep(0.2)
+        return None
+
+    def find_lines(self, needle: str) -> list[str]:
+        """Return all lines containing *needle*."""
+        with self._lock:
+            return [line for line in self.lines if needle in line]
+
+    def dump_all(self) -> list[str]:
+        with self._lock:
+            return list(self.lines)
+
+    def dump_last(self, n: int = 20) -> list[str]:
+        with self._lock:
+            return list(self.lines[-n:])

--- a/apps/server/tests/e2e/infrastructure/otlp_collector.py
+++ b/apps/server/tests/e2e/infrastructure/otlp_collector.py
@@ -1,0 +1,230 @@
+"""Lightweight in-process OTLP HTTP collector for capturing spans in tests.
+
+Runs an ``http.server`` in a daemon thread that accepts
+``POST /v1/traces`` with protobuf-encoded ``ExportTraceServiceRequest``
+bodies, deserializes them, and stores the spans for assertion.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+
+@dataclass
+class CollectedSpan:
+    """A single span received by the collector."""
+
+    name: str
+    trace_id: str
+    span_id: str
+    parent_span_id: str | None
+    attributes: dict[str, Any]
+    start_time_ns: int
+    end_time_ns: int
+    status_code: int  # 0=UNSET, 1=OK, 2=ERROR
+    kind: int  # SpanKind enum value
+    events: list[dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def duration_ms(self) -> float:
+        return (self.end_time_ns - self.start_time_ns) / 1_000_000
+
+
+def _bytes_to_hex(b: bytes) -> str:
+    return b.hex()
+
+
+def _extract_attribute_value(kv: Any) -> Any:
+    """Extract a typed value from an OTLP KeyValue's ``value`` field."""
+    v = kv.value
+    if v.HasField("string_value"):
+        return v.string_value
+    if v.HasField("int_value"):
+        return v.int_value
+    if v.HasField("double_value"):
+        return v.double_value
+    if v.HasField("bool_value"):
+        return v.bool_value
+    if v.HasField("bytes_value"):
+        return v.bytes_value
+    if v.HasField("array_value"):
+        return [_extract_attribute_value_inner(el) for el in v.array_value.values]
+    return str(v)
+
+
+def _extract_attribute_value_inner(v: Any) -> Any:
+    """Extract value from an AnyValue (used in array elements)."""
+    if v.HasField("string_value"):
+        return v.string_value
+    if v.HasField("int_value"):
+        return v.int_value
+    if v.HasField("double_value"):
+        return v.double_value
+    if v.HasField("bool_value"):
+        return v.bool_value
+    return str(v)
+
+
+def _parse_spans(body: bytes) -> list[CollectedSpan]:
+    """Deserialize protobuf ExportTraceServiceRequest into CollectedSpan list."""
+    from opentelemetry.proto.collector.trace.v1 import trace_service_pb2
+
+    request = trace_service_pb2.ExportTraceServiceRequest.FromString(body)
+    spans: list[CollectedSpan] = []
+
+    for resource_spans in request.resource_spans:
+        for scope_spans in resource_spans.scope_spans:
+            for span in scope_spans.spans:
+                attrs = {}
+                for kv in span.attributes:
+                    attrs[kv.key] = _extract_attribute_value(kv)
+
+                events = []
+                for event in span.events:
+                    event_attrs = {}
+                    for kv in event.attributes:
+                        event_attrs[kv.key] = _extract_attribute_value(kv)
+                    events.append(
+                        {
+                            "name": event.name,
+                            "timestamp_ns": event.time_unix_nano,
+                            "attributes": event_attrs,
+                        }
+                    )
+
+                parent_id = _bytes_to_hex(span.parent_span_id)
+                spans.append(
+                    CollectedSpan(
+                        name=span.name,
+                        trace_id=_bytes_to_hex(span.trace_id),
+                        span_id=_bytes_to_hex(span.span_id),
+                        parent_span_id=parent_id if parent_id != "0" * 16 else None,
+                        attributes=attrs,
+                        start_time_ns=span.start_time_unix_nano,
+                        end_time_ns=span.end_time_unix_nano,
+                        status_code=span.status.code,
+                        kind=span.kind,
+                        events=events,
+                    )
+                )
+
+    return spans
+
+
+class _OTLPHandler(BaseHTTPRequestHandler):
+    """HTTP handler that accepts OTLP trace exports."""
+
+    collector: OTLPCollector  # set by OTLPCollector before serving
+
+    def do_POST(self) -> None:
+        if self.path != "/v1/traces":
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(content_length)
+
+        try:
+            spans = _parse_spans(body)
+            self.server._collector.add_spans(spans)  # type: ignore[attr-defined]
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b"{}")
+        except Exception as exc:
+            self.send_response(500)
+            self.end_headers()
+            self.wfile.write(str(exc).encode())
+
+    def log_message(self, format: str, *args: Any) -> None:
+        # Suppress HTTP access logs during tests
+        pass
+
+
+class OTLPCollector:
+    """In-process OTLP HTTP collector for test span capture."""
+
+    def __init__(self, port: int = 0) -> None:
+        self._port = port
+        self._spans: list[CollectedSpan] = []
+        self._lock = threading.Lock()
+        self._new_span_event = threading.Event()
+        self._server: HTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> int:
+        """Start the collector server. Returns the bound port."""
+        self._server = HTTPServer(("127.0.0.1", self._port), _OTLPHandler)
+        self._server._collector = self  # type: ignore[attr-defined]
+        self._port = self._server.server_address[1]
+
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return self._port
+
+    def stop(self) -> None:
+        if self._server:
+            self._server.shutdown()
+            self._server = None
+        self._thread = None
+
+    @property
+    def endpoint(self) -> str:
+        """OTLP endpoint URL for server config."""
+        return f"http://127.0.0.1:{self._port}/v1/traces"
+
+    @property
+    def spans(self) -> list[CollectedSpan]:
+        with self._lock:
+            return list(self._spans)
+
+    def add_spans(self, spans: list[CollectedSpan]) -> None:
+        """Called by the HTTP handler to add received spans."""
+        with self._lock:
+            self._spans.extend(spans)
+        self._new_span_event.set()
+
+    def wait_for_spans(self, count: int, timeout: float = 15) -> list[CollectedSpan]:
+        """Block until at least *count* spans have been received."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            with self._lock:
+                if len(self._spans) >= count:
+                    return list(self._spans)
+            self._new_span_event.clear()
+            remaining = deadline - time.monotonic()
+            if remaining > 0:
+                self._new_span_event.wait(timeout=min(remaining, 0.5))
+        with self._lock:
+            return list(self._spans)
+
+    def find_spans(
+        self,
+        name: str | None = None,
+        attributes: dict[str, Any] | None = None,
+    ) -> list[CollectedSpan]:
+        """Filter spans by name substring and/or attribute key-value pairs."""
+        with self._lock:
+            result = list(self._spans)
+        if name:
+            result = [s for s in result if name in s.name]
+        if attributes:
+            for k, v in attributes.items():
+                result = [s for s in result if s.attributes.get(k) == v]
+        return result
+
+    def get_children(self, parent_span_id: str) -> list[CollectedSpan]:
+        """Return all spans whose parent is *parent_span_id*."""
+        with self._lock:
+            return [s for s in self._spans if s.parent_span_id == parent_span_id]
+
+    def clear(self) -> None:
+        """Clear all collected spans."""
+        with self._lock:
+            self._spans.clear()
+        self._new_span_event.clear()

--- a/apps/server/tests/e2e/infrastructure/server_manager.py
+++ b/apps/server/tests/e2e/infrastructure/server_manager.py
@@ -1,0 +1,133 @@
+"""Manages an SF server subprocess for e2e tests."""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import socket
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+from .log_collector import LogCollector
+
+SERVER_DIR = Path(__file__).resolve().parents[3]  # apps/server/
+
+
+class ServerManager:
+    """Start, monitor, and stop an SF server subprocess."""
+
+    def __init__(
+        self,
+        config: dict[str, Any],
+        *,
+        session_id: str | None = None,
+        env_extra: dict[str, str] | None = None,
+    ) -> None:
+        self._config = config
+        self._session_id = session_id
+        self._env_extra = env_extra or {}
+        self._proc: subprocess.Popen | None = None
+        self._logs: LogCollector | None = None
+        self._ready_info: dict[str, Any] = {}
+
+    def start(self, timeout: float = 30) -> dict[str, Any]:
+        """Start the server subprocess and wait for the ready event.
+
+        Returns the parsed ready-event dict (contains host, port, pid, etc.).
+        Raises ``RuntimeError`` if the server does not become ready.
+        """
+        env = {**os.environ, "_SF_SUBPROCESS": "1"}
+        env.update(self._env_extra)
+        if self._session_id:
+            env["_SF_SESSION_ID"] = self._session_id
+
+        cmd = [
+            "sf",
+            "run",
+            "--no-ssl",
+            "--no-reload",
+            "--config-json",
+            json.dumps(self._config),
+        ]
+
+        self._proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            env=env,
+            cwd=str(SERVER_DIR),
+        )
+        self._logs = LogCollector(self._proc)
+
+        ready = self._logs.wait_for_ready(timeout=timeout)
+        if not ready:
+            last_lines = "\n".join(self._logs.dump_last())
+            self.stop()
+            raise RuntimeError(
+                f"Server did not emit ready event within {timeout}s.\nLast log lines:\n{last_lines}"
+            )
+
+        self._ready_info = ready
+        return ready
+
+    def stop(self, timeout: float = 10) -> None:
+        """Stop the server subprocess gracefully (SIGTERM → SIGKILL)."""
+        if self._proc is None:
+            return
+        try:
+            self._proc.send_signal(signal.SIGTERM)
+            self._proc.wait(timeout=timeout)
+        except (subprocess.TimeoutExpired, ProcessLookupError):
+            self._proc.kill()
+            try:
+                self._proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+        self._proc = None
+
+    @property
+    def base_url(self) -> str:
+        host = self._ready_info.get("host", "0.0.0.0")
+        if host == "0.0.0.0":
+            host = "127.0.0.1"
+        port = self._ready_info.get("port", 8000)
+        scheme = self._ready_info.get("scheme", "http")
+        return f"{scheme}://{host}:{port}"
+
+    @property
+    def logs(self) -> LogCollector:
+        assert self._logs is not None, "Server not started"
+        return self._logs
+
+    @property
+    def pid(self) -> int | None:
+        return self._proc.pid if self._proc else None
+
+    @staticmethod
+    def wait_for_port(port: int, host: str = "127.0.0.1", timeout: float = 15) -> bool:
+        """Poll until a TCP port is accepting connections."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                if sock.connect_ex((host, port)) == 0:
+                    return True
+            time.sleep(0.2)
+        return False
+
+    @staticmethod
+    def find_free_port() -> int:
+        """Bind to port 0 and return the OS-assigned port number."""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("", 0))
+            return s.getsockname()[1]
+
+    def __enter__(self) -> ServerManager:
+        self.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.stop()

--- a/apps/server/tests/e2e/test_cat_breeds_spec.py
+++ b/apps/server/tests/e2e/test_cat_breeds_spec.py
@@ -1,0 +1,222 @@
+"""E2E test for the cat-breeds-3sources url4 spec.
+
+Spec expression (decoded):
+  /claude?q=(src1.csv, src2.csv, src3.txt)!$prompt
+
+Pipeline:
+  1. Proxy substitutes $prompt → /data/{blob_key}
+  2. The entire expression is a relative URL to /claude?q=...
+  3. /claude endpoint URL-decodes q, gets: (src1,src2,src3)!/data/{key}
+  4. ClaudeInterpreter resolves 3 GitHub sources in parallel
+  5. Fetches /data/{key} to get the user's original prompt
+  6. Sends sources + prompt to Claude CLI
+  7. Claude's response is injected into the user message
+
+Tests:
+  - Source resolution (3 GitHub URLs) — no Claude CLI needed
+  - Full pipeline through proxy — requires Claude CLI (e2e_live)
+"""
+
+from __future__ import annotations
+
+import shutil
+from urllib.parse import quote
+
+import httpx
+import pytest
+
+from tests.e2e.infrastructure.claude_code_client import ClaudeCodeClient
+from tests.e2e.infrastructure.otlp_collector import OTLPCollector
+from tests.e2e.infrastructure.server_manager import ServerManager
+
+CAT_SOURCES = [
+    "https://raw.githubusercontent.com/phiggins/phiggins_coding_challenge/master/examples/cat_breeds.csv",
+    "https://raw.githubusercontent.com/prasertcbs/basic-dataset/master/cat.csv",
+    "https://raw.githubusercontent.com/multimandan/PetSave/refs/heads/master/cat-breeds.txt",
+]
+
+# The spec expression — URL-encoded parens/commas/bang inside the q= parameter.
+# $prompt must stay unencoded so the proxy detects it for substitution.
+_inner = quote(f"({','.join(CAT_SOURCES)})!$prompt", safe="$")
+CAT_SPEC_EXPRESSION = f"/claude?q={_inner}"
+
+
+# ---------------------------------------------------------------------------
+# Level 1: Source resolution only (no Claude CLI)
+# ---------------------------------------------------------------------------
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.mark.timeout(30)
+class TestCatBreedSources:
+    """Verify the 3 GitHub cat-breed sources are fetchable and contain data."""
+
+    @pytest.mark.parametrize("url", CAT_SOURCES, ids=["csv1", "csv2", "txt"])
+    def test_individual_source(self, sf_server: ServerManager, url: str):
+        """Each source URL resolves to non-empty content via /ensemble."""
+        resp = httpx.get(
+            f"{sf_server.base_url}/ensemble",
+            params={"q": url},
+            timeout=15,
+        )
+        assert resp.status_code == 200
+        assert len(resp.text.strip()) > 0, f"Empty response from {url}"
+
+    def test_all_sources_parallel(self, sf_server: ServerManager):
+        """All 3 sources resolve in parallel via parenthesized group."""
+        expr = f"({','.join(CAT_SOURCES)})"
+        resp = httpx.get(
+            f"{sf_server.base_url}/ensemble",
+            params={"q": expr},
+            timeout=30,
+        )
+        assert resp.status_code == 200
+        text = resp.text
+        # Should contain data from multiple sources
+        assert len(text) > 100, f"Combined sources too short: {len(text)} chars"
+
+    def test_sources_contain_breed_data(self, sf_server: ServerManager):
+        """Resolved sources should contain actual cat breed names."""
+        expr = f"({','.join(CAT_SOURCES)})"
+        resp = httpx.get(
+            f"{sf_server.base_url}/ensemble",
+            params={"q": expr},
+            timeout=30,
+        )
+        assert resp.status_code == 200
+        text = resp.text.lower()
+        # At least some well-known breeds should appear
+        known_breeds = ["persian", "siamese", "bengal", "maine"]
+        found = [b for b in known_breeds if b in text]
+        assert len(found) >= 2, (
+            f"Expected cat breed names in sources. Found: {found}. Text preview: {resp.text[:300]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Level 2: Full pipeline through proxy (requires Claude CLI)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def cat_proxy(otlp_collector: OTLPCollector):
+    """Start a proxy with the cat-breeds-3sources spec pointing at Claude."""
+    internal_port = ServerManager.find_free_port()
+    proxy_port = ServerManager.find_free_port()
+
+    config = {
+        "version": "0.1.0",
+        "server": {
+            "host": "127.0.0.1",
+            "port": internal_port,
+            "ssl": False,
+            "reload": False,
+        },
+        "plugins": [
+            "tracing",
+            "claude-frontend",
+            "claude-backend",
+            "url4-specs",
+            "url4-executor",
+            "data-store",
+        ],
+        "plugin_config": {
+            "tracing": {
+                "phoenix_launch": False,
+                "otlp_endpoint": otlp_collector.endpoint,
+            },
+            "claude-frontend": {
+                "active_spec": "cat-breeds-3sources",
+                "upstream_url": "https://httpbin.org/anything",
+                "listen_host": "127.0.0.1",
+                "listen_port": proxy_port,
+            },
+            "claude-backend": {
+                "default_model": "claude-sonnet-4-20250514",
+            },
+            "url4-specs": {
+                "specs": {
+                    "cat-breeds-3sources": {
+                        "expression": CAT_SPEC_EXPRESSION,
+                    },
+                },
+            },
+        },
+    }
+
+    mgr = ServerManager(config, session_id="e2e-cat-breeds")
+    mgr.start(timeout=30)
+    if not ServerManager.wait_for_port(proxy_port):
+        mgr.stop()
+        raise RuntimeError(f"Cat breeds proxy not listening on port {proxy_port}")
+    yield mgr, proxy_port
+    mgr.stop()
+
+
+@pytest.mark.e2e
+@pytest.mark.timeout(120)
+class TestCatBreedsFullPipeline:
+    """Full pipeline: proxy → /claude → 3 sources → Claude CLI → user message."""
+
+    @pytest.fixture(autouse=True)
+    def _require_claude(self):
+        if not shutil.which("claude"):
+            pytest.skip("Claude CLI not found in PATH")
+
+    def test_cat_breeds_through_proxy(
+        self,
+        cat_proxy: tuple[ServerManager, int],
+        otlp_collector: OTLPCollector,
+    ):
+        """Send a prompt about cats, verify Claude processes the 3 sources."""
+        _, proxy_port = cat_proxy
+        client = ClaudeCodeClient(proxy_url=f"http://127.0.0.1:{proxy_port}")
+
+        # Long timeout: fetches 3 GitHub files + Claude CLI processing
+        resp = client.send_message(
+            "What breed of cat is best for apartments?",
+            timeout=90,
+        )
+
+        assert resp.status_code == 200
+
+        # The response is echoed by httpbin — check the forwarded user message
+        user_text = resp.last_user_text
+
+        # The user message should contain the original prompt
+        assert "apartment" in user_text.lower(), (
+            f"Original prompt missing from user message: {user_text[:300]}"
+        )
+
+        # The user message should contain Claude's response about cat breeds
+        # (the /claude endpoint processes the 3 sources and returns analysis)
+        assert len(user_text) > 100, (
+            f"User message too short ({len(user_text)} chars) — "
+            f"Claude response may not have been injected: {user_text[:300]}"
+        )
+
+    def test_cat_breeds_trace_shows_3_fetches(
+        self,
+        cat_proxy: tuple[ServerManager, int],
+        otlp_collector: OTLPCollector,
+    ):
+        """Trace should show 3 parallel url4.fetch spans for the GitHub sources."""
+        _, proxy_port = cat_proxy
+        otlp_collector.clear()
+
+        client = ClaudeCodeClient(proxy_url=f"http://127.0.0.1:{proxy_port}")
+        client.send_message("List some cat breeds")
+
+        import time
+
+        time.sleep(8)
+        spans = otlp_collector.wait_for_spans(5, timeout=15)
+
+        fetch_spans = otlp_collector.find_spans(name="url4.fetch")
+        fetched_urls = [s.attributes.get("http.url", "") for s in fetch_spans]
+
+        assert len(fetch_spans) >= 3, (
+            f"Expected 3+ url4.fetch spans (one per source), got {len(fetch_spans)}. "
+            f"URLs: {fetched_urls}. All spans: {[s.name for s in spans]}"
+        )

--- a/apps/server/tests/e2e/test_cat_breeds_spec.py
+++ b/apps/server/tests/e2e/test_cat_breeds_spec.py
@@ -100,7 +100,7 @@ class TestCatBreedSources:
 
 
 @pytest.fixture(scope="module")
-def cat_proxy(otlp_collector: OTLPCollector):
+def cat_proxy(otlp_collector: OTLPCollector):  # type: ignore[misc]
     """Start a proxy with the cat-breeds-3sources spec pointing at Claude."""
     internal_port = ServerManager.find_free_port()
     proxy_port = ServerManager.find_free_port()

--- a/apps/server/tests/e2e/test_proxy_context_injection.py
+++ b/apps/server/tests/e2e/test_proxy_context_injection.py
@@ -1,0 +1,117 @@
+"""E2E tests for claude-frontend proxy context injection.
+
+Migrated from test_e2e_claude_frontend.py — tests that the proxy correctly
+injects url4-resolved context into the system prompt (static spec, no $prompt).
+Uses httpbin /anything as upstream echo server.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e.infrastructure.claude_code_client import ClaudeCodeClient
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.fixture(scope="session")
+def static_proxy_config(otlp_collector, proxy_server_port):
+    """Proxy config using a static spec (no $prompt) for system-prompt injection."""
+    from tests.e2e.infrastructure.server_manager import ServerManager
+
+    main_port = ServerManager.find_free_port()
+    return {
+        "version": "0.1.0",
+        "server": {
+            "host": "127.0.0.1",
+            "port": main_port,
+            "ssl": False,
+            "reload": False,
+        },
+        "plugins": [
+            "tracing",
+            "claude-frontend",
+            "url4-specs",
+            "url4-executor",
+        ],
+        "plugin_config": {
+            "tracing": {
+                "phoenix_launch": False,
+                "otlp_endpoint": otlp_collector.endpoint,
+            },
+            "claude-frontend": {
+                "active_spec": "httpbin-robots",
+                "upstream_url": "https://httpbin.org/anything",
+                "listen_host": "127.0.0.1",
+                "listen_port": proxy_server_port + 100,
+                "embed_target": "system",
+            },
+            "url4-specs": {
+                "specs": {
+                    "httpbin-robots": {
+                        "expression": "(https://httpbin.org/robots.txt)!"
+                        "'You are an API testing assistant'",
+                    },
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture(scope="session")
+def static_proxy(static_proxy_config, proxy_server_port):
+    """Start a proxy with static spec (context → system prompt)."""
+    from tests.e2e.infrastructure.server_manager import ServerManager
+
+    mgr = ServerManager(static_proxy_config, session_id="e2e-static")
+    mgr.start(timeout=30)
+    listen_port = proxy_server_port + 100
+    if not ServerManager.wait_for_port(listen_port):
+        mgr.stop()
+        raise RuntimeError(f"Static proxy not listening on port {listen_port}")
+    yield mgr, listen_port
+    mgr.stop()
+
+
+@pytest.fixture
+def static_client(static_proxy):
+    _, port = static_proxy
+    client = ClaudeCodeClient(proxy_url=f"http://127.0.0.1:{port}")
+    yield client
+    client.reset()
+
+
+@pytest.mark.timeout(30)
+class TestStaticContextInjection:
+    """Tests for static spec (no $prompt) — context injected into system prompt."""
+
+    def test_context_injection_with_string_system(self, static_client: ClaudeCodeClient):
+        """url4 context + original system prompt both present in forwarded request."""
+        resp = static_client.send_message("Hello", system="Be helpful")
+
+        assert resp.status_code == 200
+
+        system = str(resp.forwarded_system)
+        assert "User-agent" in system, f"url4 source content missing: {system[:200]}"
+        assert "Be helpful" in system, f"original system prompt missing: {system[:200]}"
+        assert "API testing assistant" in system, f"intent text missing: {system[:200]}"
+
+    def test_context_injection_no_system(self, static_client: ClaudeCodeClient):
+        """url4 context injected even when no system prompt provided."""
+        resp = static_client.send_message("Hello")
+
+        assert resp.status_code == 200
+
+        system = str(resp.forwarded_system)
+        assert "User-agent" in system, f"url4 source content missing: {system[:200]}"
+        assert "API testing assistant" in system, f"intent text missing: {system[:200]}"
+
+    def test_extra_fields_passthrough(self, static_client: ClaudeCodeClient):
+        """Custom fields in the request body survive proxying."""
+        resp = static_client.send_message(
+            "Hello",
+            extra_body={"custom_field": "should_survive"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.echoed_body.get("custom_field") == "should_survive"

--- a/apps/server/tests/e2e/test_proxy_multi_turn.py
+++ b/apps/server/tests/e2e/test_proxy_multi_turn.py
@@ -1,0 +1,83 @@
+"""E2E tests for multi-turn conversation handling through the proxy."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e.infrastructure.claude_code_client import ClaudeCodeClient
+
+pytestmark = [pytest.mark.e2e, pytest.mark.timeout(30)]
+
+
+class TestMultiTurn:
+    """Tests for multi-turn conversation patterns through the proxy."""
+
+    def test_multi_turn_history_preserved(self, claude_client: ClaudeCodeClient):
+        """Message array grows correctly across turns."""
+        # First turn
+        resp1 = claude_client.send_message("First message")
+        assert resp1.status_code == 200
+        assert len(resp1.forwarded_messages) == 1
+
+        # Inject assistant response for multi-turn
+        claude_client.inject_assistant_response(
+            [
+                {"type": "text", "text": "I received your first message."},
+            ]
+        )
+
+        # Second turn
+        resp2 = claude_client.send_message("Second message")
+        assert resp2.status_code == 200
+        assert len(resp2.forwarded_messages) == 3  # user, assistant, user
+
+        msgs = resp2.forwarded_messages
+        assert msgs[0]["role"] == "user"
+        assert msgs[1]["role"] == "assistant"
+        assert msgs[2]["role"] == "user"
+
+    def test_system_reminders_filtered(self, claude_client: ClaudeCodeClient):
+        """<system-reminder> blocks should not be treated as user prompt text."""
+        claude_client.add_system_reminder("You have access to tools: Bash, Read, Write")
+
+        resp = claude_client.send_message("What can you do?")
+        assert resp.status_code == 200
+
+        # The user's actual text should be in the response, not the reminder
+        content = resp.last_user_text
+        # The proxy's _extract_last_user_text filters system-reminders
+        # So the $prompt substitution should use "What can you do?" not the reminder
+        assert "What can you do?" in content or "User-agent" in content
+
+    def test_tool_use_tool_result_cycle(self, claude_client: ClaudeCodeClient):
+        """Full tool_use → tool_result round-trip through the proxy."""
+        # User asks something
+        resp1 = claude_client.send_message("List files in current directory")
+        assert resp1.status_code == 200
+
+        # Simulate assistant using a tool
+        claude_client.inject_assistant_response(
+            [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_01ABC",
+                    "name": "bash",
+                    "input": {"command": "ls"},
+                },
+            ]
+        )
+
+        # User sends tool result
+        resp2 = claude_client.send_tool_result(
+            "toolu_01ABC",
+            "file1.txt\nfile2.py\nREADME.md",
+        )
+        assert resp2.status_code == 200
+
+        # Verify the full message sequence was forwarded
+        msgs = resp2.forwarded_messages
+        assert len(msgs) >= 3
+
+        # Check roles alternate correctly
+        roles = [m["role"] for m in msgs]
+        assert roles[-3:] == ["user", "assistant", "user"]

--- a/apps/server/tests/e2e/test_proxy_prompt_flow.py
+++ b/apps/server/tests/e2e/test_proxy_prompt_flow.py
@@ -1,0 +1,75 @@
+"""E2E tests for the $prompt substitution flow.
+
+Migrated from scripts/test_prompt_e2e.py — tests that the proxy correctly
+substitutes $prompt in url4 expressions, stores blobs, and injects resolved
+context into the user message.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e.infrastructure.claude_code_client import ClaudeCodeClient
+
+pytestmark = [pytest.mark.e2e, pytest.mark.timeout(30)]
+
+
+class TestPromptSubstitution:
+    """Tests for $prompt url4 specs — context injected into user message."""
+
+    def test_prompt_text_mode(self, claude_client: ClaudeCodeClient):
+        """$prompt in intent position: user msg replaced with 'prompt + resolved context'."""
+        resp = claude_client.send_message("Summarize this for me")
+
+        assert resp.status_code == 200
+
+        content = resp.last_user_text
+        assert "Summarize this" in content, f"original prompt missing: {content[:200]}"
+        assert "User-agent" in content, f"resolved robots.txt missing: {content[:200]}"
+
+    def test_prompt_skips_tool_result(self, claude_client: ClaudeCodeClient):
+        """Last user msg is pure tool_result → $prompt substitution skipped."""
+        # Set up multi-turn: user → assistant (tool_use) → user (tool_result)
+        claude_client.send_message("Hello", track_history=True)
+        claude_client.inject_assistant_response(
+            [
+                {"type": "tool_use", "id": "t1", "name": "bash", "input": {"cmd": "ls"}},
+            ]
+        )
+
+        resp = claude_client.send_tool_result("t1", "file.txt")
+
+        assert resp.status_code == 200
+
+        # The tool_result should be preserved as-is, not substituted
+        msgs = resp.forwarded_messages
+        last_user = msgs[-1] if msgs else None
+        assert last_user is not None
+
+        content = last_user.get("content", "")
+        if isinstance(content, list):
+            has_tool_result = any(
+                b.get("type") == "tool_result" for b in content if isinstance(b, dict)
+            )
+            assert has_tool_result, f"tool_result not preserved: {content}"
+
+    def test_blob_dedup(self):
+        """Same prompt text → same blob key (SHA-256 content hash)."""
+        from screamingface.plugins.data_store.routes import store_blob
+
+        key1 = store_blob(b"What breed for apartments?", "text/plain")
+        key2 = store_blob(b"What breed for apartments?", "text/plain")
+        key3 = store_blob(b"Different prompt", "text/plain")
+
+        assert key1 == key2, f"dedup failed: {key1} != {key2}"
+        assert key1 != key3, f"different content same key: {key1} == {key3}"
+
+    def test_no_prompt_system_clean(self, claude_client: ClaudeCodeClient):
+        """With $prompt spec, url4 context goes into user msg, NOT system prompt."""
+        resp = claude_client.send_message("Hello test", system="Be helpful")
+
+        assert resp.status_code == 200
+
+        # System prompt should NOT have url4 content (it goes into user msg with $prompt)
+        system = str(resp.forwarded_system or "")
+        assert "User-agent" not in system, f"url4 context leaked into system prompt: {system[:200]}"

--- a/apps/server/tests/e2e/test_trace_structure.py
+++ b/apps/server/tests/e2e/test_trace_structure.py
@@ -1,0 +1,192 @@
+"""E2E tests for OpenTelemetry trace structure.
+
+Verifies that the proxy creates correct span hierarchies and attributes
+when processing requests. Uses the OTLP collector to capture spans.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from tests.e2e.infrastructure.claude_code_client import ClaudeCodeClient
+from tests.e2e.infrastructure.otlp_collector import OTLPCollector
+
+pytestmark = [pytest.mark.e2e, pytest.mark.timeout(30)]
+
+
+class TestTraceStructure:
+    """Verify OTel span structure from proxy requests."""
+
+    def test_proxy_request_creates_spans(
+        self, claude_client: ClaudeCodeClient, otlp_collector: OTLPCollector
+    ):
+        """A proxy request should generate at least one span."""
+        claude_client.send_message("Hello trace test")
+
+        # BatchSpanProcessor flushes async — wait for spans
+        spans = otlp_collector.wait_for_spans(1, timeout=15)
+        assert len(spans) >= 1, "No spans received from proxy request"
+
+    def test_url4_prompt_span_exists(
+        self, claude_client: ClaudeCodeClient, otlp_collector: OTLPCollector
+    ):
+        """$prompt substitution should create a url4.$prompt span."""
+        claude_client.send_message("Hello url4 test")
+
+        spans = otlp_collector.wait_for_spans(2, timeout=15)
+        prompt_spans = otlp_collector.find_spans(name="url4.$prompt")
+
+        assert len(prompt_spans) >= 1, (
+            f"No url4.$prompt span found. All spans: {[s.name for s in spans]}"
+        )
+
+    def test_anthropic_request_body_span(
+        self, claude_client: ClaudeCodeClient, otlp_collector: OTLPCollector
+    ):
+        """The anthropic.request_body span should record model and message count."""
+        claude_client.send_message("Hello body trace")
+
+        spans = otlp_collector.wait_for_spans(3, timeout=15)
+        body_spans = otlp_collector.find_spans(name="anthropic.request_body")
+
+        assert len(body_spans) >= 1, (
+            f"No anthropic.request_body span found. All spans: {[s.name for s in spans]}"
+        )
+
+        body_span = body_spans[0]
+        assert body_span.attributes.get("sf.plugin") == "claude-frontend"
+
+    def test_prompt_span_attributes(
+        self, claude_client: ClaudeCodeClient, otlp_collector: OTLPCollector
+    ):
+        """url4.$prompt span should have url4.* attributes."""
+        claude_client.send_message("Check attributes test")
+
+        otlp_collector.wait_for_spans(2, timeout=15)
+        prompt_spans = otlp_collector.find_spans(name="url4.$prompt")
+
+        if not prompt_spans:
+            pytest.skip("url4.$prompt span not found (tracing may be disabled)")
+
+        span = prompt_spans[0]
+        assert "url4.raw_expression" in span.attributes
+        assert "url4.status" in span.attributes
+
+    def test_span_parent_child_relationships(
+        self, claude_client: ClaudeCodeClient, otlp_collector: OTLPCollector
+    ):
+        """Spans should form a proper parent-child tree."""
+        claude_client.send_message("Parent child test")
+
+        # Wait for a reasonable number of spans
+        time.sleep(2)
+        spans = otlp_collector.wait_for_spans(3, timeout=15)
+
+        # At least some spans should have parent IDs
+        child_spans = [s for s in spans if s.parent_span_id is not None]
+        assert len(child_spans) >= 1, (
+            f"No child spans found. All spans: {[(s.name, s.parent_span_id) for s in spans]}"
+        )
+
+    def test_url4_fetch_span_exists(
+        self, claude_client: ClaudeCodeClient, otlp_collector: OTLPCollector
+    ):
+        """url4 source fetches should create url4.fetch spans."""
+        claude_client.send_message("Hello fetch test")
+
+        spans = otlp_collector.wait_for_spans(5, timeout=15)
+        fetch_spans = otlp_collector.find_spans(name="url4.fetch")
+
+        assert len(fetch_spans) >= 1, (
+            f"No url4.fetch span found. All spans: {[s.name for s in spans]}"
+        )
+        s = fetch_spans[0]
+        assert "http.url" in s.attributes or "url4.path" in s.attributes
+
+    def test_url4_evaluate_span_exists(
+        self, claude_client: ClaudeCodeClient, otlp_collector: OTLPCollector
+    ):
+        """url4 evaluation pipeline should create url4.evaluate span."""
+        claude_client.send_message("Hello evaluate test")
+
+        spans = otlp_collector.wait_for_spans(5, timeout=15)
+        eval_spans = otlp_collector.find_spans(name="url4.evaluate")
+
+        assert len(eval_spans) >= 1, (
+            f"No url4.evaluate span found. All spans: {[s.name for s in spans]}"
+        )
+        s = eval_spans[0]
+        assert "url4.expression" in s.attributes
+        assert "url4.result_length" in s.attributes
+        assert "url4.response_body" in s.attributes, (
+            f"url4.response_body missing from evaluate span. "
+            f"Attributes: {list(s.attributes.keys())}"
+        )
+        assert len(s.attributes["url4.response_body"]) > 0
+
+    def test_url4_resolve_sources_span(
+        self, claude_client: ClaudeCodeClient, otlp_collector: OTLPCollector
+    ):
+        """url4.resolve_sources span should be a child of url4.evaluate."""
+        claude_client.send_message("Hello sources test")
+
+        spans = otlp_collector.wait_for_spans(5, timeout=15)
+        src_spans = otlp_collector.find_spans(name="url4.resolve_sources")
+
+        assert len(src_spans) >= 1, (
+            f"No url4.resolve_sources span found. All spans: {[s.name for s in spans]}"
+        )
+        s = src_spans[0]
+        assert "url4.response_body" in s.attributes, (
+            f"url4.response_body missing from resolve_sources span. "
+            f"Attributes: {list(s.attributes.keys())}"
+        )
+        assert len(s.attributes["url4.response_body"]) > 0
+
+    def test_fetch_span_contains_response_body(
+        self, claude_client: ClaudeCodeClient, otlp_collector: OTLPCollector
+    ):
+        """url4.fetch spans should include the response body content."""
+        # The proxy spec fetches httpbin.org/robots.txt
+        claude_client.send_message("Hello body trace test")
+
+        spans = otlp_collector.wait_for_spans(5, timeout=15)
+        fetch_spans = otlp_collector.find_spans(name="url4.fetch")
+
+        assert len(fetch_spans) >= 1, (
+            f"No url4.fetch span found. All spans: {[s.name for s in spans]}"
+        )
+
+        s = fetch_spans[0]
+        assert "url4.response_body" in s.attributes, (
+            f"url4.response_body missing from fetch span. Attributes: {list(s.attributes.keys())}"
+        )
+        body = s.attributes["url4.response_body"]
+        assert len(body) > 0, "url4.response_body is empty"
+        # The test spec fetches robots.txt which contains "User-agent"
+        assert "User-agent" in body, (
+            f"Expected robots.txt content in response_body. Got: {body[:200]}"
+        )
+
+    def test_fetch_relative_span_contains_response_body(
+        self, claude_client: ClaudeCodeClient, otlp_collector: OTLPCollector
+    ):
+        """url4.fetch_relative spans should include the response body content."""
+        claude_client.send_message("Hello relative body test")
+
+        spans = otlp_collector.wait_for_spans(5, timeout=15)
+        rel_spans = otlp_collector.find_spans(name="url4.fetch_relative")
+
+        assert len(rel_spans) >= 1, (
+            f"No url4.fetch_relative span found. All spans: {[s.name for s in spans]}"
+        )
+
+        s = rel_spans[0]
+        assert "url4.response_body" in s.attributes, (
+            f"url4.response_body missing from fetch_relative span. "
+            f"Attributes: {list(s.attributes.keys())}"
+        )
+        body = s.attributes["url4.response_body"]
+        assert len(body) > 0, "url4.response_body is empty"

--- a/apps/server/tests/e2e/test_url4_resolution.py
+++ b/apps/server/tests/e2e/test_url4_resolution.py
@@ -1,0 +1,116 @@
+"""E2E tests for url4 expression resolution via /ensemble endpoint.
+
+Migrated from test_e2e_url4.py — tests basic url4 resolution and intent
+dispatch without mocks.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import httpx
+import pytest
+
+from tests.e2e.infrastructure.server_manager import ServerManager
+
+pytestmark = [pytest.mark.e2e, pytest.mark.timeout(30)]
+
+
+class TestUrl4Resolution:
+    """Tests for the /ensemble endpoint — url4 expression resolution."""
+
+    def test_resolve_plain_text(self, sf_server: ServerManager):
+        resp = httpx.get(f"{sf_server.base_url}/ensemble", params={"q": "hello"})
+
+        assert resp.status_code == 200
+        assert "hello" in resp.text
+
+    def test_missing_q_rejected(self, sf_server: ServerManager):
+        resp = httpx.get(f"{sf_server.base_url}/ensemble", params={"context": "hello"})
+
+        assert resp.status_code == 400
+
+    def test_text_intent_returns_combined(self, sf_server: ServerManager):
+        """Text intent is treated as literal — returns intent + sources."""
+        resp = httpx.get(f"{sf_server.base_url}/ensemble", params={"q": "hello!echo"})
+
+        assert resp.status_code == 200
+        assert "echo" in resp.text
+        assert "hello" in resp.text
+
+    def test_resolve_http_url(self, sf_server: ServerManager):
+        """Fetches a real URL and returns its content."""
+        resp = httpx.get(
+            f"{sf_server.base_url}/ensemble",
+            params={"q": "https://httpbin.org/robots.txt"},
+            timeout=15,
+        )
+
+        assert resp.status_code == 200
+        assert "User-agent" in resp.text
+
+    def test_resolve_parenthesized_group(self, sf_server: ServerManager):
+        """Resolves a parenthesized group of text atoms."""
+        resp = httpx.get(f"{sf_server.base_url}/ensemble", params={"q": "(hello, world)"})
+
+        assert resp.status_code == 200
+        assert "hello" in resp.text
+        assert "world" in resp.text
+
+    def test_ast_mode(self, sf_server: ServerManager):
+        """?ast=true returns JSON with both AST and resolved result."""
+        resp = httpx.get(
+            f"{sf_server.base_url}/ensemble",
+            params={"q": "hello", "ast": "true"},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "ast" in data
+        assert "result" in data
+
+
+@pytest.mark.e2e_live
+@pytest.mark.timeout(120)
+class TestUrl4IntentDispatch:
+    """Tests that require Claude CLI for intent dispatch."""
+
+    @pytest.fixture(autouse=True)
+    def _require_claude(self):
+        if not shutil.which("claude"):
+            pytest.skip("Claude CLI not found in PATH")
+
+    def test_intent_dispatch_to_claude(self, sf_server: ServerManager):
+        """Plain text context dispatched to claude-backend."""
+        from urllib.parse import quote
+
+        backend_url = f"{sf_server.base_url}/claude/default"
+        prompt = "respond with exactly: E2E_OK"
+        intent_url = f"{backend_url}?prompt={quote(prompt)}"
+
+        resp = httpx.get(
+            f"{sf_server.base_url}/ensemble",
+            params={"q": f"hello!{intent_url}"},
+            timeout=60,
+        )
+
+        assert resp.status_code == 200
+        assert resp.text.strip() != ""
+
+    def test_intent_fetch_then_dispatch(self, sf_server: ServerManager):
+        """Fetched resource context dispatched to claude-backend."""
+        from urllib.parse import quote
+
+        health_url = f"{sf_server.base_url}/health"
+        backend_url = f"{sf_server.base_url}/claude/default"
+        prompt = "describe what you see in one sentence"
+        intent_url = f"{backend_url}?prompt={quote(prompt)}"
+
+        resp = httpx.get(
+            f"{sf_server.base_url}/ensemble",
+            params={"q": f"({health_url})!{intent_url}"},
+            timeout=60,
+        )
+
+        assert resp.status_code == 200
+        assert resp.text.strip() != ""

--- a/apps/server/tests/e2e/test_url4_specs_live.py
+++ b/apps/server/tests/e2e/test_url4_specs_live.py
@@ -1,0 +1,110 @@
+"""E2E tests for url4 spec evaluation against real external resources.
+
+These tests fetch real URLs and verify that url4 resolution produces
+non-empty, expected content. Useful for ongoing correctness monitoring.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from tests.e2e.infrastructure.server_manager import ServerManager
+
+pytestmark = [pytest.mark.e2e, pytest.mark.timeout(30)]
+
+
+class TestUrl4SpecsLive:
+    """Tests that evaluate url4 specs against real external URLs."""
+
+    def test_single_url_resolution(self, sf_server: ServerManager):
+        """Single URL expression resolves to non-empty content."""
+        resp = httpx.get(
+            f"{sf_server.base_url}/ensemble",
+            params={"q": "https://httpbin.org/robots.txt"},
+            timeout=15,
+        )
+
+        assert resp.status_code == 200
+        assert len(resp.text.strip()) > 0
+        assert "User-agent" in resp.text
+
+    def test_multiple_urls_parallel(self, sf_server: ServerManager):
+        """Parenthesized group of URLs resolved in parallel."""
+        expr = "(https://httpbin.org/robots.txt, https://httpbin.org/user-agent)"
+        resp = httpx.get(
+            f"{sf_server.base_url}/ensemble",
+            params={"q": expr},
+            timeout=15,
+        )
+
+        assert resp.status_code == 200
+        assert "User-agent" in resp.text
+
+    def test_mixed_text_and_url(self, sf_server: ServerManager):
+        """Mix of text atoms and URL atoms in a group."""
+        expr = "(context preamble, https://httpbin.org/robots.txt)"
+        resp = httpx.get(
+            f"{sf_server.base_url}/ensemble",
+            params={"q": expr},
+            timeout=15,
+        )
+
+        assert resp.status_code == 200
+        assert "context preamble" in resp.text
+        assert "User-agent" in resp.text
+
+    def test_resolution_idempotency(self, sf_server: ServerManager):
+        """Same expression resolves to same content across runs."""
+        expr = "https://httpbin.org/robots.txt"
+
+        resp1 = httpx.get(
+            f"{sf_server.base_url}/ensemble",
+            params={"q": expr},
+            timeout=15,
+        )
+        resp2 = httpx.get(
+            f"{sf_server.base_url}/ensemble",
+            params={"q": expr},
+            timeout=15,
+        )
+
+        assert resp1.status_code == 200
+        assert resp2.status_code == 200
+        assert resp1.text == resp2.text
+
+    def test_relative_url_data_store(self, sf_server: ServerManager):
+        """Relative URL /data/{key} resolved via in-process ASGI."""
+        # First store a blob
+        store_resp = httpx.post(
+            f"{sf_server.base_url}/data",
+            content=b"test blob content",
+            headers={"content-type": "text/plain"},
+            timeout=10,
+        )
+        assert store_resp.status_code == 200
+        key = store_resp.json()["key"]
+
+        # Now resolve it via url4
+        resp = httpx.get(
+            f"{sf_server.base_url}/ensemble",
+            params={"q": f"/data/{key}"},
+            timeout=10,
+        )
+
+        assert resp.status_code == 200
+        assert "test blob content" in resp.text
+
+    def test_intent_with_text(self, sf_server: ServerManager):
+        """Expression with text intent (quoted string after !)."""
+        expr = "(https://httpbin.org/robots.txt)!'Summarize this'"
+        resp = httpx.get(
+            f"{sf_server.base_url}/ensemble",
+            params={"q": expr},
+            timeout=15,
+        )
+
+        assert resp.status_code == 200
+        # With text intent, result is: intent + "\n\n" + sources
+        assert "Summarize this" in resp.text
+        assert "User-agent" in resp.text

--- a/apps/server/uv.lock
+++ b/apps/server/uv.lock
@@ -2196,6 +2196,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2614,6 +2626,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
 ]
 
@@ -2650,6 +2663,7 @@ dev = [
     { name = "pyright", specifier = ">=1.1.393" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-timeout", specifier = ">=2.3" },
     { name = "ruff", specifier = ">=0.8" },
 ]
 


### PR DESCRIPTION
## Summary

- **E2E testing pipeline** — pytest-integrated infrastructure (ClaudeCodeClient, ServerManager, OTLPCollector) with 34 tests covering proxy, url4 resolution, trace structure, multi-turn, and cat-breeds-3sources full pipeline
- **OTel trace coverage** — all url4 fetch/evaluate/resolve spans now include `url4.response_body`; proxy spans for POST /data, GET /ensemble, session hooks; /ensemble and /claude routes record response body on their FastAPI spans
- **Configurable context embedding** — `embed_target` (system/user), `embed_mode` (concat/replace), editable `system_prompt` replacing hardcoded prefix
- **Session edit/restart** — stopped sessions can be edited (pencil) and restarted (play) with stored pluginConfig; NewSessionDialog supports edit mode with pre-filled settings
- **UI cleanup** — hidden fields fully removed from schema (not grayed out), embed_target/embed_mode/system_prompt ordered at top, textarea widget for system_prompt, backend_url hidden
- **Claude CLI runner** — auto-creates /tmp/sf-<uuid> workdir when cwd not provided

## Test plan

- [x] `uv run pytest -m "not e2e and not e2e_live"` — 266 unit tests pass
- [x] `uv run pytest tests/e2e/ -m e2e` — 34 e2e tests pass (32 + 2 skipped e2e_live)
- [x] CI green (unit + e2e steps both pass)
- [ ] Manual: create session, verify embed_target/embed_mode/system_prompt in dialog
- [ ] Manual: stop session → edit → save & restart, verify new settings applied
- [ ] Manual: verify trace tree shows url4.response_body on all fetch spans

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1213916252540210

🤖 Generated with [Claude Code](https://claude.com/claude-code)