### PR TITLE
feat(SF-79): Ensemble fan-out-reduce + claude-backend-api defaults & desktop fixes

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -32,6 +32,10 @@ function createWindow(): void {
     mainWindow?.webContents.openDevTools({ mode: 'detach' });
   });
 
+  mainWindow.on('closed', () => {
+    mainWindow = null;
+  });
+
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
     shell.openExternal(url);
     return { action: 'deny' };
@@ -128,7 +132,10 @@ app.on('before-quit', (event) => {
 });
 
 app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
+  // In dev mode, always quit — no reason to linger in the dock when the
+  // Vite dev server has stopped. In production, follow macOS convention
+  // and keep the app alive for reactivation via the dock icon.
+  if (process.platform !== 'darwin' || is.dev) {
     app.quit();
   }
 });

--- a/apps/desktop/src/renderer/src/views/SettingsView.tsx
+++ b/apps/desktop/src/renderer/src/views/SettingsView.tsx
@@ -62,7 +62,7 @@ function StatusDot({ status }: { status: PluginStatus }) {
     missing: 'Not found on server',
   }[status];
 
-  return <span className={`inline-block h-2 w-2 rounded-full ${color}`} title={title} />;
+  return <span className={`inline-block h-2 w-2 shrink-0 rounded-full ${color}`} title={title} />;
 }
 
 function buildServerUrl(config: AppConfig): string {

--- a/apps/server/sf.json
+++ b/apps/server/sf.json
@@ -12,9 +12,10 @@
     "tracing",
     "url4-executor",
     "url4-specs",
-    "claude-backend",
     "claude-frontend",
-    "data-store"
+    "data-store",
+    "llm-base",
+    "claude-backend-api"
   ],
   "plugin_config": {
     "claude-frontend": {
@@ -68,6 +69,36 @@
         }
       },
       "default_profile": null
+    },
+    "claude-backend-api": {
+      "default_model": "claude-sonnet-4-6",
+      "default_effort": "medium",
+      "timeout_seconds": 300,
+      "max_budget_usd": null,
+      "permission_mode": null,
+      "dangerously_skip_permissions": false,
+      "profiles": {
+        "default": {
+          "context": null,
+          "system_prompt": null,
+          "append_system_prompt": null,
+          "model": null,
+          "output_format": null,
+          "max_budget_usd": null,
+          "effort": null,
+          "tools": null,
+          "allowed_tools": null,
+          "disallowed_tools": null,
+          "mcp_config": null,
+          "permission_mode": null,
+          "add_dirs": null,
+          "fallback_model": null,
+          "dangerously_skip_permissions": false,
+          "no_session_persistence": true,
+          "timeout_seconds": null
+        }
+      },
+      "default_profile": "default"
     },
     "url4-specs": {
       "specs": {

--- a/apps/server/src/screamingface/plugin.py
+++ b/apps/server/src/screamingface/plugin.py
@@ -62,6 +62,16 @@ class Plugin:
     required_port: int | None = None
     settings: PluginSettings | None = None
 
+    # Paths this plugin handles when it's the target of a url4 backend_call
+    # (``/<path>()!<intent>`` form). The url4 resolver walks active plugins
+    # looking for one whose ``backend_call_paths`` contains the target path
+    # and calls its :meth:`handle_backend_call`. Plugins that don't support
+    # backend-call dispatch leave this empty.
+    #
+    # Example: ``ClaudeBackendApiPlugin`` declares ``["/claude"]`` so that
+    # ``/claude()!hello`` dispatches to it.
+    backend_call_paths: list[str] = []
+
     def preflight(self) -> tuple[bool, str]:
         """Check if this plugin can activate. Return (ok, reason).
 
@@ -90,6 +100,33 @@ class Plugin:
 
     def teardown(self) -> None:
         """Called when the plugin is deactivated. Clean up resources here."""
+
+    async def handle_backend_call(self, intent: str, *, app: FastAPI) -> str:
+        """Handle a url4 backend-call dispatch.
+
+        Called by the url4 resolver when it encounters a ``/<path>()!<intent>``
+        node whose path is in this plugin's :attr:`backend_call_paths`.
+        The *intent* has already been flattened to a string by the resolver
+        (text literals are passed as-is; ``/data/<key>`` relurls are fetched
+        and their body becomes the intent string; etc.).
+
+        Implementations typically construct their plugin-specific
+        Url4Interpreter and delegate to :meth:`process`, or call directly
+        into the llm-base ``Backend.run()`` method with a single-user-turn
+        :class:`CoreMessage`.
+
+        Return value: the assistant's response as a plain string. The
+        resolver returns this as the result of evaluating the
+        Url4BackendCall node.
+
+        Default implementation raises :class:`NotImplementedError`. Plugins
+        that declare non-empty ``backend_call_paths`` MUST override this.
+        """
+        raise NotImplementedError(
+            f"Plugin {self.name!r} declares backend_call_paths="
+            f"{self.backend_call_paths!r} but does not override "
+            f"handle_backend_call(). This is a plugin implementation bug."
+        )
 
     def cleanup_stale(self) -> None:
         """Remove leftover side effects from a previously active instance.

--- a/apps/server/src/screamingface/plugins/claude_backend_api/__init__.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/__init__.py
@@ -1,0 +1,12 @@
+"""claude-backend-api plugin — direct Anthropic Messages API, OAuth from Keychain.
+
+Drop-in replacement for the CLI-subprocess ``claude-backend`` plugin.
+Same routes, same request/response shapes, same profile config.
+Implementation replaces ``claude -p`` with a raw httpx POST to
+``https://api.anthropic.com/v1/messages`` authenticated by the OAuth
+bearer token read from the platform credential store
+(``Claude Code-credentials``).
+
+Conflicts with ``claude-backend`` — operators pick exactly one by listing
+it in ``sf.json`` plugins array.
+"""

--- a/apps/server/src/screamingface/plugins/claude_backend_api/adapter.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/adapter.py
@@ -1,0 +1,352 @@
+"""Adapter between CoreMessage lists and Anthropic Messages API shape.
+
+Phase 1 scope — handles the message-content block types we actually use:
+
+- ``TextPart`` ↔ Anthropic text block (``{"type": "text", "text": "..."}``)
+- ``ToolCallPart`` ↔ Anthropic ``tool_use`` block
+- ``ToolResultPart`` ↔ Anthropic ``tool_result`` block
+- ``ReasoningPart`` → Anthropic ``thinking`` block (one-way, best effort)
+
+Not yet handled (Phase 3 follow-ups):
+
+- ``ImagePart`` — requires base64 encoding + media_type header
+  detection. Phase 3.
+- ``ReasoningPart`` inbound — Anthropic's thinking blocks carry
+  signatures that we preserve via ``provider_metadata`` but don't
+  currently produce from our own response parser.
+- Anthropic's ``server_tool_use`` / ``*_tool_result`` variants — these
+  come from Anthropic's server-side tools (web search, code exec,
+  etc.). Phase 3.
+- Tools with ``input_schema`` containing non-trivial JSON Schema
+  features. The naive passthrough works for the common case.
+
+Also performs the **orphan repair pass**: strips assistant ``tool_use``
+blocks whose matching user ``tool_result`` is absent, and vice versa.
+Anthropic's API enforces strict pairing and returns 400 when a
+``tool_use`` has no matching ``tool_result`` in a subsequent user
+message.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from screamingface.plugins.llm_base.adapter_base import Adapter
+from screamingface.plugins.llm_base.errors import AdapterError
+from screamingface.plugins.llm_base.messages import (
+    CoreMessage,
+    ReasoningPart,
+    TextPart,
+    ToolCallPart,
+    ToolDefinition,
+    ToolResultPart,
+)
+
+
+class AnthropicAdapter(Adapter):
+    """Hand-rolled adapter between CoreMessage and Anthropic Messages API shape.
+
+    No external dependencies beyond ``llm_base``. See the module docstring
+    for the Phase 1 scope and known limitations.
+    """
+
+    # ------------------------------------------------------------------
+    # Outbound: CoreMessage → Anthropic request body
+    # ------------------------------------------------------------------
+
+    def to_provider_format(
+        self,
+        messages: list[CoreMessage],
+        *,
+        model: str,
+        system: str | None = None,
+        tools: list[ToolDefinition] | None = None,
+        max_tokens: int = 16000,
+        temperature: float | None = None,
+    ) -> dict[str, Any]:
+        """Produce an Anthropic Messages API request body.
+
+        Separates the ``system`` field from the ``messages`` array (Anthropic
+        requires system at the top level, not as a role). Drops any
+        ``CoreMessage`` with ``role == "system"`` after merging its content
+        into the top-level system string.
+
+        Applies the orphan-repair pass before emitting.
+        """
+        body: dict[str, Any] = {
+            "model": model,
+            "max_tokens": max_tokens,
+        }
+
+        if temperature is not None:
+            body["temperature"] = temperature
+
+        # Collect system content: explicit system arg + any "system"-role
+        # messages (merged in order with newline separators).
+        system_chunks: list[str] = []
+        if system:
+            system_chunks.append(system)
+
+        non_system_messages: list[CoreMessage] = []
+        for msg in messages:
+            if msg.role == "system":
+                text = self._extract_system_text(msg)
+                if text:
+                    system_chunks.append(text)
+            else:
+                non_system_messages.append(msg)
+
+        if system_chunks:
+            body["system"] = "\n\n".join(system_chunks)
+
+        # Translate each non-system message
+        anthropic_messages = [self._message_to_anthropic(m) for m in non_system_messages]
+
+        # Orphan-repair pass — strip unpaired tool_use / tool_result
+        body["messages"] = self._repair_tool_pairs(anthropic_messages)
+
+        if tools:
+            body["tools"] = [self._tool_to_anthropic(t) for t in tools]
+
+        return body
+
+    # ------------------------------------------------------------------
+    # Inbound: Anthropic response → CoreMessage
+    # ------------------------------------------------------------------
+
+    def from_provider_response(self, data: dict[str, Any]) -> CoreMessage:
+        """Parse a successful Anthropic /v1/messages 200 response.
+
+        The response shape is::
+
+            {
+              "id": "msg_...",
+              "type": "message",
+              "role": "assistant",
+              "content": [
+                {"type": "text", "text": "..."},
+                {"type": "tool_use", "id": "...", "name": "...", "input": {...}},
+                ...
+              ],
+              "model": "...",
+              "stop_reason": "...",
+              "usage": {...}
+            }
+        """
+        if not isinstance(data, dict):
+            raise AdapterError(f"Anthropic response is not a dict: got {type(data).__name__}")
+
+        if data.get("type") != "message":
+            raise AdapterError(
+                f"Anthropic response.type is {data.get('type')!r}, expected 'message'"
+            )
+
+        role = data.get("role", "assistant")
+        if role not in ("assistant",):
+            raise AdapterError(f"Anthropic response.role is {role!r}, expected 'assistant'")
+
+        raw_content = data.get("content", [])
+        if not isinstance(raw_content, list):
+            raise AdapterError(
+                f"Anthropic response.content is not a list: got {type(raw_content).__name__}"
+            )
+
+        parts: list[Any] = []
+        for block in raw_content:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "text":
+                parts.append(TextPart(text=block.get("text", "")))
+            elif btype == "tool_use":
+                parts.append(
+                    ToolCallPart(
+                        tool_call_id=block.get("id", ""),
+                        tool_name=block.get("name", ""),
+                        input=block.get("input", {}) or {},
+                    )
+                )
+            elif btype == "thinking":
+                parts.append(
+                    ReasoningPart(
+                        text=block.get("thinking", ""),
+                        signature=block.get("signature"),
+                    )
+                )
+            # Unknown block types are dropped silently. Phase 3 will
+            # handle server_tool_use / *_tool_result variants.
+
+        # Carry over the Anthropic-level metadata as provider_metadata on
+        # the returned message. Useful for observability downstream.
+        provider_metadata: dict[str, Any] = {}
+        for key in ("id", "model", "stop_reason", "stop_sequence", "usage"):
+            if key in data:
+                provider_metadata[f"anthropic.{key}"] = data[key]
+
+        return CoreMessage(
+            role="assistant",
+            content=parts,
+            provider_metadata=provider_metadata or None,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _extract_system_text(self, msg: CoreMessage) -> str:
+        """Flatten a system CoreMessage into a plain string.
+
+        Anthropic's ``system`` field is a string or a list of text blocks;
+        we use the string form for simplicity.
+        """
+        if isinstance(msg.content, str):
+            return msg.content
+        chunks = []
+        for part in msg.content:
+            if isinstance(part, TextPart):
+                chunks.append(part.text)
+        return "\n\n".join(chunks)
+
+    def _message_to_anthropic(self, msg: CoreMessage) -> dict[str, Any]:
+        """Translate a single non-system CoreMessage to Anthropic shape."""
+        # Anthropic roles: user or assistant only (no "tool" role; tool
+        # results go inside user messages with tool_result blocks).
+        role = msg.role
+        if role == "tool":
+            role = "user"
+
+        if isinstance(msg.content, str):
+            return {
+                "role": role,
+                "content": [{"type": "text", "text": msg.content}],
+            }
+
+        blocks: list[dict[str, Any]] = []
+        for part in msg.content:
+            block = self._part_to_anthropic(part)
+            if block is not None:
+                blocks.append(block)
+
+        return {"role": role, "content": blocks}
+
+    def _part_to_anthropic(self, part: Any) -> dict[str, Any] | None:
+        """Translate a single content part to its Anthropic block shape.
+
+        Unknown part types return None (skipped). Known types map as:
+
+        - TextPart → {"type": "text", "text": ...}
+        - ToolCallPart → {"type": "tool_use", "id": ..., "name": ..., "input": ...}
+        - ToolResultPart → {"type": "tool_result", "tool_use_id": ..., "content": ...}
+        - ReasoningPart → {"type": "thinking", "thinking": ..., "signature": ...}
+        - ImagePart → NotImplemented (Phase 3)
+        """
+        if isinstance(part, TextPart):
+            return {"type": "text", "text": part.text}
+        if isinstance(part, ToolCallPart):
+            return {
+                "type": "tool_use",
+                "id": part.tool_call_id,
+                "name": part.tool_name,
+                "input": part.input,
+            }
+        if isinstance(part, ToolResultPart):
+            # Anthropic tool_result content can be a string or a list of
+            # content blocks. We send strings for simplicity; if the
+            # output is a dict we JSON-encode it.
+            import json as _json
+
+            if isinstance(part.output, str):
+                content: Any = part.output
+            else:
+                content = _json.dumps(part.output)
+            block: dict[str, Any] = {
+                "type": "tool_result",
+                "tool_use_id": part.tool_call_id,
+                "content": content,
+            }
+            if part.is_error:
+                block["is_error"] = True
+            return block
+        if isinstance(part, ReasoningPart):
+            block = {"type": "thinking", "thinking": part.text}
+            if part.signature is not None:
+                block["signature"] = part.signature
+            return block
+        # ImagePart and any unknown types: drop (Phase 3 handles images)
+        return None
+
+    def _tool_to_anthropic(self, tool: ToolDefinition) -> dict[str, Any]:
+        """Translate a ToolDefinition to Anthropic's tool shape."""
+        return {
+            "name": tool.name,
+            "description": tool.description,
+            "input_schema": tool.input_schema,
+        }
+
+    def _repair_tool_pairs(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Strip orphaned tool_use / tool_result blocks.
+
+        Anthropic's API rejects requests where an assistant ``tool_use``
+        has no matching user ``tool_result`` in a subsequent message
+        (and vice versa). This pass removes such orphans and drops any
+        message whose content list becomes empty as a result.
+
+        Algorithm:
+          1. Collect the set of tool_use IDs from assistant blocks.
+          2. Collect the set of tool_use_ids referenced by user
+             tool_result blocks.
+          3. Valid IDs = intersection of the two sets.
+          4. Walk messages; for each block, keep it if it's not
+             tool-related, or its ID is in the valid set.
+          5. Drop messages whose content becomes empty.
+          6. Preserve order and all non-tool content.
+        """
+        use_ids: set[str] = set()
+        result_ids: set[str] = set()
+
+        for msg in messages:
+            content = msg.get("content", [])
+            if not isinstance(content, list):
+                continue
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                btype = block.get("type")
+                if btype == "tool_use" and msg.get("role") == "assistant":
+                    if "id" in block:
+                        use_ids.add(block["id"])
+                elif btype == "tool_result" and msg.get("role") == "user":
+                    if "tool_use_id" in block:
+                        result_ids.add(block["tool_use_id"])
+
+        valid = use_ids & result_ids
+
+        repaired: list[dict[str, Any]] = []
+        for msg in messages:
+            content = msg.get("content", [])
+            if not isinstance(content, list):
+                repaired.append(msg)
+                continue
+
+            new_content: list[dict[str, Any]] = []
+            for block in content:
+                if not isinstance(block, dict):
+                    new_content.append(block)
+                    continue
+                btype = block.get("type")
+                if btype == "tool_use":
+                    if block.get("id") in valid:
+                        new_content.append(block)
+                    # else: orphan — drop
+                elif btype == "tool_result":
+                    if block.get("tool_use_id") in valid:
+                        new_content.append(block)
+                    # else: orphan — drop
+                else:
+                    new_content.append(block)
+
+            if new_content:
+                repaired.append({"role": msg["role"], "content": new_content})
+            # else: message became empty, drop it
+
+        return repaired

--- a/apps/server/src/screamingface/plugins/claude_backend_api/auth.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/auth.py
@@ -1,0 +1,300 @@
+"""Claude Code OAuth auth strategy — reads the token from the credential store.
+
+Every detail here was validated by the SF-77 spike
+(``apps/server/scripts/oauth_spike.py``,
+``apps/server/docs/oauth-spike-findings.md``). Do not change without
+re-running the spike or at least understanding the spike's findings.
+
+The flow:
+
+1. Read the JSON credential from the credential store at service name
+   ``"Claude Code-credentials"``. This is where Claude Code's
+   ``claude auth login`` command writes.
+2. Parse the JSON, extract ``claudeAiOauth.{accessToken, refreshToken,
+   expiresAt, scopes, subscriptionType}``.
+3. If ``expiresAt`` is within 60 seconds of now, proactively refresh by
+   POSTing to ``https://console.anthropic.com/v1/oauth/token`` with
+   ``{grant_type: "refresh_token", refresh_token, client_id}``.
+4. Convert the refresh response (snake_case, ``expires_in`` seconds) to
+   the keychain shape (camelCase, ``expiresAt`` ms) and write back to
+   the credential store.
+5. Build the outbound headers for ``/v1/messages`` calls:
+   - ``Authorization: Bearer <accessToken>``
+   - ``anthropic-version: 2023-06-01``
+   - ``anthropic-beta: oauth-2025-04-20``  (REQUIRED — without it the
+     scope check rejects even a valid token)
+
+Concurrency: a per-instance asyncio.Lock protects the refresh path so
+two concurrent coroutines don't both fire a refresh and race on the
+credential store. Uses double-checked locking to avoid unnecessary lock
+acquisition on the common (cache-hit) path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+
+import httpx
+
+from screamingface.plugins.llm_base.auth_base import AuthStrategy
+from screamingface.plugins.llm_base.credential_store import (
+    CredentialStore,
+    get_credential_store,
+)
+from screamingface.plugins.llm_base.errors import AuthError, CredentialNotFoundError
+
+logger = logging.getLogger(__name__)
+
+# These constants are the load-bearing values validated by the SF-77 spike.
+KEYCHAIN_SERVICE = "Claude Code-credentials"
+OAUTH_REFRESH_URL = "https://console.anthropic.com/v1/oauth/token"
+OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"  # public Claude Code OAuth app
+ANTHROPIC_VERSION = "2023-06-01"
+ANTHROPIC_BETA = "oauth-2025-04-20"  # REQUIRED on every call with an OAuth bearer
+
+# Proactive refresh window — refresh when the token has less than this
+# many seconds of validity remaining. 60s matches the plan's locked-in
+# decision and mirrors Claude Code's own behavior.
+REFRESH_WINDOW_SECONDS = 60
+
+
+class ClaudeCodeOAuth(AuthStrategy):
+    """Reads Claude Code's OAuth token from the platform credential store.
+
+    Args:
+        credential_store: The credential store to read from. Defaults to
+            whatever ``get_credential_store()`` returns for the current
+            platform. Tests can inject a fake store here.
+        account: The account name to look up. Defaults to the ``USER``
+            env var (which is what Claude Code writes).
+        http_client_factory: Callable returning a new ``httpx.AsyncClient``.
+            Tests can inject a factory that returns a mocked client.
+    """
+
+    def __init__(
+        self,
+        *,
+        credential_store: CredentialStore | None = None,
+        account: str | None = None,
+        http_client_factory=None,
+    ) -> None:
+        self._store = credential_store or get_credential_store()
+        self._account = account if account is not None else os.environ.get("USER", "")
+        self._http_factory = http_client_factory or (
+            lambda: httpx.AsyncClient(timeout=httpx.Timeout(30.0))
+        )
+        self._cached: dict | None = None
+        self._lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def get_authorization_header(self) -> dict[str, str]:
+        """Build the full header set for an outbound /v1/messages call.
+
+        Returns the three headers every OAuth-authenticated Anthropic
+        Messages call needs: ``Authorization`` (Bearer), ``anthropic-version``,
+        ``anthropic-beta``. The beta header is required — the spike
+        proved its absence causes scope rejection.
+
+        Handles caching, proactive refresh, and the credential-missing
+        hard-fail path.
+        """
+        # Fast path: cache hit and not expired
+        if self._cached is not None and not self._is_expired(self._cached):
+            return self._build_headers(self._cached)
+
+        # Slow path: read + maybe refresh, under lock
+        async with self._lock:
+            # Double-check inside the lock — another coroutine may have
+            # refreshed while we were waiting.
+            if self._cached is None:
+                self._cached = self._read_from_store()
+            if self._is_expired(self._cached):
+                self._cached = await self._do_refresh(self._cached)
+
+        return self._build_headers(self._cached)
+
+    async def refresh(self) -> None:
+        """Force-refresh the cached credential.
+
+        Used by ``POST /backends/claude-backend-api/refresh`` in Phase 5
+        and as the on-401 recovery path in the Anthropic backend.
+        """
+        async with self._lock:
+            if self._cached is None:
+                self._cached = self._read_from_store()
+            self._cached = await self._do_refresh(self._cached)
+
+    def invalidate_cache(self) -> None:
+        """Drop the in-memory cache without touching the credential store.
+
+        Used as the on-401 recovery path: the backend catches a 401 from
+        /v1/messages, calls invalidate_cache(), then retries once. The
+        next get_authorization_header() call re-reads from the store and
+        refreshes if needed.
+        """
+        self._cached = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _read_from_store(self) -> dict:
+        """Read the credential store and parse the JSON payload.
+
+        Raises:
+            CredentialNotFoundError: The credential store has no entry.
+            AuthError: The entry exists but doesn't parse as expected.
+        """
+        raw = self._store.read(KEYCHAIN_SERVICE, self._account)
+        if raw is None:
+            raise CredentialNotFoundError(
+                "No Claude Code OAuth token found. Run 'claude auth login' to authenticate."
+            )
+
+        try:
+            outer = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise AuthError(
+                f"Claude Code credential store entry is not valid JSON: {exc}. "
+                "Try running 'claude auth login' again."
+            ) from exc
+
+        if not isinstance(outer, dict) or "claudeAiOauth" not in outer:
+            raise AuthError(
+                "Claude Code credential store entry is missing the "
+                "'claudeAiOauth' key. Try running 'claude auth login' again."
+            )
+
+        creds = outer["claudeAiOauth"]
+        required = {"accessToken", "refreshToken", "expiresAt"}
+        missing = required - set(creds.keys())
+        if missing:
+            raise AuthError(
+                f"Claude Code credential store entry missing required keys: "
+                f"{sorted(missing)}. Try running 'claude auth login' again."
+            )
+        return creds
+
+    def _is_expired(self, creds: dict) -> bool:
+        """Return True if the token should be refreshed.
+
+        Uses the 60-second proactive refresh window — we refresh when
+        the token has less than REFRESH_WINDOW_SECONDS of validity
+        remaining, not when it's already expired.
+
+        The ``expiresAt`` field is a unix epoch in **milliseconds** (not
+        seconds), per the spike-validated Claude Code format.
+        """
+        expires_at_ms = creds.get("expiresAt", 0)
+        now_ms = time.time() * 1000
+        return now_ms >= expires_at_ms - (REFRESH_WINDOW_SECONDS * 1000)
+
+    def _build_headers(self, creds: dict) -> dict[str, str]:
+        """Build the three required headers from a validated credential."""
+        return {
+            "Authorization": f"Bearer {creds['accessToken']}",
+            "anthropic-version": ANTHROPIC_VERSION,
+            "anthropic-beta": ANTHROPIC_BETA,
+        }
+
+    async def _do_refresh(self, creds: dict) -> dict:
+        """POST to the refresh endpoint and write back on success.
+
+        Must be called while holding self._lock.
+
+        Raises:
+            AuthError: Refresh failed (401, network, 5xx after retries).
+        """
+        body = {
+            "grant_type": "refresh_token",
+            "refresh_token": creds["refreshToken"],
+            "client_id": OAUTH_CLIENT_ID,
+        }
+        headers = {"content-type": "application/json"}
+
+        try:
+            async with self._http_factory() as client:
+                resp = await client.post(OAUTH_REFRESH_URL, json=body, headers=headers)
+        except httpx.RequestError as exc:
+            raise AuthError(f"Refresh endpoint unreachable: {exc}. Try again in a moment.") from exc
+
+        if resp.status_code == 401:
+            raise AuthError(
+                "Claude Code OAuth token expired and could not be refreshed. "
+                "Run 'claude auth login' to re-authenticate."
+            )
+
+        if resp.status_code != 200:
+            raise AuthError(
+                f"OAuth refresh failed with status {resp.status_code}: "
+                f"{resp.text[:500]}. Run 'claude auth login' to re-authenticate."
+            )
+
+        try:
+            data = resp.json()
+        except json.JSONDecodeError as exc:
+            raise AuthError(f"OAuth refresh response is not valid JSON: {exc}") from exc
+
+        new_creds = self._convert_refresh_response(data, old_creds=creds)
+        self._write_to_store(new_creds)
+        logger.info(
+            "claude-backend-api: OAuth token refreshed, new expiry in %.0fs",
+            (new_creds["expiresAt"] - time.time() * 1000) / 1000,
+        )
+        return new_creds
+
+    def _convert_refresh_response(self, data: dict, *, old_creds: dict) -> dict:
+        """Convert the OAuth 2.0 refresh response to keychain shape.
+
+        The refresh endpoint returns standard OAuth 2.0 fields:
+          - access_token (string)
+          - refresh_token (string, may be rotated)
+          - expires_in (SECONDS)
+          - token_type ("Bearer")
+          - scope (space-separated string)
+
+        The keychain stores:
+          - accessToken (string)
+          - refreshToken (string)
+          - expiresAt (MILLISECONDS since epoch)
+          - scopes (list of strings)
+          - subscriptionType, rateLimitTier (preserved from old creds)
+        """
+        if "access_token" not in data:
+            raise AuthError("OAuth refresh response missing 'access_token' field")
+        if "refresh_token" not in data:
+            raise AuthError("OAuth refresh response missing 'refresh_token' field")
+        if "expires_in" not in data:
+            raise AuthError("OAuth refresh response missing 'expires_in' field")
+
+        # Convert seconds → milliseconds relative to now
+        expires_at_ms = int((time.time() + int(data["expires_in"])) * 1000)
+
+        # scope is a space-separated string; scopes is a list
+        scope_str = data.get("scope", "")
+        scopes = scope_str.split() if scope_str else old_creds.get("scopes", [])
+
+        return {
+            "accessToken": data["access_token"],
+            "refreshToken": data["refresh_token"],
+            "expiresAt": expires_at_ms,
+            "scopes": scopes,
+            # Preserve metadata the refresh response doesn't include
+            "subscriptionType": old_creds.get("subscriptionType", "max"),
+            "rateLimitTier": old_creds.get("rateLimitTier", "default_claude_max_5x"),
+        }
+
+    def _write_to_store(self, creds: dict) -> None:
+        """Write the updated credential back to the platform store.
+
+        Preserves the outer wrapper shape the CLI expects.
+        """
+        value = json.dumps({"claudeAiOauth": creds})
+        self._store.write(KEYCHAIN_SERVICE, self._account, value)

--- a/apps/server/src/screamingface/plugins/claude_backend_api/backend.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/backend.py
@@ -1,0 +1,195 @@
+"""AnthropicBackend — raw httpx POST to api.anthropic.com/v1/messages.
+
+Wires the three pieces of the provider stack together:
+
+1. :class:`~claude_backend_api.auth.ClaudeCodeOAuth` builds the headers
+   (OAuth bearer + ``anthropic-version`` + ``anthropic-beta``).
+2. :class:`~claude_backend_api.adapter.AnthropicAdapter` converts the
+   incoming :class:`CoreMessage` list into an Anthropic Messages API
+   request body and parses the response back.
+3. This module does the transport: ``httpx.AsyncClient.post()`` to
+   ``https://api.anthropic.com/v1/messages``, handles status codes,
+   one-shot 401 retry path via auth cache invalidation.
+
+No streaming yet — Phase 1 is non-streaming only. Streaming comes in a
+follow-up ticket and lives on a separate ``stream()`` method so the
+simple path stays simple.
+"""
+
+from __future__ import annotations
+
+import logging
+import ssl
+
+import certifi
+import httpx
+
+from screamingface.plugins.claude_backend_api.adapter import AnthropicAdapter
+from screamingface.plugins.claude_backend_api.auth import ClaudeCodeOAuth
+from screamingface.plugins.llm_base.backend_base import Backend
+from screamingface.plugins.llm_base.errors import AuthError, BackendError
+from screamingface.plugins.llm_base.messages import CoreMessage, ToolDefinition
+
+logger = logging.getLogger(__name__)
+
+ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
+
+
+class AnthropicBackend(Backend):
+    """Direct-to-API backend for Anthropic's Messages endpoint.
+
+    Args:
+        auth: The auth strategy to build headers with. Defaults to
+            :class:`ClaudeCodeOAuth` using the platform credential store.
+        adapter: The shape adapter to use. Defaults to
+            :class:`AnthropicAdapter`.
+        http_client_factory: Callable returning an ``httpx.AsyncClient``.
+            Tests inject a factory that returns a mocked client.
+    """
+
+    def __init__(
+        self,
+        *,
+        auth: ClaudeCodeOAuth | None = None,
+        adapter: AnthropicAdapter | None = None,
+        http_client_factory=None,
+    ) -> None:
+        self._auth = auth or ClaudeCodeOAuth()
+        self._adapter = adapter or AnthropicAdapter()
+        # Lazy-construct the SSL context so import-time failures don't
+        # block plugin loading. certifi.where() does a disk read.
+        self._http_factory = http_client_factory or self._default_http_factory
+
+    @staticmethod
+    def _default_http_factory():
+        ssl_ctx = ssl.create_default_context(cafile=certifi.where())
+        return httpx.AsyncClient(
+            timeout=httpx.Timeout(connect=10.0, read=300.0, write=10.0, pool=10.0),
+            verify=ssl_ctx,
+        )
+
+    async def run(
+        self,
+        messages: list[CoreMessage],
+        *,
+        model: str,
+        system: str | None = None,
+        tools: list[ToolDefinition] | None = None,
+        max_tokens: int = 16000,
+        temperature: float | None = None,
+        timeout_seconds: float = 300.0,
+    ) -> CoreMessage:
+        """Execute one non-streaming round-trip against Anthropic.
+
+        Flow:
+
+        1. Build the outbound request body via the adapter.
+        2. Get auth headers from :class:`ClaudeCodeOAuth`.
+        3. POST to ``/v1/messages``.
+        4. On 401: invalidate auth cache, retry exactly once.
+        5. On 200: parse via the adapter, return the CoreMessage.
+        6. On any other error status: raise :class:`BackendError` with
+           the status code and, when present, ``retry-after`` header.
+        """
+        body = self._adapter.to_provider_format(
+            messages,
+            model=model,
+            system=system,
+            tools=tools,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+
+        response_data = await self._post_with_retry(body)
+        return self._adapter.from_provider_response(response_data)
+
+    async def _post_with_retry(self, body: dict) -> dict:
+        """POST with the one-shot 401-retry recovery path.
+
+        Called with an already-built request body. Handles auth header
+        construction, the upstream POST, and the 401→invalidate→retry
+        cycle. Returns the parsed response dict on success.
+        """
+        # First attempt
+        headers = await self._auth.get_authorization_header()
+        headers["content-type"] = "application/json"
+        resp = await self._do_post(body, headers)
+
+        # 401 recovery: the cached token went bad between header-build
+        # and POST (rare race with concurrent refresh). Invalidate the
+        # cache and retry exactly once.
+        if resp.status_code == 401:
+            logger.warning(
+                "claude-backend-api: /v1/messages returned 401, invalidating "
+                "auth cache and retrying once"
+            )
+            self._auth.invalidate_cache()
+            headers = await self._auth.get_authorization_header()
+            headers["content-type"] = "application/json"
+            resp = await self._do_post(body, headers)
+
+            if resp.status_code == 401:
+                # Two consecutive 401s means the credential itself is bad.
+                raise AuthError(
+                    "Authentication failed twice in a row against "
+                    "api.anthropic.com/v1/messages; token state may be "
+                    "corrupt. Run 'claude auth login' to re-authenticate."
+                )
+
+        # Status code handling
+        if resp.status_code == 200:
+            try:
+                return resp.json()
+            except ValueError as exc:
+                raise BackendError(
+                    f"Anthropic returned 200 but the body is not JSON: {exc}",
+                    status=200,
+                ) from exc
+
+        # 429 = rate limited. Token is fine; propagate with retry hint.
+        if resp.status_code == 429:
+            retry_after_raw = resp.headers.get("retry-after")
+            retry_after: float | None = None
+            if retry_after_raw is not None:
+                try:
+                    retry_after = float(retry_after_raw)
+                except ValueError:
+                    retry_after = None
+            raise BackendError(
+                f"Anthropic rate limit exceeded (429). "
+                f"Retry after {retry_after_raw or 'unknown'} seconds.",
+                status=429,
+                retry_after=retry_after,
+            )
+
+        # 403 = scope rejected (should be impossible with user:inference but
+        # surface it clearly if it happens).
+        if resp.status_code == 403:
+            raise AuthError(
+                f"Anthropic returned 403 Forbidden. Token is valid but "
+                f"lacks permission. Response: {resp.text[:500]}. "
+                f"Run 'claude auth login' to re-authenticate with "
+                f"the correct scopes."
+            )
+
+        # Everything else: regular BackendError with the status code.
+        raise BackendError(
+            f"Anthropic API error {resp.status_code}: {resp.text[:500]}",
+            status=resp.status_code,
+        )
+
+    async def _do_post(self, body: dict, headers: dict[str, str]) -> httpx.Response:
+        """Single httpx POST. Wraps network errors as :class:`BackendError`."""
+        try:
+            async with self._http_factory() as client:
+                return await client.post(ANTHROPIC_MESSAGES_URL, json=body, headers=headers)
+        except httpx.TimeoutException as exc:
+            raise BackendError(
+                f"Anthropic request timed out: {exc}",
+                status=None,
+            ) from exc
+        except httpx.RequestError as exc:
+            raise BackendError(
+                f"Anthropic request failed: {exc}",
+                status=None,
+            ) from exc

--- a/apps/server/src/screamingface/plugins/claude_backend_api/interpreter.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/interpreter.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 
 # Final fallback model if neither the request nor the plugin settings
 # specify one. Matches the plan's locked-in default.
-_DEFAULT_MODEL = "claude-sonnet-4-5"
+_DEFAULT_MODEL = "claude-sonnet-4-6"
 
 
 class ClaudeBackendApiInterpreter(Url4Interpreter):

--- a/apps/server/src/screamingface/plugins/claude_backend_api/interpreter.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/interpreter.py
@@ -1,0 +1,114 @@
+"""ClaudeBackendApiInterpreter — url4 interpreter that calls the direct Anthropic API.
+
+Subclass of :class:`Url4Interpreter`. Used by the ``GET /claude?q=…``
+endpoint: the url4-executor splits the expression into ``sources``
+(parenthesized group of URLs/text) and ``intent`` (text after ``!``),
+then calls our :meth:`process` to produce the final response.
+
+Mirrors :class:`~claude_backend.interpreter.ClaudeInterpreter` byte-for-
+byte semantically — the only difference is the transport. The
+concatenation rule (``intent`` first, ``sources`` second, separated by
+``\\n\\n``) is preserved because existing url4 specs depend on it.
+
+Key differences from the CLI-based interpreter:
+
+- No temp-directory dance. The direct API has no concept of ``cwd``, so
+  there's nothing to isolate.
+- No subprocess, no exit code to interpret. The response comes back as
+  a :class:`CoreMessage`; we return its text.
+- Auth errors bubble up as :class:`AuthError` from the OAuth strategy
+  instead of non-zero exit codes from the CLI.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from screamingface.plugins.claude_backend_api.backend import AnthropicBackend
+from screamingface.plugins.llm_base.messages import CoreMessage, TextPart
+from screamingface.plugins.url4_executor.interpreter import Url4Interpreter
+
+if TYPE_CHECKING:
+    from screamingface.plugins.claude_backend_api.plugin import ClaudeBackendApiSettings
+
+logger = logging.getLogger(__name__)
+
+# Final fallback model if neither the request nor the plugin settings
+# specify one. Matches the plan's locked-in default.
+_DEFAULT_MODEL = "claude-sonnet-4-5"
+
+
+class ClaudeBackendApiInterpreter(Url4Interpreter):
+    """Url4 interpreter that routes to the direct Anthropic Messages API.
+
+    Args:
+        app: The FastAPI app (used by the Url4Interpreter base for
+            in-process ASGI fetches of relative URLs like /data/<key>).
+        settings: The claude-backend-api plugin settings. Provides the
+            default model, the interpreter system prompt, and the
+            timeout.
+        backend: Optional :class:`AnthropicBackend` to inject. Defaults
+            to a new instance with the platform's default auth +
+            adapter. Tests override this.
+    """
+
+    def __init__(
+        self,
+        app: Any = None,
+        settings: ClaudeBackendApiSettings | None = None,
+        *,
+        backend: AnthropicBackend | None = None,
+    ) -> None:
+        super().__init__(app)
+        self.settings = settings
+        self._backend = backend or AnthropicBackend()
+
+    async def process(self, sources: str, intent: str | None) -> str:
+        """Combine intent + sources, send as a user message to Anthropic.
+
+        Matches :class:`ClaudeInterpreter.process` semantics so existing
+        url4 specs (e.g. the ``cat-breeds-3sources`` e2e test) work
+        unchanged. The combined text becomes a single user message;
+        the interpreter system prompt from settings becomes the
+        Anthropic ``system`` field.
+        """
+        combined = f"{intent}\n\n{sources}" if intent and sources else (intent or sources or "")
+
+        if not combined:
+            # Empty input — nothing meaningful to ask. Return empty
+            # string for parity with the CLI path (which would also
+            # produce no output).
+            return ""
+
+        messages = [CoreMessage(role="user", content=[TextPart(text=combined)])]
+
+        model = (self.settings.default_model if self.settings else None) or _DEFAULT_MODEL
+        system = self.settings.interpreter_system_prompt if self.settings else None
+        timeout = self.settings.timeout_seconds if self.settings else 300.0
+
+        result = await self._backend.run(
+            messages,
+            model=model,
+            system=system,
+            timeout_seconds=timeout,
+        )
+
+        return _extract_text(result)
+
+
+def _extract_text(msg: CoreMessage) -> str:
+    """Pull concatenated text out of a response CoreMessage.
+
+    The AnthropicAdapter packs multiple assistant text blocks (and any
+    tool_use, thinking, etc.) into the content list. For the interpreter
+    we only care about the text — other block types are ignored for the
+    legacy drop-in semantics.
+    """
+    if isinstance(msg.content, str):
+        return msg.content
+    chunks: list[str] = []
+    for part in msg.content:
+        if isinstance(part, TextPart):
+            chunks.append(part.text)
+    return "".join(chunks)

--- a/apps/server/src/screamingface/plugins/claude_backend_api/models.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/models.py
@@ -1,0 +1,44 @@
+"""Request/response/profile models for claude-backend-api.
+
+These are **identical** to the models in ``claude_backend/models.py``
+by design: the whole point of claude-backend-api is to be a drop-in
+replacement for claude-backend, and that means the wire shapes must
+be byte-for-byte compatible.
+
+Rather than copy-paste (which would drift), we re-export the classes
+directly from claude_backend. This creates a one-way dependency
+claude_backend_api → claude_backend at the Python import level, but
+NOT at the plugin level (the two plugins still conflict in
+``sf.json``). The import works because the claude_backend package is
+always present on disk; only its SF Plugin class is disabled when
+claude-backend-api is active.
+
+Rationale:
+
+- **Drop-in compat is exact, not approximate.** Every field, every
+  alias, every default is guaranteed identical because it's literally
+  the same Python class.
+- **Tests don't have to re-verify** alias compatibility across the
+  two plugins — it's impossible for them to disagree.
+- **Future schema changes** happen in exactly one place.
+
+If we ever need to deprecate claude_backend entirely, this module
+becomes the owning location by copying the class definitions over.
+Until then, forwarding is the right call.
+"""
+
+from __future__ import annotations
+
+from screamingface.plugins.claude_backend.models import (
+    ClaudeProfile,
+    ClaudeRunRequest,
+    ClaudeRunResponse,
+    FileInput,
+)
+
+__all__ = [
+    "ClaudeProfile",
+    "ClaudeRunRequest",
+    "ClaudeRunResponse",
+    "FileInput",
+]

--- a/apps/server/src/screamingface/plugins/claude_backend_api/plugin.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/plugin.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 from pydantic_settings import SettingsConfigDict
 
 from screamingface.plugin import Plugin, PluginSettings
@@ -60,7 +60,7 @@ class ClaudeBackendApiSettings(PluginSettings):
         default=None,
         description=(
             "Default Claude model for requests that don't specify one. "
-            "Falls back to 'claude-sonnet-4-5' if still unset at call time."
+            "Falls back to 'claude-sonnet-4-6' if still unset at call time."
         ),
     )
     default_effort: str = Field(
@@ -104,9 +104,9 @@ class ClaudeBackendApiSettings(PluginSettings):
         default_factory=dict,
         description="Named pre-configured Claude execution profiles.",
     )
-    default_profile: str | None = Field(
-        default=None,
-        description="Profile to use when none is specified.",
+    default_profile: str = Field(
+        default="default",
+        description="Profile to use when none is specified. Must exist in profiles.",
     )
 
     @field_validator("profiles")
@@ -121,6 +121,16 @@ class ClaudeBackendApiSettings(PluginSettings):
                 )
                 raise ValueError(msg)
         return v
+
+    @model_validator(mode="after")
+    def _validate_default_profile(self) -> ClaudeBackendApiSettings:
+        if self.default_profile and self.profiles and self.default_profile not in self.profiles:
+            msg = (
+                f"default_profile {self.default_profile!r} not found in profiles. "
+                f"Available: {list(self.profiles.keys())}"
+            )
+            raise ValueError(msg)
+        return self
 
 
 class ClaudeBackendApiPlugin(Plugin):

--- a/apps/server/src/screamingface/plugins/claude_backend_api/plugin.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/plugin.py
@@ -133,6 +133,12 @@ class ClaudeBackendApiPlugin(Plugin):
     )
     depends: list[str] = ["llm-base"]
     conflicts: list[str] = ["claude-backend"]
+    # Registered for url4 backend-call dispatch via /claude()!<intent>.
+    # The url4 resolver walks active plugins looking for one whose
+    # backend_call_paths contains the target path and calls its
+    # handle_backend_call method. This is how SF-79 Stage B wires fan-out
+    # calls to the underlying llm-base Backend.
+    backend_call_paths: list[str] = ["/claude"]
     settings_class = ClaudeBackendApiSettings
 
     def customize_schema(self, schema: dict) -> dict:
@@ -154,3 +160,27 @@ class ClaudeBackendApiPlugin(Plugin):
     ) -> None:
         router = create_router(self.settings, app)  # type: ignore[arg-type]
         routes.add_router(self.name, router, prefix="")
+
+    async def handle_backend_call(self, intent: str, *, app: FastAPI) -> str:
+        """Dispatch a url4 backend-call to the direct Anthropic API.
+
+        Constructs a :class:`ClaudeBackendApiInterpreter` and delegates to
+        its ``process(sources="", intent=...)`` method — the same path the
+        existing ``GET /claude?q=`` route uses. Reusing the interpreter
+        means the backend-call dispatch inherits every behavior it already
+        has (default model, system prompt, timeout, auth strategy).
+        """
+        # Lazy import to avoid a circular dependency at module load.
+        from screamingface.plugins.claude_backend_api.interpreter import (
+            ClaudeBackendApiInterpreter,
+        )
+
+        interpreter = ClaudeBackendApiInterpreter(
+            app=app,
+            settings=self.settings,  # type: ignore[arg-type]
+        )
+        # process() takes (sources, intent). For a bare /claude()!<intent>
+        # call, sources is empty — there's no auxiliary context beyond the
+        # intent itself. The interpreter concatenates intent + sources as
+        # ``intent\n\nsources`` so empty sources gives us just the intent.
+        return await interpreter.process(sources="", intent=intent)

--- a/apps/server/src/screamingface/plugins/claude_backend_api/plugin.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/plugin.py
@@ -1,0 +1,156 @@
+"""claude-backend-api plugin — direct Anthropic Messages API implementation.
+
+Declares:
+
+- ``depends = ["llm-base"]`` — needs the shared ABCs and credential store
+- ``conflicts = ["claude-backend"]`` — mutually exclusive with the
+  CLI-subprocess plugin. The SF plugin loader refuses to activate both
+  at the same time; operators pick exactly one by listing it in the
+  ``sf.json`` plugins array.
+
+Exposes the same routes as ``claude-backend`` (``/claude/run``,
+``/claude``, ``/claude/{profile_name}``) so existing url4 specs and
+tests work unchanged. Only the implementation under the routes differs
+— subprocess → direct httpx POST.
+
+Settings mirror ``claude-backend`` field-for-field. Env prefix is
+``SF_CLAUDE_BACKEND_API__`` (not ``SF_CLAUDE_BACKEND__``) so env-var
+overrides for the two plugins stay independent. Per-field names
+(``default_model``, ``default_effort``, etc.) are the same.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from pydantic import Field, field_validator
+from pydantic_settings import SettingsConfigDict
+
+from screamingface.plugin import Plugin, PluginSettings
+from screamingface.plugins.claude_backend_api.models import ClaudeProfile
+from screamingface.plugins.claude_backend_api.routes import create_router
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+    from screamingface.core.classes import ClassRegistry
+    from screamingface.core.hooks import HookRegistry
+    from screamingface.core.routes import RouteRegistry
+
+
+_PROFILE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
+
+class ClaudeBackendApiSettings(PluginSettings):
+    """Settings for claude-backend-api.
+
+    Mirrors ``ClaudeBackendSettings`` in all user-visible field names.
+    CLI-only settings (``permission_mode``, ``dangerously_skip_permissions``)
+    are accepted but silently ignored at request time, per the locked-in
+    drop-in-compat decision in the plan.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="SF_CLAUDE_BACKEND_API__",
+        env_nested_delimiter="__",
+    )
+
+    default_model: str | None = Field(
+        default=None,
+        description=(
+            "Default Claude model for requests that don't specify one. "
+            "Falls back to 'claude-sonnet-4-5' if still unset at call time."
+        ),
+    )
+    default_effort: str = Field(
+        default="medium",
+        description="Default effort level.",
+    )
+    interpreter_system_prompt: str = Field(
+        default=(
+            "You are a helpful assistant. Answer the user's question based only on "
+            "the provided context. Be concise and factual."
+        ),
+        description=("System prompt used by the /claude?q= url4 interpreter endpoint."),
+    )
+    timeout_seconds: float = Field(
+        default=300.0,
+        description="Default request timeout in seconds (httpx read timeout).",
+    )
+    max_budget_usd: float | None = Field(
+        default=None,
+        description=(
+            "CLI-only budget cap. Accepted for sf.json compatibility but "
+            "silently ignored by the direct-API backend (no budget "
+            "enforcement on this path)."
+        ),
+    )
+    permission_mode: str | None = Field(
+        default=None,
+        description=(
+            "CLI-only setting. Accepted for sf.json compatibility but "
+            "silently ignored by the direct-API backend."
+        ),
+    )
+    dangerously_skip_permissions: bool = Field(
+        default=False,
+        description=(
+            "CLI-only setting. Accepted for sf.json compatibility but "
+            "silently ignored by the direct-API backend."
+        ),
+    )
+    profiles: dict[str, ClaudeProfile] = Field(
+        default_factory=dict,
+        description="Named pre-configured Claude execution profiles.",
+    )
+    default_profile: str | None = Field(
+        default=None,
+        description="Profile to use when none is specified.",
+    )
+
+    @field_validator("profiles")
+    @classmethod
+    def _validate_profile_keys(cls, v: dict[str, ClaudeProfile]) -> dict[str, ClaudeProfile]:
+        for key in v:
+            if not _PROFILE_NAME_RE.match(key):
+                msg = (
+                    f"Invalid profile name {key!r}: must be lowercase "
+                    "alphanumeric, hyphens, or underscores, starting with "
+                    "a letter or digit."
+                )
+                raise ValueError(msg)
+        return v
+
+
+class ClaudeBackendApiPlugin(Plugin):
+    name = "claude-backend-api"
+    description = (
+        "Direct Anthropic Messages API backend — drop-in replacement for "
+        "claude-backend that uses OAuth from the Claude Code credential "
+        "store instead of shelling out to the claude CLI. Same routes, "
+        "same request/response shapes, same profile config."
+    )
+    depends: list[str] = ["llm-base"]
+    conflicts: list[str] = ["claude-backend"]
+    settings_class = ClaudeBackendApiSettings
+
+    def customize_schema(self, schema: dict) -> dict:
+        settings: ClaudeBackendApiSettings = self.settings  # type: ignore[assignment]
+        profile_names = list(settings.profiles.keys())
+        props = schema.get("properties", {})
+        if profile_names and "default_profile" in props:
+            props["default_profile"]["enum"] = profile_names
+        if "profiles" in props:
+            props["profiles"]["x-link-base"] = "/claude/"
+        return schema
+
+    def setup(
+        self,
+        app: FastAPI,
+        hooks: HookRegistry,
+        classes: ClassRegistry,
+        routes: RouteRegistry,
+    ) -> None:
+        router = create_router(self.settings, app)  # type: ignore[arg-type]
+        routes.add_router(self.name, router, prefix="")

--- a/apps/server/src/screamingface/plugins/claude_backend_api/routes.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/routes.py
@@ -1,0 +1,387 @@
+"""Routes for claude-backend-api.
+
+Drop-in replacement for ``claude_backend/routes.py``. Same paths, same
+operation IDs, same request/response shapes. Implementation differs:
+
+- No ``tempfile.mkdtemp``, no file uploads, no subprocess.
+- ``_execute_claude`` builds a :class:`CoreMessage` list and calls
+  :class:`AnthropicBackend.run` instead of ``run_claude``.
+- CLI-only fields (``add_dirs``, ``files``, ``mcp_config``,
+  ``permission_mode``, ``dangerously_skip_permissions``,
+  ``no_session_persistence``, ``tools``, ``allowed_tools``,
+  ``disallowed_tools``) are accepted in the request body (for drop-in
+  compat with existing sf.json profiles and CC CLI configs) but
+  silently ignored — recorded as OTEL span attributes so their
+  dropping is still observable.
+- Streaming is NOT yet supported — requests with
+  ``output_format == "stream-json"`` currently raise 501 Not Implemented.
+  Phase 1 follow-up will add SSE streaming with the legacy
+  ``text``/``done``/``error`` envelope.
+- ``files`` is rejected with 400 if present — writing files to a
+  non-existent sandbox has no sensible direct-API interpretation.
+
+Error mapping:
+
+- :class:`CredentialNotFoundError` / :class:`AuthError` → HTTP 500 with
+  the user-facing "Run 'claude auth login'" message
+- :class:`BackendError` → HTTP 502 (upstream error), 429 preserved
+- Any other exception → HTTP 500 with the exception message
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
+
+from screamingface.plugins.claude_backend_api.backend import AnthropicBackend
+from screamingface.plugins.claude_backend_api.models import (
+    ClaudeRunRequest,
+    ClaudeRunResponse,
+)
+from screamingface.plugins.llm_base.errors import (
+    AuthError,
+    BackendError,
+    CredentialNotFoundError,
+)
+from screamingface.plugins.llm_base.messages import CoreMessage, TextPart
+from screamingface.plugins.url4_executor.interpreter import Url4Interpreter
+from screamingface.plugins.url4_executor.url4 import resolve_str
+
+if TYPE_CHECKING:
+    from screamingface.plugins.claude_backend_api.plugin import ClaudeBackendApiSettings
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MODEL = "claude-sonnet-4-5"
+
+# The six fields we silently ignore because they're subprocess-only.
+_CLI_ONLY_FIELDS = (
+    "add_dirs",
+    "mcp_config",
+    "permission_mode",
+    "dangerously_skip_permissions",
+    "no_session_persistence",
+    "tools",
+    "allowed_tools",
+    "disallowed_tools",
+)
+
+
+def create_router(settings: ClaudeBackendApiSettings, app: Any = None) -> APIRouter:
+    router = APIRouter(tags=["claude-backend-api"])
+
+    # Single shared backend instance — AnthropicBackend holds no
+    # per-request state; the auth strategy handles its own locking.
+    _backend = AnthropicBackend()
+
+    async def _execute(
+        request: ClaudeRunRequest,
+    ) -> JSONResponse | StreamingResponse:
+        # Reject streaming in Phase 1 — not yet implemented.
+        if request.output_format == "stream-json":
+            raise HTTPException(
+                status_code=501,
+                detail=(
+                    "stream-json output is not yet implemented in "
+                    "claude-backend-api. Use output_format='text' or "
+                    "'json', or switch to the legacy claude-backend "
+                    "plugin for streaming support."
+                ),
+            )
+
+        # Reject file uploads — no sandbox to write to.
+        if request.files:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "The 'files' field is not supported by "
+                    "claude-backend-api (no sandbox to write to). "
+                    "Include file contents directly in the prompt instead."
+                ),
+            )
+
+        # Silently drop CLI-only fields; record them on the OTEL span
+        # for observability.
+        _record_ignored_fields(request)
+
+        timeout = request.timeout_seconds or settings.timeout_seconds
+        model = request.model or settings.default_model or _DEFAULT_MODEL
+
+        # Build system prompt: request's system_prompt (+ append_system_prompt)
+        system_parts: list[str] = []
+        if request.system_prompt:
+            system_parts.append(request.system_prompt)
+        if request.append_system_prompt:
+            system_parts.append(request.append_system_prompt)
+        system = "\n\n".join(system_parts) if system_parts else None
+
+        # Build a single user-turn CoreMessage from the prompt.
+        messages = [CoreMessage(role="user", content=[TextPart(text=request.prompt)])]
+
+        start = time.monotonic()
+        try:
+            result = await _backend.run(
+                messages,
+                model=model,
+                system=system,
+                max_tokens=16000,
+                temperature=None,
+                timeout_seconds=timeout,
+            )
+            duration = time.monotonic() - start
+            stdout = _extract_text(result)
+            parsed_result: dict | list | str | None = None
+            if request.output_format == "json" and stdout.strip():
+                try:
+                    parsed_result = json.loads(stdout)
+                except json.JSONDecodeError:
+                    parsed_result = None
+
+            resp = ClaudeRunResponse(
+                exit_code=0,
+                stdout=stdout,
+                stderr="",
+                duration_seconds=round(duration, 3),
+                result=parsed_result,
+            )
+            _record_span_success(result, duration, stdout)
+            return JSONResponse(content=resp.model_dump(by_alias=True))
+
+        except (CredentialNotFoundError, AuthError) as exc:
+            duration = time.monotonic() - start
+            logger.warning("claude-backend-api auth failure: %s", exc)
+            resp = ClaudeRunResponse(
+                exit_code=1,
+                stdout="",
+                stderr=str(exc),
+                duration_seconds=round(duration, 3),
+                result=None,
+            )
+            return JSONResponse(content=resp.model_dump(by_alias=True), status_code=500)
+
+        except BackendError as exc:
+            duration = time.monotonic() - start
+            logger.warning("claude-backend-api backend error: %s", exc)
+            status = 429 if exc.status == 429 else 502
+            resp = ClaudeRunResponse(
+                exit_code=1,
+                stdout="",
+                stderr=str(exc),
+                duration_seconds=round(duration, 3),
+                result=None,
+            )
+            return JSONResponse(content=resp.model_dump(by_alias=True), status_code=status)
+
+    @router.post("/claude/run", response_model=None, operation_id="claude_run")
+    async def claude_run(
+        request: ClaudeRunRequest,
+    ) -> JSONResponse | StreamingResponse:
+        return await _execute(request)
+
+    @router.get("/claude", response_model=None, operation_id="claude_url4")
+    async def claude_url4(q: str) -> PlainTextResponse:
+        """Evaluate a url4 expression through the direct Anthropic API."""
+        from screamingface.plugins.claude_backend_api.interpreter import (
+            ClaudeBackendApiInterpreter,
+        )
+
+        interpreter = ClaudeBackendApiInterpreter(app=app, settings=settings, backend=_backend)
+        try:
+            result = await interpreter.evaluate(q)
+        except (CredentialNotFoundError, AuthError) as exc:
+            raise HTTPException(status_code=500, detail=str(exc))
+        except BackendError as exc:
+            status = 429 if exc.status == 429 else 502
+            raise HTTPException(status_code=status, detail=str(exc))
+        except Exception as exc:
+            logger.warning("url4 evaluation failed: %s", exc, exc_info=True)
+            raise HTTPException(status_code=502, detail=f"url4 evaluation failed: {exc}")
+
+        try:
+            from opentelemetry import trace
+
+            span = trace.get_current_span()
+            if span and span.is_recording():
+                span.set_attribute("sf.plugin", "claude-backend-api")
+                span.set_attribute("url4.expression", q[:500])
+                span.set_attribute("url4.result_length", len(result))
+                preview = result[:4000]
+                if len(result) > 4000:
+                    preview += f"\n... ({len(result) - 4000} more chars)"
+                span.set_attribute("url4.response_body", preview)
+        except ImportError:
+            pass
+
+        return PlainTextResponse(content=result)
+
+    async def _handle_profile(
+        profile_name: str,
+        prompt: str,
+        context: str | None = None,
+        raw_context: str | None = None,
+    ) -> JSONResponse | StreamingResponse | PlainTextResponse:
+        prof = settings.profiles.get(profile_name)
+        if not prof:
+            raise HTTPException(status_code=404, detail=f"Unknown profile: {profile_name!r}")
+
+        # url4-shaped prompts (starting with "(" and containing "!") get
+        # resolved through the base Url4Interpreter first.
+        is_url4 = False
+        url4_interpreter = Url4Interpreter(app=app)
+        stripped = prompt.strip()
+        if stripped.startswith("(") and "!" in stripped:
+            try:
+                prompt = await url4_interpreter.evaluate(stripped)
+                is_url4 = True
+            except Exception as exc:
+                logger.warning("url4 prompt resolution failed: %s", exc, exc_info=True)
+                raise HTTPException(
+                    status_code=502,
+                    detail=f"url4 prompt resolution failed: {exc}",
+                )
+
+        resolved_context = ""
+        if raw_context:
+            resolved_context = raw_context
+        elif not is_url4:
+            context_expr = context or prof.context
+            if context_expr:
+                try:
+                    resolved_context = await resolve_str(context_expr, app)
+                except Exception as exc:
+                    logger.warning("Context resolution failed: %s", exc, exc_info=True)
+                    raise HTTPException(
+                        status_code=502,
+                        detail=f"Context resolution failed: {exc}",
+                    )
+
+        full_prompt = f"{resolved_context}\n\n{prompt}" if resolved_context else prompt
+
+        run_request = ClaudeRunRequest(
+            prompt=full_prompt,
+            model=prof.model,
+            system_prompt=prof.system_prompt,
+            append_system_prompt=prof.append_system_prompt,
+            output_format=prof.output_format,
+            json_schema=prof.json_schema,
+            max_budget_usd=prof.max_budget_usd,
+            effort=prof.effort,
+            tools=prof.tools,
+            allowed_tools=prof.allowed_tools,
+            disallowed_tools=prof.disallowed_tools,
+            mcp_config=prof.mcp_config,
+            permission_mode=prof.permission_mode,
+            add_dirs=prof.add_dirs,
+            fallback_model=prof.fallback_model,
+            dangerously_skip_permissions=prof.dangerously_skip_permissions,
+            no_session_persistence=prof.no_session_persistence,
+            timeout_seconds=prof.timeout_seconds,
+        )
+        result = await _execute(run_request)
+
+        # url4 mode — return just stdout as plain text
+        if is_url4 and isinstance(result, JSONResponse):
+            body = json.loads(bytes(result.body).decode())
+            stdout = body.get("so") or body.get("stdout") or ""
+            return PlainTextResponse(content=stdout)
+
+        return result
+
+    @router.get(
+        "/claude/{profile_name}",
+        response_model=None,
+        operation_id="claude_profile_get",
+    )
+    async def claude_profile_get(
+        profile_name: str,
+        prompt: str,
+        context: str | None = None,
+        raw_context: str | None = None,
+    ) -> JSONResponse | StreamingResponse | PlainTextResponse:
+        return await _handle_profile(profile_name, prompt, context, raw_context)
+
+    @router.post(
+        "/claude/{profile_name}",
+        response_model=None,
+        operation_id="claude_profile_post",
+    )
+    async def claude_profile_post(
+        profile_name: str,
+        prompt: str,
+        context: str | None = None,
+        raw_context: str | None = None,
+    ) -> JSONResponse | StreamingResponse | PlainTextResponse:
+        return await _handle_profile(profile_name, prompt, context, raw_context)
+
+    return router
+
+
+# ----------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------
+
+
+def _extract_text(msg: CoreMessage) -> str:
+    """Pull concatenated text out of an assistant CoreMessage."""
+    if isinstance(msg.content, str):
+        return msg.content
+    chunks: list[str] = []
+    for part in msg.content:
+        if isinstance(part, TextPart):
+            chunks.append(part.text)
+    return "".join(chunks)
+
+
+def _record_ignored_fields(request: ClaudeRunRequest) -> None:
+    """Record which CLI-only fields were present so the drop is observable."""
+    try:
+        from opentelemetry import trace
+
+        span = trace.get_current_span()
+        if not (span and span.is_recording()):
+            return
+        for field_name in _CLI_ONLY_FIELDS:
+            value = getattr(request, field_name, None)
+            if value:  # truthy — non-empty list, non-empty string, True bool
+                span.set_attribute(f"claude_backend_api.ignored_field.{field_name}", True)
+    except ImportError:
+        pass
+
+
+def _record_span_success(result: CoreMessage, duration: float, stdout: str) -> None:
+    """Record success-path attributes on the OTEL span."""
+    try:
+        from opentelemetry import trace
+
+        span = trace.get_current_span()
+        if not (span and span.is_recording()):
+            return
+        span.set_attribute("sf.plugin", "claude-backend-api")
+        span.set_attribute("claude.exit_code", 0)
+        span.set_attribute("claude.duration_seconds", round(duration, 3))
+        span.set_attribute("claude.stdout_length", len(stdout))
+        preview = stdout[:1000]
+        if len(stdout) > 1000:
+            preview += f"\n... ({len(stdout) - 1000} more chars)"
+        span.set_attribute("claude.stdout_preview", preview)
+        # Provider metadata from the adapter (tokens, stop_reason, etc.)
+        if result.provider_metadata:
+            for key, value in result.provider_metadata.items():
+                try:
+                    span.set_attribute(key, _otel_attr_value(value))
+                except Exception:
+                    pass
+    except ImportError:
+        pass
+
+
+def _otel_attr_value(value: Any) -> Any:
+    """Coerce a value to something OTEL spans accept as an attribute."""
+    if isinstance(value, (str, bool, int, float)):
+        return value
+    return json.dumps(value)

--- a/apps/server/src/screamingface/plugins/claude_backend_api/routes.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/routes.py
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_MODEL = "claude-sonnet-4-5"
+_DEFAULT_MODEL = "claude-sonnet-4-6"
 
 # The six fields we silently ignore because they're subprocess-only.
 _CLI_ONLY_FIELDS = (

--- a/apps/server/src/screamingface/plugins/claude_backend_api/tests/test_adapter.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/tests/test_adapter.py
@@ -1,0 +1,485 @@
+"""Unit tests for claude-backend-api AnthropicAdapter.
+
+Covers CoreMessage ↔ Anthropic Messages round-trips, the orphan
+tool_use/tool_result repair pass, and the system-prompt merging
+behavior.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from screamingface.plugins.claude_backend_api.adapter import AnthropicAdapter
+from screamingface.plugins.llm_base.errors import AdapterError
+from screamingface.plugins.llm_base.messages import (
+    CoreMessage,
+    ReasoningPart,
+    TextPart,
+    ToolCallPart,
+    ToolDefinition,
+    ToolResultPart,
+)
+
+
+@pytest.fixture
+def adapter() -> AnthropicAdapter:
+    return AnthropicAdapter()
+
+
+# ----------------------------------------------------------------------------
+# to_provider_format: basic message shapes
+# ----------------------------------------------------------------------------
+
+
+class TestToProviderFormatBasic:
+    def test_single_user_text_message(self, adapter: AnthropicAdapter):
+        messages = [CoreMessage(role="user", content=[TextPart(text="hi")])]
+        body = adapter.to_provider_format(messages, model="claude-sonnet-4-5")
+
+        assert body["model"] == "claude-sonnet-4-5"
+        assert body["max_tokens"] == 16000
+        assert body["messages"] == [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+
+    def test_string_content_shorthand_expanded(self, adapter: AnthropicAdapter):
+        """CoreMessage with a bare string content gets wrapped in a text block."""
+        messages = [CoreMessage(role="user", content="hello")]
+        body = adapter.to_provider_format(messages, model="claude-sonnet-4-5")
+        assert body["messages"][0]["content"] == [{"type": "text", "text": "hello"}]
+
+    def test_system_arg_becomes_top_level_system(self, adapter: AnthropicAdapter):
+        messages = [CoreMessage(role="user", content="hi")]
+        body = adapter.to_provider_format(
+            messages, model="claude-sonnet-4-5", system="You are helpful."
+        )
+        assert body["system"] == "You are helpful."
+
+    def test_system_role_messages_merged_into_top_level(self, adapter: AnthropicAdapter):
+        """CoreMessage(role="system", …) entries get hoisted into the
+        top-level system field, not the messages array."""
+        messages = [
+            CoreMessage(role="system", content="rule 1"),
+            CoreMessage(role="system", content="rule 2"),
+            CoreMessage(role="user", content="hi"),
+        ]
+        body = adapter.to_provider_format(messages, model="claude-sonnet-4-5")
+
+        # Both system messages merged with \n\n separator
+        assert body["system"] == "rule 1\n\nrule 2"
+        # Only the user message remains in messages array
+        assert len(body["messages"]) == 1
+        assert body["messages"][0]["role"] == "user"
+
+    def test_explicit_system_and_system_role_both_merge(self, adapter: AnthropicAdapter):
+        """system arg comes first, then any system-role message contents."""
+        messages = [
+            CoreMessage(role="system", content="from message"),
+            CoreMessage(role="user", content="hi"),
+        ]
+        body = adapter.to_provider_format(messages, model="claude-sonnet-4-5", system="from arg")
+        assert body["system"] == "from arg\n\nfrom message"
+
+    def test_max_tokens_passed_through(self, adapter: AnthropicAdapter):
+        messages = [CoreMessage(role="user", content="hi")]
+        body = adapter.to_provider_format(messages, model="claude-sonnet-4-5", max_tokens=500)
+        assert body["max_tokens"] == 500
+
+    def test_temperature_only_included_when_set(self, adapter: AnthropicAdapter):
+        messages = [CoreMessage(role="user", content="hi")]
+        body_default = adapter.to_provider_format(messages, model="claude-sonnet-4-5")
+        body_explicit = adapter.to_provider_format(
+            messages, model="claude-sonnet-4-5", temperature=0.7
+        )
+        assert "temperature" not in body_default
+        assert body_explicit["temperature"] == 0.7
+
+
+# ----------------------------------------------------------------------------
+# to_provider_format: content block translation
+# ----------------------------------------------------------------------------
+
+
+class TestContentBlockTranslation:
+    def test_tool_call_part_becomes_tool_use(self, adapter: AnthropicAdapter):
+        messages = [
+            CoreMessage(
+                role="user",
+                content=[TextPart(text="call bash")],
+            ),
+            CoreMessage(
+                role="assistant",
+                content=[
+                    ToolCallPart(
+                        tool_call_id="toolu_01",
+                        tool_name="Bash",
+                        input={"command": "ls"},
+                    )
+                ],
+            ),
+            CoreMessage(
+                role="user",
+                content=[
+                    ToolResultPart(
+                        tool_call_id="toolu_01",
+                        tool_name="Bash",
+                        output="a.txt\nb.txt",
+                    )
+                ],
+            ),
+        ]
+        body = adapter.to_provider_format(messages, model="claude-sonnet-4-5")
+
+        assistant_msg = body["messages"][1]
+        assert assistant_msg["role"] == "assistant"
+        assert assistant_msg["content"][0] == {
+            "type": "tool_use",
+            "id": "toolu_01",
+            "name": "Bash",
+            "input": {"command": "ls"},
+        }
+
+        user_result_msg = body["messages"][2]
+        assert user_result_msg["role"] == "user"
+        assert user_result_msg["content"][0] == {
+            "type": "tool_result",
+            "tool_use_id": "toolu_01",
+            "content": "a.txt\nb.txt",
+        }
+
+    def test_tool_result_with_dict_output_json_encoded(self, adapter: AnthropicAdapter):
+        messages = [
+            CoreMessage(
+                role="assistant",
+                content=[
+                    ToolCallPart(tool_call_id="t1", tool_name="search", input={"q": "pandas"})
+                ],
+            ),
+            CoreMessage(
+                role="user",
+                content=[
+                    ToolResultPart(
+                        tool_call_id="t1",
+                        tool_name="search",
+                        output={"rows": 5, "top": "panda"},
+                    )
+                ],
+            ),
+        ]
+        body = adapter.to_provider_format(messages, model="claude-sonnet-4-5")
+
+        result_block = body["messages"][1]["content"][0]
+        # dict output gets JSON-encoded as a string
+        import json as _json
+
+        assert _json.loads(result_block["content"]) == {"rows": 5, "top": "panda"}
+
+    def test_tool_result_is_error_propagated(self, adapter: AnthropicAdapter):
+        messages = [
+            CoreMessage(
+                role="assistant",
+                content=[ToolCallPart(tool_call_id="t1", tool_name="bash", input={"cmd": "x"})],
+            ),
+            CoreMessage(
+                role="user",
+                content=[
+                    ToolResultPart(
+                        tool_call_id="t1",
+                        tool_name="bash",
+                        output="cmd not found",
+                        is_error=True,
+                    )
+                ],
+            ),
+        ]
+        body = adapter.to_provider_format(messages, model="claude-sonnet-4-5")
+        assert body["messages"][1]["content"][0]["is_error"] is True
+
+    def test_reasoning_part_becomes_thinking_block(self, adapter: AnthropicAdapter):
+        messages = [
+            CoreMessage(role="user", content="solve"),
+            CoreMessage(
+                role="assistant",
+                content=[
+                    ReasoningPart(text="Let me think...", signature="sig-1"),
+                    TextPart(text="The answer is 42."),
+                ],
+            ),
+        ]
+        body = adapter.to_provider_format(messages, model="claude-sonnet-4-5")
+        assistant = body["messages"][1]
+        assert assistant["content"][0] == {
+            "type": "thinking",
+            "thinking": "Let me think...",
+            "signature": "sig-1",
+        }
+        assert assistant["content"][1] == {"type": "text", "text": "The answer is 42."}
+
+
+# ----------------------------------------------------------------------------
+# to_provider_format: tool definitions
+# ----------------------------------------------------------------------------
+
+
+class TestToolDefinitions:
+    def test_tools_list_serialized(self, adapter: AnthropicAdapter):
+        tools = [
+            ToolDefinition(
+                name="get_weather",
+                description="Get current weather",
+                input_schema={
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                    "required": ["location"],
+                },
+            )
+        ]
+        body = adapter.to_provider_format(
+            [CoreMessage(role="user", content="hi")],
+            model="claude-sonnet-4-5",
+            tools=tools,
+        )
+        assert body["tools"] == [
+            {
+                "name": "get_weather",
+                "description": "Get current weather",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                    "required": ["location"],
+                },
+            }
+        ]
+
+    def test_no_tools_no_tools_field(self, adapter: AnthropicAdapter):
+        body = adapter.to_provider_format(
+            [CoreMessage(role="user", content="hi")], model="claude-sonnet-4-5"
+        )
+        assert "tools" not in body
+
+
+# ----------------------------------------------------------------------------
+# Orphan repair pass
+# ----------------------------------------------------------------------------
+
+
+class TestOrphanRepair:
+    def test_valid_pair_kept(self, adapter: AnthropicAdapter):
+        messages = [
+            CoreMessage(role="user", content="call tool"),
+            CoreMessage(
+                role="assistant",
+                content=[ToolCallPart(tool_call_id="t1", tool_name="bash", input={"cmd": "ls"})],
+            ),
+            CoreMessage(
+                role="user",
+                content=[ToolResultPart(tool_call_id="t1", tool_name="bash", output="a.txt")],
+            ),
+        ]
+        body = adapter.to_provider_format(messages, model="claude-sonnet-4-5")
+        # All three messages survived
+        assert len(body["messages"]) == 3
+        # The tool_use and tool_result are both present
+        types = [block.get("type") for msg in body["messages"] for block in msg["content"]]
+        assert "tool_use" in types
+        assert "tool_result" in types
+
+    def test_orphan_tool_use_dropped(self, adapter: AnthropicAdapter):
+        """Assistant tool_use with no matching user tool_result is dropped."""
+        messages = [
+            CoreMessage(role="user", content="call tool"),
+            CoreMessage(
+                role="assistant",
+                content=[
+                    TextPart(text="Let me try..."),
+                    ToolCallPart(
+                        tool_call_id="orphan_1",
+                        tool_name="bash",
+                        input={"cmd": "ls"},
+                    ),
+                ],
+            ),
+            # No user tool_result follows
+        ]
+        body = adapter.to_provider_format(messages, model="claude-sonnet-4-5")
+
+        # Assistant message survives but only the text block
+        assistant = body["messages"][1]
+        assert len(assistant["content"]) == 1
+        assert assistant["content"][0]["type"] == "text"
+
+    def test_orphan_tool_result_dropped(self, adapter: AnthropicAdapter):
+        """User tool_result with no matching assistant tool_use is dropped."""
+        messages = [
+            CoreMessage(role="user", content="query"),
+            CoreMessage(
+                role="user",
+                content=[
+                    ToolResultPart(
+                        tool_call_id="orphan_result",
+                        tool_name="bash",
+                        output="data",
+                    )
+                ],
+            ),
+        ]
+        body = adapter.to_provider_format(messages, model="claude-sonnet-4-5")
+
+        # The orphan-only user message should be dropped entirely
+        # (it had no non-tool-result content)
+        roles = [m["role"] for m in body["messages"]]
+        # Only the first user message ("query") survives
+        assert len(body["messages"]) == 1
+        assert roles == ["user"]
+
+    def test_mixed_orphan_and_valid_pair(self, adapter: AnthropicAdapter):
+        messages = [
+            CoreMessage(
+                role="assistant",
+                content=[
+                    ToolCallPart(tool_call_id="valid", tool_name="bash", input={"cmd": "ls"}),
+                    ToolCallPart(tool_call_id="orphan", tool_name="bash", input={"cmd": "cat"}),
+                ],
+            ),
+            CoreMessage(
+                role="user",
+                content=[ToolResultPart(tool_call_id="valid", tool_name="bash", output="a.txt")],
+            ),
+        ]
+        body = adapter.to_provider_format(messages, model="claude-sonnet-4-5")
+
+        assistant = body["messages"][0]
+        # Only the valid tool_use survived
+        tool_uses = [b for b in assistant["content"] if b["type"] == "tool_use"]
+        assert len(tool_uses) == 1
+        assert tool_uses[0]["id"] == "valid"
+
+    def test_message_with_only_orphan_blocks_dropped_entirely(self, adapter: AnthropicAdapter):
+        messages = [
+            CoreMessage(role="user", content="hi"),
+            CoreMessage(
+                role="assistant",
+                content=[ToolCallPart(tool_call_id="orphan", tool_name="x", input={})],
+            ),
+        ]
+        body = adapter.to_provider_format(messages, model="claude-sonnet-4-5")
+
+        # Assistant message had ONLY the orphan → dropped entirely
+        roles = [m["role"] for m in body["messages"]]
+        assert roles == ["user"]
+
+
+# ----------------------------------------------------------------------------
+# from_provider_response: parsing
+# ----------------------------------------------------------------------------
+
+
+class TestFromProviderResponse:
+    def test_text_only_response(self, adapter: AnthropicAdapter):
+        data = {
+            "id": "msg_01",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Hello!"}],
+            "model": "claude-sonnet-4-5",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+        result = adapter.from_provider_response(data)
+
+        assert result.role == "assistant"
+        assert len(result.content) == 1
+        assert isinstance(result.content[0], TextPart)
+        assert result.content[0].text == "Hello!"
+
+    def test_response_preserves_metadata_in_provider_metadata(self, adapter: AnthropicAdapter):
+        data = {
+            "id": "msg_01",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Hi"}],
+            "model": "claude-sonnet-4-5",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 2},
+        }
+        result = adapter.from_provider_response(data)
+        assert result.provider_metadata is not None
+        assert result.provider_metadata["anthropic.id"] == "msg_01"
+        assert result.provider_metadata["anthropic.model"] == "claude-sonnet-4-5"
+        assert result.provider_metadata["anthropic.stop_reason"] == "end_turn"
+        assert result.provider_metadata["anthropic.usage"] == {
+            "input_tokens": 10,
+            "output_tokens": 2,
+        }
+
+    def test_tool_use_in_response(self, adapter: AnthropicAdapter):
+        data = {
+            "type": "message",
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Running command"},
+                {
+                    "type": "tool_use",
+                    "id": "toolu_01",
+                    "name": "Bash",
+                    "input": {"command": "ls"},
+                },
+            ],
+        }
+        result = adapter.from_provider_response(data)
+
+        assert len(result.content) == 2
+        assert isinstance(result.content[0], TextPart)
+        assert isinstance(result.content[1], ToolCallPart)
+        assert result.content[1].tool_call_id == "toolu_01"
+        assert result.content[1].tool_name == "Bash"
+        assert result.content[1].input == {"command": "ls"}
+
+    def test_thinking_block_in_response(self, adapter: AnthropicAdapter):
+        data = {
+            "type": "message",
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "thinking",
+                    "thinking": "Let me analyze...",
+                    "signature": "sig-abc",
+                },
+                {"type": "text", "text": "Answer"},
+            ],
+        }
+        result = adapter.from_provider_response(data)
+        assert isinstance(result.content[0], ReasoningPart)
+        assert result.content[0].text == "Let me analyze..."
+        assert result.content[0].signature == "sig-abc"
+
+    def test_unknown_block_type_dropped_silently(self, adapter: AnthropicAdapter):
+        data = {
+            "type": "message",
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "hi"},
+                {"type": "future_block", "data": "?"},
+            ],
+        }
+        result = adapter.from_provider_response(data)
+        assert len(result.content) == 1
+        assert isinstance(result.content[0], TextPart)
+
+
+class TestFromProviderResponseErrors:
+    def test_non_dict_raises(self, adapter: AnthropicAdapter):
+        with pytest.raises(AdapterError, match="not a dict"):
+            adapter.from_provider_response("not a dict")  # type: ignore[arg-type]
+
+    def test_wrong_type_field_raises(self, adapter: AnthropicAdapter):
+        with pytest.raises(AdapterError, match="expected 'message'"):
+            adapter.from_provider_response({"type": "error", "role": "assistant"})
+
+    def test_wrong_role_raises(self, adapter: AnthropicAdapter):
+        with pytest.raises(AdapterError, match="expected 'assistant'"):
+            adapter.from_provider_response({"type": "message", "role": "user", "content": []})
+
+    def test_non_list_content_raises(self, adapter: AnthropicAdapter):
+        with pytest.raises(AdapterError, match="not a list"):
+            adapter.from_provider_response(
+                {"type": "message", "role": "assistant", "content": "hi"}
+            )

--- a/apps/server/src/screamingface/plugins/claude_backend_api/tests/test_auth.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/tests/test_auth.py
@@ -1,0 +1,399 @@
+"""Unit tests for claude-backend-api ClaudeCodeOAuth.
+
+All tests mock the credential store and the httpx client so they run
+in milliseconds and are fully hermetic. No real Keychain reads, no
+real network calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from screamingface.plugins.claude_backend_api.auth import (
+    ANTHROPIC_BETA,
+    ANTHROPIC_VERSION,
+    KEYCHAIN_SERVICE,
+    OAUTH_CLIENT_ID,
+    OAUTH_REFRESH_URL,
+    REFRESH_WINDOW_SECONDS,
+    ClaudeCodeOAuth,
+)
+from screamingface.plugins.llm_base.credential_store import CredentialStore
+from screamingface.plugins.llm_base.errors import AuthError, CredentialNotFoundError
+
+# ----------------------------------------------------------------------------
+# Fixtures and helpers
+# ----------------------------------------------------------------------------
+
+
+class FakeCredentialStore(CredentialStore):
+    """In-memory credential store fake for tests."""
+
+    def __init__(self, initial: dict[tuple[str, str], str] | None = None) -> None:
+        self._store = dict(initial or {})
+        self.read_calls: list[tuple[str, str]] = []
+        self.write_calls: list[tuple[str, str, str]] = []
+
+    def read(self, service: str, account: str) -> str | None:
+        self.read_calls.append((service, account))
+        return self._store.get((service, account))
+
+    def write(self, service: str, account: str, value: str) -> None:
+        self.write_calls.append((service, account, value))
+        self._store[(service, account)] = value
+
+
+def _fresh_creds(seconds_from_now: float = 3600) -> dict:
+    """Build a valid in-keychain credential with a chosen expiry offset."""
+    return {
+        "accessToken": "sk-ant-oat01-CURRENT_ACCESS",
+        "refreshToken": "sk-ant-ort01-CURRENT_REFRESH",
+        "expiresAt": int((time.time() + seconds_from_now) * 1000),
+        "scopes": ["user:inference", "user:profile"],
+        "subscriptionType": "max",
+        "rateLimitTier": "default_claude_max_5x",
+    }
+
+
+def _keychain_value(creds: dict) -> str:
+    """Wrap a credential dict in the claudeAiOauth envelope and JSON-encode."""
+    return json.dumps({"claudeAiOauth": creds})
+
+
+def _refresh_response_body(expires_in: int = 28800) -> dict:
+    """Build a successful OAuth refresh response body (OAuth 2.0 shape)."""
+    return {
+        "access_token": "sk-ant-oat01-NEW_ACCESS",
+        "refresh_token": "sk-ant-ort01-NEW_REFRESH",
+        "expires_in": expires_in,
+        "token_type": "Bearer",
+        "scope": "user:inference user:profile user:mcp_servers",
+    }
+
+
+def _mock_httpx_client(response: httpx.Response) -> tuple[MagicMock, AsyncMock]:
+    """Build a (factory, fake_client) pair for injecting into ClaudeCodeOAuth.
+
+    The factory, when called, returns an async context manager that yields
+    a fake AsyncClient whose ``.post()`` returns *response*. Returns both
+    so tests can assert on the fake_client's call args.
+    """
+    fake_client = AsyncMock()
+    fake_client.post.return_value = response
+
+    factory = MagicMock()
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=fake_client)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    factory.return_value = cm
+    return factory, fake_client
+
+
+# ----------------------------------------------------------------------------
+# Tests
+# ----------------------------------------------------------------------------
+
+
+class TestConstants:
+    """Sanity-check the constants match the values the SF-77 spike validated."""
+
+    def test_keychain_service_name(self):
+        assert KEYCHAIN_SERVICE == "Claude Code-credentials"
+
+    def test_refresh_url(self):
+        assert OAUTH_REFRESH_URL == "https://console.anthropic.com/v1/oauth/token"
+
+    def test_client_id(self):
+        assert OAUTH_CLIENT_ID == "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+
+    def test_anthropic_version(self):
+        assert ANTHROPIC_VERSION == "2023-06-01"
+
+    def test_anthropic_beta_header_present(self):
+        # Critical: without this header the OAuth scope check rejects
+        # even valid tokens. Verified by the SF-77 spike.
+        assert ANTHROPIC_BETA == "oauth-2025-04-20"
+
+    def test_refresh_window(self):
+        assert REFRESH_WINDOW_SECONDS == 60
+
+
+class TestReadFromStore:
+    @pytest.mark.anyio
+    async def test_first_call_reads_credential_store(self):
+        creds = _fresh_creds()
+        store = FakeCredentialStore({(KEYCHAIN_SERVICE, "me"): _keychain_value(creds)})
+        auth = ClaudeCodeOAuth(credential_store=store, account="me")
+
+        headers = await auth.get_authorization_header()
+
+        assert store.read_calls == [(KEYCHAIN_SERVICE, "me")]
+        assert headers["Authorization"] == "Bearer sk-ant-oat01-CURRENT_ACCESS"
+        assert headers["anthropic-version"] == ANTHROPIC_VERSION
+        assert headers["anthropic-beta"] == ANTHROPIC_BETA
+
+    @pytest.mark.anyio
+    async def test_second_call_uses_cache(self):
+        creds = _fresh_creds()
+        store = FakeCredentialStore({(KEYCHAIN_SERVICE, "me"): _keychain_value(creds)})
+        auth = ClaudeCodeOAuth(credential_store=store, account="me")
+
+        await auth.get_authorization_header()
+        await auth.get_authorization_header()
+
+        # Only one read — second call hit the cache
+        assert len(store.read_calls) == 1
+
+    @pytest.mark.anyio
+    async def test_missing_credential_raises_credential_not_found_error(self):
+        store = FakeCredentialStore({})  # no entry
+        auth = ClaudeCodeOAuth(credential_store=store, account="me")
+
+        with pytest.raises(CredentialNotFoundError, match="claude auth login"):
+            await auth.get_authorization_header()
+
+    @pytest.mark.anyio
+    async def test_invalid_json_raises_auth_error(self):
+        store = FakeCredentialStore({(KEYCHAIN_SERVICE, "me"): "not json"})
+        auth = ClaudeCodeOAuth(credential_store=store, account="me")
+
+        with pytest.raises(AuthError, match="not valid JSON"):
+            await auth.get_authorization_header()
+
+    @pytest.mark.anyio
+    async def test_missing_claudeAiOauth_key_raises_auth_error(self):
+        store = FakeCredentialStore({(KEYCHAIN_SERVICE, "me"): json.dumps({"wrongKey": {}})})
+        auth = ClaudeCodeOAuth(credential_store=store, account="me")
+
+        with pytest.raises(AuthError, match="claudeAiOauth"):
+            await auth.get_authorization_header()
+
+    @pytest.mark.anyio
+    async def test_missing_required_fields_raises_auth_error(self):
+        partial = {"accessToken": "x"}  # missing refreshToken + expiresAt
+        store = FakeCredentialStore(
+            {(KEYCHAIN_SERVICE, "me"): json.dumps({"claudeAiOauth": partial})}
+        )
+        auth = ClaudeCodeOAuth(credential_store=store, account="me")
+
+        with pytest.raises(AuthError, match="missing required keys"):
+            await auth.get_authorization_header()
+
+
+class TestExpiryDetection:
+    def _make(self, seconds_from_now: float) -> ClaudeCodeOAuth:
+        store = FakeCredentialStore(
+            {(KEYCHAIN_SERVICE, "me"): _keychain_value(_fresh_creds(seconds_from_now))}
+        )
+        return ClaudeCodeOAuth(credential_store=store, account="me")
+
+    def test_fresh_token_not_expired(self):
+        auth = self._make(seconds_from_now=3600)
+        creds = _fresh_creds(3600)
+        assert auth._is_expired(creds) is False
+
+    def test_token_outside_refresh_window_not_expired(self):
+        auth = self._make(seconds_from_now=120)
+        creds = _fresh_creds(120)
+        assert auth._is_expired(creds) is False
+
+    def test_token_inside_refresh_window_expired(self):
+        auth = self._make(seconds_from_now=30)
+        creds = _fresh_creds(30)
+        # 30s remaining is less than 60s refresh window → counted as expired
+        assert auth._is_expired(creds) is True
+
+    def test_already_expired_token_expired(self):
+        auth = self._make(seconds_from_now=-100)
+        creds = _fresh_creds(-100)
+        assert auth._is_expired(creds) is True
+
+
+class TestRefresh:
+    @pytest.mark.anyio
+    async def test_expired_token_triggers_refresh(self):
+        store = FakeCredentialStore(
+            {(KEYCHAIN_SERVICE, "me"): _keychain_value(_fresh_creds(seconds_from_now=-100))}
+        )
+        refresh_resp = httpx.Response(200, json=_refresh_response_body())
+        factory, fake_client = _mock_httpx_client(refresh_resp)
+        auth = ClaudeCodeOAuth(credential_store=store, account="me", http_client_factory=factory)
+
+        headers = await auth.get_authorization_header()
+
+        # Refresh called
+        fake_client.post.assert_called_once()
+        args, kwargs = fake_client.post.call_args
+        assert args[0] == OAUTH_REFRESH_URL
+        assert kwargs["json"]["grant_type"] == "refresh_token"
+        assert kwargs["json"]["client_id"] == OAUTH_CLIENT_ID
+        assert kwargs["json"]["refresh_token"] == "sk-ant-ort01-CURRENT_REFRESH"
+
+        # Headers use the new token
+        assert headers["Authorization"] == "Bearer sk-ant-oat01-NEW_ACCESS"
+
+    @pytest.mark.anyio
+    async def test_refresh_writes_back_to_credential_store(self):
+        store = FakeCredentialStore(
+            {(KEYCHAIN_SERVICE, "me"): _keychain_value(_fresh_creds(seconds_from_now=-100))}
+        )
+        refresh_resp = httpx.Response(200, json=_refresh_response_body())
+        factory, _ = _mock_httpx_client(refresh_resp)
+        auth = ClaudeCodeOAuth(credential_store=store, account="me", http_client_factory=factory)
+
+        await auth.get_authorization_header()
+
+        # Store was written with the new token
+        assert len(store.write_calls) == 1
+        _svc, _acct, value = store.write_calls[0]
+        parsed = json.loads(value)
+        assert parsed["claudeAiOauth"]["accessToken"] == "sk-ant-oat01-NEW_ACCESS"
+        assert parsed["claudeAiOauth"]["refreshToken"] == "sk-ant-ort01-NEW_REFRESH"
+
+    @pytest.mark.anyio
+    async def test_refresh_response_field_conversion(self):
+        """expires_in (seconds) → expiresAt (ms), scope string → scopes list."""
+        store = FakeCredentialStore(
+            {(KEYCHAIN_SERVICE, "me"): _keychain_value(_fresh_creds(seconds_from_now=-100))}
+        )
+        refresh_resp = httpx.Response(200, json=_refresh_response_body(expires_in=7200))
+        factory, _ = _mock_httpx_client(refresh_resp)
+        auth = ClaudeCodeOAuth(credential_store=store, account="me", http_client_factory=factory)
+
+        await auth.get_authorization_header()
+
+        # Check what ended up in the store
+        value = store.write_calls[0][2]
+        parsed = json.loads(value)["claudeAiOauth"]
+
+        # expires_in=7200 seconds → expiresAt in ms, roughly 7200_000 ms from now
+        now_ms = time.time() * 1000
+        assert parsed["expiresAt"] >= now_ms + 7100_000  # ≥ 7100s from now
+        assert parsed["expiresAt"] <= now_ms + 7300_000  # ≤ 7300s from now
+
+        # scope "user:inference user:profile user:mcp_servers" → list
+        assert parsed["scopes"] == [
+            "user:inference",
+            "user:profile",
+            "user:mcp_servers",
+        ]
+
+    @pytest.mark.anyio
+    async def test_refresh_preserves_subscription_metadata(self):
+        """subscriptionType / rateLimitTier are NOT in the refresh response
+        and must be preserved from the old credential."""
+        initial = _fresh_creds(seconds_from_now=-100)
+        initial["subscriptionType"] = "max"
+        initial["rateLimitTier"] = "default_claude_max_5x"
+        store = FakeCredentialStore({(KEYCHAIN_SERVICE, "me"): _keychain_value(initial)})
+        refresh_resp = httpx.Response(200, json=_refresh_response_body())
+        factory, _ = _mock_httpx_client(refresh_resp)
+        auth = ClaudeCodeOAuth(credential_store=store, account="me", http_client_factory=factory)
+
+        await auth.get_authorization_header()
+
+        parsed = json.loads(store.write_calls[0][2])["claudeAiOauth"]
+        assert parsed["subscriptionType"] == "max"
+        assert parsed["rateLimitTier"] == "default_claude_max_5x"
+
+    @pytest.mark.anyio
+    async def test_refresh_401_raises_auth_error(self):
+        store = FakeCredentialStore(
+            {(KEYCHAIN_SERVICE, "me"): _keychain_value(_fresh_creds(seconds_from_now=-100))}
+        )
+        factory, _ = _mock_httpx_client(httpx.Response(401, json={"error": "invalid_grant"}))
+        auth = ClaudeCodeOAuth(credential_store=store, account="me", http_client_factory=factory)
+
+        with pytest.raises(AuthError, match="claude auth login"):
+            await auth.get_authorization_header()
+
+    @pytest.mark.anyio
+    async def test_refresh_5xx_raises_auth_error(self):
+        store = FakeCredentialStore(
+            {(KEYCHAIN_SERVICE, "me"): _keychain_value(_fresh_creds(seconds_from_now=-100))}
+        )
+        factory, _ = _mock_httpx_client(httpx.Response(500, text="internal server error"))
+        auth = ClaudeCodeOAuth(credential_store=store, account="me", http_client_factory=factory)
+
+        with pytest.raises(AuthError, match="500"):
+            await auth.get_authorization_header()
+
+    @pytest.mark.anyio
+    async def test_refresh_network_error_raises_auth_error(self):
+        store = FakeCredentialStore(
+            {(KEYCHAIN_SERVICE, "me"): _keychain_value(_fresh_creds(seconds_from_now=-100))}
+        )
+
+        def factory():
+            cm = MagicMock()
+            fake_client = AsyncMock()
+            fake_client.post.side_effect = httpx.ConnectError("no network")
+            cm.__aenter__ = AsyncMock(return_value=fake_client)
+            cm.__aexit__ = AsyncMock(return_value=None)
+            return cm
+
+        auth = ClaudeCodeOAuth(credential_store=store, account="me", http_client_factory=factory)
+
+        with pytest.raises(AuthError, match="unreachable"):
+            await auth.get_authorization_header()
+
+    @pytest.mark.anyio
+    async def test_refresh_response_missing_access_token_raises(self):
+        store = FakeCredentialStore(
+            {(KEYCHAIN_SERVICE, "me"): _keychain_value(_fresh_creds(seconds_from_now=-100))}
+        )
+        bad_body = {"refresh_token": "x", "expires_in": 3600}  # missing access_token
+        factory, _ = _mock_httpx_client(httpx.Response(200, json=bad_body))
+        auth = ClaudeCodeOAuth(credential_store=store, account="me", http_client_factory=factory)
+
+        with pytest.raises(AuthError, match="access_token"):
+            await auth.get_authorization_header()
+
+
+class TestConcurrency:
+    @pytest.mark.anyio
+    async def test_concurrent_calls_serialize_refresh(self):
+        """Two coroutines hit expired token at once; only one refresh fires;
+        both see the new token."""
+        store = FakeCredentialStore(
+            {(KEYCHAIN_SERVICE, "me"): _keychain_value(_fresh_creds(seconds_from_now=-100))}
+        )
+        refresh_resp = httpx.Response(200, json=_refresh_response_body())
+        factory, fake_client = _mock_httpx_client(refresh_resp)
+        auth = ClaudeCodeOAuth(credential_store=store, account="me", http_client_factory=factory)
+
+        # Fire two concurrent get_authorization_header calls
+        headers_a, headers_b = await asyncio.gather(
+            auth.get_authorization_header(),
+            auth.get_authorization_header(),
+        )
+
+        # Only one refresh call actually went through
+        assert fake_client.post.call_count == 1
+
+        # Both callers got the new token
+        assert headers_a["Authorization"] == "Bearer sk-ant-oat01-NEW_ACCESS"
+        assert headers_b["Authorization"] == "Bearer sk-ant-oat01-NEW_ACCESS"
+
+
+class TestInvalidateCache:
+    @pytest.mark.anyio
+    async def test_invalidate_forces_re_read(self):
+        creds = _fresh_creds(seconds_from_now=3600)
+        store = FakeCredentialStore({(KEYCHAIN_SERVICE, "me"): _keychain_value(creds)})
+        auth = ClaudeCodeOAuth(credential_store=store, account="me")
+
+        await auth.get_authorization_header()
+        assert len(store.read_calls) == 1
+
+        auth.invalidate_cache()
+        await auth.get_authorization_header()
+
+        # Cache invalidation forced another read
+        assert len(store.read_calls) == 2

--- a/apps/server/src/screamingface/plugins/claude_backend_api/tests/test_backend.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/tests/test_backend.py
@@ -1,0 +1,251 @@
+"""Unit tests for claude-backend-api AnthropicBackend.
+
+Mocks the auth strategy and httpx so every test is hermetic.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from screamingface.plugins.claude_backend_api.adapter import AnthropicAdapter
+from screamingface.plugins.claude_backend_api.backend import (
+    ANTHROPIC_MESSAGES_URL,
+    AnthropicBackend,
+)
+from screamingface.plugins.llm_base.errors import AuthError, BackendError
+from screamingface.plugins.llm_base.messages import CoreMessage, TextPart
+
+
+def _mock_auth(headers: dict[str, str]) -> MagicMock:
+    """Build a fake AuthStrategy that returns the given headers."""
+    auth = MagicMock()
+    auth.get_authorization_header = AsyncMock(return_value=headers)
+    auth.invalidate_cache = MagicMock()
+    return auth
+
+
+def _mock_factory(response: httpx.Response) -> tuple[MagicMock, AsyncMock]:
+    """Build a (factory, fake_client) pair. Same shape as test_auth."""
+    fake_client = AsyncMock()
+    fake_client.post.return_value = response
+
+    factory = MagicMock()
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=fake_client)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    factory.return_value = cm
+    return factory, fake_client
+
+
+def _success_response() -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "id": "msg_test",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "pong"}],
+            "model": "claude-sonnet-4-5",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 5, "output_tokens": 1},
+        },
+    )
+
+
+@pytest.mark.anyio
+class TestRunSuccessPath:
+    async def test_success_returns_core_message(self):
+        auth = _mock_auth(
+            {
+                "Authorization": "Bearer sk-test",
+                "anthropic-version": "2023-06-01",
+                "anthropic-beta": "oauth-2025-04-20",
+            }
+        )
+        factory, _ = _mock_factory(_success_response())
+        backend = AnthropicBackend(
+            auth=auth, adapter=AnthropicAdapter(), http_client_factory=factory
+        )
+
+        result = await backend.run(
+            [CoreMessage(role="user", content="ping")],
+            model="claude-sonnet-4-5",
+        )
+
+        assert isinstance(result, CoreMessage)
+        assert result.role == "assistant"
+        assert isinstance(result.content[0], TextPart)
+        assert result.content[0].text == "pong"
+
+    async def test_posts_to_correct_url(self):
+        auth = _mock_auth({"Authorization": "Bearer sk-test"})
+        factory, fake_client = _mock_factory(_success_response())
+        backend = AnthropicBackend(auth=auth, http_client_factory=factory)
+
+        await backend.run([CoreMessage(role="user", content="ping")], model="claude-sonnet-4-5")
+
+        fake_client.post.assert_called_once()
+        args, kwargs = fake_client.post.call_args
+        assert args[0] == ANTHROPIC_MESSAGES_URL
+
+    async def test_includes_auth_headers(self):
+        auth = _mock_auth(
+            {
+                "Authorization": "Bearer sk-test",
+                "anthropic-version": "2023-06-01",
+                "anthropic-beta": "oauth-2025-04-20",
+            }
+        )
+        factory, fake_client = _mock_factory(_success_response())
+        backend = AnthropicBackend(auth=auth, http_client_factory=factory)
+
+        await backend.run([CoreMessage(role="user", content="ping")], model="claude-sonnet-4-5")
+
+        args, kwargs = fake_client.post.call_args
+        headers = kwargs["headers"]
+        assert headers["Authorization"] == "Bearer sk-test"
+        assert headers["anthropic-version"] == "2023-06-01"
+        assert headers["anthropic-beta"] == "oauth-2025-04-20"
+        assert headers["content-type"] == "application/json"
+
+    async def test_passes_model_and_system_to_body(self):
+        auth = _mock_auth({"Authorization": "Bearer sk-test"})
+        factory, fake_client = _mock_factory(_success_response())
+        backend = AnthropicBackend(auth=auth, http_client_factory=factory)
+
+        await backend.run(
+            [CoreMessage(role="user", content="hi")],
+            model="claude-opus-4",
+            system="You are helpful.",
+        )
+
+        args, kwargs = fake_client.post.call_args
+        body = kwargs["json"]
+        assert body["model"] == "claude-opus-4"
+        assert body["system"] == "You are helpful."
+
+
+@pytest.mark.anyio
+class TestRunErrorPaths:
+    async def test_429_raises_backend_error_with_retry_after(self):
+        auth = _mock_auth({"Authorization": "Bearer sk-test"})
+        factory, _ = _mock_factory(
+            httpx.Response(
+                429,
+                json={"type": "error", "error": {"type": "rate_limit_error"}},
+                headers={"retry-after": "60"},
+            )
+        )
+        backend = AnthropicBackend(auth=auth, http_client_factory=factory)
+
+        with pytest.raises(BackendError, match="rate limit") as exc_info:
+            await backend.run(
+                [CoreMessage(role="user", content="ping")],
+                model="claude-sonnet-4-5",
+            )
+
+        assert exc_info.value.status == 429
+        assert exc_info.value.retry_after == 60.0
+
+    async def test_403_raises_auth_error(self):
+        auth = _mock_auth({"Authorization": "Bearer sk-test"})
+        factory, _ = _mock_factory(httpx.Response(403, json={"error": "forbidden"}))
+        backend = AnthropicBackend(auth=auth, http_client_factory=factory)
+
+        with pytest.raises(AuthError, match="403"):
+            await backend.run(
+                [CoreMessage(role="user", content="ping")],
+                model="claude-sonnet-4-5",
+            )
+
+    async def test_500_raises_backend_error(self):
+        auth = _mock_auth({"Authorization": "Bearer sk-test"})
+        factory, _ = _mock_factory(httpx.Response(500, text="internal server error"))
+        backend = AnthropicBackend(auth=auth, http_client_factory=factory)
+
+        with pytest.raises(BackendError) as exc_info:
+            await backend.run(
+                [CoreMessage(role="user", content="ping")],
+                model="claude-sonnet-4-5",
+            )
+        assert exc_info.value.status == 500
+
+    async def test_timeout_raises_backend_error(self):
+        auth = _mock_auth({"Authorization": "Bearer sk-test"})
+
+        def factory():
+            cm = MagicMock()
+            fake_client = AsyncMock()
+            fake_client.post.side_effect = httpx.ReadTimeout("too slow")
+            cm.__aenter__ = AsyncMock(return_value=fake_client)
+            cm.__aexit__ = AsyncMock(return_value=None)
+            return cm
+
+        backend = AnthropicBackend(auth=auth, http_client_factory=factory)
+
+        with pytest.raises(BackendError, match="timed out"):
+            await backend.run(
+                [CoreMessage(role="user", content="ping")],
+                model="claude-sonnet-4-5",
+            )
+
+
+@pytest.mark.anyio
+class TestRun401Recovery:
+    async def test_single_401_recovered_by_retry(self):
+        """First POST returns 401; backend invalidates cache, retries,
+        second POST returns 200. Caller sees success."""
+        auth = _mock_auth({"Authorization": "Bearer sk-test"})
+
+        # httpx.Response objects, in order returned by the mock
+        responses = [
+            httpx.Response(401, json={"error": "expired"}),
+            _success_response(),
+        ]
+        call_count = {"n": 0}
+
+        def factory():
+            cm = MagicMock()
+            fake_client = AsyncMock()
+
+            async def post(*args, **kwargs):
+                resp = responses[call_count["n"]]
+                call_count["n"] += 1
+                return resp
+
+            fake_client.post.side_effect = post
+            cm.__aenter__ = AsyncMock(return_value=fake_client)
+            cm.__aexit__ = AsyncMock(return_value=None)
+            return cm
+
+        backend = AnthropicBackend(auth=auth, http_client_factory=factory)
+        result = await backend.run(
+            [CoreMessage(role="user", content="ping")], model="claude-sonnet-4-5"
+        )
+
+        assert call_count["n"] == 2
+        auth.invalidate_cache.assert_called_once()
+        assert result.content[0].text == "pong"
+
+    async def test_double_401_raises_auth_error(self):
+        """Two consecutive 401s mean the credential is actually bad."""
+        auth = _mock_auth({"Authorization": "Bearer sk-test"})
+
+        def factory():
+            cm = MagicMock()
+            fake_client = AsyncMock()
+            fake_client.post.return_value = httpx.Response(401, json={"error": "still expired"})
+            cm.__aenter__ = AsyncMock(return_value=fake_client)
+            cm.__aexit__ = AsyncMock(return_value=None)
+            return cm
+
+        backend = AnthropicBackend(auth=auth, http_client_factory=factory)
+
+        with pytest.raises(AuthError, match="twice in a row"):
+            await backend.run(
+                [CoreMessage(role="user", content="ping")],
+                model="claude-sonnet-4-5",
+            )

--- a/apps/server/src/screamingface/plugins/claude_backend_api/tests/test_plugin_conflicts.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/tests/test_plugin_conflicts.py
@@ -1,0 +1,91 @@
+"""Tests that the claude-backend-api plugin declares its dependency and
+conflict relationships correctly.
+
+These are pure class-attribute checks — they run without starting any
+server, touching any routes, or importing the FastAPI layer. Their
+purpose is to catch accidental changes to the plugin's static metadata
+(depends, conflicts, name) that would silently break operator
+expectations.
+
+Actual enforcement of ``conflicts`` happens in the SF plugin loader
+(``screamingface.core.registry``). That logic is tested by the loader's
+own tests; here we just confirm we declared the right strings.
+"""
+
+from __future__ import annotations
+
+from screamingface.plugins.claude_backend_api.plugin import (
+    ClaudeBackendApiPlugin,
+    ClaudeBackendApiSettings,
+)
+
+
+class TestPluginMetadata:
+    def test_name_is_canonical(self):
+        assert ClaudeBackendApiPlugin.name == "claude-backend-api"
+
+    def test_depends_on_llm_base(self):
+        assert "llm-base" in ClaudeBackendApiPlugin.depends
+
+    def test_conflicts_with_claude_backend(self):
+        assert "claude-backend" in ClaudeBackendApiPlugin.conflicts
+
+    def test_settings_class_set(self):
+        assert ClaudeBackendApiPlugin.settings_class is ClaudeBackendApiSettings
+
+
+class TestSettings:
+    def test_default_settings_load_cleanly(self):
+        s = ClaudeBackendApiSettings()
+        assert s.default_effort == "medium"
+        assert s.timeout_seconds == 300.0
+        assert s.profiles == {}
+        # Default interpreter_system_prompt is non-empty
+        assert s.interpreter_system_prompt
+
+    def test_profile_name_validator_accepts_valid_names(self):
+        from screamingface.plugins.claude_backend_api.models import ClaudeProfile
+
+        s = ClaudeBackendApiSettings(
+            profiles={
+                "default": ClaudeProfile(),
+                "code-review": ClaudeProfile(),
+                "reviewer_1": ClaudeProfile(),
+            }
+        )
+        assert set(s.profiles.keys()) == {"default", "code-review", "reviewer_1"}
+
+    def test_profile_name_validator_rejects_invalid_names(self):
+        import pytest
+
+        from screamingface.plugins.claude_backend_api.models import ClaudeProfile
+
+        # Capitalized
+        with pytest.raises(ValueError, match="Invalid profile name"):
+            ClaudeBackendApiSettings(profiles={"Default": ClaudeProfile()})
+
+        # Leading dash
+        with pytest.raises(ValueError, match="Invalid profile name"):
+            ClaudeBackendApiSettings(profiles={"-bad": ClaudeProfile()})
+
+        # Contains period
+        with pytest.raises(ValueError, match="Invalid profile name"):
+            ClaudeBackendApiSettings(profiles={"a.b": ClaudeProfile()})
+
+
+class TestEnvPrefixIndependence:
+    """Ensure the env prefix is different from claude-backend so the two
+    plugins can be configured independently even if both are defined
+    (only one will be active, per the conflicts declaration)."""
+
+    def test_env_prefix_differs_from_claude_backend(self):
+        # Rebuild the settings class's config to read the prefix
+        config = ClaudeBackendApiSettings.model_config
+        assert config.get("env_prefix") == "SF_CLAUDE_BACKEND_API__"
+
+    def test_env_prefix_does_not_collide_with_claude_backend(self):
+        from screamingface.plugins.claude_backend.plugin import ClaudeBackendSettings
+
+        assert ClaudeBackendApiSettings.model_config.get(
+            "env_prefix"
+        ) != ClaudeBackendSettings.model_config.get("env_prefix")

--- a/apps/server/src/screamingface/plugins/llm_base/__init__.py
+++ b/apps/server/src/screamingface/plugins/llm_base/__init__.py
@@ -1,0 +1,91 @@
+"""llm-base plugin — shared ABCs and types for multi-backend LLM providers.
+
+This plugin registers no routes, no hooks, and no settings. Its only
+purpose is to exist in the SF plugin registry (so other plugins can
+declare ``depends = ["llm-base"]``) and to expose a stable Python import
+surface that every concrete provider plugin builds on.
+
+Public API
+----------
+
+Types:
+  - :class:`CoreMessage` — provider-agnostic message shape (Vercel AI SDK
+    inspired). Each message has a role and a content list of typed parts.
+  - :class:`TextPart`, :class:`ImagePart`, :class:`ToolCallPart`,
+    :class:`ToolResultPart`, :class:`ReasoningPart` — content block types.
+  - :class:`ToolDefinition` — minimal tool-use schema.
+
+ABCs:
+  - :class:`CredentialStore` — cross-platform secret storage
+    (macOS Keychain / Linux libsecret / Windows Credential Manager).
+  - :class:`AuthStrategy` — how to build the ``Authorization`` header
+    for an outbound provider call. Concrete subclasses live in each
+    provider plugin (e.g. ``ClaudeCodeOAuth`` in claude_backend_api).
+  - :class:`Adapter` — converts CoreMessage lists to/from a specific
+    provider's wire format (Gang-of-Four Adapter pattern).
+  - :class:`Backend` — the runtime for a provider. Combines auth +
+    adapter + httpx client.
+
+Errors:
+  All errors inherit from :class:`LlmBaseError`.
+
+Concrete helpers:
+  :func:`get_credential_store` returns the platform-appropriate concrete
+  :class:`CredentialStore` implementation.
+"""
+
+from __future__ import annotations
+
+from screamingface.plugins.llm_base.adapter_base import Adapter
+from screamingface.plugins.llm_base.auth_base import AuthStrategy
+from screamingface.plugins.llm_base.backend_base import Backend
+from screamingface.plugins.llm_base.credential_store import (
+    CredentialStore,
+    LinuxLibsecretStore,
+    MacOSKeychainStore,
+    WindowsCredentialManagerStore,
+    get_credential_store,
+)
+from screamingface.plugins.llm_base.errors import (
+    AdapterError,
+    AuthError,
+    BackendError,
+    CredentialNotFoundError,
+    LlmBaseError,
+)
+from screamingface.plugins.llm_base.messages import (
+    CoreMessage,
+    ImagePart,
+    ReasoningPart,
+    TextPart,
+    ToolCallPart,
+    ToolDefinition,
+    ToolResultPart,
+)
+
+__all__ = [
+    # ABCs
+    "AuthStrategy",
+    "Backend",
+    "CredentialStore",
+    "Adapter",
+    # Concrete credential stores
+    "LinuxLibsecretStore",
+    "MacOSKeychainStore",
+    "WindowsCredentialManagerStore",
+    "get_credential_store",
+    # Messages
+    "CoreMessage",
+    "TextPart",
+    "ImagePart",
+    "ToolCallPart",
+    "ToolResultPart",
+    "ReasoningPart",
+    "ToolDefinition",
+    # Errors
+    "LlmBaseError",
+    "AuthError",
+    "BackendError",
+    "CredentialNotFoundError",
+    "AdapterError",
+]

--- a/apps/server/src/screamingface/plugins/llm_base/adapter_base.py
+++ b/apps/server/src/screamingface/plugins/llm_base/adapter_base.py
@@ -1,0 +1,67 @@
+"""Adapter ABC — converts CoreMessage lists to/from a specific provider's wire format.
+
+An :class:`Adapter` is the shape-conversion layer between our neutral
+:class:`CoreMessage` list and a specific provider's expected request /
+response bodies. This is the classic Gang-of-Four Adapter pattern: "one
+interface, many wire shapes behind it."
+
+Each provider plugin implements one concrete :class:`Adapter` subclass
+that knows how to serialize a :class:`CoreMessage` list into that
+provider's request body and how to parse the provider's response back
+into a :class:`CoreMessage`.
+
+Adapters should be **stateless** — just a shape transformation, no
+cache, no state. :class:`Backend` instances hold the auth strategy and
+httpx client; adapters hold nothing.
+
+See the plan's Phase 2 section for the hand-rolled-vs-dependency
+decision. Phase 1 uses exactly one concrete adapter
+(``AnthropicAdapter`` in ``claude_backend_api``).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from screamingface.plugins.llm_base.messages import CoreMessage, ToolDefinition
+
+
+class Adapter(ABC):
+    """Abstract contract for provider wire-format adapters."""
+
+    @abstractmethod
+    def to_provider_format(
+        self,
+        messages: list[CoreMessage],
+        *,
+        model: str,
+        system: str | None = None,
+        tools: list[ToolDefinition] | None = None,
+        max_tokens: int = 16000,
+        temperature: float | None = None,
+    ) -> dict[str, Any]:
+        """Build the provider-specific request body.
+
+        The returned dict is passed directly to httpx as the JSON body
+        of the outbound POST. It must conform to the target provider's
+        Messages/Chat API schema.
+
+        Raises:
+            AdapterError: The input contains a construct the target
+                provider cannot represent (e.g. an orphaned tool_use
+                with no matching tool_result that would produce a
+                schema-invalid Anthropic request body).
+        """
+
+    @abstractmethod
+    def from_provider_response(self, data: dict[str, Any]) -> CoreMessage:
+        """Parse the provider's HTTP response body into a CoreMessage.
+
+        The response is always assumed to be a successful 200 OK body —
+        error handling happens before this is called.
+
+        Raises:
+            AdapterError: The response shape is unexpected (missing
+                required fields, unknown block types, etc.).
+        """

--- a/apps/server/src/screamingface/plugins/llm_base/auth_base.py
+++ b/apps/server/src/screamingface/plugins/llm_base/auth_base.py
@@ -1,0 +1,67 @@
+"""AuthStrategy ABC — how to build the Authorization header for a provider call.
+
+Each provider plugin implements one or more concrete
+:class:`AuthStrategy` subclasses. For example, ``claude_backend_api``
+will provide:
+
+- ``ClaudeCodeOAuth`` — reads the OAuth token Claude Code stores in the
+  platform credential store, refreshes it proactively, and returns a
+  ``Bearer`` header.
+- (future) ``AnthropicApiKeyAuth`` — reads an API key from settings or
+  env var and returns an ``x-api-key`` header. Alternate flow for users
+  who don't want a CLI dependency.
+
+The ABC exposes two async methods: :meth:`get_authorization_header`
+(called on every outbound request) and :meth:`refresh` (called when an
+access token expires).
+
+Concurrency note: implementations that cache tokens MUST protect the
+refresh path with an ``asyncio.Lock`` so two concurrent coroutines
+don't both fire a refresh and race on the credential store.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class AuthStrategy(ABC):
+    """Abstract contract for building provider auth headers."""
+
+    @abstractmethod
+    async def get_authorization_header(self) -> dict[str, str]:
+        """Return the headers the backend should include on the outbound call.
+
+        Typically returns ``{"Authorization": "Bearer <token>"}`` for
+        OAuth-based strategies or ``{"x-api-key": "<key>"}`` for API-key
+        strategies. Implementations may return additional provider-
+        specific headers (e.g. ``anthropic-beta`` for OAuth-authenticated
+        Anthropic calls).
+
+        Implementations must handle cache-and-refresh internally. Callers
+        should not have to know whether a refresh happened.
+
+        Raises:
+            CredentialNotFoundError: The credential doesn't exist and
+                the user needs to run their CLI login command.
+            AuthError: The credential exists but is broken (refresh
+                failed, scope rejected, etc.) and the user must
+                re-authenticate.
+        """
+
+    @abstractmethod
+    async def refresh(self) -> None:
+        """Force-refresh the cached credential.
+
+        Used by :meth:`get_authorization_header` internally and by the
+        Phase 5 UI's ``POST /backends/<name>/refresh`` endpoint.
+
+        Implementations should acquire their internal lock before
+        touching the credential cache, perform the refresh round-trip,
+        update the in-memory cache, and write back to the credential
+        store.
+
+        Raises:
+            AuthError: Refresh failed in a way the user must fix
+                (refresh token expired, invalid_grant, etc.).
+        """

--- a/apps/server/src/screamingface/plugins/llm_base/backend_base.py
+++ b/apps/server/src/screamingface/plugins/llm_base/backend_base.py
@@ -1,0 +1,59 @@
+"""Backend ABC — the runtime for a specific provider.
+
+A concrete :class:`Backend` is the top-level entry point for one
+provider (Anthropic, OpenAI, Gemini, etc.). It combines:
+
+- an :class:`AuthStrategy` that knows how to get auth headers
+- an :class:`Adapter` that knows the wire format
+- an httpx client (or equivalent transport)
+
+The :meth:`run` method is the public API. It takes a CoreMessage list
+plus the usual knobs (model, system, tools, …), handles everything
+needed to fulfill the request (auth → translate → POST → parse), and
+returns a single :class:`CoreMessage` (the assistant's reply).
+
+Backends are **per-request stateless**. A single instance is safe to
+share across many concurrent ``run()`` calls — the auth strategy holds
+its own lock for refresh concurrency.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from screamingface.plugins.llm_base.messages import CoreMessage, ToolDefinition
+
+
+class Backend(ABC):
+    """Abstract contract for a provider backend."""
+
+    @abstractmethod
+    async def run(
+        self,
+        messages: list[CoreMessage],
+        *,
+        model: str,
+        system: str | None = None,
+        tools: list[ToolDefinition] | None = None,
+        max_tokens: int = 16000,
+        temperature: float | None = None,
+        timeout_seconds: float = 300.0,
+    ) -> CoreMessage:
+        """Execute one round-trip against the provider.
+
+        Flow:
+          1. Call ``auth.get_authorization_header()`` for headers.
+          2. Call ``adapter.to_provider_format(messages, ...)`` for
+             the request body.
+          3. POST to the provider's endpoint.
+          4. On 200: ``adapter.from_provider_response(data)``.
+          5. On 401: invalidate auth cache, retry once.
+          6. On other errors: raise :class:`BackendError` with status.
+
+        Raises:
+            AuthError: Auth path broke and the user must re-auth.
+            BackendError: Provider returned a non-success status or
+                the network failed.
+            AdapterError: Request or response couldn't be adapted
+                to/from our canonical shape.
+        """

--- a/apps/server/src/screamingface/plugins/llm_base/credential_store.py
+++ b/apps/server/src/screamingface/plugins/llm_base/credential_store.py
@@ -1,0 +1,350 @@
+"""Cross-platform credential store — wraps the OS-level secret manager.
+
+Three concrete implementations:
+
+- :class:`MacOSKeychainStore` — shells out to ``security``. Verified
+  working by the SF-77 spike on this machine.
+- :class:`LinuxLibsecretStore` — shells out to ``secret-tool``. Not yet
+  verified against a real Linux machine's Claude Code install; Phase 0
+  follow-up will confirm the service name is the same on Linux.
+- :class:`WindowsCredentialManagerStore` — delegates to ``python-keyring``
+  if installed, otherwise shells out to ``cmdkey``. Not yet verified.
+
+The soft dep on ``python-keyring`` is checked at module import. When
+available, all three platforms can optionally route through keyring for
+a cleaner API — but the subprocess fallbacks are the source of truth
+and must always work.
+
+Public factory: :func:`get_credential_store` returns the appropriate
+concrete implementation for the current platform.
+
+All read/write operations are synchronous. The credential store is
+typically called from inside an async function, but the underlying OS
+calls are fast (low ms range) and wrapping them in ``asyncio.to_thread``
+is the caller's responsibility if they need to.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+import sys
+from abc import ABC, abstractmethod
+
+logger = logging.getLogger(__name__)
+
+
+def _try_import_keyring():
+    """Return the keyring module if installed, else None.
+
+    Soft dep — the module works without it, falling back to subprocess
+    calls on each platform. When installed, Windows delegates to keyring
+    because writing the Windows CredMan API without it is awful.
+    """
+    try:
+        import keyring  # type: ignore[import-not-found]
+
+        return keyring
+    except ImportError:
+        return None
+
+
+class CredentialStore(ABC):
+    """Abstract contract for reading/writing secrets to the OS credential store.
+
+    All methods raise no exceptions for "not found" — :meth:`read`
+    returns ``None`` in that case. Callers that need to distinguish
+    "not found" from "corrupted" should call :meth:`read` and check
+    for ``None``, then raise :class:`CredentialNotFoundError` themselves
+    at the semantic layer.
+
+    Exceptions are raised only for genuinely exceptional cases: the
+    credential store command is missing (not installed), the store is
+    locked and a prompt failed, the subprocess crashed, etc. These
+    surface as ``RuntimeError``.
+    """
+
+    @abstractmethod
+    def read(self, service: str, account: str) -> str | None:
+        """Return the password value for (service, account).
+
+        Returns:
+            The stored password as a string, or ``None`` if no entry
+            exists for the given service+account combination.
+
+        Raises:
+            RuntimeError: The credential store is unreachable (command
+                missing, keychain locked, subprocess crashed, etc.).
+        """
+
+    @abstractmethod
+    def write(self, service: str, account: str, value: str) -> None:
+        """Create or update the password for (service, account).
+
+        Overwrites an existing entry if one is present.
+
+        Raises:
+            RuntimeError: Same conditions as :meth:`read`.
+        """
+
+
+# ----------------------------------------------------------------------------
+# macOS Keychain — verified working by SF-77 spike
+# ----------------------------------------------------------------------------
+
+
+class MacOSKeychainStore(CredentialStore):
+    """macOS Keychain via the built-in ``security`` command.
+
+    Read command::
+
+        security find-generic-password -s <service> -a <account> -w
+
+    Write command::
+
+        security add-generic-password -U -s <service> -a <account> -w <value>
+
+    The ``-U`` flag on write updates an existing entry instead of
+    erroring. Without it, a second ``add-generic-password`` call for the
+    same service+account returns a non-zero exit code.
+
+    Output from read is the stripped password string on stdout.
+    Exit code 44 means "not found"; we convert that to ``None``.
+    """
+
+    def read(self, service: str, account: str) -> str | None:
+        try:
+            result = subprocess.run(
+                [
+                    "security",
+                    "find-generic-password",
+                    "-s",
+                    service,
+                    "-a",
+                    account,
+                    "-w",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError("`security` command not found — not a macOS system?") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"`security` command timed out after 5s for service={service!r}; "
+                "keychain may be locked"
+            ) from exc
+
+        if result.returncode == 44:
+            # "The specified item could not be found in the keychain"
+            return None
+
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"`security` failed with exit {result.returncode}: "
+                f"{result.stderr.strip() or '<no stderr>'}"
+            )
+
+        return result.stdout.strip() or None
+
+    def write(self, service: str, account: str, value: str) -> None:
+        try:
+            result = subprocess.run(
+                [
+                    "security",
+                    "add-generic-password",
+                    "-U",
+                    "-s",
+                    service,
+                    "-a",
+                    account,
+                    "-w",
+                    value,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError("`security` command not found — not a macOS system?") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"`security` write timed out after 5s for service={service!r}"
+            ) from exc
+
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"`security add-generic-password` failed with exit "
+                f"{result.returncode}: {result.stderr.strip() or '<no stderr>'}"
+            )
+
+
+# ----------------------------------------------------------------------------
+# Linux libsecret — via secret-tool subprocess
+# ----------------------------------------------------------------------------
+
+
+class LinuxLibsecretStore(CredentialStore):
+    """Linux libsecret via the ``secret-tool`` command.
+
+    Read command::
+
+        secret-tool lookup service <service> account <account>
+
+    Write command::
+
+        echo -n "<value>" | secret-tool store --label="<label>" \\
+            service <service> account <account>
+
+    We use ``service`` and ``account`` as custom attributes (libsecret
+    is a flat key-value store; there's no native service/account
+    distinction). This matches how most python-keyring backends map
+    their attributes onto libsecret.
+
+    NOTE: not yet verified against a real Linux machine's Claude Code
+    install. Phase 0 follow-up will confirm the Claude Code CLI uses the
+    same service name (``"Claude Code-credentials"``) on Linux.
+    """
+
+    def read(self, service: str, account: str) -> str | None:
+        if shutil.which("secret-tool") is None:
+            raise RuntimeError(
+                "`secret-tool` command not found. Install with "
+                "`apt install libsecret-tools` or equivalent."
+            )
+
+        try:
+            result = subprocess.run(
+                [
+                    "secret-tool",
+                    "lookup",
+                    "service",
+                    service,
+                    "account",
+                    account,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(f"`secret-tool lookup` timed out for service={service!r}") from exc
+
+        # secret-tool exits 1 with empty stdout when not found.
+        if result.returncode != 0 or not result.stdout:
+            return None
+
+        return result.stdout.strip() or None
+
+    def write(self, service: str, account: str, value: str) -> None:
+        if shutil.which("secret-tool") is None:
+            raise RuntimeError(
+                "`secret-tool` command not found. Install with "
+                "`apt install libsecret-tools` or equivalent."
+            )
+
+        label = f"{service} ({account})"
+        try:
+            # secret-tool store reads the value from stdin
+            result = subprocess.run(
+                [
+                    "secret-tool",
+                    "store",
+                    "--label",
+                    label,
+                    "service",
+                    service,
+                    "account",
+                    account,
+                ],
+                input=value,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(f"`secret-tool store` timed out for service={service!r}") from exc
+
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"`secret-tool store` failed with exit {result.returncode}: "
+                f"{result.stderr.strip() or '<no stderr>'}"
+            )
+
+
+# ----------------------------------------------------------------------------
+# Windows Credential Manager — via python-keyring or cmdkey fallback
+# ----------------------------------------------------------------------------
+
+
+class WindowsCredentialManagerStore(CredentialStore):
+    """Windows Credential Manager.
+
+    When ``python-keyring`` is installed we delegate to it (cleanest
+    path — the keyring maintainers handle all the Win32 quirks). When
+    it's not, we fall back to ``cmdkey`` for writes and a best-effort
+    read via PowerShell, but that path is limited and tests should
+    assume python-keyring is available on Windows.
+
+    NOTE: not yet verified against a real Windows machine. Phase 0
+    follow-up will confirm whether Claude Code CLI uses the same
+    service name on Windows.
+    """
+
+    def read(self, service: str, account: str) -> str | None:
+        keyring = _try_import_keyring()
+        if keyring is None:
+            raise RuntimeError(
+                "Windows credential read requires `python-keyring`. "
+                "Install with: pip install keyring"
+            )
+        try:
+            return keyring.get_password(service, account)
+        except Exception as exc:  # pragma: no cover - platform specific
+            raise RuntimeError(
+                f"keyring.get_password failed for service={service!r}: {exc}"
+            ) from exc
+
+    def write(self, service: str, account: str, value: str) -> None:
+        keyring = _try_import_keyring()
+        if keyring is None:
+            raise RuntimeError(
+                "Windows credential write requires `python-keyring`. "
+                "Install with: pip install keyring"
+            )
+        try:
+            keyring.set_password(service, account, value)
+        except Exception as exc:  # pragma: no cover - platform specific
+            raise RuntimeError(
+                f"keyring.set_password failed for service={service!r}: {exc}"
+            ) from exc
+
+
+# ----------------------------------------------------------------------------
+# Factory — selects the right implementation at call time
+# ----------------------------------------------------------------------------
+
+
+def get_credential_store() -> CredentialStore:
+    """Return the :class:`CredentialStore` appropriate for the current platform.
+
+    Selection logic:
+
+    - ``sys.platform == "darwin"`` → :class:`MacOSKeychainStore`
+    - ``sys.platform.startswith("linux")`` → :class:`LinuxLibsecretStore`
+    - ``sys.platform == "win32"`` → :class:`WindowsCredentialManagerStore`
+    - Anything else → raises :class:`RuntimeError`
+
+    The function is a factory not a module-level singleton so tests can
+    monkeypatch ``sys.platform`` to exercise different branches. Each
+    call is cheap (constructs a new instance with no I/O).
+    """
+    if sys.platform == "darwin":
+        return MacOSKeychainStore()
+    if sys.platform.startswith("linux"):
+        return LinuxLibsecretStore()
+    if sys.platform == "win32":
+        return WindowsCredentialManagerStore()
+    raise RuntimeError(f"No credential store implementation for platform {sys.platform!r}")

--- a/apps/server/src/screamingface/plugins/llm_base/errors.py
+++ b/apps/server/src/screamingface/plugins/llm_base/errors.py
@@ -1,0 +1,63 @@
+"""Error hierarchy for llm-base and its consumers.
+
+All errors inherit from :class:`LlmBaseError` so callers can catch the
+whole family with one ``except`` clause. Specific subclasses exist for
+the common failure modes so callers can differentiate when they need to.
+"""
+
+from __future__ import annotations
+
+
+class LlmBaseError(Exception):
+    """Base class for every error raised by llm-base or its consumers."""
+
+
+class CredentialNotFoundError(LlmBaseError):
+    """Raised when a credential store doesn't have the requested entry.
+
+    Distinguished from :class:`AuthError` because this is a "user hasn't
+    authenticated yet" state, not a "token is broken" state. The typical
+    user action is to run the provider's CLI login command (e.g.
+    ``claude auth login``).
+    """
+
+
+class AuthError(LlmBaseError):
+    """Raised when authentication fails in a way the user must fix.
+
+    Covers: refresh token expired / invalidated, OAuth scope rejected,
+    refresh endpoint returning 401 or ``invalid_grant``. The typical
+    user action is also to re-run the provider's CLI login command, but
+    the cause is a broken existing credential rather than an absent one.
+    """
+
+
+class AdapterError(LlmBaseError):
+    """Raised when an :class:`Adapter` cannot convert between shapes.
+
+    Typically means the input CoreMessage list contains a construct the
+    target provider cannot represent (e.g. a content block type the
+    adapter doesn't support, or a tool_use/tool_result pairing that
+    would produce an invalid provider-side request).
+    """
+
+
+class BackendError(LlmBaseError):
+    """Raised when a :class:`Backend` call fails at the transport level.
+
+    Covers: provider HTTP 4xx/5xx responses (other than 401/403 which
+    become :class:`AuthError`), network failures, timeouts, malformed
+    responses. Carries the HTTP status code and optional retry-after
+    hint as attributes.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: int | None = None,
+        retry_after: float | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status = status
+        self.retry_after = retry_after

--- a/apps/server/src/screamingface/plugins/llm_base/messages.py
+++ b/apps/server/src/screamingface/plugins/llm_base/messages.py
@@ -1,0 +1,159 @@
+"""Provider-agnostic message shape — the CoreMessage type.
+
+The design is ported from the Vercel AI SDK ``CoreMessage`` schema
+(https://ai-sdk.dev/docs/foundations/prompts). It is the single
+neutral shape every :class:`~screamingface.plugins.llm_base.Adapter`
+converts to/from.
+
+Why this shape and not Anthropic Messages or OpenAI Chat directly:
+
+- **Anthropic Messages** is the highest-fidelity native shape but it's
+  vendor-coupled. Choosing it as canonical implies "Anthropic is the
+  home shape, everyone else is an exception."
+- **OpenAI Chat** is the lowest common denominator and loses
+  Anthropic-side detail (cache_control, citations, structured
+  tool_result content lists, parallel tool calls with IDs).
+- **Vercel-AI-SDK-style parts** are the only field-proven neutral shape
+  that round-trips Anthropic content blocks faithfully *and* is easy to
+  translate to OpenAI Chat / Gemini ``Content[]``.
+
+The ``provider_metadata`` escape hatch on each message and each part is
+the standard pattern for "carry vendor-specific extras through the
+canonical type without breaking other consumers." Adapters are free
+to inspect and honor provider_metadata but must never depend on its
+presence.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# ----------------------------------------------------------------------------
+# Content parts — each part is a discriminated-union member via its ``type``
+# ----------------------------------------------------------------------------
+
+
+class _PartBase(BaseModel):
+    """Common base for every content part."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    provider_metadata: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Vendor-specific extras that should survive translation but "
+            "don't map to any neutral field. Examples: cache_control, "
+            "citations, image media_type hints."
+        ),
+    )
+
+
+class TextPart(_PartBase):
+    """Plain text content."""
+
+    type: Literal["text"] = "text"
+    text: str
+
+
+class ImagePart(_PartBase):
+    """Image content — URL-based or base64-encoded.
+
+    Exactly one of ``image_url`` or ``image_b64`` must be set.
+    """
+
+    type: Literal["image"] = "image"
+    image_url: str | None = None
+    image_b64: str | None = None
+    media_type: str | None = None
+
+
+class ToolCallPart(_PartBase):
+    """Model's request to invoke a tool.
+
+    Lives in an ``assistant`` message. The ``tool_call_id`` links this
+    call to a later :class:`ToolResultPart` in a user/tool message.
+    """
+
+    type: Literal["tool-call"] = "tool-call"
+    tool_call_id: str
+    tool_name: str
+    input: dict[str, Any] = Field(default_factory=dict)
+
+
+class ToolResultPart(_PartBase):
+    """Result of a prior tool call, fed back to the model.
+
+    Lives in a ``user`` or ``tool`` message. ``tool_call_id`` must match
+    a prior :class:`ToolCallPart`.
+    """
+
+    type: Literal["tool-result"] = "tool-result"
+    tool_call_id: str
+    tool_name: str
+    output: dict[str, Any] | str
+    is_error: bool = False
+
+
+class ReasoningPart(_PartBase):
+    """Model reasoning / extended thinking.
+
+    Some providers (Anthropic) produce signed thinking blocks that must
+    be preserved across turns. The ``signature`` field carries that
+    provider-specific signature; translators that don't need it ignore
+    it.
+    """
+
+    type: Literal["reasoning"] = "reasoning"
+    text: str
+    signature: str | None = None
+
+
+# The union of every part type. Discriminated on the ``type`` field.
+ContentPart = TextPart | ImagePart | ToolCallPart | ToolResultPart | ReasoningPart
+
+
+# ----------------------------------------------------------------------------
+# Message
+# ----------------------------------------------------------------------------
+
+
+class CoreMessage(BaseModel):
+    """A single turn in a conversation.
+
+    Content is either a bare string (shorthand for a single TextPart) or
+    a list of typed parts. Adapters should handle both forms.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    role: Literal["system", "user", "assistant", "tool"]
+    content: str | list[ContentPart]
+    provider_metadata: dict[str, Any] | None = None
+
+
+# ----------------------------------------------------------------------------
+# Tool definition — what a backend advertises it can call
+# ----------------------------------------------------------------------------
+
+
+class ToolDefinition(BaseModel):
+    """Schema describing a tool the model may call.
+
+    Maps directly to both Anthropic's ``tools`` field and OpenAI's
+    ``tools`` field (modulo a parameters/input_schema rename that
+    translators handle).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    description: str
+    input_schema: dict[str, Any] = Field(
+        default_factory=lambda: {"type": "object", "properties": {}},
+        description=(
+            "JSON Schema describing the tool's input. Anthropic calls "
+            "this ``input_schema``; OpenAI calls it ``parameters``."
+        ),
+    )

--- a/apps/server/src/screamingface/plugins/llm_base/plugin.py
+++ b/apps/server/src/screamingface/plugins/llm_base/plugin.py
@@ -1,0 +1,47 @@
+"""llm-base SF plugin.
+
+Registers no routes, no settings, no hooks. Exists only to be discoverable
+by the SF plugin loader so other plugins can declare
+``depends = ["llm-base"]`` and the dependency machinery handles activation
+ordering.
+
+The public API of the plugin is the Python import surface exposed by
+``screamingface.plugins.llm_base.__init__``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from screamingface.plugin import Plugin
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+    from screamingface.core.classes import ClassRegistry
+    from screamingface.core.hooks import HookRegistry
+    from screamingface.core.routes import RouteRegistry
+
+
+class LlmBasePlugin(Plugin):
+    name = "llm-base"
+    description = (
+        "Shared ABCs and types for multi-backend LLM providers "
+        "(Anthropic, OpenAI, Gemini, Qwen, Ollama, …). Provides CoreMessage, "
+        "Backend, AuthStrategy, Adapter, and the cross-platform "
+        "CredentialStore. No routes or settings of its own — other plugins "
+        "import from it and build concrete provider backends on top."
+    )
+    depends: list[str] = []
+    settings_class = None
+
+    def setup(
+        self,
+        app: FastAPI,
+        hooks: HookRegistry,
+        classes: ClassRegistry,
+        routes: RouteRegistry,
+    ) -> None:
+        # Nothing to register — the plugin exposes its API via Python
+        # imports, not via FastAPI routes or hooks.
+        pass

--- a/apps/server/src/screamingface/plugins/llm_base/tests/test_abc_contracts.py
+++ b/apps/server/src/screamingface/plugins/llm_base/tests/test_abc_contracts.py
@@ -1,0 +1,130 @@
+"""Tests that the ABCs actually enforce their contracts.
+
+These tests catch the case where someone adds a new abstract method to
+the base class but forgets to implement it in the concrete subclass —
+the ABC machinery should refuse to instantiate incomplete subclasses.
+
+Also includes sanity checks that the llm-base plugin itself is loadable
+and registers nothing (no routes, no settings).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from screamingface.plugins.llm_base import (
+    Adapter,
+    AuthStrategy,
+    Backend,
+    CredentialStore,
+)
+from screamingface.plugins.llm_base.plugin import LlmBasePlugin
+
+
+class TestAuthStrategyABC:
+    def test_cannot_instantiate_directly(self):
+        with pytest.raises(TypeError, match="abstract"):
+            AuthStrategy()  # type: ignore[abstract]
+
+    def test_concrete_subclass_instantiates(self):
+        class FakeAuth(AuthStrategy):
+            async def get_authorization_header(self):
+                return {"Authorization": "Bearer fake"}
+
+            async def refresh(self):
+                pass
+
+        FakeAuth()  # should not raise
+
+
+class TestBackendABC:
+    def test_cannot_instantiate_directly(self):
+        with pytest.raises(TypeError, match="abstract"):
+            Backend()  # type: ignore[abstract]
+
+    def test_concrete_subclass_instantiates(self):
+        from screamingface.plugins.llm_base.messages import CoreMessage
+
+        class FakeBackend(Backend):
+            async def run(
+                self,
+                messages,
+                *,
+                model,
+                system=None,
+                tools=None,
+                max_tokens=16000,
+                temperature=None,
+                timeout_seconds=300.0,
+            ):
+                return CoreMessage(role="assistant", content="fake")
+
+        FakeBackend()  # should not raise
+
+
+class TestAdapterABC:
+    def test_cannot_instantiate_directly(self):
+        with pytest.raises(TypeError, match="abstract"):
+            Adapter()  # type: ignore[abstract]
+
+    def test_concrete_subclass_instantiates(self):
+        from screamingface.plugins.llm_base.messages import CoreMessage
+
+        class FakeAdapter(Adapter):
+            def to_provider_format(
+                self,
+                messages,
+                *,
+                model,
+                system=None,
+                tools=None,
+                max_tokens=16000,
+                temperature=None,
+            ):
+                return {"model": model}
+
+            def from_provider_response(self, data):
+                return CoreMessage(role="assistant", content="fake")
+
+        FakeAdapter()  # should not raise
+
+
+class TestCredentialStoreABC:
+    def test_cannot_instantiate_directly(self):
+        with pytest.raises(TypeError, match="abstract"):
+            CredentialStore()  # type: ignore[abstract]
+
+    def test_missing_method_still_abstract(self):
+        """A subclass that implements only one abstract method still can't instantiate."""
+
+        class HalfStore(CredentialStore):
+            def read(self, service, account):
+                return None
+
+            # write is NOT implemented
+
+        with pytest.raises(TypeError, match="abstract"):
+            HalfStore()  # type: ignore[abstract]
+
+
+class TestLlmBasePlugin:
+    def test_plugin_class_attributes(self):
+        assert LlmBasePlugin.name == "llm-base"
+        assert LlmBasePlugin.depends == []
+        assert LlmBasePlugin.conflicts == []
+        assert LlmBasePlugin.settings_class is None
+
+    def test_plugin_instantiates(self):
+        LlmBasePlugin()  # no args required
+
+    def test_plugin_preflight_succeeds(self):
+        plugin = LlmBasePlugin()
+        ok, reason = plugin.preflight()
+        assert ok is True
+        assert reason == ""
+
+    def test_setup_is_noop(self):
+        """setup() takes the standard args and registers nothing."""
+        plugin = LlmBasePlugin()
+        # Pass None for each arg — llm-base should never touch them
+        plugin.setup(None, None, None, None)  # type: ignore[arg-type]

--- a/apps/server/src/screamingface/plugins/llm_base/tests/test_credential_store.py
+++ b/apps/server/src/screamingface/plugins/llm_base/tests/test_credential_store.py
@@ -1,0 +1,261 @@
+"""Unit tests for the cross-platform credential store.
+
+All platform branches are tested with mocked subprocess calls so every
+test runs on any host regardless of which OS you're running on.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from screamingface.plugins.llm_base.credential_store import (
+    LinuxLibsecretStore,
+    MacOSKeychainStore,
+    WindowsCredentialManagerStore,
+    get_credential_store,
+)
+
+
+def _completed(returncode: int, stdout: str = "", stderr: str = "") -> MagicMock:
+    """Build a fake subprocess.CompletedProcess result."""
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = stderr
+    return result
+
+
+# ----------------------------------------------------------------------------
+# Factory
+# ----------------------------------------------------------------------------
+
+
+class TestGetCredentialStoreFactory:
+    def test_returns_macos_on_darwin(self):
+        with patch("sys.platform", "darwin"):
+            store = get_credential_store()
+            assert isinstance(store, MacOSKeychainStore)
+
+    def test_returns_linux_on_linux(self):
+        with patch("sys.platform", "linux"):
+            store = get_credential_store()
+            assert isinstance(store, LinuxLibsecretStore)
+
+    def test_returns_windows_on_win32(self):
+        with patch("sys.platform", "win32"):
+            store = get_credential_store()
+            assert isinstance(store, WindowsCredentialManagerStore)
+
+    def test_raises_on_unknown_platform(self):
+        with patch("sys.platform", "plan9"):
+            with pytest.raises(RuntimeError, match="plan9"):
+                get_credential_store()
+
+
+# ----------------------------------------------------------------------------
+# macOS Keychain
+# ----------------------------------------------------------------------------
+
+
+class TestMacOSKeychainStore:
+    def test_read_success(self):
+        store = MacOSKeychainStore()
+        with patch(
+            "subprocess.run",
+            return_value=_completed(0, stdout='{"claudeAiOauth":{"accessToken":"sk-ant-X"}}\n'),
+        ) as run:
+            value = store.read("Claude Code-credentials", "sergey")
+        assert value == '{"claudeAiOauth":{"accessToken":"sk-ant-X"}}'
+        # Verify the right subprocess args went in
+        args = run.call_args.args[0]
+        assert args[0] == "security"
+        assert args[1] == "find-generic-password"
+        assert "-s" in args
+        assert "Claude Code-credentials" in args
+        assert "-a" in args
+        assert "sergey" in args
+        assert "-w" in args
+
+    def test_read_not_found_returns_none(self):
+        """Exit code 44 is macOS Keychain's 'item not found' signal."""
+        store = MacOSKeychainStore()
+        with patch("subprocess.run", return_value=_completed(44, stderr="item not found")):
+            value = store.read("Claude Code-credentials", "sergey")
+        assert value is None
+
+    def test_read_other_error_raises(self):
+        store = MacOSKeychainStore()
+        with patch("subprocess.run", return_value=_completed(1, stderr="generic failure")):
+            with pytest.raises(RuntimeError, match="exit 1"):
+                store.read("Claude Code-credentials", "sergey")
+
+    def test_read_empty_stdout_returns_none(self):
+        """Edge case: exit 0 but no password value."""
+        store = MacOSKeychainStore()
+        with patch("subprocess.run", return_value=_completed(0, stdout="\n")):
+            value = store.read("Claude Code-credentials", "sergey")
+        assert value is None
+
+    def test_read_command_missing(self):
+        store = MacOSKeychainStore()
+        with patch("subprocess.run", side_effect=FileNotFoundError("security")):
+            with pytest.raises(RuntimeError, match="not a macOS system"):
+                store.read("Claude Code-credentials", "sergey")
+
+    def test_read_timeout(self):
+        store = MacOSKeychainStore()
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired("security", 5),
+        ):
+            with pytest.raises(RuntimeError, match="timed out"):
+                store.read("Claude Code-credentials", "sergey")
+
+    def test_write_success(self):
+        store = MacOSKeychainStore()
+        with patch("subprocess.run", return_value=_completed(0)) as run:
+            store.write("Claude Code-credentials", "sergey", '{"accessToken":"new"}')
+        args = run.call_args.args[0]
+        assert args[0] == "security"
+        assert args[1] == "add-generic-password"
+        assert "-U" in args  # update flag is critical
+        assert '{"accessToken":"new"}' in args
+
+    def test_write_failure_raises(self):
+        store = MacOSKeychainStore()
+        with patch("subprocess.run", return_value=_completed(1, stderr="permission denied")):
+            with pytest.raises(RuntimeError, match="permission denied"):
+                store.write("Claude Code-credentials", "sergey", '{"x":1}')
+
+
+# ----------------------------------------------------------------------------
+# Linux libsecret
+# ----------------------------------------------------------------------------
+
+
+class TestLinuxLibsecretStore:
+    def test_read_success(self):
+        store = LinuxLibsecretStore()
+        with (
+            patch("shutil.which", return_value="/usr/bin/secret-tool"),
+            patch(
+                "subprocess.run",
+                return_value=_completed(0, stdout='{"claudeAiOauth":{"accessToken":"sk-ant-X"}}\n'),
+            ) as run,
+        ):
+            value = store.read("Claude Code-credentials", "sergey")
+        assert value == '{"claudeAiOauth":{"accessToken":"sk-ant-X"}}'
+        args = run.call_args.args[0]
+        assert args[0] == "secret-tool"
+        assert args[1] == "lookup"
+        assert "service" in args
+        assert "Claude Code-credentials" in args
+        assert "account" in args
+        assert "sergey" in args
+
+    def test_read_not_found_returns_none(self):
+        """secret-tool exits 1 with empty stdout when the item isn't there."""
+        store = LinuxLibsecretStore()
+        with (
+            patch("shutil.which", return_value="/usr/bin/secret-tool"),
+            patch("subprocess.run", return_value=_completed(1, stdout="")),
+        ):
+            value = store.read("Claude Code-credentials", "sergey")
+        assert value is None
+
+    def test_read_command_missing(self):
+        store = LinuxLibsecretStore()
+        with patch("shutil.which", return_value=None):
+            with pytest.raises(RuntimeError, match="secret-tool.*not found"):
+                store.read("Claude Code-credentials", "sergey")
+
+    def test_write_success(self):
+        store = LinuxLibsecretStore()
+        with (
+            patch("shutil.which", return_value="/usr/bin/secret-tool"),
+            patch("subprocess.run", return_value=_completed(0)) as run,
+        ):
+            store.write("Claude Code-credentials", "sergey", '{"accessToken":"new"}')
+        args = run.call_args.args[0]
+        assert args[0] == "secret-tool"
+        assert args[1] == "store"
+        assert "--label" in args
+        assert "service" in args
+        assert "account" in args
+        # The value goes via stdin, not args
+        assert run.call_args.kwargs.get("input") == '{"accessToken":"new"}'
+
+    def test_write_failure_raises(self):
+        store = LinuxLibsecretStore()
+        with (
+            patch("shutil.which", return_value="/usr/bin/secret-tool"),
+            patch(
+                "subprocess.run",
+                return_value=_completed(1, stderr="dbus error"),
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="dbus error"):
+                store.write("Claude Code-credentials", "sergey", '{"x":1}')
+
+
+# ----------------------------------------------------------------------------
+# Windows Credential Manager
+# ----------------------------------------------------------------------------
+
+
+class TestWindowsCredentialManagerStore:
+    def test_read_with_keyring_installed(self):
+        store = WindowsCredentialManagerStore()
+        fake_keyring = MagicMock()
+        fake_keyring.get_password.return_value = '{"accessToken":"X"}'
+        with patch(
+            "screamingface.plugins.llm_base.credential_store._try_import_keyring",
+            return_value=fake_keyring,
+        ):
+            value = store.read("Claude Code-credentials", "sergey")
+        assert value == '{"accessToken":"X"}'
+        fake_keyring.get_password.assert_called_once_with("Claude Code-credentials", "sergey")
+
+    def test_read_without_keyring_raises(self):
+        store = WindowsCredentialManagerStore()
+        with patch(
+            "screamingface.plugins.llm_base.credential_store._try_import_keyring",
+            return_value=None,
+        ):
+            with pytest.raises(RuntimeError, match="python-keyring"):
+                store.read("Claude Code-credentials", "sergey")
+
+    def test_write_with_keyring_installed(self):
+        store = WindowsCredentialManagerStore()
+        fake_keyring = MagicMock()
+        with patch(
+            "screamingface.plugins.llm_base.credential_store._try_import_keyring",
+            return_value=fake_keyring,
+        ):
+            store.write("Claude Code-credentials", "sergey", '{"new":"val"}')
+        fake_keyring.set_password.assert_called_once_with(
+            "Claude Code-credentials", "sergey", '{"new":"val"}'
+        )
+
+    def test_write_without_keyring_raises(self):
+        store = WindowsCredentialManagerStore()
+        with patch(
+            "screamingface.plugins.llm_base.credential_store._try_import_keyring",
+            return_value=None,
+        ):
+            with pytest.raises(RuntimeError, match="python-keyring"):
+                store.write("Claude Code-credentials", "sergey", "x")
+
+    def test_read_keyring_raises_wrapped(self):
+        store = WindowsCredentialManagerStore()
+        fake_keyring = MagicMock()
+        fake_keyring.get_password.side_effect = RuntimeError("win32 broken")
+        with patch(
+            "screamingface.plugins.llm_base.credential_store._try_import_keyring",
+            return_value=fake_keyring,
+        ):
+            with pytest.raises(RuntimeError, match="win32 broken"):
+                store.read("Claude Code-credentials", "sergey")

--- a/apps/server/src/screamingface/plugins/llm_base/tests/test_messages.py
+++ b/apps/server/src/screamingface/plugins/llm_base/tests/test_messages.py
@@ -1,0 +1,192 @@
+"""Unit tests for the CoreMessage pydantic types.
+
+Pure pydantic round-trips. No FastAPI, no httpx, no I/O.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from screamingface.plugins.llm_base.messages import (
+    CoreMessage,
+    ImagePart,
+    ReasoningPart,
+    TextPart,
+    ToolCallPart,
+    ToolDefinition,
+    ToolResultPart,
+)
+
+
+class TestTextPart:
+    def test_roundtrip(self):
+        p = TextPart(text="hello")
+        assert p.type == "text"
+        assert p.text == "hello"
+        assert p.model_dump()["type"] == "text"
+
+    def test_json_roundtrip(self):
+        p = TextPart(text="hi")
+        loaded = TextPart.model_validate_json(p.model_dump_json())
+        assert loaded == p
+
+    def test_provider_metadata_preserved(self):
+        p = TextPart(text="hi", provider_metadata={"cache_control": {"type": "ephemeral"}})
+        assert p.provider_metadata == {"cache_control": {"type": "ephemeral"}}
+
+    def test_extra_fields_forbidden(self):
+        with pytest.raises(ValidationError):
+            TextPart(text="hi", bogus="field")  # type: ignore[call-arg]
+
+
+class TestImagePart:
+    def test_url_source(self):
+        p = ImagePart(image_url="https://example.com/img.png", media_type="image/png")
+        assert p.image_url == "https://example.com/img.png"
+        assert p.image_b64 is None
+        assert p.media_type == "image/png"
+
+    def test_base64_source(self):
+        p = ImagePart(image_b64="iVBOR...", media_type="image/png")
+        assert p.image_b64 == "iVBOR..."
+        assert p.image_url is None
+
+
+class TestToolCallPart:
+    def test_basic(self):
+        p = ToolCallPart(tool_call_id="call_1", tool_name="search", input={"q": "pandas"})
+        assert p.type == "tool-call"
+        assert p.tool_call_id == "call_1"
+        assert p.tool_name == "search"
+        assert p.input == {"q": "pandas"}
+
+    def test_empty_input_default(self):
+        p = ToolCallPart(tool_call_id="call_1", tool_name="search")
+        assert p.input == {}
+
+
+class TestToolResultPart:
+    def test_success(self):
+        p = ToolResultPart(tool_call_id="call_1", tool_name="search", output={"rows": 5})
+        assert p.type == "tool-result"
+        assert p.output == {"rows": 5}
+        assert p.is_error is False
+
+    def test_error(self):
+        p = ToolResultPart(
+            tool_call_id="call_1",
+            tool_name="search",
+            output="timeout",
+            is_error=True,
+        )
+        assert p.is_error is True
+        assert p.output == "timeout"
+
+
+class TestReasoningPart:
+    def test_with_signature(self):
+        p = ReasoningPart(text="thinking...", signature="sig-abc")
+        assert p.type == "reasoning"
+        assert p.signature == "sig-abc"
+
+    def test_without_signature(self):
+        p = ReasoningPart(text="thinking...")
+        assert p.signature is None
+
+
+class TestCoreMessage:
+    def test_string_content_shorthand(self):
+        m = CoreMessage(role="user", content="hi")
+        assert m.content == "hi"
+
+    def test_list_content(self):
+        m = CoreMessage(
+            role="user",
+            content=[TextPart(text="hi"), TextPart(text="there")],
+        )
+        assert isinstance(m.content, list)
+        assert len(m.content) == 2
+
+    def test_mixed_parts(self):
+        m = CoreMessage(
+            role="assistant",
+            content=[
+                TextPart(text="Let me search."),
+                ToolCallPart(
+                    tool_call_id="call_1",
+                    tool_name="search",
+                    input={"q": "pandas"},
+                ),
+            ],
+        )
+        assert len(m.content) == 2
+        assert m.content[0].type == "text"
+        assert m.content[1].type == "tool-call"
+
+    def test_roles(self):
+        for role in ("system", "user", "assistant", "tool"):
+            CoreMessage(role=role, content="x")  # no validation error
+
+    def test_invalid_role_rejected(self):
+        with pytest.raises(ValidationError):
+            CoreMessage(role="wizard", content="x")  # type: ignore[arg-type]
+
+    def test_json_roundtrip_preserves_types(self):
+        m = CoreMessage(
+            role="user",
+            content=[
+                TextPart(text="look at this"),
+                ImagePart(image_url="https://ex.com/a.png"),
+                ToolResultPart(
+                    tool_call_id="c1",
+                    tool_name="web_fetch",
+                    output={"html": "<p>hi</p>"},
+                ),
+            ],
+        )
+        as_json = m.model_dump_json()
+        loaded = CoreMessage.model_validate_json(as_json)
+        # pydantic discriminated union should reconstruct each part as its type
+        assert loaded.content[0].type == "text"
+        assert loaded.content[1].type == "image"
+        assert loaded.content[2].type == "tool-result"
+
+    def test_provider_metadata_at_message_level(self):
+        m = CoreMessage(
+            role="user",
+            content="hi",
+            provider_metadata={"request_id": "req_abc"},
+        )
+        assert m.provider_metadata == {"request_id": "req_abc"}
+
+
+class TestToolDefinition:
+    def test_basic(self):
+        t = ToolDefinition(
+            name="get_weather",
+            description="Get the current weather",
+            input_schema={
+                "type": "object",
+                "properties": {"location": {"type": "string"}},
+                "required": ["location"],
+            },
+        )
+        assert t.name == "get_weather"
+        assert t.input_schema["type"] == "object"
+
+    def test_default_input_schema(self):
+        t = ToolDefinition(name="ping", description="Check liveness")
+        assert t.input_schema == {"type": "object", "properties": {}}
+
+    def test_json_serializable(self):
+        t = ToolDefinition(
+            name="get_weather",
+            description="Get the current weather",
+            input_schema={"type": "object", "properties": {}},
+        )
+        # Must round-trip through json.dumps cleanly (translators will do this)
+        serialized = json.dumps(t.model_dump())
+        assert "get_weather" in serialized

--- a/apps/server/src/screamingface/plugins/url4_executor/decoder.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/decoder.py
@@ -7,6 +7,29 @@ def split_intent(expr: str) -> tuple[str, str | None]:
     """Split on outermost ``!`` (outside balanced parens).
 
     Returns ``(source_expression, intent)`` or ``(expr, None)`` if no intent.
+
+    Backend-call awareness (SF-79 Stage B): a ``!`` immediately preceded
+    by ``()`` is treated as part of a backend_call's intent tail, not as
+    a top-level intent separator. This makes the user-friendly form
+    ``/claude()!hello`` parse as a single backend_call rather than
+    splitting into ``source=/claude()`` + ``intent=hello`` (which would
+    leave the backend with an empty prompt).
+
+    Examples::
+
+        split_intent("/claude()!hello")
+            → ("/claude()!hello", None)   # NEW: not split, the whole
+                                          # thing is a backend_call
+
+        split_intent("(/claude()!a, /claude()!b)!reduce")
+            → ("(/claude()!a, /claude()!b)", "reduce")  # outer ! has
+                                          # ')e' preceding, not '()'
+
+        split_intent("(/claude())!reduce")
+            → ("(/claude())", "reduce")   # ! has '))' preceding, splits
+
+        split_intent("(https://ex.com)!summarize")
+            → ("(https://ex.com)", "summarize")  # unchanged
     """
     depth = 0
     for i, ch in enumerate(expr):
@@ -15,5 +38,10 @@ def split_intent(expr: str) -> tuple[str, str | None]:
         elif ch == ")":
             depth -= 1
         elif ch == "!" and depth == 0:
+            # If the ! is immediately preceded by '()', it belongs to a
+            # backend_call (``/path()!intent``) and is NOT a top-level
+            # intent separator. Skip it and keep scanning.
+            if i >= 2 and expr[i - 2 : i] == "()":
+                continue
             return expr[:i], expr[i + 1 :]
     return expr, None

--- a/apps/server/src/screamingface/plugins/url4_executor/ensemble.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/ensemble.py
@@ -1,0 +1,254 @@
+"""Ensemble interpreter — fan-out N backend calls, then reduce to one response.
+
+Subclass of :class:`Url4Interpreter`. When the expression's source is a
+``Url4List`` where **every element** is a ``Url4BackendCall``, the
+interpreter enters "ensemble mode":
+
+1. **Fan-out:** dispatch each ``Url4BackendCall`` in parallel via
+   ``asyncio.gather``, collecting N string responses.
+2. **Reduce:** call a single "reducer" backend (specified by the
+   ``processor`` parameter) with the N responses as separate content
+   parts in one user message, plus the outer intent as the instruction.
+3. **Return:** the reducer's response as JSON (Anthropic Messages shape).
+
+If the expression does NOT match the fan-out shape (e.g. it's a regular
+URL list or a single backend call), the ensemble interpreter falls
+through to the base :class:`Url4Interpreter` behavior — no change for
+existing expressions.
+
+Design decisions (SF-79 ticket, all locked in):
+
+- Q1 = (a): reducer sees only the N responses, NOT the original prompt.
+- Q2 = (ii): each response is a separate TextPart in one user message.
+- Q3 = (b): unlabeled — no source backend names attached.
+- Q4 = (iii): processor is a backend path (``/claude``, ``/claude/synthesizer``).
+- Q6 = (a): abort on any fan-out failure — propagate HTTP error.
+- Q7 = (a): reducer tool_calls pass through to the caller.
+- Q9 = JSON response: ensemble mode returns JSONResponse with the full
+  Anthropic Messages shape (via the adapter's from_provider_response).
+- Q10 = structured replay: the /data/<key> blob is parsed into
+  CoreMessage[] via the adapter layer, not sent as flat text.
+
+Precompilation note: ``$prompt`` and ``$reducer`` are frontend-only
+reserved variables. By the time this interpreter sees the expression,
+they have been replaced with concrete paths (``/data/<key>`` and
+``/claude``). The executor never sees ``$`` variables.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from screamingface.plugins.url4_executor.interpreter import Url4Interpreter
+from screamingface.plugins.url4_executor.url4 import (
+    Url4BackendCall,
+    Url4List,
+    Url4Node,
+    resolve,
+)
+
+logger = logging.getLogger(__name__)
+
+# Default reducer backend path when ?processor= is not specified.
+DEFAULT_PROCESSOR = "/claude"
+
+
+class EnsembleInterpreter(Url4Interpreter):
+    """Url4 interpreter with fan-out-reduce semantics.
+
+    Args:
+        app: FastAPI app (for plugin lookup and in-process ASGI).
+        processor: Backend path for the reducer step (e.g. ``"/claude"``
+            or ``"/claude/synthesizer"``). Overrides the default.
+    """
+
+    def __init__(self, app: Any = None, *, processor: str | None = None) -> None:
+        super().__init__(app)
+        self._processor = processor or DEFAULT_PROCESSOR
+
+    async def process(self, sources: str, intent: str | None) -> str:
+        """Fallback for non-ensemble expressions. Delegates to base class."""
+        return await super().process(sources, intent)
+
+    async def evaluate(self, expr: str) -> str:
+        """Full evaluation pipeline with ensemble detection.
+
+        Overrides :meth:`Url4Interpreter.evaluate` to intercept the
+        fan-out-reduce shape BEFORE ``resolve()`` flattens the results
+        to a single concatenated string.
+        """
+        from screamingface.plugins.url4_executor._tracing import set_span_attrs, traced
+        from screamingface.plugins.url4_executor.decoder import split_intent
+        from screamingface.plugins.url4_executor.url4 import parse, resolve_str
+
+        with traced("url4.evaluate"):
+            set_span_attrs({"url4.expression": expr[:500]})
+
+            source_expr, raw_intent = split_intent(expr.strip())
+            set_span_attrs({"url4.has_intent": raw_intent is not None})
+
+            source_node = parse(source_expr) if source_expr else None
+
+            if source_node is not None and self._is_fanout(source_node) and raw_intent:
+                set_span_attrs({"url4.ensemble": True})
+                return await self._ensemble_evaluate(source_node, raw_intent)
+
+            # Not ensemble — fall through to base behavior.
+            set_span_attrs({"url4.ensemble": False})
+
+            with traced("url4.resolve_sources"):
+                sources = await resolve_str(source_expr, self.app) if source_expr else ""
+                src_preview = sources[:4000]
+                if len(sources) > 4000:
+                    src_preview += f"\n... ({len(sources) - 4000} more chars)"
+                set_span_attrs(
+                    {
+                        "url4.sources_length": len(sources),
+                        "url4.response_body": src_preview,
+                    }
+                )
+
+            from screamingface.plugins.url4_executor.interpreter import resolve_intent
+
+            with traced("url4.resolve_intent"):
+                intent = await resolve_intent(raw_intent, self.app) if raw_intent else None
+                set_span_attrs(
+                    {
+                        "url4.intent_length": len(intent) if intent else 0,
+                        "url4.response_body": intent[:4000] if intent else "",
+                    }
+                )
+
+            result = await self.process(sources, intent)
+            result_preview = result[:4000]
+            if len(result) > 4000:
+                result_preview += f"\n... ({len(result) - 4000} more chars)"
+            set_span_attrs(
+                {
+                    "url4.result_length": len(result),
+                    "url4.response_body": result_preview,
+                }
+            )
+            return result
+
+    # ------------------------------------------------------------------
+    # Ensemble internals
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _is_fanout(node: Url4Node) -> bool:
+        """Return True if *node* is a Url4List where every item is a
+        Url4BackendCall."""
+        if not isinstance(node, Url4List):
+            return False
+        if not node.items:
+            return False
+        return all(isinstance(item, Url4BackendCall) for item in node.items)
+
+    async def _ensemble_evaluate(self, source_node: Url4List, raw_intent: str) -> str:
+        """Run the fan-out-reduce pipeline.
+
+        1. Resolve the outer intent (the reducer instruction).
+        2. Dispatch each Url4BackendCall in parallel.
+        3. On any failure, abort with the error (Q6=a).
+        4. Build the reducer input as separate content parts (Q2=ii, Q3=b).
+        5. Call the reducer backend via the processor path.
+        6. Return the reducer's response as JSON string.
+        """
+        from screamingface.plugins.url4_executor._tracing import set_span_attrs, traced
+        from screamingface.plugins.url4_executor.interpreter import resolve_intent
+
+        # Resolve the outer intent (could be a literal, /data/<key>, or URL).
+        with traced("url4.ensemble.resolve_intent"):
+            reducer_instruction = await resolve_intent(raw_intent, self.app) if raw_intent else ""
+            set_span_attrs({"url4.ensemble.reducer_instruction_length": len(reducer_instruction)})
+
+        # --- Stage 1: Fan-out ---
+        with traced("url4.ensemble.fanout"):
+            items = source_node.items
+            set_span_attrs({"url4.ensemble.fanout_count": len(items)})
+
+            # Dispatch all in parallel. Q6=(a): any failure aborts the
+            # whole ensemble — we do NOT catch exceptions per-element.
+            # asyncio.gather with return_exceptions=False (default) will
+            # cancel remaining tasks and raise the first exception.
+            responses: list[str] = list(
+                await asyncio.gather(*[resolve(item, self.app) for item in items])
+            )
+
+            set_span_attrs({"url4.ensemble.response_count": len(responses)})
+
+        # --- Stage 2: Reduce ---
+        with traced("url4.ensemble.reduce"):
+            set_span_attrs({"url4.ensemble.processor": self._processor})
+
+            # Build the reducer input: each fan-out response as a separate
+            # part, plus the instruction as the final part (Q2=ii, Q3=b).
+            reducer_input = _build_reducer_input(responses, reducer_instruction)
+
+            set_span_attrs({"url4.ensemble.reducer_input_length": len(reducer_input)})
+
+            # Dispatch the reducer through the same backend_call path.
+            from screamingface.plugins.url4_executor.url4 import (
+                Url4Text,
+                _dispatch_backend_call,
+            )
+
+            reducer_node = Url4BackendCall(
+                path=self._processor,
+                intent=Url4Text(value=reducer_input),
+            )
+            result = await _dispatch_backend_call(reducer_node, self.app)
+
+            result_preview = result[:4000]
+            if len(result) > 4000:
+                result_preview += f"\n... ({len(result) - 4000} more chars)"
+            set_span_attrs(
+                {
+                    "url4.ensemble.result_length": len(result),
+                    "url4.ensemble.response_body": result_preview,
+                }
+            )
+
+            return result
+
+
+def _build_reducer_input(responses: list[str], instruction: str) -> str:
+    """Format the N fan-out responses + the reducer instruction.
+
+    Q2 = (ii): each response as a separate section. Since the dispatch
+    chain is string-based (handle_backend_call takes str), we format
+    them as clearly delimited sections. The backend's interpreter will
+    place this entire string as the user message content.
+
+    Q3 = (b): unlabeled — no source backend names.
+
+    The format:
+
+    ::
+
+        [Response 1]
+        Two plus two equals four.
+
+        [Response 2]
+        4
+
+        [Response 3]
+        The answer is 4.
+
+        [Instruction]
+        Synthesize these responses into the best, single coherent response.
+    """
+    parts: list[str] = []
+
+    for i, text in enumerate(responses, 1):
+        parts.append(f"[Response {i}]")
+        parts.append(text.strip())
+        parts.append("")  # blank line separator
+
+    parts.append("[Instruction]")
+    parts.append(instruction)
+
+    return "\n".join(parts)

--- a/apps/server/src/screamingface/plugins/url4_executor/routes.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/routes.py
@@ -8,9 +8,15 @@ from fastapi import APIRouter, HTTPException
 from fastapi.responses import JSONResponse, PlainTextResponse
 
 from screamingface.plugins.url4_executor.decoder import split_intent
+from screamingface.plugins.url4_executor.ensemble import EnsembleInterpreter
 from screamingface.plugins.url4_executor.highlight import tokenize
-from screamingface.plugins.url4_executor.interpreter import Url4Interpreter
-from screamingface.plugins.url4_executor.url4 import Url4List, Url4RelUrl, Url4Url, parse
+from screamingface.plugins.url4_executor.url4 import (
+    Url4BackendCall,
+    Url4List,
+    Url4RelUrl,
+    Url4Url,
+    parse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +27,11 @@ def _ast_to_dict(node) -> dict | str:
         return {"type": "url", "value": node.value}
     if isinstance(node, Url4RelUrl):
         return {"type": "relurl", "value": node.value}
+    if isinstance(node, Url4BackendCall):
+        result: dict = {"type": "backend_call", "path": node.path}
+        if node.intent is not None:
+            result["intent"] = _ast_to_dict(node.intent)
+        return result
     if isinstance(node, Url4List):
         return {"type": "list", "items": [_ast_to_dict(item) for item in node.items]}
     # Url4Text
@@ -45,11 +56,16 @@ def create_router(app=None) -> APIRouter:  # type: ignore[no-untyped-def]
     async def url4_resolve(
         q: str | None = None,
         ast: bool = False,
+        processor: str | None = None,
     ) -> PlainTextResponse | JSONResponse:
         if not q:
             raise HTTPException(status_code=400, detail="Missing 'q' query parameter")
 
-        interpreter = Url4Interpreter(app=app)
+        # Use EnsembleInterpreter when a processor is specified OR the
+        # expression matches the fan-out shape. The ensemble interpreter
+        # falls through to base Url4Interpreter behavior for non-ensemble
+        # expressions, so it's safe to always use it.
+        interpreter = EnsembleInterpreter(app=app, processor=processor)
 
         try:
             result = await interpreter.evaluate(q)

--- a/apps/server/src/screamingface/plugins/url4_executor/tests/test_decoder.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/tests/test_decoder.py
@@ -1,0 +1,112 @@
+"""Unit tests for split_intent in decoder.py.
+
+Most of the existing url4 tests exercise split_intent indirectly via
+the /ensemble HTTP route. These tests pin down its exact behavior at the
+function level — especially the SF-79 Stage B backend-call awareness.
+"""
+
+from __future__ import annotations
+
+from screamingface.plugins.url4_executor.decoder import split_intent
+
+# ----------------------------------------------------------------------------
+# Pre-existing behavior — preserved
+# ----------------------------------------------------------------------------
+
+
+class TestExistingBehavior:
+    def test_no_intent_returns_expr_unchanged(self):
+        assert split_intent("hello world") == ("hello world", None)
+
+    def test_top_level_intent_split(self):
+        assert split_intent("(https://ex.com)!summarize") == (
+            "(https://ex.com)",
+            "summarize",
+        )
+
+    def test_intent_inside_parens_not_split(self):
+        # The ! is inside the group, depth=1, ignored as a separator
+        assert split_intent("(a!b)") == ("(a!b)", None)
+
+    def test_first_top_level_bang_wins(self):
+        assert split_intent("a!b!c") == ("a", "b!c")
+
+    def test_empty_expression(self):
+        assert split_intent("") == ("", None)
+
+
+# ----------------------------------------------------------------------------
+# SF-79 Stage B — backend-call awareness
+# ----------------------------------------------------------------------------
+
+
+class TestBackendCallAwareness:
+    def test_top_level_backend_call_with_intent_not_split(self):
+        """The user-friendly form: /claude()!hello at the top level
+        should stay together so the parser sees the full backend_call."""
+        assert split_intent("/claude()!hello") == ("/claude()!hello", None)
+
+    def test_top_level_backend_call_without_intent_unchanged(self):
+        assert split_intent("/claude()") == ("/claude()", None)
+
+    def test_backend_call_with_relurl_intent(self):
+        """The frontend-substituted form: /claude()!/data/<key>"""
+        assert split_intent("/claude()!/data/abc123") == (
+            "/claude()!/data/abc123",
+            None,
+        )
+
+    def test_backend_call_then_top_level_bang(self):
+        """``/claude()!hello!reduce`` — the first ! after () is part of
+        the backend_call, but the second ! is a real top-level split."""
+        # With our rule, the ! after ()/i=9 is skipped (preceded by ()),
+        # then the next ! at i=15 is checked: preceded by 'lo' not '()',
+        # so it splits.
+        source, intent = split_intent("/claude()!hello!reduce")
+        assert source == "/claude()!hello"
+        assert intent == "reduce"
+
+    def test_fan_out_list_with_backend_calls_then_outer_intent(self):
+        """The target ensemble spec shape: outer ! is a real intent
+        separator because it's preceded by `)` not `()`."""
+        expr = "(/claude()!a, /claude()!b, /claude()!c)!reduce"
+        source, intent = split_intent(expr)
+        assert source == "(/claude()!a, /claude()!b, /claude()!c)"
+        assert intent == "reduce"
+
+    def test_paren_group_with_inner_backend_calls_not_split_at_inner_bangs(self):
+        """Each ! inside the group is at depth 1, so it's ignored even
+        without the new rule. The new rule doesn't change this case;
+        this test pins it down for safety."""
+        expr = "(/claude()!a, /claude()!b)"
+        assert split_intent(expr) == (expr, None)
+
+    def test_backend_call_with_text_intent_containing_bang(self):
+        """``/claude()!some!text`` — the second ! is part of the intent,
+        not a separator. After the first ! is skipped (preceded by ()),
+        we keep scanning, find the next ! preceded by 'me', and split.
+
+        Note: this is a tradeoff. A user who literally wants 'some!text'
+        as their intent has to write it inside parens or escape somehow.
+        For now we accept the split-at-second-bang behavior; the doc
+        in the function explains the limitation.
+        """
+        source, intent = split_intent("/claude()!some!text")
+        assert source == "/claude()!some"
+        assert intent == "text"
+
+    def test_double_paren_close_then_bang_does_split(self):
+        """``(/claude())!intent`` — the ! is preceded by ``))``, not
+        ``()``, so it splits normally."""
+        expr = "(/claude())!intent"
+        source, intent = split_intent(expr)
+        assert source == "(/claude())"
+        assert intent == "intent"
+
+    def test_bare_parens_then_bang_skipped(self):
+        """Edge case: literal '()!x' with no path — the rule still skips
+        the !, so the parser later fails on the malformed form. That's
+        fine; it's not a user-meaningful expression."""
+        source, intent = split_intent("()!x")
+        assert source == "()!x"
+        assert intent is None

--- a/apps/server/src/screamingface/plugins/url4_executor/tests/test_ensemble.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/tests/test_ensemble.py
@@ -1,0 +1,311 @@
+"""Unit tests for the EnsembleInterpreter fan-out-reduce logic.
+
+Uses the same fake plugin/app stubs from test_url4.py's Stage B tests.
+No real network calls or Anthropic API — everything is mocked.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from screamingface.plugins.url4_executor.ensemble import (
+    EnsembleInterpreter,
+    _build_reducer_input,
+)
+from screamingface.plugins.url4_executor.url4 import (
+    Url4BackendCall,
+    Url4List,
+    Url4Text,
+)
+
+# ----------------------------------------------------------------------------
+# Fake plugin stubs (same as test_url4.py Stage B tests)
+# ----------------------------------------------------------------------------
+
+
+class _FakePluginRegistry:
+    def __init__(self, active: dict) -> None:
+        self.active_plugins = active
+
+
+class _FakeAppState:
+    def __init__(self, plugins: _FakePluginRegistry) -> None:
+        self.plugins = plugins
+
+
+class _FakeApp:
+    def __init__(self, plugins: _FakePluginRegistry) -> None:
+        self.state = _FakeAppState(plugins)
+
+
+class _FakeDispatchPlugin:
+    """Plugin stub that records calls and returns canned responses.
+
+    If ``responses`` is a list, returns them in order (round-robin for
+    calls beyond the list length). If a single string, returns it every time.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        paths: list[str],
+        responses: str | list[str],
+    ) -> None:
+        self.name = name
+        self.backend_call_paths = paths
+        self._responses = responses if isinstance(responses, list) else [responses]
+        self._call_idx = 0
+        self.calls: list[tuple[str, object]] = []
+
+    async def handle_backend_call(self, intent: str, *, app) -> str:
+        self.calls.append((intent, app))
+        resp = self._responses[self._call_idx % len(self._responses)]
+        self._call_idx += 1
+        return resp
+
+
+def _make_app(*plugins: _FakeDispatchPlugin) -> _FakeApp:
+    registry = _FakePluginRegistry({p.name: p for p in plugins})
+    return _FakeApp(registry)
+
+
+# ----------------------------------------------------------------------------
+# _is_fanout tests
+# ----------------------------------------------------------------------------
+
+
+class TestIsFanout:
+    def test_list_of_all_backend_calls_is_fanout(self):
+        node = Url4List(
+            items=(
+                Url4BackendCall(path="/claude", intent=Url4Text(value="a")),
+                Url4BackendCall(path="/codex", intent=Url4Text(value="b")),
+            )
+        )
+        assert EnsembleInterpreter._is_fanout(node) is True
+
+    def test_list_with_mixed_types_is_not_fanout(self):
+        node = Url4List(
+            items=(
+                Url4BackendCall(path="/claude", intent=Url4Text(value="a")),
+                Url4Text(value="plain text"),
+            )
+        )
+        assert EnsembleInterpreter._is_fanout(node) is False
+
+    def test_empty_list_is_not_fanout(self):
+        node = Url4List(items=())
+        assert EnsembleInterpreter._is_fanout(node) is False
+
+    def test_single_backend_call_not_in_list_is_not_fanout(self):
+        node = Url4BackendCall(path="/claude", intent=Url4Text(value="a"))
+        assert EnsembleInterpreter._is_fanout(node) is False
+
+    def test_text_node_is_not_fanout(self):
+        node = Url4Text(value="hello")
+        assert EnsembleInterpreter._is_fanout(node) is False
+
+
+# ----------------------------------------------------------------------------
+# _build_reducer_input tests
+# ----------------------------------------------------------------------------
+
+
+class TestBuildReducerInput:
+    def test_three_responses_unlabeled(self):
+        result = _build_reducer_input(
+            ["Four", "Paris", "Blue"],
+            "Combine these facts.",
+        )
+        assert "[Response 1]" in result
+        assert "[Response 2]" in result
+        assert "[Response 3]" in result
+        assert "Four" in result
+        assert "Paris" in result
+        assert "Blue" in result
+        assert "[Instruction]" in result
+        assert "Combine these facts." in result
+
+    def test_no_source_labels(self):
+        """Q3=(b): responses must NOT contain backend names."""
+        result = _build_reducer_input(["answer"], "merge")
+        assert "/claude" not in result
+        assert "/codex" not in result
+        assert "from" not in result.lower().split("[response")[0]
+
+    def test_single_response(self):
+        result = _build_reducer_input(["only one"], "pass through")
+        assert "[Response 1]" in result
+        assert "[Response 2]" not in result
+        assert "only one" in result
+        assert "pass through" in result
+
+    def test_instruction_is_last(self):
+        result = _build_reducer_input(["a", "b"], "instruction")
+        lines = result.strip().split("\n")
+        # Last non-empty line should be the instruction
+        non_empty = [line for line in lines if line.strip()]
+        assert non_empty[-1] == "instruction"
+
+
+# ----------------------------------------------------------------------------
+# Full ensemble evaluate tests
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+class TestEnsembleEvaluate:
+    async def test_fanout_dispatches_n_calls(self):
+        """Three fan-out elements → backend called 3 times."""
+        plugin = _FakeDispatchPlugin(
+            name="claude-api",
+            paths=["/claude"],
+            responses=["resp1", "resp2", "resp3"],
+        )
+        app = _make_app(plugin)
+        interp = EnsembleInterpreter(app=app, processor="/claude")
+
+        await interp.evaluate(
+            "(/claude()!question1, /claude()!question2, /claude()!question3)!Combine these."
+        )
+
+        # 3 fan-out calls + 1 reducer call = 4 total
+        assert len(plugin.calls) == 4
+        # First 3 are the fan-out intents
+        assert plugin.calls[0][0] == "question1"
+        assert plugin.calls[1][0] == "question2"
+        assert plugin.calls[2][0] == "question3"
+
+    async def test_reducer_receives_all_responses(self):
+        """The reducer call (4th) receives all three fan-out responses."""
+        plugin = _FakeDispatchPlugin(
+            name="claude-api",
+            paths=["/claude"],
+            responses=["alpha", "beta", "gamma", "REDUCED"],
+        )
+        app = _make_app(plugin)
+        interp = EnsembleInterpreter(app=app, processor="/claude")
+
+        await interp.evaluate("(/claude()!a, /claude()!b, /claude()!c)!Merge them.")
+
+        # 4th call is the reducer
+        reducer_intent = plugin.calls[3][0]
+        assert "alpha" in reducer_intent
+        assert "beta" in reducer_intent
+        assert "gamma" in reducer_intent
+        assert "Merge them." in reducer_intent
+
+    async def test_reducer_instruction_from_outer_intent(self):
+        """The outer !"..." string becomes the reducer's instruction."""
+        plugin = _FakeDispatchPlugin(
+            name="claude-api",
+            paths=["/claude"],
+            responses=["x", "REDUCED"],
+        )
+        app = _make_app(plugin)
+        interp = EnsembleInterpreter(app=app, processor="/claude")
+
+        await interp.evaluate("(/claude()!q)!Synthesize into one coherent answer.")
+
+        reducer_intent = plugin.calls[1][0]
+        assert "Synthesize into one coherent answer." in reducer_intent
+
+    async def test_returns_reducer_response(self):
+        """The ensemble's return value is the reducer's output."""
+        plugin = _FakeDispatchPlugin(
+            name="claude-api",
+            paths=["/claude"],
+            responses=["fan1", "fan2", "THE FINAL ANSWER"],
+        )
+        app = _make_app(plugin)
+        interp = EnsembleInterpreter(app=app, processor="/claude")
+
+        result = await interp.evaluate("(/claude()!a, /claude()!b)!reduce")
+
+        assert result == "THE FINAL ANSWER"
+
+    async def test_processor_param_routes_reducer(self):
+        """The processor path determines which backend runs the reducer."""
+        fanout_plugin = _FakeDispatchPlugin(
+            name="claude-api",
+            paths=["/claude"],
+            responses=["response"],
+        )
+        reducer_plugin = _FakeDispatchPlugin(
+            name="codex-api",
+            paths=["/codex"],
+            responses=["CODEX REDUCED"],
+        )
+        app = _make_app(fanout_plugin, reducer_plugin)
+        interp = EnsembleInterpreter(app=app, processor="/codex")
+
+        result = await interp.evaluate("(/claude()!question)!reduce")
+
+        # Fan-out went to /claude
+        assert len(fanout_plugin.calls) == 1
+        # Reducer went to /codex
+        assert len(reducer_plugin.calls) == 1
+        assert result == "CODEX REDUCED"
+
+    async def test_fanout_failure_aborts_ensemble(self):
+        """Q6=(a): if any fan-out element fails, the whole ensemble aborts."""
+
+        class _FailingPlugin:
+            name = "failing"
+            backend_call_paths = ["/failing"]
+
+            async def handle_backend_call(self, intent, *, app):
+                raise RuntimeError("backend exploded")
+
+        plugin = _FakeDispatchPlugin(name="claude-api", paths=["/claude"], responses=["ok"])
+        failing = _FailingPlugin()
+        app = _make_app(plugin, failing)
+        interp = EnsembleInterpreter(app=app, processor="/claude")
+
+        with pytest.raises(RuntimeError, match="backend exploded"):
+            await interp.evaluate("(/claude()!a, /failing()!b)!reduce")
+
+        # The reducer should NOT have been called
+        assert len(plugin.calls) <= 1  # at most the successful fan-out
+
+    async def test_non_fanout_expression_falls_through(self):
+        """A regular url4 expression (not a fan-out list) goes through
+        the base Url4Interpreter behavior, not the ensemble path."""
+        interp = EnsembleInterpreter(app=None)
+
+        # Plain text expression — no fan-out, no backend calls.
+        result = await interp.evaluate("hello world")
+        assert result == "hello world"
+
+    async def test_fanout_without_outer_intent_falls_through(self):
+        """A fan-out list WITHOUT an outer !"..." instruction is not
+        treated as ensemble — no reducer to call."""
+        plugin = _FakeDispatchPlugin(
+            name="claude-api",
+            paths=["/claude"],
+            responses=["response"],
+        )
+        app = _make_app(plugin)
+        interp = EnsembleInterpreter(app=app, processor="/claude")
+
+        # No outer intent — the list resolves via base path
+        # (Stage B dispatch, results joined by newlines)
+        result = await interp.evaluate("(/claude()!a, /claude()!b)")
+        assert result == "response\nresponse"
+        # Only 2 calls (no reducer)
+        assert len(plugin.calls) == 2
+
+    async def test_single_element_fanout_still_reduces(self):
+        """N=1 degenerate fan-out: one backend call + reducer."""
+        plugin = _FakeDispatchPlugin(
+            name="claude-api",
+            paths=["/claude"],
+            responses=["solo answer", "REDUCED"],
+        )
+        app = _make_app(plugin)
+        interp = EnsembleInterpreter(app=app, processor="/claude")
+
+        result = await interp.evaluate("(/claude()!q)!reduce")
+
+        assert result == "REDUCED"
+        assert len(plugin.calls) == 2  # 1 fan-out + 1 reducer

--- a/apps/server/src/screamingface/plugins/url4_executor/tests/test_url4.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/tests/test_url4.py
@@ -377,33 +377,161 @@ def test_parse_mixed_list_backend_call_and_fetch() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Backend-call resolver tests — Stage B is not yet implemented
+# Backend-call resolver tests — Stage B dispatch
 # ---------------------------------------------------------------------------
 #
-# Stage A commits to parsing but NOT execution. The resolver raises
-# NotImplementedError when it encounters a Url4BackendCall. Stage B lands
-# the dispatch and removes this guard.
+# Stage B wires Url4BackendCall resolution through the active plugin
+# registry. The resolver walks ``app.state.plugins.active_plugins`` looking
+# for one whose ``backend_call_paths`` contains the target path and calls
+# its ``handle_backend_call`` method.
+#
+# These tests use a minimal fake plugin registry so they don't need the
+# real FastAPI + llm-base stack.
+
+
+class _FakePluginRegistry:
+    """Minimal stand-in for screamingface.core.registry.PluginRegistry.
+
+    Only implements the attribute the resolver touches: active_plugins is
+    a dict of name → plugin-like object.
+    """
+
+    def __init__(self, active: dict) -> None:
+        self.active_plugins = active
+
+
+class _FakeAppState:
+    def __init__(self, plugins: _FakePluginRegistry) -> None:
+        self.plugins = plugins
+
+
+class _FakeApp:
+    def __init__(self, plugins: _FakePluginRegistry) -> None:
+        self.state = _FakeAppState(plugins)
+
+
+class _FakeDispatchPlugin:
+    """Minimal plugin stub with the two attributes the resolver inspects."""
+
+    def __init__(self, name: str, paths: list[str], response: str) -> None:
+        self.name = name
+        self.backend_call_paths = paths
+        self._response = response
+        self.calls: list[tuple[str, object]] = []
+
+    async def handle_backend_call(self, intent: str, *, app) -> str:
+        self.calls.append((intent, app))
+        return self._response
 
 
 @pytest.mark.anyio
-async def test_resolve_backend_call_raises_not_implemented() -> None:
+async def test_resolve_backend_call_dispatches_to_matching_plugin() -> None:
+    plugin = _FakeDispatchPlugin(name="claude-backend-api", paths=["/claude"], response="Four")
+    app = _FakeApp(_FakePluginRegistry({"claude-backend-api": plugin}))
+    node = Url4BackendCall(path="/claude", intent=Url4Text(value="What is 2+2?"))
+
+    result = await resolve(node, app=app)
+
+    assert result == "Four"
+    assert plugin.calls == [("What is 2+2?", app)]
+
+
+@pytest.mark.anyio
+async def test_resolve_backend_call_flattens_relurl_intent() -> None:
+    """When the intent is a Url4RelUrl, the resolver fetches it first
+    (via in-process ASGI) and hands the body to the plugin as a string.
+    That's how $prompt substitution works: /claude()!/data/<key> becomes
+    'whatever is in the blob' as the intent string."""
+    plugin = _FakeDispatchPlugin(name="claude-backend-api", paths=["/claude"], response="ok")
+    app = _FakeApp(_FakePluginRegistry({"claude-backend-api": plugin}))
+    node = Url4BackendCall(path="/claude", intent=Url4RelUrl(value="/data/abc"))
+
+    with patch(
+        "screamingface.plugins.url4_executor.url4._fetch_relative",
+        new_callable=AsyncMock,
+        return_value="user's question from the blob",
+    ):
+        await resolve(node, app=app)
+
+    assert plugin.calls == [("user's question from the blob", app)]
+
+
+@pytest.mark.anyio
+async def test_resolve_backend_call_empty_intent_is_empty_string() -> None:
+    plugin = _FakeDispatchPlugin(name="claude-backend-api", paths=["/claude"], response="ok")
+    app = _FakeApp(_FakePluginRegistry({"claude-backend-api": plugin}))
+    node = Url4BackendCall(path="/claude", intent=None)
+
+    await resolve(node, app=app)
+
+    assert plugin.calls == [("", app)]
+
+
+@pytest.mark.anyio
+async def test_resolve_backend_call_no_app_raises() -> None:
     node = Url4BackendCall(path="/claude", intent=Url4Text(value="hi"))
-    with pytest.raises(NotImplementedError, match="Stage B"):
-        await resolve(node)
+    with pytest.raises(RuntimeError, match="without an app context"):
+        await resolve(node, app=None)
 
 
 @pytest.mark.anyio
-async def test_resolve_list_with_backend_call_raises_not_implemented() -> None:
-    """A list containing a backend call cannot be fully resolved until
-    Stage B, because at least one element needs dispatch support."""
+async def test_resolve_backend_call_no_matching_plugin_raises() -> None:
+    app = _FakeApp(_FakePluginRegistry({}))
+    node = Url4BackendCall(path="/claude", intent=Url4Text(value="hi"))
+
+    with pytest.raises(RuntimeError, match="No active plugin handles"):
+        await resolve(node, app=app)
+
+
+@pytest.mark.anyio
+async def test_resolve_backend_call_error_lists_known_paths() -> None:
+    """Error message includes the set of known backend_call_paths from
+    active plugins so the user can see what IS available."""
+    other_plugin = _FakeDispatchPlugin(name="other", paths=["/codex", "/gemini"], response="x")
+    app = _FakeApp(_FakePluginRegistry({"other": other_plugin}))
+    node = Url4BackendCall(path="/claude", intent=Url4Text(value="hi"))
+
+    with pytest.raises(RuntimeError, match="/codex") as exc_info:
+        await resolve(node, app=app)
+    assert "/gemini" in str(exc_info.value)
+
+
+@pytest.mark.anyio
+async def test_resolve_list_with_backend_call_dispatches() -> None:
+    """A list mixing plain text and backend calls resolves each element
+    through its appropriate path. Proves fan-out across N backend calls
+    works — this is the foundation the ensemble reducer builds on."""
+    plugin = _FakeDispatchPlugin(name="claude-backend-api", paths=["/claude"], response="LLM reply")
+    app = _FakeApp(_FakePluginRegistry({"claude-backend-api": plugin}))
     node = Url4List(
         items=(
             Url4Text(value="plain text"),
             Url4BackendCall(path="/claude", intent=Url4Text(value="hi")),
+            Url4BackendCall(path="/claude", intent=Url4Text(value="bye")),
         )
     )
-    with pytest.raises(NotImplementedError, match="Stage B"):
-        await resolve(node)
+
+    result = await resolve(node, app=app)
+
+    # Results joined with newlines (standard Url4List resolver behavior)
+    assert result == "plain text\nLLM reply\nLLM reply"
+    # Both backend calls dispatched in order
+    assert plugin.calls == [("hi", app), ("bye", app)]
+
+
+@pytest.mark.anyio
+async def test_resolve_fanout_list_of_three_backend_calls() -> None:
+    """The target ensemble fan-out shape. Three backend calls to the
+    same backend, collected in order. This is the Stage B foundation
+    that Stage C's ensemble executor builds fan-out-reduce on top of."""
+    plugin = _FakeDispatchPlugin(name="claude-backend-api", paths=["/claude"], response="response")
+    app = _FakeApp(_FakePluginRegistry({"claude-backend-api": plugin}))
+    node = parse("(/claude()!a, /claude()!b, /claude()!c)")
+
+    result = await resolve(node, app=app)
+
+    assert result == "response\nresponse\nresponse"
+    assert [call[0] for call in plugin.calls] == ["a", "b", "c"]
 
 
 # ---------------------------------------------------------------------------

--- a/apps/server/src/screamingface/plugins/url4_executor/tests/test_url4.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/tests/test_url4.py
@@ -7,7 +7,9 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from screamingface.plugins.url4_executor.url4 import (
+    Url4BackendCall,
     Url4List,
+    Url4RelUrl,
     Url4Text,
     Url4Url,
     parse,
@@ -256,6 +258,152 @@ def test_parse_list_strips_item_whitespace() -> None:
     assert url_item.value == "http://a.com"
     assert isinstance(text_item, Url4Text)
     assert text_item.value == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Backend-call tests — /path()!<intent> form
+# ---------------------------------------------------------------------------
+#
+# The backend_call syntax is the new shorthand for "invoke a plugin as a
+# backend LLM call, with <intent> as its instruction." It parses into a
+# Url4BackendCall AST node distinct from Url4RelUrl (which stays a URL fetch).
+#
+# Stage A (SF-79) implements only the parser-level recognition. Execution
+# (Stage B) is tested separately — here we only assert AST shape.
+
+
+def test_parse_backend_call_without_intent() -> None:
+    node = parse("/claude()")
+    assert isinstance(node, Url4BackendCall)
+    assert node.path == "/claude"
+    assert node.intent is None
+
+
+def test_parse_backend_call_with_text_intent() -> None:
+    node = parse("/claude()!hello")
+    assert isinstance(node, Url4BackendCall)
+    assert node.path == "/claude"
+    assert isinstance(node.intent, Url4Text)
+    assert node.intent.value == "hello"
+
+
+def test_parse_backend_call_with_relurl_intent() -> None:
+    """The common frontend-substituted shape: /claude()!/data/<blob-key>."""
+    node = parse("/claude()!/data/abc123")
+    assert isinstance(node, Url4BackendCall)
+    assert node.path == "/claude"
+    assert isinstance(node.intent, Url4RelUrl)
+    assert node.intent.value == "/data/abc123"
+
+
+def test_parse_backend_call_with_url_intent() -> None:
+    """Edge case: the intent can be an absolute URL. Not the common shape,
+    but the grammar should accept it without special-casing."""
+    node = parse("/claude()!https://example.com/data")
+    assert isinstance(node, Url4BackendCall)
+    assert isinstance(node.intent, Url4Url)
+    assert node.intent.value == "https://example.com/data"
+
+
+def test_parse_backend_call_with_variable_intent() -> None:
+    """The $prompt variable shape. Parser treats the literal '$prompt'
+    string as Url4Text — the frontend substitutes it to a /data/<key>
+    reference BEFORE the parser runs on the substituted expression."""
+    node = parse("/codex()!$prompt")
+    assert isinstance(node, Url4BackendCall)
+    assert node.path == "/codex"
+    assert isinstance(node.intent, Url4Text)
+    assert node.intent.value == "$prompt"
+
+
+def test_parse_backend_call_different_paths() -> None:
+    """Parser must accept every backend path, not just /claude."""
+    for path in ("/claude", "/codex", "/gemini", "/qwen", "/ollama"):
+        node = parse(f"{path}()!test")
+        assert isinstance(node, Url4BackendCall)
+        assert node.path == path
+
+
+def test_parse_list_of_backend_calls_fanout_shape() -> None:
+    """The target spec's fan-out shape: a parenthesized list where every
+    element is a backend call to a different backend with the same intent."""
+    node = parse("(/claude()!$prompt,/codex()!$prompt,/gemini()!$prompt)")
+    assert isinstance(node, Url4List)
+    assert len(node.items) == 3
+
+    for item, expected_path in zip(node.items, ["/claude", "/codex", "/gemini"], strict=True):
+        assert isinstance(item, Url4BackendCall)
+        assert item.path == expected_path
+        assert isinstance(item.intent, Url4Text)
+        assert item.intent.value == "$prompt"
+
+
+def test_parse_list_of_backend_calls_different_intents() -> None:
+    """Each element of a fan-out list can have its own distinct intent.
+    This shape is used for deterministic manual testing and e2e tests
+    that want to assert the reducer received three specific responses."""
+    node = parse("(/claude()!hello, /claude()!world, /claude()!again)")
+    assert isinstance(node, Url4List)
+    assert len(node.items) == 3
+    intents = [item.intent.value for item in node.items]  # type: ignore[union-attr]
+    assert intents == ["hello", "world", "again"]
+
+
+def test_parse_backend_call_does_not_shadow_regular_relurl() -> None:
+    """Regression: /claude (no parens) must still parse as a Url4RelUrl,
+    not as a Url4BackendCall. The backend_call alternative only matches
+    when () is present immediately after the path."""
+    node = parse("/claude")
+    assert isinstance(node, Url4RelUrl)
+    assert node.value == "/claude"
+
+
+def test_parse_backend_call_does_not_shadow_querystring_relurl() -> None:
+    """Regression: /claude?q=... still parses as a Url4RelUrl (URL fetch),
+    not as a backend call — there are no () after the path."""
+    node = parse("/claude?q=(https://ex.com)!summarize")
+    assert isinstance(node, Url4RelUrl)
+    assert node.value == "/claude?q=(https://ex.com)!summarize"
+
+
+def test_parse_mixed_list_backend_call_and_fetch() -> None:
+    """A list can contain both backend calls and plain URL fetches.
+    This isn't a common shape but the grammar shouldn't reject it."""
+    node = parse("(/claude()!hi, /data/abc, https://example.com)")
+    assert isinstance(node, Url4List)
+    assert isinstance(node.items[0], Url4BackendCall)
+    assert isinstance(node.items[1], Url4RelUrl)
+    assert isinstance(node.items[2], Url4Url)
+
+
+# ---------------------------------------------------------------------------
+# Backend-call resolver tests — Stage B is not yet implemented
+# ---------------------------------------------------------------------------
+#
+# Stage A commits to parsing but NOT execution. The resolver raises
+# NotImplementedError when it encounters a Url4BackendCall. Stage B lands
+# the dispatch and removes this guard.
+
+
+@pytest.mark.anyio
+async def test_resolve_backend_call_raises_not_implemented() -> None:
+    node = Url4BackendCall(path="/claude", intent=Url4Text(value="hi"))
+    with pytest.raises(NotImplementedError, match="Stage B"):
+        await resolve(node)
+
+
+@pytest.mark.anyio
+async def test_resolve_list_with_backend_call_raises_not_implemented() -> None:
+    """A list containing a backend call cannot be fully resolved until
+    Stage B, because at least one element needs dispatch support."""
+    node = Url4List(
+        items=(
+            Url4Text(value="plain text"),
+            Url4BackendCall(path="/claude", intent=Url4Text(value="hi")),
+        )
+    )
+    with pytest.raises(NotImplementedError, match="Stage B"):
+        await resolve(node)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/server/src/screamingface/plugins/url4_executor/url4.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/url4.py
@@ -42,6 +42,36 @@ GRAMMAR = r"""
     group = '(' elems:','%{ context } ')' ;
 
     atom
+        = backend_call
+        | url
+        | relurl
+        | text
+        ;
+
+    # Backend-call form: /path()!<intent>
+    #
+    # Recognizes a plugin/backend invocation shorthand where ``/path`` is
+    # the backend route (e.g. ``/claude``, ``/codex``, ``/gemini``), ``()``
+    # marks it as a backend call (not a URL fetch), and ``!<intent>`` is
+    # the LLM instruction for that backend.
+    #
+    # The intent is any atom EXCEPT another backend_call — a trailing
+    # ``!intent!more`` is parsed with ``!more`` as the intent text, not as
+    # a nested call.
+    backend_call = path:backend_path '(' ')' [ '!' intent:atom_no_bc ] ;
+
+    # Path prefix for a backend_call: starts with /, continues until
+    # the first '(' or ',' or whitespace or '!'. Also excludes URL
+    # query/fragment chars ('?', '&', '#') so that URLs like
+    # ``/claude?q=()`` don't get captured as backend_call paths — those
+    # stay as regular URL fetches (Url4RelUrl).
+    backend_path = /\/[^\s,()!?&#]+/ ;
+
+    # atom alternatives used INSIDE a backend_call intent — excludes
+    # backend_call itself to avoid ambiguous nesting. ``/claude()!a`` is a
+    # single backend_call; ``/claude()!/other()!b`` puts ``/other()!b`` as
+    # the intent (a relurl, since intent can't contain another backend_call).
+    atom_no_bc
         = url
         | relurl
         | text
@@ -79,7 +109,26 @@ class Url4List:
     items: tuple[Url4Node, ...]
 
 
-Url4Node = Url4Url | Url4RelUrl | Url4Text | Url4List
+@dataclass(frozen=True)
+class Url4BackendCall:
+    """A backend-invocation node: ``/path()!<intent>``.
+
+    This is the shorthand for "invoke the plugin mounted at ``path`` as a
+    backend LLM call, passing ``intent`` as the instruction." Distinct from
+    a :class:`Url4RelUrl`, which is a URL fetch via in-process ASGI GET.
+
+    The distinction matters at execution time: a :class:`Url4RelUrl`
+    becomes an HTTP GET and the response body is concatenated into the
+    source text, whereas a :class:`Url4BackendCall` becomes a single LLM
+    invocation via the llm-base ``Backend`` abstraction and the response
+    is a structured assistant message.
+    """
+
+    path: str
+    intent: Url4Node | None = None
+
+
+Url4Node = Url4Url | Url4RelUrl | Url4Text | Url4List | Url4BackendCall
 
 # ---------------------------------------------------------------------------
 # TatSu semantics — transforms raw AST into typed dataclasses
@@ -96,10 +145,25 @@ class Url4Semantics:
     def text(self, ast):
         return Url4Text(value=ast.value.strip())
 
+    def backend_call(self, ast):
+        # ast.path is the backend_path rule's matched value (e.g. "/claude").
+        # ast.intent is None when the optional ``!<intent>`` tail is absent,
+        # or the semantics-produced node (Url4Url / Url4RelUrl / Url4Text)
+        # when present.
+        return Url4BackendCall(path=ast.path.strip(), intent=ast.intent)
+
+    def backend_path(self, ast):
+        # TatSu returns the matched string directly for a regex rule
+        return ast
+
     def group(self, ast):
         elems = ast.elems if isinstance(ast.elems, list) else [ast.elems] if ast.elems else []
         # Filter out comma separator tokens from join operator
-        nodes = [e for e in elems if isinstance(e, Url4Url | Url4RelUrl | Url4Text | Url4List)]
+        nodes = [
+            e
+            for e in elems
+            if isinstance(e, Url4Url | Url4RelUrl | Url4Text | Url4List | Url4BackendCall)
+        ]
         return Url4List(items=tuple(nodes))
 
     def context(self, ast):
@@ -137,6 +201,17 @@ async def resolve(node: Url4Node, app: Any = None) -> str:
     if isinstance(node, Url4List):
         results = list(await asyncio.gather(*[resolve(item, app) for item in node.items]))
         return "\n".join(results)
+    if isinstance(node, Url4BackendCall):
+        # Stage B will implement dispatch. For now, the parser accepts
+        # the new form but the resolver refuses to execute it so we don't
+        # silently fall back to a URL fetch that would hit a nonexistent
+        # route.
+        raise NotImplementedError(
+            f"Backend call {node.path}() is not yet executable. "
+            "Stage B of SF-79 wires the dispatch through the llm-base "
+            "Backend abstraction. For now, only parser-level AST "
+            "inspection is supported."
+        )
     raise TypeError(f"Unknown node type: {type(node)}")
 
 

--- a/apps/server/src/screamingface/plugins/url4_executor/url4.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/url4.py
@@ -202,17 +202,65 @@ async def resolve(node: Url4Node, app: Any = None) -> str:
         results = list(await asyncio.gather(*[resolve(item, app) for item in node.items]))
         return "\n".join(results)
     if isinstance(node, Url4BackendCall):
-        # Stage B will implement dispatch. For now, the parser accepts
-        # the new form but the resolver refuses to execute it so we don't
-        # silently fall back to a URL fetch that would hit a nonexistent
-        # route.
-        raise NotImplementedError(
-            f"Backend call {node.path}() is not yet executable. "
-            "Stage B of SF-79 wires the dispatch through the llm-base "
-            "Backend abstraction. For now, only parser-level AST "
-            "inspection is supported."
-        )
+        return await _dispatch_backend_call(node, app)
     raise TypeError(f"Unknown node type: {type(node)}")
+
+
+async def _dispatch_backend_call(node: Url4BackendCall, app: Any) -> str:
+    """Dispatch a :class:`Url4BackendCall` through an active plugin.
+
+    Walks ``app.state.plugins.active_plugins`` looking for one whose
+    :attr:`backend_call_paths` contains ``node.path``, flattens the
+    intent into a plain string, then awaits the plugin's
+    ``handle_backend_call(intent, app=app)`` method.
+
+    Error modes:
+
+    - No *app* available (e.g. resolver called without a FastAPI context)
+      → raises :class:`RuntimeError`.
+    - No active plugin handles ``node.path`` → raises :class:`RuntimeError`
+      with the list of known backend_call_paths so the user knows what's
+      available.
+    - Target plugin has no ``handle_backend_call`` override → raises
+      whatever the plugin base's default raises (``NotImplementedError``).
+    - Target plugin raises during dispatch → propagated unchanged so the
+      ensemble layer above can catch provider-specific errors.
+    """
+    if app is None:
+        raise RuntimeError(
+            f"Cannot dispatch backend call {node.path}() without an app "
+            "context. Backend-call resolution needs access to the active "
+            "plugin registry via app.state.plugins."
+        )
+
+    # Flatten the intent node to a string. For a text intent this is a
+    # no-op; for a relurl intent this fetches the blob body; for a URL
+    # intent this fetches the remote URL.
+    if node.intent is None:
+        intent_text = ""
+    else:
+        intent_text = await resolve(node.intent, app)
+
+    # Find the plugin that registered this path.
+    plugins_registry = getattr(getattr(app, "state", None), "plugins", None)
+    if plugins_registry is None:
+        raise RuntimeError(
+            f"Cannot dispatch backend call {node.path}(): app.state.plugins is not set."
+        )
+
+    known_paths: list[str] = []
+    for plugin in plugins_registry.active_plugins.values():
+        paths = getattr(plugin, "backend_call_paths", [])
+        known_paths.extend(paths)
+        if node.path in paths:
+            return await plugin.handle_backend_call(intent_text, app=app)
+
+    raise RuntimeError(
+        f"No active plugin handles the backend call {node.path}(). "
+        f"Known backend_call_paths across active plugins: {known_paths!r}. "
+        "Activate a plugin that declares this path in its "
+        "backend_call_paths attribute."
+    )
 
 
 async def resolve_str(context: str, app: Any = None) -> str:


### PR DESCRIPTION
## Summary
- **SF-78**: llm-base plugin + claude-backend-api plugin scaffold with unit tests
- **SF-79**: url4 parser extension for `/backend()!<intent>` syntax, dispatch through plugin registry, EnsembleInterpreter fan-out-reduce
- **Fixes**: StatusDot squished in settings, Electron lingering in macOS dock after dev exit, claude-backend-api default model updated to claude-sonnet-4-6, full config + default_profile validation

## Test plan
- [ ] Run `uv run pytest` in apps/server
- [ ] Verify green status dot is circular in Settings view
- [ ] Run `npm run dev` in apps/desktop, close window, confirm app quits from dock
- [ ] Verify `rg "claude-sonnet-4-6" apps/server/` shows 3 matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)