### PR TITLE
feat(SF-85): Codex frontend plugin

### DIFF
--- a/apps/server/src/screamingface/plugins/codex_frontend/__init__.py
+++ b/apps/server/src/screamingface/plugins/codex_frontend/__init__.py
@@ -1,0 +1,6 @@
+"""codex-frontend plugin — transparent proxy for Codex CLI on a dedicated port.
+
+Mirrors claude-frontend architecture: runs its own HTTP server so routes
+don't clash with the main SF server. Intercepts /v1/responses traffic
+from the Codex CLI and injects url4-resolved context.
+"""

--- a/apps/server/src/screamingface/plugins/codex_frontend/plugin.py
+++ b/apps/server/src/screamingface/plugins/codex_frontend/plugin.py
@@ -1,0 +1,298 @@
+"""Codex Frontend plugin — transparent proxy on a dedicated port.
+
+Mirrors claude-frontend: runs its own HTTP server so its routes
+(/v1/responses, /v1/*) don't clash with the main SF server.
+
+The Codex CLI uses the OpenAI Responses API, not Chat Completions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+import socket
+import threading
+import time
+from typing import TYPE_CHECKING, Literal
+
+import httpx
+import uvicorn
+from fastapi import FastAPI
+from pydantic import Field
+from pydantic_settings import SettingsConfigDict
+
+from screamingface.plugin import Plugin, PluginSettings
+from screamingface.plugins.codex_frontend.proxy import create_router
+
+if TYPE_CHECKING:
+    from screamingface.core.classes import ClassRegistry
+    from screamingface.core.hooks import HookRegistry
+    from screamingface.core.routes import RouteRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class CodexFrontendSettings(PluginSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="SF_CODEX_FRONTEND__",
+        env_nested_delimiter="__",
+    )
+    active_spec: str | None = Field(
+        default=None,
+        description="Active url4-spec to resolve and prepend as context.",
+    )
+    upstream_url: str = "https://api.openai.com"
+    listen_host: str = "127.0.0.1"
+    listen_port: int = 9102
+    session_service_url: str | None = Field(
+        default=None,
+        description="URL of the session service. Enables session persistence.",
+    )
+    backend_url: str | None = Field(
+        default=None,
+        description=(
+            "URL of the main SF server for url4/data/backend calls."
+            " When set (per-session mode), proxy uses HTTP calls instead of in-process."
+        ),
+    )
+    resolve_timeout: float = Field(
+        default=300.0,
+        description="Max seconds to wait for url4 spec resolution on first request.",
+    )
+    embed_target: Literal["system", "user"] = Field(
+        default="user",
+        description="Where to inject url4-resolved context: 'system' or 'user'.",
+    )
+    embed_mode: Literal["concat", "replace"] = Field(
+        default="concat",
+        description="How to embed in user message: 'concat' or 'replace'.",
+    )
+    system_prompt: str = Field(
+        default=(
+            "You are a helpful assistant. Answer the user's question based only on "
+            "the provided context. Be concise and factual."
+        ),
+        description="System prompt prepended to resolved context when embed_target is 'system'.",
+    )
+
+
+class CodexFrontendPlugin(Plugin):
+    name = "codex-frontend"
+    description = "Transparent proxy between Codex CLI and the OpenAI API"
+    depends: list[str] = ["url4-specs", "url4-executor"]
+    settings_class = CodexFrontendSettings
+
+    def __init__(self) -> None:
+        self._server: uvicorn.Server | None = None
+        self._thread: threading.Thread | None = None
+        self._cache: dict[str, str] = {}
+        self._resolved_context: str | None = None
+        self._active_key: str | None = None
+        self._lock = threading.Lock()
+
+    def _get_spec_names(self) -> list[str] | None:
+        if not hasattr(self, "_app") or not self._app:
+            return None
+        specs_plugin = self._app.state.plugins.active_plugins.get("url4-specs")
+        if specs_plugin and specs_plugin.settings:
+            names = list(specs_plugin.settings.specs.keys())
+            if names:
+                return names
+        return None
+
+    def customize_schema(self, schema: dict) -> dict:
+        props = schema.get("properties", {})
+        spec_names = self._get_spec_names()
+        if spec_names and "active_spec" in props:
+            props["active_spec"]["enum"] = spec_names
+        return schema
+
+    def preflight(self) -> tuple[bool, str]:
+        if not shutil.which("codex"):
+            return False, (
+                "Codex CLI not found in PATH. "
+                "Install it with: npm install -g @openai/codex"
+            )
+        return True, ""
+
+    def _collect_spec_names(self) -> list[str]:
+        settings: CodexFrontendSettings = self.settings  # type: ignore[assignment]
+        if settings.active_spec:
+            return [settings.active_spec]
+        return []
+
+    def _get_spec_urls(self) -> list[tuple[str, str]]:
+        spec_names = self._collect_spec_names()
+        if not spec_names or not hasattr(self, "_app") or not self._app:
+            return []
+        specs_plugin = self._app.state.plugins.active_plugins.get("url4-specs")
+        if not specs_plugin or not specs_plugin.settings:
+            return []
+        result: list[tuple[str, str]] = []
+        for name in spec_names:
+            spec = specs_plugin.settings.specs.get(name)
+            if spec and spec.expression:
+                result.append((name, spec.expression))
+        return result
+
+    def get_active_expression(self) -> str | None:
+        spec_urls = self._get_spec_urls()
+        if not spec_urls:
+            return None
+        return spec_urls[0][1]
+
+    def resolve_context(self) -> str | None:
+        """Resolve active specs lazily. Called on first request."""
+        spec_urls = self._get_spec_urls()
+        spec_urls = [(n, e) for n, e in spec_urls if "$prompt" not in e]
+        if not spec_urls:
+            return None
+
+        active_key = ",".join(name for name, _ in spec_urls)
+        if self._active_key == active_key and self._resolved_context is not None:
+            return self._resolved_context
+
+        with self._lock:
+            if self._active_key == active_key and self._resolved_context is not None:
+                return self._resolved_context
+
+            settings: CodexFrontendSettings = self.settings  # type: ignore[assignment]
+            timeout = settings.resolve_timeout
+            resolved_parts: list[str] = []
+
+            for name, url in spec_urls:
+                if name in self._cache:
+                    resolved_parts.append(self._cache[name])
+                    continue
+                try:
+                    result = self._fetch_sync(url, timeout)
+                    if result:
+                        self._cache[name] = result
+                        resolved_parts.append(result)
+                except Exception:
+                    logger.warning("Failed to resolve spec %r", name, exc_info=True)
+
+            if resolved_parts:
+                self._resolved_context = "\n\n".join(resolved_parts)
+                self._active_key = active_key
+            else:
+                self._resolved_context = None
+                self._active_key = active_key
+
+            return self._resolved_context
+
+    def _get_backend_url(self) -> str:
+        settings: CodexFrontendSettings = self.settings  # type: ignore[assignment]
+        if settings.backend_url:
+            return settings.backend_url.rstrip("/")
+        cfg = getattr(self._app.state, "config", None) if self._app else None
+        port = cfg.server.port if cfg else 8000
+        use_ssl = cfg.server.ssl if cfg else False
+        scheme = "https" if use_ssl else "http"
+        return f"{scheme}://localhost:{port}"
+
+    def _fetch_sync(self, expression: str, timeout: float) -> str:
+        base = self._get_backend_url()
+        result_holder: list[str] = []
+
+        def _run() -> None:
+            loop = asyncio.new_event_loop()
+            try:
+                result_holder.append(loop.run_until_complete(_fetch(base, expression)))
+            finally:
+                loop.close()
+
+        thread = threading.Thread(target=_run, name="url4-fetch", daemon=True)
+        thread.start()
+        thread.join(timeout=timeout)
+
+        if not result_holder:
+            raise TimeoutError(f"Spec resolution timed out after {timeout}s")
+        return result_holder[0]
+
+    def setup(
+        self,
+        app: FastAPI,
+        hooks: HookRegistry,
+        classes: ClassRegistry,
+        routes: RouteRegistry,
+    ) -> None:
+        settings: CodexFrontendSettings = self.settings  # type: ignore[assignment]
+        self._app = app
+
+        is_session = bool(os.environ.get("_SF_SESSION_ID"))
+
+        if is_session:
+            frontend_app = FastAPI(title="codex-frontend")
+            router = create_router(settings, app, plugin=self, hooks=hooks)
+            frontend_app.include_router(router)
+
+            try:
+                from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+                FastAPIInstrumentor.instrument_app(frontend_app)
+            except ImportError:
+                pass
+
+            config = uvicorn.Config(
+                frontend_app,
+                host=settings.listen_host,
+                port=settings.listen_port,
+                log_level="info",
+            )
+            self._server = uvicorn.Server(config)
+            self._thread = threading.Thread(
+                target=self._run_server, daemon=True, name="codex-frontend"
+            )
+            self._thread.start()
+
+            if not _wait_for_port(settings.listen_port, host=settings.listen_host):
+                logger.warning("codex-frontend server may not be ready yet")
+
+            logger.info(
+                "codex-frontend listening on http://%s:%d",
+                settings.listen_host,
+                settings.listen_port,
+            )
+        else:
+            logger.info("codex-frontend registered (proxy launches per-session only)")
+
+        hooks.register("app.shutdown", self._on_shutdown, plugin_name=self.name)
+
+    def _run_server(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(self._server.serve())  # type: ignore[union-attr]
+
+    async def _on_shutdown(self) -> None:
+        self._stop()
+
+    def teardown(self) -> None:
+        self._stop()
+
+    def _stop(self) -> None:
+        if self._server:
+            self._server.should_exit = True
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=5)
+        self._server = None
+        self._thread = None
+
+
+async def _fetch(base_url: str, expression: str) -> str:
+    async with httpx.AsyncClient(timeout=300, verify=False) as client:
+        resp = await client.get(f"{base_url}/ensemble", params={"q": expression})
+        resp.raise_for_status()
+        return resp.text
+
+
+def _wait_for_port(port: int, host: str = "127.0.0.1", timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            if sock.connect_ex((host, port)) == 0:
+                return True
+        time.sleep(0.1)
+    return False

--- a/apps/server/src/screamingface/plugins/codex_frontend/proxy.py
+++ b/apps/server/src/screamingface/plugins/codex_frontend/proxy.py
@@ -1,0 +1,509 @@
+"""Codex (OpenAI Responses API) proxy router — streaming and non-streaming."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import ssl
+from typing import TYPE_CHECKING, Any
+
+import certifi
+import httpx
+from fastapi import APIRouter, Request, Response
+from fastapi.responses import JSONResponse, StreamingResponse
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from screamingface.plugins.codex_frontend.plugin import CodexFrontendSettings
+
+# Headers to forward from the Codex CLI request to the upstream API.
+FORWARD_HEADERS = {
+    "content-type",
+    "authorization",
+    "accept",
+    "x-sf-trace-id",
+    "openai-organization",
+    "openai-project",
+}
+
+_SENSITIVE_HEADERS = {"authorization"}
+_PLUGIN_NAME = "codex-frontend"
+
+
+def _redact_headers(headers: dict[str, str]) -> dict[str, str]:
+    return {
+        k: (v[:8] + "…" if k.lower() in _SENSITIVE_HEADERS and len(v) > 8 else v)
+        for k, v in headers.items()
+    }
+
+
+def _truncate(text: str, limit: int = 4000) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit] + f"\n... ({len(text) - limit} more chars)"
+
+
+def _get_tracer():  # type: ignore[no-untyped-def]
+    try:
+        from opentelemetry import trace
+
+        return trace.get_tracer(f"screamingface.{_PLUGIN_NAME}")
+    except ImportError:
+        return None
+
+
+def _set_span_attrs(attrs: dict[str, Any], span=None) -> None:  # type: ignore[no-untyped-def]
+    try:
+        from opentelemetry import trace
+
+        span = span or trace.get_current_span()
+        if span and span.is_recording():
+            span.set_attribute("sf.plugin", _PLUGIN_NAME)
+            for k, v in attrs.items():
+                span.set_attribute(k, v)
+    except ImportError:
+        pass
+
+
+def _set_span_headers(prefix: str, headers: dict[str, str], span=None) -> None:  # type: ignore[no-untyped-def]
+    try:
+        from opentelemetry import trace
+
+        span = span or trace.get_current_span()
+        if span and span.is_recording():
+            for k, v in headers.items():
+                span.set_attribute(f"{prefix}.{k}", v)
+    except ImportError:
+        pass
+
+
+def _start_client_span(tracer, name: str):  # type: ignore[no-untyped-def]
+    from opentelemetry.trace import SpanKind
+
+    return tracer.start_as_current_span(name, kind=SpanKind.CLIENT)
+
+
+def _start_client_span_detached(tracer, name: str):  # type: ignore[no-untyped-def]
+    from opentelemetry.trace import SpanKind
+
+    return tracer.start_span(name, kind=SpanKind.CLIENT)
+
+
+def _record_trace_id(request: Request) -> str | None:
+    trace_id = request.headers.get("x-sf-trace-id")
+    if trace_id:
+        _set_span_attrs({"sf.trace_id": trace_id})
+    return trace_id
+
+
+# ---------------------------------------------------------------------------
+# OpenAI Responses API helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_last_user_text(body: dict[str, Any]) -> str | None:
+    """Extract the user's actual prompt from a Responses API request.
+
+    The Responses API ``input`` field can be:
+    - A plain string (simple prompt)
+    - A list of message dicts with role/content
+    """
+    inp = body.get("input")
+    if isinstance(inp, str):
+        return inp
+    if isinstance(inp, list):
+        for msg in reversed(inp):
+            if not isinstance(msg, dict):
+                continue
+            if msg.get("role") != "user":
+                continue
+            content = msg.get("content")
+            if isinstance(content, str):
+                return content
+    return None
+
+
+def _replace_user_text(body: dict[str, Any], new_text: str) -> None:
+    """Replace the user's text in a Responses API request body."""
+    inp = body.get("input")
+    if isinstance(inp, str):
+        body["input"] = new_text
+        return
+    if isinstance(inp, list):
+        for i in range(len(inp) - 1, -1, -1):
+            msg = inp[i]
+            if isinstance(msg, dict) and msg.get("role") == "user":
+                if isinstance(msg.get("content"), str):
+                    inp[i]["content"] = new_text
+                    return
+        # No user message found — append
+        inp.append({"role": "user", "content": new_text})
+
+
+def _inject_system_context(body: dict[str, Any], text: str) -> None:
+    """Inject text into the Responses API ``instructions`` field."""
+    existing = body.get("instructions")
+    if existing:
+        body["instructions"] = existing + "\n\n" + text
+    else:
+        body["instructions"] = text
+
+
+def _embed_context(
+    body: dict[str, Any],
+    resolved_context: str,
+    settings: CodexFrontendSettings,
+) -> None:
+    """Embed resolved url4 context into the request body per settings."""
+    if settings.embed_target == "user":
+        last_user_text = _extract_last_user_text(body)
+        if last_user_text:
+            if settings.embed_mode == "concat":
+                combined = f"{last_user_text}\n\n{resolved_context}"
+            else:
+                combined = resolved_context
+            _replace_user_text(body, combined)
+    else:  # system
+        wrapped = f"{settings.system_prompt}\n\n{resolved_context}"
+        _inject_system_context(body, wrapped)
+
+
+def _parse_sse_response(raw: str) -> dict[str, Any] | None:
+    """Reconstruct an OpenAI Responses API response from SSE stream data.
+
+    OpenAI streaming uses ``response.created``, ``response.output_item.*``,
+    ``response.content_part.*``, ``response.output_text.*``, and
+    ``response.completed`` events.
+    """
+    response: dict[str, Any] = {}
+    output_items: list[dict[str, Any]] = []
+    current_item: dict[str, Any] = {}
+    current_text = ""
+
+    for line in raw.split("\n"):
+        line = line.strip()
+        if not line.startswith("data: "):
+            continue
+        data_str = line[6:]
+        if data_str == "[DONE]":
+            break
+        try:
+            event = json.loads(data_str)
+        except json.JSONDecodeError:
+            continue
+
+        etype = event.get("type", "")
+
+        if etype == "response.created":
+            resp_data = event.get("response", {})
+            response.update({
+                "id": resp_data.get("id"),
+                "object": "response",
+                "model": resp_data.get("model"),
+                "status": resp_data.get("status"),
+            })
+        elif etype == "response.output_item.added":
+            current_item = event.get("item", {})
+            current_text = ""
+        elif etype == "response.output_text.delta":
+            current_text += event.get("delta", "")
+        elif etype == "response.output_item.done":
+            item = event.get("item", current_item)
+            if current_text and item.get("type") == "message":
+                item["content"] = [{"type": "output_text", "text": current_text}]
+            output_items.append(item)
+            current_item = {}
+            current_text = ""
+        elif etype == "response.completed":
+            resp_data = event.get("response", {})
+            response.update({
+                "status": resp_data.get("status", "completed"),
+                "usage": resp_data.get("usage", {}),
+            })
+
+    if not response:
+        return None
+
+    response["output"] = output_items
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Router factory
+# ---------------------------------------------------------------------------
+
+
+def create_router(
+    settings: CodexFrontendSettings,
+    app: Any = None,
+    plugin: Any = None,
+    hooks: Any = None,
+) -> APIRouter:
+    upstream_url = settings.upstream_url.rstrip("/")
+    session_service_url = settings.session_service_url
+    ssl_ctx = ssl.create_default_context(cafile=certifi.where())
+
+    router = APIRouter(tags=["codex-frontend"])
+
+    def _build_headers(request: Request) -> dict[str, str]:
+        headers = {}
+        for key in FORWARD_HEADERS:
+            value = request.headers.get(key)
+            if value:
+                headers[key] = value
+        if "authorization" not in headers:
+            api_key = os.environ.get("OPENAI_API_KEY", "")
+            if api_key:
+                headers["authorization"] = f"Bearer {api_key}"
+        return headers
+
+    @router.post("/v1/responses", response_model=None, operation_id="proxy_responses")
+    async def proxy_responses(request: Request) -> Response:
+        body = await request.json()
+
+        # --- Session enrichment ---
+        session_id = os.environ.get("_SF_SESSION_ID") or request.headers.get("x-session-id")
+        original_user_msg = None
+        if session_id and session_service_url and hooks:
+            original_user_msg = _extract_last_user_text(body)
+            try:
+                results = await hooks.emit_async(
+                    "session.enrich_request",
+                    body=body,
+                    session_id=session_id,
+                    session_service_url=session_service_url,
+                )
+                for result in results:
+                    if result is not None:
+                        body = result
+                        break
+            except Exception:
+                logger.warning("Session enrichment failed for %s", session_id, exc_info=True)
+
+        # --- URL4 context injection ---
+        raw_expression = plugin.get_active_expression() if plugin else None
+
+        if raw_expression and "$prompt" in raw_expression:
+            last_user_text = _extract_last_user_text(body)
+            if last_user_text:
+                try:
+                    backend_url = (
+                        settings.backend_url.rstrip("/") if settings.backend_url else None
+                    )
+
+                    if backend_url:
+                        blob_url_target = f"{backend_url}/data"
+                        async with httpx.AsyncClient(
+                            timeout=httpx.Timeout(30.0), verify=False
+                        ) as dc:
+                            blob_resp = await dc.post(
+                                blob_url_target,
+                                content=last_user_text.encode("utf-8"),
+                                headers={"content-type": "text/plain; charset=utf-8"},
+                            )
+                            blob_resp.raise_for_status()
+                            blob_key = blob_resp.json()["key"]
+                    else:
+                        from screamingface.plugins.data_store.routes import store_blob
+
+                        blob_key = store_blob(
+                            last_user_text.encode("utf-8"), "text/plain; charset=utf-8"
+                        )
+
+                    blob_url = f"/data/{blob_key}"
+                    substituted = raw_expression.replace("$prompt", blob_url)
+
+                    if backend_url:
+                        ens_url = f"{backend_url}/ensemble"
+                        async with httpx.AsyncClient(
+                            timeout=httpx.Timeout(300.0), verify=False
+                        ) as ec:
+                            ens_resp = await ec.get(ens_url, params={"q": substituted})
+                            ens_resp.raise_for_status()
+                            final_text = ens_resp.text
+                    else:
+                        from screamingface.plugins.url4_executor.interpreter import (
+                            Url4Interpreter,
+                        )
+
+                        interpreter = Url4Interpreter(app=app)
+                        final_text = await interpreter.evaluate(substituted)
+
+                    if final_text:
+                        _embed_context(body, final_text, settings)
+                except Exception as exc:
+                    logger.warning("$prompt substitution failed", exc_info=True)
+                    error_response = {
+                        "id": f"sf_error_{id(exc):x}",
+                        "object": "response",
+                        "output": [
+                            {
+                                "type": "message",
+                                "role": "assistant",
+                                "content": [
+                                    {
+                                        "type": "output_text",
+                                        "text": f"[url4 error] {exc.__class__.__name__}: {exc}",
+                                    }
+                                ],
+                            }
+                        ],
+                        "status": "failed",
+                    }
+                    return JSONResponse(content=error_response, status_code=200)
+        elif raw_expression:
+            try:
+                resolved_context = plugin.resolve_context() if plugin else None
+            except Exception as exc:
+                logger.warning("Static context resolution failed", exc_info=True)
+                error_response = {
+                    "id": f"sf_error_{id(exc):x}",
+                    "object": "response",
+                    "output": [
+                        {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [
+                                {
+                                    "type": "output_text",
+                                    "text": f"[url4 error] {exc.__class__.__name__}: {exc}",
+                                }
+                            ],
+                        }
+                    ],
+                    "status": "failed",
+                }
+                return JSONResponse(content=error_response, status_code=200)
+            if resolved_context:
+                _embed_context(body, resolved_context, settings)
+
+        # --- Forward to upstream ---
+        headers = _build_headers(request)
+        qs = str(request.url.query)
+        url = f"{upstream_url}/v1/responses"
+        if qs:
+            url = f"{url}?{qs}"
+        timeout = httpx.Timeout(connect=10.0, read=600.0, write=10.0, pool=10.0)
+
+        _record_trace_id(request)
+        _set_span_attrs({"request.body": _truncate(json.dumps(body))})
+        _set_span_headers("request.headers", _redact_headers(headers))
+
+        is_streaming = body.get("stream", False)
+
+        logger.info(
+            "PROXY >>> forwarding to %s | stream=%s | model=%s",
+            url,
+            is_streaming,
+            body.get("model", "?"),
+        )
+
+        if is_streaming:
+            client = httpx.AsyncClient(timeout=timeout, verify=ssl_ctx)
+            tracer = _get_tracer()
+            upstream_span = (
+                _start_client_span_detached(tracer, "openai.POST /v1/responses")
+                if tracer
+                else None
+            )
+
+            async def stream_response():
+                chunks: list[bytes] = []
+                try:
+                    async with client.stream("POST", url, json=body, headers=headers) as resp:
+                        if upstream_span:
+                            _set_span_attrs({"http.status_code": resp.status_code}, upstream_span)
+                        async for chunk in resp.aiter_bytes():
+                            chunks.append(chunk)
+                            yield chunk
+                except Exception as exc:
+                    logger.error("STREAM >>> ERROR: %s", exc, exc_info=True)
+                    raise
+                finally:
+                    if chunks:
+                        raw = b"".join(chunks).decode(errors="replace")
+                        _set_span_attrs({"response.body": _truncate(raw)})
+
+                        if session_id and session_service_url and hooks and original_user_msg:
+                            response_data = _parse_sse_response(raw)
+                            if response_data:
+                                try:
+                                    await hooks.emit_async(
+                                        "session.save_response",
+                                        session_id=session_id,
+                                        session_service_url=session_service_url,
+                                        user_message_body=original_user_msg,
+                                        response_body=response_data,
+                                    )
+                                except Exception:
+                                    logger.warning(
+                                        "Session save (stream) failed for %s",
+                                        session_id,
+                                        exc_info=True,
+                                    )
+
+                    if upstream_span:
+                        upstream_span.end()
+                    await client.aclose()
+
+            return StreamingResponse(stream_response(), media_type="text/event-stream")
+        else:
+            async with httpx.AsyncClient(timeout=timeout, verify=ssl_ctx) as client:
+                resp = await client.post(url, json=body, headers=headers)
+
+            _set_span_attrs({
+                "response.body": _truncate(resp.text),
+                "http.status_code": resp.status_code,
+            })
+
+            response_data = resp.json()
+
+            if session_id and session_service_url and hooks and original_user_msg:
+                try:
+                    await hooks.emit_async(
+                        "session.save_response",
+                        session_id=session_id,
+                        session_service_url=session_service_url,
+                        user_message_body=original_user_msg,
+                        response_body=response_data,
+                    )
+                except Exception:
+                    logger.warning("Session save failed for %s", session_id, exc_info=True)
+
+            return JSONResponse(content=response_data, status_code=resp.status_code)
+
+    @router.get("/v1/{path:path}", response_model=None, operation_id="proxy_catchall_get")
+    @router.post("/v1/{path:path}", response_model=None, operation_id="proxy_catchall_post")
+    async def proxy_catchall(request: Request, path: str) -> Response:
+        """Forward any other /v1/* requests to upstream."""
+        headers = _build_headers(request)
+        url = f"{upstream_url}/v1/{path}"
+        method = request.method
+        timeout = httpx.Timeout(connect=10.0, read=600.0, write=10.0, pool=10.0)
+
+        body = await request.body()
+        kwargs: dict[str, Any] = {"headers": headers}
+        if body:
+            kwargs["content"] = body
+
+        async with httpx.AsyncClient(timeout=timeout, verify=ssl_ctx) as client:
+            resp = await client.request(method, url, **kwargs)
+
+        content_type = resp.headers.get("content-type", "")
+        if "text/event-stream" in content_type:
+            return StreamingResponse(
+                iter([resp.content]),
+                media_type="text/event-stream",
+                status_code=resp.status_code,
+            )
+        if "json" in content_type:
+            return JSONResponse(content=resp.json(), status_code=resp.status_code)
+        return Response(
+            content=resp.content,
+            status_code=resp.status_code,
+            media_type=content_type,
+        )
+
+    return router

--- a/apps/server/src/screamingface/plugins/codex_frontend/tests/test_plugin.py
+++ b/apps/server/src/screamingface/plugins/codex_frontend/tests/test_plugin.py
@@ -1,0 +1,62 @@
+"""Tests for codex-frontend plugin metadata and settings."""
+
+from __future__ import annotations
+
+import shutil
+from unittest.mock import patch
+
+from screamingface.plugins.codex_frontend.plugin import (
+    CodexFrontendPlugin,
+    CodexFrontendSettings,
+)
+
+
+class TestPluginMetadata:
+    def test_name(self):
+        assert CodexFrontendPlugin.name == "codex-frontend"
+
+    def test_depends(self):
+        assert "url4-specs" in CodexFrontendPlugin.depends
+        assert "url4-executor" in CodexFrontendPlugin.depends
+
+    def test_settings_class(self):
+        assert CodexFrontendPlugin.settings_class is CodexFrontendSettings
+
+
+class TestSettings:
+    def test_defaults(self):
+        s = CodexFrontendSettings()
+        assert s.upstream_url == "https://api.openai.com"
+        assert s.listen_port == 9102
+        assert s.listen_host == "127.0.0.1"
+        assert s.active_spec is None
+        assert s.embed_target == "user"
+        assert s.embed_mode == "concat"
+
+    def test_env_prefix(self):
+        config = CodexFrontendSettings.model_config
+        assert config.get("env_prefix") == "SF_CODEX_FRONTEND__"
+
+    def test_env_prefix_differs_from_claude(self):
+        from screamingface.plugins.claude_frontend.plugin import ClaudeFrontendSettings
+
+        assert CodexFrontendSettings.model_config.get(
+            "env_prefix"
+        ) != ClaudeFrontendSettings.model_config.get("env_prefix")
+
+
+class TestPreflight:
+    def test_passes_when_codex_installed(self):
+        plugin = CodexFrontendPlugin()
+        with patch.object(shutil, "which", return_value="/usr/bin/codex"):
+            ok, reason = plugin.preflight()
+        assert ok is True
+        assert reason == ""
+
+    def test_fails_when_codex_missing(self):
+        plugin = CodexFrontendPlugin()
+        with patch.object(shutil, "which", return_value=None):
+            ok, reason = plugin.preflight()
+        assert ok is False
+        assert "codex cli not found" in reason.lower()
+        assert "npm install" in reason

--- a/apps/server/src/screamingface/plugins/codex_frontend/tests/test_proxy.py
+++ b/apps/server/src/screamingface/plugins/codex_frontend/tests/test_proxy.py
@@ -1,0 +1,133 @@
+"""Tests for codex-frontend proxy helpers."""
+
+from __future__ import annotations
+
+from screamingface.plugins.codex_frontend.proxy import (
+    _embed_context,
+    _extract_last_user_text,
+    _inject_system_context,
+    _parse_sse_response,
+    _replace_user_text,
+)
+
+
+class TestExtractLastUserText:
+    def test_string_input(self):
+        body = {"input": "Hello world"}
+        assert _extract_last_user_text(body) == "Hello world"
+
+    def test_message_array(self):
+        body = {
+            "input": [
+                {"role": "user", "content": "First"},
+                {"role": "assistant", "content": "Reply"},
+                {"role": "user", "content": "Second"},
+            ]
+        }
+        assert _extract_last_user_text(body) == "Second"
+
+    def test_empty_input(self):
+        assert _extract_last_user_text({}) is None
+        assert _extract_last_user_text({"input": []}) is None
+
+    def test_no_user_messages(self):
+        body = {"input": [{"role": "assistant", "content": "hi"}]}
+        assert _extract_last_user_text(body) is None
+
+
+class TestReplaceUserText:
+    def test_string_input(self):
+        body = {"input": "old text"}
+        _replace_user_text(body, "new text")
+        assert body["input"] == "new text"
+
+    def test_message_array(self):
+        body = {
+            "input": [
+                {"role": "user", "content": "old"},
+                {"role": "assistant", "content": "reply"},
+            ]
+        }
+        _replace_user_text(body, "new")
+        assert body["input"][0]["content"] == "new"
+
+
+class TestInjectSystemContext:
+    def test_no_existing_instructions(self):
+        body = {}
+        _inject_system_context(body, "Context here")
+        assert body["instructions"] == "Context here"
+
+    def test_existing_instructions(self):
+        body = {"instructions": "Be helpful"}
+        _inject_system_context(body, "Context here")
+        assert "Be helpful" in body["instructions"]
+        assert "Context here" in body["instructions"]
+
+
+class TestEmbedContext:
+    def test_user_concat(self):
+        from unittest.mock import MagicMock
+
+        settings = MagicMock()
+        settings.embed_target = "user"
+        settings.embed_mode = "concat"
+        body = {"input": "My question"}
+        _embed_context(body, "Some context", settings)
+        assert "My question" in body["input"]
+        assert "Some context" in body["input"]
+
+    def test_system_embed(self):
+        from unittest.mock import MagicMock
+
+        settings = MagicMock()
+        settings.embed_target = "system"
+        settings.system_prompt = "You are helpful"
+        body = {"input": "Question"}
+        _embed_context(body, "Context", settings)
+        assert "You are helpful" in body["instructions"]
+        assert "Context" in body["instructions"]
+
+
+class TestParseSSEResponse:
+    def test_simple_response(self):
+        import json
+
+        def _evt(data):
+            return f"data: {json.dumps(data)}\n"
+
+        raw = (
+            _evt({
+                "type": "response.created",
+                "response": {"id": "resp_1", "model": "o4-mini", "status": "in_progress"},
+            })
+            + _evt({
+                "type": "response.output_item.added",
+                "item": {"type": "message", "role": "assistant"},
+            })
+            + _evt({"type": "response.output_text.delta", "delta": "Hello"})
+            + _evt({"type": "response.output_text.delta", "delta": " world"})
+            + _evt({
+                "type": "response.output_item.done",
+                "item": {"type": "message", "role": "assistant"},
+            })
+            + _evt({
+                "type": "response.completed",
+                "response": {
+                    "status": "completed",
+                    "usage": {"input_tokens": 5, "output_tokens": 2},
+                },
+            })
+            + "data: [DONE]\n"
+        )
+        result = _parse_sse_response(raw)
+        assert result is not None
+        assert result["id"] == "resp_1"
+        assert result["status"] == "completed"
+        assert len(result["output"]) == 1
+        assert result["output"][0]["type"] == "message"
+        assert result["output"][0]["content"][0]["text"] == "Hello world"
+
+    def test_empty_stream(self):
+        assert _parse_sse_response("") is None
+        assert _parse_sse_response("data: [DONE]\n") is None


### PR DESCRIPTION
## Summary
- New `codex-frontend` plugin — transparent proxy for Codex CLI on dedicated port (9102)
- Proxies `/v1/responses` (OpenAI Responses API) with url4 context injection
- Preflight check verifies `codex` CLI is installed in PATH
- SSE streaming support with session enrichment/save hooks
- 20 tests (plugin metadata, preflight, proxy helpers, SSE parsing)

## Test plan
- [x] `uv run pytest --ignore=tests/e2e -x -q` — 527 passed
- [x] Preflight returns `(False, ...)` when codex CLI missing
- [x] Preflight returns `(True, "")` when codex CLI present

🤖 Generated with [Claude Code](https://claude.com/claude-code)