### PR TITLE
fix: add CLI preflight check to claude-frontend

### DIFF
--- a/apps/server/src/screamingface/plugins/claude_frontend/plugin.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/plugin.py
@@ -119,7 +119,14 @@ class ClaudeFrontendPlugin(Plugin):
         return schema
 
     def preflight(self) -> tuple[bool, str]:
-        return super().preflight()
+        import shutil
+
+        if not shutil.which("claude"):
+            return False, (
+                "Claude CLI not found in PATH. "
+                "Install it from https://docs.anthropic.com/en/docs/claude-code"
+            )
+        return True, ""
 
     def _collect_spec_names(self) -> list[str]:
         """Return the active spec as a single-element list, or empty."""


### PR DESCRIPTION
## Summary
- claude-frontend was missing `shutil.which("claude")` in `preflight()` — it just called `super().preflight()` which checks nothing
- This allowed the plugin to activate even without the Claude CLI installed
- codex-frontend and gemini-frontend already had their respective checks

## Test plan
- [x] 558 passed, 0 failed