### PR TITLE
fix: validate plugin preflight before saving config

### DIFF
--- a/apps/desktop/src/renderer/src/views/SettingsView.tsx
+++ b/apps/desktop/src/renderer/src/views/SettingsView.tsx
@@ -224,10 +224,33 @@ export function SettingsView() {
     markDirty();
   };
 
-  const updatePlugins = (plugins: string[]) => {
-    setConfig((prev) => ({ ...prev, plugins }));
+  const updatePlugins = async (plugins: string[]) => {
+    if (initialLoadRef.current) {
+      setConfig((prev) => ({ ...prev, plugins }));
+      return;
+    }
 
-    if (initialLoadRef.current) return;
+    // Validate via server before saving (preflight checks, conflict detection)
+    if (serverStatus === 'ready') {
+      try {
+        const res = await serverFetch(`${serverUrlRef.current}/config/validate`, {
+          method: 'POST',
+          body: JSON.stringify({ plugins }),
+        });
+        const data = res.json();
+        if (!data.valid && data.errors?.length) {
+          const msgs = data.errors.map(
+            (e: { plugin: string; error: string }) => `${e.plugin}: ${e.error}`,
+          );
+          toast(msgs.join('\n'), 'error', 5000);
+          return; // Don't save — validation failed
+        }
+      } catch {
+        // Server unreachable — skip validation, allow save
+      }
+    }
+
+    setConfig((prev) => ({ ...prev, plugins }));
 
     // Plugin changes require a server restart — save immediately (skip debounce)
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
@@ -392,7 +415,8 @@ export function SettingsView() {
                         )}
                         {name === 'claude-frontend' && (
                           <p className="text-[10px] leading-tight text-chart-3/80">
-                            Settings here are defaults for new sessions — override per session in the Sessions tab
+                            Settings here are defaults for new sessions — override per session in
+                            the Sessions tab
                           </p>
                         )}
                         {meta?.requires_root && (
@@ -401,16 +425,18 @@ export function SettingsView() {
                             starting the server
                           </p>
                         )}
-                        {meta?.depends && meta.depends.length > 0 && (() => {
-                          const unmet = meta.depends!.filter(
-                            (dep) => !config.plugins.includes(dep) && !serverPlugins?.[dep],
-                          );
-                          return unmet.length > 0 ? (
-                            <p className="text-[10px] leading-tight text-amber-500">
-                              Depends on: {unmet.join(', ')} (will be auto-added at startup)
-                            </p>
-                          ) : null;
-                        })()}
+                        {meta?.depends &&
+                          meta.depends.length > 0 &&
+                          (() => {
+                            const unmet = meta.depends!.filter(
+                              (dep) => !config.plugins.includes(dep) && !serverPlugins?.[dep],
+                            );
+                            return unmet.length > 0 ? (
+                              <p className="text-[10px] leading-tight text-amber-500">
+                                Depends on: {unmet.join(', ')} (will be auto-added at startup)
+                              </p>
+                            ) : null;
+                          })()}
                       </div>
                     </div>
                     <div className="flex items-center gap-1 ml-2 shrink-0">
@@ -499,9 +525,11 @@ export function SettingsView() {
                           omitExtraData
                           uiSchema={{
                             'ui:submitButtonOptions': { norender: true },
-                            ...(name === 'claude-frontend' ? {
-                              active_spec: { 'ui:widget': 'SpecSelectorWidget' },
-                            } : {}),
+                            ...(name === 'claude-frontend'
+                              ? {
+                                  active_spec: { 'ui:widget': 'SpecSelectorWidget' },
+                                }
+                              : {}),
                           }}
                         />
                       )}

--- a/apps/server/src/screamingface/core/app.py
+++ b/apps/server/src/screamingface/core/app.py
@@ -304,6 +304,65 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
         except Exception as exc:
             raise HTTPException(422, detail=str(exc)) from exc
 
+    @app.post("/config/validate")
+    async def validate_config(request: Request) -> dict:
+        """Validate a proposed sf.json config before saving.
+
+        Checks each plugin in the proposed ``plugins`` list:
+        - Is it a known/discovered plugin?
+        - Does it pass preflight (CLI tool installed, deps met)?
+        - Are there conflicts with other proposed plugins?
+
+        Returns ``{"valid": true}`` or ``{"valid": false, "errors": [...]}``.
+        The desktop app should call this before writing sf.json.
+        """
+        body = await request.json()
+        proposed_plugins = body.get("plugins", [])
+        errors: list[dict[str, str]] = []
+
+        discovered = app.state.plugins.discovered_plugins
+
+        for name in proposed_plugins:
+            if name not in discovered:
+                errors.append({
+                    "plugin": name,
+                    "error": f"Plugin {name!r} is not installed or not found.",
+                })
+                continue
+
+            try:
+                instance = app.state.plugins.load_plugin(name)
+            except Exception as exc:
+                errors.append({
+                    "plugin": name,
+                    "error": f"Failed to load plugin {name!r}: {exc}",
+                })
+                continue
+
+            # Run preflight check
+            ok, reason = instance.preflight()
+            if not ok:
+                errors.append({
+                    "plugin": name,
+                    "error": reason,
+                })
+                continue
+
+            # Check conflicts with other proposed plugins
+            for conflict in instance.conflicts:
+                if conflict in proposed_plugins:
+                    errors.append({
+                        "plugin": name,
+                        "error": (
+                            f"Conflicts with {conflict!r} — "
+                            f"only one can be active at a time."
+                        ),
+                    })
+
+        if errors:
+            return {"valid": False, "errors": errors}
+        return {"valid": True}
+
     # Discover and activate plugins
     plugin_registry.discover()
     if config.plugins:


### PR DESCRIPTION
## Summary
- Adds `POST /config/validate` server endpoint that checks proposed plugins:
  - Is the plugin discovered/installed?
  - Does `preflight()` pass (CLI tool in PATH)?
  - Any conflicts with other proposed plugins?
- Desktop Settings UI calls this before saving plugin changes to sf.json
- If validation fails, shows toast with errors and blocks the save
- Prevents enabling frontend plugins when their CLI tools aren't installed

## Test plan
- [x] Server: 558 passed
- [x] Desktop: TypeScript compiles clean
- [ ] Manual: try adding gemini-frontend without gemini CLI — should show error toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)