### PR TITLE
fix: enable SpecSelectorWidget for all frontend plugins

### DIFF
--- a/apps/desktop/src/renderer/src/views/SettingsView.tsx
+++ b/apps/desktop/src/renderer/src/views/SettingsView.tsx
@@ -525,7 +525,9 @@ export function SettingsView() {
                           omitExtraData
                           uiSchema={{
                             'ui:submitButtonOptions': { norender: true },
-                            ...(name === 'claude-frontend'
+                            ...(['claude-frontend', 'codex-frontend', 'gemini-frontend'].includes(
+                              name,
+                            )
                               ? {
                                   active_spec: { 'ui:widget': 'SpecSelectorWidget' },
                                 }


### PR DESCRIPTION
The active_spec SpecSelectorWidget was only wired for claude-frontend. Now all three frontends get it.