### PR TITLE
feat(SF-87): product tags + grouped plugin list in Settings

### DIFF
--- a/apps/desktop/src/renderer/src/views/SettingsView.tsx
+++ b/apps/desktop/src/renderer/src/views/SettingsView.tsx
@@ -299,6 +299,7 @@ export function SettingsView() {
         requires_root: serverPlugins[name].requires_root,
         depends: serverPlugins[name].depends,
         conflicts: serverPlugins[name].conflicts,
+        tags: serverPlugins[name].tags,
       };
     }
     if (discoveredPlugins?.[name]) {
@@ -308,6 +309,7 @@ export function SettingsView() {
         requires_root: discoveredPlugins[name].requires_root,
         depends: discoveredPlugins[name].depends,
         conflicts: discoveredPlugins[name].conflicts,
+        tags: discoveredPlugins[name].tags,
       };
     }
     return null;
@@ -381,267 +383,327 @@ export function SettingsView() {
           {config.plugins.length === 0 ? (
             <p className="text-xs italic text-muted-foreground">No plugins enabled</p>
           ) : (
-            [...config.plugins]
-              .sort((a, b) => a.localeCompare(b))
-              .map((name, _idx, sortedArr) => {
-                const i = config.plugins.indexOf(name);
-                const letter = name[0].toUpperCase();
-                const prevLetter = _idx > 0 ? sortedArr[_idx - 1][0].toUpperCase() : null;
-                const showHeader = letter !== prevLetter;
-                const pluginStatus = getPluginStatus(name);
-                const meta = getPluginMeta(name);
-                const hasSettings = serverPlugins?.[name]?.has_settings === true;
-                const isExpanded = hasSettings && expandedPlugin === name;
-                const schema = pluginSchemas[name];
-                return (
-                  <div key={name}>
-                    {showHeader && (
-                      <div className="flex items-center gap-2 mt-3 mb-1 first:mt-0">
-                        <span className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground/50">
-                          {letter}
-                        </span>
-                        <div className="h-px flex-1 bg-border/30" />
-                      </div>
-                    )}
-                    <div className="rounded-md bg-secondary">
-                      <div
-                        className={`flex items-center justify-between px-3 py-2 select-none ${hasSettings ? 'cursor-pointer' : ''}`}
-                        onClick={
-                          hasSettings
-                            ? () => setExpandedPlugin(isExpanded ? null : name)
-                            : undefined
-                        }
-                      >
-                        <div className="flex items-center gap-2.5 min-w-0">
-                          {hasSettings ? (
-                            <StatusDot status={pluginStatus} />
-                          ) : (
-                            <span className="inline-block h-2 w-2" />
-                          )}
-                          <div className="min-w-0">
-                            <span className="font-mono text-xs text-foreground">{name}</span>
-                            {meta?.version && (
-                              <span className="ml-2 text-[10px] text-muted-foreground">
-                                v{meta.version}
-                              </span>
-                            )}
-                            {meta?.description && (
-                              <p className="text-[10px] leading-tight text-muted-foreground/70 truncate">
-                                {meta.description}
-                              </p>
-                            )}
-                            {name === 'claude-frontend' && (
-                              <p className="text-[10px] leading-tight text-chart-3/80">
-                                Settings here are defaults for new sessions — override per session
-                                in the Sessions tab
-                              </p>
-                            )}
-                            {meta?.requires_root && (
-                              <p className="text-[10px] leading-tight text-amber-500">
-                                Requires root privileges — the app will prompt for your password
-                                when starting the server
-                              </p>
-                            )}
-                            {meta?.depends &&
-                              meta.depends.length > 0 &&
-                              (() => {
-                                const unmet = meta.depends!.filter(
-                                  (dep) => !config.plugins.includes(dep) && !serverPlugins?.[dep],
-                                );
-                                return unmet.length > 0 ? (
-                                  <p className="text-[10px] leading-tight text-amber-500">
-                                    Depends on: {unmet.join(', ')} (will be auto-added at startup)
-                                  </p>
-                                ) : null;
-                              })()}
-                          </div>
-                        </div>
-                        <div className="flex items-center gap-1 ml-2 shrink-0">
-                          {hasSettings && (
-                            <span className="p-1 text-muted-foreground">
-                              {isExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-                            </span>
-                          )}
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              // Warn if other enabled plugins depend on this one
-                              const dependents = config.plugins.filter((p) => {
-                                const pMeta = getPluginMeta(p);
-                                return pMeta?.depends?.includes(name);
-                              });
-                              if (dependents.length > 0) {
-                                const ok = window.confirm(
-                                  `${dependents.join(', ')} depend${dependents.length === 1 ? 's' : ''} on ${name}. Remove anyway?`,
-                                );
-                                if (!ok) return;
-                              }
-                              if (expandedPlugin === name) setExpandedPlugin(null);
-                              updatePlugins(config.plugins.filter((_, j) => j !== i));
-                            }}
-                            className="text-xs text-muted-foreground transition-colors hover:text-destructive"
-                          >
-                            Remove
-                          </button>
-                        </div>
-                      </div>
-                      {isExpanded && (
-                        <div className="border-t border-border/50 px-4 py-4">
-                          {/* Dependency map */}
-                          {(() => {
-                            const deps = meta?.depends || [];
-                            const conflicts = meta?.conflicts || [];
-                            const dependents = config.plugins.filter((p) => {
-                              const pMeta = getPluginMeta(p);
-                              return pMeta?.depends?.includes(name);
-                            });
-                            if (
-                              deps.length === 0 &&
-                              conflicts.length === 0 &&
-                              dependents.length === 0
-                            )
-                              return null;
-                            return (
-                              <div className="mb-4 rounded-lg bg-muted/30 p-3">
-                                <p className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
-                                  Dependencies
-                                </p>
-                                <div className="flex items-center gap-3 flex-wrap">
-                                  {deps.length > 0 && (
-                                    <div className="flex items-center gap-1.5">
-                                      <span className="text-[10px] text-muted-foreground/50">
-                                        needs
-                                      </span>
-                                      {deps.map((d) => (
-                                        <span
-                                          key={d}
-                                          className={`inline-flex items-center rounded-full px-2 py-0.5 font-mono text-[10px] ${
-                                            config.plugins.includes(d)
-                                              ? 'bg-emerald-500/10 text-emerald-400 ring-1 ring-emerald-500/20'
-                                              : 'bg-amber-500/10 text-amber-400 ring-1 ring-amber-500/20'
-                                          }`}
-                                        >
-                                          <span
-                                            className={`mr-1 inline-block h-1.5 w-1.5 rounded-full ${
-                                              config.plugins.includes(d)
-                                                ? 'bg-emerald-400'
-                                                : 'bg-amber-400'
-                                            }`}
-                                          />
-                                          {d}
-                                        </span>
-                                      ))}
-                                    </div>
-                                  )}
-                                  {dependents.length > 0 && (
-                                    <div className="flex items-center gap-1.5">
-                                      <span className="text-[10px] text-muted-foreground/50">
-                                        used by
-                                      </span>
-                                      {dependents.map((d) => (
-                                        <span
-                                          key={d}
-                                          className="inline-flex items-center rounded-full bg-blue-500/10 px-2 py-0.5 font-mono text-[10px] text-blue-400 ring-1 ring-blue-500/20"
-                                        >
-                                          <span className="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-blue-400" />
-                                          {d}
-                                        </span>
-                                      ))}
-                                    </div>
-                                  )}
-                                  {conflicts.length > 0 && (
-                                    <div className="flex items-center gap-1.5">
-                                      <span className="text-[10px] text-muted-foreground/50">
-                                        conflicts
-                                      </span>
-                                      {conflicts.map((c) => (
-                                        <span
-                                          key={c}
-                                          className="inline-flex items-center rounded-full bg-red-500/10 px-2 py-0.5 font-mono text-[10px] text-red-400 ring-1 ring-red-500/20"
-                                        >
-                                          <span className="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-red-400" />
-                                          {c}
-                                        </span>
-                                      ))}
-                                    </div>
-                                  )}
-                                </div>
-                              </div>
-                            );
-                          })()}
-                          {schemaLoading[name] && (
-                            <p className="text-xs text-muted-foreground">Loading settings...</p>
-                          )}
-                          {schemaErrors[name] && !schemaLoading[name] && (
-                            <p className="text-xs text-muted-foreground/60 italic">
-                              No configurable settings or server not reachable
-                            </p>
-                          )}
-                          {schema && !schemaLoading[name] && (
-                            <ThemedForm
-                              schema={schema}
-                              formData={{
-                                ...pluginLiveSettings[name],
-                                ...config.plugin_config[name],
-                              }}
-                              formContext={{
-                                serverUrl,
-                                serverFetch,
-                                addDictEntry: (path: string[], entryName: string) => {
-                                  setConfig((prev) => {
-                                    const base = {
-                                      ...pluginLiveSettings[name],
-                                      ...prev.plugin_config[name],
-                                    };
-                                    let target: Record<string, unknown> = base;
-                                    for (const key of path) {
-                                      target[key] = { ...(target[key] as Record<string, unknown>) };
-                                      target = target[key] as Record<string, unknown>;
-                                    }
-                                    target[entryName] = {};
-                                    return {
-                                      ...prev,
-                                      plugin_config: { ...prev.plugin_config, [name]: base },
-                                    };
-                                  });
-                                  markDirty();
-                                },
-                              }}
-                              validator={validator}
-                              liveValidate
-                              onChange={({ formData, errors }) => {
-                                setConfig((prev) => ({
-                                  ...prev,
-                                  plugin_config: {
-                                    ...prev.plugin_config,
-                                    [name]: formData,
-                                  },
-                                }));
-                                if (!errors || errors.length === 0) {
-                                  markDirty();
-                                }
-                              }}
-                              omitExtraData
-                              uiSchema={{
-                                'ui:submitButtonOptions': { norender: true },
-                                ...([
-                                  'claude-frontend',
-                                  'codex-frontend',
-                                  'gemini-frontend',
-                                ].includes(name)
-                                  ? {
-                                      active_spec: { 'ui:widget': 'SpecSelectorWidget' },
-                                    }
-                                  : {}),
-                              }}
-                            />
-                          )}
-                        </div>
-                      )}
-                    </div>
+            (() => {
+              // Group plugins by product tag
+              const getProductTag = (pluginName: string): string => {
+                const meta = getPluginMeta(pluginName);
+                const tags: string[] = (meta?.tags as string[]) || [];
+                const productTag = tags.find((t: string) => t.startsWith('product:'));
+                return productTag ? productTag.replace('product:', '') : 'etc';
+              };
+
+              const groups: Record<string, string[]> = {};
+              for (const name of config.plugins) {
+                const group = getProductTag(name);
+                if (!groups[group]) groups[group] = [];
+                groups[group].push(name);
+              }
+
+              // Sort plugins within each group
+              for (const g of Object.keys(groups)) {
+                groups[g].sort((a, b) => a.localeCompare(b));
+              }
+
+              // Sort groups: alphabetically, but 'system' and 'etc' go last
+              const groupOrder = Object.keys(groups).sort((a, b) => {
+                if (a === 'etc') return 1;
+                if (b === 'etc') return -1;
+                if (a === 'system') return 1;
+                if (b === 'system') return -1;
+                return a.localeCompare(b);
+              });
+
+              const GROUP_COLORS: Record<string, string> = {
+                claude: 'from-orange-500/20 to-orange-500/5 text-orange-300',
+                openai: 'from-green-500/20 to-green-500/5 text-green-300',
+                gemini: 'from-blue-500/20 to-blue-500/5 text-blue-300',
+                url4: 'from-purple-500/20 to-purple-500/5 text-purple-300',
+                system: 'from-zinc-500/20 to-zinc-500/5 text-zinc-400',
+                etc: 'from-zinc-500/20 to-zinc-500/5 text-zinc-400',
+              };
+
+              return groupOrder.map((group) => (
+                <div key={group} className="mb-3">
+                  <div className={`flex items-center gap-2 mb-1.5 px-1`}>
+                    <span
+                      className={`text-[10px] font-bold uppercase tracking-widest ${GROUP_COLORS[group]?.split(' ').pop() || 'text-muted-foreground/50'}`}
+                    >
+                      {group}
+                    </span>
+                    <div
+                      className={`h-px flex-1 bg-gradient-to-r ${GROUP_COLORS[group]?.split(' ').slice(0, 2).join(' ') || 'from-border/30 to-transparent'}`}
+                    />
+                    <span className="text-[9px] text-muted-foreground/30">
+                      {groups[group].length}
+                    </span>
                   </div>
-                );
-              })
+                  {groups[group].map((name) => {
+                    const i = config.plugins.indexOf(name);
+                    const pluginStatus = getPluginStatus(name);
+                    const meta = getPluginMeta(name);
+                    const hasSettings = serverPlugins?.[name]?.has_settings === true;
+                    const isExpanded = hasSettings && expandedPlugin === name;
+                    const schema = pluginSchemas[name];
+                    return (
+                      <div key={name}>
+                        {showHeader && (
+                          <div className="flex items-center gap-2 mt-3 mb-1 first:mt-0">
+                            <span className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground/50">
+                              {letter}
+                            </span>
+                            <div className="h-px flex-1 bg-border/30" />
+                          </div>
+                        )}
+                        <div className="rounded-md bg-secondary">
+                          <div
+                            className={`flex items-center justify-between px-3 py-2 select-none ${hasSettings ? 'cursor-pointer' : ''}`}
+                            onClick={
+                              hasSettings
+                                ? () => setExpandedPlugin(isExpanded ? null : name)
+                                : undefined
+                            }
+                          >
+                            <div className="flex items-center gap-2.5 min-w-0">
+                              {hasSettings ? (
+                                <StatusDot status={pluginStatus} />
+                              ) : (
+                                <span className="inline-block h-2 w-2" />
+                              )}
+                              <div className="min-w-0">
+                                <span className="font-mono text-xs text-foreground">{name}</span>
+                                {meta?.version && (
+                                  <span className="ml-2 text-[10px] text-muted-foreground">
+                                    v{meta.version}
+                                  </span>
+                                )}
+                                {meta?.description && (
+                                  <p className="text-[10px] leading-tight text-muted-foreground/70 truncate">
+                                    {meta.description}
+                                  </p>
+                                )}
+                                {name === 'claude-frontend' && (
+                                  <p className="text-[10px] leading-tight text-chart-3/80">
+                                    Settings here are defaults for new sessions — override per
+                                    session in the Sessions tab
+                                  </p>
+                                )}
+                                {meta?.requires_root && (
+                                  <p className="text-[10px] leading-tight text-amber-500">
+                                    Requires root privileges — the app will prompt for your password
+                                    when starting the server
+                                  </p>
+                                )}
+                                {meta?.depends &&
+                                  meta.depends.length > 0 &&
+                                  (() => {
+                                    const unmet = meta.depends!.filter(
+                                      (dep) =>
+                                        !config.plugins.includes(dep) && !serverPlugins?.[dep],
+                                    );
+                                    return unmet.length > 0 ? (
+                                      <p className="text-[10px] leading-tight text-amber-500">
+                                        Depends on: {unmet.join(', ')} (will be auto-added at
+                                        startup)
+                                      </p>
+                                    ) : null;
+                                  })()}
+                              </div>
+                            </div>
+                            <div className="flex items-center gap-1 ml-2 shrink-0">
+                              {hasSettings && (
+                                <span className="p-1 text-muted-foreground">
+                                  {isExpanded ? (
+                                    <ChevronDown size={14} />
+                                  ) : (
+                                    <ChevronRight size={14} />
+                                  )}
+                                </span>
+                              )}
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  // Warn if other enabled plugins depend on this one
+                                  const dependents = config.plugins.filter((p) => {
+                                    const pMeta = getPluginMeta(p);
+                                    return pMeta?.depends?.includes(name);
+                                  });
+                                  if (dependents.length > 0) {
+                                    const ok = window.confirm(
+                                      `${dependents.join(', ')} depend${dependents.length === 1 ? 's' : ''} on ${name}. Remove anyway?`,
+                                    );
+                                    if (!ok) return;
+                                  }
+                                  if (expandedPlugin === name) setExpandedPlugin(null);
+                                  updatePlugins(config.plugins.filter((_, j) => j !== i));
+                                }}
+                                className="text-xs text-muted-foreground transition-colors hover:text-destructive"
+                              >
+                                Remove
+                              </button>
+                            </div>
+                          </div>
+                          {isExpanded && (
+                            <div className="border-t border-border/50 px-4 py-4">
+                              {/* Dependency map */}
+                              {(() => {
+                                const deps = meta?.depends || [];
+                                const conflicts = meta?.conflicts || [];
+                                const dependents = config.plugins.filter((p) => {
+                                  const pMeta = getPluginMeta(p);
+                                  return pMeta?.depends?.includes(name);
+                                });
+                                if (
+                                  deps.length === 0 &&
+                                  conflicts.length === 0 &&
+                                  dependents.length === 0
+                                )
+                                  return null;
+                                return (
+                                  <div className="mb-4 rounded-lg bg-background/80 ring-1 ring-border/40 p-3">
+                                    <p className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+                                      Dependencies
+                                    </p>
+                                    <div className="flex items-center gap-3 flex-wrap">
+                                      {deps.length > 0 && (
+                                        <div className="flex items-center gap-1.5">
+                                          <span className="text-[10px] text-muted-foreground/50">
+                                            needs
+                                          </span>
+                                          {deps.map((d) => (
+                                            <span
+                                              key={d}
+                                              className={`inline-flex items-center rounded-full px-2 py-0.5 font-mono text-[10px] ${
+                                                config.plugins.includes(d)
+                                                  ? 'bg-emerald-500/10 text-emerald-400 ring-1 ring-emerald-500/20'
+                                                  : 'bg-amber-500/10 text-amber-400 ring-1 ring-amber-500/20'
+                                              }`}
+                                            >
+                                              <span
+                                                className={`mr-1 inline-block h-1.5 w-1.5 rounded-full ${
+                                                  config.plugins.includes(d)
+                                                    ? 'bg-emerald-400'
+                                                    : 'bg-amber-400'
+                                                }`}
+                                              />
+                                              {d}
+                                            </span>
+                                          ))}
+                                        </div>
+                                      )}
+                                      {dependents.length > 0 && (
+                                        <div className="flex items-center gap-1.5">
+                                          <span className="text-[10px] text-muted-foreground/50">
+                                            used by
+                                          </span>
+                                          {dependents.map((d) => (
+                                            <span
+                                              key={d}
+                                              className="inline-flex items-center rounded-full bg-blue-500/10 px-2 py-0.5 font-mono text-[10px] text-blue-400 ring-1 ring-blue-500/20"
+                                            >
+                                              <span className="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-blue-400" />
+                                              {d}
+                                            </span>
+                                          ))}
+                                        </div>
+                                      )}
+                                      {conflicts.length > 0 && (
+                                        <div className="flex items-center gap-1.5">
+                                          <span className="text-[10px] text-muted-foreground/50">
+                                            conflicts
+                                          </span>
+                                          {conflicts.map((c) => (
+                                            <span
+                                              key={c}
+                                              className="inline-flex items-center rounded-full bg-red-500/10 px-2 py-0.5 font-mono text-[10px] text-red-400 ring-1 ring-red-500/20"
+                                            >
+                                              <span className="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-red-400" />
+                                              {c}
+                                            </span>
+                                          ))}
+                                        </div>
+                                      )}
+                                    </div>
+                                  </div>
+                                );
+                              })()}
+                              {schemaLoading[name] && (
+                                <p className="text-xs text-muted-foreground">Loading settings...</p>
+                              )}
+                              {schemaErrors[name] && !schemaLoading[name] && (
+                                <p className="text-xs text-muted-foreground/60 italic">
+                                  No configurable settings or server not reachable
+                                </p>
+                              )}
+                              {schema && !schemaLoading[name] && (
+                                <ThemedForm
+                                  schema={schema}
+                                  formData={{
+                                    ...pluginLiveSettings[name],
+                                    ...config.plugin_config[name],
+                                  }}
+                                  formContext={{
+                                    serverUrl,
+                                    serverFetch,
+                                    addDictEntry: (path: string[], entryName: string) => {
+                                      setConfig((prev) => {
+                                        const base = {
+                                          ...pluginLiveSettings[name],
+                                          ...prev.plugin_config[name],
+                                        };
+                                        let target: Record<string, unknown> = base;
+                                        for (const key of path) {
+                                          target[key] = {
+                                            ...(target[key] as Record<string, unknown>),
+                                          };
+                                          target = target[key] as Record<string, unknown>;
+                                        }
+                                        target[entryName] = {};
+                                        return {
+                                          ...prev,
+                                          plugin_config: { ...prev.plugin_config, [name]: base },
+                                        };
+                                      });
+                                      markDirty();
+                                    },
+                                  }}
+                                  validator={validator}
+                                  liveValidate
+                                  onChange={({ formData, errors }) => {
+                                    setConfig((prev) => ({
+                                      ...prev,
+                                      plugin_config: {
+                                        ...prev.plugin_config,
+                                        [name]: formData,
+                                      },
+                                    }));
+                                    if (!errors || errors.length === 0) {
+                                      markDirty();
+                                    }
+                                  }}
+                                  omitExtraData
+                                  uiSchema={{
+                                    'ui:submitButtonOptions': { norender: true },
+                                    ...([
+                                      'claude-frontend',
+                                      'codex-frontend',
+                                      'gemini-frontend',
+                                    ].includes(name)
+                                      ? {
+                                          active_spec: { 'ui:widget': 'SpecSelectorWidget' },
+                                        }
+                                      : {}),
+                                  }}
+                                />
+                              )}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              ));
+            })()
           )}
         </div>
 

--- a/apps/server/src/screamingface/plugins/claude_backend/plugin.py
+++ b/apps/server/src/screamingface/plugins/claude_backend/plugin.py
@@ -65,6 +65,7 @@ class ClaudeBackendSettings(PluginSettings):
 class ClaudeBackendPlugin(Plugin):
     name = "claude-backend"
     description = "REST wrapper for the local Claude Code CLI"
+    tags: list[str] = ["product:claude"]
     depends: list[str] = ["url4-executor"]
     settings_class = ClaudeBackendSettings
     system_deps = ["claude"]

--- a/apps/server/src/screamingface/plugins/claude_backend_api/plugin.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/plugin.py
@@ -141,6 +141,7 @@ class ClaudeBackendApiPlugin(Plugin):
         "store instead of shelling out to the claude CLI. Same routes, "
         "same request/response shapes, same profile config."
     )
+    tags: list[str] = ["product:claude"]
     depends: list[str] = ["llm-base"]
     conflicts: list[str] = ["claude-backend"]
     # Registered for url4 backend-call dispatch via /claude()!<intent>.

--- a/apps/server/src/screamingface/plugins/claude_env_intercept/plugin.py
+++ b/apps/server/src/screamingface/plugins/claude_env_intercept/plugin.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 class ClaudeEnvInterceptPlugin(Plugin):
     name = "claude-env-intercept"
     description = "Redirect Claude Code via env vars — no sudo, no /etc/hosts, no port 443"
+    tags: list[str] = ["product:claude"]
     depends = ["claude-frontend"]
     conflicts = ["claude-intercept", "mitmproxy-intercept"]
 

--- a/apps/server/src/screamingface/plugins/claude_frontend/plugin.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/plugin.py
@@ -90,6 +90,7 @@ class ClaudeFrontendSettings(PluginSettings):
 class ClaudeFrontendPlugin(Plugin):
     name = "claude-frontend"
     description = "Transparent proxy between Claude Code and the Anthropic API"
+    tags: list[str] = ["product:claude"]
     depends = ["url4-specs", "url4-executor"]
     settings_class = ClaudeFrontendSettings
 

--- a/apps/server/src/screamingface/plugins/claude_intercept/plugin.py
+++ b/apps/server/src/screamingface/plugins/claude_intercept/plugin.py
@@ -58,6 +58,7 @@ class ClaudeInterceptSettings(PluginSettings):
 class ClaudeInterceptPlugin(Plugin):
     name = "claude-intercept"
     description = "Transparent DNS/SSL proxy — redirects AI API traffic through ScreamingFace"
+    tags: list[str] = ["product:claude"]
     settings_class = ClaudeInterceptSettings
     system_deps = ["mkcert"]
     depends = ["claude-frontend"]

--- a/apps/server/src/screamingface/plugins/codex_backend_api/plugin.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/plugin.py
@@ -132,6 +132,7 @@ class CodexBackendApiPlugin(Plugin):
         "from the Codex CLI credential store (~/.codex/auth.json). "
         "Same route shapes as claude-backend-api but at /codex/* prefix."
     )
+    tags: list[str] = ["product:openai"]
     depends: list[str] = ["llm-base"]
     conflicts: list[str] = []
     backend_call_paths: list[str] = ["/codex"]

--- a/apps/server/src/screamingface/plugins/codex_frontend/plugin.py
+++ b/apps/server/src/screamingface/plugins/codex_frontend/plugin.py
@@ -81,6 +81,7 @@ class CodexFrontendSettings(PluginSettings):
 class CodexFrontendPlugin(Plugin):
     name = "codex-frontend"
     description = "Transparent proxy between Codex CLI and the OpenAI API"
+    tags: list[str] = ["product:openai"]
     depends: list[str] = ["url4-specs", "url4-executor"]
     settings_class = CodexFrontendSettings
 

--- a/apps/server/src/screamingface/plugins/data_store/plugin.py
+++ b/apps/server/src/screamingface/plugins/data_store/plugin.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 class DataStorePlugin(Plugin):
     name = "data-store"
     description = "In-memory key-value data store — turn user data into fetchable URLs for URL4"
+    tags: list[str] = ["product:system"]
     depends: list[str] = []
     settings_class = None
 

--- a/apps/server/src/screamingface/plugins/gemini_backend_api/plugin.py
+++ b/apps/server/src/screamingface/plugins/gemini_backend_api/plugin.py
@@ -70,6 +70,7 @@ class GeminiBackendApiSettings(PluginSettings):
 class GeminiBackendApiPlugin(Plugin):
     name = "gemini-backend-api"
     description = "Direct Google AI Gemini API backend for ensemble fan-out"
+    tags: list[str] = ["product:gemini"]
     depends: list[str] = ["llm-base"]
     conflicts: list[str] = []
     backend_call_paths: list[str] = ["/gemini"]

--- a/apps/server/src/screamingface/plugins/gemini_frontend/plugin.py
+++ b/apps/server/src/screamingface/plugins/gemini_frontend/plugin.py
@@ -79,6 +79,7 @@ class GeminiFrontendSettings(PluginSettings):
 class GeminiFrontendPlugin(Plugin):
     name = "gemini-frontend"
     description = "Transparent proxy between Gemini CLI and the Google AI API"
+    tags: list[str] = ["product:gemini"]
     depends: list[str] = ["url4-specs", "url4-executor"]
     settings_class = GeminiFrontendSettings
 

--- a/apps/server/src/screamingface/plugins/llm_base/plugin.py
+++ b/apps/server/src/screamingface/plugins/llm_base/plugin.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 
 class LlmBasePlugin(Plugin):
     name = "llm-base"
+    tags: list[str] = ["product:system"]
     description = (
         "Shared ABCs and types for multi-backend LLM providers "
         "(Anthropic, OpenAI, Gemini, Qwen, Ollama, …). Provides CoreMessage, "

--- a/apps/server/src/screamingface/plugins/mitmproxy_intercept/plugin.py
+++ b/apps/server/src/screamingface/plugins/mitmproxy_intercept/plugin.py
@@ -109,6 +109,7 @@ def _resolve_rules(
 class MitmproxyInterceptPlugin(Plugin):
     name = "mitmproxy-intercept"
     description = "Transparent traffic interception via mitmproxy --mode local (requires sudo)"
+    tags: list[str] = ["product:system"]
     settings_class = MitmproxyInterceptSettings
     system_deps: list[str] = []
     conflicts = ["claude-intercept", "claude-env-intercept"]

--- a/apps/server/src/screamingface/plugins/tracing/plugin.py
+++ b/apps/server/src/screamingface/plugins/tracing/plugin.py
@@ -34,6 +34,7 @@ class TracingSettings(PluginSettings):
 class TracingPlugin(Plugin):
     name = "tracing"
     description = "Lightweight local tracing via OpenTelemetry + Phoenix"
+    tags: list[str] = ["product:system"]
     settings_class = TracingSettings
 
     def preflight(self) -> tuple[bool, str]:

--- a/apps/server/src/screamingface/plugins/url4_executor/plugin.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/plugin.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 class Url4ExecutorPlugin(Plugin):
     name = "url4-executor"
     description = "url4 protocol engine — parsing, resolution, and HTTP endpoint"
+    tags: list[str] = ["product:url4"]
     depends: list[str] = []
     settings_class = None
 

--- a/apps/server/src/screamingface/plugins/url4_specs/plugin.py
+++ b/apps/server/src/screamingface/plugins/url4_specs/plugin.py
@@ -53,6 +53,7 @@ class Url4SpecsSettings(PluginSettings):
 class Url4SpecsPlugin(Plugin):
     name = "url4-specs"
     description = "Named URL4 expression library with copyable links"
+    tags: list[str] = ["product:url4"]
     depends: list[str] = []
     settings_class = Url4SpecsSettings
 


### PR DESCRIPTION
## Summary
- All 14 plugins tagged with `product:claude|openai|gemini|url4|system`
- Settings plugin list grouped by product tag with color-coded headers
- Groups and plugins sorted alphabetically (system/etc last)
- Dependency map has darker rounded background

## Test plan
- [x] 558 server tests passed
- [x] TypeScript compiles clean
- [ ] Manual: plugins appear grouped by product with colored headers