### PR TITLE
fix: clarify backend_url + add default_backend_path per frontend

### DIFF
--- a/apps/server/src/screamingface/plugins/claude_frontend/plugin.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/plugin.py
@@ -52,9 +52,16 @@ class ClaudeFrontendSettings(PluginSettings):
     backend_url: str | None = Field(
         default=None,
         description=(
-            "URL of the main SF server for url4/data/backend calls"
-            " (e.g. http://127.0.0.1:8000). When set (per-session mode),"
-            " proxy uses HTTP calls instead of in-process."
+            "SF server URL used for $prompt substitution — stores user text "
+            "on /data and resolves url4 expressions via /ensemble. "
+            "Set automatically in per-session mode."
+        ),
+    )
+    default_backend_path: str = Field(
+        default="/claude",
+        description=(
+            "Default backend path for ensemble fan-out (e.g. /claude). "
+            "Used when resolving $prompt expressions through this frontend."
         ),
     )
     resolve_timeout: float = Field(

--- a/apps/server/src/screamingface/plugins/codex_frontend/plugin.py
+++ b/apps/server/src/screamingface/plugins/codex_frontend/plugin.py
@@ -53,8 +53,16 @@ class CodexFrontendSettings(PluginSettings):
     backend_url: str | None = Field(
         default=None,
         description=(
-            "URL of the main SF server for url4/data/backend calls."
-            " When set (per-session mode), proxy uses HTTP calls instead of in-process."
+            "SF server URL used for $prompt substitution — stores user text "
+            "on /data and resolves url4 expressions via /ensemble. "
+            "Set automatically in per-session mode."
+        ),
+    )
+    default_backend_path: str = Field(
+        default="/codex",
+        description=(
+            "Default backend path for ensemble fan-out (e.g. /codex). "
+            "Used when resolving $prompt expressions through this frontend."
         ),
     )
     resolve_timeout: float = Field(

--- a/apps/server/src/screamingface/plugins/gemini_frontend/plugin.py
+++ b/apps/server/src/screamingface/plugins/gemini_frontend/plugin.py
@@ -53,7 +53,18 @@ class GeminiFrontendSettings(PluginSettings):
     )
     backend_url: str | None = Field(
         default=None,
-        description="URL of the main SF server for url4/data/backend calls.",
+        description=(
+            "SF server URL used for $prompt substitution — stores user text "
+            "on /data and resolves url4 expressions via /ensemble. "
+            "Set automatically in per-session mode."
+        ),
+    )
+    default_backend_path: str = Field(
+        default="/gemini",
+        description=(
+            "Default backend path for ensemble fan-out (e.g. /gemini). "
+            "Used when resolving $prompt expressions through this frontend."
+        ),
     )
     resolve_timeout: float = Field(
         default=300.0,


### PR DESCRIPTION
Updates backend_url description and adds default_backend_path (/claude, /codex, /gemini) to each frontend.