### PR TITLE
fix: show session defaults disclaimer on all frontends

### DIFF
--- a/apps/desktop/src/renderer/src/views/SettingsView.tsx
+++ b/apps/desktop/src/renderer/src/views/SettingsView.tsx
@@ -471,7 +471,11 @@ export function SettingsView() {
                                       {meta.description}
                                     </p>
                                   )}
-                                  {name === 'claude-frontend' && (
+                                  {[
+                                    'claude-frontend',
+                                    'codex-frontend',
+                                    'gemini-frontend',
+                                  ].includes(name) && (
                                     <p className="text-[10px] leading-tight text-chart-3/80">
                                       Settings here are defaults for new sessions — override per
                                       session in the Sessions tab


### PR DESCRIPTION
The green 'Settings here are defaults for new sessions' note now shows for codex-frontend and gemini-frontend too, not just claude-frontend.