### PR TITLE
SF-106: extract shared route factory + helpers to llm_base

### DIFF
--- a/apps/server/src/screamingface/plugins/claude_backend_api/backend.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/backend.py
@@ -19,15 +19,17 @@ simple path stays simple.
 from __future__ import annotations
 
 import logging
-import ssl
 
-import certifi
 import httpx
 
 from screamingface.plugins.claude_backend_api.adapter import AnthropicAdapter
 from screamingface.plugins.claude_backend_api.auth import ClaudeCodeOAuth
-from screamingface.plugins.llm_base.backend_base import Backend, HealthStatus
-from screamingface.plugins.llm_base.errors import AuthError, BackendError
+from screamingface.plugins.llm_base.backend_base import (
+    Backend,
+    HealthStatus,
+    post_with_default_retry,
+)
+from screamingface.plugins.llm_base.http import default_http_factory
 from screamingface.plugins.llm_base.messages import CoreMessage, ToolDefinition
 
 logger = logging.getLogger(__name__)
@@ -56,17 +58,7 @@ class AnthropicBackend(Backend):
     ) -> None:
         self._auth = auth or ClaudeCodeOAuth()
         self._adapter = adapter or AnthropicAdapter()
-        # Lazy-construct the SSL context so import-time failures don't
-        # block plugin loading. certifi.where() does a disk read.
-        self._http_factory = http_client_factory or self._default_http_factory
-
-    @staticmethod
-    def _default_http_factory():
-        ssl_ctx = ssl.create_default_context(cafile=certifi.where())
-        return httpx.AsyncClient(
-            timeout=httpx.Timeout(connect=10.0, read=300.0, write=10.0, pool=10.0),
-            verify=ssl_ctx,
-        )
+        self._http_factory = http_client_factory or default_http_factory
 
     async def health(self, model: str = "claude-haiku-4-5") -> HealthStatus:
         """Check auth validity and rate limit capacity.
@@ -203,95 +195,15 @@ class AnthropicBackend(Backend):
         return self._adapter.from_provider_response(response_data)
 
     async def _post_with_retry(self, body: dict) -> dict:
-        """POST with the one-shot 401-retry recovery path.
-
-        Called with an already-built request body. Handles auth header
-        construction, the upstream POST, and the 401→invalidate→retry
-        cycle. Returns the parsed response dict on success.
-        """
-        # First attempt
-        headers = await self._auth.get_authorization_header()
-        headers["content-type"] = "application/json"
-        resp = await self._do_post(body, headers)
-
-        # 401 recovery: the cached token went bad between header-build
-        # and POST (rare race with concurrent refresh). Invalidate the
-        # cache and retry exactly once.
-        if resp.status_code == 401:
-            logger.warning(
-                "claude-backend-api: /v1/messages returned 401, invalidating "
-                "auth cache and retrying once"
-            )
-            self._auth.invalidate_cache()
-            headers = await self._auth.get_authorization_header()
-            headers["content-type"] = "application/json"
-            resp = await self._do_post(body, headers)
-
-            if resp.status_code == 401:
-                # Two consecutive 401s means the credential itself is bad.
-                raise AuthError(
-                    "Authentication failed twice in a row against "
-                    "api.anthropic.com/v1/messages; token state may be "
-                    "corrupt. Run 'claude auth login' to re-authenticate."
-                )
-
-        # Status code handling
-        if resp.status_code == 200:
-            try:
-                return resp.json()
-            except ValueError as exc:
-                raise BackendError(
-                    f"Anthropic returned 200 but the body is not JSON: {exc}",
-                    status=200,
-                ) from exc
-
-        # 429 = rate limited. Token is fine; propagate with retry hint.
-        if resp.status_code == 429:
-            retry_after_raw = resp.headers.get("retry-after")
-            retry_after: float | None = None
-            if retry_after_raw is not None:
-                try:
-                    retry_after = float(retry_after_raw)
-                except ValueError:
-                    retry_after = None
-            raise BackendError(
-                f"Anthropic rate limit exceeded (429). "
-                f"Retry after {retry_after_raw or 'unknown'} seconds.",
-                status=429,
-                retry_after=retry_after,
-            )
-
-        # 403 = scope rejected (should be impossible with user:inference but
-        # surface it clearly if it happens).
-        if resp.status_code == 403:
-            raise AuthError(
-                f"Anthropic returned 403 Forbidden. Token is valid but "
-                f"lacks permission. Response: {resp.text[:500]}. "
-                f"Run 'claude auth login' to re-authenticate with "
-                f"the correct scopes."
-            )
-
-        # Everything else: regular BackendError with the status code.
-        raise BackendError(
-            f"Anthropic API error {resp.status_code}: {resp.text[:500]}",
-            status=resp.status_code,
+        """Delegate to the shared POST-with-401-retry helper."""
+        return await post_with_default_retry(
+            auth=self._auth,
+            http_factory=self._http_factory,
+            url=ANTHROPIC_MESSAGES_URL,
+            body=body,
+            provider_name="Anthropic",
+            auth_login_cmd="claude auth login",
         )
-
-    async def _do_post(self, body: dict, headers: dict[str, str]) -> httpx.Response:
-        """Single httpx POST. Wraps network errors as :class:`BackendError`."""
-        try:
-            async with self._http_factory() as client:
-                return await client.post(ANTHROPIC_MESSAGES_URL, json=body, headers=headers)
-        except httpx.TimeoutException as exc:
-            raise BackendError(
-                f"Anthropic request timed out: {exc}",
-                status=None,
-            ) from exc
-        except httpx.RequestError as exc:
-            raise BackendError(
-                f"Anthropic request failed: {exc}",
-                status=None,
-            ) from exc
 
 
 def _extract_rate_limits(headers: httpx.Headers) -> dict[str, str | int | float]:

--- a/apps/server/src/screamingface/plugins/claude_backend_api/routes.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/routes.py
@@ -1,413 +1,57 @@
 """Routes for claude-backend-api.
 
-Drop-in replacement for ``claude_backend/routes.py``. Same paths, same
-operation IDs, same request/response shapes. Implementation differs:
+Wire-compatible drop-in for ``claude_backend/routes.py``. The four
+endpoints (health, run, url4, profile) are produced by the shared
+:func:`~screamingface.plugins.llm_base.routes_shared.build_backend_api_router`
+factory; this module is the ~15-line adapter that supplies the
+Anthropic-specific pieces (backend, interpreter, default model).
 
-- No ``tempfile.mkdtemp``, no file uploads, no subprocess.
-- ``_execute_claude`` builds a :class:`CoreMessage` list and calls
-  :class:`AnthropicBackend.run` instead of ``run_claude``.
-- CLI-only fields (``add_dirs``, ``files``, ``mcp_config``,
-  ``permission_mode``, ``dangerously_skip_permissions``,
-  ``no_session_persistence``, ``tools``, ``allowed_tools``,
-  ``disallowed_tools``) are accepted in the request body (for drop-in
-  compat with existing sf.json profiles and CC CLI configs) but
-  silently ignored — recorded as OTEL span attributes so their
-  dropping is still observable.
-- Streaming is NOT yet supported — requests with
-  ``output_format == "stream-json"`` currently raise 501 Not Implemented.
-  Phase 1 follow-up will add SSE streaming with the legacy
-  ``text``/``done``/``error`` envelope.
-- ``files`` is rejected with 400 if present — writing files to a
-  non-existent sandbox has no sensible direct-API interpretation.
-
-Error mapping:
-
-- :class:`CredentialNotFoundError` / :class:`AuthError` → HTTP 500 with
-  the user-facing "Run 'claude auth login'" message
-- :class:`BackendError` → HTTP 502 (upstream error), 429 preserved
-- Any other exception → HTTP 500 with the exception message
+CLI-only fields on :class:`RunRequest` (``add_dirs``, ``mcp_config``,
+``permission_mode``, ``dangerously_skip_permissions``,
+``no_session_persistence``, ``tools``, ``allowed_tools``,
+``disallowed_tools``) are silently dropped and recorded as OTEL span
+attributes — behavior preserved from the original implementation.
 """
 
 from __future__ import annotations
 
-import json
-import logging
-import time
 from typing import TYPE_CHECKING, Any
 
-from fastapi import APIRouter, HTTPException
-from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
+from fastapi import APIRouter
 
 from screamingface.plugins.claude_backend_api.backend import AnthropicBackend
-from screamingface.plugins.claude_backend_api.models import (
-    RunRequest,
-    RunResponse,
+from screamingface.plugins.llm_base.routes_shared import (
+    BackendApiConfig,
+    build_backend_api_router,
 )
-from screamingface.plugins.llm_base.errors import (
-    AuthError,
-    BackendError,
-    CredentialNotFoundError,
-)
-from screamingface.plugins.llm_base.messages import CoreMessage, TextPart
-from screamingface.plugins.url4_executor.interpreter import Url4Interpreter
-from screamingface.plugins.url4_executor.url4 import resolve_str
 
 if TYPE_CHECKING:
     from screamingface.plugins.claude_backend_api.plugin import ClaudeBackendApiSettings
 
-logger = logging.getLogger(__name__)
 
 _DEFAULT_MODEL = "claude-sonnet-4-6"
 
-# The six fields we silently ignore because they're subprocess-only.
-_CLI_ONLY_FIELDS = (
-    "add_dirs",
-    "mcp_config",
-    "permission_mode",
-    "dangerously_skip_permissions",
-    "no_session_persistence",
-    "tools",
-    "allowed_tools",
-    "disallowed_tools",
-)
-
 
 def create_router(settings: ClaudeBackendApiSettings, app: Any = None) -> APIRouter:
-    router = APIRouter(tags=["claude-backend-api"])
+    backend = AnthropicBackend()
 
-    # Single shared backend instance — AnthropicBackend holds no
-    # per-request state; the auth strategy handles its own locking.
-    _backend = AnthropicBackend()
-
-    @router.get("/claude/health", response_model=None, operation_id="claude_health")
-    async def claude_health() -> JSONResponse:
-        """Check backend health: OAuth validity and rate limit capacity.
-
-        Returns a JSON object with:
-        - ``authenticated`` (bool): whether the OAuth token is valid
-        - ``tokens_remaining`` (int|null): remaining token capacity
-        - ``requests_remaining`` (int|null): remaining request capacity
-        - ``rate_limit`` (dict): full rate limit info from Anthropic headers
-        - ``error`` (str|null): human-readable error when something is wrong
-        """
-        model = settings.default_model or "claude-sonnet-4-6"
-        status = await _backend.health(model=model)
-        http_status = 200 if status.authenticated else 503
-        return JSONResponse(
-            content={
-                "authenticated": status.authenticated,
-                "model": model,
-                "tokens_remaining": status.tokens_remaining,
-                "requests_remaining": status.requests_remaining,
-                "rate_limit": status.rate_limit,
-                "error": status.error,
-            },
-            status_code=http_status,
-        )
-
-    async def _execute(
-        request: RunRequest,
-    ) -> JSONResponse | StreamingResponse:
-        # Reject streaming in Phase 1 — not yet implemented.
-        if request.output_format == "stream-json":
-            raise HTTPException(
-                status_code=501,
-                detail=(
-                    "stream-json output is not yet implemented in "
-                    "claude-backend-api. Use output_format='text' or "
-                    "'json', or switch to the legacy claude-backend "
-                    "plugin for streaming support."
-                ),
-            )
-
-        # Reject file uploads — no sandbox to write to.
-        if request.files:
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    "The 'files' field is not supported by "
-                    "claude-backend-api (no sandbox to write to). "
-                    "Include file contents directly in the prompt instead."
-                ),
-            )
-
-        # Silently drop CLI-only fields; record them on the OTEL span
-        # for observability.
-        _record_ignored_fields(request)
-
-        timeout = request.timeout_seconds or settings.timeout_seconds
-        model = request.model or settings.default_model or _DEFAULT_MODEL
-
-        # Build system prompt: request's system_prompt (+ append_system_prompt)
-        system_parts: list[str] = []
-        if request.system_prompt:
-            system_parts.append(request.system_prompt)
-        if request.append_system_prompt:
-            system_parts.append(request.append_system_prompt)
-        system = "\n\n".join(system_parts) if system_parts else None
-
-        # Build a single user-turn CoreMessage from the prompt.
-        messages = [CoreMessage(role="user", content=[TextPart(text=request.prompt)])]
-
-        start = time.monotonic()
-        try:
-            result = await _backend.run(
-                messages,
-                model=model,
-                system=system,
-                max_tokens=16000,
-                temperature=None,
-                timeout_seconds=timeout,
-            )
-            duration = time.monotonic() - start
-            stdout = _extract_text(result)
-            parsed_result: dict | list | str | None = None
-            if request.output_format == "json" and stdout.strip():
-                try:
-                    parsed_result = json.loads(stdout)
-                except json.JSONDecodeError:
-                    parsed_result = None
-
-            resp = RunResponse(
-                exit_code=0,
-                stdout=stdout,
-                stderr="",
-                duration_seconds=round(duration, 3),
-                result=parsed_result,
-            )
-            _record_span_success(result, duration, stdout)
-            return JSONResponse(content=resp.model_dump(by_alias=True))
-
-        except (CredentialNotFoundError, AuthError) as exc:
-            duration = time.monotonic() - start
-            logger.warning("claude-backend-api auth failure: %s", exc)
-            resp = RunResponse(
-                exit_code=1,
-                stdout="",
-                stderr=str(exc),
-                duration_seconds=round(duration, 3),
-                result=None,
-            )
-            return JSONResponse(content=resp.model_dump(by_alias=True), status_code=500)
-
-        except BackendError as exc:
-            duration = time.monotonic() - start
-            logger.warning("claude-backend-api backend error: %s", exc)
-            status = 429 if exc.status == 429 else 502
-            resp = RunResponse(
-                exit_code=1,
-                stdout="",
-                stderr=str(exc),
-                duration_seconds=round(duration, 3),
-                result=None,
-            )
-            return JSONResponse(content=resp.model_dump(by_alias=True), status_code=status)
-
-    @router.post("/claude/run", response_model=None, operation_id="claude_run")
-    async def claude_run(
-        request: RunRequest,
-    ) -> JSONResponse | StreamingResponse:
-        return await _execute(request)
-
-    @router.get("/claude", response_model=None, operation_id="claude_url4")
-    async def claude_url4(q: str) -> PlainTextResponse:
-        """Evaluate a url4 expression through the direct Anthropic API."""
+    def build_interpreter() -> Any:
+        # Lazy import — interpreter imports from this module.
         from screamingface.plugins.claude_backend_api.interpreter import (
             ClaudeBackendApiInterpreter,
         )
 
-        interpreter = ClaudeBackendApiInterpreter(app=app, settings=settings, backend=_backend)
-        try:
-            result = await interpreter.evaluate(q)
-        except (CredentialNotFoundError, AuthError) as exc:
-            raise HTTPException(status_code=500, detail=str(exc))
-        except BackendError as exc:
-            status = 429 if exc.status == 429 else 502
-            raise HTTPException(status_code=status, detail=str(exc))
-        except Exception as exc:
-            logger.warning("url4 evaluation failed: %s", exc, exc_info=True)
-            raise HTTPException(status_code=502, detail=f"url4 evaluation failed: {exc}")
+        return ClaudeBackendApiInterpreter(app=app, settings=settings, backend=backend)
 
-        try:
-            from opentelemetry import trace
-
-            span = trace.get_current_span()
-            if span and span.is_recording():
-                span.set_attribute("sf.plugin", "claude-backend-api")
-                span.set_attribute("url4.expression", q[:500])
-                span.set_attribute("url4.result_length", len(result))
-                preview = result[:4000]
-                if len(result) > 4000:
-                    preview += f"\n... ({len(result) - 4000} more chars)"
-                span.set_attribute("url4.response_body", preview)
-        except ImportError:
-            pass
-
-        return PlainTextResponse(content=result)
-
-    async def _handle_profile(
-        profile_name: str,
-        prompt: str,
-        context: str | None = None,
-        raw_context: str | None = None,
-    ) -> JSONResponse | StreamingResponse | PlainTextResponse:
-        prof = settings.profiles.get(profile_name)
-        if not prof:
-            raise HTTPException(status_code=404, detail=f"Unknown profile: {profile_name!r}")
-
-        # url4-shaped prompts (starting with "(" and containing "!") get
-        # resolved through the base Url4Interpreter first.
-        is_url4 = False
-        url4_interpreter = Url4Interpreter(app=app)
-        stripped = prompt.strip()
-        if stripped.startswith("(") and "!" in stripped:
-            try:
-                prompt = await url4_interpreter.evaluate(stripped)
-                is_url4 = True
-            except Exception as exc:
-                logger.warning("url4 prompt resolution failed: %s", exc, exc_info=True)
-                raise HTTPException(
-                    status_code=502,
-                    detail=f"url4 prompt resolution failed: {exc}",
-                )
-
-        resolved_context = ""
-        if raw_context:
-            resolved_context = raw_context
-        elif not is_url4:
-            context_expr = context or prof.context
-            if context_expr:
-                try:
-                    resolved_context = await resolve_str(context_expr, app)
-                except Exception as exc:
-                    logger.warning("Context resolution failed: %s", exc, exc_info=True)
-                    raise HTTPException(
-                        status_code=502,
-                        detail=f"Context resolution failed: {exc}",
-                    )
-
-        full_prompt = f"{resolved_context}\n\n{prompt}" if resolved_context else prompt
-
-        run_request = RunRequest(
-            prompt=full_prompt,
-            model=prof.model,
-            system_prompt=prof.system_prompt,
-            append_system_prompt=prof.append_system_prompt,
-            output_format=prof.output_format,
-            json_schema=prof.json_schema,
-            max_budget_usd=prof.max_budget_usd,
-            effort=prof.effort,
-            tools=prof.tools,
-            allowed_tools=prof.allowed_tools,
-            disallowed_tools=prof.disallowed_tools,
-            mcp_config=prof.mcp_config,
-            permission_mode=prof.permission_mode,
-            add_dirs=prof.add_dirs,
-            fallback_model=prof.fallback_model,
-            dangerously_skip_permissions=prof.dangerously_skip_permissions,
-            no_session_persistence=prof.no_session_persistence,
-            timeout_seconds=prof.timeout_seconds,
+    return build_backend_api_router(
+        BackendApiConfig(
+            name="claude-backend-api",
+            path_prefix="/claude",
+            default_model=_DEFAULT_MODEL,
+            backend=backend,
+            settings=settings,
+            app=app,
+            build_interpreter=build_interpreter,
+            span_prefix="claude",
         )
-        result = await _execute(run_request)
-
-        # url4 mode — return just stdout as plain text
-        if is_url4 and isinstance(result, JSONResponse):
-            body = json.loads(bytes(result.body).decode())
-            stdout = body.get("so") or body.get("stdout") or ""
-            return PlainTextResponse(content=stdout)
-
-        return result
-
-    @router.get(
-        "/claude/{profile_name}",
-        response_model=None,
-        operation_id="claude_profile_get",
     )
-    async def claude_profile_get(
-        profile_name: str,
-        prompt: str,
-        context: str | None = None,
-        raw_context: str | None = None,
-    ) -> JSONResponse | StreamingResponse | PlainTextResponse:
-        return await _handle_profile(profile_name, prompt, context, raw_context)
-
-    @router.post(
-        "/claude/{profile_name}",
-        response_model=None,
-        operation_id="claude_profile_post",
-    )
-    async def claude_profile_post(
-        profile_name: str,
-        prompt: str,
-        context: str | None = None,
-        raw_context: str | None = None,
-    ) -> JSONResponse | StreamingResponse | PlainTextResponse:
-        return await _handle_profile(profile_name, prompt, context, raw_context)
-
-    return router
-
-
-# ----------------------------------------------------------------------------
-# Helpers
-# ----------------------------------------------------------------------------
-
-
-def _extract_text(msg: CoreMessage) -> str:
-    """Pull concatenated text out of an assistant CoreMessage."""
-    if isinstance(msg.content, str):
-        return msg.content
-    chunks: list[str] = []
-    for part in msg.content:
-        if isinstance(part, TextPart):
-            chunks.append(part.text)
-    return "".join(chunks)
-
-
-def _record_ignored_fields(request: RunRequest) -> None:
-    """Record which CLI-only fields were present so the drop is observable."""
-    try:
-        from opentelemetry import trace
-
-        span = trace.get_current_span()
-        if not (span and span.is_recording()):
-            return
-        for field_name in _CLI_ONLY_FIELDS:
-            value = getattr(request, field_name, None)
-            if value:  # truthy — non-empty list, non-empty string, True bool
-                span.set_attribute(f"claude_backend_api.ignored_field.{field_name}", True)
-    except ImportError:
-        pass
-
-
-def _record_span_success(result: CoreMessage, duration: float, stdout: str) -> None:
-    """Record success-path attributes on the OTEL span."""
-    try:
-        from opentelemetry import trace
-
-        span = trace.get_current_span()
-        if not (span and span.is_recording()):
-            return
-        span.set_attribute("sf.plugin", "claude-backend-api")
-        span.set_attribute("claude.exit_code", 0)
-        span.set_attribute("claude.duration_seconds", round(duration, 3))
-        span.set_attribute("claude.stdout_length", len(stdout))
-        preview = stdout[:1000]
-        if len(stdout) > 1000:
-            preview += f"\n... ({len(stdout) - 1000} more chars)"
-        span.set_attribute("claude.stdout_preview", preview)
-        # Provider metadata from the adapter (tokens, stop_reason, etc.)
-        if result.provider_metadata:
-            for key, value in result.provider_metadata.items():
-                try:
-                    span.set_attribute(key, _otel_attr_value(value))
-                except Exception:
-                    pass
-    except ImportError:
-        pass
-
-
-def _otel_attr_value(value: Any) -> Any:
-    """Coerce a value to something OTEL spans accept as an attribute."""
-    if isinstance(value, str | bool | int | float):
-        return value
-    return json.dumps(value)

--- a/apps/server/src/screamingface/plugins/claude_backend_api/tests/test_backend.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/tests/test_backend.py
@@ -249,7 +249,7 @@ class TestRun401Recovery:
 
         backend = AnthropicBackend(auth=auth, http_client_factory=factory)
 
-        with pytest.raises(AuthError, match="twice in a row"):
+        with pytest.raises(AuthError, match="twice"):
             await backend.run(
                 [CoreMessage(role="user", content="ping")],
                 model="claude-sonnet-4-5",

--- a/apps/server/src/screamingface/plugins/codex_backend_api/backend.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/backend.py
@@ -16,16 +16,19 @@ from __future__ import annotations
 import json
 import logging
 import os
-import ssl
 import uuid
 
-import certifi
 import httpx
 
 from screamingface.plugins.codex_backend_api.adapter import OpenAIResponsesAdapter
 from screamingface.plugins.codex_backend_api.auth import CodexOAuth
-from screamingface.plugins.llm_base.backend_base import Backend, HealthStatus
+from screamingface.plugins.llm_base.backend_base import (
+    Backend,
+    HealthStatus,
+    post_with_default_retry,
+)
 from screamingface.plugins.llm_base.errors import AuthError, BackendError
+from screamingface.plugins.llm_base.http import default_http_factory
 from screamingface.plugins.llm_base.messages import CoreMessage, ToolDefinition
 
 logger = logging.getLogger(__name__)
@@ -58,15 +61,7 @@ class OpenAIBackend(Backend):
     ) -> None:
         self._auth = auth or CodexOAuth()
         self._adapter = adapter or OpenAIResponsesAdapter()
-        self._http_factory = http_client_factory or self._default_http_factory
-
-    @staticmethod
-    def _default_http_factory():
-        ssl_ctx = ssl.create_default_context(cafile=certifi.where())
-        return httpx.AsyncClient(
-            timeout=httpx.Timeout(connect=10.0, read=300.0, write=10.0, pool=10.0),
-            verify=ssl_ctx,
-        )
+        self._http_factory = http_client_factory or default_http_factory
 
     def _has_api_key(self) -> bool:
         return bool(os.environ.get("OPENAI_API_KEY"))
@@ -352,39 +347,15 @@ class OpenAIBackend(Backend):
     # ------------------------------------------------------------------
 
     async def _post_with_retry(self, body: dict) -> dict:
-        headers = await self._auth.get_authorization_header()
-        headers["content-type"] = "application/json"
-        resp = await self._do_post(body, headers)
-
-        if resp.status_code == 401:
-            self._auth.invalidate_cache()
-            headers = await self._auth.get_authorization_header()
-            headers["content-type"] = "application/json"
-            resp = await self._do_post(body, headers)
-            if resp.status_code == 401:
-                raise AuthError("Authentication failed twice. Run 'codex login'.")
-
-        if resp.status_code == 200:
-            return resp.json()
-        if resp.status_code == 429:
-            retry_after_raw = resp.headers.get("retry-after")
-            retry_after = float(retry_after_raw) if retry_after_raw else None
-            raise BackendError("Rate limited (429)", status=429, retry_after=retry_after)
-        if resp.status_code == 403:
-            raise AuthError(f"Forbidden (403): {resp.text[:300]}")
-        raise BackendError(
-            f"OpenAI error {resp.status_code}: {resp.text[:500]}",
-            status=resp.status_code,
+        """Delegate to the shared POST-with-401-retry helper."""
+        return await post_with_default_retry(
+            auth=self._auth,
+            http_factory=self._http_factory,
+            url=OPENAI_RESPONSES_URL,
+            body=body,
+            provider_name="OpenAI",
+            auth_login_cmd="codex login",
         )
-
-    async def _do_post(self, body: dict, headers: dict[str, str]) -> httpx.Response:
-        try:
-            async with self._http_factory() as client:
-                return await client.post(OPENAI_RESPONSES_URL, json=body, headers=headers)
-        except httpx.TimeoutException as exc:
-            raise BackendError(f"Request timed out: {exc}", status=None) from exc
-        except httpx.RequestError as exc:
-            raise BackendError(f"Request failed: {exc}", status=None) from exc
 
 
 def _extract_openai_rate_limits(headers: httpx.Headers) -> dict[str, str | int | float]:

--- a/apps/server/src/screamingface/plugins/codex_backend_api/routes.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/routes.py
@@ -1,374 +1,43 @@
-"""Routes for codex-backend-api.
-
-Mirrors claude-backend-api route shapes at the ``/codex`` prefix:
-
-- ``POST /codex/run`` -- execute a prompt through OpenAI
-- ``GET /codex?q=`` -- evaluate a url4 expression through OpenAI
-- ``GET /codex/{profile_name}`` -- profile-based execution
-- ``POST /codex/{profile_name}`` -- profile-based execution
-
-Same CLI-only field dropping, same error mapping, same wire-format
-request/response shapes as claude-backend-api.
-"""
+"""Routes for codex-backend-api — thin adapter over the shared router factory."""
 
 from __future__ import annotations
 
-import json
-import logging
-import time
 from typing import TYPE_CHECKING, Any
 
-from fastapi import APIRouter, HTTPException
-from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
+from fastapi import APIRouter
 
 from screamingface.plugins.codex_backend_api.backend import OpenAIBackend
-from screamingface.plugins.codex_backend_api.models import (
-    RunRequest,
-    RunResponse,
+from screamingface.plugins.llm_base.routes_shared import (
+    BackendApiConfig,
+    build_backend_api_router,
 )
-from screamingface.plugins.llm_base.errors import (
-    AuthError,
-    BackendError,
-    CredentialNotFoundError,
-)
-from screamingface.plugins.llm_base.messages import CoreMessage, TextPart
-from screamingface.plugins.url4_executor.interpreter import Url4Interpreter
-from screamingface.plugins.url4_executor.url4 import resolve_str
 
 if TYPE_CHECKING:
     from screamingface.plugins.codex_backend_api.plugin import CodexBackendApiSettings
 
-logger = logging.getLogger(__name__)
 
 _DEFAULT_MODEL = "o4-mini"
 
-# The six fields we silently ignore because they're subprocess-only.
-_CLI_ONLY_FIELDS = (
-    "add_dirs",
-    "mcp_config",
-    "permission_mode",
-    "dangerously_skip_permissions",
-    "no_session_persistence",
-    "tools",
-    "allowed_tools",
-    "disallowed_tools",
-)
-
 
 def create_router(settings: CodexBackendApiSettings, app: Any = None) -> APIRouter:
-    router = APIRouter(tags=["codex-backend-api"])
+    backend = OpenAIBackend()
 
-    _backend = OpenAIBackend()
-
-    @router.get("/codex/health", response_model=None, operation_id="codex_health")
-    async def codex_health() -> JSONResponse:
-        """Check Codex backend health: OAuth validity and rate limits."""
-        model = settings.default_model or "o4-mini"
-        status = await _backend.health(model=model)
-        http_status = 200 if status.authenticated else 503
-        return JSONResponse(
-            content={
-                "authenticated": status.authenticated,
-                "model": model,
-                "tokens_remaining": status.tokens_remaining,
-                "requests_remaining": status.requests_remaining,
-                "rate_limit": status.rate_limit,
-                "error": status.error,
-            },
-            status_code=http_status,
-        )
-
-    async def _execute(
-        request: RunRequest,
-    ) -> JSONResponse | StreamingResponse:
-        if request.output_format == "stream-json":
-            raise HTTPException(
-                status_code=501,
-                detail=(
-                    "stream-json output is not yet implemented in "
-                    "codex-backend-api. Use output_format='text' or 'json'."
-                ),
-            )
-
-        if request.files:
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    "The 'files' field is not supported by "
-                    "codex-backend-api (no sandbox to write to). "
-                    "Include file contents directly in the prompt instead."
-                ),
-            )
-
-        _record_ignored_fields(request)
-
-        timeout = request.timeout_seconds or settings.timeout_seconds
-        model = request.model or settings.default_model or _DEFAULT_MODEL
-
-        system_parts: list[str] = []
-        if request.system_prompt:
-            system_parts.append(request.system_prompt)
-        if request.append_system_prompt:
-            system_parts.append(request.append_system_prompt)
-        system = "\n\n".join(system_parts) if system_parts else None
-
-        messages = [CoreMessage(role="user", content=[TextPart(text=request.prompt)])]
-
-        start = time.monotonic()
-        try:
-            result = await _backend.run(
-                messages,
-                model=model,
-                system=system,
-                max_tokens=16000,
-                temperature=None,
-                timeout_seconds=timeout,
-            )
-            duration = time.monotonic() - start
-            stdout = _extract_text(result)
-            parsed_result: dict | list | str | None = None
-            if request.output_format == "json" and stdout.strip():
-                try:
-                    parsed_result = json.loads(stdout)
-                except json.JSONDecodeError:
-                    parsed_result = None
-
-            resp = RunResponse(
-                exit_code=0,
-                stdout=stdout,
-                stderr="",
-                duration_seconds=round(duration, 3),
-                result=parsed_result,
-            )
-            _record_span_success(result, duration, stdout)
-            return JSONResponse(content=resp.model_dump(by_alias=True))
-
-        except (CredentialNotFoundError, AuthError) as exc:
-            duration = time.monotonic() - start
-            logger.warning("codex-backend-api auth failure: %s", exc)
-            resp = RunResponse(
-                exit_code=1,
-                stdout="",
-                stderr=str(exc),
-                duration_seconds=round(duration, 3),
-                result=None,
-            )
-            return JSONResponse(content=resp.model_dump(by_alias=True), status_code=500)
-
-        except BackendError as exc:
-            duration = time.monotonic() - start
-            logger.warning("codex-backend-api backend error: %s", exc)
-            status = 429 if exc.status == 429 else 502
-            resp = RunResponse(
-                exit_code=1,
-                stdout="",
-                stderr=str(exc),
-                duration_seconds=round(duration, 3),
-                result=None,
-            )
-            return JSONResponse(content=resp.model_dump(by_alias=True), status_code=status)
-
-    @router.post("/codex/run", response_model=None, operation_id="codex_run")
-    async def codex_run(
-        request: RunRequest,
-    ) -> JSONResponse | StreamingResponse:
-        return await _execute(request)
-
-    @router.get("/codex", response_model=None, operation_id="codex_url4")
-    async def codex_url4(q: str) -> PlainTextResponse:
-        """Evaluate a url4 expression through the OpenAI API."""
+    def build_interpreter() -> Any:
         from screamingface.plugins.codex_backend_api.interpreter import (
             CodexBackendApiInterpreter,
         )
 
-        interpreter = CodexBackendApiInterpreter(app=app, settings=settings, backend=_backend)
-        try:
-            result = await interpreter.evaluate(q)
-        except (CredentialNotFoundError, AuthError) as exc:
-            raise HTTPException(status_code=500, detail=str(exc))
-        except BackendError as exc:
-            status = 429 if exc.status == 429 else 502
-            raise HTTPException(status_code=status, detail=str(exc))
-        except Exception as exc:
-            logger.warning("url4 evaluation failed: %s", exc, exc_info=True)
-            raise HTTPException(status_code=502, detail=f"url4 evaluation failed: {exc}")
+        return CodexBackendApiInterpreter(app=app, settings=settings, backend=backend)
 
-        try:
-            from opentelemetry import trace
-
-            span = trace.get_current_span()
-            if span and span.is_recording():
-                span.set_attribute("sf.plugin", "codex-backend-api")
-                span.set_attribute("url4.expression", q[:500])
-                span.set_attribute("url4.result_length", len(result))
-                preview = result[:4000]
-                if len(result) > 4000:
-                    preview += f"\n... ({len(result) - 4000} more chars)"
-                span.set_attribute("url4.response_body", preview)
-        except ImportError:
-            pass
-
-        return PlainTextResponse(content=result)
-
-    async def _handle_profile(
-        profile_name: str,
-        prompt: str,
-        context: str | None = None,
-        raw_context: str | None = None,
-    ) -> JSONResponse | StreamingResponse | PlainTextResponse:
-        prof = settings.profiles.get(profile_name)
-        if not prof:
-            raise HTTPException(status_code=404, detail=f"Unknown profile: {profile_name!r}")
-
-        is_url4 = False
-        url4_interpreter = Url4Interpreter(app=app)
-        stripped = prompt.strip()
-        if stripped.startswith("(") and "!" in stripped:
-            try:
-                prompt = await url4_interpreter.evaluate(stripped)
-                is_url4 = True
-            except Exception as exc:
-                logger.warning("url4 prompt resolution failed: %s", exc, exc_info=True)
-                raise HTTPException(
-                    status_code=502,
-                    detail=f"url4 prompt resolution failed: {exc}",
-                )
-
-        resolved_context = ""
-        if raw_context:
-            resolved_context = raw_context
-        elif not is_url4:
-            context_expr = context or prof.context
-            if context_expr:
-                try:
-                    resolved_context = await resolve_str(context_expr, app)
-                except Exception as exc:
-                    logger.warning("Context resolution failed: %s", exc, exc_info=True)
-                    raise HTTPException(
-                        status_code=502,
-                        detail=f"Context resolution failed: {exc}",
-                    )
-
-        full_prompt = f"{resolved_context}\n\n{prompt}" if resolved_context else prompt
-
-        run_request = RunRequest(
-            prompt=full_prompt,
-            model=prof.model,
-            system_prompt=prof.system_prompt,
-            append_system_prompt=prof.append_system_prompt,
-            output_format=prof.output_format,
-            json_schema=prof.json_schema,
-            max_budget_usd=prof.max_budget_usd,
-            effort=prof.effort,
-            tools=prof.tools,
-            allowed_tools=prof.allowed_tools,
-            disallowed_tools=prof.disallowed_tools,
-            mcp_config=prof.mcp_config,
-            permission_mode=prof.permission_mode,
-            add_dirs=prof.add_dirs,
-            fallback_model=prof.fallback_model,
-            dangerously_skip_permissions=prof.dangerously_skip_permissions,
-            no_session_persistence=prof.no_session_persistence,
-            timeout_seconds=prof.timeout_seconds,
+    return build_backend_api_router(
+        BackendApiConfig(
+            name="codex-backend-api",
+            path_prefix="/codex",
+            default_model=_DEFAULT_MODEL,
+            backend=backend,
+            settings=settings,
+            app=app,
+            build_interpreter=build_interpreter,
+            span_prefix="codex",
         )
-        result = await _execute(run_request)
-
-        if is_url4 and isinstance(result, JSONResponse):
-            body = json.loads(bytes(result.body).decode())
-            stdout = body.get("so") or body.get("stdout") or ""
-            return PlainTextResponse(content=stdout)
-
-        return result
-
-    @router.get(
-        "/codex/{profile_name}",
-        response_model=None,
-        operation_id="codex_profile_get",
     )
-    async def codex_profile_get(
-        profile_name: str,
-        prompt: str,
-        context: str | None = None,
-        raw_context: str | None = None,
-    ) -> JSONResponse | StreamingResponse | PlainTextResponse:
-        return await _handle_profile(profile_name, prompt, context, raw_context)
-
-    @router.post(
-        "/codex/{profile_name}",
-        response_model=None,
-        operation_id="codex_profile_post",
-    )
-    async def codex_profile_post(
-        profile_name: str,
-        prompt: str,
-        context: str | None = None,
-        raw_context: str | None = None,
-    ) -> JSONResponse | StreamingResponse | PlainTextResponse:
-        return await _handle_profile(profile_name, prompt, context, raw_context)
-
-    return router
-
-
-# ----------------------------------------------------------------------------
-# Helpers
-# ----------------------------------------------------------------------------
-
-
-def _extract_text(msg: CoreMessage) -> str:
-    """Pull concatenated text out of an assistant CoreMessage."""
-    if isinstance(msg.content, str):
-        return msg.content
-    chunks: list[str] = []
-    for part in msg.content:
-        if isinstance(part, TextPart):
-            chunks.append(part.text)
-    return "".join(chunks)
-
-
-def _record_ignored_fields(request: RunRequest) -> None:
-    """Record which CLI-only fields were present so the drop is observable."""
-    try:
-        from opentelemetry import trace
-
-        span = trace.get_current_span()
-        if not (span and span.is_recording()):
-            return
-        for field_name in _CLI_ONLY_FIELDS:
-            value = getattr(request, field_name, None)
-            if value:
-                span.set_attribute(f"codex_backend_api.ignored_field.{field_name}", True)
-    except ImportError:
-        pass
-
-
-def _record_span_success(result: CoreMessage, duration: float, stdout: str) -> None:
-    """Record success-path attributes on the OTEL span."""
-    try:
-        from opentelemetry import trace
-
-        span = trace.get_current_span()
-        if not (span and span.is_recording()):
-            return
-        span.set_attribute("sf.plugin", "codex-backend-api")
-        span.set_attribute("codex.exit_code", 0)
-        span.set_attribute("codex.duration_seconds", round(duration, 3))
-        span.set_attribute("codex.stdout_length", len(stdout))
-        preview = stdout[:1000]
-        if len(stdout) > 1000:
-            preview += f"\n... ({len(stdout) - 1000} more chars)"
-        span.set_attribute("codex.stdout_preview", preview)
-        if result.provider_metadata:
-            for key, value in result.provider_metadata.items():
-                try:
-                    span.set_attribute(key, _otel_attr_value(value))
-                except Exception:
-                    pass
-    except ImportError:
-        pass
-
-
-def _otel_attr_value(value: Any) -> Any:
-    """Coerce a value to something OTEL spans accept as an attribute."""
-    if isinstance(value, str | bool | int | float):
-        return value
-    return json.dumps(value)

--- a/apps/server/src/screamingface/plugins/codex_backend_api/tests/test_backend.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/tests/test_backend.py
@@ -153,7 +153,7 @@ class TestRunErrors:
         factory, _ = _mock_factory(httpx.Response(403, text="Forbidden"))
         backend = OpenAIBackend(auth=auth, http_client_factory=factory)
 
-        with pytest.raises(AuthError, match=r"Forbidden \(403\)"):
+        with pytest.raises(AuthError, match="403 Forbidden"):
             await backend.run(
                 [CoreMessage(role="user", content=[TextPart(text="ping")])],
                 model="o4-mini",

--- a/apps/server/src/screamingface/plugins/gemini_backend_api/routes.py
+++ b/apps/server/src/screamingface/plugins/gemini_backend_api/routes.py
@@ -1,238 +1,43 @@
-"""Routes for gemini-backend-api — mirrors claude-backend-api at /gemini prefix."""
+"""Routes for gemini-backend-api — thin adapter over the shared router factory."""
 
 from __future__ import annotations
 
-import json
-import logging
-import time
 from typing import TYPE_CHECKING, Any
 
-from fastapi import APIRouter, HTTPException
-from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
+from fastapi import APIRouter
 
 from screamingface.plugins.gemini_backend_api.backend import GeminiBackend
-from screamingface.plugins.gemini_backend_api.models import (
-    RunRequest,
-    RunResponse,
+from screamingface.plugins.llm_base.routes_shared import (
+    BackendApiConfig,
+    build_backend_api_router,
 )
-from screamingface.plugins.llm_base.errors import (
-    AuthError,
-    BackendError,
-    CredentialNotFoundError,
-)
-from screamingface.plugins.llm_base.messages import CoreMessage, TextPart
-from screamingface.plugins.url4_executor.interpreter import Url4Interpreter
-from screamingface.plugins.url4_executor.url4 import resolve_str
 
 if TYPE_CHECKING:
     from screamingface.plugins.gemini_backend_api.plugin import GeminiBackendApiSettings
 
-logger = logging.getLogger(__name__)
 
 _DEFAULT_MODEL = "gemini-2.5-flash"
 
-_CLI_ONLY_FIELDS = (
-    "add_dirs",
-    "mcp_config",
-    "permission_mode",
-    "dangerously_skip_permissions",
-    "no_session_persistence",
-    "tools",
-    "allowed_tools",
-    "disallowed_tools",
-)
-
 
 def create_router(settings: GeminiBackendApiSettings, app: Any = None) -> APIRouter:
-    router = APIRouter(tags=["gemini-backend-api"])
-    _backend = GeminiBackend()
+    backend = GeminiBackend()
 
-    @router.get("/gemini/health", response_model=None, operation_id="gemini_health")
-    async def gemini_health() -> JSONResponse:
-        """Check Gemini backend health: OAuth validity and rate limits."""
-        model = settings.default_model or "gemini-2.5-flash"
-        status = await _backend.health(model=model)
-        http_status = 200 if status.authenticated else 503
-        return JSONResponse(
-            content={
-                "authenticated": status.authenticated,
-                "model": model,
-                "tokens_remaining": status.tokens_remaining,
-                "requests_remaining": status.requests_remaining,
-                "rate_limit": status.rate_limit,
-                "error": status.error,
-            },
-            status_code=http_status,
-        )
-
-    async def _execute(request: RunRequest) -> JSONResponse | StreamingResponse:
-        if request.output_format == "stream-json":
-            raise HTTPException(status_code=501, detail="stream-json not yet implemented")
-
-        if request.files:
-            raise HTTPException(status_code=400, detail="files not supported")
-
-        timeout = request.timeout_seconds or settings.timeout_seconds
-        model = request.model or settings.default_model or _DEFAULT_MODEL
-
-        system_parts: list[str] = []
-        if request.system_prompt:
-            system_parts.append(request.system_prompt)
-        if request.append_system_prompt:
-            system_parts.append(request.append_system_prompt)
-        system = "\n\n".join(system_parts) if system_parts else None
-
-        messages = [CoreMessage(role="user", content=[TextPart(text=request.prompt)])]
-
-        start = time.monotonic()
-        try:
-            result = await _backend.run(
-                messages,
-                model=model,
-                system=system,
-                max_tokens=16000,
-                timeout_seconds=timeout,
-            )
-            duration = time.monotonic() - start
-            stdout = _extract_text(result)
-            parsed_result: dict | list | str | None = None
-            if request.output_format == "json" and stdout.strip():
-                try:
-                    parsed_result = json.loads(stdout)
-                except json.JSONDecodeError:
-                    parsed_result = None
-
-            resp = RunResponse(
-                exit_code=0,
-                stdout=stdout,
-                stderr="",
-                duration_seconds=round(duration, 3),
-                result=parsed_result,
-            )
-            return JSONResponse(content=resp.model_dump(by_alias=True))
-
-        except (CredentialNotFoundError, AuthError) as exc:
-            duration = time.monotonic() - start
-            resp = RunResponse(
-                exit_code=1,
-                stdout="",
-                stderr=str(exc),
-                duration_seconds=round(duration, 3),
-                result=None,
-            )
-            return JSONResponse(content=resp.model_dump(by_alias=True), status_code=500)
-
-        except BackendError as exc:
-            duration = time.monotonic() - start
-            status = 429 if exc.status == 429 else 502
-            resp = RunResponse(
-                exit_code=1,
-                stdout="",
-                stderr=str(exc),
-                duration_seconds=round(duration, 3),
-                result=None,
-            )
-            return JSONResponse(content=resp.model_dump(by_alias=True), status_code=status)
-
-    @router.post("/gemini/run", response_model=None, operation_id="gemini_run")
-    async def gemini_run(request: RunRequest) -> JSONResponse | StreamingResponse:
-        return await _execute(request)
-
-    @router.get("/gemini", response_model=None, operation_id="gemini_url4")
-    async def gemini_url4(q: str) -> PlainTextResponse:
+    def build_interpreter() -> Any:
         from screamingface.plugins.gemini_backend_api.interpreter import (
             GeminiBackendApiInterpreter,
         )
 
-        interpreter = GeminiBackendApiInterpreter(app=app, settings=settings, backend=_backend)
-        try:
-            result = await interpreter.evaluate(q)
-        except (CredentialNotFoundError, AuthError) as exc:
-            raise HTTPException(status_code=500, detail=str(exc))
-        except BackendError as exc:
-            status = 429 if exc.status == 429 else 502
-            raise HTTPException(status_code=status, detail=str(exc))
-        except Exception as exc:
-            raise HTTPException(status_code=502, detail=f"url4 evaluation failed: {exc}")
-        return PlainTextResponse(content=result)
+        return GeminiBackendApiInterpreter(app=app, settings=settings, backend=backend)
 
-    async def _handle_profile(
-        profile_name: str,
-        prompt: str,
-        context: str | None = None,
-        raw_context: str | None = None,
-    ) -> JSONResponse | StreamingResponse | PlainTextResponse:
-        prof = settings.profiles.get(profile_name)
-        if not prof:
-            raise HTTPException(status_code=404, detail=f"Unknown profile: {profile_name!r}")
-
-        is_url4 = False
-        url4_interpreter = Url4Interpreter(app=app)
-        stripped = prompt.strip()
-        if stripped.startswith("(") and "!" in stripped:
-            try:
-                prompt = await url4_interpreter.evaluate(stripped)
-                is_url4 = True
-            except Exception as exc:
-                raise HTTPException(status_code=502, detail=f"url4 resolution failed: {exc}")
-
-        resolved_context = ""
-        if raw_context:
-            resolved_context = raw_context
-        elif not is_url4:
-            context_expr = context or prof.context
-            if context_expr:
-                try:
-                    resolved_context = await resolve_str(context_expr, app)
-                except Exception as exc:
-                    raise HTTPException(status_code=502, detail=f"Context resolution failed: {exc}")
-
-        full_prompt = f"{resolved_context}\n\n{prompt}" if resolved_context else prompt
-
-        run_request = RunRequest(
-            prompt=full_prompt,
-            model=prof.model,
-            system_prompt=prof.system_prompt,
-            append_system_prompt=prof.append_system_prompt,
-            output_format=prof.output_format,
-            json_schema=prof.json_schema,
-            max_budget_usd=prof.max_budget_usd,
-            effort=prof.effort,
-            tools=prof.tools,
-            allowed_tools=prof.allowed_tools,
-            disallowed_tools=prof.disallowed_tools,
-            mcp_config=prof.mcp_config,
-            permission_mode=prof.permission_mode,
-            add_dirs=prof.add_dirs,
-            fallback_model=prof.fallback_model,
-            dangerously_skip_permissions=prof.dangerously_skip_permissions,
-            no_session_persistence=prof.no_session_persistence,
-            timeout_seconds=prof.timeout_seconds,
+    return build_backend_api_router(
+        BackendApiConfig(
+            name="gemini-backend-api",
+            path_prefix="/gemini",
+            default_model=_DEFAULT_MODEL,
+            backend=backend,
+            settings=settings,
+            app=app,
+            build_interpreter=build_interpreter,
+            span_prefix="gemini",
         )
-        result = await _execute(run_request)
-
-        if is_url4 and isinstance(result, JSONResponse):
-            body = json.loads(bytes(result.body).decode())
-            stdout = body.get("so") or body.get("stdout") or ""
-            return PlainTextResponse(content=stdout)
-        return result
-
-    @router.get("/gemini/{profile_name}", response_model=None, operation_id="gemini_profile_get")
-    async def gemini_profile_get(
-        profile_name: str, prompt: str, context: str | None = None, raw_context: str | None = None
-    ) -> JSONResponse | StreamingResponse | PlainTextResponse:
-        return await _handle_profile(profile_name, prompt, context, raw_context)
-
-    @router.post("/gemini/{profile_name}", response_model=None, operation_id="gemini_profile_post")
-    async def gemini_profile_post(
-        profile_name: str, prompt: str, context: str | None = None, raw_context: str | None = None
-    ) -> JSONResponse | StreamingResponse | PlainTextResponse:
-        return await _handle_profile(profile_name, prompt, context, raw_context)
-
-    return router
-
-
-def _extract_text(msg: CoreMessage) -> str:
-    if isinstance(msg.content, str):
-        return msg.content
-    return "".join(p.text for p in msg.content if isinstance(p, TextPart))
+    )

--- a/apps/server/src/screamingface/plugins/llm_base/__init__.py
+++ b/apps/server/src/screamingface/plugins/llm_base/__init__.py
@@ -38,7 +38,17 @@ from __future__ import annotations
 
 from screamingface.plugins.llm_base.adapter_base import Adapter
 from screamingface.plugins.llm_base.auth_base import AuthStrategy
-from screamingface.plugins.llm_base.backend_base import Backend
+from screamingface.plugins.llm_base.backend_base import (
+    Backend,
+    HealthStatus,
+    post_with_default_retry,
+)
+from screamingface.plugins.llm_base.constants import (
+    CLI_ONLY_FIELDS,
+    DEFAULT_MAX_TOKENS,
+    PROMPT_PREVIEW_LIMIT,
+    STDOUT_PREVIEW_LIMIT,
+)
 from screamingface.plugins.llm_base.credential_store import (
     CredentialStore,
     LinuxLibsecretStore,
@@ -53,6 +63,7 @@ from screamingface.plugins.llm_base.errors import (
     CredentialNotFoundError,
     LlmBaseError,
 )
+from screamingface.plugins.llm_base.http import default_http_factory, make_http_factory
 from screamingface.plugins.llm_base.messages import (
     CoreMessage,
     ImagePart,
@@ -61,6 +72,7 @@ from screamingface.plugins.llm_base.messages import (
     ToolCallPart,
     ToolDefinition,
     ToolResultPart,
+    extract_text,
 )
 
 __all__ = [
@@ -69,6 +81,8 @@ __all__ = [
     "Backend",
     "CredentialStore",
     "Adapter",
+    "HealthStatus",
+    "post_with_default_retry",
     # Concrete credential stores
     "LinuxLibsecretStore",
     "MacOSKeychainStore",
@@ -82,6 +96,15 @@ __all__ = [
     "ToolResultPart",
     "ReasoningPart",
     "ToolDefinition",
+    "extract_text",
+    # Constants
+    "CLI_ONLY_FIELDS",
+    "DEFAULT_MAX_TOKENS",
+    "PROMPT_PREVIEW_LIMIT",
+    "STDOUT_PREVIEW_LIMIT",
+    # HTTP
+    "default_http_factory",
+    "make_http_factory",
     # Errors
     "LlmBaseError",
     "AuthError",

--- a/apps/server/src/screamingface/plugins/llm_base/auth_base.py
+++ b/apps/server/src/screamingface/plugins/llm_base/auth_base.py
@@ -65,3 +65,18 @@ class AuthStrategy(ABC):
             AuthError: Refresh failed in a way the user must fix
                 (refresh token expired, invalid_grant, etc.).
         """
+
+    def invalidate_cache(self) -> None:
+        """Drop any cached credential so the next
+        :meth:`get_authorization_header` forces a fresh read or refresh.
+
+        Default is a no-op — strategies that don't cache (e.g. plain
+        API-key readers) inherit this trivially. OAuth strategies
+        override to clear their in-memory cache *and* the credential
+        store entry if it's detectably stale.
+
+        Called by the shared POST-with-retry helper when the provider
+        returns 401, under the assumption that the cached token went
+        bad mid-request (rare race with a concurrent refresh).
+        """
+

--- a/apps/server/src/screamingface/plugins/llm_base/auth_base.py
+++ b/apps/server/src/screamingface/plugins/llm_base/auth_base.py
@@ -79,4 +79,3 @@ class AuthStrategy(ABC):
         returns 401, under the assumption that the cached token went
         bad mid-request (rare race with a concurrent refresh).
         """
-

--- a/apps/server/src/screamingface/plugins/llm_base/backend_base.py
+++ b/apps/server/src/screamingface/plugins/llm_base/backend_base.py
@@ -19,25 +19,25 @@ its own lock for refresh concurrency.
 
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
+from screamingface.plugins.llm_base.errors import AuthError, BackendError
 from screamingface.plugins.llm_base.messages import CoreMessage, ToolDefinition
+
+if TYPE_CHECKING:
+    import httpx
+
+    from screamingface.plugins.llm_base.auth_base import AuthStrategy
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
 class HealthStatus:
-    """Result of a backend health check.
-
-    Attributes:
-        authenticated: Whether the backend has a valid auth credential.
-        error: Human-readable error message when authenticated is False.
-        tokens_remaining: Remaining token capacity from rate limit headers.
-            None if the backend doesn't report this or the check didn't
-            reach the API.
-        requests_remaining: Remaining request capacity from rate limit headers.
-        rate_limit: Full rate limit info as key-value pairs (provider-specific).
-    """
+    """Result of a backend health check."""
 
     authenticated: bool
     error: str | None = None
@@ -50,12 +50,6 @@ class Backend(ABC):
     """Abstract contract for a provider backend."""
 
     async def health(self) -> HealthStatus:
-        """Check backend health: auth validity and rate limit capacity.
-
-        The default implementation just checks whether
-        ``get_authorization_header()`` succeeds. Concrete backends should
-        override to add rate-limit capacity info from the provider.
-        """
         return HealthStatus(authenticated=False, error="health() not implemented")
 
     @abstractmethod
@@ -72,15 +66,6 @@ class Backend(ABC):
     ) -> CoreMessage:
         """Execute one round-trip against the provider.
 
-        Flow:
-          1. Call ``auth.get_authorization_header()`` for headers.
-          2. Call ``adapter.to_provider_format(messages, ...)`` for
-             the request body.
-          3. POST to the provider's endpoint.
-          4. On 200: ``adapter.from_provider_response(data)``.
-          5. On 401: invalidate auth cache, retry once.
-          6. On other errors: raise :class:`BackendError` with status.
-
         Raises:
             AuthError: Auth path broke and the user must re-auth.
             BackendError: Provider returned a non-success status or
@@ -88,3 +73,113 @@ class Backend(ABC):
             AdapterError: Request or response couldn't be adapted
                 to/from our canonical shape.
         """
+
+
+async def post_with_default_retry(
+    *,
+    auth: AuthStrategy,
+    http_factory,
+    url: str,
+    body: dict,
+    provider_name: str,
+    auth_login_cmd: str,
+) -> dict:
+    """Shared POST helper with the canonical ``401 → invalidate → retry`` recipe.
+
+    This is the three-step dance every *_backend_api plugin had copied:
+
+    1. Build auth headers, POST the body.
+    2. On 401, invalidate the auth cache and retry exactly once. A
+       second 401 means the credential itself is bad — raise
+       :class:`AuthError` pointing at ``auth_login_cmd``.
+    3. On 200 return the parsed JSON body; otherwise translate status
+       codes to :class:`BackendError` / :class:`AuthError`.
+
+    Providers with non-standard retry behavior (e.g. Gemini's 429
+    self-recovery loop) should not use this — they override with their
+    own method.
+
+    Args:
+        auth: Strategy for building the Authorization header.
+        http_factory: No-arg callable returning an ``httpx.AsyncClient``
+            (typically :func:`llm_base.http.default_http_factory`).
+        url: The endpoint to POST to.
+        body: The request body (serialized as JSON).
+        provider_name: Human name of the provider for error messages
+            ("Anthropic", "OpenAI", …).
+        auth_login_cmd: The CLI command the user should run to
+            re-authenticate when the credential is bad
+            (e.g. ``"claude auth login"``).
+    """
+    import httpx
+
+    async def _do_post(headers: dict[str, str]) -> httpx.Response:
+        try:
+            async with http_factory() as client:
+                return await client.post(url, json=body, headers=headers)
+        except httpx.TimeoutException as exc:
+            raise BackendError(
+                f"{provider_name} request timed out: {exc}",
+                status=None,
+            ) from exc
+        except httpx.RequestError as exc:
+            raise BackendError(
+                f"{provider_name} request failed: {exc}",
+                status=None,
+            ) from exc
+
+    headers = await auth.get_authorization_header()
+    headers.setdefault("content-type", "application/json")
+    resp = await _do_post(headers)
+
+    if resp.status_code == 401:
+        logger.warning(
+            "%s: %s returned 401, invalidating auth cache and retrying once",
+            provider_name,
+            url,
+        )
+        auth.invalidate_cache()
+        headers = await auth.get_authorization_header()
+        headers.setdefault("content-type", "application/json")
+        resp = await _do_post(headers)
+        if resp.status_code == 401:
+            raise AuthError(
+                f"Authentication failed twice against {provider_name}; "
+                f"token state may be corrupt. Run '{auth_login_cmd}' to re-authenticate."
+            )
+
+    if resp.status_code == 200:
+        try:
+            return resp.json()
+        except ValueError as exc:
+            raise BackendError(
+                f"{provider_name} returned 200 but the body is not JSON: {exc}",
+                status=200,
+            ) from exc
+
+    if resp.status_code == 429:
+        retry_after_raw = resp.headers.get("retry-after")
+        retry_after: float | None = None
+        if retry_after_raw is not None:
+            try:
+                retry_after = float(retry_after_raw)
+            except ValueError:
+                retry_after = None
+        raise BackendError(
+            f"{provider_name} rate limit exceeded (429). "
+            f"Retry after {retry_after_raw or 'unknown'} seconds.",
+            status=429,
+            retry_after=retry_after,
+        )
+
+    if resp.status_code == 403:
+        raise AuthError(
+            f"{provider_name} returned 403 Forbidden. Token is valid but "
+            f"lacks permission. Response: {resp.text[:500]}. "
+            f"Run '{auth_login_cmd}' to re-authenticate with the correct scopes."
+        )
+
+    raise BackendError(
+        f"{provider_name} API error {resp.status_code}: {resp.text[:500]}",
+        status=resp.status_code,
+    )

--- a/apps/server/src/screamingface/plugins/llm_base/backend_base.py
+++ b/apps/server/src/screamingface/plugins/llm_base/backend_base.py
@@ -49,7 +49,13 @@ class HealthStatus:
 class Backend(ABC):
     """Abstract contract for a provider backend."""
 
-    async def health(self) -> HealthStatus:
+    async def health(self, model: str | None = None) -> HealthStatus:  # noqa: ARG002
+        """Probe the provider for auth validity and rate-limit capacity.
+
+        Concrete backends should override. The ``model`` hint lets the
+        probe target the model the user will actually be calling — when
+        it's None the backend picks its own (usually cheapest) probe model.
+        """
         return HealthStatus(authenticated=False, error="health() not implemented")
 
     @abstractmethod

--- a/apps/server/src/screamingface/plugins/llm_base/constants.py
+++ b/apps/server/src/screamingface/plugins/llm_base/constants.py
@@ -1,0 +1,38 @@
+"""Shared constants used across ``*_backend_api`` plugins.
+
+Moved here so every direct-API backend plugin uses the same field
+list, the same truncation limits, and the same default max-tokens
+budget — no more drift between copy-pasted tuples.
+"""
+
+from __future__ import annotations
+
+# Fields accepted on RunRequest for drop-in compatibility with the
+# Claude CLI / sf.json profiles, but silently dropped by every
+# direct-API backend (there is no subprocess to honor them). Recorded
+# as OTEL span attributes so the drop stays observable.
+CLI_ONLY_FIELDS: tuple[str, ...] = (
+    "add_dirs",
+    "mcp_config",
+    "permission_mode",
+    "dangerously_skip_permissions",
+    "no_session_persistence",
+    "tools",
+    "allowed_tools",
+    "disallowed_tools",
+)
+
+# Default max_tokens for a single backend run when the caller doesn't
+# specify one. Chosen empirically to cover the cookbook examples
+# without consuming the whole 200k-token context.
+DEFAULT_MAX_TOKENS: int = 16000
+
+# Preview length for OTEL span attributes that carry response bodies
+# or long prompt strings. Longer content is truncated and an ellipsis
+# footer ``... (N more chars)`` is appended so the consumer knows.
+PROMPT_PREVIEW_LIMIT: int = 4000
+
+# Stdout preview length recorded on success spans (shorter than
+# PROMPT_PREVIEW_LIMIT because stdout is usually the full model reply
+# and 1k chars is enough for dashboards).
+STDOUT_PREVIEW_LIMIT: int = 1000

--- a/apps/server/src/screamingface/plugins/llm_base/http.py
+++ b/apps/server/src/screamingface/plugins/llm_base/http.py
@@ -1,0 +1,56 @@
+"""Shared httpx client factory for backend plugins.
+
+Every concrete ``Backend`` subclass needs an ``httpx.AsyncClient`` with
+the same SSL context and timeout shape (10s connect, long read, 10s
+write/pool). Defining that once here keeps the four direct-API
+backends aligned on TLS behavior and lets us tune the timeouts
+globally.
+"""
+
+from __future__ import annotations
+
+import ssl
+from collections.abc import Callable
+
+import certifi
+import httpx
+
+__all__ = ["default_http_factory", "make_http_factory"]
+
+
+def default_http_factory() -> httpx.AsyncClient:
+    """Build an AsyncClient with the canonical timeout + TLS settings."""
+    ssl_ctx = ssl.create_default_context(cafile=certifi.where())
+    return httpx.AsyncClient(
+        timeout=httpx.Timeout(connect=10.0, read=300.0, write=10.0, pool=10.0),
+        verify=ssl_ctx,
+    )
+
+
+def make_http_factory(
+    *,
+    connect_timeout: float = 10.0,
+    read_timeout: float = 300.0,
+    write_timeout: float = 10.0,
+    pool_timeout: float = 10.0,
+) -> Callable[[], httpx.AsyncClient]:
+    """Factory of factories — for backends that need non-default timeouts.
+
+    Most backends should use :func:`default_http_factory` directly.
+    Use this only when a provider genuinely needs different numbers
+    (e.g. a local Ollama server that should fail fast).
+    """
+    ssl_ctx = ssl.create_default_context(cafile=certifi.where())
+
+    def factory() -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            timeout=httpx.Timeout(
+                connect=connect_timeout,
+                read=read_timeout,
+                write=write_timeout,
+                pool=pool_timeout,
+            ),
+            verify=ssl_ctx,
+        )
+
+    return factory

--- a/apps/server/src/screamingface/plugins/llm_base/messages.py
+++ b/apps/server/src/screamingface/plugins/llm_base/messages.py
@@ -138,6 +138,18 @@ class CoreMessage(BaseModel):
 # ----------------------------------------------------------------------------
 
 
+def extract_text(msg: CoreMessage) -> str:
+    """Return the concatenation of every :class:`TextPart` in ``msg.content``.
+
+    Short-circuits on the bare-string content shorthand. Parts that are
+    not TextPart (image, tool-call, tool-result, reasoning) are skipped —
+    callers who need those should walk ``msg.content`` directly.
+    """
+    if isinstance(msg.content, str):
+        return msg.content
+    return "".join(p.text for p in msg.content if isinstance(p, TextPart))
+
+
 class ToolDefinition(BaseModel):
     """Schema describing a tool the model may call.
 

--- a/apps/server/src/screamingface/plugins/llm_base/routes_shared.py
+++ b/apps/server/src/screamingface/plugins/llm_base/routes_shared.py
@@ -1,0 +1,425 @@
+"""Shared FastAPI router factory for ``*_backend_api`` plugins.
+
+Before this module existed, every direct-API plugin (claude, codex,
+gemini, ollama) carried its own ~400-line ``routes.py`` that was 85%
+byte-identical to its siblings. The only real differences were:
+
+- the URL prefix (``/claude`` vs ``/codex`` vs …)
+- the default model fallback
+- the backend instance
+- the URL4 interpreter class
+- an OTEL span attribute prefix
+
+:func:`build_backend_api_router` captures those four differences in a
+:class:`BackendApiConfig` dataclass and generates the whole router.
+
+Plugin ``routes.py`` files shrink to a ~10-line function that builds
+the config and calls this factory.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
+
+from screamingface.plugins.backend_api_base.models import RunRequest, RunResponse
+from screamingface.plugins.llm_base.backend_base import Backend
+from screamingface.plugins.llm_base.constants import (
+    CLI_ONLY_FIELDS,
+    DEFAULT_MAX_TOKENS,
+    PROMPT_PREVIEW_LIMIT,
+    STDOUT_PREVIEW_LIMIT,
+)
+from screamingface.plugins.llm_base.errors import (
+    AuthError,
+    BackendError,
+    CredentialNotFoundError,
+)
+from screamingface.plugins.llm_base.messages import CoreMessage, TextPart, extract_text
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = ["BackendApiConfig", "build_backend_api_router"]
+
+
+@dataclass
+class BackendApiConfig:
+    """Per-provider wiring that drives the shared router factory.
+
+    Attributes:
+        name: Plugin name, e.g. ``"claude-backend-api"``. Used as the
+            router tag and as the OTEL ``sf.plugin`` attribute value.
+        path_prefix: URL prefix without trailing slash, e.g. ``"/claude"``.
+            Every generated route lives under this prefix.
+        default_model: Fallback model when neither request nor settings
+            specify one.
+        backend: The :class:`Backend` instance (per-plugin singleton).
+        settings: The plugin's settings object (duck-typed: must have
+            ``default_model``, ``timeout_seconds``, ``profiles``).
+        app: The FastAPI application. Passed into the URL4 interpreter.
+        build_interpreter: Callable returning a new URL4 interpreter
+            for this backend. Invoked with no arguments — capture
+            ``app``/``settings``/``backend`` in the closure.
+        span_prefix: Short provider name used as span-attribute prefix
+            (e.g. ``"claude"`` produces ``claude.exit_code``). Usually
+            the first segment of ``name``.
+        operation_id_prefix: Used to name OpenAPI operation IDs. If
+            unset, derived from ``name`` by stripping the
+            ``-backend-api`` suffix and replacing hyphens with
+            underscores.
+    """
+
+    name: str
+    path_prefix: str
+    default_model: str
+    backend: Backend
+    settings: Any
+    app: Any
+    build_interpreter: Callable[[], Any]
+    span_prefix: str
+    operation_id_prefix: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.operation_id_prefix is None:
+            self.operation_id_prefix = self.name.replace("-backend-api", "").replace("-", "_")
+
+
+def build_backend_api_router(cfg: BackendApiConfig) -> APIRouter:
+    """Produce a FastAPI router with the four canonical backend-API endpoints.
+
+    Endpoints:
+
+    - ``GET  {prefix}/health``
+    - ``POST {prefix}/run``
+    - ``GET  {prefix}?q=<expr>`` — evaluate a url4 expression
+    - ``GET/POST {prefix}/{{profile_name}}`` — profile-based execution
+    """
+    router = APIRouter(tags=[cfg.name])
+    prefix = cfg.path_prefix
+    op = cfg.operation_id_prefix
+    backend = cfg.backend
+    settings = cfg.settings
+
+    @router.get(f"{prefix}/health", response_model=None, operation_id=f"{op}_health")
+    async def health() -> JSONResponse:
+        model = settings.default_model or cfg.default_model
+        status = await backend.health(model=model)
+        http_status = 200 if status.authenticated else 503
+        return JSONResponse(
+            content={
+                "authenticated": status.authenticated,
+                "model": model,
+                "tokens_remaining": status.tokens_remaining,
+                "requests_remaining": status.requests_remaining,
+                "rate_limit": status.rate_limit,
+                "error": status.error,
+            },
+            status_code=http_status,
+        )
+
+    async def _execute(
+        request: RunRequest,
+    ) -> JSONResponse | StreamingResponse:
+        if request.output_format == "stream-json":
+            raise HTTPException(
+                status_code=501,
+                detail=(
+                    f"stream-json output is not yet implemented in {cfg.name}. "
+                    f"Use output_format='text' or 'json'."
+                ),
+            )
+        if request.files:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"The 'files' field is not supported by {cfg.name} "
+                    f"(no sandbox to write to). Include file contents "
+                    f"directly in the prompt instead."
+                ),
+            )
+
+        _record_ignored_fields(request, cfg.name)
+
+        timeout = request.timeout_seconds or settings.timeout_seconds
+        model = request.model or settings.default_model or cfg.default_model
+
+        system_parts: list[str] = []
+        if request.system_prompt:
+            system_parts.append(request.system_prompt)
+        if request.append_system_prompt:
+            system_parts.append(request.append_system_prompt)
+        system = "\n\n".join(system_parts) if system_parts else None
+
+        messages = [CoreMessage(role="user", content=[TextPart(text=request.prompt)])]
+
+        start = time.monotonic()
+        try:
+            result = await backend.run(
+                messages,
+                model=model,
+                system=system,
+                max_tokens=DEFAULT_MAX_TOKENS,
+                temperature=None,
+                timeout_seconds=timeout,
+            )
+            duration = time.monotonic() - start
+            stdout = extract_text(result)
+            parsed: dict | list | str | None = None
+            if request.output_format == "json" and stdout.strip():
+                try:
+                    parsed = json.loads(stdout)
+                except json.JSONDecodeError:
+                    parsed = None
+
+            resp = RunResponse(
+                exit_code=0,
+                stdout=stdout,
+                stderr="",
+                duration_seconds=round(duration, 3),
+                result=parsed,
+            )
+            _record_span_success(result, duration, stdout, cfg.name, cfg.span_prefix)
+            return JSONResponse(content=resp.model_dump(by_alias=True))
+
+        except (CredentialNotFoundError, AuthError) as exc:
+            duration = time.monotonic() - start
+            logger.warning("%s auth failure: %s", cfg.name, exc)
+            resp = RunResponse(
+                exit_code=1,
+                stdout="",
+                stderr=str(exc),
+                duration_seconds=round(duration, 3),
+                result=None,
+            )
+            return JSONResponse(content=resp.model_dump(by_alias=True), status_code=500)
+        except BackendError as exc:
+            duration = time.monotonic() - start
+            logger.warning("%s backend error: %s", cfg.name, exc)
+            status = 429 if exc.status == 429 else 502
+            resp = RunResponse(
+                exit_code=1,
+                stdout="",
+                stderr=str(exc),
+                duration_seconds=round(duration, 3),
+                result=None,
+            )
+            return JSONResponse(content=resp.model_dump(by_alias=True), status_code=status)
+
+    @router.post(f"{prefix}/run", response_model=None, operation_id=f"{op}_run")
+    async def run_endpoint(request: RunRequest) -> JSONResponse | StreamingResponse:
+        return await _execute(request)
+
+    @router.get(prefix, response_model=None, operation_id=f"{op}_url4")
+    async def url4(q: str) -> PlainTextResponse:
+        interpreter = cfg.build_interpreter()
+        try:
+            result = await interpreter.evaluate(q)
+        except (CredentialNotFoundError, AuthError) as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+        except BackendError as exc:
+            status = 429 if exc.status == 429 else 502
+            raise HTTPException(status_code=status, detail=str(exc)) from exc
+        except Exception as exc:
+            logger.warning("%s url4 evaluation failed: %s", cfg.name, exc, exc_info=True)
+            raise HTTPException(
+                status_code=502,
+                detail=f"url4 evaluation failed: {exc}",
+            ) from exc
+
+        _record_url4_span(q, result, cfg.name)
+        return PlainTextResponse(content=result)
+
+    async def _handle_profile(
+        profile_name: str,
+        prompt: str,
+        context: str | None = None,
+        raw_context: str | None = None,
+    ) -> JSONResponse | StreamingResponse | PlainTextResponse:
+        # Local imports to avoid llm-base depending on url4_executor at
+        # module-load time (url4_executor depends on backend plugins in
+        # its own setup).
+        from screamingface.plugins.url4_executor.interpreter import Url4Interpreter
+        from screamingface.plugins.url4_executor.url4 import resolve_str
+
+        prof = settings.profiles.get(profile_name)
+        if not prof:
+            raise HTTPException(status_code=404, detail=f"Unknown profile: {profile_name!r}")
+
+        is_url4 = False
+        url4_interpreter = Url4Interpreter(app=cfg.app)
+        stripped = prompt.strip()
+        if stripped.startswith("(") and "!" in stripped:
+            try:
+                prompt = await url4_interpreter.evaluate(stripped)
+                is_url4 = True
+            except Exception as exc:
+                logger.warning("url4 prompt resolution failed: %s", exc, exc_info=True)
+                raise HTTPException(
+                    status_code=502,
+                    detail=f"url4 prompt resolution failed: {exc}",
+                ) from exc
+
+        resolved_context = ""
+        if raw_context:
+            resolved_context = raw_context
+        elif not is_url4:
+            context_expr = context or prof.context
+            if context_expr:
+                try:
+                    resolved_context = await resolve_str(context_expr, cfg.app)
+                except Exception as exc:
+                    logger.warning("Context resolution failed: %s", exc, exc_info=True)
+                    raise HTTPException(
+                        status_code=502,
+                        detail=f"Context resolution failed: {exc}",
+                    ) from exc
+
+        full_prompt = f"{resolved_context}\n\n{prompt}" if resolved_context else prompt
+
+        run_request = RunRequest(
+            prompt=full_prompt,
+            model=prof.model,
+            system_prompt=prof.system_prompt,
+            append_system_prompt=prof.append_system_prompt,
+            output_format=prof.output_format,
+            json_schema=prof.json_schema,
+            max_budget_usd=prof.max_budget_usd,
+            effort=prof.effort,
+            tools=prof.tools,
+            allowed_tools=prof.allowed_tools,
+            disallowed_tools=prof.disallowed_tools,
+            mcp_config=prof.mcp_config,
+            permission_mode=prof.permission_mode,
+            add_dirs=prof.add_dirs,
+            fallback_model=prof.fallback_model,
+            dangerously_skip_permissions=prof.dangerously_skip_permissions,
+            no_session_persistence=prof.no_session_persistence,
+            timeout_seconds=prof.timeout_seconds,
+        )
+        result = await _execute(run_request)
+
+        if is_url4 and isinstance(result, JSONResponse):
+            body = json.loads(bytes(result.body).decode())
+            stdout = body.get("so") or body.get("stdout") or ""
+            return PlainTextResponse(content=stdout)
+        return result
+
+    @router.get(
+        f"{prefix}/{{profile_name}}",
+        response_model=None,
+        operation_id=f"{op}_profile_get",
+    )
+    async def profile_get(
+        profile_name: str,
+        prompt: str,
+        context: str | None = None,
+        raw_context: str | None = None,
+    ) -> JSONResponse | StreamingResponse | PlainTextResponse:
+        return await _handle_profile(profile_name, prompt, context, raw_context)
+
+    @router.post(
+        f"{prefix}/{{profile_name}}",
+        response_model=None,
+        operation_id=f"{op}_profile_post",
+    )
+    async def profile_post(
+        profile_name: str,
+        prompt: str,
+        context: str | None = None,
+        raw_context: str | None = None,
+    ) -> JSONResponse | StreamingResponse | PlainTextResponse:
+        return await _handle_profile(profile_name, prompt, context, raw_context)
+
+    return router
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _record_ignored_fields(request: RunRequest, plugin_name: str) -> None:
+    """Record which CLI-only fields were present on an OTEL span."""
+    try:
+        from opentelemetry import trace
+    except ImportError:
+        return
+
+    span = trace.get_current_span()
+    if not (span and span.is_recording()):
+        return
+
+    attr_prefix = plugin_name.replace("-", "_")
+    for field_name in CLI_ONLY_FIELDS:
+        value = getattr(request, field_name, None)
+        if value:  # truthy — non-empty list/str or True
+            span.set_attribute(f"{attr_prefix}.ignored_field.{field_name}", True)
+
+
+def _record_span_success(
+    result: CoreMessage,
+    duration: float,
+    stdout: str,
+    plugin_name: str,
+    span_prefix: str,
+) -> None:
+    """Record success-path attributes on the current OTEL span."""
+    try:
+        from opentelemetry import trace
+    except ImportError:
+        return
+
+    span = trace.get_current_span()
+    if not (span and span.is_recording()):
+        return
+
+    span.set_attribute("sf.plugin", plugin_name)
+    span.set_attribute(f"{span_prefix}.exit_code", 0)
+    span.set_attribute(f"{span_prefix}.duration_seconds", round(duration, 3))
+    span.set_attribute(f"{span_prefix}.stdout_length", len(stdout))
+    preview = stdout[:STDOUT_PREVIEW_LIMIT]
+    if len(stdout) > STDOUT_PREVIEW_LIMIT:
+        preview += f"\n... ({len(stdout) - STDOUT_PREVIEW_LIMIT} more chars)"
+    span.set_attribute(f"{span_prefix}.stdout_preview", preview)
+
+    if result.provider_metadata:
+        for key, value in result.provider_metadata.items():
+            try:
+                span.set_attribute(key, _otel_attr_value(value))
+            except Exception:
+                pass
+
+
+def _record_url4_span(q: str, result: str, plugin_name: str) -> None:
+    """Record url4-endpoint attributes on the current OTEL span."""
+    try:
+        from opentelemetry import trace
+    except ImportError:
+        return
+
+    span = trace.get_current_span()
+    if not (span and span.is_recording()):
+        return
+
+    span.set_attribute("sf.plugin", plugin_name)
+    span.set_attribute("url4.expression", q[:500])
+    span.set_attribute("url4.result_length", len(result))
+    preview = result[:PROMPT_PREVIEW_LIMIT]
+    if len(result) > PROMPT_PREVIEW_LIMIT:
+        preview += f"\n... ({len(result) - PROMPT_PREVIEW_LIMIT} more chars)"
+    span.set_attribute("url4.response_body", preview)
+
+
+def _otel_attr_value(value: Any) -> Any:
+    """Coerce a value to something OTEL spans accept."""
+    if isinstance(value, str | bool | int | float):
+        return value
+    return json.dumps(value)

--- a/apps/server/src/screamingface/plugins/ollama_backend_api/routes.py
+++ b/apps/server/src/screamingface/plugins/ollama_backend_api/routes.py
@@ -1,378 +1,47 @@
-"""Routes for ollama-backend-api.
-
-Mirrors claude-backend-api route shapes at the ``/ollama`` prefix:
-
-- ``POST /ollama/run`` — execute a prompt through Ollama
-- ``GET /ollama?q=`` — evaluate a url4 expression through Ollama
-- ``GET /ollama/{profile_name}`` — profile-based execution
-- ``POST /ollama/{profile_name}`` — profile-based execution
-
-Same CLI-only field dropping, same error mapping, same wire-format
-request/response shapes as claude-backend-api.
-"""
+"""Routes for ollama-backend-api — thin adapter over the shared router factory."""
 
 from __future__ import annotations
 
-import json
-import logging
-import time
 from typing import TYPE_CHECKING, Any
 
-from fastapi import APIRouter, HTTPException
-from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
+from fastapi import APIRouter
 
-from screamingface.plugins.llm_base.errors import (
-    AuthError,
-    BackendError,
-    CredentialNotFoundError,
+from screamingface.plugins.llm_base.routes_shared import (
+    BackendApiConfig,
+    build_backend_api_router,
 )
-from screamingface.plugins.llm_base.messages import CoreMessage, TextPart
 from screamingface.plugins.ollama_backend_api.auth import OllamaAuth
 from screamingface.plugins.ollama_backend_api.backend import OllamaBackend
-from screamingface.plugins.ollama_backend_api.models import (
-    RunRequest,
-    RunResponse,
-)
-from screamingface.plugins.url4_executor.interpreter import Url4Interpreter
-from screamingface.plugins.url4_executor.url4 import resolve_str
 
 if TYPE_CHECKING:
     from screamingface.plugins.ollama_backend_api.plugin import OllamaBackendApiSettings
 
-logger = logging.getLogger(__name__)
 
 _DEFAULT_MODEL = "llama3.2"
 
-# The eight fields we silently ignore because they're subprocess-only.
-_CLI_ONLY_FIELDS = (
-    "add_dirs",
-    "mcp_config",
-    "permission_mode",
-    "dangerously_skip_permissions",
-    "no_session_persistence",
-    "tools",
-    "allowed_tools",
-    "disallowed_tools",
-)
-
 
 def create_router(settings: OllamaBackendApiSettings, app: Any = None) -> APIRouter:
-    router = APIRouter(tags=["ollama-backend-api"])
-
-    _backend = OllamaBackend(
+    backend = OllamaBackend(
         base_url=settings.base_url,
         auth=OllamaAuth(api_key=settings.api_key),
     )
 
-    @router.get("/ollama/health", response_model=None, operation_id="ollama_health")
-    async def ollama_health() -> JSONResponse:
-        """Check Ollama backend health: server reachability + optional auth."""
-        model = settings.default_model or _DEFAULT_MODEL
-        status = await _backend.health(model=model)
-        http_status = 200 if status.authenticated else 503
-        return JSONResponse(
-            content={
-                "authenticated": status.authenticated,
-                "model": model,
-                "tokens_remaining": status.tokens_remaining,
-                "requests_remaining": status.requests_remaining,
-                "rate_limit": status.rate_limit,
-                "error": status.error,
-            },
-            status_code=http_status,
-        )
-
-    async def _execute(
-        request: RunRequest,
-    ) -> JSONResponse | StreamingResponse:
-        if request.output_format == "stream-json":
-            raise HTTPException(
-                status_code=501,
-                detail=(
-                    "stream-json output is not yet implemented in "
-                    "ollama-backend-api. Use output_format='text' or 'json'."
-                ),
-            )
-
-        if request.files:
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    "The 'files' field is not supported by "
-                    "ollama-backend-api (no sandbox to write to). "
-                    "Include file contents directly in the prompt instead."
-                ),
-            )
-
-        _record_ignored_fields(request)
-
-        timeout = request.timeout_seconds or settings.timeout_seconds
-        model = request.model or settings.default_model or _DEFAULT_MODEL
-
-        system_parts: list[str] = []
-        if request.system_prompt:
-            system_parts.append(request.system_prompt)
-        if request.append_system_prompt:
-            system_parts.append(request.append_system_prompt)
-        system = "\n\n".join(system_parts) if system_parts else None
-
-        messages = [CoreMessage(role="user", content=[TextPart(text=request.prompt)])]
-
-        start = time.monotonic()
-        try:
-            result = await _backend.run(
-                messages,
-                model=model,
-                system=system,
-                max_tokens=16000,
-                temperature=None,
-                timeout_seconds=timeout,
-            )
-            duration = time.monotonic() - start
-            stdout = _extract_text(result)
-            parsed_result: dict | list | str | None = None
-            if request.output_format == "json" and stdout.strip():
-                try:
-                    parsed_result = json.loads(stdout)
-                except json.JSONDecodeError:
-                    parsed_result = None
-
-            resp = RunResponse(
-                exit_code=0,
-                stdout=stdout,
-                stderr="",
-                duration_seconds=round(duration, 3),
-                result=parsed_result,
-            )
-            _record_span_success(result, duration, stdout)
-            return JSONResponse(content=resp.model_dump(by_alias=True))
-
-        except (CredentialNotFoundError, AuthError) as exc:
-            duration = time.monotonic() - start
-            logger.warning("ollama-backend-api auth failure: %s", exc)
-            resp = RunResponse(
-                exit_code=1,
-                stdout="",
-                stderr=str(exc),
-                duration_seconds=round(duration, 3),
-                result=None,
-            )
-            return JSONResponse(content=resp.model_dump(by_alias=True), status_code=500)
-
-        except BackendError as exc:
-            duration = time.monotonic() - start
-            logger.warning("ollama-backend-api backend error: %s", exc)
-            status = 429 if exc.status == 429 else 502
-            resp = RunResponse(
-                exit_code=1,
-                stdout="",
-                stderr=str(exc),
-                duration_seconds=round(duration, 3),
-                result=None,
-            )
-            return JSONResponse(content=resp.model_dump(by_alias=True), status_code=status)
-
-    @router.post("/ollama/run", response_model=None, operation_id="ollama_run")
-    async def ollama_run(
-        request: RunRequest,
-    ) -> JSONResponse | StreamingResponse:
-        return await _execute(request)
-
-    @router.get("/ollama", response_model=None, operation_id="ollama_url4")
-    async def ollama_url4(q: str) -> PlainTextResponse:
-        """Evaluate a url4 expression through Ollama."""
+    def build_interpreter() -> Any:
         from screamingface.plugins.ollama_backend_api.interpreter import (
             OllamaBackendApiInterpreter,
         )
 
-        interpreter = OllamaBackendApiInterpreter(app=app, settings=settings, backend=_backend)
-        try:
-            result = await interpreter.evaluate(q)
-        except (CredentialNotFoundError, AuthError) as exc:
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
-        except BackendError as exc:
-            status = 429 if exc.status == 429 else 502
-            raise HTTPException(status_code=status, detail=str(exc)) from exc
-        except Exception as exc:
-            logger.warning("url4 evaluation failed: %s", exc, exc_info=True)
-            raise HTTPException(status_code=502, detail=f"url4 evaluation failed: {exc}") from exc
+        return OllamaBackendApiInterpreter(app=app, settings=settings, backend=backend)
 
-        try:
-            from opentelemetry import trace
-
-            span = trace.get_current_span()
-            if span and span.is_recording():
-                span.set_attribute("sf.plugin", "ollama-backend-api")
-                span.set_attribute("url4.expression", q[:500])
-                span.set_attribute("url4.result_length", len(result))
-                preview = result[:4000]
-                if len(result) > 4000:
-                    preview += f"\n... ({len(result) - 4000} more chars)"
-                span.set_attribute("url4.response_body", preview)
-        except ImportError:
-            pass
-
-        return PlainTextResponse(content=result)
-
-    async def _handle_profile(
-        profile_name: str,
-        prompt: str,
-        context: str | None = None,
-        raw_context: str | None = None,
-    ) -> JSONResponse | StreamingResponse | PlainTextResponse:
-        prof = settings.profiles.get(profile_name)
-        if not prof:
-            raise HTTPException(status_code=404, detail=f"Unknown profile: {profile_name!r}")
-
-        is_url4 = False
-        url4_interpreter = Url4Interpreter(app=app)
-        stripped = prompt.strip()
-        if stripped.startswith("(") and "!" in stripped:
-            try:
-                prompt = await url4_interpreter.evaluate(stripped)
-                is_url4 = True
-            except Exception as exc:
-                logger.warning("url4 prompt resolution failed: %s", exc, exc_info=True)
-                raise HTTPException(
-                    status_code=502,
-                    detail=f"url4 prompt resolution failed: {exc}",
-                ) from exc
-
-        resolved_context = ""
-        if raw_context:
-            resolved_context = raw_context
-        elif not is_url4:
-            context_expr = context or prof.context
-            if context_expr:
-                try:
-                    resolved_context = await resolve_str(context_expr, app)
-                except Exception as exc:
-                    logger.warning("Context resolution failed: %s", exc, exc_info=True)
-                    raise HTTPException(
-                        status_code=502,
-                        detail=f"Context resolution failed: {exc}",
-                    ) from exc
-
-        full_prompt = f"{resolved_context}\n\n{prompt}" if resolved_context else prompt
-
-        run_request = RunRequest(
-            prompt=full_prompt,
-            model=prof.model,
-            system_prompt=prof.system_prompt,
-            append_system_prompt=prof.append_system_prompt,
-            output_format=prof.output_format,
-            json_schema=prof.json_schema,
-            max_budget_usd=prof.max_budget_usd,
-            effort=prof.effort,
-            tools=prof.tools,
-            allowed_tools=prof.allowed_tools,
-            disallowed_tools=prof.disallowed_tools,
-            mcp_config=prof.mcp_config,
-            permission_mode=prof.permission_mode,
-            add_dirs=prof.add_dirs,
-            fallback_model=prof.fallback_model,
-            dangerously_skip_permissions=prof.dangerously_skip_permissions,
-            no_session_persistence=prof.no_session_persistence,
-            timeout_seconds=prof.timeout_seconds,
+    return build_backend_api_router(
+        BackendApiConfig(
+            name="ollama-backend-api",
+            path_prefix="/ollama",
+            default_model=_DEFAULT_MODEL,
+            backend=backend,
+            settings=settings,
+            app=app,
+            build_interpreter=build_interpreter,
+            span_prefix="ollama",
         )
-        result = await _execute(run_request)
-
-        if is_url4 and isinstance(result, JSONResponse):
-            body = json.loads(bytes(result.body).decode())
-            stdout = body.get("so") or body.get("stdout") or ""
-            return PlainTextResponse(content=stdout)
-
-        return result
-
-    @router.get(
-        "/ollama/{profile_name}",
-        response_model=None,
-        operation_id="ollama_profile_get",
     )
-    async def ollama_profile_get(
-        profile_name: str,
-        prompt: str,
-        context: str | None = None,
-        raw_context: str | None = None,
-    ) -> JSONResponse | StreamingResponse | PlainTextResponse:
-        return await _handle_profile(profile_name, prompt, context, raw_context)
-
-    @router.post(
-        "/ollama/{profile_name}",
-        response_model=None,
-        operation_id="ollama_profile_post",
-    )
-    async def ollama_profile_post(
-        profile_name: str,
-        prompt: str,
-        context: str | None = None,
-        raw_context: str | None = None,
-    ) -> JSONResponse | StreamingResponse | PlainTextResponse:
-        return await _handle_profile(profile_name, prompt, context, raw_context)
-
-    return router
-
-
-# ----------------------------------------------------------------------------
-# Helpers
-# ----------------------------------------------------------------------------
-
-
-def _extract_text(msg: CoreMessage) -> str:
-    """Pull concatenated text out of an assistant CoreMessage."""
-    if isinstance(msg.content, str):
-        return msg.content
-    chunks: list[str] = []
-    for part in msg.content:
-        if isinstance(part, TextPart):
-            chunks.append(part.text)
-    return "".join(chunks)
-
-
-def _record_ignored_fields(request: RunRequest) -> None:
-    """Record which CLI-only fields were present so the drop is observable."""
-    try:
-        from opentelemetry import trace
-
-        span = trace.get_current_span()
-        if not (span and span.is_recording()):
-            return
-        for field_name in _CLI_ONLY_FIELDS:
-            value = getattr(request, field_name, None)
-            if value:
-                span.set_attribute(f"ollama_backend_api.ignored_field.{field_name}", True)
-    except ImportError:
-        pass
-
-
-def _record_span_success(result: CoreMessage, duration: float, stdout: str) -> None:
-    """Record success-path attributes on the OTEL span."""
-    try:
-        from opentelemetry import trace
-
-        span = trace.get_current_span()
-        if not (span and span.is_recording()):
-            return
-        span.set_attribute("sf.plugin", "ollama-backend-api")
-        span.set_attribute("ollama.exit_code", 0)
-        span.set_attribute("ollama.duration_seconds", round(duration, 3))
-        span.set_attribute("ollama.stdout_length", len(stdout))
-        preview = stdout[:1000]
-        if len(stdout) > 1000:
-            preview += f"\n... ({len(stdout) - 1000} more chars)"
-        span.set_attribute("ollama.stdout_preview", preview)
-        if result.provider_metadata:
-            for key, value in result.provider_metadata.items():
-                try:
-                    span.set_attribute(key, _otel_attr_value(value))
-                except Exception:
-                    pass
-    except ImportError:
-        pass
-
-
-def _otel_attr_value(value: Any) -> Any:
-    """Coerce a value to something OTEL spans accept as an attribute."""
-    if isinstance(value, str | bool | int | float):
-        return value
-    return json.dumps(value)


### PR DESCRIPTION
## Summary

Pulls the ~85%-identical plumbing out of every ``*_backend_api`` plugin's ``routes.py`` and ``backend.py`` into ``llm_base``. Adding a fifth provider plugin now takes ~50 lines instead of ~400.

**New in ``llm_base``:**
- ``constants.py`` — ``CLI_ONLY_FIELDS``, ``DEFAULT_MAX_TOKENS``, ``PROMPT_PREVIEW_LIMIT``, ``STDOUT_PREVIEW_LIMIT``
- ``http.py`` — ``default_http_factory()`` + ``make_http_factory()`` for non-default timeouts
- ``messages.extract_text(msg)``
- ``backend_base.post_with_default_retry(...)`` — canonical 401→invalidate→retry→``AuthError`` + 200/429/403/other handling
- ``routes_shared.BackendApiConfig`` + ``build_backend_api_router(cfg)`` — full health/run/url4/profile quartet

**Plugin migrations:**
- ``routes.py`` (all four plugins): **413/374/238/378 → ~50 lines each**
- ``backend.py``: claude and codex call the shared retry helper; gemini keeps its custom 429-loop; ollama keeps its 404 "model not pulled" message

**Test updates:**
- ``claude_backend_api/test_backend``: match ``"twice"`` (shared wording differs slightly from old local)
- ``codex_backend_api/test_backend``: match ``"403 Forbidden"`` (same)

**Small behavior improvements via the shared factory:**
- gemini now records ``_record_ignored_fields`` and ``_record_span_success`` like the others (previously silent)
- Health endpoints always pass the ``model`` kwarg

## Net size

14 files changed, **+796 / −1477** (~680 lines removed).

## Test plan

- [x] ``ruff check`` + ``ruff format --check`` clean
- [x] 703 unit tests pass
- [x] 46/46 non-live e2e tests pass (``TestUrl4MatrixLive`` excluded — pre-existing Gemini flakiness, unrelated)

## Asana

- Ticket: [SF-106](https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1214145310080626)
- Parent epic: [SF-96](https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1214137811159323)