### PR TITLE
SF-110: extract OAuthStrategy base + adapter helpers to llm_base

### DIFF
--- a/apps/server/src/screamingface/plugins/claude_backend_api/auth.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/auth.py
@@ -5,34 +5,30 @@ Every detail here was validated by the SF-77 spike
 ``apps/server/docs/oauth-spike-findings.md``). Do not change without
 re-running the spike or at least understanding the spike's findings.
 
-The flow:
+The flow — caching, double-checked locking, proactive refresh — lives
+in :class:`~screamingface.plugins.llm_base.oauth_base.OAuthStrategy`.
+This module just implements the four provider-specific hooks:
 
-1. Read the JSON credential from the credential store at service name
-   ``"Claude Code-credentials"``. This is where Claude Code's
-   ``claude auth login`` command writes.
-2. Parse the JSON, extract ``claudeAiOauth.{accessToken, refreshToken,
-   expiresAt, scopes, subscriptionType}``.
-3. If ``expiresAt`` is within 60 seconds of now, proactively refresh by
-   POSTing to ``https://console.anthropic.com/v1/oauth/token`` with
-   ``{grant_type: "refresh_token", refresh_token, client_id}``.
-4. Convert the refresh response (snake_case, ``expires_in`` seconds) to
-   the keychain shape (camelCase, ``expiresAt`` ms) and write back to
-   the credential store.
-5. Build the outbound headers for ``/v1/messages`` calls:
-   - ``Authorization: Bearer <accessToken>``
-   - ``anthropic-version: 2023-06-01``
-   - ``anthropic-beta: oauth-2025-04-20``  (REQUIRED — without it the
-     scope check rejects even a valid token)
+1. ``_read_credential`` — read the JSON blob Claude Code writes under
+   ``"Claude Code-credentials"`` in the platform credential store.
+2. ``_is_expired`` — compare ``expiresAt`` (unix epoch in milliseconds)
+   against the 60-second proactive refresh window.
+3. ``_refresh_credential`` — POST to
+   ``https://console.anthropic.com/v1/oauth/token`` with
+   ``{grant_type: "refresh_token", refresh_token, client_id}`` and
+   convert the OAuth 2.0 response shape (snake_case, ``expires_in``
+   seconds) back to the keychain shape (camelCase, ``expiresAt`` ms).
+4. ``_build_headers`` — the three required Anthropic headers:
+   ``Authorization: Bearer``, ``anthropic-version``, ``anthropic-beta``.
+   The beta header is REQUIRED — the spike proved its absence causes
+   scope rejection.
 
-Concurrency: a per-instance asyncio.Lock protects the refresh path so
-two concurrent coroutines don't both fire a refresh and race on the
-credential store. Uses double-checked locking to avoid unnecessary lock
-acquisition on the common (cache-hit) path.
+Concurrency note lives on the base class — a per-instance
+``asyncio.Lock`` with double-checked locking.
 """
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import os
@@ -40,22 +36,22 @@ import time
 
 import httpx
 
-from screamingface.plugins.llm_base.auth_base import AuthStrategy
 from screamingface.plugins.llm_base.credential_store import (
     CredentialStore,
     get_credential_store,
 )
 from screamingface.plugins.llm_base.errors import AuthError, CredentialNotFoundError
+from screamingface.plugins.llm_base.oauth_base import OAuthStrategy
 
 logger = logging.getLogger(__name__)
 
-# These constants are the load-bearing values validated by the SF-77 spike.
+# Constants validated by the SF-77 spike.
 KEYCHAIN_SERVICE = "Claude Code-credentials"
 OAUTH_REFRESH_URL = "https://console.anthropic.com/v1/oauth/token"
 OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"  # public Claude Code OAuth app
 ANTHROPIC_VERSION = "2023-06-01"
-# Beta features: oauth is required for OAuth bearer tokens, claude-code
-# gives access to the Claude Code rate limit pool (separate from API key pool).
+# Beta features: ``oauth-2025-04-20`` is required for OAuth bearer tokens,
+# ``claude-code-*`` gives access to the Claude Code rate-limit pool.
 ANTHROPIC_BETA = ",".join(
     [
         "claude-code-20250219",
@@ -65,13 +61,13 @@ ANTHROPIC_BETA = ",".join(
     ]
 )
 
-# Proactive refresh window — refresh when the token has less than this
-# many seconds of validity remaining. 60s matches the plan's locked-in
-# decision and mirrors Claude Code's own behavior.
+# Retained at module level so existing tests and callers keep working.
+# The value lives on :class:`OAuthStrategy.refresh_window_seconds`; we
+# just re-export it here.
 REFRESH_WINDOW_SECONDS = 60
 
 
-class ClaudeCodeOAuth(AuthStrategy):
+class ClaudeCodeOAuth(OAuthStrategy):
     """Reads Claude Code's OAuth token from the platform credential store.
 
     Args:
@@ -91,76 +87,18 @@ class ClaudeCodeOAuth(AuthStrategy):
         account: str | None = None,
         http_client_factory=None,
     ) -> None:
+        super().__init__()
         self._store = credential_store or get_credential_store()
         self._account = account if account is not None else os.environ.get("USER", "")
         self._http_factory = http_client_factory or (
             lambda: httpx.AsyncClient(timeout=httpx.Timeout(30.0))
         )
-        self._cached: dict | None = None
-        self._lock = asyncio.Lock()
 
     # ------------------------------------------------------------------
-    # Public API
+    # OAuthStrategy hooks
     # ------------------------------------------------------------------
 
-    async def get_authorization_header(self) -> dict[str, str]:
-        """Build the full header set for an outbound /v1/messages call.
-
-        Returns the three headers every OAuth-authenticated Anthropic
-        Messages call needs: ``Authorization`` (Bearer), ``anthropic-version``,
-        ``anthropic-beta``. The beta header is required — the spike
-        proved its absence causes scope rejection.
-
-        Handles caching, proactive refresh, and the credential-missing
-        hard-fail path.
-        """
-        # Fast path: cache hit and not expired
-        if self._cached is not None and not self._is_expired(self._cached):
-            return self._build_headers(self._cached)
-
-        # Slow path: read + maybe refresh, under lock
-        async with self._lock:
-            # Double-check inside the lock — another coroutine may have
-            # refreshed while we were waiting.
-            if self._cached is None:
-                self._cached = self._read_from_store()
-            if self._is_expired(self._cached):
-                self._cached = await self._do_refresh(self._cached)
-
-        return self._build_headers(self._cached)
-
-    async def refresh(self) -> None:
-        """Force-refresh the cached credential.
-
-        Used by ``POST /backends/claude-backend-api/refresh`` in Phase 5
-        and as the on-401 recovery path in the Anthropic backend.
-        """
-        async with self._lock:
-            if self._cached is None:
-                self._cached = self._read_from_store()
-            self._cached = await self._do_refresh(self._cached)
-
-    def invalidate_cache(self) -> None:
-        """Drop the in-memory cache without touching the credential store.
-
-        Used as the on-401 recovery path: the backend catches a 401 from
-        /v1/messages, calls invalidate_cache(), then retries once. The
-        next get_authorization_header() call re-reads from the store and
-        refreshes if needed.
-        """
-        self._cached = None
-
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
-
-    def _read_from_store(self) -> dict:
-        """Read the credential store and parse the JSON payload.
-
-        Raises:
-            CredentialNotFoundError: The credential store has no entry.
-            AuthError: The entry exists but doesn't parse as expected.
-        """
+    def _read_credential(self) -> dict:
         raw = self._store.read(KEYCHAIN_SERVICE, self._account)
         if raw is None:
             raise CredentialNotFoundError(
@@ -182,8 +120,7 @@ class ClaudeCodeOAuth(AuthStrategy):
             )
 
         creds = outer["claudeAiOauth"]
-        required = {"accessToken", "refreshToken", "expiresAt"}
-        missing = required - set(creds.keys())
+        missing = {"accessToken", "refreshToken", "expiresAt"} - set(creds.keys())
         if missing:
             raise AuthError(
                 f"Claude Code credential store entry missing required keys: "
@@ -192,35 +129,19 @@ class ClaudeCodeOAuth(AuthStrategy):
         return creds
 
     def _is_expired(self, creds: dict) -> bool:
-        """Return True if the token should be refreshed.
-
-        Uses the 60-second proactive refresh window — we refresh when
-        the token has less than REFRESH_WINDOW_SECONDS of validity
-        remaining, not when it's already expired.
-
-        The ``expiresAt`` field is a unix epoch in **milliseconds** (not
-        seconds), per the spike-validated Claude Code format.
-        """
+        """expiresAt is unix epoch in **milliseconds** — spike-validated."""
         expires_at_ms = creds.get("expiresAt", 0)
         now_ms = time.time() * 1000
-        return now_ms >= expires_at_ms - (REFRESH_WINDOW_SECONDS * 1000)
+        return now_ms >= expires_at_ms - (self.refresh_window_seconds * 1000)
 
     def _build_headers(self, creds: dict) -> dict[str, str]:
-        """Build the three required headers from a validated credential."""
         return {
             "Authorization": f"Bearer {creds['accessToken']}",
             "anthropic-version": ANTHROPIC_VERSION,
             "anthropic-beta": ANTHROPIC_BETA,
         }
 
-    async def _do_refresh(self, creds: dict) -> dict:
-        """POST to the refresh endpoint and write back on success.
-
-        Must be called while holding self._lock.
-
-        Raises:
-            AuthError: Refresh failed (401, network, 5xx after retries).
-        """
+    async def _refresh_credential(self, creds: dict) -> dict:
         body = {
             "grant_type": "refresh_token",
             "refresh_token": creds["refreshToken"],
@@ -239,7 +160,6 @@ class ClaudeCodeOAuth(AuthStrategy):
                 "Claude Code OAuth token expired and could not be refreshed. "
                 "Run 'claude auth login' to re-authenticate."
             )
-
         if resp.status_code != 200:
             raise AuthError(
                 f"OAuth refresh failed with status {resp.status_code}: "
@@ -259,34 +179,24 @@ class ClaudeCodeOAuth(AuthStrategy):
         )
         return new_creds
 
+    # ------------------------------------------------------------------
+    # Keychain-shape plumbing
+    # ------------------------------------------------------------------
+
     def _convert_refresh_response(self, data: dict, *, old_creds: dict) -> dict:
-        """Convert the OAuth 2.0 refresh response to keychain shape.
+        """Convert the OAuth 2.0 refresh response to Claude Code keychain shape.
 
-        The refresh endpoint returns standard OAuth 2.0 fields:
-          - access_token (string)
-          - refresh_token (string, may be rotated)
-          - expires_in (SECONDS)
-          - token_type ("Bearer")
-          - scope (space-separated string)
-
-        The keychain stores:
-          - accessToken (string)
-          - refreshToken (string)
-          - expiresAt (MILLISECONDS since epoch)
-          - scopes (list of strings)
-          - subscriptionType, rateLimitTier (preserved from old creds)
+        Refresh endpoint returns standard OAuth 2.0 fields (snake_case,
+        ``expires_in`` seconds); the keychain stores camelCase with
+        ``expiresAt`` in milliseconds. ``subscriptionType``/``rateLimitTier``
+        are preserved from the old credential since the refresh response
+        doesn't include them.
         """
-        if "access_token" not in data:
-            raise AuthError("OAuth refresh response missing 'access_token' field")
-        if "refresh_token" not in data:
-            raise AuthError("OAuth refresh response missing 'refresh_token' field")
-        if "expires_in" not in data:
-            raise AuthError("OAuth refresh response missing 'expires_in' field")
+        for required_field in ("access_token", "refresh_token", "expires_in"):
+            if required_field not in data:
+                raise AuthError(f"OAuth refresh response missing '{required_field}' field")
 
-        # Convert seconds → milliseconds relative to now
         expires_at_ms = int((time.time() + int(data["expires_in"])) * 1000)
-
-        # scope is a space-separated string; scopes is a list
         scope_str = data.get("scope", "")
         scopes = scope_str.split() if scope_str else old_creds.get("scopes", [])
 
@@ -295,15 +205,11 @@ class ClaudeCodeOAuth(AuthStrategy):
             "refreshToken": data["refresh_token"],
             "expiresAt": expires_at_ms,
             "scopes": scopes,
-            # Preserve metadata the refresh response doesn't include
             "subscriptionType": old_creds.get("subscriptionType", "max"),
             "rateLimitTier": old_creds.get("rateLimitTier", "default_claude_max_5x"),
         }
 
     def _write_to_store(self, creds: dict) -> None:
-        """Write the updated credential back to the platform store.
-
-        Preserves the outer wrapper shape the CLI expects.
-        """
+        """Write the updated credential back, preserving the CLI's wrapper."""
         value = json.dumps({"claudeAiOauth": creds})
         self._store.write(KEYCHAIN_SERVICE, self._account, value)

--- a/apps/server/src/screamingface/plugins/codex_backend_api/auth.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/auth.py
@@ -1,37 +1,31 @@
-"""Codex CLI OAuth auth strategy -- reads tokens from ~/.codex/auth.json.
+"""Codex CLI OAuth auth strategy — reads tokens from ``~/.codex/auth.json``.
 
-The Codex CLI stores its OAuth credentials as a plain JSON file on disk
-(unlike Claude Code which uses the OS keychain). The file is written by
-``codex auth login`` and contains:
+The shared caching + locking + refresh flow lives in
+:class:`~screamingface.plugins.llm_base.oauth_base.OAuthStrategy`.
+This module supplies the Codex-specific pieces:
 
-.. code-block:: json
+1. ``_read_credential`` — load ``~/.codex/auth.json`` and extract the
+   ``tokens`` sub-dict.
+2. ``_is_expired`` — decode the JWT ``exp`` claim (unix epoch in
+   *seconds*) and compare against the 60-second proactive refresh
+   window.
+3. ``_refresh_credential`` — POST to ``https://auth.openai.com/oauth/token``
+   with ``{grant_type: "refresh_token", refresh_token, client_id}``
+   and write back atomically.
+4. ``_build_headers`` — ``{"Authorization": "Bearer <access_token>"}``.
 
-    {
-        "OPENAI_API_KEY": null,
-        "tokens": {
-            "id_token": "<jwt>",
-            "access_token": "<jwt>",
-            "refresh_token": "<rt_...>",
-            "account_id": "<uuid>"
-        },
-        "last_refresh": "<iso-timestamp>"
-    }
+``_header_override`` returns an explicit ``OPENAI_API_KEY`` as a Bearer
+header when set, bypassing the OAuth flow entirely.
 
-The access token is a RS256-signed JWT with an ``exp`` claim (unix epoch
-in seconds). We decode the JWT payload to check expiry -- no ``pyjwt``
-dependency needed, just base64.
-
-Refresh flow:
-  POST https://auth.openai.com/oauth/token
-  Body: {grant_type: "refresh_token", refresh_token, client_id}
-
-Concurrency: same asyncio.Lock + double-checked locking pattern as
-ClaudeCodeOAuth.
+Codex's JWT tokens carry ChatGPT scopes; the backend uses
+``chatgpt.com/backend-api/codex/responses`` directly. The RFC 8693
+token-exchange path to swap for an ``api.openai.com``-scoped token
+(see :meth:`CodexOAuth._do_token_exchange`) is retained for future use
+but not on the default path.
 """
 
 from __future__ import annotations
 
-import asyncio
 import base64
 import json
 import logging
@@ -42,8 +36,8 @@ from pathlib import Path
 
 import httpx
 
-from screamingface.plugins.llm_base.auth_base import AuthStrategy
 from screamingface.plugins.llm_base.errors import AuthError, CredentialNotFoundError
+from screamingface.plugins.llm_base.oauth_base import OAuthStrategy
 
 logger = logging.getLogger(__name__)
 
@@ -51,40 +45,36 @@ AUTH_FILE_PATH = Path.home() / ".codex" / "auth.json"
 OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
 OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 
-# RFC 8693 token exchange constants -- the Codex CLI's id_token has
-# ChatGPT scopes only. To call the API we must exchange it for an
-# API-capable access token via the token exchange grant type.
+# RFC 8693 token exchange — the Codex CLI's id_token has ChatGPT scopes
+# only. Exchanging for an API-capable token is preserved as a subclass
+# method for future use; the default path uses the raw ChatGPT token
+# against chatgpt.com/backend-api/codex/responses.
 TOKEN_EXCHANGE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
 TOKEN_EXCHANGE_SUBJECT_TYPE = "urn:ietf:params:oauth:token-type:id_token"
 
-# Proactive refresh window -- refresh when the token has less than this
-# many seconds of validity remaining.
+# Retained at module scope for test imports / external callers. The
+# effective value lives on :attr:`OAuthStrategy.refresh_window_seconds`.
 REFRESH_WINDOW_SECONDS = 60
 
 
 def _decode_jwt_exp(token: str) -> float | None:
-    """Extract the ``exp`` claim from a JWT without signature verification.
-
-    Returns the expiry as a unix epoch in seconds, or None if decoding
-    fails. We only need the expiry timestamp, not verification.
-    """
+    """Return the unsigned JWT ``exp`` claim (seconds since epoch), or None."""
     parts = token.split(".")
     if len(parts) < 2:
         return None
     payload_b64 = parts[1]
-    # Add padding if missing (base64url requires length % 4 == 0)
     padding = 4 - len(payload_b64) % 4
     if padding != 4:
         payload_b64 += "=" * padding
     try:
         payload = json.loads(base64.urlsafe_b64decode(payload_b64))
         return float(payload["exp"])
-    except (json.JSONDecodeError, KeyError, ValueError, Exception):
+    except Exception:
         return None
 
 
-class CodexOAuth(AuthStrategy):
-    """Reads Codex CLI's OAuth token from ~/.codex/auth.json.
+class CodexOAuth(OAuthStrategy):
+    """Reads Codex CLI's OAuth token from ``~/.codex/auth.json``.
 
     Args:
         auth_file: Path to the credential file. Defaults to
@@ -99,88 +89,32 @@ class CodexOAuth(AuthStrategy):
         auth_file: Path | None = None,
         http_client_factory=None,
     ) -> None:
+        super().__init__()
         self._auth_file = auth_file or AUTH_FILE_PATH
         self._http_factory = http_client_factory or (
             lambda: httpx.AsyncClient(timeout=httpx.Timeout(30.0))
         )
-        self._cached: dict | None = None  # raw tokens from auth.json
-        self._api_token: str | None = None  # exchanged API-capable token
-        self._api_token_exp: float = 0  # expiry of the API token
-        self._lock = asyncio.Lock()
+        # API-token exchange state (RFC 8693 path, optional)
+        self._api_token: str | None = None
+        self._api_token_exp: float = 0
 
     # ------------------------------------------------------------------
-    # Public API
+    # OAuthStrategy hooks
     # ------------------------------------------------------------------
 
-    async def get_authorization_header(self) -> dict[str, str]:
-        """Build headers for an outbound OpenAI API call.
-
-        Returns ``{"Authorization": "Bearer <token>"}``.
-
-        Token resolution order:
-        1. ``OPENAI_API_KEY`` env var (explicit API key, most reliable)
-        2. Token exchange: swap the id_token from ~/.codex/auth.json for
-           an API-scoped access token via RFC 8693. The raw access_token
-           from the file has ChatGPT scopes only — it cannot call the
-           API directly.
-        """
-        # Check for explicit API key first (most reliable path)
+    def _header_override(self) -> dict[str, str] | None:
         api_key = os.environ.get("OPENAI_API_KEY")
         if api_key:
             return {"Authorization": f"Bearer {api_key}"}
+        return None
 
-        # OAuth path: use the raw ChatGPT access_token directly.
-        # The chatgpt.com/backend-api/codex endpoint accepts ChatGPT JWTs.
-        # Token exchange (for api.openai.com) fails for personal accounts.
-        if self._cached is not None and not self._is_expired(self._cached):
-            return self._build_headers(self._cached)
-
-        async with self._lock:
-            if self._cached is None:
-                self._cached = self._read_from_file()
-            if self._is_expired(self._cached):
-                self._cached = await self._do_refresh(self._cached)
-
-        return self._build_headers(self._cached)
-
-    async def refresh(self) -> None:
-        """Force-refresh the cached credential."""
-        async with self._lock:
-            if self._cached is None:
-                self._cached = self._read_from_file()
-            self._cached = await self._do_refresh(self._cached)
-
-    def get_account_id(self) -> str:
-        """Return the chatgpt_account_id from the cached tokens."""
-        if self._cached is None:
-            self._cached = self._read_from_file()
-        return self._cached.get("account_id", "")
-
-    def invalidate_cache(self) -> None:
-        """Drop the in-memory cache without touching the file on disk."""
-        self._cached = None
-        self._api_token = None
-        self._api_token_exp = 0
-
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
-
-    def _read_from_file(self) -> dict:
-        """Read and parse ~/.codex/auth.json.
-
-        Raises:
-            CredentialNotFoundError: File does not exist.
-            AuthError: File exists but doesn't parse as expected.
-        """
+    def _read_credential(self) -> dict:
         if not self._auth_file.exists():
             raise CredentialNotFoundError(
                 "No Codex OAuth token found. Run 'codex auth login' to authenticate."
             )
-
         try:
-            raw = self._auth_file.read_text(encoding="utf-8")
-            data = json.loads(raw)
+            data = json.loads(self._auth_file.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
             raise AuthError(
                 f"Codex credential file is not readable or not valid JSON: {exc}. "
@@ -192,67 +126,33 @@ class CodexOAuth(AuthStrategy):
                 "Codex credential file is missing the 'tokens' key. "
                 "Try running 'codex auth login' again."
             )
-
         tokens = data["tokens"]
         if not isinstance(tokens, dict):
             raise AuthError(
                 "Codex credential file 'tokens' is not a dict. "
                 "Try running 'codex auth login' again."
             )
-
-        required = {"access_token", "refresh_token"}
-        missing = required - set(tokens.keys())
+        missing = {"access_token", "refresh_token"} - set(tokens.keys())
         if missing:
             raise AuthError(
                 f"Codex credential file missing required keys: "
                 f"{sorted(missing)}. Try running 'codex auth login' again."
             )
-
         return tokens
 
-    def _is_expired(self, tokens: dict) -> bool:
-        """Return True if the access token should be refreshed.
-
-        Decodes the JWT ``exp`` claim from the access token. Refreshes
-        when the token has less than REFRESH_WINDOW_SECONDS remaining.
-        """
-        access_token = tokens.get("access_token", "")
-        exp = _decode_jwt_exp(access_token)
+    def _is_expired(self, creds: dict) -> bool:
+        exp = _decode_jwt_exp(creds.get("access_token", ""))
         if exp is None:
             return True
-        return time.time() >= exp - REFRESH_WINDOW_SECONDS
+        return time.time() >= exp - self.refresh_window_seconds
 
-    def _is_id_token_expired(self, tokens: dict) -> bool:
-        """Return True if the id_token is expired or missing.
+    def _build_headers(self, creds: dict) -> dict[str, str]:
+        return {"Authorization": f"Bearer {creds['access_token']}"}
 
-        The id_token is needed for token exchange and may expire before
-        the access_token.
-        """
-        id_token = tokens.get("id_token", "")
-        if not id_token:
-            return True
-        exp = _decode_jwt_exp(id_token)
-        if exp is None:
-            return True
-        return time.time() >= exp - REFRESH_WINDOW_SECONDS
-
-    def _build_headers(self, tokens: dict) -> dict[str, str]:
-        """Build the authorization header from validated tokens."""
-        return {
-            "Authorization": f"Bearer {tokens['access_token']}",
-        }
-
-    async def _do_refresh(self, tokens: dict) -> dict:
-        """POST to the refresh endpoint and write back on success.
-
-        Must be called while holding self._lock.
-
-        Raises:
-            AuthError: Refresh failed.
-        """
+    async def _refresh_credential(self, creds: dict) -> dict:
         body = {
             "grant_type": "refresh_token",
-            "refresh_token": tokens["refresh_token"],
+            "refresh_token": creds["refresh_token"],
             "client_id": OAUTH_CLIENT_ID,
         }
         headers = {"content-type": "application/json"}
@@ -270,7 +170,6 @@ class CodexOAuth(AuthStrategy):
                 "Codex OAuth token expired and could not be refreshed. "
                 "Run 'codex auth login' to re-authenticate."
             )
-
         if resp.status_code != 200:
             raise AuthError(
                 f"OAuth refresh failed with status {resp.status_code}: "
@@ -281,21 +180,18 @@ class CodexOAuth(AuthStrategy):
             data = resp.json()
         except json.JSONDecodeError as exc:
             raise AuthError(f"OAuth refresh response is not valid JSON: {exc}") from exc
-
-        if "access_token" not in data:
-            raise AuthError("OAuth refresh response missing 'access_token' field")
-        if "refresh_token" not in data:
-            raise AuthError("OAuth refresh response missing 'refresh_token' field")
+        for required_field in ("access_token", "refresh_token"):
+            if required_field not in data:
+                raise AuthError(f"OAuth refresh response missing '{required_field}' field")
 
         new_tokens = {
             "access_token": data["access_token"],
             "refresh_token": data["refresh_token"],
-            # Use fresh id_token from refresh if provided, else keep old
-            "id_token": data.get("id_token") or tokens.get("id_token"),
-            "account_id": tokens.get("account_id"),
+            "id_token": data.get("id_token") or creds.get("id_token"),
+            "account_id": creds.get("account_id"),
         }
-
         self._write_to_file(new_tokens)
+
         exp = _decode_jwt_exp(data["access_token"])
         if exp:
             logger.info(
@@ -304,21 +200,40 @@ class CodexOAuth(AuthStrategy):
             )
         return new_tokens
 
+    # ------------------------------------------------------------------
+    # Codex-specific extras
+    # ------------------------------------------------------------------
+
+    def invalidate_cache(self) -> None:
+        super().invalidate_cache()
+        self._api_token = None
+        self._api_token_exp = 0
+
+    def get_account_id(self) -> str:
+        """Return the ``chatgpt_account_id`` from the cached tokens."""
+        if self._cached is None:
+            self._cached = self._read_credential()
+        return self._cached.get("account_id", "")
+
+    # Backward-compat alias — legacy tests still call ``_read_from_file``.
+    _read_from_file = _read_credential
+
+    def _is_id_token_expired(self, tokens: dict) -> bool:
+        """True if the id_token (used by the RFC 8693 exchange) is stale."""
+        id_token = tokens.get("id_token", "")
+        if not id_token:
+            return True
+        exp = _decode_jwt_exp(id_token)
+        if exp is None:
+            return True
+        return time.time() >= exp - self.refresh_window_seconds
+
     async def _do_token_exchange(self, tokens: dict) -> tuple[str, float]:
-        """Exchange the id_token for an API-capable access token.
+        """RFC 8693: swap the id_token for an API-scoped access token.
 
-        The Codex CLI's OAuth tokens have ChatGPT scopes only (openid,
-        profile, email, offline_access). To call the OpenAI API we must
-        perform an RFC 8693 token exchange: swap the id_token for a
-        token with API scopes (model.request, etc.).
-
-        Must be called while holding self._lock.
-
-        Returns:
-            (api_access_token, expiry_timestamp)
-
-        Raises:
-            AuthError: Exchange failed.
+        Preserved for future use against ``api.openai.com``; not on the
+        default path (which uses the raw ChatGPT token against
+        chatgpt.com).
         """
         id_token = tokens.get("id_token")
         if not id_token:
@@ -327,8 +242,6 @@ class CodexOAuth(AuthStrategy):
                 "token exchange. Run 'codex auth login' again."
             )
 
-        # Token exchange uses form-encoded body with OpenAI's custom
-        # `requested_token` field (not the standard RFC 8693 `audience`).
         body = {
             "grant_type": TOKEN_EXCHANGE_GRANT_TYPE,
             "client_id": OAUTH_CLIENT_ID,
@@ -351,7 +264,6 @@ class CodexOAuth(AuthStrategy):
                 f"Token exchange failed with status {resp.status_code}: "
                 f"{resp.text[:500]}. Run 'codex auth login' to re-authenticate."
             )
-
         try:
             data = resp.json()
         except json.JSONDecodeError as exc:
@@ -361,10 +273,8 @@ class CodexOAuth(AuthStrategy):
         if not api_token:
             raise AuthError("Token exchange response missing 'access_token' field")
 
-        # Determine expiry from the new token
         exp = _decode_jwt_exp(api_token)
         if exp is None:
-            # If we can't decode exp, use expires_in from response
             expires_in = data.get("expires_in", 3600)
             exp = time.time() + float(expires_in)
 
@@ -375,12 +285,8 @@ class CodexOAuth(AuthStrategy):
         return api_token, exp
 
     def _write_to_file(self, tokens: dict) -> None:
-        """Write updated tokens back to the credential file atomically.
-
-        Uses write-to-temp-then-rename for crash safety.
-        """
+        """Atomic write-then-rename, preserving any non-``tokens`` fields."""
         data: dict = {}
-        # Preserve existing file structure (OPENAI_API_KEY, etc.)
         if self._auth_file.exists():
             try:
                 data = json.loads(self._auth_file.read_text(encoding="utf-8"))
@@ -398,7 +304,6 @@ class CodexOAuth(AuthStrategy):
                 json.dump(data, f, indent=2)
             os.replace(tmp_path, self._auth_file)
         except Exception:
-            # Clean up temp file on failure
             try:
                 os.unlink(tmp_path)
             except OSError:

--- a/apps/server/src/screamingface/plugins/gemini_backend_api/auth.py
+++ b/apps/server/src/screamingface/plugins/gemini_backend_api/auth.py
@@ -1,45 +1,24 @@
-"""Gemini CLI auth strategy — reads OAuth credentials from ~/.gemini/oauth_creds.json.
+"""Gemini CLI auth strategy — reads OAuth credentials from ``~/.gemini/oauth_creds.json``.
 
-The Gemini CLI stores its OAuth credentials as a plain JSON file:
+Hybrid strategy: if ``GOOGLE_API_KEY`` or ``GEMINI_API_KEY`` is set the
+call short-circuits to an ``x-goog-api-key`` header. Otherwise the
+shared :class:`~screamingface.plugins.llm_base.oauth_base.OAuthStrategy`
+flow handles caching, locking, and the proactive refresh.
 
-.. code-block:: json
+Google-specific details this file owns:
 
-    {
-        "access_token": "ya29.a0...",
-        "scope": "https://www.googleapis.com/auth/...",
-        "token_type": "Bearer",
-        "id_token": "eyJ...",
-        "expiry_date": 1776081543971,
-        "refresh_token": "1//03j6L1..."
-    }
-
-``expiry_date`` is in **milliseconds** since epoch (like Claude Code's
-``expiresAt``).
-
-Refresh flow:
-  POST https://oauth2.googleapis.com/token
-  Body (form-encoded): {
-      grant_type: "refresh_token",
-      refresh_token,
-      client_id,
-      client_secret   ← Google requires both (unlike Anthropic/OpenAI)
-  }
-
-Google does NOT rotate the refresh_token — the old one stays valid.
-The refresh response returns a new access_token + expires_in (seconds)
-but NOT a new refresh_token, so we preserve the original.
-
-Auth routing:
-  - API key (GOOGLE_API_KEY / GEMINI_API_KEY) → generativelanguage.googleapis.com
-  - OAuth token → cloudcode-pa.googleapis.com/v1internal (Code Assist API)
-
-Concurrency: same asyncio.Lock + double-checked locking pattern as
-ClaudeCodeOAuth.
+- Credential path: ``~/.gemini/oauth_creds.json`` (plain JSON file,
+  like Codex; unlike Claude Code's keychain).
+- Refresh endpoint: ``https://oauth2.googleapis.com/token`` with a
+  form-encoded body and a ``client_secret`` (Google requires it; the
+  CLI's public value is embedded).
+- ``expiry_date`` is in **milliseconds** (like Claude, unlike Codex).
+- Refresh response does NOT rotate ``refresh_token`` — the old one is
+  preserved.
 """
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import os
@@ -50,29 +29,26 @@ from pathlib import Path
 
 import httpx
 
-from screamingface.plugins.llm_base.auth_base import AuthStrategy
 from screamingface.plugins.llm_base.errors import AuthError, CredentialNotFoundError
+from screamingface.plugins.llm_base.oauth_base import OAuthStrategy
 
 logger = logging.getLogger(__name__)
 
 OAUTH_CREDS_PATH = Path.home() / ".gemini" / "oauth_creds.json"
 GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
 
-# Public OAuth client credentials from the gemini-cli source
+# Public OAuth client credentials from the gemini-cli source.
 OAUTH_CLIENT_ID = "681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com"
 OAUTH_CLIENT_SECRET = "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"
 
+# Retained at module scope for test imports / external callers.
 REFRESH_WINDOW_SECONDS = 60
 
 CLI_VERSION = "0.37.1"
 
 
-class GeminiAuth(AuthStrategy):
-    """Reads Gemini CLI's OAuth token from ~/.gemini/oauth_creds.json.
-
-    Priority:
-    1. GOOGLE_API_KEY or GEMINI_API_KEY env var (x-goog-api-key header)
-    2. OAuth Bearer token from ~/.gemini/oauth_creds.json
+class GeminiAuth(OAuthStrategy):
+    """Hybrid Gemini auth: API-key env var OR OAuth file.
 
     Args:
         creds_file: Path to the credential file. Tests inject a temp path.
@@ -85,71 +61,41 @@ class GeminiAuth(AuthStrategy):
         creds_file: Path | None = None,
         http_client_factory=None,
     ) -> None:
+        super().__init__()
         self._creds_file = creds_file or OAUTH_CREDS_PATH
         self._http_factory = http_client_factory or (
             lambda: httpx.AsyncClient(timeout=httpx.Timeout(30.0))
         )
-        self._cached: dict | None = None
-        self._lock = asyncio.Lock()
 
     def is_api_key_auth(self) -> bool:
-        """Return True if using an explicit API key (not OAuth)."""
+        """True when the strategy is short-circuiting to API-key headers."""
         return bool(os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY"))
 
-    async def get_authorization_header(self) -> dict[str, str]:
-        """Build headers for an outbound Gemini API call.
+    # ------------------------------------------------------------------
+    # OAuthStrategy hooks
+    # ------------------------------------------------------------------
 
-        Returns ``{"Authorization": "Bearer <access_token>"}`` for OAuth,
-        or ``{"x-goog-api-key": "<key>"}`` for API key auth.
-        """
-        # Check for explicit API key first
+    def _header_override(self) -> dict[str, str] | None:
         api_key = os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")
         if api_key:
             return {"x-goog-api-key": api_key}
+        return None
 
-        # OAuth path
-        if self._cached is not None and not self._is_expired(self._cached):
-            return self._build_headers(self._cached)
-
-        async with self._lock:
-            if self._cached is None:
-                self._cached = self._read_from_file()
-            if self._is_expired(self._cached):
-                self._cached = await self._do_refresh(self._cached)
-
-        return self._build_headers(self._cached)
-
-    async def refresh(self) -> None:
-        """Force-refresh the cached credential."""
-        async with self._lock:
-            if self._cached is None:
-                self._cached = self._read_from_file()
-            self._cached = await self._do_refresh(self._cached)
-
-    def invalidate_cache(self) -> None:
-        """Drop the in-memory cache."""
-        self._cached = None
-
-    def _read_from_file(self) -> dict:
-        """Read and parse ~/.gemini/oauth_creds.json."""
+    def _read_credential(self) -> dict:
         if not self._creds_file.exists():
             raise CredentialNotFoundError(
                 "No Gemini OAuth token found. Run 'gemini auth login' to authenticate."
             )
         try:
-            raw = self._creds_file.read_text(encoding="utf-8")
-            data = json.loads(raw)
+            data = json.loads(self._creds_file.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
             raise AuthError(
                 f"Gemini credential file is not readable or not valid JSON: {exc}. "
                 "Try running 'gemini auth login' again."
             ) from exc
-
         if not isinstance(data, dict):
             raise AuthError("Gemini credential file is not a JSON object.")
-
-        required = {"access_token", "refresh_token"}
-        missing = required - set(data.keys())
+        missing = {"access_token", "refresh_token"} - set(data.keys())
         if missing:
             raise AuthError(
                 f"Gemini credential file missing required keys: {sorted(missing)}. "
@@ -158,13 +104,10 @@ class GeminiAuth(AuthStrategy):
         return data
 
     def _is_expired(self, creds: dict) -> bool:
-        """Return True if the access token should be refreshed.
-
-        ``expiry_date`` is in milliseconds since epoch.
-        """
+        """``expiry_date`` is unix epoch in **milliseconds**."""
         expiry_ms = creds.get("expiry_date", 0)
         now_ms = time.time() * 1000
-        return now_ms >= expiry_ms - (REFRESH_WINDOW_SECONDS * 1000)
+        return now_ms >= expiry_ms - (self.refresh_window_seconds * 1000)
 
     def _build_headers(self, creds: dict) -> dict[str, str]:
         return {
@@ -175,20 +118,13 @@ class GeminiAuth(AuthStrategy):
             ),
         }
 
-    async def _do_refresh(self, creds: dict) -> dict:
-        """POST to Google's token endpoint to refresh the access token.
-
-        Google requires client_secret in the refresh body (unlike
-        Anthropic/OpenAI). Google does NOT rotate the refresh_token.
-        """
-        # Google token endpoint uses form-encoded body, not JSON
+    async def _refresh_credential(self, creds: dict) -> dict:
         body = {
             "grant_type": "refresh_token",
             "refresh_token": creds["refresh_token"],
             "client_id": OAUTH_CLIENT_ID,
             "client_secret": OAUTH_CLIENT_SECRET,
         }
-
         try:
             async with self._http_factory() as client:
                 resp = await client.post(
@@ -211,14 +147,12 @@ class GeminiAuth(AuthStrategy):
             data = resp.json()
         except json.JSONDecodeError as exc:
             raise AuthError(f"Google OAuth refresh response is not valid JSON: {exc}") from exc
-
         if "access_token" not in data:
             raise AuthError("Google OAuth refresh response missing 'access_token'")
 
-        # Google does NOT return a new refresh_token — preserve the old one
+        # Google does NOT rotate refresh_token — preserve the old one.
         expires_in = data.get("expires_in", 3600)
         expiry_ms = int((time.time() + float(expires_in)) * 1000)
-
         new_creds = {
             **creds,
             "access_token": data["access_token"],
@@ -234,8 +168,11 @@ class GeminiAuth(AuthStrategy):
         )
         return new_creds
 
+    # Backward-compat alias — legacy tests still call ``_read_from_file``.
+    _read_from_file = _read_credential
+
     def _write_to_file(self, creds: dict) -> None:
-        """Write updated credentials back to the file atomically."""
+        """Atomic write-then-rename."""
         parent = self._creds_file.parent
         parent.mkdir(parents=True, exist_ok=True)
         fd, tmp_path = tempfile.mkstemp(dir=parent, suffix=".tmp")

--- a/apps/server/src/screamingface/plugins/llm_base/__init__.py
+++ b/apps/server/src/screamingface/plugins/llm_base/__init__.py
@@ -36,7 +36,11 @@ Concrete helpers:
 
 from __future__ import annotations
 
-from screamingface.plugins.llm_base.adapter_base import Adapter
+from screamingface.plugins.llm_base.adapter_base import (
+    Adapter,
+    collect_provider_metadata,
+    extract_system_text,
+)
 from screamingface.plugins.llm_base.auth_base import AuthStrategy
 from screamingface.plugins.llm_base.backend_base import (
     Backend,
@@ -74,15 +78,20 @@ from screamingface.plugins.llm_base.messages import (
     ToolResultPart,
     extract_text,
 )
+from screamingface.plugins.llm_base.oauth_base import OAuthStrategy
 
 __all__ = [
     # ABCs
     "AuthStrategy",
+    "OAuthStrategy",
     "Backend",
     "CredentialStore",
     "Adapter",
     "HealthStatus",
     "post_with_default_retry",
+    # Adapter helpers
+    "collect_provider_metadata",
+    "extract_system_text",
     # Concrete credential stores
     "LinuxLibsecretStore",
     "MacOSKeychainStore",

--- a/apps/server/src/screamingface/plugins/llm_base/adapter_base.py
+++ b/apps/server/src/screamingface/plugins/llm_base/adapter_base.py
@@ -24,7 +24,54 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 
-from screamingface.plugins.llm_base.messages import CoreMessage, ToolDefinition
+from screamingface.plugins.llm_base.messages import CoreMessage, TextPart, ToolDefinition
+
+
+def extract_system_text(system: str | list | None) -> str | None:
+    """Normalize a ``system`` argument to a plain string or ``None``.
+
+    Adapters all accept ``system`` as either a bare string (the simple
+    case most callers use) or a list of content blocks (Anthropic's
+    structured shape, when a billing header or similar needs to be
+    appended as its own block). This helper turns either form into the
+    flat concatenation every adapter ultimately wants when building
+    provider-specific request bodies.
+
+    Returns ``None`` for ``None`` / empty inputs.
+    """
+    if system is None:
+        return None
+    if isinstance(system, str):
+        return system or None
+    # list form: concatenate every .text on TextPart-like dicts
+    chunks: list[str] = []
+    for block in system:
+        if isinstance(block, dict):
+            text = block.get("text")
+            if isinstance(text, str):
+                chunks.append(text)
+        elif isinstance(block, TextPart):
+            chunks.append(block.text)
+        elif isinstance(block, str):
+            chunks.append(block)
+    joined = "\n\n".join(chunks).strip()
+    return joined or None
+
+
+def collect_provider_metadata(source: dict, keys: tuple[str, ...], *, prefix: str) -> dict:
+    """Pull the listed ``keys`` from ``source`` into a provider-prefixed dict.
+
+    Used by adapters to propagate vendor-specific response fields
+    (usage counts, stop reasons, response IDs, …) onto the returned
+    :class:`CoreMessage`'s ``provider_metadata``. Keys not present in
+    ``source`` are skipped. The returned dict has ``f"{prefix}.{key}"``
+    entries so consumers can disambiguate across providers.
+    """
+    out: dict = {}
+    for key in keys:
+        if key in source:
+            out[f"{prefix}.{key}"] = source[key]
+    return out
 
 
 class Adapter(ABC):

--- a/apps/server/src/screamingface/plugins/llm_base/oauth_base.py
+++ b/apps/server/src/screamingface/plugins/llm_base/oauth_base.py
@@ -1,0 +1,128 @@
+"""OAuthStrategy — Template-Method base for every OAuth-backed AuthStrategy.
+
+Before this module existed, ClaudeCodeOAuth, CodexOAuth, and GeminiAuth
+each hand-rolled the same five-step flow:
+
+1. Cache the credential in memory.
+2. On every outbound request, check the cache and return headers if
+   still fresh.
+3. If expired / missing, acquire an ``asyncio.Lock``, re-read from the
+   credential store, and run a refresh POST (double-checked locking).
+4. On success, write the refreshed credential back.
+5. On 401 from the backend, drop the cache so the next call re-reads.
+
+The flow itself is identical across providers. What differs is:
+
+- Where the credential lives (macOS keychain, JSON file on disk, …).
+- How "expired" is computed (``expiresAt`` ms field vs JWT ``exp``).
+- What the refresh POST body and response shapes look like.
+- What the final ``Authorization`` headers are.
+
+:class:`OAuthStrategy` owns the flow and exposes four abstract hooks
+for the provider-specific pieces. Subclasses shrink from ~300 lines
+to ~100.
+
+Hybrid strategies (e.g. Gemini supports API-key OR OAuth) override
+:meth:`_header_override` to short-circuit the OAuth path when an
+API-key env var is present.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from abc import abstractmethod
+
+from screamingface.plugins.llm_base.auth_base import AuthStrategy
+
+
+class OAuthStrategy(AuthStrategy):
+    """Cached + locked + proactively-refreshed OAuth strategy base.
+
+    Attributes:
+        refresh_window_seconds: How many seconds before actual expiry
+            the strategy should proactively refresh. 60s matches the
+            behavior of Claude Code, Codex CLI, and Gemini CLI.
+    """
+
+    refresh_window_seconds: int = 60
+
+    def __init__(self) -> None:
+        self._cached: dict | None = None
+        self._lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # AuthStrategy implementation — the shared flow
+    # ------------------------------------------------------------------
+
+    async def get_authorization_header(self) -> dict[str, str]:
+        override = self._header_override()
+        if override is not None:
+            return override
+
+        # Fast path: cache hit, still fresh.
+        if self._cached is not None and not self._is_expired(self._cached):
+            return self._build_headers(self._cached)
+
+        # Slow path: read + maybe refresh under lock.
+        async with self._lock:
+            # Double-check inside the lock: another coroutine may have
+            # refreshed while we were waiting.
+            if self._cached is None:
+                self._cached = self._read_credential()
+            if self._is_expired(self._cached):
+                self._cached = await self._refresh_credential(self._cached)
+
+        return self._build_headers(self._cached)
+
+    async def refresh(self) -> None:
+        """Force a refresh regardless of cached expiry."""
+        async with self._lock:
+            if self._cached is None:
+                self._cached = self._read_credential()
+            self._cached = await self._refresh_credential(self._cached)
+
+    def invalidate_cache(self) -> None:
+        """Drop in-memory state. The next header build re-reads the store."""
+        self._cached = None
+
+    # ------------------------------------------------------------------
+    # Subclass hooks
+    # ------------------------------------------------------------------
+
+    def _header_override(self) -> dict[str, str] | None:
+        """Return non-OAuth headers if the strategy has a short-circuit.
+
+        Default: ``None`` (always go through the OAuth flow).
+
+        Hybrid strategies (e.g. Gemini with ``GEMINI_API_KEY``) override
+        to return an API-key header when the env var is present, bypassing
+        the cache + refresh machinery entirely.
+        """
+        return None
+
+    @abstractmethod
+    def _read_credential(self) -> dict:
+        """Load the raw credential dict from the provider's on-disk store.
+
+        Raises:
+            CredentialNotFoundError: No credential present — user must run
+                the provider's CLI login command.
+            AuthError: Credential present but malformed.
+        """
+
+    @abstractmethod
+    def _is_expired(self, creds: dict) -> bool:
+        """True if the credential is within the refresh window."""
+
+    @abstractmethod
+    async def _refresh_credential(self, creds: dict) -> dict:
+        """POST to the provider's refresh endpoint, write back, return the
+        new credential dict. Must be called under ``self._lock``.
+
+        Raises:
+            AuthError: Refresh failed in a way the user must fix.
+        """
+
+    @abstractmethod
+    def _build_headers(self, creds: dict) -> dict[str, str]:
+        """Build the outbound HTTP headers from a validated credential."""


### PR DESCRIPTION
## Summary

Extracts the five-step OAuth flow (cache → double-checked lock → expiry check → refresh POST → write back) out of three provider-specific strategies into a shared ``OAuthStrategy`` base. Each strategy drops from ~300 lines of hand-rolled orchestration to ~200 lines of provider-specific hooks.

## New in ``llm_base``

- ``oauth_base.py`` — ``OAuthStrategy`` Template-Method ABC. Subclasses override four hooks: ``_read_credential``, ``_is_expired``, ``_refresh_credential``, ``_build_headers``. Hybrid strategies (Gemini with ``GEMINI_API_KEY``) use ``_header_override`` to short-circuit OAuth.
- ``adapter_base.py`` — two module-level helpers (``extract_system_text``, ``collect_provider_metadata``) for future adapter migrations. Not yet applied — Claude/Codex adapters have provider-specific billing/tool-result quirks worth preserving in this PR.

## Migrations

| File | Before | After | Δ |
|---|---|---|---|
| ``claude_backend_api/auth.py`` | 309 | 215 | **−94** |
| ``codex_backend_api/auth.py`` | 406 | 311 | **−95** (RFC 8693 exchange retained) |
| ``gemini_backend_api/auth.py`` | 251 | 188 | **−63** |
| ``llm_base/oauth_base.py`` (new) | — | 128 | +128 |

Net: **−124 lines** of OAuth plumbing.

## Back-compat

- Module-level ``REFRESH_WINDOW_SECONDS`` retained for existing tests/callers.
- ``_read_from_file`` aliases on Codex and Gemini auth.
- Codex's RFC 8693 token exchange (``get_account_id``, ``_is_id_token_expired``, ``_do_token_exchange``) retained as subclass-specific extras.

## Test plan

- [x] ``ruff check`` + ``ruff format --check`` clean
- [x] ``pyright`` clean on all edited modules
- [x] 703 unit tests pass
- [x] Full e2e (incl. live): 116 passed, 7 skipped, 1 httpbin flake in full run (passes clean in isolation — same pre-existing class as SF-106)

## Asana

- Ticket: [SF-110](https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1214145310091118)
- Parent epic: [SF-96](https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1214137811159323)