### PR TITLE
SF-107: decompose claude_frontend proxy_messages into focused helpers

### DIFF
--- a/apps/server/src/screamingface/plugins/claude_frontend/_session.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/_session.py
@@ -1,0 +1,161 @@
+"""Session enrichment + save helpers used by ``proxy_messages``.
+
+The proxy sits between Claude Code and Anthropic. When a per-session
+proxy is active, these helpers run two ends of the request lifecycle:
+
+- Before forwarding: :meth:`SessionHook.enrich` calls the
+  ``session.enrich_request`` hook, which may rewrite the request body
+  (typically to prepend prior conversation turns from session state).
+- After the upstream response: :meth:`SessionHook.save` calls the
+  ``session.save_response`` hook to persist the new user/assistant
+  turn back to session state.
+
+Both are no-ops when no session-id or hook registry is configured.
+
+Extracted from ``proxy.py`` during SF-107 so the hot ``proxy_messages``
+handler stays focused on HTTP forwarding and url4 context injection,
+not on session plumbing.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import nullcontext as _nullcontext
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SessionHook:
+    """Per-request session hook bundle.
+
+    ``from_request`` builds one from the current request headers plus
+    the plugin-level settings / hook registry; if any required piece
+    is missing, :attr:`enabled` is ``False`` and ``enrich``/``save``
+    become no-ops.
+    """
+
+    session_id: str | None
+    service_url: str | None
+    hooks: Any
+    # Snapshot of the last user message taken at enrich time so save()
+    # can pair it with the assistant response when persisting the turn.
+    original_user_msg: dict | None = None
+
+    @classmethod
+    def from_request(
+        cls,
+        *,
+        session_id: str | None,
+        service_url: str | None,
+        hooks: Any,
+    ) -> SessionHook:
+        return cls(session_id=session_id, service_url=service_url, hooks=hooks)
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.session_id and self.service_url and self.hooks)
+
+    async def enrich(self, body: dict[str, Any], *, tracer: Any = None) -> dict[str, Any]:
+        """Emit ``session.enrich_request`` and apply any hook-returned body.
+
+        Also snapshots the last user message so :meth:`save` has
+        something to pair with the assistant response.
+
+        Returns the (possibly modified) body — never None.
+        """
+        if not self.enabled:
+            return body
+
+        msgs = body.get("messages", [])
+        if msgs:
+            last = msgs[-1]
+            self.original_user_msg = last.copy() if isinstance(last, dict) else last
+
+        enrich_ctx = (
+            tracer.start_as_current_span("session.enrich_request") if tracer else _nullcontext()
+        )
+        with enrich_ctx:
+            _record_session_attrs(self.session_id, self.service_url)
+            try:
+                results = await self.hooks.emit_async(
+                    "session.enrich_request",
+                    body=body,
+                    session_id=self.session_id,
+                    session_service_url=self.service_url,
+                )
+                modified = False
+                for result in results:
+                    if result is not None:
+                        body = result
+                        modified = True
+                        break
+                _record_session_attrs(modified=modified)
+            except (httpx.HTTPError, TimeoutError, ConnectionError) as exc:
+                # Narrowed from the original bare ``except Exception`` —
+                # transport-layer failures are expected; everything else
+                # should bubble so we see bugs.
+                logger.warning("Session enrichment failed for %s: %s", self.session_id, exc)
+
+        return body
+
+    async def save(
+        self,
+        response_data: dict[str, Any] | None,
+        *,
+        streaming: bool,
+        tracer: Any = None,
+    ) -> None:
+        """Emit ``session.save_response`` for the completed turn."""
+        if not self.enabled or response_data is None or self.original_user_msg is None:
+            return
+
+        save_ctx = (
+            tracer.start_as_current_span("session.save_response") if tracer else _nullcontext()
+        )
+        with save_ctx:
+            _record_session_attrs(self.session_id, self.service_url, streaming=streaming)
+            try:
+                await self.hooks.emit_async(
+                    "session.save_response",
+                    session_id=self.session_id,
+                    session_service_url=self.service_url,
+                    user_message_body=self.original_user_msg,
+                    response_body=response_data,
+                )
+            except (httpx.HTTPError, TimeoutError, ConnectionError) as exc:
+                logger.warning(
+                    "Session save (%s) failed for %s: %s",
+                    "stream" if streaming else "non-stream",
+                    self.session_id,
+                    exc,
+                )
+
+
+def _record_session_attrs(
+    session_id: str | None = None,
+    service_url: str | None = None,
+    *,
+    modified: bool | None = None,
+    streaming: bool | None = None,
+) -> None:
+    """Record session-hook attributes on the current OTEL span, best-effort."""
+    try:
+        from opentelemetry import trace
+    except ImportError:
+        return
+    span = trace.get_current_span()
+    if not (span and span.is_recording()):
+        return
+    if session_id is not None:
+        span.set_attribute("session.id", session_id)
+    if service_url is not None:
+        span.set_attribute("session.service_url", service_url)
+    if modified is not None:
+        span.set_attribute("session.modified", modified)
+    if streaming is not None:
+        span.set_attribute("session.streaming", streaming)

--- a/apps/server/src/screamingface/plugins/claude_frontend/_url4_context.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/_url4_context.py
@@ -1,0 +1,282 @@
+"""URL4 context resolution helpers used by ``proxy_messages``.
+
+Two resolution paths live here:
+
+- **``$prompt`` substitution** (:func:`resolve_prompt_expression`) —
+  the active spec contains the ``$prompt`` sentinel. The user's last
+  message text is stored as a blob, the sentinel is substituted with
+  the blob URL, the full expression is evaluated through url4, and
+  the result is embedded back into the outgoing request.
+
+- **Static resolution** (:func:`resolve_static_context`) — the active
+  spec has no ``$prompt``. The plugin's cached resolved context is
+  embedded directly.
+
+Both paths return ``None`` on success (request body is mutated in
+place) and a :class:`JSONResponse` error on failure — the proxy
+short-circuits with that response instead of forwarding. Error
+responses are shaped as fake-200 Anthropic messages so Claude Code
+surfaces the error text in the chat UI.
+
+Extracted from ``proxy.py`` during SF-107.
+"""
+
+from __future__ import annotations
+
+import logging
+import traceback
+from contextlib import nullcontext as _nullcontext
+from typing import Any
+
+import httpx
+from fastapi.responses import JSONResponse
+
+from screamingface.plugins.llm_base.constants import PROMPT_PREVIEW_LIMIT
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = ["resolve_prompt_expression", "resolve_static_context"]
+
+
+def _truncate(text: str, limit: int = PROMPT_PREVIEW_LIMIT) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit] + f"\n... ({len(text) - limit} more chars)"
+
+
+def _build_error_response(
+    body: dict[str, Any],
+    *,
+    spec_name: str,
+    header: str,
+    raw_expression: str,
+    substituted: str | None,
+    exc: Exception,
+) -> JSONResponse:
+    """Build a fake-200 Anthropic response whose text is the url4 error."""
+    tb_str = "".join(traceback.format_exception(exc))
+    lines: list[str] = [
+        f"[url4 error] {header} for spec '{spec_name}'",
+        "",
+        f"Expression: {_truncate(raw_expression, 200)}",
+    ]
+    if substituted is not None:
+        lines.append(f"Substituted: {_truncate(substituted, 200)}")
+    lines += [
+        "",
+        f"Error: {exc.__class__.__name__}: {exc}",
+        "",
+        "Traceback:",
+        tb_str,
+    ]
+    return JSONResponse(
+        content={
+            "id": f"sf_error_{id(exc):x}",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "\n".join(lines)}],
+            "model": body.get("model", "unknown"),
+            "stop_reason": "end_turn",
+            "stop_sequence": None,
+            "usage": {"input_tokens": 0, "output_tokens": 0},
+        },
+        status_code=200,
+    )
+
+
+async def _store_prompt_blob(
+    text: str,
+    *,
+    backend_url: str | None,
+    tracer: Any,
+    _start_client_span: Any,
+    _set_span_attrs: Any,
+) -> str:
+    """Store the user prompt text as a blob and return its key."""
+    if backend_url:
+        blob_url_target = f"{backend_url}/data"
+        blob_span_ctx = _start_client_span(tracer, "POST /data") if tracer else _nullcontext()
+        with blob_span_ctx:
+            _set_span_attrs({"http.method": "POST", "http.url": blob_url_target})
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0), verify=False) as dc:
+                blob_resp = await dc.post(
+                    blob_url_target,
+                    content=text.encode("utf-8"),
+                    headers={"content-type": "text/plain; charset=utf-8"},
+                )
+                blob_resp.raise_for_status()
+                blob_key = blob_resp.json()["key"]
+            _set_span_attrs(
+                {
+                    "http.status_code": blob_resp.status_code,
+                    "data.key": blob_key,
+                    "data.size": len(text),
+                }
+            )
+        return blob_key
+
+    # In-process fallback
+    from screamingface.plugins.data_store.routes import store_blob
+
+    return store_blob(text.encode("utf-8"), "text/plain; charset=utf-8")
+
+
+async def _resolve_expression(
+    expression: str,
+    *,
+    app: Any,
+    backend_url: str | None,
+    tracer: Any,
+    _start_client_span: Any,
+    _set_span_attrs: Any,
+) -> str:
+    """Evaluate a url4 expression and return the final text."""
+    if backend_url:
+        ens_url = f"{backend_url}/ensemble"
+        ens_span_ctx = _start_client_span(tracer, "GET /ensemble") if tracer else _nullcontext()
+        with ens_span_ctx:
+            _set_span_attrs(
+                {
+                    "http.method": "GET",
+                    "http.url": ens_url,
+                    "url4.expression": _truncate(expression, 500),
+                }
+            )
+            async with httpx.AsyncClient(timeout=httpx.Timeout(300.0), verify=False) as ec:
+                ens_resp = await ec.get(ens_url, params={"q": expression})
+                ens_resp.raise_for_status()
+                final_text = ens_resp.text
+            _set_span_attrs(
+                {
+                    "http.status_code": ens_resp.status_code,
+                    "url4.result_length": len(final_text),
+                    "url4.response_body": _truncate(final_text),
+                }
+            )
+        return final_text
+
+    # In-process fallback
+    from screamingface.plugins.url4_executor.interpreter import Url4Interpreter
+
+    interpreter = Url4Interpreter(app=app)
+    return await interpreter.evaluate(expression)
+
+
+async def resolve_prompt_expression(
+    body: dict[str, Any],
+    *,
+    raw_expression: str,
+    settings: Any,
+    plugin: Any,  # noqa: ARG001 — reserved for future plugin-scoped hooks
+    app: Any,
+    tracer: Any,
+    last_user_text: str,
+    embed_context: Any,
+    _start_client_span: Any,
+    _set_span_attrs: Any,
+) -> JSONResponse | None:
+    """Substitute ``$prompt``, resolve, embed the result back into body.
+
+    Returns ``None`` on success (body mutated in place) or a
+    :class:`JSONResponse` if anything in the pipeline raises; the
+    proxy uses that return value to short-circuit with a fake-200
+    error response.
+    """
+    span_ctx = tracer.start_as_current_span("url4.$prompt") if tracer else _nullcontext()
+    substituted: str | None = None
+    with span_ctx as prompt_span:
+        try:
+            if prompt_span and prompt_span.is_recording():
+                prompt_span.set_attribute("sf.plugin", "claude-frontend")
+                prompt_span.set_attribute("url4.raw_expression", raw_expression)
+                prompt_span.set_attribute("url4.user_text_length", len(last_user_text))
+
+            backend_url = settings.backend_url.rstrip("/") if settings.backend_url else None
+
+            blob_key = await _store_prompt_blob(
+                last_user_text,
+                backend_url=backend_url,
+                tracer=tracer,
+                _start_client_span=_start_client_span,
+                _set_span_attrs=_set_span_attrs,
+            )
+            blob_url = f"/data/{blob_key}"
+            substituted = raw_expression.replace("$prompt", blob_url)
+
+            if prompt_span and prompt_span.is_recording():
+                prompt_span.set_attribute("url4.blob_url", blob_url)
+                prompt_span.set_attribute("url4.substituted_expression", _truncate(substituted))
+
+            final_text = await _resolve_expression(
+                substituted,
+                app=app,
+                backend_url=backend_url,
+                tracer=tracer,
+                _start_client_span=_start_client_span,
+                _set_span_attrs=_set_span_attrs,
+            )
+
+            if prompt_span and prompt_span.is_recording():
+                prompt_span.set_attribute("url4.final_text_length", len(final_text))
+                prompt_span.set_attribute("url4.final_text_preview", _truncate(final_text, 1000))
+                prompt_span.set_attribute("url4.status", "ok")
+
+            if final_text:
+                embed_context(body, final_text, settings)
+                logger.info(
+                    "$prompt: blob=%s resolved %d chars → target=%s mode=%s",
+                    blob_key,
+                    len(final_text),
+                    settings.embed_target,
+                    settings.embed_mode,
+                )
+            return None
+
+        except Exception as exc:
+            if prompt_span and prompt_span.is_recording():
+                prompt_span.set_attribute("url4.status", "error")
+                prompt_span.set_attribute("url4.error", str(exc))
+                prompt_span.record_exception(exc)
+            logger.warning("$prompt substitution failed", exc_info=True)
+            return _build_error_response(
+                body,
+                spec_name=settings.active_spec or "unknown",
+                header="Resolution failed",
+                raw_expression=raw_expression,
+                substituted=substituted,
+                exc=exc,
+            )
+
+
+def resolve_static_context(
+    body: dict[str, Any],
+    *,
+    raw_expression: str,
+    settings: Any,
+    plugin: Any,
+    embed_context: Any,
+) -> JSONResponse | None:
+    """No ``$prompt`` — use plugin-cached resolved context."""
+    try:
+        resolved_context = plugin.resolve_context() if plugin else None
+    except Exception as exc:
+        logger.warning("Static context resolution failed", exc_info=True)
+        return _build_error_response(
+            body,
+            spec_name=settings.active_spec or "unknown",
+            header="Static context resolution failed",
+            raw_expression=raw_expression,
+            substituted=None,
+            exc=exc,
+        )
+
+    if resolved_context:
+        embed_context(body, resolved_context, settings)
+        logger.info(
+            "Injected cached url4 context (%d chars) embed_target=%s embed_mode=%s",
+            len(resolved_context),
+            settings.embed_target,
+            settings.embed_mode,
+        )
+    return None

--- a/apps/server/src/screamingface/plugins/claude_frontend/proxy.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/proxy.py
@@ -1,4 +1,15 @@
-"""Claude API proxy router — streaming and non-streaming support."""
+"""Claude API proxy router — streaming and non-streaming support.
+
+The hot path is :func:`proxy_messages`. Its three responsibilities are
+implemented as focused helpers and orchestrated from a thin handler:
+
+- Session enrichment + save — :mod:`._session`
+- URL4 ``$prompt`` / static context resolution — :mod:`._url4_context`
+- Upstream forwarding (streaming + non-streaming) — inline below
+
+All tracing, SSE reconstruction, and message-surgery utilities live in
+this file (they're small and specific to the Anthropic wire format).
+"""
 
 from __future__ import annotations
 
@@ -13,6 +24,13 @@ import certifi
 import httpx
 from fastapi import APIRouter, Request, Response
 from fastapi.responses import JSONResponse, StreamingResponse
+
+from screamingface.plugins.claude_frontend._session import SessionHook
+from screamingface.plugins.claude_frontend._url4_context import (
+    resolve_prompt_expression,
+    resolve_static_context,
+)
+from screamingface.plugins.llm_base.constants import PROMPT_PREVIEW_LIMIT
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +49,11 @@ FORWARD_HEADERS = {
 
 _SENSITIVE_HEADERS = {"x-api-key", "authorization"}
 
+_PLUGIN_NAME = "claude-frontend"
+
+# Always-on request dumps are noisy; opt-in via env var.
+_DEBUG_DUMP_ENV = "SF_PROXY_DEBUG_DUMP"
+
 
 def _redact_headers(headers: dict[str, str]) -> dict[str, str]:
     return {
@@ -39,13 +62,10 @@ def _redact_headers(headers: dict[str, str]) -> dict[str, str]:
     }
 
 
-def _truncate(text: str, limit: int = 4000) -> str:
+def _truncate(text: str, limit: int = PROMPT_PREVIEW_LIMIT) -> str:
     if len(text) <= limit:
         return text
     return text[:limit] + f"\n... ({len(text) - limit} more chars)"
-
-
-_PLUGIN_NAME = "claude-frontend"
 
 
 def _get_tracer():  # type: ignore[no-untyped-def]
@@ -103,14 +123,13 @@ def _record_trace_id(request: Request) -> str | None:
 
 
 def _trace_request_context(body: dict[str, Any]) -> None:
-    """Create child spans for each system block and message in the final request to Anthropic."""
+    """Create child spans for each system block and message in the final request."""
     tracer = _get_tracer()
     if not tracer:
         return
 
-    _t = _truncate  # alias for readability
+    _t = _truncate
 
-    # Request-level attributes on the current (server) span
     _set_span_attrs(
         {
             "anthropic.model": body.get("model", "?"),
@@ -123,7 +142,6 @@ def _trace_request_context(body: dict[str, Any]) -> None:
         }
     )
 
-    # System blocks
     system = body.get("system")
     if isinstance(system, list):
         for i, block in enumerate(system):
@@ -142,7 +160,6 @@ def _trace_request_context(body: dict[str, Any]) -> None:
             span.set_attribute("text_length", len(system))
             span.set_attribute("text", _t(system, 1000))
 
-    # Messages — each as a child span with role, content preview, and block breakdown
     messages = body.get("messages", [])
     for i, msg in enumerate(messages):
         role = msg.get("role", "?")
@@ -183,11 +200,7 @@ def _trace_request_context(body: dict[str, Any]) -> None:
 
 
 def _parse_sse_response(raw: str) -> dict[str, Any] | None:
-    """Reconstruct an Anthropic Messages response from SSE stream data.
-
-    Parses message_start, content_block_start/delta/stop, and message_delta
-    events to build a response dict equivalent to a non-streaming response.
-    """
+    """Reconstruct an Anthropic Messages response from SSE stream data."""
     response: dict[str, Any] = {}
     content_blocks: list[dict[str, Any]] = []
     current_block: dict[str, Any] = {}
@@ -205,7 +218,6 @@ def _parse_sse_response(raw: str) -> dict[str, Any] | None:
             continue
 
         etype = event.get("type")
-
         if etype == "message_start":
             msg = event.get("message", {})
             response.update(
@@ -263,13 +275,9 @@ def _parse_sse_response(raw: str) -> dict[str, Any] | None:
 def _extract_last_user_text(messages: list[dict[str, Any]]) -> str | None:
     """Extract the user's actual prompt from the last user message.
 
-    Claude Code packs system-reminder blocks (MCP instructions, skills, etc.)
-    as text blocks inside the user message alongside the real prompt.  We only
-    want the user's text — skip any block whose text starts with
-    ``<system-reminder>``.
-
-    Returns None only if the last user message has no eligible text blocks
-    (pure tool_result submission with no user text).
+    Claude Code packs ``<system-reminder>`` blocks (MCP instructions,
+    skills, etc.) inside user messages alongside the real prompt. We
+    skip any text block starting with ``<system-reminder>``.
     """
     for msg in reversed(messages):
         if msg.get("role") != "user":
@@ -295,22 +303,16 @@ def _replace_last_user_message(messages: list[dict[str, Any]], new_text: str) ->
     """Replace only the user's actual text in the last user message.
 
     Preserves ``<system-reminder>`` blocks, ``cache_control`` markers,
-    ``tool_result`` blocks, and any other content blocks — only the last
-    non-system-reminder text block is swapped.
+    ``tool_result`` blocks, and any other content blocks.
     """
     for i in range(len(messages) - 1, -1, -1):
         if messages[i].get("role") != "user":
             continue
         content = messages[i].get("content")
-
-        # String shorthand — replace directly
         if isinstance(content, str):
             messages[i] = {"role": "user", "content": new_text}
             return
-
-        # Array of blocks — find and replace only the user's text block
         if isinstance(content, list):
-            # Walk backwards to find the last non-system-reminder text block
             for j in range(len(content) - 1, -1, -1):
                 block = content[j]
                 if (
@@ -320,20 +322,11 @@ def _replace_last_user_message(messages: list[dict[str, Any]], new_text: str) ->
                 ):
                     content[j] = {"type": "text", "text": new_text}
                     return
-
-            # No eligible text block found — append as new block
             content.append({"type": "text", "text": new_text})
         return
 
 
 def _inject_system_context(body: dict[str, Any], text: str) -> None:
-    """Inject *text* into the request body's system prompt.
-
-    Handles the three formats Anthropic accepts:
-    - None → create a new list with a single text block
-    - str  → concatenate with ``\\n\\n``
-    - list → append as a new text block
-    """
     existing = body.get("system")
     if existing is None:
         body["system"] = [{"type": "text", "text": text}]
@@ -348,17 +341,17 @@ def _embed_context(
     resolved_context: str,
     settings: ClaudeFrontendSettings,
 ) -> None:
-    """Embed resolved url4 context into the request body per settings."""
+    """Embed resolved url4 context per plugin settings."""
     if settings.embed_target == "user":
         messages = body.get("messages", [])
         last_user_text = _extract_last_user_text(messages)
         if last_user_text:
             if settings.embed_mode == "concat":
                 combined = f"{last_user_text}\n\n{resolved_context}"
-            else:  # replace
+            else:
                 combined = resolved_context
             _replace_last_user_message(messages, combined)
-    else:  # system
+    else:
         wrapped = f"{settings.system_prompt}\n\n{resolved_context}"
         _inject_system_context(body, wrapped)
 
@@ -374,14 +367,13 @@ def create_router(
     ssl_ctx = ssl.create_default_context(cafile=certifi.where())
     logger.info("Proxy SSL context using certifi CA: %s", certifi.where())
 
-    # Diagnostic: check DNS override at request time
     import socket as _sock
 
     def _log_dns(domain: str) -> None:
         try:
             results = _sock.getaddrinfo(domain, 443, _sock.AF_INET)
             logger.info("DNS probe for %s → %s", domain, results[0][4][0])
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 — diagnostic only
             logger.warning("DNS probe for %s failed: %s", domain, e)
 
     router = APIRouter(tags=["claude-frontend"])
@@ -402,286 +394,70 @@ def create_router(
     async def proxy_messages(request: Request) -> Response:
         body = await request.json()
 
-        # --- Session enrichment (before url4 injection) ---
-        # Prefer env-var session ID (per-session proxy) over header (legacy)
-        session_id = os.environ.get("_SF_SESSION_ID") or request.headers.get("x-session-id")
-        original_user_msg = None
-        if session_id and session_service_url and hooks:
-            msgs = body.get("messages", [])
-            if msgs:
-                original_user_msg = msgs[-1].copy() if isinstance(msgs[-1], dict) else msgs[-1]
-            tracer = _get_tracer()
-            enrich_ctx = (
-                tracer.start_as_current_span("session.enrich_request") if tracer else _nullcontext()
-            )
-            with enrich_ctx:
-                _set_span_attrs(
-                    {
-                        "session.id": session_id,
-                        "session.service_url": session_service_url,
-                    }
-                )
-                try:
-                    results = await hooks.emit_async(
-                        "session.enrich_request",
-                        body=body,
-                        session_id=session_id,
-                        session_service_url=session_service_url,
-                    )
-                    modified = False
-                    for result in results:
-                        if result is not None:
-                            body = result
-                            modified = True
-                            break
-                    _set_span_attrs({"session.modified": modified})
-                except Exception:
-                    logger.warning("Session enrichment failed for %s", session_id, exc_info=True)
+        # Stage 1: session enrichment
+        session = SessionHook.from_request(
+            session_id=os.environ.get("_SF_SESSION_ID") or request.headers.get("x-session-id"),
+            service_url=session_service_url,
+            hooks=hooks,
+        )
+        body = await session.enrich(body, tracer=_get_tracer())
 
-        # --- URL4 context injection ---
-        # If the active spec contains $prompt, substitute the user's last message
-        # text inline (quoted for url4 grammar), resolve the full expression via
-        # the url4-executor, and replace the last user message with the result.
-        # Otherwise fall back to the original behavior (append to system prompt).
+        # Stage 2: url4 context injection (either path may short-circuit)
         raw_expression = plugin.get_active_expression() if plugin else None
-
         if raw_expression and "$prompt" in raw_expression:
-            messages = body.get("messages", [])
-            last_user_text = _extract_last_user_text(messages)
+            last_user_text = _extract_last_user_text(body.get("messages", []))
             if last_user_text:
-                tracer = _get_tracer()
-                span_ctx = (
-                    tracer.start_as_current_span("url4.$prompt") if tracer else _nullcontext()
+                short_circuit = await resolve_prompt_expression(
+                    body,
+                    raw_expression=raw_expression,
+                    settings=settings,
+                    plugin=plugin,
+                    app=app,
+                    tracer=_get_tracer(),
+                    last_user_text=last_user_text,
+                    embed_context=_embed_context,
+                    _start_client_span=_start_client_span,
+                    _set_span_attrs=_set_span_attrs,
                 )
-                with span_ctx as prompt_span:
-                    try:
-                        if prompt_span and prompt_span.is_recording():
-                            prompt_span.set_attribute("sf.plugin", _PLUGIN_NAME)
-                            prompt_span.set_attribute("url4.raw_expression", raw_expression)
-                            prompt_span.set_attribute("url4.user_text_length", len(last_user_text))
-
-                        # Determine backend: HTTP to main server, or in-process
-                        backend_url = (
-                            settings.backend_url.rstrip("/") if settings.backend_url else None
-                        )
-
-                        # Store user prompt as blob on the backend server
-                        if backend_url:
-                            blob_url_target = f"{backend_url}/data"
-                            blob_span_ctx = (
-                                _start_client_span(tracer, "POST /data")
-                                if tracer
-                                else _nullcontext()
-                            )
-                            with blob_span_ctx:
-                                _set_span_attrs(
-                                    {
-                                        "http.method": "POST",
-                                        "http.url": blob_url_target,
-                                    }
-                                )
-                                async with httpx.AsyncClient(
-                                    timeout=httpx.Timeout(30.0), verify=False
-                                ) as dc:
-                                    blob_resp = await dc.post(
-                                        blob_url_target,
-                                        content=last_user_text.encode("utf-8"),
-                                        headers={"content-type": "text/plain; charset=utf-8"},
-                                    )
-                                    blob_resp.raise_for_status()
-                                    blob_key = blob_resp.json()["key"]
-                                _set_span_attrs(
-                                    {
-                                        "http.status_code": blob_resp.status_code,
-                                        "data.key": blob_key,
-                                        "data.size": len(last_user_text),
-                                    }
-                                )
-                        else:
-                            from screamingface.plugins.data_store.routes import store_blob
-
-                            blob_key = store_blob(
-                                last_user_text.encode("utf-8"), "text/plain; charset=utf-8"
-                            )
-
-                        blob_url = f"/data/{blob_key}"
-                        substituted = raw_expression.replace("$prompt", blob_url)
-
-                        if prompt_span and prompt_span.is_recording():
-                            prompt_span.set_attribute("url4.blob_url", blob_url)
-                            prompt_span.set_attribute(
-                                "url4.substituted_expression", _truncate(substituted)
-                            )
-
-                        # Resolve the full expression via /ensemble endpoint
-                        if backend_url:
-                            ens_url = f"{backend_url}/ensemble"
-                            ens_span_ctx = (
-                                _start_client_span(tracer, "GET /ensemble")
-                                if tracer
-                                else _nullcontext()
-                            )
-                            with ens_span_ctx:
-                                _set_span_attrs(
-                                    {
-                                        "http.method": "GET",
-                                        "http.url": ens_url,
-                                        "url4.expression": _truncate(substituted, 500),
-                                    }
-                                )
-                                async with httpx.AsyncClient(
-                                    timeout=httpx.Timeout(300.0), verify=False
-                                ) as ec:
-                                    ens_resp = await ec.get(ens_url, params={"q": substituted})
-                                    ens_resp.raise_for_status()
-                                    final_text = ens_resp.text
-                                body_preview = final_text[:4000]
-                                if len(final_text) > 4000:
-                                    body_preview += f"\n... ({len(final_text) - 4000} more chars)"
-                                _set_span_attrs(
-                                    {
-                                        "http.status_code": ens_resp.status_code,
-                                        "url4.result_length": len(final_text),
-                                        "url4.response_body": body_preview,
-                                    }
-                                )
-                        else:
-                            from screamingface.plugins.url4_executor.interpreter import (
-                                Url4Interpreter,
-                            )
-
-                            interpreter = Url4Interpreter(app=app)
-                            final_text = await interpreter.evaluate(substituted)
-
-                        if prompt_span and prompt_span.is_recording():
-                            prompt_span.set_attribute("url4.final_text_length", len(final_text))
-                            prompt_span.set_attribute(
-                                "url4.final_text_preview", _truncate(final_text, 1000)
-                            )
-                            prompt_span.set_attribute("url4.status", "ok")
-
-                        if final_text:
-                            _embed_context(body, final_text, settings)
-                            logger.info(
-                                "$prompt: blob=%s resolved %d chars → target=%s mode=%s",
-                                blob_key,
-                                len(final_text),
-                                settings.embed_target,
-                                settings.embed_mode,
-                            )
-                    except Exception as exc:
-                        if prompt_span and prompt_span.is_recording():
-                            prompt_span.set_attribute("url4.status", "error")
-                            prompt_span.set_attribute("url4.error", str(exc))
-                            prompt_span.record_exception(exc)
-                        import traceback as _tb
-
-                        logger.warning("$prompt substitution failed", exc_info=True)
-                        tb_str = "".join(_tb.format_exception(exc))
-                        spec_name = settings.active_spec or "unknown"
-                        error_lines = [
-                            f"[url4 error] Resolution failed for spec '{spec_name}'",
-                            "",
-                            f"Expression: {_truncate(raw_expression, 200)}",
-                            f"Substituted: {_truncate(substituted, 200)}"
-                            if "substituted" in dir()
-                            else "",
-                            "",
-                            f"Error: {exc.__class__.__name__}: {exc}",
-                            "",
-                            "Traceback:",
-                            tb_str,
-                        ]
-                        error_response = {
-                            "id": f"sf_error_{id(exc):x}",
-                            "type": "message",
-                            "role": "assistant",
-                            "content": [{"type": "text", "text": "\n".join(error_lines)}],
-                            "model": body.get("model", "unknown"),
-                            "stop_reason": "end_turn",
-                            "stop_sequence": None,
-                            "usage": {"input_tokens": 0, "output_tokens": 0},
-                        }
-                        return JSONResponse(content=error_response, status_code=200)
+                if short_circuit is not None:
+                    return short_circuit
         elif raw_expression:
-            # No $prompt — resolve statically and append to system prompt
-            try:
-                resolved_context = plugin.resolve_context() if plugin else None
-            except Exception as exc:
-                import traceback as _tb
+            short_circuit = resolve_static_context(
+                body,
+                raw_expression=raw_expression,
+                settings=settings,
+                plugin=plugin,
+                embed_context=_embed_context,
+            )
+            if short_circuit is not None:
+                return short_circuit
 
-                logger.warning("Static context resolution failed", exc_info=True)
-                tb_str = "".join(_tb.format_exception(exc))
-                spec_name = settings.active_spec or "unknown"
-                error_lines = [
-                    f"[url4 error] Static context resolution failed for spec '{spec_name}'",
-                    "",
-                    f"Expression: {_truncate(raw_expression, 200)}",
-                    "",
-                    f"Error: {exc.__class__.__name__}: {exc}",
-                    "",
-                    "Traceback:",
-                    tb_str,
-                ]
-                error_response = {
-                    "id": f"sf_error_{id(exc):x}",
-                    "type": "message",
-                    "role": "assistant",
-                    "content": [{"type": "text", "text": "\n".join(error_lines)}],
-                    "model": body.get("model", "unknown"),
-                    "stop_reason": "end_turn",
-                    "stop_sequence": None,
-                    "usage": {"input_tokens": 0, "output_tokens": 0},
-                }
-                return JSONResponse(content=error_response, status_code=200)
-            if resolved_context:
-                _embed_context(body, resolved_context, settings)
-                logger.info(
-                    "Injected cached url4 context (%d chars) embed_target=%s embed_mode=%s",
-                    len(resolved_context),
-                    settings.embed_target,
-                    settings.embed_mode,
-                )
-
-        # Trace the FINAL request body (after all modifications) as child spans.
-        # This is exactly what gets sent to api.anthropic.com.
+        # Stage 3: trace the final body and forward to Anthropic
         tracer = _get_tracer()
         if tracer:
             with tracer.start_as_current_span("anthropic.request_body") as body_span:
                 body_span.set_attribute("sf.plugin", _PLUGIN_NAME)
                 body_span.set_attribute(
-                    "description", "Final request body sent to Anthropic API (after url4 injection)"
+                    "description",
+                    "Final request body sent to Anthropic API (after url4 injection)",
                 )
                 _trace_request_context(body)
         else:
             _trace_request_context(body)
 
         headers = _build_headers(request)
-        # Preserve query params (e.g. ?beta=true) that Claude Code sends
         qs = str(request.url.query)
         url = f"{upstream_url}/v1/messages"
         if qs:
             url = f"{url}?{qs}"
         timeout = httpx.Timeout(connect=10.0, read=600.0, write=10.0, pool=10.0)
-        tracer = _get_tracer()
-
-        # Record trace ID on the server span
         trace_id = _record_trace_id(request)
 
-        # Server span: just record the raw request body
         _set_span_attrs({"request.body": _truncate(json.dumps(body))})
         _set_span_headers("request.headers", _redact_headers(headers))
 
         is_streaming = body.get("stream", False)
-        # Debug: dump full request body to temp file for inspection
-        import tempfile
-        from pathlib import Path
-
-        debug_dir = Path(tempfile.gettempdir()) / "sf-proxy-debug"
-        debug_dir.mkdir(exist_ok=True)
-        debug_file = debug_dir / "last_request.json"
-        debug_file.write_text(json.dumps(body, indent=2, ensure_ascii=False))
-        logger.info("PROXY >>> dumped request body to %s", debug_file)
+        _maybe_dump_request(body)
         logger.info(
             "PROXY >>> forwarding to %s | stream=%s | sys_len=%s | msgs=%s | trace=%s",
             url,
@@ -697,166 +473,26 @@ def create_router(
         )
 
         if is_streaming:
-            client = httpx.AsyncClient(timeout=timeout, verify=ssl_ctx)
-            upstream_span = (
-                _start_client_span_detached(tracer, "anthropic.POST /v1/messages")
-                if tracer
-                else None
+            return await _forward_streaming(
+                url=url,
+                headers=headers,
+                body=body,
+                timeout=timeout,
+                ssl_ctx=ssl_ctx,
+                tracer=tracer,
+                trace_id=trace_id,
+                session=session,
             )
-            if upstream_span:
-                _set_span_attrs({"sf.plugin": _PLUGIN_NAME}, upstream_span)
-                _set_span_attrs({"http.method": "POST", "http.url": url}, upstream_span)
-                if trace_id:
-                    _set_span_attrs({"sf.trace_id": trace_id}, upstream_span)
-                _set_span_headers("request.headers", _redact_headers(headers), upstream_span)
-                _set_span_attrs({"request.body": _truncate(json.dumps(body))}, upstream_span)
-                logger.info(
-                    "TRACE: created upstream span %s", upstream_span.get_span_context().span_id
-                )
-
-            async def stream_response():
-                chunks: list[bytes] = []
-                try:
-                    logger.info("STREAM >>> opening upstream connection to Anthropic")
-                    async with client.stream("POST", url, json=body, headers=headers) as resp:
-                        logger.info(
-                            "STREAM >>> upstream responded: status=%s content-type=%s",
-                            resp.status_code,
-                            resp.headers.get("content-type", "?"),
-                        )
-                        if upstream_span:
-                            _set_span_attrs({"http.status_code": resp.status_code}, upstream_span)
-                            _set_span_headers(
-                                "response.headers",
-                                dict(resp.headers),
-                                upstream_span,
-                            )
-                        chunk_count = 0
-                        async for chunk in resp.aiter_bytes():
-                            chunk_count += 1
-                            chunks.append(chunk)
-                            if chunk_count <= 3:
-                                logger.info(
-                                    "STREAM >>> chunk #%d (%d bytes): %s",
-                                    chunk_count,
-                                    len(chunk),
-                                    chunk[:200],
-                                )
-                            yield chunk
-                        logger.info(
-                            "STREAM >>> finished: %d chunks, %d total bytes",
-                            chunk_count,
-                            sum(len(c) for c in chunks),
-                        )
-                        logger.info("[E2E-TRACE] PROXY response status=%d", resp.status_code)
-                except Exception as exc:
-                    logger.error("STREAM >>> ERROR during streaming: %s", exc, exc_info=True)
-                    raise
-                finally:
-                    if chunks:
-                        raw = b"".join(chunks).decode(errors="replace")
-                        if upstream_span:
-                            _set_span_attrs({"response.body": _truncate(raw)}, upstream_span)
-                        _set_span_attrs({"response.body": _truncate(raw)})
-
-                        # --- Session save (streaming) ---
-                        if session_id and session_service_url and hooks and original_user_msg:
-                            response_data = _parse_sse_response(raw)
-                            if response_data:
-                                save_tracer = _get_tracer()
-                                save_ctx = (
-                                    save_tracer.start_as_current_span("session.save_response")
-                                    if save_tracer
-                                    else _nullcontext()
-                                )
-                                with save_ctx:
-                                    _set_span_attrs(
-                                        {
-                                            "session.id": session_id,
-                                            "session.service_url": session_service_url,
-                                            "session.streaming": True,
-                                        }
-                                    )
-                                    try:
-                                        await hooks.emit_async(
-                                            "session.save_response",
-                                            session_id=session_id,
-                                            session_service_url=session_service_url,
-                                            user_message_body=original_user_msg,
-                                            response_body=response_data,
-                                        )
-                                    except Exception:
-                                        logger.warning(
-                                            "Session save (stream) failed for %s",
-                                            session_id,
-                                            exc_info=True,
-                                        )
-
-                    if upstream_span:
-                        upstream_span.end()
-                    await client.aclose()
-                    logger.info("STREAM >>> client closed")
-
-            return StreamingResponse(stream_response(), media_type="text/event-stream")
-        else:
-            if tracer:
-                with _start_client_span(tracer, f"POST {url}") as span:
-                    _set_span_attrs({"http.method": "POST", "http.url": url}, span)
-                    if trace_id:
-                        _set_span_attrs({"sf.trace_id": trace_id}, span)
-                    _set_span_headers("request.headers", _redact_headers(headers), span)
-                    _set_span_attrs({"request.body": _truncate(json.dumps(body))}, span)
-                    async with httpx.AsyncClient(timeout=timeout, verify=ssl_ctx) as client:
-                        resp = await client.post(url, json=body, headers=headers)
-                    _set_span_attrs(
-                        {
-                            "http.status_code": resp.status_code,
-                            "response.body": _truncate(resp.text),
-                        },
-                        span,
-                    )
-                    _set_span_headers("response.headers", dict(resp.headers), span)
-            else:
-                async with httpx.AsyncClient(timeout=timeout, verify=ssl_ctx) as client:
-                    resp = await client.post(url, json=body, headers=headers)
-            _set_span_attrs(
-                {
-                    "response.body": _truncate(resp.text),
-                    "http.status_code": resp.status_code,
-                },
-            )
-            _set_span_headers("response.headers", dict(resp.headers))
-            logger.info("[E2E-TRACE] PROXY response status=%d", resp.status_code)
-
-            # --- Session save (non-streaming) ---
-            response_data = resp.json()
-            if session_id and session_service_url and hooks and original_user_msg:
-                save_tracer = _get_tracer()
-                save_ctx = (
-                    save_tracer.start_as_current_span("session.save_response")
-                    if save_tracer
-                    else _nullcontext()
-                )
-                with save_ctx:
-                    _set_span_attrs(
-                        {
-                            "session.id": session_id,
-                            "session.service_url": session_service_url,
-                            "session.streaming": False,
-                        }
-                    )
-                    try:
-                        await hooks.emit_async(
-                            "session.save_response",
-                            session_id=session_id,
-                            session_service_url=session_service_url,
-                            user_message_body=original_user_msg,
-                            response_body=response_data,
-                        )
-                    except Exception:
-                        logger.warning("Session save failed for %s", session_id, exc_info=True)
-
-            return JSONResponse(content=response_data, status_code=resp.status_code)
+        return await _forward_unary(
+            url=url,
+            headers=headers,
+            body=body,
+            timeout=timeout,
+            ssl_ctx=ssl_ctx,
+            tracer=tracer,
+            trace_id=trace_id,
+            session=session,
+        )
 
     @router.get("/v1/{path:path}", response_model=None, operation_id="proxy_catchall_get")
     @router.post("/v1/{path:path}", response_model=None, operation_id="proxy_catchall_post")
@@ -866,9 +502,7 @@ def create_router(
         method = request.method
         timeout = httpx.Timeout(connect=10.0, read=600.0, write=10.0, pool=10.0)
         tracer = _get_tracer()
-
         trace_id = _record_trace_id(request)
-
         body = await request.body()
         kwargs: dict[str, Any] = {"headers": headers}
         if body:
@@ -904,10 +538,7 @@ def create_router(
                 resp = await client.request(method, url, **kwargs)
 
         _set_span_attrs(
-            {
-                "response.body": _truncate(resp.text),
-                "http.status_code": resp.status_code,
-            },
+            {"response.body": _truncate(resp.text), "http.status_code": resp.status_code}
         )
         _set_span_headers("response.headers", dict(resp.headers))
 
@@ -927,7 +558,7 @@ def create_router(
         operation_id="proxy_passthrough",
     )
     async def proxy_passthrough(request: Request, path: str) -> Response:
-        """Forward /api/* requests to the real upstream (Claude Code telemetry, OAuth, etc.)."""
+        """Forward /api/* requests to the real upstream (telemetry, OAuth, etc.)."""
         headers = _build_headers(request)
         url = f"{upstream_url}/api/{path}"
         method = request.method
@@ -954,3 +585,140 @@ def create_router(
         )
 
     return router
+
+
+# ---------------------------------------------------------------------------
+# Stage 3 helpers — upstream forwarding
+# ---------------------------------------------------------------------------
+
+
+def _maybe_dump_request(body: dict[str, Any]) -> None:
+    """Dump the outgoing request body to /tmp for debugging — opt-in."""
+    if not os.environ.get(_DEBUG_DUMP_ENV):
+        return
+    import tempfile
+    from pathlib import Path
+
+    debug_dir = Path(tempfile.gettempdir()) / "sf-proxy-debug"
+    debug_dir.mkdir(exist_ok=True)
+    debug_file = debug_dir / "last_request.json"
+    debug_file.write_text(json.dumps(body, indent=2, ensure_ascii=False))
+    logger.info("PROXY >>> dumped request body to %s", debug_file)
+
+
+async def _forward_streaming(
+    *,
+    url: str,
+    headers: dict[str, str],
+    body: dict[str, Any],
+    timeout: httpx.Timeout,
+    ssl_ctx: ssl.SSLContext,
+    tracer: Any,
+    trace_id: str | None,
+    session: SessionHook,
+) -> StreamingResponse:
+    """Stream Anthropic's SSE response through, saving the session turn on completion."""
+    client = httpx.AsyncClient(timeout=timeout, verify=ssl_ctx)
+    upstream_span = (
+        _start_client_span_detached(tracer, "anthropic.POST /v1/messages") if tracer else None
+    )
+    if upstream_span:
+        _set_span_attrs({"sf.plugin": _PLUGIN_NAME}, upstream_span)
+        _set_span_attrs({"http.method": "POST", "http.url": url}, upstream_span)
+        if trace_id:
+            _set_span_attrs({"sf.trace_id": trace_id}, upstream_span)
+        _set_span_headers("request.headers", _redact_headers(headers), upstream_span)
+        _set_span_attrs({"request.body": _truncate(json.dumps(body))}, upstream_span)
+        logger.info("TRACE: created upstream span %s", upstream_span.get_span_context().span_id)
+
+    async def stream_response():
+        chunks: list[bytes] = []
+        try:
+            logger.info("STREAM >>> opening upstream connection to Anthropic")
+            async with client.stream("POST", url, json=body, headers=headers) as resp:
+                logger.info(
+                    "STREAM >>> upstream responded: status=%s content-type=%s",
+                    resp.status_code,
+                    resp.headers.get("content-type", "?"),
+                )
+                if upstream_span:
+                    _set_span_attrs({"http.status_code": resp.status_code}, upstream_span)
+                    _set_span_headers("response.headers", dict(resp.headers), upstream_span)
+                chunk_count = 0
+                async for chunk in resp.aiter_bytes():
+                    chunk_count += 1
+                    chunks.append(chunk)
+                    if chunk_count <= 3:
+                        logger.info(
+                            "STREAM >>> chunk #%d (%d bytes): %s",
+                            chunk_count,
+                            len(chunk),
+                            chunk[:200],
+                        )
+                    yield chunk
+                logger.info(
+                    "STREAM >>> finished: %d chunks, %d total bytes",
+                    chunk_count,
+                    sum(len(c) for c in chunks),
+                )
+                logger.info("[E2E-TRACE] PROXY response status=%d", resp.status_code)
+        except Exception as exc:
+            logger.error("STREAM >>> ERROR during streaming: %s", exc, exc_info=True)
+            raise
+        finally:
+            if chunks:
+                raw = b"".join(chunks).decode(errors="replace")
+                if upstream_span:
+                    _set_span_attrs({"response.body": _truncate(raw)}, upstream_span)
+                _set_span_attrs({"response.body": _truncate(raw)})
+                if session.enabled:
+                    response_data = _parse_sse_response(raw)
+                    if response_data:
+                        await session.save(response_data, streaming=True, tracer=_get_tracer())
+            if upstream_span:
+                upstream_span.end()
+            await client.aclose()
+            logger.info("STREAM >>> client closed")
+
+    return StreamingResponse(stream_response(), media_type="text/event-stream")
+
+
+async def _forward_unary(
+    *,
+    url: str,
+    headers: dict[str, str],
+    body: dict[str, Any],
+    timeout: httpx.Timeout,
+    ssl_ctx: ssl.SSLContext,
+    tracer: Any,
+    trace_id: str | None,
+    session: SessionHook,
+) -> JSONResponse:
+    """Non-streaming POST, parse JSON, save session turn."""
+    span_ctx = _start_client_span(tracer, f"POST {url}") if tracer else _nullcontext()
+    with span_ctx as span:
+        if tracer and span:
+            _set_span_attrs({"http.method": "POST", "http.url": url}, span)
+            if trace_id:
+                _set_span_attrs({"sf.trace_id": trace_id}, span)
+            _set_span_headers("request.headers", _redact_headers(headers), span)
+            _set_span_attrs({"request.body": _truncate(json.dumps(body))}, span)
+        async with httpx.AsyncClient(timeout=timeout, verify=ssl_ctx) as client:
+            resp = await client.post(url, json=body, headers=headers)
+        if tracer and span:
+            _set_span_attrs(
+                {
+                    "http.status_code": resp.status_code,
+                    "response.body": _truncate(resp.text),
+                },
+                span,
+            )
+            _set_span_headers("response.headers", dict(resp.headers), span)
+
+    _set_span_attrs({"response.body": _truncate(resp.text), "http.status_code": resp.status_code})
+    _set_span_headers("response.headers", dict(resp.headers))
+    logger.info("[E2E-TRACE] PROXY response status=%d", resp.status_code)
+
+    response_data = resp.json()
+    await session.save(response_data, streaming=False, tracer=_get_tracer())
+    return JSONResponse(content=response_data, status_code=resp.status_code)

--- a/apps/server/src/screamingface/plugins/claude_frontend/tests/test_session.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/tests/test_session.py
@@ -1,0 +1,113 @@
+"""Unit tests for the extracted ``SessionHook`` helper.
+
+These test the hook shape in isolation — they don't spin up a real
+proxy or talk to the session service. Hooks are mocked and asserted
+on directly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from screamingface.plugins.claude_frontend._session import SessionHook
+
+
+class TestSessionHookEnabled:
+    def test_all_three_required(self):
+        assert SessionHook(session_id="sid", service_url="url", hooks=MagicMock()).enabled
+        assert not SessionHook(session_id=None, service_url="url", hooks=MagicMock()).enabled
+        assert not SessionHook(session_id="sid", service_url=None, hooks=MagicMock()).enabled
+        assert not SessionHook(session_id="sid", service_url="url", hooks=None).enabled
+
+
+class TestEnrich:
+    @pytest.mark.anyio
+    async def test_disabled_returns_body_unchanged(self):
+        hook = SessionHook(session_id=None, service_url=None, hooks=None)
+        body = {"messages": [{"role": "user", "content": "hi"}]}
+        result = await hook.enrich(body)
+        assert result is body
+
+    @pytest.mark.anyio
+    async def test_snapshots_last_user_message(self):
+        hooks = MagicMock()
+        hooks.emit_async = AsyncMock(return_value=[None])
+        hook = SessionHook(session_id="sid", service_url="url", hooks=hooks)
+        body = {"messages": [{"role": "user", "content": "hi"}]}
+        await hook.enrich(body)
+        assert hook.original_user_msg == {"role": "user", "content": "hi"}
+
+    @pytest.mark.anyio
+    async def test_hook_modified_body_replaces(self):
+        hooks = MagicMock()
+        hooks.emit_async = AsyncMock(
+            return_value=[None, {"messages": [{"role": "user", "content": "modified"}]}]
+        )
+        hook = SessionHook(session_id="sid", service_url="url", hooks=hooks)
+        body = {"messages": [{"role": "user", "content": "original"}]}
+        result = await hook.enrich(body)
+        assert result["messages"][0]["content"] == "modified"
+
+    @pytest.mark.anyio
+    async def test_transport_error_swallowed(self):
+        hooks = MagicMock()
+        hooks.emit_async = AsyncMock(side_effect=httpx.ConnectError("down"))
+        hook = SessionHook(session_id="sid", service_url="url", hooks=hooks)
+        body = {"messages": []}
+        result = await hook.enrich(body)  # should not raise
+        assert result is body
+
+    @pytest.mark.anyio
+    async def test_unexpected_error_propagates(self):
+        """Narrowed exception handling — unrelated bugs should surface."""
+        hooks = MagicMock()
+        hooks.emit_async = AsyncMock(side_effect=ValueError("bug"))
+        hook = SessionHook(session_id="sid", service_url="url", hooks=hooks)
+        with pytest.raises(ValueError, match="bug"):
+            await hook.enrich({"messages": []})
+
+
+class TestSave:
+    @pytest.mark.anyio
+    async def test_disabled_noop(self):
+        hook = SessionHook(session_id=None, service_url=None, hooks=None)
+        await hook.save({"id": "msg_1"}, streaming=False)  # should not raise
+
+    @pytest.mark.anyio
+    async def test_skips_when_no_original_user_message(self):
+        hooks = MagicMock()
+        hooks.emit_async = AsyncMock()
+        hook = SessionHook(session_id="sid", service_url="url", hooks=hooks)
+        # original_user_msg is None — save must skip
+        await hook.save({"id": "msg_1"}, streaming=False)
+        hooks.emit_async.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_emits_when_everything_set(self):
+        hooks = MagicMock()
+        hooks.emit_async = AsyncMock()
+        hook = SessionHook(session_id="sid", service_url="url", hooks=hooks)
+        hook.original_user_msg = {"role": "user", "content": "hi"}
+        response = {"id": "msg_1", "content": []}
+        await hook.save(response, streaming=True)
+        hooks.emit_async.assert_awaited_once()
+        name, kwargs = hooks.emit_async.call_args.args[0], hooks.emit_async.call_args.kwargs
+        assert name == "session.save_response"
+        assert kwargs["session_id"] == "sid"
+        assert kwargs["response_body"] is response
+
+    @pytest.mark.anyio
+    async def test_transport_error_swallowed(self):
+        hooks = MagicMock()
+        hooks.emit_async = AsyncMock(side_effect=httpx.ConnectError("down"))
+        hook = SessionHook(session_id="sid", service_url="url", hooks=hooks)
+        hook.original_user_msg = {"role": "user", "content": "hi"}
+        await hook.save({"id": "msg_1"}, streaming=False)  # should not raise
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"


### PR DESCRIPTION
## Summary

The ``proxy_messages`` handler was a ~460-line monolith with three concerns interleaved at 8 levels of nesting — session enrichment, url4 context injection, and upstream forwarding — and zero unit tests.

This PR extracts the first two into focused, unit-testable modules and shrinks ``proxy_messages`` to ~100 lines that read as three explicit stages.

## New modules

- **``_session.py``** — ``SessionHook`` dataclass with ``enrich``/``save`` methods. Captures the last user message at enrich time so ``save`` can pair it with the assistant response. Narrowed the bare ``except Exception`` to transport errors only; unrelated bugs now surface instead of being swallowed.
- **``_url4_context.py``** — ``resolve_prompt_expression`` (the ``$prompt`` pipeline: store blob → substitute → resolve → embed) and ``resolve_static_context`` (plugin-cached context). Both return ``None`` on success (body mutated in place) or a ``JSONResponse`` for short-circuit error handling.

## ``proxy.py`` changes

- ``proxy_messages``: **460 → ~100 lines**, orchestrates the three stages.
- Extracted ``_forward_streaming`` / ``_forward_unary`` to split Stage 3 cleanly.
- Magic ``4000`` → ``PROMPT_PREVIEW_LIMIT`` (from SF-106).
- ``/tmp/sf-proxy-debug/`` dumps gated behind ``SF_PROXY_DEBUG_DUMP`` env var (was always-on).
- ``proxy.py`` net: **956 → 726 lines**.

## New tests

10 unit tests for ``SessionHook`` in ``tests/test_session.py`` — the first proxy-handler unit tests. Cover: enabled flag, enrich snapshot, hook-modified body, transport-error swallowing, unexpected-error propagation, save preconditions.

## Test gate

- ✅ ``ruff check`` + ``ruff format --check`` clean
- ✅ ``pyright`` clean on edited modules
- ✅ **713 unit tests pass** (703 + 10 new)
- ✅ **117 e2e tests pass** including live Claude / Codex / Gemini (memory rule: always run full e2e incl. live before asking to merge)

## Asana

- Ticket: [SF-107](https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1214145309896776)
- Parent epic: [SF-96](https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1214137811159323)