### PR TITLE
SF-112: decouple frontends from data_store.routes; named plugins-registry invariant

### DIFF
--- a/apps/server/src/screamingface/core/helpers.py
+++ b/apps/server/src/screamingface/core/helpers.py
@@ -1,0 +1,41 @@
+"""Small cross-plugin utilities that live above any single plugin.
+
+Currently holds :func:`get_plugins_registry`, which lets plugin code
+reach the active-plugin registry through a single named invariant
+instead of defensively walking ``getattr(app, "state", None)`` every
+time.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from screamingface.core.registry import PluginRegistry
+
+
+def get_plugins_registry(app: Any) -> PluginRegistry:
+    """Return ``app.state.plugins``, raising if the invariant is broken.
+
+    The SF bootstrap (:func:`screamingface.core.app.create_app`) always
+    sets ``app.state.plugins`` before the first request lands. Plugin
+    code that needs to walk the active-plugin list can rely on that
+    invariant — the defensive ``getattr(getattr(app, "state", None),
+    "plugins", None)`` dance was only there because we didn't have a
+    single assertion point.
+
+    Raises:
+        RuntimeError: ``app.state.plugins`` is missing. This indicates
+            a broken bootstrap path (test harness that skipped
+            ``create_app``, or plugin ``setup()`` running before the
+            registry was attached).
+    """
+    state = getattr(app, "state", None)
+    registry = getattr(state, "plugins", None) if state is not None else None
+    if registry is None:
+        raise RuntimeError(
+            "app.state.plugins is not set — the SF bootstrap did not run. "
+            "This usually means a test harness is using a bare FastAPI app "
+            "instead of screamingface.core.app.create_app()."
+        )
+    return registry

--- a/apps/server/src/screamingface/plugins/claude_frontend/_url4_context.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/_url4_context.py
@@ -117,7 +117,7 @@ async def _store_prompt_blob(
         return blob_key
 
     # In-process fallback
-    from screamingface.plugins.data_store.routes import store_blob
+    from screamingface.plugins.data_store.storage import store_blob
 
     return store_blob(text.encode("utf-8"), "text/plain; charset=utf-8")
 

--- a/apps/server/src/screamingface/plugins/codex_frontend/proxy.py
+++ b/apps/server/src/screamingface/plugins/codex_frontend/proxy.py
@@ -288,7 +288,7 @@ def create_router(
                             blob_resp.raise_for_status()
                             blob_key = blob_resp.json()["key"]
                     else:
-                        from screamingface.plugins.data_store.routes import store_blob
+                        from screamingface.plugins.data_store.storage import store_blob
 
                         blob_key = store_blob(
                             last_user_text.encode("utf-8"), "text/plain; charset=utf-8"

--- a/apps/server/src/screamingface/plugins/data_store/routes.py
+++ b/apps/server/src/screamingface/plugins/data_store/routes.py
@@ -1,26 +1,21 @@
-"""Routes for the data-store plugin — store and retrieve blobs by key."""
+"""Routes for the data-store plugin — store and retrieve blobs by key.
+
+The storage itself lives in :mod:`.storage` so other plugins can use
+``store_blob`` / ``get_blob`` without reaching into a ``.routes``
+module (routes are FastAPI implementation detail, not public API).
+"""
 
 from __future__ import annotations
-
-import hashlib
 
 from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import JSONResponse
 
-# Module-level store so it can be accessed in-process by other plugins
-_store: dict[str, tuple[bytes, str]] = {}
+from screamingface.plugins.data_store.storage import get_blob, store_blob
 
-
-def store_blob(data: bytes, content_type: str = "application/octet-stream") -> str:
-    """Store a blob in-process and return its content-addressed key."""
-    key = hashlib.sha256(data).hexdigest()[:16]
-    _store[key] = (data, content_type)
-    return key
-
-
-def get_blob(key: str) -> tuple[bytes, str] | None:
-    """Retrieve a blob by key. Returns (data, content_type) or None."""
-    return _store.get(key)
+# Re-export for back-compat: older callers imported ``store_blob`` /
+# ``get_blob`` from this module directly. New code should import from
+# :mod:`.storage`.
+__all__ = ["create_router", "get_blob", "store_blob"]
 
 
 def create_router() -> APIRouter:
@@ -49,7 +44,7 @@ def create_router() -> APIRouter:
 
     @router.get("/data/{key}", response_model=None, operation_id="data_store_get")
     async def get_blob_route(key: str) -> Response:
-        entry = _store.get(key)
+        entry = get_blob(key)
         if entry is None:
             raise HTTPException(status_code=404, detail="Not found")
         body, content_type = entry

--- a/apps/server/src/screamingface/plugins/data_store/storage.py
+++ b/apps/server/src/screamingface/plugins/data_store/storage.py
@@ -1,0 +1,68 @@
+"""In-process blob storage backing the data-store plugin.
+
+Split out of :mod:`.routes` in SF-112 so that other plugins can import
+``store_blob`` / ``get_blob`` without reaching into a ``.routes``
+module (which is an implementation detail of the FastAPI layer).
+
+Thread-safe: the underlying dict is guarded by a ``threading.Lock``
+because frontends occasionally call ``store_blob`` from synchronous
+threads (``_fetch_sync`` in each frontend plugin) while the routes
+access it from the async event loop.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+
+__all__ = ["BlobStore", "get_blob", "store_blob"]
+
+
+class BlobStore:
+    """Thread-safe, content-addressed byte store.
+
+    ``store(data)`` returns a stable 16-hex-char content hash as the
+    key. ``get(key)`` returns ``(bytes, content_type)`` or ``None``.
+    Unbounded — callers are expected to keep entries small (prompt
+    blobs, resolver payloads) and let the process lifetime bound it.
+    """
+
+    def __init__(self) -> None:
+        self._entries: dict[str, tuple[bytes, str]] = {}
+        self._lock = threading.Lock()
+
+    def store(self, data: bytes, content_type: str = "application/octet-stream") -> str:
+        key = hashlib.sha256(data).hexdigest()[:16]
+        with self._lock:
+            self._entries[key] = (data, content_type)
+        return key
+
+    def get(self, key: str) -> tuple[bytes, str] | None:
+        with self._lock:
+            return self._entries.get(key)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._entries)
+
+
+# Module-level singleton. Kept because the in-process fallback path
+# (frontends calling store_blob without going through HTTP) needs a
+# shared instance — and there's exactly one data-store plugin per
+# server. ``app.state`` would be cleaner but requires plumbing `app`
+# through every caller; this is a pragmatic middle ground.
+_default_store = BlobStore()
+
+
+def store_blob(data: bytes, content_type: str = "application/octet-stream") -> str:
+    """Store a blob and return its content-addressed key."""
+    return _default_store.store(data, content_type)
+
+
+def get_blob(key: str) -> tuple[bytes, str] | None:
+    """Retrieve a blob by key. Returns ``(data, content_type)`` or ``None``."""
+    return _default_store.get(key)

--- a/apps/server/src/screamingface/plugins/gemini_frontend/proxy.py
+++ b/apps/server/src/screamingface/plugins/gemini_frontend/proxy.py
@@ -217,7 +217,7 @@ def create_router(
                             blob_resp.raise_for_status()
                             blob_key = blob_resp.json()["key"]
                     else:
-                        from screamingface.plugins.data_store.routes import store_blob
+                        from screamingface.plugins.data_store.storage import store_blob
 
                         blob_key = store_blob(
                             last_user_text.encode("utf-8"),

--- a/apps/server/src/screamingface/plugins/ollama_frontend/proxy.py
+++ b/apps/server/src/screamingface/plugins/ollama_frontend/proxy.py
@@ -291,7 +291,7 @@ def create_router(
                                 blob_resp.raise_for_status()
                                 blob_key = blob_resp.json()["key"]
                         else:
-                            from screamingface.plugins.data_store.routes import store_blob
+                            from screamingface.plugins.data_store.storage import store_blob
 
                             blob_key = store_blob(
                                 last_user_text.encode("utf-8"), "text/plain; charset=utf-8"

--- a/apps/server/src/screamingface/plugins/url4_executor/url4.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/url4.py
@@ -342,11 +342,9 @@ async def _dispatch_backend_call(node: Url4BackendCall, app: Any) -> str:
     sources_text = node.packed_context or ""
 
     # Find the plugin that registered this path.
-    plugins_registry = getattr(getattr(app, "state", None), "plugins", None)
-    if plugins_registry is None:
-        raise RuntimeError(
-            f"Cannot dispatch backend call {node.path}(): app.state.plugins is not set."
-        )
+    from screamingface.core.helpers import get_plugins_registry
+
+    plugins_registry = get_plugins_registry(app)
 
     known_paths: list[str] = []
     for plugin in plugins_registry.active_plugins.values():


### PR DESCRIPTION
Closes the two highest-leverage items from the SF-96 plugin-architecture review.

**1. Frontend → data_store.routes coupling (review item 7.1)**

Four frontends (claude, codex, gemini, ollama) reached into data_store/routes.py (FastAPI-implementation-detail) to import store_blob. Moved to dedicated data_store/storage.py with a thread-safe BlobStore class. routes.py re-exports for back-compat.

**2. Defensive app.state dance (review item 7.5)**

Added core/helpers.py:get_plugins_registry(app) that asserts the invariant with a named error. url4.py uses it instead of the getattr-double-dance.

**Out of scope:** core/app.py:create_app split; removing module-level default store; tracing lifecycle (already idempotent).

**Tests:** 714 unit tests pass, ruff + format clean. Full e2e incl. live: 116 passed, 7 skipped, 1 flake (passes in isolation).

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1214145163384259