### PR TITLE
SF-126: provider-partitioned parallel e2e execution [PERF]

### DIFF
--- a/apps/server/scripts/run_e2e_parallel.sh
+++ b/apps/server/scripts/run_e2e_parallel.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Run e2e tests partitioned by provider:
+#   Phase 1 — claude / codex / gemini queues run in parallel (each sequential
+#             internally to respect provider rate limits).
+#   Phase 2 — multi-provider + provider-agnostic tests run after Phase 1.
+#
+# Usage:  scripts/run_e2e_parallel.sh [extra pytest args...]
+#
+# Exit code is non-zero if any phase failed.
+
+set -u
+
+cd "$(dirname "$0")/.."
+
+LOG_DIR="${LOG_DIR:-/tmp/sf-e2e-$$}"
+mkdir -p "$LOG_DIR"
+echo "Logs: $LOG_DIR"
+
+EXTRA=("$@")
+
+run_phase() {
+  local provider=$1
+  local log="$LOG_DIR/$provider.log"
+  echo "[start] $provider -> $log"
+  uv run pytest tests/e2e --provider="$provider" -v "${EXTRA[@]}" \
+    > "$log" 2>&1
+  local rc=$?
+  echo "[done ] $provider rc=$rc"
+  return $rc
+}
+
+# --- Phase 1: parallel provider queues ---
+declare -A PIDS
+for p in claude codex gemini; do
+  run_phase "$p" &
+  PIDS[$p]=$!
+done
+
+PHASE1_RC=0
+for p in claude codex gemini; do
+  if ! wait "${PIDS[$p]}"; then
+    PHASE1_RC=1
+    echo "[fail ] $p — see $LOG_DIR/$p.log"
+  fi
+done
+
+# --- Phase 2: multi/other (only after Phase 1 done) ---
+echo "[start] phase2 (multi)"
+run_phase "multi"
+PHASE2_RC=$?
+
+# --- Summary ---
+echo
+echo "=== Summary ==="
+for p in claude codex gemini multi; do
+  tail -n 3 "$LOG_DIR/$p.log" | sed "s|^|[$p] |"
+done
+
+if [[ $PHASE1_RC -ne 0 || $PHASE2_RC -ne 0 ]]; then
+  echo "FAIL (phase1=$PHASE1_RC phase2=$PHASE2_RC). Logs in $LOG_DIR"
+  exit 1
+fi
+echo "PASS. Logs in $LOG_DIR"

--- a/apps/server/scripts/run_e2e_parallel.sh
+++ b/apps/server/scripts/run_e2e_parallel.sh
@@ -7,8 +7,7 @@
 # Usage:  scripts/run_e2e_parallel.sh [extra pytest args...]
 #
 # Exit code is non-zero if any phase failed.
-
-set -u
+# Compatible with bash 3.2 (default on macOS) — no associative arrays.
 
 cd "$(dirname "$0")/.."
 
@@ -22,41 +21,41 @@ run_phase() {
   local provider=$1
   local log="$LOG_DIR/$provider.log"
   echo "[start] $provider -> $log"
-  uv run pytest tests/e2e --provider="$provider" -v "${EXTRA[@]}" \
-    > "$log" 2>&1
+  if [ ${#EXTRA[@]} -gt 0 ]; then
+    uv run pytest tests/e2e --provider="$provider" -v "${EXTRA[@]}" > "$log" 2>&1
+  else
+    uv run pytest tests/e2e --provider="$provider" -v > "$log" 2>&1
+  fi
   local rc=$?
   echo "[done ] $provider rc=$rc"
   return $rc
 }
 
 # --- Phase 1: parallel provider queues ---
-declare -A PIDS
-for p in claude codex gemini; do
-  run_phase "$p" &
-  PIDS[$p]=$!
-done
+run_phase claude  & PID_CLAUDE=$!
+run_phase codex   & PID_CODEX=$!
+run_phase gemini  & PID_GEMINI=$!
 
 PHASE1_RC=0
-for p in claude codex gemini; do
-  if ! wait "${PIDS[$p]}"; then
-    PHASE1_RC=1
-    echo "[fail ] $p — see $LOG_DIR/$p.log"
-  fi
-done
+wait "$PID_CLAUDE" || { PHASE1_RC=1; echo "[fail ] claude — see $LOG_DIR/claude.log"; }
+wait "$PID_CODEX"  || { PHASE1_RC=1; echo "[fail ] codex  — see $LOG_DIR/codex.log"; }
+wait "$PID_GEMINI" || { PHASE1_RC=1; echo "[fail ] gemini — see $LOG_DIR/gemini.log"; }
 
 # --- Phase 2: multi/other (only after Phase 1 done) ---
 echo "[start] phase2 (multi)"
-run_phase "multi"
+run_phase multi
 PHASE2_RC=$?
 
 # --- Summary ---
 echo
 echo "=== Summary ==="
 for p in claude codex gemini multi; do
-  tail -n 3 "$LOG_DIR/$p.log" | sed "s|^|[$p] |"
+  if [ -f "$LOG_DIR/$p.log" ]; then
+    tail -n 3 "$LOG_DIR/$p.log" | sed "s|^|[$p] |"
+  fi
 done
 
-if [[ $PHASE1_RC -ne 0 || $PHASE2_RC -ne 0 ]]; then
+if [ $PHASE1_RC -ne 0 ] || [ $PHASE2_RC -ne 0 ]; then
   echo "FAIL (phase1=$PHASE1_RC phase2=$PHASE2_RC). Logs in $LOG_DIR"
   exit 1
 fi

--- a/apps/server/tests/e2e/conftest.py
+++ b/apps/server/tests/e2e/conftest.py
@@ -4,26 +4,115 @@ from __future__ import annotations
 
 import os
 from collections.abc import Generator
+from pathlib import Path
 
 import pytest
+import yaml
 
 from tests.e2e.infrastructure.claude_code_client import ClaudeCodeClient
 from tests.e2e.infrastructure.otlp_collector import OTLPCollector
 from tests.e2e.infrastructure.server_manager import ServerManager
 
 # ---------------------------------------------------------------------------
-# Auto-skip e2e_live tests without API key
+# Provider partitioning (for parallel e2e runs by provider queue)
 # ---------------------------------------------------------------------------
+
+_PROVIDERS = ("claude", "codex", "gemini", "multi", "other")
+_DATA_DIR = Path(__file__).parent / "data"
+
+# Files that target a specific provider exclusively. Files not listed are
+# considered provider-agnostic and run only in the "multi" phase.
+_PROVIDER_BY_FILE: dict[str, str] = {
+    "test_proxy_context_injection.py": "claude",
+    "test_proxy_multi_turn.py": "claude",
+    "test_proxy_prompt_flow.py": "claude",
+    "test_trace_structure.py": "claude",
+    "test_cat_breeds_spec.py": "claude",
+    "test_url4_specs_live.py": "claude",
+    "test_ensemble_features.py": "claude",
+    "test_url4_resolution.py": "claude",
+    # test_url4_matrix.py is classified per-test-id below.
+}
+
+
+def _build_matrix_id_map() -> dict[str, str]:
+    """Map every YAML matrix test id to its provider folder."""
+    out: dict[str, str] = {}
+    if not _DATA_DIR.exists():
+        return out
+    for path in _DATA_DIR.rglob("*.yaml"):
+        rel = path.relative_to(_DATA_DIR)
+        provider = rel.parts[0] if len(rel.parts) > 1 else "other"
+        try:
+            cases = yaml.safe_load(path.read_text()) or []
+        except Exception:
+            continue
+        for case in cases:
+            cid = case.get("id")
+            if cid:
+                out[cid] = provider
+    return out
+
+
+_MATRIX_ID_PROVIDER = _build_matrix_id_map()
+
+
+def _provider_for_item(item: pytest.Item) -> str:
+    """Classify a collected test item to a provider bucket."""
+    fname = Path(str(item.fspath)).name
+    if fname == "test_url4_matrix.py":
+        # Param id is wrapped in [brackets] at the end of nodeid
+        nodeid = item.nodeid
+        if "[" in nodeid and nodeid.endswith("]"):
+            param = nodeid.rsplit("[", 1)[1][:-1]
+            return _MATRIX_ID_PROVIDER.get(param, "multi")
+        return "multi"
+    return _PROVIDER_BY_FILE.get(fname, "multi")
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--provider",
+        action="store",
+        default=None,
+        choices=[*_PROVIDERS, "all"],
+        help=(
+            "Run only e2e tests classified to the given provider queue. "
+            "Used by scripts/run_e2e_parallel.sh to shard execution."
+        ),
+    )
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    # 1) Auto-skip live tests without API key
     has_api_key = bool(os.environ.get("ANTHROPIC_API_KEY"))
-    if has_api_key:
+    if not has_api_key:
+        skip_live = pytest.mark.skip(reason="ANTHROPIC_API_KEY not set")
+        for item in items:
+            if "e2e_live" in item.keywords:
+                item.add_marker(skip_live)
+
+    # 2) Provider filter — deselect items not in the requested queue
+    selected_provider = config.getoption("--provider")
+    if not selected_provider or selected_provider == "all":
         return
-    skip_marker = pytest.mark.skip(reason="ANTHROPIC_API_KEY not set")
+
+    # The "multi" queue absorbs anything provider-agnostic ("other") too.
+    multi_buckets = {"multi", "other"}
+    keep, drop = [], []
     for item in items:
-        if "e2e_live" in item.keywords:
-            item.add_marker(skip_marker)
+        bucket = _provider_for_item(item)
+        if selected_provider == "multi":
+            matched = bucket in multi_buckets
+        else:
+            matched = bucket == selected_provider
+        if matched:
+            keep.append(item)
+        else:
+            drop.append(item)
+    if drop:
+        config.hook.pytest_deselected(items=drop)
+        items[:] = keep
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Run claude / codex / gemini e2e queues **in parallel** (each sequential internally to respect provider rate limits)
- Multi-provider tests run in a Phase 2 after all three queues finish
- Expected ~30-40% wall-time drop on full e2e

## Mechanism
- `tests/e2e/conftest.py`: new `--provider {claude,codex,gemini,multi,all}` pytest CLI option. Classifier:
  - `test_url4_matrix.py` → bucket = source YAML folder (`data/<provider>/`)
  - non-matrix files → static basename map (mostly Claude-only proxy/trace tests)
  - `multi` queue absorbs `data/multi/` + `data/other/` (provider-agnostic)
- `apps/server/scripts/run_e2e_parallel.sh`: two-phase orchestrator. Phase 1 forks 3 pytest processes; Phase 2 runs `--provider=multi` after wait.

## Distribution
| Queue | Tests |
|-------|-------|
| claude | 73 |
| codex | 23 |
| gemini | 14 |
| multi | 14 |
| **total** | **124** ✓ |

## Test plan
- [x] `pytest --provider=X --collect-only` returns expected counts per queue (124 total preserved)
- [x] ruff check + format clean
- [ ] End-to-end run of `scripts/run_e2e_parallel.sh` locally
- [ ] CI green

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1214306814522249