### PR TITLE
SF-114: Gemini model fallback when configured model 429s [BUG]

### DIFF
--- a/apps/server/src/screamingface/plugins/gemini_backend_api/backend.py
+++ b/apps/server/src/screamingface/plugins/gemini_backend_api/backend.py
@@ -45,6 +45,7 @@ class GeminiBackend(Backend):
         auth: GeminiAuth | None = None,
         adapter: GeminiAdapter | None = None,
         http_client_factory=None,
+        fallback_models: list[str] | None = None,
     ) -> None:
         self._auth = auth or GeminiAuth()
         self._adapter = adapter or GeminiAdapter()
@@ -53,6 +54,11 @@ class GeminiBackend(Backend):
         self._project_id: str | None = None
         self._session_id: str = str(uuid.uuid4())
         self._setup_lock = asyncio.Lock()
+        # 429 cascade fallback chain — when the configured model returns
+        # quota-exhausted 429s, try the next model in this list before
+        # giving up. Each model has its own quota bucket on Code Assist.
+        # Empty list = no fallback (legacy behavior).
+        self._fallback_models = fallback_models or []
 
     @staticmethod
     def _default_http_factory():
@@ -242,13 +248,44 @@ class GeminiBackend(Backend):
         )
 
         api_model = body.pop("_model", model)
+        is_api_key = self._auth.is_api_key_auth()
 
-        if self._auth.is_api_key_auth():
-            response_data = await self._run_api_key(body, api_model)
-        else:
-            response_data = await self._run_oauth(body, api_model)
+        # Build the model-attempt chain: the configured model first, then
+        # any fallback models (deduplicated, preserving order). When the
+        # configured model returns 429 QUOTA_EXHAUSTED, the next entry's
+        # quota bucket may still be intact.
+        chain: list[str] = [api_model]
+        for fb in self._fallback_models:
+            if fb not in chain:
+                chain.append(fb)
 
-        return self._adapter.from_provider_response(response_data)
+        last_429: BackendError | None = None
+        for attempt_model in chain:
+            try:
+                if is_api_key:
+                    response_data = await self._run_api_key(body, attempt_model)
+                else:
+                    response_data = await self._run_oauth(body, attempt_model)
+                if attempt_model != api_model:
+                    logger.warning(
+                        "gemini-backend-api: %s 429-exhausted, served from fallback %s",
+                        api_model,
+                        attempt_model,
+                    )
+                return self._adapter.from_provider_response(response_data)
+            except BackendError as exc:
+                if exc.status != 429:
+                    raise
+                last_429 = exc
+                logger.info(
+                    "gemini-backend-api: 429 on %s, trying next model in chain",
+                    attempt_model,
+                )
+                continue
+
+        # Whole chain exhausted; surface the last 429.
+        assert last_429 is not None
+        raise last_429
 
     async def _run_api_key(self, body: dict, model: str) -> dict:
         """Standard path: generativelanguage.googleapis.com with API key."""

--- a/apps/server/src/screamingface/plugins/gemini_backend_api/plugin.py
+++ b/apps/server/src/screamingface/plugins/gemini_backend_api/plugin.py
@@ -33,6 +33,16 @@ class GeminiBackendApiSettings(PluginSettings):
         default=None,
         description="Default Gemini model. Falls back to 'gemini-2.5-flash'.",
     )
+    fallback_models: list[str] = Field(
+        default_factory=lambda: ["gemini-2.5-pro", "gemini-2.5-flash-lite"],
+        description=(
+            "Fallback chain when the configured model returns "
+            "QUOTA_EXHAUSTED 429. Each model has its own quota bucket "
+            "on Code Assist, so flash → pro → flash-lite usually "
+            "self-heals during a single-model burnout. Empty list "
+            "disables fallback."
+        ),
+    )
     default_effort: str = Field(default="medium")
     interpreter_system_prompt: str = Field(
         default=(

--- a/apps/server/src/screamingface/plugins/gemini_backend_api/routes.py
+++ b/apps/server/src/screamingface/plugins/gemini_backend_api/routes.py
@@ -20,7 +20,7 @@ _DEFAULT_MODEL = "gemini-2.5-flash"
 
 
 def create_router(settings: GeminiBackendApiSettings, app: Any = None) -> APIRouter:
-    backend = GeminiBackend()
+    backend = GeminiBackend(fallback_models=list(settings.fallback_models))
 
     def build_interpreter() -> Any:
         from screamingface.plugins.gemini_backend_api.interpreter import (

--- a/apps/server/src/screamingface/plugins/gemini_backend_api/tests/test_backend.py
+++ b/apps/server/src/screamingface/plugins/gemini_backend_api/tests/test_backend.py
@@ -555,3 +555,113 @@ class TestCodeAssistSetup:
 
         with pytest.raises(BackendError, match="unreachable"):
             await backend.run([CoreMessage(role="user", content="ping")], model="gemini-2.5-flash")
+
+
+@pytest.mark.anyio
+class TestModelFallback:
+    """SF-114: when configured model 429s, fall back to next in chain."""
+
+    async def test_first_model_429_second_model_succeeds(self):
+        """flash 429 → pro succeeds → returns pro's response."""
+        auth = _mock_auth({"x-goog-api-key": "test-key"}, is_api_key=True)
+        factory, fake_client = _sequenced_factory(
+            httpx.Response(429, json={"error": {"message": "Quota exhausted"}}),
+            _api_key_success_response(),
+        )
+        backend = GeminiBackend(
+            auth=auth,
+            http_client_factory=factory,
+            fallback_models=["gemini-2.5-pro"],
+        )
+
+        result = await backend.run(
+            [CoreMessage(role="user", content=[TextPart(text="ping")])],
+            model="gemini-2.5-flash",
+        )
+
+        assert isinstance(result, CoreMessage)
+        assert result.content[0].text == "pong"
+        # Two POSTs: one to flash (429), one to pro (200).
+        assert fake_client.post.call_count == 2
+        first_url = fake_client.post.call_args_list[0].args[0]
+        second_url = fake_client.post.call_args_list[1].args[0]
+        assert "gemini-2.5-flash" in first_url
+        assert "gemini-2.5-pro" in second_url
+
+    async def test_chain_exhausted_raises_last_429(self):
+        """Every model in the chain 429s — surface the last error."""
+        auth = _mock_auth({"x-goog-api-key": "test-key"}, is_api_key=True)
+        factory, _ = _mock_factory(
+            httpx.Response(429, json={"error": {"message": "Quota exhausted"}})
+        )
+        backend = GeminiBackend(
+            auth=auth,
+            http_client_factory=factory,
+            fallback_models=["gemini-2.5-pro", "gemini-2.5-flash-lite"],
+        )
+
+        with pytest.raises(BackendError) as exc_info:
+            await backend.run(
+                [CoreMessage(role="user", content=[TextPart(text="ping")])],
+                model="gemini-2.5-flash",
+            )
+        assert exc_info.value.status == 429
+
+    async def test_dedup_chain_does_not_retry_same_model(self):
+        """Configured model already in fallback list — only tried once."""
+        auth = _mock_auth({"x-goog-api-key": "test-key"}, is_api_key=True)
+        factory, fake_client = _mock_factory(
+            httpx.Response(429, json={"error": {"message": "Quota exhausted"}})
+        )
+        backend = GeminiBackend(
+            auth=auth,
+            http_client_factory=factory,
+            fallback_models=["gemini-2.5-flash", "gemini-2.5-pro"],
+        )
+
+        with pytest.raises(BackendError):
+            await backend.run(
+                [CoreMessage(role="user", content=[TextPart(text="ping")])],
+                model="gemini-2.5-flash",
+            )
+        # 2 distinct models attempted (flash, pro), each retried up to
+        # MAX_429_RETRIES+1 by _post_with_retry. flash should appear
+        # exactly once in the unique-attempt set.
+        urls_attempted = {call.args[0] for call in fake_client.post.call_args_list}
+        assert sum("gemini-2.5-flash:" in u for u in urls_attempted) == 1
+        assert any("gemini-2.5-pro" in u for u in urls_attempted)
+
+    async def test_non_429_error_no_fallback(self):
+        """500 from configured model — do NOT try fallback (real outage)."""
+        auth = _mock_auth({"x-goog-api-key": "test-key"}, is_api_key=True)
+        factory, fake_client = _mock_factory(httpx.Response(500, text="internal"))
+        backend = GeminiBackend(
+            auth=auth,
+            http_client_factory=factory,
+            fallback_models=["gemini-2.5-pro"],
+        )
+
+        with pytest.raises(BackendError) as exc_info:
+            await backend.run(
+                [CoreMessage(role="user", content=[TextPart(text="ping")])],
+                model="gemini-2.5-flash",
+            )
+        assert exc_info.value.status == 500
+        # Exactly one URL should appear (the original — no fallback).
+        urls = {c.args[0] for c in fake_client.post.call_args_list}
+        assert all("gemini-2.5-flash" in u for u in urls)
+
+    async def test_no_fallback_chain_legacy_behavior(self):
+        """Empty fallback_models — single attempt, raise on 429."""
+        auth = _mock_auth({"x-goog-api-key": "test-key"}, is_api_key=True)
+        factory, _ = _mock_factory(
+            httpx.Response(429, json={"error": {"message": "Quota exhausted"}})
+        )
+        backend = GeminiBackend(auth=auth, http_client_factory=factory)  # no fallback
+
+        with pytest.raises(BackendError) as exc_info:
+            await backend.run(
+                [CoreMessage(role="user", content=[TextPart(text="ping")])],
+                model="gemini-2.5-flash",
+            )
+        assert exc_info.value.status == 429


### PR DESCRIPTION
## Summary
- When the configured Gemini model returns 429 (quota exhausted), the backend now tries the next model in a configurable fallback chain before giving up.
- Each Gemini model has its own quota bucket on Code Assist, so `flash → pro → flash-lite` usually self-heals during a single-model burnout.

## Changes
- **backend.py**: build deduplicated chain `[api_model, *fallback_models]` in `run()`; retry next model on `BackendError(status=429)`; raise last 429 if exhausted; log warning when fallback served the response.
- **plugin.py**: new `fallback_models` setting (default `["gemini-2.5-pro", "gemini-2.5-flash-lite"]`). Empty list disables.
- **routes.py**: wires `settings.fallback_models` into `GeminiBackend`.
- **tests/test_backend.py**: `TestModelFallback` — 5 new tests covering fallback success, chain exhaustion, dedup, non-429 propagation, and legacy empty-chain behavior.

## Test plan
- [x] Unit: 29 backend tests pass (24 existing + 5 new)
- [x] ruff check + format clean
- [ ] Full e2e via `scripts/run_e2e_parallel.sh` (in progress locally)
- [ ] CI green

Asana: SF-114