### PR TITLE
SF-115: reject CLI-only fields explicitly at /run [BUG]

### DIFF
--- a/apps/server/src/screamingface/plugins/llm_base/constants.py
+++ b/apps/server/src/screamingface/plugins/llm_base/constants.py
@@ -22,6 +22,22 @@ CLI_ONLY_FIELDS: tuple[str, ...] = (
     "disallowed_tools",
 )
 
+# Default values for each CLI-only field on RunRequest. A request is
+# rejected at the route boundary when any of these is set to a value
+# other than the default. Kept here (not derived from RunRequest at
+# import time) to avoid a circular import between llm_base and
+# backend_api_base.
+CLI_ONLY_FIELD_DEFAULTS: dict[str, object] = {
+    "add_dirs": None,
+    "mcp_config": None,
+    "permission_mode": None,
+    "dangerously_skip_permissions": False,
+    "no_session_persistence": True,
+    "tools": None,
+    "allowed_tools": None,
+    "disallowed_tools": None,
+}
+
 # Default max_tokens for a single backend run when the caller doesn't
 # specify one. Chosen empirically to cover the cookbook examples
 # without consuming the whole 200k-token context.

--- a/apps/server/src/screamingface/plugins/llm_base/routes_shared.py
+++ b/apps/server/src/screamingface/plugins/llm_base/routes_shared.py
@@ -32,6 +32,7 @@ from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 from screamingface.plugins.backend_api_base.models import RunRequest, RunResponse
 from screamingface.plugins.llm_base.backend_base import Backend
 from screamingface.plugins.llm_base.constants import (
+    CLI_ONLY_FIELD_DEFAULTS,
     CLI_ONLY_FIELDS,
     DEFAULT_MAX_TOKENS,
     PROMPT_PREVIEW_LIMIT,
@@ -215,6 +216,7 @@ def build_backend_api_router(cfg: BackendApiConfig) -> APIRouter:
 
     @router.post(f"{prefix}/run", response_model=None, operation_id=f"{op}_run")
     async def run_endpoint(request: RunRequest) -> JSONResponse | StreamingResponse:
+        _reject_cli_only_fields(request, cfg.name)
         return await _execute(request)
 
     @router.get(prefix, response_model=None, operation_id=f"{op}_url4")
@@ -344,6 +346,35 @@ def build_backend_api_router(cfg: BackendApiConfig) -> APIRouter:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _reject_cli_only_fields(request: RunRequest, plugin_name: str) -> None:
+    """Raise HTTP 422 when a direct API request sets CLI-only fields.
+
+    Direct ``*_backend_api`` plugins talk to provider HTTP APIs — they
+    have no CLI subprocess that could honor sandbox flags, MCP configs,
+    or tool allow/deny lists. Silently dropping these fields used to
+    leave callers thinking their toggles took effect. Reject explicitly
+    instead so the surprise is visible at the boundary.
+
+    Profile-driven paths (``GET/POST /<plugin>/<profile_name>``) bypass
+    this check so existing ``sf.json`` profiles keep working.
+    """
+    offending = [
+        f for f in CLI_ONLY_FIELDS if getattr(request, f, None) != CLI_ONLY_FIELD_DEFAULTS[f]
+    ]
+    if not offending:
+        return
+    raise HTTPException(
+        status_code=422,
+        detail=(
+            f"{plugin_name} does not accept CLI-only fields: "
+            f"{', '.join(offending)}. These flags only apply to the "
+            f"matching CLI tool (e.g. claude-cli) — direct API backends "
+            f"have no subprocess to honor them. Remove the field(s) or "
+            f"call the CLI-frontend plugin instead."
+        ),
+    )
 
 
 def _record_ignored_fields(request: RunRequest, plugin_name: str) -> None:

--- a/apps/server/src/screamingface/plugins/llm_base/tests/test_routes_shared.py
+++ b/apps/server/src/screamingface/plugins/llm_base/tests/test_routes_shared.py
@@ -1,0 +1,67 @@
+"""Unit tests for the shared backend-api route helpers.
+
+Specifically covers the SF-115 boundary check that rejects CLI-only
+fields explicitly at the ``/run`` route.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from screamingface.plugins.backend_api_base.models import RunRequest
+from screamingface.plugins.llm_base.constants import (
+    CLI_ONLY_FIELD_DEFAULTS,
+    CLI_ONLY_FIELDS,
+)
+from screamingface.plugins.llm_base.routes_shared import _reject_cli_only_fields
+
+
+def _default_request(**overrides) -> RunRequest:
+    return RunRequest(prompt="hi", **overrides)
+
+
+def test_default_request_passes() -> None:
+    _reject_cli_only_fields(_default_request(), "claude-backend-api")
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("add_dirs", ["/tmp"]),
+        ("mcp_config", "/etc/mcp.json"),
+        ("permission_mode", "ask"),
+        ("dangerously_skip_permissions", True),
+        ("no_session_persistence", False),  # default is True; False is non-default
+        ("tools", ["bash"]),
+        ("allowed_tools", ["read"]),
+        ("disallowed_tools", ["write"]),
+    ],
+)
+def test_each_cli_field_rejected(field: str, value: object) -> None:
+    req = _default_request(**{field: value})
+    with pytest.raises(HTTPException) as ei:
+        _reject_cli_only_fields(req, "claude-backend-api")
+    assert ei.value.status_code == 422
+    assert field in ei.value.detail
+    assert "claude-backend-api" in ei.value.detail
+
+
+def test_multiple_offending_fields_all_named() -> None:
+    req = _default_request(mcp_config="/x", tools=["bash"], permission_mode="ask")
+    with pytest.raises(HTTPException) as ei:
+        _reject_cli_only_fields(req, "codex-backend-api")
+    detail = ei.value.detail
+    for f in ("mcp_config", "tools", "permission_mode"):
+        assert f in detail
+
+
+def test_constant_covers_runrequest_defaults() -> None:
+    """Defaults map must match the actual RunRequest defaults — guards
+    drift if a new CLI-only field is added without updating both."""
+    req = _default_request()
+    for f in CLI_ONLY_FIELDS:
+        assert getattr(req, f) == CLI_ONLY_FIELD_DEFAULTS[f], (
+            f"Default mismatch for {f}: model={getattr(req, f)!r} "
+            f"vs constant={CLI_ONLY_FIELD_DEFAULTS[f]!r}"
+        )


### PR DESCRIPTION
Direct *_backend_api plugins now return HTTP 422 when /run receives any of the CLI-only fields (add_dirs, mcp_config, permission_mode, dangerously_skip_permissions, no_session_persistence, tools, allowed_tools, disallowed_tools) set to a non-default value. Previously silently dropped. Profile-driven paths still accept them for sf.json compat.

Tests: 11 new unit tests pass; 690 unit tests total pass. Local parallel e2e: claude 66 passed; codex 2 flakes (pre-existing 503 + LLM non-determinism); gemini rate-limited (skipped); multi pending.

Asana: SF-115