### PR TITLE
SF-116: cap cumulative 429 retry-wait in GeminiBackend [BUG]

### DIFF
--- a/apps/server/src/screamingface/plugins/gemini_backend_api/backend.py
+++ b/apps/server/src/screamingface/plugins/gemini_backend_api/backend.py
@@ -37,6 +37,13 @@ CODE_ASSIST_API_VERSION = "v1internal"
 
 MAX_429_RETRIES = 3
 
+# Cap on cumulative 429-retry sleep within a single request. The
+# request-level test timeout is 45s; if we obey provider retry-after
+# headers without a cap, multiple long delays stack and surface as
+# httpx.ReadTimeout instead of a clean BackendError(429). Stop early
+# once the next sleep would exceed this budget.
+MAX_TOTAL_429_WAIT_SECONDS = 30.0
+
 
 class GeminiBackend(Backend):
     def __init__(
@@ -46,6 +53,7 @@ class GeminiBackend(Backend):
         adapter: GeminiAdapter | None = None,
         http_client_factory=None,
         fallback_models: list[str] | None = None,
+        max_total_wait_seconds: float = MAX_TOTAL_429_WAIT_SECONDS,
     ) -> None:
         self._auth = auth or GeminiAuth()
         self._adapter = adapter or GeminiAdapter()
@@ -59,6 +67,7 @@ class GeminiBackend(Backend):
         # giving up. Each model has its own quota bucket on Code Assist.
         # Empty list = no fallback (legacy behavior).
         self._fallback_models = fallback_models or []
+        self._max_total_wait_seconds = max_total_wait_seconds
 
     @staticmethod
     def _default_http_factory():
@@ -303,6 +312,7 @@ class GeminiBackend(Backend):
     async def _post_with_retry(self, body: dict, url: str) -> dict:
         headers = await self._auth.get_authorization_header()
         headers["content-type"] = "application/json"
+        total_waited = 0.0
 
         for attempt in range(MAX_429_RETRIES + 1):
             resp = await self._do_post(body, headers, url)
@@ -332,6 +342,22 @@ class GeminiBackend(Backend):
                 retry_delay = self._parse_retry_delay(resp)
                 if attempt < MAX_429_RETRIES and retry_delay is not None:
                     wait = retry_delay + 0.5
+                    if total_waited + wait > self._max_total_wait_seconds:
+                        logger.warning(
+                            "gemini-backend-api: 429 retry-after %.1fs would exceed "
+                            "max_total_wait %.1fs (already waited %.1fs); raising",
+                            wait,
+                            self._max_total_wait_seconds,
+                            total_waited,
+                        )
+                        raise BackendError(
+                            f"Gemini rate limit exceeded (429); cumulative retry "
+                            f"wait would exceed {self._max_total_wait_seconds:.0f}s "
+                            f"budget (next retry-after={wait:.1f}s, "
+                            f"already waited={total_waited:.1f}s).",
+                            status=429,
+                            retry_after=retry_delay,
+                        )
                     logger.info(
                         "gemini-backend-api: 429, retrying in %.1fs (attempt %d/%d)",
                         wait,
@@ -339,6 +365,7 @@ class GeminiBackend(Backend):
                         MAX_429_RETRIES,
                     )
                     await asyncio.sleep(wait)
+                    total_waited += wait
                     continue
                 raise BackendError(
                     "Gemini rate limit exceeded (429).",

--- a/apps/server/src/screamingface/plugins/gemini_backend_api/plugin.py
+++ b/apps/server/src/screamingface/plugins/gemini_backend_api/plugin.py
@@ -43,6 +43,16 @@ class GeminiBackendApiSettings(PluginSettings):
             "disables fallback."
         ),
     )
+    max_total_429_wait_seconds: float = Field(
+        default=30.0,
+        description=(
+            "Cap on cumulative sleep across 429 retries within a single "
+            "request. Past this budget the backend raises BackendError(429) "
+            "instead of continuing to obey provider retry-after, so request-"
+            "level timeouts (e.g. 45s in tests) surface a clean error rather "
+            "than an httpx ReadTimeout."
+        ),
+    )
     default_effort: str = Field(default="medium")
     interpreter_system_prompt: str = Field(
         default=(

--- a/apps/server/src/screamingface/plugins/gemini_backend_api/routes.py
+++ b/apps/server/src/screamingface/plugins/gemini_backend_api/routes.py
@@ -20,7 +20,10 @@ _DEFAULT_MODEL = "gemini-2.5-flash"
 
 
 def create_router(settings: GeminiBackendApiSettings, app: Any = None) -> APIRouter:
-    backend = GeminiBackend(fallback_models=list(settings.fallback_models))
+    backend = GeminiBackend(
+        fallback_models=list(settings.fallback_models),
+        max_total_wait_seconds=settings.max_total_429_wait_seconds,
+    )
 
     def build_interpreter() -> Any:
         from screamingface.plugins.gemini_backend_api.interpreter import (

--- a/apps/server/src/screamingface/plugins/gemini_backend_api/tests/test_backend.py
+++ b/apps/server/src/screamingface/plugins/gemini_backend_api/tests/test_backend.py
@@ -665,3 +665,101 @@ class TestModelFallback:
                 model="gemini-2.5-flash",
             )
         assert exc_info.value.status == 429
+
+
+@pytest.mark.anyio
+class TestMaxTotalRetryWait:
+    """SF-116: cumulative 429-retry sleep is capped per request.
+
+    Without the cap, a sequence of long retry-after headers can stack
+    until the request-level timeout (45s in tests) fires as a confusing
+    httpx ReadTimeout instead of a clean BackendError(429).
+    """
+
+    @staticmethod
+    def _retry_response(delay_s: float) -> httpx.Response:
+        return httpx.Response(
+            429,
+            json={
+                "error": {
+                    "code": 429,
+                    "message": "Rate limited",
+                    "details": [
+                        {
+                            "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                            "retryDelay": f"{delay_s}s",
+                        }
+                    ],
+                }
+            },
+        )
+
+    async def test_total_wait_exceeded_raises_immediately(self, monkeypatch):
+        """Second retry-after would push cumulative wait past cap → raise.
+
+        cap=10s. First retry-after=6s (sleep 6.5s, total=6.5).
+        Second retry-after=6s (next sleep 6.5s; 6.5+6.5=13 > 10 → raise).
+        Asserts only one sleep happened.
+        """
+        sleeps: list[float] = []
+
+        async def fake_sleep(s):
+            sleeps.append(s)
+
+        monkeypatch.setattr(
+            "screamingface.plugins.gemini_backend_api.backend.asyncio.sleep",
+            fake_sleep,
+        )
+
+        auth = _mock_auth({"x-goog-api-key": "test-key"}, is_api_key=True)
+        factory, _ = _mock_factory(self._retry_response(6.0))
+        backend = GeminiBackend(
+            auth=auth,
+            http_client_factory=factory,
+            max_total_wait_seconds=10.0,
+        )
+
+        with pytest.raises(BackendError) as ei:
+            await backend.run(
+                [CoreMessage(role="user", content=[TextPart(text="ping")])],
+                model="gemini-2.5-flash",
+            )
+        assert ei.value.status == 429
+        assert "cumulative retry" in str(ei.value)
+        assert len(sleeps) == 1, f"expected exactly one sleep before cap; got {sleeps}"
+
+    async def test_under_cap_retries_normally(self, monkeypatch):
+        """Cumulative wait stays under cap — retries proceed until exhausted."""
+        sleeps: list[float] = []
+
+        async def fake_sleep(s):
+            sleeps.append(s)
+
+        monkeypatch.setattr(
+            "screamingface.plugins.gemini_backend_api.backend.asyncio.sleep",
+            fake_sleep,
+        )
+
+        auth = _mock_auth({"x-goog-api-key": "test-key"}, is_api_key=True)
+        factory, _ = _mock_factory(self._retry_response(0.1))
+        backend = GeminiBackend(
+            auth=auth,
+            http_client_factory=factory,
+            max_total_wait_seconds=30.0,
+        )
+
+        with pytest.raises(BackendError):
+            await backend.run(
+                [CoreMessage(role="user", content=[TextPart(text="ping")])],
+                model="gemini-2.5-flash",
+            )
+        # MAX_429_RETRIES = 3 → up to 3 sleeps before final raise
+        assert len(sleeps) == 3
+        assert all(abs(s - 0.6) < 1e-6 for s in sleeps)  # 0.1 + 0.5 jitter
+
+    async def test_default_cap_is_30_seconds(self):
+        """Default constructor value matches MAX_TOTAL_429_WAIT_SECONDS."""
+        auth = _mock_auth({"x-goog-api-key": "test-key"}, is_api_key=True)
+        factory, _ = _mock_factory(httpx.Response(200, json={}))
+        backend = GeminiBackend(auth=auth, http_client_factory=factory)
+        assert backend._max_total_wait_seconds == 30.0


### PR DESCRIPTION
Without a cap, a sequence of long retry-after headers stack until the request-level timeout (45s in tests) fires as a confusing httpx.ReadTimeout instead of a clean BackendError(429). Past the 30s budget the backend now raises BackendError(429) immediately, naming the cap, the next retry-after, and the time already spent waiting.

Configurable via new `max_total_429_wait_seconds` setting (default 30.0).

Tests: 3 new unit tests (TestMaxTotalRetryWait); 32 backend tests pass; 693 plugin unit tests pass.

Asana: SF-116