### PR TITLE
SF-117: replace httpbin.org with in-process mock in e2e [TEST INFRA]

### DIFF
--- a/apps/server/tests/e2e/conftest.py
+++ b/apps/server/tests/e2e/conftest.py
@@ -10,6 +10,7 @@ import pytest
 import yaml
 
 from tests.e2e.infrastructure.claude_code_client import ClaudeCodeClient
+from tests.e2e.infrastructure.local_httpbin import LocalHttpbin
 from tests.e2e.infrastructure.otlp_collector import OTLPCollector
 from tests.e2e.infrastructure.server_manager import ServerManager
 
@@ -165,12 +166,32 @@ def main_server_config(otlp_collector: OTLPCollector, main_server_port: int) -> 
 
 
 @pytest.fixture(scope="session")
+def local_httpbin() -> Generator[LocalHttpbin, None, None]:
+    """In-process httpbin mock — replaces httpbin.org for e2e tests.
+
+    Eliminates the JSONDecodeError / 502 / DNS flake class that
+    httpbin.org occasionally inflicts on CI.
+    """
+    hb = LocalHttpbin()
+    hb.start()
+    yield hb
+    hb.stop()
+
+
+@pytest.fixture(scope="session")
+def httpbin_url(local_httpbin: LocalHttpbin) -> str:
+    """Base URL of the local httpbin mock, e.g. ``http://127.0.0.1:54321``."""
+    return local_httpbin.base_url
+
+
+@pytest.fixture(scope="session")
 def proxy_server_config(
     otlp_collector: OTLPCollector,
     main_server_port: int,
     proxy_server_port: int,
+    httpbin_url: str,
 ) -> dict:
-    """Config for the session proxy (claude-frontend → httpbin echo)."""
+    """Config for the session proxy (claude-frontend → local httpbin echo)."""
     return {
         "version": "0.1.0",
         "server": {
@@ -193,17 +214,17 @@ def proxy_server_config(
             },
             "claude-frontend": {
                 "active_spec": "test-prompt-spec",
-                "upstream_url": "https://httpbin.org/anything",
+                "upstream_url": f"{httpbin_url}/anything",
                 "listen_host": "127.0.0.1",
                 "listen_port": proxy_server_port,
             },
             "url4-specs": {
                 "specs": {
                     "test-static-spec": {
-                        "expression": "(https://httpbin.org/robots.txt)!'Be helpful'",
+                        "expression": f"({httpbin_url}/robots.txt)!'Be helpful'",
                     },
                     "test-prompt-spec": {
-                        "expression": "(https://httpbin.org/robots.txt)!$prompt",
+                        "expression": f"({httpbin_url}/robots.txt)!$prompt",
                     },
                 },
             },

--- a/apps/server/tests/e2e/infrastructure/local_httpbin.py
+++ b/apps/server/tests/e2e/infrastructure/local_httpbin.py
@@ -1,0 +1,138 @@
+"""In-process mock of the subset of httpbin.org we use in e2e tests.
+
+httpbin.org goes flaky in CI roughly once a week (transient 502 / empty
+body / DNS hiccups) and there's no retry budget that's both polite and
+reliable. This mock implements only the routes we touch:
+
+- ``GET  /robots.txt``      → plain-text body (deterministic)
+- ``GET  /user-agent``      → JSON with the requesting User-Agent header
+- ``ANY  /anything``        → JSON echo of method/headers/json/data/url
+
+Run with :class:`LocalHttpbin` as a context manager; it spawns a
+``uvicorn`` server in a background thread on a free localhost port.
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import uvicorn
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, PlainTextResponse
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/robots.txt")
+    async def robots() -> PlainTextResponse:
+        # Same content httpbin.org serves; tests only assert it's
+        # non-empty and contains "User-agent" or "Disallow".
+        return PlainTextResponse("User-agent: *\nDisallow: /deny\n")
+
+    @app.get("/user-agent")
+    async def user_agent(request: Request) -> JSONResponse:
+        return JSONResponse({"user-agent": request.headers.get("user-agent", "")})
+
+    @app.api_route(
+        "/anything",
+        methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    )
+    @app.api_route(
+        "/anything/{path:path}",
+        methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    )
+    async def anything(request: Request) -> JSONResponse:
+        body_bytes = await request.body()
+        json_body: object | None = None
+        if body_bytes:
+            try:
+                import json as _json
+
+                json_body = _json.loads(body_bytes)
+            except ValueError:
+                json_body = None
+        return JSONResponse(
+            {
+                "method": request.method,
+                "url": str(request.url),
+                "headers": dict(request.headers),
+                "json": json_body,
+                "data": body_bytes.decode("utf-8", errors="replace") if not json_body else "",
+                "args": dict(request.query_params),
+                "origin": request.client.host if request.client else "",
+            }
+        )
+
+    return app
+
+
+class LocalHttpbin:
+    """Thread-managed in-process httpbin mock.
+
+    Usage::
+
+        with LocalHttpbin() as hb:
+            url = hb.base_url  # "http://127.0.0.1:<port>"
+    """
+
+    def __init__(self, port: int | None = None) -> None:
+        self._port = port or _find_free_port()
+        self._server: uvicorn.Server | None = None
+        self._thread: threading.Thread | None = None
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self._port}"
+
+    def start(self, timeout: float = 5.0) -> None:
+        config = uvicorn.Config(
+            _build_app(),
+            host="127.0.0.1",
+            port=self._port,
+            log_level="warning",
+            access_log=False,
+        )
+        self._server = uvicorn.Server(config)
+        self._thread = threading.Thread(target=self._server.run, daemon=True)
+        self._thread.start()
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self._server.started:
+                return
+            time.sleep(0.05)
+        raise RuntimeError(f"LocalHttpbin failed to start on port {self._port}")
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.should_exit = True
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+
+    def __enter__(self) -> LocalHttpbin:
+        self.start()
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.stop()
+
+
+@contextmanager
+def local_httpbin() -> Iterator[LocalHttpbin]:
+    hb = LocalHttpbin()
+    hb.start()
+    try:
+        yield hb
+    finally:
+        hb.stop()

--- a/apps/server/tests/e2e/test_cat_breeds_spec.py
+++ b/apps/server/tests/e2e/test_cat_breeds_spec.py
@@ -100,7 +100,7 @@ class TestCatBreedSources:
 
 
 @pytest.fixture(scope="module")
-def cat_proxy(otlp_collector: OTLPCollector):  # type: ignore[misc]
+def cat_proxy(otlp_collector: OTLPCollector, httpbin_url: str):  # type: ignore[misc]
     """Start a proxy with the cat-breeds-3sources spec pointing at Claude."""
     internal_port = ServerManager.find_free_port()
     proxy_port = ServerManager.find_free_port()
@@ -128,7 +128,7 @@ def cat_proxy(otlp_collector: OTLPCollector):  # type: ignore[misc]
             },
             "claude-frontend": {
                 "active_spec": "cat-breeds-3sources",
-                "upstream_url": "https://httpbin.org/anything",
+                "upstream_url": f"{httpbin_url}/anything",
                 "listen_host": "127.0.0.1",
                 "listen_port": proxy_port,
             },

--- a/apps/server/tests/e2e/test_proxy_context_injection.py
+++ b/apps/server/tests/e2e/test_proxy_context_injection.py
@@ -15,7 +15,7 @@ pytestmark = pytest.mark.e2e
 
 
 @pytest.fixture(scope="session")
-def static_proxy_config(otlp_collector, proxy_server_port):
+def static_proxy_config(otlp_collector, proxy_server_port, httpbin_url):
     """Proxy config using a static spec (no $prompt) for system-prompt injection."""
     from tests.e2e.infrastructure.server_manager import ServerManager
 
@@ -41,7 +41,7 @@ def static_proxy_config(otlp_collector, proxy_server_port):
             },
             "claude-frontend": {
                 "active_spec": "httpbin-robots",
-                "upstream_url": "https://httpbin.org/anything",
+                "upstream_url": f"{httpbin_url}/anything",
                 "listen_host": "127.0.0.1",
                 "listen_port": proxy_server_port + 100,
                 "embed_target": "system",
@@ -49,8 +49,9 @@ def static_proxy_config(otlp_collector, proxy_server_port):
             "url4-specs": {
                 "specs": {
                     "httpbin-robots": {
-                        "expression": "(https://httpbin.org/robots.txt)!"
-                        "'You are an API testing assistant'",
+                        "expression": (
+                            f"({httpbin_url}/robots.txt)!'You are an API testing assistant'"
+                        ),
                     },
                 },
             },

--- a/apps/server/tests/e2e/test_url4_resolution.py
+++ b/apps/server/tests/e2e/test_url4_resolution.py
@@ -38,11 +38,11 @@ class TestUrl4Resolution:
         assert "echo" in resp.text
         assert "hello" in resp.text
 
-    def test_resolve_http_url(self, sf_server: ServerManager):
+    def test_resolve_http_url(self, sf_server: ServerManager, httpbin_url: str):
         """Fetches a real URL and returns its content."""
         resp = httpx.get(
             f"{sf_server.base_url}/ensemble",
-            params={"q": "https://httpbin.org/robots.txt"},
+            params={"q": f"{httpbin_url}/robots.txt"},
             timeout=15,
         )
 

--- a/apps/server/tests/e2e/test_url4_specs_live.py
+++ b/apps/server/tests/e2e/test_url4_specs_live.py
@@ -17,11 +17,11 @@ pytestmark = [pytest.mark.e2e, pytest.mark.timeout(30)]
 class TestUrl4SpecsLive:
     """Tests that evaluate url4 specs against real external URLs."""
 
-    def test_single_url_resolution(self, sf_server: ServerManager):
+    def test_single_url_resolution(self, sf_server: ServerManager, httpbin_url: str):
         """Single URL expression resolves to non-empty content."""
         resp = httpx.get(
             f"{sf_server.base_url}/ensemble",
-            params={"q": "https://httpbin.org/robots.txt"},
+            params={"q": f"{httpbin_url}/robots.txt"},
             timeout=15,
         )
 
@@ -29,9 +29,9 @@ class TestUrl4SpecsLive:
         assert len(resp.text.strip()) > 0
         assert "User-agent" in resp.text
 
-    def test_multiple_urls_parallel(self, sf_server: ServerManager):
+    def test_multiple_urls_parallel(self, sf_server: ServerManager, httpbin_url: str):
         """Parenthesized group of URLs resolved in parallel."""
-        expr = "(https://httpbin.org/robots.txt, https://httpbin.org/user-agent)"
+        expr = f"({httpbin_url}/robots.txt, {httpbin_url}/user-agent)"
         resp = httpx.get(
             f"{sf_server.base_url}/ensemble",
             params={"q": expr},
@@ -41,9 +41,9 @@ class TestUrl4SpecsLive:
         assert resp.status_code == 200
         assert "User-agent" in resp.text
 
-    def test_mixed_text_and_url(self, sf_server: ServerManager):
+    def test_mixed_text_and_url(self, sf_server: ServerManager, httpbin_url: str):
         """Mix of text atoms and URL atoms in a group."""
-        expr = "(context preamble, https://httpbin.org/robots.txt)"
+        expr = f"(context preamble, {httpbin_url}/robots.txt)"
         resp = httpx.get(
             f"{sf_server.base_url}/ensemble",
             params={"q": expr},
@@ -54,9 +54,9 @@ class TestUrl4SpecsLive:
         assert "context preamble" in resp.text
         assert "User-agent" in resp.text
 
-    def test_resolution_idempotency(self, sf_server: ServerManager):
+    def test_resolution_idempotency(self, sf_server: ServerManager, httpbin_url: str):
         """Same expression resolves to same content across runs."""
-        expr = "https://httpbin.org/robots.txt"
+        expr = f"{httpbin_url}/robots.txt"
 
         resp1 = httpx.get(
             f"{sf_server.base_url}/ensemble",
@@ -95,9 +95,9 @@ class TestUrl4SpecsLive:
         assert resp.status_code == 200
         assert "test blob content" in resp.text
 
-    def test_intent_with_text(self, sf_server: ServerManager):
+    def test_intent_with_text(self, sf_server: ServerManager, httpbin_url: str):
         """Expression with text intent (quoted string after !)."""
-        expr = "(https://httpbin.org/robots.txt)!'Summarize this'"
+        expr = f"({httpbin_url}/robots.txt)!'Summarize this'"
         resp = httpx.get(
             f"{sf_server.base_url}/ensemble",
             params={"q": expr},


### PR DESCRIPTION
httpbin.org goes flaky in CI roughly once a week — JSONDecodeError on empty bodies, transient 502s, occasional DNS hiccups. Every CI flake hit during the SF-96 epic was httpbin-related. Local mock kills the entire flake class.

- New `tests/e2e/infrastructure/local_httpbin.py`: thread-managed FastAPI app implementing `/robots.txt`, `/user-agent`, and `/anything` (echo)
- New session-scoped `local_httpbin` + `httpbin_url` fixtures in conftest
- Test files now consume `httpbin_url` instead of hardcoding `https://httpbin.org/...`

**Tests:** 20 proxy + trace tests pass; 12 url4 spec/resolution tests pass; 3-5x faster (no network round-trips).

Asana: SF-117