### PR TITLE
SF-118: decompose OpenAIBackend into focused modules [ARCH]

### DIFF
--- a/apps/server/src/screamingface/plugins/codex_backend_api/backend.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/backend.py
@@ -1,27 +1,37 @@
-"""OpenAIBackend — direct HTTP POST to chatgpt.com/backend-api/codex/responses.
+"""OpenAIBackend — direct HTTP POST to chatgpt.com or api.openai.com.
 
-Uses ``curl_cffi`` with browser TLS impersonation to bypass Cloudflare's
-bot detection on chatgpt.com. This is the same endpoint the Codex CLI
-uses via WebSocket, but accessed over standard HTTP SSE streaming.
+Two auth paths, dispatched by ``OPENAI_API_KEY``:
 
-Two auth paths:
-- ChatGPT OAuth (default): reads JWT from ``~/.codex/auth.json``,
-  POSTs to ``chatgpt.com/backend-api/codex/responses``
-- API key (``OPENAI_API_KEY`` env var): standard httpx POST to
-  ``api.openai.com/v1/responses``
+- **API key set** → standard ``api.openai.com/v1/responses`` over httpx.
+- **No API key** → ``chatgpt.com/backend-api/codex/responses`` via
+  ``curl_cffi`` (Cloudflare bypass) with the ChatGPT OAuth JWT.
+
+This file is intentionally short: it only dispatches and maps errors.
+The heavy machinery lives in:
+
+- :mod:`.chatgpt_session` — curl_cffi POST, header / body builders.
+- :mod:`.sse_parser` — turn an SSE stream into a :class:`CoreMessage`.
+- :mod:`.rate_limits` — parse OpenAI's ``x-ratelimit-*`` headers.
 """
 
 from __future__ import annotations
 
-import json
+import asyncio
 import logging
 import os
-import uuid
-
-import httpx
 
 from screamingface.plugins.codex_backend_api.adapter import OpenAIResponsesAdapter
 from screamingface.plugins.codex_backend_api.auth import CodexOAuth
+from screamingface.plugins.codex_backend_api.chatgpt_session import (
+    CHATGPT_RESPONSES_URL,
+    auth_headers_for,
+    build_chatgpt_headers,
+    build_health_probe_body,
+    build_responses_body,
+    post_responses_sync,
+)
+from screamingface.plugins.codex_backend_api.rate_limits import extract_openai_rate_limits
+from screamingface.plugins.codex_backend_api.sse_parser import parse_responses_sse
 from screamingface.plugins.llm_base.backend_base import (
     Backend,
     HealthStatus,
@@ -33,20 +43,7 @@ from screamingface.plugins.llm_base.messages import CoreMessage, ToolDefinition
 
 logger = logging.getLogger(__name__)
 
-# Standard public API (API-key auth only)
 OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses"
-
-# ChatGPT backend (OAuth auth, requires curl_cffi for Cloudflare bypass)
-CHATGPT_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses"
-
-# curl_cffi TLS profile that bypasses Cloudflare on chatgpt.com
-CURL_CFFI_PROFILE = "chrome99_android"
-
-# Default instructions (required by the chatgpt.com endpoint)
-_DEFAULT_INSTRUCTIONS = (
-    "You are a helpful assistant. Answer the user's question based only on "
-    "the provided context. Be concise and factual."
-)
 
 
 class OpenAIBackend(Backend):
@@ -66,94 +63,63 @@ class OpenAIBackend(Backend):
     def _has_api_key(self) -> bool:
         return bool(os.environ.get("OPENAI_API_KEY"))
 
-    # ------------------------------------------------------------------
-    # ChatGPT backend path (curl_cffi + chatgpt.com)
-    # ------------------------------------------------------------------
-
-    def _chatgpt_post(
-        self,
-        url: str,
-        body: dict,
-        headers: dict[str, str],
-        timeout: float = 300.0,
-    ) -> tuple[int, str, dict]:
-        """Synchronous POST via curl_cffi with Cloudflare bypass.
-
-        Returns (status_code, response_text, response_headers).
-        curl_cffi is sync-only; we call it from async via run_in_executor.
-        """
-        from curl_cffi.requests import Session
-
-        with Session(impersonate=CURL_CFFI_PROFILE) as s:
-            r = s.post(url, json=body, headers=headers, timeout=timeout)
-            return r.status_code, r.text, dict(r.headers)
-
-    async def _chatgpt_run(
+    async def run(
         self,
         messages: list[CoreMessage],
         *,
         model: str,
         system: str | None = None,
+        tools: list[ToolDefinition] | None = None,
         max_tokens: int = 16000,
+        temperature: float | None = None,
         timeout_seconds: float = 300.0,
     ) -> CoreMessage:
-        """POST to chatgpt.com/backend-api/codex/responses with ChatGPT JWT."""
-        import asyncio
-
-        headers = await self._auth.get_authorization_header()
-        account_id = self._auth.get_account_id()
-        session_id = str(uuid.uuid4())
-
-        headers.update(
-            {
-                "chatgpt-account-id": account_id,
-                "originator": "codex_exec",
-                "session_id": session_id,
-                "version": "0.120.0",
-                "x-client-request-id": session_id,
-                "x-codex-window-id": f"{session_id}:0",
-                "accept": "text/event-stream",
-                "content-type": "application/json",
-            }
+        """Execute one round-trip against OpenAI."""
+        if self._has_api_key():
+            return await self._run_api_key(
+                messages,
+                model=model,
+                system=system,
+                tools=tools,
+                max_tokens=max_tokens,
+                temperature=temperature,
+            )
+        return await self._run_chatgpt(
+            messages, model=model, system=system, timeout_seconds=timeout_seconds
         )
 
-        # Build the body — chatgpt.com requires "instructions"
-        prompt_parts = []
-        for msg in messages:
-            if isinstance(msg.content, str):
-                prompt_parts.append(msg.content)
-            else:
-                from screamingface.plugins.llm_base.messages import TextPart
+    async def health(self, model: str = "gpt-5.4") -> HealthStatus:
+        if self._has_api_key():
+            return await self._health_api_key(model)
+        return await self._health_chatgpt()
 
-                for part in msg.content:
-                    if isinstance(part, TextPart):
-                        prompt_parts.append(part.text)
+    # ------------------------------------------------------------------
+    # ChatGPT path
+    # ------------------------------------------------------------------
 
-        body: dict = {
-            "model": model,
-            "instructions": system or _DEFAULT_INSTRUCTIONS,
-            "input": [
-                {
-                    "role": "user",
-                    "content": [{"type": "input_text", "text": t}],
-                }
-                for t in prompt_parts
-            ],
-            "store": False,
-            "stream": True,
-            "reasoning": {"effort": "high"},
-            "text": {"verbosity": "low"},
-            "client_metadata": {"x-codex-installation-id": str(uuid.uuid4())},
-        }
+    async def _run_chatgpt(
+        self,
+        messages: list[CoreMessage],
+        *,
+        model: str,
+        system: str | None,
+        timeout_seconds: float,
+    ) -> CoreMessage:
+        try:
+            auth_headers, account_id = await auth_headers_for(self._auth)
+        except Exception as exc:
+            raise AuthError(f"ChatGPT OAuth header error: {exc}") from exc
+
+        headers = build_chatgpt_headers(auth_headers, account_id)
+        body = build_responses_body(messages, model=model, system=system)
 
         loop = asyncio.get_event_loop()
-        status, text, resp_headers = await loop.run_in_executor(
-            None, self._chatgpt_post, CHATGPT_RESPONSES_URL, body, headers, timeout_seconds
+        status, text, _ = await loop.run_in_executor(
+            None, post_responses_sync, body, headers, timeout_seconds, CHATGPT_RESPONSES_URL
         )
 
         if status == 200:
-            return self._parse_sse_response(text)
-
+            return parse_responses_sse(text)
         if status == 429:
             raise BackendError("Codex rate limited (429)", status=429)
         if status in (401, 403):
@@ -163,86 +129,19 @@ class OpenAIBackend(Backend):
             )
         raise BackendError(f"ChatGPT backend error {status}: {text[:500]}", status=status)
 
-    @staticmethod
-    def _parse_sse_response(sse_text: str) -> CoreMessage:
-        """Parse SSE event stream from chatgpt.com into a CoreMessage."""
-        from screamingface.plugins.llm_base.messages import TextPart
-
-        text_parts: list[str] = []
-        provider_metadata: dict = {}
-
-        for line in sse_text.split("\n"):
-            if not line.startswith("data: "):
-                continue
-            try:
-                data = json.loads(line[6:])
-            except json.JSONDecodeError:
-                continue
-
-            event_type = data.get("type", "")
-            if event_type == "response.output_text.delta":
-                text_parts.append(data.get("delta", ""))
-            elif event_type == "response.completed":
-                resp = data.get("response", {})
-                usage = resp.get("usage", {})
-                if usage:
-                    provider_metadata["openai.usage"] = usage
-                provider_metadata["openai.model"] = resp.get("model", "")
-
-        return CoreMessage(
-            role="assistant",
-            content=[TextPart(text="".join(text_parts))],
-            provider_metadata=provider_metadata or None,
-        )
-
-    # ------------------------------------------------------------------
-    # Health check
-    # ------------------------------------------------------------------
-
-    async def health(self, model: str = "gpt-5.4") -> HealthStatus:
-        """Check auth validity via a minimal probe call."""
-        if self._has_api_key():
-            return await self._health_api_key(model)
-        return await self._health_chatgpt()
-
     async def _health_chatgpt(self) -> HealthStatus:
-        """Probe chatgpt.com/backend-api/codex/responses with a tiny call."""
-        import asyncio
-
         try:
-            headers = await self._auth.get_authorization_header()
+            auth_headers, account_id = await auth_headers_for(self._auth)
         except Exception as exc:
             return HealthStatus(authenticated=False, error=str(exc))
 
-        account_id = self._auth.get_account_id()
-        session_id = str(uuid.uuid4())
-        headers.update(
-            {
-                "chatgpt-account-id": account_id,
-                "originator": "codex_exec",
-                "session_id": session_id,
-                "version": "0.120.0",
-                "x-client-request-id": session_id,
-                "x-codex-window-id": f"{session_id}:0",
-                "accept": "text/event-stream",
-                "content-type": "application/json",
-            }
-        )
-
-        body = {
-            "model": "gpt-5.4",
-            "instructions": "Say OK.",
-            "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
-            "store": False,
-            "stream": True,
-            "reasoning": {"effort": "high"},
-            "text": {"verbosity": "low"},
-        }
+        headers = build_chatgpt_headers(auth_headers, account_id)
+        body = build_health_probe_body()
 
         loop = asyncio.get_event_loop()
         try:
             status, text, _ = await loop.run_in_executor(
-                None, self._chatgpt_post, CHATGPT_RESPONSES_URL, body, headers, 15.0
+                None, post_responses_sync, body, headers, 15.0, CHATGPT_RESPONSES_URL
             )
         except Exception as exc:
             return HealthStatus(authenticated=True, error=f"API unreachable: {exc}")
@@ -255,8 +154,39 @@ class OpenAIBackend(Backend):
             return HealthStatus(authenticated=False, error=f"HTTP {status}: {text[:200]}")
         return HealthStatus(authenticated=True, error=f"HTTP {status}: {text[:200]}")
 
+    # ------------------------------------------------------------------
+    # API-key path
+    # ------------------------------------------------------------------
+
+    async def _run_api_key(
+        self,
+        messages: list[CoreMessage],
+        *,
+        model: str,
+        system: str | None,
+        tools: list[ToolDefinition] | None,
+        max_tokens: int,
+        temperature: float | None,
+    ) -> CoreMessage:
+        body = self._adapter.to_provider_format(
+            messages,
+            model=model,
+            system=system,
+            tools=tools,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        response_data = await post_with_default_retry(
+            auth=self._auth,
+            http_factory=self._http_factory,
+            url=OPENAI_RESPONSES_URL,
+            body=body,
+            provider_name="OpenAI",
+            auth_login_cmd="codex login",
+        )
+        return self._adapter.from_provider_response(response_data)
+
     async def _health_api_key(self, model: str) -> HealthStatus:
-        """Probe api.openai.com with API key."""
         try:
             headers = await self._auth.get_authorization_header()
         except Exception as exc:
@@ -274,27 +204,25 @@ class OpenAIBackend(Backend):
         except Exception as exc:
             return HealthStatus(authenticated=True, error=f"API unreachable: {exc}")
 
-        rate_limit = _extract_openai_rate_limits(resp.headers)
+        rate_limit = extract_openai_rate_limits(resp.headers)
         tokens_remaining = rate_limit.get("tokens_remaining")
         requests_remaining = rate_limit.get("requests_remaining")
+        tr = int(tokens_remaining) if tokens_remaining is not None else None
+        rr = int(requests_remaining) if requests_remaining is not None else None
 
         if resp.status_code == 200:
             return HealthStatus(
                 authenticated=True,
-                tokens_remaining=int(tokens_remaining) if tokens_remaining is not None else None,
-                requests_remaining=(
-                    int(requests_remaining) if requests_remaining is not None else None
-                ),
+                tokens_remaining=tr,
+                requests_remaining=rr,
                 rate_limit=rate_limit,
             )
         if resp.status_code == 429:
             return HealthStatus(
                 authenticated=True,
                 error="rate limited",
-                tokens_remaining=int(tokens_remaining) if tokens_remaining is not None else None,
-                requests_remaining=(
-                    int(requests_remaining) if requests_remaining is not None else None
-                ),
+                tokens_remaining=tr,
+                requests_remaining=rr,
                 rate_limit=rate_limit,
             )
         if resp.status_code in (401, 403):
@@ -307,72 +235,3 @@ class OpenAIBackend(Backend):
             error=f"Unexpected status {resp.status_code}: {resp.text[:300]}",
             rate_limit=rate_limit,
         )
-
-    # ------------------------------------------------------------------
-    # run() — the main entry point
-    # ------------------------------------------------------------------
-
-    async def run(
-        self,
-        messages: list[CoreMessage],
-        *,
-        model: str,
-        system: str | None = None,
-        tools: list[ToolDefinition] | None = None,
-        max_tokens: int = 16000,
-        temperature: float | None = None,
-        timeout_seconds: float = 300.0,
-    ) -> CoreMessage:
-        """Execute one round-trip against OpenAI."""
-        if not self._has_api_key():
-            # ChatGPT OAuth → chatgpt.com/backend-api/codex/responses
-            return await self._chatgpt_run(
-                messages, model=model, system=system, timeout_seconds=timeout_seconds
-            )
-
-        # API key → standard api.openai.com/v1/responses
-        body = self._adapter.to_provider_format(
-            messages,
-            model=model,
-            system=system,
-            tools=tools,
-            max_tokens=max_tokens,
-            temperature=temperature,
-        )
-        response_data = await self._post_with_retry(body)
-        return self._adapter.from_provider_response(response_data)
-
-    # ------------------------------------------------------------------
-    # API-key path helpers (httpx)
-    # ------------------------------------------------------------------
-
-    async def _post_with_retry(self, body: dict) -> dict:
-        """Delegate to the shared POST-with-401-retry helper."""
-        return await post_with_default_retry(
-            auth=self._auth,
-            http_factory=self._http_factory,
-            url=OPENAI_RESPONSES_URL,
-            body=body,
-            provider_name="OpenAI",
-            auth_login_cmd="codex login",
-        )
-
-
-def _extract_openai_rate_limits(headers: httpx.Headers) -> dict[str, str | int | float]:
-    prefix = "x-ratelimit-"
-    result: dict[str, str | int | float] = {}
-    for key, value in headers.items():
-        if key.lower().startswith(prefix):
-            short_key = key[len(prefix) :].replace("-", "_")
-            try:
-                result[short_key] = int(value)
-            except ValueError:
-                try:
-                    result[short_key] = float(value)
-                except ValueError:
-                    result[short_key] = value
-    if "remaining_tokens" in result:
-        result["tokens_remaining"] = result["remaining_tokens"]
-    if "remaining_requests" in result:
-        result["requests_remaining"] = result["remaining_requests"]
-    return result

--- a/apps/server/src/screamingface/plugins/codex_backend_api/chatgpt_session.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/chatgpt_session.py
@@ -1,0 +1,120 @@
+"""ChatGPT-backend session helpers (curl_cffi + Cloudflare bypass).
+
+The chatgpt.com/backend-api endpoint requires browser-fingerprint TLS
+to bypass Cloudflare. We use ``curl_cffi`` with the
+``chrome99_android`` profile. ``curl_cffi`` is sync-only, so callers
+should invoke :func:`post_responses` from an async context via
+``run_in_executor``.
+
+Header building, body framing, and the curl_cffi POST live here so the
+main backend class stays focused on dispatch + error mapping.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterable
+
+from screamingface.plugins.codex_backend_api.auth import CodexOAuth
+from screamingface.plugins.llm_base.messages import CoreMessage, TextPart
+
+CHATGPT_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses"
+CURL_CFFI_PROFILE = "chrome99_android"
+CHATGPT_CLIENT_VERSION = "0.120.0"
+
+_DEFAULT_INSTRUCTIONS = (
+    "You are a helpful assistant. Answer the user's question based only on "
+    "the provided context. Be concise and factual."
+)
+
+
+def build_chatgpt_headers(auth_headers: dict[str, str], account_id: str) -> dict[str, str]:
+    """Layer the chatgpt.com session headers on top of an Authorization header."""
+    session_id = str(uuid.uuid4())
+    headers = dict(auth_headers)
+    headers.update(
+        {
+            "chatgpt-account-id": account_id,
+            "originator": "codex_exec",
+            "session_id": session_id,
+            "version": CHATGPT_CLIENT_VERSION,
+            "x-client-request-id": session_id,
+            "x-codex-window-id": f"{session_id}:0",
+            "accept": "text/event-stream",
+            "content-type": "application/json",
+        }
+    )
+    return headers
+
+
+def build_responses_body(
+    messages: Iterable[CoreMessage],
+    *,
+    model: str,
+    system: str | None = None,
+) -> dict:
+    """Build the ``/codex/responses`` POST body from canonical messages.
+
+    Only text parts are forwarded; chatgpt.com requires a non-empty
+    ``instructions`` field, so a short default is used when no
+    ``system`` is given.
+    """
+    prompt_parts: list[str] = []
+    for msg in messages:
+        if isinstance(msg.content, str):
+            prompt_parts.append(msg.content)
+            continue
+        for part in msg.content:
+            if isinstance(part, TextPart):
+                prompt_parts.append(part.text)
+
+    return {
+        "model": model,
+        "instructions": system or _DEFAULT_INSTRUCTIONS,
+        "input": [
+            {
+                "role": "user",
+                "content": [{"type": "input_text", "text": t}],
+            }
+            for t in prompt_parts
+        ],
+        "store": False,
+        "stream": True,
+        "reasoning": {"effort": "high"},
+        "text": {"verbosity": "low"},
+        "client_metadata": {"x-codex-installation-id": str(uuid.uuid4())},
+    }
+
+
+def build_health_probe_body() -> dict:
+    """Tiny body used by the health endpoint to check auth + connectivity."""
+    return {
+        "model": "gpt-5.4",
+        "instructions": "Say OK.",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+        "store": False,
+        "stream": True,
+        "reasoning": {"effort": "high"},
+        "text": {"verbosity": "low"},
+    }
+
+
+def post_responses_sync(
+    body: dict,
+    headers: dict[str, str],
+    *,
+    timeout: float = 300.0,
+    url: str = CHATGPT_RESPONSES_URL,
+) -> tuple[int, str, dict]:
+    """POST to chatgpt.com via curl_cffi (sync). Returns (status, text, headers)."""
+    from curl_cffi.requests import Session
+
+    with Session(impersonate=CURL_CFFI_PROFILE) as s:
+        r = s.post(url, json=body, headers=headers, timeout=timeout)
+        return r.status_code, r.text, dict(r.headers)
+
+
+async def auth_headers_for(auth: CodexOAuth) -> tuple[dict[str, str], str]:
+    """Bundle OAuth header + account id retrieval used by both run() and health()."""
+    headers = await auth.get_authorization_header()
+    return headers, auth.get_account_id()

--- a/apps/server/src/screamingface/plugins/codex_backend_api/chatgpt_session.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/chatgpt_session.py
@@ -102,7 +102,6 @@ def build_health_probe_body() -> dict:
 def post_responses_sync(
     body: dict,
     headers: dict[str, str],
-    *,
     timeout: float = 300.0,
     url: str = CHATGPT_RESPONSES_URL,
 ) -> tuple[int, str, dict]:

--- a/apps/server/src/screamingface/plugins/codex_backend_api/rate_limits.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/rate_limits.py
@@ -1,0 +1,31 @@
+"""Rate-limit header parsing for OpenAI's ``api.openai.com`` responses.
+
+OpenAI ships ``x-ratelimit-*`` headers; we normalize the prefix off
+and coerce numeric values. Callers also expect ``tokens_remaining`` /
+``requests_remaining`` aliases for the legacy ``remaining_*`` names.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+
+def extract_openai_rate_limits(headers: httpx.Headers) -> dict[str, str | int | float]:
+    prefix = "x-ratelimit-"
+    result: dict[str, str | int | float] = {}
+    for key, value in headers.items():
+        if not key.lower().startswith(prefix):
+            continue
+        short_key = key[len(prefix) :].replace("-", "_")
+        try:
+            result[short_key] = int(value)
+        except ValueError:
+            try:
+                result[short_key] = float(value)
+            except ValueError:
+                result[short_key] = value
+    if "remaining_tokens" in result:
+        result["tokens_remaining"] = result["remaining_tokens"]
+    if "remaining_requests" in result:
+        result["requests_remaining"] = result["remaining_requests"]
+    return result

--- a/apps/server/src/screamingface/plugins/codex_backend_api/sse_parser.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/sse_parser.py
@@ -1,0 +1,57 @@
+"""SSE parser for OpenAI Responses API event streams.
+
+The chatgpt.com/backend-api/codex/responses endpoint returns server-
+sent events. We collect text deltas and final usage metadata into a
+single :class:`CoreMessage`.
+
+Pulled out of ``backend.py`` so the parser can be unit-tested and
+shared across paths without touching the OAuth/HTTP machinery.
+"""
+
+from __future__ import annotations
+
+import json
+
+from screamingface.plugins.llm_base.messages import CoreMessage, TextPart
+
+
+def parse_responses_sse(sse_text: str) -> CoreMessage:
+    """Parse an SSE stream from the OpenAI Responses API.
+
+    Recognized event types:
+
+    - ``response.output_text.delta`` — incremental text chunk; we
+      concatenate ``data.delta``.
+    - ``response.completed`` — final event carrying ``usage`` and
+      ``model`` metadata; surfaced under ``provider_metadata`` as
+      ``openai.usage`` and ``openai.model``.
+
+    Lines that don't start with ``"data: "`` or that don't parse as
+    JSON are skipped — keepalives and partial frames are tolerated.
+    """
+    text_parts: list[str] = []
+    provider_metadata: dict = {}
+
+    for line in sse_text.split("\n"):
+        if not line.startswith("data: "):
+            continue
+        try:
+            data = json.loads(line[6:])
+        except json.JSONDecodeError:
+            continue
+
+        event_type = data.get("type", "")
+        if event_type == "response.output_text.delta":
+            text_parts.append(data.get("delta", ""))
+        elif event_type == "response.completed":
+            resp = data.get("response", {})
+            usage = resp.get("usage", {})
+            if usage:
+                provider_metadata["openai.usage"] = usage
+            provider_metadata["openai.model"] = resp.get("model", "")
+
+    return CoreMessage(
+        role="assistant",
+        content=[TextPart(text="".join(text_parts))],
+        provider_metadata=provider_metadata or None,
+    )

--- a/apps/server/src/screamingface/plugins/codex_backend_api/tests/test_chatgpt_session.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/tests/test_chatgpt_session.py
@@ -1,0 +1,71 @@
+"""Unit tests for chatgpt_session helpers (header/body builders)."""
+
+from __future__ import annotations
+
+from screamingface.plugins.codex_backend_api.chatgpt_session import (
+    CHATGPT_CLIENT_VERSION,
+    build_chatgpt_headers,
+    build_health_probe_body,
+    build_responses_body,
+)
+from screamingface.plugins.llm_base.messages import CoreMessage, TextPart
+
+
+def test_build_chatgpt_headers_layers_session_metadata() -> None:
+    headers = build_chatgpt_headers({"authorization": "Bearer t"}, "acct-123")
+    assert headers["authorization"] == "Bearer t"
+    assert headers["chatgpt-account-id"] == "acct-123"
+    assert headers["originator"] == "codex_exec"
+    assert headers["version"] == CHATGPT_CLIENT_VERSION
+    assert headers["accept"] == "text/event-stream"
+    assert headers["content-type"] == "application/json"
+    # session ids are reused across the three id-bearing headers
+    assert headers["session_id"] == headers["x-client-request-id"]
+    assert headers["x-codex-window-id"].startswith(headers["session_id"])
+
+
+def test_build_chatgpt_headers_does_not_mutate_input() -> None:
+    src = {"authorization": "Bearer t"}
+    build_chatgpt_headers(src, "acct")
+    assert src == {"authorization": "Bearer t"}
+
+
+def test_build_responses_body_with_string_content() -> None:
+    body = build_responses_body([CoreMessage(role="user", content="hi there")], model="gpt-5.4")
+    assert body["model"] == "gpt-5.4"
+    assert body["instructions"]
+    assert body["input"] == [
+        {"role": "user", "content": [{"type": "input_text", "text": "hi there"}]}
+    ]
+    assert body["stream"] is True
+    assert body["store"] is False
+
+
+def test_build_responses_body_with_text_parts() -> None:
+    body = build_responses_body(
+        [
+            CoreMessage(
+                role="user",
+                content=[TextPart(text="part one"), TextPart(text="part two")],
+            )
+        ],
+        model="gpt-5.4",
+    )
+    texts = [item["content"][0]["text"] for item in body["input"]]
+    assert texts == ["part one", "part two"]
+
+
+def test_build_responses_body_uses_custom_system() -> None:
+    body = build_responses_body(
+        [CoreMessage(role="user", content="hi")],
+        model="gpt-5.4",
+        system="be terse",
+    )
+    assert body["instructions"] == "be terse"
+
+
+def test_build_health_probe_body_is_minimal() -> None:
+    body = build_health_probe_body()
+    assert body["model"] == "gpt-5.4"
+    assert body["instructions"] == "Say OK."
+    assert body["input"][0]["role"] == "user"

--- a/apps/server/src/screamingface/plugins/codex_backend_api/tests/test_rate_limits.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/tests/test_rate_limits.py
@@ -1,0 +1,38 @@
+"""Unit tests for OpenAI rate-limit header parsing."""
+
+from __future__ import annotations
+
+import httpx
+
+from screamingface.plugins.codex_backend_api.rate_limits import extract_openai_rate_limits
+
+
+def _headers(items: dict[str, str]) -> httpx.Headers:
+    return httpx.Headers(items)
+
+
+def test_extracts_known_keys_and_aliases_remaining() -> None:
+    h = _headers(
+        {
+            "x-ratelimit-remaining-tokens": "1234",
+            "x-ratelimit-remaining-requests": "5",
+            "x-ratelimit-reset-tokens": "60s",
+        }
+    )
+    out = extract_openai_rate_limits(h)
+    assert out["remaining_tokens"] == 1234
+    assert out["remaining_requests"] == 5
+    assert out["tokens_remaining"] == 1234
+    assert out["requests_remaining"] == 5
+    assert out["reset_tokens"] == "60s"  # non-numeric stays str
+
+
+def test_ignores_unrelated_headers() -> None:
+    h = _headers({"content-type": "application/json", "x-other": "v"})
+    assert extract_openai_rate_limits(h) == {}
+
+
+def test_coerces_floats() -> None:
+    h = _headers({"x-ratelimit-reset-seconds": "1.5"})
+    out = extract_openai_rate_limits(h)
+    assert out["reset_seconds"] == 1.5

--- a/apps/server/src/screamingface/plugins/codex_backend_api/tests/test_sse_parser.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/tests/test_sse_parser.py
@@ -1,3 +1,4 @@
+# pyright: reportAttributeAccessIssue=false
 """Unit tests for the OpenAI Responses SSE parser."""
 
 from __future__ import annotations

--- a/apps/server/src/screamingface/plugins/codex_backend_api/tests/test_sse_parser.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/tests/test_sse_parser.py
@@ -1,0 +1,48 @@
+"""Unit tests for the OpenAI Responses SSE parser."""
+
+from __future__ import annotations
+
+from screamingface.plugins.codex_backend_api.sse_parser import parse_responses_sse
+
+
+def test_collects_text_deltas_in_order() -> None:
+    sse = (
+        'data: {"type":"response.output_text.delta","delta":"hel"}\n'
+        'data: {"type":"response.output_text.delta","delta":"lo "}\n'
+        'data: {"type":"response.output_text.delta","delta":"world"}\n'
+    )
+    msg = parse_responses_sse(sse)
+    assert msg.role == "assistant"
+    assert msg.content[0].text == "hello world"
+
+
+def test_extracts_completed_event_metadata() -> None:
+    sse = (
+        'data: {"type":"response.output_text.delta","delta":"ok"}\n'
+        'data: {"type":"response.completed","response":{"model":"gpt-5.4",'
+        '"usage":{"input_tokens":10,"output_tokens":2}}}\n'
+    )
+    msg = parse_responses_sse(sse)
+    assert msg.provider_metadata == {
+        "openai.usage": {"input_tokens": 10, "output_tokens": 2},
+        "openai.model": "gpt-5.4",
+    }
+
+
+def test_skips_unknown_events_and_invalid_json() -> None:
+    sse = (
+        ":keepalive\n"
+        "event: ping\n"
+        "data: not-json\n"
+        'data: {"type":"unknown.event","x":1}\n'
+        'data: {"type":"response.output_text.delta","delta":"x"}\n'
+    )
+    msg = parse_responses_sse(sse)
+    assert msg.content[0].text == "x"
+    assert msg.provider_metadata is None
+
+
+def test_empty_stream_produces_empty_message() -> None:
+    msg = parse_responses_sse("")
+    assert msg.content[0].text == ""
+    assert msg.provider_metadata is None


### PR DESCRIPTION
OpenAIBackend was the last big god class — 378 lines of dual-path routing, header/body marshaling, curl_cffi POST, SSE parsing, and rate-limit header extraction tangled together.

Applied the SF-110 Template-Method playbook: extract helpers, leave the main class as pure dispatch + error mapping.

## New modules
- `chatgpt_session.py` (120 lines): `build_chatgpt_headers`, `build_responses_body`, `build_health_probe_body`, `post_responses_sync`, `auth_headers_for`. Owns the curl_cffi/Cloudflare bypass and chatgpt.com request shape.
- `sse_parser.py` (57 lines): `parse_responses_sse` — pure function from SSE string to `CoreMessage` with provider metadata.
- `rate_limits.py` (31 lines): `extract_openai_rate_limits` — parses `x-ratelimit-*` headers.

## Result
`backend.py`: **378 → 237 lines (-37%)**. Now just dispatches between `_run_api_key` / `_run_chatgpt` and maps status codes to errors.

## Tests
- 13 new unit tests across `test_sse_parser`, `test_chatgpt_session`, `test_rate_limits`
- 62 codex tests total pass (was 49)
- Full plugin suite: **706 pass** / 17 skipped (was 693)

Asana: SF-118