### PR TITLE
SF-120: move data_store BlobStore singleton to app.state [ARCH]

### DIFF
--- a/apps/server/src/screamingface/plugins/claude_frontend/_url4_context.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/_url4_context.py
@@ -88,6 +88,7 @@ def _build_error_response(
 async def _store_prompt_blob(
     text: str,
     *,
+    app: Any,
     backend_url: str | None,
     tracer: Any,
     _start_client_span: Any,
@@ -116,10 +117,8 @@ async def _store_prompt_blob(
             )
         return blob_key
 
-    # In-process fallback
-    from screamingface.plugins.data_store.storage import store_blob
-
-    return store_blob(text.encode("utf-8"), "text/plain; charset=utf-8")
+    # In-process fallback — use the app-scoped BlobStore.
+    return app.state.blob_store.store(text.encode("utf-8"), "text/plain; charset=utf-8")
 
 
 async def _resolve_expression(
@@ -196,6 +195,7 @@ async def resolve_prompt_expression(
 
             blob_key = await _store_prompt_blob(
                 last_user_text,
+                app=app,
                 backend_url=backend_url,
                 tracer=tracer,
                 _start_client_span=_start_client_span,

--- a/apps/server/src/screamingface/plugins/codex_frontend/proxy.py
+++ b/apps/server/src/screamingface/plugins/codex_frontend/proxy.py
@@ -288,9 +288,7 @@ def create_router(
                             blob_resp.raise_for_status()
                             blob_key = blob_resp.json()["key"]
                     else:
-                        from screamingface.plugins.data_store.storage import store_blob
-
-                        blob_key = store_blob(
+                        blob_key = request.app.state.blob_store.store(
                             last_user_text.encode("utf-8"), "text/plain; charset=utf-8"
                         )
 

--- a/apps/server/src/screamingface/plugins/data_store/plugin.py
+++ b/apps/server/src/screamingface/plugins/data_store/plugin.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from screamingface.plugin import Plugin
 from screamingface.plugins.data_store.routes import create_router
+from screamingface.plugins.data_store.storage import BlobStore
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
@@ -29,5 +30,6 @@ class DataStorePlugin(Plugin):
         classes: ClassRegistry,
         routes: RouteRegistry,
     ) -> None:
+        app.state.blob_store = BlobStore()
         router = create_router()
         routes.add_router(self.name, router, prefix="")

--- a/apps/server/src/screamingface/plugins/data_store/routes.py
+++ b/apps/server/src/screamingface/plugins/data_store/routes.py
@@ -1,8 +1,9 @@
 """Routes for the data-store plugin — store and retrieve blobs by key.
 
-The storage itself lives in :mod:`.storage` so other plugins can use
-``store_blob`` / ``get_blob`` without reaching into a ``.routes``
-module (routes are FastAPI implementation detail, not public API).
+The :class:`BlobStore` itself lives in :mod:`.storage`; the per-app
+instance is attached to ``app.state.blob_store`` by
+:meth:`DataStorePlugin.setup`. These handlers reach it via
+``request.app.state.blob_store``.
 """
 
 from __future__ import annotations
@@ -10,12 +11,7 @@ from __future__ import annotations
 from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import JSONResponse
 
-from screamingface.plugins.data_store.storage import get_blob, store_blob
-
-# Re-export for back-compat: older callers imported ``store_blob`` /
-# ``get_blob`` from this module directly. New code should import from
-# :mod:`.storage`.
-__all__ = ["create_router", "get_blob", "store_blob"]
+__all__ = ["create_router"]
 
 
 def create_router() -> APIRouter:
@@ -27,7 +23,7 @@ def create_router() -> APIRouter:
         if not body:
             raise HTTPException(status_code=400, detail="Empty body")
         content_type = request.headers.get("content-type", "application/octet-stream")
-        key = store_blob(body, content_type)
+        key = request.app.state.blob_store.store(body, content_type)
 
         try:
             from opentelemetry import trace
@@ -43,13 +39,12 @@ def create_router() -> APIRouter:
         return JSONResponse(content={"key": key, "url": f"/data/{key}"})
 
     @router.get("/data/{key}", response_model=None, operation_id="data_store_get")
-    async def get_blob_route(key: str) -> Response:
-        entry = get_blob(key)
+    async def get_blob_route(key: str, request: Request) -> Response:
+        entry = request.app.state.blob_store.get(key)
         if entry is None:
             raise HTTPException(status_code=404, detail="Not found")
         body, content_type = entry
 
-        # Add truncated body preview to the current OTEL span (auto-created by FastAPI)
         try:
             from opentelemetry import trace
 

--- a/apps/server/src/screamingface/plugins/data_store/storage.py
+++ b/apps/server/src/screamingface/plugins/data_store/storage.py
@@ -1,11 +1,12 @@
 """In-process blob storage backing the data-store plugin.
 
-Split out of :mod:`.routes` in SF-112 so that other plugins can import
-``store_blob`` / ``get_blob`` without reaching into a ``.routes``
-module (which is an implementation detail of the FastAPI layer).
+Owned by the plugin: every running app gets its own ``BlobStore`` on
+``app.state.blob_store`` (set in :meth:`DataStorePlugin.setup`). Other
+plugins reach it via ``request.app.state.blob_store`` from FastAPI
+handlers, or via the ``app`` they receive in their own ``setup``.
 
 Thread-safe: the underlying dict is guarded by a ``threading.Lock``
-because frontends occasionally call ``store_blob`` from synchronous
+because frontends occasionally call ``store(...)`` from synchronous
 threads (``_fetch_sync`` in each frontend plugin) while the routes
 access it from the async event loop.
 """
@@ -15,7 +16,7 @@ from __future__ import annotations
 import hashlib
 import threading
 
-__all__ = ["BlobStore", "get_blob", "store_blob"]
+__all__ = ["BlobStore"]
 
 
 class BlobStore:
@@ -48,21 +49,3 @@ class BlobStore:
     def __len__(self) -> int:
         with self._lock:
             return len(self._entries)
-
-
-# Module-level singleton. Kept because the in-process fallback path
-# (frontends calling store_blob without going through HTTP) needs a
-# shared instance — and there's exactly one data-store plugin per
-# server. ``app.state`` would be cleaner but requires plumbing `app`
-# through every caller; this is a pragmatic middle ground.
-_default_store = BlobStore()
-
-
-def store_blob(data: bytes, content_type: str = "application/octet-stream") -> str:
-    """Store a blob and return its content-addressed key."""
-    return _default_store.store(data, content_type)
-
-
-def get_blob(key: str) -> tuple[bytes, str] | None:
-    """Retrieve a blob by key. Returns ``(data, content_type)`` or ``None``."""
-    return _default_store.get(key)

--- a/apps/server/src/screamingface/plugins/data_store/tests/test_data_store.py
+++ b/apps/server/src/screamingface/plugins/data_store/tests/test_data_store.py
@@ -8,7 +8,7 @@ from fastapi.testclient import TestClient
 
 from screamingface.core.app import create_app
 from screamingface.core.config import AppConfig
-from screamingface.plugins.data_store.routes import get_blob, store_blob
+from screamingface.plugins.data_store.storage import BlobStore
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -27,39 +27,42 @@ def client(app: FastAPI) -> TestClient:
 
 
 # ---------------------------------------------------------------------------
-# In-process API (store_blob / get_blob)
+# In-process API — BlobStore class is used directly. The data-store
+# plugin attaches a single instance to ``app.state.blob_store`` which
+# is exercised via the HTTP route tests below.
 # ---------------------------------------------------------------------------
 
 
-def test_store_blob_returns_key() -> None:
-    key = store_blob(b"hello world")
+def test_blobstore_returns_key() -> None:
+    store = BlobStore()
+    key = store.store(b"hello world")
     assert isinstance(key, str)
     assert len(key) == 16
 
 
-def test_store_blob_content_addressed() -> None:
-    k1 = store_blob(b"same content")
-    k2 = store_blob(b"same content")
-    assert k1 == k2
+def test_blobstore_content_addressed() -> None:
+    store = BlobStore()
+    assert store.store(b"same content") == store.store(b"same content")
 
 
-def test_store_blob_different_content() -> None:
-    k1 = store_blob(b"aaa")
-    k2 = store_blob(b"bbb")
-    assert k1 != k2
+def test_blobstore_different_content() -> None:
+    store = BlobStore()
+    assert store.store(b"aaa") != store.store(b"bbb")
 
 
-def test_get_blob_returns_data() -> None:
-    key = store_blob(b"test data", "text/plain")
-    result = get_blob(key)
-    assert result is not None
-    data, ct = result
-    assert data == b"test data"
-    assert ct == "text/plain"
+def test_blobstore_get_returns_data() -> None:
+    store = BlobStore()
+    key = store.store(b"test data", "text/plain")
+    result = store.get(key)
+    assert result == (b"test data", "text/plain")
 
 
-def test_get_blob_missing_key() -> None:
-    assert get_blob("nonexistent_key_") is None
+def test_blobstore_get_missing_key() -> None:
+    assert BlobStore().get("nonexistent_key_") is None
+
+
+def test_plugin_attaches_blob_store_to_app_state(app: FastAPI) -> None:
+    assert isinstance(app.state.blob_store, BlobStore)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/server/src/screamingface/plugins/gemini_frontend/proxy.py
+++ b/apps/server/src/screamingface/plugins/gemini_frontend/proxy.py
@@ -217,9 +217,7 @@ def create_router(
                             blob_resp.raise_for_status()
                             blob_key = blob_resp.json()["key"]
                     else:
-                        from screamingface.plugins.data_store.storage import store_blob
-
-                        blob_key = store_blob(
+                        blob_key = request.app.state.blob_store.store(
                             last_user_text.encode("utf-8"),
                             "text/plain; charset=utf-8",
                         )

--- a/apps/server/src/screamingface/plugins/ollama_frontend/proxy.py
+++ b/apps/server/src/screamingface/plugins/ollama_frontend/proxy.py
@@ -291,9 +291,7 @@ def create_router(
                                 blob_resp.raise_for_status()
                                 blob_key = blob_resp.json()["key"]
                         else:
-                            from screamingface.plugins.data_store.storage import store_blob
-
-                            blob_key = store_blob(
+                            blob_key = request.app.state.blob_store.store(
                                 last_user_text.encode("utf-8"), "text/plain; charset=utf-8"
                             )
 

--- a/apps/server/tests/e2e/test_proxy_prompt_flow.py
+++ b/apps/server/tests/e2e/test_proxy_prompt_flow.py
@@ -55,11 +55,12 @@ class TestPromptSubstitution:
 
     def test_blob_dedup(self):
         """Same prompt text → same blob key (SHA-256 content hash)."""
-        from screamingface.plugins.data_store.routes import store_blob
+        from screamingface.plugins.data_store.storage import BlobStore
 
-        key1 = store_blob(b"What breed for apartments?", "text/plain")
-        key2 = store_blob(b"What breed for apartments?", "text/plain")
-        key3 = store_blob(b"Different prompt", "text/plain")
+        store = BlobStore()
+        key1 = store.store(b"What breed for apartments?", "text/plain")
+        key2 = store.store(b"What breed for apartments?", "text/plain")
+        key3 = store.store(b"Different prompt", "text/plain")
 
         assert key1 == key2, f"dedup failed: {key1} != {key2}"
         assert key1 != key3, f"different content same key: {key1} == {key3}"


### PR DESCRIPTION
SF-112 wrapped blob storage as a class but kept the module-level `_default_store` global. The plugin now owns lifecycle:

- `storage.py` — class only, no globals/shims
- `plugin.py` — `setup` does `app.state.blob_store = BlobStore()`
- `routes.py` — handlers use `request.app.state.blob_store`
- 4 frontends — use `request.app.state.blob_store.store(...)` (already receive Request)
- `claude_frontend/_url4_context` — `app` threaded into `_store_prompt_blob`

Behavior unchanged. 707 unit tests pass (+1 new for the app.state assertion).

Asana: SF-120