### PR TITLE
SF-123: wire SF-110 adapter helpers into existing adapters [ARCH]

### DIFF
--- a/apps/server/src/screamingface/plugins/claude_backend_api/adapter.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/adapter.py
@@ -32,7 +32,11 @@ from __future__ import annotations
 import hashlib
 from typing import Any
 
-from screamingface.plugins.llm_base.adapter_base import Adapter
+from screamingface.plugins.llm_base.adapter_base import (
+    Adapter,
+    collect_provider_metadata,
+    extract_system_text,
+)
 from screamingface.plugins.llm_base.errors import AdapterError
 from screamingface.plugins.llm_base.messages import (
     CoreMessage,
@@ -191,10 +195,11 @@ class AnthropicAdapter(Adapter):
 
         # Carry over the Anthropic-level metadata as provider_metadata on
         # the returned message. Useful for observability downstream.
-        provider_metadata: dict[str, Any] = {}
-        for key in ("id", "model", "stop_reason", "stop_sequence", "usage"):
-            if key in data:
-                provider_metadata[f"anthropic.{key}"] = data[key]
+        provider_metadata = collect_provider_metadata(
+            data,
+            ("id", "model", "stop_reason", "stop_sequence", "usage"),
+            prefix="anthropic",
+        )
 
         return CoreMessage(
             role="assistant",
@@ -219,19 +224,10 @@ class AnthropicAdapter(Adapter):
                     return part.text
         return ""
 
-    def _extract_system_text(self, msg: CoreMessage) -> str:
-        """Flatten a system CoreMessage into a plain string.
-
-        Anthropic's ``system`` field is a string or a list of text blocks;
-        we use the string form for simplicity.
-        """
-        if isinstance(msg.content, str):
-            return msg.content
-        chunks = []
-        for part in msg.content:
-            if isinstance(part, TextPart):
-                chunks.append(part.text)
-        return "\n\n".join(chunks)
+    @staticmethod
+    def _extract_system_text(msg: CoreMessage) -> str:
+        """Flatten a system CoreMessage into a plain string."""
+        return extract_system_text(msg.content) or ""
 
     def _message_to_anthropic(self, msg: CoreMessage) -> dict[str, Any]:
         """Translate a single non-system CoreMessage to Anthropic shape."""

--- a/apps/server/src/screamingface/plugins/codex_backend_api/adapter.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/adapter.py
@@ -26,7 +26,11 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from screamingface.plugins.llm_base.adapter_base import Adapter
+from screamingface.plugins.llm_base.adapter_base import (
+    Adapter,
+    collect_provider_metadata,
+    extract_system_text,
+)
 from screamingface.plugins.llm_base.errors import AdapterError
 from screamingface.plugins.llm_base.messages import (
     CoreMessage,
@@ -164,11 +168,9 @@ class OpenAIResponsesAdapter(Adapter):
                     )
                 )
 
-        # Provider metadata
-        provider_metadata: dict[str, Any] = {}
-        for key in ("id", "model", "usage"):
-            if key in data:
-                provider_metadata[f"openai.{key}"] = data[key]
+        provider_metadata = collect_provider_metadata(
+            data, ("id", "model", "usage"), prefix="openai"
+        )
         status = data.get("status")
         if status:
             provider_metadata["openai.status"] = status
@@ -183,15 +185,10 @@ class OpenAIResponsesAdapter(Adapter):
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _extract_system_text(self, msg: CoreMessage) -> str:
+    @staticmethod
+    def _extract_system_text(msg: CoreMessage) -> str:
         """Flatten a system CoreMessage into a plain string."""
-        if isinstance(msg.content, str):
-            return msg.content
-        chunks = []
-        for part in msg.content:
-            if isinstance(part, TextPart):
-                chunks.append(part.text)
-        return "\n\n".join(chunks)
+        return extract_system_text(msg.content) or ""
 
     def _message_to_responses(
         self, msg: CoreMessage

--- a/apps/server/src/screamingface/plugins/gemini_backend_api/adapter.py
+++ b/apps/server/src/screamingface/plugins/gemini_backend_api/adapter.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from screamingface.plugins.llm_base.adapter_base import Adapter
+from screamingface.plugins.llm_base.adapter_base import Adapter, extract_system_text
 from screamingface.plugins.llm_base.errors import AdapterError
 from screamingface.plugins.llm_base.messages import (
     CoreMessage,
@@ -126,10 +126,9 @@ class GeminiAdapter(Adapter):
             provider_metadata=provider_metadata or None,
         )
 
-    def _extract_text(self, msg: CoreMessage) -> str:
-        if isinstance(msg.content, str):
-            return msg.content
-        return "\n\n".join(p.text for p in msg.content if isinstance(p, TextPart))
+    @staticmethod
+    def _extract_text(msg: CoreMessage) -> str:
+        return extract_system_text(msg.content) or ""
 
     def _message_to_gemini(self, msg: CoreMessage) -> dict[str, Any] | None:
         # Gemini uses "user" and "model" roles

--- a/apps/server/src/screamingface/plugins/llm_base/adapter_base.py
+++ b/apps/server/src/screamingface/plugins/llm_base/adapter_base.py
@@ -58,7 +58,13 @@ def extract_system_text(system: str | list | None) -> str | None:
     return joined or None
 
 
-def collect_provider_metadata(source: dict, keys: tuple[str, ...], *, prefix: str) -> dict:
+def collect_provider_metadata(
+    source: dict,
+    keys: tuple[str, ...],
+    *,
+    prefix: str,
+    skip_none: bool = False,
+) -> dict:
     """Pull the listed ``keys`` from ``source`` into a provider-prefixed dict.
 
     Used by adapters to propagate vendor-specific response fields
@@ -66,11 +72,19 @@ def collect_provider_metadata(source: dict, keys: tuple[str, ...], *, prefix: st
     :class:`CoreMessage`'s ``provider_metadata``. Keys not present in
     ``source`` are skipped. The returned dict has ``f"{prefix}.{key}"``
     entries so consumers can disambiguate across providers.
+
+    Pass ``skip_none=True`` to also drop keys whose value is ``None``
+    (Ollama's response carries explicit ``None`` for fields that
+    weren't filled in for that response shape).
     """
     out: dict = {}
     for key in keys:
-        if key in source:
-            out[f"{prefix}.{key}"] = source[key]
+        if key not in source:
+            continue
+        value = source[key]
+        if skip_none and value is None:
+            continue
+        out[f"{prefix}.{key}"] = value
     return out
 
 

--- a/apps/server/src/screamingface/plugins/ollama_backend_api/adapter.py
+++ b/apps/server/src/screamingface/plugins/ollama_backend_api/adapter.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from screamingface.plugins.llm_base.adapter_base import Adapter
+from screamingface.plugins.llm_base.adapter_base import Adapter, collect_provider_metadata
 from screamingface.plugins.llm_base.errors import AdapterError
 from screamingface.plugins.llm_base.messages import (
     ContentPart,
@@ -130,10 +130,9 @@ class OllamaAdapter(Adapter):
             "eval_count",
             "eval_duration",
         )
-        provider_metadata: dict[str, Any] = {}
-        for key in metadata_keys:
-            if key in data and data[key] is not None:
-                provider_metadata[f"ollama.{key}"] = data[key]
+        provider_metadata = collect_provider_metadata(
+            data, metadata_keys, prefix="ollama", skip_none=True
+        )
 
         return CoreMessage(
             role="assistant",


### PR DESCRIPTION
SF-110 added `extract_system_text()` / `collect_provider_metadata()` to adapter_base but adapters still had inline copies. Wired the shared helpers in:

- claude — both helpers
- codex — both helpers (status appended outside)
- gemini — extract_system_text only (metadata custom shape)
- ollama — collect_provider_metadata only (with new `skip_none=True` opt-in to preserve None-filtering)

`collect_provider_metadata` gains `skip_none=False` keyword (default off — preserves claude/codex behavior).

707 unit tests pass.

Asana: SF-123