### PR TITLE
SF-124: consolidate adapter tool-result + parts-to-text helpers [ARCH]

### DIFF
--- a/apps/server/src/screamingface/plugins/claude_backend_api/adapter.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/adapter.py
@@ -36,6 +36,7 @@ from screamingface.plugins.llm_base.adapter_base import (
     Adapter,
     collect_provider_metadata,
     extract_system_text,
+    serialize_tool_output,
 )
 from screamingface.plugins.llm_base.errors import AdapterError
 from screamingface.plugins.llm_base.messages import (
@@ -272,19 +273,12 @@ class AnthropicAdapter(Adapter):
                 "input": part.input,
             }
         if isinstance(part, ToolResultPart):
-            # Anthropic tool_result content can be a string or a list of
-            # content blocks. We send strings for simplicity; if the
-            # output is a dict we JSON-encode it.
-            import json as _json
-
-            if isinstance(part.output, str):
-                content: Any = part.output
-            else:
-                content = _json.dumps(part.output)
+            # Anthropic tool_result.content is a string for non-string
+            # outputs we JSON-encode (shared helper).
             block: dict[str, Any] = {
                 "type": "tool_result",
                 "tool_use_id": part.tool_call_id,
-                "content": content,
+                "content": serialize_tool_output(part.output),
             }
             if part.is_error:
                 block["is_error"] = True

--- a/apps/server/src/screamingface/plugins/codex_backend_api/adapter.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/adapter.py
@@ -30,6 +30,8 @@ from screamingface.plugins.llm_base.adapter_base import (
     Adapter,
     collect_provider_metadata,
     extract_system_text,
+    parts_to_text,
+    serialize_tool_output,
 )
 from screamingface.plugins.llm_base.errors import AdapterError
 from screamingface.plugins.llm_base.messages import (
@@ -208,12 +210,11 @@ class OpenAIResponsesAdapter(Adapter):
                     if text:
                         items.append({"role": "user", "content": text})
                 for tr in tool_results:
-                    output = tr.output if isinstance(tr.output, str) else json.dumps(tr.output)
                     items.append(
                         {
                             "type": "function_call_output",
                             "call_id": tr.tool_call_id,
-                            "output": output,
+                            "output": serialize_tool_output(tr.output),
                         }
                     )
                 return items if items else None
@@ -244,13 +245,10 @@ class OpenAIResponsesAdapter(Adapter):
         text = self._parts_to_text(msg.content)
         return {"role": msg.role, "content": text} if text else None
 
-    def _parts_to_text(self, parts: list) -> str:
+    @staticmethod
+    def _parts_to_text(parts: list) -> str:
         """Extract concatenated text from a list of content parts."""
-        chunks = []
-        for part in parts:
-            if isinstance(part, TextPart):
-                chunks.append(part.text)
-        return "".join(chunks)
+        return parts_to_text(parts)
 
     def _tool_to_openai(self, tool: ToolDefinition) -> dict[str, Any]:
         """Translate a ToolDefinition to OpenAI's function-wrapped shape."""

--- a/apps/server/src/screamingface/plugins/llm_base/adapter_base.py
+++ b/apps/server/src/screamingface/plugins/llm_base/adapter_base.py
@@ -58,6 +58,36 @@ def extract_system_text(system: str | list | None) -> str | None:
     return joined or None
 
 
+def serialize_tool_output(output: object) -> str:
+    """Stringify a :class:`ToolResultPart.output` for providers that expect a string.
+
+    String outputs are passed through unchanged; everything else is
+    JSON-encoded. Used by claude (Anthropic ``tool_result.content``)
+    and codex (OpenAI Responses ``function_call_output.output``).
+    """
+    import json as _json
+
+    if isinstance(output, str):
+        return output
+    return _json.dumps(output)
+
+
+def parts_to_text(parts: object, *, separator: str = "") -> str:
+    """Concatenate every ``TextPart.text`` in *parts*, dropping non-text parts.
+
+    Used by adapters when converting a ``CoreMessage.content`` list to
+    a flat string for providers that don't accept content-block arrays
+    (e.g. Codex's user content shorthand).
+    """
+    if not parts:
+        return ""
+    chunks: list[str] = []
+    for part in parts:  # type: ignore[union-attr]
+        if isinstance(part, TextPart):
+            chunks.append(part.text)
+    return separator.join(chunks)
+
+
 def collect_provider_metadata(
     source: dict,
     keys: tuple[str, ...],

--- a/apps/server/src/screamingface/plugins/llm_base/tests/test_adapter_base.py
+++ b/apps/server/src/screamingface/plugins/llm_base/tests/test_adapter_base.py
@@ -1,0 +1,99 @@
+"""Unit tests for the shared adapter_base helpers (SF-110/SF-123/SF-124)."""
+
+from __future__ import annotations
+
+from screamingface.plugins.llm_base.adapter_base import (
+    collect_provider_metadata,
+    extract_system_text,
+    parts_to_text,
+    serialize_tool_output,
+)
+from screamingface.plugins.llm_base.messages import TextPart
+
+# ---------------------------------------------------------------------------
+# extract_system_text
+# ---------------------------------------------------------------------------
+
+
+def test_extract_system_text_string_passthrough() -> None:
+    assert extract_system_text("hello") == "hello"
+
+
+def test_extract_system_text_none_inputs_return_none() -> None:
+    assert extract_system_text(None) is None
+    assert extract_system_text("") is None
+    assert extract_system_text([]) is None
+
+
+def test_extract_system_text_concatenates_textparts() -> None:
+    parts = [TextPart(text="a"), TextPart(text="b")]
+    assert extract_system_text(parts) == "a\n\nb"
+
+
+def test_extract_system_text_handles_dict_blocks() -> None:
+    blocks = [{"text": "x"}, {"text": "y"}]
+    assert extract_system_text(blocks) == "x\n\ny"
+
+
+def test_extract_system_text_mixed_inputs() -> None:
+    blocks = [{"text": "x"}, TextPart(text="y"), "z"]
+    assert extract_system_text(blocks) == "x\n\ny\n\nz"
+
+
+# ---------------------------------------------------------------------------
+# parts_to_text
+# ---------------------------------------------------------------------------
+
+
+def test_parts_to_text_default_no_separator() -> None:
+    parts = [TextPart(text="ab"), TextPart(text="cd")]
+    assert parts_to_text(parts) == "abcd"
+
+
+def test_parts_to_text_custom_separator() -> None:
+    assert parts_to_text([TextPart(text="a"), TextPart(text="b")], separator=" | ") == "a | b"
+
+
+def test_parts_to_text_empty_input() -> None:
+    assert parts_to_text([]) == ""
+    assert parts_to_text(None) == ""  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# serialize_tool_output
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_tool_output_string_passthrough() -> None:
+    assert serialize_tool_output("plain text") == "plain text"
+
+
+def test_serialize_tool_output_dict_jsondumps() -> None:
+    assert serialize_tool_output({"k": 1}) == '{"k": 1}'
+
+
+def test_serialize_tool_output_list_jsondumps() -> None:
+    assert serialize_tool_output([1, "two"]) == '[1, "two"]'
+
+
+# ---------------------------------------------------------------------------
+# collect_provider_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_collect_provider_metadata_basic() -> None:
+    out = collect_provider_metadata({"a": 1, "b": 2, "c": 3}, ("a", "c"), prefix="x")
+    assert out == {"x.a": 1, "x.c": 3}
+
+
+def test_collect_provider_metadata_skips_missing_keys() -> None:
+    assert collect_provider_metadata({"a": 1}, ("a", "missing"), prefix="x") == {"x.a": 1}
+
+
+def test_collect_provider_metadata_includes_none_by_default() -> None:
+    assert collect_provider_metadata({"a": None}, ("a",), prefix="x") == {"x.a": None}
+
+
+def test_collect_provider_metadata_skip_none_drops_explicit_none() -> None:
+    out = collect_provider_metadata({"a": None, "b": 2}, ("a", "b"), prefix="x", skip_none=True)
+    assert out == {"x.b": 2}


### PR DESCRIPTION
Last bit of adapter duplication. Two new helpers in adapter_base.py:

- `serialize_tool_output(output)` — string or json.dumps. Used by claude + codex tool-result paths. Gemini stays custom (dict shape).
- `parts_to_text(parts, *, separator='')` — concatenate TextPart.text. Used by codex's `_parts_to_text`.

15 new unit tests covering all four adapter_base helpers. Total: 722 plugin unit tests pass (+15 new).

Asana: SF-124