### PR TITLE
SF-135: extract FrontendPluginBase from 4 frontend plugins [ARCH]

### DIFF
--- a/apps/server/src/screamingface/plugins/claude_frontend/plugin.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/plugin.py
@@ -2,362 +2,41 @@
 
 Runs its own HTTP server so its routes (/v1/messages, /v1/*, /api/*) don't
 clash with the main SF server or other frontend plugins.
+
+Most behavior lives in :class:`frontend_base.FrontendPluginBase`. This
+module declares the Claude-specific overrides only.
 """
 
 from __future__ import annotations
 
-import asyncio
-import logging
-import os
-import socket
-import threading
-import time
-from typing import TYPE_CHECKING, Literal
-
-import httpx
-import uvicorn
-from fastapi import FastAPI
-from pydantic import Field
 from pydantic_settings import SettingsConfigDict
 
-from screamingface.plugin import Plugin, PluginSettings
 from screamingface.plugins.claude_frontend.proxy import create_router
-
-if TYPE_CHECKING:
-    from screamingface.core.classes import ClassRegistry
-    from screamingface.core.hooks import HookRegistry
-    from screamingface.core.routes import RouteRegistry
-
-logger = logging.getLogger(__name__)
+from screamingface.plugins.frontend_base import (
+    FrontendPluginBase,
+    FrontendSettingsBase,
+)
 
 
-class ClaudeFrontendSettings(PluginSettings):
+class ClaudeFrontendSettings(FrontendSettingsBase):
     model_config = SettingsConfigDict(
         env_prefix="SF_CLAUDE_FRONTEND__",
         env_nested_delimiter="__",
     )
-    active_spec: str | None = Field(
-        default=None,
-        description="Active url4-spec to resolve and prepend as system context.",
-    )
+
     upstream_url: str = "https://api.anthropic.com"
-    listen_host: str = "127.0.0.1"
     listen_port: int = 9101
-    session_service_url: str | None = Field(
-        default=None,
-        description=(
-            "URL of the session service (e.g. http://127.0.0.1:9200). Enables session persistence."
-        ),
-    )
-    backend_url: str | None = Field(
-        default=None,
-        description=(
-            "SF server URL used for $prompt substitution — stores user text "
-            "on /data and resolves url4 expressions via /ensemble. "
-            "Set automatically in per-session mode."
-        ),
-    )
-    default_backend_path: str = Field(
-        default="/claude",
-        description=(
-            "Default backend path for ensemble fan-out (e.g. /claude). "
-            "Used when resolving $prompt expressions through this frontend."
-        ),
-    )
-    resolve_timeout: float = Field(
-        default=300.0,
-        description="Max seconds to wait for url4 spec resolution on first request.",
-    )
-    embed_target: Literal["system", "user"] = Field(
-        default="user",
-        description=(
-            "Where to inject url4-resolved context: "
-            "'system' (prepend to system prompt) or 'user' (inject into user message)."
-        ),
-    )
-    embed_mode: Literal["concat", "replace"] = Field(
-        default="concat",
-        description=(
-            "How to embed in user message: "
-            "'concat' (original prompt + context) or 'replace' (context only). "
-            "Only used when embed_target is 'user'."
-        ),
-    )
-    system_prompt: str = Field(
-        default=(
-            "You are a helpful assistant. Answer the user's question based only on "
-            "the provided context. Be concise and factual."
-        ),
-        description=(
-            "System prompt prepended to the resolved context when embed_target is 'system'."
-        ),
-    )
+    default_backend_path: str = "/claude"
 
 
-class ClaudeFrontendPlugin(Plugin):
+class ClaudeFrontendPlugin(FrontendPluginBase):
     name = "claude-frontend"
     description = "Transparent proxy between Claude Code and the Anthropic API"
     tags: list[str] = ["product:claude"]
-    depends = ["url4-specs", "url4-executor", "frontend-base"]
+    depends: list[str] = ["url4-specs", "url4-executor", "frontend-base"]
     settings_class = ClaudeFrontendSettings
 
-    def __init__(self) -> None:
-        self._server: uvicorn.Server | None = None
-        self._thread: threading.Thread | None = None
-        self._cache: dict[str, str] = {}  # spec_name → resolved text
-        self._resolved_context: str | None = None
-        self._active_key: str | None = None  # tracks which specs produced the cache
-        self._lock = threading.Lock()
-
-    def _get_spec_names(self) -> list[str] | None:
-        if not hasattr(self, "_app") or not self._app:
-            return None
-        specs_plugin = self._app.state.plugins.active_plugins.get("url4-specs")
-        if specs_plugin and specs_plugin.settings:
-            names = list(specs_plugin.settings.specs.keys())
-            if names:
-                return names
-        return None
-
-    def customize_schema(self, schema: dict) -> dict:
-        props = schema.get("properties", {})
-        spec_names = self._get_spec_names()
-        if spec_names and "active_spec" in props:
-            props["active_spec"]["enum"] = spec_names
-        return schema
-
-    def preflight(self) -> tuple[bool, str]:
-        import shutil
-
-        # Skip the CLI check in test subprocesses (ServerManager sets this).
-        # The proxy itself doesn't need the Claude CLI — the check exists to
-        # prevent a confusing runtime for end-users who haven't installed it.
-        if os.environ.get("_SF_SUBPROCESS"):
-            return True, ""
-        if not shutil.which("claude"):
-            return False, (
-                "Claude CLI not found in PATH. "
-                "Install it from https://docs.anthropic.com/en/docs/claude-code"
-            )
-        return True, ""
-
-    def _collect_spec_names(self) -> list[str]:
-        """Return the active spec as a single-element list, or empty."""
-        settings: ClaudeFrontendSettings = self.settings  # type: ignore[assignment]
-        if settings.active_spec:
-            return [settings.active_spec]
-        return []
-
-    def _get_spec_urls(self) -> list[tuple[str, str]]:
-        """Get (name, expression_url) pairs for active specs."""
-        spec_names = self._collect_spec_names()
-        if not spec_names or not hasattr(self, "_app") or not self._app:
-            return []
-
-        specs_plugin = self._app.state.plugins.active_plugins.get("url4-specs")
-        if not specs_plugin or not specs_plugin.settings:
-            return []
-
-        result: list[tuple[str, str]] = []
-        for name in spec_names:
-            spec = specs_plugin.settings.specs.get(name)
-            if spec and spec.expression:
-                result.append((name, spec.expression))
-        return result
-
-    def get_active_expression(self) -> str | None:
-        """Return the raw URL4 expression for the active spec, without resolving it."""
-        spec_urls = self._get_spec_urls()
-        if not spec_urls:
-            return None
-        return spec_urls[0][1]
-
-    def resolve_context(self) -> str | None:
-        """Resolve active specs lazily. Called on first request.
-
-        - Checks if current active specs match what's cached
-        - If cache hit (same specs) → return cached
-        - If cache miss (new/changed specs) → fetch, cache, return
-        - Thread-safe via lock
-        - Skips specs containing $prompt (handled by proxy_messages instead)
-        """
-        spec_urls = self._get_spec_urls()
-        # Skip $prompt specs — they need per-request substitution in the proxy
-        spec_urls = [(n, e) for n, e in spec_urls if "$prompt" not in e]
-        if not spec_urls:
-            return None
-
-        # Build a cache key from the spec names
-        active_key = ",".join(name for name, _ in spec_urls)
-
-        # Fast path: already resolved for these exact specs
-        if self._active_key == active_key and self._resolved_context is not None:
-            return self._resolved_context
-
-        with self._lock:
-            # Double-check after acquiring lock
-            if self._active_key == active_key and self._resolved_context is not None:
-                return self._resolved_context
-
-            settings: ClaudeFrontendSettings = self.settings  # type: ignore[assignment]
-            timeout = settings.resolve_timeout
-            resolved_parts: list[str] = []
-
-            for name, url in spec_urls:
-                # Check per-spec cache first
-                if name in self._cache:
-                    resolved_parts.append(self._cache[name])
-                    logger.info("Cache hit for spec %r (%d chars)", name, len(self._cache[name]))
-                    continue
-
-                # Fetch and cache
-                try:
-                    result = self._fetch_sync(url, timeout)
-                    if result:
-                        self._cache[name] = result
-                        resolved_parts.append(result)
-                        logger.info("Resolved spec %r (%d chars)", name, len(result))
-                except Exception:
-                    logger.warning("Failed to resolve spec %r", name, exc_info=True)
-
-            if resolved_parts:
-                self._resolved_context = "\n\n".join(resolved_parts)
-                self._active_key = active_key
-                logger.info(
-                    "Cached %d chars of resolved url4 context",
-                    len(self._resolved_context),
-                )
-            else:
-                self._resolved_context = None
-                self._active_key = active_key
-
-            return self._resolved_context
-
-    def _get_backend_url(self) -> str:
-        """Return the base URL for backend/ensemble/data calls."""
-        settings: ClaudeFrontendSettings = self.settings  # type: ignore[assignment]
-        if settings.backend_url:
-            return settings.backend_url.rstrip("/")
-        # Fallback: same server (non-session mode)
-        cfg = getattr(self._app.state, "config", None) if self._app else None
-        port = cfg.server.port if cfg else 8000
-        use_ssl = cfg.server.ssl if cfg else False
-        scheme = "https" if use_ssl else "http"
-        return f"{scheme}://localhost:{port}"
-
-    def _fetch_sync(self, expression: str, timeout: float) -> str:
-        """Resolve a url4 expression by calling the /ensemble endpoint."""
-        base = self._get_backend_url()
-
-        result_holder: list[str] = []
-
-        def _run() -> None:
-            loop = asyncio.new_event_loop()
-            try:
-                result_holder.append(loop.run_until_complete(_fetch(base, expression)))
-            finally:
-                loop.close()
-
-        thread = threading.Thread(target=_run, name="url4-fetch", daemon=True)
-        thread.start()
-        thread.join(timeout=timeout)
-
-        if not result_holder:
-            raise TimeoutError(f"Spec resolution timed out after {timeout}s for {expression[:100]}")
-        return result_holder[0]
-
-    def setup(
-        self,
-        app: FastAPI,
-        hooks: HookRegistry,
-        classes: ClassRegistry,
-        routes: RouteRegistry,
-    ) -> None:
-        settings: ClaudeFrontendSettings = self.settings  # type: ignore[assignment]
-        self._app = app  # store for customize_schema and spec lookup
-
-        # Only launch the proxy daemon thread in per-session mode.
-        # In the main server the plugin stays active (for settings/discovery)
-        # but doesn't bind a port — sessions spawn their own instances.
-        is_session = bool(os.environ.get("_SF_SESSION_ID"))
-
-        if is_session:
-            # Build a standalone FastAPI app with proxy routes.
-            # Pass `self` so the router can call resolve_context() lazily.
-            frontend_app = FastAPI(title="claude-frontend")
-            router = create_router(settings, app, plugin=self, hooks=hooks)
-            frontend_app.include_router(router)
-
-            # Instrument with OTEL if tracing extras are installed.
-            try:
-                from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
-
-                FastAPIInstrumentor.instrument_app(frontend_app)
-            except ImportError:
-                pass
-
-            # Start HTTP server in a background thread
-            config = uvicorn.Config(
-                frontend_app,
-                host=settings.listen_host,
-                port=settings.listen_port,
-                log_level="info",
-            )
-            self._server = uvicorn.Server(config)
-            self._thread = threading.Thread(
-                target=self._run_server, daemon=True, name="claude-frontend"
-            )
-            self._thread.start()
-
-            # Wait for the server to be listening before continuing
-            if not _wait_for_port(settings.listen_port, host=settings.listen_host):
-                logger.warning("claude-frontend server may not be ready yet")
-
-            logger.info(
-                "claude-frontend listening on http://%s:%d",
-                settings.listen_host,
-                settings.listen_port,
-            )
-        else:
-            logger.info("claude-frontend registered (proxy launches per-session only)")
-
-        # Clean up on shutdown
-        hooks.register("app.shutdown", self._on_shutdown, plugin_name=self.name)
-
-    def _run_server(self) -> None:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.run_until_complete(self._server.serve())  # type: ignore[union-attr]
-
-    async def _on_shutdown(self) -> None:
-        self._stop()
-
-    def teardown(self) -> None:
-        self._stop()
-
-    def _stop(self) -> None:
-        if self._server:
-            self._server.should_exit = True
-        if self._thread and self._thread.is_alive():
-            self._thread.join(timeout=5)
-        self._server = None
-        self._thread = None
-
-
-async def _fetch(base_url: str, expression: str) -> str:
-    """Call the local /ensemble endpoint with a url4 expression and return plain text."""
-    async with httpx.AsyncClient(timeout=300, verify=False) as client:
-        resp = await client.get(f"{base_url}/ensemble", params={"q": expression})
-        resp.raise_for_status()
-        return resp.text
-
-
-def _wait_for_port(port: int, host: str = "127.0.0.1", timeout: float = 5.0) -> bool:
-    """Wait for a TCP port to be listening."""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            if sock.connect_ex((host, port)) == 0:
-                return True
-        time.sleep(0.1)
-    return False
+    cli_binary = "claude"
+    cli_install_hint = "Install it from https://docs.anthropic.com/en/docs/claude-code"
+    app_title = "claude-frontend"
+    create_router = staticmethod(create_router)

--- a/apps/server/src/screamingface/plugins/claude_intercept/tests/test_intercept.py
+++ b/apps/server/src/screamingface/plugins/claude_intercept/tests/test_intercept.py
@@ -974,13 +974,15 @@ class TestInterceptE2E:
             # Stub socket.getaddrinfo for DNS resolution
             patch("socket.getaddrinfo", return_value=fake_addr),
             # Prevent claude-frontend from starting a real server
-            patch("screamingface.plugins.claude_frontend.plugin.uvicorn.Config"),
+            # (uvicorn + _wait_for_port were moved to frontend_base.plugin_base
+            # during SF-135 — claude_frontend.plugin is now a thin subclass.)
+            patch("screamingface.plugins.frontend_base.plugin_base.uvicorn.Config"),
             patch(
-                "screamingface.plugins.claude_frontend.plugin.uvicorn.Server",
+                "screamingface.plugins.frontend_base.plugin_base.uvicorn.Server",
                 return_value=mock_server,
             ),
             patch(
-                "screamingface.plugins.claude_frontend.plugin._wait_for_port",
+                "screamingface.plugins.frontend_base.plugin_base._wait_for_port",
                 return_value=True,
             ),
         ):

--- a/apps/server/src/screamingface/plugins/codex_frontend/plugin.py
+++ b/apps/server/src/screamingface/plugins/codex_frontend/plugin.py
@@ -4,303 +4,41 @@ Mirrors claude-frontend: runs its own HTTP server so its routes
 (/v1/responses, /v1/*) don't clash with the main SF server.
 
 The Codex CLI uses the OpenAI Responses API, not Chat Completions.
+
+Most behavior lives in :class:`frontend_base.FrontendPluginBase`. This
+module declares the Codex-specific overrides only.
 """
 
 from __future__ import annotations
 
-import asyncio
-import logging
-import os
-import shutil
-import socket
-import threading
-import time
-from typing import TYPE_CHECKING, Literal
-
-import httpx
-import uvicorn
-from fastapi import FastAPI
-from pydantic import Field
 from pydantic_settings import SettingsConfigDict
 
-from screamingface.plugin import Plugin, PluginSettings
 from screamingface.plugins.codex_frontend.proxy import create_router
-
-if TYPE_CHECKING:
-    from screamingface.core.classes import ClassRegistry
-    from screamingface.core.hooks import HookRegistry
-    from screamingface.core.routes import RouteRegistry
-
-logger = logging.getLogger(__name__)
+from screamingface.plugins.frontend_base import (
+    FrontendPluginBase,
+    FrontendSettingsBase,
+)
 
 
-class CodexFrontendSettings(PluginSettings):
+class CodexFrontendSettings(FrontendSettingsBase):
     model_config = SettingsConfigDict(
         env_prefix="SF_CODEX_FRONTEND__",
         env_nested_delimiter="__",
     )
-    active_spec: str | None = Field(
-        default=None,
-        description="Active url4-spec to resolve and prepend as context.",
-    )
+
     upstream_url: str = "https://api.openai.com"
-    listen_host: str = "127.0.0.1"
     listen_port: int = 9102
-    session_service_url: str | None = Field(
-        default=None,
-        description="URL of the session service. Enables session persistence.",
-    )
-    backend_url: str | None = Field(
-        default=None,
-        description=(
-            "SF server URL used for $prompt substitution — stores user text "
-            "on /data and resolves url4 expressions via /ensemble. "
-            "Set automatically in per-session mode."
-        ),
-    )
-    default_backend_path: str = Field(
-        default="/codex",
-        description=(
-            "Default backend path for ensemble fan-out (e.g. /codex). "
-            "Used when resolving $prompt expressions through this frontend."
-        ),
-    )
-    resolve_timeout: float = Field(
-        default=300.0,
-        description="Max seconds to wait for url4 spec resolution on first request.",
-    )
-    embed_target: Literal["system", "user"] = Field(
-        default="user",
-        description="Where to inject url4-resolved context: 'system' or 'user'.",
-    )
-    embed_mode: Literal["concat", "replace"] = Field(
-        default="concat",
-        description="How to embed in user message: 'concat' or 'replace'.",
-    )
-    system_prompt: str = Field(
-        default=(
-            "You are a helpful assistant. Answer the user's question based only on "
-            "the provided context. Be concise and factual."
-        ),
-        description="System prompt prepended to resolved context when embed_target is 'system'.",
-    )
+    default_backend_path: str = "/codex"
 
 
-class CodexFrontendPlugin(Plugin):
+class CodexFrontendPlugin(FrontendPluginBase):
     name = "codex-frontend"
     description = "Transparent proxy between Codex CLI and the OpenAI API"
     tags: list[str] = ["product:openai"]
     depends: list[str] = ["url4-specs", "url4-executor", "frontend-base"]
     settings_class = CodexFrontendSettings
 
-    def __init__(self) -> None:
-        self._server: uvicorn.Server | None = None
-        self._thread: threading.Thread | None = None
-        self._cache: dict[str, str] = {}
-        self._resolved_context: str | None = None
-        self._active_key: str | None = None
-        self._lock = threading.Lock()
-
-    def _get_spec_names(self) -> list[str] | None:
-        if not hasattr(self, "_app") or not self._app:
-            return None
-        specs_plugin = self._app.state.plugins.active_plugins.get("url4-specs")
-        if specs_plugin and specs_plugin.settings:
-            names = list(specs_plugin.settings.specs.keys())
-            if names:
-                return names
-        return None
-
-    def customize_schema(self, schema: dict) -> dict:
-        props = schema.get("properties", {})
-        spec_names = self._get_spec_names()
-        if spec_names and "active_spec" in props:
-            props["active_spec"]["enum"] = spec_names
-        return schema
-
-    def preflight(self) -> tuple[bool, str]:
-        if not shutil.which("codex"):
-            return False, (
-                "Codex CLI not found in PATH. Install it with: npm install -g @openai/codex"
-            )
-        return True, ""
-
-    def _collect_spec_names(self) -> list[str]:
-        settings: CodexFrontendSettings = self.settings  # type: ignore[assignment]
-        if settings.active_spec:
-            return [settings.active_spec]
-        return []
-
-    def _get_spec_urls(self) -> list[tuple[str, str]]:
-        spec_names = self._collect_spec_names()
-        if not spec_names or not hasattr(self, "_app") or not self._app:
-            return []
-        specs_plugin = self._app.state.plugins.active_plugins.get("url4-specs")
-        if not specs_plugin or not specs_plugin.settings:
-            return []
-        result: list[tuple[str, str]] = []
-        for name in spec_names:
-            spec = specs_plugin.settings.specs.get(name)
-            if spec and spec.expression:
-                result.append((name, spec.expression))
-        return result
-
-    def get_active_expression(self) -> str | None:
-        spec_urls = self._get_spec_urls()
-        if not spec_urls:
-            return None
-        return spec_urls[0][1]
-
-    def resolve_context(self) -> str | None:
-        """Resolve active specs lazily. Called on first request."""
-        spec_urls = self._get_spec_urls()
-        spec_urls = [(n, e) for n, e in spec_urls if "$prompt" not in e]
-        if not spec_urls:
-            return None
-
-        active_key = ",".join(name for name, _ in spec_urls)
-        if self._active_key == active_key and self._resolved_context is not None:
-            return self._resolved_context
-
-        with self._lock:
-            if self._active_key == active_key and self._resolved_context is not None:
-                return self._resolved_context
-
-            settings: CodexFrontendSettings = self.settings  # type: ignore[assignment]
-            timeout = settings.resolve_timeout
-            resolved_parts: list[str] = []
-
-            for name, url in spec_urls:
-                if name in self._cache:
-                    resolved_parts.append(self._cache[name])
-                    continue
-                try:
-                    result = self._fetch_sync(url, timeout)
-                    if result:
-                        self._cache[name] = result
-                        resolved_parts.append(result)
-                except Exception:
-                    logger.warning("Failed to resolve spec %r", name, exc_info=True)
-
-            if resolved_parts:
-                self._resolved_context = "\n\n".join(resolved_parts)
-                self._active_key = active_key
-            else:
-                self._resolved_context = None
-                self._active_key = active_key
-
-            return self._resolved_context
-
-    def _get_backend_url(self) -> str:
-        settings: CodexFrontendSettings = self.settings  # type: ignore[assignment]
-        if settings.backend_url:
-            return settings.backend_url.rstrip("/")
-        cfg = getattr(self._app.state, "config", None) if self._app else None
-        port = cfg.server.port if cfg else 8000
-        use_ssl = cfg.server.ssl if cfg else False
-        scheme = "https" if use_ssl else "http"
-        return f"{scheme}://localhost:{port}"
-
-    def _fetch_sync(self, expression: str, timeout: float) -> str:
-        base = self._get_backend_url()
-        result_holder: list[str] = []
-
-        def _run() -> None:
-            loop = asyncio.new_event_loop()
-            try:
-                result_holder.append(loop.run_until_complete(_fetch(base, expression)))
-            finally:
-                loop.close()
-
-        thread = threading.Thread(target=_run, name="url4-fetch", daemon=True)
-        thread.start()
-        thread.join(timeout=timeout)
-
-        if not result_holder:
-            raise TimeoutError(f"Spec resolution timed out after {timeout}s")
-        return result_holder[0]
-
-    def setup(
-        self,
-        app: FastAPI,
-        hooks: HookRegistry,
-        classes: ClassRegistry,
-        routes: RouteRegistry,
-    ) -> None:
-        settings: CodexFrontendSettings = self.settings  # type: ignore[assignment]
-        self._app = app
-
-        is_session = bool(os.environ.get("_SF_SESSION_ID"))
-
-        if is_session:
-            frontend_app = FastAPI(title="codex-frontend")
-            router = create_router(settings, app, plugin=self, hooks=hooks)
-            frontend_app.include_router(router)
-
-            try:
-                from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
-
-                FastAPIInstrumentor.instrument_app(frontend_app)
-            except ImportError:
-                pass
-
-            config = uvicorn.Config(
-                frontend_app,
-                host=settings.listen_host,
-                port=settings.listen_port,
-                log_level="info",
-            )
-            self._server = uvicorn.Server(config)
-            self._thread = threading.Thread(
-                target=self._run_server, daemon=True, name="codex-frontend"
-            )
-            self._thread.start()
-
-            if not _wait_for_port(settings.listen_port, host=settings.listen_host):
-                logger.warning("codex-frontend server may not be ready yet")
-
-            logger.info(
-                "codex-frontend listening on http://%s:%d",
-                settings.listen_host,
-                settings.listen_port,
-            )
-        else:
-            logger.info("codex-frontend registered (proxy launches per-session only)")
-
-        hooks.register("app.shutdown", self._on_shutdown, plugin_name=self.name)
-
-    def _run_server(self) -> None:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.run_until_complete(self._server.serve())  # type: ignore[union-attr]
-
-    async def _on_shutdown(self) -> None:
-        self._stop()
-
-    def teardown(self) -> None:
-        self._stop()
-
-    def _stop(self) -> None:
-        if self._server:
-            self._server.should_exit = True
-        if self._thread and self._thread.is_alive():
-            self._thread.join(timeout=5)
-        self._server = None
-        self._thread = None
-
-
-async def _fetch(base_url: str, expression: str) -> str:
-    async with httpx.AsyncClient(timeout=300, verify=False) as client:
-        resp = await client.get(f"{base_url}/ensemble", params={"q": expression})
-        resp.raise_for_status()
-        return resp.text
-
-
-def _wait_for_port(port: int, host: str = "127.0.0.1", timeout: float = 5.0) -> bool:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            if sock.connect_ex((host, port)) == 0:
-                return True
-        time.sleep(0.1)
-    return False
+    cli_binary = "codex"
+    cli_install_hint = "Install it with: npm install -g @openai/codex"
+    app_title = "codex-frontend"
+    create_router = staticmethod(create_router)

--- a/apps/server/src/screamingface/plugins/frontend_base/__init__.py
+++ b/apps/server/src/screamingface/plugins/frontend_base/__init__.py
@@ -20,6 +20,10 @@ plugin only so other plugins can declare ``depends = ["frontend-base"]``.
 
 from __future__ import annotations
 
+from screamingface.plugins.frontend_base.plugin_base import (
+    FrontendPluginBase,
+    FrontendSettingsBase,
+)
 from screamingface.plugins.frontend_base.tracing import (
     ProxyTracer,
     make_tracer,
@@ -28,6 +32,8 @@ from screamingface.plugins.frontend_base.tracing import (
 )
 
 __all__ = [
+    "FrontendPluginBase",
+    "FrontendSettingsBase",
     "ProxyTracer",
     "make_tracer",
     "redact_headers",

--- a/apps/server/src/screamingface/plugins/frontend_base/plugin_base.py
+++ b/apps/server/src/screamingface/plugins/frontend_base/plugin_base.py
@@ -1,0 +1,381 @@
+"""Shared :class:`FrontendPluginBase` for transparent-proxy frontends.
+
+Every ``*_frontend`` plugin (claude, codex, gemini, ollama) ran ~300
+lines of nearly-identical bookkeeping: spec resolution + caching, a
+side-spawned FastAPI server, lifecycle hooks. The only real
+differences are: plugin metadata, settings defaults, the CLI binary
+name to check at preflight, and the per-provider router factory.
+
+This base concentrates the shared behavior and asks each subclass for
+those four hooks. Each frontend plugin shrinks to ~50 lines.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+import socket
+import threading
+import time
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
+
+import httpx
+import uvicorn
+from fastapi import FastAPI
+from pydantic import Field
+from pydantic_settings import SettingsConfigDict
+
+from screamingface.plugin import Plugin, PluginSettings
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from screamingface.core.classes import ClassRegistry
+    from screamingface.core.hooks import HookRegistry
+    from screamingface.core.routes import RouteRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class FrontendSettingsBase(PluginSettings):
+    """Base settings shared by every transparent-proxy frontend plugin.
+
+    Subclasses only need to override:
+    - ``model_config.env_prefix`` (e.g. ``"SF_CLAUDE_FRONTEND__"``)
+    - ``upstream_url`` default
+    - ``listen_port`` default
+    - ``default_backend_path`` default
+
+    Everything else is shared.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="SF_FRONTEND__",
+        env_nested_delimiter="__",
+    )
+
+    active_spec: str | None = Field(
+        default=None,
+        description="Active url4-spec to resolve and prepend as context.",
+    )
+    upstream_url: str = "https://example.com"
+    listen_host: str = "127.0.0.1"
+    listen_port: int = 9100
+    session_service_url: str | None = Field(
+        default=None,
+        description="URL of the session service. Enables session persistence.",
+    )
+    backend_url: str | None = Field(
+        default=None,
+        description=(
+            "SF server URL used for $prompt substitution — stores user text "
+            "on /data and resolves url4 expressions via /ensemble. "
+            "Set automatically in per-session mode."
+        ),
+    )
+    default_backend_path: str = Field(
+        default="/claude",
+        description="Default backend path for ensemble fan-out.",
+    )
+    resolve_timeout: float = Field(
+        default=300.0,
+        description="Max seconds to wait for url4 spec resolution on first request.",
+    )
+    embed_target: Literal["system", "user"] = Field(
+        default="user",
+        description="Where to inject url4-resolved context: 'system' or 'user'.",
+    )
+    embed_mode: Literal["concat", "replace"] = Field(
+        default="concat",
+        description="How to embed in user message: 'concat' or 'replace'.",
+    )
+    system_prompt: str = Field(
+        default=(
+            "You are a helpful assistant. Answer the user's question based only on "
+            "the provided context. Be concise and factual."
+        ),
+        description="System prompt prepended to resolved context when embed_target='system'.",
+    )
+
+
+class FrontendPluginBase(Plugin):
+    """Shared lifecycle for transparent-proxy frontend plugins.
+
+    Subclasses must declare:
+
+    - The standard :class:`Plugin` class attrs (``name``, ``description``,
+      ``tags``, ``depends``, ``settings_class``).
+    - ``cli_binary``: the CLI binary name to look up at preflight, or
+      ``None`` to skip the check.
+    - ``cli_install_hint``: text appended to the preflight error message
+      when ``cli_binary`` is missing.
+    - ``app_title``: title for the spawned FastAPI app (mostly cosmetic).
+    - ``create_router``: a static-method-style callable returning the
+      provider's :class:`fastapi.APIRouter`. Signature
+      ``(settings, app, plugin, hooks)`` matches the existing factories.
+    """
+
+    cli_binary: ClassVar[str | None] = None
+    cli_install_hint: ClassVar[str] = ""
+    app_title: ClassVar[str] = "frontend"
+    create_router: ClassVar[Callable[..., Any]]
+
+    def __init__(self) -> None:
+        self._server: uvicorn.Server | None = None
+        self._thread: threading.Thread | None = None
+        self._cache: dict[str, str] = {}  # spec_name → resolved text
+        self._resolved_context: str | None = None
+        self._active_key: str | None = None  # tracks which specs produced the cache
+        self._lock = threading.Lock()
+        self._app: Any = None
+
+    # ------------------------------------------------------------------
+    # Schema customization
+    # ------------------------------------------------------------------
+
+    def _get_spec_names(self) -> list[str] | None:
+        if not self._app:
+            return None
+        specs_plugin = self._app.state.plugins.active_plugins.get("url4-specs")
+        if specs_plugin and specs_plugin.settings:
+            names = list(specs_plugin.settings.specs.keys())
+            if names:
+                return names
+        return None
+
+    def customize_schema(self, schema: dict) -> dict:
+        props = schema.get("properties", {})
+        spec_names = self._get_spec_names()
+        if spec_names and "active_spec" in props:
+            props["active_spec"]["enum"] = spec_names
+        return schema
+
+    # ------------------------------------------------------------------
+    # Preflight
+    # ------------------------------------------------------------------
+
+    def preflight(self) -> tuple[bool, str]:
+        # Skip the CLI check in test subprocesses (ServerManager sets this).
+        # The proxy itself doesn't need the CLI — the check exists to
+        # prevent a confusing runtime for end-users who haven't installed it.
+        if os.environ.get("_SF_SUBPROCESS"):
+            return True, ""
+        if self.cli_binary and not shutil.which(self.cli_binary):
+            return (
+                False,
+                f"{self.cli_binary} CLI not found in PATH. {self.cli_install_hint}".strip(),
+            )
+        return True, ""
+
+    # ------------------------------------------------------------------
+    # Spec resolution
+    # ------------------------------------------------------------------
+
+    def _collect_spec_names(self) -> list[str]:
+        """Return the active spec as a single-element list, or empty."""
+        settings: FrontendSettingsBase = self.settings  # type: ignore[assignment]
+        if settings.active_spec:
+            return [settings.active_spec]
+        return []
+
+    def _get_spec_urls(self) -> list[tuple[str, str]]:
+        """Get (name, expression_url) pairs for active specs."""
+        spec_names = self._collect_spec_names()
+        if not spec_names or not self._app:
+            return []
+        specs_plugin = self._app.state.plugins.active_plugins.get("url4-specs")
+        if not specs_plugin or not specs_plugin.settings:
+            return []
+        result: list[tuple[str, str]] = []
+        for name in spec_names:
+            spec = specs_plugin.settings.specs.get(name)
+            if spec and spec.expression:
+                result.append((name, spec.expression))
+        return result
+
+    def get_active_expression(self) -> str | None:
+        """Return the raw URL4 expression for the active spec, without resolving it."""
+        spec_urls = self._get_spec_urls()
+        if not spec_urls:
+            return None
+        return spec_urls[0][1]
+
+    def resolve_context(self) -> str | None:
+        """Resolve active specs lazily.
+
+        Cache hit (same spec set) returns cached text; cache miss
+        fetches via :meth:`_fetch_sync` and stores. Specs containing
+        ``$prompt`` are skipped — they need per-request substitution
+        in the proxy.
+        """
+        spec_urls = self._get_spec_urls()
+        spec_urls = [(n, e) for n, e in spec_urls if "$prompt" not in e]
+        if not spec_urls:
+            return None
+
+        active_key = ",".join(name for name, _ in spec_urls)
+        if self._active_key == active_key and self._resolved_context is not None:
+            return self._resolved_context
+
+        with self._lock:
+            if self._active_key == active_key and self._resolved_context is not None:
+                return self._resolved_context
+
+            settings: FrontendSettingsBase = self.settings  # type: ignore[assignment]
+            timeout = settings.resolve_timeout
+            resolved_parts: list[str] = []
+
+            for name, url in spec_urls:
+                if name in self._cache:
+                    resolved_parts.append(self._cache[name])
+                    logger.info("Cache hit for spec %r (%d chars)", name, len(self._cache[name]))
+                    continue
+                try:
+                    result = self._fetch_sync(url, timeout)
+                    if result:
+                        self._cache[name] = result
+                        resolved_parts.append(result)
+                        logger.info("Resolved spec %r (%d chars)", name, len(result))
+                except Exception:
+                    logger.warning("Failed to resolve spec %r", name, exc_info=True)
+
+            if resolved_parts:
+                self._resolved_context = "\n\n".join(resolved_parts)
+                self._active_key = active_key
+                logger.info(
+                    "Cached %d chars of resolved url4 context",
+                    len(self._resolved_context),
+                )
+            else:
+                self._resolved_context = None
+                self._active_key = active_key
+
+            return self._resolved_context
+
+    def _get_backend_url(self) -> str:
+        """Return the base URL for backend/ensemble/data calls."""
+        settings: FrontendSettingsBase = self.settings  # type: ignore[assignment]
+        if settings.backend_url:
+            return settings.backend_url.rstrip("/")
+        cfg = getattr(self._app.state, "config", None) if self._app else None
+        port = cfg.server.port if cfg else 8000
+        use_ssl = cfg.server.ssl if cfg else False
+        scheme = "https" if use_ssl else "http"
+        return f"{scheme}://localhost:{port}"
+
+    def _fetch_sync(self, expression: str, timeout: float) -> str:
+        """Resolve a url4 expression by calling the /ensemble endpoint."""
+        base = self._get_backend_url()
+        result_holder: list[str] = []
+
+        def _run() -> None:
+            loop = asyncio.new_event_loop()
+            try:
+                result_holder.append(loop.run_until_complete(_fetch(base, expression)))
+            finally:
+                loop.close()
+
+        thread = threading.Thread(target=_run, name="url4-fetch", daemon=True)
+        thread.start()
+        thread.join(timeout=timeout)
+
+        if not result_holder:
+            raise TimeoutError(f"Spec resolution timed out after {timeout}s")
+        return result_holder[0]
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def setup(
+        self,
+        app: FastAPI,
+        hooks: HookRegistry,
+        classes: ClassRegistry,  # noqa: ARG002 — required by Plugin contract
+        routes: RouteRegistry,  # noqa: ARG002 — required by Plugin contract
+    ) -> None:
+        settings: FrontendSettingsBase = self.settings  # type: ignore[assignment]
+        self._app = app
+
+        is_session = bool(os.environ.get("_SF_SESSION_ID"))
+
+        if is_session:
+            frontend_app = FastAPI(title=self.app_title)
+            router = type(self).create_router(settings, app, plugin=self, hooks=hooks)
+            frontend_app.include_router(router)
+
+            try:
+                from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+                FastAPIInstrumentor.instrument_app(frontend_app)
+            except ImportError:
+                pass
+
+            config = uvicorn.Config(
+                frontend_app,
+                host=settings.listen_host,
+                port=settings.listen_port,
+                log_level="info",
+            )
+            self._server = uvicorn.Server(config)
+            self._thread = threading.Thread(
+                target=self._run_server, daemon=True, name=self.app_title
+            )
+            self._thread.start()
+
+            if not _wait_for_port(settings.listen_port, host=settings.listen_host):
+                logger.warning("%s server may not be ready yet", self.app_title)
+
+            logger.info(
+                "%s listening on http://%s:%d",
+                self.app_title,
+                settings.listen_host,
+                settings.listen_port,
+            )
+        else:
+            logger.info("%s registered (proxy launches per-session only)", self.app_title)
+
+        hooks.register("app.shutdown", self._on_shutdown, plugin_name=self.name)
+
+    def _run_server(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(self._server.serve())  # type: ignore[union-attr]
+
+    async def _on_shutdown(self) -> None:
+        self._stop()
+
+    def teardown(self) -> None:
+        self._stop()
+
+    def _stop(self) -> None:
+        if self._server:
+            self._server.should_exit = True
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=5)
+        self._server = None
+        self._thread = None
+
+
+async def _fetch(base_url: str, expression: str) -> str:
+    """Call /ensemble with a url4 expression and return plain text."""
+    async with httpx.AsyncClient(timeout=300, verify=False) as client:
+        resp = await client.get(f"{base_url}/ensemble", params={"q": expression})
+        resp.raise_for_status()
+        return resp.text
+
+
+def _wait_for_port(port: int, host: str = "127.0.0.1", timeout: float = 5.0) -> bool:
+    """Wait for a TCP port to be listening."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            if sock.connect_ex((host, port)) == 0:
+                return True
+        time.sleep(0.1)
+    return False
+
+
+__all__ = ["FrontendPluginBase", "FrontendSettingsBase"]

--- a/apps/server/src/screamingface/plugins/gemini_frontend/plugin.py
+++ b/apps/server/src/screamingface/plugins/gemini_frontend/plugin.py
@@ -1,287 +1,43 @@
 """Gemini Frontend plugin — transparent proxy on a dedicated port.
 
-Mirrors claude-frontend/codex-frontend: runs its own HTTP server so
-its routes don't clash with the main SF server.
-
-The Gemini CLI uses the Google AI Gemini API at
-generativelanguage.googleapis.com.
+Proxies the Google AI Gemini API. Most behavior lives in
+:class:`frontend_base.FrontendPluginBase`; this module declares the
+Gemini-specific overrides only.
 """
 
 from __future__ import annotations
 
-import asyncio
-import logging
-import os
-import shutil
-import socket
-import threading
-import time
-from typing import TYPE_CHECKING, Literal
-
-import httpx
-import uvicorn
-from fastapi import FastAPI
-from pydantic import Field
 from pydantic_settings import SettingsConfigDict
 
-from screamingface.plugin import Plugin, PluginSettings
+from screamingface.plugins.frontend_base import (
+    FrontendPluginBase,
+    FrontendSettingsBase,
+)
 from screamingface.plugins.gemini_frontend.proxy import create_router
 
-if TYPE_CHECKING:
-    from screamingface.core.classes import ClassRegistry
-    from screamingface.core.hooks import HookRegistry
-    from screamingface.core.routes import RouteRegistry
 
-logger = logging.getLogger(__name__)
-
-
-class GeminiFrontendSettings(PluginSettings):
+class GeminiFrontendSettings(FrontendSettingsBase):
     model_config = SettingsConfigDict(
         env_prefix="SF_GEMINI_FRONTEND__",
         env_nested_delimiter="__",
     )
-    active_spec: str | None = Field(
-        default=None,
-        description="Active url4-spec to resolve and prepend as context.",
-    )
+
     upstream_url: str = "https://generativelanguage.googleapis.com"
-    listen_host: str = "127.0.0.1"
     listen_port: int = 9103
-    session_service_url: str | None = Field(
-        default=None,
-        description="URL of the session service. Enables session persistence.",
-    )
-    backend_url: str | None = Field(
-        default=None,
-        description=(
-            "SF server URL used for $prompt substitution — stores user text "
-            "on /data and resolves url4 expressions via /ensemble. "
-            "Set automatically in per-session mode."
-        ),
-    )
-    default_backend_path: str = Field(
-        default="/gemini",
-        description=(
-            "Default backend path for ensemble fan-out (e.g. /gemini). "
-            "Used when resolving $prompt expressions through this frontend."
-        ),
-    )
-    resolve_timeout: float = Field(
-        default=300.0,
-        description="Max seconds to wait for url4 spec resolution.",
-    )
-    embed_target: Literal["system", "user"] = Field(
-        default="user",
-        description="Where to inject url4-resolved context.",
-    )
-    embed_mode: Literal["concat", "replace"] = Field(
-        default="concat",
-        description="How to embed in user message.",
-    )
-    system_prompt: str = Field(
-        default=(
-            "You are a helpful assistant. Answer the user's question based only on "
-            "the provided context. Be concise and factual."
-        ),
-        description="System prompt prepended to resolved context.",
-    )
+    default_backend_path: str = "/gemini"
 
 
-class GeminiFrontendPlugin(Plugin):
+class GeminiFrontendPlugin(FrontendPluginBase):
     name = "gemini-frontend"
     description = "Transparent proxy between Gemini CLI and the Google AI API"
     tags: list[str] = ["product:gemini"]
     depends: list[str] = ["url4-specs", "url4-executor", "frontend-base"]
     settings_class = GeminiFrontendSettings
 
-    def __init__(self) -> None:
-        self._server: uvicorn.Server | None = None
-        self._thread: threading.Thread | None = None
-        self._cache: dict[str, str] = {}
-        self._resolved_context: str | None = None
-        self._active_key: str | None = None
-        self._lock = threading.Lock()
-
-    def _get_spec_names(self) -> list[str] | None:
-        if not hasattr(self, "_app") or not self._app:
-            return None
-        specs_plugin = self._app.state.plugins.active_plugins.get("url4-specs")
-        if specs_plugin and specs_plugin.settings:
-            names = list(specs_plugin.settings.specs.keys())
-            if names:
-                return names
-        return None
-
-    def customize_schema(self, schema: dict) -> dict:
-        props = schema.get("properties", {})
-        spec_names = self._get_spec_names()
-        if spec_names and "active_spec" in props:
-            props["active_spec"]["enum"] = spec_names
-        return schema
-
-    def preflight(self) -> tuple[bool, str]:
-        if not shutil.which("gemini"):
-            return False, (
-                "Gemini CLI not found in PATH. "
-                "Install it with: npm install -g @anthropic-ai/gemini-cli "
-                "or see https://github.com/anthropics/gemini-cli"
-            )
-        return True, ""
-
-    def _collect_spec_names(self) -> list[str]:
-        settings: GeminiFrontendSettings = self.settings  # type: ignore[assignment]
-        if settings.active_spec:
-            return [settings.active_spec]
-        return []
-
-    def _get_spec_urls(self) -> list[tuple[str, str]]:
-        spec_names = self._collect_spec_names()
-        if not spec_names or not hasattr(self, "_app") or not self._app:
-            return []
-        specs_plugin = self._app.state.plugins.active_plugins.get("url4-specs")
-        if not specs_plugin or not specs_plugin.settings:
-            return []
-        result: list[tuple[str, str]] = []
-        for name in spec_names:
-            spec = specs_plugin.settings.specs.get(name)
-            if spec and spec.expression:
-                result.append((name, spec.expression))
-        return result
-
-    def get_active_expression(self) -> str | None:
-        spec_urls = self._get_spec_urls()
-        return spec_urls[0][1] if spec_urls else None
-
-    def resolve_context(self) -> str | None:
-        spec_urls = self._get_spec_urls()
-        spec_urls = [(n, e) for n, e in spec_urls if "$prompt" not in e]
-        if not spec_urls:
-            return None
-        active_key = ",".join(name for name, _ in spec_urls)
-        if self._active_key == active_key and self._resolved_context is not None:
-            return self._resolved_context
-        with self._lock:
-            if self._active_key == active_key and self._resolved_context is not None:
-                return self._resolved_context
-            settings: GeminiFrontendSettings = self.settings  # type: ignore[assignment]
-            resolved_parts: list[str] = []
-            for name, url in spec_urls:
-                if name in self._cache:
-                    resolved_parts.append(self._cache[name])
-                    continue
-                try:
-                    result = self._fetch_sync(url, settings.resolve_timeout)
-                    if result:
-                        self._cache[name] = result
-                        resolved_parts.append(result)
-                except Exception:
-                    logger.warning("Failed to resolve spec %r", name, exc_info=True)
-            self._resolved_context = "\n\n".join(resolved_parts) if resolved_parts else None
-            self._active_key = active_key
-            return self._resolved_context
-
-    def _get_backend_url(self) -> str:
-        settings: GeminiFrontendSettings = self.settings  # type: ignore[assignment]
-        if settings.backend_url:
-            return settings.backend_url.rstrip("/")
-        cfg = getattr(self._app.state, "config", None) if self._app else None
-        port = cfg.server.port if cfg else 8000
-        use_ssl = cfg.server.ssl if cfg else False
-        scheme = "https" if use_ssl else "http"
-        return f"{scheme}://localhost:{port}"
-
-    def _fetch_sync(self, expression: str, timeout: float) -> str:
-        base = self._get_backend_url()
-        result_holder: list[str] = []
-
-        def _run() -> None:
-            loop = asyncio.new_event_loop()
-            try:
-                result_holder.append(loop.run_until_complete(_fetch(base, expression)))
-            finally:
-                loop.close()
-
-        thread = threading.Thread(target=_run, name="url4-fetch", daemon=True)
-        thread.start()
-        thread.join(timeout=timeout)
-        if not result_holder:
-            raise TimeoutError(f"Spec resolution timed out after {timeout}s")
-        return result_holder[0]
-
-    def setup(
-        self,
-        app: FastAPI,
-        hooks: HookRegistry,
-        classes: ClassRegistry,
-        routes: RouteRegistry,
-    ) -> None:
-        settings: GeminiFrontendSettings = self.settings  # type: ignore[assignment]
-        self._app = app
-        is_session = bool(os.environ.get("_SF_SESSION_ID"))
-        if is_session:
-            frontend_app = FastAPI(title="gemini-frontend")
-            router = create_router(settings, app, plugin=self, hooks=hooks)
-            frontend_app.include_router(router)
-            try:
-                from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
-
-                FastAPIInstrumentor.instrument_app(frontend_app)
-            except ImportError:
-                pass
-            config = uvicorn.Config(
-                frontend_app,
-                host=settings.listen_host,
-                port=settings.listen_port,
-                log_level="info",
-            )
-            self._server = uvicorn.Server(config)
-            self._thread = threading.Thread(
-                target=self._run_server, daemon=True, name="gemini-frontend"
-            )
-            self._thread.start()
-            if not _wait_for_port(settings.listen_port, host=settings.listen_host):
-                logger.warning("gemini-frontend server may not be ready yet")
-            logger.info(
-                "gemini-frontend listening on http://%s:%d",
-                settings.listen_host,
-                settings.listen_port,
-            )
-        else:
-            logger.info("gemini-frontend registered (proxy launches per-session only)")
-        hooks.register("app.shutdown", self._on_shutdown, plugin_name=self.name)
-
-    def _run_server(self) -> None:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.run_until_complete(self._server.serve())  # type: ignore[union-attr]
-
-    async def _on_shutdown(self) -> None:
-        self._stop()
-
-    def teardown(self) -> None:
-        self._stop()
-
-    def _stop(self) -> None:
-        if self._server:
-            self._server.should_exit = True
-        if self._thread and self._thread.is_alive():
-            self._thread.join(timeout=5)
-        self._server = None
-        self._thread = None
-
-
-async def _fetch(base_url: str, expression: str) -> str:
-    async with httpx.AsyncClient(timeout=300, verify=False) as client:
-        resp = await client.get(f"{base_url}/ensemble", params={"q": expression})
-        resp.raise_for_status()
-        return resp.text
-
-
-def _wait_for_port(port: int, host: str = "127.0.0.1", timeout: float = 5.0) -> bool:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            if sock.connect_ex((host, port)) == 0:
-                return True
-        time.sleep(0.1)
-    return False
+    cli_binary = "gemini"
+    cli_install_hint = (
+        "Install it with: npm install -g @anthropic-ai/gemini-cli "
+        "or see https://github.com/anthropics/gemini-cli"
+    )
+    app_title = "gemini-frontend"
+    create_router = staticmethod(create_router)

--- a/apps/server/src/screamingface/plugins/ollama_frontend/plugin.py
+++ b/apps/server/src/screamingface/plugins/ollama_frontend/plugin.py
@@ -1,308 +1,50 @@
 """Ollama Frontend plugin — transparent proxy on a dedicated port.
 
-Runs its own HTTP server so its routes (/api/chat and /api/* passthrough)
-don't clash with the main SF server or other frontend plugins.  Mirrors
-``claude_frontend`` in structure; adapted for Ollama's wire format.
+Most behavior lives in :class:`frontend_base.FrontendPluginBase`. This
+module declares the Ollama-specific overrides only.
+
+Notable differences from the other frontends:
+- No CLI binary check at preflight (Ollama is a server, not a CLI).
+- ``embed_target`` defaults to ``"system"`` (others default to
+  ``"user"``).
 """
 
 from __future__ import annotations
 
-import asyncio
-import logging
-import os
-import socket
-import threading
-import time
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
-import httpx
-import uvicorn
-from fastapi import FastAPI
 from pydantic import Field
 from pydantic_settings import SettingsConfigDict
 
-from screamingface.plugin import Plugin, PluginSettings
+from screamingface.plugins.frontend_base import (
+    FrontendPluginBase,
+    FrontendSettingsBase,
+)
 from screamingface.plugins.ollama_frontend.proxy import create_router
 
-if TYPE_CHECKING:
-    from screamingface.core.classes import ClassRegistry
-    from screamingface.core.hooks import HookRegistry
-    from screamingface.core.routes import RouteRegistry
 
-logger = logging.getLogger(__name__)
-
-
-class OllamaFrontendSettings(PluginSettings):
+class OllamaFrontendSettings(FrontendSettingsBase):
     model_config = SettingsConfigDict(
         env_prefix="SF_OLLAMA_FRONTEND__",
         env_nested_delimiter="__",
     )
-    active_spec: str | None = Field(
-        default=None,
-        description="Active url4-spec to resolve and inject as context.",
-    )
+
     upstream_url: str = "http://localhost:11434"
-    listen_host: str = "127.0.0.1"
     listen_port: int = 9103
-    session_service_url: str | None = Field(
-        default=None,
-        description=(
-            "URL of the session service (e.g. http://127.0.0.1:9200). Enables session persistence."
-        ),
-    )
-    backend_url: str | None = Field(
-        default=None,
-        description=(
-            "URL of the main SF server for url4/data/backend calls"
-            " (e.g. http://127.0.0.1:8000). When set (per-session mode),"
-            " proxy uses HTTP calls instead of in-process."
-        ),
-    )
-    resolve_timeout: float = Field(
-        default=300.0,
-        description="Max seconds to wait for url4 spec resolution on first request.",
-    )
-    embed_target: Literal["system", "user"] = Field(
-        default="system",
-        description=(
-            "Where to inject url4-resolved context: "
-            "'system' (prepend a system message) or 'user' (inject into last user message)."
-        ),
-    )
-    embed_mode: Literal["concat", "replace"] = Field(
-        default="concat",
-        description=("How to embed: 'concat' (original + context) or 'replace' (context only)."),
-    )
-    system_prompt: str = Field(
-        default=(
-            "You are a helpful assistant. Answer the user's question based only on "
-            "the provided context. Be concise and factual."
-        ),
-        description=(
-            "System prompt prepended to the resolved context when embed_target is 'system'."
-        ),
-    )
+    default_backend_path: str = "/ollama"
+    # Ollama frontend prefers system-prompt injection as the default
+    # because its default chat template treats messages[0] specially.
+    embed_target: Literal["system", "user"] = Field(default="system")
 
 
-class OllamaFrontendPlugin(Plugin):
+class OllamaFrontendPlugin(FrontendPluginBase):
     name = "ollama-frontend"
     description = "Transparent proxy between local clients and a local/remote Ollama server"
     tags: list[str] = ["product:ollama"]
-    depends = ["url4-specs", "url4-executor", "frontend-base"]
+    depends: list[str] = ["url4-specs", "url4-executor", "frontend-base"]
     settings_class = OllamaFrontendSettings
 
-    def __init__(self) -> None:
-        self._server: uvicorn.Server | None = None
-        self._thread: threading.Thread | None = None
-        self._cache: dict[str, str] = {}  # spec_name → resolved text
-        self._resolved_context: str | None = None
-        self._active_key: str | None = None
-        self._lock = threading.Lock()
-
-    def _get_spec_names(self) -> list[str] | None:
-        if not hasattr(self, "_app") or not self._app:
-            return None
-        specs_plugin = self._app.state.plugins.active_plugins.get("url4-specs")
-        if specs_plugin and specs_plugin.settings:
-            names = list(specs_plugin.settings.specs.keys())
-            if names:
-                return names
-        return None
-
-    def customize_schema(self, schema: dict) -> dict:
-        props = schema.get("properties", {})
-        spec_names = self._get_spec_names()
-        if spec_names and "active_spec" in props:
-            props["active_spec"]["enum"] = spec_names
-        return schema
-
-    def preflight(self) -> tuple[bool, str]:
-        return super().preflight()
-
-    def _collect_spec_names(self) -> list[str]:
-        settings: OllamaFrontendSettings = self.settings  # type: ignore[assignment]
-        if settings.active_spec:
-            return [settings.active_spec]
-        return []
-
-    def _get_spec_urls(self) -> list[tuple[str, str]]:
-        spec_names = self._collect_spec_names()
-        if not spec_names or not hasattr(self, "_app") or not self._app:
-            return []
-
-        specs_plugin = self._app.state.plugins.active_plugins.get("url4-specs")
-        if not specs_plugin or not specs_plugin.settings:
-            return []
-
-        result: list[tuple[str, str]] = []
-        for name in spec_names:
-            spec = specs_plugin.settings.specs.get(name)
-            if spec and spec.expression:
-                result.append((name, spec.expression))
-        return result
-
-    def get_active_expression(self) -> str | None:
-        """Return the raw url4 expression for the active spec, without resolving."""
-        spec_urls = self._get_spec_urls()
-        if not spec_urls:
-            return None
-        return spec_urls[0][1]
-
-    def resolve_context(self) -> str | None:
-        """Resolve active specs lazily on first request. Skips $prompt specs."""
-        spec_urls = self._get_spec_urls()
-        spec_urls = [(n, e) for n, e in spec_urls if "$prompt" not in e]
-        if not spec_urls:
-            return None
-
-        active_key = ",".join(name for name, _ in spec_urls)
-
-        if self._active_key == active_key and self._resolved_context is not None:
-            return self._resolved_context
-
-        with self._lock:
-            if self._active_key == active_key and self._resolved_context is not None:
-                return self._resolved_context
-
-            settings: OllamaFrontendSettings = self.settings  # type: ignore[assignment]
-            timeout = settings.resolve_timeout
-            resolved_parts: list[str] = []
-
-            for name, url in spec_urls:
-                if name in self._cache:
-                    resolved_parts.append(self._cache[name])
-                    logger.info("Cache hit for spec %r (%d chars)", name, len(self._cache[name]))
-                    continue
-
-                try:
-                    result = self._fetch_sync(url, timeout)
-                    if result:
-                        self._cache[name] = result
-                        resolved_parts.append(result)
-                        logger.info("Resolved spec %r (%d chars)", name, len(result))
-                except Exception:
-                    logger.warning("Failed to resolve spec %r", name, exc_info=True)
-
-            if resolved_parts:
-                self._resolved_context = "\n\n".join(resolved_parts)
-                self._active_key = active_key
-                logger.info("Cached %d chars of resolved url4 context", len(self._resolved_context))
-            else:
-                self._resolved_context = None
-                self._active_key = active_key
-
-            return self._resolved_context
-
-    def _get_backend_url(self) -> str:
-        settings: OllamaFrontendSettings = self.settings  # type: ignore[assignment]
-        if settings.backend_url:
-            return settings.backend_url.rstrip("/")
-        cfg = getattr(self._app.state, "config", None) if self._app else None
-        port = cfg.server.port if cfg else 8000
-        use_ssl = cfg.server.ssl if cfg else False
-        scheme = "https" if use_ssl else "http"
-        return f"{scheme}://localhost:{port}"
-
-    def _fetch_sync(self, expression: str, timeout: float) -> str:
-        base = self._get_backend_url()
-        result_holder: list[str] = []
-
-        def _run() -> None:
-            loop = asyncio.new_event_loop()
-            try:
-                result_holder.append(loop.run_until_complete(_fetch(base, expression)))
-            finally:
-                loop.close()
-
-        thread = threading.Thread(target=_run, name="url4-fetch", daemon=True)
-        thread.start()
-        thread.join(timeout=timeout)
-
-        if not result_holder:
-            raise TimeoutError(f"Spec resolution timed out after {timeout}s for {expression[:100]}")
-        return result_holder[0]
-
-    def setup(
-        self,
-        app: FastAPI,
-        hooks: HookRegistry,
-        classes: ClassRegistry,
-        routes: RouteRegistry,
-    ) -> None:
-        settings: OllamaFrontendSettings = self.settings  # type: ignore[assignment]
-        self._app = app
-
-        is_session = bool(os.environ.get("_SF_SESSION_ID"))
-
-        if is_session:
-            frontend_app = FastAPI(title="ollama-frontend")
-            router = create_router(settings, app, plugin=self, hooks=hooks)
-            frontend_app.include_router(router)
-
-            try:
-                from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
-
-                FastAPIInstrumentor.instrument_app(frontend_app)
-            except ImportError:
-                pass
-
-            config = uvicorn.Config(
-                frontend_app,
-                host=settings.listen_host,
-                port=settings.listen_port,
-                log_level="info",
-            )
-            self._server = uvicorn.Server(config)
-            self._thread = threading.Thread(
-                target=self._run_server, daemon=True, name="ollama-frontend"
-            )
-            self._thread.start()
-
-            if not _wait_for_port(settings.listen_port, host=settings.listen_host):
-                logger.warning("ollama-frontend server may not be ready yet")
-
-            logger.info(
-                "ollama-frontend listening on http://%s:%d",
-                settings.listen_host,
-                settings.listen_port,
-            )
-        else:
-            logger.info("ollama-frontend registered (proxy launches per-session only)")
-
-        hooks.register("app.shutdown", self._on_shutdown, plugin_name=self.name)
-
-    def _run_server(self) -> None:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.run_until_complete(self._server.serve())  # type: ignore[union-attr]
-
-    async def _on_shutdown(self) -> None:
-        self._stop()
-
-    def teardown(self) -> None:
-        self._stop()
-
-    def _stop(self) -> None:
-        if self._server:
-            self._server.should_exit = True
-        if self._thread and self._thread.is_alive():
-            self._thread.join(timeout=5)
-        self._server = None
-        self._thread = None
-
-
-async def _fetch(base_url: str, expression: str) -> str:
-    async with httpx.AsyncClient(timeout=300, verify=False) as client:
-        resp = await client.get(f"{base_url}/ensemble", params={"q": expression})
-        resp.raise_for_status()
-        return resp.text
-
-
-def _wait_for_port(port: int, host: str = "127.0.0.1", timeout: float = 5.0) -> bool:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            if sock.connect_ex((host, port)) == 0:
-                return True
-        time.sleep(0.1)
-    return False
+    # Ollama is a server, not a CLI — no preflight binary check.
+    cli_binary = None
+    app_title = "ollama-frontend"
+    create_router = staticmethod(create_router)

--- a/apps/server/tests/core/test_plugin_settings.py
+++ b/apps/server/tests/core/test_plugin_settings.py
@@ -85,12 +85,15 @@ def _mock_frontend_server():
     mock_server.serve = _noop_serve
     return (
         patch("shutil.which", return_value="/usr/bin/claude"),
-        patch("screamingface.plugins.claude_frontend.plugin.uvicorn.Config"),
+        patch("screamingface.plugins.frontend_base.plugin_base.uvicorn.Config"),
         patch(
-            "screamingface.plugins.claude_frontend.plugin.uvicorn.Server",
+            "screamingface.plugins.frontend_base.plugin_base.uvicorn.Server",
             return_value=mock_server,
         ),
-        patch("screamingface.plugins.claude_frontend.plugin._wait_for_port", return_value=True),
+        patch(
+            "screamingface.plugins.frontend_base.plugin_base._wait_for_port",
+            return_value=True,
+        ),
     )
 
 


### PR DESCRIPTION
Major DRY win. claude/codex/gemini/ollama frontend plugin.py files shared ~70% identical structure (~1264 LOC). Extract `FrontendPluginBase` + `FrontendSettingsBase` to frontend_base/plugin_base.py.

| Plugin | Before | After | Δ |
|--------|--------|-------|---|
| claude_frontend/plugin.py | 363 | 42 | -88% |
| codex_frontend/plugin.py | 306 | 44 | -86% |
| gemini_frontend/plugin.py | 287 | 43 | -85% |
| ollama_frontend/plugin.py | 308 | 50 | -84% |
| frontend_base/plugin_base.py (new) | 0 | 378 | +378 |
| **Net** | **1264** | **557** | **-707** |

Subclass contract: `cli_binary` (None to skip), `cli_install_hint`, `app_title`, `create_router`. All else inherited.

722 plugin unit tests pass; claude_intercept tests' patch targets updated to point at frontend_base.plugin_base.

Asana: SF-135