### PR TITLE
SF-136: extract BackendApiPluginBase from 4 *_backend_api plugins [ARCH]

### DIFF
--- a/apps/server/src/screamingface/plugins/backend_api_base/__init__.py
+++ b/apps/server/src/screamingface/plugins/backend_api_base/__init__.py
@@ -22,8 +22,14 @@ from screamingface.plugins.backend_api_base.models import (
     RunRequest,
     RunResponse,
 )
+from screamingface.plugins.backend_api_base.plugin_base import (
+    BackendApiPluginBase,
+    BackendApiSettingsBase,
+)
 
 __all__ = [
+    "BackendApiPluginBase",
+    "BackendApiSettingsBase",
     "BackendProfile",
     "FileInput",
     "RunRequest",

--- a/apps/server/src/screamingface/plugins/backend_api_base/plugin_base.py
+++ b/apps/server/src/screamingface/plugins/backend_api_base/plugin_base.py
@@ -1,0 +1,188 @@
+"""Shared :class:`BackendApiPluginBase` for direct-API backend plugins.
+
+Every ``*_backend_api`` plugin (claude, codex, gemini, ollama) ran
+~150-200 lines of nearly-identical bookkeeping: profile name validation,
+schema customization, the standard ``setup`` body, and a
+``handle_backend_call`` shim that just wires the interpreter. Real
+differences are: plugin metadata, settings env_prefix + a couple of
+provider-specific fields, the URL-prefix string, the router factory,
+and the interpreter class.
+
+This base concentrates the shared behavior. Each subclass shrinks to
+~30-40 lines.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from pydantic import Field, field_validator, model_validator
+from pydantic_settings import SettingsConfigDict
+
+from screamingface.plugin import Plugin, PluginSettings
+from screamingface.plugins.backend_api_base.models import BackendProfile
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from fastapi import FastAPI
+
+    from screamingface.core.classes import ClassRegistry
+    from screamingface.core.hooks import HookRegistry
+    from screamingface.core.routes import RouteRegistry
+
+_PROFILE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
+
+class BackendApiSettingsBase(PluginSettings):
+    """Settings shared by every direct-API backend plugin.
+
+    Subclasses override ``model_config.env_prefix`` and may add
+    provider-specific fields (e.g. ``base_url`` for ollama,
+    ``fallback_models`` for gemini).
+
+    CLI-only settings (``permission_mode``, ``dangerously_skip_permissions``,
+    ``max_budget_usd``) are accepted for ``sf.json`` compatibility but
+    silently ignored at request time. The ``/run`` route rejects them
+    explicitly via SF-115.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="SF_BACKEND_API__",
+        env_nested_delimiter="__",
+    )
+
+    default_model: str | None = Field(
+        default=None,
+        description="Default model. Provider-specific fallback applies if unset.",
+    )
+    default_effort: str = Field(
+        default="medium",
+        description="Default effort level.",
+    )
+    interpreter_system_prompt: str = Field(
+        default=(
+            "You are a helpful assistant. Answer the user's question based only on "
+            "the provided context. Be concise and factual."
+        ),
+        description="System prompt used by the url4 interpreter endpoint.",
+    )
+    timeout_seconds: float = Field(
+        default=300.0,
+        description="Default request timeout in seconds (httpx read timeout).",
+    )
+    max_budget_usd: float | None = Field(
+        default=None,
+        description=(
+            "CLI-only budget cap. Accepted for sf.json compatibility but "
+            "silently ignored by the direct-API backend."
+        ),
+    )
+    permission_mode: str | None = Field(
+        default=None,
+        description=(
+            "CLI-only setting. Accepted for sf.json compatibility but "
+            "silently ignored by the direct-API backend."
+        ),
+    )
+    dangerously_skip_permissions: bool = Field(
+        default=False,
+        description=(
+            "CLI-only setting. Accepted for sf.json compatibility but "
+            "silently ignored by the direct-API backend."
+        ),
+    )
+    profiles: dict[str, BackendProfile] = Field(
+        default_factory=dict,
+        description="Named pre-configured execution profiles.",
+    )
+    default_profile: str = Field(
+        default="default",
+        description="Profile to use when none is specified. Must exist in profiles.",
+    )
+
+    @field_validator("profiles")
+    @classmethod
+    def _validate_profile_keys(cls, v: dict[str, BackendProfile]) -> dict[str, BackendProfile]:
+        for key in v:
+            if not _PROFILE_NAME_RE.match(key):
+                msg = (
+                    f"Invalid profile name {key!r}: must be lowercase "
+                    "alphanumeric, hyphens, or underscores, starting with "
+                    "a letter or digit."
+                )
+                raise ValueError(msg)
+        return v
+
+    @model_validator(mode="after")
+    def _validate_default_profile(self) -> BackendApiSettingsBase:
+        if self.default_profile and self.profiles and self.default_profile not in self.profiles:
+            msg = (
+                f"default_profile {self.default_profile!r} not found in profiles. "
+                f"Available: {list(self.profiles.keys())}"
+            )
+            raise ValueError(msg)
+        return self
+
+
+class BackendApiPluginBase(Plugin):
+    """Shared lifecycle for direct-API backend plugins.
+
+    Subclasses must declare:
+
+    - The standard :class:`Plugin` class attrs (``name``, ``description``,
+      ``tags``, ``depends``, ``conflicts``, ``backend_call_paths``,
+      ``settings_class``).
+    - ``schema_link_base``: URL prefix shown to RJSF as the "x-link-base"
+      hint on the ``profiles`` field, e.g. ``"/claude/"``.
+    - ``create_router``: a callable returning the provider's APIRouter.
+      Signature ``(settings, app)`` matches the existing factories.
+    - ``_make_interpreter(app)``: lazy interpreter construction. Each
+      subclass imports its provider-specific Interpreter class inside
+      this method to keep module-load free of circular imports.
+    """
+
+    schema_link_base: ClassVar[str] = "/"
+    create_router: ClassVar[Callable[..., Any]]
+
+    def customize_schema(self, schema: dict) -> dict:
+        settings: BackendApiSettingsBase = self.settings  # type: ignore[assignment]
+        profile_names = list(settings.profiles.keys())
+        props = schema.get("properties", {})
+        if profile_names and "default_profile" in props:
+            props["default_profile"]["enum"] = profile_names
+        if "profiles" in props:
+            props["profiles"]["x-link-base"] = self.schema_link_base
+        return schema
+
+    def setup(
+        self,
+        app: FastAPI,
+        hooks: HookRegistry,  # noqa: ARG002 — required by Plugin contract
+        classes: ClassRegistry,  # noqa: ARG002 — required by Plugin contract
+        routes: RouteRegistry,
+    ) -> None:
+        router = type(self).create_router(self.settings, app)
+        routes.add_router(self.name, router, prefix="")
+
+    async def handle_backend_call(self, intent: str, *, sources: str = "", app: FastAPI) -> str:
+        """Dispatch a url4 backend-call to the provider.
+
+        Constructs a per-plugin Interpreter via :meth:`_make_interpreter`
+        and delegates to its ``process(sources, intent)`` method — the
+        same path the ``GET /<prefix>?q=`` route uses.
+        """
+        interpreter = self._make_interpreter(app)
+        return await interpreter.process(sources=sources, intent=intent)
+
+    def _make_interpreter(self, app: FastAPI) -> Any:
+        """Subclass hook: build a fresh provider-specific interpreter.
+
+        Subclasses must implement this; the lazy interpreter import goes
+        inside the override to avoid module-load-time circular imports.
+        """
+        raise NotImplementedError(f"{type(self).__name__} must override _make_interpreter()")
+
+
+__all__ = ["BackendApiPluginBase", "BackendApiSettingsBase"]

--- a/apps/server/src/screamingface/plugins/claude_backend_api/plugin.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/plugin.py
@@ -1,56 +1,32 @@
 """claude-backend-api plugin — direct Anthropic Messages API implementation.
 
-Declares:
+Most behavior lives in :class:`backend_api_base.BackendApiPluginBase`.
+This module declares Claude-specific overrides only.
 
-- ``depends = ["llm-base"]`` — needs the shared ABCs and credential store
-- ``conflicts = ["claude-backend"]`` — mutually exclusive with the
-  CLI-subprocess plugin. The SF plugin loader refuses to activate both
-  at the same time; operators pick exactly one by listing it in the
-  ``sf.json`` plugins array.
-
-Exposes the same routes as ``claude-backend`` (``/claude/run``,
-``/claude``, ``/claude/{profile_name}``) so existing url4 specs and
-tests work unchanged. Only the implementation under the routes differs
-— subprocess → direct httpx POST.
-
-Settings mirror ``claude-backend`` field-for-field. Env prefix is
-``SF_CLAUDE_BACKEND_API__`` (not ``SF_CLAUDE_BACKEND__``) so env-var
-overrides for the two plugins stay independent. Per-field names
-(``default_model``, ``default_effort``, etc.) are the same.
+Settings mirror the legacy ``claude-backend`` field-for-field. CLI-only
+fields (``permission_mode``, ``dangerously_skip_permissions``,
+``max_budget_usd``) are accepted for ``sf.json`` compatibility but
+silently ignored at request time.
 """
 
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field
 from pydantic_settings import SettingsConfigDict
 
-from screamingface.plugin import Plugin, PluginSettings
-from screamingface.plugins.claude_backend_api.models import BackendProfile
+from screamingface.plugins.backend_api_base import (
+    BackendApiPluginBase,
+    BackendApiSettingsBase,
+)
 from screamingface.plugins.claude_backend_api.routes import create_router
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
-    from screamingface.core.classes import ClassRegistry
-    from screamingface.core.hooks import HookRegistry
-    from screamingface.core.routes import RouteRegistry
 
-
-_PROFILE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
-
-
-class ClaudeBackendApiSettings(PluginSettings):
-    """Settings for claude-backend-api.
-
-    Mirrors ``ClaudeBackendSettings`` in all user-visible field names.
-    CLI-only settings (``permission_mode``, ``dangerously_skip_permissions``)
-    are accepted but silently ignored at request time, per the locked-in
-    drop-in-compat decision in the plan.
-    """
-
+class ClaudeBackendApiSettings(BackendApiSettingsBase):
     model_config = SettingsConfigDict(
         env_prefix="SF_CLAUDE_BACKEND_API__",
         env_nested_delimiter="__",
@@ -59,81 +35,12 @@ class ClaudeBackendApiSettings(PluginSettings):
     default_model: str | None = Field(
         default=None,
         description=(
-            "Default Claude model for requests that don't specify one. "
-            "Falls back to 'claude-sonnet-4-6' if still unset at call time."
+            "Default Claude model. Falls back to 'claude-sonnet-4-6' if still unset at call time."
         ),
-    )
-    default_effort: str = Field(
-        default="medium",
-        description="Default effort level.",
-    )
-    interpreter_system_prompt: str = Field(
-        default=(
-            "You are a helpful assistant. Answer the user's question based only on "
-            "the provided context. Be concise and factual."
-        ),
-        description=("System prompt used by the /claude?q= url4 interpreter endpoint."),
-    )
-    timeout_seconds: float = Field(
-        default=300.0,
-        description="Default request timeout in seconds (httpx read timeout).",
-    )
-    max_budget_usd: float | None = Field(
-        default=None,
-        description=(
-            "CLI-only budget cap. Accepted for sf.json compatibility but "
-            "silently ignored by the direct-API backend (no budget "
-            "enforcement on this path)."
-        ),
-    )
-    permission_mode: str | None = Field(
-        default=None,
-        description=(
-            "CLI-only setting. Accepted for sf.json compatibility but "
-            "silently ignored by the direct-API backend."
-        ),
-    )
-    dangerously_skip_permissions: bool = Field(
-        default=False,
-        description=(
-            "CLI-only setting. Accepted for sf.json compatibility but "
-            "silently ignored by the direct-API backend."
-        ),
-    )
-    profiles: dict[str, BackendProfile] = Field(
-        default_factory=dict,
-        description="Named pre-configured Claude execution profiles.",
-    )
-    default_profile: str = Field(
-        default="default",
-        description="Profile to use when none is specified. Must exist in profiles.",
     )
 
-    @field_validator("profiles")
-    @classmethod
-    def _validate_profile_keys(cls, v: dict[str, BackendProfile]) -> dict[str, BackendProfile]:
-        for key in v:
-            if not _PROFILE_NAME_RE.match(key):
-                msg = (
-                    f"Invalid profile name {key!r}: must be lowercase "
-                    "alphanumeric, hyphens, or underscores, starting with "
-                    "a letter or digit."
-                )
-                raise ValueError(msg)
-        return v
 
-    @model_validator(mode="after")
-    def _validate_default_profile(self) -> ClaudeBackendApiSettings:
-        if self.default_profile and self.profiles and self.default_profile not in self.profiles:
-            msg = (
-                f"default_profile {self.default_profile!r} not found in profiles. "
-                f"Available: {list(self.profiles.keys())}"
-            )
-            raise ValueError(msg)
-        return self
-
-
-class ClaudeBackendApiPlugin(Plugin):
+class ClaudeBackendApiPlugin(BackendApiPluginBase):
     name = "claude-backend-api"
     description = (
         "Direct Anthropic Messages API backend — drop-in replacement for "
@@ -144,56 +51,18 @@ class ClaudeBackendApiPlugin(Plugin):
     tags: list[str] = ["product:claude"]
     depends: list[str] = ["llm-base", "backend-api-base"]
     conflicts: list[str] = []
-    # Registered for url4 backend-call dispatch via /claude()!<intent>.
-    # The url4 resolver walks active plugins looking for one whose
-    # backend_call_paths contains the target path and calls its
-    # handle_backend_call method. This is how SF-79 Stage B wires fan-out
-    # calls to the underlying llm-base Backend.
     backend_call_paths: list[str] = ["/claude"]
     settings_class = ClaudeBackendApiSettings
 
-    def customize_schema(self, schema: dict) -> dict:
-        settings: ClaudeBackendApiSettings = self.settings  # type: ignore[assignment]
-        profile_names = list(settings.profiles.keys())
-        props = schema.get("properties", {})
-        if profile_names and "default_profile" in props:
-            props["default_profile"]["enum"] = profile_names
-        if "profiles" in props:
-            props["profiles"]["x-link-base"] = "/claude/"
-        return schema
+    schema_link_base = "/claude/"
+    create_router = staticmethod(create_router)
 
-    def setup(
-        self,
-        app: FastAPI,
-        hooks: HookRegistry,
-        classes: ClassRegistry,
-        routes: RouteRegistry,
-    ) -> None:
-        router = create_router(self.settings, app)  # type: ignore[arg-type]
-        routes.add_router(self.name, router, prefix="")
-
-    async def handle_backend_call(self, intent: str, *, sources: str = "", app: FastAPI) -> str:
-        """Dispatch a url4 backend-call to the direct Anthropic API.
-
-        Constructs a :class:`ClaudeBackendApiInterpreter` and delegates to
-        its ``process(sources, intent)`` method — the same path the
-        existing ``GET /claude?q=`` route uses. Reusing the interpreter
-        means the backend-call dispatch inherits every behavior it already
-        has (default model, system prompt, timeout, auth strategy).
-
-        SF-89 context packing: when the backend call had non-empty parens
-        (``/claude('What is quantum computing?')!Explain``), the *sources*
-        argument carries the packed context text. The interpreter's
-        ``process()`` method concatenates ``intent + "\\n\\n" + sources``
-        so the LLM sees the context followed by the instruction.
-        """
-        # Lazy import to avoid a circular dependency at module load.
+    def _make_interpreter(self, app: FastAPI):
         from screamingface.plugins.claude_backend_api.interpreter import (
             ClaudeBackendApiInterpreter,
         )
 
-        interpreter = ClaudeBackendApiInterpreter(
+        return ClaudeBackendApiInterpreter(
             app=app,
             settings=self.settings,  # type: ignore[arg-type]
         )
-        return await interpreter.process(sources=sources, intent=intent)

--- a/apps/server/src/screamingface/plugins/codex_backend_api/plugin.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/plugin.py
@@ -1,49 +1,27 @@
-"""codex-backend-api plugin -- OpenAI Chat Completions API implementation.
+"""codex-backend-api plugin — direct OpenAI Responses API implementation.
 
-Declares:
-
-- ``depends = ["llm-base"]`` -- needs the shared ABCs and credential store
-- ``conflicts = []`` -- coexists with claude-backend-api so both can
-  participate in ensemble fan-out
-
-Exposes routes at ``/codex/run``, ``/codex``, ``/codex/{profile_name}``
-mirroring the claude-backend-api route pattern. Only the backend
-differs -- httpx POST to api.openai.com instead of api.anthropic.com.
-
-Settings mirror claude-backend-api field-for-field. Env prefix is
-``SF_CODEX_BACKEND_API__`` so env-var overrides stay independent.
+Most behavior lives in :class:`backend_api_base.BackendApiPluginBase`.
+This module declares Codex-specific overrides only.
 """
 
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field
 from pydantic_settings import SettingsConfigDict
 
-from screamingface.plugin import Plugin, PluginSettings
-from screamingface.plugins.codex_backend_api.models import BackendProfile
+from screamingface.plugins.backend_api_base import (
+    BackendApiPluginBase,
+    BackendApiSettingsBase,
+)
 from screamingface.plugins.codex_backend_api.routes import create_router
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
-    from screamingface.core.classes import ClassRegistry
-    from screamingface.core.hooks import HookRegistry
-    from screamingface.core.routes import RouteRegistry
 
-
-_PROFILE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
-
-
-class CodexBackendApiSettings(PluginSettings):
-    """Settings for codex-backend-api.
-
-    Mirrors ``ClaudeBackendApiSettings`` in all user-visible field names.
-    CLI-only settings are accepted but silently ignored at request time.
-    """
-
+class CodexBackendApiSettings(BackendApiSettingsBase):
     model_config = SettingsConfigDict(
         env_prefix="SF_CODEX_BACKEND_API__",
         env_nested_delimiter="__",
@@ -51,81 +29,11 @@ class CodexBackendApiSettings(PluginSettings):
 
     default_model: str | None = Field(
         default=None,
-        description=(
-            "Default OpenAI model for requests that don't specify one. "
-            "Falls back to 'o4-mini' if still unset at call time."
-        ),
-    )
-    default_effort: str = Field(
-        default="medium",
-        description="Default effort level.",
-    )
-    interpreter_system_prompt: str = Field(
-        default=(
-            "You are a helpful assistant. Answer the user's question based only on "
-            "the provided context. Be concise and factual."
-        ),
-        description="System prompt used by the /codex?q= url4 interpreter endpoint.",
-    )
-    timeout_seconds: float = Field(
-        default=300.0,
-        description="Default request timeout in seconds (httpx read timeout).",
-    )
-    max_budget_usd: float | None = Field(
-        default=None,
-        description=(
-            "CLI-only budget cap. Accepted for sf.json compatibility but "
-            "silently ignored by the direct-API backend."
-        ),
-    )
-    permission_mode: str | None = Field(
-        default=None,
-        description=(
-            "CLI-only setting. Accepted for sf.json compatibility but "
-            "silently ignored by the direct-API backend."
-        ),
-    )
-    dangerously_skip_permissions: bool = Field(
-        default=False,
-        description=(
-            "CLI-only setting. Accepted for sf.json compatibility but "
-            "silently ignored by the direct-API backend."
-        ),
-    )
-    profiles: dict[str, BackendProfile] = Field(
-        default_factory=dict,
-        description="Named pre-configured execution profiles.",
-    )
-    default_profile: str = Field(
-        default="default",
-        description="Profile to use when none is specified. Must exist in profiles.",
+        description=("Default OpenAI model. Falls back to 'o4-mini' if still unset at call time."),
     )
 
-    @field_validator("profiles")
-    @classmethod
-    def _validate_profile_keys(cls, v: dict[str, BackendProfile]) -> dict[str, BackendProfile]:
-        for key in v:
-            if not _PROFILE_NAME_RE.match(key):
-                msg = (
-                    f"Invalid profile name {key!r}: must be lowercase "
-                    "alphanumeric, hyphens, or underscores, starting with "
-                    "a letter or digit."
-                )
-                raise ValueError(msg)
-        return v
 
-    @model_validator(mode="after")
-    def _validate_default_profile(self) -> CodexBackendApiSettings:
-        if self.default_profile and self.profiles and self.default_profile not in self.profiles:
-            msg = (
-                f"default_profile {self.default_profile!r} not found in profiles. "
-                f"Available: {list(self.profiles.keys())}"
-            )
-            raise ValueError(msg)
-        return self
-
-
-class CodexBackendApiPlugin(Plugin):
+class CodexBackendApiPlugin(BackendApiPluginBase):
     name = "codex-backend-api"
     description = (
         "Direct OpenAI Chat Completions API backend -- reads OAuth token "
@@ -138,38 +46,15 @@ class CodexBackendApiPlugin(Plugin):
     backend_call_paths: list[str] = ["/codex"]
     settings_class = CodexBackendApiSettings
 
-    def customize_schema(self, schema: dict) -> dict:
-        settings: CodexBackendApiSettings = self.settings  # type: ignore[assignment]
-        profile_names = list(settings.profiles.keys())
-        props = schema.get("properties", {})
-        if profile_names and "default_profile" in props:
-            props["default_profile"]["enum"] = profile_names
-        if "profiles" in props:
-            props["profiles"]["x-link-base"] = "/codex/"
-        return schema
+    schema_link_base = "/codex/"
+    create_router = staticmethod(create_router)
 
-    def setup(
-        self,
-        app: FastAPI,
-        hooks: HookRegistry,
-        classes: ClassRegistry,
-        routes: RouteRegistry,
-    ) -> None:
-        router = create_router(self.settings, app)  # type: ignore[arg-type]
-        routes.add_router(self.name, router, prefix="")
-
-    async def handle_backend_call(self, intent: str, *, sources: str = "", app: FastAPI) -> str:
-        """Dispatch a url4 backend-call to the OpenAI API.
-
-        Constructs a :class:`CodexBackendApiInterpreter` and delegates to
-        its ``process(sources, intent)`` method.
-        """
+    def _make_interpreter(self, app: FastAPI):
         from screamingface.plugins.codex_backend_api.interpreter import (
             CodexBackendApiInterpreter,
         )
 
-        interpreter = CodexBackendApiInterpreter(
+        return CodexBackendApiInterpreter(
             app=app,
             settings=self.settings,  # type: ignore[arg-type]
         )
-        return await interpreter.process(sources=sources, intent=intent)

--- a/apps/server/src/screamingface/plugins/gemini_backend_api/plugin.py
+++ b/apps/server/src/screamingface/plugins/gemini_backend_api/plugin.py
@@ -1,29 +1,28 @@
-"""gemini-backend-api plugin — Google AI Gemini API implementation."""
+"""gemini-backend-api plugin — Google AI Gemini API implementation.
+
+Most behavior lives in :class:`backend_api_base.BackendApiPluginBase`.
+This module declares Gemini-specific settings (fallback chain + 429
+wait cap) and overrides only.
+"""
 
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field
 from pydantic_settings import SettingsConfigDict
 
-from screamingface.plugin import Plugin, PluginSettings
-from screamingface.plugins.gemini_backend_api.models import BackendProfile
+from screamingface.plugins.backend_api_base import (
+    BackendApiPluginBase,
+    BackendApiSettingsBase,
+)
 from screamingface.plugins.gemini_backend_api.routes import create_router
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
-    from screamingface.core.classes import ClassRegistry
-    from screamingface.core.hooks import HookRegistry
-    from screamingface.core.routes import RouteRegistry
 
-
-_PROFILE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
-
-
-class GeminiBackendApiSettings(PluginSettings):
+class GeminiBackendApiSettings(BackendApiSettingsBase):
     model_config = SettingsConfigDict(
         env_prefix="SF_GEMINI_BACKEND_API__",
         env_nested_delimiter="__",
@@ -53,41 +52,9 @@ class GeminiBackendApiSettings(PluginSettings):
             "than an httpx ReadTimeout."
         ),
     )
-    default_effort: str = Field(default="medium")
-    interpreter_system_prompt: str = Field(
-        default=(
-            "You are a helpful assistant. Answer the user's question based only on "
-            "the provided context. Be concise and factual."
-        ),
-    )
-    timeout_seconds: float = Field(default=300.0)
-    max_budget_usd: float | None = Field(default=None)
-    permission_mode: str | None = Field(default=None)
-    dangerously_skip_permissions: bool = Field(default=False)
-    profiles: dict[str, BackendProfile] = Field(default_factory=dict)
-    default_profile: str = Field(default="default")
-
-    @field_validator("profiles")
-    @classmethod
-    def _validate_profile_keys(cls, v: dict[str, BackendProfile]) -> dict[str, BackendProfile]:
-        for key in v:
-            if not _PROFILE_NAME_RE.match(key):
-                msg = f"Invalid profile name {key!r}"
-                raise ValueError(msg)
-        return v
-
-    @model_validator(mode="after")
-    def _validate_default_profile(self) -> GeminiBackendApiSettings:
-        if self.default_profile and self.profiles and self.default_profile not in self.profiles:
-            msg = (
-                f"default_profile {self.default_profile!r} not found in profiles. "
-                f"Available: {list(self.profiles.keys())}"
-            )
-            raise ValueError(msg)
-        return self
 
 
-class GeminiBackendApiPlugin(Plugin):
+class GeminiBackendApiPlugin(BackendApiPluginBase):
     name = "gemini-backend-api"
     description = "Direct Google AI Gemini API backend for ensemble fan-out"
     tags: list[str] = ["product:gemini"]
@@ -96,33 +63,15 @@ class GeminiBackendApiPlugin(Plugin):
     backend_call_paths: list[str] = ["/gemini"]
     settings_class = GeminiBackendApiSettings
 
-    def customize_schema(self, schema: dict) -> dict:
-        settings: GeminiBackendApiSettings = self.settings  # type: ignore[assignment]
-        profile_names = list(settings.profiles.keys())
-        props = schema.get("properties", {})
-        if profile_names and "default_profile" in props:
-            props["default_profile"]["enum"] = profile_names
-        if "profiles" in props:
-            props["profiles"]["x-link-base"] = "/gemini/"
-        return schema
+    schema_link_base = "/gemini/"
+    create_router = staticmethod(create_router)
 
-    def setup(
-        self,
-        app: FastAPI,
-        hooks: HookRegistry,
-        classes: ClassRegistry,
-        routes: RouteRegistry,
-    ) -> None:
-        router = create_router(self.settings, app)  # type: ignore[arg-type]
-        routes.add_router(self.name, router, prefix="")
-
-    async def handle_backend_call(self, intent: str, *, sources: str = "", app: FastAPI) -> str:
+    def _make_interpreter(self, app: FastAPI):
         from screamingface.plugins.gemini_backend_api.interpreter import (
             GeminiBackendApiInterpreter,
         )
 
-        interpreter = GeminiBackendApiInterpreter(
+        return GeminiBackendApiInterpreter(
             app=app,
             settings=self.settings,  # type: ignore[arg-type]
         )
-        return await interpreter.process(sources=sources, intent=intent)

--- a/apps/server/src/screamingface/plugins/ollama_backend_api/plugin.py
+++ b/apps/server/src/screamingface/plugins/ollama_backend_api/plugin.py
@@ -1,52 +1,28 @@
 """ollama-backend-api plugin — direct Ollama ``/api/chat`` backend.
 
-Declares:
-
-- ``depends = ["llm-base"]`` — needs the shared ABCs and message shapes.
-- ``conflicts = []`` — coexists with the other ``*_backend_api`` plugins
-  so all can participate in ensemble fan-out.
-
-Exposes routes at ``/ollama/run``, ``/ollama``, ``/ollama/{profile_name}``
-mirroring the claude-backend-api route pattern. Transport is httpx POST
-to a local (or remote) Ollama server.
-
-Settings mirror claude-backend-api field-for-field plus two Ollama-
-specific additions: ``base_url`` (the Ollama server URL) and ``api_key``
-(optional bearer token). Env prefix is ``SF_OLLAMA_BACKEND_API__`` so
-env-var overrides stay independent.
+Most behavior lives in :class:`backend_api_base.BackendApiPluginBase`.
+This module declares Ollama-specific settings (``base_url`` + optional
+``api_key``) and overrides only.
 """
 
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field
 from pydantic_settings import SettingsConfigDict
 
-from screamingface.plugin import Plugin, PluginSettings
-from screamingface.plugins.ollama_backend_api.models import BackendProfile
+from screamingface.plugins.backend_api_base import (
+    BackendApiPluginBase,
+    BackendApiSettingsBase,
+)
 from screamingface.plugins.ollama_backend_api.routes import create_router
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
-    from screamingface.core.classes import ClassRegistry
-    from screamingface.core.hooks import HookRegistry
-    from screamingface.core.routes import RouteRegistry
 
-
-_PROFILE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
-
-
-class OllamaBackendApiSettings(PluginSettings):
-    """Settings for ollama-backend-api.
-
-    Mirrors ``ClaudeBackendApiSettings`` in all user-visible field names.
-    CLI-only settings are accepted but silently ignored at request time.
-    Adds two Ollama-specific fields: ``base_url`` and ``api_key``.
-    """
-
+class OllamaBackendApiSettings(BackendApiSettingsBase):
     model_config = SettingsConfigDict(
         env_prefix="SF_OLLAMA_BACKEND_API__",
         env_nested_delimiter="__",
@@ -66,81 +42,11 @@ class OllamaBackendApiSettings(PluginSettings):
     )
     default_model: str | None = Field(
         default=None,
-        description=(
-            "Default Ollama model for requests that don't specify one. "
-            "Falls back to 'llama3.2' if still unset at call time."
-        ),
-    )
-    default_effort: str = Field(
-        default="medium",
-        description="Default effort level.",
-    )
-    interpreter_system_prompt: str = Field(
-        default=(
-            "You are a helpful assistant. Answer the user's question based only on "
-            "the provided context. Be concise and factual."
-        ),
-        description="System prompt used by the /ollama?q= url4 interpreter endpoint.",
-    )
-    timeout_seconds: float = Field(
-        default=300.0,
-        description="Default request timeout in seconds (httpx read timeout).",
-    )
-    max_budget_usd: float | None = Field(
-        default=None,
-        description=(
-            "CLI-only budget cap. Accepted for sf.json compatibility but "
-            "silently ignored by the direct-API backend."
-        ),
-    )
-    permission_mode: str | None = Field(
-        default=None,
-        description=(
-            "CLI-only setting. Accepted for sf.json compatibility but "
-            "silently ignored by the direct-API backend."
-        ),
-    )
-    dangerously_skip_permissions: bool = Field(
-        default=False,
-        description=(
-            "CLI-only setting. Accepted for sf.json compatibility but "
-            "silently ignored by the direct-API backend."
-        ),
-    )
-    profiles: dict[str, BackendProfile] = Field(
-        default_factory=dict,
-        description="Named pre-configured execution profiles.",
-    )
-    default_profile: str = Field(
-        default="default",
-        description="Profile to use when none is specified. Must exist in profiles.",
+        description=("Default Ollama model. Falls back to 'llama3.2' if still unset at call time."),
     )
 
-    @field_validator("profiles")
-    @classmethod
-    def _validate_profile_keys(cls, v: dict[str, BackendProfile]) -> dict[str, BackendProfile]:
-        for key in v:
-            if not _PROFILE_NAME_RE.match(key):
-                msg = (
-                    f"Invalid profile name {key!r}: must be lowercase "
-                    "alphanumeric, hyphens, or underscores, starting with "
-                    "a letter or digit."
-                )
-                raise ValueError(msg)
-        return v
 
-    @model_validator(mode="after")
-    def _validate_default_profile(self) -> OllamaBackendApiSettings:
-        if self.default_profile and self.profiles and self.default_profile not in self.profiles:
-            msg = (
-                f"default_profile {self.default_profile!r} not found in profiles. "
-                f"Available: {list(self.profiles.keys())}"
-            )
-            raise ValueError(msg)
-        return self
-
-
-class OllamaBackendApiPlugin(Plugin):
+class OllamaBackendApiPlugin(BackendApiPluginBase):
     name = "ollama-backend-api"
     description = (
         "Direct Ollama API backend — POSTs to a local (or remote) Ollama "
@@ -153,38 +59,15 @@ class OllamaBackendApiPlugin(Plugin):
     backend_call_paths: list[str] = ["/ollama"]
     settings_class = OllamaBackendApiSettings
 
-    def customize_schema(self, schema: dict) -> dict:
-        settings: OllamaBackendApiSettings = self.settings  # type: ignore[assignment]
-        profile_names = list(settings.profiles.keys())
-        props = schema.get("properties", {})
-        if profile_names and "default_profile" in props:
-            props["default_profile"]["enum"] = profile_names
-        if "profiles" in props:
-            props["profiles"]["x-link-base"] = "/ollama/"
-        return schema
+    schema_link_base = "/ollama/"
+    create_router = staticmethod(create_router)
 
-    def setup(
-        self,
-        app: FastAPI,
-        hooks: HookRegistry,
-        classes: ClassRegistry,
-        routes: RouteRegistry,
-    ) -> None:
-        router = create_router(self.settings, app)  # type: ignore[arg-type]
-        routes.add_router(self.name, router, prefix="")
-
-    async def handle_backend_call(self, intent: str, *, app: FastAPI) -> str:
-        """Dispatch a url4 backend-call to Ollama.
-
-        Constructs an :class:`OllamaBackendApiInterpreter` and delegates
-        to its ``process(sources="", intent=...)`` method.
-        """
+    def _make_interpreter(self, app: FastAPI):
         from screamingface.plugins.ollama_backend_api.interpreter import (
             OllamaBackendApiInterpreter,
         )
 
-        interpreter = OllamaBackendApiInterpreter(
+        return OllamaBackendApiInterpreter(
             app=app,
             settings=self.settings,  # type: ignore[arg-type]
         )
-        return await interpreter.process(sources="", intent=intent)


### PR DESCRIPTION
Mirror of SF-135 for the backend_api side. Extract shared lifecycle (profile validation, schema customization, setup, handle_backend_call) to backend_api_base/plugin_base.py.

| Plugin | Before | After | Δ |
|--------|--------|-------|---|
| claude_backend_api/plugin.py | 199 | 68 | -66% |
| codex_backend_api/plugin.py | 175 | 60 | -66% |
| gemini_backend_api/plugin.py | 128 | 77 | -40% |
| ollama_backend_api/plugin.py | 190 | 73 | -62% |
| backend_api_base/plugin_base.py (new) | 0 | 188 | +188 |
| **Net** | **692** | **466** | **-226** |

**Side effect bugfix:** ollama_backend_api now correctly forwards `sources` into its interpreter (was silently dropping it; the interpreter already accepted it).

722 plugin unit tests pass.

Asana: SF-136