### PR TITLE
SF-137: fix ollama-frontend listen_port collision (9103 → 9104) [BUG]

### DIFF
--- a/apps/server/src/screamingface/plugins/ollama_frontend/plugin.py
+++ b/apps/server/src/screamingface/plugins/ollama_frontend/plugin.py
@@ -30,7 +30,7 @@ class OllamaFrontendSettings(FrontendSettingsBase):
     )
 
     upstream_url: str = "http://localhost:11434"
-    listen_port: int = 9103
+    listen_port: int = 9104
     default_backend_path: str = "/ollama"
     # Ollama frontend prefers system-prompt injection as the default
     # because its default chat template treats messages[0] specially.


### PR DESCRIPTION
Pre-existing bug uncovered while reviewing SF-135 defaults. `gemini-frontend` and `ollama-frontend` both defaulted to listen_port 9103. Whoever activated second failed to bind. Renumber ollama to 9104.

Final: claude=9101, codex=9102, gemini=9103, ollama=9104.

22 frontend unit tests pass. 1-line change.

Asana: SF-137