### PR TITLE
feat(SF-141): apps/server plugins for AI Gateway integration

### DIFF
--- a/apps/aigateway/src/aigateway/core/bootstrap.py
+++ b/apps/aigateway/src/aigateway/core/bootstrap.py
@@ -55,9 +55,7 @@ async def bootstrap_from_claude_code(
             "token_type": "Bearer",
         }
     except (KeyError, ValueError, TypeError) as exc:
-        raise BootstrapError(
-            f"Claude Code keychain entry has unexpected shape: {exc}"
-        ) from exc
+        raise BootstrapError(f"Claude Code keychain entry has unexpected shape: {exc}") from exc
 
     store.write(
         keychain_service_for("default"),

--- a/apps/aigateway/src/aigateway/core/credential_store.py
+++ b/apps/aigateway/src/aigateway/core/credential_store.py
@@ -98,7 +98,9 @@ class MacOSKeychainStore(CredentialStore):
         try:
             result = subprocess.run(
                 ["security", "delete-generic-password", "-s", service, "-a", account],
-                capture_output=True, text=True, timeout=5,
+                capture_output=True,
+                text=True,
+                timeout=5,
             )
         except FileNotFoundError as exc:
             raise RuntimeError("`security` command not found") from exc
@@ -169,7 +171,9 @@ class LinuxLibsecretStore(CredentialStore):
         try:
             subprocess.run(
                 ["secret-tool", "clear", "service", service, "account", account],
-                check=True, timeout=5, capture_output=True,
+                check=True,
+                timeout=5,
+                capture_output=True,
             )
         except subprocess.TimeoutExpired as exc:
             raise RuntimeError("`secret-tool clear` timed out") from exc

--- a/apps/aigateway/src/aigateway/core/oauth_pkce.py
+++ b/apps/aigateway/src/aigateway/core/oauth_pkce.py
@@ -9,9 +9,7 @@ def generate_pkce() -> tuple[str, str]:
     """Return (code_verifier, code_challenge_S256)."""
     verifier = secrets.token_urlsafe(64)[:128]
     challenge = (
-        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
-        .rstrip(b"=")
-        .decode()
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
     )
     return verifier, challenge
 

--- a/apps/aigateway/src/aigateway/core/plugin_base.py
+++ b/apps/aigateway/src/aigateway/core/plugin_base.py
@@ -28,7 +28,10 @@ class OAuthStrategy(ABC):
 
     @abstractmethod
     async def get_authorization_header(self) -> dict[str, str]:
-        """Return headers to merge into the upstream request (e.g. `{"Authorization": "Bearer ..."}`)."""
+        """Return headers to merge into the upstream request.
+
+        Example: ``{"Authorization": "Bearer ..."}``.
+        """
 
     async def invalidate(self) -> None:
         """Drop any cached token. Called after a 401 from upstream."""

--- a/apps/aigateway/src/aigateway/core/profile_models.py
+++ b/apps/aigateway/src/aigateway/core/profile_models.py
@@ -6,7 +6,7 @@ from enum import Enum
 from pydantic import BaseModel, Field
 
 
-class ProfileState(str, Enum):
+class ProfileState(str, Enum):  # noqa: UP042 - keep tuple-base for pydantic-v1 compat
     PENDING = "pending"
     AUTHENTICATED = "authenticated"
     ERROR = "error"

--- a/apps/aigateway/src/aigateway/plugins/anthropic_provider/auth.py
+++ b/apps/aigateway/src/aigateway/plugins/anthropic_provider/auth.py
@@ -60,7 +60,8 @@ class AnthropicOAuth(BaseOAuthStrategy):
         raw = self._store.read(self.keychain_service(), self.keychain_account())
         if raw is None:
             raise CredentialNotFoundError(
-                f"No tokens for anthropic profile {self.profile_name!r}. Re-authenticate via Electron."
+                f"No tokens for anthropic profile {self.profile_name!r}. "
+                "Re-authenticate via Electron."
             )
         try:
             creds = json.loads(raw)
@@ -74,10 +75,7 @@ class AnthropicOAuth(BaseOAuthStrategy):
         return creds
 
     def _is_expired(self, creds: dict) -> bool:
-        return (
-            time.time() * 1000
-            >= creds["expires_at_ms"] - (self.refresh_window_seconds * 1000)
-        )
+        return time.time() * 1000 >= creds["expires_at_ms"] - (self.refresh_window_seconds * 1000)
 
     def _build_headers(self, creds: dict) -> dict[str, str]:
         return {
@@ -107,9 +105,7 @@ class AnthropicOAuth(BaseOAuthStrategy):
                 f"Refresh returned 401 for profile {self.profile_name!r}. Re-auth required."
             )
         if resp.status_code != 200:
-            raise AuthError(
-                f"OAuth refresh failed status {resp.status_code}: {resp.text[:500]}"
-            )
+            raise AuthError(f"OAuth refresh failed status {resp.status_code}: {resp.text[:500]}")
         try:
             data = resp.json()
         except json.JSONDecodeError as exc:

--- a/apps/aigateway/src/aigateway/routes/auth.py
+++ b/apps/aigateway/src/aigateway/routes/auth.py
@@ -36,11 +36,7 @@ async def list_profiles(request: Request) -> dict:
 @router.get("/v1/auth/{provider}/profiles")
 async def list_provider_profiles(provider: str, request: Request) -> dict:
     idx = await _index_store(request).read()
-    return {
-        "profiles": [
-            p.model_dump(mode="json") for p in idx.profiles if p.provider == provider
-        ]
-    }
+    return {"profiles": [p.model_dump(mode="json") for p in idx.profiles if p.provider == provider]}
 
 
 @router.get("/v1/auth/{provider}/profiles/{name}")
@@ -63,7 +59,9 @@ class StartAuthRequest(BaseModel):
 async def start_oauth(provider: str, body: StartAuthRequest, request: Request) -> dict:
     plugin = _registry(request).get(provider)
     if plugin is None:
-        raise HTTPException(status_code=404, detail={"code": "unknown_provider", "provider": provider})
+        raise HTTPException(
+            status_code=404, detail={"code": "unknown_provider", "provider": provider}
+        )
 
     cfg = plugin.oauth_config()
     if cfg is None:

--- a/apps/aigateway/src/aigateway/routes/chat.py
+++ b/apps/aigateway/src/aigateway/routes/chat.py
@@ -58,9 +58,7 @@ async def chat_completions(request: Request) -> Any:
     model = body.get("model", "")
     provider = model.split("/", 1)[0] if "/" in model else None
     if not provider:
-        raise HTTPException(
-            status_code=400, detail="model must be prefixed (e.g. anthropic/...)"
-        )
+        raise HTTPException(status_code=400, detail="model must be prefixed (e.g. anthropic/...)")
 
     registry: ProviderRegistry = request.app.state.providers
     plugin = registry.get(provider)

--- a/apps/aigateway/tests/unit/test_auth_routes.py
+++ b/apps/aigateway/tests/unit/test_auth_routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
@@ -69,9 +70,6 @@ def test_get_profile_404_on_missing(client_with_index) -> None:
     assert resp.json()["detail"]["code"] == "profile_not_found"
 
 
-import httpx
-
-
 def test_start_oauth_returns_authorize_url(client_with_index) -> None:
     client, _ = client_with_index
     resp = client.post("/v1/auth/anthropic/profiles", json={"name": "work"})
@@ -131,6 +129,7 @@ def test_callback_completes_auth(client_with_index) -> None:
     assert prof["state"] == "authenticated"
 
     from aigateway.plugins.anthropic_provider.auth import keychain_service_for
+
     blob = fake_keychain.read(keychain_service_for("work"), "default")
     assert "new-tok" in blob
 
@@ -185,6 +184,7 @@ def test_delete_removes_profile_and_tokens(client_with_index) -> None:
     client.get("/v1/auth/anthropic/callback", params={"code": "c", "state": start.json()["state"]})
 
     from aigateway.plugins.anthropic_provider.auth import keychain_service_for
+
     assert fake_keychain.read(keychain_service_for("z"), "default") is not None
 
     resp = client.delete("/v1/auth/anthropic/profiles/z")

--- a/apps/aigateway/tests/unit/test_bootstrap.py
+++ b/apps/aigateway/tests/unit/test_bootstrap.py
@@ -2,6 +2,7 @@ import json
 import time
 
 import pytest
+from fastapi.testclient import TestClient
 
 from aigateway.core.bootstrap import bootstrap_from_claude_code
 from aigateway.core.profile_index import INDEX_KEYCHAIN_SERVICE, ProfileIndexStore
@@ -47,7 +48,11 @@ async def test_bootstrap_imports_cc_default_when_index_empty(fake_keychain) -> N
 
 @pytest.mark.asyncio
 async def test_bootstrap_noop_when_index_already_exists(fake_keychain) -> None:
-    fake_keychain.write(INDEX_KEYCHAIN_SERVICE, "default", '{"version":1,"profiles":[{"id":"x:y","provider":"x","name":"y"}]}')
+    fake_keychain.write(
+        INDEX_KEYCHAIN_SERVICE,
+        "default",
+        '{"version":1,"profiles":[{"id":"x:y","provider":"x","name":"y"}]}',
+    )
     fake_keychain.write(
         CC_SERVICE,
         "alice",
@@ -69,9 +74,6 @@ async def test_bootstrap_noop_when_cc_entry_missing(fake_keychain) -> None:
         cc_account="alice",
     )
     assert fake_keychain.read(INDEX_KEYCHAIN_SERVICE, "default") is None
-
-
-from fastapi.testclient import TestClient
 
 
 def test_app_lifespan_runs_bootstrap(fake_keychain, monkeypatch) -> None:

--- a/apps/aigateway/tests/unit/test_oauth_pkce.py
+++ b/apps/aigateway/tests/unit/test_oauth_pkce.py
@@ -7,7 +7,9 @@ from aigateway.core.oauth_pkce import generate_pkce, generate_state
 def test_pkce_returns_verifier_and_challenge_pair() -> None:
     verifier, challenge = generate_pkce()
     assert 43 <= len(verifier) <= 128
-    expected = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
+    expected = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
+    )
     assert challenge == expected
 
 

--- a/apps/aigateway/tests/unit/test_profile_index.py
+++ b/apps/aigateway/tests/unit/test_profile_index.py
@@ -57,12 +57,14 @@ async def test_index_store_round_trip(fake_keychain) -> None:
 async def test_index_store_upsert_replaces_by_id(fake_keychain) -> None:
     store = ProfileIndexStore(credential_store=fake_keychain)
     await store.upsert(Profile(id="anthropic:default", provider="anthropic", name="default"))
-    await store.upsert(Profile(
-        id="anthropic:default",
-        provider="anthropic",
-        name="default",
-        account_label="updated@example.com",
-    ))
+    await store.upsert(
+        Profile(
+            id="anthropic:default",
+            provider="anthropic",
+            name="default",
+            account_label="updated@example.com",
+        )
+    )
     idx = await store.read()
     assert len(idx.profiles) == 1
     assert idx.profiles[0].account_label == "updated@example.com"

--- a/apps/desktop/src/main/services/session-manager.ts
+++ b/apps/desktop/src/main/services/session-manager.ts
@@ -346,12 +346,27 @@ class SessionManager extends EventEmitter {
     chmodSync(scriptPath, 0o755);
     session.scriptPath = scriptPath;
 
-    // Open Terminal.app and run the script
+    // Open Terminal.app and run the script.
+    //
+    // The default Terminal.app profile inherits whatever the user has set
+    // in Preferences. When that profile uses a swapped/light palette, our
+    // CLI tools emit codes that render every cell with a white block —
+    // even on a window that "looks" dark — because reverse-video and
+    // default-bg interactions break in that profile.
+    //
+    // Force a known-good dark profile ("Pro" ships with macOS Terminal
+    // and has bg=black/fg=light by default, which is what every TUI we
+    // care about expects).
+    //
     // AppleScript strings use double quotes, so escape any double quotes in the path
     const escapedPath = scriptPath.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
     const appleScript = `tell application "Terminal"
   activate
-  do script "${escapedPath}"
+  set newTab to do script "${escapedPath}"
+  delay 0.05
+  try
+    set current settings of newTab to settings set "Pro"
+  end try
 end tell`;
 
     this.emit('log', session.id, `Opening terminal: ${scriptPath}`);

--- a/apps/desktop/src/main/services/session-manager.ts
+++ b/apps/desktop/src/main/services/session-manager.ts
@@ -312,12 +312,33 @@ class SessionManager extends EventEmitter {
 
     // Write a temp script that records its PID before exec'ing the CLI.
     // exec replaces the shell but keeps the same PID, so we can kill it later.
+    //
+    // Ink (the TUI library Claude Code/Codex/Gemini use) detects color
+    // support via COLORTERM / FORCE_COLOR / COLORFGBG. AppleScript's
+    // `do script` launches a fresh login shell whose env may not have
+    // these set; without them, Ink/chalk emits highlighted regions
+    // using ANSI codes that render as solid white blocks on a dark
+    // terminal profile (the visible-cell-background effect users see).
+    //
+    // Setting these explicitly tells Ink:
+    //   - COLORTERM=truecolor     → 24-bit color path; cleaner highlights
+    //   - FORCE_COLOR=3           → never auto-disable color (truecolor)
+    //   - COLORFGBG="15;0"        → "light foreground, dark background"
+    //                                 — Ink uses this to pick a palette
+    //                                 that doesn't paint white cells
+    //   - TERM defaults to xterm-256color if Terminal.app didn't set it
     const scriptPath = join(tmpdir(), `sf-session-${session.id}.sh`);
     const pidPath = join(tmpdir(), `sf-session-${session.id}.pid`);
     const scriptContent = [
       '#!/bin/bash',
       `echo $$ > ${this.shellEscape(pidPath)}`,
       `cd ${this.shellEscape(session.workingDir)}`,
+      // Terminal color environment (must be set BEFORE exec so the CLI inherits)
+      'export TERM="${TERM:-xterm-256color}"',
+      'export COLORTERM="${COLORTERM:-truecolor}"',
+      'export FORCE_COLOR="${FORCE_COLOR:-3}"',
+      'export COLORFGBG="${COLORFGBG:-15;0}"',
+      // Proxy routing
       `export ${envVar}=${this.shellEscape(baseUrl)}`,
       `exec ${cmd}`,
     ].join('\n');

--- a/apps/desktop/src/main/services/session-manager.ts
+++ b/apps/desktop/src/main/services/session-manager.ts
@@ -340,6 +340,15 @@ class SessionManager extends EventEmitter {
       'export COLORFGBG="${COLORFGBG:-15;0}"',
       // Proxy routing
       `export ${envVar}=${this.shellEscape(baseUrl)}`,
+      // Wipe the terminal buffer before launching the TUI. PTY capture
+      // (see /tmp/capture-claude-output.py) proved Claude Code emits NO
+      // background-color codes; it uses `\e[1C` (CUF — cursor right) as
+      // its inter-word gap. CUF moves the cursor without erasing cells,
+      // so any pre-existing content (shell prompt PS1 with background
+      // segments, Terminal.app startup banner, etc.) shows through the
+      // gaps as solid blocks. RIS (\ec) is a full terminal reset; it
+      // wipes the screen, scrollback, and lingering SGR/charset modes.
+      "printf '\\ec'",
       `exec ${cmd}`,
     ].join('\n');
     writeFileSync(scriptPath, scriptContent, 'utf-8');

--- a/apps/desktop/src/main/services/session-manager.ts
+++ b/apps/desktop/src/main/services/session-manager.ts
@@ -310,91 +310,42 @@ class SessionManager extends EventEmitter {
     const cmd = this.cliCommand(session.type);
     const envVar = this.envVarName(session.type);
 
-    // Write a temp script that records its PID before exec'ing the CLI.
-    // exec replaces the shell but keeps the same PID, so we can kill it later.
+    // Bare-minimum launcher script. NO color env, NO terminal-buffer
+    // hygiene, NO escape-sequence emission, NO Terminal.app profile
+    // override. The shell starts clean from Terminal.app's default
+    // profile and inherits whatever environment Terminal.app provides.
     //
-    // Ink (the TUI library Claude Code/Codex/Gemini use) detects color
-    // support via COLORTERM / FORCE_COLOR / COLORFGBG. AppleScript's
-    // `do script` launches a fresh login shell whose env may not have
-    // these set; without them, Ink/chalk emits highlighted regions
-    // using ANSI codes that render as solid white blocks on a dark
-    // terminal profile (the visible-cell-background effect users see).
+    // The earlier experiments (COLORTERM/FORCE_COLOR/COLORFGBG, RIS,
+    // alt-screen buffer, "Pro" profile force-set) were chasing a visual
+    // artifact that turned out to come from macOS's "Increase Contrast"
+    // accessibility setting (System Settings → Accessibility → Display).
+    // None of the app-side mitigations could affect a compositor-level
+    // overlay; they're removed so we can isolate the actual cause.
     //
-    // Setting these explicitly tells Ink:
-    //   - COLORTERM=truecolor     → 24-bit color path; cleaner highlights
-    //   - FORCE_COLOR=3           → never auto-disable color (truecolor)
-    //   - COLORFGBG="15;0"        → "light foreground, dark background"
-    //                                 — Ink uses this to pick a palette
-    //                                 that doesn't paint white cells
-    //   - TERM defaults to xterm-256color if Terminal.app didn't set it
+    // Two functional lines remain because they're not cosmetic:
+    //   - cd into the working dir so the CLI sees the right project
+    //   - export the proxy BASE_URL so the CLI talks to claude-frontend
     const scriptPath = join(tmpdir(), `sf-session-${session.id}.sh`);
     const pidPath = join(tmpdir(), `sf-session-${session.id}.pid`);
     const scriptContent = [
       '#!/bin/bash',
       `echo $$ > ${this.shellEscape(pidPath)}`,
       `cd ${this.shellEscape(session.workingDir)}`,
-      // Terminal color environment (must be set BEFORE exec so the CLI inherits)
-      'export TERM="${TERM:-xterm-256color}"',
-      'export COLORTERM="${COLORTERM:-truecolor}"',
-      'export FORCE_COLOR="${FORCE_COLOR:-3}"',
-      'export COLORFGBG="${COLORFGBG:-15;0}"',
-      // Proxy routing
       `export ${envVar}=${this.shellEscape(baseUrl)}`,
-      // Terminal-buffer hygiene before launching the TUI.
-      //
-      // Diagnosis (PTY capture analysis at /tmp/capture-claude-output.py):
-      //   - Claude Code does NOT emit \e[?1049h (alternate screen buffer)
-      //     on startup, so it runs in INLINE mode.
-      //   - Inline-mode redraws use CUF (\e[NC, "cursor right N") to space
-      //     between words instead of writing literal characters.
-      //   - CUF moves the cursor over cells WITHOUT erasing them, so any
-      //     pre-existing content (shell prompt PS1 segments, scrollback,
-      //     and crucially the previous frame of Claude's own UI) leaks
-      //     through the gaps as visible blocks.
-      //   - The single reverse-video cursor cell (\e[7m \e[27m) accumulates
-      //     a trail across redraws because old cursor positions are never
-      //     overwritten.
-      //
-      // Mitigations applied here:
-      //   1. \ec (RIS) — full terminal reset before anything starts;
-      //      wipes screen, scrollback, modes, character sets.
-      //   2. \e[?1049h — manually enter the alternate screen buffer.
-      //      Cells in alt-screen are guaranteed clear on entry, and the
-      //      original screen is restored verbatim when the CLI exits.
-      //      Even though Claude itself doesn't request this, the shell
-      //      can request it on Claude's behalf — Claude is happy to
-      //      draw into whichever buffer is active.
-      //   3. \e[2J\e[H — belt-and-suspenders explicit clear inside the
-      //      alt-screen so the very first frame draws over a known-clean
-      //      canvas (some terminals enter alt-screen with leftover content).
-      "printf '\\ec\\e[?1049h\\e[2J\\e[H'",
       `exec ${cmd}`,
     ].join('\n');
     writeFileSync(scriptPath, scriptContent, 'utf-8');
     chmodSync(scriptPath, 0o755);
     session.scriptPath = scriptPath;
 
-    // Open Terminal.app and run the script.
+    // Open Terminal.app and run the script. No profile override —
+    // user's Terminal.app default profile is used as-is.
     //
-    // The default Terminal.app profile inherits whatever the user has set
-    // in Preferences. When that profile uses a swapped/light palette, our
-    // CLI tools emit codes that render every cell with a white block —
-    // even on a window that "looks" dark — because reverse-video and
-    // default-bg interactions break in that profile.
-    //
-    // Force a known-good dark profile ("Pro" ships with macOS Terminal
-    // and has bg=black/fg=light by default, which is what every TUI we
-    // care about expects).
-    //
-    // AppleScript strings use double quotes, so escape any double quotes in the path
+    // AppleScript strings use double quotes, so escape any double quotes in the path.
     const escapedPath = scriptPath.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
     const appleScript = `tell application "Terminal"
   activate
-  set newTab to do script "${escapedPath}"
-  delay 0.05
-  try
-    set current settings of newTab to settings set "Pro"
-  end try
+  do script "${escapedPath}"
 end tell`;
 
     this.emit('log', session.id, `Opening terminal: ${scriptPath}`);

--- a/apps/desktop/src/main/services/session-manager.ts
+++ b/apps/desktop/src/main/services/session-manager.ts
@@ -340,15 +340,34 @@ class SessionManager extends EventEmitter {
       'export COLORFGBG="${COLORFGBG:-15;0}"',
       // Proxy routing
       `export ${envVar}=${this.shellEscape(baseUrl)}`,
-      // Wipe the terminal buffer before launching the TUI. PTY capture
-      // (see /tmp/capture-claude-output.py) proved Claude Code emits NO
-      // background-color codes; it uses `\e[1C` (CUF — cursor right) as
-      // its inter-word gap. CUF moves the cursor without erasing cells,
-      // so any pre-existing content (shell prompt PS1 with background
-      // segments, Terminal.app startup banner, etc.) shows through the
-      // gaps as solid blocks. RIS (\ec) is a full terminal reset; it
-      // wipes the screen, scrollback, and lingering SGR/charset modes.
-      "printf '\\ec'",
+      // Terminal-buffer hygiene before launching the TUI.
+      //
+      // Diagnosis (PTY capture analysis at /tmp/capture-claude-output.py):
+      //   - Claude Code does NOT emit \e[?1049h (alternate screen buffer)
+      //     on startup, so it runs in INLINE mode.
+      //   - Inline-mode redraws use CUF (\e[NC, "cursor right N") to space
+      //     between words instead of writing literal characters.
+      //   - CUF moves the cursor over cells WITHOUT erasing them, so any
+      //     pre-existing content (shell prompt PS1 segments, scrollback,
+      //     and crucially the previous frame of Claude's own UI) leaks
+      //     through the gaps as visible blocks.
+      //   - The single reverse-video cursor cell (\e[7m \e[27m) accumulates
+      //     a trail across redraws because old cursor positions are never
+      //     overwritten.
+      //
+      // Mitigations applied here:
+      //   1. \ec (RIS) — full terminal reset before anything starts;
+      //      wipes screen, scrollback, modes, character sets.
+      //   2. \e[?1049h — manually enter the alternate screen buffer.
+      //      Cells in alt-screen are guaranteed clear on entry, and the
+      //      original screen is restored verbatim when the CLI exits.
+      //      Even though Claude itself doesn't request this, the shell
+      //      can request it on Claude's behalf — Claude is happy to
+      //      draw into whichever buffer is active.
+      //   3. \e[2J\e[H — belt-and-suspenders explicit clear inside the
+      //      alt-screen so the very first frame draws over a known-clean
+      //      canvas (some terminals enter alt-screen with leftover content).
+      "printf '\\ec\\e[?1049h\\e[2J\\e[H'",
       `exec ${cmd}`,
     ].join('\n');
     writeFileSync(scriptPath, scriptContent, 'utf-8');

--- a/apps/desktop/src/renderer/src/views/SettingsView.tsx
+++ b/apps/desktop/src/renderer/src/views/SettingsView.tsx
@@ -404,29 +404,36 @@ export function SettingsView() {
                 groups[g].sort((a, b) => a.localeCompare(b));
               }
 
-              // Sort groups: alphabetically, but 'system' and 'etc' go last
-              const groupOrder = Object.keys(groups).sort((a, b) => {
-                if (a === 'etc') return 1;
-                if (b === 'etc') return -1;
-                if (a === 'system') return 1;
-                if (b === 'system') return -1;
-                return a.localeCompare(b);
-              });
-
-              const GROUP_COLORS: Record<string, string> = {
-                claude: 'from-orange-500/20 to-orange-500/5 text-orange-300',
-                openai: 'from-green-500/20 to-green-500/5 text-green-300',
-                gemini: 'from-blue-500/20 to-blue-500/5 text-blue-300',
-                url4: 'from-purple-500/20 to-purple-500/5 text-purple-300',
-                system: 'from-zinc-500/20 to-zinc-500/5 text-zinc-400',
-                etc: 'from-zinc-500/20 to-zinc-500/5 text-zinc-400',
+              // 24 vivid rainbow hues — saturated enough to read clearly on
+              // the dark slate/zinc background, never close to grey or black.
+              // Hue is stepped 15° around the wheel; saturation 92%, lightness
+              // 62% keeps every swatch unambiguously colored.
+              const RAINBOW_COLORS = Array.from(
+                { length: 24 },
+                (_, i) => `hsl(${i * 15}, 92%, 62%)`,
+              );
+              const colorIndex = (group: string): number => {
+                let h = 0;
+                for (let i = 0; i < group.length; i++) {
+                  h = (h * 31 + group.charCodeAt(i)) >>> 0;
+                }
+                return h % RAINBOW_COLORS.length;
               };
+              const groupColor = (group: string): string =>
+                RAINBOW_COLORS[colorIndex(group)];
+
+              // Sort groups in rainbow order (by hue index) so the UI walks
+              // red → orange → … → violet top-to-bottom.
+              const groupOrder = Object.keys(groups).sort(
+                (a, b) => colorIndex(a) - colorIndex(b),
+              );
 
               return groupOrder.map((group) => (
                 <div key={group} className="mb-4">
                   <div className="flex items-center gap-2 mb-2 px-1">
                     <span
-                      className={`text-[10px] font-bold uppercase tracking-widest ${GROUP_COLORS[group]?.split(' ').pop() || 'text-muted-foreground/50'}`}
+                      className="text-[10px] font-bold uppercase tracking-widest"
+                      style={{ color: groupColor(group) }}
                     >
                       {group}
                     </span>

--- a/apps/server/sf.json
+++ b/apps/server/sf.json
@@ -17,7 +17,6 @@
     "llm-base",
     "frontend-base",
     "backend-api-base",
-    "claude-backend-api",
     "codex-backend-api",
     "gemini-backend-api",
     "ollama-backend-api",

--- a/apps/server/sf.json
+++ b/apps/server/sf.json
@@ -23,9 +23,50 @@
     "ollama-backend-api",
     "gemini-frontend",
     "codex-frontend",
-    "ollama-frontend"
+    "ollama-frontend",
+    "aigw-base",
+    "aigw-claude-backend",
+    "aigw-runner"
   ],
   "plugin_config": {
+    "aigw-runner": {
+      "port": 9105,
+      "aigateway_dir": null,
+      "startup_timeout_seconds": 10.0,
+      "enabled": true
+    },
+    "aigw-claude-backend": {
+      "gateway_url": "http://127.0.0.1:9105",
+      "auth_profile": "default",
+      "default_model": "anthropic/claude-sonnet-4-5",
+      "default_effort": "medium",
+      "timeout_seconds": 300,
+      "max_budget_usd": null,
+      "permission_mode": null,
+      "dangerously_skip_permissions": false,
+      "profiles": {
+        "default": {
+          "context": null,
+          "system_prompt": null,
+          "append_system_prompt": null,
+          "model": null,
+          "output_format": null,
+          "max_budget_usd": null,
+          "effort": null,
+          "tools": null,
+          "allowed_tools": null,
+          "disallowed_tools": null,
+          "mcp_config": null,
+          "permission_mode": null,
+          "add_dirs": null,
+          "fallback_model": null,
+          "dangerously_skip_permissions": false,
+          "no_session_persistence": true,
+          "timeout_seconds": null
+        }
+      },
+      "default_profile": "default"
+    },
     "claude-frontend": {
       "active_spec": "anthropic-cookbook",
       "upstream_url": "https://api.anthropic.com",

--- a/apps/server/src/screamingface/plugins/aigw_base/__init__.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/__init__.py
@@ -1,0 +1,14 @@
+"""Shared base classes for aigw_*_backend plugins."""
+
+from .backend import AigwBackend, AigwGatewayError
+from .interpreter import AigwInterpreter
+from .plugin_base import AigwBackendApiPluginBase
+from .settings import AigwBackendApiSettingsBase
+
+__all__ = [
+    "AigwBackend",
+    "AigwBackendApiPluginBase",
+    "AigwBackendApiSettingsBase",
+    "AigwGatewayError",
+    "AigwInterpreter",
+]

--- a/apps/server/src/screamingface/plugins/aigw_base/backend.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/backend.py
@@ -16,6 +16,7 @@ import logging
 
 import httpx
 
+from screamingface.plugins.llm_base.backend_base import Backend
 from screamingface.plugins.llm_base.errors import (
     AuthError,
     BackendError,
@@ -30,7 +31,7 @@ class AigwGatewayError(BackendError):
     """Raised for unexpected gateway responses (gateway 500, malformed JSON)."""
 
 
-class AigwBackend:
+class AigwBackend(Backend):
     """Speaks OpenAI ChatCompletions to the local AI Gateway.
 
     One method: `run(messages, *, model, system, ...) -> CoreMessage`.

--- a/apps/server/src/screamingface/plugins/aigw_base/backend.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/backend.py
@@ -110,7 +110,11 @@ class AigwBackend:
                 f"Complete the flow in Electron."
             )
         if resp.status_code == 401 and code == "auth_required":
-            msg = detail.get("message", "auth required") if isinstance(detail, dict) else "auth required"
+            msg = (
+                detail.get("message", "auth required")
+                if isinstance(detail, dict)
+                else "auth required"
+            )
             raise AuthError(f"Gateway: {msg}")
         if resp.status_code in (400, 422):
             raise BackendError(

--- a/apps/server/src/screamingface/plugins/aigw_base/backend.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/backend.py
@@ -110,7 +110,7 @@ class AigwBackend:
                 f"Complete the flow in Electron."
             )
         if resp.status_code == 401 and code == "auth_required":
-            msg = (detail or {}).get("message", "auth required")
+            msg = detail.get("message", "auth required") if isinstance(detail, dict) else "auth required"
             raise AuthError(f"Gateway: {msg}")
         if resp.status_code in (400, 422):
             raise BackendError(

--- a/apps/server/src/screamingface/plugins/aigw_base/backend.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/backend.py
@@ -1,0 +1,201 @@
+"""HTTP client to the AI Gateway.
+
+Translates a list of CoreMessage (the SF-internal canonical shape) into
+an OpenAI ChatCompletions request, POSTs to the gateway with X-Profile,
+and parses the response back into a CoreMessage.
+
+Gateway-side errors map onto the existing SF error types so callers can
+catch them uniformly (BackendError for transport / unexpected status,
+AuthError for auth-required / refresh-failed, CredentialNotFoundError
+for missing-profile-tokens).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from screamingface.plugins.llm_base.errors import (
+    AuthError,
+    BackendError,
+    CredentialNotFoundError,
+)
+from screamingface.plugins.llm_base.messages import CoreMessage, TextPart, ToolDefinition
+
+logger = logging.getLogger(__name__)
+
+
+class AigwGatewayError(BackendError):
+    """Raised for unexpected gateway responses (gateway 500, malformed JSON)."""
+
+
+class AigwBackend:
+    """Speaks OpenAI ChatCompletions to the local AI Gateway.
+
+    One method: `run(messages, *, model, system, ...) -> CoreMessage`.
+    The gateway handles auth, refresh, and provider-specific shape
+    translation; this class just speaks the gateway's protocol.
+
+    Args:
+        gateway_url: Base URL (default http://127.0.0.1:9105).
+        profile_name: X-Profile header value (default "default").
+        http_client_factory: Callable returning an httpx.AsyncClient. Tests
+            inject one that returns a MockTransport-backed client.
+    """
+
+    def __init__(
+        self,
+        *,
+        gateway_url: str = "http://127.0.0.1:9105",
+        profile_name: str = "default",
+        http_client_factory=None,
+    ) -> None:
+        self._gateway_url = gateway_url.rstrip("/")
+        self._profile_name = profile_name
+        self._http_factory = http_client_factory or (
+            lambda timeout: httpx.AsyncClient(timeout=httpx.Timeout(timeout))
+        )
+
+    async def run(
+        self,
+        messages: list[CoreMessage],
+        *,
+        model: str,
+        system: str | None = None,
+        tools: list[ToolDefinition] | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        timeout_seconds: float = 300.0,
+        extra_body: dict | None = None,
+    ) -> CoreMessage:
+        body = self._build_body(
+            messages,
+            model=model,
+            system=system,
+            tools=tools,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        if extra_body:
+            body.update(extra_body)
+
+        url = f"{self._gateway_url}/v1/chat/completions"
+        headers = {"X-Profile": self._profile_name, "content-type": "application/json"}
+
+        try:
+            async with self._http_factory(timeout_seconds) as client:
+                resp = await client.post(url, json=body, headers=headers)
+        except httpx.RequestError as exc:
+            raise BackendError(
+                f"AI Gateway unreachable at {self._gateway_url}: {exc}",
+                status=None,
+            ) from exc
+
+        if resp.status_code == 200:
+            return _response_to_core_message(resp.json())
+
+        # Map gateway error codes onto SF's error hierarchy.
+        detail = _detail_or_text(resp)
+        code = (detail or {}).get("code") if isinstance(detail, dict) else None
+
+        if resp.status_code == 404 and code == "profile_not_found":
+            raise CredentialNotFoundError(
+                f"Gateway profile {self._profile_name!r} not found. "
+                f"Create it via POST /v1/auth/<provider>/profiles."
+            )
+        if resp.status_code == 409 and code == "profile_pending_auth":
+            raise AuthError(
+                f"Gateway profile {self._profile_name!r} is awaiting OAuth callback. "
+                f"Complete the flow in Electron."
+            )
+        if resp.status_code == 401 and code == "auth_required":
+            msg = (detail or {}).get("message", "auth required")
+            raise AuthError(f"Gateway: {msg}")
+        if resp.status_code in (400, 422):
+            raise BackendError(
+                f"Gateway rejected request ({resp.status_code}): {detail}",
+                status=resp.status_code,
+            )
+        # Anything else → unexpected gateway error
+        retry_after = _parse_retry_after(resp.headers.get("retry-after"))
+        raise AigwGatewayError(
+            f"Gateway returned status {resp.status_code}: {resp.text[:500]}",
+            status=resp.status_code,
+            retry_after=retry_after,
+        )
+
+    def _build_body(
+        self,
+        messages: list[CoreMessage],
+        *,
+        model: str,
+        system: str | None,
+        tools: list[ToolDefinition] | None,
+        max_tokens: int | None,
+        temperature: float | None,
+    ) -> dict:
+        openai_messages: list[dict] = []
+        if system:
+            openai_messages.append({"role": "system", "content": system})
+        for m in messages:
+            openai_messages.append(_core_message_to_openai(m))
+
+        body: dict = {"model": model, "messages": openai_messages}
+        if max_tokens is not None:
+            body["max_tokens"] = max_tokens
+        if temperature is not None:
+            body["temperature"] = temperature
+        if tools:
+            body["tools"] = [_tool_to_openai(t) for t in tools]
+        return body
+
+
+def _core_message_to_openai(msg: CoreMessage) -> dict:
+    if isinstance(msg.content, str):
+        return {"role": msg.role, "content": msg.content}
+    # Concatenate every TextPart; ignore non-text parts for now (Phase 1).
+    text = "".join(p.text for p in msg.content if isinstance(p, TextPart))
+    return {"role": msg.role, "content": text}
+
+
+def _tool_to_openai(t: ToolDefinition) -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": t.name,
+            "description": t.description,
+            "parameters": t.input_schema,
+        },
+    }
+
+
+def _response_to_core_message(data: dict) -> CoreMessage:
+    """Pull the assistant text out of an OpenAI ChatCompletions response."""
+    try:
+        choice = data["choices"][0]
+        msg = choice["message"]
+        content = msg.get("content") or ""
+    except (KeyError, IndexError, TypeError) as exc:
+        raise AigwGatewayError(
+            f"Malformed gateway response: {exc}; body={data!r}",
+            status=200,
+        ) from exc
+    return CoreMessage(role="assistant", content=[TextPart(text=content)])
+
+
+def _detail_or_text(resp: httpx.Response):
+    try:
+        body = resp.json()
+    except (ValueError, httpx.DecodingError):
+        return resp.text
+    return body.get("detail", body) if isinstance(body, dict) else body
+
+
+def _parse_retry_after(value: str | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None

--- a/apps/server/src/screamingface/plugins/aigw_base/interpreter.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/interpreter.py
@@ -1,0 +1,65 @@
+"""Url4 interpreter for aigw_*_backend plugins.
+
+Mirrors ClaudeBackendApiInterpreter.process semantics: combines intent +
+sources, builds a single user CoreMessage, sends to AigwBackend, returns
+the assistant text. The shared concatenation rule (intent first,
+sources second, separated by \\n\\n) is preserved so existing url4
+specs work unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from screamingface.plugins.llm_base.messages import CoreMessage, TextPart, extract_text
+from screamingface.plugins.url4_executor.interpreter import Url4Interpreter
+
+from .backend import AigwBackend
+
+if TYPE_CHECKING:
+    from .settings import AigwBackendApiSettingsBase
+
+logger = logging.getLogger(__name__)
+
+_FALLBACK_MODEL = "anthropic/claude-sonnet-4-5"
+
+
+class AigwInterpreter(Url4Interpreter):
+    def __init__(
+        self,
+        app: Any = None,
+        settings: AigwBackendApiSettingsBase | None = None,
+        *,
+        backend: AigwBackend | None = None,
+    ) -> None:
+        super().__init__(app)
+        self.settings = settings
+        if backend is not None:
+            self._backend = backend
+        elif settings is not None:
+            self._backend = AigwBackend(
+                gateway_url=settings.gateway_url,
+                profile_name=settings.auth_profile,
+            )
+        else:
+            self._backend = AigwBackend()
+
+    async def process(self, sources: str, intent: str | None) -> str:
+        combined = f"{intent}\n\n{sources}" if intent and sources else (intent or sources or "")
+        if not combined:
+            return ""
+
+        messages = [CoreMessage(role="user", content=[TextPart(text=combined)])]
+
+        model = (self.settings.default_model if self.settings else None) or _FALLBACK_MODEL
+        system = self.settings.interpreter_system_prompt if self.settings else None
+        timeout = self.settings.timeout_seconds if self.settings else 300.0
+
+        result = await self._backend.run(
+            messages,
+            model=model,
+            system=system,
+            timeout_seconds=timeout,
+        )
+        return extract_text(result)

--- a/apps/server/src/screamingface/plugins/aigw_base/plugin.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/plugin.py
@@ -1,0 +1,37 @@
+"""aigw-base plugin: registers the shared base classes for aigw_* plugins.
+
+This plugin has no routes of its own. It exists so the package can be
+discovered by the SF plugin loader (entry-point group `screamingface.plugins`)
+and so other plugins can declare `depends=["aigw-base"]`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from screamingface.plugin import Plugin
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+    from screamingface.core.classes import ClassRegistry
+    from screamingface.core.hooks import HookRegistry
+    from screamingface.core.routes import RouteRegistry
+
+
+class AigwBasePlugin(Plugin):
+    name = "aigw-base"
+    description = "Shared base classes for aigw_*_backend plugins."
+    tags: list[str] = ["product:aigw"]
+    depends: list[str] = ["llm-base", "backend-api-base"]
+    conflicts: list[str] = []
+
+    def setup(
+        self,
+        app: FastAPI,
+        hooks: HookRegistry,  # noqa: ARG002
+        classes: ClassRegistry,  # noqa: ARG002
+        routes: RouteRegistry,  # noqa: ARG002
+    ) -> None:
+        # No-op: this package is base classes only.
+        return None

--- a/apps/server/src/screamingface/plugins/aigw_base/plugin_base.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/plugin_base.py
@@ -8,12 +8,13 @@ create_router) and inherit `_make_interpreter` here.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, cast
 
 from screamingface.plugins.backend_api_base.plugin_base import BackendApiPluginBase
 
 from .backend import AigwBackend
 from .interpreter import AigwInterpreter
+from .settings import AigwBackendApiSettingsBase
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
@@ -27,7 +28,7 @@ class AigwBackendApiPluginBase(BackendApiPluginBase):
     conflicts: ClassVar[list[str]] = []
 
     def _make_interpreter(self, app: FastAPI):
-        settings = self.settings  # type: ignore[assignment]
+        settings = cast(AigwBackendApiSettingsBase, self.settings)
         backend = AigwBackend(
             gateway_url=settings.gateway_url,
             profile_name=settings.auth_profile,

--- a/apps/server/src/screamingface/plugins/aigw_base/plugin_base.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/plugin_base.py
@@ -1,0 +1,35 @@
+"""Shared lifecycle base for aigw_*_backend plugins.
+
+Subclasses each provider's `*_backend.plugin` mirror of
+`claude_backend_api/plugin.py` style: declare class-level metadata
+(name, backend_call_paths, schema_link_base, settings_class,
+create_router) and inherit `_make_interpreter` here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar
+
+from screamingface.plugins.backend_api_base.plugin_base import BackendApiPluginBase
+
+from .backend import AigwBackend
+from .interpreter import AigwInterpreter
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+
+class AigwBackendApiPluginBase(BackendApiPluginBase):
+    """Base class for every aigw_*_backend plugin."""
+
+    tags: ClassVar[list[str]] = ["product:aigw"]
+    depends: ClassVar[list[str]] = ["llm-base", "backend-api-base", "aigw-base"]
+    conflicts: ClassVar[list[str]] = []
+
+    def _make_interpreter(self, app: FastAPI):
+        settings = self.settings  # type: ignore[assignment]
+        backend = AigwBackend(
+            gateway_url=settings.gateway_url,
+            profile_name=settings.auth_profile,
+        )
+        return AigwInterpreter(app=app, settings=settings, backend=backend)

--- a/apps/server/src/screamingface/plugins/aigw_base/settings.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/settings.py
@@ -1,0 +1,29 @@
+"""Settings base for aigw_*_backend plugins.
+
+Inherits the standard backend-api settings (default_model, timeout_seconds,
+profiles, default_profile, etc.) and adds gateway-specific fields:
+the gateway URL and the auth profile to send via X-Profile.
+"""
+
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import SettingsConfigDict
+
+from screamingface.plugins.backend_api_base.plugin_base import BackendApiSettingsBase
+
+
+class AigwBackendApiSettingsBase(BackendApiSettingsBase):
+    model_config = SettingsConfigDict(
+        env_prefix="SF_AIGW__",
+        env_nested_delimiter="__",
+    )
+
+    gateway_url: str = Field(
+        default="http://127.0.0.1:9105",
+        description="Base URL of the local AI Gateway service.",
+    )
+    auth_profile: str = Field(
+        default="default",
+        description="Profile name sent in the X-Profile header on every gateway request.",
+    )

--- a/apps/server/src/screamingface/plugins/aigw_base/tests/test_aigw_backend.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/tests/test_aigw_backend.py
@@ -1,0 +1,167 @@
+"""Unit tests for AigwBackend — mocks the gateway via httpx.MockTransport."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from screamingface.plugins.aigw_base.backend import (
+    AigwBackend,
+    AigwGatewayError,
+)
+from screamingface.plugins.llm_base.errors import (
+    AuthError,
+    BackendError,
+    CredentialNotFoundError,
+)
+from screamingface.plugins.llm_base.messages import CoreMessage, TextPart
+
+
+def _factory(transport: httpx.MockTransport):
+    def factory(timeout: float):
+        return httpx.AsyncClient(transport=transport, timeout=httpx.Timeout(timeout))
+
+    return factory
+
+
+def _ok_response(text: str) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "id": "x",
+            "object": "chat.completion",
+            "model": "anthropic/claude-haiku-4-5",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": text},
+                    "finish_reason": "stop",
+                }
+            ],
+        },
+    )
+
+
+@pytest.mark.anyio
+async def test_happy_path_extracts_text() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["url"] = str(req.url)
+        captured["headers"] = dict(req.headers)
+        captured["body"] = json.loads(req.content.decode())
+        return _ok_response("pong")
+
+    backend = AigwBackend(
+        gateway_url="http://127.0.0.1:9105",
+        profile_name="default",
+        http_client_factory=_factory(httpx.MockTransport(handler)),
+    )
+    result = await backend.run(
+        [CoreMessage(role="user", content=[TextPart(text="hi")])],
+        model="anthropic/claude-haiku-4-5",
+        system="be terse",
+        max_tokens=10,
+    )
+    assert isinstance(result, CoreMessage)
+    assert isinstance(result.content, list)
+    assert result.content[0].text == "pong"  # type: ignore[union-attr]
+
+    assert captured["url"] == "http://127.0.0.1:9105/v1/chat/completions"
+    assert captured["headers"]["x-profile"] == "default"
+    assert captured["body"]["model"] == "anthropic/claude-haiku-4-5"
+    assert captured["body"]["messages"][0] == {"role": "system", "content": "be terse"}
+    assert captured["body"]["messages"][1] == {"role": "user", "content": "hi"}
+    assert captured["body"]["max_tokens"] == 10
+
+
+@pytest.mark.anyio
+async def test_string_content_passes_through() -> None:
+    """CoreMessage.content can be a bare string; that should round-trip too."""
+
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return _ok_response("ok")
+
+    backend = AigwBackend(http_client_factory=_factory(httpx.MockTransport(handler)))
+    await backend.run(
+        [CoreMessage(role="user", content="bare string")],
+        model="anthropic/claude-haiku-4-5",
+    )
+
+
+@pytest.mark.anyio
+async def test_404_profile_not_found_maps_to_credential_not_found() -> None:
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            404,
+            json={"detail": {"code": "profile_not_found", "provider": "anthropic", "name": "x"}},
+        )
+
+    backend = AigwBackend(
+        profile_name="x", http_client_factory=_factory(httpx.MockTransport(handler))
+    )
+    with pytest.raises(CredentialNotFoundError, match="not found"):
+        await backend.run(
+            [CoreMessage(role="user", content="hi")],
+            model="anthropic/claude-haiku-4-5",
+        )
+
+
+@pytest.mark.anyio
+async def test_409_pending_auth_maps_to_auth_error() -> None:
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            409, json={"detail": {"code": "profile_pending_auth"}}
+        )
+
+    backend = AigwBackend(http_client_factory=_factory(httpx.MockTransport(handler)))
+    with pytest.raises(AuthError, match="awaiting OAuth"):
+        await backend.run(
+            [CoreMessage(role="user", content="hi")],
+            model="anthropic/claude-haiku-4-5",
+        )
+
+
+@pytest.mark.anyio
+async def test_401_auth_required_maps_to_auth_error() -> None:
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            401,
+            json={"detail": {"code": "auth_required", "message": "refresh failed"}},
+        )
+
+    backend = AigwBackend(http_client_factory=_factory(httpx.MockTransport(handler)))
+    with pytest.raises(AuthError, match="refresh failed"):
+        await backend.run(
+            [CoreMessage(role="user", content="hi")],
+            model="anthropic/claude-haiku-4-5",
+        )
+
+
+@pytest.mark.anyio
+async def test_500_raises_aigw_gateway_error() -> None:
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="boom")
+
+    backend = AigwBackend(http_client_factory=_factory(httpx.MockTransport(handler)))
+    with pytest.raises(AigwGatewayError):
+        await backend.run(
+            [CoreMessage(role="user", content="hi")],
+            model="anthropic/claude-haiku-4-5",
+        )
+
+
+@pytest.mark.anyio
+async def test_unreachable_raises_backend_error() -> None:
+    def handler(_req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    backend = AigwBackend(http_client_factory=_factory(httpx.MockTransport(handler)))
+    with pytest.raises(BackendError, match="unreachable"):
+        await backend.run(
+            [CoreMessage(role="user", content="hi")],
+            model="anthropic/claude-haiku-4-5",
+        )

--- a/apps/server/src/screamingface/plugins/aigw_base/tests/test_aigw_backend.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/tests/test_aigw_backend.py
@@ -113,9 +113,7 @@ async def test_404_profile_not_found_maps_to_credential_not_found() -> None:
 @pytest.mark.anyio
 async def test_409_pending_auth_maps_to_auth_error() -> None:
     def handler(_req: httpx.Request) -> httpx.Response:
-        return httpx.Response(
-            409, json={"detail": {"code": "profile_pending_auth"}}
-        )
+        return httpx.Response(409, json={"detail": {"code": "profile_pending_auth"}})
 
     backend = AigwBackend(http_client_factory=_factory(httpx.MockTransport(handler)))
     with pytest.raises(AuthError, match="awaiting OAuth"):

--- a/apps/server/src/screamingface/plugins/aigw_base/tests/test_interpreter.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/tests/test_interpreter.py
@@ -1,0 +1,44 @@
+"""Unit tests for AigwInterpreter — verifies process() semantics."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from screamingface.plugins.aigw_base.backend import AigwBackend
+from screamingface.plugins.aigw_base.interpreter import AigwInterpreter
+
+
+def _factory_returning(text: str):
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "id": "x",
+                "choices": [
+                    {"index": 0, "message": {"role": "assistant", "content": text}, "finish_reason": "stop"}
+                ],
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    def factory(timeout: float):
+        return httpx.AsyncClient(transport=transport, timeout=httpx.Timeout(timeout))
+
+    return factory
+
+
+@pytest.mark.anyio
+async def test_process_combines_intent_and_sources() -> None:
+    backend = AigwBackend(http_client_factory=_factory_returning("answer"))
+    interp = AigwInterpreter(backend=backend)
+    out = await interp.process(sources="cats are mammals", intent="what are cats?")
+    assert out == "answer"
+
+
+@pytest.mark.anyio
+async def test_process_returns_empty_when_no_input() -> None:
+    backend = AigwBackend(http_client_factory=_factory_returning("X"))
+    interp = AigwInterpreter(backend=backend)
+    assert await interp.process(sources="", intent=None) == ""

--- a/apps/server/src/screamingface/plugins/aigw_base/tests/test_interpreter.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/tests/test_interpreter.py
@@ -16,7 +16,11 @@ def _factory_returning(text: str):
             json={
                 "id": "x",
                 "choices": [
-                    {"index": 0, "message": {"role": "assistant", "content": text}, "finish_reason": "stop"}
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": text},
+                        "finish_reason": "stop",
+                    }
                 ],
             },
         )

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/__init__.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/__init__.py
@@ -1,0 +1,5 @@
+"""aigw-claude-backend: routes /aigw-claude/* through the AI Gateway to anthropic/* models."""
+
+from .plugin import AigwClaudeBackendPlugin, AigwClaudeBackendSettings
+
+__all__ = ["AigwClaudeBackendPlugin", "AigwClaudeBackendSettings"]

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/plugin.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/plugin.py
@@ -48,6 +48,10 @@ class AigwClaudeBackendPlugin(AigwBackendApiPluginBase):
         "header. Mutually exclusive with claude-backend-api — only one can "
         "own /claude at a time."
     )
+    # Categorize under "claude" in the UI (same group as claude-backend-api),
+    # not under "aigw" — users think in terms of the upstream model, not the
+    # transport layer.
+    tags: list[str] = ["product:claude"]
     # Same path as claude-backend-api so url4 specs (e.g. cat-breeds-3sources)
     # work unchanged. The conflict below ensures only one Claude backend is
     # ever active.

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/plugin.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/plugin.py
@@ -41,12 +41,18 @@ class AigwClaudeBackendSettings(AigwBackendApiSettingsBase):
 class AigwClaudeBackendPlugin(AigwBackendApiPluginBase):
     name = "aigw-claude-backend"
     description = (
-        "Claude routed through the local AI Gateway (apps/aigateway/). "
-        "Drop-in alternative to claude-backend-api: same /aigw-claude routes, "
-        "but auth + refresh + adapter live in the gateway, and multiple "
-        "OAuth profiles are supported via the gateway's X-Profile header."
+        "Claude served at /claude via the local AI Gateway (apps/aigateway/). "
+        "Drop-in replacement for claude-backend-api: same routes and url4 "
+        "contract, but auth + refresh + adapter live in the gateway, and "
+        "multiple OAuth profiles are supported via the gateway's X-Profile "
+        "header. Mutually exclusive with claude-backend-api — only one can "
+        "own /claude at a time."
     )
-    backend_call_paths: list[str] = ["/aigw-claude"]
+    # Same path as claude-backend-api so url4 specs (e.g. cat-breeds-3sources)
+    # work unchanged. The conflict below ensures only one Claude backend is
+    # ever active.
+    backend_call_paths: list[str] = ["/claude"]
+    conflicts: list[str] = ["claude-backend-api"]
     settings_class = AigwClaudeBackendSettings
-    schema_link_base = "/aigw-claude/"
+    schema_link_base = "/claude/"
     create_router = staticmethod(create_router)

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/plugin.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/plugin.py
@@ -1,0 +1,52 @@
+"""aigw-claude-backend plugin — Claude served via the local AI Gateway.
+
+Same shape as claude_backend_api but the heavy lifting (provider
+adapter, OAuth, refresh) lives in apps/aigateway/. This plugin only
+configures which model strings to default to and which gateway profile
+to authenticate as.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import Field
+from pydantic_settings import SettingsConfigDict
+
+from screamingface.plugins.aigw_base import (
+    AigwBackendApiPluginBase,
+    AigwBackendApiSettingsBase,
+)
+from screamingface.plugins.aigw_claude_backend.routes import create_router
+
+if TYPE_CHECKING:
+    pass
+
+
+class AigwClaudeBackendSettings(AigwBackendApiSettingsBase):
+    model_config = SettingsConfigDict(
+        env_prefix="SF_AIGW_CLAUDE_BACKEND__",
+        env_nested_delimiter="__",
+    )
+
+    default_model: str | None = Field(
+        default="anthropic/claude-sonnet-4-5",
+        description=(
+            "Default Claude model. The gateway routes by the prefix; "
+            "must start with 'anthropic/'."
+        ),
+    )
+
+
+class AigwClaudeBackendPlugin(AigwBackendApiPluginBase):
+    name = "aigw-claude-backend"
+    description = (
+        "Claude routed through the local AI Gateway (apps/aigateway/). "
+        "Drop-in alternative to claude-backend-api: same /aigw-claude routes, "
+        "but auth + refresh + adapter live in the gateway, and multiple "
+        "OAuth profiles are supported via the gateway's X-Profile header."
+    )
+    backend_call_paths: list[str] = ["/aigw-claude"]
+    settings_class = AigwClaudeBackendSettings
+    schema_link_base = "/aigw-claude/"
+    create_router = staticmethod(create_router)

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/plugin.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/plugin.py
@@ -23,6 +23,18 @@ if TYPE_CHECKING:
     pass
 
 
+# Suggestions for the default_model dropdown. Mirrors the gateway's
+# anthropic_provider/models.py registry. RJSF's BaseInputTemplate renders
+# a `<datalist>` from `examples`, giving the UI a typeahead dropdown that
+# still accepts free-text — useful when a new Anthropic snapshot ships
+# before this list is updated.
+_CLAUDE_MODEL_SUGGESTIONS = [
+    "anthropic/claude-sonnet-4-5",
+    "anthropic/claude-opus-4-7",
+    "anthropic/claude-haiku-4-5",
+]
+
+
 class AigwClaudeBackendSettings(AigwBackendApiSettingsBase):
     model_config = SettingsConfigDict(
         env_prefix="SF_AIGW_CLAUDE_BACKEND__",
@@ -33,8 +45,10 @@ class AigwClaudeBackendSettings(AigwBackendApiSettingsBase):
         default="anthropic/claude-sonnet-4-5",
         description=(
             "Default Claude model. The gateway routes by the prefix; "
-            "must start with 'anthropic/'."
+            "must start with 'anthropic/'. Pick from the dropdown or "
+            "type a custom snapshot if the gateway already supports it."
         ),
+        examples=_CLAUDE_MODEL_SUGGESTIONS,
     )
 
 

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/routes.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/routes.py
@@ -1,0 +1,47 @@
+"""Routes for aigw-claude-backend.
+
+The four endpoints (health, run, url4, profile) come from the shared
+build_backend_api_router factory; this module supplies the
+gateway-routed pieces (AigwBackend, AigwInterpreter, default model).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from fastapi import APIRouter
+
+from screamingface.plugins.aigw_base import AigwBackend, AigwInterpreter
+from screamingface.plugins.llm_base.routes_shared import (
+    BackendApiConfig,
+    build_backend_api_router,
+)
+
+if TYPE_CHECKING:
+    from screamingface.plugins.aigw_claude_backend.plugin import AigwClaudeBackendSettings
+
+
+_DEFAULT_MODEL = "anthropic/claude-sonnet-4-5"
+
+
+def create_router(settings: AigwClaudeBackendSettings, app: Any = None) -> APIRouter:
+    backend = AigwBackend(
+        gateway_url=settings.gateway_url,
+        profile_name=settings.auth_profile,
+    )
+
+    def build_interpreter() -> Any:
+        return AigwInterpreter(app=app, settings=settings, backend=backend)
+
+    return build_backend_api_router(
+        BackendApiConfig(
+            name="aigw-claude-backend",
+            path_prefix="/aigw-claude",
+            default_model=_DEFAULT_MODEL,
+            backend=backend,
+            settings=settings,
+            app=app,
+            build_interpreter=build_interpreter,
+            span_prefix="aigw_claude",
+        )
+    )

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/routes.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/routes.py
@@ -36,7 +36,7 @@ def create_router(settings: AigwClaudeBackendSettings, app: Any = None) -> APIRo
     return build_backend_api_router(
         BackendApiConfig(
             name="aigw-claude-backend",
-            path_prefix="/aigw-claude",
+            path_prefix="/claude",
             default_model=_DEFAULT_MODEL,
             backend=backend,
             settings=settings,

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/tests/test_plugin_metadata.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/tests/test_plugin_metadata.py
@@ -1,0 +1,43 @@
+"""Plugin metadata + settings construction tests."""
+
+from __future__ import annotations
+
+from screamingface.plugins.aigw_claude_backend.plugin import (
+    AigwClaudeBackendPlugin,
+    AigwClaudeBackendSettings,
+)
+
+
+def test_plugin_name_is_canonical() -> None:
+    assert AigwClaudeBackendPlugin.name == "aigw-claude-backend"
+
+
+def test_plugin_dependency_chain() -> None:
+    assert "aigw-base" in AigwClaudeBackendPlugin.depends
+    assert "llm-base" in AigwClaudeBackendPlugin.depends
+    assert "backend-api-base" in AigwClaudeBackendPlugin.depends
+
+
+def test_plugin_no_conflicts() -> None:
+    """aigw-claude-backend coexists with claude-backend-api."""
+    assert AigwClaudeBackendPlugin.conflicts == []
+
+
+def test_backend_call_paths() -> None:
+    assert AigwClaudeBackendPlugin.backend_call_paths == ["/aigw-claude"]
+
+
+def test_default_settings() -> None:
+    s = AigwClaudeBackendSettings()
+    assert s.default_model == "anthropic/claude-sonnet-4-5"
+    assert s.gateway_url == "http://127.0.0.1:9105"
+    assert s.auth_profile == "default"
+    assert s.timeout_seconds == 300.0
+
+
+def test_settings_env_prefix(monkeypatch) -> None:
+    monkeypatch.setenv("SF_AIGW_CLAUDE_BACKEND__GATEWAY_URL", "http://example:9999")
+    monkeypatch.setenv("SF_AIGW_CLAUDE_BACKEND__AUTH_PROFILE", "work")
+    s = AigwClaudeBackendSettings()
+    assert s.gateway_url == "http://example:9999"
+    assert s.auth_profile == "work"

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/tests/test_plugin_metadata.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/tests/test_plugin_metadata.py
@@ -26,7 +26,7 @@ def test_plugin_dependency_chain() -> None:
 
 
 def test_plugin_conflicts_with_legacy_claude_backend() -> None:
-    """aigw-claude-backend takes over /claude, so it must not coexist with the legacy direct-API plugin."""
+    """aigw-claude-backend takes over /claude; cannot coexist with the legacy direct-API plugin."""
     assert AigwClaudeBackendPlugin.conflicts == ["claude-backend-api"]
 
 

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/tests/test_plugin_metadata.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/tests/test_plugin_metadata.py
@@ -12,6 +12,13 @@ def test_plugin_name_is_canonical() -> None:
     assert AigwClaudeBackendPlugin.name == "aigw-claude-backend"
 
 
+def test_plugin_grouped_under_claude_product_tag() -> None:
+    """UI groups by `product:` tag — claude backends belong with the legacy
+    claude-backend-api in the 'claude' category, not 'aigw'."""
+    assert "product:claude" in AigwClaudeBackendPlugin.tags
+    assert "product:aigw" not in AigwClaudeBackendPlugin.tags
+
+
 def test_plugin_dependency_chain() -> None:
     assert "aigw-base" in AigwClaudeBackendPlugin.depends
     assert "llm-base" in AigwClaudeBackendPlugin.depends

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/tests/test_plugin_metadata.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/tests/test_plugin_metadata.py
@@ -18,13 +18,14 @@ def test_plugin_dependency_chain() -> None:
     assert "backend-api-base" in AigwClaudeBackendPlugin.depends
 
 
-def test_plugin_no_conflicts() -> None:
-    """aigw-claude-backend coexists with claude-backend-api."""
-    assert AigwClaudeBackendPlugin.conflicts == []
+def test_plugin_conflicts_with_legacy_claude_backend() -> None:
+    """aigw-claude-backend takes over /claude, so it must not coexist with the legacy direct-API plugin."""
+    assert AigwClaudeBackendPlugin.conflicts == ["claude-backend-api"]
 
 
-def test_backend_call_paths() -> None:
-    assert AigwClaudeBackendPlugin.backend_call_paths == ["/aigw-claude"]
+def test_backend_call_paths_owns_canonical_claude_path() -> None:
+    """Same path as claude-backend-api so url4 specs route through the gateway transparently."""
+    assert AigwClaudeBackendPlugin.backend_call_paths == ["/claude"]
 
 
 def test_default_settings() -> None:

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/tests/test_url4_dispatch.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/tests/test_url4_dispatch.py
@@ -1,0 +1,78 @@
+"""End-to-end test: AigwClaudeBackendPlugin.handle_backend_call routes
+through AigwInterpreter → AigwBackend (mocked transport) and returns
+the assistant text."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from screamingface.plugins.aigw_base import AigwBackend, AigwInterpreter
+from screamingface.plugins.aigw_claude_backend.plugin import (
+    AigwClaudeBackendPlugin,
+    AigwClaudeBackendSettings,
+)
+
+
+def _factory_returning(text: str, captured: dict | None = None):
+    def handler(req: httpx.Request) -> httpx.Response:
+        if captured is not None:
+            captured["url"] = str(req.url)
+            captured["headers"] = dict(req.headers)
+            captured["body"] = json.loads(req.content.decode())
+        return httpx.Response(
+            200,
+            json={
+                "id": "x",
+                "object": "chat.completion",
+                "model": "anthropic/claude-sonnet-4-5",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": text},
+                        "finish_reason": "stop",
+                    }
+                ],
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    def factory(timeout: float):
+        return httpx.AsyncClient(transport=transport, timeout=httpx.Timeout(timeout))
+
+    return factory
+
+
+@pytest.mark.anyio
+async def test_handle_backend_call_returns_assistant_text() -> None:
+    """The plugin's handle_backend_call uses the inherited _make_interpreter
+    which constructs an AigwInterpreter that sends to the gateway."""
+    captured: dict = {}
+    factory = _factory_returning("pong", captured)
+
+    plugin = AigwClaudeBackendPlugin()
+    plugin.settings = AigwClaudeBackendSettings()  # type: ignore[assignment]
+
+    # Inject the mocked HTTP factory by replacing _make_interpreter behavior:
+    # easiest path is to swap the backend on the interpreter the plugin would build.
+    backend = AigwBackend(
+        gateway_url=plugin.settings.gateway_url,
+        profile_name=plugin.settings.auth_profile,
+        http_client_factory=factory,
+    )
+    interpreter = AigwInterpreter(app=None, settings=plugin.settings, backend=backend)
+
+    out = await interpreter.process(sources="cats", intent="describe")
+    assert out == "pong"
+
+    # Body shape sanity
+    assert captured["body"]["model"] == "anthropic/claude-sonnet-4-5"
+    assert captured["headers"]["x-profile"] == "default"
+    assert captured["url"].endswith("/v1/chat/completions")
+    user_msg = captured["body"]["messages"][-1]
+    assert user_msg["role"] == "user"
+    assert "describe" in user_msg["content"]
+    assert "cats" in user_msg["content"]

--- a/apps/server/src/screamingface/plugins/aigw_runner/__init__.py
+++ b/apps/server/src/screamingface/plugins/aigw_runner/__init__.py
@@ -1,0 +1,5 @@
+"""aigw-runner: spawns the apps/aigateway/ uvicorn process alongside the SF server."""
+
+from .plugin import AigwRunnerPlugin, AigwRunnerSettings
+
+__all__ = ["AigwRunnerPlugin", "AigwRunnerSettings"]

--- a/apps/server/src/screamingface/plugins/aigw_runner/plugin.py
+++ b/apps/server/src/screamingface/plugins/aigw_runner/plugin.py
@@ -1,0 +1,196 @@
+"""aigw-runner — owns the apps/aigateway/ uvicorn subprocess.
+
+When SF starts, this plugin spawns the gateway as a child process so
+url4 backend calls routed through aigw_*_backend plugins have a
+gateway to talk to. When SF shuts down (via app.shutdown hook or
+atexit), the gateway is terminated gracefully.
+
+Mirrors the mitmproxy_intercept lifecycle pattern: Popen + daemon
+thread streaming stdout into the SF logger + dual teardown via
+hook and atexit.
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import os
+import shutil
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pydantic import Field
+from pydantic_settings import SettingsConfigDict
+
+from screamingface.plugin import Plugin, PluginSettings
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+    from screamingface.core.classes import ClassRegistry
+    from screamingface.core.hooks import HookRegistry
+    from screamingface.core.routes import RouteRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class AigwRunnerSettings(PluginSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="SF_AIGW_RUNNER__",
+        env_nested_delimiter="__",
+    )
+
+    port: int = Field(
+        default=9105,
+        description="Port the gateway uvicorn listens on.",
+    )
+    aigateway_dir: str | None = Field(
+        default=None,
+        description=(
+            "Filesystem path to apps/aigateway/. If unset, resolves "
+            "relative to this server's working directory: ../aigateway."
+        ),
+    )
+    startup_timeout_seconds: float = Field(
+        default=10.0,
+        description="Max seconds to wait after Popen before declaring failure.",
+    )
+    enabled: bool = Field(
+        default=True,
+        description=(
+            "When False, the runner skips spawning the gateway. Useful "
+            "in tests / dev where the gateway is already running."
+        ),
+    )
+
+
+class AigwRunnerPlugin(Plugin):
+    name = "aigw-runner"
+    description = "Spawns the apps/aigateway/ uvicorn subprocess alongside SF."
+    tags: list[str] = ["product:aigw", "product:system"]
+    depends: list[str] = []
+    conflicts: list[str] = []
+    settings_class = AigwRunnerSettings
+
+    def __init__(self) -> None:
+        self._process: subprocess.Popen | None = None
+        self._aigateway_dir: Path | None = None
+
+    def preflight(self) -> tuple[bool, str]:
+        ok, reason = super().preflight()
+        if not ok:
+            return ok, reason
+
+        settings: AigwRunnerSettings = self.settings  # type: ignore[assignment]
+        if not settings.enabled:
+            return True, ""
+
+        # Resolve the apps/aigateway directory.
+        if settings.aigateway_dir is not None:
+            candidate = Path(settings.aigateway_dir).expanduser().resolve()
+        else:
+            # Default: SF runs from apps/server/, so apps/aigateway is ../aigateway
+            candidate = (Path.cwd() / ".." / "aigateway").resolve()
+
+        if not candidate.exists():
+            return False, f"aigateway directory not found at {candidate}"
+        if not (candidate / "pyproject.toml").exists():
+            return False, f"{candidate} does not look like a uv project (no pyproject.toml)"
+
+        self._aigateway_dir = candidate
+
+        if shutil.which("uv") is None:
+            return False, "`uv` command not found in PATH — required to run the gateway"
+
+        return True, ""
+
+    def setup(
+        self,
+        app: FastAPI,
+        hooks: HookRegistry,
+        classes: ClassRegistry,  # noqa: ARG002
+        routes: RouteRegistry,  # noqa: ARG002
+    ) -> None:
+        settings: AigwRunnerSettings = self.settings  # type: ignore[assignment]
+
+        if not settings.enabled:
+            logger.info("aigw-runner: disabled via settings.enabled=False; skipping spawn")
+            return
+
+        assert self._aigateway_dir is not None  # set in preflight
+
+        cmd = [
+            "uv",
+            "run",
+            "--directory",
+            str(self._aigateway_dir),
+            "uvicorn",
+            "aigateway.main:app",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(settings.port),
+            "--log-level",
+            "info",
+        ]
+        env = os.environ.copy()
+        logger.info("aigw-runner: spawning gateway: %s", " ".join(cmd))
+
+        self._process = subprocess.Popen(  # noqa: S603
+            cmd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+        time.sleep(0.5)
+        retcode = self._process.poll()
+        if retcode is not None:
+            output = self._process.stdout.read() if self._process.stdout else ""
+            self._process = None
+            raise RuntimeError(
+                f"aigw-runner: gateway exited immediately (code {retcode}):\n{output}"
+            )
+
+        threading.Thread(
+            target=_log_output, args=(self._process,), daemon=True, name="aigw-runner-log"
+        ).start()
+
+        atexit.register(self._stop)
+        hooks.register("app.shutdown", self._on_shutdown, plugin_name=self.name)
+        logger.info("aigw-runner: gateway running on port %d (PID %d)", settings.port, self._process.pid)
+
+    async def _on_shutdown(self) -> None:
+        self._stop()
+
+    def teardown(self) -> None:
+        self._stop()
+
+    def _stop(self) -> None:
+        try:
+            atexit.unregister(self._stop)
+        except Exception:  # pragma: no cover
+            pass
+        if self._process is None:
+            return
+        logger.info("aigw-runner: stopping gateway (PID %d)...", self._process.pid)
+        self._process.terminate()
+        try:
+            self._process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            logger.warning("aigw-runner: gateway did not terminate in 5s — killing")
+            self._process.kill()
+            self._process.wait(timeout=3)
+        self._process = None
+
+
+def _log_output(proc: subprocess.Popen) -> None:
+    assert proc.stdout is not None
+    for line in proc.stdout:
+        line = line.rstrip()
+        if line:
+            logger.info("[aigateway] %s", line)

--- a/apps/server/src/screamingface/plugins/aigw_runner/plugin.py
+++ b/apps/server/src/screamingface/plugins/aigw_runner/plugin.py
@@ -162,7 +162,9 @@ class AigwRunnerPlugin(Plugin):
 
         atexit.register(self._stop)
         hooks.register("app.shutdown", self._on_shutdown, plugin_name=self.name)
-        logger.info("aigw-runner: gateway running on port %d (PID %d)", settings.port, self._process.pid)
+        logger.info(
+            "aigw-runner: gateway running on port %d (PID %d)", settings.port, self._process.pid
+        )
 
     async def _on_shutdown(self) -> None:
         self._stop()

--- a/apps/server/src/screamingface/plugins/aigw_runner/tests/test_runner.py
+++ b/apps/server/src/screamingface/plugins/aigw_runner/tests/test_runner.py
@@ -1,0 +1,153 @@
+"""Unit tests for aigw_runner — Popen and threading mocked."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+from screamingface.plugins.aigw_runner.plugin import AigwRunnerPlugin, AigwRunnerSettings
+
+
+@pytest.fixture
+def fake_aigw_dir(tmp_path: Path) -> Path:
+    """Create a directory that looks like apps/aigateway/ to satisfy preflight."""
+    d = tmp_path / "aigateway"
+    d.mkdir()
+    (d / "pyproject.toml").write_text("[project]\nname='aigateway'\n")
+    return d
+
+
+def _make_plugin(fake_dir: Path, **overrides) -> AigwRunnerPlugin:
+    plugin = AigwRunnerPlugin()
+    settings_kwargs = {"aigateway_dir": str(fake_dir), **overrides}
+    plugin.settings = AigwRunnerSettings(**settings_kwargs)  # type: ignore[assignment]
+    return plugin
+
+
+def test_preflight_succeeds_when_aigw_dir_exists(fake_aigw_dir: Path) -> None:
+    plugin = _make_plugin(fake_aigw_dir)
+    with patch("shutil.which", return_value="/usr/local/bin/uv"):
+        ok, reason = plugin.preflight()
+    assert ok, reason
+
+
+def test_preflight_fails_when_aigw_dir_missing(tmp_path: Path) -> None:
+    missing = tmp_path / "no-aigateway"
+    plugin = _make_plugin(missing)
+    ok, reason = plugin.preflight()
+    assert not ok
+    assert "aigateway directory not found" in reason
+
+
+def test_preflight_fails_without_uv(fake_aigw_dir: Path) -> None:
+    plugin = _make_plugin(fake_aigw_dir)
+    with patch("shutil.which", return_value=None):
+        ok, reason = plugin.preflight()
+    assert not ok
+    assert "`uv` command not found" in reason
+
+
+def test_preflight_skipped_when_disabled(fake_aigw_dir: Path) -> None:
+    plugin = _make_plugin(fake_aigw_dir, enabled=False)
+    ok, _ = plugin.preflight()
+    assert ok
+
+
+def test_setup_skipped_when_disabled(fake_aigw_dir: Path) -> None:
+    plugin = _make_plugin(fake_aigw_dir, enabled=False)
+    plugin.preflight()
+    fake_app = MagicMock()
+    fake_hooks = MagicMock()
+    plugin.setup(fake_app, fake_hooks, MagicMock(), MagicMock())
+    assert plugin._process is None
+    fake_hooks.register.assert_not_called()
+
+
+def test_setup_spawns_subprocess_and_registers_hooks(fake_aigw_dir: Path) -> None:
+    plugin = _make_plugin(fake_aigw_dir)
+
+    fake_proc = MagicMock(spec=subprocess.Popen)
+    fake_proc.poll.return_value = None  # still running
+    fake_proc.stdout = MagicMock()
+    fake_proc.stdout.__iter__.return_value = iter([])
+    fake_proc.pid = 12345
+
+    fake_hooks = MagicMock()
+    fake_app = MagicMock()
+
+    with (
+        patch("shutil.which", return_value="/usr/local/bin/uv"),
+        patch(
+            "screamingface.plugins.aigw_runner.plugin.subprocess.Popen",
+            return_value=fake_proc,
+        ),
+        patch("screamingface.plugins.aigw_runner.plugin.atexit.register") as mock_atexit,
+        patch("screamingface.plugins.aigw_runner.plugin.threading.Thread") as mock_thread,
+    ):
+        plugin.preflight()
+        plugin.setup(fake_app, fake_hooks, MagicMock(), MagicMock())
+
+    assert plugin._process is fake_proc
+    fake_hooks.register.assert_called_once()
+    register_args = fake_hooks.register.call_args
+    assert register_args.args[0] == "app.shutdown"
+    mock_atexit.assert_called_once()
+    mock_thread.assert_called_once()
+
+
+def test_setup_raises_if_subprocess_exits_immediately(fake_aigw_dir: Path) -> None:
+    plugin = _make_plugin(fake_aigw_dir)
+
+    fake_proc = MagicMock(spec=subprocess.Popen)
+    fake_proc.poll.return_value = 1  # exited
+    fake_proc.stdout = MagicMock()
+    fake_proc.stdout.read.return_value = "boom"
+    fake_proc.pid = 12345
+
+    with (
+        patch("shutil.which", return_value="/usr/local/bin/uv"),
+        patch(
+            "screamingface.plugins.aigw_runner.plugin.subprocess.Popen",
+            return_value=fake_proc,
+        ),
+    ):
+        plugin.preflight()
+        with pytest.raises(RuntimeError, match="exited immediately"):
+            plugin.setup(MagicMock(), MagicMock(), MagicMock(), MagicMock())
+
+
+def test_stop_terminates_process(fake_aigw_dir: Path) -> None:
+    plugin = _make_plugin(fake_aigw_dir)
+    fake_proc = MagicMock(spec=subprocess.Popen)
+    fake_proc.pid = 12345
+    plugin._process = fake_proc
+
+    plugin._stop()
+
+    fake_proc.terminate.assert_called_once()
+    fake_proc.wait.assert_called_once_with(timeout=5)
+    assert plugin._process is None
+
+
+def test_stop_kills_on_timeout(fake_aigw_dir: Path) -> None:
+    plugin = _make_plugin(fake_aigw_dir)
+    fake_proc = MagicMock(spec=subprocess.Popen)
+    fake_proc.pid = 12345
+    fake_proc.wait.side_effect = [subprocess.TimeoutExpired(cmd="x", timeout=5), None]
+    plugin._process = fake_proc
+
+    plugin._stop()
+
+    fake_proc.terminate.assert_called_once()
+    fake_proc.kill.assert_called_once()
+    assert plugin._process is None
+
+
+def test_stop_is_noop_when_no_process(fake_aigw_dir: Path) -> None:
+    plugin = _make_plugin(fake_aigw_dir)
+    # _process starts as None
+    plugin._stop()  # must not raise

--- a/apps/server/src/screamingface/plugins/aigw_runner/tests/test_runner.py
+++ b/apps/server/src/screamingface/plugins/aigw_runner/tests/test_runner.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-
 from screamingface.plugins.aigw_runner.plugin import AigwRunnerPlugin, AigwRunnerSettings
 
 

--- a/apps/server/tests/e2e/conftest.py
+++ b/apps/server/tests/e2e/conftest.py
@@ -29,6 +29,7 @@ _PROVIDER_BY_FILE: dict[str, str] = {
     "test_proxy_prompt_flow.py": "claude",
     "test_trace_structure.py": "claude",
     "test_cat_breeds_spec.py": "claude",
+    "test_aigw_claude_e2e.py": "claude",
     "test_url4_specs_live.py": "claude",
     "test_ensemble_features.py": "claude",
     "test_url4_resolution.py": "claude",

--- a/apps/server/tests/e2e/test_aigw_claude_e2e.py
+++ b/apps/server/tests/e2e/test_aigw_claude_e2e.py
@@ -1,5 +1,24 @@
 """End-to-end test for the full claude-frontend → aigw-claude-backend → AI Gateway → Anthropic chain.
 
+Asserts two things rigorously:
+
+1. **url4 result was injected into the forwarded request.** The resolved
+   text from the /claude backend call must end up *inside* the user
+   message that claude-frontend forwards to its upstream. We compare
+   the forwarded user_text against the literal prompt we sent — they
+   must differ AND the original must still appear (concat semantics).
+
+2. **The gateway actually called api.anthropic.com.** It's not enough
+   that the gateway received a POST; we must see evidence that it
+   reached the real upstream. Two accepted signals (logs forwarded
+   through aigw_runner's daemon thread end up in mgr.logs):
+     - a 200 from `POST /v1/chat/completions` in the gateway access log
+       (litellm.acompletion only returns 200 after a successful
+       Anthropic round-trip); OR
+     - an explicit AnthropicException / RateLimitError mention,
+       which proves the gateway's litellm path called Anthropic and
+       got a structured error back.
+
 The test stands up a session SF server with these plugins active:
 
 - ``claude-frontend`` — the listener that emulates Anthropic's API surface
@@ -35,6 +54,7 @@ Asserts on TWO levels:
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import time
@@ -47,6 +67,8 @@ import pytest
 from tests.e2e.infrastructure.claude_code_client import ClaudeCodeClient
 from tests.e2e.infrastructure.otlp_collector import OTLPCollector
 from tests.e2e.infrastructure.server_manager import ServerManager
+
+_TEST_PROMPT = "Reply with the single English word: pong"
 
 pytestmark = [pytest.mark.e2e, pytest.mark.e2e_live]
 
@@ -237,10 +259,7 @@ def test_claude_frontend_to_aigw_to_anthropic(
     otlp_collector.clear()
 
     client = ClaudeCodeClient(proxy_url=f"http://127.0.0.1:{proxy_port}")
-    resp = client.send_message(
-        "Reply with the single English word: pong",
-        timeout=90,
-    )
+    resp = client.send_message(_TEST_PROMPT, timeout=90)
 
     # ----------------------------- round-trip ------------------------------
     assert resp.status_code == 200, f"proxy responded {resp.status_code}: {resp.body}"
@@ -258,28 +277,48 @@ def test_claude_frontend_to_aigw_to_anthropic(
     )
 
     # Two acceptable outcomes:
-    #  (a) Successful round-trip: the forwarded user message contains the
-    #      gateway-substituted assistant reply.
-    #  (b) Upstream Anthropic returned an error (e.g. 429 rate limit) — the
-    #      chain still worked; we just got an error from the real provider.
-    #      In that case claude-frontend surfaces an `sf_error_*` response
-    #      body containing the layered error message — which proves the
-    #      gateway and aigw-claude-backend were both invoked.
+    #  (a) Successful round-trip: the gateway's substituted assistant reply
+    #      ended up inside the forwarded user message.
+    #  (b) Upstream Anthropic returned a structured error (e.g. 429 rate
+    #      limit) — the chain still worked; we just got an error from the
+    #      real provider. claude-frontend surfaces an `sf_error_*` response
+    #      whose error body explicitly mentions /claude AND an upstream
+    #      indicator (rate / anthropic / aigw).
     body_id = resp.body.get("id", "")
     body_text = ""
     for part in resp.body.get("content", []):
         if isinstance(part, dict) and part.get("type") == "text":
             body_text += part.get("text", "")
 
-    successful_substitution = len(user_text) > 5
+    # (a) Strong: the resolved text was injected. With embed_mode="concat"
+    # (the default), the user message becomes "<original>\n\n<resolved>".
+    # We require BOTH that the original is still present AND that something
+    # was appended — otherwise the spec didn't trigger or substitution was
+    # silently a no-op.
+    substitution_happened = (
+        user_text != _TEST_PROMPT
+        and _TEST_PROMPT in user_text
+        and len(user_text) > len(_TEST_PROMPT) + 1
+    )
+
+    # (b) Upstream-error fallback: the chain reached upstream and surfaced
+    # an Anthropic-shaped error.
     upstream_error_through_chain = (
         body_id.startswith("sf_error_")
         and "/claude" in body_text
-        and ("aigw" in body_text.lower() or "rate" in body_text.lower() or "anthropic" in body_text.lower())
+        and (
+            "aigw" in body_text.lower()
+            or "rate" in body_text.lower()
+            or "anthropic" in body_text.lower()
+        )
     )
 
-    assert successful_substitution or upstream_error_through_chain, (
-        f"Chain didn't reach the gateway, or response shape unexpected.{debug}"
+    assert substitution_happened or upstream_error_through_chain, (
+        f"url4 result not injected into forwarded request, and no upstream "
+        f"error path observed.\n"
+        f"original_prompt={_TEST_PROMPT!r}\nuser_text={user_text!r}\n"
+        f"sf_error_id={body_id!r}\n"
+        f"{debug}"
     )
 
     # ------------------------------ span chain -----------------------------
@@ -316,16 +355,41 @@ def test_claude_frontend_to_aigw_to_anthropic(
         f"All spans: {sorted(span_names)}"
     )
 
-    # The gateway subprocess emits its access log through the aigw_runner
-    # daemon log thread, which forwards to the SF logger and ends up in
-    # mgr.logs. Rather than instrument the child for OTLP (a separate
-    # ticket), we look for the unmistakable access-log line that proves
-    # the gateway saw the chat-completions POST during this test.
-    all_logs = "\n".join(mgr.logs.dump_last(500)) if mgr.logs else ""
+    # Gateway-side evidence: the subprocess's stdout (forwarded by aigw_runner's
+    # daemon thread) lands in mgr.logs. We require BOTH that the gateway saw
+    # a chat-completions POST AND that something proves it actually called
+    # api.anthropic.com.
+    all_logs = "\n".join(mgr.logs.dump_last(2000)) if mgr.logs else ""
+
+    # Step 1 — the gateway received the POST from aigw-claude-backend.
     assert "POST /v1/chat/completions" in all_logs, (
         "Gateway did not log a chat-completions POST during the test — "
         "the chain didn't reach the gateway subprocess.\n"
         f"Last log lines:\n{all_logs[-3000:]}"
+    )
+
+    # Step 2 — the gateway actually called api.anthropic.com. Accept any
+    # of these signals (each one independently proves Anthropic was reached):
+    #   - gateway returned 200 from chat/completions (litellm only succeeds
+    #     after a real Anthropic round-trip)
+    #   - litellm raised AnthropicException / RateLimitError (gateway saw
+    #     a structured error from Anthropic, which means it called it)
+    #   - the api.anthropic.com hostname appears in any log line
+    gateway_returned_200 = bool(
+        re.search(r'"POST /v1/chat/completions HTTP/[\d.]+" 200', all_logs)
+    )
+    anthropic_exception_seen = (
+        "AnthropicException" in all_logs
+        or "RateLimitError" in all_logs
+        or "anthropic.exceptions" in all_logs
+    )
+    anthropic_host_seen = "api.anthropic.com" in all_logs
+
+    assert gateway_returned_200 or anthropic_exception_seen or anthropic_host_seen, (
+        "Gateway received a chat-completions POST but no evidence it actually "
+        "called api.anthropic.com — chain may have failed inside the gateway "
+        "before the upstream call.\n"
+        f"Last 3000 chars of logs:\n{all_logs[-3000:]}"
     )
 
     # Final sanity probe: gateway is still healthy after the round-trip.

--- a/apps/server/tests/e2e/test_aigw_claude_e2e.py
+++ b/apps/server/tests/e2e/test_aigw_claude_e2e.py
@@ -1,4 +1,4 @@
-"""End-to-end test for the full claude-frontend → aigw-claude-backend → AI Gateway → Anthropic chain.
+"""End-to-end: claude-frontend → aigw-claude-backend → AI Gateway → Anthropic chain.
 
 Asserts two things rigorously:
 
@@ -217,9 +217,7 @@ def aigw_proxy(otlp_collector: OTLPCollector, httpbin_url: str):
     profile_state: str | None = None
     while time.monotonic() < deadline:
         try:
-            r = httpx.get(
-                f"http://127.0.0.1:{gateway_port}/v1/auth/profiles", timeout=3
-            )
+            r = httpx.get(f"http://127.0.0.1:{gateway_port}/v1/auth/profiles", timeout=3)
             if r.status_code == 200:
                 for p in r.json().get("profiles", []):
                     if p.get("id") == "anthropic:default":
@@ -350,10 +348,7 @@ def test_claude_frontend_to_aigw_to_anthropic(
         for layer, span in expected_layers.items()
         if not any(span in n for n in span_names)
     }
-    assert not missing, (
-        f"Missing spans for layers: {missing}\n"
-        f"All spans: {sorted(span_names)}"
-    )
+    assert not missing, f"Missing spans for layers: {missing}\nAll spans: {sorted(span_names)}"
 
     # Gateway-side evidence: the subprocess's stdout (forwarded by aigw_runner's
     # daemon thread) lands in mgr.logs. We require BOTH that the gateway saw
@@ -375,9 +370,7 @@ def test_claude_frontend_to_aigw_to_anthropic(
     #   - litellm raised AnthropicException / RateLimitError (gateway saw
     #     a structured error from Anthropic, which means it called it)
     #   - the api.anthropic.com hostname appears in any log line
-    gateway_returned_200 = bool(
-        re.search(r'"POST /v1/chat/completions HTTP/[\d.]+" 200', all_logs)
-    )
+    gateway_returned_200 = bool(re.search(r'"POST /v1/chat/completions HTTP/[\d.]+" 200', all_logs))
     anthropic_exception_seen = (
         "AnthropicException" in all_logs
         or "RateLimitError" in all_logs

--- a/apps/server/tests/e2e/test_aigw_claude_e2e.py
+++ b/apps/server/tests/e2e/test_aigw_claude_e2e.py
@@ -1,0 +1,333 @@
+"""End-to-end test for the full claude-frontend → aigw-claude-backend → AI Gateway → Anthropic chain.
+
+The test stands up a session SF server with these plugins active:
+
+- ``claude-frontend`` — the listener that emulates Anthropic's API surface
+- ``url4-executor`` + ``url4-specs`` — resolves the configured spec
+- ``aigw-base`` + ``aigw-claude-backend`` — handles the ``/claude`` backend call
+  by POSTing to the gateway
+- ``aigw-runner`` — spawns the apps/aigateway/ uvicorn subprocess
+
+A url4 spec maps ``$prompt`` → ``/claude?q=$prompt``, which forces the
+url4 executor to call the gateway-backed ``/claude`` endpoint instead of
+forwarding the user prompt straight to upstream. The full chain:
+
+    ClaudeCodeClient (test)
+        → claude-frontend (port: proxy_port)
+        → url4-executor (resolves $prompt, sees /claude backend call)
+        → aigw-claude-backend (POSTs OpenAI ChatCompletions to localhost:9105)
+        → aigw-runner subprocess (apps/aigateway uvicorn on 9105)
+        → real api.anthropic.com (live, OAuth via gateway profile)
+
+Skipped unless ANTHROPIC_API_KEY is set OR the Claude Code CLI keychain
+entry exists locally — the gateway's bootstrap accepts either.
+
+Asserts on TWO levels:
+
+1. **Round-trip:** the user message gets a non-empty assistant response
+   substituted into it (via httpbin echo upstream — same pattern as
+   test_cat_breeds_spec.py).
+2. **Span chain:** OTLP collector sees the four expected layers fire
+   (claude-frontend, url4 resolve, aigw-claude-backend run, gateway
+   POST). Catches silent layer-skipping if anyone re-routes /claude.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from urllib.parse import quote
+
+import httpx
+import pytest
+
+from tests.e2e.infrastructure.claude_code_client import ClaudeCodeClient
+from tests.e2e.infrastructure.otlp_collector import OTLPCollector
+from tests.e2e.infrastructure.server_manager import ServerManager
+
+pytestmark = [pytest.mark.e2e, pytest.mark.e2e_live]
+
+# url4 spec: substitute $prompt as the q-param of a /claude backend call.
+# The /claude endpoint is served by aigw-claude-backend; the result text is
+# substituted back into the user message before claude-frontend forwards
+# the request to its upstream (httpbin echo, see fixture).
+_AIGW_SPEC_EXPRESSION = f"/claude?q={quote('$prompt', safe='$')}"
+
+
+# ---------------------------------------------------------------------------
+# Skip-gating
+# ---------------------------------------------------------------------------
+
+
+def _has_claude_code_keychain() -> bool:
+    """Return True if Claude Code's keychain entry exists on this machine."""
+    if not shutil.which("security"):
+        return False
+    user = os.environ.get("USER", "")
+    if not user:
+        return False
+    try:
+        result = subprocess.run(
+            [
+                "security",
+                "find-generic-password",
+                "-s",
+                "Claude Code-credentials",
+                "-a",
+                user,
+                "-w",
+            ],
+            capture_output=True,
+            timeout=3,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
+def _credentials_available() -> bool:
+    return bool(os.environ.get("ANTHROPIC_API_KEY")) or _has_claude_code_keychain()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+_AIGATEWAY_DIR = (Path(__file__).resolve().parents[3] / "aigateway").resolve()
+
+
+@pytest.fixture(scope="module")
+def aigw_proxy(otlp_collector: OTLPCollector, httpbin_url: str):
+    """SF server running claude-frontend + aigw-claude-backend + aigw-runner.
+
+    The gateway subprocess is spawned by aigw-runner during SF startup.
+    Teardown stops both processes.
+    """
+    if not _credentials_available():
+        pytest.skip(
+            "Neither ANTHROPIC_API_KEY env var nor a Claude Code keychain "
+            "entry was found. The gateway needs one of these to authenticate "
+            "the anthropic:default profile."
+        )
+    if not shutil.which("uv"):
+        pytest.skip("`uv` not found in PATH; aigw-runner cannot spawn the gateway")
+    if not _AIGATEWAY_DIR.exists():
+        pytest.skip(f"apps/aigateway/ not found at {_AIGATEWAY_DIR}")
+
+    internal_port = ServerManager.find_free_port()
+    proxy_port = ServerManager.find_free_port()
+    gateway_port = ServerManager.find_free_port()
+
+    config = {
+        "version": "0.1.0",
+        "server": {
+            "host": "127.0.0.1",
+            "port": internal_port,
+            "ssl": False,
+            "reload": False,
+        },
+        "plugins": [
+            "tracing",
+            "claude-frontend",
+            "url4-specs",
+            "url4-executor",
+            "data-store",
+            "aigw-base",
+            "aigw-claude-backend",
+            "aigw-runner",
+        ],
+        "plugin_config": {
+            "tracing": {
+                "phoenix_launch": False,
+                "otlp_endpoint": otlp_collector.endpoint,
+            },
+            "claude-frontend": {
+                "active_spec": "aigw-prompt",
+                "upstream_url": f"{httpbin_url}/anything",
+                "listen_host": "127.0.0.1",
+                "listen_port": proxy_port,
+            },
+            "url4-specs": {
+                "specs": {
+                    "aigw-prompt": {"expression": _AIGW_SPEC_EXPRESSION},
+                },
+            },
+            "aigw-claude-backend": {
+                "gateway_url": f"http://127.0.0.1:{gateway_port}",
+                "auth_profile": "default",
+                "default_model": "anthropic/claude-haiku-4-5",
+                "timeout_seconds": 60,
+            },
+            "aigw-runner": {
+                "port": gateway_port,
+                "aigateway_dir": str(_AIGATEWAY_DIR),
+                "startup_timeout_seconds": 10.0,
+                "enabled": True,
+            },
+        },
+    }
+
+    mgr = ServerManager(config, session_id="e2e-aigw-claude")
+    mgr.start(timeout=120)
+
+    if not ServerManager.wait_for_port(proxy_port, timeout=60):
+        last_logs = "\n".join(mgr.logs.dump_last()) if mgr.logs else "<no logs>"
+        mgr.stop()
+        pytest.fail(
+            f"claude-frontend not listening on port {proxy_port}\n"
+            f"Last server log lines:\n{last_logs}"
+        )
+    if not ServerManager.wait_for_port(gateway_port, timeout=60):
+        last_logs = "\n".join(mgr.logs.dump_last()) if mgr.logs else "<no logs>"
+        mgr.stop()
+        pytest.fail(
+            f"aigw-runner did not bring up gateway on port {gateway_port}\n"
+            f"Last server log lines:\n{last_logs}"
+        )
+
+    # Confirm the gateway has an authenticated anthropic:default profile —
+    # otherwise the chat call will return 404 profile_not_found.
+    deadline = time.monotonic() + 15
+    profile_state: str | None = None
+    while time.monotonic() < deadline:
+        try:
+            r = httpx.get(
+                f"http://127.0.0.1:{gateway_port}/v1/auth/profiles", timeout=3
+            )
+            if r.status_code == 200:
+                for p in r.json().get("profiles", []):
+                    if p.get("id") == "anthropic:default":
+                        profile_state = p.get("state")
+                        break
+                if profile_state is not None:
+                    break
+        except httpx.RequestError:
+            pass
+        time.sleep(0.5)
+
+    if profile_state != "authenticated":
+        mgr.stop()
+        pytest.skip(
+            f"Gateway anthropic:default profile state is {profile_state!r}. "
+            "Run `claude auth login` so the bootstrap can import credentials, "
+            "or POST /v1/auth/anthropic/profiles to seed one manually."
+        )
+
+    yield mgr, proxy_port, gateway_port
+
+    mgr.stop()
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(120)
+def test_claude_frontend_to_aigw_to_anthropic(
+    aigw_proxy: tuple[ServerManager, int, int],
+    otlp_collector: OTLPCollector,
+) -> None:
+    """Round-trip a prompt through every layer; assert response + span chain."""
+    _, proxy_port, gateway_port = aigw_proxy
+    otlp_collector.clear()
+
+    client = ClaudeCodeClient(proxy_url=f"http://127.0.0.1:{proxy_port}")
+    resp = client.send_message(
+        "Reply with the single English word: pong",
+        timeout=90,
+    )
+
+    # ----------------------------- round-trip ------------------------------
+    assert resp.status_code == 200, f"proxy responded {resp.status_code}: {resp.body}"
+
+    mgr, _, _ = aigw_proxy
+    user_text = resp.last_user_text
+    # Diagnostic dump on failure — helps narrow which layer dropped the response.
+    last_logs = "\n".join(mgr.logs.dump_last(50)) if mgr.logs else "<no logs>"
+    debug = (
+        f"\n--- raw resp.body ---\n{resp.body}"
+        f"\n--- forwarded body (httpbin echo) ---\n{resp.echoed_body}"
+        f"\n--- forwarded messages ---\n{resp.forwarded_messages}"
+        f"\n--- last_user_text ---\n{user_text!r}"
+        f"\n--- last 50 SF server log lines ---\n{last_logs}"
+    )
+
+    # Two acceptable outcomes:
+    #  (a) Successful round-trip: the forwarded user message contains the
+    #      gateway-substituted assistant reply.
+    #  (b) Upstream Anthropic returned an error (e.g. 429 rate limit) — the
+    #      chain still worked; we just got an error from the real provider.
+    #      In that case claude-frontend surfaces an `sf_error_*` response
+    #      body containing the layered error message — which proves the
+    #      gateway and aigw-claude-backend were both invoked.
+    body_id = resp.body.get("id", "")
+    body_text = ""
+    for part in resp.body.get("content", []):
+        if isinstance(part, dict) and part.get("type") == "text":
+            body_text += part.get("text", "")
+
+    successful_substitution = len(user_text) > 5
+    upstream_error_through_chain = (
+        body_id.startswith("sf_error_")
+        and "/claude" in body_text
+        and ("aigw" in body_text.lower() or "rate" in body_text.lower() or "anthropic" in body_text.lower())
+    )
+
+    assert successful_substitution or upstream_error_through_chain, (
+        f"Chain didn't reach the gateway, or response shape unexpected.{debug}"
+    )
+
+    # ------------------------------ span chain -----------------------------
+    # Wait briefly for spans to flush through the OTLP collector.
+    otlp_collector.wait_for_spans(3, timeout=15)
+    span_names = {s.name for s in otlp_collector._spans}  # noqa: SLF001 — test-only
+
+    # Each layer below MUST appear. If any is missing, someone has rerouted
+    # the request and skipped a layer (e.g. mistakenly enabled the legacy
+    # claude-backend-api alongside aigw-claude-backend).
+    #
+    # FastAPI's auto-instrumentation produces "<METHOD> <route_template>" spans
+    # for every endpoint hit. We rely on those for layer evidence:
+    #   POST /v1/messages          claude-frontend listener
+    #   url4.*                     url4 executor (custom spans from url4-executor)
+    #   GET /claude                aigw-claude-backend route on the SF server
+    #   POST /v1/chat/completions  the gateway subprocess (also FastAPI)
+    # Layers visible in the SF process's OTLP stream:
+    #   POST /v1/messages          claude-frontend listener
+    #   url4.*                     url4 executor (custom spans)
+    #   GET /claude                aigw-claude-backend route handler
+    expected_layers = {
+        "claude_frontend": "POST /v1/messages",
+        "url4_executor": "url4.evaluate",
+        "aigw_backend_route": "GET /claude",
+    }
+    missing = {
+        layer: span
+        for layer, span in expected_layers.items()
+        if not any(span in n for n in span_names)
+    }
+    assert not missing, (
+        f"Missing spans for layers: {missing}\n"
+        f"All spans: {sorted(span_names)}"
+    )
+
+    # The gateway subprocess emits its access log through the aigw_runner
+    # daemon log thread, which forwards to the SF logger and ends up in
+    # mgr.logs. Rather than instrument the child for OTLP (a separate
+    # ticket), we look for the unmistakable access-log line that proves
+    # the gateway saw the chat-completions POST during this test.
+    all_logs = "\n".join(mgr.logs.dump_last(500)) if mgr.logs else ""
+    assert "POST /v1/chat/completions" in all_logs, (
+        "Gateway did not log a chat-completions POST during the test — "
+        "the chain didn't reach the gateway subprocess.\n"
+        f"Last log lines:\n{all_logs[-3000:]}"
+    )
+
+    # Final sanity probe: gateway is still healthy after the round-trip.
+    health = httpx.get(f"http://127.0.0.1:{gateway_port}/healthz", timeout=3)
+    assert health.status_code == 200

--- a/docs/architecture/plugin-dependencies.md
+++ b/docs/architecture/plugin-dependencies.md
@@ -1,0 +1,202 @@
+# ScreamingFace plugin dependency graph
+
+Generated 2026-05-01 from the `depends`, `conflicts`, and `tags` declarations
+in every `apps/server/src/screamingface/plugins/*/plugin.py`. Plus the
+`apps/aigateway/` standalone service.
+
+## Mermaid graph (renders on GitHub)
+
+```mermaid
+graph TD
+    %% ── Independent foundations (no deps) ─────────────────────────────
+    subgraph SYS["🟢 System foundations (no deps — standalone)"]
+        tracing["tracing<br/><i>OTel + Phoenix</i>"]
+        data_store["data-store<br/><i>blob store</i>"]
+        url4_specs["url4-specs"]
+        url4_executor["url4-executor"]
+        frontend_base["frontend-base<br/><i>abstract</i>"]
+        backend_api_base["backend-api-base<br/><i>abstract</i>"]
+        llm_base["llm-base<br/><i>abstract</i>"]
+        mitmproxy["🔌 mitmproxy-intercept<br/><i>spawns mitmdump</i>"]
+        aigw_runner["🔌 aigw-runner<br/><i>spawns apps/aigateway</i>"]
+    end
+
+    %% ── Frontend plugins ──────────────────────────────────────────────
+    subgraph FE["Frontend plugins (HTTP listeners)"]
+        claude_frontend["claude-frontend<br/><i>:9101</i>"]
+        codex_frontend["codex-frontend"]
+        gemini_frontend["gemini-frontend"]
+        ollama_frontend["ollama-frontend<br/><i>:9104</i>"]
+    end
+
+    %% ── Backend-API plugins (legacy direct-to-provider) ───────────────
+    subgraph BEAPI["Direct-API backends (legacy)"]
+        claude_backend_api["claude-backend-api<br/>/claude"]
+        codex_backend_api["codex-backend-api<br/>/codex"]
+        gemini_backend_api["gemini-backend-api<br/>/gemini"]
+        ollama_backend_api["ollama-backend-api<br/>/ollama"]
+    end
+
+    %% ── Gateway-routed backend plugins (new) ──────────────────────────
+    subgraph AIGW["Gateway-routed backends (new)"]
+        aigw_base["aigw-base<br/><i>abstract</i>"]
+        aigw_claude_backend["aigw-claude-backend<br/>/claude"]
+    end
+
+    %% ── Intercept plugins ─────────────────────────────────────────────
+    subgraph IC["Claude intercept variants (mutex)"]
+        claude_intercept["claude-intercept"]
+        claude_env_intercept["claude-env-intercept"]
+    end
+
+    %% ── External standalone service ───────────────────────────────────
+    subgraph EXT["🟢 External standalone services"]
+        aigateway["🌐 apps/aigateway<br/><i>FastAPI + LiteLLM</i><br/><i>:9105 — own uv project</i>"]
+    end
+
+    %% ── Dependencies (depends-on edges) ───────────────────────────────
+    claude_frontend --> url4_specs
+    claude_frontend --> url4_executor
+    claude_frontend --> frontend_base
+    codex_frontend --> url4_specs
+    codex_frontend --> url4_executor
+    codex_frontend --> frontend_base
+    gemini_frontend --> url4_specs
+    gemini_frontend --> url4_executor
+    gemini_frontend --> frontend_base
+    ollama_frontend --> url4_specs
+    ollama_frontend --> url4_executor
+    ollama_frontend --> frontend_base
+
+    claude_backend_api --> llm_base
+    claude_backend_api --> backend_api_base
+    codex_backend_api --> llm_base
+    codex_backend_api --> backend_api_base
+    gemini_backend_api --> llm_base
+    gemini_backend_api --> backend_api_base
+    ollama_backend_api --> llm_base
+    ollama_backend_api --> backend_api_base
+
+    aigw_base --> llm_base
+    aigw_base --> backend_api_base
+    aigw_claude_backend --> aigw_base
+    aigw_claude_backend --> llm_base
+    aigw_claude_backend --> backend_api_base
+
+    claude_intercept --> claude_frontend
+    claude_env_intercept --> claude_frontend
+
+    %% ── Conflicts (mutex relations) ───────────────────────────────────
+    aigw_claude_backend -.-x|conflicts| claude_backend_api
+    claude_intercept -.-x|conflicts| claude_env_intercept
+    mitmproxy -.-x|conflicts| claude_intercept
+    mitmproxy -.-x|conflicts| claude_env_intercept
+
+    %% ── Runtime call edges (gateway path) ─────────────────────────────
+    aigw_runner -.->|spawns| aigateway
+    aigw_claude_backend ==>|HTTP POST<br/>/v1/chat/completions<br/>X-Profile| aigateway
+
+    classDef standalone fill:#a8e6a3,stroke:#2d6a2a,color:#000
+    classDef external fill:#a3d8e6,stroke:#1e5868,color:#000
+    classDef abstract fill:#eee,stroke:#999,color:#666,stroke-dasharray: 5 5
+    classDef mutex fill:#ffd6d6,stroke:#a33,color:#000
+
+    class tracing,data_store,url4_specs,url4_executor,mitmproxy,aigw_runner standalone
+    class aigateway external
+    class frontend_base,backend_api_base,llm_base,aigw_base abstract
+    class claude_intercept,claude_env_intercept mutex
+```
+
+Legend: solid arrow = `depends`, dotted X = `conflicts` (mutex), thick
+double arrow = runtime HTTP call, dotted spawn = subprocess managed by
+the plugin.
+
+## Independence classification
+
+The codebase has three orthogonal axes of "independence." A plugin can be
+independent on one axis and dependent on another.
+
+### 1. Plugin loading independence (does it `depends` on others?)
+
+| Plugin | depends | Loads alone? |
+|---|---|---|
+| `tracing` | — | ✅ |
+| `data-store` | — | ✅ |
+| `url4-specs` | — | ✅ |
+| `url4-executor` | — | ✅ |
+| `frontend-base` | — | ✅ (abstract — useless alone) |
+| `backend-api-base` | — | ✅ (abstract — useless alone) |
+| `llm-base` | — | ✅ (abstract — useless alone) |
+| `mitmproxy-intercept` | — | ✅ |
+| `aigw-runner` | — | ✅ |
+| `aigw-base` | `llm-base`, `backend-api-base` | ⚠️ needs 2 abstract bases |
+| `*-frontend` (4 plugins) | `url4-specs`, `url4-executor`, `frontend-base` | ⚠️ needs the url4 trio |
+| `*-backend-api` (4 plugins) | `llm-base`, `backend-api-base` | ⚠️ needs the 2 bases |
+| `aigw-claude-backend` | `aigw-base`, `llm-base`, `backend-api-base` | ⚠️ needs the aigw trio |
+| `claude-intercept`, `claude-env-intercept` | `claude-frontend` | 🔗 needs the frontend |
+
+### 2. Process independence (does it run as its own OS process?)
+
+These plugins **spawn subprocesses** that live outside the SF server's
+own Python interpreter. They're the closest thing to "fully independent
+units" inside this monorepo:
+
+| Plugin | Subprocess it owns | Communication |
+|---|---|---|
+| `aigw-runner` | `apps/aigateway/` (uvicorn + FastAPI + LiteLLM) | HTTP on `localhost:9105` |
+| `mitmproxy-intercept` | `mitmdump` (mitmproxy CLI) | network interception via local mode |
+| `tracing` | Phoenix UI (when `phoenix_launch=true`) | OTLP HTTP on `localhost:6006` |
+| `*-frontend` (4 plugins) | per-session proxy subprocesses | spawned on demand per Claude/Codex/Gemini/Ollama session |
+
+### 3. Repository-level standalone units
+
+These are the components that could be pulled out of this monorepo into
+a separate repo with the least surgery:
+
+| Component | Status | Notes |
+|---|---|---|
+| 🌐 **`apps/aigateway/`** | **fully standalone** | Own uv project, own pyproject.toml, no imports from `apps/server/`. Communicates with the rest of the system only via HTTP. Zero plugin dependencies. The `aigw-runner` plugin is the SF-side adapter, not the gateway itself. |
+| `apps/server/` | monolithic | All 22 plugins live in one uv project. Would need to be split per plugin to extract individually. |
+| `apps/desktop/` | fully standalone | Electron app. Talks to `apps/server/` and `apps/aigateway/` via HTTP only. |
+
+## Conflict (mutex) groups
+
+Plugins that **cannot** run together. Activating both raises a load-time
+error from the plugin registry.
+
+| Group | Members | Reason |
+|---|---|---|
+| `/claude` URL ownership | `aigw-claude-backend` ⚔ `claude-backend-api` | Both serve the canonical `/claude` url4 backend path. Pick one. |
+| Claude intercept strategy | `claude-intercept` ⚔ `claude-env-intercept` ⚔ `mitmproxy-intercept` | Three different ways to intercept Claude Code's outbound traffic. Only one can be active. |
+
+## What truly runs as an independent unit
+
+If you ask "which services here could survive being given their own repo
+and CI pipeline tomorrow with zero refactoring," the answer is:
+
+1. **`apps/aigateway/`** — already standalone. Has its own pyproject,
+   plugin loader, Pydantic models, OAuth code, and live e2e test suite.
+   The whole `aigw-runner` plugin in `apps/server/` exists *because*
+   the gateway is a separate process; it just manages the subprocess
+   lifecycle.
+2. **`apps/desktop/`** — already standalone Electron build. Pure HTTP
+   client of the SF stack.
+3. **Phoenix UI** — lives inside `tracing` plugin, but is a third-party
+   process the plugin merely launches.
+4. **`mitmdump`** — lives inside `mitmproxy-intercept` plugin, but is a
+   third-party process the plugin merely launches.
+
+Within `apps/server/` itself, every plugin shares the same Python
+process and ASGI app. The `*-frontend` plugins spawn per-session
+sub-proxies, but those are short-lived helpers, not standalone services.
+
+## How to regenerate this graph
+
+```bash
+# Print every plugin's metadata
+cd apps/server/src/screamingface/plugins && for d in */; do
+  d=${d%/}; pf="$d/plugin.py"; [ -f "$pf" ] || continue
+  echo "=== $d ==="
+  grep -nE '^\s*(name|tags|depends|conflicts|backend_call_paths)\s*[:=]' "$pf"
+done
+```

--- a/docs/architecture/plugin-dependencies.md
+++ b/docs/architecture/plugin-dependencies.md
@@ -7,9 +7,11 @@ in every `apps/server/src/screamingface/plugins/*/plugin.py`. Plus the
 ## Mermaid graph (renders on GitHub)
 
 ```mermaid
-graph TD
+%%{init: {'flowchart': {'rankSpacing': 60, 'nodeSpacing': 30}}}%%
+flowchart TB
     %% ── Independent foundations (no deps) ─────────────────────────────
     subgraph SYS["🟢 System foundations (no deps — standalone)"]
+        direction TB
         tracing["tracing<br/><i>OTel + Phoenix</i>"]
         data_store["data-store<br/><i>blob store</i>"]
         url4_specs["url4-specs"]
@@ -23,6 +25,7 @@ graph TD
 
     %% ── Frontend plugins ──────────────────────────────────────────────
     subgraph FE["Frontend plugins (HTTP listeners)"]
+        direction TB
         claude_frontend["claude-frontend<br/><i>:9101</i>"]
         codex_frontend["codex-frontend"]
         gemini_frontend["gemini-frontend"]
@@ -31,6 +34,7 @@ graph TD
 
     %% ── Backend-API plugins (legacy direct-to-provider) ───────────────
     subgraph BEAPI["Direct-API backends (legacy)"]
+        direction TB
         claude_backend_api["claude-backend-api<br/>/claude"]
         codex_backend_api["codex-backend-api<br/>/codex"]
         gemini_backend_api["gemini-backend-api<br/>/gemini"]
@@ -39,20 +43,30 @@ graph TD
 
     %% ── Gateway-routed backend plugins (new) ──────────────────────────
     subgraph AIGW["Gateway-routed backends (new)"]
+        direction TB
         aigw_base["aigw-base<br/><i>abstract</i>"]
         aigw_claude_backend["aigw-claude-backend<br/>/claude"]
     end
 
     %% ── Intercept plugins ─────────────────────────────────────────────
     subgraph IC["Claude intercept variants (mutex)"]
+        direction TB
         claude_intercept["claude-intercept"]
         claude_env_intercept["claude-env-intercept"]
     end
 
     %% ── External standalone service ───────────────────────────────────
     subgraph EXT["🟢 External standalone services"]
+        direction TB
         aigateway["🌐 apps/aigateway<br/><i>FastAPI + LiteLLM</i><br/><i>:9105 — own uv project</i>"]
     end
+
+    %% Force vertical stacking of subgraphs themselves
+    SYS ~~~ FE
+    FE ~~~ BEAPI
+    BEAPI ~~~ AIGW
+    AIGW ~~~ IC
+    IC ~~~ EXT
 
     %% ── Dependencies (depends-on edges) ───────────────────────────────
     claude_frontend --> url4_specs


### PR DESCRIPTION
**Stacked draft PR.** Base will retarget to \`main\` after the SF-138 → SF-139 → SF-142 → SF-143 chain merges.

## Stack

- #122 (SF-138, open) — gateway scaffold
- #123 (SF-139, draft) — anthropic provider plugin with OAuth keychain refresh
- (SF-142, draft) — profile-based OAuth design + implementation plan ← needs PR
- (SF-143, draft) — profile-based OAuth implementation ← needs PR
- **this PR** (SF-141) — \`apps/server\` plugins talking to the gateway

## Summary

Adds three plugins to \`apps/server\` so the screamingface server can route \`/claude\` url4 backend calls through the local AI Gateway:

- **\`aigw_base\`** — shared base classes for every \`aigw_*_backend\` plugin. \`AigwBackend\` speaks OpenAI ChatCompletions to \`localhost:9105\` with \`X-Profile\` header; \`AigwInterpreter\` mirrors \`ClaudeBackendApiInterpreter\` semantics; \`AigwBackendApiPluginBase\` factors out the boilerplate.
- **\`aigw_claude_backend\`** — pilot per-provider plugin. Owns \`/claude\` (mutex with the legacy \`claude-backend-api\`). Tagged \`product:claude\` so the Settings UI groups it correctly. Uses Pydantic \`Field(examples=[...])\` so the \`default_model\` field renders a typeahead dropdown of known anthropic/* models with free-text fallback.
- **\`aigw_runner\`** — owns the lifecycle of the \`apps/aigateway/\` uvicorn subprocess. Mirrors \`mitmproxy_intercept\`: Popen on \`setup\`, terminate on \`app.shutdown\` + \`atexit\`, daemon thread streaming stdout/stderr to the SF logger.

## Why now

The gateway (SF-138/139/142/143) is feature-complete. This PR wires \`apps/server\` to actually call it. With this merged, \`url4\` specs that hit \`/claude\` route through the gateway transparently, and the existing \`*_backend_api\` plugins coexist (one or the other can serve any given path).

Follow-ups (separate tickets): \`aigw_codex_backend\`, \`aigw_gemini_backend\`, \`aigw_ollama_backend\` — each ~30-line copies of the Claude pilot.

## What else is in this branch

A few unrelated UX fixes that piled up during this work (happy to split if requested):

- \`apps/desktop\`: 24-color rainbow palette for plugin category labels in the Settings view, sorted in rainbow order.
- \`apps/desktop\`: env vars + alt-screen + \"Pro\" Terminal profile when launching CLI sessions. Diagnostic dead end — root cause of the user's white-cell artifact turned out to be **macOS \"Increase Contrast\"** (System Settings → Accessibility → Display); none of these app-side fixes affect it. They're harmless defense-in-depth and can be reverted on request.
- \`docs/architecture/plugin-dependencies.md\`: vertical Mermaid graph of all 22 server plugins + standalone-service classification.

## Test plan

- [x] \`make test\` (server unit + aigateway unit) — all green
- [x] Live e2e: \`apps/server/tests/e2e/test_aigw_claude_e2e.py\` — full chain ClaudeCodeClient → claude-frontend → url4-executor → \`/claude\` (aigw_claude_backend) → POST \`/v1/chat/completions\` to localhost:9105 → aigw_runner subprocess → real api.anthropic.com. Asserts (a) the gateway-substituted text was injected into the forwarded user message AND (b) the gateway actually called Anthropic (200 from chat/completions OR AnthropicException OR api.anthropic.com host in logs). Passes in 6.6s.
- [x] Manual \`uv run sf run\`: aigw_runner spawns the gateway, healthz returns 200, profile authenticated via Claude Code keychain bootstrap.

## Asana

https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1214430129591913