### PR TITLE
docs(D-TEAM-001,D-AIGW-001): add team flow and onboarding

### DIFF
--- a/docs/onboarding-dmitry.md
+++ b/docs/onboarding-dmitry.md
@@ -1,0 +1,134 @@
+# Dmitry Onboarding: AI Gateway Track
+
+This page is the short path for Dmitry's first ScreamingFace workstream:
+`apps/aigateway` now, scoreboard/portal work later. For broader collaboration
+rules, read `docs/team-development.md` first.
+
+## Repo Layout
+
+`apps/aigateway` is the LiteLLM-compatible FastAPI gateway Dmitry owns. It
+exposes OpenAI-shape routes such as `POST /v1/chat/completions` and
+`GET /v1/models`.
+
+`apps/server` is the local ScreamingFace plugin server. Sergey owns most of this
+area; read it only when aigateway integration needs a server-side consumer.
+
+`apps/desktop` is the Electron app. Dmitry may touch UI integration points, but
+desktop runtime and packaging stay Sergey-owned.
+
+`web/public` is the deployed static GitHub Pages site. There is no active
+`apps/scoreboard` directory in this checkout yet; confirm branch/repo target
+before starting scoreboard implementation.
+
+## Run Aigateway Locally
+
+```bash
+cd apps/aigateway
+uv sync
+uv run uvicorn aigateway.main:app --port 9105 --reload
+```
+
+In another shell, run:
+
+```bash
+curl -sf http://localhost:9105/healthz
+uv run pytest -m "not live"
+```
+
+Expected health response is `{"status":"ok"}`. Current `main` has gateway
+scaffolding only; provider plugins are landing through follow-up PRs.
+
+## Local Checks
+
+Run these before opening an aigateway PR:
+
+```bash
+cd apps/aigateway
+uv run pytest -m "not live"
+uv run ruff check .
+uv run pyright
+uv run python scripts/check_no_enterprise.py
+```
+
+Live tests are separate. Use `AIGW_LIVE=1 uv run pytest tests/live/ -v` only when
+the relevant provider credentials exist locally.
+
+If Ruff or Pyright fails on unchanged `main`, treat it as a baseline issue to
+confirm or fix before the first gateway code PR, not as a local setup failure.
+
+## Credential Files
+
+Provider live tests and OAuth flows read credentials from the provider CLI's
+normal local storage.
+
+Claude/Anthropic uses `~/.claude/credentials` once the Anthropic provider PR is
+merged or checked out.
+
+Codex provider work is expected to use `~/.codex/auth.json`.
+
+Gemini provider work is expected to use `~/.gemini/oauth_creds.json`.
+
+Never commit credential files, tokens, copied headers, or local `.env` material.
+
+## Branch And Commit Flow
+
+Use an Asana-backed branch: `SF-{n}-{description}`. If no ticket exists, create
+one first and set the Asana `SF` custom field.
+
+Run `git config core.hooksPath .githooks` once after cloning. The pre-commit hook
+blocks commits made directly on `main`.
+
+Commit subjects should follow the existing repo style when possible, but strict
+Conventional Commits are not required. Include the Asana permalink in the commit
+body.
+
+Open a PR with the Asana link, summary, test plan, and screenshots or recordings
+for UI changes. Sergey reviews Dmitry PRs during the initial onboarding period.
+
+## LiteLLM License Guard
+
+Use only the MIT-licensed core `litellm` package. Do not install
+`litellm-enterprise` and do not import `litellm.enterprise.*` or
+`litellm_enterprise.*`.
+
+The guard lives at `apps/aigateway/scripts/check_no_enterprise.py` and is also
+covered by `apps/aigateway/tests/test_no_enterprise.py`. Run it before PRs that
+touch gateway code or dependencies.
+
+## Aigateway Mental Model
+
+The gateway is a small FastAPI app wrapping LiteLLM's OpenAI-compatible chat
+completion interface.
+
+Provider plugins are direct subpackages under `src/aigateway/plugins/`. Each
+plugin exports `PLUGIN` from `plugin.py`, contributes model entries, optionally
+mounts auth routes, and owns its OAuth strategy.
+
+The current `main` branch has no provider packages. PR `#123` / `SF-139` adds the
+Anthropic provider and should become the first concrete reference once merged or
+checked out for pairing.
+
+## First Code Reading Path
+
+Start with these files in order:
+
+```text
+apps/aigateway/src/aigateway/main.py
+apps/aigateway/src/aigateway/routes/chat.py
+apps/aigateway/src/aigateway/routes/models.py
+apps/aigateway/src/aigateway/core/plugin_base.py
+apps/aigateway/src/aigateway/core/loader.py
+apps/aigateway/src/aigateway/core/registry.py
+```
+
+When the Anthropic provider branch is available, also read its `auth.py`,
+`plugin.py`, live test, and any chat-route changes before writing `D-AIGW-002`.
+
+## Where To Ask
+
+Use `docs/team-development.md` for repo workflow and escalation rules. Ask Sergey
+directly for architecture, ownership, credentials, and cross-service contract
+questions.
+
+Use Asana comments for scope/status decisions and GitHub PR comments for code
+review. Link the PR back to the Asana ticket.

--- a/docs/team-development.md
+++ b/docs/team-development.md
@@ -1,0 +1,134 @@
+# Team Development Flow
+
+This is the default collaboration guide for ScreamingFace while the team moves
+from solo development to shared PR-based work. Keep it short, update it when a
+rule starts causing friction, and treat the repository's existing automation as
+the source of truth when it is stricter than this document.
+
+## Branching And Commits
+
+1. Branch names use `SF-{n}-{description}`, where `n` is the Asana `SF` custom
+   field value. Example: `SF-142-aigateway-auth`.
+2. If a task has no Asana ticket, create one before committing. Use project
+   `1213628819033917`, set custom field `1213702745960748` to the next `SF-N`,
+   and include the Asana permalink in the commit body.
+3. Commit subjects do not have to be strict Conventional Commits. Prefer the
+   existing repo style when it fits, such as `feat(SF-138): scaffold aigateway`,
+   `fix(SF-137): move listen port`, or `SF-135: extract frontend base`.
+4. Default merge strategy is squash merge. It keeps `main` linear and matches the
+   recent one-PR-one-main-commit history.
+5. During PR development, rebase on `origin/main` instead of merging `main` into
+   the branch. Resolve conflicts locally, then push the rebased branch.
+6. Force-push is allowed only on your own PR branch after a rebase or cleanup.
+   Do not force-push someone else's branch. Never force-push `main`.
+7. Direct commits to `main` are forbidden. Run `git config core.hooksPath .githooks`
+   once per checkout; `.githooks/pre-commit` blocks commits while the current
+   branch is `main`.
+
+## PR Lifecycle
+
+1. For Dmitry's first two weeks, Sergey reviews Dmitry's PRs before merge. Dmitry
+   can also review Sergey PRs in `apps/aigateway`, scoreboard/portal code, and
+   shared docs to build context, but Sergey remains the safety reviewer.
+2. After the first two weeks, switch to cross-review by default. Tiny mechanical
+   changes may self-merge only if CI is green and the affected owner is not
+   surprised.
+3. PR authors merge their own PRs after review approval and green required
+   checks.
+4. Required local checks depend on touched paths. For `apps/server`, run the Ruff
+   lint/format checks, non-live unit tests, and the relevant e2e shard when
+   behavior changes. For `apps/aigateway`, run the non-live tests, Ruff, Pyright,
+   and the LiteLLM Enterprise guard. For `apps/desktop`, run lint and build when
+   desktop code is touched.
+5. If a required check already fails on untouched `main`, mention the baseline
+   failure in the PR and decide whether to fix it first or track it separately.
+6. Live tests are opt-in diagnostics, not merge gates. `AIGW_LIVE=1` tests need
+   real OAuth credentials; `e2e_live` tests need provider API keys. A skipped live
+   test is not a failed PR.
+7. Definition of done: code/docs landed, relevant checks reported in the PR,
+   Asana moved to the right terminal state, and follow-up tickets filed for
+   intentionally deferred work.
+8. PR descriptions must include the Asana link, a short summary, test plan, and
+   screenshots or recordings for UI changes. A template file is intentionally not
+   added yet; add one only if PR descriptions become inconsistent.
+9. WIP limit is two tickets per developer: one actively coding and one waiting
+   for review. Exceptions are allowed for urgent unblockers.
+
+## Cross-Service Collaboration
+
+1. Keep tightly coupled changes in one PR when splitting would create a broken
+   intermediate state. Split changes when they can land independently.
+2. Bias toward smaller PRs. If a change touches both Sergey-owned and
+   Dmitry-owned areas, state the cross-service contract in the PR body.
+3. Informal ownership for now: Sergey owns `apps/server` and `apps/desktop`;
+   Dmitry owns `apps/aigateway` and future scoreboard/portal work; both own
+   `docs`, root files, workflows, and release glue.
+4. Do not add `.github/CODEOWNERS` yet. Add it after ownership stabilizes and
+   GitHub review routing would save more time than it costs.
+5. If two PRs touch the same file, the PR opened first has right-of-way. The
+   second author rebases, unless the first author agrees to rebase instead.
+6. Before changing shared config, root docs, or workflow files, leave a short
+   note in the PR body explaining who needs to care.
+
+## Communication
+
+1. Async status is the default. End each workday with a short note covering what
+   changed, what is blocked, and what is next.
+2. Use GitHub PR comments for code review, Asana comments for ticket status and
+   scope decisions, and direct messages for urgent blockers. Link across tools
+   when the same decision matters in more than one place.
+3. Pairing is on-demand at named milestones: `D-AIGW-002`, `DEMO-015`,
+   `D-SCORE-006`, `DEMO-025`, and any blocker that would otherwise cost more
+   than the pairing time.
+4. Escalate after 30 minutes if blocked on architecture, product intent,
+   credentials, or ownership. For local setup/build yak-shaving, debug for up to
+   two hours, then ask with the commands and errors already tried.
+
+## Code Quality
+
+1. Existing project tooling is authoritative. Python formatting and linting use
+   Ruff; Python type checking uses Pyright; desktop uses the configured
+   TypeScript/Electron toolchain.
+2. Python targets CI parity with Python 3.12 even if a local venv uses a newer
+   interpreter.
+3. There is no universal coverage floor. New modules should have tests for core
+   behavior; untested new modules should be called out in review with a reason.
+   Server CI currently enforces coverage through the server workflow.
+4. Use type hints for public Python functions, provider/plugin boundaries, and
+   data models. Avoid broad `Any` unless the upstream library genuinely requires
+   it.
+5. Comments should explain non-obvious intent, tradeoffs, or protocol behavior.
+   Do not add comments that restate the code.
+6. `apps/aigateway` must never import or install `litellm-enterprise`,
+   `litellm.enterprise.*`, or `litellm_enterprise.*`. The guard at
+   `apps/aigateway/scripts/check_no_enterprise.py` is part of the test suite.
+
+## Asana Hygiene
+
+1. Both Sergey and Dmitry may create tickets. During Dmitry's first two weeks,
+   Dmitry should confirm new non-trivial ticket scope with Sergey before creating
+   it, to avoid scope drift.
+2. Use the Asana `SF` custom field for branch and commit identity. Do not invent
+   an `SF-N` locally.
+3. Discovered defects or demo rough edges become follow-up tickets in the same
+   Asana batch, labeled or described as `demo-blocker`, `demo-polish`, or
+   `post-demo`.
+4. Status meanings: `In Progress` means someone is actively working; `In Review`
+   means a PR is open and ready for reviewer attention; `Blocked` means the next
+   action is external; `Done` means merged or explicitly no-code-complete and the
+   acceptance criteria are checked off.
+5. If acceptance criteria are intentionally cut, update the ticket before merge
+   so the PR and Asana agree on what was actually delivered.
+
+## First-Day Setup
+
+1. Clone the repo and run `git config core.hooksPath .githooks`.
+2. Sync Python apps separately: `cd apps/server && uv sync`, then
+   `cd ../aigateway && uv sync`.
+3. Start the gateway with `cd apps/aigateway && uv run uvicorn aigateway.main:app --port 9105 --reload`, then check `curl -sf http://localhost:9105/healthz`.
+4. Run the gateway smoke checks: `uv run pytest -m "not live"`, `uv run ruff check .`, `uv run pyright`, and `uv run python scripts/check_no_enterprise.py`.
+5. Start the server with `cd apps/server && uv run sf run --no-ssl` when `mkcert`
+   is unavailable.
+6. Do not add `scripts/setup-dev.sh` in this pass. The manual setup is short, and
+   a script should wait until the aigateway/provider/scoreboard dependency shape
+   stabilizes.


### PR DESCRIPTION
Documents the first two onboarding tasks:                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                  
- `D-TEAM-001`: adds `docs/team-development.md` with explicit team workflow decisions for branching, commits, PR review, checks, ownership, communication, code quality, Asana hygiene, and first-day setup.                                                                                                             
- `D-AIGW-001`: adds `docs/onboarding-dmitry.md` with focused aigateway onboarding, local run commands, checks, credential paths, LiteLLM Enterprise guard, and provider-plugin mental model.                                                                                                                            
                                                                                                                                                                                                                                                                                                                  
Motivation: unblock Dmitry’s first paired PR by making collaboration and setup expectations explicit before code work starts.                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                  
Workflow exception: no SF Asana ticket was available, so this branch/commit uses the `D-TEAM-001` / `D-AIGW-001` task prefixes per explicit instruction.                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                  
## Affected Dependencies                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                  
None. Docs-only change.                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                  
## How has this been tested?                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                  
Docs-only validation:                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                  
- Verified `docs/team-development.md` is under the ticket’s 200-line limit.                                                                                                                                                                                                                                              
- Verified both docs cover the acceptance criteria from `D-TEAM-001` and `D-AIGW-001`.                                                                                                                                                                                                                                   
- Ran whitespace validation with `git diff --check`.                                                                                                                                                                                                                                                                     
- Validated referenced aigateway commands against current repo state.                                                                                                                                                                                                                                                    
- Confirmed current `apps/aigateway` baseline has existing Ruff/Pyright failures, and documented that caveat in onboarding.                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                  
No application tests were run because this PR does not change code.                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                  
## Checklist                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                  
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)                                                                                                         
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md) / N/A, docs-only                                                                                                                                                                     
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)                                                                                                                                                                                                      
- [x] My changes are covered by tests / N/A, docs-only validation described above