### PR TITLE
test(D-AIGW-002): add Anthropic streaming and tool-call live tests

### DIFF
--- a/apps/aigateway/src/aigateway/routes/chat.py
+++ b/apps/aigateway/src/aigateway/routes/chat.py
@@ -121,13 +121,13 @@ async def chat_completions(request: Request) -> Any:
     if body.get("stream"):
         return StreamingResponse(_stream(body), media_type="text/event-stream")
 
-    response = await litellm.acompletion(**body)
+    response: Any = await litellm.acompletion(**body)
     return response.model_dump() if hasattr(response, "model_dump") else response
 
 
 async def _stream(body: dict[str, Any]):
     try:
-        stream = await litellm.acompletion(**body)
+        stream: Any = await litellm.acompletion(**body)
         async for chunk in stream:
             payload = chunk.model_dump() if hasattr(chunk, "model_dump") else chunk
             yield f"data: {json.dumps(payload)}\n\n"

--- a/apps/aigateway/tests/live/test_anthropic_live.py
+++ b/apps/aigateway/tests/live/test_anthropic_live.py
@@ -7,6 +7,7 @@ Claude Code bootstrap importing existing CC credentials.
 
 from __future__ import annotations
 
+import json
 import os
 
 import pytest
@@ -21,15 +22,29 @@ def _live_enabled() -> bool:
     return os.environ.get("AIGW_LIVE") == "1"
 
 
+def _require_default_profile(client: TestClient) -> None:
+    listing = client.get("/v1/auth/profiles")
+    assert listing.status_code == 200, listing.text
+    profiles = {p["id"]: p for p in listing.json()["profiles"]}
+    profile = profiles.get("anthropic:default")
+    if profile is None:
+        pytest.skip(
+            "anthropic:default profile not present. Run `claude auth login` or seed a "
+            "profile via /v1/auth/anthropic/profiles."
+        )
+    assert profile is not None
+    state = profile["state"]
+    if state != "authenticated":
+        pytest.skip(
+            f"anthropic:default profile is {state!r}, not 'authenticated'. "
+            "Complete auth before running live Anthropic tests."
+        )
+
+
 @pytest.mark.skipif(not _live_enabled(), reason="AIGW_LIVE=1 not set")
 def test_anthropic_round_trip_via_default_profile() -> None:
     with TestClient(create_app()) as client:
-        listing = client.get("/v1/auth/profiles").json()
-        ids = {p["id"] for p in listing["profiles"]}
-        assert "anthropic:default" in ids, (
-            "anthropic:default profile not present. "
-            "Run `claude auth login` or seed a profile via /v1/auth/anthropic/profiles."
-        )
+        _require_default_profile(client)
 
         resp = client.post(
             "/v1/chat/completions",
@@ -43,3 +58,85 @@ def test_anthropic_round_trip_via_default_profile() -> None:
         assert resp.status_code == 200, resp.text
         body = resp.json()
         assert body["choices"][0]["message"]["content"]
+
+
+@pytest.mark.skipif(not _live_enabled(), reason="AIGW_LIVE=1 not set")
+def test_anthropic_streaming() -> None:
+    with TestClient(create_app()) as client:
+        _require_default_profile(client)
+
+        with client.stream(
+            "POST",
+            "/v1/chat/completions",
+            headers={"X-Profile": "default"},
+            json={
+                "model": "anthropic/claude-haiku-4-5",
+                "messages": [{"role": "user", "content": "Reply with the word stream."}],
+                "max_tokens": 20,
+                "stream": True,
+            },
+        ) as resp:
+            assert resp.status_code == 200, resp.text
+            data_lines = [
+                line.removeprefix("data: ")
+                for line in resp.iter_lines()
+                if line.startswith("data: ")
+            ]
+
+    assert data_lines
+    assert data_lines[-1] == "[DONE]"
+
+    chunks = [json.loads(line) for line in data_lines[:-1]]
+    text = "".join(
+        choice.get("delta", {}).get("content") or ""
+        for chunk in chunks
+        for choice in chunk.get("choices", [])
+    )
+    assert chunks
+    assert text.strip()
+
+
+@pytest.mark.skipif(not _live_enabled(), reason="AIGW_LIVE=1 not set")
+def test_anthropic_tool_calls() -> None:
+    with TestClient(create_app()) as client:
+        _require_default_profile(client)
+
+        resp = client.post(
+            "/v1/chat/completions",
+            headers={"X-Profile": "default"},
+            json={
+                "model": "anthropic/claude-haiku-4-5",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "Use the get_weather tool for Paris, France.",
+                    }
+                ],
+                "max_tokens": 128,
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "description": "Get the current weather for a location.",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "location": {
+                                        "type": "string",
+                                        "description": "City and country, e.g. Paris, France.",
+                                    }
+                                },
+                                "required": ["location"],
+                            },
+                        },
+                    }
+                ],
+                "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        tool_calls = body["choices"][0]["message"].get("tool_calls") or []
+        assert tool_calls
+        assert tool_calls[0]["function"]["name"] == "get_weather"


### PR DESCRIPTION
Adds the D-AIGW-002 Anthropic live-test coverage for the profile-based AI Gateway path.                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                  
Summary:                                                                                                                                                                                                                                                                                                                 
- Adds `test_anthropic_streaming` to verify `/v1/chat/completions` returns SSE `data:` chunks, non-empty streamed text, and final `[DONE]`.                                                                                                                                                                              
- Adds `test_anthropic_tool_calls` to verify OpenAI-style `tools`/`tool_choice` requests return `message.tool_calls`.                                                                                                                                                                                                    
- Refactors the existing live test setup into `_require_default_profile()` so live tests skip cleanly unless `anthropic:default` exists and is authenticated.                                                                                                                                                            
- Adds narrow `Any` annotations around LiteLLM `acompletion()` return values so Pyright accepts LiteLLM’s stream/non-stream dynamic return shape.                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                  
Motivation: exercise the existing Anthropic provider with the two live behaviors Dmitry will need to mirror for later providers: streaming and tool calls.                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                  
Workflow exception: no SF Asana ticket was available, so I used the D-AIGW-002 prefix.                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                  
## Affected Dependencies                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                  
None. This uses the existing `litellm`, FastAPI, and pytest setup.                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                  
## How has this been tested?                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                  
Tested locally from `apps/aigateway`:                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                  
```bash                                                                                                                                                                                                                                                                                                                  
uv run pytest tests/live/test_anthropic_live.py -q                                                                                                                                                                                                                                                                       
AIGW_LIVE=1 uv run pytest tests/live/test_anthropic_live.py -v                                                                                                                                                                                                                                                           
uv run pyright                                                                                                                                                                                                                                                                                                           
uv run pytest -q                                                                                                                                                                                                                                                                                                         
uv run ruff check .                                                                                                                                                                                                                                                                                                      
uv run python scripts/check_no_enterprise.py                                                                                                                                                                                                                                                                             
Results:                                                                                                                                                                                                                                                                                                                 
- Without AIGW_LIVE=1: 3 skipped                                                                                                                                                                                                                                                                                         
- With AIGW_LIVE=1: 3 passed                                                                                                                                                                                                                                                                                             
- Full test suite: 48 passed, 3 skipped                                                                                                                                                                                                                                                                                  
- Pyright: clean                                                                                                                                                                                                                                                                                                         
- Ruff: clean                                                                                                                                                                                                                                                                                                            
- LiteLLM Enterprise guard: clean                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                  
Live test configuration:                                                                                                                                                                                                                                                                                                 
- Requires an authenticated anthropic:default profile.                                                                                                                                                                                                                                                                   
- On this machine, that profile is bootstrapped from existing Claude Code credentials.                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                  
Checklist                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                  
- [ ] I have followed the Contribution Guidelines (https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and Code of Conduct (https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)                                                                                                           
- [x] I have commented my code following the OpenMined Styleguide (https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md) / N/A, test-focused change                                                                                                                                                            
- [ ] I have labeled this PR with the relevant Type labels (https://github.com/OpenMined/.github/labels?q=Type%3A)                                                                                                                                                                                                       
- [x] My changes are covered by tests