### PR TITLE
ci: split release pipeline per app (desktop / server / aigateway)

### DIFF
--- a/.github/workflows/release-aigateway.yml
+++ b/.github/workflows/release-aigateway.yml
@@ -1,0 +1,99 @@
+name: Release AI Gateway
+
+on:
+  push:
+    tags: ["aigateway-v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. aigateway-v0.1.0)"
+        required: true
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      tag: ${{ steps.v.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: v
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          VERSION="${TAG#aigateway-v}"
+          MANIFEST=$(awk -F'"' '/^version[[:space:]]*=/{print $2; exit}' apps/aigateway/pyproject.toml)
+          if [ "$MANIFEST" != "$VERSION" ]; then
+            echo "::error::tag $TAG implies version $VERSION but apps/aigateway/pyproject.toml reports $MANIFEST"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  image:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/aigateway/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/openmined/screamingface-aigateway:${{ needs.verify.outputs.version }}
+            ghcr.io/openmined/screamingface-aigateway:latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ needs.verify.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+  release:
+    needs: [verify, image]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.verify.outputs.tag }}
+          name: ScreamingFace AI Gateway ${{ needs.verify.outputs.version }}
+          draft: true
+          body: |
+            Container image:
+            ```
+            docker pull ghcr.io/openmined/screamingface-aigateway:${{ needs.verify.outputs.version }}
+            ```
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish to sf-installer (public)
+        env:
+          GH_TOKEN: ${{ secrets.SF_INSTALLER_TOKEN }}
+          TAG: ${{ needs.verify.outputs.tag }}
+          VERSION: ${{ needs.verify.outputs.version }}
+        run: |
+          gh release delete "$TAG" --repo OpenMined/sf-installer --yes 2>/dev/null || true
+          gh release create "$TAG" \
+            --repo OpenMined/sf-installer \
+            --title "ScreamingFace AI Gateway $VERSION" \
+            --notes "AI Gateway container image: \`ghcr.io/openmined/screamingface-aigateway:$VERSION\`"

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,19 +1,46 @@
-name: Release
+name: Release Desktop
 
 on:
   push:
-    tags: ["v*"]
+    tags: ["desktop-v*"]
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag (e.g. v0.1.0)"
+        description: "Release tag (e.g. desktop-v0.2.0)"
         required: true
 
 permissions:
   contents: write
 
 jobs:
+  verify:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      tag: ${{ steps.v.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: v
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          VERSION="${TAG#desktop-v}"
+          MANIFEST=$(jq -r .version apps/desktop/package.json)
+          if [ "$MANIFEST" != "$VERSION" ]; then
+            echo "::error::tag $TAG implies version $VERSION but apps/desktop/package.json reports $MANIFEST"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: verify
     strategy:
       fail-fast: false
       matrix:
@@ -27,10 +54,6 @@ jobs:
           - runner: ubuntu-latest
             os: linux
             arch: x64
-          # TODO: enable when repo has access to GitHub ARM runners
-          # - runner: ubuntu-24.04-arm
-          #   os: linux
-          #   arch: arm64
 
     runs-on: ${{ matrix.runner }}
 
@@ -77,7 +100,7 @@ jobs:
           if-no-files-found: error
 
   release:
-    needs: build
+    needs: [verify, build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -87,23 +110,11 @@ jobs:
           path: artifacts
           merge-multiple: true
 
-      - name: Determine tag
-        id: tag
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          INPUT_TAG: ${{ github.event.inputs.tag }}
-        run: |
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            echo "tag=$INPUT_TAG" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.tag.outputs.tag }}
-          name: ScreamingFace ${{ steps.tag.outputs.tag }}
+          tag_name: ${{ needs.verify.outputs.tag }}
+          name: ScreamingFace Desktop ${{ needs.verify.outputs.version }}
           draft: true
           files: artifacts/*
         env:
@@ -112,13 +123,12 @@ jobs:
       - name: Publish to sf-installer (public)
         env:
           GH_TOKEN: ${{ secrets.SF_INSTALLER_TOKEN }}
-          TAG: ${{ steps.tag.outputs.tag }}
+          TAG: ${{ needs.verify.outputs.tag }}
+          VERSION: ${{ needs.verify.outputs.version }}
         run: |
-          # Delete existing release if re-running
           gh release delete "$TAG" --repo OpenMined/sf-installer --yes 2>/dev/null || true
-          # Create public release with all artifacts
           gh release create "$TAG" \
             --repo OpenMined/sf-installer \
-            --title "ScreamingFace $TAG" \
-            --notes "Automated release from ScreamingFace build pipeline." \
+            --title "ScreamingFace Desktop $VERSION" \
+            --notes "Desktop app build for ScreamingFace $VERSION." \
             artifacts/*

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -1,0 +1,99 @@
+name: Release Server
+
+on:
+  push:
+    tags: ["server-v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. server-v0.1.0)"
+        required: true
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      tag: ${{ steps.v.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: v
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          VERSION="${TAG#server-v}"
+          MANIFEST=$(awk -F'"' '/^version[[:space:]]*=/{print $2; exit}' apps/server/pyproject.toml)
+          if [ "$MANIFEST" != "$VERSION" ]; then
+            echo "::error::tag $TAG implies version $VERSION but apps/server/pyproject.toml reports $MANIFEST"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  image:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/server/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/openmined/screamingface-server:${{ needs.verify.outputs.version }}
+            ghcr.io/openmined/screamingface-server:latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ needs.verify.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+  release:
+    needs: [verify, image]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.verify.outputs.tag }}
+          name: ScreamingFace Server ${{ needs.verify.outputs.version }}
+          draft: true
+          body: |
+            Container image:
+            ```
+            docker pull ghcr.io/openmined/screamingface-server:${{ needs.verify.outputs.version }}
+            ```
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish to sf-installer (public)
+        env:
+          GH_TOKEN: ${{ secrets.SF_INSTALLER_TOKEN }}
+          TAG: ${{ needs.verify.outputs.tag }}
+          VERSION: ${{ needs.verify.outputs.version }}
+        run: |
+          gh release delete "$TAG" --repo OpenMined/sf-installer --yes 2>/dev/null || true
+          gh release create "$TAG" \
+            --repo OpenMined/sf-installer \
+            --title "ScreamingFace Server $VERSION" \
+            --notes "Server container image: \`ghcr.io/openmined/screamingface-server:$VERSION\`"

--- a/apps/aigateway/CHANGELOG.md
+++ b/apps/aigateway/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to the ScreamingFace AI Gateway are documented here.
+This project follows [Semantic Versioning](https://semver.org/) and uses
+release tags of the form `aigateway-v<version>`.
+
+## [Unreleased]
+
+## [0.1.0]
+
+- Initial release.

--- a/apps/aigateway/Dockerfile
+++ b/apps/aigateway/Dockerfile
@@ -1,0 +1,36 @@
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+
+ENV UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    UV_PYTHON_DOWNLOADS=never
+
+WORKDIR /app
+
+COPY apps/aigateway/pyproject.toml apps/aigateway/uv.lock /app/
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-install-project --no-dev
+
+COPY apps/aigateway/src /app/src
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev
+
+
+FROM python:3.12-slim-bookworm AS runtime
+
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN useradd --system --uid 1000 --create-home app
+
+COPY --from=builder --chown=app:app /app /app
+
+USER app
+
+EXPOSE 8000
+
+ENTRYPOINT ["aigateway"]

--- a/apps/desktop/CHANGELOG.md
+++ b/apps/desktop/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to the ScreamingFace Desktop app are documented here.
+This project follows [Semantic Versioning](https://semver.org/) and uses
+release tags of the form `desktop-v<version>`.
+
+## [Unreleased]
+
+## [0.1.0]
+
+- Initial release.

--- a/apps/server/CHANGELOG.md
+++ b/apps/server/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to the ScreamingFace Server are documented here.
+This project follows [Semantic Versioning](https://semver.org/) and uses
+release tags of the form `server-v<version>`.
+
+## [Unreleased]
+
+## [0.1.0]
+
+- Initial release.

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -1,0 +1,37 @@
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+
+ENV UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    UV_PYTHON_DOWNLOADS=never
+
+WORKDIR /app
+
+COPY apps/server/pyproject.toml apps/server/uv.lock /app/
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-install-project --no-dev
+
+COPY apps/server/src /app/src
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev
+
+
+FROM python:3.12-slim-bookworm AS runtime
+
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN useradd --system --uid 1000 --create-home app
+
+COPY --from=builder --chown=app:app /app /app
+
+USER app
+
+EXPOSE 8000
+
+ENTRYPOINT ["sf"]
+CMD ["serve"]


### PR DESCRIPTION
## Summary
Decouple the monolithic \`v*\` release pipeline into three independent flows so each app can ship on its own cadence.

| App | Tag prefix | Artifact | Channel |
|---|---|---|---|
| \`apps/desktop\` | \`desktop-v\` | DMG / AppImage / tar.gz (mac arm64/x64, linux x64) | GH Release (draft) + \`OpenMined/sf-installer\` (public) |
| \`apps/server\` | \`server-v\` | Container \`ghcr.io/openmined/screamingface-server\` (linux amd64/arm64) | ghcr.io + GH Release notes + \`sf-installer\` reference |
| \`apps/aigateway\` | \`aigateway-v\` | Container \`ghcr.io/openmined/screamingface-aigateway\` (linux amd64/arm64) | ghcr.io + GH Release notes + \`sf-installer\` reference |

## Changes
- New: \`.github/workflows/release-desktop.yml\`, \`release-server.yml\`, \`release-aigateway.yml\`
- Renamed legacy \`release.yml\` → \`release-desktop.yml\` (rewritten under new tag scheme)
- Old \`v*\` tags are **preserved** — only future releases use the new prefixed scheme
- New: minimal multi-stage \`apps/server/Dockerfile\` and \`apps/aigateway/Dockerfile\` (uv builder → \`python:3.12-slim\` runtime, non-root)
- New: per-app \`CHANGELOG.md\` stubs

## Tag-vs-manifest verification
Each workflow's first job re-reads the manifest (\`package.json\` or \`pyproject.toml\`) and fails fast if the tag's implied version disagrees.

## Required secrets
- \`SF_INSTALLER_TOKEN\` (already in use for desktop)
- \`GITHUB_TOKEN\` with \`packages: write\` (default; permission is requested in workflow)

## Migration
Next desktop release must use prefix \`desktop-v0.x.y\` (not \`v0.x.y\`).

## Smoke order
1. \`aigateway-v0.1.0\` (lowest blast radius)
2. \`server-v0.1.0\`
3. \`desktop-v0.2.0\`

## Test plan
- [ ] Workflow YAML lints clean (validated locally)
- [ ] CI verifies tag↔manifest mismatch path on a deliberately-wrong tag
- [ ] First aigateway-v0.1.0 image lands in ghcr.io and \`sf-installer\` shows the reference release