### PR TITLE
ci: add release-please for per-app version automation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,20 @@
+name: Release Please
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,5 @@
+{
+  "apps/desktop": "0.1.0",
+  "apps/server": "0.1.0",
+  "apps/aigateway": "0.1.0"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "node",
+  "include-component-in-tag": false,
+  "separate-pull-requests": true,
+  "pull-request-title-pattern": "chore${scope}: release ${component} ${version}",
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance" },
+    { "type": "deps", "section": "Dependencies" },
+    { "type": "refactor", "section": "Refactors" },
+    { "type": "docs", "section": "Documentation" },
+    { "type": "ci", "section": "Build / CI", "hidden": true },
+    { "type": "chore", "section": "Chores", "hidden": true },
+    { "type": "test", "section": "Tests", "hidden": true }
+  ],
+  "packages": {
+    "apps/desktop": {
+      "release-type": "node",
+      "package-name": "screamingface-desktop",
+      "component": "desktop",
+      "tag-separator": "-v",
+      "include-component-in-tag": true
+    },
+    "apps/server": {
+      "release-type": "python",
+      "package-name": "screamingface",
+      "component": "server",
+      "tag-separator": "-v",
+      "include-component-in-tag": true,
+      "version-file": "apps/server/pyproject.toml"
+    },
+    "apps/aigateway": {
+      "release-type": "python",
+      "package-name": "aigateway",
+      "component": "aigateway",
+      "tag-separator": "-v",
+      "include-component-in-tag": true,
+      "version-file": "apps/aigateway/pyproject.toml"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds `release-please` to drive per-app SemVer bumps, changelog generation, and tag creation. Pairs with #147 (which defines the per-app release workflows that fire on the prefixed tags).

## How it works
1. You land conventional commits scoped per app (`feat(server): ...`, `fix(desktop): ...`, `deps(aigateway): ...`).
2. On every push to `main`, the `release-please` workflow opens (or updates) one release PR **per app** that has unreleased changes.
3. Merging a release PR:
   - bumps the version in that app's manifest (`package.json` / `pyproject.toml`)
   - regenerates that app's `CHANGELOG.md`
   - pushes a prefixed tag (`desktop-vX.Y.Z`, `server-vX.Y.Z`, `aigateway-vX.Y.Z`)
4. The tag triggers the matching `release-<app>.yml` workflow from #147 → ships the artifact.

## Files
- `release-please-config.json` — three packages, prefixed tags, custom changelog sections
- `.release-please-manifest.json` — current versions (all `0.1.0`)
- `.github/workflows/release-please.yml` — runs on push-to-main + manual dispatch

## Depends on
#147 (per-app release workflows). Merging this before #147 is harmless — release-please will open release PRs but the resulting tags won't trigger anything yet.

## Test plan
- [ ] First push to main after merge: confirm one release PR per app appears (may be empty if no relevant commits since `0.1.0`)
- [ ] Land a `feat(aigateway):` commit; release-please updates only the aigateway PR
- [ ] Merge aigateway release PR; tag `aigateway-v0.2.0` lands and triggers `release-aigateway.yml`