### PR TITLE
Sf 162 aigateway auth layer

### DIFF
--- a/.github/workflows/aigateway-tests.yml
+++ b/.github/workflows/aigateway-tests.yml
@@ -64,8 +64,9 @@ jobs:
 
       - name: Run auth surface coverage
         run: |
-          uv run pytest tests/unit/auth \
+          uv run pytest tests/unit/auth tests/unit/test_auth_routes.py \
             --cov=aigateway.core.auth \
+            --cov=aigateway.routes.auth \
             --cov=aigateway.routes.auth_session \
             --cov=aigateway.routes.accounts \
             --cov-report=term-missing \

--- a/.github/workflows/aigateway-tests.yml
+++ b/.github/workflows/aigateway-tests.yml
@@ -1,0 +1,94 @@
+name: AI Gateway Tests
+
+on:
+  push:
+    paths:
+      - "apps/aigateway/**"
+      - ".github/workflows/aigateway-tests.yml"
+  pull_request:
+    paths:
+      - "apps/aigateway/**"
+      - ".github/workflows/aigateway-tests.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+    defaults:
+      run:
+        working-directory: apps/aigateway
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Lint (ruff check)
+        run: uv run ruff check --output-format=github
+
+      - name: Lint (ruff format)
+        run: uv run ruff format --check
+
+      - name: Typecheck
+        run: uv run pyright
+
+      - name: Enterprise import guard
+        run: uv run python scripts/check_no_enterprise.py
+
+      - name: Run unit tests with aggregate coverage
+        run: |
+          uv run pytest \
+            --tb=short \
+            --junitxml=results.xml \
+            --cov=aigateway \
+            --cov-report=xml:coverage.xml \
+            --cov-report=term-missing \
+            --cov-fail-under=85 \
+            -m "not live and not needs_postgres" \
+            -v
+
+      - name: Run auth surface coverage
+        run: |
+          uv run pytest tests/unit/auth \
+            --cov=aigateway.core.auth \
+            --cov=aigateway.routes.auth_session \
+            --cov=aigateway.routes.accounts \
+            --cov-report=term-missing \
+            --cov-fail-under=95 \
+            -v
+
+      - name: Run Postgres migration smoke
+        env:
+          AIGW_TEST_PG: "1"
+        run: uv run pytest -m needs_postgres -v
+
+      - name: Test report
+        uses: dorny/test-reporter@v2
+        if: always()
+        with:
+          name: AI Gateway Test Results (${{ matrix.python-version }})
+          path: apps/aigateway/results.xml
+          reporter: java-junit
+
+      - name: Coverage report
+        uses: orgoro/coverage@v3.2
+        if: always() && github.event_name == 'pull_request'
+        with:
+          coverageFile: apps/aigateway/coverage.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          thresholdAll: 0.85

--- a/apps/aigateway/README.md
+++ b/apps/aigateway/README.md
@@ -13,6 +13,7 @@ cd apps/aigateway
 uv sync
 
 # Apply migrations for a persistent local DB. Re-running is safe.
+# If your DB URL is in .env, export it first: set -a && source .env && set +a
 uv run tortoise -c aigateway.db.TORTOISE_CONFIG migrate
 
 uv run uvicorn aigateway.main:app --port 9105 --reload

--- a/apps/aigateway/README.md
+++ b/apps/aigateway/README.md
@@ -11,11 +11,62 @@ plugins under `src/aigateway/plugins/`.
 ```bash
 cd apps/aigateway
 uv sync
+
+# Apply migrations for a persistent local DB. Re-running is safe.
+uv run tortoise -c aigateway.db.TORTOISE_CONFIG migrate
+
 uv run uvicorn aigateway.main:app --port 9105 --reload
 
 # Sanity check
 curl -sf http://localhost:9105/healthz
 ```
+
+On first boot, set `AIGATEWAY_ADMIN_PASSWORD` to choose the admin password.
+If it is unset, the gateway generates a 24-character password and logs it once
+as `Bootstrap admin password: ...`.
+
+Authenticated endpoints require a JWT:
+
+```bash
+TOKEN=$(curl -sX POST http://localhost:9105/v1/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","password":"<admin-password>"}' | jq -r .token)
+
+curl http://localhost:9105/v1/models -H "Authorization: Bearer $TOKEN"
+```
+
+User provisioning is intentionally separate from JWT auth. Set
+`AIGATEWAY_PROVISIONING_TOKEN` to enable `POST /v1/accounts`:
+
+```bash
+curl -sX POST http://localhost:9105/v1/accounts \
+  -H "X-Aigw-Provisioning-Token: $AIGATEWAY_PROVISIONING_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"alice","password":"alicepass123","display_name":"Alice"}'
+```
+
+If you expose aigateway to the public internet, you MUST front it with
+rate-limiting such as Cloudflare or `nginx limit_req`. v1 does not implement
+application-level rate limiting on `/v1/auth/login`.
+
+Multi-worker deployments (`uvicorn --workers N` or a process manager equivalent)
+MUST set `AIGATEWAY_JWT_SECRET` explicitly. The generated keychain fallback is a
+local/single-worker convenience only.
+
+## Operations
+
+### Rotate `AIGATEWAY_JWT_SECRET`
+
+Changing the JWT secret invalidates all sessions.
+
+For explicit-env deployments, change `AIGATEWAY_JWT_SECRET` and restart all
+workers. For local generated-secret deployments, delete the keychain entry with
+service `aigateway:jwt-secret` and account `default`, then restart.
+
+### Rotate `AIGATEWAY_PROVISIONING_TOKEN`
+
+Change the `AIGATEWAY_PROVISIONING_TOKEN` environment variable and restart the
+gateway. Existing JWTs are unaffected.
 
 ## Layout
 
@@ -28,8 +79,10 @@ src/aigateway/
     plugin_base.py   ProviderPluginBase contract
     registry.py      ProviderRegistry (custom_llm_provider → plugin)
     loader.py        Discovers plugins under aigateway.plugins.*
-    oauth_bridge.py  litellm pre_call_hook → injects auth headers
+    auth/            Account model, JWT, password, provisioning helpers
   routes/
+    auth_session.py  POST /v1/auth/login and GET /v1/auth/me
+    accounts.py      POST /v1/accounts provisioning endpoint
     chat.py          POST /v1/chat/completions (stream + non-stream)
     models.py        GET /v1/models (aggregated from plugins)
     health.py        GET /healthz

--- a/apps/aigateway/README.md
+++ b/apps/aigateway/README.md
@@ -36,6 +36,12 @@ TOKEN=$(curl -sX POST http://localhost:9105/v1/auth/login \
 curl http://localhost:9105/v1/models -H "Authorization: Bearer $TOKEN"
 ```
 
+For local-only development, auth can be bypassed with `AIGATEWAY_AUTH_ENABLED=0`.
+Protected endpoints then run as an anonymous account with ID
+`00000000-0000-0000-0000-000000000000`. Auth is enabled by default; do not use
+this mode for shared or hosted deployments. OAuth profiles created in this mode
+are scoped to the anonymous account.
+
 User provisioning is intentionally separate from JWT auth. Set
 `AIGATEWAY_PROVISIONING_TOKEN` to enable `POST /v1/accounts`:
 

--- a/apps/aigateway/pyproject.toml
+++ b/apps/aigateway/pyproject.toml
@@ -10,6 +10,10 @@ dependencies = [
     "pydantic>=2.0",
     "pydantic-settings>=2.0",
     "litellm>=1.55",
+    "tortoise-orm[asyncpg]==1.1.7",
+    "PyJWT==2.12.1",
+    "bcrypt==5.0.0",
+    "asyncpg==0.31.0",
 ]
 
 [project.scripts]
@@ -30,16 +34,25 @@ target-version = "py312"
 select = ["E", "F", "I", "UP"]
 
 [tool.pytest.ini_options]
+asyncio_mode = "strict"
 testpaths = ["tests", "src/aigateway"]
 markers = [
     "live: tests hitting real upstream providers (skipped in CI)",
+    "needs_postgres: tests requiring Postgres/testcontainers",
+]
+filterwarnings = [
+    "error::DeprecationWarning:aigateway",
+    "ignore::DeprecationWarning:tortoise",
 ]
 
 [dependency-groups]
 dev = [
     "pytest>=9.0",
-    "pytest-asyncio>=0.24",
+    "pytest-asyncio>=1.3,<2",
+    "pytest-cov>=5",
     "pyright>=1.1.393",
     "ruff>=0.8",
     "httpx>=0.28",
+    "aiosqlite==0.22.1",
+    "testcontainers[postgres]==4.14.2",
 ]

--- a/apps/aigateway/src/aigateway/config.py
+++ b/apps/aigateway/src/aigateway/config.py
@@ -1,11 +1,48 @@
 from __future__ import annotations
 
+from pydantic import Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_prefix="AIGW_", env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(
+        env_prefix="AIGW_",
+        env_file=".env",
+        extra="ignore",
+        populate_by_name=True,
+    )
 
     host: str = "127.0.0.1"
     port: int = 9105
     log_level: str = "info"
+    database_url: SecretStr = Field(
+        default=SecretStr("postgres://aigateway:aigateway@localhost:5432/aigateway"),
+        validation_alias="AIGATEWAY_DATABASE_URL",
+    )
+    jwt_secret: SecretStr | None = Field(default=None, validation_alias="AIGATEWAY_JWT_SECRET")
+    admin_password: SecretStr | None = Field(
+        default=None, validation_alias="AIGATEWAY_ADMIN_PASSWORD"
+    )
+    provisioning_token: SecretStr | None = Field(
+        default=None, validation_alias="AIGATEWAY_PROVISIONING_TOKEN"
+    )
+    jwt_ttl_seconds: int = Field(default=86_400, validation_alias="AIGATEWAY_JWT_TTL_SECONDS")
+
+    @field_validator("jwt_secret", "provisioning_token")
+    @classmethod
+    def _validate_secret_length(cls, value: SecretStr | None) -> SecretStr | None:
+        if value is None:
+            return value
+        if len(value.get_secret_value()) < 32:
+            raise ValueError("secret must be at least 32 characters")
+        return value
+
+    @field_validator("admin_password")
+    @classmethod
+    def _validate_admin_password(cls, value: SecretStr | None) -> SecretStr | None:
+        if value is None:
+            return value
+        size = len(value.get_secret_value().encode("utf-8"))
+        if not 8 <= size <= 72:
+            raise ValueError("password must be 8-72 UTF-8 bytes")
+        return value

--- a/apps/aigateway/src/aigateway/config.py
+++ b/apps/aigateway/src/aigateway/config.py
@@ -26,6 +26,7 @@ class Settings(BaseSettings):
     provisioning_token: SecretStr | None = Field(
         default=None, validation_alias="AIGATEWAY_PROVISIONING_TOKEN"
     )
+    auth_enabled: bool = Field(default=True, validation_alias="AIGATEWAY_AUTH_ENABLED")
     jwt_ttl_seconds: int = Field(default=86_400, validation_alias="AIGATEWAY_JWT_TTL_SECONDS")
 
     @field_validator("jwt_secret", "provisioning_token")

--- a/apps/aigateway/src/aigateway/core/auth/__init__.py
+++ b/apps/aigateway/src/aigateway/core/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Account authentication primitives for the gateway."""

--- a/apps/aigateway/src/aigateway/core/auth/bootstrap_admin.py
+++ b/apps/aigateway/src/aigateway/core/auth/bootstrap_admin.py
@@ -19,17 +19,19 @@ def _generate_password(length: int = 24) -> str:
     return "".join(secrets.choice(_PASSWORD_ALPHABET) for _ in range(length))
 
 
-async def ensure_admin_account(env_password: SecretStr | None) -> None:
-    if await Account.get_or_none(username="admin") is not None:
-        return
+async def ensure_admin_account(env_password: SecretStr | None) -> Account:
+    existing = await Account.get_or_none(username="admin")
+    if existing is not None:
+        return existing
 
     generated_password = None if env_password is not None else _generate_password()
     password = env_password if env_password is not None else SecretStr(generated_password or "")
     password_hash = await hash_password(password)
     try:
-        await Account.create(username="admin", password_hash=password_hash)
+        admin = await Account.create(username="admin", password_hash=password_hash)
     except IntegrityError:
-        return
+        return await Account.get(username="admin")
 
     if generated_password is not None:
         logger.warning("Bootstrap admin password: %s", generated_password)
+    return admin

--- a/apps/aigateway/src/aigateway/core/auth/bootstrap_admin.py
+++ b/apps/aigateway/src/aigateway/core/auth/bootstrap_admin.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import logging
+import secrets
+import string
+
+from pydantic import SecretStr
+from tortoise.exceptions import IntegrityError
+
+from .models import Account
+from .passwords import hash_password
+
+logger = logging.getLogger(__name__)
+
+_PASSWORD_ALPHABET = string.ascii_letters + string.digits
+
+
+def _generate_password(length: int = 24) -> str:
+    return "".join(secrets.choice(_PASSWORD_ALPHABET) for _ in range(length))
+
+
+async def ensure_admin_account(env_password: SecretStr | None) -> None:
+    if await Account.get_or_none(username="admin") is not None:
+        return
+
+    generated_password = None if env_password is not None else _generate_password()
+    password = env_password if env_password is not None else SecretStr(generated_password or "")
+    password_hash = await hash_password(password)
+    try:
+        await Account.create(username="admin", password_hash=password_hash)
+    except IntegrityError:
+        return
+
+    if generated_password is not None:
+        logger.warning("Bootstrap admin password: %s", generated_password)

--- a/apps/aigateway/src/aigateway/core/auth/jwt.py
+++ b/apps/aigateway/src/aigateway/core/auth/jwt.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import jwt
+
+
+def encode_token(
+    *,
+    account_id: str,
+    username: str,
+    secret: str,
+    ttl_seconds: int,
+) -> tuple[str, datetime]:
+    now = datetime.now(UTC)
+    expires_at = now + timedelta(seconds=ttl_seconds)
+    claims = {
+        "sub": account_id,
+        "username": username,
+        "iat": int(now.timestamp()),
+        "exp": int(expires_at.timestamp()),
+    }
+    return jwt.encode(claims, secret, algorithm="HS256"), expires_at
+
+
+def decode_token(token: str, secret: str) -> dict[str, Any]:
+    return jwt.decode(
+        token,
+        secret,
+        algorithms=["HS256"],
+        options={"require": ["exp", "iat", "sub"]},
+    )

--- a/apps/aigateway/src/aigateway/core/auth/jwt_secret.py
+++ b/apps/aigateway/src/aigateway/core/auth/jwt_secret.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import secrets
+
+from pydantic import SecretStr
+
+from ..credential_store import CredentialStore
+
+JWT_SECRET_SERVICE = "aigateway:jwt-secret"
+JWT_SECRET_ACCOUNT = "default"
+
+logger = logging.getLogger(__name__)
+
+
+async def get_or_create_jwt_secret(
+    credential_store: CredentialStore,
+    env_secret: SecretStr | None = None,
+) -> str:
+    """Return the gateway JWT secret as a plain string.
+
+    Auto-generation is a local/single-worker convenience only. Multi-process
+    deployments must set AIGATEWAY_JWT_SECRET so every worker starts with the
+    same secret instead of racing through a non-atomic keychain read/write path.
+    """
+    if env_secret is not None:
+        return env_secret.get_secret_value()
+
+    existing = await asyncio.to_thread(
+        credential_store.read,
+        JWT_SECRET_SERVICE,
+        JWT_SECRET_ACCOUNT,
+    )
+    if existing:
+        if len(existing) < 32:
+            raise RuntimeError(
+                "Persisted aigateway JWT secret must be at least 32 characters; "
+                "delete keychain entry aigateway:jwt-secret/default or set AIGATEWAY_JWT_SECRET"
+            )
+        return existing
+
+    generated = secrets.token_urlsafe(48)
+    await asyncio.to_thread(
+        credential_store.write,
+        JWT_SECRET_SERVICE,
+        JWT_SECRET_ACCOUNT,
+        generated,
+    )
+    logger.warning("Generated and persisted aigateway JWT secret")
+    return generated

--- a/apps/aigateway/src/aigateway/core/auth/log_filter.py
+++ b/apps/aigateway/src/aigateway/core/auth/log_filter.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 class RedactProvisioningTokenFilter(logging.Filter):
     _HEADER_NAME = "x-aigw-provisioning-token"
     _PATTERN = re.compile(
-        r"(X-Aigw-Provisioning-Token[:=\s\"']*)([^\s\"',}]+)",
+        r"(X-Aigw-Provisioning-Token(?:\s*[:=]\s*|\s+[\"']))([^\s\"',}]+)",
         re.IGNORECASE,
     )
     _RAW_HEADER_PATTERN = re.compile(

--- a/apps/aigateway/src/aigateway/core/auth/log_filter.py
+++ b/apps/aigateway/src/aigateway/core/auth/log_filter.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, cast
+
+
+class RedactProvisioningTokenFilter(logging.Filter):
+    _HEADER_NAME = "x-aigw-provisioning-token"
+    _PATTERN = re.compile(
+        r"(X-Aigw-Provisioning-Token[:=\s\"']*)([^\s\"',}]+)",
+        re.IGNORECASE,
+    )
+    _RAW_HEADER_PATTERN = re.compile(
+        r"(b?[\"']x-aigw-provisioning-token[\"']\s*,\s*b?[\"'])([^\"']+)",
+        re.IGNORECASE,
+    )
+
+    @classmethod
+    def _redact(cls, value: str) -> str:
+        redacted = cls._PATTERN.sub(r"\1[REDACTED]", value)
+        return cls._RAW_HEADER_PATTERN.sub(r"\1[REDACTED]", redacted)
+
+    @classmethod
+    def _is_header_key(cls, value: object) -> bool:
+        if isinstance(value, bytes):
+            value = value.decode("latin-1")
+        if not isinstance(value, str):
+            return False
+        return value.lower() == cls._HEADER_NAME
+
+    @staticmethod
+    def _redacted_like(value: object) -> object:
+        return b"[REDACTED]" if isinstance(value, bytes) else "[REDACTED]"
+
+    @classmethod
+    def _redact_obj(cls, value: object) -> object:
+        if isinstance(value, str):
+            return cls._redact(value)
+        if isinstance(value, bytes):
+            redacted = cls._redact(value.decode("latin-1"))
+            return redacted.encode("latin-1")
+        if isinstance(value, tuple):
+            if len(value) == 2 and cls._is_header_key(value[0]):
+                return (value[0], cls._redacted_like(value[1]))
+            return tuple(cls._redact_obj(item) for item in value)
+        if isinstance(value, list):
+            if len(value) == 2 and cls._is_header_key(value[0]):
+                return [value[0], cls._redacted_like(value[1])]
+            return [cls._redact_obj(item) for item in value]
+        if isinstance(value, dict):
+            return {
+                key: cls._redacted_like(item) if cls._is_header_key(key) else cls._redact_obj(item)
+                for key, item in value.items()
+            }
+        return value
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        rendered = record.getMessage()
+        redacted_rendered = self._redact(rendered)
+        if redacted_rendered != rendered and record.name != "uvicorn.access":
+            record.msg = redacted_rendered
+            record.args = ()
+            return True
+
+        record.msg = self._redact_obj(record.msg)
+        record.args = cast(Any, self._redact_obj(record.args))
+        return True
+
+
+def install_provisioning_token_redaction() -> None:
+    """Install process-wide redaction for records from any logger/handler path."""
+    current_factory = logging.getLogRecordFactory()
+    if getattr(current_factory, "_aigw_provisioning_token_redaction", False):
+        return
+
+    redactor = RedactProvisioningTokenFilter()
+
+    def redacting_factory(*args: Any, **kwargs: Any) -> logging.LogRecord:
+        record = current_factory(*args, **kwargs)
+        redactor.filter(record)
+        return record
+
+    setattr(redacting_factory, "_aigw_provisioning_token_redaction", True)
+    logging.setLogRecordFactory(redacting_factory)

--- a/apps/aigateway/src/aigateway/core/auth/middleware.py
+++ b/apps/aigateway/src/aigateway/core/auth/middleware.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Annotated
+from uuid import UUID
 
 import jwt
 from fastapi import Depends, HTTPException, Request
@@ -22,7 +23,12 @@ async def current_account(request: Request) -> Account:
     except jwt.InvalidTokenError as exc:
         raise HTTPException(status_code=401, detail=f"Invalid token: {exc}") from exc
 
-    account = await Account.get_or_none(id=claims["sub"])
+    try:
+        account_id = UUID(claims["sub"])
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=401, detail="Invalid token: malformed subject") from exc
+
+    account = await Account.get_or_none(id=account_id)
     if account is None or not account.is_active:
         raise HTTPException(status_code=401, detail="Account not found or inactive")
     return account

--- a/apps/aigateway/src/aigateway/core/auth/middleware.py
+++ b/apps/aigateway/src/aigateway/core/auth/middleware.py
@@ -8,12 +8,12 @@ import jwt
 from fastapi import Depends, HTTPException, Request
 
 from .jwt import decode_token
-from .models import Account
+from .models import Account, BaseAccount
 
 ANONYMOUS_ACCOUNT_ID = UUID("00000000-0000-0000-0000-000000000000")
 
 
-def anonymous_account() -> Account:
+def anonymous_account() -> BaseAccount:
     return Account(
         id=ANONYMOUS_ACCOUNT_ID,
         username="anonymous",
@@ -25,7 +25,7 @@ def anonymous_account() -> Account:
     )
 
 
-async def current_account(request: Request) -> Account:
+async def current_account(request: Request) -> BaseAccount:
     if not request.app.state.settings.auth_enabled:
         return anonymous_account()
 
@@ -52,4 +52,4 @@ async def current_account(request: Request) -> Account:
     return account
 
 
-CurrentAccount = Annotated[Account, Depends(current_account)]
+CurrentAccount = Annotated[BaseAccount, Depends(current_account)]

--- a/apps/aigateway/src/aigateway/core/auth/middleware.py
+++ b/apps/aigateway/src/aigateway/core/auth/middleware.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+import jwt
+from fastapi import Depends, HTTPException, Request
+
+from .jwt import decode_token
+from .models import Account
+
+
+async def current_account(request: Request) -> Account:
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing bearer token")
+
+    token = auth_header[len("Bearer ") :]
+    try:
+        claims = decode_token(token, secret=request.app.state.jwt_secret)
+    except jwt.ExpiredSignatureError as exc:
+        raise HTTPException(status_code=401, detail=f"Invalid token: expired ({exc})") from exc
+    except jwt.InvalidTokenError as exc:
+        raise HTTPException(status_code=401, detail=f"Invalid token: {exc}") from exc
+
+    account = await Account.get_or_none(id=claims["sub"])
+    if account is None or not account.is_active:
+        raise HTTPException(status_code=401, detail="Account not found or inactive")
+    return account
+
+
+CurrentAccount = Annotated[Account, Depends(current_account)]

--- a/apps/aigateway/src/aigateway/core/auth/middleware.py
+++ b/apps/aigateway/src/aigateway/core/auth/middleware.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Annotated
 from uuid import UUID
 
@@ -9,8 +10,25 @@ from fastapi import Depends, HTTPException, Request
 from .jwt import decode_token
 from .models import Account
 
+ANONYMOUS_ACCOUNT_ID = UUID("00000000-0000-0000-0000-000000000000")
+
+
+def anonymous_account() -> Account:
+    return Account(
+        id=ANONYMOUS_ACCOUNT_ID,
+        username="anonymous",
+        password_hash="",
+        display_name="Anonymous",
+        created_at=datetime.fromtimestamp(0, UTC),
+        last_login_at=None,
+        is_active=True,
+    )
+
 
 async def current_account(request: Request) -> Account:
+    if not request.app.state.settings.auth_enabled:
+        return anonymous_account()
+
     auth_header = request.headers.get("Authorization", "")
     if not auth_header.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Missing bearer token")

--- a/apps/aigateway/src/aigateway/core/auth/models.py
+++ b/apps/aigateway/src/aigateway/core/auth/models.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import uuid
+
+from tortoise import fields
+from tortoise.models import Model
+
+
+class Account(Model):
+    id = fields.UUIDField(pk=True, default=uuid.uuid4)
+    username = fields.CharField(max_length=64, unique=True, index=True)
+    password_hash = fields.CharField(max_length=255)
+    display_name = fields.CharField(max_length=255, null=True)
+    created_at = fields.DatetimeField(auto_now_add=True)
+    last_login_at = fields.DatetimeField(null=True)
+    is_active = fields.BooleanField(default=True)
+
+    class Meta:
+        table = "accounts"

--- a/apps/aigateway/src/aigateway/core/auth/models/__init__.py
+++ b/apps/aigateway/src/aigateway/core/auth/models/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from .account import Account, BaseAccount
+
+__all__ = ["Account", "BaseAccount"]
+__models__ = [Account]

--- a/apps/aigateway/src/aigateway/core/auth/models/account.py
+++ b/apps/aigateway/src/aigateway/core/auth/models/account.py
@@ -6,7 +6,10 @@ from tortoise import fields
 from tortoise.models import Model
 
 
-class Account(Model):
+class BaseAccount(Model):
+    class Meta:
+        abstract = True
+
     id = fields.UUIDField(pk=True, default=uuid.uuid4)
     username = fields.CharField(max_length=64, unique=True, index=True)
     password_hash = fields.CharField(max_length=255)
@@ -15,5 +18,7 @@ class Account(Model):
     last_login_at = fields.DatetimeField(null=True)
     is_active = fields.BooleanField(default=True)
 
+
+class Account(BaseAccount):
     class Meta:
         table = "accounts"

--- a/apps/aigateway/src/aigateway/core/auth/passwords.py
+++ b/apps/aigateway/src/aigateway/core/auth/passwords.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import threading
+
+import bcrypt
+from fastapi.concurrency import run_in_threadpool
+from pydantic import SecretStr
+
+_BCRYPT_ROUNDS = 12
+_DUMMY_PASSWORD = b"screamingface-dummy-password"
+_dummy_hash: bytes | None = None
+_dummy_lock = threading.Lock()
+
+
+def _password_bytes(password: SecretStr | str) -> bytes:
+    raw = password.get_secret_value() if isinstance(password, SecretStr) else password
+    encoded = raw.encode("utf-8")
+    if not 8 <= len(encoded) <= 72:
+        raise ValueError("password must be 8-72 UTF-8 bytes")
+    return encoded
+
+
+def _hash_password_sync(password: SecretStr | str) -> str:
+    hashed = bcrypt.hashpw(_password_bytes(password), bcrypt.gensalt(rounds=_BCRYPT_ROUNDS))
+    return hashed.decode("ascii")
+
+
+def _verify_password_sync(password: SecretStr | str, password_hash: str | bytes) -> bool:
+    stored = password_hash.encode("ascii") if isinstance(password_hash, str) else password_hash
+    try:
+        return bcrypt.checkpw(_password_bytes(password), stored)
+    except ValueError:
+        return False
+
+
+def _get_dummy_hash() -> bytes:
+    global _dummy_hash
+    if _dummy_hash is None:
+        with _dummy_lock:
+            if _dummy_hash is None:
+                _dummy_hash = bcrypt.hashpw(
+                    _DUMMY_PASSWORD,
+                    bcrypt.gensalt(rounds=_BCRYPT_ROUNDS),
+                )
+    return _dummy_hash
+
+
+async def hash_password(password: SecretStr | str) -> str:
+    return await run_in_threadpool(_hash_password_sync, password)
+
+
+async def verify_password(password: SecretStr | str, password_hash: str | bytes) -> bool:
+    return await run_in_threadpool(_verify_password_sync, password, password_hash)
+
+
+async def verify_password_or_dummy(
+    password: SecretStr | str, password_hash: str | bytes | None
+) -> bool:
+    if password_hash is None:
+        password_hash = await run_in_threadpool(_get_dummy_hash)
+    return await verify_password(password, password_hash)

--- a/apps/aigateway/src/aigateway/core/auth/provisioning.py
+++ b/apps/aigateway/src/aigateway/core/auth/provisioning.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import hmac
+
+from pydantic import SecretStr
+
+PROVISIONING_HEADER = "X-Aigw-Provisioning-Token"
+
+
+def verify_provisioning_token(candidate: str | None, expected: SecretStr) -> bool:
+    if candidate is None:
+        return False
+    return hmac.compare_digest(candidate, expected.get_secret_value())

--- a/apps/aigateway/src/aigateway/core/auth/schemas.py
+++ b/apps/aigateway/src/aigateway/core/auth/schemas.py
@@ -5,6 +5,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator
 
+_USERNAME_PATTERN = r"^[A-Za-z0-9_.-]+$"
+
 
 def _validate_password_bytes(value: SecretStr) -> SecretStr:
     size = len(value.get_secret_value().encode("utf-8"))
@@ -14,7 +16,7 @@ def _validate_password_bytes(value: SecretStr) -> SecretStr:
 
 
 class LoginRequest(BaseModel):
-    username: str = Field(min_length=1, max_length=64)
+    username: str = Field(min_length=1, max_length=64, pattern=_USERNAME_PATTERN)
     password: SecretStr
 
     @field_validator("password")
@@ -24,7 +26,7 @@ class LoginRequest(BaseModel):
 
 
 class CreateAccountRequest(BaseModel):
-    username: str = Field(min_length=1, max_length=64)
+    username: str = Field(min_length=1, max_length=64, pattern=_USERNAME_PATTERN)
     password: SecretStr
     display_name: str | None = Field(default=None, max_length=255)
 

--- a/apps/aigateway/src/aigateway/core/auth/schemas.py
+++ b/apps/aigateway/src/aigateway/core/auth/schemas.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator
+
+
+def _validate_password_bytes(value: SecretStr) -> SecretStr:
+    size = len(value.get_secret_value().encode("utf-8"))
+    if not 8 <= size <= 72:
+        raise ValueError("password must be 8-72 UTF-8 bytes")
+    return value
+
+
+class LoginRequest(BaseModel):
+    username: str = Field(min_length=1, max_length=64)
+    password: SecretStr
+
+    @field_validator("password")
+    @classmethod
+    def validate_password_bytes(cls, value: SecretStr) -> SecretStr:
+        return _validate_password_bytes(value)
+
+
+class CreateAccountRequest(BaseModel):
+    username: str = Field(min_length=1, max_length=64)
+    password: SecretStr
+    display_name: str | None = Field(default=None, max_length=255)
+
+    @field_validator("password")
+    @classmethod
+    def validate_password_bytes(cls, value: SecretStr) -> SecretStr:
+        return _validate_password_bytes(value)
+
+
+class AccountOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    username: str
+    display_name: str | None = None
+    created_at: datetime
+    last_login_at: datetime | None = None
+    is_active: bool
+
+
+class LoginResponse(BaseModel):
+    token: str
+    expires_at: datetime
+    account: AccountOut

--- a/apps/aigateway/src/aigateway/core/bootstrap.py
+++ b/apps/aigateway/src/aigateway/core/bootstrap.py
@@ -7,8 +7,8 @@ via the UI rather than seeing a "default" profile they never OAuthed for.
 
 When enabled: if the gateway has no profile index yet but the Claude Code
 CLI has stored credentials on this machine, copy the token blob into the
-gateway's per-profile namespace (`aigateway:anthropic:default`) and seed
-an index with one `anthropic:default` profile in the `authenticated`
+    gateway's account-scoped per-profile namespace and seed an index with
+    one account-owned `anthropic:default` profile in the `authenticated`
 state. The original Claude Code entry is left in place.
 
 Idempotent: if the gateway index already exists, this function is a no-op.
@@ -23,7 +23,13 @@ import os
 from aigateway.core.credential_store import CredentialStore, get_credential_store
 from aigateway.core.errors import BootstrapError
 from aigateway.core.profile_index import ProfileIndexStore
-from aigateway.core.profile_models import Profile, ProfileDefaults, ProfileState
+from aigateway.core.profile_models import (
+    Profile,
+    ProfileDefaults,
+    ProfileState,
+    credential_name_for,
+    profile_id_for,
+)
 from aigateway.plugins.anthropic_provider.auth import keychain_service_for
 
 logger = logging.getLogger(__name__)
@@ -32,6 +38,7 @@ CLAUDE_CODE_SERVICE = "Claude Code-credentials"
 
 
 async def bootstrap_from_claude_code(
+    account_id: str,
     credential_store: CredentialStore | None = None,
     index_store: ProfileIndexStore | None = None,
     cc_account: str | None = None,
@@ -40,9 +47,9 @@ async def bootstrap_from_claude_code(
     idx = index_store or ProfileIndexStore(credential_store=store)
     account = cc_account if cc_account is not None else os.environ.get("USER", "")
 
-    existing = await idx.read()
-    if existing.profiles:
-        logger.debug("bootstrap: gateway index already populated; skipping")
+    existing = await idx.list(account_id)
+    if existing:
+        logger.debug("bootstrap: account index already populated; skipping")
         return
 
     cc_raw = store.read(CLAUDE_CODE_SERVICE, account)
@@ -63,12 +70,13 @@ async def bootstrap_from_claude_code(
         raise BootstrapError(f"Claude Code keychain entry has unexpected shape: {exc}") from exc
 
     store.write(
-        keychain_service_for("default"),
+        keychain_service_for(credential_name_for(account_id, "default")),
         "default",
         json.dumps(converted),
     )
     profile = Profile(
-        id="anthropic:default",
+        id=profile_id_for(account_id, "anthropic", "default"),
+        account_id=account_id,
         provider="anthropic",
         name="default",
         scopes=cc_creds.get("scopes", []),
@@ -76,4 +84,4 @@ async def bootstrap_from_claude_code(
         defaults=ProfileDefaults(),
     )
     await idx.upsert(profile)
-    logger.info("bootstrap: imported Claude Code creds into anthropic:default")
+    logger.info("bootstrap: imported Claude Code creds into account-scoped anthropic:default")

--- a/apps/aigateway/src/aigateway/core/pending_auth.py
+++ b/apps/aigateway/src/aigateway/core/pending_auth.py
@@ -6,6 +6,9 @@ from dataclasses import dataclass
 
 @dataclass
 class PendingAuthEntry:
+    account_id: str
+    provider: str
+    profile_name: str
     profile_id: str
     code_verifier: str
 

--- a/apps/aigateway/src/aigateway/core/plugin_base.py
+++ b/apps/aigateway/src/aigateway/core/plugin_base.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .credential_store import CredentialStore
+    from .profile_index import ProfileIndexStore
 
 
 @dataclass(frozen=True)
@@ -78,4 +82,14 @@ class ProviderPluginBase(ABC):
         Handlers should require `CurrentAccount` unless they are OAuth callback
         targets protected by a pending-auth state nonce.
         """
+        return None
+
+    async def bootstrap_profiles(
+        self,
+        *,
+        account_id: str,
+        credential_store: CredentialStore | None = None,
+        index_store: ProfileIndexStore | None = None,
+    ) -> None:
+        """Import provider-owned local credentials into the profile index, if any."""
         return None

--- a/apps/aigateway/src/aigateway/core/plugin_base.py
+++ b/apps/aigateway/src/aigateway/core/plugin_base.py
@@ -73,5 +73,9 @@ class ProviderPluginBase(ABC):
         return None
 
     def auth_router(self):
-        """Provider-specific auth routes. Default: handled by the shared `routes/auth.py`."""
+        """Provider-specific auth routes.
+
+        Handlers should require `CurrentAccount` unless they are OAuth callback
+        targets protected by a pending-auth state nonce.
+        """
         return None

--- a/apps/aigateway/src/aigateway/core/profile_index.py
+++ b/apps/aigateway/src/aigateway/core/profile_index.py
@@ -9,7 +9,7 @@ from .profile_models import Profile, ProfileIndex
 logger = logging.getLogger(__name__)
 
 INDEX_KEYCHAIN_SERVICE = "aigateway:index"
-_INDEX_ACCOUNT = "default"  # single-tenant; every install has one index
+_INDEX_ACCOUNT = "default"  # one keychain entry holds account-scoped profile metadata
 
 
 class ProfileIndexStore:
@@ -26,6 +26,8 @@ class ProfileIndexStore:
         return ProfileIndex.model_validate_json(raw)
 
     async def upsert(self, profile: Profile) -> None:
+        if not profile.account_id:
+            raise ValueError("profile.account_id is required")
         async with self._lock:
             idx = await self.read()
             idx.profiles = [p for p in idx.profiles if p.id != profile.id] + [profile]
@@ -47,9 +49,17 @@ class ProfileIndexStore:
                 idx.model_dump_json(),
             )
 
-    async def get(self, provider: str, name: str) -> Profile | None:
+    async def list(self, account_id: str, provider: str | None = None) -> list[Profile]:
+        idx = await self.read()
+        return [
+            p
+            for p in idx.profiles
+            if p.account_id == account_id and (provider is None or p.provider == provider)
+        ]
+
+    async def get(self, account_id: str, provider: str, name: str) -> Profile | None:
         idx = await self.read()
         for p in idx.profiles:
-            if p.provider == provider and p.name == name:
+            if p.account_id == account_id and p.provider == provider and p.name == name:
                 return p
         return None

--- a/apps/aigateway/src/aigateway/core/profile_models.py
+++ b/apps/aigateway/src/aigateway/core/profile_models.py
@@ -6,6 +6,14 @@ from enum import Enum
 from pydantic import BaseModel, Field
 
 
+def profile_id_for(account_id: str, provider: str, name: str) -> str:
+    return f"{account_id}:{provider}:{name}"
+
+
+def credential_name_for(account_id: str, name: str) -> str:
+    return f"{account_id}:{name}"
+
+
 class ProfileState(str, Enum):  # noqa: UP042 - keep tuple-base for pydantic-v1 compat
     PENDING = "pending"
     AUTHENTICATED = "authenticated"
@@ -24,7 +32,8 @@ class ProfileDefaults(BaseModel):
 
 
 class Profile(BaseModel):
-    id: str  # f"{provider}:{name}"
+    id: str  # f"{account_id}:{provider}:{name}"
+    account_id: str = ""
     provider: str
     name: str
     account_label: str | None = None

--- a/apps/aigateway/src/aigateway/db.py
+++ b/apps/aigateway/src/aigateway/db.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import os
+from copy import deepcopy
+from typing import Any
+
+from tortoise import Tortoise
+
+DEFAULT_DATABASE_URL = "postgres://aigateway:aigateway@localhost:5432/aigateway"
+
+
+def _default_database_url() -> str:
+    return os.environ.get("AIGATEWAY_DATABASE_URL", DEFAULT_DATABASE_URL)
+
+
+TORTOISE_CONFIG: dict[str, Any] = {
+    "connections": {"default": _default_database_url()},
+    "apps": {
+        "models": {
+            "models": ["aigateway.core.auth.models"],
+            "default_connection": "default",
+            "migrations": "aigateway.migrations",
+        }
+    },
+}
+
+
+def build_tortoise_config(database_url: str) -> dict[str, Any]:
+    config = deepcopy(TORTOISE_CONFIG)
+    config["connections"]["default"] = database_url
+    return config
+
+
+async def init_db(database_url: str) -> None:
+    await Tortoise.init(config=build_tortoise_config(database_url), _enable_global_fallback=True)
+
+
+async def close_db() -> None:
+    await Tortoise.close_connections()

--- a/apps/aigateway/src/aigateway/main.py
+++ b/apps/aigateway/src/aigateway/main.py
@@ -47,7 +47,7 @@ async def _lifespan(app):
             credential_store,
             app.state.settings.jwt_secret,
         )
-        await ensure_admin_account(app.state.settings.admin_password)
+        admin = await ensure_admin_account(app.state.settings.admin_password)
 
         # Auto-import of the developer's Claude Code keychain entry is opt-in.
         # By default the gateway boots with an empty profile index so the user
@@ -62,6 +62,7 @@ async def _lifespan(app):
             if fake_store is not None:
                 try:
                     await bootstrap_from_claude_code(
+                        account_id=str(admin.id),
                         credential_store=fake_store,
                         index_store=app.state.profile_index,
                     )
@@ -69,7 +70,10 @@ async def _lifespan(app):
                     logger.exception("bootstrap failed; gateway will start with empty index")
             else:
                 try:
-                    await bootstrap_from_claude_code(index_store=app.state.profile_index)
+                    await bootstrap_from_claude_code(
+                        account_id=str(admin.id),
+                        index_store=app.state.profile_index,
+                    )
                 except Exception:
                     logger.exception("bootstrap failed; gateway will start with empty index")
         yield

--- a/apps/aigateway/src/aigateway/main.py
+++ b/apps/aigateway/src/aigateway/main.py
@@ -13,6 +13,7 @@ from .core.auth.log_filter import (
     RedactProvisioningTokenFilter,
     install_provisioning_token_redaction,
 )
+from .core.auth.middleware import ANONYMOUS_ACCOUNT_ID
 from .core.bootstrap import bootstrap_from_claude_code
 from .core.credential_store import JsonFileCredentialStore, get_credential_store
 from .core.loader import load_plugins
@@ -48,6 +49,9 @@ async def _lifespan(app):
             app.state.settings.jwt_secret,
         )
         admin = await ensure_admin_account(app.state.settings.admin_password)
+        bootstrap_account_id = (
+            str(admin.id) if app.state.settings.auth_enabled else str(ANONYMOUS_ACCOUNT_ID)
+        )
 
         # Auto-import of the developer's Claude Code keychain entry is opt-in.
         # By default the gateway boots with an empty profile index so the user
@@ -62,7 +66,7 @@ async def _lifespan(app):
             if fake_store is not None:
                 try:
                     await bootstrap_from_claude_code(
-                        account_id=str(admin.id),
+                        account_id=bootstrap_account_id,
                         credential_store=fake_store,
                         index_store=app.state.profile_index,
                     )
@@ -71,7 +75,7 @@ async def _lifespan(app):
             else:
                 try:
                     await bootstrap_from_claude_code(
-                        account_id=str(admin.id),
+                        account_id=bootstrap_account_id,
                         index_store=app.state.profile_index,
                     )
                 except Exception:

--- a/apps/aigateway/src/aigateway/main.py
+++ b/apps/aigateway/src/aigateway/main.py
@@ -7,45 +7,80 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from .config import Settings
+from .core.auth.bootstrap_admin import ensure_admin_account
+from .core.auth.jwt_secret import get_or_create_jwt_secret
+from .core.auth.log_filter import (
+    RedactProvisioningTokenFilter,
+    install_provisioning_token_redaction,
+)
 from .core.bootstrap import bootstrap_from_claude_code
-from .core.credential_store import JsonFileCredentialStore
+from .core.credential_store import JsonFileCredentialStore, get_credential_store
 from .core.loader import load_plugins
 from .core.pending_auth import PendingAuthTable
 from .core.profile_index import ProfileIndexStore
 from .core.registry import ProviderRegistry
-from .routes import auth, chat, health, models
+from .db import close_db, init_db
+from .routes import accounts, auth, auth_session, chat, health, models
 
 logger = logging.getLogger(__name__)
 
 
+def _attach_log_filter() -> None:
+    install_provisioning_token_redaction()
+    for name in ("", "uvicorn.access", "uvicorn.error", "aigateway"):
+        target = logging.getLogger(name)
+        if not any(isinstance(f, RedactProvisioningTokenFilter) for f in target.filters):
+            target.addFilter(RedactProvisioningTokenFilter())
+        for handler in target.handlers:
+            if not any(isinstance(f, RedactProvisioningTokenFilter) for f in handler.filters):
+                handler.addFilter(RedactProvisioningTokenFilter())
+
+
 @asynccontextmanager
 async def _lifespan(app):
-    # Auto-import of the developer's Claude Code keychain entry is opt-in.
-    # By default the gateway boots with an empty profile index so the user
-    # explicitly authenticates via the UI rather than seeing a "default"
-    # profile they never OAuthed for. Set
-    # AIGATEWAY_BOOTSTRAP_FROM_CLAUDE_CODE=1 to restore the legacy import.
-    #
-    # When the fake-keychain test hook is active, bootstrap (if enabled)
-    # uses the same fake store so it cannot pull in the developer's real
-    # Claude Code credentials behind the test's back.
-    if os.getenv("AIGATEWAY_BOOTSTRAP_FROM_CLAUDE_CODE") == "1":
+    database_url = app.state.settings.database_url.get_secret_value()
+    await init_db(database_url)
+    try:
         fake_store = getattr(app.state, "_fake_credential_store", None)
-        try:
+        credential_store = fake_store if fake_store is not None else get_credential_store()
+        app.state.jwt_secret = await get_or_create_jwt_secret(
+            credential_store,
+            app.state.settings.jwt_secret,
+        )
+        await ensure_admin_account(app.state.settings.admin_password)
+
+        # Auto-import of the developer's Claude Code keychain entry is opt-in.
+        # By default the gateway boots with an empty profile index so the user
+        # explicitly authenticates via the UI rather than seeing a "default"
+        # profile they never OAuthed for. Set
+        # AIGATEWAY_BOOTSTRAP_FROM_CLAUDE_CODE=1 to restore the legacy import.
+        #
+        # When the fake-keychain test hook is active, bootstrap (if enabled)
+        # uses the same fake store so it cannot pull in the developer's real
+        # Claude Code credentials behind the test's back.
+        if os.getenv("AIGATEWAY_BOOTSTRAP_FROM_CLAUDE_CODE") == "1":
             if fake_store is not None:
-                await bootstrap_from_claude_code(
-                    credential_store=fake_store, index_store=app.state.profile_index
-                )
+                try:
+                    await bootstrap_from_claude_code(
+                        credential_store=fake_store,
+                        index_store=app.state.profile_index,
+                    )
+                except Exception:
+                    logger.exception("bootstrap failed; gateway will start with empty index")
             else:
-                await bootstrap_from_claude_code(index_store=app.state.profile_index)
-        except Exception:
-            logger.exception("bootstrap failed; gateway will start with empty index")
-    yield
+                try:
+                    await bootstrap_from_claude_code(index_store=app.state.profile_index)
+                except Exception:
+                    logger.exception("bootstrap failed; gateway will start with empty index")
+        yield
+    finally:
+        await close_db()
 
 
 def create_app(settings: Settings | None = None) -> FastAPI:
     if settings is None:
         settings = Settings()
+    _attach_log_filter()
     app = FastAPI(title="aigateway", version="0.1.0", lifespan=_lifespan)
     app.state.settings = settings
 
@@ -107,6 +142,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         if auth_router is not None:
             app.include_router(auth_router, prefix=f"/v1/auth/{plugin.custom_llm_provider}")
 
+    app.include_router(auth_session.router)
+    app.include_router(accounts.router)
     app.include_router(auth.router)
     app.include_router(health.router)
     app.include_router(models.router)

--- a/apps/aigateway/src/aigateway/main.py
+++ b/apps/aigateway/src/aigateway/main.py
@@ -14,7 +14,6 @@ from .core.auth.log_filter import (
     install_provisioning_token_redaction,
 )
 from .core.auth.middleware import ANONYMOUS_ACCOUNT_ID
-from .core.bootstrap import bootstrap_from_claude_code
 from .core.credential_store import JsonFileCredentialStore, get_credential_store
 from .core.loader import load_plugins
 from .core.pending_auth import PendingAuthTable
@@ -63,23 +62,18 @@ async def _lifespan(app):
         # uses the same fake store so it cannot pull in the developer's real
         # Claude Code credentials behind the test's back.
         if os.getenv("AIGATEWAY_BOOTSTRAP_FROM_CLAUDE_CODE") == "1":
-            if fake_store is not None:
+            for plugin in app.state.providers.all():
                 try:
-                    await bootstrap_from_claude_code(
+                    await plugin.bootstrap_profiles(
                         account_id=bootstrap_account_id,
-                        credential_store=fake_store,
+                        credential_store=credential_store,
                         index_store=app.state.profile_index,
                     )
                 except Exception:
-                    logger.exception("bootstrap failed; gateway will start with empty index")
-            else:
-                try:
-                    await bootstrap_from_claude_code(
-                        account_id=bootstrap_account_id,
-                        index_store=app.state.profile_index,
+                    logger.exception(
+                        "bootstrap failed for provider %s; gateway will continue",
+                        plugin.custom_llm_provider,
                     )
-                except Exception:
-                    logger.exception("bootstrap failed; gateway will start with empty index")
         yield
     finally:
         await close_db()

--- a/apps/aigateway/src/aigateway/migrations/0001_initial_accounts.py
+++ b/apps/aigateway/src/aigateway/migrations/0001_initial_accounts.py
@@ -1,0 +1,31 @@
+from uuid import uuid4
+
+from tortoise import fields, migrations
+from tortoise.migrations import operations as ops
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    operations = [
+        ops.CreateModel(
+            name="Account",
+            fields=[
+                (
+                    "id",
+                    fields.UUIDField(primary_key=True, default=uuid4, unique=True, db_index=True),
+                ),
+                ("username", fields.CharField(unique=True, db_index=True, max_length=64)),
+                ("password_hash", fields.CharField(max_length=255)),
+                ("display_name", fields.CharField(null=True, max_length=255)),
+                ("created_at", fields.DatetimeField(auto_now=False, auto_now_add=True)),
+                (
+                    "last_login_at",
+                    fields.DatetimeField(null=True, auto_now=False, auto_now_add=False),
+                ),
+                ("is_active", fields.BooleanField(default=True)),
+            ],
+            options={"table": "accounts", "app": "models", "pk_attr": "id"},
+            bases=["Model"],
+        ),
+    ]

--- a/apps/aigateway/src/aigateway/migrations/__init__.py
+++ b/apps/aigateway/src/aigateway/migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Tortoise built-in migrations for aigateway."""

--- a/apps/aigateway/src/aigateway/plugins/anthropic_provider/auth.py
+++ b/apps/aigateway/src/aigateway/plugins/anthropic_provider/auth.py
@@ -1,7 +1,7 @@
-"""Anthropic OAuth strategy keyed by profile name.
+"""Anthropic OAuth strategy keyed by an account-scoped credential name.
 
 Each profile has its own keychain entry under
-`aigateway:anthropic:<profile_name>`. The token blob is the flat shape
+`aigateway:anthropic:<account_id>:<profile_name>`. The token blob is the flat shape
 defined in the spec (snake_case keys; expires_at_ms in milliseconds).
 """
 
@@ -31,7 +31,7 @@ def keychain_service_for(profile_name: str) -> str:
     return f"aigateway:anthropic:{profile_name}"
 
 
-_ACCOUNT = "default"  # single account inside each provider keychain entry
+_ACCOUNT = "default"  # keychain account is stable; the service name carries ownership
 
 
 class AnthropicOAuth(BaseOAuthStrategy):

--- a/apps/aigateway/src/aigateway/plugins/anthropic_provider/bootstrap.py
+++ b/apps/aigateway/src/aigateway/plugins/anthropic_provider/bootstrap.py
@@ -1,18 +1,4 @@
-"""One-time import of Claude Code's keychain entry into the gateway's index.
-
-Opt-in: only runs on FastAPI startup when the env var
-``AIGATEWAY_BOOTSTRAP_FROM_CLAUDE_CODE=1`` is set. By default the gateway
-boots with an empty profile index so the user explicitly authenticates
-via the UI rather than seeing a "default" profile they never OAuthed for.
-
-When enabled: if the gateway has no profile index yet but the Claude Code
-CLI has stored credentials on this machine, copy the token blob into the
-    gateway's account-scoped per-profile namespace and seed an index with
-    one account-owned `anthropic:default` profile in the `authenticated`
-state. The original Claude Code entry is left in place.
-
-Idempotent: if the gateway index already exists, this function is a no-op.
-"""
+"""Anthropic bootstrap helpers for importing Claude Code credentials."""
 
 from __future__ import annotations
 
@@ -30,7 +16,8 @@ from aigateway.core.profile_models import (
     credential_name_for,
     profile_id_for,
 )
-from aigateway.plugins.anthropic_provider.auth import keychain_service_for
+
+from .auth import keychain_service_for
 
 logger = logging.getLogger(__name__)
 

--- a/apps/aigateway/src/aigateway/plugins/anthropic_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/anthropic_provider/plugin.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from aigateway.core.plugin_base import (
     ModelEntry,
     OAuthConfig,
@@ -8,6 +10,7 @@ from aigateway.core.plugin_base import (
 )
 
 from .auth import AnthropicOAuth
+from .bootstrap import bootstrap_from_claude_code
 from .models import MODELS
 from .oauth_config import (
     ANTHROPIC_AUTHORIZE_EXTRA_PARAMS,
@@ -17,6 +20,10 @@ from .oauth_config import (
     ANTHROPIC_SCOPES,
     ANTHROPIC_TOKEN_URL,
 )
+
+if TYPE_CHECKING:
+    from aigateway.core.credential_store import CredentialStore
+    from aigateway.core.profile_index import ProfileIndexStore
 
 
 class AnthropicProviderPlugin(ProviderPluginBase):
@@ -37,6 +44,19 @@ class AnthropicProviderPlugin(ProviderPluginBase):
 
     def oauth_strategy_for(self, profile_name: str) -> OAuthStrategy:
         return AnthropicOAuth(profile_name=profile_name)
+
+    async def bootstrap_profiles(
+        self,
+        *,
+        account_id: str,
+        credential_store: CredentialStore | None = None,
+        index_store: ProfileIndexStore | None = None,
+    ) -> None:
+        await bootstrap_from_claude_code(
+            account_id=account_id,
+            credential_store=credential_store,
+            index_store=index_store,
+        )
 
 
 PLUGIN = AnthropicProviderPlugin()

--- a/apps/aigateway/src/aigateway/routes/__init__.py
+++ b/apps/aigateway/src/aigateway/routes/__init__.py
@@ -1,0 +1,5 @@
+"""Gateway route modules.
+
+`auth.py` owns OAuth profile routes. `auth_session.py` owns account login and
+session routes.
+"""

--- a/apps/aigateway/src/aigateway/routes/accounts.py
+++ b/apps/aigateway/src/aigateway/routes/accounts.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.routing import APIRoute
+from pydantic import SecretStr
+from starlette.responses import Response
+from tortoise.exceptions import IntegrityError
+
+from ..core.auth.models import Account
+from ..core.auth.passwords import hash_password
+from ..core.auth.provisioning import PROVISIONING_HEADER, verify_provisioning_token
+from ..core.auth.schemas import AccountOut, CreateAccountRequest
+
+logger = logging.getLogger(__name__)
+
+
+def _audit_provisioning_attempt(request: Request, status_code: int) -> None:
+    if status_code == 201:
+        username = getattr(request.state, "provisioned_username", None)
+        if username is None:
+            logger.info("account_created")
+        else:
+            logger.info("account_created username=%s", username)
+        return
+    username = getattr(request.state, "provisioning_username", None)
+    if username is None:
+        logger.info("provisioning_token_rejected status_code=%d", status_code)
+    else:
+        logger.info("provisioning_token_rejected status_code=%d username=%s", status_code, username)
+
+
+class ProvisioningAuditRoute(APIRoute):
+    def get_route_handler(self) -> Callable[[Request], Awaitable[Response]]:
+        original_handler = super().get_route_handler()
+
+        async def audited_handler(request: Request) -> Response:
+            try:
+                response = await original_handler(request)
+            except HTTPException as exc:
+                _audit_provisioning_attempt(request, exc.status_code)
+                raise
+            except RequestValidationError:
+                _audit_provisioning_attempt(request, 422)
+                raise
+            except Exception:
+                _audit_provisioning_attempt(request, 500)
+                raise
+            _audit_provisioning_attempt(request, response.status_code)
+            return response
+
+        return audited_handler
+
+
+router = APIRouter(route_class=ProvisioningAuditRoute)
+
+_BAD_TOKEN = {"code": "invalid_provisioning_token", "message": "Invalid provisioning token"}
+
+
+async def require_provisioning_token(
+    request: Request,
+    token: Annotated[str | None, Header(alias=PROVISIONING_HEADER)] = None,
+) -> SecretStr:
+    expected = request.app.state.settings.provisioning_token
+    if expected is None:
+        raise HTTPException(status_code=503, detail="Provisioning is disabled")
+    if not verify_provisioning_token(token, expected):
+        raise HTTPException(status_code=401, detail=_BAD_TOKEN)
+    return expected
+
+
+@router.post("/v1/accounts", status_code=201, response_model=AccountOut)
+async def create_account(
+    request: Request,
+    body: CreateAccountRequest,
+    _token: Annotated[SecretStr, Depends(require_provisioning_token)],
+) -> AccountOut:
+    request.state.provisioning_username = body.username
+    password_hash = await hash_password(body.password)
+    try:
+        account = await Account.create(
+            username=body.username,
+            password_hash=password_hash,
+            display_name=body.display_name,
+        )
+    except IntegrityError as exc:
+        raise HTTPException(status_code=409, detail="username already exists") from exc
+
+    request.state.provisioned_username = account.username
+    return AccountOut.model_validate(account)

--- a/apps/aigateway/src/aigateway/routes/accounts.py
+++ b/apps/aigateway/src/aigateway/routes/accounts.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Awaitable, Callable
-from typing import Annotated
+from collections.abc import Callable, Coroutine
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
@@ -35,7 +35,7 @@ def _audit_provisioning_attempt(request: Request, status_code: int) -> None:
 
 
 class ProvisioningAuditRoute(APIRoute):
-    def get_route_handler(self) -> Callable[[Request], Awaitable[Response]]:
+    def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
         original_handler = super().get_route_handler()
 
         async def audited_handler(request: Request) -> Response:

--- a/apps/aigateway/src/aigateway/routes/auth.py
+++ b/apps/aigateway/src/aigateway/routes/auth.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
+from ..core.auth.middleware import CurrentAccount
 from ..core.oauth_pkce import generate_pkce, generate_state
 from ..core.pending_auth import PendingAuthEntry
 from ..core.profile_index import ProfileIndexStore
@@ -28,19 +29,19 @@ def _pending(request: Request):
 
 
 @router.get("/v1/auth/profiles")
-async def list_profiles(request: Request) -> dict:
+async def list_profiles(request: Request, _current: CurrentAccount) -> dict:
     idx = await _index_store(request).read()
     return {"profiles": [p.model_dump(mode="json") for p in idx.profiles]}
 
 
 @router.get("/v1/auth/{provider}/profiles")
-async def list_provider_profiles(provider: str, request: Request) -> dict:
+async def list_provider_profiles(provider: str, request: Request, _current: CurrentAccount) -> dict:
     idx = await _index_store(request).read()
     return {"profiles": [p.model_dump(mode="json") for p in idx.profiles if p.provider == provider]}
 
 
 @router.get("/v1/auth/{provider}/profiles/{name}")
-async def get_profile(provider: str, name: str, request: Request) -> dict:
+async def get_profile(provider: str, name: str, request: Request, _current: CurrentAccount) -> dict:
     p = await _index_store(request).get(provider, name)
     if p is None:
         raise HTTPException(
@@ -56,7 +57,12 @@ class StartAuthRequest(BaseModel):
 
 
 @router.post("/v1/auth/{provider}/profiles", status_code=201)
-async def start_oauth(provider: str, body: StartAuthRequest, request: Request) -> dict:
+async def start_oauth(
+    provider: str,
+    body: StartAuthRequest,
+    request: Request,
+    _current: CurrentAccount,
+) -> dict:
     plugin = _registry(request).get(provider)
     if plugin is None:
         raise HTTPException(
@@ -162,7 +168,7 @@ async def _complete_oauth(provider: str, code: str, state: str, request: Request
     Used by both the GET browser-redirect callback and the POST manual
     paste-code endpoint. Raises HTTPException on failure.
     """
-    pending = _pending(request).pop(state)
+    pending = _pending(request).peek(state)
     if pending is None:
         raise HTTPException(
             status_code=400,
@@ -197,6 +203,7 @@ async def _complete_oauth(provider: str, code: str, state: str, request: Request
     if p is not None:
         p.state = ProfileState.AUTHENTICATED
         await _index_store(request).upsert(p)
+    _pending(request).pop(state)
 
 
 async def _generic_callback(provider: str, code: str, state: str, request: Request):
@@ -210,7 +217,12 @@ class ExchangeCodeRequest(BaseModel):
 
 
 @router.post("/v1/auth/{provider}/exchange-code")
-async def exchange_code(provider: str, body: ExchangeCodeRequest, request: Request) -> dict:
+async def exchange_code(
+    provider: str,
+    body: ExchangeCodeRequest,
+    request: Request,
+    _current: CurrentAccount,
+) -> dict:
     """Manual paste-code path for OAuth flows where the provider shows the
     authorization code on screen instead of redirecting (e.g. claude.ai/oauth
     with `code=true`).
@@ -220,7 +232,9 @@ async def exchange_code(provider: str, body: ExchangeCodeRequest, request: Reque
 
 
 @router.get("/v1/auth/{provider}/profiles/{name}/status")
-async def profile_status(provider: str, name: str, request: Request) -> dict:
+async def profile_status(
+    provider: str, name: str, request: Request, _current: CurrentAccount
+) -> dict:
     p = await _index_store(request).get(provider, name)
     if p is None:
         raise HTTPException(
@@ -241,7 +255,11 @@ class PatchProfileRequest(BaseModel):
 
 @router.patch("/v1/auth/{provider}/profiles/{name}")
 async def patch_profile(
-    provider: str, name: str, body: PatchProfileRequest, request: Request
+    provider: str,
+    name: str,
+    body: PatchProfileRequest,
+    request: Request,
+    _current: CurrentAccount,
 ) -> dict:
     idx = _index_store(request)
     p = await idx.get(provider, name)
@@ -256,7 +274,7 @@ async def patch_profile(
 
 
 @router.delete("/v1/auth/{provider}/profiles/{name}", status_code=204)
-async def delete_profile(provider: str, name: str, request: Request):
+async def delete_profile(provider: str, name: str, request: Request, _current: CurrentAccount):
     plugin = _registry(request).get(provider)
     if plugin is None:
         raise HTTPException(status_code=404, detail={"code": "unknown_provider"})
@@ -271,7 +289,9 @@ async def delete_profile(provider: str, name: str, request: Request):
 
 
 @router.post("/v1/auth/{provider}/profiles/{name}/refresh")
-async def refresh_profile(provider: str, name: str, request: Request) -> dict:
+async def refresh_profile(
+    provider: str, name: str, request: Request, _current: CurrentAccount
+) -> dict:
     plugin = _registry(request).get(provider)
     if plugin is None:
         raise HTTPException(status_code=404, detail={"code": "unknown_provider"})

--- a/apps/aigateway/src/aigateway/routes/auth.py
+++ b/apps/aigateway/src/aigateway/routes/auth.py
@@ -328,11 +328,11 @@ async def refresh_profile(
     if plugin is None:
         raise HTTPException(status_code=404, detail={"code": "unknown_provider"})
     account_id = str(current.id)
+    p = await _index_store(request).get(account_id, provider, name)
+    if p is None:
+        raise HTTPException(status_code=404, detail={"code": "profile_not_found"})
     strategy = plugin.oauth_strategy_for(credential_name_for(account_id, name))
     if strategy is None:
         raise HTTPException(status_code=400, detail={"code": "provider_does_not_use_oauth"})
     await strategy.refresh()
-    p = await _index_store(request).get(account_id, provider, name)
-    if p is None:
-        raise HTTPException(status_code=404, detail={"code": "profile_not_found"})
     return p.model_dump(mode="json")

--- a/apps/aigateway/src/aigateway/routes/auth.py
+++ b/apps/aigateway/src/aigateway/routes/auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from html import escape
 from urllib.parse import urlencode
 
 from fastapi import APIRouter, HTTPException, Request
@@ -10,7 +11,13 @@ from ..core.auth.middleware import CurrentAccount
 from ..core.oauth_pkce import generate_pkce, generate_state
 from ..core.pending_auth import PendingAuthEntry
 from ..core.profile_index import ProfileIndexStore
-from ..core.profile_models import Profile, ProfileDefaults, ProfileState
+from ..core.profile_models import (
+    Profile,
+    ProfileDefaults,
+    ProfileState,
+    credential_name_for,
+    profile_id_for,
+)
 from ..plugins.anthropic_provider import auth as anthropic_auth_module
 
 router = APIRouter()
@@ -29,20 +36,20 @@ def _pending(request: Request):
 
 
 @router.get("/v1/auth/profiles")
-async def list_profiles(request: Request, _current: CurrentAccount) -> dict:
-    idx = await _index_store(request).read()
-    return {"profiles": [p.model_dump(mode="json") for p in idx.profiles]}
+async def list_profiles(request: Request, current: CurrentAccount) -> dict:
+    profiles = await _index_store(request).list(str(current.id))
+    return {"profiles": [p.model_dump(mode="json") for p in profiles]}
 
 
 @router.get("/v1/auth/{provider}/profiles")
-async def list_provider_profiles(provider: str, request: Request, _current: CurrentAccount) -> dict:
-    idx = await _index_store(request).read()
-    return {"profiles": [p.model_dump(mode="json") for p in idx.profiles if p.provider == provider]}
+async def list_provider_profiles(provider: str, request: Request, current: CurrentAccount) -> dict:
+    profiles = await _index_store(request).list(str(current.id), provider)
+    return {"profiles": [p.model_dump(mode="json") for p in profiles]}
 
 
 @router.get("/v1/auth/{provider}/profiles/{name}")
-async def get_profile(provider: str, name: str, request: Request, _current: CurrentAccount) -> dict:
-    p = await _index_store(request).get(provider, name)
+async def get_profile(provider: str, name: str, request: Request, current: CurrentAccount) -> dict:
+    p = await _index_store(request).get(str(current.id), provider, name)
     if p is None:
         raise HTTPException(
             status_code=404,
@@ -61,7 +68,7 @@ async def start_oauth(
     provider: str,
     body: StartAuthRequest,
     request: Request,
-    _current: CurrentAccount,
+    current: CurrentAccount,
 ) -> dict:
     plugin = _registry(request).get(provider)
     if plugin is None:
@@ -73,13 +80,20 @@ async def start_oauth(
     if cfg is None:
         raise HTTPException(status_code=400, detail={"code": "provider_does_not_use_oauth"})
 
-    profile_id = f"{provider}:{body.name}"
+    account_id = str(current.id)
+    profile_id = profile_id_for(account_id, provider, body.name)
     code_verifier, code_challenge = generate_pkce()
     state = generate_state()
 
     _pending(request).put(
         state,
-        PendingAuthEntry(profile_id=profile_id, code_verifier=code_verifier),
+        PendingAuthEntry(
+            account_id=account_id,
+            provider=provider,
+            profile_name=body.name,
+            profile_id=profile_id,
+            code_verifier=code_verifier,
+        ),
     )
 
     # The Claude Code public OAuth client (and similar public clients) only
@@ -103,6 +117,7 @@ async def start_oauth(
 
     profile = Profile(
         id=profile_id,
+        account_id=account_id,
         provider=provider,
         name=body.name,
         state=ProfileState.PENDING,
@@ -127,6 +142,11 @@ _CALLBACK_HTML = """<!doctype html>
 async def oauth_callback(code: str, state: str, request: Request):
     """Provider-agnostic OAuth callback.
 
+    This route intentionally does not require a JWT because OAuth providers
+    redirect browser tabs here after the user leaves the app. The pending-auth
+    state nonce is the callback credential; it maps back to the initiating
+    account and profile.
+
     Anthropic's public Claude Code OAuth client (and most OAuth providers
     using public clients) only accepts ``http://localhost:*/callback`` as
     the redirect URI — i.e. the path is fixed at ``/callback`` and is not
@@ -139,7 +159,7 @@ async def oauth_callback(code: str, state: str, request: Request):
             status_code=400,
             detail={"code": "unknown_state", "message": "OAuth state not recognized or expired"},
         )
-    provider, _name = pending_entry.profile_id.split(":", 1)
+    provider = pending_entry.provider
     try:
         return await _generic_callback(provider, code, state, request)
     except Exception as exc:
@@ -149,8 +169,9 @@ async def oauth_callback(code: str, state: str, request: Request):
         return HTMLResponse(
             f"<!doctype html><html><body>"
             f"<h2>Authentication failed</h2>"
-            f"<p>Provider: {provider}</p>"
-            f"<pre style='white-space:pre-wrap'>{type(exc).__name__}: {exc}</pre>"
+            f"<p>Provider: {escape(provider)}</p>"
+            f"<pre style='white-space:pre-wrap'>{escape(type(exc).__name__)}: "
+            f"{escape(str(exc))}</pre>"
             f"</body></html>",
             status_code=500,
         )
@@ -159,10 +180,17 @@ async def oauth_callback(code: str, state: str, request: Request):
 # Back-compat: older OAuth flows (and tests) still use the per-provider path.
 @router.get("/v1/auth/anthropic/callback")
 async def anthropic_callback(code: str, state: str, request: Request):
+    """Unauthenticated OAuth callback protected by the pending-auth state nonce."""
     return await _generic_callback("anthropic", code, state, request)
 
 
-async def _complete_oauth(provider: str, code: str, state: str, request: Request) -> None:
+async def _complete_oauth(
+    provider: str,
+    code: str,
+    state: str,
+    request: Request,
+    current_account_id: str | None = None,
+) -> None:
     """Run the OAuth token exchange and persist credentials.
 
     Used by both the GET browser-redirect callback and the POST manual
@@ -175,9 +203,12 @@ async def _complete_oauth(provider: str, code: str, state: str, request: Request
             detail={"code": "unknown_state", "message": "OAuth state not recognized or expired"},
         )
 
-    expected_provider, name = pending.profile_id.split(":", 1)
-    if expected_provider != provider:
+    if pending.provider != provider:
         raise HTTPException(status_code=400, detail={"code": "provider_mismatch"})
+    account_id = pending.account_id
+    if current_account_id is not None and current_account_id != account_id:
+        raise HTTPException(status_code=404, detail={"code": "profile_not_found"})
+    name = pending.profile_name
 
     factory = getattr(request.app.state, f"{provider}_http_factory", None)
     # Must match the redirect_uri sent to /authorize. Both the start-OAuth
@@ -193,13 +224,13 @@ async def _complete_oauth(provider: str, code: str, state: str, request: Request
     )
 
     plugin = _registry(request).get(provider)
-    strategy = plugin.oauth_strategy_for(name)
+    strategy = plugin.oauth_strategy_for(credential_name_for(account_id, name))
     # Inject the same credential store as the profile index so tests/fake keychain work.
     if hasattr(strategy, "_store"):
         strategy._store = _index_store(request)._store
     strategy.set_credentials(creds)
 
-    p = await _index_store(request).get(provider, name)
+    p = await _index_store(request).get(account_id, provider, name)
     if p is not None:
         p.state = ProfileState.AUTHENTICATED
         await _index_store(request).upsert(p)
@@ -221,21 +252,21 @@ async def exchange_code(
     provider: str,
     body: ExchangeCodeRequest,
     request: Request,
-    _current: CurrentAccount,
+    current: CurrentAccount,
 ) -> dict:
     """Manual paste-code path for OAuth flows where the provider shows the
     authorization code on screen instead of redirecting (e.g. claude.ai/oauth
     with `code=true`).
     """
-    await _complete_oauth(provider, body.code, body.state, request)
+    await _complete_oauth(provider, body.code, body.state, request, str(current.id))
     return {"state": "authenticated"}
 
 
 @router.get("/v1/auth/{provider}/profiles/{name}/status")
 async def profile_status(
-    provider: str, name: str, request: Request, _current: CurrentAccount
+    provider: str, name: str, request: Request, current: CurrentAccount
 ) -> dict:
-    p = await _index_store(request).get(provider, name)
+    p = await _index_store(request).get(str(current.id), provider, name)
     if p is None:
         raise HTTPException(
             status_code=404,
@@ -259,10 +290,10 @@ async def patch_profile(
     name: str,
     body: PatchProfileRequest,
     request: Request,
-    _current: CurrentAccount,
+    current: CurrentAccount,
 ) -> dict:
     idx = _index_store(request)
-    p = await idx.get(provider, name)
+    p = await idx.get(str(current.id), provider, name)
     if p is None:
         raise HTTPException(status_code=404, detail={"code": "profile_not_found"})
     if body.defaults is not None:
@@ -274,14 +305,15 @@ async def patch_profile(
 
 
 @router.delete("/v1/auth/{provider}/profiles/{name}", status_code=204)
-async def delete_profile(provider: str, name: str, request: Request, _current: CurrentAccount):
+async def delete_profile(provider: str, name: str, request: Request, current: CurrentAccount):
     plugin = _registry(request).get(provider)
     if plugin is None:
         raise HTTPException(status_code=404, detail={"code": "unknown_provider"})
-    p = await _index_store(request).get(provider, name)
+    account_id = str(current.id)
+    p = await _index_store(request).get(account_id, provider, name)
     if p is None:
         raise HTTPException(status_code=404, detail={"code": "profile_not_found"})
-    strategy = plugin.oauth_strategy_for(name)
+    strategy = plugin.oauth_strategy_for(credential_name_for(account_id, name))
     if strategy is not None and hasattr(strategy, "_store"):
         strategy._store = _index_store(request)._store
         strategy._store.delete(strategy.keychain_service(), strategy.keychain_account())
@@ -290,16 +322,17 @@ async def delete_profile(provider: str, name: str, request: Request, _current: C
 
 @router.post("/v1/auth/{provider}/profiles/{name}/refresh")
 async def refresh_profile(
-    provider: str, name: str, request: Request, _current: CurrentAccount
+    provider: str, name: str, request: Request, current: CurrentAccount
 ) -> dict:
     plugin = _registry(request).get(provider)
     if plugin is None:
         raise HTTPException(status_code=404, detail={"code": "unknown_provider"})
-    strategy = plugin.oauth_strategy_for(name)
+    account_id = str(current.id)
+    strategy = plugin.oauth_strategy_for(credential_name_for(account_id, name))
     if strategy is None:
         raise HTTPException(status_code=400, detail={"code": "provider_does_not_use_oauth"})
     await strategy.refresh()
-    p = await _index_store(request).get(provider, name)
+    p = await _index_store(request).get(account_id, provider, name)
     if p is None:
         raise HTTPException(status_code=404, detail={"code": "profile_not_found"})
     return p.model_dump(mode="json")

--- a/apps/aigateway/src/aigateway/routes/auth_session.py
+++ b/apps/aigateway/src/aigateway/routes/auth_session.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, HTTPException, Request
+
+from ..core.auth.jwt import encode_token
+from ..core.auth.middleware import CurrentAccount
+from ..core.auth.models import Account
+from ..core.auth.passwords import verify_password_or_dummy
+from ..core.auth.schemas import AccountOut, LoginRequest, LoginResponse
+
+router = APIRouter()
+
+_INVALID_CREDENTIALS = {"code": "invalid_credentials", "message": "Invalid username or password"}
+
+
+@router.post("/v1/auth/login", response_model=LoginResponse)
+async def login(body: LoginRequest, request: Request) -> LoginResponse:
+    """Authenticate an account and return a stateless JWT session.
+
+    Inactive accounts return 423. This leaks that a username exists, but v1 is
+    single-tenant/admin-provisioned and the distinction is operationally useful.
+    """
+    account = await Account.get_or_none(username=body.username)
+    password_hash = account.password_hash if account is not None else None
+    password_ok = await verify_password_or_dummy(body.password, password_hash)
+    if account is None or not password_ok:
+        raise HTTPException(status_code=401, detail=_INVALID_CREDENTIALS)
+    if not account.is_active:
+        raise HTTPException(status_code=423, detail={"code": "account_locked"})
+
+    account.last_login_at = datetime.now(UTC)
+    await account.save(update_fields=["last_login_at"])
+    token, expires_at = encode_token(
+        account_id=str(account.id),
+        username=account.username,
+        secret=request.app.state.jwt_secret,
+        ttl_seconds=request.app.state.settings.jwt_ttl_seconds,
+    )
+    return LoginResponse(
+        token=token,
+        expires_at=expires_at,
+        account=AccountOut.model_validate(account),
+    )
+
+
+@router.get("/v1/auth/me", response_model=AccountOut)
+async def me(current: CurrentAccount) -> AccountOut:
+    return AccountOut.model_validate(current)

--- a/apps/aigateway/src/aigateway/routes/chat.py
+++ b/apps/aigateway/src/aigateway/routes/chat.py
@@ -13,7 +13,7 @@ from fastapi.responses import StreamingResponse
 from ..core.auth.middleware import CurrentAccount
 from ..core.errors import AuthError, CredentialNotFoundError
 from ..core.profile_index import ProfileIndexStore
-from ..core.profile_models import ProfileDefaults, ProfileState
+from ..core.profile_models import ProfileDefaults, ProfileState, credential_name_for
 from ..core.registry import ProviderRegistry
 
 logger = logging.getLogger(__name__)
@@ -50,7 +50,7 @@ def _apply_defaults(body: dict[str, Any], defaults: ProfileDefaults) -> dict[str
 
 
 @router.post("/v1/chat/completions")
-async def chat_completions(request: Request, _current: CurrentAccount) -> Any:
+async def chat_completions(request: Request, current: CurrentAccount) -> Any:
     body = await request.json()
     if not isinstance(body, dict) or "model" not in body or "messages" not in body:
         raise HTTPException(status_code=400, detail="model and messages are required")
@@ -67,7 +67,8 @@ async def chat_completions(request: Request, _current: CurrentAccount) -> Any:
         raise HTTPException(status_code=400, detail=f"unknown provider: {provider}")
 
     idx: ProfileIndexStore = request.app.state.profile_index
-    profile = await idx.get(provider, profile_name)
+    account_id = str(current.id)
+    profile = await idx.get(account_id, provider, profile_name)
     if profile is None:
         raise HTTPException(
             status_code=404,
@@ -89,7 +90,7 @@ async def chat_completions(request: Request, _current: CurrentAccount) -> Any:
 
     body = _apply_defaults(body, profile.defaults)
 
-    strategy = plugin.oauth_strategy_for(profile_name)
+    strategy = plugin.oauth_strategy_for(credential_name_for(account_id, profile_name))
     if strategy is not None:
         # Same `_store` injection pattern Tasks 7-9 introduced for parity with the
         # tests' fake keychain. In production both reference the same singleton.

--- a/apps/aigateway/src/aigateway/routes/chat.py
+++ b/apps/aigateway/src/aigateway/routes/chat.py
@@ -10,6 +10,7 @@ import litellm
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
+from ..core.auth.middleware import CurrentAccount
 from ..core.errors import AuthError, CredentialNotFoundError
 from ..core.profile_index import ProfileIndexStore
 from ..core.profile_models import ProfileDefaults, ProfileState
@@ -49,7 +50,7 @@ def _apply_defaults(body: dict[str, Any], defaults: ProfileDefaults) -> dict[str
 
 
 @router.post("/v1/chat/completions")
-async def chat_completions(request: Request) -> Any:
+async def chat_completions(request: Request, _current: CurrentAccount) -> Any:
     body = await request.json()
     if not isinstance(body, dict) or "model" not in body or "messages" not in body:
         raise HTTPException(status_code=400, detail="model and messages are required")

--- a/apps/aigateway/src/aigateway/routes/models.py
+++ b/apps/aigateway/src/aigateway/routes/models.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Request
 
+from ..core.auth.middleware import CurrentAccount
+
 router = APIRouter()
 
 
 @router.get("/v1/models")
-async def list_models(request: Request) -> dict:
+async def list_models(request: Request, _current: CurrentAccount) -> dict:
     """OpenAI-compatible model listing, aggregated from all loaded provider plugins."""
     registry = request.app.state.providers
     data = []

--- a/apps/aigateway/tests/conftest.py
+++ b/apps/aigateway/tests/conftest.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Callable, Generator
+from pathlib import Path
+
 import pytest
+from fastapi.testclient import TestClient
+from tortoise import Tortoise
 
 from aigateway.core.credential_store import CredentialStore
+from aigateway.db import build_tortoise_config
 
 
 class FakeKeychain(CredentialStore):
@@ -22,3 +29,86 @@ class FakeKeychain(CredentialStore):
 @pytest.fixture
 def fake_keychain() -> FakeKeychain:
     return FakeKeychain()
+
+
+@pytest.fixture(autouse=True)
+def _fast_bcrypt(monkeypatch):
+    from aigateway.core.auth import passwords
+
+    monkeypatch.setattr(passwords, "_BCRYPT_ROUNDS", 4)
+    passwords._dummy_hash = None
+    yield
+    passwords._dummy_hash = None
+
+
+def _prepare_sqlite_db(database_url: str) -> None:
+    async def _prepare() -> None:
+        await Tortoise.close_connections()
+        await Tortoise.init(
+            config=build_tortoise_config(database_url), _enable_global_fallback=True
+        )
+        await Tortoise.generate_schemas()
+        await Tortoise.close_connections()
+
+    asyncio.run(_prepare())
+
+
+@pytest.fixture
+def patch_credential_factories(fake_keychain, monkeypatch) -> FakeKeychain:
+    from aigateway import main as main_module
+    from aigateway.core import bootstrap as bs_module
+    from aigateway.core import credential_store as cs_module
+    from aigateway.core import profile_index as pi_module
+    from aigateway.plugins.anthropic_provider import auth as auth_module
+
+    monkeypatch.setattr(cs_module, "get_credential_store", lambda: fake_keychain)
+    monkeypatch.setattr(pi_module, "get_credential_store", lambda: fake_keychain)
+    monkeypatch.setattr(bs_module, "get_credential_store", lambda: fake_keychain)
+    monkeypatch.setattr(auth_module, "get_credential_store", lambda: fake_keychain)
+    monkeypatch.setattr(main_module, "get_credential_store", lambda: fake_keychain)
+    return fake_keychain
+
+
+@pytest.fixture
+def client(
+    tmp_path: Path,
+    monkeypatch,
+    patch_credential_factories,
+) -> Generator[TestClient, None, None]:
+    db_path = tmp_path / "aigateway.sqlite3"
+    database_url = f"sqlite://{db_path}"
+    monkeypatch.setenv("AIGATEWAY_DATABASE_URL", database_url)
+    monkeypatch.setenv("AIGATEWAY_ADMIN_PASSWORD", "test-admin-password")
+    monkeypatch.setenv("AIGATEWAY_JWT_SECRET", "x" * 32)
+    monkeypatch.setenv("AIGATEWAY_PROVISIONING_TOKEN", "p" * 32)
+    _prepare_sqlite_db(database_url)
+
+    from aigateway.main import create_app
+
+    with TestClient(create_app()) as test_client:
+        yield test_client
+
+
+@pytest.fixture
+def authenticated_client(client: TestClient) -> TestClient:
+    response = client.post(
+        "/v1/auth/login",
+        json={"username": "admin", "password": "test-admin-password"},
+    )
+    assert response.status_code == 200, response.text
+    client.headers.update({"Authorization": f"Bearer {response.json()['token']}"})
+    return client
+
+
+@pytest.fixture
+def provisioned_user_factory(client: TestClient) -> Callable[[str, str], dict]:
+    def _create(username: str, password: str = "test-user-password") -> dict:
+        response = client.post(
+            "/v1/accounts",
+            headers={"X-Aigw-Provisioning-Token": "p" * 32},
+            json={"username": username, "password": password},
+        )
+        assert response.status_code == 201, response.text
+        return response.json()
+
+    return _create

--- a/apps/aigateway/tests/conftest.py
+++ b/apps/aigateway/tests/conftest.py
@@ -56,10 +56,10 @@ def _prepare_sqlite_db(database_url: str) -> None:
 @pytest.fixture
 def patch_credential_factories(fake_keychain, monkeypatch) -> FakeKeychain:
     from aigateway import main as main_module
-    from aigateway.core import bootstrap as bs_module
     from aigateway.core import credential_store as cs_module
     from aigateway.core import profile_index as pi_module
     from aigateway.plugins.anthropic_provider import auth as auth_module
+    from aigateway.plugins.anthropic_provider import bootstrap as bs_module
 
     monkeypatch.setattr(cs_module, "get_credential_store", lambda: fake_keychain)
     monkeypatch.setattr(pi_module, "get_credential_store", lambda: fake_keychain)

--- a/apps/aigateway/tests/integration/test_tortoise_migration_smoke.py
+++ b/apps/aigateway/tests/integration/test_tortoise_migration_smoke.py
@@ -7,9 +7,9 @@ import sys
 from pathlib import Path
 from urllib.parse import quote
 
-import asyncpg
+import asyncpg  # type: ignore[import-untyped]
 import pytest
-from testcontainers.postgres import PostgresContainer
+from testcontainers.postgres import PostgresContainer  # type: ignore[import-untyped]
 
 pytestmark = pytest.mark.needs_postgres
 
@@ -24,14 +24,24 @@ def test_tortoise_migrate_creates_accounts_table() -> None:
             f"/{postgres.dbname}"
         )
         env = {**os.environ, "AIGATEWAY_DATABASE_URL": database_url}
-        subprocess.run(
-            [sys.executable, "-m", "tortoise", "-c", "aigateway.db.TORTOISE_CONFIG", "migrate"],
+        command = [
+            sys.executable,
+            "-m",
+            "tortoise",
+            "-c",
+            "aigateway.db.TORTOISE_CONFIG",
+            "migrate",
+        ]
+        subprocess.run(command, cwd=app_dir, env=env, check=True, capture_output=True, text=True)
+        rerun = subprocess.run(
+            command,
             cwd=app_dir,
             env=env,
             check=True,
             capture_output=True,
             text=True,
         )
+        assert "No migrations to apply" in rerun.stdout
 
         async def _tables() -> set[str]:
             conn = await asyncpg.connect(database_url)

--- a/apps/aigateway/tests/integration/test_tortoise_migration_smoke.py
+++ b/apps/aigateway/tests/integration/test_tortoise_migration_smoke.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import quote
+
+import asyncpg
+import pytest
+from testcontainers.postgres import PostgresContainer
+
+pytestmark = pytest.mark.needs_postgres
+
+
+@pytest.mark.skipif(os.environ.get("AIGW_TEST_PG") != "1", reason="AIGW_TEST_PG=1 not set")
+def test_tortoise_migrate_creates_accounts_table() -> None:
+    app_dir = Path(__file__).resolve().parents[2]
+    with PostgresContainer("postgres:16-alpine", driver=None) as postgres:
+        database_url = (
+            f"postgres://{postgres.username}:{quote(postgres.password, safe='')}"
+            f"@{postgres.get_container_host_ip()}:{postgres.get_exposed_port(5432)}"
+            f"/{postgres.dbname}"
+        )
+        env = {**os.environ, "AIGATEWAY_DATABASE_URL": database_url}
+        subprocess.run(
+            [sys.executable, "-m", "tortoise", "-c", "aigateway.db.TORTOISE_CONFIG", "migrate"],
+            cwd=app_dir,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        async def _tables() -> set[str]:
+            conn = await asyncpg.connect(database_url)
+            try:
+                rows = await conn.fetch(
+                    "select table_name from information_schema.tables where table_schema = 'public'"
+                )
+                return {row["table_name"] for row in rows}
+            finally:
+                await conn.close()
+
+        assert {"accounts", "tortoise_migrations"} <= asyncio.run(_tables())

--- a/apps/aigateway/tests/live/test_anthropic_live.py
+++ b/apps/aigateway/tests/live/test_anthropic_live.py
@@ -41,9 +41,21 @@ def _require_default_profile(client: TestClient) -> None:
         )
 
 
+def _login_admin(client: TestClient) -> None:
+    password = os.environ.get("AIGW_LIVE_ADMIN_PASSWORD") or os.environ.get(
+        "AIGATEWAY_ADMIN_PASSWORD"
+    )
+    if not password:
+        pytest.skip("Live auth tests require AIGW_LIVE_ADMIN_PASSWORD or AIGATEWAY_ADMIN_PASSWORD")
+    response = client.post("/v1/auth/login", json={"username": "admin", "password": password})
+    assert response.status_code == 200, response.text
+    client.headers.update({"Authorization": f"Bearer {response.json()['token']}"})
+
+
 @pytest.mark.skipif(not _live_enabled(), reason="AIGW_LIVE=1 not set")
 def test_anthropic_round_trip_via_default_profile() -> None:
     with TestClient(create_app()) as client:
+        _login_admin(client)
         _require_default_profile(client)
 
         resp = client.post(
@@ -63,6 +75,7 @@ def test_anthropic_round_trip_via_default_profile() -> None:
 @pytest.mark.skipif(not _live_enabled(), reason="AIGW_LIVE=1 not set")
 def test_anthropic_streaming() -> None:
     with TestClient(create_app()) as client:
+        _login_admin(client)
         _require_default_profile(client)
 
         with client.stream(
@@ -99,6 +112,7 @@ def test_anthropic_streaming() -> None:
 @pytest.mark.skipif(not _live_enabled(), reason="AIGW_LIVE=1 not set")
 def test_anthropic_tool_calls() -> None:
     with TestClient(create_app()) as client:
+        _login_admin(client)
         _require_default_profile(client)
 
         resp = client.post(

--- a/apps/aigateway/tests/live/test_anthropic_live.py
+++ b/apps/aigateway/tests/live/test_anthropic_live.py
@@ -1,8 +1,8 @@
 """End-to-end live test against api.anthropic.com via the profile-based path.
 
-Skipped unless AIGW_LIVE=1. Requires the gateway's `anthropic:default`
-profile to be authenticated — typically achieved on this machine by the
-Claude Code bootstrap importing existing CC credentials.
+Skipped unless AIGW_LIVE=1. Requires the logged-in admin account to have an
+authenticated `anthropic:default` profile — typically achieved on this machine
+by the Claude Code bootstrap importing existing CC credentials.
 """
 
 from __future__ import annotations
@@ -25,8 +25,14 @@ def _live_enabled() -> bool:
 def _require_default_profile(client: TestClient) -> None:
     listing = client.get("/v1/auth/profiles")
     assert listing.status_code == 200, listing.text
-    profiles = {p["id"]: p for p in listing.json()["profiles"]}
-    profile = profiles.get("anthropic:default")
+    profile = next(
+        (
+            p
+            for p in listing.json()["profiles"]
+            if p["provider"] == "anthropic" and p["name"] == "default"
+        ),
+        None,
+    )
     if profile is None:
         pytest.skip(
             "anthropic:default profile not present. Run `claude auth login` or seed a "
@@ -42,18 +48,25 @@ def _require_default_profile(client: TestClient) -> None:
 
 
 def _login_admin(client: TestClient) -> None:
-    password = os.environ.get("AIGW_LIVE_ADMIN_PASSWORD") or os.environ.get(
-        "AIGATEWAY_ADMIN_PASSWORD"
-    )
-    if not password:
-        pytest.skip("Live auth tests require AIGW_LIVE_ADMIN_PASSWORD or AIGATEWAY_ADMIN_PASSWORD")
+    password = _live_admin_password()
     response = client.post("/v1/auth/login", json={"username": "admin", "password": password})
     assert response.status_code == 200, response.text
     client.headers.update({"Authorization": f"Bearer {response.json()['token']}"})
 
 
+def _live_admin_password() -> str:
+    password = os.environ.get("AIGW_LIVE_ADMIN_PASSWORD") or os.environ.get(
+        "AIGATEWAY_ADMIN_PASSWORD"
+    )
+    if not password:
+        pytest.skip("Live auth tests require AIGW_LIVE_ADMIN_PASSWORD or AIGATEWAY_ADMIN_PASSWORD")
+    assert password is not None
+    return password
+
+
 @pytest.mark.skipif(not _live_enabled(), reason="AIGW_LIVE=1 not set")
 def test_anthropic_round_trip_via_default_profile() -> None:
+    _live_admin_password()
     with TestClient(create_app()) as client:
         _login_admin(client)
         _require_default_profile(client)
@@ -74,6 +87,7 @@ def test_anthropic_round_trip_via_default_profile() -> None:
 
 @pytest.mark.skipif(not _live_enabled(), reason="AIGW_LIVE=1 not set")
 def test_anthropic_streaming() -> None:
+    _live_admin_password()
     with TestClient(create_app()) as client:
         _login_admin(client)
         _require_default_profile(client)
@@ -111,6 +125,7 @@ def test_anthropic_streaming() -> None:
 
 @pytest.mark.skipif(not _live_enabled(), reason="AIGW_LIVE=1 not set")
 def test_anthropic_tool_calls() -> None:
+    _live_admin_password()
     with TestClient(create_app()) as client:
         _login_admin(client)
         _require_default_profile(client)

--- a/apps/aigateway/tests/unit/anthropic/test_bootstrap.py
+++ b/apps/aigateway/tests/unit/anthropic/test_bootstrap.py
@@ -1,0 +1,145 @@
+import json
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+
+from aigateway.core.profile_index import INDEX_KEYCHAIN_SERVICE, ProfileIndexStore
+from aigateway.core.profile_models import Profile, profile_id_for
+from aigateway.plugins.anthropic_provider.auth import keychain_service_for
+from aigateway.plugins.anthropic_provider.bootstrap import bootstrap_from_claude_code
+from tests.conftest import _prepare_sqlite_db
+
+CC_SERVICE = "Claude Code-credentials"
+ACCOUNT_ID = "account-1"
+
+
+def _configure_app_db(monkeypatch, tmp_path) -> None:
+    database_url = f"sqlite://{tmp_path / 'aigateway.sqlite3'}"
+    monkeypatch.setenv("AIGATEWAY_DATABASE_URL", database_url)
+    monkeypatch.setenv("AIGATEWAY_ADMIN_PASSWORD", "test-admin-password")
+    monkeypatch.setenv("AIGATEWAY_JWT_SECRET", "x" * 32)
+    monkeypatch.setenv("AIGATEWAY_PROVISIONING_TOKEN", "p" * 32)
+    _prepare_sqlite_db(database_url)
+
+
+def _auth_header(client: TestClient) -> dict[str, str]:
+    response = client.post(
+        "/v1/auth/login",
+        json={"username": "admin", "password": "test-admin-password"},
+    )
+    assert response.status_code == 200, response.text
+    return {"Authorization": f"Bearer {response.json()['token']}"}
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_imports_cc_default_when_index_empty(fake_keychain) -> None:
+    cc_payload = json.dumps(
+        {
+            "claudeAiOauth": {
+                "accessToken": "cc-tok",
+                "refreshToken": "cc-rt",
+                "expiresAt": int(time.time() * 1000) + 3_600_000,
+                "scopes": ["user:inference"],
+            }
+        }
+    )
+    fake_keychain.write(CC_SERVICE, "alice", cc_payload)
+
+    await bootstrap_from_claude_code(
+        account_id=ACCOUNT_ID,
+        credential_store=fake_keychain,
+        index_store=ProfileIndexStore(credential_store=fake_keychain),
+        cc_account="alice",
+    )
+
+    aigw_payload = fake_keychain.read(keychain_service_for(f"{ACCOUNT_ID}:default"), "default")
+    assert aigw_payload is not None
+    converted = json.loads(aigw_payload)
+    assert converted["access_token"] == "cc-tok"
+    assert converted["refresh_token"] == "cc-rt"
+    assert "expires_at_ms" in converted
+
+    idx_raw = fake_keychain.read(INDEX_KEYCHAIN_SERVICE, "default")
+    assert idx_raw is not None
+    assert profile_id_for(ACCOUNT_ID, "anthropic", "default") in idx_raw
+
+    # CC entry untouched
+    assert fake_keychain.read(CC_SERVICE, "alice") == cc_payload
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_noop_when_index_already_exists(fake_keychain) -> None:
+    await ProfileIndexStore(credential_store=fake_keychain).upsert(
+        Profile(
+            id=profile_id_for(ACCOUNT_ID, "x", "y"),
+            account_id=ACCOUNT_ID,
+            provider="x",
+            name="y",
+        )
+    )
+    fake_keychain.write(
+        CC_SERVICE,
+        "alice",
+        json.dumps({"claudeAiOauth": {"accessToken": "x", "refreshToken": "y", "expiresAt": 1}}),
+    )
+    await bootstrap_from_claude_code(
+        account_id=ACCOUNT_ID,
+        credential_store=fake_keychain,
+        index_store=ProfileIndexStore(credential_store=fake_keychain),
+        cc_account="alice",
+    )
+    assert fake_keychain.read(keychain_service_for(f"{ACCOUNT_ID}:default"), "default") is None
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_noop_when_cc_entry_missing(fake_keychain) -> None:
+    await bootstrap_from_claude_code(
+        account_id=ACCOUNT_ID,
+        credential_store=fake_keychain,
+        index_store=ProfileIndexStore(credential_store=fake_keychain),
+        cc_account="alice",
+    )
+    assert fake_keychain.read(INDEX_KEYCHAIN_SERVICE, "default") is None
+
+
+def test_app_lifespan_runs_anthropic_bootstrap(fake_keychain, monkeypatch, tmp_path) -> None:
+    _configure_app_db(monkeypatch, tmp_path)
+    fake_keychain.write(
+        CC_SERVICE,
+        "alice",
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "boot-tok",
+                    "refreshToken": "boot-rt",
+                    "expiresAt": int(time.time() * 1000) + 3_600_000,
+                    "scopes": ["user:inference"],
+                }
+            }
+        ),
+    )
+    monkeypatch.setenv("USER", "alice")
+    monkeypatch.setenv("AIGATEWAY_BOOTSTRAP_FROM_CLAUDE_CODE", "1")
+
+    from aigateway import main as main_module
+    from aigateway.core import credential_store as cs_module
+    from aigateway.core import profile_index as pi_module
+    from aigateway.plugins.anthropic_provider import auth as auth_module
+
+    monkeypatch.setattr(cs_module, "get_credential_store", lambda: fake_keychain)
+    monkeypatch.setattr(pi_module, "get_credential_store", lambda: fake_keychain)
+    monkeypatch.setattr(auth_module, "get_credential_store", lambda: fake_keychain)
+    monkeypatch.setattr(main_module, "get_credential_store", lambda: fake_keychain)
+
+    from aigateway.main import create_app
+
+    app = create_app()
+    with TestClient(app) as client:  # `with` triggers the lifespan
+        resp = client.get("/v1/auth/profiles", headers=_auth_header(client))
+        assert resp.status_code == 200
+        profiles = resp.json()["profiles"]
+        assert len(profiles) == 1
+        assert profiles[0]["provider"] == "anthropic"
+        assert profiles[0]["name"] == "default"
+        assert profiles[0]["account_id"]

--- a/apps/aigateway/tests/unit/auth/__init__.py
+++ b/apps/aigateway/tests/unit/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Auth unit tests."""

--- a/apps/aigateway/tests/unit/auth/conftest.py
+++ b/apps/aigateway/tests/unit/auth/conftest.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import pytest_asyncio
+from tortoise.contrib.test import tortoise_test_context
+
+
+@pytest_asyncio.fixture
+async def db():
+    async with tortoise_test_context(["aigateway.core.auth.models"]):
+        yield

--- a/apps/aigateway/tests/unit/auth/test_accounts.py
+++ b/apps/aigateway/tests/unit/auth/test_accounts.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+from tortoise.exceptions import IntegrityError
+
+from aigateway.core.auth.models import Account
+
+
+@pytest.mark.asyncio
+async def test_account_crud(db) -> None:
+    account = await Account.create(username="alice", password_hash="hash")
+    fetched = await Account.get(username="alice")
+    assert fetched.id == account.id
+    assert fetched.is_active
+
+
+@pytest.mark.asyncio
+async def test_username_unique(db) -> None:
+    await Account.create(username="alice", password_hash="hash")
+    with pytest.raises(IntegrityError):
+        await Account.create(username="alice", password_hash="hash")

--- a/apps/aigateway/tests/unit/auth/test_accounts_routes.py
+++ b/apps/aigateway/tests/unit/auth/test_accounts_routes.py
@@ -2,6 +2,14 @@ from __future__ import annotations
 
 import logging
 from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+from typing import cast
+
+from fastapi import APIRouter, FastAPI, Request
+from fastapi.testclient import TestClient
+
+from aigateway.core.auth.models import Account
+from aigateway.routes.accounts import ProvisioningAuditRoute, _audit_provisioning_attempt
 
 
 def _assert_secret_not_logged(caplog, secret: str) -> None:
@@ -36,6 +44,30 @@ def test_create_account_success_and_duplicate(client, caplog) -> None:
     assert duplicate.json()["detail"] == "username already exists"
     assert "provisioning_token_rejected status_code=409 username=alice" in caplog.text
     _assert_secret_not_logged(caplog, headers["X-Aigw-Provisioning-Token"])
+
+
+def test_provisioning_audit_fallback_paths(caplog) -> None:
+    request = cast(Request, SimpleNamespace(state=SimpleNamespace()))
+    with caplog.at_level(logging.INFO, logger="aigateway.routes.accounts"):
+        _audit_provisioning_attempt(request, 201)
+    assert "account_created" in caplog.text
+
+    caplog.clear()
+    router = APIRouter(route_class=ProvisioningAuditRoute)
+
+    @router.get("/boom")
+    async def boom(request: Request) -> None:
+        request.state.provisioning_username = "alice"
+        raise RuntimeError("boom")
+
+    app = FastAPI()
+    app.include_router(router)
+    with caplog.at_level(logging.INFO, logger="aigateway.routes.accounts"):
+        with TestClient(app, raise_server_exceptions=False) as client:
+            response = client.get("/boom")
+
+    assert response.status_code == 500
+    assert "provisioning_token_rejected status_code=500 username=alice" in caplog.text
 
 
 def test_missing_and_wrong_provisioning_token_match(client, caplog) -> None:
@@ -83,11 +115,17 @@ def test_create_account_validation(client, caplog) -> None:
             headers=headers,
             json={"username": "a", "password": "a" * 73},
         )
+        bad_username = client.post(
+            "/v1/accounts",
+            headers=headers,
+            json={"username": "bad\nuser", "password": "alicepass123"},
+        )
     assert short.status_code == 422
     assert missing.status_code == 422
     assert overlong.status_code == 422
+    assert bad_username.status_code == 422
     assert "password" in missing.text
-    assert caplog.text.count("provisioning_token_rejected status_code=422") == 3
+    assert caplog.text.count("provisioning_token_rejected status_code=422") == 4
     _assert_secret_not_logged(caplog, headers["X-Aigw-Provisioning-Token"])
 
 
@@ -115,10 +153,14 @@ def test_concurrent_duplicate_username_returns_409(client) -> None:
             json={"username": "alice", "password": "alicepass123"},
         ).status_code
 
+    async def _count_alice() -> int:
+        return await Account.filter(username="alice").count()
+
     with ThreadPoolExecutor(max_workers=4) as pool:
         statuses = list(pool.map(lambda _: _create(), range(4)))
 
     assert sorted(statuses) == [201, 409, 409, 409]
+    assert client.portal.call(_count_alice) == 1
 
 
 def test_provisioning_token_not_logged(client, caplog) -> None:

--- a/apps/aigateway/tests/unit/auth/test_accounts_routes.py
+++ b/apps/aigateway/tests/unit/auth/test_accounts_routes.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import logging
+from concurrent.futures import ThreadPoolExecutor
+
+
+def _assert_secret_not_logged(caplog, secret: str) -> None:
+    assert secret not in caplog.text
+    assert secret not in "\n".join(record.getMessage() for record in caplog.records)
+
+
+def test_create_account_success_and_duplicate(client, caplog) -> None:
+    headers = {"X-Aigw-Provisioning-Token": "p" * 32}
+    with caplog.at_level(logging.INFO, logger="aigateway.routes.accounts"):
+        response = client.post(
+            "/v1/accounts",
+            headers=headers,
+            json={"username": "alice", "password": "alicepass123", "display_name": "Alice"},
+        )
+    assert response.status_code == 201
+    body = response.json()
+    assert body["username"] == "alice"
+    assert "password" not in body
+    assert "password_hash" not in body
+    assert "account_created username=alice" in caplog.text
+    _assert_secret_not_logged(caplog, headers["X-Aigw-Provisioning-Token"])
+
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="aigateway.routes.accounts"):
+        duplicate = client.post(
+            "/v1/accounts",
+            headers=headers,
+            json={"username": "alice", "password": "alicepass123"},
+        )
+    assert duplicate.status_code == 409
+    assert duplicate.json()["detail"] == "username already exists"
+    assert "provisioning_token_rejected status_code=409 username=alice" in caplog.text
+    _assert_secret_not_logged(caplog, headers["X-Aigw-Provisioning-Token"])
+
+
+def test_missing_and_wrong_provisioning_token_match(client, caplog) -> None:
+    payload = {"username": "alice", "password": "alicepass123"}
+    wrong_token = "wrong-token-value"
+    with caplog.at_level(logging.INFO, logger="aigateway.routes.accounts"):
+        missing = client.post("/v1/accounts", json=payload)
+        wrong = client.post(
+            "/v1/accounts",
+            headers={"X-Aigw-Provisioning-Token": wrong_token},
+            json=payload,
+        )
+    assert missing.status_code == 401
+    assert wrong.status_code == 401
+    assert wrong.content == missing.content
+    assert wrong.json()["detail"]["code"] == "invalid_provisioning_token"
+    assert caplog.text.count("provisioning_token_rejected status_code=401") == 2
+    _assert_secret_not_logged(caplog, wrong_token)
+
+
+def test_provisioning_disabled_returns_503(client, caplog) -> None:
+    client.app.state.settings.provisioning_token = None
+    token = "p" * 32
+    with caplog.at_level(logging.INFO, logger="aigateway.routes.accounts"):
+        response = client.post(
+            "/v1/accounts",
+            headers={"X-Aigw-Provisioning-Token": token},
+            json={"username": "alice", "password": "alicepass123"},
+        )
+    assert response.status_code == 503
+    assert "Provisioning is disabled" in response.text
+    assert "provisioning_token_rejected status_code=503" in caplog.text
+    _assert_secret_not_logged(caplog, token)
+
+
+def test_create_account_validation(client, caplog) -> None:
+    headers = {"X-Aigw-Provisioning-Token": "p" * 32}
+    with caplog.at_level(logging.INFO, logger="aigateway.routes.accounts"):
+        short = client.post(
+            "/v1/accounts", headers=headers, json={"username": "a", "password": "x"}
+        )
+        missing = client.post("/v1/accounts", headers=headers, json={"username": "a"})
+        overlong = client.post(
+            "/v1/accounts",
+            headers=headers,
+            json={"username": "a", "password": "a" * 73},
+        )
+    assert short.status_code == 422
+    assert missing.status_code == 422
+    assert overlong.status_code == 422
+    assert "password" in missing.text
+    assert caplog.text.count("provisioning_token_rejected status_code=422") == 3
+    _assert_secret_not_logged(caplog, headers["X-Aigw-Provisioning-Token"])
+
+
+def test_created_account_can_login(client) -> None:
+    client.post(
+        "/v1/accounts",
+        headers={"X-Aigw-Provisioning-Token": "p" * 32},
+        json={"username": "alice", "password": "alicepass123"},
+    )
+    response = client.post(
+        "/v1/auth/login",
+        json={"username": "alice", "password": "alicepass123"},
+    )
+    assert response.status_code == 200
+    assert response.json()["token"]
+
+
+def test_concurrent_duplicate_username_returns_409(client) -> None:
+    headers = {"X-Aigw-Provisioning-Token": "p" * 32}
+
+    def _create() -> int:
+        return client.post(
+            "/v1/accounts",
+            headers=headers,
+            json={"username": "alice", "password": "alicepass123"},
+        ).status_code
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        statuses = list(pool.map(lambda _: _create(), range(4)))
+
+    assert sorted(statuses) == [201, 409, 409, 409]
+
+
+def test_provisioning_token_not_logged(client, caplog) -> None:
+    token = "p" * 32
+    client.post(
+        "/v1/accounts",
+        headers={"X-Aigw-Provisioning-Token": token},
+        json={"username": "alice", "password": "alicepass123"},
+    )
+    assert token not in caplog.text
+    assert token not in "\n".join(record.getMessage() for record in caplog.records)

--- a/apps/aigateway/tests/unit/auth/test_bootstrap_admin.py
+++ b/apps/aigateway/tests/unit/auth/test_bootstrap_admin.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+from pydantic import SecretStr
+
+from aigateway.core.auth.bootstrap_admin import ensure_admin_account
+from aigateway.core.auth.models import Account
+from aigateway.core.auth.passwords import verify_password
+
+
+@pytest.mark.asyncio
+async def test_env_admin_password_creates_loginable_admin(db) -> None:
+    await ensure_admin_account(SecretStr("admin-password"))
+    admin = await Account.get(username="admin")
+    assert await verify_password("admin-password", admin.password_hash)
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_logs_generated_password_once(db, caplog) -> None:
+    with caplog.at_level(logging.WARNING):
+        await ensure_admin_account(None)
+        await ensure_admin_account(None)
+    messages = [record.getMessage() for record in caplog.records]
+    bootstraps = [message for message in messages if "Bootstrap admin password:" in message]
+    assert len(bootstraps) == 1
+    generated = bootstraps[0].split(": ", 1)[1]
+    admin = await Account.get(username="admin")
+    assert await verify_password(generated, admin.password_hash)
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_concurrent_race_logs_one_password(db, caplog) -> None:
+    with caplog.at_level(logging.WARNING):
+        await asyncio.gather(*[ensure_admin_account(None) for _ in range(4)])
+    assert await Account.all().count() == 1
+    bootstraps = [
+        record.getMessage()
+        for record in caplog.records
+        if "Bootstrap admin password:" in record.getMessage()
+    ]
+    assert len(bootstraps) == 1
+    generated = bootstraps[0].split(": ", 1)[1]
+    admin = await Account.get(username="admin")
+    assert await verify_password(generated, admin.password_hash)

--- a/apps/aigateway/tests/unit/auth/test_jwt.py
+++ b/apps/aigateway/tests/unit/auth/test_jwt.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import jwt
+import pytest
+
+from aigateway.core.auth.jwt import decode_token, encode_token
+
+
+def test_encode_decode_token_round_trip() -> None:
+    token, expires_at = encode_token(
+        account_id="account-id",
+        username="admin",
+        secret="s" * 32,
+        ttl_seconds=60,
+    )
+    claims = decode_token(token, "s" * 32)
+    assert claims["sub"] == "account-id"
+    assert claims["username"] == "admin"
+    assert claims["exp"] >= int(expires_at.timestamp())
+
+
+def test_alg_none_rejected() -> None:
+    token = jwt.encode(
+        {"sub": "x", "username": "u", "iat": 1, "exp": 4_102_444_800},
+        key="",
+        algorithm="none",
+    )
+    with pytest.raises(jwt.InvalidAlgorithmError):
+        decode_token(token, "s" * 32)
+
+
+def test_missing_required_claim_rejected() -> None:
+    token = jwt.encode({"sub": "x", "exp": 4_102_444_800}, "s" * 32, algorithm="HS256")
+    with pytest.raises(jwt.MissingRequiredClaimError):
+        decode_token(token, "s" * 32)

--- a/apps/aigateway/tests/unit/auth/test_jwt_secret.py
+++ b/apps/aigateway/tests/unit/auth/test_jwt_secret.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+from pydantic import SecretStr
+
+from aigateway.core.auth.jwt_secret import (
+    JWT_SECRET_ACCOUNT,
+    JWT_SECRET_SERVICE,
+    get_or_create_jwt_secret,
+)
+
+
+@pytest.mark.asyncio
+async def test_env_jwt_secret_wins(fake_keychain) -> None:
+    secret = await get_or_create_jwt_secret(fake_keychain, SecretStr("s" * 32))
+    assert secret == "s" * 32
+    assert fake_keychain.read(JWT_SECRET_SERVICE, JWT_SECRET_ACCOUNT) is None
+
+
+@pytest.mark.asyncio
+async def test_existing_keychain_secret_reused(fake_keychain) -> None:
+    fake_keychain.write(JWT_SECRET_SERVICE, JWT_SECRET_ACCOUNT, "p" * 32)
+    assert await get_or_create_jwt_secret(fake_keychain) == "p" * 32
+
+
+@pytest.mark.asyncio
+async def test_existing_keychain_secret_must_be_strong(fake_keychain) -> None:
+    fake_keychain.write(JWT_SECRET_SERVICE, JWT_SECRET_ACCOUNT, "too-short")
+    with pytest.raises(RuntimeError, match="at least 32 characters"):
+        await get_or_create_jwt_secret(fake_keychain)
+
+
+@pytest.mark.asyncio
+async def test_generates_and_logs_without_leaking_secret(fake_keychain, caplog) -> None:
+    with caplog.at_level(logging.WARNING):
+        secret = await get_or_create_jwt_secret(fake_keychain)
+    assert len(secret) >= 32
+    assert fake_keychain.read(JWT_SECRET_SERVICE, JWT_SECRET_ACCOUNT) == secret
+    assert "Generated and persisted aigateway JWT secret" in caplog.text
+    assert secret not in caplog.text

--- a/apps/aigateway/tests/unit/auth/test_log_filter.py
+++ b/apps/aigateway/tests/unit/auth/test_log_filter.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import logging
+
+from uvicorn.logging import AccessFormatter
+
+from aigateway.core.auth.log_filter import (
+    RedactProvisioningTokenFilter,
+    install_provisioning_token_redaction,
+)
+
+
+def test_redacts_provisioning_token_header(caplog) -> None:
+    logger = logging.getLogger("aigateway.test.redact")
+    logger.addFilter(RedactProvisioningTokenFilter())
+    token = "super-secret-token"
+    with caplog.at_level(logging.INFO, logger="aigateway.test.redact"):
+        logger.info("X-Aigw-Provisioning-Token: %s", token)
+    assert token not in caplog.text
+    assert "[REDACTED]" in caplog.text
+
+
+def test_process_wide_redaction_handles_child_loggers(caplog) -> None:
+    install_provisioning_token_redaction()
+    logger = logging.getLogger("aigateway.routes.accounts.child")
+    token = "super-secret-token"
+    with caplog.at_level(logging.INFO):
+        logger.info("X-Aigw-Provisioning-Token: %s", token)
+    assert token not in caplog.text
+    assert token not in "\n".join(record.getMessage() for record in caplog.records)
+    assert "[REDACTED]" in caplog.text
+
+
+def test_redacts_raw_asgi_header_tuple(caplog) -> None:
+    install_provisioning_token_redaction()
+    logger = logging.getLogger("third_party.asgi")
+    token = "tuple-secret-token"
+    with caplog.at_level(logging.INFO):
+        logger.info("headers=%r", [(b"x-aigw-provisioning-token", token.encode())])
+    assert token not in caplog.text
+    assert token not in "\n".join(record.getMessage() for record in caplog.records)
+    assert "[REDACTED]" in caplog.text
+
+
+def test_redacts_structured_header_args_without_rendering_first() -> None:
+    token = "structured-secret-token"
+    record = logging.LogRecord(
+        "uvicorn.access",
+        logging.INFO,
+        "",
+        1,
+        "headers=%r extra=%r raw=%r",
+        (
+            [[b"x-aigw-provisioning-token", token.encode()]],
+            {"X-Aigw-Provisioning-Token": token, "safe": "value"},
+            b"X-Aigw-Provisioning-Token: byte-secret",
+        ),
+        None,
+    )
+
+    RedactProvisioningTokenFilter().filter(record)
+
+    assert token not in record.getMessage()
+    assert "byte-secret" not in record.getMessage()
+    assert "safe" in record.getMessage()
+    assert "[REDACTED]" in record.getMessage()
+
+
+def test_ignores_non_header_keys_in_structured_args() -> None:
+    record = logging.LogRecord(
+        "uvicorn.access",
+        logging.INFO,
+        "",
+        1,
+        "value=%r",
+        ({b"not-the-provisioning-header": "kept", "nested": ("ok",)},),
+        None,
+    )
+
+    RedactProvisioningTokenFilter().filter(record)
+
+    assert "kept" in record.getMessage()
+    assert "ok" in record.getMessage()
+
+
+def test_preserves_uvicorn_access_log_args() -> None:
+    record = logging.LogRecord(
+        "uvicorn.access",
+        logging.INFO,
+        "",
+        1,
+        '%s - "%s %s HTTP/%s" %d',
+        ("127.0.0.1:12345", "GET", "/healthz", "1.1", 200),
+        None,
+    )
+    RedactProvisioningTokenFilter().filter(record)
+
+    assert record.args == ("127.0.0.1:12345", "GET", "/healthz", "1.1", 200)
+    formatted = AccessFormatter('%(client_addr)s - "%(request_line)s" %(status_code)s').format(
+        record
+    )
+    assert "GET /healthz HTTP/1.1" in formatted

--- a/apps/aigateway/tests/unit/auth/test_log_filter.py
+++ b/apps/aigateway/tests/unit/auth/test_log_filter.py
@@ -20,6 +20,20 @@ def test_redacts_provisioning_token_header(caplog) -> None:
     assert "[REDACTED]" in caplog.text
 
 
+def test_does_not_redact_plain_header_name_mentions() -> None:
+    record = logging.LogRecord(
+        "aigateway.test.redact",
+        logging.INFO,
+        "",
+        1,
+        "Checking X-Aigw-Provisioning-Token header presence",
+        (),
+        None,
+    )
+    RedactProvisioningTokenFilter().filter(record)
+    assert record.getMessage() == "Checking X-Aigw-Provisioning-Token header presence"
+
+
 def test_process_wide_redaction_handles_child_loggers(caplog) -> None:
     install_provisioning_token_redaction()
     logger = logging.getLogger("aigateway.routes.accounts.child")

--- a/apps/aigateway/tests/unit/auth/test_login.py
+++ b/apps/aigateway/tests/unit/auth/test_login.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import threading
 from statistics import median
 
 import pytest
@@ -86,31 +85,23 @@ async def test_unknown_user_timing_close_to_wrong_password(client, monkeypatch) 
     assert abs(missing - wrong) / wrong < 0.10
 
 
-@pytest.mark.asyncio
-async def test_concurrent_logins_verify_passwords_in_threadpool(client, monkeypatch) -> None:
-    barrier = threading.Barrier(10, timeout=5)
-    lock = threading.Lock()
-    verifier_threads: set[int] = set()
+def test_login_delegates_to_password_verification_helper(client, monkeypatch) -> None:
+    from aigateway.routes import auth_session
 
-    def _verify_password_sync(_password, _password_hash) -> bool:
-        with lock:
-            verifier_threads.add(threading.get_ident())
-        try:
-            barrier.wait()
-        except threading.BrokenBarrierError as exc:
-            raise AssertionError("password verification did not overlap") from exc
+    calls: list[tuple[str, str | bytes | None]] = []
+
+    async def fake_verify_password_or_dummy(password, password_hash) -> bool:
+        calls.append((password.get_secret_value(), password_hash))
         return True
 
-    monkeypatch.setattr(passwords, "_verify_password_sync", _verify_password_sync)
+    monkeypatch.setattr(auth_session, "verify_password_or_dummy", fake_verify_password_or_dummy)
 
-    async def _login():
-        return await asyncio.to_thread(
-            client.post,
-            "/v1/auth/login",
-            json={"username": "admin", "password": "test-admin-password"},
-        )
+    response = client.post(
+        "/v1/auth/login",
+        json={"username": "admin", "password": "test-admin-password"},
+    )
 
-    responses = await asyncio.gather(*[_login() for _ in range(10)])
-
-    assert all(response.status_code == 200 for response in responses)
-    assert len(verifier_threads) > 1
+    assert response.status_code == 200
+    assert len(calls) == 1
+    assert calls[0][0] == "test-admin-password"
+    assert isinstance(calls[0][1], str)

--- a/apps/aigateway/tests/unit/auth/test_login.py
+++ b/apps/aigateway/tests/unit/auth/test_login.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 from statistics import median
 
 import pytest
@@ -86,16 +87,21 @@ async def test_unknown_user_timing_close_to_wrong_password(client, monkeypatch) 
 
 
 @pytest.mark.asyncio
-async def test_concurrent_logins_finish_under_5x_single_login(client, monkeypatch) -> None:
-    loop = asyncio.get_running_loop()
-    monkeypatch.setattr(passwords, "_BCRYPT_ROUNDS", 8)
+async def test_concurrent_logins_verify_passwords_in_threadpool(client, monkeypatch) -> None:
+    barrier = threading.Barrier(10, timeout=5)
+    lock = threading.Lock()
+    verifier_threads: set[int] = set()
 
-    async def _strengthen_admin_hash() -> None:
-        admin = await Account.get(username="admin")
-        admin.password_hash = await hash_password("test-admin-password")
-        await admin.save(update_fields=["password_hash"])
+    def _verify_password_sync(_password, _password_hash) -> bool:
+        with lock:
+            verifier_threads.add(threading.get_ident())
+        try:
+            barrier.wait()
+        except threading.BrokenBarrierError as exc:
+            raise AssertionError("password verification did not overlap") from exc
+        return True
 
-    client.portal.call(_strengthen_admin_hash)
+    monkeypatch.setattr(passwords, "_verify_password_sync", _verify_password_sync)
 
     async def _login():
         return await asyncio.to_thread(
@@ -104,14 +110,7 @@ async def test_concurrent_logins_finish_under_5x_single_login(client, monkeypatc
             json={"username": "admin", "password": "test-admin-password"},
         )
 
-    single_start = loop.time()
-    single_response = await _login()
-    single = loop.time() - single_start
-
-    many_start = loop.time()
     responses = await asyncio.gather(*[_login() for _ in range(10)])
-    many = loop.time() - many_start
 
-    assert single_response.status_code == 200
     assert all(response.status_code == 200 for response in responses)
-    assert many < single * 5
+    assert len(verifier_threads) > 1

--- a/apps/aigateway/tests/unit/auth/test_login.py
+++ b/apps/aigateway/tests/unit/auth/test_login.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import asyncio
+from statistics import median
+
+import pytest
+
+from aigateway.core.auth import passwords
+from aigateway.core.auth.models import Account
+from aigateway.core.auth.passwords import hash_password
+
+
+def test_login_and_me(authenticated_client) -> None:
+    response = authenticated_client.get("/v1/auth/me")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["username"] == "admin"
+    assert "password" not in body
+    assert "password_hash" not in body
+
+
+def test_wrong_password_and_unknown_user_match(client) -> None:
+    wrong = client.post(
+        "/v1/auth/login",
+        json={"username": "admin", "password": "wrong-pass"},
+    )
+    missing = client.post(
+        "/v1/auth/login",
+        json={"username": "missing", "password": "wrong-pass"},
+    )
+    assert wrong.status_code == 401
+    assert missing.status_code == 401
+    assert wrong.content == missing.content
+
+
+def test_login_rejects_overlong_password(client) -> None:
+    response = client.post(
+        "/v1/auth/login",
+        json={"username": "admin", "password": "a" * 73},
+    )
+    assert response.status_code == 422
+
+
+def test_inactive_account_returns_locked(client) -> None:
+    async def _deactivate() -> None:
+        admin = await Account.get(username="admin")
+        admin.is_active = False
+        await admin.save(update_fields=["is_active"])
+
+    client.portal.call(_deactivate)
+    response = client.post(
+        "/v1/auth/login",
+        json={"username": "admin", "password": "test-admin-password"},
+    )
+    assert response.status_code == 423
+
+
+@pytest.mark.asyncio
+async def test_unknown_user_timing_close_to_wrong_password(client, monkeypatch) -> None:
+    loop = asyncio.get_running_loop()
+    monkeypatch.setattr(passwords, "_BCRYPT_ROUNDS", 12)
+    monkeypatch.setattr(passwords, "_dummy_hash", None)
+
+    async def _strengthen_admin_hash() -> None:
+        admin = await Account.get(username="admin")
+        admin.password_hash = await hash_password("test-admin-password")
+        await admin.save(update_fields=["password_hash"])
+
+    client.portal.call(_strengthen_admin_hash)
+
+    async def _post(username: str) -> float:
+        start = loop.time()
+        await asyncio.to_thread(
+            client.post,
+            "/v1/auth/login",
+            json={"username": username, "password": "wrong-pass"},
+        )
+        return loop.time() - start
+
+    await _post("admin")
+    await _post("missing")
+
+    wrong = median([await _post("admin") for _ in range(20)])
+    missing = median([await _post("missing") for _ in range(20)])
+    assert abs(missing - wrong) / wrong < 0.10
+
+
+@pytest.mark.asyncio
+async def test_concurrent_logins_finish_under_5x_single_login(client, monkeypatch) -> None:
+    loop = asyncio.get_running_loop()
+    monkeypatch.setattr(passwords, "_BCRYPT_ROUNDS", 8)
+
+    async def _strengthen_admin_hash() -> None:
+        admin = await Account.get(username="admin")
+        admin.password_hash = await hash_password("test-admin-password")
+        await admin.save(update_fields=["password_hash"])
+
+    client.portal.call(_strengthen_admin_hash)
+
+    async def _login():
+        return await asyncio.to_thread(
+            client.post,
+            "/v1/auth/login",
+            json={"username": "admin", "password": "test-admin-password"},
+        )
+
+    single_start = loop.time()
+    single_response = await _login()
+    single = loop.time() - single_start
+
+    many_start = loop.time()
+    responses = await asyncio.gather(*[_login() for _ in range(10)])
+    many = loop.time() - many_start
+
+    assert single_response.status_code == 200
+    assert all(response.status_code == 200 for response in responses)
+    assert many < single * 5

--- a/apps/aigateway/tests/unit/auth/test_middleware.py
+++ b/apps/aigateway/tests/unit/auth/test_middleware.py
@@ -2,12 +2,28 @@ from __future__ import annotations
 
 from aigateway.core.auth import middleware
 from aigateway.core.auth.jwt import encode_token
+from aigateway.core.auth.middleware import ANONYMOUS_ACCOUNT_ID
 from aigateway.core.auth.models import Account
 
 
 def test_missing_authorization_rejected(client) -> None:
     response = client.get("/v1/models")
     assert response.status_code == 401
+
+
+def test_auth_disabled_returns_anonymous_account_without_token(client, monkeypatch) -> None:
+    client.app.state.settings.auth_enabled = False
+
+    async def fail_lookup(*_args, **_kwargs):
+        raise AssertionError("disabled auth should not look up accounts")
+
+    monkeypatch.setattr(middleware.Account, "get_or_none", staticmethod(fail_lookup))
+    response = client.get("/v1/auth/me")
+
+    assert response.status_code == 200
+    assert response.json()["id"] == str(ANONYMOUS_ACCOUNT_ID)
+    assert response.json()["username"] == "anonymous"
+    assert response.json()["display_name"] == "Anonymous"
 
 
 def test_malformed_token_rejected(client) -> None:

--- a/apps/aigateway/tests/unit/auth/test_middleware.py
+++ b/apps/aigateway/tests/unit/auth/test_middleware.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from aigateway.core.auth import middleware
 from aigateway.core.auth.jwt import encode_token
-from aigateway.core.auth.middleware import ANONYMOUS_ACCOUNT_ID
-from aigateway.core.auth.models import Account
+from aigateway.core.auth.middleware import ANONYMOUS_ACCOUNT_ID, anonymous_account
+from aigateway.core.auth.models import Account, BaseAccount
 
 
 def test_missing_authorization_rejected(client) -> None:
@@ -24,6 +24,14 @@ def test_auth_disabled_returns_anonymous_account_without_token(client, monkeypat
     assert response.json()["id"] == str(ANONYMOUS_ACCOUNT_ID)
     assert response.json()["username"] == "anonymous"
     assert response.json()["display_name"] == "Anonymous"
+
+
+def test_anonymous_account_uses_base_account_interface() -> None:
+    account = anonymous_account()
+    assert isinstance(account, BaseAccount)
+    assert isinstance(account, Account)
+    assert account.id == ANONYMOUS_ACCOUNT_ID
+    assert account.username == "anonymous"
 
 
 def test_malformed_token_rejected(client) -> None:

--- a/apps/aigateway/tests/unit/auth/test_middleware.py
+++ b/apps/aigateway/tests/unit/auth/test_middleware.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from aigateway.core.auth import middleware
 from aigateway.core.auth.jwt import encode_token
 from aigateway.core.auth.models import Account
 
@@ -35,6 +36,23 @@ def test_token_for_nonexistent_account_rejected(client) -> None:
     )
     response = client.get("/v1/models", headers={"Authorization": f"Bearer {token}"})
     assert response.status_code == 401
+
+
+def test_token_with_malformed_subject_rejected_before_db_lookup(client, monkeypatch) -> None:
+    token, _ = encode_token(
+        account_id="not-a-uuid",
+        username="ghost",
+        secret="x" * 32,
+        ttl_seconds=60,
+    )
+
+    async def fail_lookup(*_args, **_kwargs):
+        raise AssertionError("malformed subject should be rejected before DB lookup")
+
+    monkeypatch.setattr(middleware.Account, "get_or_none", staticmethod(fail_lookup))
+    response = client.get("/v1/models", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 401
+    assert "malformed subject" in response.text
 
 
 def test_token_for_inactive_account_rejected(client) -> None:

--- a/apps/aigateway/tests/unit/auth/test_middleware.py
+++ b/apps/aigateway/tests/unit/auth/test_middleware.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from aigateway.core.auth.jwt import encode_token
+from aigateway.core.auth.models import Account
+
+
+def test_missing_authorization_rejected(client) -> None:
+    response = client.get("/v1/models")
+    assert response.status_code == 401
+
+
+def test_malformed_token_rejected(client) -> None:
+    response = client.get("/v1/models", headers={"Authorization": "Bearer not-a-token"})
+    assert response.status_code == 401
+
+
+def test_expired_token_rejected(client) -> None:
+    token, _ = encode_token(
+        account_id="missing",
+        username="missing",
+        secret="x" * 32,
+        ttl_seconds=-1,
+    )
+    response = client.get("/v1/models", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 401
+    assert "expired" in response.text.lower()
+
+
+def test_token_for_nonexistent_account_rejected(client) -> None:
+    token, _ = encode_token(
+        account_id="00000000-0000-0000-0000-000000000000",
+        username="ghost",
+        secret="x" * 32,
+        ttl_seconds=60,
+    )
+    response = client.get("/v1/models", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 401
+
+
+def test_token_for_inactive_account_rejected(client) -> None:
+    async def _deactivate() -> None:
+        admin = await Account.get(username="admin")
+        admin.is_active = False
+        await admin.save(update_fields=["is_active"])
+
+    token = client.post(
+        "/v1/auth/login",
+        json={"username": "admin", "password": "test-admin-password"},
+    ).json()["token"]
+    client.portal.call(_deactivate)
+    response = client.get("/v1/models", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 401
+
+
+def test_valid_token_allowed(authenticated_client) -> None:
+    response = authenticated_client.get("/v1/models")
+    assert response.status_code == 200
+
+
+def test_healthz_stays_open(client) -> None:
+    response = client.get("/healthz")
+    assert response.status_code == 200

--- a/apps/aigateway/tests/unit/auth/test_passwords.py
+++ b/apps/aigateway/tests/unit/auth/test_passwords.py
@@ -48,3 +48,25 @@ async def test_bcrypt_runs_in_threadpool() -> None:
         assert not task.done()
         release.set()
         assert await task == "hashed:password123"
+
+
+@pytest.mark.asyncio
+async def test_verify_password_runs_in_threadpool() -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    def _verify(_password: str, _password_hash: str) -> bool:
+        started.set()
+        release.wait(timeout=1)
+        return True
+
+    with patch("aigateway.core.auth.passwords._verify_password_sync", _verify):
+        task = asyncio.create_task(verify_password("password123", "stored-hash"))
+        for _ in range(100):
+            if started.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert started.is_set()
+        assert not task.done()
+        release.set()
+        assert await task is True

--- a/apps/aigateway/tests/unit/auth/test_passwords.py
+++ b/apps/aigateway/tests/unit/auth/test_passwords.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from unittest.mock import patch
+
+import pytest
+
+from aigateway.core.auth.passwords import hash_password, verify_password
+
+
+@pytest.mark.asyncio
+async def test_hash_and_verify_password() -> None:
+    hashed = await hash_password("password123")
+    assert hashed.startswith("$2")
+    assert await verify_password("password123", hashed)
+    assert not await verify_password("wrongpass", hashed)
+
+
+@pytest.mark.asyncio
+async def test_malformed_hash_returns_false() -> None:
+    assert not await verify_password("password123", "not-a-bcrypt-hash")
+
+
+@pytest.mark.asyncio
+async def test_password_over_72_bytes_rejected() -> None:
+    with pytest.raises(ValueError, match="8-72 UTF-8 bytes"):
+        await hash_password("a" * 73)
+
+
+@pytest.mark.asyncio
+async def test_bcrypt_runs_in_threadpool() -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    def _thread_id(password: str) -> str:
+        started.set()
+        release.wait(timeout=1)
+        return f"hashed:{password}"
+
+    with patch("aigateway.core.auth.passwords._hash_password_sync", _thread_id):
+        task = asyncio.create_task(hash_password("password123"))
+        for _ in range(100):
+            if started.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert started.is_set()
+        assert not task.done()
+        release.set()
+        assert await task == "hashed:password123"

--- a/apps/aigateway/tests/unit/auth/test_provisioning.py
+++ b/apps/aigateway/tests/unit/auth/test_provisioning.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import inspect
+
+from pydantic import SecretStr
+
+from aigateway.core.auth import provisioning
+
+
+def test_provisioning_token_uses_compare_digest() -> None:
+    source = inspect.getsource(provisioning.verify_provisioning_token)
+    assert "hmac.compare_digest" in source
+    assert "token ==" not in source
+    assert "== token" not in source
+    assert provisioning.verify_provisioning_token("x" * 32, SecretStr("x" * 32))
+    assert not provisioning.verify_provisioning_token("x" * 31 + "y", SecretStr("x" * 32))

--- a/apps/aigateway/tests/unit/auth/test_settings_redaction.py
+++ b/apps/aigateway/tests/unit/auth/test_settings_redaction.py
@@ -19,6 +19,14 @@ def test_secret_settings_are_redacted() -> None:
     assert "p" * 32 not in rendered
 
 
+def test_auth_enabled_defaults_true_and_parses_env_zero(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert Settings().auth_enabled is True
+
+    monkeypatch.setenv("AIGATEWAY_AUTH_ENABLED", "0")
+    assert Settings().auth_enabled is False
+
+
 def test_short_secret_rejected() -> None:
     try:
         Settings(jwt_secret=SecretStr("short"))

--- a/apps/aigateway/tests/unit/auth/test_settings_redaction.py
+++ b/apps/aigateway/tests/unit/auth/test_settings_redaction.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pydantic import SecretStr
+
+from aigateway.config import Settings
+
+
+def test_secret_settings_are_redacted() -> None:
+    settings = Settings(
+        database_url=SecretStr("postgres://secret:secret@localhost:5432/secret"),
+        jwt_secret=SecretStr("j" * 32),
+        admin_password=SecretStr("admin-pass"),
+        provisioning_token=SecretStr("p" * 32),
+    )
+    rendered = "\n".join([repr(settings), str(settings), settings.model_dump_json()])
+    assert "postgres://secret" not in rendered
+    assert "j" * 32 not in rendered
+    assert "admin-pass" not in rendered
+    assert "p" * 32 not in rendered
+
+
+def test_short_secret_rejected() -> None:
+    try:
+        Settings(jwt_secret=SecretStr("short"))
+    except ValueError as exc:
+        assert "secret must be at least 32 characters" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("short jwt_secret was accepted")

--- a/apps/aigateway/tests/unit/auth/test_settings_redaction.py
+++ b/apps/aigateway/tests/unit/auth/test_settings_redaction.py
@@ -26,3 +26,21 @@ def test_short_secret_rejected() -> None:
         assert "secret must be at least 32 characters" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("short jwt_secret was accepted")
+
+
+def test_short_provisioning_token_rejected() -> None:
+    try:
+        Settings(provisioning_token=SecretStr("short"))
+    except ValueError as exc:
+        assert "secret must be at least 32 characters" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("short provisioning_token was accepted")
+
+
+def test_invalid_admin_password_rejected() -> None:
+    try:
+        Settings(admin_password=SecretStr("short"))
+    except ValueError as exc:
+        assert "password must be 8-72 UTF-8 bytes" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("short admin_password was accepted")

--- a/apps/aigateway/tests/unit/test_auth_routes.py
+++ b/apps/aigateway/tests/unit/test_auth_routes.py
@@ -490,18 +490,8 @@ def test_refresh_unknown_provider_404(client_with_index) -> None:
     assert resp.json()["detail"]["code"] == "unknown_provider"
 
 
-def test_refresh_missing_profile_404(client_with_index, monkeypatch) -> None:
+def test_refresh_missing_profile_404(client_with_index) -> None:
     client, _ = client_with_index
-
-    class _Strategy:
-        async def refresh(self) -> None:
-            return None
-
-    monkeypatch.setattr(
-        client.app.state.providers.get("anthropic"),
-        "oauth_strategy_for",
-        lambda _name: _Strategy(),
-    )
     resp = client.post("/v1/auth/anthropic/profiles/missing/refresh")
     assert resp.status_code == 404
     assert resp.json()["detail"]["code"] == "profile_not_found"

--- a/apps/aigateway/tests/unit/test_auth_routes.py
+++ b/apps/aigateway/tests/unit/test_auth_routes.py
@@ -2,26 +2,14 @@ from __future__ import annotations
 
 import httpx
 import pytest
-from fastapi.testclient import TestClient
 
 from aigateway.core.profile_index import ProfileIndexStore
 from aigateway.core.profile_models import Profile, ProfileDefaults, ProfileState
-from aigateway.main import create_app
 
 
 @pytest.fixture
-def client_with_index(fake_keychain, monkeypatch):
-    """Patch the global credential store factory so create_app() picks up our fake."""
-    from aigateway.core import bootstrap as bs_module
-    from aigateway.core import credential_store as cs_module
-    from aigateway.core import profile_index as pi_module
-
-    monkeypatch.setattr(cs_module, "get_credential_store", lambda: fake_keychain)
-    monkeypatch.setattr(pi_module, "get_credential_store", lambda: fake_keychain)
-    monkeypatch.setattr(bs_module, "get_credential_store", lambda: fake_keychain)
-
-    app = create_app()
-    return TestClient(app), fake_keychain
+def client_with_index(authenticated_client, fake_keychain):
+    return authenticated_client, fake_keychain
 
 
 def test_list_profiles_empty(client_with_index) -> None:
@@ -32,15 +20,7 @@ def test_list_profiles_empty(client_with_index) -> None:
 
 
 @pytest.mark.asyncio
-async def test_list_profiles_returns_seeded(fake_keychain, monkeypatch) -> None:
-    from aigateway.core import bootstrap as bs_module
-    from aigateway.core import credential_store as cs_module
-    from aigateway.core import profile_index as pi_module
-
-    monkeypatch.setattr(cs_module, "get_credential_store", lambda: fake_keychain)
-    monkeypatch.setattr(pi_module, "get_credential_store", lambda: fake_keychain)
-    monkeypatch.setattr(bs_module, "get_credential_store", lambda: fake_keychain)
-
+async def test_list_profiles_returns_seeded(fake_keychain, authenticated_client) -> None:
     idx = ProfileIndexStore(credential_store=fake_keychain)
     await idx.upsert(
         Profile(
@@ -52,10 +32,7 @@ async def test_list_profiles_returns_seeded(fake_keychain, monkeypatch) -> None:
         )
     )
 
-    app = create_app()
-    client = TestClient(app)
-
-    resp = client.get("/v1/auth/profiles")
+    resp = authenticated_client.get("/v1/auth/profiles")
     body = resp.json()
     assert resp.status_code == 200
     assert len(body["profiles"]) == 1
@@ -103,11 +80,15 @@ def test_top_level_callback_dispatches_by_state(client_with_index) -> None:
     start = client.post("/v1/auth/anthropic/profiles", json={"name": "topcb"})
     state = start.json()["state"]
 
-    resp = client.get(
-        "/callback",
-        params={"code": "auth-code-top", "state": state},
-        follow_redirects=False,
-    )
+    auth_header = client.headers.pop("Authorization")
+    try:
+        resp = client.get(
+            "/callback",
+            params={"code": "auth-code-top", "state": state},
+            follow_redirects=False,
+        )
+    finally:
+        client.headers["Authorization"] = auth_header
     assert resp.status_code == 200
     prof = client.get("/v1/auth/anthropic/profiles/topcb").json()
     assert prof["state"] == "authenticated"
@@ -115,7 +96,11 @@ def test_top_level_callback_dispatches_by_state(client_with_index) -> None:
 
 def test_top_level_callback_unknown_state_400(client_with_index) -> None:
     client, _ = client_with_index
-    resp = client.get("/callback", params={"code": "x", "state": "never-issued"})
+    auth_header = client.headers.pop("Authorization")
+    try:
+        resp = client.get("/callback", params={"code": "x", "state": "never-issued"})
+    finally:
+        client.headers["Authorization"] = auth_header
     assert resp.status_code == 400
 
 
@@ -148,6 +133,13 @@ def _mock_token_factory():
     return lambda: httpx.AsyncClient(transport=transport, timeout=httpx.Timeout(5.0))
 
 
+def _failing_token_factory():
+    transport = httpx.MockTransport(
+        lambda req: httpx.Response(400, json={"error": "invalid_grant"})
+    )
+    return lambda: httpx.AsyncClient(transport=transport, timeout=httpx.Timeout(5.0))
+
+
 def test_callback_completes_auth(client_with_index) -> None:
     client, fake_keychain = client_with_index
     client.app.state.anthropic_http_factory = _mock_token_factory()
@@ -155,11 +147,15 @@ def test_callback_completes_auth(client_with_index) -> None:
     start = client.post("/v1/auth/anthropic/profiles", json={"name": "work"})
     state = start.json()["state"]
 
-    cb = client.get(
-        "/v1/auth/anthropic/callback",
-        params={"code": "auth-code-1", "state": state},
-        follow_redirects=False,
-    )
+    auth_header = client.headers.pop("Authorization")
+    try:
+        cb = client.get(
+            "/v1/auth/anthropic/callback",
+            params={"code": "auth-code-1", "state": state},
+            follow_redirects=False,
+        )
+    finally:
+        client.headers["Authorization"] = auth_header
     assert cb.status_code == 200
 
     prof = client.get("/v1/auth/anthropic/profiles/work").json()
@@ -171,12 +167,45 @@ def test_callback_completes_auth(client_with_index) -> None:
     assert "new-tok" in blob
 
 
+def test_callback_exchange_failure_keeps_pending_state(client_with_index) -> None:
+    client, _ = client_with_index
+    client.app.state.anthropic_http_factory = _failing_token_factory()
+
+    start = client.post("/v1/auth/anthropic/profiles", json={"name": "retry"})
+    state = start.json()["state"]
+
+    auth_header = client.headers.pop("Authorization")
+    try:
+        failed = client.get(
+            "/callback",
+            params={"code": "bad-code", "state": state},
+            follow_redirects=False,
+        )
+        client.app.state.anthropic_http_factory = _mock_token_factory()
+        retried = client.get(
+            "/callback",
+            params={"code": "good-code", "state": state},
+            follow_redirects=False,
+        )
+    finally:
+        client.headers["Authorization"] = auth_header
+
+    assert failed.status_code == 500
+    assert retried.status_code == 200
+    prof = client.get("/v1/auth/anthropic/profiles/retry").json()
+    assert prof["state"] == "authenticated"
+
+
 def test_callback_with_unknown_state_400(client_with_index) -> None:
     client, _ = client_with_index
-    resp = client.get(
-        "/v1/auth/anthropic/callback",
-        params={"code": "x", "state": "never-issued"},
-    )
+    auth_header = client.headers.pop("Authorization")
+    try:
+        resp = client.get(
+            "/v1/auth/anthropic/callback",
+            params={"code": "x", "state": "never-issued"},
+        )
+    finally:
+        client.headers["Authorization"] = auth_header
     assert resp.status_code == 400
 
 

--- a/apps/aigateway/tests/unit/test_auth_routes.py
+++ b/apps/aigateway/tests/unit/test_auth_routes.py
@@ -4,12 +4,22 @@ import httpx
 import pytest
 
 from aigateway.core.profile_index import ProfileIndexStore
-from aigateway.core.profile_models import Profile, ProfileDefaults, ProfileState
+from aigateway.core.profile_models import (
+    Profile,
+    ProfileDefaults,
+    ProfileState,
+    credential_name_for,
+    profile_id_for,
+)
 
 
 @pytest.fixture
 def client_with_index(authenticated_client, fake_keychain):
     return authenticated_client, fake_keychain
+
+
+def _account_id(client) -> str:
+    return client.get("/v1/auth/me").json()["id"]
 
 
 def test_list_profiles_empty(client_with_index) -> None:
@@ -21,10 +31,12 @@ def test_list_profiles_empty(client_with_index) -> None:
 
 @pytest.mark.asyncio
 async def test_list_profiles_returns_seeded(fake_keychain, authenticated_client) -> None:
+    account_id = _account_id(authenticated_client)
     idx = ProfileIndexStore(credential_store=fake_keychain)
     await idx.upsert(
         Profile(
-            id="anthropic:default",
+            id=profile_id_for(account_id, "anthropic", "default"),
+            account_id=account_id,
             provider="anthropic",
             name="default",
             state=ProfileState.AUTHENTICATED,
@@ -36,7 +48,8 @@ async def test_list_profiles_returns_seeded(fake_keychain, authenticated_client)
     body = resp.json()
     assert resp.status_code == 200
     assert len(body["profiles"]) == 1
-    assert body["profiles"][0]["id"] == "anthropic:default"
+    assert body["profiles"][0]["id"] == profile_id_for(account_id, "anthropic", "default")
+    assert body["profiles"][0]["account_id"] == account_id
     assert "access_token" not in str(body)
 
 
@@ -49,10 +62,11 @@ def test_get_profile_404_on_missing(client_with_index) -> None:
 
 def test_start_oauth_returns_authorize_url(client_with_index) -> None:
     client, _ = client_with_index
+    account_id = _account_id(client)
     resp = client.post("/v1/auth/anthropic/profiles", json={"name": "work"})
     assert resp.status_code == 201
     body = resp.json()
-    assert body["profile_id"] == "anthropic:work"
+    assert body["profile_id"] == profile_id_for(account_id, "anthropic", "work")
     assert body["authorize_url"].startswith("https://claude.ai/oauth/authorize")
     assert "state=" in body["authorize_url"]
     assert "code_challenge=" in body["authorize_url"]
@@ -110,12 +124,99 @@ def test_start_oauth_for_unknown_provider_404(client_with_index) -> None:
     assert resp.status_code == 404
 
 
+class _NoOAuthPlugin:
+    custom_llm_provider = "local"
+
+    def register_models(self) -> list:
+        return []
+
+    def oauth_config(self):
+        return None
+
+
+def test_start_oauth_for_non_oauth_provider_400(client_with_index) -> None:
+    client, _ = client_with_index
+    client.app.state.providers._plugins["local"] = _NoOAuthPlugin()
+
+    resp = client.post("/v1/auth/local/profiles", json={"name": "x"})
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["code"] == "provider_does_not_use_oauth"
+
+
 def test_start_oauth_creates_pending_profile(client_with_index) -> None:
     client, _ = client_with_index
     client.post("/v1/auth/anthropic/profiles", json={"name": "work"})
     resp = client.get("/v1/auth/anthropic/profiles/work")
     assert resp.status_code == 200
     assert resp.json()["state"] == "pending"
+
+
+def test_profiles_are_scoped_to_current_account(
+    client_with_index, provisioned_user_factory
+) -> None:
+    client, _ = client_with_index
+    admin_account_id = _account_id(client)
+    start = client.post("/v1/auth/anthropic/profiles", json={"name": "admin-owned"})
+    assert start.status_code == 201
+
+    provisioned_user_factory("bob", "bob-pass1")
+    login = client.post("/v1/auth/login", json={"username": "bob", "password": "bob-pass1"})
+    bob_token = login.json()["token"]
+    client.headers.update({"Authorization": f"Bearer {bob_token}"})
+
+    listing = client.get("/v1/auth/profiles")
+    assert listing.status_code == 200
+    assert listing.json() == {"profiles": []}
+    assert client.get("/v1/auth/anthropic/profiles/admin-owned").status_code == 404
+    assert (
+        profile_id_for(admin_account_id, "anthropic", "admin-owned") == start.json()["profile_id"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_provider_profiles_returns_only_current_account(
+    fake_keychain, authenticated_client, provisioned_user_factory
+) -> None:
+    admin_account_id = _account_id(authenticated_client)
+    idx = ProfileIndexStore(credential_store=fake_keychain)
+    await idx.upsert(
+        Profile(
+            id=profile_id_for(admin_account_id, "anthropic", "admin-owned"),
+            account_id=admin_account_id,
+            provider="anthropic",
+            name="admin-owned",
+            state=ProfileState.AUTHENTICATED,
+        )
+    )
+    provisioned_user_factory("bob", "bob-pass1")
+    login = authenticated_client.post(
+        "/v1/auth/login", json={"username": "bob", "password": "bob-pass1"}
+    )
+    bob_token = login.json()["token"]
+    authenticated_client.headers.update({"Authorization": f"Bearer {bob_token}"})
+
+    resp = authenticated_client.get("/v1/auth/anthropic/profiles")
+    assert resp.status_code == 200
+    assert resp.json() == {"profiles": []}
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "json"),
+    [
+        ("GET", "/v1/auth/profiles", None),
+        ("GET", "/v1/auth/anthropic/profiles", None),
+        ("GET", "/v1/auth/anthropic/profiles/default", None),
+        ("POST", "/v1/auth/anthropic/profiles", {"name": "default"}),
+        ("POST", "/v1/auth/anthropic/exchange-code", {"code": "x", "state": "y"}),
+        ("GET", "/v1/auth/anthropic/profiles/default/status", None),
+        ("PATCH", "/v1/auth/anthropic/profiles/default", {"account_label": "x"}),
+        ("DELETE", "/v1/auth/anthropic/profiles/default", None),
+        ("POST", "/v1/auth/anthropic/profiles/default/refresh", None),
+    ],
+)
+def test_oauth_profile_routes_require_jwt(client, method, path, json) -> None:
+    response = client.request(method, path, json=json)
+    assert response.status_code == 401
 
 
 def _mock_token_factory():
@@ -140,8 +241,16 @@ def _failing_token_factory():
     return lambda: httpx.AsyncClient(transport=transport, timeout=httpx.Timeout(5.0))
 
 
+def _html_failing_token_factory():
+    transport = httpx.MockTransport(
+        lambda req: httpx.Response(400, text="<script>alert('x')</script>")
+    )
+    return lambda: httpx.AsyncClient(transport=transport, timeout=httpx.Timeout(5.0))
+
+
 def test_callback_completes_auth(client_with_index) -> None:
     client, fake_keychain = client_with_index
+    account_id = _account_id(client)
     client.app.state.anthropic_http_factory = _mock_token_factory()
 
     start = client.post("/v1/auth/anthropic/profiles", json={"name": "work"})
@@ -163,7 +272,9 @@ def test_callback_completes_auth(client_with_index) -> None:
 
     from aigateway.plugins.anthropic_provider.auth import keychain_service_for
 
-    blob = fake_keychain.read(keychain_service_for("work"), "default")
+    blob = fake_keychain.read(
+        keychain_service_for(credential_name_for(account_id, "work")), "default"
+    )
     assert "new-tok" in blob
 
 
@@ -194,6 +305,27 @@ def test_callback_exchange_failure_keeps_pending_state(client_with_index) -> Non
     assert retried.status_code == 200
     prof = client.get("/v1/auth/anthropic/profiles/retry").json()
     assert prof["state"] == "authenticated"
+
+
+def test_callback_error_html_escapes_provider_response(client_with_index) -> None:
+    client, _ = client_with_index
+    client.app.state.anthropic_http_factory = _html_failing_token_factory()
+    start = client.post("/v1/auth/anthropic/profiles", json={"name": "htmlfail"})
+    state = start.json()["state"]
+
+    auth_header = client.headers.pop("Authorization")
+    try:
+        resp = client.get(
+            "/callback",
+            params={"code": "bad-code", "state": state},
+            follow_redirects=False,
+        )
+    finally:
+        client.headers["Authorization"] = auth_header
+
+    assert resp.status_code == 500
+    assert "<script>" not in resp.text
+    assert "&lt;script&gt;alert(&#x27;x&#x27;)&lt;/script&gt;" in resp.text
 
 
 def test_callback_with_unknown_state_400(client_with_index) -> None:
@@ -245,6 +377,7 @@ def test_patch_updates_defaults(client_with_index) -> None:
 def test_exchange_code_runs_oauth(client_with_index) -> None:
     """POST /v1/auth/{provider}/exchange-code completes auth same as GET callback."""
     client, fake_keychain = client_with_index
+    account_id = _account_id(client)
     client.app.state.anthropic_http_factory = _mock_token_factory()
 
     start = client.post("/v1/auth/anthropic/profiles", json={"name": "paste"})
@@ -262,7 +395,9 @@ def test_exchange_code_runs_oauth(client_with_index) -> None:
 
     from aigateway.plugins.anthropic_provider.auth import keychain_service_for
 
-    blob = fake_keychain.read(keychain_service_for("paste"), "default")
+    blob = fake_keychain.read(
+        keychain_service_for(credential_name_for(account_id, "paste")), "default"
+    )
     assert "new-tok" in blob
 
 
@@ -276,8 +411,105 @@ def test_exchange_code_with_unknown_state_400(client_with_index) -> None:
     assert resp.json()["detail"]["code"] == "unknown_state"
 
 
+def test_exchange_code_with_provider_mismatch_400(client_with_index) -> None:
+    client, _ = client_with_index
+    start = client.post("/v1/auth/anthropic/profiles", json={"name": "mismatch"})
+
+    resp = client.post(
+        "/v1/auth/ghost/exchange-code",
+        json={"code": "x", "state": start.json()["state"]},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["code"] == "provider_mismatch"
+
+
+def test_exchange_code_with_other_accounts_state_404(
+    client_with_index, provisioned_user_factory
+) -> None:
+    client, _ = client_with_index
+    start = client.post("/v1/auth/anthropic/profiles", json={"name": "admin-only"})
+    provisioned_user_factory("bob", "bob-pass1")
+    login = client.post("/v1/auth/login", json={"username": "bob", "password": "bob-pass1"})
+    client.headers.update({"Authorization": f"Bearer {login.json()['token']}"})
+
+    resp = client.post(
+        "/v1/auth/anthropic/exchange-code",
+        json={"code": "x", "state": start.json()["state"]},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["code"] == "profile_not_found"
+
+
+def test_status_404_on_missing_profile(client_with_index) -> None:
+    client, _ = client_with_index
+    resp = client.get("/v1/auth/anthropic/profiles/missing/status")
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["code"] == "profile_not_found"
+
+
+def test_patch_404_on_missing_profile(client_with_index) -> None:
+    client, _ = client_with_index
+    resp = client.patch(
+        "/v1/auth/anthropic/profiles/missing",
+        json={"account_label": "user@example.com"},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["code"] == "profile_not_found"
+
+
+def test_patch_updates_account_label(client_with_index) -> None:
+    client, _ = client_with_index
+    client.post("/v1/auth/anthropic/profiles", json={"name": "label"})
+
+    resp = client.patch(
+        "/v1/auth/anthropic/profiles/label",
+        json={"account_label": "user@example.com"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["account_label"] == "user@example.com"
+
+
+def test_delete_unknown_provider_404(client_with_index) -> None:
+    client, _ = client_with_index
+    resp = client.delete("/v1/auth/ghost/profiles/default")
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["code"] == "unknown_provider"
+
+
+def test_delete_missing_profile_404(client_with_index) -> None:
+    client, _ = client_with_index
+    resp = client.delete("/v1/auth/anthropic/profiles/missing")
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["code"] == "profile_not_found"
+
+
+def test_refresh_unknown_provider_404(client_with_index) -> None:
+    client, _ = client_with_index
+    resp = client.post("/v1/auth/ghost/profiles/default/refresh")
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["code"] == "unknown_provider"
+
+
+def test_refresh_missing_profile_404(client_with_index, monkeypatch) -> None:
+    client, _ = client_with_index
+
+    class _Strategy:
+        async def refresh(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        client.app.state.providers.get("anthropic"),
+        "oauth_strategy_for",
+        lambda _name: _Strategy(),
+    )
+    resp = client.post("/v1/auth/anthropic/profiles/missing/refresh")
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["code"] == "profile_not_found"
+
+
 def test_delete_removes_profile_and_tokens(client_with_index) -> None:
     client, fake_keychain = client_with_index
+    account_id = _account_id(client)
     client.app.state.anthropic_http_factory = _mock_token_factory()
 
     start = client.post("/v1/auth/anthropic/profiles", json={"name": "z"})
@@ -285,10 +517,16 @@ def test_delete_removes_profile_and_tokens(client_with_index) -> None:
 
     from aigateway.plugins.anthropic_provider.auth import keychain_service_for
 
-    assert fake_keychain.read(keychain_service_for("z"), "default") is not None
+    assert (
+        fake_keychain.read(keychain_service_for(credential_name_for(account_id, "z")), "default")
+        is not None
+    )
 
     resp = client.delete("/v1/auth/anthropic/profiles/z")
     assert resp.status_code == 204
-    assert fake_keychain.read(keychain_service_for("z"), "default") is None
+    assert (
+        fake_keychain.read(keychain_service_for(credential_name_for(account_id, "z")), "default")
+        is None
+    )
     g = client.get("/v1/auth/anthropic/profiles/z")
     assert g.status_code == 404

--- a/apps/aigateway/tests/unit/test_bootstrap.py
+++ b/apps/aigateway/tests/unit/test_bootstrap.py
@@ -1,20 +1,10 @@
-import json
-import time
 from typing import Any
 
-import pytest
 from fastapi.testclient import TestClient
 
 from aigateway.core.auth.middleware import ANONYMOUS_ACCOUNT_ID
 from aigateway.core.plugin_base import ModelEntry, ProviderPluginBase
-from aigateway.core.profile_index import INDEX_KEYCHAIN_SERVICE, ProfileIndexStore
-from aigateway.core.profile_models import Profile, profile_id_for
-from aigateway.plugins.anthropic_provider.auth import keychain_service_for
-from aigateway.plugins.anthropic_provider.bootstrap import bootstrap_from_claude_code
 from tests.conftest import _prepare_sqlite_db
-
-CC_SERVICE = "Claude Code-credentials"
-ACCOUNT_ID = "account-1"
 
 
 def _configure_app_db(monkeypatch, tmp_path) -> None:
@@ -53,119 +43,6 @@ def _install_bootstrap_spy(monkeypatch, main_module, bootstrap_mock) -> None:
         registry.register(_BootstrapSpyPlugin(bootstrap_mock))
 
     monkeypatch.setattr(main_module, "load_plugins", _load_plugins)
-
-
-@pytest.mark.asyncio
-async def test_bootstrap_imports_cc_default_when_index_empty(fake_keychain) -> None:
-    cc_payload = json.dumps(
-        {
-            "claudeAiOauth": {
-                "accessToken": "cc-tok",
-                "refreshToken": "cc-rt",
-                "expiresAt": int(time.time() * 1000) + 3_600_000,
-                "scopes": ["user:inference"],
-            }
-        }
-    )
-    fake_keychain.write(CC_SERVICE, "alice", cc_payload)
-
-    await bootstrap_from_claude_code(
-        account_id=ACCOUNT_ID,
-        credential_store=fake_keychain,
-        index_store=ProfileIndexStore(credential_store=fake_keychain),
-        cc_account="alice",
-    )
-
-    aigw_payload = fake_keychain.read(keychain_service_for(f"{ACCOUNT_ID}:default"), "default")
-    assert aigw_payload is not None
-    converted = json.loads(aigw_payload)
-    assert converted["access_token"] == "cc-tok"
-    assert converted["refresh_token"] == "cc-rt"
-    assert "expires_at_ms" in converted
-
-    idx_raw = fake_keychain.read(INDEX_KEYCHAIN_SERVICE, "default")
-    assert idx_raw is not None
-    assert profile_id_for(ACCOUNT_ID, "anthropic", "default") in idx_raw
-
-    # CC entry untouched
-    assert fake_keychain.read(CC_SERVICE, "alice") == cc_payload
-
-
-@pytest.mark.asyncio
-async def test_bootstrap_noop_when_index_already_exists(fake_keychain) -> None:
-    await ProfileIndexStore(credential_store=fake_keychain).upsert(
-        Profile(
-            id=profile_id_for(ACCOUNT_ID, "x", "y"),
-            account_id=ACCOUNT_ID,
-            provider="x",
-            name="y",
-        )
-    )
-    fake_keychain.write(
-        CC_SERVICE,
-        "alice",
-        json.dumps({"claudeAiOauth": {"accessToken": "x", "refreshToken": "y", "expiresAt": 1}}),
-    )
-    await bootstrap_from_claude_code(
-        account_id=ACCOUNT_ID,
-        credential_store=fake_keychain,
-        index_store=ProfileIndexStore(credential_store=fake_keychain),
-        cc_account="alice",
-    )
-    assert fake_keychain.read(keychain_service_for(f"{ACCOUNT_ID}:default"), "default") is None
-
-
-@pytest.mark.asyncio
-async def test_bootstrap_noop_when_cc_entry_missing(fake_keychain) -> None:
-    await bootstrap_from_claude_code(
-        account_id=ACCOUNT_ID,
-        credential_store=fake_keychain,
-        index_store=ProfileIndexStore(credential_store=fake_keychain),
-        cc_account="alice",
-    )
-    assert fake_keychain.read(INDEX_KEYCHAIN_SERVICE, "default") is None
-
-
-def test_app_lifespan_runs_bootstrap(fake_keychain, monkeypatch, tmp_path) -> None:
-    _configure_app_db(monkeypatch, tmp_path)
-    fake_keychain.write(
-        CC_SERVICE,
-        "alice",
-        json.dumps(
-            {
-                "claudeAiOauth": {
-                    "accessToken": "boot-tok",
-                    "refreshToken": "boot-rt",
-                    "expiresAt": int(time.time() * 1000) + 3_600_000,
-                    "scopes": ["user:inference"],
-                }
-            }
-        ),
-    )
-    monkeypatch.setenv("USER", "alice")
-    monkeypatch.setenv("AIGATEWAY_BOOTSTRAP_FROM_CLAUDE_CODE", "1")
-
-    from aigateway import main as main_module
-    from aigateway.core import credential_store as cs_module
-    from aigateway.core import profile_index as pi_module
-    from aigateway.plugins.anthropic_provider import auth as auth_module
-
-    monkeypatch.setattr(cs_module, "get_credential_store", lambda: fake_keychain)
-    monkeypatch.setattr(pi_module, "get_credential_store", lambda: fake_keychain)
-    monkeypatch.setattr(auth_module, "get_credential_store", lambda: fake_keychain)
-    monkeypatch.setattr(main_module, "get_credential_store", lambda: fake_keychain)
-
-    from aigateway.main import create_app
-
-    app = create_app()
-    with TestClient(app) as client:  # `with` triggers the lifespan
-        resp = client.get("/v1/auth/profiles", headers=_auth_header(client))
-        assert resp.status_code == 200
-        profiles = resp.json()["profiles"]
-        assert len(profiles) == 1
-        assert profiles[0]["provider"] == "anthropic"
-        assert profiles[0]["name"] == "default"
-        assert profiles[0]["account_id"]
 
 
 def test_lifespan_skips_bootstrap_by_default(monkeypatch, fake_keychain, tmp_path) -> None:

--- a/apps/aigateway/tests/unit/test_bootstrap.py
+++ b/apps/aigateway/tests/unit/test_bootstrap.py
@@ -7,8 +7,27 @@ from fastapi.testclient import TestClient
 from aigateway.core.bootstrap import bootstrap_from_claude_code
 from aigateway.core.profile_index import INDEX_KEYCHAIN_SERVICE, ProfileIndexStore
 from aigateway.plugins.anthropic_provider.auth import keychain_service_for
+from tests.conftest import _prepare_sqlite_db
 
 CC_SERVICE = "Claude Code-credentials"
+
+
+def _configure_app_db(monkeypatch, tmp_path) -> None:
+    database_url = f"sqlite://{tmp_path / 'aigateway.sqlite3'}"
+    monkeypatch.setenv("AIGATEWAY_DATABASE_URL", database_url)
+    monkeypatch.setenv("AIGATEWAY_ADMIN_PASSWORD", "test-admin-password")
+    monkeypatch.setenv("AIGATEWAY_JWT_SECRET", "x" * 32)
+    monkeypatch.setenv("AIGATEWAY_PROVISIONING_TOKEN", "p" * 32)
+    _prepare_sqlite_db(database_url)
+
+
+def _auth_header(client: TestClient) -> dict[str, str]:
+    response = client.post(
+        "/v1/auth/login",
+        json={"username": "admin", "password": "test-admin-password"},
+    )
+    assert response.status_code == 200, response.text
+    return {"Authorization": f"Bearer {response.json()['token']}"}
 
 
 @pytest.mark.asyncio
@@ -76,7 +95,8 @@ async def test_bootstrap_noop_when_cc_entry_missing(fake_keychain) -> None:
     assert fake_keychain.read(INDEX_KEYCHAIN_SERVICE, "default") is None
 
 
-def test_app_lifespan_runs_bootstrap(fake_keychain, monkeypatch) -> None:
+def test_app_lifespan_runs_bootstrap(fake_keychain, monkeypatch, tmp_path) -> None:
+    _configure_app_db(monkeypatch, tmp_path)
     fake_keychain.write(
         CC_SERVICE,
         "alice",
@@ -94,6 +114,7 @@ def test_app_lifespan_runs_bootstrap(fake_keychain, monkeypatch) -> None:
     monkeypatch.setenv("USER", "alice")
     monkeypatch.setenv("AIGATEWAY_BOOTSTRAP_FROM_CLAUDE_CODE", "1")
 
+    from aigateway import main as main_module
     from aigateway.core import bootstrap as bs_module
     from aigateway.core import credential_store as cs_module
     from aigateway.core import profile_index as pi_module
@@ -103,22 +124,24 @@ def test_app_lifespan_runs_bootstrap(fake_keychain, monkeypatch) -> None:
     monkeypatch.setattr(pi_module, "get_credential_store", lambda: fake_keychain)
     monkeypatch.setattr(bs_module, "get_credential_store", lambda: fake_keychain)
     monkeypatch.setattr(auth_module, "get_credential_store", lambda: fake_keychain)
+    monkeypatch.setattr(main_module, "get_credential_store", lambda: fake_keychain)
 
     from aigateway.main import create_app
 
     app = create_app()
     with TestClient(app) as client:  # `with` triggers the lifespan
-        resp = client.get("/v1/auth/profiles")
+        resp = client.get("/v1/auth/profiles", headers=_auth_header(client))
         assert resp.status_code == 200
         ids = [p["id"] for p in resp.json()["profiles"]]
         assert "anthropic:default" in ids
 
 
-def test_lifespan_skips_bootstrap_by_default(monkeypatch, fake_keychain) -> None:
+def test_lifespan_skips_bootstrap_by_default(monkeypatch, fake_keychain, tmp_path) -> None:
     """When AIGATEWAY_BOOTSTRAP_FROM_CLAUDE_CODE is unset, _lifespan does not call bootstrap."""
     from unittest.mock import AsyncMock
 
     monkeypatch.delenv("AIGATEWAY_BOOTSTRAP_FROM_CLAUDE_CODE", raising=False)
+    _configure_app_db(monkeypatch, tmp_path)
 
     # Isolate from the developer's real OS keychain.
     from aigateway.core import credential_store as cs_module
@@ -134,18 +157,19 @@ def test_lifespan_skips_bootstrap_by_default(monkeypatch, fake_keychain) -> None
 
     app = main_module.create_app()
     with TestClient(app) as client:
-        resp = client.get("/v1/auth/profiles")
+        resp = client.get("/v1/auth/profiles", headers=_auth_header(client))
         assert resp.status_code == 200
         assert resp.json() == {"profiles": []}
 
     assert mock_bootstrap.call_count == 0
 
 
-def test_lifespan_runs_bootstrap_when_env_set(monkeypatch, fake_keychain) -> None:
+def test_lifespan_runs_bootstrap_when_env_set(monkeypatch, fake_keychain, tmp_path) -> None:
     """When AIGATEWAY_BOOTSTRAP_FROM_CLAUDE_CODE=1, _lifespan calls bootstrap."""
     from unittest.mock import AsyncMock
 
     monkeypatch.setenv("AIGATEWAY_BOOTSTRAP_FROM_CLAUDE_CODE", "1")
+    _configure_app_db(monkeypatch, tmp_path)
 
     from aigateway.core import credential_store as cs_module
     from aigateway.core import profile_index as pi_module
@@ -160,6 +184,6 @@ def test_lifespan_runs_bootstrap_when_env_set(monkeypatch, fake_keychain) -> Non
 
     app = main_module.create_app()
     with TestClient(app) as client:
-        client.get("/v1/auth/profiles")
+        client.get("/v1/auth/profiles", headers=_auth_header(client))
 
     assert mock_bootstrap.call_count == 1

--- a/apps/aigateway/tests/unit/test_bootstrap.py
+++ b/apps/aigateway/tests/unit/test_bootstrap.py
@@ -4,6 +4,7 @@ import time
 import pytest
 from fastapi.testclient import TestClient
 
+from aigateway.core.auth.middleware import ANONYMOUS_ACCOUNT_ID
 from aigateway.core.bootstrap import bootstrap_from_claude_code
 from aigateway.core.profile_index import INDEX_KEYCHAIN_SERVICE, ProfileIndexStore
 from aigateway.core.profile_models import Profile, profile_id_for
@@ -199,3 +200,32 @@ def test_lifespan_runs_bootstrap_when_env_set(monkeypatch, fake_keychain, tmp_pa
 
     assert mock_bootstrap.call_count == 1
     assert mock_bootstrap.call_args.kwargs["account_id"]
+
+
+def test_lifespan_bootstraps_disabled_auth_under_anonymous_account(
+    monkeypatch, fake_keychain, tmp_path
+) -> None:
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setenv("AIGATEWAY_AUTH_ENABLED", "0")
+    monkeypatch.setenv("AIGATEWAY_BOOTSTRAP_FROM_CLAUDE_CODE", "1")
+    _configure_app_db(monkeypatch, tmp_path)
+
+    from aigateway.core import credential_store as cs_module
+    from aigateway.core import profile_index as pi_module
+
+    monkeypatch.setattr(cs_module, "get_credential_store", lambda: fake_keychain)
+    monkeypatch.setattr(pi_module, "get_credential_store", lambda: fake_keychain)
+
+    from aigateway import main as main_module
+
+    mock_bootstrap = AsyncMock()
+    monkeypatch.setattr(main_module, "bootstrap_from_claude_code", mock_bootstrap)
+
+    app = main_module.create_app()
+    with TestClient(app) as client:
+        resp = client.get("/v1/auth/me")
+        assert resp.status_code == 200
+
+    assert mock_bootstrap.call_count == 1
+    assert mock_bootstrap.call_args.kwargs["account_id"] == str(ANONYMOUS_ACCOUNT_ID)

--- a/apps/aigateway/tests/unit/test_bootstrap.py
+++ b/apps/aigateway/tests/unit/test_bootstrap.py
@@ -6,10 +6,12 @@ from fastapi.testclient import TestClient
 
 from aigateway.core.bootstrap import bootstrap_from_claude_code
 from aigateway.core.profile_index import INDEX_KEYCHAIN_SERVICE, ProfileIndexStore
+from aigateway.core.profile_models import Profile, profile_id_for
 from aigateway.plugins.anthropic_provider.auth import keychain_service_for
 from tests.conftest import _prepare_sqlite_db
 
 CC_SERVICE = "Claude Code-credentials"
+ACCOUNT_ID = "account-1"
 
 
 def _configure_app_db(monkeypatch, tmp_path) -> None:
@@ -45,12 +47,13 @@ async def test_bootstrap_imports_cc_default_when_index_empty(fake_keychain) -> N
     fake_keychain.write(CC_SERVICE, "alice", cc_payload)
 
     await bootstrap_from_claude_code(
+        account_id=ACCOUNT_ID,
         credential_store=fake_keychain,
         index_store=ProfileIndexStore(credential_store=fake_keychain),
         cc_account="alice",
     )
 
-    aigw_payload = fake_keychain.read(keychain_service_for("default"), "default")
+    aigw_payload = fake_keychain.read(keychain_service_for(f"{ACCOUNT_ID}:default"), "default")
     assert aigw_payload is not None
     converted = json.loads(aigw_payload)
     assert converted["access_token"] == "cc-tok"
@@ -59,7 +62,7 @@ async def test_bootstrap_imports_cc_default_when_index_empty(fake_keychain) -> N
 
     idx_raw = fake_keychain.read(INDEX_KEYCHAIN_SERVICE, "default")
     assert idx_raw is not None
-    assert "anthropic:default" in idx_raw
+    assert profile_id_for(ACCOUNT_ID, "anthropic", "default") in idx_raw
 
     # CC entry untouched
     assert fake_keychain.read(CC_SERVICE, "alice") == cc_payload
@@ -67,10 +70,13 @@ async def test_bootstrap_imports_cc_default_when_index_empty(fake_keychain) -> N
 
 @pytest.mark.asyncio
 async def test_bootstrap_noop_when_index_already_exists(fake_keychain) -> None:
-    fake_keychain.write(
-        INDEX_KEYCHAIN_SERVICE,
-        "default",
-        '{"version":1,"profiles":[{"id":"x:y","provider":"x","name":"y"}]}',
+    await ProfileIndexStore(credential_store=fake_keychain).upsert(
+        Profile(
+            id=profile_id_for(ACCOUNT_ID, "x", "y"),
+            account_id=ACCOUNT_ID,
+            provider="x",
+            name="y",
+        )
     )
     fake_keychain.write(
         CC_SERVICE,
@@ -78,16 +84,18 @@ async def test_bootstrap_noop_when_index_already_exists(fake_keychain) -> None:
         json.dumps({"claudeAiOauth": {"accessToken": "x", "refreshToken": "y", "expiresAt": 1}}),
     )
     await bootstrap_from_claude_code(
+        account_id=ACCOUNT_ID,
         credential_store=fake_keychain,
         index_store=ProfileIndexStore(credential_store=fake_keychain),
         cc_account="alice",
     )
-    assert fake_keychain.read(keychain_service_for("default"), "default") is None
+    assert fake_keychain.read(keychain_service_for(f"{ACCOUNT_ID}:default"), "default") is None
 
 
 @pytest.mark.asyncio
 async def test_bootstrap_noop_when_cc_entry_missing(fake_keychain) -> None:
     await bootstrap_from_claude_code(
+        account_id=ACCOUNT_ID,
         credential_store=fake_keychain,
         index_store=ProfileIndexStore(credential_store=fake_keychain),
         cc_account="alice",
@@ -132,8 +140,11 @@ def test_app_lifespan_runs_bootstrap(fake_keychain, monkeypatch, tmp_path) -> No
     with TestClient(app) as client:  # `with` triggers the lifespan
         resp = client.get("/v1/auth/profiles", headers=_auth_header(client))
         assert resp.status_code == 200
-        ids = [p["id"] for p in resp.json()["profiles"]]
-        assert "anthropic:default" in ids
+        profiles = resp.json()["profiles"]
+        assert len(profiles) == 1
+        assert profiles[0]["provider"] == "anthropic"
+        assert profiles[0]["name"] == "default"
+        assert profiles[0]["account_id"]
 
 
 def test_lifespan_skips_bootstrap_by_default(monkeypatch, fake_keychain, tmp_path) -> None:
@@ -187,3 +198,4 @@ def test_lifespan_runs_bootstrap_when_env_set(monkeypatch, fake_keychain, tmp_pa
         client.get("/v1/auth/profiles", headers=_auth_header(client))
 
     assert mock_bootstrap.call_count == 1
+    assert mock_bootstrap.call_args.kwargs["account_id"]

--- a/apps/aigateway/tests/unit/test_bootstrap.py
+++ b/apps/aigateway/tests/unit/test_bootstrap.py
@@ -1,14 +1,16 @@
 import json
 import time
+from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
 
 from aigateway.core.auth.middleware import ANONYMOUS_ACCOUNT_ID
-from aigateway.core.bootstrap import bootstrap_from_claude_code
+from aigateway.core.plugin_base import ModelEntry, ProviderPluginBase
 from aigateway.core.profile_index import INDEX_KEYCHAIN_SERVICE, ProfileIndexStore
 from aigateway.core.profile_models import Profile, profile_id_for
 from aigateway.plugins.anthropic_provider.auth import keychain_service_for
+from aigateway.plugins.anthropic_provider.bootstrap import bootstrap_from_claude_code
 from tests.conftest import _prepare_sqlite_db
 
 CC_SERVICE = "Claude Code-credentials"
@@ -31,6 +33,26 @@ def _auth_header(client: TestClient) -> dict[str, str]:
     )
     assert response.status_code == 200, response.text
     return {"Authorization": f"Bearer {response.json()['token']}"}
+
+
+class _BootstrapSpyPlugin(ProviderPluginBase):
+    custom_llm_provider = "spy"
+
+    def __init__(self, bootstrap_mock) -> None:
+        self.bootstrap_mock = bootstrap_mock
+
+    def register_models(self) -> list[ModelEntry]:
+        return []
+
+    async def bootstrap_profiles(self, **kwargs: Any) -> None:
+        await self.bootstrap_mock(**kwargs)
+
+
+def _install_bootstrap_spy(monkeypatch, main_module, bootstrap_mock) -> None:
+    def _load_plugins(registry) -> None:
+        registry.register(_BootstrapSpyPlugin(bootstrap_mock))
+
+    monkeypatch.setattr(main_module, "load_plugins", _load_plugins)
 
 
 @pytest.mark.asyncio
@@ -124,14 +146,12 @@ def test_app_lifespan_runs_bootstrap(fake_keychain, monkeypatch, tmp_path) -> No
     monkeypatch.setenv("AIGATEWAY_BOOTSTRAP_FROM_CLAUDE_CODE", "1")
 
     from aigateway import main as main_module
-    from aigateway.core import bootstrap as bs_module
     from aigateway.core import credential_store as cs_module
     from aigateway.core import profile_index as pi_module
     from aigateway.plugins.anthropic_provider import auth as auth_module
 
     monkeypatch.setattr(cs_module, "get_credential_store", lambda: fake_keychain)
     monkeypatch.setattr(pi_module, "get_credential_store", lambda: fake_keychain)
-    monkeypatch.setattr(bs_module, "get_credential_store", lambda: fake_keychain)
     monkeypatch.setattr(auth_module, "get_credential_store", lambda: fake_keychain)
     monkeypatch.setattr(main_module, "get_credential_store", lambda: fake_keychain)
 
@@ -165,7 +185,7 @@ def test_lifespan_skips_bootstrap_by_default(monkeypatch, fake_keychain, tmp_pat
     from aigateway import main as main_module
 
     mock_bootstrap = AsyncMock()
-    monkeypatch.setattr(main_module, "bootstrap_from_claude_code", mock_bootstrap)
+    _install_bootstrap_spy(monkeypatch, main_module, mock_bootstrap)
 
     app = main_module.create_app()
     with TestClient(app) as client:
@@ -192,7 +212,7 @@ def test_lifespan_runs_bootstrap_when_env_set(monkeypatch, fake_keychain, tmp_pa
     from aigateway import main as main_module
 
     mock_bootstrap = AsyncMock()
-    monkeypatch.setattr(main_module, "bootstrap_from_claude_code", mock_bootstrap)
+    _install_bootstrap_spy(monkeypatch, main_module, mock_bootstrap)
 
     app = main_module.create_app()
     with TestClient(app) as client:
@@ -220,7 +240,7 @@ def test_lifespan_bootstraps_disabled_auth_under_anonymous_account(
     from aigateway import main as main_module
 
     mock_bootstrap = AsyncMock()
-    monkeypatch.setattr(main_module, "bootstrap_from_claude_code", mock_bootstrap)
+    _install_bootstrap_spy(monkeypatch, main_module, mock_bootstrap)
 
     app = main_module.create_app()
     with TestClient(app) as client:

--- a/apps/aigateway/tests/unit/test_chat_x_profile.py
+++ b/apps/aigateway/tests/unit/test_chat_x_profile.py
@@ -7,13 +7,23 @@ from unittest.mock import patch
 import pytest
 
 from aigateway.core.profile_index import ProfileIndexStore
-from aigateway.core.profile_models import Profile, ProfileDefaults, ProfileState
+from aigateway.core.profile_models import (
+    Profile,
+    ProfileDefaults,
+    ProfileState,
+    credential_name_for,
+    profile_id_for,
+)
 from aigateway.plugins.anthropic_provider.auth import keychain_service_for
 
 
-def _seed_authenticated_profile(fake_keychain) -> None:
+def _account_id(client) -> str:
+    return client.get("/v1/auth/me").json()["id"]
+
+
+def _seed_authenticated_profile(fake_keychain, account_id: str) -> None:
     fake_keychain.write(
-        keychain_service_for("default"),
+        keychain_service_for(credential_name_for(account_id, "default")),
         "default",
         json.dumps(
             {
@@ -42,10 +52,12 @@ async def test_chat_404_when_profile_missing(authenticated_client) -> None:
 
 @pytest.mark.asyncio
 async def test_chat_409_when_profile_pending(fake_keychain, authenticated_client) -> None:
+    account_id = _account_id(authenticated_client)
     idx = ProfileIndexStore(credential_store=fake_keychain)
     await idx.upsert(
         Profile(
-            id="anthropic:default",
+            id=profile_id_for(account_id, "anthropic", "default"),
+            account_id=account_id,
             provider="anthropic",
             name="default",
             state=ProfileState.PENDING,
@@ -64,12 +76,14 @@ async def test_chat_409_when_profile_pending(fake_keychain, authenticated_client
 
 @pytest.mark.asyncio
 async def test_chat_merges_profile_defaults(fake_keychain, authenticated_client) -> None:
-    _seed_authenticated_profile(fake_keychain)
+    account_id = _account_id(authenticated_client)
+    _seed_authenticated_profile(fake_keychain, account_id)
 
     idx = ProfileIndexStore(credential_store=fake_keychain)
     await idx.upsert(
         Profile(
-            id="anthropic:default",
+            id=profile_id_for(account_id, "anthropic", "default"),
+            account_id=account_id,
             provider="anthropic",
             name="default",
             state=ProfileState.AUTHENTICATED,
@@ -103,7 +117,42 @@ async def test_chat_merges_profile_defaults(fake_keychain, authenticated_client)
         assert resp.status_code == 200
         assert captured["max_tokens"] == 4096
         assert captured["reasoning_effort"] == "high"
-        assert captured["api_key"] == "tok"
+    assert captured["api_key"] == "tok"
+
+
+@pytest.mark.asyncio
+async def test_chat_cannot_use_other_accounts_profile(
+    fake_keychain, authenticated_client, provisioned_user_factory
+) -> None:
+    admin_account_id = _account_id(authenticated_client)
+    _seed_authenticated_profile(fake_keychain, admin_account_id)
+    idx = ProfileIndexStore(credential_store=fake_keychain)
+    await idx.upsert(
+        Profile(
+            id=profile_id_for(admin_account_id, "anthropic", "shared"),
+            account_id=admin_account_id,
+            provider="anthropic",
+            name="shared",
+            state=ProfileState.AUTHENTICATED,
+        )
+    )
+
+    provisioned_user_factory("bob", "bob-pass1")
+    login = authenticated_client.post(
+        "/v1/auth/login",
+        json={"username": "bob", "password": "bob-pass1"},
+    )
+    authenticated_client.headers.update({"Authorization": f"Bearer {login.json()['token']}"})
+
+    resp = authenticated_client.post(
+        "/v1/chat/completions",
+        headers={"X-Profile": "shared"},
+        json={
+            "model": "anthropic/claude-haiku-4-5",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert resp.status_code == 404
 
 
 def test_chat_requires_auth(client) -> None:

--- a/apps/aigateway/tests/unit/test_chat_x_profile.py
+++ b/apps/aigateway/tests/unit/test_chat_x_profile.py
@@ -5,11 +5,9 @@ import time
 from unittest.mock import patch
 
 import pytest
-from fastapi.testclient import TestClient
 
 from aigateway.core.profile_index import ProfileIndexStore
 from aigateway.core.profile_models import Profile, ProfileDefaults, ProfileState
-from aigateway.main import create_app
 from aigateway.plugins.anthropic_provider.auth import keychain_service_for
 
 
@@ -28,24 +26,9 @@ def _seed_authenticated_profile(fake_keychain) -> None:
     )
 
 
-def _patch_credential_factory(monkeypatch, fake_keychain):
-    from aigateway.core import bootstrap as bs_module
-    from aigateway.core import credential_store as cs_module
-    from aigateway.core import profile_index as pi_module
-    from aigateway.plugins.anthropic_provider import auth as auth_module
-
-    monkeypatch.setattr(cs_module, "get_credential_store", lambda: fake_keychain)
-    monkeypatch.setattr(pi_module, "get_credential_store", lambda: fake_keychain)
-    monkeypatch.setattr(bs_module, "get_credential_store", lambda: fake_keychain)
-    monkeypatch.setattr(auth_module, "get_credential_store", lambda: fake_keychain)
-
-
 @pytest.mark.asyncio
-async def test_chat_404_when_profile_missing(fake_keychain, monkeypatch) -> None:
-    _patch_credential_factory(monkeypatch, fake_keychain)
-
-    client = TestClient(create_app())
-    resp = client.post(
+async def test_chat_404_when_profile_missing(authenticated_client) -> None:
+    resp = authenticated_client.post(
         "/v1/chat/completions",
         headers={"X-Profile": "missing"},
         json={
@@ -58,9 +41,7 @@ async def test_chat_404_when_profile_missing(fake_keychain, monkeypatch) -> None
 
 
 @pytest.mark.asyncio
-async def test_chat_409_when_profile_pending(fake_keychain, monkeypatch) -> None:
-    _patch_credential_factory(monkeypatch, fake_keychain)
-
+async def test_chat_409_when_profile_pending(fake_keychain, authenticated_client) -> None:
     idx = ProfileIndexStore(credential_store=fake_keychain)
     await idx.upsert(
         Profile(
@@ -70,8 +51,7 @@ async def test_chat_409_when_profile_pending(fake_keychain, monkeypatch) -> None
             state=ProfileState.PENDING,
         )
     )
-    client = TestClient(create_app())
-    resp = client.post(
+    resp = authenticated_client.post(
         "/v1/chat/completions",
         json={
             "model": "anthropic/claude-haiku-4-5",
@@ -83,8 +63,7 @@ async def test_chat_409_when_profile_pending(fake_keychain, monkeypatch) -> None
 
 
 @pytest.mark.asyncio
-async def test_chat_merges_profile_defaults(fake_keychain, monkeypatch) -> None:
-    _patch_credential_factory(monkeypatch, fake_keychain)
+async def test_chat_merges_profile_defaults(fake_keychain, authenticated_client) -> None:
     _seed_authenticated_profile(fake_keychain)
 
     idx = ProfileIndexStore(credential_store=fake_keychain)
@@ -112,8 +91,7 @@ async def test_chat_merges_profile_defaults(fake_keychain, monkeypatch) -> None:
         )
 
     with patch("aigateway.routes.chat.litellm.acompletion", fake_acompletion):
-        client = TestClient(create_app())
-        resp = client.post(
+        resp = authenticated_client.post(
             "/v1/chat/completions",
             json={
                 "model": "anthropic/claude-haiku-4-5",
@@ -126,3 +104,11 @@ async def test_chat_merges_profile_defaults(fake_keychain, monkeypatch) -> None:
         assert captured["max_tokens"] == 4096
         assert captured["reasoning_effort"] == "high"
         assert captured["api_key"] == "tok"
+
+
+def test_chat_requires_auth(client) -> None:
+    resp = client.post(
+        "/v1/chat/completions",
+        json={"model": "anthropic/claude-haiku-4-5", "messages": []},
+    )
+    assert resp.status_code == 401

--- a/apps/aigateway/tests/unit/test_credential_store.py
+++ b/apps/aigateway/tests/unit/test_credential_store.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from aigateway.core import credential_store as module
+from aigateway.core.credential_store import (
+    JsonFileCredentialStore,
+    LinuxLibsecretStore,
+    MacOSKeychainStore,
+    WindowsCredentialManagerStore,
+)
+
+
+def _completed(
+    returncode: int = 0, stdout: str = "", stderr: str = ""
+) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_json_file_credential_store_round_trip(tmp_path: Path) -> None:
+    path = tmp_path / "creds.json"
+    store = JsonFileCredentialStore(path)
+    assert store.read("service", "account") is None
+    store.write("service", "account", "secret")
+    assert JsonFileCredentialStore(path).read("service", "account") == "secret"
+    store.delete("service", "account")
+    assert store.read("service", "account") is None
+
+
+def test_json_file_credential_store_ignores_bad_json(tmp_path: Path) -> None:
+    path = tmp_path / "creds.json"
+    path.write_text("not-json")
+    assert JsonFileCredentialStore(path).read("service", "account") is None
+
+
+def test_macos_keychain_read_write_delete(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[1] == "find-generic-password":
+            return _completed(stdout="secret\n")
+        return _completed()
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    store = MacOSKeychainStore()
+    assert store.read("service", "account") == "secret"
+    store.write("service", "account", "secret")
+    store.delete("service", "account")
+    assert [call[1] for call in calls] == [
+        "find-generic-password",
+        "add-generic-password",
+        "delete-generic-password",
+    ]
+
+
+def test_macos_keychain_missing_and_errors(monkeypatch) -> None:
+    monkeypatch.setattr(module.subprocess, "run", lambda *a, **k: _completed(returncode=44))
+    assert MacOSKeychainStore().read("service", "account") is None
+    MacOSKeychainStore().delete("service", "account")
+
+    monkeypatch.setattr(
+        module.subprocess, "run", lambda *a, **k: _completed(returncode=1, stderr="nope")
+    )
+    with pytest.raises(RuntimeError, match="security.*failed"):
+        MacOSKeychainStore().read("service", "account")
+
+
+def test_linux_libsecret_read_write_delete(monkeypatch) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(module.shutil, "which", lambda name: "/usr/bin/secret-tool")
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[1] == "lookup":
+            return _completed(stdout="secret\n")
+        return _completed()
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    store = LinuxLibsecretStore()
+    assert store.read("service", "account") == "secret"
+    store.write("service", "account", "secret")
+    store.delete("service", "account")
+    assert [call[1] for call in calls] == ["lookup", "store", "clear"]
+
+
+def test_linux_libsecret_missing_tool_and_values(monkeypatch) -> None:
+    monkeypatch.setattr(module.shutil, "which", lambda name: None)
+    with pytest.raises(RuntimeError, match="secret-tool"):
+        LinuxLibsecretStore().read("service", "account")
+
+    monkeypatch.setattr(module.shutil, "which", lambda name: "/usr/bin/secret-tool")
+    monkeypatch.setattr(module.subprocess, "run", lambda *a, **k: _completed(returncode=1))
+    assert LinuxLibsecretStore().read("service", "account") is None
+
+    monkeypatch.setattr(
+        module.subprocess, "run", lambda *a, **k: _completed(returncode=1, stderr="nope")
+    )
+    with pytest.raises(RuntimeError, match="secret-tool store"):
+        LinuxLibsecretStore().write("service", "account", "secret")
+
+
+def test_windows_credential_manager(monkeypatch) -> None:
+    class FakeKeyring:
+        value: str | None = None
+
+        def get_password(self, service: str, account: str) -> str | None:
+            return self.value
+
+        def set_password(self, service: str, account: str, value: str) -> None:
+            self.value = value
+
+        def delete_password(self, service: str, account: str) -> None:
+            self.value = None
+
+    keyring = FakeKeyring()
+    monkeypatch.setattr(module, "_try_import_keyring", lambda: keyring)
+    store = WindowsCredentialManagerStore()
+    assert store.read("service", "account") is None
+    store.write("service", "account", "secret")
+    assert store.read("service", "account") == "secret"
+    store.delete("service", "account")
+    assert store.read("service", "account") is None
+
+
+def test_windows_credential_manager_without_keyring(monkeypatch) -> None:
+    monkeypatch.setattr(module, "_try_import_keyring", lambda: None)
+    with pytest.raises(RuntimeError, match="python-keyring"):
+        WindowsCredentialManagerStore().read("service", "account")
+    with pytest.raises(RuntimeError, match="python-keyring"):
+        WindowsCredentialManagerStore().write("service", "account", "secret")
+    with pytest.raises(RuntimeError, match="python-keyring"):
+        WindowsCredentialManagerStore().delete("service", "account")
+
+
+def test_get_credential_store_platforms(monkeypatch) -> None:
+    monkeypatch.setattr(module.sys, "platform", "darwin")
+    assert isinstance(module.get_credential_store(), MacOSKeychainStore)
+    monkeypatch.setattr(module.sys, "platform", "linux")
+    assert isinstance(module.get_credential_store(), LinuxLibsecretStore)
+    monkeypatch.setattr(module.sys, "platform", "win32")
+    assert isinstance(module.get_credential_store(), WindowsCredentialManagerStore)
+    monkeypatch.setattr(module.sys, "platform", "plan9")
+    with pytest.raises(RuntimeError, match="No credential store"):
+        module.get_credential_store()

--- a/apps/aigateway/tests/unit/test_health.py
+++ b/apps/aigateway/tests/unit/test_health.py
@@ -1,22 +1,21 @@
 from __future__ import annotations
 
-from fastapi.testclient import TestClient
 
-from aigateway.main import create_app
-
-
-def test_healthz() -> None:
-    client = TestClient(create_app())
+def test_healthz(client) -> None:
     resp = client.get("/healthz")
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok"}
 
 
-def test_models_lists_loaded_providers() -> None:
-    client = TestClient(create_app())
-    resp = client.get("/v1/models")
+def test_models_lists_loaded_providers(authenticated_client) -> None:
+    resp = authenticated_client.get("/v1/models")
     assert resp.status_code == 200
     body = resp.json()
     assert body["object"] == "list"
     owners = {entry["owned_by"] for entry in body["data"]}
     assert "anthropic" in owners
+
+
+def test_models_requires_auth(client) -> None:
+    resp = client.get("/v1/models")
+    assert resp.status_code == 401

--- a/apps/aigateway/tests/unit/test_main.py
+++ b/apps/aigateway/tests/unit/test_main.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import APIRouter
+
+
+@pytest.mark.asyncio
+async def test_create_app_fake_anthropic_oauth_factory(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AIGATEWAY_FAKE_KEYCHAIN", "1")
+    monkeypatch.setenv("AIGATEWAY_KEYCHAIN_FILE", str(tmp_path / "keychain.json"))
+    monkeypatch.setenv("AIGATEWAY_FAKE_ANTHROPIC_OAUTH", "1")
+
+    from aigateway.main import create_app
+
+    app = create_app()
+    assert app.state._fake_credential_store is app.state.profile_index._store
+
+    async with app.state.anthropic_http_factory() as client:
+        token = await client.post("https://platform.claude.com/oauth/token")
+        unmapped = await client.post("https://example.com/oauth/token")
+
+    assert token.status_code == 200
+    assert token.json()["access_token"] == "fake-tok"
+    assert unmapped.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_create_app_fake_anthropic_oauth_fail_mode(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AIGATEWAY_FAKE_KEYCHAIN", "1")
+    monkeypatch.setenv("AIGATEWAY_KEYCHAIN_FILE", str(tmp_path / "keychain.json"))
+    monkeypatch.setenv("AIGATEWAY_FAKE_ANTHROPIC_OAUTH", "1")
+    monkeypatch.setenv("AIGATEWAY_FAKE_ANTHROPIC_OAUTH_FAIL", "1")
+
+    from aigateway.main import create_app
+
+    app = create_app()
+
+    async with app.state.anthropic_http_factory() as client:
+        token = await client.post("https://console.anthropic.com/oauth/token")
+
+    assert token.status_code == 400
+    assert token.json() == {"error": "invalid_grant"}
+
+
+def test_create_app_mounts_provider_auth_router(monkeypatch) -> None:
+    from aigateway import main as main_module
+
+    class _Plugin:
+        custom_llm_provider = "dummy"
+
+        def register_models(self) -> list:
+            return []
+
+        def auth_router(self) -> APIRouter:
+            router = APIRouter()
+
+            @router.get("/ping")
+            async def ping() -> dict[str, bool]:
+                return {"ok": True}
+
+            return router
+
+    def _load_plugins(registry) -> None:
+        registry.register(_Plugin())
+
+    monkeypatch.setattr(main_module, "load_plugins", _load_plugins)
+
+    app = main_module.create_app()
+    assert any(getattr(route, "path", None) == "/v1/auth/dummy/ping" for route in app.routes)

--- a/apps/aigateway/tests/unit/test_pending_auth.py
+++ b/apps/aigateway/tests/unit/test_pending_auth.py
@@ -2,19 +2,30 @@ import time
 
 from aigateway.core.pending_auth import PendingAuthEntry, PendingAuthTable
 
+ENTRY = PendingAuthEntry(
+    account_id="account-1",
+    provider="anthropic",
+    profile_name="work",
+    profile_id="account-1:anthropic:work",
+    code_verifier="v",
+)
+
 
 def test_pending_table_round_trip() -> None:
     table = PendingAuthTable(ttl_seconds=600)
-    table.put("state-1", PendingAuthEntry(profile_id="anthropic:work", code_verifier="v"))
+    table.put("state-1", ENTRY)
     entry = table.pop("state-1")
     assert entry is not None
-    assert entry.profile_id == "anthropic:work"
+    assert entry.account_id == "account-1"
+    assert entry.provider == "anthropic"
+    assert entry.profile_name == "work"
+    assert entry.profile_id == "account-1:anthropic:work"
     assert entry.code_verifier == "v"
 
 
 def test_pop_consumes_entry() -> None:
     table = PendingAuthTable(ttl_seconds=600)
-    table.put("state-1", PendingAuthEntry(profile_id="anthropic:work", code_verifier="v"))
+    table.put("state-1", ENTRY)
     table.pop("state-1")
     assert table.pop("state-1") is None  # second pop is a miss
 
@@ -23,7 +34,7 @@ def test_expired_entry_is_swept(monkeypatch) -> None:
     fake = {"now": 1000.0}
     monkeypatch.setattr(time, "monotonic", lambda: fake["now"])
     table = PendingAuthTable(ttl_seconds=10)
-    table.put("state-1", PendingAuthEntry(profile_id="anthropic:work", code_verifier="v"))
+    table.put("state-1", ENTRY)
     fake["now"] = 1100.0  # 100s later
     assert table.pop("state-1") is None
 

--- a/apps/aigateway/tests/unit/test_profile_index.py
+++ b/apps/aigateway/tests/unit/test_profile_index.py
@@ -3,12 +3,22 @@ from __future__ import annotations
 import pytest
 
 from aigateway.core.profile_index import INDEX_KEYCHAIN_SERVICE, ProfileIndexStore
-from aigateway.core.profile_models import Profile, ProfileDefaults, ProfileIndex, ProfileState
+from aigateway.core.profile_models import (
+    Profile,
+    ProfileDefaults,
+    ProfileIndex,
+    ProfileState,
+    profile_id_for,
+)
+
+ACCOUNT_ID = "account-1"
+OTHER_ACCOUNT_ID = "account-2"
 
 
 def test_profile_round_trips_through_json() -> None:
     p = Profile(
-        id="anthropic:default",
+        id=profile_id_for(ACCOUNT_ID, "anthropic", "default"),
+        account_id=ACCOUNT_ID,
         provider="anthropic",
         name="default",
         account_label="user@example.com",
@@ -40,7 +50,8 @@ async def test_index_store_returns_empty_index_when_keychain_empty(fake_keychain
 async def test_index_store_round_trip(fake_keychain) -> None:
     store = ProfileIndexStore(credential_store=fake_keychain)
     p = Profile(
-        id="anthropic:default",
+        id=profile_id_for(ACCOUNT_ID, "anthropic", "default"),
+        account_id=ACCOUNT_ID,
         provider="anthropic",
         name="default",
         defaults=ProfileDefaults(model="anthropic/claude-sonnet-4-5"),
@@ -48,18 +59,27 @@ async def test_index_store_round_trip(fake_keychain) -> None:
     await store.upsert(p)
     idx = await store.read()
     assert len(idx.profiles) == 1
-    assert idx.profiles[0].id == "anthropic:default"
+    assert idx.profiles[0].id == profile_id_for(ACCOUNT_ID, "anthropic", "default")
+    assert idx.profiles[0].account_id == ACCOUNT_ID
     raw = fake_keychain.read(INDEX_KEYCHAIN_SERVICE, "default")
-    assert "anthropic:default" in raw
+    assert profile_id_for(ACCOUNT_ID, "anthropic", "default") in raw
 
 
 @pytest.mark.asyncio
 async def test_index_store_upsert_replaces_by_id(fake_keychain) -> None:
     store = ProfileIndexStore(credential_store=fake_keychain)
-    await store.upsert(Profile(id="anthropic:default", provider="anthropic", name="default"))
     await store.upsert(
         Profile(
-            id="anthropic:default",
+            id=profile_id_for(ACCOUNT_ID, "anthropic", "default"),
+            account_id=ACCOUNT_ID,
+            provider="anthropic",
+            name="default",
+        )
+    )
+    await store.upsert(
+        Profile(
+            id=profile_id_for(ACCOUNT_ID, "anthropic", "default"),
+            account_id=ACCOUNT_ID,
             provider="anthropic",
             name="default",
             account_label="updated@example.com",
@@ -73,7 +93,41 @@ async def test_index_store_upsert_replaces_by_id(fake_keychain) -> None:
 @pytest.mark.asyncio
 async def test_index_store_remove(fake_keychain) -> None:
     store = ProfileIndexStore(credential_store=fake_keychain)
-    await store.upsert(Profile(id="anthropic:default", provider="anthropic", name="default"))
-    await store.remove("anthropic:default")
+    await store.upsert(
+        Profile(
+            id=profile_id_for(ACCOUNT_ID, "anthropic", "default"),
+            account_id=ACCOUNT_ID,
+            provider="anthropic",
+            name="default",
+        )
+    )
+    await store.remove(profile_id_for(ACCOUNT_ID, "anthropic", "default"))
     idx = await store.read()
     assert idx.profiles == []
+
+
+@pytest.mark.asyncio
+async def test_index_store_filters_by_account(fake_keychain) -> None:
+    store = ProfileIndexStore(credential_store=fake_keychain)
+    await store.upsert(
+        Profile(
+            id=profile_id_for(ACCOUNT_ID, "anthropic", "default"),
+            account_id=ACCOUNT_ID,
+            provider="anthropic",
+            name="default",
+        )
+    )
+    await store.upsert(
+        Profile(
+            id=profile_id_for(OTHER_ACCOUNT_ID, "anthropic", "default"),
+            account_id=OTHER_ACCOUNT_ID,
+            provider="anthropic",
+            name="default",
+        )
+    )
+
+    profiles = await store.list(ACCOUNT_ID)
+    assert len(profiles) == 1
+    assert profiles[0].account_id == ACCOUNT_ID
+    assert await store.get(OTHER_ACCOUNT_ID, "anthropic", "default") is not None
+    assert await store.get(ACCOUNT_ID, "anthropic", "missing") is None

--- a/apps/aigateway/uv.lock
+++ b/apps/aigateway/uv.lock
@@ -7,40 +7,54 @@ name = "aigateway"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "asyncpg" },
+    { name = "bcrypt" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "litellm" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt" },
+    { name = "tortoise-orm", extra = ["asyncpg"] },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "aiosqlite" },
     { name = "httpx" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "testcontainers" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "asyncpg", specifier = "==0.31.0" },
+    { name = "bcrypt", specifier = "==5.0.0" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "litellm", specifier = ">=1.55" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
+    { name = "pyjwt", specifier = "==2.12.1" },
+    { name = "tortoise-orm", extras = ["asyncpg"], specifier = "==1.1.7" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "aiosqlite", specifier = "==0.22.1" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "pyright", specifier = ">=1.1.393" },
     { name = "pytest", specifier = ">=9.0" },
-    { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "pytest-asyncio", specifier = ">=1.3,<2" },
+    { name = "pytest-cov", specifier = ">=5" },
     { name = "ruff", specifier = ">=0.8" },
+    { name = "testcontainers", extras = ["postgres"], specifier = "==4.14.2" },
 ]
 
 [[package]]
@@ -151,6 +165,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -182,12 +205,118 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/a6/59d0a146e61d20e18db7396583242e32e0f120693b67a8de43f1557033e2/asyncpg-0.31.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b44c31e1efc1c15188ef183f287c728e2046abb1d26af4d20858215d50d91fad", size = 662042, upload-time = "2025-11-24T23:25:49.578Z" },
+    { url = "https://files.pythonhosted.org/packages/36/01/ffaa189dcb63a2471720615e60185c3f6327716fdc0fc04334436fbb7c65/asyncpg-0.31.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0c89ccf741c067614c9b5fc7f1fc6f3b61ab05ae4aaa966e6fd6b93097c7d20d", size = 638504, upload-time = "2025-11-24T23:25:51.501Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/62/3f699ba45d8bd24c5d65392190d19656d74ff0185f42e19d0bbd973bb371/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:12b3b2e39dc5470abd5e98c8d3373e4b1d1234d9fbdedf538798b2c13c64460a", size = 3426241, upload-time = "2025-11-24T23:25:53.278Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d1/a867c2150f9c6e7af6462637f613ba67f78a314b00db220cd26ff559d532/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:aad7a33913fb8bcb5454313377cc330fbb19a0cd5faa7272407d8a0c4257b671", size = 3520321, upload-time = "2025-11-24T23:25:54.982Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1a/cce4c3f246805ecd285a3591222a2611141f1669d002163abef999b60f98/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3df118d94f46d85b2e434fd62c84cb66d5834d5a890725fe625f498e72e4d5ec", size = 3316685, upload-time = "2025-11-24T23:25:57.43Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/0fc961179e78cc579e138fad6eb580448ecae64908f95b8cb8ee2f241f67/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bd5b6efff3c17c3202d4b37189969acf8927438a238c6257f66be3c426beba20", size = 3471858, upload-time = "2025-11-24T23:25:59.636Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b2/b20e09670be031afa4cbfabd645caece7f85ec62d69c312239de568e058e/asyncpg-0.31.0-cp312-cp312-win32.whl", hash = "sha256:027eaa61361ec735926566f995d959ade4796f6a49d3bde17e5134b9964f9ba8", size = 527852, upload-time = "2025-11-24T23:26:01.084Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/f0/f2ed1de154e15b107dc692262395b3c17fc34eafe2a78fc2115931561730/asyncpg-0.31.0-cp312-cp312-win_amd64.whl", hash = "sha256:72d6bdcbc93d608a1158f17932de2321f68b1a967a13e014998db87a72ed3186", size = 597175, upload-time = "2025-11-24T23:26:02.564Z" },
+    { url = "https://files.pythonhosted.org/packages/95/11/97b5c2af72a5d0b9bc3fa30cd4b9ce22284a9a943a150fdc768763caf035/asyncpg-0.31.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c204fab1b91e08b0f47e90a75d1b3c62174dab21f670ad6c5d0f243a228f015b", size = 661111, upload-time = "2025-11-24T23:26:04.467Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/71/157d611c791a5e2d0423f09f027bd499935f0906e0c2a416ce712ba51ef3/asyncpg-0.31.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54a64f91839ba59008eccf7aad2e93d6e3de688d796f35803235ea1c4898ae1e", size = 636928, upload-time = "2025-11-24T23:26:05.944Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fc/9e3486fb2bbe69d4a867c0b76d68542650a7ff1574ca40e84c3111bb0c6e/asyncpg-0.31.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0e0822b1038dc7253b337b0f3f676cadc4ac31b126c5d42691c39691962e403", size = 3424067, upload-time = "2025-11-24T23:26:07.957Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c6/8c9d076f73f07f995013c791e018a1cd5f31823c2a3187fc8581706aa00f/asyncpg-0.31.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bef056aa502ee34204c161c72ca1f3c274917596877f825968368b2c33f585f4", size = 3518156, upload-time = "2025-11-24T23:26:09.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/60683a0baf50fbc546499cfb53132cb6835b92b529a05f6a81471ab60d0c/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0bfbcc5b7ffcd9b75ab1558f00db2ae07db9c80637ad1b2469c43df79d7a5ae2", size = 3319636, upload-time = "2025-11-24T23:26:11.168Z" },
+    { url = "https://files.pythonhosted.org/packages/50/dc/8487df0f69bd398a61e1792b3cba0e47477f214eff085ba0efa7eac9ce87/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22bc525ebbdc24d1261ecbf6f504998244d4e3be1721784b5f64664d61fbe602", size = 3472079, upload-time = "2025-11-24T23:26:13.164Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a1/c5bbeeb8531c05c89135cb8b28575ac2fac618bcb60119ee9696c3faf71c/asyncpg-0.31.0-cp313-cp313-win32.whl", hash = "sha256:f890de5e1e4f7e14023619399a471ce4b71f5418cd67a51853b9910fdfa73696", size = 527606, upload-time = "2025-11-24T23:26:14.78Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/b25ccb84a246b470eb943b0107c07edcae51804912b824054b3413995a10/asyncpg-0.31.0-cp313-cp313-win_amd64.whl", hash = "sha256:dc5f2fa9916f292e5c5c8b2ac2813763bcd7f58e130055b4ad8a0531314201ab", size = 596569, upload-time = "2025-11-24T23:26:16.189Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/36/e9450d62e84a13aea6580c83a47a437f26c7ca6fa0f0fd40b6670793ea30/asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44", size = 660867, upload-time = "2025-11-24T23:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/82/4b/1d0a2b33b3102d210439338e1beea616a6122267c0df459ff0265cd5807a/asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5", size = 638349, upload-time = "2025-11-24T23:26:19.689Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/e7f7ac9a7974f08eff9183e392b2d62516f90412686532d27e196c0f0eeb/asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2", size = 3410428, upload-time = "2025-11-24T23:26:21.275Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/de/bf1b60de3dede5c2731e6788617a512bc0ebd9693eac297ee74086f101d7/asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2", size = 3471678, upload-time = "2025-11-24T23:26:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/fc3ade003e22d8bd53aaf8f75f4be48f0b460fa73738f0391b9c856a9147/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218", size = 3313505, upload-time = "2025-11-24T23:26:25.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e9/73eb8a6789e927816f4705291be21f2225687bfa97321e40cd23055e903a/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d", size = 3434744, upload-time = "2025-11-24T23:26:26.944Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/f10b880534413c65c5b5862f79b8e81553a8f364e5238832ad4c0af71b7f/asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b", size = 532251, upload-time = "2025-11-24T23:26:28.404Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2d/7aa40750b7a19efa5d66e67fc06008ca0f27ba1bd082e457ad82f59aba49/asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be", size = 604901, upload-time = "2025-11-24T23:26:30.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fe/b9dfe349b83b9dee28cc42360d2c86b2cdce4cb551a2c2d27e156bcac84d/asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2", size = 702280, upload-time = "2025-11-24T23:26:32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/e6be6e37e560bd91e6c23ea8a6138a04fd057b08cf63d3c5055c98e81c1d/asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31", size = 682931, upload-time = "2025-11-24T23:26:33.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/45/6009040da85a1648dd5bc75b3b0a062081c483e75a1a29041ae63a0bf0dc/asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7", size = 3581608, upload-time = "2025-11-24T23:26:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/06/2e3d4d7608b0b2b3adbee0d0bd6a2d29ca0fc4d8a78f8277df04e2d1fd7b/asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e", size = 3498738, upload-time = "2025-11-24T23:26:37.275Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/aa/7d75ede780033141c51d83577ea23236ba7d3a23593929b32b49db8ed36e/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c", size = 3401026, upload-time = "2025-11-24T23:26:39.423Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "bcrypt"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/36/3329e2518d70ad8e2e5817d5a4cac6bba05a47767ec416c7d020a965f408/bcrypt-5.0.0.tar.gz", hash = "sha256:f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd", size = 25386, upload-time = "2025-09-25T19:50:47.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/85/3e65e01985fddf25b64ca67275bb5bdb4040bd1a53b66d355c6c37c8a680/bcrypt-5.0.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f3c08197f3039bec79cee59a606d62b96b16669cff3949f21e74796b6e3cd2be", size = 481806, upload-time = "2025-09-25T19:49:05.102Z" },
+    { url = "https://files.pythonhosted.org/packages/44/dc/01eb79f12b177017a726cbf78330eb0eb442fae0e7b3dfd84ea2849552f3/bcrypt-5.0.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:200af71bc25f22006f4069060c88ed36f8aa4ff7f53e67ff04d2ab3f1e79a5b2", size = 268626, upload-time = "2025-09-25T19:49:06.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/cf/e82388ad5959c40d6afd94fb4743cc077129d45b952d46bdc3180310e2df/bcrypt-5.0.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:baade0a5657654c2984468efb7d6c110db87ea63ef5a4b54732e7e337253e44f", size = 271853, upload-time = "2025-09-25T19:49:08.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/86/7134b9dae7cf0efa85671651341f6afa695857fae172615e960fb6a466fa/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c58b56cdfb03202b3bcc9fd8daee8e8e9b6d7e3163aa97c631dfcfcc24d36c86", size = 269793, upload-time = "2025-09-25T19:49:09.727Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/6296688ac1b9e503d034e7d0614d56e80c5d1a08402ff856a4549cb59207/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4bfd2a34de661f34d0bda43c3e4e79df586e4716ef401fe31ea39d69d581ef23", size = 289930, upload-time = "2025-09-25T19:49:11.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/18/884a44aa47f2a3b88dd09bc05a1e40b57878ecd111d17e5bba6f09f8bb77/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ed2e1365e31fc73f1825fa830f1c8f8917ca1b3ca6185773b349c20fd606cec2", size = 272194, upload-time = "2025-09-25T19:49:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/8f/371a3ab33c6982070b674f1788e05b656cfbf5685894acbfef0c65483a59/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_aarch64.whl", hash = "sha256:83e787d7a84dbbfba6f250dd7a5efd689e935f03dd83b0f919d39349e1f23f83", size = 269381, upload-time = "2025-09-25T19:49:14.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/34/7e4e6abb7a8778db6422e88b1f06eb07c47682313997ee8a8f9352e5a6f1/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_x86_64.whl", hash = "sha256:137c5156524328a24b9fac1cb5db0ba618bc97d11970b39184c1d87dc4bf1746", size = 271750, upload-time = "2025-09-25T19:49:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f416be2499bd72123c70d98d36c6cd61a4e33d9b89562c22481c81bb30/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:38cac74101777a6a7d3b3e3cfefa57089b5ada650dce2baf0cbdd9d65db22a9e", size = 303757, upload-time = "2025-09-25T19:49:17.244Z" },
+    { url = "https://files.pythonhosted.org/packages/13/62/062c24c7bcf9d2826a1a843d0d605c65a755bc98002923d01fd61270705a/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:d8d65b564ec849643d9f7ea05c6d9f0cd7ca23bdd4ac0c2dbef1104ab504543d", size = 306740, upload-time = "2025-09-25T19:49:18.693Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/c8/1fdbfc8c0f20875b6b4020f3c7dc447b8de60aa0be5faaf009d24242aec9/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:741449132f64b3524e95cd30e5cd3343006ce146088f074f31ab26b94e6c75ba", size = 334197, upload-time = "2025-09-25T19:49:20.523Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c1/8b84545382d75bef226fbc6588af0f7b7d095f7cd6a670b42a86243183cd/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:212139484ab3207b1f0c00633d3be92fef3c5f0af17cad155679d03ff2ee1e41", size = 352974, upload-time = "2025-09-25T19:49:22.254Z" },
+    { url = "https://files.pythonhosted.org/packages/10/a6/ffb49d4254ed085e62e3e5dd05982b4393e32fe1e49bb1130186617c29cd/bcrypt-5.0.0-cp313-cp313t-win32.whl", hash = "sha256:9d52ed507c2488eddd6a95bccee4e808d3234fa78dd370e24bac65a21212b861", size = 148498, upload-time = "2025-09-25T19:49:24.134Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a9/259559edc85258b6d5fc5471a62a3299a6aa37a6611a169756bf4689323c/bcrypt-5.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f6984a24db30548fd39a44360532898c33528b74aedf81c26cf29c51ee47057e", size = 145853, upload-time = "2025-09-25T19:49:25.702Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/df/9714173403c7e8b245acf8e4be8876aac64a209d1b392af457c79e60492e/bcrypt-5.0.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9fffdb387abe6aa775af36ef16f55e318dcda4194ddbf82007a6f21da29de8f5", size = 139626, upload-time = "2025-09-25T19:49:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/14/c18006f91816606a4abe294ccc5d1e6f0e42304df5a33710e9e8e95416e1/bcrypt-5.0.0-cp314-cp314t-macosx_10_12_universal2.whl", hash = "sha256:4870a52610537037adb382444fefd3706d96d663ac44cbb2f37e3919dca3d7ef", size = 481862, upload-time = "2025-09-25T19:49:28.365Z" },
+    { url = "https://files.pythonhosted.org/packages/67/49/dd074d831f00e589537e07a0725cf0e220d1f0d5d8e85ad5bbff251c45aa/bcrypt-5.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48f753100931605686f74e27a7b49238122aa761a9aefe9373265b8b7aa43ea4", size = 268544, upload-time = "2025-09-25T19:49:30.39Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/91/50ccba088b8c474545b034a1424d05195d9fcbaaf802ab8bfe2be5a4e0d7/bcrypt-5.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f70aadb7a809305226daedf75d90379c397b094755a710d7014b8b117df1ebbf", size = 271787, upload-time = "2025-09-25T19:49:32.144Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e7/d7dba133e02abcda3b52087a7eea8c0d4f64d3e593b4fffc10c31b7061f3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:744d3c6b164caa658adcb72cb8cc9ad9b4b75c7db507ab4bc2480474a51989da", size = 269753, upload-time = "2025-09-25T19:49:33.885Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fc/5b145673c4b8d01018307b5c2c1fc87a6f5a436f0ad56607aee389de8ee3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a28bc05039bdf3289d757f49d616ab3efe8cf40d8e8001ccdd621cd4f98f4fc9", size = 289587, upload-time = "2025-09-25T19:49:35.144Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d7/1ff22703ec6d4f90e62f1a5654b8867ef96bafb8e8102c2288333e1a6ca6/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:7f277a4b3390ab4bebe597800a90da0edae882c6196d3038a73adf446c4f969f", size = 272178, upload-time = "2025-09-25T19:49:36.793Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/88/815b6d558a1e4d40ece04a2f84865b0fef233513bd85fd0e40c294272d62/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:79cfa161eda8d2ddf29acad370356b47f02387153b11d46042e93a0a95127493", size = 269295, upload-time = "2025-09-25T19:49:38.164Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/e0db387c79ab4931fc89827d37608c31cc57b6edc08ccd2386139028dc0d/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a5393eae5722bcef046a990b84dff02b954904c36a194f6cfc817d7dca6c6f0b", size = 271700, upload-time = "2025-09-25T19:49:39.917Z" },
+    { url = "https://files.pythonhosted.org/packages/06/83/1570edddd150f572dbe9fc00f6203a89fc7d4226821f67328a85c330f239/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f4c94dec1b5ab5d522750cb059bb9409ea8872d4494fd152b53cca99f1ddd8c", size = 334034, upload-time = "2025-09-25T19:49:41.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f2/ea64e51a65e56ae7a8a4ec236c2bfbdd4b23008abd50ac33fbb2d1d15424/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0cae4cb350934dfd74c020525eeae0a5f79257e8a201c0c176f4b84fdbf2a4b4", size = 352766, upload-time = "2025-09-25T19:49:43.08Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/d4/1a388d21ee66876f27d1a1f41287897d0c0f1712ef97d395d708ba93004c/bcrypt-5.0.0-cp314-cp314t-win32.whl", hash = "sha256:b17366316c654e1ad0306a6858e189fc835eca39f7eb2cafd6aaca8ce0c40a2e", size = 152449, upload-time = "2025-09-25T19:49:44.971Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/61/3291c2243ae0229e5bca5d19f4032cecad5dfb05a2557169d3a69dc0ba91/bcrypt-5.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:92864f54fb48b4c718fc92a32825d0e42265a627f956bc0361fe869f1adc3e7d", size = 149310, upload-time = "2025-09-25T19:49:46.162Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/89/4b01c52ae0c1a681d4021e5dd3e45b111a8fb47254a274fa9a378d8d834b/bcrypt-5.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dd19cf5184a90c873009244586396a6a884d591a5323f0e8a5922560718d4993", size = 143761, upload-time = "2025-09-25T19:49:47.345Z" },
+    { url = "https://files.pythonhosted.org/packages/84/29/6237f151fbfe295fe3e074ecc6d44228faa1e842a81f6d34a02937ee1736/bcrypt-5.0.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:fc746432b951e92b58317af8e0ca746efe93e66555f1b40888865ef5bf56446b", size = 494553, upload-time = "2025-09-25T19:49:49.006Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b6/4c1205dde5e464ea3bd88e8742e19f899c16fa8916fb8510a851fae985b5/bcrypt-5.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c2388ca94ffee269b6038d48747f4ce8df0ffbea43f31abfa18ac72f0218effb", size = 275009, upload-time = "2025-09-25T19:49:50.581Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/71/427945e6ead72ccffe77894b2655b695ccf14ae1866cd977e185d606dd2f/bcrypt-5.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:560ddb6ec730386e7b3b26b8b4c88197aaed924430e7b74666a586ac997249ef", size = 278029, upload-time = "2025-09-25T19:49:52.533Z" },
+    { url = "https://files.pythonhosted.org/packages/17/72/c344825e3b83c5389a369c8a8e58ffe1480b8a699f46c127c34580c4666b/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d79e5c65dcc9af213594d6f7f1fa2c98ad3fc10431e7aa53c176b441943efbdd", size = 275907, upload-time = "2025-09-25T19:49:54.709Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7e/d4e47d2df1641a36d1212e5c0514f5291e1a956a7749f1e595c07a972038/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2b732e7d388fa22d48920baa267ba5d97cca38070b69c0e2d37087b381c681fd", size = 296500, upload-time = "2025-09-25T19:49:56.013Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c3/0ae57a68be2039287ec28bc463b82e4b8dc23f9d12c0be331f4782e19108/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0c8e093ea2532601a6f686edbc2c6b2ec24131ff5c52f7610dd64fa4553b5464", size = 278412, upload-time = "2025-09-25T19:49:57.356Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2b/77424511adb11e6a99e3a00dcc7745034bee89036ad7d7e255a7e47be7d8/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5b1589f4839a0899c146e8892efe320c0fa096568abd9b95593efac50a87cb75", size = 275486, upload-time = "2025-09-25T19:49:59.116Z" },
+    { url = "https://files.pythonhosted.org/packages/43/0a/405c753f6158e0f3f14b00b462d8bca31296f7ecfc8fc8bc7919c0c7d73a/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:89042e61b5e808b67daf24a434d89bab164d4de1746b37a8d173b6b14f3db9ff", size = 277940, upload-time = "2025-09-25T19:50:00.869Z" },
+    { url = "https://files.pythonhosted.org/packages/62/83/b3efc285d4aadc1fa83db385ec64dcfa1707e890eb42f03b127d66ac1b7b/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e3cf5b2560c7b5a142286f69bde914494b6d8f901aaa71e453078388a50881c4", size = 310776, upload-time = "2025-09-25T19:50:02.393Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/47ee337dacecde6d234890fe929936cb03ebc4c3a7460854bbd9c97780b8/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f632fd56fc4e61564f78b46a2269153122db34988e78b6be8b32d28507b7eaeb", size = 312922, upload-time = "2025-09-25T19:50:04.232Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3a/43d494dfb728f55f4e1cf8fd435d50c16a2d75493225b54c8d06122523c6/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:801cad5ccb6b87d1b430f183269b94c24f248dddbbc5c1f78b6ed231743e001c", size = 341367, upload-time = "2025-09-25T19:50:05.559Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ab/a0727a4547e383e2e22a630e0f908113db37904f58719dc48d4622139b5c/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3cf67a804fc66fc217e6914a5635000259fbbbb12e78a99488e4d5ba445a71eb", size = 359187, upload-time = "2025-09-25T19:50:06.916Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bb/461f352fdca663524b4643d8b09e8435b4990f17fbf4fea6bc2a90aa0cc7/bcrypt-5.0.0-cp38-abi3-win32.whl", hash = "sha256:3abeb543874b2c0524ff40c57a4e14e5d3a66ff33fb423529c88f180fd756538", size = 153752, upload-time = "2025-09-25T19:50:08.515Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/4190e60921927b7056820291f56fc57d00d04757c8b316b2d3c0d1d6da2c/bcrypt-5.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:35a77ec55b541e5e583eb3436ffbbf53b0ffa1fa16ca6782279daf95d146dcd9", size = 150881, upload-time = "2025-09-25T19:50:09.742Z" },
+    { url = "https://files.pythonhosted.org/packages/54/12/cd77221719d0b39ac0b55dbd39358db1cd1246e0282e104366ebbfb8266a/bcrypt-5.0.0-cp38-abi3-win_arm64.whl", hash = "sha256:cde08734f12c6a4e28dc6755cd11d3bdfea608d93d958fffbe95a7026ebe4980", size = 144931, upload-time = "2025-09-25T19:50:11.016Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0c418ca99fd47e9c59a301744d63328f17798b5947b0f791e9af3c1c499c2d0a", size = 495313, upload-time = "2025-09-25T19:50:12.309Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ee/2f4985dbad090ace5ad1f7dd8ff94477fe089b5fab2040bd784a3d5f187b/bcrypt-5.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb4e1500f6efdd402218ffe34d040a1196c072e07929b9820f363a1fd1f4191", size = 275290, upload-time = "2025-09-25T19:50:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6e/b77ade812672d15cf50842e167eead80ac3514f3beacac8902915417f8b7/bcrypt-5.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7aeef54b60ceddb6f30ee3db090351ecf0d40ec6e2abf41430997407a46d2254", size = 278253, upload-time = "2025-09-25T19:50:15.089Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c4/ed00ed32f1040f7990dac7115f82273e3c03da1e1a1587a778d8cea496d8/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f0ce778135f60799d89c9693b9b398819d15f1921ba15fe719acb3178215a7db", size = 276084, upload-time = "2025-09-25T19:50:16.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/fa6e16145e145e87f1fa351bbd54b429354fd72145cd3d4e0c5157cf4c70/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a71f70ee269671460b37a449f5ff26982a6f2ba493b3eabdd687b4bf35f875ac", size = 297185, upload-time = "2025-09-25T19:50:18.525Z" },
+    { url = "https://files.pythonhosted.org/packages/24/b4/11f8a31d8b67cca3371e046db49baa7c0594d71eb40ac8121e2fc0888db0/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8429e1c410b4073944f03bd778a9e066e7fad723564a52ff91841d278dfc822", size = 278656, upload-time = "2025-09-25T19:50:19.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/31/79f11865f8078e192847d2cb526e3fa27c200933c982c5b2869720fa5fce/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:edfcdcedd0d0f05850c52ba3127b1fce70b9f89e0fe5ff16517df7e81fa3cbb8", size = 275662, upload-time = "2025-09-25T19:50:21.567Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8d/5e43d9584b3b3591a6f9b68f755a4da879a59712981ef5ad2a0ac1379f7a/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:611f0a17aa4a25a69362dcc299fda5c8a3d4f160e2abb3831041feb77393a14a", size = 278240, upload-time = "2025-09-25T19:50:23.305Z" },
+    { url = "https://files.pythonhosted.org/packages/89/48/44590e3fc158620f680a978aafe8f87a4c4320da81ed11552f0323aa9a57/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:db99dca3b1fdc3db87d7c57eac0c82281242d1eabf19dcb8a6b10eb29a2e72d1", size = 311152, upload-time = "2025-09-25T19:50:24.597Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/e4fbfc46f14f47b0d20493669a625da5827d07e8a88ee460af6cd9768b44/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5feebf85a9cefda32966d8171f5db7e3ba964b77fdfe31919622256f80f9cf42", size = 313284, upload-time = "2025-09-25T19:50:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ae/479f81d3f4594456a01ea2f05b132a519eff9ab5768a70430fa1132384b1/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3ca8a166b1140436e058298a34d88032ab62f15aae1c598580333dc21d27ef10", size = 341643, upload-time = "2025-09-25T19:50:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d2/36a086dee1473b14276cd6ea7f61aef3b2648710b5d7f1c9e032c29b859f/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61afc381250c3182d9078551e3ac3a41da14154fbff647ddf52a769f588c4172", size = 359698, upload-time = "2025-09-25T19:50:31.347Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725, upload-time = "2025-09-25T19:50:34.384Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912, upload-time = "2025-09-25T19:50:35.69Z" },
+    { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953, upload-time = "2025-09-25T19:50:37.32Z" },
 ]
 
 [[package]]
@@ -294,12 +423,110 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c3/a396306ba7db865bf96fc1fb3b7fd29bcbf3d829df642e77b13555163cd6/coverage-7.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01", size = 219554, upload-time = "2026-03-17T10:30:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a68a19e5384e93f811dccc51034b1fd0b865841c390e3c931dcc4699e035/coverage-7.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422", size = 219908, upload-time = "2026-03-17T10:30:43.906Z" },
+    { url = "https://files.pythonhosted.org/packages/29/72/20b917c6793af3a5ceb7fb9c50033f3ec7865f2911a1416b34a7cfa0813b/coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f", size = 251419, upload-time = "2026-03-17T10:30:45.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5", size = 254159, upload-time = "2026-03-17T10:30:47.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/00/7b0edcfe64e2ed4c0340dac14a52ad0f4c9bd0b8b5e531af7d55b703db7c/coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376", size = 255270, upload-time = "2026-03-17T10:30:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/93/89/7ffc4ba0f5d0a55c1e84ea7cee39c9fc06af7b170513d83fbf3bbefce280/coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256", size = 257538, upload-time = "2026-03-17T10:30:50.77Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bd/73ddf85f93f7e6fa83e77ccecb6162d9415c79007b4bc124008a4995e4a7/coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c", size = 251821, upload-time = "2026-03-17T10:30:52.5Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/81/278aff4e8dec4926a0bcb9486320752811f543a3ce5b602cc7a29978d073/coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5", size = 253191, upload-time = "2026-03-17T10:30:54.543Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ee/fe1621488e2e0a58d7e94c4800f0d96f79671553488d401a612bebae324b/coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09", size = 251337, upload-time = "2026-03-17T10:30:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/f79fb37aa104b562207cc23cb5711ab6793608e246cae1e93f26b2236ed9/coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9", size = 255404, upload-time = "2026-03-17T10:30:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f0/ed15262a58ec81ce457ceb717b7f78752a1713556b19081b76e90896e8d4/coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf", size = 250903, upload-time = "2026-03-17T10:31:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/9129958f20e7e9d4d56d51d42ccf708d15cac355ff4ac6e736e97a9393d2/coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c", size = 252780, upload-time = "2026-03-17T10:31:01.916Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d7/0ad9b15812d81272db94379fe4c6df8fd17781cc7671fdfa30c76ba5ff7b/coverage-7.13.5-cp312-cp312-win32.whl", hash = "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf", size = 222093, upload-time = "2026-03-17T10:31:03.642Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3d/821a9a5799fac2556bcf0bd37a70d1d11fa9e49784b6d22e92e8b2f85f18/coverage-7.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810", size = 222900, upload-time = "2026-03-17T10:31:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/2238c2ad08e35cf4f020ea721f717e09ec3152aea75d191a7faf3ef009a8/coverage-7.13.5-cp312-cp312-win_arm64.whl", hash = "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de", size = 221515, upload-time = "2026-03-17T10:31:07.293Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8c/74fedc9663dcf168b0a059d4ea756ecae4da77a489048f94b5f512a8d0b3/coverage-7.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ec4af212df513e399cf11610cc27063f1586419e814755ab362e50a85ea69c1", size = 219576, upload-time = "2026-03-17T10:31:09.045Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c9/44fb661c55062f0818a6ffd2685c67aa30816200d5f2817543717d4b92eb/coverage-7.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:941617e518602e2d64942c88ec8499f7fbd49d3f6c4327d3a71d43a1973032f3", size = 219942, upload-time = "2026-03-17T10:31:10.708Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/13/93419671cee82b780bab7ea96b67c8ef448f5f295f36bf5031154ec9a790/coverage-7.13.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:da305e9937617ee95c2e39d8ff9f040e0487cbf1ac174f777ed5eddd7a7c1f26", size = 250935, upload-time = "2026-03-17T10:31:12.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/68/1666e3a4462f8202d836920114fa7a5ee9275d1fa45366d336c551a162dd/coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:78e696e1cc714e57e8b25760b33a8b1026b7048d270140d25dafe1b0a1ee05a3", size = 253541, upload-time = "2026-03-17T10:31:14.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5e/3ee3b835647be646dcf3c65a7c6c18f87c27326a858f72ab22c12730773d/coverage-7.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02ca0eed225b2ff301c474aeeeae27d26e2537942aa0f87491d3e147e784a82b", size = 254780, upload-time = "2026-03-17T10:31:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/cb5bd1a04cfcc49ede6cd8409d80bee17661167686741e041abc7ee1b9a9/coverage-7.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:04690832cbea4e4663d9149e05dba142546ca05cb1848816760e7f58285c970a", size = 256912, upload-time = "2026-03-17T10:31:17.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/66/c1dceb7b9714473800b075f5c8a84f4588f887a90eb8645282031676e242/coverage-7.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0590e44dd2745c696a778f7bab6aa95256de2cbc8b8cff4f7db8ff09813d6969", size = 251165, upload-time = "2026-03-17T10:31:19.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/62/5502b73b97aa2e53ea22a39cf8649ff44827bef76d90bf638777daa27a9d/coverage-7.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7cfad2d6d81dd298ab6b89fe72c3b7b05ec7544bdda3b707ddaecff8d25c161", size = 252908, upload-time = "2026-03-17T10:31:21.312Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/37/7792c2d69854397ca77a55c4646e5897c467928b0e27f2d235d83b5d08c6/coverage-7.13.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e092b9499de38ae0fbfbc603a74660eb6ff3e869e507b50d85a13b6db9863e15", size = 250873, upload-time = "2026-03-17T10:31:23.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/23/bc866fb6163be52a8a9e5d708ba0d3b1283c12158cefca0a8bbb6e247a43/coverage-7.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:48c39bc4a04d983a54a705a6389512883d4a3b9862991b3617d547940e9f52b1", size = 255030, upload-time = "2026-03-17T10:31:25.58Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8b/ef67e1c222ef49860701d346b8bbb70881bef283bd5f6cbba68a39a086c7/coverage-7.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2d3807015f138ffea1ed9afeeb8624fd781703f2858b62a8dd8da5a0994c57b6", size = 250694, upload-time = "2026-03-17T10:31:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0d/866d1f74f0acddbb906db212e096dee77a8e2158ca5e6bb44729f9d93298/coverage-7.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee2aa19e03161671ec964004fb74b2257805d9710bf14a5c704558b9d8dbaf17", size = 252469, upload-time = "2026-03-17T10:31:29.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f5/be742fec31118f02ce42b21c6af187ad6a344fed546b56ca60caacc6a9a0/coverage-7.13.5-cp313-cp313-win32.whl", hash = "sha256:ce1998c0483007608c8382f4ff50164bfc5bd07a2246dd272aa4043b75e61e85", size = 222112, upload-time = "2026-03-17T10:31:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/7732d648ab9d069a46e686043241f01206348e2bbf128daea85be4d6414b/coverage-7.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:631efb83f01569670a5e866ceb80fe483e7c159fac6f167e6571522636104a0b", size = 222923, upload-time = "2026-03-17T10:31:33.633Z" },
+    { url = "https://files.pythonhosted.org/packages/48/af/fea819c12a095781f6ccd504890aaddaf88b8fab263c4940e82c7b770124/coverage-7.13.5-cp313-cp313-win_arm64.whl", hash = "sha256:f4cd16206ad171cbc2470dbea9103cf9a7607d5fe8c242fdf1edf36174020664", size = 221540, upload-time = "2026-03-17T10:31:35.445Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d2/17879af479df7fbbd44bd528a31692a48f6b25055d16482fdf5cdb633805/coverage-7.13.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0428cbef5783ad91fe240f673cc1f76b25e74bbfe1a13115e4aa30d3f538162d", size = 220262, upload-time = "2026-03-17T10:31:37.184Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4c/d20e554f988c8f91d6a02c5118f9abbbf73a8768a3048cb4962230d5743f/coverage-7.13.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e0b216a19534b2427cc201a26c25da4a48633f29a487c61258643e89d28200c0", size = 220617, upload-time = "2026-03-17T10:31:39.245Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/f9f5277b95184f764b24e7231e166dfdb5780a46d408a2ac665969416d61/coverage-7.13.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:972a9cd27894afe4bc2b1480107054e062df08e671df7c2f18c205e805ccd806", size = 261912, upload-time = "2026-03-17T10:31:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f6/7f1ab39393eeb50cfe4747ae8ef0e4fc564b989225aa1152e13a180d74f8/coverage-7.13.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4b59148601efcd2bac8c4dbf1f0ad6391693ccf7a74b8205781751637076aee3", size = 263987, upload-time = "2026-03-17T10:31:43.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d7/62c084fb489ed9c6fbdf57e006752e7c516ea46fd690e5ed8b8617c7d52e/coverage-7.13.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:505d7083c8b0c87a8fa8c07370c285847c1f77739b22e299ad75a6af6c32c5c9", size = 266416, upload-time = "2026-03-17T10:31:45.769Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f6/df63d8660e1a0bff6125947afda112a0502736f470d62ca68b288ea762d8/coverage-7.13.5-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:60365289c3741e4db327e7baff2a4aaacf22f788e80fa4683393891b70a89fbd", size = 267558, upload-time = "2026-03-17T10:31:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/02/353ca81d36779bd108f6d384425f7139ac3c58c750dcfaafe5d0bee6436b/coverage-7.13.5-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1b88c69c8ef5d4b6fe7dea66d6636056a0f6a7527c440e890cf9259011f5e606", size = 261163, upload-time = "2026-03-17T10:31:50.125Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/16/2e79106d5749bcaf3aee6d309123548e3276517cd7851faa8da213bc61bf/coverage-7.13.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5b13955d31d1633cf9376908089b7cebe7d15ddad7aeaabcbe969a595a97e95e", size = 263981, upload-time = "2026-03-17T10:31:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c7/c29e0c59ffa6942030ae6f50b88ae49988e7e8da06de7ecdbf49c6d4feae/coverage-7.13.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f70c9ab2595c56f81a89620e22899eea8b212a4041bd728ac6f4a28bf5d3ddd0", size = 261604, upload-time = "2026-03-17T10:31:53.872Z" },
+    { url = "https://files.pythonhosted.org/packages/40/48/097cdc3db342f34006a308ab41c3a7c11c3f0d84750d340f45d88a782e00/coverage-7.13.5-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:084b84a8c63e8d6fc7e3931b316a9bcafca1458d753c539db82d31ed20091a87", size = 265321, upload-time = "2026-03-17T10:31:55.997Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/4994af354689e14fd03a75f8ec85a9a68d94e0188bbdab3fc1516b55e512/coverage-7.13.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ad14385487393e386e2ea988b09d62dd42c397662ac2dabc3832d71253eee479", size = 260502, upload-time = "2026-03-17T10:31:58.308Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/9bb9ef55903e628033560885f5c31aa227e46878118b63ab15dc7ba87797/coverage-7.13.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f2c47b36fe7709a6e83bfadf4eefb90bd25fbe4014d715224c4316f808e59a2", size = 262688, upload-time = "2026-03-17T10:32:00.141Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4f/f5df9007e50b15e53e01edea486814783a7f019893733d9e4d6caad75557/coverage-7.13.5-cp313-cp313t-win32.whl", hash = "sha256:67e9bc5449801fad0e5dff329499fb090ba4c5800b86805c80617b4e29809b2a", size = 222788, upload-time = "2026-03-17T10:32:02.246Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/98/aa7fccaa97d0f3192bec013c4e6fd6d294a6ed44b640e6bb61f479e00ed5/coverage-7.13.5-cp313-cp313t-win_amd64.whl", hash = "sha256:da86cdcf10d2519e10cabb8ac2de03da1bcb6e4853790b7fbd48523332e3a819", size = 223851, upload-time = "2026-03-17T10:32:04.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8b/e5c469f7352651e5f013198e9e21f97510b23de957dd06a84071683b4b60/coverage-7.13.5-cp313-cp313t-win_arm64.whl", hash = "sha256:0ecf12ecb326fe2c339d93fc131816f3a7367d223db37817208905c89bded911", size = 222104, upload-time = "2026-03-17T10:32:06.65Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
 ]
 
 [[package]]
@@ -612,6 +839,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "iso8601"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/f3/ef59cee614d5e0accf6fd0cbba025b93b272e626ca89fb70a3e9187c5d15/iso8601-2.1.0.tar.gz", hash = "sha256:6b1d3829ee8921c4301998c909f7829fa9ed3cbdac0d3b16af2d743aed1ba8df", size = 6522, upload-time = "2023-10-03T00:25:39.317Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/0c/f37b6a241f0759b7653ffa7213889d89ad49a2b76eb2ddf3b57b2738c347/iso8601-2.1.0-py3-none-any.whl", hash = "sha256:aac4145c4dcb66ad8b648a02830f5e2ff6c24af20f4f482689be402db2429242", size = 7545, upload-time = "2023-10-03T00:25:32.304Z" },
 ]
 
 [[package]]
@@ -1171,6 +1407,24 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[[package]]
+name = "pypika-tortoise"
+version = "0.6.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/06/89fe5fff93c5a01dbdeb9f3d843a7e997dc6e3a87222a260a164ff91fb81/pypika_tortoise-0.6.5.tar.gz", hash = "sha256:64d96c9b88450f6360ad22a7063933b6a90961a7317f04b2b63c98fd5d705506", size = 81468, upload-time = "2026-03-13T20:44:54.439Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/b8/502910eb8b315f719d8f6a6509f13a38b6c4c05378f14ac151ff347bff0a/pypika_tortoise-0.6.5-py3-none-any.whl", hash = "sha256:9194ac6ce6ac9bdfc6e959c831c5788ef05ee1371e82ba281b0eb75f4a2bd4f1", size = 47936, upload-time = "2026-03-13T20:44:53.541Z" },
+]
+
+[[package]]
 name = "pyright"
 version = "1.1.409"
 source = { registry = "https://pypi.org/simple" }
@@ -1213,12 +1467,42 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
 ]
 
 [[package]]
@@ -1535,6 +1819,22 @@ wheels = [
 ]
 
 [[package]]
+name = "testcontainers"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
+]
+
+[[package]]
 name = "tiktoken"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1605,6 +1905,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
     { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
     { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+]
+
+[[package]]
+name = "tortoise-orm"
+version = "1.1.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiosqlite" },
+    { name = "anyio" },
+    { name = "iso8601", marker = "python_full_version < '4'" },
+    { name = "pypika-tortoise" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/55/e75d3ae0dd2c96cf961bf068f465fb62ec481d802beb65f406620bfd40a0/tortoise_orm-1.1.7.tar.gz", hash = "sha256:a0f0f27f9c92547739f0a3f0862c257ab64d8baadbc0e548cbcfa2d70bcbe275", size = 387489, upload-time = "2026-03-21T20:03:29.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/9b/e7e5b4f4e9433b9d9c389afc62ea0ed2597626842dc0f76dd7b54eb32cdd/tortoise_orm-1.1.7-py3-none-any.whl", hash = "sha256:b640b786905891cc120aa16d1a7af18cd54b111a812f9b1c1d1c7b294d62949d", size = 272437, upload-time = "2026-03-21T20:03:27.539Z" },
+]
+
+[package.optional-dependencies]
+asyncpg = [
+    { name = "asyncpg" },
 ]
 
 [[package]]
@@ -1833,6 +2153,70 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/b6/1db817582c49c7fcbb7df6809d0f515af29d7c2fbf57eb44c36e98fb1492/wrapt-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9", size = 61255, upload-time = "2026-03-06T02:52:45.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/16/9b02a6b99c09227c93cd4b73acc3678114154ec38da53043c0ddc1fba0dc/wrapt-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748", size = 61848, upload-time = "2026-03-06T02:53:48.728Z" },
+    { url = "https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e", size = 121433, upload-time = "2026-03-06T02:54:40.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/9f/742c7c7cdf58b59085a1ee4b6c37b013f66ac33673a7ef4aaed5e992bc33/wrapt-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8", size = 123013, upload-time = "2026-03-06T02:53:26.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/44/2c3dd45d53236b7ed7c646fcf212251dc19e48e599debd3926b52310fafb/wrapt-2.1.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c", size = 117326, upload-time = "2026-03-06T02:53:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e2/b17d66abc26bd96f89dec0ecd0ef03da4a1286e6ff793839ec431b9fae57/wrapt-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c", size = 121444, upload-time = "2026-03-06T02:54:09.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/62/e2977843fdf9f03daf1586a0ff49060b1b2fc7ff85a7ea82b6217c1ae36e/wrapt-2.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1", size = 116237, upload-time = "2026-03-06T02:54:03.884Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/27fc67914e68d740bce512f11734aec08696e6b17641fef8867c00c949fc/wrapt-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2", size = 120563, upload-time = "2026-03-06T02:53:20.412Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9f/b750b3692ed2ef4705cb305bd68858e73010492b80e43d2a4faa5573cbe7/wrapt-2.1.2-cp312-cp312-win32.whl", hash = "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0", size = 58198, upload-time = "2026-03-06T02:53:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b2/feecfe29f28483d888d76a48f03c4c4d8afea944dbee2b0cd3380f9df032/wrapt-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63", size = 60441, upload-time = "2026-03-06T02:52:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/44/e1/e328f605d6e208547ea9fd120804fcdec68536ac748987a68c47c606eea8/wrapt-2.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf", size = 58836, upload-time = "2026-03-06T02:53:22.053Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259, upload-time = "2026-03-06T02:53:41.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851, upload-time = "2026-03-06T02:52:48.672Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446, upload-time = "2026-03-06T02:54:14.013Z" },
+    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056, upload-time = "2026-03-06T02:54:10.829Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359, upload-time = "2026-03-06T02:53:03.623Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479, upload-time = "2026-03-06T02:53:45.844Z" },
+    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271, upload-time = "2026-03-06T02:54:46.356Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573, upload-time = "2026-03-06T02:52:50.163Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205, upload-time = "2026-03-06T02:53:47.494Z" },
+    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452, upload-time = "2026-03-06T02:53:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842, upload-time = "2026-03-06T02:52:52.114Z" },
+    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075, upload-time = "2026-03-06T02:53:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719, upload-time = "2026-03-06T02:54:33.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643, upload-time = "2026-03-06T02:52:42.721Z" },
+    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805, upload-time = "2026-03-06T02:54:25.441Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990, upload-time = "2026-03-06T02:53:57.456Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670, upload-time = "2026-03-06T02:54:55.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357, upload-time = "2026-03-06T02:54:24.092Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269, upload-time = "2026-03-06T02:53:31.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894, upload-time = "2026-03-06T02:54:15.391Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197, upload-time = "2026-03-06T02:54:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363, upload-time = "2026-03-06T02:54:48.093Z" },
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
 ]
 
 [[package]]

--- a/apps/server/tests/e2e/test_aigw_auth_e2e.py
+++ b/apps/server/tests/e2e/test_aigw_auth_e2e.py
@@ -36,6 +36,8 @@ from screamingface.plugins.aigw_claude_backend.plugin import (
 
 pytestmark = pytest.mark.e2e
 
+_ANONYMOUS_ACCOUNT_ID = "00000000-0000-0000-0000-000000000000"
+
 
 def _free_port() -> int:
     with socket.socket() as s:
@@ -51,10 +53,34 @@ def _aigateway_dir() -> Path:
 def _boot_gateway(extra_env: dict[str, str], tmp_path: Path) -> tuple[int, subprocess.Popen[str]]:
     port = _free_port()
     env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
     env["AIGATEWAY_FAKE_KEYCHAIN"] = "1"
     env["AIGATEWAY_KEYCHAIN_FILE"] = str(tmp_path / "fake-kc.json")
     env["AIGATEWAY_FAKE_ANTHROPIC_OAUTH"] = "1"
+    env["AIGATEWAY_DATABASE_URL"] = f"sqlite://{tmp_path / 'aigateway.sqlite3'}"
+    env["AIGATEWAY_AUTH_ENABLED"] = "0"
+    env["AIGATEWAY_ADMIN_PASSWORD"] = "test-admin-password"
+    env["AIGATEWAY_JWT_SECRET"] = "x" * 32
+    env["AIGATEWAY_PROVISIONING_TOKEN"] = "p" * 32
     env.update(extra_env)
+    subprocess.run(
+        [
+            "uv",
+            "run",
+            "--directory",
+            str(_aigateway_dir()),
+            "python",
+            "-m",
+            "tortoise",
+            "-c",
+            "aigateway.db.TORTOISE_CONFIG",
+            "migrate",
+        ],
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
     proc = subprocess.Popen(
         [
             "uv",
@@ -140,7 +166,7 @@ def test_full_oauth_cycle_via_sf_auth_proxy(aigw: dict) -> None:
     resp = sf.post("/claude/auth/start")
     assert resp.status_code == 200, resp.text
     body = resp.json()
-    assert body["profile_id"] == "anthropic:default"
+    assert body["profile_id"] == f"{_ANONYMOUS_ACCOUNT_ID}:anthropic:default"
     assert body["authorize_url"].startswith("https://")
     state = body["state"]
 


### PR DESCRIPTION
## Description                                                                                                                                                                                                                                                                                                           
Implements D-AIGW-010 / SF-162: the aigateway auth layer.                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                          
This adds account-based authentication and authorization for aigateway:                                                                                                                                                                                                                                                  
- Tortoise-backed `accounts` model and initial migration.                                                                                                                                                                                                                                                                
- First-boot admin bootstrap with env-password or generated-password fallback.                                                                                                                                                                                                                                           
- `/v1/auth/login` and `/v1/auth/me`.                                                                                                                                                                                                                                                                                    
- JWT session issuance and validation middleware.                                                                                                                                                                                                                                                                        
- JWT protection for `/v1/models`, `/v1/chat/completions`, and OAuth profile routes.                                                                                                                                                                                                                                     
- `/v1/accounts` provisioning endpoint gated by `X-Aigw-Provisioning-Token`.                                                                                                                                                                                                                                             
- Account-scoped OAuth profiles, pending OAuth state, provider credentials, profile refresh, and `X-Profile` chat resolution.                                                                                                                                                                                            
- Secret redaction, password/JWT hardening, migration smoke coverage, CI coverage gates, and README operations notes.                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                          
Asana: https://app.asana.com/0/1213628819033917/1214568319770655/f                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                          
### Notes / Follow-ups                                                                                                                                                                                                                                                                                                   
The auth layer satisfies the D-AIGW-010 acceptance criteria. During final review, these non-blocking hardening opportunities were also identified:                                                                                                                                                                       
                                                                                                                                                                                                                                                                          
- **Multi-worker generated JWT secret:** documented constraint. Multi-worker deployments must set `AIGATEWAY_JWT_SECRET`; auto-generated keychain secrets are intended for local/single-worker use only.                                                                                                                 
- **macOS credential store write path:** existing keychain wrapper passes secret values through `security -w <value>` argv. This predates the auth layer but is worth hardening in a credential-store follow-up.                                                                                                         
- **Login metadata update:** `last_login_at` is updated before returning the JWT. This satisfies the AC, but could be made best-effort if we want login to tolerate metadata-write failures.                                                                                                                             
- **Timing-equalization test:** currently uses real bcrypt timing. It passes locally, but a structural test would be less CI-sensitive.                                                                                                                                                                                  
                                                                                                                                                                                                                                                                          
## Affected Dependencies                                                                                                                                                                                                                                                                                                 
New aigateway runtime dependencies:                                                                                                                                                                                                                                                                                      
- `tortoise-orm[asyncpg]==1.1.7`                                                                                                                                                                                                                                                                                         
- `PyJWT==2.12.1`                                                                                                                                                                                                                                                                                                        
- `bcrypt==5.0.0`                                                                                                                                                                                                                                                                                                        
- `asyncpg==0.31.0`                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                          
New dev/test dependencies:                                                                                                                                                                                                                                                                                               
- `pytest-asyncio>=1.3,<2`                                                                                                                                                                                                                                                                                               
- `pytest-cov>=5`                                                                                                                                                                                                                                                                                                        
- `aiosqlite==0.22.1`                                                                                                                                                                                                                                                                                                    
- `testcontainers[postgres]==4.14.2`                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                          
## How has this been tested?                                                                                                                                                                                                                                                                                             
Validated locally from `apps/aigateway` with:                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                          
```bash                                                                                                                                                                                                                                                                                                                  
uv run ruff check .                                                                                                                                                                                                                                                                                                      
uv run ruff format --check .                                                                                                                                                                                                                                                                                             
uv run pyright                                                                                                                                                                                                                                                                                                           
uv run --with mypy mypy .                                                                                                                                                                                                                                                                                                
uv run python scripts/check_no_enterprise.py                                                                                                                                                                                                                                                                             
uv run pytest --cov=aigateway --cov-report=term-missing --cov-fail-under=85 -m "not live and not needs_postgres" -q                                                                                                                                                                                                      
uv run pytest tests/unit/auth tests/unit/test_auth_routes.py --cov=aigateway.core.auth --cov=aigateway.routes.auth_session --cov=aigateway.routes.accounts --cov=aigateway.routes.auth --cov-report=term-missing --cov-fail-under=95 -q                                                                                  
uv run pytest tests/live/ -q                                                                                                                                                                                                                                                                                             
AIGW_TEST_PG=1 uv run pytest -m needs_postgres -q      
```                                                                                                                                                                                                                                                                  
## Results:                                                                                                                                                                                                                                                                                                                 
- Ruff, Pyright, mypy, and Enterprise import guard passed.                                                                                                                                                                                                                                                               
- Aggregate coverage passed: `143 passed`, `91.35%`.                                                                                                                                                                                                                                                                     
- Expanded auth coverage passed: `88 passed`, `98.76%`.                                                                                                                                                                                                                                                                  
- Live tests skipped without live env: `3 skipped`.                                                                                                                                                                                                                                                                      
- Postgres migration smoke passed: `1 passed`.                                                                                                                                                                                                                                                                           
- Isolated Uvicorn auth lifecycle smoke passed.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       

## Checklist
- [x] I have followed the Contribution Guidelines (https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and Code of Conduct (https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the OpenMined Styleguide (https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant Type labels (https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests