### PR TITLE
fix(ci): correct release-please tag separator + enable workflow chain

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "apps/desktop": "0.1.0",
   "apps/server": "0.1.0",
-  "apps/aigateway": "0.2.0"
+  "apps/aigateway": "0.1.0"
 }

--- a/apps/aigateway/CHANGELOG.md
+++ b/apps/aigateway/CHANGELOG.md
@@ -4,13 +4,6 @@ All notable changes to the ScreamingFace AI Gateway are documented here.
 This project follows [Semantic Versioning](https://semver.org/) and uses
 release tags of the form `aigateway-v<version>`.
 
-## [0.2.0](https://github.com/OpenMined/screamingface/compare/aigateway-vv0.1.0...aigateway-vv0.2.0) (2026-05-11)
-
-
-### Features
-
-* **SF-138:** scaffold apps/aigateway/ standalone LiteLLM-compatible service ([#122](https://github.com/OpenMined/screamingface/issues/122)) ([3a66bf9](https://github.com/OpenMined/screamingface/commit/3a66bf9269f20848b7bc3fadca5809527b7bb901))
-
 ## [Unreleased]
 
 ## [0.1.0]

--- a/apps/aigateway/pyproject.toml
+++ b/apps/aigateway/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aigateway"
-version = "0.2.0"
+version = "0.1.0"
 description = "LiteLLM-compatible AI gateway: unified OpenAI-shape API in front of Anthropic / OpenAI / Gemini / Ollama"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/aigateway/src/aigateway/__init__.py
+++ b/apps/aigateway/src/aigateway/__init__.py
@@ -1,3 +1,3 @@
 """LiteLLM-compatible AI gateway for ScreamingFace."""
 
-__version__ = "0.2.0"
+__version__ = "0.1.0"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,14 +20,14 @@
       "release-type": "node",
       "package-name": "screamingface-desktop",
       "component": "desktop",
-      "tag-separator": "-v",
+      "tag-separator": "-",
       "include-component-in-tag": true
     },
     "apps/server": {
       "release-type": "python",
       "package-name": "screamingface",
       "component": "server",
-      "tag-separator": "-v",
+      "tag-separator": "-",
       "include-component-in-tag": true,
       "version-file": "apps/server/pyproject.toml"
     },
@@ -35,7 +35,7 @@
       "release-type": "python",
       "package-name": "aigateway",
       "component": "aigateway",
-      "tag-separator": "-v",
+      "tag-separator": "-",
       "include-component-in-tag": true,
       "version-file": "apps/aigateway/pyproject.toml"
     }


### PR DESCRIPTION
## Summary
Fixes two bugs in the release-please setup from #148.

### Bug 1 — Tag separator
\`tag-separator\` was \`-v\`, but release-please auto-prepends \`v\` to the version. Result: tags came out as \`aigateway-vv0.2.0\` (double-v). Set to \`-\` so tags are \`aigateway-v0.2.0\` as the workflows expect.

### Bug 2 — Downstream workflows didn't trigger
release-please-action used the default \`GITHUB_TOKEN\`. Tag pushes made by \`GITHUB_TOKEN\` do **not** trigger other workflows (GitHub docs). Result: \`release-aigateway.yml\` etc. never ran when release-please pushed a tag.

Fix: switch to \`secrets.RELEASE_PAT || secrets.GITHUB_TOKEN\`. With the PAT, tag pushes will trigger the per-app workflows; without it, release-please still works for opening PRs (just no auto-chain on tag push).

## Required action: create the PAT
**You must create a PAT** with scope \`contents:write\` + \`actions:write\` (or fine-grained equivalent: \`Contents: Read and Write\`, \`Pull requests: Read and Write\`, \`Actions: Read and Write\`) and add it as repo secret \`RELEASE_PAT\`. Without it, this PR is harmless but doesn't fix bug 2.

## Includes
- Revert of \`chore(main): release aigateway 0.2.0 (#149)\` — rolls manifest + pyproject back to \`0.1.0\` so release-please reopens the aigateway release PR with the corrected tag

## Cleanup already done out-of-band
- Deleted malformed tag \`aigateway-vv0.2.0\` (local + remote)
- Deleted empty GitHub Release \`aigateway: v0.2.0\` (\`OpenMined/screamingface\`)
- ghcr.io and sf-installer were never touched (downstream workflows didn't run), nothing to clean there

## Test plan
- [ ] Merge this PR
- [ ] release-please reopens the \`aigateway\` release PR (component now back at 0.1.0 → next bump is 0.2.0)
- [ ] After PAT is added: merging that release PR pushes tag \`aigateway-v0.2.0\` (single v) and \`release-aigateway.yml\` triggers automatically
- [ ] Image \`ghcr.io/openmined/screamingface-aigateway:0.2.0\` lands and \`sf-installer\` gets a reference release