### PR TITLE
SF-150 / DEMO-004: Env scope chain for url4_executor

### DIFF
--- a/apps/server/src/screamingface/plugins/aigw_base/interpreter.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/interpreter.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 from screamingface.plugins.llm_base.messages import CoreMessage, TextPart, extract_text
 from screamingface.plugins.url4_executor.interpreter import Url4Interpreter
+from screamingface.plugins.url4_executor.scope import Env
 
 from .backend import AigwBackend
 
@@ -45,7 +46,7 @@ class AigwInterpreter(Url4Interpreter):
         else:
             self._backend = AigwBackend()
 
-    async def process(self, sources: str, intent: str | None) -> str:
+    async def process(self, sources: str, intent: str | None, env: Env | None = None) -> str:
         combined = f"{intent}\n\n{sources}" if intent and sources else (intent or sources or "")
         if not combined:
             return ""

--- a/apps/server/src/screamingface/plugins/claude_backend_api/interpreter.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/interpreter.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any
 from screamingface.plugins.claude_backend_api.backend import AnthropicBackend
 from screamingface.plugins.llm_base.messages import CoreMessage, TextPart
 from screamingface.plugins.url4_executor.interpreter import Url4Interpreter
+from screamingface.plugins.url4_executor.scope import Env
 
 if TYPE_CHECKING:
     from screamingface.plugins.claude_backend_api.plugin import ClaudeBackendApiSettings
@@ -64,7 +65,7 @@ class ClaudeBackendApiInterpreter(Url4Interpreter):
         self.settings = settings
         self._backend = backend or AnthropicBackend()
 
-    async def process(self, sources: str, intent: str | None) -> str:
+    async def process(self, sources: str, intent: str | None, env: Env | None = None) -> str:
         """Combine intent + sources, send as a user message to Anthropic.
 
         Matches :class:`ClaudeInterpreter.process` semantics so existing

--- a/apps/server/src/screamingface/plugins/codex_backend_api/interpreter.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/interpreter.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 from screamingface.plugins.codex_backend_api.backend import OpenAIBackend
 from screamingface.plugins.llm_base.messages import CoreMessage, TextPart
 from screamingface.plugins.url4_executor.interpreter import Url4Interpreter
+from screamingface.plugins.url4_executor.scope import Env
 
 if TYPE_CHECKING:
     from screamingface.plugins.codex_backend_api.plugin import CodexBackendApiSettings
@@ -42,7 +43,7 @@ class CodexBackendApiInterpreter(Url4Interpreter):
         self.settings = settings
         self._backend = backend or OpenAIBackend()
 
-    async def process(self, sources: str, intent: str | None) -> str:
+    async def process(self, sources: str, intent: str | None, env: Env | None = None) -> str:
         """Combine intent + sources and send to OpenAI.
 
         Concatenation rule: ``intent\\n\\nsources`` (intent first so the

--- a/apps/server/src/screamingface/plugins/gemini_backend_api/interpreter.py
+++ b/apps/server/src/screamingface/plugins/gemini_backend_api/interpreter.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 from screamingface.plugins.gemini_backend_api.backend import GeminiBackend
 from screamingface.plugins.llm_base.messages import CoreMessage, TextPart
 from screamingface.plugins.url4_executor.interpreter import Url4Interpreter
+from screamingface.plugins.url4_executor.scope import Env
 
 if TYPE_CHECKING:
     from screamingface.plugins.gemini_backend_api.plugin import GeminiBackendApiSettings
@@ -29,7 +30,7 @@ class GeminiBackendApiInterpreter(Url4Interpreter):
         self.settings = settings
         self._backend = backend or GeminiBackend()
 
-    async def process(self, sources: str, intent: str | None) -> str:
+    async def process(self, sources: str, intent: str | None, env: Env | None = None) -> str:
         parts: list[str] = []
         if intent:
             parts.append(intent)

--- a/apps/server/src/screamingface/plugins/ollama_backend_api/interpreter.py
+++ b/apps/server/src/screamingface/plugins/ollama_backend_api/interpreter.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 from screamingface.plugins.llm_base.messages import CoreMessage, TextPart
 from screamingface.plugins.ollama_backend_api.backend import OllamaBackend
 from screamingface.plugins.url4_executor.interpreter import Url4Interpreter
+from screamingface.plugins.url4_executor.scope import Env
 
 if TYPE_CHECKING:
     from screamingface.plugins.ollama_backend_api.plugin import OllamaBackendApiSettings
@@ -42,7 +43,7 @@ class OllamaBackendApiInterpreter(Url4Interpreter):
         self.settings = settings
         self._backend = backend or _build_backend(settings)
 
-    async def process(self, sources: str, intent: str | None) -> str:
+    async def process(self, sources: str, intent: str | None, env: Env | None = None) -> str:
         """Combine intent + sources and send to Ollama.
 
         Concatenation rule: ``intent\\n\\nsources`` (intent first so the

--- a/apps/server/src/screamingface/plugins/url4_executor/ensemble.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/ensemble.py
@@ -50,6 +50,7 @@ from screamingface.plugins.url4_executor.ensemble_helpers import (
     substitute_response_vars,
 )
 from screamingface.plugins.url4_executor.interpreter import Url4Interpreter
+from screamingface.plugins.url4_executor.scope import Env
 from screamingface.plugins.url4_executor.url4 import (
     Url4BackendCall,
     Url4List,
@@ -76,15 +77,15 @@ class EnsembleInterpreter(Url4Interpreter):
         super().__init__(app)
         self._processor = processor or DEFAULT_PROCESSOR
 
-    async def process(self, sources: str, intent: str | None) -> str:
+    async def process(self, sources: str, intent: str | None, env: Env | None = None) -> str:
         """Fallback for non-ensemble expressions. Delegates to base class."""
-        return await super().process(sources, intent)
+        return await super().process(sources, intent, env)
 
     # ------------------------------------------------------------------
     # Dispatcher — picks the right evaluation strategy for the expression
     # ------------------------------------------------------------------
 
-    async def evaluate(self, expr: str) -> str:
+    async def evaluate(self, expr: str, env: Env | None = None) -> str:
         """Choose one of four evaluation strategies and run it.
 
         The dispatcher owns only the decision tree. Each strategy (the
@@ -97,6 +98,8 @@ class EnsembleInterpreter(Url4Interpreter):
         from screamingface.plugins.url4_executor.url4 import parse
 
         with traced("url4.evaluate"):
+            if env is None:
+                env = Env.root()
             set_span_attrs({"url4.expression": expr[:500]})
             source_expr, raw_intent, broadcast = split_intent(expr.strip())
             set_span_attrs(
@@ -112,7 +115,7 @@ class EnsembleInterpreter(Url4Interpreter):
             if collection_source is not None and iteration_body is not None:
                 set_span_attrs({"url4.collection_iteration": True})
                 return await self._collection_iterate(
-                    collection_source, iteration_body, raw_intent or ""
+                    collection_source, iteration_body, raw_intent or "", env
                 )
 
             source_node = parse(source_expr) if source_expr else None
@@ -120,23 +123,27 @@ class EnsembleInterpreter(Url4Interpreter):
             # 2. Broadcast (``!*`` operator) — apply intent per-source.
             if broadcast and raw_intent and source_node is not None:
                 set_span_attrs({"url4.ensemble": False, "url4.broadcast_mode": True})
-                return await self._broadcast_evaluate(source_node, raw_intent)
+                return await self._broadcast_evaluate(source_node, raw_intent, env)
 
             # 3. Fan-out + reduce — source is a list of backend calls.
             if source_node is not None and self._is_fanout(source_node) and raw_intent:
                 set_span_attrs({"url4.ensemble": True})
-                return await self._ensemble_evaluate(source_node, raw_intent)
+                return await self._ensemble_evaluate(source_node, raw_intent, env)
 
             # 4. Default single-source path.
             set_span_attrs({"url4.ensemble": False})
-            return await self._single_source_evaluate(source_expr, raw_intent)
+            return await self._single_source_evaluate(source_expr, raw_intent, env)
 
     # ------------------------------------------------------------------
     # Strategy 1: collection iteration (SF-91)
     # ------------------------------------------------------------------
 
     async def _collection_iterate(
-        self, collection_source: str, iteration_body: str, intent: str
+        self,
+        collection_source: str,
+        iteration_body: str,
+        intent: str,
+        env: Env | None = None,
     ) -> str:
         """Iterate over a collection, applying the body expression to each item.
 
@@ -153,7 +160,7 @@ class EnsembleInterpreter(Url4Interpreter):
         from screamingface.plugins.url4_executor.url4 import resolve_str
 
         with traced("url4.collection_iterate"):
-            collection_body = await resolve_str(collection_source, self.app)
+            collection_body = await resolve_str(collection_source, self.app, env)
             items = parse_collection(collection_body)
             set_span_attrs({"url4.collection.item_count": len(items)})
 
@@ -163,7 +170,7 @@ class EnsembleInterpreter(Url4Interpreter):
             async def _process_one(item_json: str) -> str:
                 substituted_body = substitute_item(iteration_body, item_json)
                 full_expr = f"({substituted_body})!{intent}" if intent else f"({substituted_body})"
-                return await self.evaluate(full_expr)
+                return await self.evaluate(full_expr, env)
 
             results = list(await asyncio.gather(*[_process_one(item) for item in items]))
             set_span_attrs({"url4.collection.result_count": len(results)})
@@ -173,7 +180,9 @@ class EnsembleInterpreter(Url4Interpreter):
     # Strategy 2: intent broadcasting (SF-93, ``!*``)
     # ------------------------------------------------------------------
 
-    async def _broadcast_evaluate(self, source_node: Url4Node, raw_intent: str) -> str:
+    async def _broadcast_evaluate(
+        self, source_node: Url4Node, raw_intent: str, env: Env | None = None
+    ) -> str:
         """Apply the intent independently to each source, collect results.
 
         ``(a, b, c)!*'intent'`` → resolve each source, apply the intent
@@ -183,7 +192,7 @@ class EnsembleInterpreter(Url4Interpreter):
         from screamingface.plugins.url4_executor.interpreter import resolve_intent
 
         with traced("url4.broadcast"):
-            intent_text = await resolve_intent(raw_intent, self.app) if raw_intent else ""
+            intent_text = await resolve_intent(raw_intent, self.app, env) if raw_intent else ""
 
             items = list(source_node.items) if isinstance(source_node, Url4List) else [source_node]
             set_span_attrs(
@@ -194,8 +203,8 @@ class EnsembleInterpreter(Url4Interpreter):
             )
 
             async def _apply_one(item: Url4Node) -> str:
-                source_text = await resolve(item, self.app)
-                return await self.process(source_text, intent_text)
+                source_text = await resolve(item, self.app, env)
+                return await self.process(source_text, intent_text, env)
 
             results = list(await asyncio.gather(*[_apply_one(item) for item in items]))
             set_span_attrs({"url4.broadcast.result_count": len(results)})
@@ -214,7 +223,9 @@ class EnsembleInterpreter(Url4Interpreter):
             return False
         return all(isinstance(item, Url4BackendCall) for item in node.items)
 
-    async def _ensemble_evaluate(self, source_node: Url4List, raw_intent: str) -> str:
+    async def _ensemble_evaluate(
+        self, source_node: Url4List, raw_intent: str, env: Env | None = None
+    ) -> str:
         """Fan-out N backend calls, reduce via the configured processor.
 
         1. Resolve the outer intent (reducer instruction).
@@ -230,7 +241,9 @@ class EnsembleInterpreter(Url4Interpreter):
         from screamingface.plugins.url4_executor.url4_resolve import _dispatch_backend_call
 
         with traced("url4.ensemble.resolve_intent"):
-            reducer_instruction = await resolve_intent(raw_intent, self.app) if raw_intent else ""
+            reducer_instruction = (
+                await resolve_intent(raw_intent, self.app, env) if raw_intent else ""
+            )
             set_span_attrs({"url4.ensemble.reducer_instruction_length": len(reducer_instruction)})
 
         with traced("url4.ensemble.fanout"):
@@ -239,7 +252,7 @@ class EnsembleInterpreter(Url4Interpreter):
             # asyncio.gather with return_exceptions=False (default) cancels
             # remaining tasks and raises the first exception (Q6=a).
             responses: list[str] = list(
-                await asyncio.gather(*[resolve(item, self.app) for item in items])
+                await asyncio.gather(*[resolve(item, self.app, env) for item in items])
             )
             set_span_attrs({"url4.ensemble.response_count": len(responses)})
 
@@ -263,7 +276,7 @@ class EnsembleInterpreter(Url4Interpreter):
                 path=self._processor,
                 intent=Url4Text(value=reducer_input),
             )
-            result = await _dispatch_backend_call(reducer_node, self.app)
+            result = await _dispatch_backend_call(reducer_node, self.app, env)
 
             result_preview = result[:4000]
             if len(result) > 4000:
@@ -280,7 +293,9 @@ class EnsembleInterpreter(Url4Interpreter):
     # Strategy 4: single source (default / base interpreter behavior)
     # ------------------------------------------------------------------
 
-    async def _single_source_evaluate(self, source_expr: str, raw_intent: str | None) -> str:
+    async def _single_source_evaluate(
+        self, source_expr: str, raw_intent: str | None, env: Env | None = None
+    ) -> str:
         """Resolve sources and apply intent via the base interpreter.
 
         Mirrors :meth:`Url4Interpreter.evaluate` with the same tracing
@@ -292,7 +307,7 @@ class EnsembleInterpreter(Url4Interpreter):
         from screamingface.plugins.url4_executor.url4 import resolve_str
 
         with traced("url4.resolve_sources"):
-            sources = await resolve_str(source_expr, self.app) if source_expr else ""
+            sources = await resolve_str(source_expr, self.app, env) if source_expr else ""
             src_preview = sources[:4000]
             if len(sources) > 4000:
                 src_preview += f"\n... ({len(sources) - 4000} more chars)"
@@ -304,7 +319,7 @@ class EnsembleInterpreter(Url4Interpreter):
             )
 
         with traced("url4.resolve_intent"):
-            intent = await resolve_intent(raw_intent, self.app) if raw_intent else None
+            intent = await resolve_intent(raw_intent, self.app, env) if raw_intent else None
             set_span_attrs(
                 {
                     "url4.intent_length": len(intent) if intent else 0,
@@ -312,7 +327,7 @@ class EnsembleInterpreter(Url4Interpreter):
                 }
             )
 
-        result = await self.process(sources, intent)
+        result = await self.process(sources, intent, env)
         result_preview = result[:4000]
         if len(result) > 4000:
             result_preview += f"\n... ({len(result) - 4000} more chars)"

--- a/apps/server/src/screamingface/plugins/url4_executor/interpreter.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/interpreter.py
@@ -11,13 +11,14 @@ import logging
 from typing import Any
 
 from screamingface.plugins.url4_executor.decoder import split_intent
+from screamingface.plugins.url4_executor.scope import Env
 from screamingface.plugins.url4_executor.url4 import resolve_str
 from screamingface.plugins.url4_executor.url4_resolve import _fetch_relative, _fetch_url
 
 logger = logging.getLogger(__name__)
 
 
-async def resolve_intent(intent: str, app: Any = None) -> str:
+async def resolve_intent(intent: str, app: Any = None, env: Env | None = None) -> str:
     """Resolve an intent string to text.
 
     - ``/path`` → relative URL, fetched via in-process ASGI
@@ -41,16 +42,34 @@ class Url4Interpreter:
 
     Override ``process()`` to change what happens with the resolved pieces.
     The default concatenates ``intent + "\\n\\n" + sources``.
+
+    Scope chain (DEMO-004)
+    ----------------------
+    ``evaluate`` and ``process`` accept an optional ``env: Env | None``
+    parameter that is threaded through every recursive call into
+    ``resolve_str``, ``resolve_intent``, and any subclass override.
+    ``None`` is treated as a fresh root env.
+
+    The chain uses parent pointers (not copy-on-write or dict-stacking)
+    because url4 binding resolution is read-heavy / write-light and the
+    chain is shallow (rarely deeper than 4 frames in practice: outer /
+    iteration / fanout / reducer). The full rationale lives in
+    :mod:`screamingface.plugins.url4_executor.scope`.
+
+    No interpreter logic actually populates bindings yet — DEMO-005/006
+    will. This class only carries the plumbing.
     """
 
     def __init__(self, app: Any = None):
         self.app = app
 
-    async def evaluate(self, expr: str) -> str:
+    async def evaluate(self, expr: str, env: Env | None = None) -> str:
         """Full evaluation pipeline."""
         from screamingface.plugins.url4_executor._tracing import set_span_attrs, traced
 
         with traced("url4.evaluate"):
+            if env is None:
+                env = Env.root()
             set_span_attrs(
                 {
                     "url4.expression": expr[:500],
@@ -62,7 +81,7 @@ class Url4Interpreter:
 
             # Resolve sources (parallel fetch of URLs, concatenate text)
             with traced("url4.resolve_sources"):
-                sources = await resolve_str(source_expr, self.app) if source_expr else ""
+                sources = await resolve_str(source_expr, self.app, env) if source_expr else ""
                 src_preview = sources[:4000]
                 if len(sources) > 4000:
                     src_preview += f"\n... ({len(sources) - 4000} more chars)"
@@ -75,7 +94,7 @@ class Url4Interpreter:
 
             # Resolve intent (text / relative URL / absolute URL)
             with traced("url4.resolve_intent"):
-                intent = await resolve_intent(raw_intent, self.app) if raw_intent else None
+                intent = await resolve_intent(raw_intent, self.app, env) if raw_intent else None
                 set_span_attrs(
                     {
                         "url4.intent_length": len(intent) if intent else 0,
@@ -83,7 +102,7 @@ class Url4Interpreter:
                     }
                 )
 
-            result = await self.process(sources, intent)
+            result = await self.process(sources, intent, env)
             result_preview = result[:4000]
             if len(result) > 4000:
                 result_preview += f"\n... ({len(result) - 4000} more chars)"
@@ -95,10 +114,11 @@ class Url4Interpreter:
             )
             return result
 
-    async def process(self, sources: str, intent: str | None) -> str:
+    async def process(self, sources: str, intent: str | None, env: Env | None = None) -> str:
         """Process resolved sources and intent. Override in subclasses.
 
-        Default: concatenate intent + sources.
+        Default: concatenate intent + sources. ``env`` is accepted for
+        signature parity with subclasses; this default does not use it.
         """
         if intent and sources:
             return f"{intent}\n\n{sources}"

--- a/apps/server/src/screamingface/plugins/url4_executor/routes.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/routes.py
@@ -10,6 +10,7 @@ from fastapi.responses import JSONResponse, PlainTextResponse
 from screamingface.plugins.url4_executor.decoder import split_intent
 from screamingface.plugins.url4_executor.ensemble import EnsembleInterpreter
 from screamingface.plugins.url4_executor.highlight import tokenize
+from screamingface.plugins.url4_executor.scope import Env
 from screamingface.plugins.url4_executor.url4 import (
     Url4BackendCall,
     Url4ExpandedSource,
@@ -77,7 +78,7 @@ def create_router(app=None) -> APIRouter:  # type: ignore[no-untyped-def]
         interpreter = EnsembleInterpreter(app=app, processor=processor)
 
         try:
-            result = await interpreter.evaluate(q)
+            result = await interpreter.evaluate(q, env=Env.root())
         except Exception as exc:
             logger.warning("url4 evaluation failed: %s", exc, exc_info=True)
             raise HTTPException(status_code=502, detail=f"url4 evaluation failed: {exc}")

--- a/apps/server/src/screamingface/plugins/url4_executor/scope.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/scope.py
@@ -1,0 +1,54 @@
+"""Parent-pointer scope chain for url4 binding resolution (DEMO-004).
+
+This is the plumbing only. No interpreter logic actually puts bindings
+into an Env yet — DEMO-005/006 will. The point of landing this first
+is so DEMO-005/006 have a stable shape to build against.
+
+Design choice — parent-pointer (not copy-on-write or dict-stacking)
+=================================================================
+
+- Bindings within an iteration body are *read* by many lookups but
+  *created* at most a handful per iteration — write-light, read-heavy.
+- The chain is already short (rarely deeper than 4 levels in practice:
+  outer / iteration / fanout / reducer).
+- ``frozen=True`` means we never mutate; ``child()`` always returns a
+  new ``Env``, so concurrent iterations cannot corrupt each other.
+
+The ``Any`` typing for binding values is intentional — at this stage
+bindings hold strings (resolved text). DEMO-005 may extend to
+AST-node bindings if eager evaluation proves wrong.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Env:
+    """A single frame in the url4 scope chain."""
+
+    bindings: dict[str, Any] = field(default_factory=dict)
+    parent: Env | None = None
+
+    def lookup(self, name: str) -> Any:
+        """Walk the parent chain. Raise ``KeyError`` if not found."""
+        env: Env | None = self
+        while env is not None:
+            if name in env.bindings:
+                return env.bindings[name]
+            env = env.parent
+        raise KeyError(name)
+
+    def child(self, **bindings: Any) -> Env:
+        """Return a child scope carrying ``bindings``; ``self`` is the parent."""
+        return Env(bindings=dict(bindings), parent=self)
+
+    @classmethod
+    def root(cls) -> Env:
+        """A fresh, empty root env. Use this where ``env`` would otherwise be ``None``."""
+        return cls()
+
+
+__all__ = ["Env"]

--- a/apps/server/src/screamingface/plugins/url4_executor/tests/test_scope.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/tests/test_scope.py
@@ -1,0 +1,56 @@
+"""Unit tests for the Env scope chain (DEMO-004)."""
+
+from __future__ import annotations
+
+import pytest
+
+from screamingface.plugins.url4_executor.scope import Env
+
+
+def test_root_is_empty():
+    env = Env.root()
+    assert env.bindings == {}
+    assert env.parent is None
+
+
+def test_lookup_finds_binding_in_current_frame():
+    env = Env.root().child(a=1)
+    assert env.lookup("a") == 1
+
+
+def test_lookup_walks_parent_chain():
+    env = Env.root().child(a=1).child(b=2)
+    assert env.lookup("a") == 1
+    assert env.lookup("b") == 2
+
+
+def test_lookup_missing_name_raises_keyerror():
+    env = Env.root().child(a=1)
+    with pytest.raises(KeyError):
+        env.lookup("nope")
+
+
+def test_child_does_not_mutate_parent():
+    parent = Env.root().child(a=1)
+    parent_snapshot = dict(parent.bindings)
+    _ = parent.child(b=2)
+    assert parent.bindings == parent_snapshot
+
+
+def test_inner_binding_shadows_outer():
+    env = Env.root().child(x="outer").child(x="inner")
+    assert env.lookup("x") == "inner"
+
+
+def test_env_is_frozen():
+    env = Env.root()
+    with pytest.raises(Exception):  # FrozenInstanceError, but don't tie test to dataclass internals
+        env.parent = Env.root()  # type: ignore[misc]
+
+
+def test_child_accepts_arbitrary_value_types():
+    """Bindings values are typed Any — strings now, possibly AST nodes later."""
+    env = Env.root().child(s="hi", n=42, lst=[1, 2, 3])
+    assert env.lookup("s") == "hi"
+    assert env.lookup("n") == 42
+    assert env.lookup("lst") == [1, 2, 3]

--- a/apps/server/src/screamingface/plugins/url4_executor/url4_resolve.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/url4_resolve.py
@@ -14,6 +14,7 @@ from urllib.parse import quote, urlparse, urlunparse
 
 import httpx
 
+from screamingface.plugins.url4_executor.scope import Env
 from screamingface.plugins.url4_executor.url4_ast import (
     Url4BackendCall,
     Url4ExpandedSource,
@@ -28,8 +29,15 @@ from screamingface.plugins.url4_executor.url4_grammar import parse
 logger = logging.getLogger(__name__)
 
 
-async def resolve(node: Url4Node, app: Any = None) -> str:
-    """Recursively resolve an AST node to a string."""
+async def resolve(node: Url4Node, app: Any = None, env: Env | None = None) -> str:
+    """Recursively resolve an AST node to a string.
+
+    ``env`` is the DEMO-004 scope chain. It is threaded through every
+    recursive call so DEMO-005/006 have a place to put bindings; this
+    function does not itself read from ``env`` yet.
+    """
+    if env is None:
+        env = Env.root()
     if isinstance(node, Url4Text):
         return node.value
     if isinstance(node, Url4Url):
@@ -37,21 +45,21 @@ async def resolve(node: Url4Node, app: Any = None) -> str:
     if isinstance(node, Url4RelUrl):
         return await _fetch_relative(app, node.value)
     if isinstance(node, Url4List):
-        results = list(await asyncio.gather(*[resolve(item, app) for item in node.items]))
+        results = list(await asyncio.gather(*[resolve(item, app, env) for item in node.items]))
         return "\n".join(results)
     if isinstance(node, Url4BackendCall):
-        return await _dispatch_backend_call(node, app)
+        return await _dispatch_backend_call(node, app, env)
     if isinstance(node, Url4ExpandedSource):
-        return await _resolve_expanded_source(node, app)
+        return await _resolve_expanded_source(node, app, env)
     raise TypeError(f"Unknown node type: {type(node)}")
 
 
-async def resolve_str(context: str, app: Any = None) -> str:
+async def resolve_str(context: str, app: Any = None, env: Env | None = None) -> str:
     """Parse a url4 context string and resolve it to a string."""
-    return await resolve(parse(context), app)
+    return await resolve(parse(context), app, env)
 
 
-async def _dispatch_backend_call(node: Url4BackendCall, app: Any) -> str:
+async def _dispatch_backend_call(node: Url4BackendCall, app: Any, env: Env | None = None) -> str:
     """Dispatch a :class:`Url4BackendCall` through an active plugin.
 
     Walks ``app.state.plugins.active_plugins`` looking for one whose
@@ -66,7 +74,7 @@ async def _dispatch_backend_call(node: Url4BackendCall, app: Any) -> str:
             "plugin registry via app.state.plugins."
         )
 
-    intent_text = "" if node.intent is None else await resolve(node.intent, app)
+    intent_text = "" if node.intent is None else await resolve(node.intent, app, env)
     sources_text = node.packed_context or ""
 
     from screamingface.core.helpers import get_plugins_registry
@@ -88,7 +96,9 @@ async def _dispatch_backend_call(node: Url4BackendCall, app: Any) -> str:
     )
 
 
-async def _resolve_expanded_source(node: Url4ExpandedSource, app: Any) -> str:
+async def _resolve_expanded_source(
+    node: Url4ExpandedSource, app: Any, env: Env | None = None
+) -> str:
     """SF-92: Resolve a ``*source`` expansion.
 
     Fetches ``inner``, parses the body as a collection (JSON array,
@@ -97,7 +107,7 @@ async def _resolve_expanded_source(node: Url4ExpandedSource, app: Any) -> str:
     """
     from screamingface.plugins.url4_executor.collection_parser import parse_collection
 
-    body = await resolve(node.inner, app)
+    body = await resolve(node.inner, app, env)
     items = parse_collection(body)
     if not items:
         return ""

--- a/docs/superpowers/plans/2026-05-11-demo-004-env-scope-chain.md
+++ b/docs/superpowers/plans/2026-05-11-demo-004-env-scope-chain.md
@@ -8,6 +8,15 @@
 
 **Tech Stack:** Python 3.12+, asyncio, `@dataclass(frozen=True)`, pytest (incl. `pytest-asyncio`), `uv` for env management.
 
+**CI/lint contract** (from `.github/workflows/server-tests.yml` + `apps/server/.pre-commit-config.yaml`):
+- `uv run ruff check` — hard fail. Config: `select = ["E", "F", "I", "UP"]` (no `ARG`, so unused `env` params are OK).
+- `uv run ruff format --check` — hard fail.
+- Pre-commit: `pyright` (strict, NOT mypy).
+- Unit suite: `pytest -m "not e2e and not e2e_live" --cov=screamingface` with PR coverage gate `thresholdAll: 0.70`.
+- E2E suite: `pytest tests/e2e/ -m "e2e" --timeout=120`.
+
+**External callers of widened functions** (verified via `rg` over `apps/`): five plugins construct `Url4Interpreter(app=app)` via kwarg (`gemini_frontend/proxy.py`, `claude_frontend/_url4_context.py`, `ollama_frontend/proxy.py`, `codex_frontend/proxy.py`, `llm_base/routes_shared.py`); one positional 2-arg call to `resolve_str(context_expr, cfg.app)` in `llm_base/routes_shared.py:282`. Adding `env` as the trailing positional/kwarg slot keeps every call site valid.
+
 **Asana:** https://app.asana.com/1/1185126988600652/task/1214567788345901
 
 **Regression bar:** every existing test in `apps/server/src/screamingface/plugins/url4_executor/tests/` plus the `e2e and not live` suite stays green.
@@ -32,20 +41,28 @@ All public callers outside this plugin keep working because every new parameter 
 
 ## Pre-flight
 
-- [ ] **Step 0.1: Branch from fresh main**
+- [ ] **Step 0.1: Worktree from fresh main**
+
+The main checkout had unrelated uncommitted changes when this plan ran (`sf.json`, `claude_backend_api/plugin.py`). To keep those out of the feature branch we use a git worktree instead of branching in-place:
 
 ```bash
 cd /Users/sergey/work/openmind/screamingface
-git fetch origin
-git checkout -b feat/demo-004-env-scope-chain origin/main
+git fetch origin main
+git worktree add -b feat/demo-004-env-scope-chain ../screamingface-demo-004 origin/main
+# Plan file already lives in main; copy it into the worktree's tree:
+mkdir -p ../screamingface-demo-004/docs/superpowers/plans
+cp docs/superpowers/plans/2026-05-11-demo-004-env-scope-chain.md ../screamingface-demo-004/docs/superpowers/plans/
+cd ../screamingface-demo-004
+git add docs/superpowers/plans/2026-05-11-demo-004-env-scope-chain.md
+git commit -m "docs: add DEMO-004 env scope chain implementation plan"
 ```
 
-Expected: clean working tree on a new branch tracking origin/main.
+If the main checkout is clean, you may instead skip the worktree and run `git checkout -b feat/demo-004-env-scope-chain origin/main` in-place — but every subsequent step assumes the worktree path `/Users/sergey/work/openmind/screamingface-demo-004`.
 
 - [ ] **Step 0.2: Baseline test run — capture the "green" state we must preserve**
 
 ```bash
-cd /Users/sergey/work/openmind/screamingface/apps/server
+cd /Users/sergey/work/openmind/screamingface-demo-004/apps/server
 uv run pytest src/screamingface/plugins/url4_executor/tests/ -q
 uv run pytest tests/e2e/ -m "e2e and not live" -q
 ```
@@ -125,7 +142,7 @@ __all__ = ["Env"]
 Run:
 
 ```bash
-cd /Users/sergey/work/openmind/screamingface/apps/server
+cd /Users/sergey/work/openmind/screamingface-demo-004/apps/server
 uv run python -c "from screamingface.plugins.url4_executor.scope import Env; print(Env.root())"
 ```
 
@@ -134,7 +151,7 @@ Expected: prints `Env(bindings={}, parent=None)`. Anything else (import error, n
 - [ ] **Step 1.3: Commit**
 
 ```bash
-cd /Users/sergey/work/openmind/screamingface
+cd /Users/sergey/work/openmind/screamingface-demo-004
 git add apps/server/src/screamingface/plugins/url4_executor/scope.py
 git commit -m "feat(url4): add Env parent-pointer scope chain (DEMO-004)"
 ```
@@ -214,7 +231,7 @@ def test_child_accepts_arbitrary_value_types():
 - [ ] **Step 2.2: Run the tests; they must pass against Task 1's `scope.py`**
 
 ```bash
-cd /Users/sergey/work/openmind/screamingface/apps/server
+cd /Users/sergey/work/openmind/screamingface-demo-004/apps/server
 uv run pytest src/screamingface/plugins/url4_executor/tests/test_scope.py -v
 ```
 
@@ -223,7 +240,7 @@ Expected: 8 passed. If `test_env_is_frozen` is the only failure, the dataclass i
 - [ ] **Step 2.3: Commit**
 
 ```bash
-cd /Users/sergey/work/openmind/screamingface
+cd /Users/sergey/work/openmind/screamingface-demo-004
 git add apps/server/src/screamingface/plugins/url4_executor/tests/test_scope.py
 git commit -m "test(url4): unit tests for Env scope chain (DEMO-004)"
 ```
@@ -342,7 +359,7 @@ Replace with:
 - [ ] **Step 3.5: Run url4_resolve-touching tests**
 
 ```bash
-cd /Users/sergey/work/openmind/screamingface/apps/server
+cd /Users/sergey/work/openmind/screamingface-demo-004/apps/server
 uv run pytest src/screamingface/plugins/url4_executor/tests/test_url4.py src/screamingface/plugins/url4_executor/tests/test_url4_executor.py src/screamingface/plugins/url4_executor/tests/test_url4_relurl.py -v
 ```
 
@@ -351,7 +368,7 @@ Expected: all green. Any failure means a signature or recursion was missed.
 - [ ] **Step 3.6: Commit**
 
 ```bash
-cd /Users/sergey/work/openmind/screamingface
+cd /Users/sergey/work/openmind/screamingface-demo-004
 git add apps/server/src/screamingface/plugins/url4_executor/url4_resolve.py
 git commit -m "refactor(url4): thread Env through url4_resolve recursion (DEMO-004)"
 ```
@@ -387,7 +404,51 @@ async def resolve_intent(intent: str, app: Any = None, env: Env | None = None) -
 
 (`env` is accepted but unused inside; this function only does fetches/literals. The argument exists so callers can pass it without special-casing.)
 
-- [ ] **Step 4.3: Widen `Url4Interpreter.evaluate`**
+- [ ] **Step 4.3a: Add Env design pointer to `Url4Interpreter`'s class docstring**
+
+Asana acceptance criterion #7 says the design rationale lives in `interpreter.py`'s docstring. The full rationale is in `scope.py`'s module docstring (so future readers of `Env` find it first); this step adds the required summary + pointer to `Url4Interpreter`.
+
+Locate the `Url4Interpreter` class docstring (currently starts at line 38: `"""Base url4 interpreter.`). Replace the entire existing docstring:
+
+```python
+    """Base url4 interpreter.
+
+    Pipeline: split intent → resolve sources (parallel) → resolve intent → process.
+
+    Override ``process()`` to change what happens with the resolved pieces.
+    The default concatenates ``intent + "\\n\\n" + sources``.
+    """
+```
+
+with:
+
+```python
+    """Base url4 interpreter.
+
+    Pipeline: split intent → resolve sources (parallel) → resolve intent → process.
+
+    Override ``process()`` to change what happens with the resolved pieces.
+    The default concatenates ``intent + "\\n\\n" + sources``.
+
+    Scope chain (DEMO-004)
+    ----------------------
+    ``evaluate`` and ``process`` accept an optional ``env: Env | None``
+    parameter that is threaded through every recursive call into
+    ``resolve_str``, ``resolve_intent``, and any subclass override.
+    ``None`` is treated as a fresh root env.
+
+    The chain uses parent pointers (not copy-on-write or dict-stacking)
+    because url4 binding resolution is read-heavy / write-light and the
+    chain is shallow (rarely deeper than 4 frames in practice: outer /
+    iteration / fanout / reducer). The full rationale lives in
+    :mod:`screamingface.plugins.url4_executor.scope`.
+
+    No interpreter logic actually populates bindings yet — DEMO-005/006
+    will. This class only carries the plumbing.
+    """
+```
+
+- [ ] **Step 4.3b: Widen `Url4Interpreter.evaluate`**
 
 Replace line 49 (`async def evaluate(self, expr: str) -> str:`) with:
 
@@ -418,6 +479,13 @@ Then, inside the function body:
 - Replace `result = await self.process(sources, intent)` with
   `result = await self.process(sources, intent, env)`.
 
+- [ ] **Step 4.3c: Run ruff format on the file** (the new docstring block must satisfy `ruff format --check`)
+
+```bash
+cd /Users/sergey/work/openmind/screamingface-demo-004/apps/server
+uv run ruff format src/screamingface/plugins/url4_executor/interpreter.py
+```
+
 - [ ] **Step 4.4: Widen `Url4Interpreter.process`**
 
 Replace lines 98-105 (the `process` method) with:
@@ -437,7 +505,7 @@ Replace lines 98-105 (the `process` method) with:
 - [ ] **Step 4.5: Run interpreter-touching tests**
 
 ```bash
-cd /Users/sergey/work/openmind/screamingface/apps/server
+cd /Users/sergey/work/openmind/screamingface-demo-004/apps/server
 uv run pytest src/screamingface/plugins/url4_executor/tests/test_url4_intent_dispatch.py src/screamingface/plugins/url4_executor/tests/test_url4_executor.py -v
 ```
 
@@ -446,7 +514,7 @@ Expected: all green.
 - [ ] **Step 4.6: Commit**
 
 ```bash
-cd /Users/sergey/work/openmind/screamingface
+cd /Users/sergey/work/openmind/screamingface-demo-004
 git add apps/server/src/screamingface/plugins/url4_executor/interpreter.py
 git commit -m "refactor(url4): thread Env through Url4Interpreter (DEMO-004)"
 ```
@@ -619,7 +687,7 @@ Inside the function:
 - [ ] **Step 5.8: Run the ensemble suite**
 
 ```bash
-cd /Users/sergey/work/openmind/screamingface/apps/server
+cd /Users/sergey/work/openmind/screamingface-demo-004/apps/server
 uv run pytest src/screamingface/plugins/url4_executor/tests/test_ensemble.py -v
 ```
 
@@ -628,7 +696,7 @@ Expected: all green. Any red here means a recursion site or signature still has 
 - [ ] **Step 5.9: Commit**
 
 ```bash
-cd /Users/sergey/work/openmind/screamingface
+cd /Users/sergey/work/openmind/screamingface-demo-004
 git add apps/server/src/screamingface/plugins/url4_executor/ensemble.py
 git commit -m "refactor(url4): thread Env through EnsembleInterpreter (DEMO-004)"
 ```
@@ -663,7 +731,7 @@ Replace `result = await interpreter.evaluate(q)` (line 80) with:
 - [ ] **Step 6.3: Run route + e2e tests**
 
 ```bash
-cd /Users/sergey/work/openmind/screamingface/apps/server
+cd /Users/sergey/work/openmind/screamingface-demo-004/apps/server
 uv run pytest src/screamingface/plugins/url4_executor/tests/test_highlight_route.py -v
 uv run pytest tests/e2e/ -m "e2e and not live" -q
 ```
@@ -673,49 +741,73 @@ Expected: route tests pass; e2e suite stays green.
 - [ ] **Step 6.4: Commit**
 
 ```bash
-cd /Users/sergey/work/openmind/screamingface
+cd /Users/sergey/work/openmind/screamingface-demo-004
 git add apps/server/src/screamingface/plugins/url4_executor/routes.py
 git commit -m "refactor(url4): pass explicit root Env from /ensemble route (DEMO-004)"
 ```
 
 ---
 
-## Task 7: Full regression bar
+## Task 7: Full regression bar + design walkthrough + push
 
-This is the "is the spike done?" gate.
+This is the "is the spike done?" gate. The lint/test sequence below mirrors `.github/workflows/server-tests.yml` exactly so local-green ⇒ CI-green.
 
 - [ ] **Step 7.1: Run the full url4_executor test directory**
 
 ```bash
-cd /Users/sergey/work/openmind/screamingface/apps/server
+cd /Users/sergey/work/openmind/screamingface-demo-004/apps/server
 uv run pytest src/screamingface/plugins/url4_executor/tests/ -v
 ```
 
-Expected: every test passes, including the new `test_scope.py`. Compare counts against the baseline from Step 0.2 — total should be baseline + 8 (the new Env tests).
+Expected: every test passes, including the new `test_scope.py`. Compare counts against the baseline from Step 0.2 — total should be **baseline + 8** (the 8 new Env tests).
 
-- [ ] **Step 7.2: Run the e2e suite (the actual regression bar)**
+- [ ] **Step 7.2: Run the unit suite with coverage (mirrors CI)**
 
 ```bash
-cd /Users/sergey/work/openmind/screamingface/apps/server
-uv run pytest tests/e2e/ -m "e2e and not live" -v
+cd /Users/sergey/work/openmind/screamingface-demo-004/apps/server
+uv run pytest --tb=short --cov=screamingface --cov-report=term-missing -m "not e2e and not e2e_live" -q
+```
+
+Expected: green. The PR coverage gate is `thresholdAll: 0.70` — `scope.py` is fully covered by `test_scope.py`; the threaded `env` params on existing functions are exercised by the existing tests they already cover. If the report shows uncovered lines inside the new conditional `if env is None: env = Env.root()` branches, that's expected (callers from CI tests pass `None`); the branches still execute.
+
+- [ ] **Step 7.3: Run the e2e suite (the actual regression bar)**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface-demo-004/apps/server
+uv run pytest tests/e2e/ --tb=short --timeout=120 -m "e2e" -v
 ```
 
 Expected: green. Anything red here means the env-threading refactor changed observable behavior — which is the one thing this ticket must not do.
 
-- [ ] **Step 7.3: Lint / typecheck (whatever this repo runs)**
+- [ ] **Step 7.4: Lint + format + typecheck (real CI sequence)**
 
 ```bash
-cd /Users/sergey/work/openmind/screamingface/apps/server
-uv run ruff check src/screamingface/plugins/url4_executor/
-uv run mypy src/screamingface/plugins/url4_executor/ 2>/dev/null || true
+cd /Users/sergey/work/openmind/screamingface-demo-004/apps/server
+uv run ruff check
+uv run ruff format --check
+uv run pyright
 ```
 
-Expected: ruff clean. If mypy isn't wired up for this package, the `|| true` silently passes — that's fine. If ruff complains, fix in place and amend the previous commit.
+Expected: all three clean. If `ruff format --check` reports a file, run `uv run ruff format <file>` and amend the relevant commit (`git commit --amend --no-edit`). If `pyright` complains about `Env | None`, double-check the import is `from screamingface.plugins.url4_executor.scope import Env` at module top, not inside a function.
 
-- [ ] **Step 7.4: Push and open PR**
+- [ ] **Step 7.5: Design walkthrough (manual checkpoint — Asana risk note)**
+
+The Asana risk note states: *"Sergey explicitly walks through the design with himself (or in the docstring) before merging."* This is the most-likely-wrong ticket in the DEMO-004→006 chain; if `Env` is wrong here, DEMO-005/006 build on a bad foundation.
+
+Re-read these three things in this order and confirm each:
+
+1. `scope.py` module docstring + class docstring + the three method bodies (`lookup`, `child`, `root`). Confirm: parent-pointer, frozen, no mutation, shadowing via insertion order.
+2. `Url4Interpreter` class docstring (Step 4.3a) — does the summary still match the implementation after all six recursion sites in `ensemble.py` were threaded?
+3. The Open Note in the Self-Review section of this plan — has it been resolved (yes, both `scope.py` and `interpreter.py` now carry the rationale).
+
+Write 2-3 sentences capturing the walkthrough conclusion. This becomes the "Design walkthrough" section in the PR body (Step 7.6).
+
+If the walkthrough surfaces a real concern (e.g., "the env should be passed positionally to `process` to avoid kwarg-shadowing in a subclass"), stop and surface it before pushing.
+
+- [ ] **Step 7.6: Push and open PR**
 
 ```bash
-cd /Users/sergey/work/openmind/screamingface
+cd /Users/sergey/work/openmind/screamingface-demo-004
 git push -u origin feat/demo-004-env-scope-chain
 gh pr create --title "DEMO-004: Env scope chain for url4_executor" --body "$(cat <<'EOF'
 ## Summary
@@ -724,13 +816,16 @@ gh pr create --title "DEMO-004: Env scope chain for url4_executor" --body "$(cat
 - Zero behavioral change. This is the plumbing DEMO-005/006 sit on.
 
 ## Why parent-pointer
-Bindings are read-heavy / write-light; the chain is shallow (≤4 frames); a frozen dataclass means concurrent iterations can't corrupt each other. See `scope.py` module docstring.
+Bindings are read-heavy / write-light; the chain is shallow (≤4 frames); a frozen dataclass means concurrent iterations can't corrupt each other. Full rationale in `scope.py`; summary in `Url4Interpreter` docstring.
+
+## Design walkthrough
+<paste the 2-3 sentence walkthrough conclusion from Step 7.5 here>
 
 ## Test plan
 - [x] `uv run pytest src/screamingface/plugins/url4_executor/tests/test_scope.py -v` — 8 new tests
-- [x] `uv run pytest src/screamingface/plugins/url4_executor/tests/ -v` — full plugin suite green
-- [x] `uv run pytest tests/e2e/ -m "e2e and not live" -v` — regression bar green
-- [x] `uv run ruff check src/screamingface/plugins/url4_executor/`
+- [x] `uv run pytest --cov=screamingface -m "not e2e and not e2e_live"` — unit suite green, coverage ≥ 0.70
+- [x] `uv run pytest tests/e2e/ -m "e2e" --timeout=120 -v` — regression bar green
+- [x] `uv run ruff check` + `uv run ruff format --check` + `uv run pyright` — all clean
 
 Asana: https://app.asana.com/1/1185126988600652/task/1214567788345901
 EOF
@@ -743,11 +838,13 @@ Expected: PR URL printed. Do **not** push earlier than this — green-bar first.
 
 ## Self-Review Notes
 
-- **Spec coverage:** all six acceptance criteria from the Asana task map to tasks above: `Env` (Task 1), unit tests (Task 2: 8 cases incl. the three required), interpreter threading (Task 4), ensemble threading (Task 5), existing-tests-green (Tasks 3.5 / 4.5 / 5.8 / 7.1), e2e green (Step 0.2 baseline + Step 7.2), design note in module docstring (Task 1.1 — `scope.py` carries the rationale; the spec asks for it in `interpreter.py`'s docstring instead — see Open Note below).
+- **Spec coverage:** all seven Asana acceptance criteria map to tasks above: `Env` exists (Task 1), unit tests for the 3 required cases + 5 extras (Task 2), all existing tests green (Steps 3.5 / 4.5 / 5.8 / 7.1), e2e green (Step 0.2 baseline + Step 7.3), design note in `interpreter.py` docstring (Step 4.3a — full rationale in `scope.py`, summary + pointer in `Url4Interpreter`).
 - **Placeholder scan:** every step shows the exact code, command, or commit message.
-- **Type consistency:** every signature uses `env: Env | None = None` and every internal call passes `env` positionally after `app` — checked across Tasks 3, 4, 5, 6.
+- **Type consistency:** every signature uses `env: Env | None = None`; every internal call passes `env` positionally after `app` — checked across Tasks 3, 4, 5, 6.
+- **External caller safety:** five plugins call `Url4Interpreter(app=app)` (kwarg) and `resolve_str(context, app)` (2-arg positional). Adding `env` as the trailing parameter keeps all call sites valid — verified via `rg` over `apps/`.
+- **Line-number drift:** Edit steps quote the *exact source text* being replaced (signatures, full method bodies, full call expressions), not just line numbers. If `main` drifts before execution, line numbers go stale but the `old_string` patterns remain unique and still match — re-locate by content.
 
-**Open Note (Task 1 vs spec wording):** The Asana task says the design note belongs in `interpreter.py`'s docstring. I parked it in `scope.py` because the rationale is about `Env` itself, not the interpreter. If the reviewer prefers the literal interpretation, copy the "Design choice — parent-pointer" block from `scope.py` into `Url4Interpreter`'s class docstring in Task 4 (no logic change).
+**Resolution of the prior Open Note:** The Asana acceptance criterion's literal wording (design note in `interpreter.py`'s docstring) is now satisfied by Step 4.3a, which adds a Scope-chain summary block + cross-reference to `scope.py`. The full design rationale stays in `scope.py` so future readers of `Env` find it at the canonical home.
 
 ---
 

--- a/docs/superpowers/plans/2026-05-11-demo-004-env-scope-chain.md
+++ b/docs/superpowers/plans/2026-05-11-demo-004-env-scope-chain.md
@@ -1,0 +1,762 @@
+# DEMO-004: Env Scope Chain for url4_executor — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce an explicit `Env` (parent-pointer scope chain) and thread it through every recursive call in `url4_executor` — zero behavioral change. This is the plumbing DEMO-005 and DEMO-006 will sit on.
+
+**Architecture:** A frozen dataclass `Env { bindings: dict, parent: Env | None }` with `lookup`, `child`, `root` methods. The interpreter, ensemble dispatcher, and AST resolver gain an optional `env: Env | None = None` parameter that defaults to a fresh root env and propagates through every recursive call. The existing flat substitutions (`substitute_item`, `substitute_response_vars`) are **not** rewired — that is DEMO-006's job.
+
+**Tech Stack:** Python 3.12+, asyncio, `@dataclass(frozen=True)`, pytest (incl. `pytest-asyncio`), `uv` for env management.
+
+**Asana:** https://app.asana.com/1/1185126988600652/task/1214567788345901
+
+**Regression bar:** every existing test in `apps/server/src/screamingface/plugins/url4_executor/tests/` plus the `e2e and not live` suite stays green.
+
+---
+
+## File Structure
+
+**Create:**
+- `apps/server/src/screamingface/plugins/url4_executor/scope.py` — `Env` dataclass + factory helpers. ~60 lines.
+- `apps/server/src/screamingface/plugins/url4_executor/tests/test_scope.py` — pure-unit tests for `Env`. No async, no app fixture.
+
+**Modify (all signature widenings + propagation of `env` argument; **no** behavioral change):**
+- `apps/server/src/screamingface/plugins/url4_executor/interpreter.py` — `Url4Interpreter.evaluate`, `Url4Interpreter.process`, module-level `resolve_intent`.
+- `apps/server/src/screamingface/plugins/url4_executor/ensemble.py` — `EnsembleInterpreter.evaluate`, `process`, `_collection_iterate`, `_broadcast_evaluate`, `_ensemble_evaluate`, `_single_source_evaluate`.
+- `apps/server/src/screamingface/plugins/url4_executor/url4_resolve.py` — `resolve`, `resolve_str`, `_dispatch_backend_call`, `_resolve_expanded_source`.
+- `apps/server/src/screamingface/plugins/url4_executor/routes.py` — pass an explicit `Env.root()` into the interpreter call (smoke for the route → env path).
+
+All public callers outside this plugin keep working because every new parameter defaults to `None`.
+
+---
+
+## Pre-flight
+
+- [ ] **Step 0.1: Branch from fresh main**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface
+git fetch origin
+git checkout -b feat/demo-004-env-scope-chain origin/main
+```
+
+Expected: clean working tree on a new branch tracking origin/main.
+
+- [ ] **Step 0.2: Baseline test run — capture the "green" state we must preserve**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface/apps/server
+uv run pytest src/screamingface/plugins/url4_executor/tests/ -q
+uv run pytest tests/e2e/ -m "e2e and not live" -q
+```
+
+Expected: both suites pass. If anything is already red on `main`, stop and surface it — do not start the refactor on a red bar.
+
+---
+
+## Task 1: `scope.py` — the `Env` dataclass
+
+**Files:**
+- Create: `apps/server/src/screamingface/plugins/url4_executor/scope.py`
+
+- [ ] **Step 1.1: Create the file with the design-spec body**
+
+Write `apps/server/src/screamingface/plugins/url4_executor/scope.py`:
+
+```python
+"""Parent-pointer scope chain for url4 binding resolution (DEMO-004).
+
+This is the plumbing only. No interpreter logic actually puts bindings
+into an Env yet — DEMO-005/006 will. The point of landing this first
+is so DEMO-005/006 have a stable shape to build against.
+
+Design choice — parent-pointer (not copy-on-write or dict-stacking)
+=================================================================
+
+- Bindings within an iteration body are *read* by many lookups but
+  *created* at most a handful per iteration — write-light, read-heavy.
+- The chain is already short (rarely deeper than 4 levels in practice:
+  outer / iteration / fanout / reducer).
+- ``frozen=True`` means we never mutate; ``child()`` always returns a
+  new ``Env``, so concurrent iterations cannot corrupt each other.
+
+The ``Any`` typing for binding values is intentional — at this stage
+bindings hold strings (resolved text). DEMO-005 may extend to
+AST-node bindings if eager evaluation proves wrong.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Env:
+    """A single frame in the url4 scope chain."""
+
+    bindings: dict[str, Any] = field(default_factory=dict)
+    parent: Env | None = None
+
+    def lookup(self, name: str) -> Any:
+        """Walk the parent chain. Raise ``KeyError`` if not found."""
+        env: Env | None = self
+        while env is not None:
+            if name in env.bindings:
+                return env.bindings[name]
+            env = env.parent
+        raise KeyError(name)
+
+    def child(self, **bindings: Any) -> Env:
+        """Return a child scope carrying ``bindings``; ``self`` is the parent."""
+        return Env(bindings=dict(bindings), parent=self)
+
+    @classmethod
+    def root(cls) -> Env:
+        """A fresh, empty root env. Use this where ``env`` would otherwise be ``None``."""
+        return cls()
+
+
+__all__ = ["Env"]
+```
+
+- [ ] **Step 1.2: Sanity-check the import path**
+
+Run:
+
+```bash
+cd /Users/sergey/work/openmind/screamingface/apps/server
+uv run python -c "from screamingface.plugins.url4_executor.scope import Env; print(Env.root())"
+```
+
+Expected: prints `Env(bindings={}, parent=None)`. Anything else (import error, name error) blocks the next task.
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface
+git add apps/server/src/screamingface/plugins/url4_executor/scope.py
+git commit -m "feat(url4): add Env parent-pointer scope chain (DEMO-004)"
+```
+
+---
+
+## Task 2: `test_scope.py` — unit tests for `Env`
+
+**Files:**
+- Create: `apps/server/src/screamingface/plugins/url4_executor/tests/test_scope.py`
+
+These are pure-unit (no app, no asyncio). They lock down the contract DEMO-005 will rely on.
+
+- [ ] **Step 2.1: Write the failing tests**
+
+Write `apps/server/src/screamingface/plugins/url4_executor/tests/test_scope.py`:
+
+```python
+"""Unit tests for the Env scope chain (DEMO-004)."""
+
+from __future__ import annotations
+
+import pytest
+
+from screamingface.plugins.url4_executor.scope import Env
+
+
+def test_root_is_empty():
+    env = Env.root()
+    assert env.bindings == {}
+    assert env.parent is None
+
+
+def test_lookup_finds_binding_in_current_frame():
+    env = Env.root().child(a=1)
+    assert env.lookup("a") == 1
+
+
+def test_lookup_walks_parent_chain():
+    env = Env.root().child(a=1).child(b=2)
+    assert env.lookup("a") == 1
+    assert env.lookup("b") == 2
+
+
+def test_lookup_missing_name_raises_keyerror():
+    env = Env.root().child(a=1)
+    with pytest.raises(KeyError):
+        env.lookup("nope")
+
+
+def test_child_does_not_mutate_parent():
+    parent = Env.root().child(a=1)
+    parent_snapshot = dict(parent.bindings)
+    _ = parent.child(b=2)
+    assert parent.bindings == parent_snapshot
+
+
+def test_inner_binding_shadows_outer():
+    env = Env.root().child(x="outer").child(x="inner")
+    assert env.lookup("x") == "inner"
+
+
+def test_env_is_frozen():
+    env = Env.root()
+    with pytest.raises(Exception):  # FrozenInstanceError, but don't tie test to dataclass internals
+        env.parent = Env.root()  # type: ignore[misc]
+
+
+def test_child_accepts_arbitrary_value_types():
+    """Bindings values are typed Any — strings now, possibly AST nodes later."""
+    env = Env.root().child(s="hi", n=42, lst=[1, 2, 3])
+    assert env.lookup("s") == "hi"
+    assert env.lookup("n") == 42
+    assert env.lookup("lst") == [1, 2, 3]
+```
+
+- [ ] **Step 2.2: Run the tests; they must pass against Task 1's `scope.py`**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface/apps/server
+uv run pytest src/screamingface/plugins/url4_executor/tests/test_scope.py -v
+```
+
+Expected: 8 passed. If `test_env_is_frozen` is the only failure, the dataclass isn't frozen — fix Task 1.
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface
+git add apps/server/src/screamingface/plugins/url4_executor/tests/test_scope.py
+git commit -m "test(url4): unit tests for Env scope chain (DEMO-004)"
+```
+
+---
+
+## Task 3: Thread `env` through `url4_resolve.py`
+
+This is the leaf-most layer; touching it first lets later tasks pass `env` confidently.
+
+**Files:**
+- Modify: `apps/server/src/screamingface/plugins/url4_executor/url4_resolve.py`
+
+- [ ] **Step 3.1: Widen `resolve` to accept `env`**
+
+In `url4_resolve.py` replace the `resolve(...)` function (current lines 31-46) with:
+
+```python
+async def resolve(node: Url4Node, app: Any = None, env: Env | None = None) -> str:
+    """Recursively resolve an AST node to a string.
+
+    ``env`` is the DEMO-004 scope chain. It is threaded through every
+    recursive call so DEMO-005/006 have a place to put bindings; this
+    function does not itself read from ``env`` yet.
+    """
+    if env is None:
+        env = Env.root()
+    if isinstance(node, Url4Text):
+        return node.value
+    if isinstance(node, Url4Url):
+        return await _fetch_url(node.value)
+    if isinstance(node, Url4RelUrl):
+        return await _fetch_relative(app, node.value)
+    if isinstance(node, Url4List):
+        results = list(
+            await asyncio.gather(*[resolve(item, app, env) for item in node.items])
+        )
+        return "\n".join(results)
+    if isinstance(node, Url4BackendCall):
+        return await _dispatch_backend_call(node, app, env)
+    if isinstance(node, Url4ExpandedSource):
+        return await _resolve_expanded_source(node, app, env)
+    raise TypeError(f"Unknown node type: {type(node)}")
+```
+
+Add the import next to the existing AST import block (top of file):
+
+```python
+from screamingface.plugins.url4_executor.scope import Env
+```
+
+- [ ] **Step 3.2: Widen `resolve_str`**
+
+Replace lines 49-51 (the `resolve_str` body) with:
+
+```python
+async def resolve_str(context: str, app: Any = None, env: Env | None = None) -> str:
+    """Parse a url4 context string and resolve it to a string."""
+    return await resolve(parse(context), app, env)
+```
+
+- [ ] **Step 3.3: Widen `_dispatch_backend_call`**
+
+Replace the `_dispatch_backend_call` signature and the one recursive `resolve(node.intent, app)` call inside it.
+
+Find:
+
+```python
+async def _dispatch_backend_call(node: Url4BackendCall, app: Any) -> str:
+```
+
+Replace with:
+
+```python
+async def _dispatch_backend_call(node: Url4BackendCall, app: Any, env: Env | None = None) -> str:
+```
+
+Find inside the same function:
+
+```python
+    intent_text = "" if node.intent is None else await resolve(node.intent, app)
+```
+
+Replace with:
+
+```python
+    intent_text = "" if node.intent is None else await resolve(node.intent, app, env)
+```
+
+- [ ] **Step 3.4: Widen `_resolve_expanded_source`**
+
+Find:
+
+```python
+async def _resolve_expanded_source(node: Url4ExpandedSource, app: Any) -> str:
+```
+
+Replace with:
+
+```python
+async def _resolve_expanded_source(node: Url4ExpandedSource, app: Any, env: Env | None = None) -> str:
+```
+
+Find inside the same function:
+
+```python
+    body = await resolve(node.inner, app)
+```
+
+Replace with:
+
+```python
+    body = await resolve(node.inner, app, env)
+```
+
+- [ ] **Step 3.5: Run url4_resolve-touching tests**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface/apps/server
+uv run pytest src/screamingface/plugins/url4_executor/tests/test_url4.py src/screamingface/plugins/url4_executor/tests/test_url4_executor.py src/screamingface/plugins/url4_executor/tests/test_url4_relurl.py -v
+```
+
+Expected: all green. Any failure means a signature or recursion was missed.
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface
+git add apps/server/src/screamingface/plugins/url4_executor/url4_resolve.py
+git commit -m "refactor(url4): thread Env through url4_resolve recursion (DEMO-004)"
+```
+
+---
+
+## Task 4: Thread `env` through `interpreter.py`
+
+**Files:**
+- Modify: `apps/server/src/screamingface/plugins/url4_executor/interpreter.py`
+
+- [ ] **Step 4.1: Add Env import**
+
+At the top of `interpreter.py` (after the existing `url4_resolve` import), add:
+
+```python
+from screamingface.plugins.url4_executor.scope import Env
+```
+
+- [ ] **Step 4.2: Widen `resolve_intent`**
+
+Replace the `resolve_intent` signature (current line 20):
+
+```python
+async def resolve_intent(intent: str, app: Any = None) -> str:
+```
+
+with:
+
+```python
+async def resolve_intent(intent: str, app: Any = None, env: Env | None = None) -> str:
+```
+
+(`env` is accepted but unused inside; this function only does fetches/literals. The argument exists so callers can pass it without special-casing.)
+
+- [ ] **Step 4.3: Widen `Url4Interpreter.evaluate`**
+
+Replace line 49 (`async def evaluate(self, expr: str) -> str:`) with:
+
+```python
+    async def evaluate(self, expr: str, env: Env | None = None) -> str:
+        """Full evaluation pipeline.
+
+        ``env`` is the DEMO-004 scope chain. ``None`` is the same as a
+        fresh root env. Propagated to ``resolve_str``, ``resolve_intent``,
+        and ``self.process`` so DEMO-005/006 can add bindings without
+        rewiring the call graph.
+        """
+```
+
+Then, inside the function body:
+
+- Immediately after the `with traced("url4.evaluate"):` line, insert:
+
+  ```python
+            if env is None:
+                env = Env.root()
+  ```
+
+- Replace `sources = await resolve_str(source_expr, self.app) if source_expr else ""` with
+  `sources = await resolve_str(source_expr, self.app, env) if source_expr else ""`.
+- Replace `intent = await resolve_intent(raw_intent, self.app) if raw_intent else None` with
+  `intent = await resolve_intent(raw_intent, self.app, env) if raw_intent else None`.
+- Replace `result = await self.process(sources, intent)` with
+  `result = await self.process(sources, intent, env)`.
+
+- [ ] **Step 4.4: Widen `Url4Interpreter.process`**
+
+Replace lines 98-105 (the `process` method) with:
+
+```python
+    async def process(self, sources: str, intent: str | None, env: Env | None = None) -> str:
+        """Process resolved sources and intent. Override in subclasses.
+
+        Default: concatenate intent + sources. ``env`` is accepted for
+        signature parity with subclasses; this default does not use it.
+        """
+        if intent and sources:
+            return f"{intent}\n\n{sources}"
+        return intent or sources or ""
+```
+
+- [ ] **Step 4.5: Run interpreter-touching tests**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface/apps/server
+uv run pytest src/screamingface/plugins/url4_executor/tests/test_url4_intent_dispatch.py src/screamingface/plugins/url4_executor/tests/test_url4_executor.py -v
+```
+
+Expected: all green.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface
+git add apps/server/src/screamingface/plugins/url4_executor/interpreter.py
+git commit -m "refactor(url4): thread Env through Url4Interpreter (DEMO-004)"
+```
+
+---
+
+## Task 5: Thread `env` through `ensemble.py`
+
+This is the busiest file — six recursion sites. Do them in one commit so signatures stay consistent.
+
+**Files:**
+- Modify: `apps/server/src/screamingface/plugins/url4_executor/ensemble.py`
+
+- [ ] **Step 5.1: Add Env import**
+
+After the existing `Url4Interpreter` import, add:
+
+```python
+from screamingface.plugins.url4_executor.scope import Env
+```
+
+- [ ] **Step 5.2: Widen `EnsembleInterpreter.process`**
+
+Replace lines 79-81:
+
+```python
+    async def process(self, sources: str, intent: str | None) -> str:
+        """Fallback for non-ensemble expressions. Delegates to base class."""
+        return await super().process(sources, intent)
+```
+
+with:
+
+```python
+    async def process(self, sources: str, intent: str | None, env: Env | None = None) -> str:
+        """Fallback for non-ensemble expressions. Delegates to base class."""
+        return await super().process(sources, intent, env)
+```
+
+- [ ] **Step 5.3: Widen `EnsembleInterpreter.evaluate`**
+
+Replace line 87 (`async def evaluate(self, expr: str) -> str:`) with:
+
+```python
+    async def evaluate(self, expr: str, env: Env | None = None) -> str:
+```
+
+Immediately after `with traced("url4.evaluate"):` add:
+
+```python
+            if env is None:
+                env = Env.root()
+```
+
+Then update each of the four dispatch calls in the function body:
+
+- `return await self._collection_iterate(collection_source, iteration_body, raw_intent or "")`
+  → `return await self._collection_iterate(collection_source, iteration_body, raw_intent or "", env)`
+- `return await self._broadcast_evaluate(source_node, raw_intent)`
+  → `return await self._broadcast_evaluate(source_node, raw_intent, env)`
+- `return await self._ensemble_evaluate(source_node, raw_intent)`
+  → `return await self._ensemble_evaluate(source_node, raw_intent, env)`
+- `return await self._single_source_evaluate(source_expr, raw_intent)`
+  → `return await self._single_source_evaluate(source_expr, raw_intent, env)`
+
+- [ ] **Step 5.4: Widen `_collection_iterate`**
+
+Replace the signature (line 138):
+
+```python
+    async def _collection_iterate(
+        self, collection_source: str, iteration_body: str, intent: str
+    ) -> str:
+```
+
+with:
+
+```python
+    async def _collection_iterate(
+        self,
+        collection_source: str,
+        iteration_body: str,
+        intent: str,
+        env: Env | None = None,
+    ) -> str:
+```
+
+Inside the function, replace `collection_body = await resolve_str(collection_source, self.app)` with
+`collection_body = await resolve_str(collection_source, self.app, env)`.
+
+In the inner `_process_one`, replace `return await self.evaluate(full_expr)` with
+`return await self.evaluate(full_expr, env)`.
+
+(The per-item `$item` binding is **not** added in this ticket — DEMO-005 will. For now `env` is just propagated.)
+
+- [ ] **Step 5.5: Widen `_broadcast_evaluate`**
+
+Replace the signature (line 176):
+
+```python
+    async def _broadcast_evaluate(self, source_node: Url4Node, raw_intent: str) -> str:
+```
+
+with:
+
+```python
+    async def _broadcast_evaluate(
+        self, source_node: Url4Node, raw_intent: str, env: Env | None = None
+    ) -> str:
+```
+
+Inside the function:
+
+- `intent_text = await resolve_intent(raw_intent, self.app) if raw_intent else ""`
+  → `intent_text = await resolve_intent(raw_intent, self.app, env) if raw_intent else ""`
+- Inside `_apply_one`: replace `source_text = await resolve(item, self.app)` with
+  `source_text = await resolve(item, self.app, env)`, and replace
+  `return await self.process(source_text, intent_text)` with
+  `return await self.process(source_text, intent_text, env)`.
+
+- [ ] **Step 5.6: Widen `_ensemble_evaluate`**
+
+Replace the signature (line 217):
+
+```python
+    async def _ensemble_evaluate(self, source_node: Url4List, raw_intent: str) -> str:
+```
+
+with:
+
+```python
+    async def _ensemble_evaluate(
+        self, source_node: Url4List, raw_intent: str, env: Env | None = None
+    ) -> str:
+```
+
+Inside the function:
+
+- `reducer_instruction = await resolve_intent(raw_intent, self.app) if raw_intent else ""`
+  → `reducer_instruction = await resolve_intent(raw_intent, self.app, env) if raw_intent else ""`
+- `await asyncio.gather(*[resolve(item, self.app) for item in items])`
+  → `await asyncio.gather(*[resolve(item, self.app, env) for item in items])`
+- `result = await _dispatch_backend_call(reducer_node, self.app)`
+  → `result = await _dispatch_backend_call(reducer_node, self.app, env)`
+
+- [ ] **Step 5.7: Widen `_single_source_evaluate`**
+
+Replace the signature (line 283):
+
+```python
+    async def _single_source_evaluate(self, source_expr: str, raw_intent: str | None) -> str:
+```
+
+with:
+
+```python
+    async def _single_source_evaluate(
+        self, source_expr: str, raw_intent: str | None, env: Env | None = None
+    ) -> str:
+```
+
+Inside the function:
+
+- `sources = await resolve_str(source_expr, self.app) if source_expr else ""`
+  → `sources = await resolve_str(source_expr, self.app, env) if source_expr else ""`
+- `intent = await resolve_intent(raw_intent, self.app) if raw_intent else None`
+  → `intent = await resolve_intent(raw_intent, self.app, env) if raw_intent else None`
+- `result = await self.process(sources, intent)` → `result = await self.process(sources, intent, env)`
+
+- [ ] **Step 5.8: Run the ensemble suite**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface/apps/server
+uv run pytest src/screamingface/plugins/url4_executor/tests/test_ensemble.py -v
+```
+
+Expected: all green. Any red here means a recursion site or signature still has the old shape.
+
+- [ ] **Step 5.9: Commit**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface
+git add apps/server/src/screamingface/plugins/url4_executor/ensemble.py
+git commit -m "refactor(url4): thread Env through EnsembleInterpreter (DEMO-004)"
+```
+
+---
+
+## Task 6: Pass an explicit root env from the `/ensemble` route
+
+Confirms the route → interpreter → resolver path is end-to-end env-aware. Tiny change, kept as its own commit so it's easy to revert if needed.
+
+**Files:**
+- Modify: `apps/server/src/screamingface/plugins/url4_executor/routes.py`
+
+- [ ] **Step 6.1: Import Env**
+
+After the existing `EnsembleInterpreter` import (top of file), add:
+
+```python
+from screamingface.plugins.url4_executor.scope import Env
+```
+
+- [ ] **Step 6.2: Pass a root env into `evaluate`**
+
+Replace `result = await interpreter.evaluate(q)` (line 80) with:
+
+```python
+            result = await interpreter.evaluate(q, env=Env.root())
+```
+
+(Behaviorally identical to passing `None`; the explicit call documents the entry point.)
+
+- [ ] **Step 6.3: Run route + e2e tests**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface/apps/server
+uv run pytest src/screamingface/plugins/url4_executor/tests/test_highlight_route.py -v
+uv run pytest tests/e2e/ -m "e2e and not live" -q
+```
+
+Expected: route tests pass; e2e suite stays green.
+
+- [ ] **Step 6.4: Commit**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface
+git add apps/server/src/screamingface/plugins/url4_executor/routes.py
+git commit -m "refactor(url4): pass explicit root Env from /ensemble route (DEMO-004)"
+```
+
+---
+
+## Task 7: Full regression bar
+
+This is the "is the spike done?" gate.
+
+- [ ] **Step 7.1: Run the full url4_executor test directory**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface/apps/server
+uv run pytest src/screamingface/plugins/url4_executor/tests/ -v
+```
+
+Expected: every test passes, including the new `test_scope.py`. Compare counts against the baseline from Step 0.2 — total should be baseline + 8 (the new Env tests).
+
+- [ ] **Step 7.2: Run the e2e suite (the actual regression bar)**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface/apps/server
+uv run pytest tests/e2e/ -m "e2e and not live" -v
+```
+
+Expected: green. Anything red here means the env-threading refactor changed observable behavior — which is the one thing this ticket must not do.
+
+- [ ] **Step 7.3: Lint / typecheck (whatever this repo runs)**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface/apps/server
+uv run ruff check src/screamingface/plugins/url4_executor/
+uv run mypy src/screamingface/plugins/url4_executor/ 2>/dev/null || true
+```
+
+Expected: ruff clean. If mypy isn't wired up for this package, the `|| true` silently passes — that's fine. If ruff complains, fix in place and amend the previous commit.
+
+- [ ] **Step 7.4: Push and open PR**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface
+git push -u origin feat/demo-004-env-scope-chain
+gh pr create --title "DEMO-004: Env scope chain for url4_executor" --body "$(cat <<'EOF'
+## Summary
+- Adds `Env` (frozen dataclass, parent-pointer scope chain) in `scope.py`.
+- Threads `env: Env | None = None` through `Url4Interpreter`, `EnsembleInterpreter`, and every `url4_resolve` recursion site.
+- Zero behavioral change. This is the plumbing DEMO-005/006 sit on.
+
+## Why parent-pointer
+Bindings are read-heavy / write-light; the chain is shallow (≤4 frames); a frozen dataclass means concurrent iterations can't corrupt each other. See `scope.py` module docstring.
+
+## Test plan
+- [x] `uv run pytest src/screamingface/plugins/url4_executor/tests/test_scope.py -v` — 8 new tests
+- [x] `uv run pytest src/screamingface/plugins/url4_executor/tests/ -v` — full plugin suite green
+- [x] `uv run pytest tests/e2e/ -m "e2e and not live" -v` — regression bar green
+- [x] `uv run ruff check src/screamingface/plugins/url4_executor/`
+
+Asana: https://app.asana.com/1/1185126988600652/task/1214567788345901
+EOF
+)"
+```
+
+Expected: PR URL printed. Do **not** push earlier than this — green-bar first.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** all six acceptance criteria from the Asana task map to tasks above: `Env` (Task 1), unit tests (Task 2: 8 cases incl. the three required), interpreter threading (Task 4), ensemble threading (Task 5), existing-tests-green (Tasks 3.5 / 4.5 / 5.8 / 7.1), e2e green (Step 0.2 baseline + Step 7.2), design note in module docstring (Task 1.1 — `scope.py` carries the rationale; the spec asks for it in `interpreter.py`'s docstring instead — see Open Note below).
+- **Placeholder scan:** every step shows the exact code, command, or commit message.
+- **Type consistency:** every signature uses `env: Env | None = None` and every internal call passes `env` positionally after `app` — checked across Tasks 3, 4, 5, 6.
+
+**Open Note (Task 1 vs spec wording):** The Asana task says the design note belongs in `interpreter.py`'s docstring. I parked it in `scope.py` because the rationale is about `Env` itself, not the interpreter. If the reviewer prefers the literal interpretation, copy the "Design choice — parent-pointer" block from `scope.py` into `Url4Interpreter`'s class docstring in Task 4 (no logic change).
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-11-demo-004-env-scope-chain.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+**Which approach?**


### PR DESCRIPTION
## Summary
- Adds `Env` (frozen dataclass, parent-pointer scope chain) in `apps/server/src/screamingface/plugins/url4_executor/scope.py`.
- Threads `env: Env | None = None` through `Url4Interpreter`, `EnsembleInterpreter`, every `url4_resolve` recursion site, and the `/ensemble` route.
- Widens `process()` in all five sibling `Url4Interpreter` subclasses (`claude_backend_api`, `codex_backend_api`, `ollama_backend_api`, `gemini_backend_api`, `aigw_base`) to keep dispatch type-compatible.
- Zero behavioral change. This is the plumbing DEMO-005/006 sit on. No interpreter logic populates bindings yet.

## Why parent-pointer (not copy-on-write or dict-stacking)
url4 binding resolution is read-heavy / write-light, and the chain is shallow (rarely deeper than 4 frames: outer / iteration / fanout / reducer). A `frozen=True` dataclass means concurrent iterations can't corrupt each other. Full rationale in `scope.py`'s module docstring; cross-reference summary in `Url4Interpreter`'s class docstring (per Asana acceptance criterion #7).

## Design walkthrough
The Env design held up after one plan-gap correction: five sibling subclasses of `Url4Interpreter` (claude/codex/ollama/gemini backend_api + aigw_base) also override `process()` and had to be widened with the `env` parameter to keep Python's method dispatch happy. The parent-pointer model itself was untouched — no copy-on-write or dict-stacking pressure surfaced during integration. Behavior bar confirmed: full e2e regression suite is **123 passed / 8 skipped, byte-identical to baseline** captured before any code change.

## Test plan
- [x] `uv run pytest src/screamingface/plugins/url4_executor/tests/test_scope.py -v` — **8 new unit tests pass** (covering the 3 Asana-required cases + frozen-ness, shadowing, non-mutation of parent, arbitrary value types, empty root)
- [x] `uv run pytest --cov=screamingface -m "not e2e and not e2e_live"` — **849 passed, 17 skipped, coverage 80%** (PR gate is 0.70)
- [x] `uv run pytest tests/e2e/ -m "e2e and not live" --timeout=120` — **123 passed, 8 skipped** (matches baseline byte-for-byte; 9m34s)
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run pyright` — **0 errors** (1 pre-existing warning on `mitmproxy_intercept`, unrelated)

## Files changed
- **New:** `apps/server/src/screamingface/plugins/url4_executor/scope.py` (`Env` dataclass)
- **New:** `apps/server/src/screamingface/plugins/url4_executor/tests/test_scope.py` (8 unit tests)
- **Widened:** `interpreter.py`, `ensemble.py`, `url4_resolve.py`, `routes.py` (url4_executor)
- **Widened:** `claude_backend_api/interpreter.py`, `codex_backend_api/interpreter.py`, `ollama_backend_api/interpreter.py`, `gemini_backend_api/interpreter.py`, `aigw_base/interpreter.py` (subclass `process()` overrides)

## Acceptance criteria (from Asana)
- [x] `Env` exists with `lookup`, `child`, `root`, `frozen=True`
- [x] `Env.root().child(a=1).child(b=2).lookup("a") == 1`
- [x] Missing-name lookup raises `KeyError`
- [x] `child()` doesn't mutate parent
- [x] All existing url4_executor tests pass unchanged
- [x] All e2e tests pass (`e2e and not live` — equivalent to CI's `-m "e2e"`)
- [x] Design note in `interpreter.py` docstring explains parent-pointer choice

Asana: https://app.asana.com/1/1185126988600652/task/1214567788345901
Plan: `docs/superpowers/plans/2026-05-11-demo-004-env-scope-chain.md`