### PR TITLE
SF-156: scaffold python-runner plugin (DEMO-009)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,17 @@ If a task involves copy, design, or positioning and you're unsure which audience
 - **Never commit directly to `main`** — the `.githooks/pre-commit` hook enforces this.
 - Include the Asana task permalink in the commit message body.
 
+## Planning Tickets
+
+When the user asks to **plan a ticket** (or any non-trivial task):
+
+- **Always use the agentic superpowers team for planning.** Use `superpowers:brainstorming` first, then `superpowers:writing-plans` (or the equivalent `write-plan` / `brainstorm` skills). Dispatch parallel agents (`superpowers:dispatching-parallel-agents`) for independent research as needed.
+- **Write output to disk** in this project:
+  - **Plans** → `/Users/sergey/work/openmind/screamingface/docs/superpowers/plans/`
+  - **Specs** → `/Users/sergey/work/openmind/screamingface/docs/superpowers/specs/`
+- **Reach ≥95% confidence before proposing the plan/spec for review.** Iterate — re-read source files, dispatch more research agents, ask the user targeted questions — until you can honestly claim ≥95% confidence in the plan's correctness, completeness, and feasibility. State the confidence level explicitly when presenting.
+- **Never switch to implementation until the user explicitly approves the plan.** Writing the plan to disk and presenting it is the end of the planning phase. Do not start editing code, creating branches, or executing the plan until the user says so in plain words. Implicit cues ("looks good", "thanks") are not approval — wait for an explicit go-ahead.
+
 ### Setup (one-time)
 
 After cloning, activate the shared git hooks:

--- a/apps/server/sf.json
+++ b/apps/server/sf.json
@@ -17,6 +17,7 @@
     "llm-base",
     "frontend-base",
     "backend-api-base",
+    "python-runner",
     "codex-backend-api",
     "gemini-backend-api",
     "ollama-backend-api",

--- a/apps/server/src/screamingface/plugins/python_runner/__init__.py
+++ b/apps/server/src/screamingface/plugins/python_runner/__init__.py
@@ -1,0 +1,14 @@
+"""python-runner plugin — runs Python scripts referenced by URL4 expressions.
+
+This package is a scaffold (DEMO-009 / SF-156). Execution arrives in:
+
+- DEMO-010 — subprocess runner + JSON I/O contract
+- DEMO-012 — sandbox-exec on darwin
+- DEMO-013 — real ``/python`` route + ``/data/code/<name>.py`` serve route
+- DEMO-016 — vendored HLE scripts under ``_vendored/``
+- DEMO-030 — Monaco RJSF widget reading the ``x-code-editor`` annotation
+"""
+
+from screamingface.plugins.python_runner.plugin import PythonRunnerPlugin
+
+__all__ = ["PythonRunnerPlugin"]

--- a/apps/server/src/screamingface/plugins/python_runner/_default_scripts.py
+++ b/apps/server/src/screamingface/plugins/python_runner/_default_scripts.py
@@ -1,0 +1,23 @@
+"""Load vendored Python scripts as defaults for the ``scripts`` setting.
+
+Reads committed ``.py`` files at import time so they're embedded as default
+values for ``PythonRunnerSettings.scripts``. The vendor directory is populated
+by DEMO-016; until then this returns an empty dict, which is a valid initial
+state.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+VENDOR_ROOT = Path(__file__).resolve().parent / "_vendored"
+
+
+def load_vendored_defaults() -> dict[str, str]:
+    """Return ``{stem: source}`` for every ``.py`` under ``_vendored/``.
+
+    Empty dict when the directory is absent or empty.
+    """
+    if not VENDOR_ROOT.is_dir():
+        return {}
+    return {path.stem: path.read_text(encoding="utf-8") for path in VENDOR_ROOT.glob("*.py")}

--- a/apps/server/src/screamingface/plugins/python_runner/_vendored/.gitkeep
+++ b/apps/server/src/screamingface/plugins/python_runner/_vendored/.gitkeep
@@ -1,0 +1,2 @@
+# Populated by DEMO-016 — vendored HLE scripts (check_correct.py, calculate_accuracy.py).
+# Until then this directory stays empty and load_vendored_defaults() returns {}.

--- a/apps/server/src/screamingface/plugins/python_runner/plugin.py
+++ b/apps/server/src/screamingface/plugins/python_runner/plugin.py
@@ -1,0 +1,97 @@
+"""python-runner plugin — scaffold (DEMO-009 / SF-156).
+
+Registers the ``/python`` URL4 backend dispatch path and exposes a
+``scripts: dict[str, str]`` settings field — Python source as config, edited
+via the SF settings UI and persisted to ``sf.json``. No execution logic
+yet; that lands in DEMO-010 / DEMO-012 / DEMO-013.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from pydantic import Field, field_validator
+from pydantic_settings import SettingsConfigDict
+
+from screamingface.plugin import Plugin, PluginSettings
+from screamingface.plugins.python_runner._default_scripts import load_vendored_defaults
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+    from screamingface.core.classes import ClassRegistry
+    from screamingface.core.hooks import HookRegistry
+    from screamingface.core.routes import RouteRegistry
+
+
+VALID_SCRIPT_NAME = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+class PythonRunnerSettings(PluginSettings):
+    """Settings for the python-runner plugin.
+
+    Scripts are Python source strings keyed by a Python-identifier-safe name.
+    The ``x-code-editor`` JSON Schema annotation tells the SF settings UI
+    (DEMO-030) to render values in a Monaco editor configured for Python.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="SF_PYTHON_RUNNER__",
+        env_nested_delimiter="__",
+    )
+
+    scripts: dict[str, str] = Field(
+        default_factory=load_vendored_defaults,
+        description=(
+            "Named Python scripts servable at /data/code/<name>.py. "
+            "Edit through the settings UI; persisted to sf.json."
+        ),
+        json_schema_extra={
+            "x-code-editor": {"language": "python"},
+        },
+    )
+
+    @field_validator("scripts")
+    @classmethod
+    def _validate_script_names(cls, v: dict[str, str]) -> dict[str, str]:
+        for name in v:
+            if not VALID_SCRIPT_NAME.match(name):
+                raise ValueError(
+                    f"Invalid script name {name!r}: must match {VALID_SCRIPT_NAME.pattern}"
+                )
+        return v
+
+
+class PythonRunnerPlugin(Plugin):
+    """Plugin scaffold. Execution lands in DEMO-013."""
+
+    name = "python-runner"
+    description = "Runs Python scripts referenced by URL4 expressions."
+    tags: list[str] = ["product:python"]
+    depends: list[str] = []
+    conflicts: list[str] = []
+    settings_class = PythonRunnerSettings
+    backend_call_paths: list[str] = ["/python"]
+
+    async def handle_backend_call(
+        self,
+        intent: str,
+        *,
+        sources: str = "",
+        app: FastAPI,
+    ) -> str:
+        del intent, sources, app  # consumed by DEMO-013
+        raise NotImplementedError("Wired in DEMO-013")
+
+    def setup(
+        self,
+        app: FastAPI,
+        hooks: HookRegistry,
+        classes: ClassRegistry,
+        routes: RouteRegistry,
+    ) -> None:
+        from screamingface.plugins.python_runner.routes import create_router
+
+        del hooks, classes  # required by Plugin contract; unused here
+        routes.add_router(self.name, create_router(app), prefix="")

--- a/apps/server/src/screamingface/plugins/python_runner/routes.py
+++ b/apps/server/src/screamingface/plugins/python_runner/routes.py
@@ -1,0 +1,20 @@
+"""Routes for the python-runner plugin.
+
+Scaffold only — the real ``/data/code/<name>.py`` serve route and the body of
+``handle_backend_call`` land in DEMO-013.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+
+def create_router(app: FastAPI) -> APIRouter:
+    """Return the plugin's APIRouter. Empty until DEMO-013 wires real routes."""
+    del app  # consumed by DEMO-013
+    return APIRouter()

--- a/apps/server/src/screamingface/plugins/python_runner/tests/test_default_scripts.py
+++ b/apps/server/src/screamingface/plugins/python_runner/tests/test_default_scripts.py
@@ -1,0 +1,47 @@
+"""``load_vendored_defaults`` reads ``_vendored/*.py`` (DEMO-009)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from screamingface.plugins.python_runner import _default_scripts
+from screamingface.plugins.python_runner._default_scripts import load_vendored_defaults
+
+
+def test_returns_empty_dict_when_dir_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(_default_scripts, "VENDOR_ROOT", tmp_path / "does_not_exist")
+    assert load_vendored_defaults() == {}
+
+
+def test_returns_empty_dict_when_dir_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(_default_scripts, "VENDOR_ROOT", tmp_path)
+    assert load_vendored_defaults() == {}
+
+
+def test_loads_py_files_keyed_by_stem(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "foo.py").write_text("def foo():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "bar_baz.py").write_text("X = 42\n", encoding="utf-8")
+    monkeypatch.setattr(_default_scripts, "VENDOR_ROOT", tmp_path)
+
+    result = load_vendored_defaults()
+
+    assert result == {
+        "foo": "def foo():\n    return 1\n",
+        "bar_baz": "X = 42\n",
+    }
+
+
+def test_ignores_non_py_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / "keep.py").write_text("Y = 1\n", encoding="utf-8")
+    (tmp_path / "ignore.txt").write_text("not python\n", encoding="utf-8")
+    monkeypatch.setattr(_default_scripts, "VENDOR_ROOT", tmp_path)
+
+    assert load_vendored_defaults() == {"keep": "Y = 1\n"}

--- a/apps/server/src/screamingface/plugins/python_runner/tests/test_default_scripts.py
+++ b/apps/server/src/screamingface/plugins/python_runner/tests/test_default_scripts.py
@@ -17,16 +17,12 @@ def test_returns_empty_dict_when_dir_missing(
     assert load_vendored_defaults() == {}
 
 
-def test_returns_empty_dict_when_dir_empty(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_returns_empty_dict_when_dir_empty(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(_default_scripts, "VENDOR_ROOT", tmp_path)
     assert load_vendored_defaults() == {}
 
 
-def test_loads_py_files_keyed_by_stem(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_loads_py_files_keyed_by_stem(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     (tmp_path / "foo.py").write_text("def foo():\n    return 1\n", encoding="utf-8")
     (tmp_path / "bar_baz.py").write_text("X = 42\n", encoding="utf-8")
     monkeypatch.setattr(_default_scripts, "VENDOR_ROOT", tmp_path)

--- a/apps/server/src/screamingface/plugins/python_runner/tests/test_plugin_loads.py
+++ b/apps/server/src/screamingface/plugins/python_runner/tests/test_plugin_loads.py
@@ -1,0 +1,25 @@
+"""Plugin class declares the right surface (DEMO-009 acceptance criteria)."""
+
+from __future__ import annotations
+
+from screamingface.plugins.python_runner.plugin import (
+    PythonRunnerPlugin,
+    PythonRunnerSettings,
+)
+
+
+def test_plugin_class_imports() -> None:
+    assert PythonRunnerPlugin is not None
+
+
+def test_plugin_metadata() -> None:
+    assert PythonRunnerPlugin.name == "python-runner"
+    assert PythonRunnerPlugin.backend_call_paths == ["/python"]
+    assert PythonRunnerPlugin.settings_class is PythonRunnerSettings
+    assert "product:python" in PythonRunnerPlugin.tags
+
+
+def test_settings_schema_has_x_code_editor() -> None:
+    schema = PythonRunnerSettings.model_json_schema()
+    scripts_field = schema["properties"]["scripts"]
+    assert scripts_field.get("x-code-editor") == {"language": "python"}

--- a/apps/server/src/screamingface/plugins/python_runner/tests/test_settings_validation.py
+++ b/apps/server/src/screamingface/plugins/python_runner/tests/test_settings_validation.py
@@ -1,0 +1,20 @@
+"""Script-name validator rejects non-identifiers (DEMO-009 acceptance)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from screamingface.plugins.python_runner.plugin import PythonRunnerSettings
+
+
+@pytest.mark.parametrize("name", ["foo", "foo_bar", "_x1", "X", "snake_case_123"])
+def test_valid_names_accepted(name: str) -> None:
+    settings = PythonRunnerSettings(scripts={name: "x = 1\n"})
+    assert name in settings.scripts
+
+
+@pytest.mark.parametrize("name", ["foo bar", "123abc", "x-y", "foo.py", "", "with space"])
+def test_invalid_names_rejected(name: str) -> None:
+    with pytest.raises(ValidationError, match="Invalid script name"):
+        PythonRunnerSettings(scripts={name: "x = 1\n"})

--- a/docs/superpowers/plans/2026-05-13-demo-009-python-runner-scaffold.md
+++ b/docs/superpowers/plans/2026-05-13-demo-009-python-runner-scaffold.md
@@ -1,0 +1,148 @@
+# DEMO-009 — `python_runner` plugin scaffold + scripts-as-config
+
+- **Asana:** [task 1214568343520691](https://app.asana.com/1/1185126988600652/task/1214568343520691)
+- **SF ticket:** SF-156
+- **Parent:** [DEMO] Leaderboard Demo — Sergey core track
+- **Owner:** A (Sergey)
+- **Due:** 2026-05-12 (overdue as of 2026-05-13)
+- **Priority:** High
+- **Estimate:** 1 day
+- **Phase / week:** Phase 1, Week 1
+- **Dependencies:** none
+- **Branch:** `SF-156-python-runner-scaffold` (off fresh `origin/main`)
+- **Confidence:** ~97% after wiring verification (auto-discovery, `add_router` signature, `PluginSettings` import, `sf.json` activation list all confirmed against current code)
+
+## Goal
+
+Land the `python_runner` plugin scaffold that registers the `/python` URL4 backend dispatch path and exposes a `scripts: dict[str, str]` settings field — Python source-as-config, edited via the SF settings UI, persisted in `sf.json`.
+
+No execution logic in this ticket; that arrives in DEMO-010 (subprocess runner), DEMO-012 (sandbox-exec), DEMO-013 (real routes), DEMO-016 (vendored scripts), and DEMO-030 (Monaco RJSF widget).
+
+## Scope
+
+In scope:
+- New plugin package `screamingface.plugins.python_runner`.
+- Plugin class subclassing the bare `Plugin` (NOT `BackendApiPluginBase`, since `/python` is unauthenticated and local-only — no OAuth/interpreter machinery).
+- `PythonRunnerSettings` with the `scripts` dict field annotated `x-code-editor`, name-validated by `^[a-zA-Z_][a-zA-Z0-9_]*$`.
+- `_default_scripts.load_vendored_defaults()` reading `_vendored/*.py` at import time, returning `{stem: source}`. Empty dict when the dir is absent.
+- Empty `routes.py` stub returning a bare `APIRouter()`.
+- Test suite covering plugin load, default-scripts loader, and settings name validation.
+
+Out of scope (explicit):
+- Subprocess runner — DEMO-010.
+- Sandbox-exec / darwin sandboxing — DEMO-012.
+- Real `/python` route + `/data/code/<name>.py` serve route — DEMO-013.
+- Vendored HLE Python scripts (`check_correct.py`, `calculate_accuracy.py`) — DEMO-016.
+- Monaco code-editor RJSF widget that reads `x-code-editor` — DEMO-030.
+
+## Risks & decisions
+
+1. **Signature drift in spec.** The Asana ticket's code excerpt uses `handle_backend_call(self, intent, sources, app)` positional. The real `Plugin` base contract is `async def handle_backend_call(self, intent: str, *, sources: str = "", app: FastAPI) -> str`. **Decision:** match the real (keyword-only) signature; body remains `raise NotImplementedError("Wired in DEMO-013")`.
+2. **`_vendored/` not yet populated.** DEMO-016 lands the vendor files. Ship `_vendored/.gitkeep` so the dir exists; `load_vendored_defaults()` returns `{}` until then — spec explicitly permits this.
+3. **Working tree dirty + main behind.** Local `main` is 13 commits behind `origin/main` with uncommitted changes to `apps/server/sf.json` and `claude_backend_api/plugin.py`. Per standing rule, branch from fresh `origin/main`. Stash the dirty changes before branching, restore after the PR opens.
+4. **`sf.json` activation list edit IS required.** Discovery (via `pkgutil.iter_modules` in `core/registry.py`) auto-finds the plugin package, but activation reads the explicit `plugins: [...]` list in `apps/server/sf.json`. `"python-runner"` must be appended. The dirty working tree already has `M apps/server/sf.json`; expect a trivial merge on `git stash pop` after the PR — both edits are list appends.
+5. **Spec's `setup()` snippet uses wrong API.** Asana ticket shows `routes.register(create_router(app=app))`. Real `RouteRegistry` (verified in `core/routes.py:28`) is `add_router(plugin_name: str, router: APIRouter, *, prefix: str = "")`. **Use:** `routes.add_router(self.name, create_router(app), prefix="")`.
+
+## Reference points in the codebase
+
+- Plugin base class & contract — `apps/server/src/screamingface/plugin.py` (`Plugin`, `PluginSettings`, `backend_call_paths`).
+- Structural template (strip OAuth) — `apps/server/src/screamingface/plugins/claude_backend_api/plugin.py`.
+- Settings base shape — `apps/server/src/screamingface/plugins/backend_api_base/plugin_base.py` (`BackendApiSettingsBase` is the model to *not* inherit; use the bare `PluginSettings`).
+- `x-…` JSON Schema annotation precedent — `apps/server/src/screamingface/plugins/url4_specs/plugin.py` (`x-placeholder`, `x-copy-link`).
+
+## Implementation steps (execution order)
+
+### Step 1 — Pre-flight on screamingface repo
+1. `git fetch origin`
+2. `git stash push -u -m "pre-SF-156 wip"` (parks the dirty `sf.json` + claude_backend_api/plugin.py edits)
+3. `git checkout -b SF-156-python-runner-scaffold origin/main`
+
+### Step 2 — Create plugin package
+Directory: `apps/server/src/screamingface/plugins/python_runner/`
+
+Files:
+- `__init__.py` — re-exports `PythonRunnerPlugin`.
+- `plugin.py`
+  - `VALID_SCRIPT_NAME = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")`
+  - `class PythonRunnerSettings(PluginSettings)`
+    - `model_config = SettingsConfigDict(env_prefix="SF_PYTHON_RUNNER__", env_nested_delimiter="__")`
+    - `scripts: dict[str, str] = Field(default_factory=load_vendored_defaults, description=..., json_schema_extra={"x-code-editor": {"language": "python"}})`
+    - `@field_validator("scripts")` rejecting any key not matching `VALID_SCRIPT_NAME`.
+  - `class PythonRunnerPlugin(Plugin)`
+    - `name = "python-runner"`
+    - `description = "Runs Python scripts referenced by URL4 expressions."`
+    - `tags = ["product:python"]`
+    - `depends = []`
+    - `settings_class = PythonRunnerSettings`
+    - `backend_call_paths = ["/python"]`
+    - `async def handle_backend_call(self, intent: str, *, sources: str = "", app: FastAPI) -> str: raise NotImplementedError("Wired in DEMO-013")`
+    - `def setup(self, app, hooks, classes, routes) -> None:` registers the empty router via `routes.add_router(self.name, create_router(app), prefix="")` (mirrors the `BackendApiPluginBase` setup shape).
+- `_default_scripts.py`
+  - `VENDOR_ROOT = Path(__file__).resolve().parent / "_vendored"`
+  - `def load_vendored_defaults() -> dict[str, str]:` returns `{}` if dir missing, else `{path.stem: path.read_text("utf-8") for path in VENDOR_ROOT.glob("*.py")}`.
+- `routes.py` — `def create_router(app) -> APIRouter: return APIRouter()` with a docstring noting "real routes land in DEMO-013".
+- `_vendored/.gitkeep` — empty file with a comment hint (in `__init__.py` or top of `_default_scripts.py`) pointing at DEMO-016.
+
+### Step 3 — Tests
+Directory: `apps/server/src/screamingface/plugins/python_runner/tests/`
+
+- `__init__.py` — empty.
+- `test_plugin_loads.py`
+  - `from screamingface.plugins.python_runner.plugin import PythonRunnerPlugin` succeeds.
+  - `PythonRunnerPlugin.name == "python-runner"`.
+  - `PythonRunnerPlugin.backend_call_paths == ["/python"]`.
+  - `PythonRunnerPlugin.settings_class is PythonRunnerSettings`.
+  - `"x-code-editor"` appears in the JSON Schema produced by `PythonRunnerSettings.model_json_schema()` under `scripts`.
+- `test_default_scripts.py`
+  - Empty/absent vendor dir → `load_vendored_defaults() == {}`.
+  - Monkeypatch `VENDOR_ROOT` to a `tmp_path` containing `foo.py` and `bar.py` → returns `{"foo": "...", "bar": "..."}`.
+- `test_settings_validation.py`
+  - Valid names (`foo`, `foo_bar`, `_x1`) — instantiates fine.
+  - Invalid (`"foo bar"`, `"123abc"`, `"x-y"`) — raises `ValidationError`.
+
+### Step 4 — Activate plugin in `sf.json`
+- Discovery is automatic (`core/registry.py` walks `screamingface.plugins` via `pkgutil.iter_modules`), but activation is gated by the explicit list at `apps/server/sf.json` → `plugins`.
+- Append `"python-runner"` to that array. Keep ordering near other backend-api / runtime plugins for readability.
+- Boot the server and `curl /plugins` → `python-runner` appears with `backend_call_paths: ["/python"]`.
+
+### Step 5 — Gates (all must be green)
+```bash
+cd apps/server
+uv run pytest src/screamingface/plugins/python_runner/tests/ -v
+uv run pyright src/screamingface/plugins/python_runner/
+uv run ruff check src/screamingface/plugins/python_runner/
+```
+
+### Step 6 — Commit & PR
+- Commit: `feat(python-runner): scaffold plugin + scripts-as-config setting (SF-156, DEMO-009)`.
+- Push branch; open PR against `main` with body that includes:
+  - Link to the Asana task.
+  - The acceptance-criteria checklist copied from the ticket, all items ticked.
+  - "Out of scope" reminder pointing at DEMO-010/012/013/016/030.
+- Do NOT auto-merge — leave for review.
+- After PR opens, `git stash pop` to restore the parked wip on `main`.
+
+## Acceptance criteria (mirrors Asana ticket)
+
+- [ ] `from screamingface.plugins.python_runner.plugin import PythonRunnerPlugin` succeeds.
+- [ ] `/plugins` listing shows `python-runner` when the SF server starts with the plugin active.
+- [ ] `backend_call_paths` contains `/python` (verifiable by introspecting the registry).
+- [ ] `PythonRunnerSettings` exposes a `scripts` field with `x-code-editor` annotation in its JSON Schema.
+- [ ] On first launch, `settings.scripts` contains the vendored entries (empty dict acceptable until DEMO-016).
+- [ ] Invalid script names (`"foo bar"`, `"123abc"`, `"x-y"`) rejected at config load with a clear error.
+- [ ] pyright + ruff clean.
+
+## File map (final)
+```
+apps/server/src/screamingface/plugins/python_runner/
+├── __init__.py
+├── plugin.py
+├── _default_scripts.py
+├── routes.py
+├── _vendored/.gitkeep                 # populated in DEMO-016
+└── tests/
+    ├── __init__.py
+    ├── test_plugin_loads.py
+    ├── test_default_scripts.py
+    └── test_settings_validation.py
+```


### PR DESCRIPTION
## Summary
Scaffolds the `python-runner` plugin that registers the `/python` URL4 backend dispatch path and exposes a `scripts: dict[str, str]` settings field (source-as-config, edited via the SF settings UI, persisted to `sf.json`).

**No execution logic yet** — `handle_backend_call` raises `NotImplementedError("Wired in DEMO-013")`. Subprocess runner lands in DEMO-010, sandbox in DEMO-012, real routes in DEMO-013, vendored HLE scripts in DEMO-016, Monaco RJSF widget in DEMO-030.

- **Asana:** https://app.asana.com/1/1185126988600652/task/1214568343520691
- **Plan:** [`docs/superpowers/plans/2026-05-13-demo-009-python-runner-scaffold.md`](docs/superpowers/plans/2026-05-13-demo-009-python-runner-scaffold.md)

## Changes
- `screamingface.plugins.python_runner/` — package with `plugin.py`, `_default_scripts.py`, `routes.py`, `_vendored/.gitkeep`
- `scripts` field carries `x-code-editor` JSON Schema annotation (read by the DEMO-030 widget)
- Script names validated against `^[a-zA-Z_][a-zA-Z0-9_]*$` at config load (clear `ValidationError` instead of a 404 surprise later)
- `load_vendored_defaults()` reads `_vendored/*.py` at import time; returns `{}` until DEMO-016 populates the dir
- Activated in `apps/server/sf.json` (`plugins[]` array)

## Acceptance criteria (from Asana)
- [x] `from screamingface.plugins.python_runner.plugin import PythonRunnerPlugin` succeeds
- [x] `/plugins` listing shows `python-runner` when the SF server starts with the plugin active
- [x] `backend_call_paths` contains `/python` (verified via `PluginRegistry`)
- [x] `PythonRunnerSettings` exposes a `scripts` field with `x-code-editor` annotation in its JSON Schema
- [x] On first launch, `settings.scripts` defaults to `{}` (vendored entries land in DEMO-016)
- [x] Invalid script names (`"foo bar"`, `"123abc"`, `"x-y"`) rejected at config load with a clear error
- [x] pyright + ruff clean

## Test plan
- [x] `uv run pytest src/screamingface/plugins/python_runner/tests/ -v` — 18/18 pass
- [x] `uv run pyright src/screamingface/plugins/python_runner/` — 0 errors, 0 warnings
- [x] `uv run ruff check src/screamingface/plugins/python_runner/` — clean
- [x] Full suite: `uv run pytest` — 982 passed, 25 skipped (no regressions)
- [x] `PluginRegistry().discover()` finds `python-runner`; `load_plugin()` returns instance with correct `backend_call_paths`

## Out of scope
DEMO-010 (subprocess runner), DEMO-012 (sandbox-exec), DEMO-013 (real routes), DEMO-016 (vendored scripts), DEMO-030 (Monaco RJSF widget).