### PR TITLE
feat(SF-157): python_runner subprocess runner (DEMO-010)

### DIFF
--- a/apps/server/src/screamingface/plugins/python_runner/runner.py
+++ b/apps/server/src/screamingface/plugins/python_runner/runner.py
@@ -1,0 +1,125 @@
+"""Subprocess runner for Python source.
+
+Pure async function: source-in, JSON-payload-on-stdin, parsed-JSON-stdout-out.
+No path arguments — the caller is responsible for producing the source from
+wherever it lives (config-stored at /data/code/, vendored, remote URL).
+Sandboxing wraps this transparently in DEMO-012; /python wires it up in
+DEMO-013.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+__all__ = ["PythonRunnerError", "run_script_source"]
+
+ErrorKind = Literal["nonzero_exit", "invalid_output", "timeout", "io_error"]
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PythonRunnerError(Exception):
+    kind: ErrorKind
+    message: str
+    stderr: str = ""
+    stdout: str = ""
+    exit_code: int | None = None
+
+    def __str__(self) -> str:
+        return f"PythonRunnerError({self.kind}): {self.message}"
+
+
+_DEFAULT_CACHE_ROOT = Path.home() / ".cache" / "screamingface" / "python-scripts"
+
+
+def _cache_root() -> Path:
+    return Path(os.environ.get("SF_PYTHON_RUNNER__CACHE_ROOT", _DEFAULT_CACHE_ROOT))
+
+
+def _cache_script(source: str) -> Path:
+    root = _cache_root()
+    digest = hashlib.sha256(source.encode("utf-8")).hexdigest()[:32]
+    target = root / f"{digest}.py"
+    if target.exists():
+        return target
+    root.mkdir(parents=True, exist_ok=True)
+    os.chmod(root, 0o700)
+    with tempfile.NamedTemporaryFile(
+        "w", dir=root, suffix=".py.tmp", delete=False
+    ) as tmp:
+        tmp.write(source)
+        tmp_path = tmp.name
+    os.chmod(tmp_path, 0o600)
+    os.rename(tmp_path, target)
+    return target
+
+
+async def run_script_source(
+    source: str,
+    payload: dict[str, Any],
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Run Python source in a subprocess; return parsed JSON output."""
+    script_path = _cache_script(source)
+    payload_bytes = json.dumps(payload).encode("utf-8")
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            str(script_path),
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except OSError as e:
+        raise PythonRunnerError(kind="io_error", message=str(e)) from e
+
+    try:
+        stdout_b, stderr_b = await asyncio.wait_for(
+            proc.communicate(input=payload_bytes),
+            timeout=timeout,
+        )
+    except TimeoutError as e:
+        proc.kill()
+        await proc.wait()
+        raise PythonRunnerError(
+            kind="timeout",
+            message=f"Script exceeded {timeout}s timeout",
+        ) from e
+
+    stdout = stdout_b.decode("utf-8", errors="replace")
+    stderr = stderr_b.decode("utf-8", errors="replace")
+    exit_code = proc.returncode
+
+    if exit_code != 0:
+        raise PythonRunnerError(
+            kind="nonzero_exit",
+            message=f"Script exited with code {exit_code}",
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=exit_code,
+        )
+
+    if stderr:
+        logger.debug("python_runner stderr (non-empty on success): %s", stderr)
+
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError as e:
+        raise PythonRunnerError(
+            kind="invalid_output",
+            message=f"Stdout is not valid JSON: {e}",
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=exit_code,
+        ) from e

--- a/apps/server/src/screamingface/plugins/python_runner/runner.py
+++ b/apps/server/src/screamingface/plugins/python_runner/runner.py
@@ -54,9 +54,7 @@ def _cache_script(source: str) -> Path:
         return target
     root.mkdir(parents=True, exist_ok=True)
     os.chmod(root, 0o700)
-    with tempfile.NamedTemporaryFile(
-        "w", dir=root, suffix=".py.tmp", delete=False
-    ) as tmp:
+    with tempfile.NamedTemporaryFile("w", dir=root, suffix=".py.tmp", delete=False) as tmp:
         tmp.write(source)
         tmp_path = tmp.name
     os.chmod(tmp_path, 0o600)

--- a/apps/server/src/screamingface/plugins/python_runner/tests/test_runner.py
+++ b/apps/server/src/screamingface/plugins/python_runner/tests/test_runner.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import os
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -10,6 +10,7 @@ import pytest
 from screamingface.plugins.python_runner.runner import (
     PythonRunnerError,
     _cache_script,
+    run_script_source,
 )
 
 
@@ -61,11 +62,45 @@ def test_cache_script_different_sources_different_paths(
     assert p1 != p2
 
 
-def test_cache_dir_and_file_permissions(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_cache_dir_and_file_permissions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     cache_root = tmp_path / "nested" / "cache"
     monkeypatch.setenv("SF_PYTHON_RUNNER__CACHE_ROOT", str(cache_root))
     p = _cache_script("print('x')\n")
     assert (cache_root.stat().st_mode & 0o777) == 0o700
     assert (p.stat().st_mode & 0o777) == 0o600
+
+
+_ECHO_SCRIPT = textwrap.dedent(
+    """\
+    import json, sys
+    data = json.load(sys.stdin)
+    print(json.dumps({"ok": True, "got": data}))
+    """
+)
+
+
+async def test_happy_path_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SF_PYTHON_RUNNER__CACHE_ROOT", str(tmp_path))
+    result = await run_script_source(_ECHO_SCRIPT, {"a": 1, "b": [2, 3]})
+    assert result == {"ok": True, "got": {"a": 1, "b": [2, 3]}}
+
+
+async def test_stderr_logged_on_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import logging
+
+    monkeypatch.setenv("SF_PYTHON_RUNNER__CACHE_ROOT", str(tmp_path))
+    script = textwrap.dedent(
+        """\
+        import json, sys
+        print("warn:something", file=sys.stderr)
+        print(json.dumps({"ok": True}))
+        """
+    )
+    with caplog.at_level(logging.DEBUG, logger="screamingface.plugins.python_runner.runner"):
+        result = await run_script_source(script, {})
+    assert result == {"ok": True}
+    assert any("warn:something" in rec.message for rec in caplog.records)

--- a/apps/server/src/screamingface/plugins/python_runner/tests/test_runner.py
+++ b/apps/server/src/screamingface/plugins/python_runner/tests/test_runner.py
@@ -1,0 +1,71 @@
+"""Tests for python_runner.runner — error type + cache helper."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from screamingface.plugins.python_runner.runner import (
+    PythonRunnerError,
+    _cache_script,
+)
+
+
+def test_error_str_includes_kind_and_message() -> None:
+    err = PythonRunnerError(kind="timeout", message="boom")
+    assert str(err) == "PythonRunnerError(timeout): boom"
+
+
+def test_error_carries_optional_fields() -> None:
+    err = PythonRunnerError(
+        kind="nonzero_exit",
+        message="bad",
+        stdout="out",
+        stderr="err",
+        exit_code=7,
+    )
+    assert err.stdout == "out"
+    assert err.stderr == "err"
+    assert err.exit_code == 7
+
+
+def test_cache_script_writes_and_returns_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SF_PYTHON_RUNNER__CACHE_ROOT", str(tmp_path))
+    p = _cache_script("print(1)\n")
+    assert p.parent == tmp_path
+    assert p.suffix == ".py"
+    assert p.read_text() == "print(1)\n"
+
+
+def test_cache_script_same_source_same_path_no_rewrite(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SF_PYTHON_RUNNER__CACHE_ROOT", str(tmp_path))
+    p1 = _cache_script("print(1)\n")
+    mtime1 = p1.stat().st_mtime_ns
+    p2 = _cache_script("print(1)\n")
+    assert p1 == p2
+    assert p2.stat().st_mtime_ns == mtime1
+
+
+def test_cache_script_different_sources_different_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SF_PYTHON_RUNNER__CACHE_ROOT", str(tmp_path))
+    p1 = _cache_script("print(1)\n")
+    p2 = _cache_script("print(2)\n")
+    assert p1 != p2
+
+
+def test_cache_dir_and_file_permissions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_root = tmp_path / "nested" / "cache"
+    monkeypatch.setenv("SF_PYTHON_RUNNER__CACHE_ROOT", str(cache_root))
+    p = _cache_script("print('x')\n")
+    assert (cache_root.stat().st_mode & 0o777) == 0o700
+    assert (p.stat().st_mode & 0o777) == 0o600

--- a/apps/server/src/screamingface/plugins/python_runner/tests/test_runner.py
+++ b/apps/server/src/screamingface/plugins/python_runner/tests/test_runner.py
@@ -104,3 +104,43 @@ async def test_stderr_logged_on_success(
         result = await run_script_source(script, {})
     assert result == {"ok": True}
     assert any("warn:something" in rec.message for rec in caplog.records)
+
+
+async def test_nonzero_exit_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SF_PYTHON_RUNNER__CACHE_ROOT", str(tmp_path))
+    script = textwrap.dedent(
+        """\
+        import sys
+        print("error happened", file=sys.stderr)
+        sys.exit(1)
+        """
+    )
+    with pytest.raises(PythonRunnerError) as ei:
+        await run_script_source(script, {})
+    assert ei.value.kind == "nonzero_exit"
+    assert ei.value.exit_code == 1
+    assert "error happened" in ei.value.stderr
+
+
+async def test_invalid_output_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SF_PYTHON_RUNNER__CACHE_ROOT", str(tmp_path))
+    script = "print('not json')\n"
+    with pytest.raises(PythonRunnerError) as ei:
+        await run_script_source(script, {})
+    assert ei.value.kind == "invalid_output"
+    assert "not json" in ei.value.stdout
+
+
+async def test_timeout_raises_and_kills_subprocess(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SF_PYTHON_RUNNER__CACHE_ROOT", str(tmp_path))
+    script = textwrap.dedent(
+        """\
+        import time
+        time.sleep(5)
+        """
+    )
+    with pytest.raises(PythonRunnerError) as ei:
+        await run_script_source(script, {}, timeout=0.5)
+    assert ei.value.kind == "timeout"

--- a/docs/superpowers/plans/2026-05-13-python-runner-subprocess.md
+++ b/docs/superpowers/plans/2026-05-13-python-runner-subprocess.md
@@ -1,0 +1,374 @@
+# `python_runner` subprocess runner — Implementation Plan (SF-157 / DEMO-010)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `run_script_source(source, payload, timeout) -> dict` and a structured `PythonRunnerError` to the existing `python_runner` plugin. Pure async function: source-in, payload-on-stdin, JSON-stdout-out.
+
+**Architecture:** A single new module `runner.py` next to the existing `plugin.py`. No changes to plugin wiring or settings — DEMO-013 will glue this into `handle_backend_call`. The runner materializes source to a content-hash-keyed cache file (atomic write, 0o600), then spawns the interpreter via asyncio subprocess, pipes JSON payload to stdin, parses JSON from stdout, captures stderr. Errors raised as `PythonRunnerError(kind=...)`.
+
+**Tech Stack:** Python 3.12, asyncio, pytest, pytest-asyncio (already installed).
+
+**Spec:** `docs/superpowers/specs/2026-05-13-python-runner-subprocess-design.md`
+**Asana:** https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1214568342345700
+
+---
+
+## File Structure
+
+**Create:**
+
+- `apps/server/src/screamingface/plugins/python_runner/runner.py` — `PythonRunnerError`, `_cache_root()`, `_cache_script()`, `run_script_source()`.
+- `apps/server/src/screamingface/plugins/python_runner/tests/test_runner.py` — 11 tests covering happy path, cache reuse, distinct sources, permissions, three error kinds, and stderr logging.
+
+**Modify:** none.
+
+---
+
+## Task 1: `PythonRunnerError` + `_cache_script` helper
+
+**Files:**
+
+- Create: `apps/server/src/screamingface/plugins/python_runner/runner.py`
+- Create: `apps/server/src/screamingface/plugins/python_runner/tests/test_runner.py` (initial cache + error-shape tests)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/server/src/screamingface/plugins/python_runner/tests/test_runner.py`:
+
+```python
+"""Tests for python_runner.runner — error type + cache helper."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from screamingface.plugins.python_runner.runner import (
+    PythonRunnerError,
+    _cache_script,
+)
+
+
+def test_error_str_includes_kind_and_message() -> None:
+    err = PythonRunnerError(kind="timeout", message="boom")
+    assert str(err) == "PythonRunnerError(timeout): boom"
+
+
+def test_error_carries_optional_fields() -> None:
+    err = PythonRunnerError(
+        kind="nonzero_exit",
+        message="bad",
+        stdout="out",
+        stderr="err",
+        exit_code=7,
+    )
+    assert err.stdout == "out"
+    assert err.stderr == "err"
+    assert err.exit_code == 7
+
+
+def test_cache_script_writes_and_returns_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SF_PYTHON_RUNNER__CACHE_ROOT", str(tmp_path))
+    p = _cache_script("print(1)\n")
+    assert p.parent == tmp_path
+    assert p.suffix == ".py"
+    assert p.read_text() == "print(1)\n"
+
+
+def test_cache_script_same_source_same_path_no_rewrite(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SF_PYTHON_RUNNER__CACHE_ROOT", str(tmp_path))
+    p1 = _cache_script("print(1)\n")
+    mtime1 = p1.stat().st_mtime_ns
+    p2 = _cache_script("print(1)\n")
+    assert p1 == p2
+    assert p2.stat().st_mtime_ns == mtime1
+
+
+def test_cache_script_different_sources_different_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SF_PYTHON_RUNNER__CACHE_ROOT", str(tmp_path))
+    p1 = _cache_script("print(1)\n")
+    p2 = _cache_script("print(2)\n")
+    assert p1 != p2
+
+
+def test_cache_dir_and_file_permissions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_root = tmp_path / "nested" / "cache"
+    monkeypatch.setenv("SF_PYTHON_RUNNER__CACHE_ROOT", str(cache_root))
+    p = _cache_script("print('x')\n")
+    assert (cache_root.stat().st_mode & 0o777) == 0o700
+    assert (p.stat().st_mode & 0o777) == 0o600
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface/apps/server
+uv run pytest src/screamingface/plugins/python_runner/tests/test_runner.py -v
+```
+
+Expected: `ModuleNotFoundError` for `screamingface.plugins.python_runner.runner`.
+
+- [ ] **Step 3: Write the runner module**
+
+See the spec for the full source: `docs/superpowers/specs/2026-05-13-python-runner-subprocess-design.md`. Implement exactly what's shown there (the `PythonRunnerError` dataclass, `_cache_root()`, `_cache_script()`, and `run_script_source()`). Path: `apps/server/src/screamingface/plugins/python_runner/runner.py`.
+
+Key points the implementer must NOT change:
+- `_cache_root()` reads `os.environ.get(...)` at call time, not at module-import time.
+- `os.chmod(root, 0o700)` is called every invocation (cheap, idempotent).
+- The atomic write uses `tempfile.NamedTemporaryFile(..., delete=False)` as a context manager, then `os.chmod(tmp_path, 0o600)`, then `os.rename(tmp_path, target)`.
+- All `raise PythonRunnerError(...)` use `from e` to preserve the cause chain.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface/apps/server
+uv run pytest src/screamingface/plugins/python_runner/tests/test_runner.py -v
+```
+
+Expected: 6 passed (2 error-shape + 4 cache tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface
+git add apps/server/src/screamingface/plugins/python_runner/runner.py \
+        apps/server/src/screamingface/plugins/python_runner/tests/test_runner.py
+git commit -m "feat(SF-157): add PythonRunnerError + cache helper for python_runner"
+```
+
+---
+
+## Task 2: Happy path — `run_script_source` round-trip
+
+**Files:**
+
+- Modify: `apps/server/src/screamingface/plugins/python_runner/tests/test_runner.py` — append tests.
+
+- [ ] **Step 1: Append the failing tests**
+
+Append to `test_runner.py`:
+
+```python
+import textwrap
+
+from screamingface.plugins.python_runner.runner import run_script_source
+
+
+_ECHO_SCRIPT = textwrap.dedent(
+    """\
+    import json, sys
+    data = json.load(sys.stdin)
+    print(json.dumps({"ok": True, "got": data}))
+    """
+)
+
+
+async def test_happy_path_roundtrip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SF_PYTHON_RUNNER__CACHE_ROOT", str(tmp_path))
+    result = await run_script_source(_ECHO_SCRIPT, {"a": 1, "b": [2, 3]})
+    assert result == {"ok": True, "got": {"a": 1, "b": [2, 3]}}
+
+
+async def test_stderr_logged_on_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import logging
+
+    monkeypatch.setenv("SF_PYTHON_RUNNER__CACHE_ROOT", str(tmp_path))
+    script = textwrap.dedent(
+        """\
+        import json, sys
+        print("warn:something", file=sys.stderr)
+        print(json.dumps({"ok": True}))
+        """
+    )
+    with caplog.at_level(
+        logging.DEBUG, logger="screamingface.plugins.python_runner.runner"
+    ):
+        result = await run_script_source(script, {})
+    assert result == {"ok": True}
+    assert any("warn:something" in rec.message for rec in caplog.records)
+```
+
+- [ ] **Step 2: Run all runner tests**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface/apps/server
+uv run pytest src/screamingface/plugins/python_runner/tests/test_runner.py -v
+```
+
+Expected: 8 passed (6 from Task 1 + 2 happy-path).
+
+Note: `asyncio_mode = "auto"` is set in `pyproject.toml`, so async tests run without per-test markers.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface
+git add apps/server/src/screamingface/plugins/python_runner/tests/test_runner.py
+git commit -m "test(SF-157): happy-path + stderr-logging tests for run_script_source"
+```
+
+---
+
+## Task 3: Error paths
+
+**Files:**
+
+- Modify: `apps/server/src/screamingface/plugins/python_runner/tests/test_runner.py` — append tests.
+
+- [ ] **Step 1: Append the failing tests**
+
+Append to `test_runner.py`:
+
+```python
+async def test_nonzero_exit_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SF_PYTHON_RUNNER__CACHE_ROOT", str(tmp_path))
+    script = textwrap.dedent(
+        """\
+        import sys
+        print("error happened", file=sys.stderr)
+        sys.exit(1)
+        """
+    )
+    with pytest.raises(PythonRunnerError) as ei:
+        await run_script_source(script, {})
+    assert ei.value.kind == "nonzero_exit"
+    assert ei.value.exit_code == 1
+    assert "error happened" in ei.value.stderr
+
+
+async def test_invalid_output_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SF_PYTHON_RUNNER__CACHE_ROOT", str(tmp_path))
+    script = "print('not json')\n"
+    with pytest.raises(PythonRunnerError) as ei:
+        await run_script_source(script, {})
+    assert ei.value.kind == "invalid_output"
+    assert "not json" in ei.value.stdout
+
+
+async def test_timeout_raises_and_kills_subprocess(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SF_PYTHON_RUNNER__CACHE_ROOT", str(tmp_path))
+    script = textwrap.dedent(
+        """\
+        import time
+        time.sleep(5)
+        """
+    )
+    with pytest.raises(PythonRunnerError) as ei:
+        await run_script_source(script, {}, timeout=0.5)
+    assert ei.value.kind == "timeout"
+```
+
+- [ ] **Step 2: Run all runner tests**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface/apps/server
+uv run pytest src/screamingface/plugins/python_runner/tests/test_runner.py -v
+```
+
+Expected: 11 passed. The timeout test should complete in ~0.5s. If it hangs, the kill+wait path in the runner has a bug — investigate before patching the test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface
+git add apps/server/src/screamingface/plugins/python_runner/tests/test_runner.py
+git commit -m "test(SF-157): error-path tests (nonzero, invalid_output, timeout)"
+```
+
+---
+
+## Task 4: Lint, type-check, regression
+
+**Files:** none.
+
+- [ ] **Step 1: ruff check + format**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface/apps/server
+uv run ruff check src/screamingface/plugins/python_runner
+uv run ruff format --check src/screamingface/plugins/python_runner
+```
+
+Expected: both clean. If `format --check` complains, run `uv run ruff format src/screamingface/plugins/python_runner` and re-stage.
+
+- [ ] **Step 2: pyright**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface/apps/server
+uv run pyright src/screamingface/plugins/python_runner
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3: Full python_runner test suite**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface/apps/server
+uv run pytest src/screamingface/plugins/python_runner/ -v
+```
+
+Expected: 11 new tests + existing DEMO-009 scaffold tests still pass.
+
+- [ ] **Step 4: Wider regression check**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface/apps/server
+uv run pytest -q
+```
+
+Expected: no new failures vs. main.
+
+- [ ] **Step 5: Commit any lint/format fixups (skip if working tree clean)**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface
+git add -u apps/server/src/screamingface/plugins/python_runner
+git commit -m "chore(SF-157): lint and type-check cleanups"
+```
+
+---
+
+## Final acceptance check (from the spec)
+
+- [ ] Happy path returns parsed JSON — Task 2.
+- [ ] Same source → same cache path, no rewrite — Task 1.
+- [ ] Different sources → different paths — Task 1.
+- [ ] nonzero_exit / invalid_output / timeout all raise `PythonRunnerError` — Task 3.
+- [ ] Stderr captured on success (DEBUG log) and preserved on error — Task 2 + Task 3.
+- [ ] Cache dir 0o700, files 0o600 — Task 1.
+- [ ] Env var read at call time — Task 1 cache tests verify by changing `SF_PYTHON_RUNNER__CACHE_ROOT` per test.
+- [ ] pyright + ruff clean — Task 4.
+
+---
+
+## Notes for the implementer
+
+- `asyncio_mode = "auto"` is already in `pyproject.toml`. No `@pytest.mark.asyncio` decorator needed.
+- `tempfile.NamedTemporaryFile(..., delete=False)` on macOS can trigger a `ResourceWarning` if pytest runs with `-W error`. We use it as a context manager and only rename after exit — should be safe. If warnings break the test, switch to `tempfile.mkstemp(...)` + manual write/close.
+- `os.chmod(root, 0o700)` runs every call (cheap, idempotent). Don't skip it when the dir already exists — a previously-too-permissive dir would never get tightened otherwise.
+- `caplog.at_level(logging.DEBUG, logger="screamingface.plugins.python_runner.runner")` is the recommended form when DEBUG and the default propagation chain might miss the record.
+- The 32-char digest is intentional — keeps filenames short while staying collision-safe.
+- This is a pure module — no plugin.py changes, no settings changes, no route changes. If you find yourself touching those files, you're out of scope.
+

--- a/docs/superpowers/specs/2026-05-13-python-runner-subprocess-design.md
+++ b/docs/superpowers/specs/2026-05-13-python-runner-subprocess-design.md
@@ -1,0 +1,278 @@
+---
+title: python_runner — subprocess runner + JSON I/O contract
+status: proposed
+asana_task: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1214568342345700
+asana_gid: 1214568342345700
+sf_id: SF-157
+depends_on: DEMO-009 (python_runner scaffold) — merged
+blocks: DEMO-012 (sandbox-exec wrap), DEMO-013 (/python route wiring)
+created: 2026-05-13
+---
+
+# `python_runner` — subprocess runner + JSON I/O contract
+
+## Goal
+
+Add `run_script_source(source, payload, timeout) -> dict` to the existing
+`python_runner` plugin. Pure async function: Python source string in, JSON
+payload to stdin, parsed JSON stdout out. Errors raised as a structured
+`PythonRunnerError`. No path arguments — the caller is responsible for
+producing the source from wherever it lives.
+
+This is the **execution primitive**. Sandboxing wraps it transparently in
+DEMO-012; the `/python` URL4 backend route wires source-fetching +
+execution in DEMO-013.
+
+## Background
+
+DEMO-009 landed the plugin scaffold: `PythonRunnerPlugin`,
+`PythonRunnerSettings` (which holds `scripts: dict[str, str]` —
+config-stored script library, a separate concern from execution),
+`routes.py` stub, and the `_vendored/` directory for bundled HLE scripts.
+The scaffold's `handle_backend_call` is a `NotImplementedError` stub until
+DEMO-013. This ticket fills in the underlying primitive DEMO-013 will call.
+
+## Scope
+
+In:
+- New module `apps/server/src/screamingface/plugins/python_runner/runner.py`
+- Public coroutine `run_script_source(source, payload, timeout=30.0) -> dict`
+- Structured exception `PythonRunnerError`
+- Internal helper `_cache_script(source) -> Path` with content-hash-keyed
+  atomic writes, 0o700 dir / 0o600 file
+- Tests: happy path, cache reuse, error paths, stderr capture, permissions
+
+Out:
+- Sandbox profile (DEMO-012)
+- Wiring to `/python` route (DEMO-013)
+- Per-call cache invalidation / size limits / LRU eviction
+- Process pool / warm interpreters
+- Modifying `plugin.py`, `routes.py`, `PythonRunnerSettings`
+
+## Design
+
+### Architecture
+
+A single module, two public names (`run_script_source`,
+`PythonRunnerError`) and one private helper (`_cache_script`). No FastAPI
+integration, no class hierarchy — just an async function. DEMO-013
+imports and awaits it from the plugin's `handle_backend_call`.
+
+### `PythonRunnerError`
+
+```python
+ErrorKind = Literal["nonzero_exit", "invalid_output", "timeout", "io_error"]
+
+
+@dataclass
+class PythonRunnerError(Exception):
+    kind: ErrorKind
+    message: str
+    stderr: str = ""
+    stdout: str = ""
+    exit_code: int | None = None
+
+    def __str__(self) -> str:
+        return f"PythonRunnerError({self.kind}): {self.message}"
+```
+
+`@dataclass` on an Exception subclass generates `__init__` and `__repr__`;
+`__str__` is explicit so log lines stay readable. All raise sites use
+`raise ... from e` to preserve the cause chain.
+
+### `_cache_script`
+
+```python
+_DEFAULT_CACHE_ROOT = Path.home() / ".cache" / "screamingface" / "python-scripts"
+
+
+def _cache_root() -> Path:
+    return Path(os.environ.get("SF_PYTHON_RUNNER__CACHE_ROOT", _DEFAULT_CACHE_ROOT))
+
+
+def _cache_script(source: str) -> Path:
+    root = _cache_root()
+    digest = hashlib.sha256(source.encode("utf-8")).hexdigest()[:32]
+    target = root / f"{digest}.py"
+    if target.exists():
+        return target
+    root.mkdir(parents=True, exist_ok=True)
+    os.chmod(root, 0o700)
+    with tempfile.NamedTemporaryFile(
+        "w", dir=root, suffix=".py.tmp", delete=False
+    ) as tmp:
+        tmp.write(source)
+        tmp_path = tmp.name
+    os.chmod(tmp_path, 0o600)
+    os.rename(tmp_path, target)
+    return target
+```
+
+> **Why read the env var at call time, not module top.** Pytest's
+> `monkeypatch.setenv` sets the env var before each test. If we cached the
+> resolved path at module-import time the first test would freeze the
+> value. Reading inside `_cache_root()` makes the function tractable from
+> tests at essentially zero runtime cost.
+
+> **Why 32-hex-char digest.** sha256 hex is 64 chars; 32 is enough
+> collision resistance for a content-addressed cache (~2^128) and keeps
+> the filename short.
+
+> **Atomic write via tmp + rename.** Same digest may be written
+> concurrently by two coroutines. Both write their own tmp file and both
+> rename to the same target — POSIX rename is atomic, and since the
+> content is identical (same digest), the result is the same regardless
+> of which rename wins.
+
+### `run_script_source`
+
+```python
+logger = logging.getLogger(__name__)
+
+
+async def run_script_source(
+    source: str,
+    payload: dict[str, Any],
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    script_path = _cache_script(source)
+    payload_bytes = json.dumps(payload).encode("utf-8")
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            str(script_path),
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except OSError as e:
+        raise PythonRunnerError(kind="io_error", message=str(e)) from e
+
+    try:
+        stdout_b, stderr_b = await asyncio.wait_for(
+            proc.communicate(input=payload_bytes),
+            timeout=timeout,
+        )
+    except TimeoutError as e:
+        proc.kill()
+        await proc.wait()
+        raise PythonRunnerError(
+            kind="timeout",
+            message=f"Script exceeded {timeout}s timeout",
+        ) from e
+
+    stdout = stdout_b.decode("utf-8", errors="replace")
+    stderr = stderr_b.decode("utf-8", errors="replace")
+    exit_code = proc.returncode
+
+    if exit_code != 0:
+        raise PythonRunnerError(
+            kind="nonzero_exit",
+            message=f"Script exited with code {exit_code}",
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=exit_code,
+        )
+
+    if stderr:
+        logger.debug("python_runner stderr (non-empty on success): %s", stderr)
+
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError as e:
+        raise PythonRunnerError(
+            kind="invalid_output",
+            message=f"Stdout is not valid JSON: {e}",
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=exit_code,
+        ) from e
+```
+
+### I/O contract for scripts
+
+Scripts read JSON from stdin, parse it, write JSON to stdout. Anything to
+stderr is treated as logs (captured but not parsed). A minimal valid
+script:
+
+```python
+# example.py
+import json, sys
+data = json.load(sys.stdin)
+print(json.dumps({"ok": True, "got": data}))
+```
+
+`run_script_source(open("example.py").read(), {"a": 1})` returns
+`{"ok": True, "got": {"a": 1}}`.
+
+## Error Handling
+
+| Condition | Behaviour |
+| --- | --- |
+| Cannot spawn interpreter (e.g. `sys.executable` missing) | `PythonRunnerError(kind="io_error")` |
+| Script exceeds `timeout` | kill + wait; `PythonRunnerError(kind="timeout")` |
+| Script exits non-zero | `PythonRunnerError(kind="nonzero_exit", exit_code=...)`, stdout/stderr populated |
+| Script exits 0 but stdout isn't JSON | `PythonRunnerError(kind="invalid_output")`, stdout/stderr populated |
+| Script exits 0 with empty stderr | Return parsed dict |
+| Script exits 0 with non-empty stderr | `logger.debug(...)`, return parsed dict |
+| Concurrent identical writes to cache | Both rename atomically to same path; safe |
+
+## Testing
+
+All tests use `tmp_path` +
+`monkeypatch.setenv("SF_PYTHON_RUNNER__CACHE_ROOT", str(tmp_path))`.
+
+- **`test_happy_path`** — inline 4-line script reads stdin, returns dict.
+- **`test_cache_reuse_same_source`** — capture mtime of cached file; call
+  again with same source; assert mtime unchanged AND path identical.
+- **`test_different_sources_different_paths`** — two slightly different
+  sources produce two cache files.
+- **`test_cache_dir_permissions`** — assert `Path.stat().st_mode & 0o777`
+  equals `0o700` on the dir and `0o600` on the file.
+- **`test_nonzero_exit_raises`** — `sys.exit(1)` script; assert
+  `PythonRunnerError(kind="nonzero_exit", exit_code=1)` with non-empty
+  stderr.
+- **`test_invalid_output_raises`** — script prints `"not json"`; assert
+  `kind="invalid_output"`.
+- **`test_timeout_raises`** — script sleeps 5s, timeout=0.5; assert
+  `kind="timeout"`; assert the proc is killed (no leftover).
+- **`test_stderr_logged_on_success`** — script writes to stderr then valid
+  JSON to stdout; with `caplog.at_level(logging.DEBUG)`, assert log
+  contains the stderr text.
+
+```
+cd apps/server
+uv run pytest src/screamingface/plugins/python_runner/tests/test_runner.py -v
+```
+
+Expected: 8 tests green, <10s.
+
+## Acceptance Criteria
+
+- [ ] `run_script_source(source, payload)` returns parsed JSON on happy path.
+- [ ] Same source → same cache path; mtime unchanged on repeat call.
+- [ ] Different sources → different cache paths.
+- [ ] `nonzero_exit` / `invalid_output` / `timeout` paths all raise
+      `PythonRunnerError` with the right `kind`.
+- [ ] Stderr captured on success (logged at DEBUG when non-empty);
+      preserved on error (in `PythonRunnerError.stderr`).
+- [ ] Cache dir is `0o700`; cache files are `0o600`.
+- [ ] `monkeypatch.setenv("SF_PYTHON_RUNNER__CACHE_ROOT", ...)` redirects
+      cache for tests (env var read at call time, not at import time).
+- [ ] pyright + ruff clean.
+
+## Out of scope
+
+- DEMO-012 sandbox wrapping (allow-lists `_cache_root()` for read+exec).
+- DEMO-013 `/python` route wiring (source fetch + dispatch to this runner).
+- Cache size bounds / eviction.
+- Worker / interpreter pool.
+
+## Follow-ups
+
+- DEMO-012 wraps `asyncio.create_subprocess_exec` with the macOS
+  sandbox-exec profile so reads + executions are only allowed under
+  `_cache_root()`, and network is denied.
+- DEMO-013 wires `handle_backend_call` in `plugin.py` to fetch source
+  from the URL, then call `run_script_source`.


### PR DESCRIPTION
## Summary

Adds `run_script_source(source, payload, timeout) -> dict` to the existing `python_runner` plugin (scaffold landed in DEMO-009). Pure async function: Python source string in, JSON payload to stdin, parsed JSON stdout out. Errors raised as a structured `PythonRunnerError(kind=...)`. This is the execution primitive that DEMO-012 will sandbox-wrap and DEMO-013 will glue into the `/python` route.

- **Spec:** `docs/superpowers/specs/2026-05-13-python-runner-subprocess-design.md`
- **Plan:** `docs/superpowers/plans/2026-05-13-python-runner-subprocess.md`
- **Asana:** [DEMO-010 / SF-157](https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1214568342345700)

## What's in this PR

- **`runner.py`** (new):
  - `PythonRunnerError` — `@dataclass` Exception with `kind` (literal: `nonzero_exit | invalid_output | timeout | io_error`), `message`, `stderr`, `stdout`, `exit_code`.
  - `_cache_root()` — reads `SF_PYTHON_RUNNER__CACHE_ROOT` at call time so `monkeypatch.setenv` works in tests.
  - `_cache_script(source)` — content-hash-keyed (sha256, 32 hex chars) atomic write under cache root. Dir `0o700`, file `0o600`. Identical content reuses the same path with no rewrite.
  - `run_script_source(source, payload, timeout=30.0)` — materializes source to cache, spawns `sys.executable <script>` via `asyncio.create_subprocess_exec`, pipes payload to stdin, captures stdout/stderr, parses stdout as JSON.
- **`tests/test_runner.py`** (new) — 11 tests:
  - Error type shape (`__str__`, optional fields)
  - Cache: writes + returns path, reuse without rewrite, distinct sources, dir/file permissions
  - Happy path: JSON round-trip
  - Stderr on success: captured to `logger.debug` (verified via `caplog`)
  - Error paths: nonzero exit (with stderr), invalid JSON output, timeout (kills subprocess)

## Design refinements vs. the original Asana ticket

1. Env var read at call time inside `_cache_root()` rather than as a module-level constant — `monkeypatch.setenv` would have been ineffective otherwise.
2. Stderr on success is logged at DEBUG when non-empty (public signature unchanged).
3. Cache dir permissions enforced explicitly via `os.chmod(root, 0o700)` after `mkdir` (since `mkdir(mode=)` is umask-modified).

## What stays out of scope

- Sandbox wrapping — DEMO-012
- `/python` route wiring — DEMO-013
- Cache size bounds / LRU eviction
- Process pool / warm interpreters
- Changes to `plugin.py`, `routes.py`, `PythonRunnerSettings`

## Test plan

- [x] `cd apps/server && uv run pytest src/screamingface/plugins/python_runner/tests/test_runner.py -v` — 11/11 pass, <1s (including the 0.5s timeout test)
- [x] `cd apps/server && uv run ruff check src/screamingface/plugins/python_runner` — clean
- [x] `cd apps/server && uv run ruff format --check src/screamingface/plugins/python_runner` — clean
- [x] `cd apps/server && uv run pyright src/screamingface/plugins/python_runner` — 0 errors
- [x] `cd apps/server && uv run pytest src/screamingface/plugins/python_runner/ -v` — 29/29 (11 new + 18 DEMO-009 scaffold)
- [x] `cd apps/server && uv run pytest -q` — 1035 passed, 25 skipped, no regressions