### PR TITLE
chore(aigateway): sync uv.lock with 0.2.0 version bump

### DIFF
--- a/apps/aigateway/uv.lock
+++ b/apps/aigateway/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "aigateway"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## Summary

`apps/aigateway/pyproject.toml` declares `version = "0.2.0"` but the committed `apps/aigateway/uv.lock` still records the editable aigateway package at `0.1.0`. Running \`uv lock --check\` in \`apps/aigateway/\` flags the drift.

This one-line fix syncs the lockfile to match the package version.

## Verification

\`\`\`
cd apps/aigateway && uv lock --check
# Resolved 85 packages in 5ms (no drift)
\`\`\`