### PR TITLE
SF-163: add Codex gateway provider

### DIFF
--- a/apps/aigateway/README.md
+++ b/apps/aigateway/README.md
@@ -42,6 +42,14 @@ Protected endpoints then run as an anonymous account with ID
 this mode for shared or hosted deployments. OAuth profiles created in this mode
 are scoped to the anonymous account.
 
+### Codex Desktop MVP persistence
+
+The packaged Desktop Codex MVP is macOS-only for now. Codex OAuth tokens remain
+file-authoritative in `${CODEX_HOME:-~/.codex}/auth.json`; the gateway stores
+only profile-index metadata in the macOS Keychain. Linux and Windows packaged
+Codex import require a follow-up Desktop-local profile-index metadata store so
+profile listing/import works without `secret-tool` or `python-keyring`.
+
 User provisioning is intentionally separate from JWT auth. Set
 `AIGATEWAY_PROVISIONING_TOKEN` to enable `POST /v1/accounts`:
 

--- a/apps/aigateway/pyproject.toml
+++ b/apps/aigateway/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "PyJWT==2.12.1",
     "bcrypt==5.0.0",
     "asyncpg==0.31.0",
+    "aiosqlite==0.22.1",
 ]
 
 [project.scripts]
@@ -53,6 +54,5 @@ dev = [
     "pyright>=1.1.393",
     "ruff>=0.8",
     "httpx>=0.28",
-    "aiosqlite==0.22.1",
     "testcontainers[postgres]==4.14.2",
 ]

--- a/apps/aigateway/src/aigateway/core/oauth_identity.py
+++ b/apps/aigateway/src/aigateway/core/oauth_identity.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AccountIdentity:
+    sub: str
+    email: str | None = None
+    name: str | None = None

--- a/apps/aigateway/src/aigateway/core/plugin_base.py
+++ b/apps/aigateway/src/aigateway/core/plugin_base.py
@@ -4,6 +4,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from .oauth_identity import AccountIdentity
+
 if TYPE_CHECKING:
     from .credential_store import CredentialStore
     from .profile_index import ProfileIndexStore
@@ -39,6 +41,9 @@ class OAuthStrategy(ABC):
 
     async def invalidate(self) -> None:
         """Drop any cached token. Called after a 401 from upstream."""
+
+    def extract_identity(self, token_response: dict) -> AccountIdentity | None:
+        return None
 
 
 @dataclass(frozen=True)

--- a/apps/aigateway/src/aigateway/core/profile_index.py
+++ b/apps/aigateway/src/aigateway/core/profile_index.py
@@ -15,12 +15,18 @@ _INDEX_ACCOUNT = "default"  # one keychain entry holds account-scoped profile me
 class ProfileIndexStore:
     """Read/write the `aigateway:index` keychain entry under an asyncio.Lock."""
 
-    def __init__(self, credential_store: CredentialStore | None = None) -> None:
+    def __init__(
+        self,
+        credential_store: CredentialStore | None = None,
+        *,
+        service: str = INDEX_KEYCHAIN_SERVICE,
+    ) -> None:
         self._store = credential_store or get_credential_store()
+        self._service = service
         self._lock = asyncio.Lock()
 
     async def read(self) -> ProfileIndex:
-        raw = await asyncio.to_thread(self._store.read, INDEX_KEYCHAIN_SERVICE, _INDEX_ACCOUNT)
+        raw = await asyncio.to_thread(self._store.read, self._service, _INDEX_ACCOUNT)
         if raw is None:
             return ProfileIndex()
         return ProfileIndex.model_validate_json(raw)
@@ -33,7 +39,7 @@ class ProfileIndexStore:
             idx.profiles = [p for p in idx.profiles if p.id != profile.id] + [profile]
             await asyncio.to_thread(
                 self._store.write,
-                INDEX_KEYCHAIN_SERVICE,
+                self._service,
                 _INDEX_ACCOUNT,
                 idx.model_dump_json(),
             )
@@ -44,7 +50,7 @@ class ProfileIndexStore:
             idx.profiles = [p for p in idx.profiles if p.id != profile_id]
             await asyncio.to_thread(
                 self._store.write,
-                INDEX_KEYCHAIN_SERVICE,
+                self._service,
                 _INDEX_ACCOUNT,
                 idx.model_dump_json(),
             )

--- a/apps/aigateway/src/aigateway/main.py
+++ b/apps/aigateway/src/aigateway/main.py
@@ -4,7 +4,9 @@ import logging
 import os
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from .config import Settings
 from .core.auth.bootstrap_admin import ensure_admin_account
@@ -25,6 +27,32 @@ from .routes import accounts, auth, auth_session, chat, health, models
 logger = logging.getLogger(__name__)
 
 
+def _host_from_authority(authority: str) -> str:
+    authority = authority.strip().lower()
+    if authority.startswith("["):
+        end = authority.find("]")
+        return authority[1:end] if end != -1 else authority
+    return authority.split(":", 1)[0]
+
+
+class LoopbackOnlyMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        host = _host_from_authority(request.headers.get("host", ""))
+        client = request.client.host if request.client else None
+        if host not in {"127.0.0.1", "localhost", "::1"} or client not in {
+            "127.0.0.1",
+            "::1",
+        }:
+            return JSONResponse(
+                status_code=403,
+                content={
+                    "code": "loopback_only",
+                    "message": "gateway accepts loopback callers only in auth-disabled mode",
+                },
+            )
+        return await call_next(request)
+
+
 def _attach_log_filter() -> None:
     install_provisioning_token_redaction()
     for name in ("", "uvicorn.access", "uvicorn.error", "aigateway"):
@@ -39,6 +67,11 @@ def _attach_log_filter() -> None:
 @asynccontextmanager
 async def _lifespan(app):
     database_url = app.state.settings.database_url.get_secret_value()
+    env_database_url = os.environ.get("AIGATEWAY_DATABASE_URL")
+    if env_database_url and database_url != env_database_url:
+        raise RuntimeError(
+            "DB URL mismatch between env and Settings; migrations may have run on a different DB"
+        )
     await init_db(database_url)
     try:
         fake_store = getattr(app.state, "_fake_credential_store", None)
@@ -47,10 +80,11 @@ async def _lifespan(app):
             credential_store,
             app.state.settings.jwt_secret,
         )
-        admin = await ensure_admin_account(app.state.settings.admin_password)
-        bootstrap_account_id = (
-            str(admin.id) if app.state.settings.auth_enabled else str(ANONYMOUS_ACCOUNT_ID)
-        )
+        if app.state.settings.auth_enabled:
+            admin = await ensure_admin_account(app.state.settings.admin_password)
+            bootstrap_account_id = str(admin.id)
+        else:
+            bootstrap_account_id = str(ANONYMOUS_ACCOUNT_ID)
 
         # Auto-import of the developer's Claude Code keychain entry is opt-in.
         # By default the gateway boots with an empty profile index so the user
@@ -85,6 +119,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     _attach_log_filter()
     app = FastAPI(title="aigateway", version="0.1.0", lifespan=_lifespan)
     app.state.settings = settings
+    if (
+        not settings.auth_enabled
+        and os.environ.get("AIGATEWAY_LOOPBACK_ONLY", "true").lower() == "true"
+    ):
+        app.add_middleware(LoopbackOnlyMiddleware)
 
     registry = ProviderRegistry()
     load_plugins(registry)

--- a/apps/aigateway/src/aigateway/plugins/codex_provider/__init__.py
+++ b/apps/aigateway/src/aigateway/plugins/codex_provider/__init__.py
@@ -1,0 +1,3 @@
+from .plugin import PLUGIN, CodexProviderPlugin
+
+__all__ = ["PLUGIN", "CodexProviderPlugin"]

--- a/apps/aigateway/src/aigateway/plugins/codex_provider/auth.py
+++ b/apps/aigateway/src/aigateway/plugins/codex_provider/auth.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+import jwt
+
+from aigateway.core.errors import AuthError, CredentialNotFoundError
+from aigateway.core.oauth_base import BaseOAuthStrategy
+from aigateway.core.oauth_identity import AccountIdentity
+
+from .oauth_config import CODEX_OAUTH_CLIENT_ID, CODEX_OAUTH_SCOPE, CODEX_OAUTH_TOKEN_URL
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_codex_auth_path() -> Path:
+    codex_home = os.getenv("CODEX_HOME")
+    if codex_home:
+        return Path(codex_home).expanduser() / "auth.json"
+    return Path.home() / ".codex" / "auth.json"
+
+
+def _decode_jwt_claims(token: str) -> dict[str, Any]:
+    return jwt.decode(token, options={"verify_signature": False})
+
+
+def _decode_jwt_exp(token: str) -> float | None:
+    try:
+        return float(_decode_jwt_claims(token)["exp"])
+    except Exception:
+        return None
+
+
+def _atomic_write_auth_file(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    original_mode = path.stat().st_mode & 0o777 if path.exists() else None
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    tmp_path = Path(tmp_name)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w") as handle:
+            json.dump(data, handle)
+            handle.write("\n")
+        os.replace(tmp_path, path)
+        if original_mode is not None and original_mode & 0o777 < 0o600:
+            try:
+                os.chmod(path, original_mode)
+            except OSError:
+                logger.warning("failed to restore restrictive permissions on %s", path)
+    except Exception:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def _read_auth_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise CredentialNotFoundError(
+            "Codex auth file not found. Run `codex login` with file-backed storage "
+            "or set CODEX_HOME to the directory containing auth.json."
+        )
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise AuthError("Codex auth file is not valid JSON") from exc
+    if not isinstance(data, dict):
+        raise AuthError("Codex auth file must contain a JSON object")
+    return data
+
+
+class CodexOAuth(BaseOAuthStrategy):
+    def __init__(
+        self,
+        profile_name: str,
+        *,
+        auth_file: Path | None = None,
+        http_client_factory=None,
+    ) -> None:
+        super().__init__(profile_name=profile_name)
+        self.auth_file = auth_file
+        self._http_factory = http_client_factory or (
+            lambda: httpx.AsyncClient(timeout=httpx.Timeout(30.0))
+        )
+
+    def keychain_service(self) -> str:
+        return f"aigateway:codex:{self.profile_name}"
+
+    def keychain_account(self) -> str:
+        return "file-backed"
+
+    def _write_to_store(self, creds: dict) -> None:
+        raise AuthError("Codex credentials are file-backed; gateway keychain writes are disabled")
+
+    def _header_override(self) -> dict[str, str] | None:
+        api_key = os.getenv("OPENAI_API_KEY")
+        if api_key:
+            return {"Authorization": f"Bearer {api_key}"}
+        return None
+
+    def _auth_path(self) -> Path:
+        return self.auth_file or resolve_codex_auth_path()
+
+    def _read_credential(self) -> dict:
+        auth_path = self._auth_path()
+        data = _read_auth_json(auth_path)
+        api_key = data.get("OPENAI_API_KEY")
+        if isinstance(api_key, str) and api_key:
+            return {"kind": "api_key", "api_key": api_key}
+        tokens = data.get("tokens")
+        if not isinstance(tokens, dict):
+            raise CredentialNotFoundError("Codex auth file has no file-backed OAuth tokens")
+        for key in ("access_token", "refresh_token"):
+            if not tokens.get(key):
+                raise CredentialNotFoundError(f"Codex auth file missing token field {key!r}")
+        return {"kind": "oauth", "auth_file": str(auth_path), **tokens}
+
+    def _is_expired(self, creds: dict) -> bool:
+        if creds.get("kind") == "api_key":
+            return False
+        access_token = creds.get("access_token")
+        if not isinstance(access_token, str):
+            return True
+        exp = _decode_jwt_exp(access_token)
+        if exp is None:
+            return True
+        return time.time() >= exp - self.refresh_window_seconds
+
+    async def _refresh_credential(self, creds: dict) -> dict:
+        if creds.get("kind") == "api_key":
+            return creds
+        refresh_token = creds.get("refresh_token")
+        if not isinstance(refresh_token, str) or not refresh_token:
+            fallback = self._api_key_fallback()
+            if fallback is not None:
+                return fallback
+            raise AuthError("Codex refresh token is missing; run `codex login` again")
+        body = {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": CODEX_OAUTH_CLIENT_ID,
+            "scope": CODEX_OAUTH_SCOPE,
+        }
+        try:
+            async with self._http_factory() as client:
+                resp = await client.post(
+                    CODEX_OAUTH_TOKEN_URL,
+                    json=body,
+                    headers={"content-type": "application/json"},
+                )
+        except httpx.RequestError as exc:
+            fallback = self._api_key_fallback()
+            if fallback is not None:
+                return fallback
+            raise AuthError(f"Codex refresh endpoint unreachable: {exc}") from exc
+        if resp.status_code != 200:
+            fallback = self._api_key_fallback()
+            if fallback is not None:
+                return fallback
+            raise AuthError(f"Codex OAuth refresh failed status {resp.status_code}")
+        try:
+            refreshed: dict[str, Any] = resp.json()
+        except json.JSONDecodeError as exc:
+            raise AuthError("Codex OAuth refresh response was not JSON") from exc
+        if not refreshed.get("access_token") or not refreshed.get("refresh_token"):
+            raise AuthError("Codex OAuth refresh response missing required tokens")
+
+        auth_path = Path(str(creds.get("auth_file") or self._auth_path()))
+        data = _read_auth_json(auth_path)
+        raw_old_tokens = data.get("tokens")
+        old_tokens: dict[str, Any] = raw_old_tokens if isinstance(raw_old_tokens, dict) else {}
+        tokens = {
+            **old_tokens,
+            "access_token": refreshed["access_token"],
+            "refresh_token": refreshed["refresh_token"],
+            "id_token": refreshed.get("id_token")
+            or creds.get("id_token")
+            or old_tokens.get("id_token"),
+            "account_id": refreshed.get("account_id")
+            or creds.get("account_id")
+            or old_tokens.get("account_id"),
+        }
+        data["tokens"] = {k: v for k, v in tokens.items() if v is not None}
+        data["last_refresh"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        _atomic_write_auth_file(auth_path, data)
+        return {"kind": "oauth", "auth_file": str(auth_path), **data["tokens"]}
+
+    def _build_headers(self, creds: dict) -> dict[str, str]:
+        if creds.get("kind") == "api_key":
+            return {"Authorization": f"Bearer {creds['api_key']}"}
+        headers = {"Authorization": f"Bearer {creds['access_token']}"}
+        account_id = creds.get("account_id")
+        if isinstance(account_id, str) and account_id:
+            headers["ChatGPT-Account-Id"] = account_id
+        return headers
+
+    def extract_identity(self, token_response: dict) -> AccountIdentity | None:
+        id_token = token_response.get("id_token")
+        if not isinstance(id_token, str) or not id_token:
+            return None
+        try:
+            claims = _decode_jwt_claims(id_token)
+        except Exception:
+            return None
+        sub = claims.get("sub")
+        if not isinstance(sub, str) or not sub:
+            return None
+        return AccountIdentity(
+            sub=sub,
+            email=claims.get("email") if isinstance(claims.get("email"), str) else None,
+            name=claims.get("name") if isinstance(claims.get("name"), str) else None,
+        )
+
+    def _api_key_fallback(self) -> dict[str, str] | None:
+        api_key = os.getenv("OPENAI_API_KEY")
+        if api_key:
+            return {"kind": "api_key", "api_key": api_key}
+        try:
+            data = _read_auth_json(self._auth_path())
+        except Exception:
+            return None
+        file_api_key = data.get("OPENAI_API_KEY")
+        if isinstance(file_api_key, str) and file_api_key:
+            return {"kind": "api_key", "api_key": file_api_key}
+        return None

--- a/apps/aigateway/src/aigateway/plugins/codex_provider/bootstrap.py
+++ b/apps/aigateway/src/aigateway/plugins/codex_provider/bootstrap.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import logging
+
+from aigateway.core.profile_index import ProfileIndexStore
+from aigateway.core.profile_models import Profile, ProfileDefaults, ProfileState, profile_id_for
+
+from .auth import CodexOAuth
+from .routes import account_label_from_claims
+
+logger = logging.getLogger(__name__)
+
+
+async def bootstrap_from_codex_cli(*, account_id: str, index_store: ProfileIndexStore) -> None:
+    existing = await index_store.get(account_id, "codex", "default")
+    if existing is not None:
+        return
+    strategy = CodexOAuth(profile_name="default")
+    try:
+        creds = strategy._read_credential()
+    except Exception:
+        logger.info("bootstrap: no usable Codex CLI auth file found; nothing to import")
+        return
+    profile = Profile(
+        id=profile_id_for(account_id, "codex", "default"),
+        account_id=account_id,
+        provider="codex",
+        name="default",
+        account_label=account_label_from_claims(creds.get("id_token")),
+        state=ProfileState.AUTHENTICATED,
+        defaults=ProfileDefaults(),
+    )
+    await index_store.upsert(profile)

--- a/apps/aigateway/src/aigateway/plugins/codex_provider/litellm_handler.py
+++ b/apps/aigateway/src/aigateway/plugins/codex_provider/litellm_handler.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+from litellm.llms.custom_llm import CustomLLM, CustomLLMError
+from litellm.types.utils import Choices, Message, ModelResponse
+
+from .models import CODEX_MODEL_SLUGS
+from .oauth_config import CODEX_ORIGINATOR, codex_chatgpt_responses_url
+
+_ALLOWED_PAYLOAD_KEYS = {
+    "model",
+    "input",
+    "instructions",
+    "stream",
+    "store",
+    "include",
+    "tools",
+    "tool_choice",
+    "reasoning",
+    "previous_response_id",
+    "truncation",
+}
+
+
+class CodexChatGPTHandler(CustomLLM):
+    async def acompletion(
+        self,
+        model: str,
+        messages: list,
+        api_base: str,
+        custom_prompt_dict: dict,
+        model_response: ModelResponse,
+        print_verbose: Callable,
+        encoding,
+        api_key,
+        logging_obj,
+        optional_params: dict,
+        acompletion=None,
+        litellm_params=None,
+        logger_fn=None,
+        headers={},
+        timeout: float | httpx.Timeout | None = None,
+        client: AsyncHTTPHandler | None = None,
+    ) -> ModelResponse:
+        slug = _slug_from_model(model)
+        if api_key and _looks_like_openai_api_key(str(api_key)):
+            raise CustomLLMError(
+                status_code=400,
+                message=(
+                    f"codex/{slug} is not available via OpenAI API key; "
+                    "this gateway profile requires a ChatGPT subscription OAuth token"
+                ),
+            )
+        if not api_key:
+            raise CustomLLMError(status_code=401, message="missing Codex OAuth bearer token")
+
+        extra_headers = dict(headers or {})
+        extra_headers.update(optional_params.pop("extra_headers", {}) or {})
+        payload = _build_payload(slug, messages, optional_params)
+        request_headers = _build_headers(str(api_key), extra_headers)
+        timeout_value = timeout if timeout is not None else httpx.Timeout(300.0)
+
+        async with httpx.AsyncClient(timeout=timeout_value) as http_client:
+            response = await http_client.post(
+                codex_chatgpt_responses_url(),
+                json=payload,
+                headers=request_headers,
+            )
+        if response.status_code >= 400:
+            raise CustomLLMError(
+                status_code=response.status_code,
+                message=(
+                    f"Codex backend returned HTTP {response.status_code}: {response.text[:500]}"
+                ),
+            )
+
+        content = _parse_responses_sse(response.text)
+        model_response.choices = [
+            Choices(index=0, message=Message(content=content, role="assistant"))
+        ]
+        model_response.created = int(time.time())
+        model_response.model = f"codex/{slug}"
+        return model_response
+
+
+def _slug_from_model(model: str) -> str:
+    prefix = "codex/"
+    slug = model[len(prefix) :] if model.startswith(prefix) else model
+    if not slug or slug not in CODEX_MODEL_SLUGS:
+        raise CustomLLMError(
+            status_code=400, message=f"missing or unknown codex model slug: {model!r}"
+        )
+    return slug
+
+
+def _looks_like_openai_api_key(value: str) -> bool:
+    return value.startswith("sk-") or value.startswith("sk-proj-")
+
+
+def _build_headers(api_key: str, extra_headers: dict[str, str]) -> dict[str, str]:
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "content-type": "application/json",
+        "accept": "text/event-stream",
+        "originator": CODEX_ORIGINATOR,
+        "user-agent": "codex_cli_rs/0.130.0",
+        "session_id": str(uuid.uuid4()),
+    }
+    account_id = extra_headers.get("ChatGPT-Account-Id") or extra_headers.get("chatgpt-account-id")
+    if account_id:
+        headers["ChatGPT-Account-Id"] = account_id
+    return headers
+
+
+def _build_payload(slug: str, messages: list, optional_params: dict[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "model": slug,
+        "input": _messages_to_input(messages),
+        "instructions": _messages_to_instructions(messages),
+        "stream": True,
+        "store": False,
+        "include": ["reasoning.encrypted_content"],
+        "reasoning": optional_params.get("reasoning") or {"effort": "medium"},
+    }
+    for key in ("tools", "tool_choice", "previous_response_id", "truncation"):
+        if key in optional_params:
+            payload[key] = optional_params[key]
+    return {key: value for key, value in payload.items() if key in _ALLOWED_PAYLOAD_KEYS}
+
+
+def _messages_to_instructions(messages: list) -> str:
+    parts: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict) or message.get("role") not in {"system", "developer"}:
+            continue
+        text = _content_to_text(message.get("content"))
+        if text:
+            parts.append(text)
+    return "\n\n".join(parts) if parts else "You are a helpful assistant."
+
+
+def _messages_to_input(messages: list) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = message.get("role")
+        if role in {"system", "developer"}:
+            continue
+        text = _content_to_text(message.get("content"))
+        if not text:
+            continue
+        items.append(
+            {
+                "role": "assistant" if role == "assistant" else "user",
+                "content": [{"type": "input_text", "text": text}],
+            }
+        )
+    return items or [{"role": "user", "content": [{"type": "input_text", "text": ""}]}]
+
+
+def _content_to_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict):
+                value = item.get("text") or item.get("content")
+                if isinstance(value, str):
+                    parts.append(value)
+        return "\n".join(parts)
+    return ""
+
+
+def _parse_responses_sse(text: str) -> str:
+    parts: list[str] = []
+    for line in text.splitlines():
+        if not line.startswith("data: "):
+            continue
+        try:
+            data = json.loads(line[6:])
+        except json.JSONDecodeError:
+            continue
+        event_type = data.get("type")
+        if event_type == "response.output_text.delta":
+            delta = data.get("delta")
+            if isinstance(delta, str):
+                parts.append(delta)
+        elif event_type == "response.completed":
+            response = data.get("response")
+            if isinstance(response, dict):
+                output = response.get("output_text")
+                if isinstance(output, str) and not parts:
+                    parts.append(output)
+    return "".join(parts)
+
+
+HANDLER = CodexChatGPTHandler()

--- a/apps/aigateway/src/aigateway/plugins/codex_provider/models.py
+++ b/apps/aigateway/src/aigateway/plugins/codex_provider/models.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from aigateway.core.plugin_base import ModelEntry
+
+CODEX_MODEL_SLUGS = {
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.3-codex",
+    "gpt-5.2",
+}
+
+MODELS: list[ModelEntry] = [
+    ModelEntry(model_name=f"codex/{slug}", litellm_params={"model": f"codex/{slug}"})
+    for slug in sorted(CODEX_MODEL_SLUGS, reverse=True)
+]

--- a/apps/aigateway/src/aigateway/plugins/codex_provider/oauth_config.py
+++ b/apps/aigateway/src/aigateway/plugins/codex_provider/oauth_config.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import os
+
+CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
+CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+CODEX_OAUTH_SCOPE = "openid profile email"
+CODEX_CHATGPT_API_BASE = "https://chatgpt.com/backend-api/codex"
+CODEX_CHATGPT_RESPONSES_URL = f"{CODEX_CHATGPT_API_BASE}/responses"
+CODEX_ORIGINATOR = "codex_cli_rs"
+
+
+def codex_chatgpt_responses_url() -> str:
+    """Return the Codex responses endpoint, with a test-only e2e override."""
+    return os.getenv("AIGATEWAY_FAKE_CODEX_RESPONSES_URL") or CODEX_CHATGPT_RESPONSES_URL

--- a/apps/aigateway/src/aigateway/plugins/codex_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/codex_provider/plugin.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import litellm
+
+from aigateway.core.plugin_base import ModelEntry, OAuthStrategy, ProviderPluginBase
+
+from .auth import CodexOAuth
+from .bootstrap import bootstrap_from_codex_cli
+from .litellm_handler import HANDLER
+from .models import CODEX_MODEL_SLUGS, MODELS
+from .routes import router
+
+if TYPE_CHECKING:
+    from aigateway.core.credential_store import CredentialStore
+    from aigateway.core.profile_index import ProfileIndexStore
+
+
+def ensure_litellm_codex_provider_registered() -> None:
+    # LiteLLM 1.83 lists these subscription slugs as OpenAI chat models.
+    # Its OpenAI branch runs before custom providers, so remove only these
+    # slugs from that shortcut while preserving explicit `openai/...` routing.
+    for slug in CODEX_MODEL_SLUGS:
+        litellm.open_ai_chat_completion_models.discard(slug)
+
+    existing = [entry for entry in litellm.custom_provider_map if entry.get("provider") == "codex"]
+    if existing:
+        return
+    litellm.custom_provider_map.append({"provider": "codex", "custom_handler": HANDLER})
+
+
+class CodexProviderPlugin(ProviderPluginBase):
+    custom_llm_provider = "codex"
+
+    def register_models(self) -> list[ModelEntry]:
+        return list(MODELS)
+
+    def oauth_strategy_for(self, profile_name: str) -> OAuthStrategy:
+        return CodexOAuth(profile_name=profile_name)
+
+    def auth_router(self):
+        return router
+
+    async def bootstrap_profiles(
+        self,
+        *,
+        account_id: str,
+        credential_store: CredentialStore | None = None,
+        index_store: ProfileIndexStore | None = None,
+    ) -> None:
+        if index_store is None:
+            return
+        await bootstrap_from_codex_cli(account_id=account_id, index_store=index_store)
+
+
+ensure_litellm_codex_provider_registered()
+PLUGIN = CodexProviderPlugin()

--- a/apps/aigateway/src/aigateway/plugins/codex_provider/routes.py
+++ b/apps/aigateway/src/aigateway/plugins/codex_provider/routes.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any
+
+import jwt
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from aigateway.core.auth.middleware import CurrentAccount
+from aigateway.core.errors import AuthError, CredentialNotFoundError
+from aigateway.core.profile_models import Profile, ProfileDefaults, ProfileState, profile_id_for
+
+from .auth import CodexOAuth, resolve_codex_auth_path
+
+router = APIRouter()
+
+
+class ImportProfileRequest(BaseModel):
+    name: str = "default"
+    defaults: ProfileDefaults | None = None
+
+
+@router.post("/profiles/import", status_code=201)
+async def import_profile(
+    body: ImportProfileRequest, request: Request, current: CurrentAccount
+) -> dict:
+    account_id = str(current.id)
+    strategy = CodexOAuth(profile_name=body.name, auth_file=resolve_codex_auth_path())
+    try:
+        creds = strategy._read_credential()
+    except CredentialNotFoundError as exc:
+        raise HTTPException(
+            status_code=401,
+            detail={"code": "auth_required", "message": str(exc)},
+        ) from exc
+    except AuthError as exc:
+        raise HTTPException(
+            status_code=401,
+            detail={
+                "code": "auth_required",
+                "message": str(exc),
+                "reauth_url": "/v1/auth/codex/profiles/import",
+            },
+        ) from exc
+
+    profile = Profile(
+        id=profile_id_for(account_id, "codex", body.name),
+        account_id=account_id,
+        provider="codex",
+        name=body.name,
+        account_label=account_label_from_claims(creds.get("id_token")),
+        state=ProfileState.AUTHENTICATED,
+        defaults=body.defaults or ProfileDefaults(),
+    )
+    await request.app.state.profile_index.upsert(profile)
+    return profile.model_dump(mode="json")
+
+
+def account_label_from_claims(id_token: Any) -> str | None:
+    if not isinstance(id_token, str) or not id_token:
+        return None
+    try:
+        claims = jwt.decode(id_token, options={"verify_signature": False})
+    except Exception:
+        return None
+    for key in ("email", "name", "https://api.openai.com/auth.chatgpt_account_id"):
+        value = claims.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None

--- a/apps/aigateway/src/aigateway/routes/auth.py
+++ b/apps/aigateway/src/aigateway/routes/auth.py
@@ -8,6 +8,7 @@ from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
 from ..core.auth.middleware import CurrentAccount
+from ..core.errors import AuthError, CredentialNotFoundError
 from ..core.oauth_pkce import generate_pkce, generate_state
 from ..core.pending_auth import PendingAuthEntry
 from ..core.profile_index import ProfileIndexStore
@@ -258,6 +259,11 @@ async def exchange_code(
     authorization code on screen instead of redirecting (e.g. claude.ai/oauth
     with `code=true`).
     """
+    plugin = _registry(request).get(provider)
+    if plugin is None:
+        raise HTTPException(status_code=404, detail={"code": "unknown_provider"})
+    if plugin.oauth_config() is None:
+        raise HTTPException(status_code=400, detail={"code": "provider_does_not_use_oauth"})
     await _complete_oauth(provider, body.code, body.state, request, str(current.id))
     return {"state": "authenticated"}
 
@@ -334,5 +340,20 @@ async def refresh_profile(
     strategy = plugin.oauth_strategy_for(credential_name_for(account_id, name))
     if strategy is None:
         raise HTTPException(status_code=400, detail={"code": "provider_does_not_use_oauth"})
-    await strategy.refresh()
+    try:
+        await strategy.refresh()
+    except CredentialNotFoundError as exc:
+        raise HTTPException(
+            status_code=401,
+            detail={"code": "auth_required", "message": str(exc)},
+        ) from exc
+    except AuthError as exc:
+        raise HTTPException(
+            status_code=401,
+            detail={
+                "code": "auth_required",
+                "message": str(exc),
+                "reauth_url": f"/v1/auth/{provider}/profiles/{name}",
+            },
+        ) from exc
     return p.model_dump(mode="json")

--- a/apps/aigateway/src/aigateway/routes/chat.py
+++ b/apps/aigateway/src/aigateway/routes/chat.py
@@ -89,6 +89,10 @@ async def chat_completions(request: Request, current: CurrentAccount) -> Any:
         )
 
     body = _apply_defaults(body, profile.defaults)
+    if provider == "codex":
+        reasoning_effort = body.pop("reasoning_effort", None)
+        if reasoning_effort is not None and "reasoning" not in body:
+            body["reasoning"] = {"effort": reasoning_effort}
 
     strategy = plugin.oauth_strategy_for(credential_name_for(account_id, profile_name))
     if strategy is not None:
@@ -119,6 +123,12 @@ async def chat_completions(request: Request, current: CurrentAccount) -> Any:
             merged = dict(body.get("extra_headers") or {})
             merged.update(headers)
             body["extra_headers"] = merged
+
+    if body.get("stream") and provider == "codex":
+        raise HTTPException(
+            status_code=501,
+            detail={"code": "streaming_not_supported", "provider": "codex"},
+        )
 
     if body.get("stream"):
         return StreamingResponse(_stream(body), media_type="text/event-stream")

--- a/apps/aigateway/tests/conftest.py
+++ b/apps/aigateway/tests/conftest.py
@@ -41,6 +41,13 @@ def _fast_bcrypt(monkeypatch):
     passwords._dummy_hash = None
 
 
+@pytest.fixture(autouse=True)
+def _isolate_codex_home(tmp_path: Path, monkeypatch) -> None:
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir(exist_ok=True)
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+
 def _prepare_sqlite_db(database_url: str) -> None:
     async def _prepare() -> None:
         await Tortoise.close_connections()

--- a/apps/aigateway/tests/integration/test_profile_index_macos_keychain.py
+++ b/apps/aigateway/tests/integration/test_profile_index_macos_keychain.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import uuid
+
+import pytest
+
+from aigateway.core.credential_store import MacOSKeychainStore
+from aigateway.core.profile_index import ProfileIndexStore
+from aigateway.core.profile_models import Profile, ProfileState, profile_id_for
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS Keychain smoke is macOS-only")
+@pytest.mark.skipif(
+    os.environ.get("AIGW_MAC_KEYCHAIN_SMOKE") != "1",
+    reason="set AIGW_MAC_KEYCHAIN_SMOKE=1 to touch the local macOS Keychain",
+)
+async def test_profile_index_persists_across_macos_keychain_store_instances() -> None:
+    if shutil.which("security") is None:
+        pytest.skip("macOS security command is unavailable")
+
+    account_id = f"account-{uuid.uuid4()}"
+    service = f"aigateway:index:test:{uuid.uuid4()}"
+    credential_store = MacOSKeychainStore()
+    profile = Profile(
+        id=profile_id_for(account_id, "codex", "default"),
+        account_id=account_id,
+        provider="codex",
+        name="default",
+        state=ProfileState.AUTHENTICATED,
+    )
+
+    try:
+        await ProfileIndexStore(credential_store=credential_store, service=service).upsert(profile)
+        restarted_store = ProfileIndexStore(credential_store=credential_store, service=service)
+
+        profiles = await restarted_store.list(account_id, provider="codex")
+        assert [p.id for p in profiles] == [profile.id]
+    finally:
+        credential_store.delete(service, "default")

--- a/apps/aigateway/tests/integration/test_sqlite_migration_smoke.py
+++ b/apps/aigateway/tests/integration/test_sqlite_migration_smoke.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_tortoise_sqlite_migrate_is_idempotent(tmp_path: Path) -> None:
+    app_dir = Path(__file__).resolve().parents[2]
+    database_path = tmp_path / "aigateway.sqlite3"
+    database_url = f"sqlite://{database_path}"
+    env = {**os.environ, "AIGATEWAY_DATABASE_URL": database_url}
+    command = [
+        sys.executable,
+        "-m",
+        "tortoise",
+        "-c",
+        "aigateway.db.TORTOISE_CONFIG",
+        "migrate",
+    ]
+
+    subprocess.run(command, cwd=app_dir, env=env, check=True, capture_output=True, text=True)
+    rerun = subprocess.run(
+        command,
+        cwd=app_dir,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "No migrations to apply" in rerun.stdout
+    with sqlite3.connect(database_path) as conn:
+        rows = conn.execute("select name from sqlite_master where type = 'table'").fetchall()
+    assert {"accounts", "tortoise_migrations"} <= {row[0] for row in rows}

--- a/apps/aigateway/tests/unit/codex/conftest.py
+++ b/apps/aigateway/tests/unit/codex/conftest.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def codex_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "codex-home"
+    home.mkdir(exist_ok=True)
+    monkeypatch.setenv("CODEX_HOME", str(home))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    return home

--- a/apps/aigateway/tests/unit/codex/helpers.py
+++ b/apps/aigateway/tests/unit/codex/helpers.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import base64
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+
+def unsigned_jwt(claims: dict[str, Any]) -> str:
+    def _segment(data: dict[str, Any]) -> str:
+        raw = json.dumps(data, separators=(",", ":")).encode()
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+    return f"{_segment({'alg': 'none', 'typ': 'JWT'})}.{_segment(claims)}."
+
+
+def write_codex_auth(
+    codex_home: Path,
+    *,
+    access_exp: float | None = None,
+    id_claims: dict[str, Any] | None = None,
+    account_id: str = "chatgpt-account-1",
+    refresh_token: str = "refresh-token-1",
+    openai_api_key: str | None = None,
+) -> Path:
+    tokens = {
+        "access_token": unsigned_jwt(
+            {"exp": access_exp if access_exp is not None else time.time() + 3600}
+        ),
+        "refresh_token": refresh_token,
+        "id_token": unsigned_jwt(id_claims or {"sub": "sub-1", "email": "user@example.com"}),
+        "account_id": account_id,
+    }
+    auth_path = codex_home / "auth.json"
+    auth_path.write_text(
+        json.dumps(
+            {
+                "auth_mode": "chatgpt",
+                "OPENAI_API_KEY": openai_api_key,
+                "tokens": tokens,
+            }
+        )
+    )
+    auth_path.chmod(0o600)
+    return auth_path

--- a/apps/aigateway/tests/unit/codex/test_codex_auth.py
+++ b/apps/aigateway/tests/unit/codex/test_codex_auth.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+
+import httpx
+import pytest
+
+from aigateway.core.errors import CredentialNotFoundError
+from aigateway.plugins.codex_provider.auth import CodexOAuth, _atomic_write_auth_file
+from aigateway.plugins.codex_provider.oauth_config import CODEX_OAUTH_TOKEN_URL
+
+from .helpers import unsigned_jwt, write_codex_auth
+
+
+def test_reads_file_backed_oauth_and_builds_chatgpt_headers(codex_home) -> None:
+    auth_path = write_codex_auth(codex_home, account_id="acct-123")
+
+    strategy = CodexOAuth(profile_name="default")
+    creds = strategy._read_credential()
+    headers = strategy._build_headers(creds)
+
+    assert creds["kind"] == "oauth"
+    assert creds["auth_file"] == str(auth_path)
+    assert headers["Authorization"].startswith("Bearer ")
+    assert headers["ChatGPT-Account-Id"] == "acct-123"
+
+
+def test_missing_codex_auth_file_raises_credential_not_found(codex_home) -> None:
+    with pytest.raises(CredentialNotFoundError):
+        CodexOAuth(profile_name="default")._read_credential()
+
+
+@pytest.mark.asyncio
+async def test_expired_oauth_refreshes_and_preserves_identity_fields(codex_home) -> None:
+    old_id_token = unsigned_jwt({"sub": "sub-1", "name": "Codex User"})
+    write_codex_auth(
+        codex_home,
+        access_exp=time.time() - 120,
+        id_claims={"sub": "sub-1", "name": "Codex User"},
+        account_id="acct-old",
+    )
+    new_access_token = unsigned_jwt({"exp": time.time() + 3600})
+    requests: list[httpx.Request] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={"access_token": new_access_token, "refresh_token": "refresh-token-2"},
+        )
+
+    strategy = CodexOAuth(
+        profile_name="default",
+        http_client_factory=lambda: httpx.AsyncClient(
+            transport=httpx.MockTransport(_handler), timeout=httpx.Timeout(5.0)
+        ),
+    )
+
+    headers = await strategy.get_authorization_header()
+    data = json.loads((codex_home / "auth.json").read_text())
+
+    assert requests[0].url == CODEX_OAUTH_TOKEN_URL
+    assert json.loads(requests[0].content)["scope"] == "openid profile email"
+    assert headers["Authorization"] == f"Bearer {new_access_token}"
+    assert headers["ChatGPT-Account-Id"] == "acct-old"
+    assert data["tokens"]["access_token"] == new_access_token
+    assert data["tokens"]["refresh_token"] == "refresh-token-2"
+    assert data["tokens"]["account_id"] == "acct-old"
+    assert data["tokens"]["id_token"] == old_id_token
+    assert data["last_refresh"]
+
+
+def test_extract_identity_from_unsigned_id_token() -> None:
+    strategy = CodexOAuth(profile_name="default")
+    identity = strategy.extract_identity(
+        {"id_token": unsigned_jwt({"sub": "sub-1", "email": "user@example.com"})}
+    )
+
+    assert identity is not None
+    assert identity.sub == "sub-1"
+    assert identity.email == "user@example.com"
+
+
+def test_atomic_write_preserves_stricter_permissions(tmp_path) -> None:
+    path = tmp_path / "auth.json"
+    path.write_text(json.dumps({"old": True}))
+    path.chmod(0o400)
+
+    _atomic_write_auth_file(path, {"new": True})
+
+    assert json.loads(path.read_text()) == {"new": True}
+    assert path.stat().st_mode & 0o777 == 0o400
+
+
+def test_atomic_write_cleans_tmp_file_when_replace_fails(tmp_path, monkeypatch) -> None:
+    path = tmp_path / "auth.json"
+    path.write_text(json.dumps({"old": True}))
+
+    def _fail_replace(src, dst):
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(os, "replace", _fail_replace)
+
+    with pytest.raises(OSError):
+        _atomic_write_auth_file(path, {"new": True})
+
+    assert json.loads(path.read_text()) == {"old": True}
+    assert not list(tmp_path.glob("*.tmp"))

--- a/apps/aigateway/tests/unit/codex/test_codex_import_route.py
+++ b/apps/aigateway/tests/unit/codex/test_codex_import_route.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from aigateway.core.profile_models import profile_id_for
+
+from .helpers import write_codex_auth
+
+
+def _account_id(client) -> str:
+    return client.get("/v1/auth/me").json()["id"]
+
+
+def test_codex_import_route_requires_jwt(client, codex_home) -> None:
+    write_codex_auth(codex_home)
+
+    resp = client.post("/v1/auth/codex/profiles/import", json={"name": "default"})
+
+    assert resp.status_code == 401
+
+
+def test_generic_codex_oauth_start_is_rejected(authenticated_client) -> None:
+    resp = authenticated_client.post("/v1/auth/codex/profiles", json={"name": "default"})
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["code"] == "provider_does_not_use_oauth"
+
+
+def test_codex_import_creates_authenticated_profile(authenticated_client, codex_home) -> None:
+    write_codex_auth(
+        codex_home,
+        id_claims={"sub": "sub-1", "email": "codex@example.com"},
+        account_id="acct-1",
+    )
+    account_id = _account_id(authenticated_client)
+
+    resp = authenticated_client.post(
+        "/v1/auth/codex/profiles/import",
+        json={"name": "work", "defaults": {"model": "codex/gpt-5.4-mini"}},
+    )
+
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["id"] == profile_id_for(account_id, "codex", "work")
+    assert body["provider"] == "codex"
+    assert body["state"] == "authenticated"
+    assert body["account_label"] == "codex@example.com"
+    assert body["defaults"]["model"] == "codex/gpt-5.4-mini"
+
+
+@pytest.mark.asyncio
+async def test_codex_chat_translates_reasoning_effort_before_litellm(
+    authenticated_client, codex_home, monkeypatch
+) -> None:
+    captured: dict = {}
+
+    class FakeResponse:
+        def model_dump(self):
+            return {"choices": [{"message": {"content": "ok"}}]}
+
+    async def fake_acompletion(**kwargs):
+        captured.update(kwargs)
+        return FakeResponse()
+
+    monkeypatch.setattr("aigateway.routes.chat.litellm.acompletion", fake_acompletion)
+    write_codex_auth(codex_home)
+    imported = authenticated_client.post(
+        "/v1/auth/codex/profiles/import",
+        json={"name": "default", "defaults": {"reasoning_effort": "high"}},
+    )
+    assert imported.status_code == 201, imported.text
+
+    resp = authenticated_client.post(
+        "/v1/chat/completions",
+        json={"model": "codex/gpt-5.4-mini", "messages": [{"role": "user", "content": "hi"}]},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert captured["reasoning"] == {"effort": "high"}
+    assert "reasoning_effort" not in captured
+
+
+def test_codex_import_returns_auth_required_when_file_missing(authenticated_client) -> None:
+    resp = authenticated_client.post("/v1/auth/codex/profiles/import", json={"name": "default"})
+
+    assert resp.status_code == 401
+    assert resp.json()["detail"]["code"] == "auth_required"
+
+
+def test_delete_codex_profile_does_not_touch_codex_auth_file(
+    authenticated_client, codex_home
+) -> None:
+    auth_path = write_codex_auth(codex_home)
+    original = json.loads(auth_path.read_text())
+    imported = authenticated_client.post("/v1/auth/codex/profiles/import", json={"name": "default"})
+    assert imported.status_code == 201
+
+    deleted = authenticated_client.delete("/v1/auth/codex/profiles/default")
+
+    assert deleted.status_code == 204
+    assert json.loads(auth_path.read_text()) == original
+
+
+@pytest.mark.asyncio
+async def test_codex_streaming_fails_before_streaming_response(
+    authenticated_client, codex_home
+) -> None:
+    write_codex_auth(codex_home)
+    imported = authenticated_client.post("/v1/auth/codex/profiles/import", json={"name": "default"})
+    assert imported.status_code == 201
+
+    resp = authenticated_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "codex/gpt-5.4-mini",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        },
+    )
+
+    assert resp.status_code == 501
+    assert resp.json()["detail"] == {"code": "streaming_not_supported", "provider": "codex"}

--- a/apps/aigateway/tests/unit/codex/test_codex_litellm_handler.py
+++ b/apps/aigateway/tests/unit/codex/test_codex_litellm_handler.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from typing import cast
+
+import litellm
+import pytest
+from litellm.llms.custom_llm import CustomLLMError
+from litellm.types.utils import ModelResponse
+
+from aigateway.plugins.codex_provider import litellm_handler as handler_module
+from aigateway.plugins.codex_provider.litellm_handler import HANDLER
+from aigateway.plugins.codex_provider.oauth_config import CODEX_CHATGPT_RESPONSES_URL
+
+
+async def _completion(api_key: str, optional_params: dict | None = None) -> ModelResponse:
+    return await HANDLER.acompletion(
+        model="codex/gpt-5.4-mini",
+        messages=[
+            {"role": "system", "content": "Be concise."},
+            {"role": "user", "content": "Hello"},
+        ],
+        api_base="",
+        custom_prompt_dict={},
+        model_response=ModelResponse(),
+        print_verbose=lambda *args, **kwargs: None,
+        encoding=None,
+        api_key=api_key,
+        logging_obj=None,
+        optional_params=optional_params or {},
+    )
+
+
+@pytest.mark.asyncio
+async def test_codex_handler_builds_allowed_chatgpt_payload(monkeypatch) -> None:
+    captured: dict = {}
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def post(self, url, *, json, headers):
+            captured["url"] = url
+            captured["json"] = json
+            captured["headers"] = headers
+            return handler_module.httpx.Response(
+                200,
+                text=(
+                    'data: {"type":"response.output_text.delta","delta":"hel"}\n\n'
+                    'data: {"type":"response.output_text.delta","delta":"lo"}\n\n'
+                    'data: {"type":"response.completed","response":{}}\n\n'
+                ),
+            )
+
+    monkeypatch.setattr(handler_module.httpx, "AsyncClient", FakeAsyncClient)
+
+    response = await _completion(
+        "oauth-token-1",
+        {
+            "extra_headers": {"ChatGPT-Account-Id": "acct-1"},
+            "max_tokens": 100,
+            "temperature": 0.5,
+            "metadata": {"drop": True},
+            "reasoning": {"effort": "high"},
+        },
+    )
+
+    assert captured["url"] == CODEX_CHATGPT_RESPONSES_URL
+    assert captured["headers"]["Authorization"] == "Bearer oauth-token-1"
+    assert captured["headers"]["ChatGPT-Account-Id"] == "acct-1"
+    assert captured["json"]["model"] == "gpt-5.4-mini"
+    assert captured["json"]["instructions"] == "Be concise."
+    assert captured["json"]["stream"] is True
+    assert captured["json"]["store"] is False
+    assert captured["json"]["reasoning"] == {"effort": "high"}
+    assert "max_tokens" not in captured["json"]
+    assert "temperature" not in captured["json"]
+    assert "metadata" not in captured["json"]
+    assert response.choices[0].message.content == "hello"
+    assert response.model == "codex/gpt-5.4-mini"
+
+
+@pytest.mark.asyncio
+async def test_litellm_dispatches_codex_slug_to_custom_handler(monkeypatch) -> None:
+    captured: dict = {}
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def post(self, url, *, json, headers):
+            captured["url"] = url
+            captured["json"] = json
+            captured["headers"] = headers
+            return handler_module.httpx.Response(
+                200,
+                text='data: {"type":"response.output_text.delta","delta":"custom"}\n\n',
+            )
+
+    monkeypatch.setattr(handler_module.httpx, "AsyncClient", FakeAsyncClient)
+
+    response = cast(
+        ModelResponse,
+        await litellm.acompletion(
+            model="codex/gpt-5.4-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            api_key="oauth-token-1",
+            reasoning={"effort": "high"},
+        ),
+    )
+
+    assert captured["url"] == CODEX_CHATGPT_RESPONSES_URL
+    assert captured["json"]["model"] == "gpt-5.4-mini"
+    assert captured["json"]["reasoning"] == {"effort": "high"}
+    assert response.choices[0].message.content == "custom"
+    assert response.model == "codex/gpt-5.4-mini"
+
+
+@pytest.mark.asyncio
+async def test_codex_handler_rejects_openai_api_keys_before_network(monkeypatch) -> None:
+    def _unexpected_client(*args, **kwargs):
+        raise AssertionError("network client should not be constructed")
+
+    monkeypatch.setattr(handler_module.httpx, "AsyncClient", _unexpected_client)
+
+    with pytest.raises(CustomLLMError) as exc_info:
+        await _completion("sk-proj-test")
+
+    assert exc_info.value.status_code == 400
+    assert "not available via OpenAI API key" in str(exc_info.value)

--- a/apps/aigateway/tests/unit/codex/test_codex_loopback_middleware.py
+++ b/apps/aigateway/tests/unit/codex/test_codex_loopback_middleware.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+from aigateway.config import Settings
+from aigateway.main import create_app
+
+
+def _app(tmp_path, monkeypatch):
+    monkeypatch.setenv("AIGATEWAY_FAKE_KEYCHAIN", "1")
+    monkeypatch.setenv("AIGATEWAY_KEYCHAIN_FILE", str(tmp_path / "keychain.json"))
+    return create_app(
+        Settings(
+            auth_enabled=False,
+            database_url=SecretStr(f"sqlite://{tmp_path / 'aigateway.sqlite3'}"),
+        )
+    )
+
+
+def test_auth_disabled_gateway_allows_loopback_host_and_client(tmp_path, monkeypatch) -> None:
+    client = TestClient(
+        _app(tmp_path, monkeypatch),
+        base_url="http://127.0.0.1:9105",
+        client=("127.0.0.1", 50000),
+    )
+
+    resp = client.get("/healthz", headers={"host": "127.0.0.1:9105"})
+
+    assert resp.status_code == 200
+
+
+def test_auth_disabled_gateway_rejects_dns_rebinding_host(tmp_path, monkeypatch) -> None:
+    client = TestClient(
+        _app(tmp_path, monkeypatch),
+        base_url="http://evil.example.com:9105",
+        client=("127.0.0.1", 50000),
+    )
+
+    resp = client.get("/healthz", headers={"host": "evil.example.com:9105"})
+
+    assert resp.status_code == 403
+    assert resp.json()["code"] == "loopback_only"
+
+
+def test_auth_disabled_gateway_rejects_non_loopback_client(tmp_path, monkeypatch) -> None:
+    client = TestClient(
+        _app(tmp_path, monkeypatch),
+        base_url="http://127.0.0.1:9105",
+        client=("192.168.1.20", 50000),
+    )
+
+    resp = client.get("/healthz", headers={"host": "127.0.0.1:9105"})
+
+    assert resp.status_code == 403
+    assert resp.json()["code"] == "loopback_only"

--- a/apps/aigateway/tests/unit/test_auth_routes.py
+++ b/apps/aigateway/tests/unit/test_auth_routes.py
@@ -411,7 +411,7 @@ def test_exchange_code_with_unknown_state_400(client_with_index) -> None:
     assert resp.json()["detail"]["code"] == "unknown_state"
 
 
-def test_exchange_code_with_provider_mismatch_400(client_with_index) -> None:
+def test_exchange_code_with_unknown_provider_404(client_with_index) -> None:
     client, _ = client_with_index
     start = client.post("/v1/auth/anthropic/profiles", json={"name": "mismatch"})
 
@@ -419,8 +419,8 @@ def test_exchange_code_with_provider_mismatch_400(client_with_index) -> None:
         "/v1/auth/ghost/exchange-code",
         json={"code": "x", "state": start.json()["state"]},
     )
-    assert resp.status_code == 400
-    assert resp.json()["detail"]["code"] == "provider_mismatch"
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["code"] == "unknown_provider"
 
 
 def test_exchange_code_with_other_accounts_state_404(

--- a/apps/aigateway/tests/unit/test_bootstrap.py
+++ b/apps/aigateway/tests/unit/test_bootstrap.py
@@ -120,7 +120,7 @@ def test_lifespan_bootstraps_disabled_auth_under_anonymous_account(
     _install_bootstrap_spy(monkeypatch, main_module, mock_bootstrap)
 
     app = main_module.create_app()
-    with TestClient(app) as client:
+    with TestClient(app, base_url="http://127.0.0.1", client=("127.0.0.1", 50000)) as client:
         resp = client.get("/v1/auth/me")
         assert resp.status_code == 200
 

--- a/apps/aigateway/tests/unit/test_codex_provider.py
+++ b/apps/aigateway/tests/unit/test_codex_provider.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import cast
+
+import litellm
+from fastapi import APIRouter
+
+from aigateway.core.loader import load_plugins
+from aigateway.core.registry import ProviderRegistry
+
+
+def test_loader_discovers_codex_provider_and_registers_custom_litellm_provider() -> None:
+    reg = ProviderRegistry()
+    load_plugins(reg)
+
+    plugin = reg.get("codex")
+    assert plugin is not None
+    assert plugin.custom_llm_provider == "codex"
+    assert plugin.oauth_config() is None
+    auth_router = cast(APIRouter, plugin.auth_router())
+    assert any(getattr(route, "path", None) == "/profiles/import" for route in auth_router.routes)
+    assert {m.model_name for m in plugin.register_models()} == {
+        "codex/gpt-5.5",
+        "codex/gpt-5.4",
+        "codex/gpt-5.4-mini",
+        "codex/gpt-5.3-codex",
+        "codex/gpt-5.2",
+    }
+    assert "gpt-5.4-mini" not in litellm.open_ai_chat_completion_models
+    assert [entry.get("provider") for entry in litellm.custom_provider_map].count("codex") == 1

--- a/apps/aigateway/uv.lock
+++ b/apps/aigateway/uv.lock
@@ -4,9 +4,10 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "aigateway"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiosqlite" },
     { name = "asyncpg" },
     { name = "bcrypt" },
     { name = "fastapi" },
@@ -21,7 +22,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "aiosqlite" },
     { name = "httpx" },
     { name = "pyright" },
     { name = "pytest" },
@@ -33,6 +33,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiosqlite", specifier = "==0.22.1" },
     { name = "asyncpg", specifier = "==0.31.0" },
     { name = "bcrypt", specifier = "==5.0.0" },
     { name = "fastapi", specifier = ">=0.115" },
@@ -47,7 +48,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "aiosqlite", specifier = "==0.22.1" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "pyright", specifier = ">=1.1.393" },
     { name = "pytest", specifier = ">=9.0" },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -72,6 +72,10 @@
     "appId": "ai.screamingface.desktop",
     "productName": "ScreamingFace",
     "icon": "build/icon",
+    "files": [
+      "out/**",
+      "package.json"
+    ],
     "directories": {
       "output": "dist"
     },
@@ -91,6 +95,18 @@
       {
         "from": "../../apps/server/sf.json",
         "to": "server/sf.json"
+      },
+      {
+        "from": "../../apps/aigateway/src",
+        "to": "aigateway/src"
+      },
+      {
+        "from": "../../apps/aigateway/pyproject.toml",
+        "to": "aigateway/pyproject.toml"
+      },
+      {
+        "from": "../../apps/aigateway/uv.lock",
+        "to": "aigateway/uv.lock"
       },
       {
         "from": "build-assets/${os}/${arch}/uv",

--- a/apps/desktop/src/main/debug-log.ts
+++ b/apps/desktop/src/main/debug-log.ts
@@ -1,11 +1,13 @@
-import { appendFileSync, writeFileSync } from 'fs';
+import { appendFileSync, mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
-import { app } from 'electron';
+import { getUserDataPath } from './user-data-path';
 
-const debugLogPath = join(app.getPath('userData'), 'debug.log');
+const debugLogDir = getUserDataPath();
+const debugLogPath = join(debugLogDir, 'debug.log');
 
 // Truncate on each app launch
 try {
+  mkdirSync(debugLogDir, { recursive: true });
   writeFileSync(debugLogPath, `=== ScreamingFace launch ${new Date().toISOString()} ===\n`);
 } catch {}
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -4,6 +4,8 @@ import { is } from '@electron-toolkit/utils';
 import { registerAllHandlers } from './ipc';
 import { log } from './debug-log';
 import { sessionManager } from './services/session-manager';
+import { isAllowedExternalUrl } from './services/external-url';
+import { setMainWindow } from './window-registry';
 
 let mainWindow: BrowserWindow | null = null;
 let phoenixWindow: BrowserWindow | null = null;
@@ -22,22 +24,24 @@ function createWindow(): void {
       sandbox: false,
     },
   });
+  setMainWindow(mainWindow);
 
   log(`[main] BrowserWindow created`);
 
   mainWindow.on('ready-to-show', () => {
     log(`[main] ready-to-show`);
     mainWindow?.show();
-    // Temporary: open DevTools in production to diagnose Finder-launch black screen
-    mainWindow?.webContents.openDevTools({ mode: 'detach' });
   });
 
   mainWindow.on('closed', () => {
     mainWindow = null;
+    setMainWindow(null);
   });
 
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url);
+    if (isAllowedExternalUrl(url)) {
+      shell.openExternal(url);
+    }
     return { action: 'deny' };
   });
 
@@ -139,7 +143,3 @@ app.on('window-all-closed', () => {
     app.quit();
   }
 });
-
-export function getMainWindow(): BrowserWindow | null {
-  return mainWindow;
-}

--- a/apps/desktop/src/main/ipc/__tests__/validate-sender.test.ts
+++ b/apps/desktop/src/main/ipc/__tests__/validate-sender.test.ts
@@ -1,0 +1,36 @@
+import type { WebFrameMain } from 'electron';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { isValidSender } from '../validate-sender';
+
+function frame(url: string): WebFrameMain {
+  return { url } as WebFrameMain;
+}
+
+afterEach(() => {
+  delete process.env.ELECTRON_RENDERER_URL;
+});
+
+describe('isValidSender', () => {
+  it('allows the configured dev renderer origin', () => {
+    process.env.ELECTRON_RENDERER_URL = 'http://localhost:5173/';
+
+    expect(isValidSender(frame('http://localhost:5173/settings'))).toBe(true);
+  });
+
+  it('rejects other dev origins', () => {
+    process.env.ELECTRON_RENDERER_URL = 'http://localhost:5173/';
+
+    expect(isValidSender(frame('http://evil.example.com/'))).toBe(false);
+  });
+
+  it('allows the packaged renderer file', () => {
+    expect(isValidSender(frame('file:///Applications/ScreamingFace.app/renderer/index.html'))).toBe(
+      true,
+    );
+  });
+
+  it('rejects unrelated file URLs', () => {
+    expect(isValidSender(frame('file:///tmp/other.html'))).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/ipc/backend-status.ipc.ts
+++ b/apps/desktop/src/main/ipc/backend-status.ipc.ts
@@ -1,4 +1,4 @@
-import { ipcMain, BrowserWindow } from 'electron';
+import { ipcMain } from 'electron';
 import { backendStatusService } from '../services/backend-status';
 import {
   runOAuthLauncher,
@@ -6,27 +6,32 @@ import {
   clearPendingAuthState,
   type LauncherResult,
 } from '../services/oauth-launcher';
+import { runImportProfile, type ImportProfileResult } from '../services/codex-import-launcher';
+import { assertValidSender } from './validate-sender';
+import { broadcastToRenderers } from './broadcast';
 
-export type ExchangeCodeResult =
-  | { ok: true }
-  | { ok: false; status?: number; message?: string };
+export type ExchangeCodeResult = { ok: true } | { ok: false; status?: number; message?: string };
 
 export function registerBackendStatusHandlers(): void {
-  ipcMain.handle('backends:getStatus', () => {
+  ipcMain.handle('backends:getStatus', (event) => {
+    assertValidSender(event.senderFrame);
     return backendStatusService.getStatus();
   });
 
-  ipcMain.handle('backends:refresh', () => {
+  ipcMain.handle('backends:refresh', (event) => {
+    assertValidSender(event.senderFrame);
     return backendStatusService.refresh();
   });
 
-  ipcMain.handle('backends:authenticate', (_event, backend: string) => {
+  ipcMain.handle('backends:authenticate', (event, backend: string) => {
+    assertValidSender(event.senderFrame);
     backendStatusService.authenticate(backend);
   });
 
   ipcMain.handle(
     'backends:authenticateOAuth',
-    async (_event, backend: string, profileName?: string): Promise<LauncherResult> => {
+    async (event, backend: string, profileName?: string): Promise<LauncherResult> => {
+      assertValidSender(event.senderFrame);
       const sfBaseUrl = backendStatusService.getServerUrl();
       console.log(
         `[oauth] authenticateOAuth invoked: backend=${backend} profileName=${profileName ?? '(default)'} sfBaseUrl=${sfBaseUrl ?? 'NULL'}`,
@@ -44,13 +49,15 @@ export function registerBackendStatusHandlers(): void {
     },
   );
 
-  ipcMain.handle('backends:getPendingAuthState', (_event, backend: string): string | null => {
+  ipcMain.handle('backends:getPendingAuthState', (event, backend: string): string | null => {
+    assertValidSender(event.senderFrame);
     return getPendingAuthState(backend);
   });
 
   ipcMain.handle(
     'backends:exchangeOAuthCode',
-    async (_event, backend: string, code: string): Promise<ExchangeCodeResult> => {
+    async (event, backend: string, code: string): Promise<ExchangeCodeResult> => {
+      assertValidSender(event.senderFrame);
       const sfBaseUrl = backendStatusService.getServerUrl();
       if (!sfBaseUrl) {
         return { ok: false, message: 'SF server is not running' };
@@ -83,7 +90,8 @@ export function registerBackendStatusHandlers(): void {
     },
   );
 
-  ipcMain.handle('backends:listProfiles', async (_event, backend: string) => {
+  ipcMain.handle('backends:listProfiles', async (event, backend: string) => {
+    assertValidSender(event.senderFrame);
     const sfBaseUrl = backendStatusService.getServerUrl();
     if (!sfBaseUrl) {
       return { profiles: [], error: 'gateway_unreachable' };
@@ -100,37 +108,41 @@ export function registerBackendStatusHandlers(): void {
     }
   });
 
+  ipcMain.handle('backends:deleteProfile', async (event, backend: string, profileName: string) => {
+    assertValidSender(event.senderFrame);
+    const sfBaseUrl = backendStatusService.getServerUrl();
+    if (!sfBaseUrl) {
+      return { ok: false, status: 0 };
+    }
+    try {
+      const resp = await fetch(
+        `${sfBaseUrl}/${backend}/auth/profiles/${encodeURIComponent(profileName)}`,
+        { method: 'DELETE' },
+      );
+      if (resp.status === 204) return { ok: true };
+      return { ok: false, status: resp.status };
+    } catch {
+      return { ok: false, status: 0 };
+    }
+  });
+
   ipcMain.handle(
-    'backends:deleteProfile',
-    async (_event, backend: string, profileName: string) => {
+    'backends:importProfile',
+    async (event, backend: string, profileName?: string): Promise<ImportProfileResult> => {
+      assertValidSender(event.senderFrame);
       const sfBaseUrl = backendStatusService.getServerUrl();
-      if (!sfBaseUrl) {
-        return { ok: false, status: 0 };
-      }
-      try {
-        const resp = await fetch(
-          `${sfBaseUrl}/${backend}/auth/profiles/${encodeURIComponent(profileName)}`,
-          { method: 'DELETE' },
-        );
-        if (resp.status === 204) return { ok: true };
-        return { ok: false, status: resp.status };
-      } catch {
-        return { ok: false, status: 0 };
-      }
+      if (!sfBaseUrl) return { ok: false, message: 'SF server is not running' };
+      return runImportProfile({ sfBaseUrl, backendName: backend, profileName });
     },
   );
 
   // Forward status changes to all renderer windows
   backendStatusService.on('statusChanged', (status) => {
-    for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send('backends:statusChanged', status);
-    }
+    broadcastToRenderers('backends:statusChanged', status);
   });
 
   // Forward alerts (state transitions) to all renderer windows
   backendStatusService.on('alert', (alert) => {
-    for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send('backends:alert', alert);
-    }
+    broadcastToRenderers('backends:alert', alert);
   });
 }

--- a/apps/desktop/src/main/ipc/broadcast.ts
+++ b/apps/desktop/src/main/ipc/broadcast.ts
@@ -1,0 +1,13 @@
+import { getMainWindow } from '../window-registry';
+
+export function broadcastToRenderers(channel: string, ...args: unknown[]): void {
+  const win = getMainWindow();
+  if (!win || win.isDestroyed() || win.webContents.isDestroyed()) return;
+
+  try {
+    win.webContents.send(channel, ...args);
+  } catch {
+    // Renderer frames can be disposed during reload/quit while backend processes
+    // are still emitting logs. Dropping that event is safer than wedging startup.
+  }
+}

--- a/apps/desktop/src/main/ipc/config.ipc.ts
+++ b/apps/desktop/src/main/ipc/config.ipc.ts
@@ -1,5 +1,6 @@
-import { ipcMain, BrowserWindow } from 'electron';
+import { ipcMain } from 'electron';
 import { configService } from '../services/config-service';
+import { broadcastToRenderers } from './broadcast';
 
 export function registerConfigHandlers(): void {
   ipcMain.handle('config:read', () => {
@@ -11,9 +12,7 @@ export function registerConfigHandlers(): void {
   });
 
   configService.on('changed', (config) => {
-    for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send('config:changed', config);
-    }
+    broadcastToRenderers('config:changed', config);
   });
 
   configService.watch();

--- a/apps/desktop/src/main/ipc/plugin-manager.ipc.ts
+++ b/apps/desktop/src/main/ipc/plugin-manager.ipc.ts
@@ -1,6 +1,7 @@
-import { ipcMain, BrowserWindow } from 'electron';
+import { ipcMain } from 'electron';
 import { pluginRegistry } from '../services/plugin-registry';
 import { venvManager } from '../services/venv-manager';
+import { broadcastToRenderers } from './broadcast';
 
 export function registerPluginHandlers(): void {
   ipcMain.handle('plugins:list', () => {
@@ -33,8 +34,6 @@ export function registerPluginHandlers(): void {
 
   pluginRegistry.on('changed', () => {
     const plugins = pluginRegistry.list();
-    for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send('plugins:changed', plugins);
-    }
+    broadcastToRenderers('plugins:changed', plugins);
   });
 }

--- a/apps/desktop/src/main/ipc/server-process.ipc.ts
+++ b/apps/desktop/src/main/ipc/server-process.ipc.ts
@@ -1,8 +1,10 @@
-import { ipcMain, BrowserWindow } from 'electron';
+import { ipcMain } from 'electron';
 import https from 'https';
 import http from 'http';
 import { serverProcess } from '../services/server-process';
 import { backendStatusService } from '../services/backend-status';
+import { assertValidSender } from './validate-sender';
+import { broadcastToRenderers } from './broadcast';
 
 interface FetchInit {
   method?: string;
@@ -42,24 +44,32 @@ function nodeFetch(url: string, init?: FetchInit): Promise<{ status: number; bod
 }
 
 export function registerServerHandlers(): void {
-  ipcMain.handle('server:start', () => {
+  ipcMain.handle('server:start', (event) => {
+    assertValidSender(event.senderFrame);
     return serverProcess.start();
   });
 
-  ipcMain.handle('server:stop', () => {
+  ipcMain.handle('server:stop', (event) => {
+    assertValidSender(event.senderFrame);
     return serverProcess.stop();
   });
 
-  ipcMain.handle('server:restart', () => {
+  ipcMain.handle('server:restart', (event) => {
+    assertValidSender(event.senderFrame);
     return serverProcess.restart();
   });
 
-  ipcMain.handle('server:getStatus', () => {
+  ipcMain.handle('server:getStatus', (event) => {
+    assertValidSender(event.senderFrame);
     return serverProcess.getStatus();
   });
 
   // Proxy fetch through main process to bypass self-signed cert issues
-  ipcMain.handle('server:fetch', async (_event, url: string, init?: FetchInit) => {
+  ipcMain.handle('server:fetch', async (event, url: string, init?: FetchInit) => {
+    assertValidSender(event.senderFrame);
+    if (!isAllowedServerFetchUrl(url)) {
+      return { ok: false, status: 403, body: '' };
+    }
     try {
       const { status, body } = await nodeFetch(url, init);
       return { ok: status >= 200 && status < 300, status, body };
@@ -70,9 +80,7 @@ export function registerServerHandlers(): void {
 
   // Forward log and status events to all renderer windows
   serverProcess.on('status', (status) => {
-    for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send('server:statusChanged', status);
-    }
+    broadcastToRenderers('server:statusChanged', status);
 
     // Start/stop backend status polling based on server state
     if (status === 'ready') {
@@ -87,8 +95,19 @@ export function registerServerHandlers(): void {
   });
 
   serverProcess.on('log', (line) => {
-    for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send('server:log', line);
-    }
+    broadcastToRenderers('server:log', line);
   });
+}
+
+function isAllowedServerFetchUrl(url: string): boolean {
+  const serverUrl = backendStatusService.getServerUrl();
+  if (!serverUrl) return false;
+  try {
+    const parsed = new URL(url);
+    const server = new URL(serverUrl);
+    if (parsed.origin !== server.origin) return false;
+    return ['127.0.0.1', 'localhost', '::1', '[::1]'].includes(parsed.hostname);
+  } catch {
+    return false;
+  }
 }

--- a/apps/desktop/src/main/ipc/session.ipc.ts
+++ b/apps/desktop/src/main/ipc/session.ipc.ts
@@ -1,5 +1,6 @@
-import { ipcMain, BrowserWindow } from 'electron';
+import { ipcMain } from 'electron';
 import { sessionManager } from '../services/session-manager';
+import { broadcastToRenderers } from './broadcast';
 
 export function registerSessionHandlers(): void {
   ipcMain.handle('session:pickDir', () => {
@@ -8,7 +9,12 @@ export function registerSessionHandlers(): void {
 
   ipcMain.handle(
     'session:create',
-    (_event, type: string, workingDir: string, pluginConfig?: Record<string, Record<string, unknown>>) => {
+    (
+      _event,
+      type: string,
+      workingDir: string,
+      pluginConfig?: Record<string, Record<string, unknown>>,
+    ) => {
       return sessionManager.createSession(
         type as 'claude' | 'codex' | 'gemini' | 'claude-desktop',
         workingDir,
@@ -35,7 +41,12 @@ export function registerSessionHandlers(): void {
 
   ipcMain.handle(
     'session:update',
-    (_event, id: string, workingDir: string, pluginConfig?: Record<string, Record<string, unknown>>) => {
+    (
+      _event,
+      id: string,
+      workingDir: string,
+      pluginConfig?: Record<string, Record<string, unknown>>,
+    ) => {
       return sessionManager.updateSession(id, workingDir, pluginConfig);
     },
   );
@@ -46,14 +57,10 @@ export function registerSessionHandlers(): void {
 
   // Forward session state changes to all renderer windows
   sessionManager.on('sessionsChanged', (sessions) => {
-    for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send('session:sessionsChanged', sessions);
-    }
+    broadcastToRenderers('session:sessionsChanged', sessions);
   });
 
   sessionManager.on('log', (id, line) => {
-    for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send('session:log', id, line);
-    }
+    broadcastToRenderers('session:log', id, line);
   });
 }

--- a/apps/desktop/src/main/ipc/validate-sender.ts
+++ b/apps/desktop/src/main/ipc/validate-sender.ts
@@ -1,0 +1,29 @@
+import type { WebFrameMain } from 'electron';
+
+function rendererDevOrigin(): string | null {
+  const value = process.env.ELECTRON_RENDERER_URL;
+  if (!value) return null;
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+export function isValidSender(frame: WebFrameMain | null): boolean {
+  if (!frame?.url) return false;
+  try {
+    const parsed = new URL(frame.url);
+    const devOrigin = rendererDevOrigin();
+    if (devOrigin) return parsed.origin === devOrigin;
+    return parsed.protocol === 'file:' && parsed.pathname.endsWith('/renderer/index.html');
+  } catch {
+    return false;
+  }
+}
+
+export function assertValidSender(frame: WebFrameMain | null): void {
+  if (!isValidSender(frame)) {
+    throw new Error('invalid IPC sender');
+  }
+}

--- a/apps/desktop/src/main/ipc/venv-manager.ipc.ts
+++ b/apps/desktop/src/main/ipc/venv-manager.ipc.ts
@@ -1,6 +1,7 @@
-import { ipcMain, BrowserWindow } from 'electron';
+import { ipcMain } from 'electron';
 import { venvManager } from '../services/venv-manager';
 import { log } from '../debug-log';
+import { broadcastToRenderers } from './broadcast';
 
 export function registerVenvHandlers(): void {
   ipcMain.handle('venv:detect', async () => {
@@ -29,14 +30,10 @@ export function registerVenvHandlers(): void {
   });
 
   venvManager.on('status', (status) => {
-    for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send('venv:statusChanged', status);
-    }
+    broadcastToRenderers('venv:statusChanged', status);
   });
 
   venvManager.on('progress', (line) => {
-    for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send('venv:progress', line);
-    }
+    broadcastToRenderers('venv:progress', line);
   });
 }

--- a/apps/desktop/src/main/services/__tests__/codex-import-launcher.test.ts
+++ b/apps/desktop/src/main/services/__tests__/codex-import-launcher.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { runImportProfile } from '../codex-import-launcher';
+
+describe('runImportProfile', () => {
+  it('posts to the backend import route with profile name', async () => {
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ ok: true }), { status: 201 }),
+    );
+
+    const result = await runImportProfile({
+      sfBaseUrl: 'http://127.0.0.1:8000',
+      backendName: 'codex',
+      profileName: 'default',
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledWith('http://127.0.0.1:8000/codex/auth/import?name=default', {
+      method: 'POST',
+    });
+  });
+
+  it('returns structured failure when import route fails', async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ detail: { code: 'auth_required', message: 'missing' } }), {
+          status: 401,
+          headers: { 'content-type': 'application/json' },
+        }),
+    );
+
+    const result = await runImportProfile({
+      sfBaseUrl: 'http://127.0.0.1:8000',
+      backendName: 'codex',
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(result).toEqual({ ok: false, status: 401, message: 'missing' });
+  });
+});

--- a/apps/desktop/src/main/services/__tests__/config-service.packaged.test.ts
+++ b/apps/desktop/src/main/services/__tests__/config-service.packaged.test.ts
@@ -1,0 +1,95 @@
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  userData: '',
+  appPath: '',
+  resourcesPath: '',
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => {
+      if (name !== 'userData') throw new Error(`unexpected app path: ${name}`);
+      return state.userData;
+    },
+    getAppPath: () => state.appPath,
+  },
+}));
+
+vi.mock('@electron-toolkit/utils', () => ({ is: { dev: false } }));
+
+afterEach(() => {
+  vi.resetModules();
+  vi.restoreAllMocks();
+});
+
+describe('ConfigService packaged Codex migration', () => {
+  it('copies sf.json to userData and activates gateway-backed Codex', async () => {
+    state.userData = mkdtempSync(join(tmpdir(), 'sf-desktop-userdata-'));
+    state.appPath = mkdtempSync(join(tmpdir(), 'sf-desktop-app-'));
+    state.resourcesPath = mkdtempSync(join(tmpdir(), 'sf-desktop-resources-'));
+    Object.defineProperty(process, 'resourcesPath', {
+      configurable: true,
+      value: state.resourcesPath,
+    });
+
+    const bundledServer = join(state.resourcesPath, 'server');
+    mkdirSync(bundledServer, { recursive: true });
+    writeFileSync(
+      join(bundledServer, 'sf.json'),
+      JSON.stringify({
+        version: '0.1.0',
+        server: { host: '0.0.0.0', port: 8000, reload: false, ssl: true },
+        plugins: ['tracing', 'codex-backend-api'],
+        plugin_config: {
+          tracing: { phoenix_launch: false },
+          'aigw-runner': { startup_timeout_seconds: 10 },
+        },
+      }),
+    );
+
+    const { configService } = await import('../config-service');
+
+    const migrated = JSON.parse(readFileSync(configService.getConfigPath(), 'utf-8'));
+    expect(migrated.plugins).toEqual(['tracing', 'aigw-runner', 'aigw-base', 'aigw-codex-backend']);
+    expect(migrated.plugins).not.toContain('codex-backend-api');
+    expect(migrated.plugin_config.tracing).toEqual({ phoenix_launch: false });
+    expect(migrated.plugin_config['aigw-runner']).toEqual({
+      startup_timeout_seconds: 60,
+      aigateway_dir: join(state.userData, 'aigateway'),
+      database_path: join(state.userData, 'aigateway', 'aigateway.db'),
+      auth_enabled: false,
+    });
+  });
+
+  it('creates userData before copying bundled config on first launch', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'sf-desktop-home-'));
+    state.userData = join(home, 'Library', 'Application Support', 'ScreamingFace');
+    state.appPath = mkdtempSync(join(tmpdir(), 'sf-desktop-app-'));
+    state.resourcesPath = mkdtempSync(join(tmpdir(), 'sf-desktop-resources-'));
+    Object.defineProperty(process, 'resourcesPath', {
+      configurable: true,
+      value: state.resourcesPath,
+    });
+
+    const bundledServer = join(state.resourcesPath, 'server');
+    mkdirSync(bundledServer, { recursive: true });
+    writeFileSync(
+      join(bundledServer, 'sf.json'),
+      JSON.stringify({
+        version: '0.1.0',
+        server: { host: '0.0.0.0', port: 8000, reload: false, ssl: true },
+        plugins: ['codex-backend-api'],
+        plugin_config: {},
+      }),
+    );
+
+    const { configService } = await import('../config-service');
+
+    expect(existsSync(state.userData)).toBe(true);
+    expect(existsSync(configService.getConfigPath())).toBe(true);
+  });
+});

--- a/apps/desktop/src/main/services/__tests__/oauth-launcher.test.ts
+++ b/apps/desktop/src/main/services/__tests__/oauth-launcher.test.ts
@@ -26,10 +26,13 @@ describe('runOAuthLauncher', () => {
   it('opens the authorize URL and resolves on AUTHENTICATED status', async () => {
     const fetchMock = makeFetch([
       () =>
-        new Response(JSON.stringify({ authorize_url: 'https://x/authorize', state: 's1' }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        }),
+        new Response(
+          JSON.stringify({ authorize_url: 'https://claude.ai/oauth/authorize', state: 's1' }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          },
+        ),
       () =>
         new Response(JSON.stringify({ state: 'pending' }), {
           status: 200,
@@ -50,17 +53,20 @@ describe('runOAuthLauncher', () => {
       fetchImpl: fetchMock as unknown as typeof fetch,
     });
 
-    expect(openExternal).toHaveBeenCalledWith('https://x/authorize');
+    expect(openExternal).toHaveBeenCalledWith('https://claude.ai/oauth/authorize');
     expect(result.kind).toBe('complete');
   });
 
   it('returns timeout when status never reaches authenticated', async () => {
     const fetchMock = makeFetch([
       () =>
-        new Response(JSON.stringify({ authorize_url: 'https://x/authorize', state: 's1' }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        }),
+        new Response(
+          JSON.stringify({ authorize_url: 'https://claude.ai/oauth/authorize', state: 's1' }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          },
+        ),
       ...Array(20).fill(
         () =>
           new Response(JSON.stringify({ state: 'pending' }), {
@@ -84,10 +90,13 @@ describe('runOAuthLauncher', () => {
   it('short-circuits to provider_error when status is error', async () => {
     const fetchMock = makeFetch([
       () =>
-        new Response(JSON.stringify({ authorize_url: 'https://x/authorize', state: 's1' }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        }),
+        new Response(
+          JSON.stringify({ authorize_url: 'https://claude.ai/oauth/authorize', state: 's1' }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          },
+        ),
       () =>
         new Response(JSON.stringify({ state: 'error', error: 'bad code' }), {
           status: 200,
@@ -110,10 +119,13 @@ describe('runOAuthLauncher', () => {
     const fetchMock = vi.fn(async (url: string) => {
       calls.push(url);
       if (calls.length === 1) {
-        return new Response(JSON.stringify({ authorize_url: 'https://x/authorize', state: 's1' }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        });
+        return new Response(
+          JSON.stringify({ authorize_url: 'https://claude.ai/oauth/authorize', state: 's1' }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          },
+        );
       }
       return new Response(JSON.stringify({ state: 'authenticated' }), {
         status: 200,
@@ -152,5 +164,30 @@ describe('runOAuthLauncher', () => {
     expect(openExternal).not.toHaveBeenCalled();
     expect(result.kind).toBe('failed');
     if (result.kind === 'failed') expect(result.reason).toBe('gateway_error');
+  });
+
+  it('rejects unsafe authorize URLs before opening a browser', async () => {
+    const fetchMock = makeFetch([
+      () =>
+        new Response(JSON.stringify({ authorize_url: 'file:///tmp/steal', state: 's1' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    ]);
+
+    const result = await runOAuthLauncher({
+      sfBaseUrl: 'http://127.0.0.1:1234',
+      backendName: 'claude',
+      pollIntervalMs: 1,
+      timeoutMs: 5_000,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(openExternal).not.toHaveBeenCalled();
+    expect(result.kind).toBe('failed');
+    if (result.kind === 'failed') {
+      expect(result.reason).toBe('gateway_error');
+      expect(result.message).toBe('authorize_url rejected');
+    }
   });
 });

--- a/apps/desktop/src/main/services/__tests__/server-process.packaged.test.ts
+++ b/apps/desktop/src/main/services/__tests__/server-process.packaged.test.ts
@@ -1,0 +1,91 @@
+import { EventEmitter } from 'events';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  userData: '',
+  spawn: vi.fn(),
+  execFileSync: vi.fn(() => Buffer.from('{}')),
+}));
+
+vi.mock('@electron-toolkit/utils', () => ({ is: { dev: false } }));
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => {
+      if (name !== 'userData') throw new Error(`unexpected app path: ${name}`);
+      return state.userData;
+    },
+  },
+}));
+
+vi.mock('child_process', () => ({
+  spawn: state.spawn,
+  execFileSync: state.execFileSync,
+  execFile: vi.fn(),
+}));
+
+vi.mock('../config-service', () => ({
+  configService: {
+    serverDir: '/unused/dev/server',
+    read: () => ({ plugins: ['aigw-runner', 'aigw-base', 'aigw-codex-backend'] }),
+  },
+}));
+
+vi.mock('../uv-resolver', () => ({
+  resolveUv: () => '/Applications/ScreamingFace.app/Contents/Resources/server/bin/uv',
+}));
+
+function fakeChild(): EventEmitter & {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: ReturnType<typeof vi.fn>;
+} {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = vi.fn();
+  return child;
+}
+
+afterEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+describe('ServerProcess packaged startup', () => {
+  it('spawns SF from userData with loopback bind and explicit gateway runner env', async () => {
+    state.userData = mkdtempSync(join(tmpdir(), 'sf-desktop-userdata-'));
+    state.spawn.mockReturnValue(fakeChild());
+
+    const { serverProcess } = await import('../server-process');
+
+    await expect(serverProcess.start()).resolves.toBe(true);
+    const [cmd, args, opts] = state.spawn.mock.calls[0];
+    expect(cmd).toBe(join(state.userData, '.venv', 'bin', 'sf'));
+    expect(args).toEqual([
+      'run',
+      '--subprocess',
+      '--config-json',
+      JSON.stringify({ plugins: ['aigw-runner', 'aigw-base', 'aigw-codex-backend'] }),
+      '--host',
+      '127.0.0.1',
+    ]);
+    expect(opts.cwd).toBe(state.userData);
+    expect(opts.env.SF_AIGW_RUNNER__AIGATEWAY_DIR).toBe(join(state.userData, 'aigateway'));
+    expect(opts.env.SF_AIGW_RUNNER__DATABASE_PATH).toBe(
+      join(state.userData, 'aigateway', 'aigateway.db'),
+    );
+    expect(opts.env.SF_AIGW_RUNNER__AUTH_ENABLED).toBe('false');
+    expect(opts.env.SF_AIGW_RUNNER__UV_BIN).toBe(
+      '/Applications/ScreamingFace.app/Contents/Resources/server/bin/uv',
+    );
+    expect(opts.env.SF_AIGW_RUNNER__AIGATEWAY_DIR).not.toContain('..');
+  });
+});

--- a/apps/desktop/src/main/services/__tests__/uv-resolver.packaged.test.ts
+++ b/apps/desktop/src/main/services/__tests__/uv-resolver.packaged.test.ts
@@ -1,0 +1,27 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@electron-toolkit/utils', () => ({ is: { dev: false } }));
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('resolveUv packaged mode', () => {
+  it('prefers bundled uv from extraResources', async () => {
+    const resourcesPath = mkdtempSync(join(tmpdir(), 'sf-desktop-resources-'));
+    const bundledUv = join(resourcesPath, 'server', 'bin', 'uv');
+    mkdirSync(join(resourcesPath, 'server', 'bin'), { recursive: true });
+    writeFileSync(bundledUv, 'uv');
+    Object.defineProperty(process, 'resourcesPath', {
+      configurable: true,
+      value: resourcesPath,
+    });
+
+    const { resolveUv } = await import('../uv-resolver');
+
+    expect(resolveUv()).toBe(bundledUv);
+  });
+});

--- a/apps/desktop/src/main/services/__tests__/venv-manager.packaged.test.ts
+++ b/apps/desktop/src/main/services/__tests__/venv-manager.packaged.test.ts
@@ -1,0 +1,123 @@
+import { EventEmitter } from 'events';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  userData: '',
+  resourcesPath: '',
+  spawn: vi.fn(),
+  execFileSync: vi.fn(() => 'Python 3.12.9\n'),
+}));
+
+vi.mock('@electron-toolkit/utils', () => ({ is: { dev: false } }));
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => {
+      if (name !== 'userData') throw new Error(`unexpected app path: ${name}`);
+      return state.userData;
+    },
+    getVersion: () => '0.1.0-test',
+  },
+}));
+
+vi.mock('child_process', () => ({
+  spawn: state.spawn,
+  execFileSync: state.execFileSync,
+  execFile: vi.fn(),
+}));
+
+vi.mock('../config-service', () => ({
+  configService: {
+    serverDir: '/unused/dev/server',
+  },
+}));
+
+vi.mock('../uv-resolver', () => ({
+  resolveUv: () => join(state.resourcesPath, 'server', 'bin', 'uv'),
+}));
+
+function successfulChild(): EventEmitter & { stdout: EventEmitter; stderr: EventEmitter } {
+  const child = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  process.nextTick(() => child.emit('close', 0));
+  return child;
+}
+
+function writePackagedResources(resourcesPath: string): void {
+  mkdirSync(join(resourcesPath, 'server', 'bin'), { recursive: true });
+  mkdirSync(join(resourcesPath, 'server', 'python', 'bin'), { recursive: true });
+  mkdirSync(join(resourcesPath, 'aigateway', 'src', 'aigateway'), { recursive: true });
+  writeFileSync(join(resourcesPath, 'server', 'bin', 'uv'), 'uv');
+  writeFileSync(join(resourcesPath, 'server', 'python', 'bin', 'python3.12'), 'python');
+  writeFileSync(join(resourcesPath, 'server', 'pyproject.toml'), '[project]\nname="server"\n');
+  writeFileSync(join(resourcesPath, 'server', 'uv.lock'), '# server lock\n');
+  writeFileSync(
+    join(resourcesPath, 'aigateway', 'pyproject.toml'),
+    '[project]\nname="aigateway"\n',
+  );
+  writeFileSync(join(resourcesPath, 'aigateway', 'uv.lock'), '# gateway lock\n');
+  writeFileSync(join(resourcesPath, 'aigateway', 'src', 'aigateway', '__init__.py'), '');
+}
+
+afterEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+describe('VenvManager packaged gateway provisioning', () => {
+  it('detects missing gateway venv as resync and copies gateway project during sync', async () => {
+    state.userData = mkdtempSync(join(tmpdir(), 'sf-desktop-userdata-'));
+    state.resourcesPath = mkdtempSync(join(tmpdir(), 'sf-desktop-resources-'));
+    writePackagedResources(state.resourcesPath);
+    mkdirSync(join(state.userData, '.venv', 'bin'), { recursive: true });
+    writeFileSync(join(state.userData, '.venv', 'bin', 'python'), 'python');
+    Object.defineProperty(process, 'resourcesPath', {
+      configurable: true,
+      value: state.resourcesPath,
+    });
+    state.spawn.mockImplementation(() => successfulChild());
+
+    const { venvManager } = await import('../venv-manager');
+
+    await expect(venvManager.detect()).resolves.toMatchObject({
+      status: 'ready',
+      uvFound: true,
+      needsSync: true,
+      autoBootstrap: false,
+    });
+    await expect(venvManager.sync()).resolves.toBe(true);
+
+    const gatewayDir = join(state.userData, 'aigateway');
+    expect(readFileSync(join(gatewayDir, 'pyproject.toml'), 'utf-8')).toContain('aigateway');
+    expect(readFileSync(join(gatewayDir, 'uv.lock'), 'utf-8')).toContain('gateway lock');
+    expect(existsSync(join(gatewayDir, 'src', 'aigateway', '__init__.py'))).toBe(true);
+    expect(readFileSync(join(state.userData, '.sf-version'), 'utf-8')).toBe('0.1.0-test');
+
+    const gatewaySync = state.spawn.mock.calls.find(
+      ([, , opts]) =>
+        opts?.cwd === gatewayDir && opts?.env?.VIRTUAL_ENV === join(gatewayDir, '.venv'),
+    );
+    expect(gatewaySync).toBeTruthy();
+    expect(gatewaySync?.[1]).toEqual([
+      'sync',
+      '--python',
+      join(state.resourcesPath, 'server', 'python', 'bin', 'python3.12'),
+      '--no-install-project',
+    ]);
+
+    const serverSync = state.spawn.mock.calls.find(
+      ([, args, opts]) => opts?.cwd === state.userData && args?.[0] === 'sync',
+    );
+    expect(serverSync?.[1]).toEqual([
+      'sync',
+      '--python',
+      join(state.resourcesPath, 'server', 'python', 'bin', 'python3.12'),
+      '--no-install-project',
+    ]);
+    expect(gatewayDir).not.toContain('..');
+  });
+});

--- a/apps/desktop/src/main/services/backend-status.ts
+++ b/apps/desktop/src/main/services/backend-status.ts
@@ -24,6 +24,7 @@ export interface BackendHealth {
   action: BackendAction;
   cli_command?: string | null;
   help_text?: string | null;
+  auth_kind?: 'cli' | 'browser' | 'import';
 }
 
 export type BackendStatusMap = Record<string, BackendHealth>;

--- a/apps/desktop/src/main/services/codex-import-launcher.ts
+++ b/apps/desktop/src/main/services/codex-import-launcher.ts
@@ -1,0 +1,28 @@
+export type ImportProfileResult = { ok: true } | { ok: false; status?: number; message?: string };
+
+export interface ImportProfileOptions {
+  sfBaseUrl: string;
+  backendName: string;
+  profileName?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export async function runImportProfile(opts: ImportProfileOptions): Promise<ImportProfileResult> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const query = opts.profileName ? `?name=${encodeURIComponent(opts.profileName)}` : '';
+  const url = `${opts.sfBaseUrl}/${opts.backendName}/auth/import${query}`;
+  try {
+    const resp = await fetchImpl(url, { method: 'POST' });
+    if (resp.ok) return { ok: true };
+    let message: string | undefined;
+    try {
+      const body = (await resp.json()) as { detail?: { code?: string; message?: string } };
+      message = body.detail?.message ?? body.detail?.code;
+    } catch {
+      /* ignore */
+    }
+    return { ok: false, status: resp.status, message };
+  } catch (e) {
+    return { ok: false, message: e instanceof Error ? e.message : String(e) };
+  }
+}

--- a/apps/desktop/src/main/services/config-service.ts
+++ b/apps/desktop/src/main/services/config-service.ts
@@ -1,8 +1,17 @@
-import { readFileSync, writeFileSync, copyFileSync, existsSync, watchFile, unwatchFile } from 'fs';
+import {
+  readFileSync,
+  writeFileSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  watchFile,
+  unwatchFile,
+} from 'fs';
 import { join, resolve } from 'path';
 import { EventEmitter } from 'events';
 import { app } from 'electron';
 import { is } from '@electron-toolkit/utils';
+import { getUserDataPath } from '../user-data-path';
 
 function resolveServerDir(): string {
   if (!is.dev) {
@@ -17,7 +26,9 @@ function resolveServerDir(): string {
 function resolveConfigPath(serverDir: string): string {
   if (!is.dev) {
     // Production: config lives in writable user data directory
-    const userDataConfig = join(app.getPath('userData'), 'sf.json');
+    const userDataDir = getUserDataPath();
+    mkdirSync(userDataDir, { recursive: true });
+    const userDataConfig = join(userDataDir, 'sf.json');
     if (!existsSync(userDataConfig)) {
       const templatePath = join(serverDir, 'sf.json');
       if (existsSync(templatePath)) {
@@ -42,6 +53,9 @@ class ConfigService extends EventEmitter {
     SERVER_DIR = resolveServerDir();
     CONFIG_PATH = resolveConfigPath(SERVER_DIR);
     this.configPath = CONFIG_PATH;
+    if (!is.dev) {
+      this.migrateDesktopGatewayCodexConfig();
+    }
   }
 
   get serverDir(): string {
@@ -82,6 +96,44 @@ class ConfigService extends EventEmitter {
 
   getConfigPath(): string {
     return this.configPath;
+  }
+
+  private migrateDesktopGatewayCodexConfig(): void {
+    const config = this.read();
+    const plugins = Array.isArray(config.plugins) ? [...config.plugins] : [];
+    const nextPlugins = plugins
+      .filter((plugin): plugin is string => typeof plugin === 'string')
+      .filter((plugin) => plugin !== 'codex-backend-api');
+
+    for (const required of ['aigw-runner', 'aigw-base', 'aigw-codex-backend']) {
+      if (!nextPlugins.includes(required)) nextPlugins.push(required);
+    }
+
+    const pluginConfig =
+      config.plugin_config && typeof config.plugin_config === 'object'
+        ? { ...(config.plugin_config as Record<string, Record<string, unknown>>) }
+        : {};
+    const gatewayDir = join(getUserDataPath(), 'aigateway');
+    const runnerConfig = pluginConfig['aigw-runner'] ?? {};
+    const startupTimeout = runnerConfig.startup_timeout_seconds;
+    pluginConfig['aigw-runner'] = {
+      ...runnerConfig,
+      aigateway_dir: gatewayDir,
+      database_path: join(gatewayDir, 'aigateway.db'),
+      auth_enabled: false,
+      startup_timeout_seconds:
+        typeof startupTimeout === 'number' && startupTimeout >= 60 ? startupTimeout : 60,
+    };
+
+    const migrated = {
+      ...config,
+      plugins: nextPlugins,
+      plugin_config: pluginConfig,
+    };
+
+    if (JSON.stringify(migrated) !== JSON.stringify(config)) {
+      this.write(migrated);
+    }
   }
 }
 

--- a/apps/desktop/src/main/services/external-url.ts
+++ b/apps/desktop/src/main/services/external-url.ts
@@ -1,0 +1,23 @@
+import { shell } from 'electron';
+
+const ALLOWED_EXTERNAL_HOSTS = new Set([
+  'claude.ai',
+  'console.anthropic.com',
+  'auth.openai.com',
+  'chatgpt.com',
+]);
+
+export function isAllowedExternalUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'https:' && ALLOWED_EXTERNAL_HOSTS.has(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
+export async function openAllowedExternalUrl(url: string): Promise<boolean> {
+  if (!isAllowedExternalUrl(url)) return false;
+  await shell.openExternal(url);
+  return true;
+}

--- a/apps/desktop/src/main/services/oauth-launcher.ts
+++ b/apps/desktop/src/main/services/oauth-launcher.ts
@@ -8,7 +8,7 @@
  *      or timeout.
  */
 
-import { shell } from 'electron';
+import { openAllowedExternalUrl } from './external-url';
 
 /**
  * In-memory cache of the most-recent OAuth `state` value per backend.
@@ -86,11 +86,17 @@ export async function runOAuthLauncher(opts: LauncherOptions): Promise<LauncherR
     };
   }
   const startBody = (await startResp.json()) as { authorize_url: string; state?: string };
+  if (!(await openAllowedExternalUrl(startBody.authorize_url))) {
+    return {
+      kind: 'failed',
+      reason: 'gateway_error',
+      message: 'authorize_url rejected',
+    };
+  }
   if (startBody.state) {
     pendingStateByBackend.set(opts.backendName, startBody.state);
   }
   console.log(`[oauth-launcher] opening browser: ${startBody.authorize_url}`);
-  await shell.openExternal(startBody.authorize_url);
 
   const deadline = Date.now() + timeoutMs;
   let networkBlips = 0;

--- a/apps/desktop/src/main/services/plugin-registry.ts
+++ b/apps/desktop/src/main/services/plugin-registry.ts
@@ -1,8 +1,8 @@
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { join } from 'path';
-import { app } from 'electron';
 import { EventEmitter } from 'events';
 import { net } from 'electron';
+import { getUserDataPath } from '../user-data-path';
 
 export interface PluginManifest {
   id: string;
@@ -27,7 +27,7 @@ class PluginRegistryService extends EventEmitter {
   private getPath(): string {
     if (!this.pluginsPath) {
       try {
-        this.pluginsPath = join(app.getPath('userData'), 'plugins.json');
+        this.pluginsPath = join(getUserDataPath(), 'plugins.json');
       } catch {
         this.pluginsPath = join(process.cwd(), 'plugins.json');
       }
@@ -108,7 +108,9 @@ class PluginRegistryService extends EventEmitter {
 
     // Validate minimum required fields
     if (!data.id || !data.name || !data.version || !data.exposedModule) {
-      throw new Error('Invalid remote entry: missing required fields (id, name, version, exposedModule)');
+      throw new Error(
+        'Invalid remote entry: missing required fields (id, name, version, exposedModule)',
+      );
     }
 
     return {

--- a/apps/desktop/src/main/services/server-process.ts
+++ b/apps/desktop/src/main/services/server-process.ts
@@ -4,9 +4,11 @@ import { EventEmitter } from 'events';
 import { promisify } from 'util';
 import https from 'https';
 import http from 'http';
-import { app } from 'electron';
 import { is } from '@electron-toolkit/utils';
 import { configService } from './config-service';
+import { resolveUv } from './uv-resolver';
+import { getUserDataPath } from '../user-data-path';
+import { log } from '../debug-log';
 
 const execFileAsync = promisify(execFileCb);
 
@@ -40,7 +42,7 @@ class ServerProcess extends EventEmitter {
 
   private get sfBin(): string {
     if (!is.dev) {
-      return join(app.getPath('userData'), '.venv', 'bin', 'sf');
+      return join(getUserDataPath(), '.venv', 'bin', 'sf');
     }
     return join(this.serverDir, '.venv', 'bin', 'sf');
   }
@@ -48,12 +50,33 @@ class ServerProcess extends EventEmitter {
   /** Writable directory used as cwd when spawning the server. */
   private get serverCwd(): string {
     if (!is.dev) {
-      return app.getPath('userData');
+      return getUserDataPath();
     }
     return this.serverDir;
   }
 
+  private get gatewayProjectDir(): string {
+    return join(getUserDataPath(), 'aigateway');
+  }
+
+  private get gatewayDatabasePath(): string {
+    return join(this.gatewayProjectDir, 'aigateway.db');
+  }
+
+  private serverEnv(): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    if (!is.dev) {
+      env.SF_AIGW_RUNNER__AIGATEWAY_DIR = this.gatewayProjectDir;
+      env.SF_AIGW_RUNNER__DATABASE_PATH = this.gatewayDatabasePath;
+      env.SF_AIGW_RUNNER__AUTH_ENABLED = 'false';
+      const uvBin = resolveUv();
+      if (uvBin) env.SF_AIGW_RUNNER__UV_BIN = uvBin;
+    }
+    return env;
+  }
+
   private setStatus(s: ServerStatus): void {
+    log(`[server] status: ${this.status} -> ${s}`);
     this.status = s;
     this.emit('status', s);
   }
@@ -108,7 +131,9 @@ class ServerProcess extends EventEmitter {
 
     const config = configService.read();
     const configJson = JSON.stringify(config);
-    const args = ['run', '--subprocess', '--config-json', configJson];
+    const args = ['run', '--subprocess', '--config-json', configJson, '--host', '127.0.0.1'];
+    const env = this.serverEnv();
+    log(`[server] start: sfBin=${this.sfBin} cwd=${this.serverCwd}`);
 
     // If a plugin requires root and we're not already root, elevate via sudo
     const elevate = this.needsRoot() && process.getuid?.() !== 0;
@@ -125,7 +150,7 @@ class ServerProcess extends EventEmitter {
       // Use sudo -S to read password from stdin; stdout/stderr stream normally
       child = spawn('sudo', ['-S', this.sfBin, ...args], {
         cwd: this.serverCwd,
-        env: { ...process.env },
+        env,
         stdio: ['pipe', 'pipe', 'pipe'],
       });
 
@@ -134,7 +159,7 @@ class ServerProcess extends EventEmitter {
     } else {
       child = spawn(this.sfBin, args, {
         cwd: this.serverCwd,
-        env: { ...process.env },
+        env,
         stdio: ['ignore', 'pipe', 'pipe'],
       });
     }
@@ -144,15 +169,18 @@ class ServerProcess extends EventEmitter {
     child.stdout!.on('data', (data: Buffer) => {
       const lines = data.toString().split('\n').filter(Boolean);
       for (const line of lines) {
+        log(`[server:stdout] ${line}`);
         this.handleStdoutLine(line);
       }
     });
 
     child.stderr!.on('data', (data: Buffer) => {
+      log(`[server:stderr] ${data.toString().trimEnd()}`);
       this.emit('log', data.toString());
     });
 
     child.on('close', (code, signal) => {
+      log(`[server] child close code=${code} signal=${signal}`);
       this.stopHealthCheck();
       this.child = null;
       this.readyInfo = null;

--- a/apps/desktop/src/main/services/session-manager.ts
+++ b/apps/desktop/src/main/services/session-manager.ts
@@ -9,6 +9,7 @@ import { app, dialog, BrowserWindow } from 'electron';
 import { is } from '@electron-toolkit/utils';
 import { configService } from './config-service';
 import { backendStatusService } from './backend-status';
+import { getUserDataPath } from '../user-data-path';
 
 export type SessionStatus = 'starting' | 'running' | 'stopping' | 'stopped' | 'error';
 export type SessionType = 'claude' | 'codex' | 'gemini' | 'claude-desktop';
@@ -52,14 +53,14 @@ class SessionManager extends EventEmitter {
 
   private get sfBin(): string {
     if (!is.dev) {
-      return join(app.getPath('userData'), '.venv', 'bin', 'sf');
+      return join(getUserDataPath(), '.venv', 'bin', 'sf');
     }
     return join(configService.serverDir, '.venv', 'bin', 'sf');
   }
 
   private get serverCwd(): string {
     if (!is.dev) {
-      return app.getPath('userData');
+      return getUserDataPath();
     }
     return configService.serverDir;
   }
@@ -195,13 +196,9 @@ class SessionManager extends EventEmitter {
         reload: false,
         ssl: false,
       },
-      plugins: [
-        'tracing',
-        'claude-frontend',
-        'url4-specs',
-      ],
+      plugins: ['tracing', 'claude-frontend', 'url4-specs'],
       plugin_config: {
-        'tracing': {
+        tracing: {
           ...(defaults['tracing'] || {}),
           phoenix_launch: false, // connect to shared Phoenix, don't spawn per-session
         },
@@ -220,8 +217,9 @@ class SessionManager extends EventEmitter {
           // configured port was busy (e.g. another local dev process held
           // it), and a stale backend_url makes /data 404 when the proxy
           // tries to store $prompt blobs.
-          backend_url: backendStatusService.getServerUrl()
-            ?? `${(config.server as Record<string, unknown>).ssl ? 'https' : 'http'}://127.0.0.1:${(config.server as Record<string, unknown>).port || 8000}`,
+          backend_url:
+            backendStatusService.getServerUrl() ??
+            `${(config.server as Record<string, unknown>).ssl ? 'https' : 'http'}://127.0.0.1:${(config.server as Record<string, unknown>).port || 8000}`,
         },
         'url4-specs': defaults['url4-specs'] || {},
       },
@@ -230,8 +228,10 @@ class SessionManager extends EventEmitter {
     const args = [
       'run',
       '--subprocess',
-      '--session-id', session.id,
-      '--config-json', JSON.stringify(proxyConfig),
+      '--session-id',
+      session.id,
+      '--config-json',
+      JSON.stringify(proxyConfig),
     ];
 
     return new Promise<void>((resolve, reject) => {
@@ -291,11 +291,16 @@ class SessionManager extends EventEmitter {
 
   private cliCommand(type: SessionType): string {
     switch (type) {
-      case 'claude': return 'claude';
-      case 'codex': return 'codex';
-      case 'gemini': return 'gemini';
-      case 'claude-desktop': return 'claude';
-      default: return 'claude';
+      case 'claude':
+        return 'claude';
+      case 'codex':
+        return 'codex';
+      case 'gemini':
+        return 'gemini';
+      case 'claude-desktop':
+        return 'claude';
+      default:
+        return 'claude';
     }
   }
 
@@ -383,14 +388,28 @@ end tell`;
         const pid = parseInt(readFileSync(pidPath, 'utf-8').trim(), 10);
         if (!isNaN(pid)) {
           this.emit('log', session.id, `Killing CLI process (PID ${pid})`);
-          try { process.kill(pid, 'SIGTERM'); } catch { /* already dead */ }
+          try {
+            process.kill(pid, 'SIGTERM');
+          } catch {
+            /* already dead */
+          }
 
           // Wait then force-kill
           await new Promise((r) => setTimeout(r, 2000));
-          try { process.kill(pid, 'SIGKILL'); } catch { /* already dead */ }
+          try {
+            process.kill(pid, 'SIGKILL');
+          } catch {
+            /* already dead */
+          }
         }
-      } catch { /* read/parse failed */ }
-      try { unlinkSync(pidPath); } catch { /* */ }
+      } catch {
+        /* read/parse failed */
+      }
+      try {
+        unlinkSync(pidPath);
+      } catch {
+        /* */
+      }
     } else {
       this.emit('log', session.id, 'No PID file found — CLI may need manual close');
     }
@@ -418,7 +437,11 @@ end tell`;
 
     // 3. Clean up temp script
     if (session.scriptPath) {
-      try { unlinkSync(session.scriptPath); } catch { /* */ }
+      try {
+        unlinkSync(session.scriptPath);
+      } catch {
+        /* */
+      }
       session.scriptPath = null;
     }
   }
@@ -438,7 +461,11 @@ end tell`;
       session.proxy.kill('SIGTERM');
       await new Promise<void>((resolve) => {
         const timer = setTimeout(() => {
-          try { session.proxy?.kill('SIGKILL'); } catch { /* */ }
+          try {
+            session.proxy?.kill('SIGKILL');
+          } catch {
+            /* */
+          }
           resolve();
         }, 5000);
         session.proxy!.once('close', () => {

--- a/apps/desktop/src/main/services/venv-manager.ts
+++ b/apps/desktop/src/main/services/venv-manager.ts
@@ -1,5 +1,5 @@
 import { spawn, execFile, execFileSync } from 'child_process';
-import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { copyFileSync, cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { EventEmitter } from 'events';
 import { app } from 'electron';
@@ -7,6 +7,7 @@ import { is } from '@electron-toolkit/utils';
 import { resolveUv } from './uv-resolver';
 import { configService } from './config-service';
 import { log } from '../debug-log';
+import { getUserDataPath } from '../user-data-path';
 
 export interface DiscoveredPlugin {
   state: 'enabled' | 'available';
@@ -27,7 +28,7 @@ class VenvManager extends EventEmitter {
   /** In production, uv commands run from userData (writable) instead of the read-only bundle. */
   private get projectDir(): string {
     if (!is.dev) {
-      return app.getPath('userData');
+      return getUserDataPath();
     }
     return this.serverDir;
   }
@@ -38,6 +39,24 @@ class VenvManager extends EventEmitter {
 
   private get pythonBin(): string {
     return join(this.venvDir, 'bin', 'python');
+  }
+
+  private get bundledPythonBin(): string | null {
+    if (is.dev) return null;
+    const bundledPython = join(process.resourcesPath, 'server', 'python', 'bin', 'python3.12');
+    return existsSync(bundledPython) ? bundledPython : null;
+  }
+
+  private get gatewayProjectDir(): string {
+    return join(getUserDataPath(), 'aigateway');
+  }
+
+  private get gatewayVenvDir(): string {
+    return join(this.gatewayProjectDir, '.venv');
+  }
+
+  private get gatewayPythonBin(): string {
+    return join(this.gatewayVenvDir, 'bin', 'python');
   }
 
   private setStatus(s: VenvStatus): void {
@@ -73,7 +92,7 @@ class VenvManager extends EventEmitter {
         const pyVer = execFileSync(this.pythonBin, ['--version'], { encoding: 'utf-8' });
         log(`[venv] python --version: ${pyVer.trim()}`);
         this.setStatus('ready');
-        const needsSync = this.needsResync();
+        const needsSync = this.needsResync() || (!is.dev && !existsSync(this.gatewayPythonBin));
         log(`[venv] needsResync=${needsSync}`);
         return { status: 'ready', uvFound: true, needsSync, autoBootstrap: false };
       } catch {
@@ -99,8 +118,8 @@ class VenvManager extends EventEmitter {
 
     // Use bundled Python interpreter in production
     if (!is.dev) {
-      const bundledPython = join(process.resourcesPath, 'server', 'python', 'bin', 'python3.12');
-      if (existsSync(bundledPython)) {
+      const bundledPython = this.bundledPythonBin;
+      if (bundledPython) {
         args.push('--python', bundledPython);
       }
     }
@@ -128,7 +147,7 @@ class VenvManager extends EventEmitter {
       this.copyProjectFiles();
 
       // Extract bundled wheel cache (async) and set up offline env vars
-      const cacheDir = join(app.getPath('userData'), 'uv-cache');
+      const cacheDir = join(getUserDataPath(), 'uv-cache');
       log(`[venv] sync: extracting cache to ${cacheDir}`);
       try {
         await this.extractCacheIfNeeded(cacheDir);
@@ -141,7 +160,11 @@ class VenvManager extends EventEmitter {
     }
 
     const args = [this.uvBin, 'sync'];
-    if (!is.dev) args.push('--no-install-project');
+    if (!is.dev) {
+      const bundledPython = this.bundledPythonBin;
+      if (bundledPython) args.push('--python', bundledPython);
+      args.push('--no-install-project');
+    }
     if (extra) args.push('--extra', extra);
 
     log(`[venv] sync: spawning ${args.join(' ')}`);
@@ -156,10 +179,16 @@ class VenvManager extends EventEmitter {
       const serverSrc = join(process.resourcesPath, 'server');
       const installArgs = [this.uvBin, 'pip', 'install', '--no-deps', serverSrc];
       log(`[venv] installing project from ${serverSrc}`);
-      const installOk = await this.runUvCommand(installArgs);
+      const installOk = await this.runUvCommand(installArgs, undefined, { suppressReady: true });
       log(`[venv] project install result=${installOk}`);
       if (!installOk) return false;
+
+      const gatewayOk = await this.syncGatewayProject(extraEnv);
+      log(`[venv] gateway project sync result=${gatewayOk}`);
+      if (!gatewayOk) return false;
+
       this.writeVersionStamp();
+      this.setStatus('ready');
     }
 
     return ok;
@@ -212,18 +241,18 @@ class VenvManager extends EventEmitter {
   private runUvCommand(
     args: string[],
     extraEnv?: Record<string, string>,
-    opts?: { suppressReady?: boolean },
+    opts?: { suppressReady?: boolean; cwd?: string; venvDir?: string },
   ): Promise<boolean> {
     return new Promise((resolve) => {
       const [cmd, ...rest] = args;
       const env: Record<string, string | undefined> = {
         ...process.env,
-        VIRTUAL_ENV: this.venvDir,
+        VIRTUAL_ENV: opts?.venvDir ?? this.venvDir,
         ...extraEnv,
       };
 
       const child = spawn(cmd, rest, {
-        cwd: this.projectDir,
+        cwd: opts?.cwd ?? this.projectDir,
         env,
       });
 
@@ -240,12 +269,14 @@ class VenvManager extends EventEmitter {
           if (!opts?.suppressReady) this.setStatus('ready');
           resolve(true);
         } else {
+          log(`[venv] command failed (${code}): ${cmd} ${rest.join(' ')}`);
           this.setStatus('error');
           resolve(false);
         }
       });
 
-      child.on('error', () => {
+      child.on('error', (err) => {
+        log(`[venv] command error: ${err.message}`);
         this.setStatus('error');
         resolve(false);
       });
@@ -254,7 +285,7 @@ class VenvManager extends EventEmitter {
 
   /** Copy pyproject.toml and uv.lock from the read-only bundle to writable userData. */
   private copyProjectFiles(): void {
-    const dest = app.getPath('userData');
+    const dest = getUserDataPath();
     for (const file of ['pyproject.toml', 'uv.lock']) {
       const src = join(process.resourcesPath, 'server', file);
       const dst = join(dest, file);
@@ -262,6 +293,46 @@ class VenvManager extends EventEmitter {
         copyFileSync(src, dst);
       }
     }
+  }
+
+  private async syncGatewayProject(extraEnv?: Record<string, string>): Promise<boolean> {
+    if (!this.uvBin) return false;
+    this.copyGatewayProjectFiles();
+
+    const syncArgs = [this.uvBin, 'sync'];
+    const bundledPython = this.bundledPythonBin;
+    if (bundledPython) syncArgs.push('--python', bundledPython);
+    syncArgs.push('--no-install-project');
+
+    const syncOk = await this.runUvCommand(syncArgs, extraEnv, {
+      suppressReady: true,
+      cwd: this.gatewayProjectDir,
+      venvDir: this.gatewayVenvDir,
+    });
+    if (!syncOk) return false;
+
+    return this.runUvCommand(
+      [this.uvBin, 'pip', 'install', '--no-deps', this.gatewayProjectDir],
+      undefined,
+      {
+        suppressReady: true,
+        cwd: this.gatewayProjectDir,
+        venvDir: this.gatewayVenvDir,
+      },
+    );
+  }
+
+  private copyGatewayProjectFiles(): void {
+    mkdirSync(this.gatewayProjectDir, { recursive: true });
+    const srcRoot = join(process.resourcesPath, 'aigateway');
+    for (const file of ['pyproject.toml', 'uv.lock']) {
+      const src = join(srcRoot, file);
+      const dst = join(this.gatewayProjectDir, file);
+      if (existsSync(src)) copyFileSync(src, dst);
+    }
+    const src = join(srcRoot, 'src');
+    const dst = join(this.gatewayProjectDir, 'src');
+    if (existsSync(src)) cpSync(src, dst, { recursive: true, force: true });
   }
 
   private extractCacheIfNeeded(cacheDir: string): Promise<void> {
@@ -281,7 +352,7 @@ class VenvManager extends EventEmitter {
   }
 
   private get versionStampPath(): string {
-    return join(app.getPath('userData'), '.sf-version');
+    return join(getUserDataPath(), '.sf-version');
   }
 
   private writeVersionStamp(): void {

--- a/apps/desktop/src/main/user-data-path.ts
+++ b/apps/desktop/src/main/user-data-path.ts
@@ -1,0 +1,15 @@
+import { mkdirSync } from 'fs';
+import { resolve } from 'path';
+import { app } from 'electron';
+
+const USER_DATA_OVERRIDE_ENV = 'SCREAMINGFACE_USER_DATA_DIR';
+
+export function getUserDataPath(): string {
+  const override = process.env[USER_DATA_OVERRIDE_ENV];
+  if (override) {
+    const dir = resolve(override);
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+  return app.getPath('userData');
+}

--- a/apps/desktop/src/main/window-registry.ts
+++ b/apps/desktop/src/main/window-registry.ts
@@ -1,0 +1,11 @@
+import type { BrowserWindow } from 'electron';
+
+let mainWindow: BrowserWindow | null = null;
+
+export function setMainWindow(window: BrowserWindow | null): void {
+  mainWindow = window;
+}
+
+export function getMainWindow(): BrowserWindow | null {
+  return mainWindow;
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -52,11 +52,12 @@ const api: ElectronAPI = {
     authenticate: (backend) => ipcRenderer.invoke('backends:authenticate', backend),
     authenticateOAuth: (backend, profileName?) =>
       ipcRenderer.invoke('backends:authenticateOAuth', backend, profileName),
-    getPendingAuthState: (backend) =>
-      ipcRenderer.invoke('backends:getPendingAuthState', backend),
+    getPendingAuthState: (backend) => ipcRenderer.invoke('backends:getPendingAuthState', backend),
     exchangeOAuthCode: (backend, code) =>
       ipcRenderer.invoke('backends:exchangeOAuthCode', backend, code),
     listProfiles: (backend) => ipcRenderer.invoke('backends:listProfiles', backend),
+    importProfile: (backend, profileName?) =>
+      ipcRenderer.invoke('backends:importProfile', backend, profileName),
     deleteProfile: (backend, profileName) =>
       ipcRenderer.invoke('backends:deleteProfile', backend, profileName),
     onStatusChanged: (cb) => onEvent('backends:statusChanged', cb),

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -54,7 +54,7 @@ export interface BackendHealth {
   action: BackendAction;
   cli_command?: string | null;
   help_text?: string | null;
-  auth_kind?: 'cli' | 'browser';
+  auth_kind?: 'cli' | 'browser' | 'import';
 }
 
 export type BackendStatusMap = Record<string, BackendHealth>;
@@ -85,6 +85,8 @@ export interface DeleteProfileResult {
   ok: boolean;
   status?: number;
 }
+
+export type ImportProfileResult = { ok: true } | { ok: false; status?: number; message?: string };
 
 export type ExchangeOAuthCodeResult =
   | { ok: true }
@@ -149,6 +151,7 @@ export interface ElectronAPI {
     authenticate: (backend: string) => Promise<void>;
     authenticateOAuth: (backend: string, profileName?: string) => Promise<OAuthLauncherResult>;
     listProfiles: (backend: string) => Promise<ListProfilesResult>;
+    importProfile: (backend: string, profileName?: string) => Promise<ImportProfileResult>;
     deleteProfile: (backend: string, profileName: string) => Promise<DeleteProfileResult>;
     getPendingAuthState: (backend: string) => Promise<string | null>;
     exchangeOAuthCode: (backend: string, code: string) => Promise<ExchangeOAuthCodeResult>;

--- a/apps/desktop/src/renderer/src/components/server/BackendStatusPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/server/BackendStatusPanel.tsx
@@ -28,6 +28,7 @@ const backendLabels: Record<string, string> = {
   claude: 'Claude',
   codex: 'Codex',
   gemini: 'Gemini',
+  ollama: 'Ollama',
 };
 
 function AuthButton({
@@ -36,7 +37,7 @@ function AuthButton({
   cliCommand,
 }: {
   name: string;
-  authKind: 'cli' | 'browser';
+  authKind: 'cli' | 'browser' | 'import';
   cliCommand?: string;
 }) {
   const [waiting, setWaiting] = useState(false);
@@ -53,7 +54,8 @@ function AuthButton({
     );
   }
 
-  // browser
+  if (authKind === 'import') return null;
+
   return (
     <button
       disabled={waiting}
@@ -74,10 +76,12 @@ function AuthButton({
 
 function ProfileRow({
   backendName,
+  authKind,
   profile,
   onChanged,
 }: {
   backendName: string;
+  authKind: 'browser' | 'import';
   profile: BackendProfile;
   onChanged: () => void;
 }) {
@@ -89,13 +93,15 @@ function ProfileRow({
     setBusy(true);
     setError(null);
     try {
-      const result = await window.electronAPI.backends.authenticateOAuth(
-        backendName,
-        profile.name,
-      );
-      if (result.kind === 'failed') {
+      const result =
+        authKind === 'import'
+          ? await window.electronAPI.backends.importProfile(backendName, profile.name)
+          : await window.electronAPI.backends.authenticateOAuth(backendName, profile.name);
+      if ('kind' in result && result.kind === 'failed') {
         const reason = result.message ? `${result.reason}: ${result.message}` : result.reason;
         setError(`Re-auth failed — ${reason}`);
+      } else if ('ok' in result && !result.ok) {
+        setError(`Import failed — ${result.message ?? result.status ?? 'unknown error'}`);
       }
     } catch (e) {
       setError(`Re-auth failed — ${e instanceof Error ? e.message : String(e)}`);
@@ -150,7 +156,7 @@ function ProfileRow({
           onClick={onReauth}
           className="rounded bg-chart-1/20 px-2 py-0.5 text-xs font-medium text-chart-1 hover:bg-chart-1/30 transition-colors disabled:opacity-60"
         >
-          {busy ? 'Working…' : 'Re-authenticate'}
+          {busy ? 'Working…' : authKind === 'import' ? 'Refresh Import' : 'Re-authenticate'}
         </button>
         <button
           disabled={busy}
@@ -161,14 +167,12 @@ function ProfileRow({
           Delete
         </button>
       </div>
-      {error && (
-        <p className="basis-full text-xs text-destructive mt-1">{error}</p>
-      )}
+      {error && <p className="basis-full text-xs text-destructive mt-1">{error}</p>}
     </div>
   );
 }
 
-function ProfilesSubPanel({ name }: { name: string }) {
+function ProfilesSubPanel({ name, authKind }: { name: string; authKind: 'browser' | 'import' }) {
   const [profiles, setProfiles] = useState<BackendProfile[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [adding, setAdding] = useState(false);
@@ -179,6 +183,7 @@ function ProfilesSubPanel({ name }: { name: string }) {
   const [pasteCode, setPasteCode] = useState('');
   const [pasteBusy, setPasteBusy] = useState(false);
   const [pasteError, setPasteError] = useState<string | null>(null);
+  const isImport = authKind === 'import';
 
   const refresh = useCallback(async () => {
     const result = await window.electronAPI.backends.listProfiles(name);
@@ -213,7 +218,9 @@ function ProfilesSubPanel({ name }: { name: string }) {
         setHasPendingAuth(false);
         await refresh();
       } else {
-        setPasteError(result.message ?? `Exchange failed${result.status ? ` (${result.status})` : ''}`);
+        setPasteError(
+          result.message ?? `Exchange failed${result.status ? ` (${result.status})` : ''}`,
+        );
       }
     } catch (err) {
       setPasteError(err instanceof Error ? err.message : String(err));
@@ -240,6 +247,28 @@ function ProfilesSubPanel({ name }: { name: string }) {
     }
     setSubmitting(true);
     setAddError(null);
+    if (isImport) {
+      void (async () => {
+        try {
+          const result = await window.electronAPI.backends.importProfile(name, candidate);
+          if (!result.ok) {
+            setAddError(
+              `Import failed for "${candidate}" — ${result.message ?? result.status ?? 'unknown error'}`,
+            );
+          }
+        } catch (err2) {
+          setAddError(
+            `Import failed for "${candidate}" — ${err2 instanceof Error ? err2.message : String(err2)}`,
+          );
+        } finally {
+          setSubmitting(false);
+          setAdding(false);
+          setNewName('');
+          void refresh();
+        }
+      })();
+      return;
+    }
     // Close the form immediately — the browser will open right away,
     // and the long-running poll happens in the background. We surface
     // any failure via panel-level addError, then refresh the list.
@@ -286,6 +315,7 @@ function ProfilesSubPanel({ name }: { name: string }) {
         <ProfileRow
           key={p.id || p.name}
           backendName={name}
+          authKind={authKind}
           profile={p}
           onChanged={() => {
             void refresh();
@@ -328,14 +358,15 @@ function ProfilesSubPanel({ name }: { name: string }) {
         </form>
       ) : (
         <button
+          disabled={submitting}
           onClick={() => setAdding(true)}
           className="rounded bg-chart-1 px-2.5 py-1 text-xs font-semibold text-background hover:bg-chart-1/90 transition-colors mt-1"
         >
-          + Add Profile
+          {isImport ? 'Import Profile' : '+ Add Profile'}
         </button>
       )}
       {addError && <p className="text-xs text-destructive mt-1">{addError}</p>}
-      {hasPendingAuth && (
+      {!isImport && hasPendingAuth && (
         <form
           onSubmit={onPasteSubmit}
           className="flex items-center gap-2 py-1.5 mt-2 border-t border-border pt-2"
@@ -371,6 +402,8 @@ function BackendRow({ name, health }: { name: string; health: BackendHealth }) {
   const config = actionConfig[health.action] || actionConfig.degraded;
   const label = backendLabels[name] || name;
   const isBrowser = health.auth_kind === 'browser';
+  const isImport = health.auth_kind === 'import';
+  const hasProfiles = isBrowser || isImport;
 
   return (
     <div className="py-2">
@@ -406,7 +439,7 @@ function BackendRow({ name, health }: { name: string; health: BackendHealth }) {
            * Authenticate button is hidden to avoid two concurrent auth UIs.
            * CLI-mode backends keep the existing Re-authenticate button.
            */}
-          {!isBrowser && health.action === 'reauth' && (
+          {!hasProfiles && health.action === 'reauth' && (
             <AuthButton
               name={name}
               authKind={health.auth_kind ?? 'cli'}
@@ -415,7 +448,7 @@ function BackendRow({ name, health }: { name: string; health: BackendHealth }) {
           )}
         </div>
       </div>
-      {isBrowser && <ProfilesSubPanel name={name} />}
+      {hasProfiles && <ProfilesSubPanel name={name} authKind={isImport ? 'import' : 'browser'} />}
     </div>
   );
 }
@@ -442,25 +475,14 @@ export function BackendStatusPanel() {
     const unsubAlert = window.electronAPI.backends.onAlert((alert: BackendAlert) => {
       const label = backendLabels[alert.backend] || alert.backend;
       if (alert.type === 'reauth') {
-        toast({
-          variant: 'error',
-          title: `${label} needs re-authentication`,
-          description: alert.health.cli_command
-            ? `Run: ${alert.health.cli_command}`
-            : 'Check backend credentials',
-        });
+        const help = alert.health.cli_command
+          ? `Run: ${alert.health.cli_command}`
+          : 'Check backend credentials';
+        toast(`${label} needs re-authentication. ${help}`, 'error', 5000);
       } else if (alert.type === 'rate_limited') {
-        toast({
-          variant: 'warning',
-          title: `${label} rate limited`,
-          description: 'API rate budget exhausted. Will recover automatically.',
-        });
+        toast(`${label} rate limited. API rate budget exhausted.`, 'warning', 5000);
       } else if (alert.type === 'recovered') {
-        toast({
-          variant: 'success',
-          title: `${label} recovered`,
-          description: 'Backend is healthy again.',
-        });
+        toast(`${label} recovered. Backend is healthy again.`, 'success');
       }
     });
 

--- a/apps/desktop/src/renderer/src/components/server/__tests__/BackendStatusPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/components/server/__tests__/BackendStatusPanel.test.tsx
@@ -9,9 +9,11 @@ const onStatusChanged = vi.fn(() => () => {});
 const onAlert = vi.fn(() => () => {});
 const refresh = vi.fn();
 const listProfiles = vi.fn(async () => ({ profiles: [] }));
+const importProfile = vi.fn(async () => ({ ok: true }));
 const deleteProfile = vi.fn(async () => ({ ok: true }));
 const getPendingAuthState = vi.fn(async (): Promise<string | null> => null);
 const exchangeOAuthCode = vi.fn(async () => ({ ok: true }) as { ok: boolean; message?: string });
+const toastMock = vi.hoisted(() => vi.fn());
 
 (window as unknown as { electronAPI: unknown }).electronAPI = {
   backends: {
@@ -22,6 +24,7 @@ const exchangeOAuthCode = vi.fn(async () => ({ ok: true }) as { ok: boolean; mes
     onAlert,
     refresh,
     listProfiles,
+    importProfile,
     deleteProfile,
     getPendingAuthState,
     exchangeOAuthCode,
@@ -30,7 +33,7 @@ const exchangeOAuthCode = vi.fn(async () => ({ ok: true }) as { ok: boolean; mes
 
 // Stub the toast hook used by the component to avoid pulling in providers.
 vi.mock('@/hooks/use-toast', () => ({
-  useToast: () => ({ toast: vi.fn() }),
+  useToast: () => ({ toast: toastMock }),
 }));
 
 // Stub cn util to a trivial implementation (it's just classname concat).
@@ -50,12 +53,15 @@ beforeEach(() => {
   authenticateOAuth.mockImplementation(async () => ({ kind: 'complete' }));
   listProfiles.mockClear();
   listProfiles.mockResolvedValue({ profiles: [] });
+  importProfile.mockClear();
+  importProfile.mockResolvedValue({ ok: true });
   deleteProfile.mockClear();
   deleteProfile.mockResolvedValue({ ok: true });
   getPendingAuthState.mockClear();
   getPendingAuthState.mockResolvedValue(null);
   exchangeOAuthCode.mockClear();
   exchangeOAuthCode.mockResolvedValue({ ok: true });
+  toastMock.mockClear();
   getStatus.mockResolvedValue({
     claude: {
       authenticated: false,
@@ -69,6 +75,31 @@ beforeEach(() => {
 });
 
 describe('BackendStatusPanel auth_kind=browser sub-panel', () => {
+  it('formats backend alerts for the app toast API', async () => {
+    render(<BackendStatusPanel />);
+    await waitFor(() => expect(onAlert).toHaveBeenCalled());
+
+    const callback = onAlert.mock.calls[0][0];
+    callback({
+      backend: 'claude',
+      type: 'reauth',
+      health: {
+        authenticated: false,
+        action: 'reauth',
+        auth_kind: 'browser',
+        cli_command: null,
+        help_text: 'Sign in via browser',
+        model: 'anthropic/claude-sonnet-4-5',
+      },
+    });
+
+    expect(toastMock).toHaveBeenCalledWith(
+      'Claude needs re-authentication. Check backend credentials',
+      'error',
+      5000,
+    );
+  });
+
   it('renders all profiles returned by listProfiles', async () => {
     listProfiles.mockResolvedValue({
       profiles: [
@@ -140,6 +171,31 @@ describe('BackendStatusPanel auth_kind=browser sub-panel', () => {
     fireEvent.change(input, { target: { value: 'work' } });
     fireEvent.click(screen.getByRole('button', { name: /Confirm/i }));
     await waitFor(() => expect(authenticateOAuth).toHaveBeenCalledWith('claude', 'work'));
+  });
+});
+
+describe('BackendStatusPanel auth_kind=import', () => {
+  it('uses import-specific add-profile flow and imports the named profile', async () => {
+    getStatus.mockResolvedValue({
+      codex: {
+        authenticated: false,
+        action: 'reauth',
+        auth_kind: 'import',
+        cli_command: null,
+        help_text: 'Import Codex login',
+        model: 'codex/gpt-5.4-mini',
+      },
+    });
+
+    render(<BackendStatusPanel />);
+    const button = await screen.findByRole('button', { name: /Import Profile/i });
+    fireEvent.click(button);
+    const input = screen.getByPlaceholderText(/profile name/i);
+    fireEvent.change(input, { target: { value: 'work' } });
+    fireEvent.click(screen.getByRole('button', { name: /Confirm/i }));
+
+    await waitFor(() => expect(importProfile).toHaveBeenCalledWith('codex', 'work'));
+    expect(authenticateOAuth).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/server/sf.json
+++ b/apps/server/sf.json
@@ -17,7 +17,6 @@
     "llm-base",
     "frontend-base",
     "backend-api-base",
-    "codex-backend-api",
     "gemini-backend-api",
     "ollama-backend-api",
     "gemini-frontend",
@@ -25,6 +24,7 @@
     "ollama-frontend",
     "aigw-base",
     "aigw-claude-backend",
+    "aigw-codex-backend",
     "aigw-runner"
   ],
   "plugin_config": {

--- a/apps/server/src/screamingface/core/registry.py
+++ b/apps/server/src/screamingface/core/registry.py
@@ -6,7 +6,7 @@ import importlib
 import importlib.metadata
 import logging
 import pkgutil
-from typing import Any
+from typing import Any, cast
 
 from screamingface.plugin import Plugin
 
@@ -39,13 +39,10 @@ class PluginRegistry:
                     continue
                 for attr in dir(mod):
                     cls = getattr(mod, attr)
-                    if (
-                        isinstance(cls, type)
-                        and issubclass(cls, Plugin)
-                        and cls is not Plugin
-                        and cls.name
-                    ):
-                        self._discovered[cls.name] = cls
+                    if isinstance(cls, type) and issubclass(cls, Plugin) and cls is not Plugin:
+                        plugin_cls = cast(type[Plugin], cls)
+                        if plugin_cls.name:
+                            self._discovered[plugin_cls.name] = plugin_cls
         except ImportError:
             logger.debug("No screamingface.plugins package found")
 
@@ -115,7 +112,11 @@ class PluginRegistry:
             logger.warning("Plugin %r skipped: %s", plugin.name, reason)
             return
 
-        plugin.setup(**kwargs)
+        try:
+            plugin.setup(**kwargs)
+        except Exception as exc:
+            logger.warning("Plugin %r skipped: setup failed - %s", plugin.name, exc)
+            return
         self._active[plugin.name] = plugin
         logger.info("Activated plugin: %s v%s", plugin.name, plugin.version)
 

--- a/apps/server/src/screamingface/plugins/aigw_base/auth_proxy_router.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/auth_proxy_router.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Literal
 
 import httpx
 from fastapi import APIRouter, HTTPException, Response
@@ -34,6 +34,10 @@ __all__ = ["build_aigw_auth_proxy_router"]
 
 
 HttpClientFactory = Callable[[float], httpx.AsyncClient]
+AuthProxyRoute = Literal["start", "status", "profiles", "exchange_code", "delete", "import"]
+_DEFAULT_ENABLED_ROUTES: frozenset[AuthProxyRoute] = frozenset(
+    {"start", "status", "profiles", "exchange_code", "delete"}
+)
 
 
 class _ExchangeCodeBody(BaseModel):
@@ -54,6 +58,7 @@ def build_aigw_auth_proxy_router(
     http_client_factory: HttpClientFactory | None = None,
     timeout_seconds: float = 10.0,
     defaults: dict[str, Any] | None = None,
+    enabled_routes: set[AuthProxyRoute] | frozenset[AuthProxyRoute] | None = None,
 ) -> APIRouter:
     """Build the SF-side proxy routes that drive the gateway OAuth flow.
 
@@ -70,154 +75,139 @@ def build_aigw_auth_proxy_router(
     router = APIRouter(tags=[f"{path_prefix.lstrip('/')}-auth"])
     base = gateway_url.rstrip("/")
     factory = http_client_factory or _default_http_factory
+    routes = enabled_routes or _DEFAULT_ENABLED_ROUTES
 
-    @router.post(f"{path_prefix}/auth/start")
-    async def start_auth(name: str | None = None) -> dict[str, Any]:
-        target = name or profile_name
-        url = f"{base}/v1/auth/{gateway_provider}/profiles"
-        body: dict[str, Any] = {"name": target}
-        # Forward SF-configured defaults only when creating the configured
-        # default profile. For other names we send no defaults.
-        if defaults and target == profile_name:
-            body["defaults"] = defaults
-        try:
-            async with factory(timeout_seconds) as client:
-                resp = await client.post(url, json=body)
-        except httpx.RequestError as exc:
-            logger.warning("aigw auth-proxy: gateway unreachable at %s: %s", base, exc)
-            raise HTTPException(
-                status_code=502,
-                detail={
-                    "code": "gateway_unreachable",
-                    "message": f"AI Gateway unreachable at {base}: {exc}",
-                },
-            ) from exc
+    if "start" in routes:
 
-        if resp.status_code >= 500:
-            logger.warning("aigw auth-proxy: gateway returned %d", resp.status_code)
-            raise HTTPException(
-                status_code=502,
-                detail={"code": "gateway_error", "upstream_status": resp.status_code},
-            )
-        if resp.status_code >= 400:
-            raise HTTPException(status_code=resp.status_code, detail=_safe_json(resp))
-        return resp.json()
+        @router.post(f"{path_prefix}/auth/start")
+        async def start_auth(name: str | None = None) -> dict[str, Any]:
+            target = name or profile_name
+            url = f"{base}/v1/auth/{gateway_provider}/profiles"
+            body = _profile_body(target, profile_name, defaults)
+            resp = await _post_json(url, body, base, factory, timeout_seconds)
+            return resp.json()
 
-    @router.get(f"{path_prefix}/auth/status")
-    async def auth_status(name: str | None = None) -> dict[str, Any]:
-        target = name or profile_name
-        url = f"{base}/v1/auth/{gateway_provider}/profiles/{target}/status"
-        try:
-            async with factory(timeout_seconds) as client:
-                resp = await client.get(url)
-        except httpx.RequestError as exc:
-            logger.warning("aigw auth-proxy: gateway unreachable at %s: %s", base, exc)
-            raise HTTPException(
-                status_code=502,
-                detail={
-                    "code": "gateway_unreachable",
-                    "message": f"AI Gateway unreachable at {base}: {exc}",
-                },
-            ) from exc
+    if "status" in routes:
 
-        if resp.status_code >= 500:
-            logger.warning("aigw auth-proxy: gateway returned %d", resp.status_code)
-            raise HTTPException(
-                status_code=502,
-                detail={"code": "gateway_error", "upstream_status": resp.status_code},
-            )
-        if resp.status_code >= 400:
-            raise HTTPException(status_code=resp.status_code, detail=_safe_json(resp))
-        return resp.json()
+        @router.get(f"{path_prefix}/auth/status")
+        async def auth_status(name: str | None = None) -> dict[str, Any]:
+            target = name or profile_name
+            url = f"{base}/v1/auth/{gateway_provider}/profiles/{target}/status"
+            resp = await _get_json(url, base, factory, timeout_seconds)
+            return resp.json()
 
-    @router.get(f"{path_prefix}/auth/profiles")
-    async def list_profiles() -> dict[str, Any]:
-        url = f"{base}/v1/auth/{gateway_provider}/profiles"
-        try:
-            async with factory(timeout_seconds) as client:
-                resp = await client.get(url)
-        except httpx.RequestError as exc:
-            logger.warning("aigw auth-proxy: gateway unreachable at %s: %s", base, exc)
-            raise HTTPException(
-                status_code=502,
-                detail={
-                    "code": "gateway_unreachable",
-                    "message": f"AI Gateway unreachable at {base}: {exc}",
-                },
-            ) from exc
+    if "profiles" in routes:
 
-        if resp.status_code >= 500:
-            logger.warning("aigw auth-proxy: gateway returned %d", resp.status_code)
-            raise HTTPException(
-                status_code=502,
-                detail={"code": "gateway_error", "upstream_status": resp.status_code},
-            )
-        if resp.status_code >= 400:
-            raise HTTPException(status_code=resp.status_code, detail=_safe_json(resp))
-        return resp.json()
+        @router.get(f"{path_prefix}/auth/profiles")
+        async def list_profiles() -> dict[str, Any]:
+            url = f"{base}/v1/auth/{gateway_provider}/profiles"
+            resp = await _get_json(url, base, factory, timeout_seconds)
+            return resp.json()
 
-    @router.post(f"{path_prefix}/auth/exchange-code")
-    async def exchange_code(body: _ExchangeCodeBody) -> dict[str, Any]:
-        """Forward a manually-pasted authorization code to the gateway.
+    if "import" in routes:
 
-        Used as a fallback when the OAuth provider displays the code on
-        screen (e.g. ``code=true``) instead of redirecting back. The
-        gateway looks up the matching pending entry by ``state``, so we
-        do not need to know which profile this targets.
-        """
-        url = f"{base}/v1/auth/{gateway_provider}/exchange-code"
-        try:
-            async with factory(timeout_seconds) as client:
-                resp = await client.post(url, json=body.model_dump())
-        except httpx.RequestError as exc:
-            logger.warning("aigw auth-proxy: gateway unreachable at %s: %s", base, exc)
-            raise HTTPException(
-                status_code=502,
-                detail={
-                    "code": "gateway_unreachable",
-                    "message": f"AI Gateway unreachable at {base}: {exc}",
-                },
-            ) from exc
+        @router.post(f"{path_prefix}/auth/import", status_code=201)
+        async def import_profile(name: str | None = None) -> dict[str, Any]:
+            target = name or profile_name
+            url = f"{base}/v1/auth/{gateway_provider}/profiles/import"
+            body = _profile_body(target, profile_name, defaults)
+            resp = await _post_json(url, body, base, factory, timeout_seconds)
+            return resp.json()
 
-        if resp.status_code >= 500:
-            logger.warning("aigw auth-proxy: gateway returned %d", resp.status_code)
-            raise HTTPException(
-                status_code=502,
-                detail={"code": "gateway_error", "upstream_status": resp.status_code},
-            )
-        if resp.status_code >= 400:
-            raise HTTPException(status_code=resp.status_code, detail=_safe_json(resp))
-        return resp.json()
+    if "exchange_code" in routes:
 
-    @router.delete(f"{path_prefix}/auth/profiles/{{name}}", status_code=204)
-    async def delete_profile(name: str) -> Response:
-        url = f"{base}/v1/auth/{gateway_provider}/profiles/{name}"
-        try:
-            async with factory(timeout_seconds) as client:
-                resp = await client.delete(url)
-        except httpx.RequestError as exc:
-            logger.warning("aigw auth-proxy: gateway unreachable at %s: %s", base, exc)
-            raise HTTPException(
-                status_code=502,
-                detail={
-                    "code": "gateway_unreachable",
-                    "message": f"AI Gateway unreachable at {base}: {exc}",
-                },
-            ) from exc
+        @router.post(f"{path_prefix}/auth/exchange-code")
+        async def exchange_code(body: _ExchangeCodeBody) -> dict[str, Any]:
+            """Forward a manually-pasted authorization code to the gateway.
 
-        if resp.status_code == 204:
+            Used as a fallback when the OAuth provider displays the code on
+            screen (e.g. ``code=true``) instead of redirecting back. The
+            gateway looks up the matching pending entry by ``state``, so we
+            do not need to know which profile this targets.
+            """
+            url = f"{base}/v1/auth/{gateway_provider}/exchange-code"
+            resp = await _post_json(url, body.model_dump(), base, factory, timeout_seconds)
+            return resp.json()
+
+    if "delete" in routes:
+
+        @router.delete(f"{path_prefix}/auth/profiles/{{name}}", status_code=204)
+        async def delete_profile(name: str) -> Response:
+            url = f"{base}/v1/auth/{gateway_provider}/profiles/{name}"
+            try:
+                async with factory(timeout_seconds) as client:
+                    resp = await client.delete(url)
+            except httpx.RequestError as exc:
+                raise _gateway_unreachable(base, exc)
+
+            if resp.status_code == 204:
+                return Response(status_code=204)
+            _raise_for_gateway_error(resp)
             return Response(status_code=204)
-        if resp.status_code >= 500:
-            logger.warning("aigw auth-proxy: gateway returned %d", resp.status_code)
-            raise HTTPException(
-                status_code=502,
-                detail={"code": "gateway_error", "upstream_status": resp.status_code},
-            )
-        if resp.status_code >= 400:
-            raise HTTPException(status_code=resp.status_code, detail=_safe_json(resp))
-        return Response(status_code=204)
 
     return router
+
+
+async def _post_json(
+    url: str,
+    body: dict[str, Any],
+    base: str,
+    factory: HttpClientFactory,
+    timeout_seconds: float,
+) -> httpx.Response:
+    try:
+        async with factory(timeout_seconds) as client:
+            resp = await client.post(url, json=body)
+    except httpx.RequestError as exc:
+        raise _gateway_unreachable(base, exc)
+    _raise_for_gateway_error(resp)
+    return resp
+
+
+async def _get_json(
+    url: str,
+    base: str,
+    factory: HttpClientFactory,
+    timeout_seconds: float,
+) -> httpx.Response:
+    try:
+        async with factory(timeout_seconds) as client:
+            resp = await client.get(url)
+    except httpx.RequestError as exc:
+        raise _gateway_unreachable(base, exc)
+    _raise_for_gateway_error(resp)
+    return resp
+
+
+def _profile_body(
+    target: str, profile_name: str, defaults: dict[str, Any] | None
+) -> dict[str, Any]:
+    body: dict[str, Any] = {"name": target}
+    if defaults and target == profile_name:
+        body["defaults"] = defaults
+    return body
+
+
+def _gateway_unreachable(base: str, exc: httpx.RequestError) -> HTTPException:
+    logger.warning("aigw auth-proxy: gateway unreachable at %s: %s", base, exc)
+    return HTTPException(
+        status_code=502,
+        detail={
+            "code": "gateway_unreachable",
+            "message": f"AI Gateway unreachable at {base}: {exc}",
+        },
+    )
+
+
+def _raise_for_gateway_error(resp: httpx.Response) -> None:
+    if resp.status_code >= 500:
+        logger.warning("aigw auth-proxy: gateway returned %d", resp.status_code)
+        raise HTTPException(
+            status_code=502,
+            detail={"code": "gateway_error", "upstream_status": resp.status_code},
+        )
+    if resp.status_code >= 400:
+        raise HTTPException(status_code=resp.status_code, detail=_safe_json(resp))
 
 
 def _safe_json(resp: httpx.Response) -> Any:

--- a/apps/server/src/screamingface/plugins/aigw_base/backend.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/backend.py
@@ -50,7 +50,7 @@ class AigwBackend(Backend):
         *,
         gateway_url: str = "http://127.0.0.1:9105",
         profile_name: str = "default",
-        gateway_provider: str = "anthropic",
+        gateway_provider: str,
         http_client_factory=None,
     ) -> None:
         self._gateway_url = gateway_url.rstrip("/")

--- a/apps/server/src/screamingface/plugins/aigw_base/interpreter.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/interpreter.py
@@ -35,15 +35,9 @@ class AigwInterpreter(Url4Interpreter):
     ) -> None:
         super().__init__(app)
         self.settings = settings
-        if backend is not None:
-            self._backend = backend
-        elif settings is not None:
-            self._backend = AigwBackend(
-                gateway_url=settings.gateway_url,
-                profile_name=settings.auth_profile,
-            )
-        else:
-            self._backend = AigwBackend()
+        if backend is None:
+            raise ValueError("AigwInterpreter requires an AigwBackend with gateway_provider")
+        self._backend = backend
 
     async def process(self, sources: str, intent: str | None) -> str:
         combined = f"{intent}\n\n{sources}" if intent and sources else (intent or sources or "")

--- a/apps/server/src/screamingface/plugins/aigw_base/plugin_base.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/plugin_base.py
@@ -9,6 +9,7 @@ create_router) and inherit `_make_interpreter` here.
 from __future__ import annotations
 
 import logging
+import os
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import httpx
@@ -42,11 +43,17 @@ class AigwBackendApiPluginBase(BackendApiPluginBase):
 
     def _make_interpreter(self, app: FastAPI):
         settings = cast(AigwBackendApiSettingsBase, self.settings)
+        assert self.gateway_provider, f"{type(self).__name__} must declare gateway_provider"
         backend = AigwBackend(
             gateway_url=settings.gateway_url,
             profile_name=settings.auth_profile,
+            gateway_provider=self.gateway_provider,
         )
         return AigwInterpreter(app=app, settings=settings, backend=backend)
+
+    def setup(self, app: FastAPI, hooks, classes, routes) -> None:  # type: ignore[override]
+        _assert_loopback_sf_bind(app)
+        super().setup(app=app, hooks=hooks, classes=classes, routes=routes)
 
     # ------------------------------------------------------------------ #
     # Schema customization
@@ -151,3 +158,17 @@ class AigwBackendApiPluginBase(BackendApiPluginBase):
                 if isinstance(name, str) and name:
                     names.append(name)
         return names
+
+
+def _assert_loopback_sf_bind(app: FastAPI) -> None:
+    if os.environ.get("SF_AIGW_ALLOW_LAN") == "1":
+        return
+    config = getattr(app.state, "config", None)
+    server = getattr(config, "server", None)
+    host = getattr(server, "host", "127.0.0.1")
+    if host in {"127.0.0.1", "localhost", "::1"}:
+        return
+    raise RuntimeError(
+        "gateway-backed backends require SF to bind loopback only; "
+        "start with --host 127.0.0.1 or set SF_AIGW_ALLOW_LAN=1 to override"
+    )

--- a/apps/server/src/screamingface/plugins/aigw_base/tests/test_aigw_backend.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/tests/test_aigw_backend.py
@@ -58,6 +58,7 @@ async def test_happy_path_extracts_text() -> None:
     backend = AigwBackend(
         gateway_url="http://127.0.0.1:9105",
         profile_name="default",
+        gateway_provider="anthropic",
         http_client_factory=_factory(httpx.MockTransport(handler)),
     )
     result = await backend.run(
@@ -85,7 +86,9 @@ async def test_string_content_passes_through() -> None:
     def handler(_req: httpx.Request) -> httpx.Response:
         return _ok_response("ok")
 
-    backend = AigwBackend(http_client_factory=_factory(httpx.MockTransport(handler)))
+    backend = AigwBackend(
+        gateway_provider="anthropic", http_client_factory=_factory(httpx.MockTransport(handler))
+    )
     await backend.run(
         [CoreMessage(role="user", content="bare string")],
         model="anthropic/claude-haiku-4-5",
@@ -101,7 +104,9 @@ async def test_404_profile_not_found_maps_to_credential_not_found() -> None:
         )
 
     backend = AigwBackend(
-        profile_name="x", http_client_factory=_factory(httpx.MockTransport(handler))
+        profile_name="x",
+        gateway_provider="anthropic",
+        http_client_factory=_factory(httpx.MockTransport(handler)),
     )
     with pytest.raises(CredentialNotFoundError, match="not found"):
         await backend.run(
@@ -115,7 +120,9 @@ async def test_409_pending_auth_maps_to_auth_error() -> None:
     def handler(_req: httpx.Request) -> httpx.Response:
         return httpx.Response(409, json={"detail": {"code": "profile_pending_auth"}})
 
-    backend = AigwBackend(http_client_factory=_factory(httpx.MockTransport(handler)))
+    backend = AigwBackend(
+        gateway_provider="anthropic", http_client_factory=_factory(httpx.MockTransport(handler))
+    )
     with pytest.raises(AuthError, match="awaiting OAuth"):
         await backend.run(
             [CoreMessage(role="user", content="hi")],
@@ -131,7 +138,9 @@ async def test_401_auth_required_maps_to_auth_error() -> None:
             json={"detail": {"code": "auth_required", "message": "refresh failed"}},
         )
 
-    backend = AigwBackend(http_client_factory=_factory(httpx.MockTransport(handler)))
+    backend = AigwBackend(
+        gateway_provider="anthropic", http_client_factory=_factory(httpx.MockTransport(handler))
+    )
     with pytest.raises(AuthError, match="refresh failed"):
         await backend.run(
             [CoreMessage(role="user", content="hi")],
@@ -144,7 +153,9 @@ async def test_500_raises_aigw_gateway_error() -> None:
     def handler(_req: httpx.Request) -> httpx.Response:
         return httpx.Response(500, text="boom")
 
-    backend = AigwBackend(http_client_factory=_factory(httpx.MockTransport(handler)))
+    backend = AigwBackend(
+        gateway_provider="anthropic", http_client_factory=_factory(httpx.MockTransport(handler))
+    )
     with pytest.raises(AigwGatewayError):
         await backend.run(
             [CoreMessage(role="user", content="hi")],
@@ -157,7 +168,9 @@ async def test_unreachable_raises_backend_error() -> None:
     def handler(_req: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("connection refused")
 
-    backend = AigwBackend(http_client_factory=_factory(httpx.MockTransport(handler)))
+    backend = AigwBackend(
+        gateway_provider="anthropic", http_client_factory=_factory(httpx.MockTransport(handler))
+    )
     with pytest.raises(BackendError, match="unreachable"):
         await backend.run(
             [CoreMessage(role="user", content="hi")],

--- a/apps/server/src/screamingface/plugins/aigw_base/tests/test_auth_proxy.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/tests/test_auth_proxy.py
@@ -9,6 +9,7 @@ in docs/superpowers/specs/2026-05-07-aigw-backend-oauth-authenticate-button-desi
 from __future__ import annotations
 
 import json
+from typing import cast
 
 import httpx
 from fastapi import FastAPI
@@ -19,7 +20,7 @@ from screamingface.plugins.aigw_base.auth_proxy_router import (
 )
 
 
-def _make_client(handler, *, defaults=None) -> TestClient:
+def _make_client(handler, *, defaults=None, enabled_routes=None) -> TestClient:
     """Mount the auth-proxy router onto a stub app, with a MockTransport gateway."""
     transport = httpx.MockTransport(handler)
 
@@ -35,6 +36,7 @@ def _make_client(handler, *, defaults=None) -> TestClient:
             profile_name="default",
             http_client_factory=http_factory,
             defaults=defaults,
+            enabled_routes=enabled_routes,
         )
     )
     return TestClient(app)
@@ -389,3 +391,40 @@ def test_delete_profile_gateway_unreachable_becomes_502() -> None:
     resp = client.delete("/claude/auth/profiles/anything")
     assert resp.status_code == 502
     assert resp.json()["detail"]["code"] == "gateway_unreachable"
+
+
+def test_import_profile_forwards_to_gateway_import_route() -> None:
+    captured: dict = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["method"] = req.method
+        captured["url"] = str(req.url)
+        captured["body"] = json.loads(req.read().decode())
+        return httpx.Response(201, json={"id": "anthropic:default", "state": "authenticated"})
+
+    client = _make_client(
+        handler,
+        defaults={"model": "anthropic/claude-sonnet-4-5"},
+        enabled_routes={"import"},
+    )
+    resp = client.post("/claude/auth/import")
+
+    assert resp.status_code == 201
+    assert captured["method"] == "POST"
+    assert captured["url"] == "http://gateway/v1/auth/anthropic/profiles/import"
+    assert captured["body"] == {
+        "name": "default",
+        "defaults": {"model": "anthropic/claude-sonnet-4-5"},
+    }
+
+
+def test_enabled_routes_omits_unsupported_oauth_routes() -> None:
+    client = _make_client(
+        lambda _req: httpx.Response(200, json={}),
+        enabled_routes={"status", "profiles", "delete", "import"},
+    )
+    paths = set(cast(FastAPI, client.app).openapi()["paths"])
+
+    assert "/claude/auth/import" in paths
+    assert "/claude/auth/start" not in paths
+    assert "/claude/auth/exchange-code" not in paths

--- a/apps/server/src/screamingface/plugins/aigw_base/tests/test_backend_health.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/tests/test_backend_health.py
@@ -21,6 +21,7 @@ def _backend(handler) -> AigwBackend:
     return AigwBackend(
         gateway_url="http://gateway",
         profile_name="default",
+        gateway_provider="anthropic",
         http_client_factory=factory,
     )
 

--- a/apps/server/src/screamingface/plugins/aigw_base/tests/test_interpreter.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/tests/test_interpreter.py
@@ -35,7 +35,9 @@ def _factory_returning(text: str):
 
 @pytest.mark.anyio
 async def test_process_combines_intent_and_sources() -> None:
-    backend = AigwBackend(http_client_factory=_factory_returning("answer"))
+    backend = AigwBackend(
+        gateway_provider="anthropic", http_client_factory=_factory_returning("answer")
+    )
     interp = AigwInterpreter(backend=backend)
     out = await interp.process(sources="cats are mammals", intent="what are cats?")
     assert out == "answer"
@@ -43,6 +45,6 @@ async def test_process_combines_intent_and_sources() -> None:
 
 @pytest.mark.anyio
 async def test_process_returns_empty_when_no_input() -> None:
-    backend = AigwBackend(http_client_factory=_factory_returning("X"))
+    backend = AigwBackend(gateway_provider="anthropic", http_client_factory=_factory_returning("X"))
     interp = AigwInterpreter(backend=backend)
     assert await interp.process(sources="", intent=None) == ""

--- a/apps/server/src/screamingface/plugins/aigw_base/tests/test_setup_lan_guard.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/tests/test_setup_lan_guard.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+
+from screamingface.plugins.aigw_base.plugin_base import _assert_loopback_sf_bind
+
+
+def _app_with_host(host: str) -> FastAPI:
+    app = FastAPI()
+    app.state.config = SimpleNamespace(server=SimpleNamespace(host=host))
+    return app
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1"])
+def test_gateway_backed_backend_allows_loopback_sf_bind(host: str) -> None:
+    _assert_loopback_sf_bind(_app_with_host(host))
+
+
+def test_gateway_backed_backend_rejects_lan_sf_bind() -> None:
+    with pytest.raises(RuntimeError, match="loopback"):
+        _assert_loopback_sf_bind(_app_with_host("0.0.0.0"))
+
+
+def test_gateway_backed_backend_allows_explicit_lan_override(monkeypatch) -> None:
+    monkeypatch.setenv("SF_AIGW_ALLOW_LAN", "1")
+
+    _assert_loopback_sf_bind(_app_with_host("0.0.0.0"))

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/tests/test_url4_dispatch.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/tests/test_url4_dispatch.py
@@ -61,6 +61,7 @@ async def test_handle_backend_call_returns_assistant_text() -> None:
     backend = AigwBackend(
         gateway_url=plugin.settings.gateway_url,
         profile_name=plugin.settings.auth_profile,
+        gateway_provider="anthropic",
         http_client_factory=factory,
     )
     interpreter = AigwInterpreter(app=None, settings=plugin.settings, backend=backend)

--- a/apps/server/src/screamingface/plugins/aigw_codex_backend/__init__.py
+++ b/apps/server/src/screamingface/plugins/aigw_codex_backend/__init__.py
@@ -1,0 +1,1 @@
+"""aigw-codex-backend: routes /codex through the local AI Gateway."""

--- a/apps/server/src/screamingface/plugins/aigw_codex_backend/_defaults.py
+++ b/apps/server/src/screamingface/plugins/aigw_codex_backend/_defaults.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from screamingface.plugins.aigw_codex_backend.plugin import AigwCodexBackendSettings
+
+
+_GATEWAY_REASONING_EFFORTS = frozenset({"low", "medium", "high"})
+
+
+def _build_profile_defaults_from_settings(settings: AigwCodexBackendSettings) -> dict[str, Any]:
+    profile = None
+    profiles = getattr(settings, "profiles", None) or {}
+    default_profile = getattr(settings, "default_profile", None)
+    if default_profile and default_profile in profiles:
+        profile = profiles[default_profile]
+
+    out: dict[str, Any] = {}
+
+    model = getattr(profile, "model", None) if profile is not None else None
+    if model is None:
+        model = getattr(settings, "default_model", None)
+    if model is not None:
+        out["model"] = model
+
+    if profile is not None:
+        system_prompt = getattr(profile, "system_prompt", None)
+        if system_prompt is not None:
+            out["system_prompt"] = system_prompt
+
+    timeout: float | None = None
+    if profile is not None:
+        timeout = getattr(profile, "timeout_seconds", None)
+    if timeout is None:
+        timeout = getattr(settings, "timeout_seconds", None)
+    if timeout is not None:
+        out["timeout_seconds"] = timeout
+
+    effort: str | None = None
+    if profile is not None:
+        effort = getattr(profile, "effort", None)
+    if effort is None:
+        effort = getattr(settings, "default_effort", None)
+    if effort in _GATEWAY_REASONING_EFFORTS:
+        out["reasoning_effort"] = effort
+
+    return out

--- a/apps/server/src/screamingface/plugins/aigw_codex_backend/plugin.py
+++ b/apps/server/src/screamingface/plugins/aigw_codex_backend/plugin.py
@@ -1,0 +1,56 @@
+"""aigw-codex-backend plugin - Codex served via the local AI Gateway."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from pydantic import Field
+from pydantic_settings import SettingsConfigDict
+
+from screamingface.plugins.aigw_base import (
+    AigwBackendApiPluginBase,
+    AigwBackendApiSettingsBase,
+)
+from screamingface.plugins.aigw_codex_backend.routes import create_router
+
+_CODEX_MODEL_SUGGESTIONS = [
+    "codex/gpt-5.5",
+    "codex/gpt-5.4",
+    "codex/gpt-5.4-mini",
+    "codex/gpt-5.3-codex",
+    "codex/gpt-5.2",
+]
+
+
+class AigwCodexBackendSettings(AigwBackendApiSettingsBase):
+    model_config = SettingsConfigDict(
+        env_prefix="SF_AIGW_CODEX_BACKEND__",
+        env_nested_delimiter="__",
+    )
+
+    default_model: str | None = Field(
+        default="codex/gpt-5.4-mini",
+        description=(
+            "Default Codex model. The gateway routes by the prefix; "
+            "must start with 'codex/'. Pick from the dropdown or type a "
+            "custom slug if the gateway already supports it."
+        ),
+        examples=_CODEX_MODEL_SUGGESTIONS,
+    )
+
+
+class AigwCodexBackendPlugin(AigwBackendApiPluginBase):
+    name = "aigw-codex-backend"
+    description = (
+        "Codex served at /codex via the local AI Gateway. The gateway reads "
+        "file-backed Codex CLI auth and exposes import-based profile setup. "
+        "Mutually exclusive with codex-backend-api because both own /codex."
+    )
+    tags: list[str] = ["product:openai"]
+    backend_call_paths: list[str] = ["/codex"]
+    conflicts: list[str] = ["codex-backend-api"]
+    gateway_provider = "codex"
+    auth_kind: ClassVar[str] = "import"
+    settings_class = AigwCodexBackendSettings
+    schema_link_base = "/codex/"
+    create_router = staticmethod(create_router)

--- a/apps/server/src/screamingface/plugins/aigw_codex_backend/routes.py
+++ b/apps/server/src/screamingface/plugins/aigw_codex_backend/routes.py
@@ -1,0 +1,62 @@
+"""Routes for aigw-codex-backend."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from fastapi import APIRouter
+
+from screamingface.plugins.aigw_base import (
+    AigwBackend,
+    AigwInterpreter,
+    build_aigw_auth_proxy_router,
+)
+from screamingface.plugins.aigw_codex_backend._defaults import (
+    _build_profile_defaults_from_settings,
+)
+from screamingface.plugins.llm_base.routes_shared import (
+    BackendApiConfig,
+    build_backend_api_router,
+)
+
+if TYPE_CHECKING:
+    from screamingface.plugins.aigw_codex_backend.plugin import AigwCodexBackendSettings
+
+
+_DEFAULT_MODEL = "codex/gpt-5.4-mini"
+
+
+def create_router(settings: AigwCodexBackendSettings, app: Any = None) -> APIRouter:
+    backend = AigwBackend(
+        gateway_url=settings.gateway_url,
+        profile_name=settings.auth_profile,
+        gateway_provider="codex",
+    )
+
+    def build_interpreter() -> Any:
+        return AigwInterpreter(app=app, settings=settings, backend=backend)
+
+    router = build_backend_api_router(
+        BackendApiConfig(
+            name="aigw-codex-backend",
+            path_prefix="/codex",
+            default_model=_DEFAULT_MODEL,
+            backend=backend,
+            settings=settings,
+            app=app,
+            build_interpreter=build_interpreter,
+            span_prefix="aigw_codex",
+        )
+    )
+    profile_defaults = _build_profile_defaults_from_settings(settings)
+    router.include_router(
+        build_aigw_auth_proxy_router(
+            path_prefix="/codex",
+            gateway_url=settings.gateway_url,
+            gateway_provider="codex",
+            profile_name=settings.auth_profile,
+            defaults=profile_defaults or None,
+            enabled_routes={"status", "profiles", "delete", "import"},
+        )
+    )
+    return router

--- a/apps/server/src/screamingface/plugins/aigw_codex_backend/tests/test_auth_proxy_mount.py
+++ b/apps/server/src/screamingface/plugins/aigw_codex_backend/tests/test_auth_proxy_mount.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.routing import Route
+
+from screamingface.plugins.aigw_codex_backend._defaults import (
+    _build_profile_defaults_from_settings,
+)
+from screamingface.plugins.aigw_codex_backend.plugin import (
+    AigwCodexBackendPlugin,
+    AigwCodexBackendSettings,
+)
+from screamingface.plugins.backend_api_base.models import BackendProfile
+
+
+def test_aigw_codex_backend_mounts_import_auth_proxy_routes_only() -> None:
+    app = FastAPI()
+    router = AigwCodexBackendPlugin.create_router(AigwCodexBackendSettings(), app=app)
+    app.include_router(router)
+
+    paths = {r.path for r in app.routes if isinstance(r, Route)}
+    assert "/codex/auth/import" in paths
+    assert "/codex/auth/status" in paths
+    assert "/codex/auth/profiles" in paths
+    assert "/codex/auth/profiles/{name}" in paths
+    assert "/codex/auth/start" not in paths
+    assert "/codex/auth/exchange-code" not in paths
+
+
+def test_build_profile_defaults_top_level_settings() -> None:
+    settings = AigwCodexBackendSettings(
+        default_model="codex/gpt-5.4-mini",
+        default_effort="high",
+        timeout_seconds=300.0,
+    )
+
+    assert _build_profile_defaults_from_settings(settings) == {
+        "model": "codex/gpt-5.4-mini",
+        "timeout_seconds": 300.0,
+        "reasoning_effort": "high",
+    }
+
+
+def test_build_profile_defaults_profile_overrides_top_level() -> None:
+    settings = AigwCodexBackendSettings(
+        default_model="codex/gpt-5.4-mini",
+        default_effort="medium",
+        timeout_seconds=300.0,
+        default_profile="default",
+        profiles={
+            "default": BackendProfile(
+                model="codex/gpt-5.5",
+                system_prompt="Profile prompt.",
+                effort="high",
+                timeout_seconds=120.0,
+            )
+        },
+    )
+
+    assert _build_profile_defaults_from_settings(settings) == {
+        "model": "codex/gpt-5.5",
+        "system_prompt": "Profile prompt.",
+        "timeout_seconds": 120.0,
+        "reasoning_effort": "high",
+    }
+
+
+def test_build_profile_defaults_drops_max_effort() -> None:
+    settings = AigwCodexBackendSettings(
+        default_model="codex/gpt-5.4-mini",
+        default_effort="max",
+        timeout_seconds=300.0,
+    )
+
+    out = _build_profile_defaults_from_settings(settings)
+
+    assert "reasoning_effort" not in out
+    assert out["model"] == "codex/gpt-5.4-mini"
+    assert out["timeout_seconds"] == 300.0
+
+
+def test_build_profile_defaults_all_none_returns_empty() -> None:
+    settings = AigwCodexBackendSettings(default_model=None, default_effort="max")
+    object.__setattr__(settings, "timeout_seconds", None)
+
+    assert _build_profile_defaults_from_settings(settings) == {}
+
+
+def test_import_route_forwards_codex_defaults(monkeypatch) -> None:
+    from screamingface.plugins.aigw_base import auth_proxy_router as apr
+
+    settings = AigwCodexBackendSettings(
+        default_model="codex/gpt-5.4-mini",
+        default_effort="medium",
+        timeout_seconds=300.0,
+    )
+    captured: dict = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["url"] = str(req.url)
+        captured["body"] = json.loads(req.read().decode())
+        return httpx.Response(201, json={"id": "codex:default", "state": "authenticated"})
+
+    transport = httpx.MockTransport(handler)
+
+    def http_factory(timeout: float) -> httpx.AsyncClient:
+        return httpx.AsyncClient(transport=transport, timeout=timeout)
+
+    monkeypatch.setattr(apr, "_default_http_factory", http_factory)
+
+    app = FastAPI()
+    app.include_router(AigwCodexBackendPlugin.create_router(settings, app=app))
+    resp = TestClient(app).post("/codex/auth/import")
+
+    assert resp.status_code == 201
+    assert captured["url"] == "http://127.0.0.1:9105/v1/auth/codex/profiles/import"
+    assert captured["body"] == {
+        "name": "default",
+        "defaults": {
+            "model": "codex/gpt-5.4-mini",
+            "timeout_seconds": 300.0,
+            "reasoning_effort": "medium",
+        },
+    }

--- a/apps/server/src/screamingface/plugins/aigw_codex_backend/tests/test_backend_health.py
+++ b/apps/server/src/screamingface/plugins/aigw_codex_backend/tests/test_backend_health.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import httpx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from screamingface.plugins.aigw_base import backend as backend_module
+from screamingface.plugins.aigw_codex_backend.plugin import (
+    AigwCodexBackendPlugin,
+    AigwCodexBackendSettings,
+)
+
+
+def test_codex_health_queries_codex_gateway_provider(monkeypatch) -> None:
+    captured: dict = {}
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def get(self, url):
+            captured["url"] = url
+            return httpx.Response(200, json={"state": "authenticated"})
+
+    monkeypatch.setattr(backend_module.httpx, "AsyncClient", FakeAsyncClient)
+    app = FastAPI()
+    app.include_router(AigwCodexBackendPlugin.create_router(AigwCodexBackendSettings(), app=app))
+
+    resp = TestClient(app).get("/codex/health")
+
+    assert resp.status_code == 200
+    assert captured["url"] == "http://127.0.0.1:9105/v1/auth/codex/profiles/default/status"

--- a/apps/server/src/screamingface/plugins/aigw_codex_backend/tests/test_plugin_metadata.py
+++ b/apps/server/src/screamingface/plugins/aigw_codex_backend/tests/test_plugin_metadata.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from screamingface.plugins.aigw_codex_backend.plugin import (
+    AigwCodexBackendPlugin,
+    AigwCodexBackendSettings,
+)
+
+
+def test_plugin_metadata() -> None:
+    assert AigwCodexBackendPlugin.name == "aigw-codex-backend"
+    assert AigwCodexBackendPlugin.backend_call_paths == ["/codex"]
+    assert AigwCodexBackendPlugin.conflicts == ["codex-backend-api"]
+    assert AigwCodexBackendPlugin.gateway_provider == "codex"
+    assert AigwCodexBackendPlugin.auth_kind == "import"
+    assert "product:openai" in AigwCodexBackendPlugin.tags
+    assert "aigw-base" in AigwCodexBackendPlugin.depends
+    assert "llm-base" in AigwCodexBackendPlugin.depends
+    assert "backend-api-base" in AigwCodexBackendPlugin.depends
+    assert AigwCodexBackendPlugin.settings_class is AigwCodexBackendSettings
+
+
+def test_default_model() -> None:
+    settings = AigwCodexBackendSettings()
+    assert settings.default_model == "codex/gpt-5.4-mini"
+    assert settings.gateway_url == "http://127.0.0.1:9105"
+    assert settings.auth_profile == "default"
+    assert settings.timeout_seconds == 300.0
+
+
+def test_settings_env_prefix(monkeypatch) -> None:
+    monkeypatch.setenv("SF_AIGW_CODEX_BACKEND__GATEWAY_URL", "http://example:9999")
+    monkeypatch.setenv("SF_AIGW_CODEX_BACKEND__AUTH_PROFILE", "work")
+
+    settings = AigwCodexBackendSettings()
+
+    assert settings.gateway_url == "http://example:9999"
+    assert settings.auth_profile == "work"

--- a/apps/server/src/screamingface/plugins/aigw_codex_backend/tests/test_settings_schema.py
+++ b/apps/server/src/screamingface/plugins/aigw_codex_backend/tests/test_settings_schema.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from screamingface.plugins.aigw_codex_backend.plugin import (
+    AigwCodexBackendPlugin,
+    AigwCodexBackendSettings,
+)
+
+
+def _emit_schema(plugin: AigwCodexBackendPlugin) -> dict[str, Any]:
+    schema = plugin.settings_class.model_json_schema()  # type: ignore[union-attr]
+    return plugin.customize_schema(schema)
+
+
+def test_schema_omits_inapplicable_inherited_fields() -> None:
+    plugin = AigwCodexBackendPlugin()
+    plugin.settings = AigwCodexBackendSettings()  # type: ignore[assignment]
+    plugin._http_transport = httpx.MockTransport(  # type: ignore[attr-defined]
+        lambda req: httpx.Response(200, json={"profiles": []})
+    )
+
+    schema = _emit_schema(plugin)
+    props = schema["properties"]
+    assert "profiles" not in props
+    assert "default_profile" not in props
+    assert "max_budget_usd" not in props
+    assert "permission_mode" not in props
+    assert "dangerously_skip_permissions" not in props
+    assert "auth_profile" in props
+
+
+def test_schema_auth_profile_enum_uses_codex_gateway_provider() -> None:
+    captured: dict = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["path"] = req.url.path
+        return httpx.Response(200, json={"profiles": [{"name": "default"}, {"name": "work"}]})
+
+    plugin = AigwCodexBackendPlugin()
+    plugin.settings = AigwCodexBackendSettings()  # type: ignore[assignment]
+    plugin._http_transport = httpx.MockTransport(handler)  # type: ignore[attr-defined]
+
+    schema = _emit_schema(plugin)
+
+    assert captured["path"] == "/v1/auth/codex/profiles"
+    assert schema["properties"]["auth_profile"]["enum"] == ["default", "work"]

--- a/apps/server/src/screamingface/plugins/aigw_codex_backend/tests/test_url4_dispatch.py
+++ b/apps/server/src/screamingface/plugins/aigw_codex_backend/tests/test_url4_dispatch.py
@@ -1,0 +1,67 @@
+"""AigwCodexBackend url4 dispatch routes through the Codex gateway provider."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from screamingface.plugins.aigw_base import AigwBackend, AigwInterpreter
+from screamingface.plugins.aigw_codex_backend.plugin import (
+    AigwCodexBackendSettings,
+)
+
+
+def _factory_returning(text: str, captured: dict | None = None):
+    def handler(req: httpx.Request) -> httpx.Response:
+        if captured is not None:
+            captured["url"] = str(req.url)
+            captured["headers"] = dict(req.headers)
+            captured["body"] = json.loads(req.content.decode())
+        return httpx.Response(
+            200,
+            json={
+                "id": "x",
+                "object": "chat.completion",
+                "model": "codex/gpt-5.4-mini",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": text},
+                        "finish_reason": "stop",
+                    }
+                ],
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    def factory(timeout: float):
+        return httpx.AsyncClient(transport=transport, timeout=httpx.Timeout(timeout))
+
+    return factory
+
+
+@pytest.mark.anyio
+async def test_handle_backend_call_returns_assistant_text() -> None:
+    captured: dict = {}
+    settings = AigwCodexBackendSettings()
+    backend = AigwBackend(
+        gateway_url=settings.gateway_url,
+        profile_name=settings.auth_profile,
+        gateway_provider="codex",
+        http_client_factory=_factory_returning("pong", captured),
+    )
+    interpreter = AigwInterpreter(app=None, settings=settings, backend=backend)
+
+    out = await interpreter.process(sources="cats", intent="describe")
+
+    assert out == "pong"
+    assert captured["body"]["model"] == "codex/gpt-5.4-mini"
+    assert captured["headers"]["x-profile"] == "default"
+    assert captured["url"].endswith("/v1/chat/completions")
+    user_msg = captured["body"]["messages"][-1]
+    assert user_msg["role"] == "user"
+    assert "describe" in user_msg["content"]
+    assert "cats" in user_msg["content"]

--- a/apps/server/src/screamingface/plugins/aigw_runner/plugin.py
+++ b/apps/server/src/screamingface/plugins/aigw_runner/plugin.py
@@ -22,6 +22,7 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import httpx
 from pydantic import Field
 from pydantic_settings import SettingsConfigDict
 
@@ -55,8 +56,27 @@ class AigwRunnerSettings(PluginSettings):
         ),
     )
     startup_timeout_seconds: float = Field(
-        default=10.0,
+        default=15.0,
         description="Max seconds to wait after Popen before declaring failure.",
+    )
+    migrations_timeout_seconds: float = Field(
+        default=30.0,
+        description="Max seconds to wait for gateway database migrations.",
+    )
+    database_path: str | None = Field(
+        default=None,
+        description=(
+            "SQLite database path for the local gateway. If unset, resolves "
+            "to .sf/aigateway.db under the SF working directory."
+        ),
+    )
+    uv_bin: str | None = Field(
+        default=None,
+        description="Explicit uv executable path. If unset, uv is resolved from PATH.",
+    )
+    auth_enabled: bool = Field(
+        default=False,
+        description="Whether the spawned local gateway should enforce its own bearer auth.",
     )
     enabled: bool = Field(
         default=True,
@@ -78,6 +98,7 @@ class AigwRunnerPlugin(Plugin):
     def __init__(self) -> None:
         self._process: subprocess.Popen | None = None
         self._aigateway_dir: Path | None = None
+        self._uv_bin: str | None = None
 
     def preflight(self) -> tuple[bool, str]:
         ok, reason = super().preflight()
@@ -102,8 +123,10 @@ class AigwRunnerPlugin(Plugin):
 
         self._aigateway_dir = candidate
 
-        if shutil.which("uv") is None:
+        uv_bin = settings.uv_bin or shutil.which("uv")
+        if uv_bin is None:
             return False, "`uv` command not found in PATH — required to run the gateway"
+        self._uv_bin = uv_bin
 
         return True, ""
 
@@ -121,9 +144,43 @@ class AigwRunnerPlugin(Plugin):
             return
 
         assert self._aigateway_dir is not None  # set in preflight
+        assert self._uv_bin is not None  # set in preflight
+
+        database_url = _database_url(settings)
+        env = _gateway_env(settings, database_url)
+        migrate_cmd = [
+            self._uv_bin,
+            "run",
+            "--directory",
+            str(self._aigateway_dir),
+            "python",
+            "-m",
+            "tortoise",
+            "-c",
+            "aigateway.db.TORTOISE_CONFIG",
+            "migrate",
+        ]
+        logger.info("aigw-runner: running gateway migrations: %s", " ".join(migrate_cmd))
+        try:
+            migration = subprocess.run(  # noqa: S603
+                migrate_cmd,
+                env=env,
+                cwd=str(self._aigateway_dir),
+                timeout=settings.migrations_timeout_seconds,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError("aigw-runner: gateway migrations timed out") from exc
+        if migration.returncode != 0:
+            raise RuntimeError(
+                "aigw-runner: gateway migrations failed "
+                f"(code {migration.returncode}):\n{migration.stdout}{migration.stderr}"
+            )
 
         cmd = [
-            "uv",
+            self._uv_bin,
             "run",
             "--directory",
             str(self._aigateway_dir),
@@ -136,7 +193,6 @@ class AigwRunnerPlugin(Plugin):
             "--log-level",
             "info",
         ]
-        env = os.environ.copy()
         logger.info("aigw-runner: spawning gateway: %s", " ".join(cmd))
 
         self._process = subprocess.Popen(  # noqa: S603
@@ -147,13 +203,18 @@ class AigwRunnerPlugin(Plugin):
             text=True,
         )
 
-        time.sleep(0.5)
-        retcode = self._process.poll()
-        if retcode is not None:
+        health_url = f"http://127.0.0.1:{settings.port}/healthz"
+        if not _wait_for_health(self._process, health_url, settings.startup_timeout_seconds):
+            retcode = self._process.poll()
             output = self._process.stdout.read() if self._process.stdout else ""
-            self._process = None
+            self._stop()
+            if retcode is not None:
+                raise RuntimeError(
+                    f"aigw-runner: gateway exited immediately (code {retcode}):\n{output}"
+                )
             raise RuntimeError(
-                f"aigw-runner: gateway exited immediately (code {retcode}):\n{output}"
+                f"aigw-runner: gateway did not become healthy at {health_url} "
+                f"within {settings.startup_timeout_seconds}s:\n{output}"
             )
 
         threading.Thread(
@@ -196,3 +257,35 @@ def _log_output(proc: subprocess.Popen) -> None:
         line = line.rstrip()
         if line:
             logger.info("[aigateway] %s", line)
+
+
+def _database_url(settings: AigwRunnerSettings) -> str:
+    if settings.database_path is not None:
+        path = Path(settings.database_path).expanduser().resolve()
+    else:
+        path = (Path.cwd() / ".sf" / "aigateway.db").resolve()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return f"sqlite://{path}"
+
+
+def _gateway_env(settings: AigwRunnerSettings, database_url: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    env["AIGATEWAY_DATABASE_URL"] = database_url
+    env["AIGATEWAY_AUTH_ENABLED"] = "true" if settings.auth_enabled else "false"
+    return env
+
+
+def _wait_for_health(proc: subprocess.Popen, url: str, timeout_seconds: float) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            return False
+        try:
+            resp = httpx.get(url, timeout=0.5)
+            if resp.status_code == 200:
+                return True
+        except httpx.HTTPError:
+            pass
+        time.sleep(0.2)
+    return False

--- a/apps/server/src/screamingface/plugins/aigw_runner/tests/test_runner.py
+++ b/apps/server/src/screamingface/plugins/aigw_runner/tests/test_runner.py
@@ -81,9 +81,14 @@ def test_setup_spawns_subprocess_and_registers_hooks(fake_aigw_dir: Path) -> Non
     with (
         patch("shutil.which", return_value="/usr/local/bin/uv"),
         patch(
+            "screamingface.plugins.aigw_runner.plugin.subprocess.run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+        ) as mock_run,
+        patch(
             "screamingface.plugins.aigw_runner.plugin.subprocess.Popen",
             return_value=fake_proc,
-        ),
+        ) as mock_popen,
+        patch("screamingface.plugins.aigw_runner.plugin._wait_for_health", return_value=True),
         patch("screamingface.plugins.aigw_runner.plugin.atexit.register") as mock_atexit,
         patch("screamingface.plugins.aigw_runner.plugin.threading.Thread") as mock_thread,
     ):
@@ -96,6 +101,23 @@ def test_setup_spawns_subprocess_and_registers_hooks(fake_aigw_dir: Path) -> Non
     assert register_args.args[0] == "app.shutdown"
     mock_atexit.assert_called_once()
     mock_thread.assert_called_once()
+    assert mock_run.call_args.args[0][:5] == [
+        "/usr/local/bin/uv",
+        "run",
+        "--directory",
+        str(fake_aigw_dir),
+        "python",
+    ]
+    assert mock_popen.call_args.args[0][:4] == [
+        "/usr/local/bin/uv",
+        "run",
+        "--directory",
+        str(fake_aigw_dir),
+    ]
+    popen_env = mock_popen.call_args.kwargs["env"]
+    assert popen_env["AIGATEWAY_AUTH_ENABLED"] == "false"
+    assert popen_env["AIGATEWAY_DATABASE_URL"].startswith("sqlite://")
+    assert "VIRTUAL_ENV" not in popen_env
 
 
 def test_setup_raises_if_subprocess_exits_immediately(fake_aigw_dir: Path) -> None:
@@ -110,13 +132,44 @@ def test_setup_raises_if_subprocess_exits_immediately(fake_aigw_dir: Path) -> No
     with (
         patch("shutil.which", return_value="/usr/local/bin/uv"),
         patch(
+            "screamingface.plugins.aigw_runner.plugin.subprocess.run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+        ),
+        patch(
             "screamingface.plugins.aigw_runner.plugin.subprocess.Popen",
             return_value=fake_proc,
         ),
+        patch("screamingface.plugins.aigw_runner.plugin._wait_for_health", return_value=False),
     ):
         plugin.preflight()
         with pytest.raises(RuntimeError, match="exited immediately"):
             plugin.setup(MagicMock(), MagicMock(), MagicMock(), MagicMock())
+
+
+def test_setup_raises_if_migrations_fail(fake_aigw_dir: Path) -> None:
+    plugin = _make_plugin(fake_aigw_dir)
+
+    with (
+        patch("shutil.which", return_value="/usr/local/bin/uv"),
+        patch(
+            "screamingface.plugins.aigw_runner.plugin.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="out", stderr="migration boom"
+            ),
+        ),
+    ):
+        plugin.preflight()
+        with pytest.raises(RuntimeError, match="migrations failed"):
+            plugin.setup(MagicMock(), MagicMock(), MagicMock(), MagicMock())
+
+
+def test_explicit_uv_bin_is_used(fake_aigw_dir: Path) -> None:
+    plugin = _make_plugin(fake_aigw_dir, uv_bin="/opt/sf/bin/uv")
+
+    ok, reason = plugin.preflight()
+
+    assert ok, reason
+    assert plugin._uv_bin == "/opt/sf/bin/uv"
 
 
 def test_stop_terminates_process(fake_aigw_dir: Path) -> None:

--- a/apps/server/src/screamingface/plugins/claude_backend_api/plugin.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/plugin.py
@@ -50,7 +50,7 @@ class ClaudeBackendApiPlugin(BackendApiPluginBase):
     )
     tags: list[str] = ["product:claude"]
     depends: list[str] = ["llm-base", "backend-api-base"]
-    conflicts: list[str] = []
+    conflicts: list[str] = ["aigw-claude-backend"]
     backend_call_paths: list[str] = ["/claude"]
     settings_class = ClaudeBackendApiSettings
 

--- a/apps/server/src/screamingface/plugins/claude_backend_api/tests/test_plugin_conflicts.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/tests/test_plugin_conflicts.py
@@ -33,6 +33,9 @@ class TestPluginMetadata:
     def test_settings_class_set(self):
         assert ClaudeBackendApiPlugin.settings_class is ClaudeBackendApiSettings
 
+    def test_conflicts_with_gateway_claude_backend(self):
+        assert ClaudeBackendApiPlugin.conflicts == ["aigw-claude-backend"]
+
 
 class TestSettings:
     def test_default_settings_load_cleanly(self):

--- a/apps/server/src/screamingface/plugins/codex_backend_api/plugin.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/plugin.py
@@ -42,7 +42,7 @@ class CodexBackendApiPlugin(BackendApiPluginBase):
     )
     tags: list[str] = ["product:openai"]
     depends: list[str] = ["llm-base", "backend-api-base"]
-    conflicts: list[str] = []
+    conflicts: list[str] = ["aigw-codex-backend"]
     backend_call_paths: list[str] = ["/codex"]
     settings_class = CodexBackendApiSettings
 

--- a/apps/server/src/screamingface/plugins/codex_backend_api/tests/test_plugin_conflicts.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/tests/test_plugin_conflicts.py
@@ -21,9 +21,8 @@ class TestPluginMetadata:
     def test_depends_on_backend_api_base(self):
         assert "backend-api-base" in CodexBackendApiPlugin.depends
 
-    def test_no_conflicts(self):
-        # codex-backend-api coexists with claude-backend-api
-        assert CodexBackendApiPlugin.conflicts == []
+    def test_conflicts_with_gateway_codex_backend(self):
+        assert CodexBackendApiPlugin.conflicts == ["aigw-codex-backend"]
 
     def test_backend_call_paths(self):
         assert CodexBackendApiPlugin.backend_call_paths == ["/codex"]

--- a/apps/server/src/screamingface/plugins/llm_base/routes.py
+++ b/apps/server/src/screamingface/plugins/llm_base/routes.py
@@ -126,6 +126,9 @@ def _classify_auth_kind(plugin: Any) -> str:
     - ``"cli"``     — spawn a terminal running the plugin's CLI auth
       command (the historical claude/codex/gemini path).
     """
+    explicit = getattr(plugin, "auth_kind", None)
+    if explicit:
+        return explicit
     if getattr(plugin, "gateway_provider", None):
         return "browser"
     return "cli"

--- a/apps/server/src/screamingface/plugins/llm_base/tests/test_backends_status_auth_kind.py
+++ b/apps/server/src/screamingface/plugins/llm_base/tests/test_backends_status_auth_kind.py
@@ -24,6 +24,14 @@ def test_auth_kind_browser_when_plugin_has_gateway_provider() -> None:
     assert _classify_auth_kind(_BrowserPlugin) == "browser"
 
 
+def test_auth_kind_prefers_explicit_plugin_auth_kind() -> None:
+    class _ImportPlugin:
+        gateway_provider = "codex"
+        auth_kind = "import"
+
+    assert _classify_auth_kind(_ImportPlugin) == "import"
+
+
 def test_auth_kind_cli_when_plugin_lacks_gateway_provider() -> None:
     assert _classify_auth_kind(_CliPlugin) == "cli"
 

--- a/apps/server/tests/core/test_gateway_backend_conflicts.py
+++ b/apps/server/tests/core/test_gateway_backend_conflicts.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from starlette.routing import Route
+
+from screamingface.core.config import AppConfig, ServerConfig
+from screamingface.core.registry import PluginRegistry
+from screamingface.core.routes import RouteRegistry
+from screamingface.plugin import Plugin
+from screamingface.plugins.aigw_claude_backend.plugin import AigwClaudeBackendPlugin
+from screamingface.plugins.aigw_codex_backend.plugin import AigwCodexBackendPlugin
+from screamingface.plugins.claude_backend_api.plugin import ClaudeBackendApiPlugin
+from screamingface.plugins.codex_backend_api.plugin import CodexBackendApiPlugin
+
+
+class _DependencyPlugin(Plugin):
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+def _registry_with_deps() -> PluginRegistry:
+    registry = PluginRegistry()
+    for name in {"llm-base", "backend-api-base", "aigw-base"}:
+        registry._active[name] = _DependencyPlugin(name)
+    return registry
+
+
+def _activate_pair(first: Plugin, second: Plugin) -> tuple[PluginRegistry, FastAPI]:
+    app = FastAPI()
+    app.state.config = AppConfig(server=ServerConfig(host="127.0.0.1"))
+    routes = RouteRegistry(app)
+    registry = _registry_with_deps()
+
+    registry.activate(first, app=app, hooks=None, classes=None, routes=routes)
+    registry.activate(second, app=app, hooks=None, classes=None, routes=routes)
+    return registry, app
+
+
+def _path_count(app: FastAPI, path: str) -> int:
+    return sum(1 for route in app.routes if isinstance(route, Route) and route.path == path)
+
+
+def test_codex_direct_and_gateway_conflict_in_both_activation_orders() -> None:
+    first_registry, first_app = _activate_pair(CodexBackendApiPlugin(), AigwCodexBackendPlugin())
+    second_registry, second_app = _activate_pair(AigwCodexBackendPlugin(), CodexBackendApiPlugin())
+
+    assert "codex-backend-api" in first_registry.active_plugins
+    assert "aigw-codex-backend" not in first_registry.active_plugins
+    assert _path_count(first_app, "/codex/health") == 1
+    assert "aigw-codex-backend" in second_registry.active_plugins
+    assert "codex-backend-api" not in second_registry.active_plugins
+    assert _path_count(second_app, "/codex/health") == 1
+
+
+def test_claude_direct_and_gateway_conflict_in_both_activation_orders() -> None:
+    first_registry, first_app = _activate_pair(ClaudeBackendApiPlugin(), AigwClaudeBackendPlugin())
+    second_registry, second_app = _activate_pair(
+        AigwClaudeBackendPlugin(), ClaudeBackendApiPlugin()
+    )
+
+    assert "claude-backend-api" in first_registry.active_plugins
+    assert "aigw-claude-backend" not in first_registry.active_plugins
+    assert _path_count(first_app, "/claude/health") == 1
+    assert "aigw-claude-backend" in second_registry.active_plugins
+    assert "claude-backend-api" not in second_registry.active_plugins
+    assert _path_count(second_app, "/claude/health") == 1

--- a/apps/server/tests/e2e/conftest.py
+++ b/apps/server/tests/e2e/conftest.py
@@ -31,6 +31,7 @@ _PROVIDER_BY_FILE: dict[str, str] = {
     "test_cat_breeds_spec.py": "claude",
     "test_aigw_claude_e2e.py": "claude",
     "test_aigw_auth_e2e.py": "claude",
+    "test_aigw_codex_auth_e2e.py": "codex",
     "test_url4_specs_live.py": "claude",
     "test_ensemble_features.py": "claude",
     "test_url4_resolution.py": "claude",

--- a/apps/server/tests/e2e/test_aigw_codex_auth_e2e.py
+++ b/apps/server/tests/e2e/test_aigw_codex_auth_e2e.py
@@ -1,0 +1,227 @@
+"""End-to-end: SF aigw-codex-backend import flow through a real gateway.
+
+This exercises the local-only Desktop posture without live ChatGPT credentials:
+SF starts aigw-runner, the runner migrates and starts apps/aigateway, Codex auth
+is imported from a fake file-backed CODEX_HOME, and the Codex handler posts to a
+loopback fake responses server.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import threading
+import time
+from collections.abc import Generator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from tests.e2e.infrastructure.server_manager import ServerManager
+
+pytestmark = [pytest.mark.e2e, pytest.mark.timeout(120)]
+
+_AIGATEWAY_DIR = (Path(__file__).resolve().parents[3] / "aigateway").resolve()
+_ANONYMOUS_ACCOUNT_ID = "00000000-0000-0000-0000-000000000000"
+
+
+class _FakeCodexServer:
+    def __init__(self) -> None:
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), self._handler())
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._lock = threading.Lock()
+        self.requests: list[dict[str, Any]] = []
+
+    @property
+    def responses_url(self) -> str:
+        return f"http://127.0.0.1:{self._server.server_port}/responses"
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+
+    def _handler(self):
+        outer = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+                length = int(self.headers.get("content-length", "0") or "0")
+                raw_body = self.rfile.read(length).decode()
+                with outer._lock:
+                    outer.requests.append(
+                        {
+                            "path": self.path,
+                            "headers": dict(self.headers),
+                            "body": json.loads(raw_body),
+                        }
+                    )
+
+                if self.path != "/responses":
+                    self.send_response(404)
+                    self.end_headers()
+                    return
+
+                body = (
+                    b'data: {"type":"response.output_text.delta","delta":"codex e2e ok"}\n\n'
+                    b'data: {"type":"response.completed","response":{}}\n\n'
+                )
+                self.send_response(200)
+                self.send_header("content-type", "text/event-stream")
+                self.send_header("content-length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+                return
+
+        return Handler
+
+
+@pytest.fixture
+def fake_codex_server() -> Generator[_FakeCodexServer, None, None]:
+    server = _FakeCodexServer()
+    server.start()
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
+def _unsigned_jwt(claims: dict[str, Any]) -> str:
+    def _segment(data: dict[str, Any]) -> str:
+        raw = json.dumps(data, separators=(",", ":")).encode()
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+    return f"{_segment({'alg': 'none', 'typ': 'JWT'})}.{_segment(claims)}."
+
+
+def _write_codex_auth(codex_home: Path) -> None:
+    codex_home.mkdir(parents=True, exist_ok=True)
+    auth_path = codex_home / "auth.json"
+    auth_path.write_text(
+        json.dumps(
+            {
+                "auth_mode": "chatgpt",
+                "OPENAI_API_KEY": None,
+                "tokens": {
+                    "access_token": _unsigned_jwt({"exp": time.time() + 3600}),
+                    "refresh_token": "refresh-token-e2e",
+                    "id_token": _unsigned_jwt({"sub": "sub-e2e", "email": "codex-e2e@example.com"}),
+                    "account_id": "chatgpt-account-e2e",
+                },
+            }
+        )
+    )
+    auth_path.chmod(0o600)
+
+
+@pytest.fixture
+def codex_aigw_stack(
+    tmp_path: Path, fake_codex_server: _FakeCodexServer
+) -> Generator[tuple[ServerManager, str, int, _FakeCodexServer], None, None]:
+    if not _AIGATEWAY_DIR.exists():
+        pytest.skip(f"apps/aigateway/ not found at {_AIGATEWAY_DIR}")
+
+    internal_port = ServerManager.find_free_port()
+    gateway_port = ServerManager.find_free_port()
+    codex_home = tmp_path / "codex-home"
+    _write_codex_auth(codex_home)
+
+    config = {
+        "version": "0.1.0",
+        "server": {"host": "127.0.0.1", "port": internal_port, "ssl": False, "reload": False},
+        "plugins": [
+            "llm-base",
+            "backend-api-base",
+            "aigw-base",
+            "aigw-codex-backend",
+            "aigw-runner",
+        ],
+        "plugin_config": {
+            "aigw-codex-backend": {
+                "gateway_url": f"http://127.0.0.1:{gateway_port}",
+                "auth_profile": "default",
+                "default_model": "codex/gpt-5.4-mini",
+                "timeout_seconds": 30,
+            },
+            "aigw-runner": {
+                "port": gateway_port,
+                "aigateway_dir": str(_AIGATEWAY_DIR),
+                "database_path": str(tmp_path / "aigateway" / "aigateway.db"),
+                "startup_timeout_seconds": 30.0,
+                "migrations_timeout_seconds": 30.0,
+                "auth_enabled": False,
+                "enabled": True,
+            },
+        },
+    }
+    env_extra = {
+        "CODEX_HOME": str(codex_home),
+        "AIGATEWAY_FAKE_KEYCHAIN": "1",
+        "AIGATEWAY_KEYCHAIN_FILE": str(tmp_path / "fake-keychain.json"),
+        "AIGATEWAY_FAKE_CODEX_RESPONSES_URL": fake_codex_server.responses_url,
+        "AIGATEWAY_ADMIN_PASSWORD": "test-admin-password",
+        "AIGATEWAY_JWT_SECRET": "x" * 32,
+        "AIGATEWAY_PROVISIONING_TOKEN": "p" * 32,
+    }
+
+    manager = ServerManager(config, session_id="e2e-aigw-codex", env_extra=env_extra)
+    manager.start(timeout=120)
+    try:
+        if not ServerManager.wait_for_port(gateway_port, timeout=60):
+            last_logs = "\n".join(manager.logs.dump_last()) if manager.logs else "<no logs>"
+            pytest.fail(f"aigw-runner did not bring up gateway on {gateway_port}\n{last_logs}")
+        yield manager, manager.base_url, gateway_port, fake_codex_server
+    finally:
+        manager.stop()
+
+
+def test_codex_import_health_and_backend_call_via_aigw_runner(
+    codex_aigw_stack: tuple[ServerManager, str, int, _FakeCodexServer],
+) -> None:
+    manager, sf_base_url, gateway_port, fake_codex = codex_aigw_stack
+
+    imported = httpx.post(f"{sf_base_url}/codex/auth/import", timeout=10)
+    assert imported.status_code == 201, imported.text
+    imported_body = imported.json()
+    assert imported_body["id"] == f"{_ANONYMOUS_ACCOUNT_ID}:codex:default"
+    assert imported_body["state"] == "authenticated"
+    assert imported_body["account_label"] == "codex-e2e@example.com"
+
+    status = httpx.get(f"{sf_base_url}/codex/auth/status", timeout=10)
+    assert status.status_code == 200, status.text
+    assert status.json()["state"] == "authenticated"
+
+    health = httpx.get(f"{sf_base_url}/codex/health", timeout=10)
+    assert health.status_code == 200, health.text
+    assert health.json()["authenticated"] is True
+
+    run = httpx.post(
+        f"{sf_base_url}/codex/run",
+        json={"prompt": "Say codex e2e ok.", "model": "codex/gpt-5.4-mini"},
+        timeout=30,
+    )
+    logs = "\n".join(manager.logs.dump_last(2000)) if manager.logs else ""
+    assert run.status_code == 200, f"{run.text}\n--- logs ---\n{logs[-5000:]}"
+    body = run.json()
+    assert body["ec"] == 0
+    assert body["so"] == "codex e2e ok"
+
+    assert fake_codex.requests
+    request = fake_codex.requests[-1]
+    assert request["path"] == "/responses"
+    assert request["headers"]["Authorization"].startswith("Bearer ")
+    assert request["headers"]["ChatGPT-Account-Id"] == "chatgpt-account-e2e"
+    assert request["body"]["model"] == "gpt-5.4-mini"
+    assert request["body"]["stream"] is True
+
+    assert "POST /v1/chat/completions" in logs
+    gateway_health = httpx.get(f"http://127.0.0.1:{gateway_port}/healthz", timeout=3)
+    assert gateway_health.status_code == 200

--- a/scripts/download-build-assets.sh
+++ b/scripts/download-build-assets.sh
@@ -111,6 +111,10 @@ SERVER_VENV="$REPO_ROOT/apps/server/.venv"
 if [ -d "$SERVER_VENV" ]; then
   mv "$SERVER_VENV" "$TMP_DIR/saved-venv"
 fi
+AIGATEWAY_VENV="$REPO_ROOT/apps/aigateway/.venv"
+if [ -d "$AIGATEWAY_VENV" ]; then
+  mv "$AIGATEWAY_VENV" "$TMP_DIR/saved-aigateway-venv"
+fi
 
 "$OUT_DIR/uv" sync \
   --no-install-project \
@@ -118,10 +122,20 @@ fi
   --directory "$REPO_ROOT/apps/server" \
   || true  # Non-fatal: cache is an optimization, not a hard requirement
 
+"$OUT_DIR/uv" sync \
+  --no-install-project \
+  --python "$OUT_DIR/python/bin/python3.12" \
+  --directory "$REPO_ROOT/apps/aigateway" \
+  || true  # Non-fatal: cache is an optimization, not a hard requirement
+
 # Clean up the venv uv sync created, restore original if it existed
 rm -rf "$SERVER_VENV"
+rm -rf "$AIGATEWAY_VENV"
 if [ -d "$TMP_DIR/saved-venv" ]; then
   mv "$TMP_DIR/saved-venv" "$SERVER_VENV"
+fi
+if [ -d "$TMP_DIR/saved-aigateway-venv" ]; then
+  mv "$TMP_DIR/saved-aigateway-venv" "$AIGATEWAY_VENV"
 fi
 
 # Package cache as tar.gz (smaller bundle, avoids macOS xattr issues with .app bundles)


### PR DESCRIPTION
## Description

This implements the D-AIGW-003 Codex path through AI Gateway.
The change adds a `codex` provider to `apps/aigateway`, exposes Codex models as `codex/...`, imports file-backed Codex CLI credentials from `${CODEX_HOME:-~/.codex}/auth.json`, and routes non-streaming Codex chat calls through a LiteLLM custom provider without invoking LiteLLM’s stock `chatgpt` device-code flow.
It also adds the SF `aigw-codex-backend` plugin and Desktop integration so packaged Desktop can provision and run the gateway from bundled resources, migrate the gateway SQLite DB, and expose Codex through the backend status UI using an import-based auth flow.
Security hardening included:
- SF is launched on loopback from Desktop.
- Auth-disabled gateway mode rejects non-loopback Host/client requests.
- Desktop validates external URLs before `shell.openExternal`.
- Backend IPC handlers validate sender frames.
- `server:fetch` is constrained to the active SF loopback origin.

## Affected Dependencies

- Moves `aiosqlite==0.22.1` into `apps/aigateway` runtime dependencies for packaged Desktop SQLite gateway mode.
- Packages `apps/aigateway` resources into the Electron app.
- No new npm dependencies.

## How has this been tested?

AIGateway:
- `uv run --python /opt/homebrew/opt/python@3.12/bin/python3.12 pytest tests/unit/codex/ tests/unit/test_codex_provider.py -v`
- `uv run --python /opt/homebrew/opt/python@3.12/bin/python3.12 pytest -m "not live"`
- `uv run --python /opt/homebrew/opt/python@3.12/bin/python3.12 ruff check .`
- `uv run --python /opt/homebrew/opt/python@3.12/bin/python3.12 pyright`
- `uv run --python /opt/homebrew/opt/python@3.12/bin/python3.12 python scripts/check_no_enterprise.py`
- `AIGW_MAC_KEYCHAIN_SMOKE=1 uv run --python /opt/homebrew/opt/python@3.12/bin/python3.12 pytest tests/integration/test_profile_index_macos_keychain.py -q`
Server:
- `uv run --python /opt/homebrew/opt/python@3.12/bin/python3.12 pytest -m "not e2e and not e2e_live"`
- `uv run --python /opt/homebrew/opt/python@3.12/bin/python3.12 pytest tests/e2e/test_aigw_codex_auth_e2e.py -v --timeout=120`
- `uv run --python /opt/homebrew/opt/python@3.12/bin/python3.12 ruff check .`
- `uv run --python /opt/homebrew/opt/python@3.12/bin/python3.12 pyright`
Desktop:
- `npx vitest run`
- Focused ESLint on touched Desktop files
- `npm run build`
- `CSC_IDENTITY_AUTO_DISCOVERY=false npx electron-builder --mac --arm64 --dir --publish never`
Packaged Desktop smoke:
- Launched the packaged macOS app with isolated `SCREAMINGFACE_USER_DATA_DIR`.
- Verified SF `/health` returns `200`.
- Verified gateway `/healthz` returns `200`.
- Verified evil Host header to gateway returns `403`.
- Verified `/backends/status` returns Codex with `auth_kind: "import"`.
- Verified `/openapi.json` includes `/codex/auth/import`.
- Verified `/openapi.json` does not include `/codex/auth/start` or `/codex/auth/exchange-code`.
- Verified renderer via CDP shows Codex, `Import Profile`, and `Refresh Import`.
- Verified renderer logs do not contain React minified errors, disposed-frame errors, or uncaught errors.
- Verified auth-disabled gateway no longer logs a bootstrap admin password.
Live Codex smoke was not run; it is optional unless product requires it.

## Checklist                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                          
 - [x] I have followed the Contribution Guidelines and Code of Conduct                                                                                                                                                                                                                                                    
 - [x] I have commented my code following the OpenMined Styleguide                                                                                                                                                                                                                                                        
 - [x] I have labeled this PR with the relevant Type labels                                                                                                                                                                                                                                                               
 - [x] My changes are covered by tests