### PR TITLE
SF-200: anchor release-please for desktop+server with bootstrap-sha

### DIFF
--- a/docs/superpowers/plans/SF-200-fix-release-please-bootstrap.md
+++ b/docs/superpowers/plans/SF-200-fix-release-please-bootstrap.md
@@ -1,0 +1,85 @@
+# SF-200: Fix Release Please CI — anchor desktop+server with bootstrap-sha
+
+> **For agentic workers:** Single-file JSON edit. No tests to run; verification is observing the next Release Please CI run on main.
+
+**Goal:** Stop the `Release Please` GitHub Action from failing on every push to `main` with `release-please failed: Server Error`.
+
+**Asana:** [SF-200](https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1214854003907795)
+
+---
+
+## Context
+
+The `Release Please` workflow has been failing on every merge to `main` since at least 2026-05-14 (SF-152 merge). Failure is not visible in PR checks (the workflow only runs on `push` to `main`), so it slips under the radar — but every merge ships with one red workflow.
+
+Server Tests, pre-commit, and WIP all pass; this is purely an issue with the auto-release-PR generator. Non-blocking for development, but worth fixing for release hygiene.
+
+### Root cause
+
+`release-please-config.json` declares three packages — `apps/desktop`, `apps/server`, `apps/aigateway` — and `.release-please-manifest.json` claims versions for all three. But only one matching git tag exists in the repo:
+
+| Package | Manifest version | Tag exists? |
+|---|---|---|
+| apps/desktop | 0.1.0 | ❌ `desktop-v0.1.0` missing |
+| apps/server | 0.1.0 | ❌ `server-v0.1.0` missing |
+| apps/aigateway | 0.2.0 | ✅ `aigateway-v0.2.0` present |
+
+Without anchor tags for `desktop` and `server`, `googleapis/release-please-action@v4` walks the full main history searching for one. The repo has 200+ merge commits; the action eventually hits a 5xx from GitHub's GraphQL API and aborts:
+
+```
+❯ Fetching merge commits on branch main with cursor: ... 199
+##[error]release-please failed: Server Error
+```
+
+## Fix
+
+Add `bootstrap-sha` to `apps/desktop` and `apps/server` in `release-please-config.json`, pointing at the most recent main commit (`080dd8c`, the SF-199 squash merge). `bootstrap-sha` tells release-please "ignore everything before this commit for this package," eliminating the backfill.
+
+Leave `apps/aigateway` alone — its tag already anchors it.
+
+### Edit
+
+In `release-please-config.json`:
+
+```json
+    "apps/desktop": {
+      "release-type": "node",
+      "package-name": "screamingface-desktop",
+      "component": "desktop",
+      "tag-separator": "-",
+      "include-component-in-tag": true,
+      "bootstrap-sha": "080dd8c59b0b2c4b4c97f48a17c2b5435df9fa68"
+    },
+    "apps/server": {
+      "release-type": "python",
+      "package-name": "screamingface",
+      "component": "server",
+      "tag-separator": "-",
+      "include-component-in-tag": true,
+      "version-file": "apps/server/pyproject.toml",
+      "bootstrap-sha": "080dd8c59b0b2c4b4c97f48a17c2b5435df9fa68"
+    },
+```
+
+(`apps/aigateway` is unchanged.)
+
+### Commit
+
+```bash
+git add release-please-config.json
+git commit -m "ci: anchor release-please for desktop+server with bootstrap-sha (SF-200)"
+```
+
+### Verify
+
+`release-please-action@v4` only runs on `push: branches: [main]`. So:
+1. Open PR, get review.
+2. After merge, observe the next workflow run on main:
+   `gh run list --branch main --workflow "Release Please" --limit 1`
+3. Expected: `success` instead of `failure`. If the action now decides to open a release PR, that's the desired side-effect — the auto-release pipeline is working again.
+
+## Out of scope
+
+- Creating retroactive `desktop-v0.1.0` / `server-v0.1.0` tags. `bootstrap-sha` makes those unnecessary; future release PRs will create tags going forward.
+- Resolving the orphaned `v0.1.0-alpha.1` tag in the repo. It doesn't match any current package's tag scheme; ignore unless someone confirms its origin.
+- Anything else release-related (changelogs, version bumps, publication).

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -21,7 +21,8 @@
       "package-name": "screamingface-desktop",
       "component": "desktop",
       "tag-separator": "-",
-      "include-component-in-tag": true
+      "include-component-in-tag": true,
+      "bootstrap-sha": "080dd8c59b0b2c4b4c97f48a17c2b5435df9fa68"
     },
     "apps/server": {
       "release-type": "python",
@@ -29,7 +30,8 @@
       "component": "server",
       "tag-separator": "-",
       "include-component-in-tag": true,
-      "version-file": "apps/server/pyproject.toml"
+      "version-file": "apps/server/pyproject.toml",
+      "bootstrap-sha": "080dd8c59b0b2c4b4c97f48a17c2b5435df9fa68"
     },
     "apps/aigateway": {
       "release-type": "python",


### PR DESCRIPTION
## Summary

The `Release Please` workflow has failed on every push to `main` since at least 2026-05-14 (visible on the SF-152, SF-198, SF-199 merges). Server Tests / pre-commit / WIP all pass; only the auto-release-PR generator is broken.

**Root cause.** `release-please-config.json` declares three packages, but only `apps/aigateway` has a matching git tag (`aigateway-v0.2.0`). Without anchor tags for `desktop` and `server`, `googleapis/release-please-action@v4` walks the full main history searching for one, eventually times out against GitHub's GraphQL API and aborts with `release-please failed: Server Error`.

**Fix.** Add `bootstrap-sha` to the `apps/desktop` and `apps/server` package configs, pointing at `080dd8c` (the SF-199 squash merge). Release-please will ignore commits before that SHA for those two packages, eliminating the backfill timeout.

`apps/aigateway` is unchanged — its tag already anchors it.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1214854003907795

## Test plan

The workflow only runs on `push: branches: [main]`, so verification happens post-merge:

- [ ] After merge, observe `gh run list --branch main --workflow "Release Please" --limit 1` — expect `success` instead of `failure`.
- [ ] If release-please opens an auto-release PR as a side effect, that's the desired outcome (the pipeline is working again).

No code paths or tests are affected by this change — it's a CI-tooling config edit only.

## Out of scope

- Creating retroactive `desktop-v0.1.0` / `server-v0.1.0` tags (bootstrap-sha makes those unnecessary).
- Resolving the orphaned `v0.1.0-alpha.1` tag (unrelated to current package tag scheme).