### PR TITLE
SF-201: read package version dynamically in plugins-list test

### DIFF
--- a/apps/server/tests/core/test_plugin_settings.py
+++ b/apps/server/tests/core/test_plugin_settings.py
@@ -9,6 +9,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from screamingface import __version__ as sf_version
 from screamingface.core.app import create_app
 from screamingface.core.config import AppConfig
 from screamingface.plugin import Plugin
@@ -123,7 +124,7 @@ def test_plugins_list_endpoint(settings_client: TestClient) -> None:
     assert resp.status_code == 200
     data = resp.json()
     assert "claude-frontend" in data
-    assert data["claude-frontend"]["version"] == "0.1.0"
+    assert data["claude-frontend"]["version"] == sf_version
     assert data["claude-frontend"]["has_settings"] is True
 
 

--- a/docs/superpowers/plans/SF-201-unhardcode-plugin-version-test.md
+++ b/docs/superpowers/plans/SF-201-unhardcode-plugin-version-test.md
@@ -1,0 +1,37 @@
+# SF-201: Unhardcode plugin version in test_plugins_list_endpoint
+
+> **Trivial single-line behavioral fix; no execution plan needed beyond this note.**
+
+**Goal:** Stop `tests/core/test_plugin_settings.py::test_plugins_list_endpoint` from failing on every release-please PR.
+
+**Asana:** [SF-201](https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1214854613057177)
+
+## Context
+
+`screamingface.__version__` is the package version (defined in `apps/server/src/screamingface/__init__.py`). Built-in plugins inherit it via `Plugin.version: str = __version__` in `apps/server/src/screamingface/plugin.py:54`. The `/plugins` admin endpoint returns each plugin's `version` field.
+
+`test_plugins_list_endpoint` asserted that value is literally `"0.1.0"`. Release-please updates `__version__` in `__init__.py` (verified by the diff on #171: `0.1.0` → `0.2.0`), so the test breaks on every release PR. Currently making #171 (server 0.2.0) and #172 (desktop 0.2.0) red.
+
+## Change
+
+Two lines in `apps/server/tests/core/test_plugin_settings.py`:
+
+1. Add `from screamingface import __version__ as sf_version` to the imports.
+2. Replace the literal `"0.1.0"` in `test_plugins_list_endpoint` with `sf_version`.
+
+The test still verifies the value is exposed; it no longer pins the value.
+
+## Verification
+
+```bash
+cd apps/server
+uv run pytest tests/core/test_plugin_settings.py -v  # 10/10 pass
+uv run ruff check tests/core/test_plugin_settings.py
+uv run ruff format --check tests/core/test_plugin_settings.py
+```
+
+After merge, rebase #171 and #172 onto main; both should go green.
+
+## Out of scope
+
+- Other `"version": "0.1.0"` strings in the repo are unrelated — they're the **config schema** version (`AppConfig.version`), not the package version. Leave them.


### PR DESCRIPTION
## Summary

`tests/core/test_plugin_settings.py::test_plugins_list_endpoint` hardcoded `assert data["claude-frontend"]["version"] == "0.1.0"`. The `/plugins` admin endpoint returns each plugin's `version`, which inherits from `screamingface.__version__` (`apps/server/src/screamingface/plugin.py:54`). Release-please bumps that constant in `__init__.py` on every release PR, so the test breaks every time — visible right now on #171 (server 0.1.0 → 0.2.0) and applicable to #172 (desktop) too.

**Fix:** import `__version__ as sf_version` and assert against it. Two-line change. The test still verifies the value is exposed; it just no longer pins to a literal.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1214854613057177

## Test plan

- [x] `uv run pytest tests/core/test_plugin_settings.py -v` → 10/10 pass
- [x] `uv run ruff check` and `ruff format --check` clean
- [ ] After merge, rebase #171 and #172 — both should turn green