### PR TITLE
Sf 163 aigateway codex oauth

### DIFF
--- a/apps/aigateway/pyproject.toml
+++ b/apps/aigateway/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "PyJWT==2.12.1",
     "bcrypt==5.0.0",
     "asyncpg==0.31.0",
+    "aiosqlite==0.22.1",
 ]
 
 [project.scripts]
@@ -53,6 +54,5 @@ dev = [
     "pyright>=1.1.393",
     "ruff>=0.8",
     "httpx>=0.28",
-    "aiosqlite==0.22.1",
     "testcontainers[postgres]==4.14.2",
 ]

--- a/apps/aigateway/src/aigateway/core/auth/local_only.py
+++ b/apps/aigateway/src/aigateway/core/auth/local_only.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from ipaddress import ip_address
+from urllib.parse import urlsplit
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+
+def _host_without_port(host_header: str | None) -> str | None:
+    if host_header is None:
+        return None
+    value = host_header.strip()
+    if not value:
+        return None
+    try:
+        hostname = urlsplit(f"//{value}").hostname
+    except ValueError:
+        return None
+    if not hostname:
+        return None
+    return hostname.rstrip(".").lower()
+
+
+def _is_loopback_host(host: str | None) -> bool:
+    hostname = _host_without_port(host)
+    if hostname == "localhost":
+        return True
+    if hostname is None:
+        return False
+    try:
+        return ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def _is_loopback_client(request: Request) -> bool:
+    if request.client is None:
+        return False
+    try:
+        return ip_address(request.client.host).is_loopback
+    except ValueError:
+        return False
+
+
+class AuthDisabledLocalOnlyMiddleware(BaseHTTPMiddleware):
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        if not _is_loopback_client(request) or not _is_loopback_host(request.headers.get("host")):
+            return JSONResponse(
+                {"detail": "Auth-disabled gateway is limited to loopback clients and hosts"},
+                status_code=403,
+            )
+        return await call_next(request)

--- a/apps/aigateway/src/aigateway/core/errors.py
+++ b/apps/aigateway/src/aigateway/core/errors.py
@@ -22,4 +22,4 @@ class ProfilePendingAuthError(AigwError):
 
 
 class BootstrapError(AigwError):
-    """Failed to bootstrap the gateway profile index from an existing CC keychain."""
+    """Failed to bootstrap the gateway profile index from provider credentials."""

--- a/apps/aigateway/src/aigateway/core/oauth_base.py
+++ b/apps/aigateway/src/aigateway/core/oauth_base.py
@@ -10,8 +10,12 @@ from __future__ import annotations
 
 import asyncio
 from abc import abstractmethod
+from typing import TYPE_CHECKING, Any
 
 from .plugin_base import OAuthStrategy
+
+if TYPE_CHECKING:
+    from .credential_store import CredentialStore
 
 
 class BaseOAuthStrategy(OAuthStrategy):
@@ -23,6 +27,7 @@ class BaseOAuthStrategy(OAuthStrategy):
     """
 
     refresh_window_seconds: int = 60
+    _store: CredentialStore
 
     def __init__(self, profile_name: str) -> None:
         self.profile_name = profile_name
@@ -54,10 +59,17 @@ class BaseOAuthStrategy(OAuthStrategy):
                 self._cached = self._read_credential()
             self._cached = await self._refresh_credential(self._cached)
 
-    def set_credentials(self, creds: dict) -> None:
-        """Store a credential blob (used after callback's code-for-token exchange)."""
-        self._cached = creds
-        self._write_to_store(creds)
+    def persist_credentials(self, credentials: dict[str, Any]) -> None:
+        """Store a credential blob after callback's code-for-token exchange."""
+        self._cached = credentials
+        self._write_to_store(credentials)
+
+    def delete_credentials(self) -> None:
+        self._cached = None
+        self._store.delete(self.keychain_service(), self.keychain_account())
+
+    async def refresh_credentials(self) -> None:
+        await self.refresh()
 
     @abstractmethod
     def keychain_service(self) -> str:
@@ -68,7 +80,7 @@ class BaseOAuthStrategy(OAuthStrategy):
         """OS keychain `account` string for this profile's tokens."""
 
     @abstractmethod
-    def _write_to_store(self, creds: dict) -> None:
+    def _write_to_store(self, creds: dict[str, Any]) -> None:
         """Persist `creds` to the OS keychain entry."""
 
     def _header_override(self) -> dict[str, str] | None:
@@ -76,13 +88,13 @@ class BaseOAuthStrategy(OAuthStrategy):
         return None
 
     @abstractmethod
-    def _read_credential(self) -> dict: ...
+    def _read_credential(self) -> dict[str, Any]: ...
 
     @abstractmethod
-    def _is_expired(self, creds: dict) -> bool: ...
+    def _is_expired(self, creds: dict[str, Any]) -> bool: ...
 
     @abstractmethod
-    async def _refresh_credential(self, creds: dict) -> dict: ...
+    async def _refresh_credential(self, creds: dict[str, Any]) -> dict[str, Any]: ...
 
     @abstractmethod
-    def _build_headers(self, creds: dict) -> dict[str, str]: ...
+    def _build_headers(self, creds: dict[str, Any]) -> dict[str, str]: ...

--- a/apps/aigateway/src/aigateway/core/pending_auth.py
+++ b/apps/aigateway/src/aigateway/core/pending_auth.py
@@ -24,6 +24,27 @@ class PendingAuthTable:
     def put(self, state: str, entry: PendingAuthEntry) -> None:
         self._entries[state] = (entry, time.monotonic())
 
+    def pop_for_profile(self, account_id: str, provider: str, profile_name: str) -> list[str]:
+        """Remove pending entries for the same account/provider/profile.
+
+        Returns the removed states so callers can tear down any state-scoped
+        loopback listeners without disturbing unrelated in-flight profiles.
+        """
+        removed: list[str] = []
+        now = time.monotonic()
+        for state, (entry, ts) in list(self._entries.items()):
+            expired = now - ts > self._ttl
+            matches = (
+                entry.account_id == account_id
+                and entry.provider == provider
+                and entry.profile_name == profile_name
+            )
+            if expired or matches:
+                self._entries.pop(state, None)
+            if matches and not expired:
+                removed.append(state)
+        return removed
+
     def pop(self, state: str) -> PendingAuthEntry | None:
         item = self._entries.pop(state, None)
         if item is None:

--- a/apps/aigateway/src/aigateway/core/pending_auth.py
+++ b/apps/aigateway/src/aigateway/core/pending_auth.py
@@ -11,6 +11,7 @@ class PendingAuthEntry:
     profile_name: str
     profile_id: str
     code_verifier: str
+    redirect_uri: str
 
 
 class PendingAuthTable:

--- a/apps/aigateway/src/aigateway/core/plugin_base.py
+++ b/apps/aigateway/src/aigateway/core/plugin_base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -39,6 +40,18 @@ class OAuthStrategy(ABC):
 
     async def invalidate(self) -> None:
         """Drop any cached token. Called after a 401 from upstream."""
+
+    @abstractmethod
+    def persist_credentials(self, credentials: dict[str, Any]) -> None:
+        """Persist newly exchanged provider credentials for this profile."""
+
+    @abstractmethod
+    def delete_credentials(self) -> None:
+        """Delete persisted provider credentials for this profile."""
+
+    @abstractmethod
+    async def refresh_credentials(self) -> None:
+        """Refresh persisted provider credentials for this profile."""
 
 
 @dataclass(frozen=True)
@@ -84,7 +97,13 @@ class ProviderPluginBase(ABC):
         """Return provider OAuth metadata, or None for no-auth providers (e.g. local Ollama)."""
         return None
 
-    def oauth_strategy_for(self, profile_name: str) -> OAuthStrategy | None:
+    def oauth_strategy_for(
+        self,
+        profile_name: str,
+        *,
+        credential_store: CredentialStore | None = None,
+        http_client_factory: Any | None = None,
+    ) -> OAuthStrategy | None:
         """Return a per-profile OAuthStrategy. Default: no auth."""
         return None
 
@@ -113,6 +132,14 @@ class ProviderPluginBase(ABC):
         import litellm
 
         return await litellm.acompletion(**body)
+
+    async def chat_completion_stream(self, body: dict[str, Any]) -> AsyncIterator[Any]:
+        """Dispatch a normalized streaming chat completion request."""
+        import litellm
+
+        stream: Any = await litellm.acompletion(**body)
+        async for chunk in stream:
+            yield chunk
 
     def auth_router(self):
         """Provider-specific auth routes.

--- a/apps/aigateway/src/aigateway/core/plugin_base.py
+++ b/apps/aigateway/src/aigateway/core/plugin_base.py
@@ -15,7 +15,7 @@ class ModelEntry:
 
     Maps directly onto the dict shape that `litellm.Router(model_list=...)`
     expects. `model_name` is the user-facing alias; `litellm_params.model`
-    is the fully-qualified provider/model string (e.g. `anthropic/claude-...`).
+    is the fully-qualified provider/model string.
     """
 
     model_name: str
@@ -49,8 +49,20 @@ class OAuthConfig:
     token_url: str
     client_id: str
     scopes: list[str]
-    redirect_path: str  # absolute path on the gateway, e.g. /v1/auth/anthropic/callback
+    redirect_path: str  # absolute path on the gateway callback surface
     extra_authorize_params: dict[str, str] | None = None
+    loopback_redirect_ports: list[int] | None = None
+
+
+@dataclass(frozen=True)
+class OAuthCodeExchangeRequest:
+    """Provider-owned authorization-code exchange input."""
+
+    code: str
+    code_verifier: str
+    redirect_uri: str
+    state: str
+    http_client_factory: Any | None = None
 
 
 class ProviderPluginBase(ABC):
@@ -76,6 +88,32 @@ class ProviderPluginBase(ABC):
         """Return a per-profile OAuthStrategy. Default: no auth."""
         return None
 
+    async def exchange_oauth_code(self, request: OAuthCodeExchangeRequest) -> dict[str, Any]:
+        """Exchange an OAuth authorization code for provider credentials."""
+        raise NotImplementedError(f"{self.custom_llm_provider} does not exchange OAuth codes")
+
+    def account_label_from_credentials(self, _credentials: dict[str, Any]) -> str | None:
+        """Return a display label for credentials persisted after OAuth, if available."""
+        return None
+
+    def supports_chat_streaming(self) -> bool:
+        """Whether `/v1/chat/completions` may create a streaming response."""
+        return True
+
+    def prepare_chat_body(self, body: dict[str, Any]) -> dict[str, Any]:
+        """Apply provider-specific request normalization before dispatch."""
+        return body
+
+    def should_apply_profile_default(self, field: str) -> bool:
+        """Return whether a profile default field should be merged into chat bodies."""
+        return True
+
+    async def chat_completion(self, body: dict[str, Any]) -> Any:
+        """Dispatch a normalized OpenAI-compatible chat completion request."""
+        import litellm
+
+        return await litellm.acompletion(**body)
+
     def auth_router(self):
         """Provider-specific auth routes.
 
@@ -91,5 +129,5 @@ class ProviderPluginBase(ABC):
         credential_store: CredentialStore | None = None,
         index_store: ProfileIndexStore | None = None,
     ) -> None:
-        """Import provider-owned local credentials into the profile index, if any."""
+        """Populate provider-owned profile metadata at startup, if any."""
         return None

--- a/apps/aigateway/src/aigateway/core/registry.py
+++ b/apps/aigateway/src/aigateway/core/registry.py
@@ -4,7 +4,7 @@ from .plugin_base import ProviderPluginBase
 
 
 class ProviderRegistry:
-    """Lookup from `custom_llm_provider` (anthropic / openai / gemini / ollama / …) to plugin."""
+    """Lookup from `custom_llm_provider` to provider plugin."""
 
     def __init__(self) -> None:
         self._plugins: dict[str, ProviderPluginBase] = {}

--- a/apps/aigateway/src/aigateway/main.py
+++ b/apps/aigateway/src/aigateway/main.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import base64
+import json
 import logging
 import os
+import time
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -9,6 +12,7 @@ from fastapi import FastAPI
 from .config import Settings
 from .core.auth.bootstrap_admin import ensure_admin_account
 from .core.auth.jwt_secret import get_or_create_jwt_secret
+from .core.auth.local_only import AuthDisabledLocalOnlyMiddleware
 from .core.auth.log_filter import (
     RedactProvisioningTokenFilter,
     install_provisioning_token_redaction,
@@ -23,6 +27,14 @@ from .db import close_db, init_db
 from .routes import accounts, auth, auth_session, chat, health, models
 
 logger = logging.getLogger(__name__)
+
+
+def _unsigned_jwt(payload: dict) -> str:
+    def encode(value: dict | bytes) -> str:
+        raw = value if isinstance(value, bytes) else json.dumps(value).encode()
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+    return f"{encode({'alg': 'none', 'typ': 'JWT'})}.{encode(payload)}.{encode(b'sig')}"
 
 
 def _attach_log_filter() -> None:
@@ -52,15 +64,14 @@ async def _lifespan(app):
             str(admin.id) if app.state.settings.auth_enabled else str(ANONYMOUS_ACCOUNT_ID)
         )
 
-        # Auto-import of the developer's Claude Code keychain entry is opt-in.
+        # Provider startup bootstrap is opt-in.
         # By default the gateway boots with an empty profile index so the user
         # explicitly authenticates via the UI rather than seeing a "default"
-        # profile they never OAuthed for. Set
-        # AIGATEWAY_BOOTSTRAP_FROM_CLAUDE_CODE=1 to restore the legacy import.
+        # profile they did not authorize through the gateway.
         #
         # When the fake-keychain test hook is active, bootstrap (if enabled)
-        # uses the same fake store so it cannot pull in the developer's real
-        # Claude Code credentials behind the test's back.
+        # uses the same fake store so it cannot pull in real local credentials
+        # behind the test's back.
         if os.getenv("AIGATEWAY_BOOTSTRAP_FROM_CLAUDE_CODE") == "1":
             for plugin in app.state.providers.all():
                 try:
@@ -85,6 +96,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     _attach_log_filter()
     app = FastAPI(title="aigateway", version="0.1.0", lifespan=_lifespan)
     app.state.settings = settings
+    if not settings.auth_enabled:
+        app.add_middleware(AuthDisabledLocalOnlyMiddleware)
 
     registry = ProviderRegistry()
     load_plugins(registry)
@@ -94,8 +107,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     # When AIGATEWAY_FAKE_KEYCHAIN=1 is set, swap the OS-keychain-backed
     # credential store for a JSON-file-backed one, and likewise install a
     # MockTransport-backed httpx factory for the Anthropic OAuth token
-    # endpoint when AIGATEWAY_FAKE_ANTHROPIC_OAUTH=1. These are gated by
-    # env vars so they only ever activate in the e2e test harness.
+    # endpoint when AIGATEWAY_FAKE_ANTHROPIC_OAUTH=1 or
+    # AIGATEWAY_FAKE_CODEX_OAUTH=1. These are gated by env vars so they only
+    # ever activate in the e2e test harness.
     if os.getenv("AIGATEWAY_FAKE_KEYCHAIN") == "1":
         kc_path = os.getenv("AIGATEWAY_KEYCHAIN_FILE")
         if not kc_path:
@@ -136,6 +150,42 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             )
 
         app.state.anthropic_http_factory = _factory
+
+    if os.getenv("AIGATEWAY_FAKE_CODEX_OAUTH") == "1":
+        import httpx
+
+        fail_mode = os.getenv("AIGATEWAY_FAKE_CODEX_OAUTH_FAIL") == "1"
+
+        def _fake_handler(req: httpx.Request) -> httpx.Response:
+            if req.url.host == "auth.openai.com" and req.url.path == "/oauth/token":
+                if fail_mode:
+                    return httpx.Response(400, json={"error": "invalid_grant"})
+                token_payload = {
+                    "sub": "codex-sub-1",
+                    "email": "codex-user@example.com",
+                    "exp": int(time.time()) + 3600,
+                    "https://api.openai.com/auth": {"chatgpt_account_id": "acct-codex-1"},
+                }
+                token = _unsigned_jwt(token_payload)
+                return httpx.Response(
+                    200,
+                    json={
+                        "access_token": token,
+                        "refresh_token": "fake-codex-rt",
+                        "id_token": token,
+                        "expires_in": 3600,
+                        "token_type": "Bearer",
+                    },
+                )
+            return httpx.Response(404, json={"error": "unmapped"})
+
+        def _factory() -> httpx.AsyncClient:
+            return httpx.AsyncClient(
+                transport=httpx.MockTransport(_fake_handler),
+                timeout=httpx.Timeout(30.0),
+            )
+
+        app.state.codex_http_factory = _factory
 
     app.state.pending_auth = PendingAuthTable(ttl_seconds=600)
 

--- a/apps/aigateway/src/aigateway/main.py
+++ b/apps/aigateway/src/aigateway/main.py
@@ -53,8 +53,7 @@ async def _lifespan(app):
     database_url = app.state.settings.database_url.get_secret_value()
     await init_db(database_url)
     try:
-        fake_store = getattr(app.state, "_fake_credential_store", None)
-        credential_store = fake_store if fake_store is not None else get_credential_store()
+        credential_store = app.state.credential_store
         app.state.jwt_secret = await get_or_create_jwt_secret(
             credential_store,
             app.state.settings.jwt_secret,
@@ -114,11 +113,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         kc_path = os.getenv("AIGATEWAY_KEYCHAIN_FILE")
         if not kc_path:
             raise RuntimeError("AIGATEWAY_FAKE_KEYCHAIN=1 requires AIGATEWAY_KEYCHAIN_FILE=<path>")
-        fake_store = JsonFileCredentialStore(kc_path)
-        app.state._fake_credential_store = fake_store
-        app.state.profile_index = ProfileIndexStore(credential_store=fake_store)
+        credential_store = JsonFileCredentialStore(kc_path)
+        app.state._fake_credential_store = credential_store
     else:
-        app.state.profile_index = ProfileIndexStore()
+        credential_store = get_credential_store()
+    app.state.credential_store = credential_store
+    app.state.profile_index = ProfileIndexStore(credential_store=credential_store)
 
     if os.getenv("AIGATEWAY_FAKE_ANTHROPIC_OAUTH") == "1":
         import httpx

--- a/apps/aigateway/src/aigateway/main.py
+++ b/apps/aigateway/src/aigateway/main.py
@@ -10,6 +10,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from .config import Settings
+from .core import credential_store as credential_store_module
 from .core.auth.bootstrap_admin import ensure_admin_account
 from .core.auth.jwt_secret import get_or_create_jwt_secret
 from .core.auth.local_only import AuthDisabledLocalOnlyMiddleware
@@ -27,6 +28,7 @@ from .db import close_db, init_db
 from .routes import accounts, auth, auth_session, chat, health, models
 
 logger = logging.getLogger(__name__)
+_ORIGINAL_GET_CREDENTIAL_STORE = get_credential_store
 
 
 def _unsigned_jwt(payload: dict) -> str:
@@ -46,6 +48,12 @@ def _attach_log_filter() -> None:
         for handler in target.handlers:
             if not any(isinstance(f, RedactProvisioningTokenFilter) for f in handler.filters):
                 handler.addFilter(RedactProvisioningTokenFilter())
+
+
+def _default_credential_store():
+    if get_credential_store is not _ORIGINAL_GET_CREDENTIAL_STORE:
+        return get_credential_store()
+    return credential_store_module.get_credential_store()
 
 
 @asynccontextmanager
@@ -116,7 +124,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         credential_store = JsonFileCredentialStore(kc_path)
         app.state._fake_credential_store = credential_store
     else:
-        credential_store = get_credential_store()
+        credential_store = _default_credential_store()
     app.state.credential_store = credential_store
     app.state.profile_index = ProfileIndexStore(credential_store=credential_store)
 

--- a/apps/aigateway/src/aigateway/plugins/anthropic_provider/auth.py
+++ b/apps/aigateway/src/aigateway/plugins/anthropic_provider/auth.py
@@ -20,6 +20,7 @@ from aigateway.core.oauth_base import BaseOAuthStrategy
 from .oauth_config import (
     ANTHROPIC_BETA,
     ANTHROPIC_CLIENT_ID,
+    ANTHROPIC_REFRESH_SCOPES,
     ANTHROPIC_TOKEN_URL,
     ANTHROPIC_VERSION,
 )
@@ -89,6 +90,7 @@ class AnthropicOAuth(BaseOAuthStrategy):
             "grant_type": "refresh_token",
             "refresh_token": creds["refresh_token"],
             "client_id": ANTHROPIC_CLIENT_ID,
+            "scope": " ".join(ANTHROPIC_REFRESH_SCOPES),
         }
         try:
             async with self._http_factory() as client:

--- a/apps/aigateway/src/aigateway/plugins/anthropic_provider/chat_handler.py
+++ b/apps/aigateway/src/aigateway/plugins/anthropic_provider/chat_handler.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+import litellm
+
+# Claude Code 2.1.142 computes this attribution block from the first user
+# message and sends it as the first system block. LiteLLM filters this block
+# when it appears as a chat `role=system` message, but preserves it when passed
+# via Anthropic's provider-specific top-level `system` parameter.
+_CLAUDE_CODE_VERSION = "2.1.142"
+_FINGERPRINT_SALT = "59cf53e54c78"
+_FINGERPRINT_INDICES = (4, 7, 20)
+_BILLING_HEADER_PREFIX = "x-anthropic-billing-header:"
+
+
+async def chat_completion(body: dict[str, Any]) -> Any:
+    return await litellm.acompletion(**prepare_claude_code_body(body))
+
+
+def prepare_claude_code_body(body: dict[str, Any]) -> dict[str, Any]:
+    out = dict(body)
+    messages = out.get("messages") or []
+    if not isinstance(messages, list):
+        return out
+
+    existing_system_blocks = _content_to_text_blocks(out.get("system"))
+    if _starts_with_billing_header(existing_system_blocks):
+        system_blocks = list(existing_system_blocks)
+        should_append_existing_system = False
+    else:
+        system_blocks = [
+            {"type": "text", "text": _build_billing_header(_first_user_text(messages))}
+        ]
+        should_append_existing_system = True
+
+    non_system_messages: list[Any] = []
+    for message in messages:
+        if not isinstance(message, dict) or message.get("role") != "system":
+            non_system_messages.append(message)
+            continue
+        system_blocks.extend(_content_to_text_blocks(message.get("content")))
+
+    if should_append_existing_system:
+        system_blocks.extend(existing_system_blocks)
+
+    out["messages"] = non_system_messages
+    out["system"] = system_blocks
+    return out
+
+
+def _first_user_text(messages: list[Any]) -> str:
+    for message in messages:
+        if not isinstance(message, dict) or message.get("role") != "user":
+            continue
+        content = message.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    text = block.get("text")
+                    if isinstance(text, str):
+                        return text
+    return ""
+
+
+def _compute_fingerprint(first_user_text: str) -> str:
+    chars = "".join(
+        first_user_text[index] if index < len(first_user_text) else "0"
+        for index in _FINGERPRINT_INDICES
+    )
+    raw = f"{_FINGERPRINT_SALT}{chars}{_CLAUDE_CODE_VERSION}"
+    return hashlib.sha256(raw.encode()).hexdigest()[:3]
+
+
+def _build_billing_header(first_user_text: str) -> str:
+    fingerprint = _compute_fingerprint(first_user_text)
+    return (
+        "x-anthropic-billing-header: "
+        f"cc_version={_CLAUDE_CODE_VERSION}.{fingerprint}; "
+        "cc_entrypoint=cli; cch=00000;"
+    )
+
+
+def _starts_with_billing_header(blocks: list[dict[str, str]]) -> bool:
+    if not blocks:
+        return False
+    return blocks[0].get("text", "").startswith(_BILLING_HEADER_PREFIX)
+
+
+def _content_to_text_blocks(content: Any) -> list[dict[str, str]]:
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}] if content else []
+    if not isinstance(content, list):
+        return []
+
+    blocks: list[dict[str, str]] = []
+    for item in content:
+        if isinstance(item, str):
+            if item:
+                blocks.append({"type": "text", "text": item})
+            continue
+        if not isinstance(item, dict) or item.get("type") != "text":
+            continue
+        text = item.get("text")
+        if isinstance(text, str) and text:
+            blocks.append({"type": "text", "text": text})
+    return blocks

--- a/apps/aigateway/src/aigateway/plugins/anthropic_provider/oauth_config.py
+++ b/apps/aigateway/src/aigateway/plugins/anthropic_provider/oauth_config.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-# Authorize URL: claude.ai/oauth/authorize is the user-consent surface
-# (the page where the user approves the OAuth request). The Claude Code
-# binary points at platform.claude.com but claude.ai forwards there and
-# is the cleaner consent UX the user sees.
-ANTHROPIC_AUTHORIZE_URL = "https://claude.ai/oauth/authorize"
+# Authorize URL for Claude subscription login. Verified against Claude Code
+# 2.1.142 (`claude auth login --claudeai`): this is distinct from the
+# platform/console OAuth entrypoint used for API-key billing flows.
+ANTHROPIC_AUTHORIZE_URL = "https://claude.com/cai/oauth/authorize"
 # Token URL: platform.claude.com/v1/oauth/token — verified from the
 # @anthropic-ai/claude-code binary. console.anthropic.com/v1/oauth/token
 # (the previous setting) rejects this client_id with the API "Invalid
@@ -12,8 +11,17 @@ ANTHROPIC_AUTHORIZE_URL = "https://claude.ai/oauth/authorize"
 # public Claude Code OAuth client.
 ANTHROPIC_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
 ANTHROPIC_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"  # public Claude Code OAuth app
+# Claude subscription tokens written by Claude Code carry only user scopes.
+# Requesting org:create_api_key here routes the flow toward Console/API-key
+# billing and can leave subscription-capacity models unavailable.
 ANTHROPIC_SCOPES = [
-    "org:create_api_key",
+    "user:profile",
+    "user:inference",
+    "user:sessions:claude_code",
+    "user:mcp_servers",
+    "user:file_upload",
+]
+ANTHROPIC_REFRESH_SCOPES = [
     "user:profile",
     "user:inference",
     "user:sessions:claude_code",
@@ -32,4 +40,4 @@ ANTHROPIC_BETA = ",".join(
         "prompt-caching-scope-2026-01-05",
     ]
 )
-ANTHROPIC_REDIRECT_PATH = "/v1/auth/anthropic/callback"
+ANTHROPIC_REDIRECT_PATH = "/callback"

--- a/apps/aigateway/src/aigateway/plugins/anthropic_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/anthropic_provider/plugin.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from aigateway.core.plugin_base import (
     ModelEntry,
+    OAuthCodeExchangeRequest,
     OAuthConfig,
     OAuthStrategy,
     ProviderPluginBase,
 )
 
-from .auth import AnthropicOAuth
+from .auth import AnthropicOAuth, exchange_authorization_code
 from .bootstrap import bootstrap_from_claude_code
+from .chat_handler import chat_completion, prepare_claude_code_body
 from .models import MODELS
 from .oauth_config import (
     ANTHROPIC_AUTHORIZE_EXTRA_PARAMS,
@@ -44,6 +46,30 @@ class AnthropicProviderPlugin(ProviderPluginBase):
 
     def oauth_strategy_for(self, profile_name: str) -> OAuthStrategy:
         return AnthropicOAuth(profile_name=profile_name)
+
+    def should_apply_profile_default(self, field: str) -> bool:
+        # The legacy SF Claude backend ignored default_effort. Applying it as a
+        # gateway profile default enables Anthropic thinking on every request and
+        # burns the Claude Code rate-limit pool unexpectedly.
+        return field != "reasoning_effort"
+
+    def prepare_chat_body(self, body: dict[str, Any]) -> dict[str, Any]:
+        out = dict(body)
+        if out.get("reasoning_effort") == "none":
+            out.pop("reasoning_effort", None)
+        return prepare_claude_code_body(out)
+
+    async def chat_completion(self, body: dict[str, Any]) -> Any:
+        return await chat_completion(body)
+
+    async def exchange_oauth_code(self, request: OAuthCodeExchangeRequest) -> dict:
+        return await exchange_authorization_code(
+            request.code,
+            request.code_verifier,
+            redirect_uri=request.redirect_uri,
+            state=request.state,
+            http_client_factory=request.http_client_factory,
+        )
 
     async def bootstrap_profiles(
         self,

--- a/apps/aigateway/src/aigateway/plugins/anthropic_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/anthropic_provider/plugin.py
@@ -44,8 +44,18 @@ class AnthropicProviderPlugin(ProviderPluginBase):
             extra_authorize_params=ANTHROPIC_AUTHORIZE_EXTRA_PARAMS,
         )
 
-    def oauth_strategy_for(self, profile_name: str) -> OAuthStrategy:
-        return AnthropicOAuth(profile_name=profile_name)
+    def oauth_strategy_for(
+        self,
+        profile_name: str,
+        *,
+        credential_store: CredentialStore | None = None,
+        http_client_factory: Any | None = None,
+    ) -> OAuthStrategy:
+        return AnthropicOAuth(
+            profile_name=profile_name,
+            credential_store=credential_store,
+            http_client_factory=http_client_factory,
+        )
 
     def should_apply_profile_default(self, field: str) -> bool:
         # The legacy SF Claude backend ignored default_effort. Applying it as a

--- a/apps/aigateway/src/aigateway/plugins/codex_provider/auth.py
+++ b/apps/aigateway/src/aigateway/plugins/codex_provider/auth.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import base64
+import json
+import time
+from typing import Any
+
+import httpx
+
+from aigateway.core.credential_store import CredentialStore, get_credential_store
+from aigateway.core.errors import AuthError, CredentialNotFoundError
+from aigateway.core.oauth_base import BaseOAuthStrategy
+
+from .oauth_config import CODEX_CLIENT_ID, CODEX_REFRESH_SCOPE, CODEX_TOKEN_URL
+
+_ACCOUNT = "default"
+_JWT_AUTH_CLAIMS_KEY = "https://api.openai.com/auth"
+
+
+def keychain_service_for(profile_name: str) -> str:
+    return f"aigateway:codex:{profile_name}"
+
+
+def _decode_jwt_claims(token: str | None) -> dict[str, Any]:
+    if not token:
+        return {}
+    parts = token.split(".")
+    if len(parts) < 2:
+        return {}
+    payload = parts[1]
+    payload += "=" * (-len(payload) % 4)
+    try:
+        decoded = json.loads(base64.urlsafe_b64decode(payload.encode("ascii")))
+    except Exception:
+        return {}
+    return decoded if isinstance(decoded, dict) else {}
+
+
+def _auth_claims(token: str | None) -> dict[str, Any]:
+    claims = _decode_jwt_claims(token)
+    nested = claims.get(_JWT_AUTH_CLAIMS_KEY)
+    return nested if isinstance(nested, dict) else {}
+
+
+def _expires_at_ms_from_token(token: str | None) -> int | None:
+    exp = _decode_jwt_claims(token).get("exp")
+    if isinstance(exp, int | float):
+        return int(float(exp) * 1000)
+    return None
+
+
+def _account_id_from_tokens(access_token: str | None, id_token: str | None) -> str | None:
+    for token in (id_token, access_token):
+        account_id = _auth_claims(token).get("chatgpt_account_id")
+        if isinstance(account_id, str) and account_id:
+            return account_id
+    return None
+
+
+def account_label_from_credentials(creds: dict[str, Any]) -> str | None:
+    id_claims = _decode_jwt_claims(creds.get("id_token"))
+    for key in ("email", "name"):
+        value = id_claims.get(key)
+        if isinstance(value, str) and value:
+            return value
+    account_id = creds.get("account_id") or _account_id_from_tokens(
+        creds.get("access_token"), creds.get("id_token")
+    )
+    if isinstance(account_id, str) and account_id:
+        return account_id
+    subject = id_claims.get("sub")
+    return subject if isinstance(subject, str) and subject else None
+
+
+def _normalize_token_response(data: dict[str, Any], previous: dict[str, Any] | None = None) -> dict:
+    previous = previous or {}
+    access_token = data.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        raise AuthError("OAuth response missing 'access_token'")
+
+    refresh_token = data.get("refresh_token") or previous.get("refresh_token")
+    if not isinstance(refresh_token, str) or not refresh_token:
+        raise AuthError("OAuth response missing 'refresh_token'")
+
+    id_token = data.get("id_token") or previous.get("id_token")
+    if not isinstance(id_token, str) or not id_token:
+        raise AuthError("OAuth response missing 'id_token'")
+
+    raw_expires_at_ms = data.get("expires_at_ms", previous.get("expires_at_ms"))
+    expires_at_ms = int(raw_expires_at_ms) if isinstance(raw_expires_at_ms, int | float) else None
+    if expires_at_ms is None:
+        raw_expires_at = data.get("expires_at") or previous.get("expires_at")
+        if isinstance(raw_expires_at, int | float):
+            expires_at_ms = int(float(raw_expires_at) * 1000)
+    expires_at_ms = expires_at_ms or _expires_at_ms_from_token(access_token)
+    expires_at_ms = expires_at_ms or _expires_at_ms_from_token(id_token)
+    expires_in = data.get("expires_in")
+    if expires_at_ms is None and isinstance(expires_in, int | float | str):
+        try:
+            expires_at_ms = int((time.time() + int(expires_in)) * 1000)
+        except (TypeError, ValueError):
+            expires_at_ms = None
+
+    creds = {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "id_token": id_token,
+        "token_type": data.get("token_type", previous.get("token_type", "Bearer")),
+    }
+    if expires_at_ms is not None:
+        creds["expires_at_ms"] = expires_at_ms
+    account_id = _account_id_from_tokens(access_token, id_token) or previous.get("account_id")
+    if account_id:
+        creds["account_id"] = account_id
+    return creds
+
+
+class CodexOAuth(BaseOAuthStrategy):
+    def __init__(
+        self,
+        profile_name: str,
+        *,
+        credential_store: CredentialStore | None = None,
+        account: str | None = None,
+        http_client_factory=None,
+    ) -> None:
+        super().__init__(profile_name=profile_name)
+        self._store = credential_store or get_credential_store()
+        self._account = account if account is not None else _ACCOUNT
+        self._http_factory = http_client_factory or (
+            lambda: httpx.AsyncClient(timeout=httpx.Timeout(30.0))
+        )
+
+    def keychain_service(self) -> str:
+        return keychain_service_for(self.profile_name)
+
+    def keychain_account(self) -> str:
+        return self._account
+
+    def _read_credential(self) -> dict:
+        raw = self._store.read(self.keychain_service(), self.keychain_account())
+        if raw is None:
+            raise CredentialNotFoundError(
+                f"No tokens for codex profile {self.profile_name!r}. Re-authenticate via Electron."
+            )
+        try:
+            loaded = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise AuthError(
+                f"Token blob for {self.profile_name!r} is not valid JSON: {exc}"
+            ) from exc
+        if not isinstance(loaded, dict):
+            raise AuthError(f"Token blob for {self.profile_name!r} is not a JSON object")
+        return _normalize_token_response(loaded, loaded)
+
+    def _is_expired(self, creds: dict) -> bool:
+        expires_at_ms = creds.get("expires_at_ms")
+        if not isinstance(expires_at_ms, int | float) or expires_at_ms <= 0:
+            expires_at_ms = _expires_at_ms_from_token(creds.get("access_token"))
+        if expires_at_ms is None:
+            return False
+        return time.time() * 1000 >= expires_at_ms - (self.refresh_window_seconds * 1000)
+
+    def _build_headers(self, creds: dict) -> dict[str, str]:
+        headers = {"Authorization": f"Bearer {creds['access_token']}"}
+        account_id = creds.get("account_id")
+        if isinstance(account_id, str) and account_id:
+            headers["ChatGPT-Account-Id"] = account_id
+        return headers
+
+    async def _refresh_credential(self, creds: dict) -> dict:
+        body = {
+            "client_id": CODEX_CLIENT_ID,
+            "grant_type": "refresh_token",
+            "refresh_token": creds["refresh_token"],
+            "scope": CODEX_REFRESH_SCOPE,
+        }
+        try:
+            async with self._http_factory() as client:
+                resp = await client.post(
+                    CODEX_TOKEN_URL,
+                    data=body,
+                    headers={"content-type": "application/x-www-form-urlencoded"},
+                )
+        except httpx.RequestError as exc:
+            raise AuthError(f"Refresh endpoint unreachable: {exc}") from exc
+
+        if resp.status_code == 401:
+            raise AuthError(
+                f"Refresh returned 401 for profile {self.profile_name!r}. Re-auth required."
+            )
+        if resp.status_code != 200:
+            raise AuthError(f"OAuth refresh failed status {resp.status_code}: {resp.text[:500]}")
+        try:
+            data = resp.json()
+        except json.JSONDecodeError as exc:
+            raise AuthError(f"OAuth refresh response not JSON: {exc}") from exc
+        if not isinstance(data, dict):
+            raise AuthError("OAuth refresh response is not a JSON object")
+
+        refreshed = _normalize_token_response(data, creds)
+        self._write_to_store(refreshed)
+        return refreshed
+
+    def _write_to_store(self, creds: dict) -> None:
+        self._store.write(self.keychain_service(), self.keychain_account(), json.dumps(creds))
+
+
+async def exchange_authorization_code(
+    code: str,
+    code_verifier: str,
+    *,
+    redirect_uri: str,
+    http_client_factory=None,
+) -> dict:
+    factory = http_client_factory or (lambda: httpx.AsyncClient(timeout=httpx.Timeout(30.0)))
+    body = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "client_id": CODEX_CLIENT_ID,
+        "code_verifier": code_verifier,
+    }
+    try:
+        async with factory() as client:
+            resp = await client.post(
+                CODEX_TOKEN_URL,
+                data=body,
+                headers={"content-type": "application/x-www-form-urlencoded"},
+            )
+    except httpx.RequestError as exc:
+        raise AuthError(f"Authorization code exchange endpoint unreachable: {exc}") from exc
+
+    if resp.status_code != 200:
+        raise AuthError(f"Authorization code exchange failed (HTTP {resp.status_code})")
+    try:
+        data = resp.json()
+    except json.JSONDecodeError as exc:
+        raise AuthError(f"Authorization code response not JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise AuthError("Authorization code response is not a JSON object")
+    return _normalize_token_response(data)

--- a/apps/aigateway/src/aigateway/plugins/codex_provider/litellm_handler.py
+++ b/apps/aigateway/src/aigateway/plugins/codex_provider/litellm_handler.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import AsyncIterable, Awaitable, Iterable
+from inspect import isawaitable
+from typing import Any, cast
+
+import httpx
+import litellm
+from litellm.llms.chatgpt.common_utils import get_chatgpt_default_headers
+from litellm.llms.custom_llm import CustomLLM, CustomLLMError
+from litellm.types.utils import ModelResponse
+
+CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses"
+_PROVIDER = "codex"
+_HANDLER: CodexCustomLLM | None = None
+_DEFAULT_INSTRUCTIONS = "You are a helpful assistant."
+
+
+def _strip_provider_prefix(model: str) -> str:
+    return model.split("/", 1)[1] if model.startswith(f"{_PROVIDER}/") else model
+
+
+def _message_content_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict):
+                text = item.get("text") or item.get("content")
+                if isinstance(text, str):
+                    parts.append(text)
+            elif isinstance(item, str):
+                parts.append(item)
+        return "\n".join(parts)
+    return "" if content is None else str(content)
+
+
+def _build_payload(model: str, messages: list[dict[str, Any]], optional_params: dict) -> dict:
+    system_messages: list[str] = []
+    input_messages: list[dict[str, str]] = []
+    for message in messages:
+        role = str(message.get("role") or "user")
+        text = _message_content_text(message.get("content"))
+        if role == "system":
+            if text:
+                system_messages.append(text)
+            continue
+        input_messages.append({"role": role, "content": text})
+
+    payload: dict[str, Any] = {
+        "model": _strip_provider_prefix(model),
+        "input": input_messages,
+        "stream": True,
+        "store": False,
+        "include": ["reasoning.encrypted_content"],
+    }
+    payload["instructions"] = (
+        "\n\n".join(system_messages) if system_messages else _DEFAULT_INSTRUCTIONS
+    )
+
+    for key in ("tools", "tool_choice", "reasoning", "previous_response_id", "truncation"):
+        if key in optional_params:
+            payload[key] = optional_params[key]
+    if "include" in optional_params and isinstance(optional_params["include"], list):
+        payload["include"] = list(dict.fromkeys([*payload["include"], *optional_params["include"]]))
+    return payload
+
+
+def _iter_sse_data(lines: Iterable[str]):
+    event_data: list[str] = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            if event_data:
+                data = "\n".join(event_data).strip()
+                event_data = []
+                if data and data != "[DONE]":
+                    yield data
+            continue
+        if line.startswith("data:"):
+            event_data.append(line.removeprefix("data:").strip())
+    if event_data:
+        data = "\n".join(event_data).strip()
+        if data and data != "[DONE]":
+            yield data
+
+
+async def _aiter_sse_data(lines: AsyncIterable[str]):
+    event_data: list[str] = []
+    async for line in lines:
+        line = line.strip()
+        if not line:
+            if event_data:
+                data = "\n".join(event_data).strip()
+                event_data = []
+                if data and data != "[DONE]":
+                    yield data
+            continue
+        if line.startswith("data:"):
+            event_data.append(line.removeprefix("data:").strip())
+    if event_data:
+        data = "\n".join(event_data).strip()
+        if data and data != "[DONE]":
+            yield data
+
+
+def _extract_text_from_response(response: dict[str, Any]) -> str:
+    output = response.get("output")
+    if not isinstance(output, list):
+        return ""
+    parts: list[str] = []
+    for item in output:
+        if not isinstance(item, dict):
+            continue
+        content = item.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            text = block.get("text")
+            if isinstance(text, str):
+                parts.append(text)
+    return "".join(parts)
+
+
+def _usage_from_response(response: dict[str, Any]) -> dict[str, int] | None:
+    usage = response.get("usage")
+    if not isinstance(usage, dict):
+        return None
+    prompt = usage.get("input_tokens", usage.get("prompt_tokens", 0))
+    completion = usage.get("output_tokens", usage.get("completion_tokens", 0))
+    try:
+        prompt_tokens = int(prompt or 0)
+        completion_tokens = int(completion or 0)
+    except (TypeError, ValueError):
+        return None
+    return {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": prompt_tokens + completion_tokens,
+    }
+
+
+def _consume_sse_event(data: str, state: dict[str, Any]) -> bool:
+    try:
+        event = json.loads(data)
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(event, dict):
+        return False
+    event_type = event.get("type")
+    if event_type in {"response.failed", "error"}:
+        state["error"] = event.get("error") or (event.get("response") or {}).get("error")
+    if event_type == "response.output_text.delta":
+        delta = event.get("delta")
+        if isinstance(delta, str):
+            state.setdefault("text_deltas", []).append(delta)
+    if event_type == "response.output_item.done" and isinstance(event.get("item"), dict):
+        state.setdefault("output_items", []).append(event["item"])
+    if event_type == "response.completed" and isinstance(event.get("response"), dict):
+        state["completed"] = event["response"]
+        return True
+    return False
+
+
+def _model_response_from_sse_events(events: Iterable[str], fallback_model: str) -> ModelResponse:
+    state: dict[str, Any] = {}
+    for data in events:
+        if _consume_sse_event(data, state):
+            break
+    return _model_response_from_state(state, fallback_model)
+
+
+async def _model_response_from_sse_stream(
+    lines: AsyncIterable[str], fallback_model: str
+) -> ModelResponse:
+    state: dict[str, Any] = {}
+    async for data in _aiter_sse_data(lines):
+        if _consume_sse_event(data, state):
+            break
+    return _model_response_from_state(state, fallback_model)
+
+
+def _model_response_from_state(state: dict[str, Any], fallback_model: str) -> ModelResponse:
+    completed = state.get("completed")
+    error = state.get("error")
+    if error is not None:
+        message = error.get("message") if isinstance(error, dict) else str(error)
+        raise CustomLLMError(status_code=502, message=message or "Codex upstream failed")
+    if not isinstance(completed, dict):
+        raise CustomLLMError(status_code=502, message="Codex upstream did not complete response")
+
+    text_deltas = state.get("text_deltas")
+    if isinstance(text_deltas, list) and all(isinstance(item, str) for item in text_deltas):
+        content = "".join(text_deltas)
+    else:
+        content = ""
+    if not content:
+        output_items = state.get("output_items")
+        if isinstance(output_items, list):
+            content = _extract_text_from_response({"output": output_items})
+    if not content:
+        content = _extract_text_from_response(completed)
+    return ModelResponse(
+        id=completed.get("id"),
+        created=int(completed.get("created_at") or time.time()),
+        model=completed.get("model") or fallback_model,
+        choices=[
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": content},
+            }
+        ],
+        usage=_usage_from_response(completed),
+    )
+
+
+def _model_response_from_sse(body: str, fallback_model: str) -> ModelResponse:
+    return _model_response_from_sse_events(_iter_sse_data(body.splitlines()), fallback_model)
+
+
+async def _status_error_from_response(response: Any) -> CustomLLMError | None:
+    status_code = int(getattr(response, "status_code", 0) or 0)
+    if status_code == 401:
+        return CustomLLMError(status_code=401, message="Codex upstream rejected OAuth token")
+    if status_code < 400:
+        return None
+
+    preview = ""
+    aread = getattr(response, "aread", None)
+    if callable(aread):
+        try:
+            raw_result = aread()
+            raw = (
+                await cast(Awaitable[bytes], raw_result)
+                if isawaitable(raw_result)
+                else cast(bytes, raw_result)
+            )
+            preview = raw.decode("utf-8", errors="replace")[:500]
+        except Exception:
+            preview = ""
+    elif isinstance(getattr(response, "text", None), str):
+        preview = response.text[:500]
+    suffix = f": {preview}" if preview else ""
+    return CustomLLMError(
+        status_code=status_code,
+        message=f"Codex upstream request failed with status {status_code}{suffix}",
+    )
+
+
+async def _close_response(response: Any) -> None:
+    aclose = getattr(response, "aclose", None)
+    if callable(aclose):
+        close_result = aclose()
+        if isawaitable(close_result):
+            await cast(Awaitable[None], close_result)
+
+
+async def _model_response_from_response(response: Any, fallback_model: str) -> ModelResponse:
+    error = await _status_error_from_response(response)
+    if error is not None:
+        raise error
+    return await _model_response_from_sse_stream(response.aiter_lines(), fallback_model)
+
+
+def _request_kwargs(
+    payload: dict[str, Any], headers: dict[str, str], timeout: Any
+) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {"json": payload, "headers": headers}
+    if timeout is not None:
+        kwargs["timeout"] = timeout
+    return kwargs
+
+
+def _status_error_from_exception(exc: httpx.HTTPStatusError) -> CustomLLMError:
+    status_code = exc.response.status_code
+    if status_code == 401:
+        return CustomLLMError(status_code=401, message="Codex upstream rejected OAuth token")
+    message = f"Codex upstream request failed with status {status_code}"
+    text = getattr(exc, "text", None) or getattr(exc, "message", None)
+    if isinstance(text, str) and text:
+        message = f"{message}: {text[:500]}"
+    return CustomLLMError(status_code=status_code, message=message)
+
+
+class CodexCustomLLM(CustomLLM):
+    def __init__(self, http_client_factory=None) -> None:
+        super().__init__()
+        self._http_client_factory = http_client_factory or (
+            lambda: httpx.AsyncClient(timeout=httpx.Timeout(120.0))
+        )
+
+    async def acompletion(
+        self,
+        model: str,
+        messages: list,
+        api_base: str | None,
+        custom_prompt_dict: dict,
+        model_response: ModelResponse,
+        print_verbose,
+        encoding,
+        api_key,
+        logging_obj,
+        optional_params: dict,
+        acompletion=None,
+        litellm_params=None,
+        logger_fn=None,
+        headers=None,
+        timeout=None,
+        client=None,
+    ) -> ModelResponse:
+        if not api_key:
+            raise CustomLLMError(
+                status_code=401,
+                message="Codex requires gateway-owned OAuth credentials",
+            )
+        if isinstance(api_key, str) and api_key.startswith(("sk-", "sk-proj-")):
+            raise CustomLLMError(
+                status_code=400,
+                message="Codex subscription models are not available via OpenAI API key fallback",
+            )
+
+        extra_headers = headers or {}
+        account_id = extra_headers.get("ChatGPT-Account-Id") or extra_headers.get(
+            "chatgpt-account-id"
+        )
+        request_headers = get_chatgpt_default_headers(str(api_key), account_id)
+        payload = _build_payload(model, messages, optional_params or {})
+
+        fallback_model = _strip_provider_prefix(model)
+        kwargs = _request_kwargs(payload, request_headers, timeout)
+        if client is not None:
+            try:
+                response = await client.post(CODEX_RESPONSES_URL, **kwargs, stream=True)
+            except httpx.HTTPStatusError as exc:
+                raise _status_error_from_exception(exc) from exc
+            try:
+                return await _model_response_from_response(response, fallback_model)
+            finally:
+                await _close_response(response)
+
+        async with self._http_client_factory() as http_client:
+            async with http_client.stream("POST", CODEX_RESPONSES_URL, **kwargs) as response:
+                return await _model_response_from_response(response, fallback_model)
+
+
+def ensure_litellm_codex_provider_registered(handler: CodexCustomLLM | None = None) -> None:
+    global _HANDLER
+    if handler is not None:
+        _HANDLER = handler
+    if _HANDLER is None:
+        _HANDLER = CodexCustomLLM()
+    for entry in litellm.custom_provider_map:
+        if entry.get("provider") == _PROVIDER:
+            entry["custom_handler"] = _HANDLER
+            litellm.utils.custom_llm_setup()
+            return
+    litellm.custom_provider_map.append({"provider": _PROVIDER, "custom_handler": _HANDLER})
+    litellm.utils.custom_llm_setup()
+
+
+def get_litellm_codex_handler() -> CodexCustomLLM:
+    ensure_litellm_codex_provider_registered()
+    assert _HANDLER is not None
+    return _HANDLER

--- a/apps/aigateway/src/aigateway/plugins/codex_provider/models.py
+++ b/apps/aigateway/src/aigateway/plugins/codex_provider/models.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from aigateway.core.plugin_base import ModelEntry
+
+_MODEL_SLUGS = [
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.3-codex",
+    "gpt-5.2",
+]
+
+MODELS: list[ModelEntry] = [
+    ModelEntry(model_name=f"codex/{slug}", litellm_params={"model": f"codex/{slug}"})
+    for slug in _MODEL_SLUGS
+]

--- a/apps/aigateway/src/aigateway/plugins/codex_provider/oauth_config.py
+++ b/apps/aigateway/src/aigateway/plugins/codex_provider/oauth_config.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+CODEX_AUTH_BASE = "https://auth.openai.com"
+CODEX_AUTHORIZE_URL = f"{CODEX_AUTH_BASE}/oauth/authorize"
+CODEX_TOKEN_URL = f"{CODEX_AUTH_BASE}/oauth/token"
+CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+CODEX_REDIRECT_PATH = "/auth/callback"
+CODEX_REDIRECT_PORTS = [1455, 1457]
+CODEX_SCOPES = [
+    "openid",
+    "profile",
+    "email",
+    "offline_access",
+    "api.connectors.read",
+    "api.connectors.invoke",
+]
+CODEX_AUTHORIZE_EXTRA_PARAMS = {
+    "id_token_add_organizations": "true",
+    "codex_cli_simplified_flow": "true",
+    "originator": "codex_cli_rs",
+}
+CODEX_REFRESH_SCOPE = "openid profile email"

--- a/apps/aigateway/src/aigateway/plugins/codex_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/codex_provider/plugin.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException
 from litellm.llms.custom_llm import CustomLLMError
@@ -30,6 +30,9 @@ from .oauth_config import (
     CODEX_TOKEN_URL,
 )
 
+if TYPE_CHECKING:
+    from aigateway.core.credential_store import CredentialStore
+
 
 class CodexProviderPlugin(ProviderPluginBase):
     custom_llm_provider = "codex"
@@ -48,8 +51,18 @@ class CodexProviderPlugin(ProviderPluginBase):
             loopback_redirect_ports=CODEX_REDIRECT_PORTS,
         )
 
-    def oauth_strategy_for(self, profile_name: str) -> OAuthStrategy:
-        return CodexOAuth(profile_name=profile_name)
+    def oauth_strategy_for(
+        self,
+        profile_name: str,
+        *,
+        credential_store: CredentialStore | None = None,
+        http_client_factory: Any | None = None,
+    ) -> OAuthStrategy:
+        return CodexOAuth(
+            profile_name=profile_name,
+            credential_store=credential_store,
+            http_client_factory=http_client_factory,
+        )
 
     async def exchange_oauth_code(self, request: OAuthCodeExchangeRequest) -> dict:
         return await exchange_authorization_code(

--- a/apps/aigateway/src/aigateway/plugins/codex_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/codex_provider/plugin.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException
+from litellm.llms.custom_llm import CustomLLMError
+from litellm.types.utils import ModelResponse
+
+from aigateway.core.plugin_base import (
+    ModelEntry,
+    OAuthCodeExchangeRequest,
+    OAuthConfig,
+    OAuthStrategy,
+    ProviderPluginBase,
+)
+
+from .auth import CodexOAuth, account_label_from_credentials, exchange_authorization_code
+from .litellm_handler import (
+    ensure_litellm_codex_provider_registered,
+    get_litellm_codex_handler,
+)
+from .models import MODELS
+from .oauth_config import (
+    CODEX_AUTHORIZE_EXTRA_PARAMS,
+    CODEX_AUTHORIZE_URL,
+    CODEX_CLIENT_ID,
+    CODEX_REDIRECT_PATH,
+    CODEX_REDIRECT_PORTS,
+    CODEX_SCOPES,
+    CODEX_TOKEN_URL,
+)
+
+
+class CodexProviderPlugin(ProviderPluginBase):
+    custom_llm_provider = "codex"
+
+    def register_models(self) -> list[ModelEntry]:
+        return list(MODELS)
+
+    def oauth_config(self) -> OAuthConfig:
+        return OAuthConfig(
+            authorize_url=CODEX_AUTHORIZE_URL,
+            token_url=CODEX_TOKEN_URL,
+            client_id=CODEX_CLIENT_ID,
+            scopes=CODEX_SCOPES,
+            redirect_path=CODEX_REDIRECT_PATH,
+            extra_authorize_params=CODEX_AUTHORIZE_EXTRA_PARAMS,
+            loopback_redirect_ports=CODEX_REDIRECT_PORTS,
+        )
+
+    def oauth_strategy_for(self, profile_name: str) -> OAuthStrategy:
+        return CodexOAuth(profile_name=profile_name)
+
+    async def exchange_oauth_code(self, request: OAuthCodeExchangeRequest) -> dict:
+        return await exchange_authorization_code(
+            request.code,
+            request.code_verifier,
+            redirect_uri=request.redirect_uri,
+            http_client_factory=request.http_client_factory,
+        )
+
+    def account_label_from_credentials(self, credentials: dict) -> str | None:
+        return account_label_from_credentials(credentials)
+
+    def supports_chat_streaming(self) -> bool:
+        return False
+
+    def prepare_chat_body(self, body: dict[str, Any]) -> dict[str, Any]:
+        if "reasoning_effort" in body:
+            effort = body.pop("reasoning_effort")
+            if effort is not None and "reasoning" not in body:
+                body["reasoning"] = {"effort": effort}
+        return body
+
+    async def chat_completion(self, body: dict[str, Any]) -> Any:
+        optional_params = {
+            key: value
+            for key, value in body.items()
+            if key not in {"model", "messages", "api_key", "extra_headers", "timeout"}
+        }
+        try:
+            return await get_litellm_codex_handler().acompletion(
+                model=body["model"],
+                messages=body["messages"],
+                api_base=None,
+                custom_prompt_dict={},
+                model_response=ModelResponse(),
+                print_verbose=lambda *_args, **_kwargs: None,
+                encoding=None,
+                api_key=body.get("api_key"),
+                logging_obj=None,
+                optional_params=optional_params,
+                headers=body.get("extra_headers"),
+                timeout=body.get("timeout"),
+            )
+        except CustomLLMError as exc:
+            raise HTTPException(
+                status_code=exc.status_code,
+                detail={"code": "provider_error", "message": exc.message},
+            ) from exc
+
+
+ensure_litellm_codex_provider_registered()
+
+PLUGIN = CodexProviderPlugin()

--- a/apps/aigateway/src/aigateway/routes/auth.py
+++ b/apps/aigateway/src/aigateway/routes/auth.py
@@ -41,6 +41,18 @@ def _registry_for_app(app):
     return app.state.providers
 
 
+def _credential_store_for_app(app):
+    return app.state.credential_store
+
+
+def _oauth_strategy_for_app(app, plugin, provider: str, account_id: str, name: str):
+    return plugin.oauth_strategy_for(
+        credential_name_for(account_id, name),
+        credential_store=_credential_store_for_app(app),
+        http_client_factory=getattr(app.state, f"{provider}_http_factory", None),
+    )
+
+
 def _pending(request: Request):
     return _pending_for_app(request.app)
 
@@ -81,15 +93,6 @@ async def _close_loopback_callback(app, state: str) -> None:
         return
     server.close()
     await server.wait_closed()
-
-
-async def _close_all_loopback_callbacks(app) -> None:
-    callbacks = getattr(app.state, "loopback_oauth_callbacks", None)
-    if not isinstance(callbacks, dict):
-        return
-    states = list(callbacks)
-    for state in states:
-        await _close_loopback_callback(app, state)
 
 
 async def _expire_loopback_callback(app, state: str, ttl_seconds: int) -> None:
@@ -210,7 +213,6 @@ async def _loopback_redirect_uri_for(
             )
         except OSError:
             continue
-        await _close_all_loopback_callbacks(request.app)
         callbacks = getattr(request.app.state, "loopback_oauth_callbacks", None)
         if not isinstance(callbacks, dict):
             callbacks = {}
@@ -282,6 +284,8 @@ async def start_oauth(
 
     account_id = str(current.id)
     profile_id = profile_id_for(account_id, provider, body.name)
+    for stale_state in _pending(request).pop_for_profile(account_id, provider, body.name):
+        await _close_loopback_callback(request.app, stale_state)
     code_verifier, code_challenge = generate_pkce()
     state = generate_state()
     redirect_uri = await _redirect_uri_for(request, provider, cfg, state)
@@ -426,16 +430,12 @@ async def _complete_oauth_for_app(
             status_code=404, detail={"code": "unknown_provider", "provider": provider}
         )
 
-    factory = getattr(app.state, f"{provider}_http_factory", None)
-    strategy = plugin.oauth_strategy_for(credential_name_for(account_id, name))
-    if strategy is None or not hasattr(strategy, "set_credentials"):
+    strategy = _oauth_strategy_for_app(app, plugin, provider, account_id, name)
+    if strategy is None:
         raise HTTPException(
             status_code=400,
             detail={"code": "provider_does_not_use_oauth", "provider": provider},
         )
-    # Inject the same credential store as the profile index so tests/fake keychain work.
-    if hasattr(strategy, "_store"):
-        strategy._store = _index_store_for_app(app)._store
 
     # Consume the OAuth state after all synchronous validation and before the
     # first await that can race another callback using the same code.
@@ -452,7 +452,7 @@ async def _complete_oauth_for_app(
                 code_verifier=pending.code_verifier,
                 redirect_uri=pending.redirect_uri,
                 state=state,
-                http_client_factory=factory,
+                http_client_factory=getattr(app.state, f"{provider}_http_factory", None),
             )
         )
     except NotImplementedError as exc:
@@ -466,13 +466,12 @@ async def _complete_oauth_for_app(
         await _mark_profile_error(app, account_id, provider, name)
         await _close_loopback_callback(app, state)
         raise
-    strategy.set_credentials(creds)
+    strategy.persist_credentials(creds)
 
     p = await _index_store_for_app(app).get(account_id, provider, name)
     if p is not None:
         p.state = ProfileState.AUTHENTICATED
-        label_factory = getattr(plugin, "account_label_from_credentials", lambda _creds: None)
-        label = label_factory(creds)
+        label = plugin.account_label_from_credentials(creds)
         if label is not None:
             p.account_label = label
         await _index_store_for_app(app).upsert(p)
@@ -561,10 +560,9 @@ async def delete_profile(provider: str, name: str, request: Request, current: Cu
     p = await _index_store(request).get(account_id, provider, name)
     if p is None:
         raise HTTPException(status_code=404, detail={"code": "profile_not_found"})
-    strategy = plugin.oauth_strategy_for(credential_name_for(account_id, name))
-    if strategy is not None and hasattr(strategy, "_store"):
-        strategy._store = _index_store(request)._store
-        strategy._store.delete(strategy.keychain_service(), strategy.keychain_account())
+    strategy = _oauth_strategy_for_app(request.app, plugin, provider, account_id, name)
+    if strategy is not None:
+        strategy.delete_credentials()
     await _index_store(request).remove(p.id)
 
 
@@ -579,8 +577,8 @@ async def refresh_profile(
     p = await _index_store(request).get(account_id, provider, name)
     if p is None:
         raise HTTPException(status_code=404, detail={"code": "profile_not_found"})
-    strategy = plugin.oauth_strategy_for(credential_name_for(account_id, name))
+    strategy = _oauth_strategy_for_app(request.app, plugin, provider, account_id, name)
     if strategy is None:
         raise HTTPException(status_code=400, detail={"code": "provider_does_not_use_oauth"})
-    await strategy.refresh()
+    await strategy.refresh_credentials()
     return p.model_dump(mode="json")

--- a/apps/aigateway/src/aigateway/routes/auth.py
+++ b/apps/aigateway/src/aigateway/routes/auth.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 from html import escape
-from urllib.parse import urlencode
+from ipaddress import ip_address
+from urllib.parse import parse_qs, urlencode, urlsplit
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse
@@ -10,6 +12,7 @@ from pydantic import BaseModel
 from ..core.auth.middleware import CurrentAccount
 from ..core.oauth_pkce import generate_pkce, generate_state
 from ..core.pending_auth import PendingAuthEntry
+from ..core.plugin_base import OAuthCodeExchangeRequest, OAuthConfig
 from ..core.profile_index import ProfileIndexStore
 from ..core.profile_models import (
     Profile,
@@ -18,21 +21,218 @@ from ..core.profile_models import (
     credential_name_for,
     profile_id_for,
 )
-from ..plugins.anthropic_provider import auth as anthropic_auth_module
 
 router = APIRouter()
 
 
 def _index_store(request: Request) -> ProfileIndexStore:
-    return request.app.state.profile_index
+    return _index_store_for_app(request.app)
+
+
+def _index_store_for_app(app) -> ProfileIndexStore:
+    return app.state.profile_index
 
 
 def _registry(request: Request):
-    return request.app.state.providers
+    return _registry_for_app(request.app)
+
+
+def _registry_for_app(app):
+    return app.state.providers
 
 
 def _pending(request: Request):
-    return request.app.state.pending_auth
+    return _pending_for_app(request.app)
+
+
+def _pending_for_app(app):
+    return app.state.pending_auth
+
+
+def _gateway_redirect_uri_for(request: Request, cfg: OAuthConfig) -> str:
+    path = cfg.redirect_path if cfg.redirect_path.startswith("/") else f"/{cfg.redirect_path}"
+    return f"http://localhost:{request.app.state.settings.port}{path}"
+
+
+def _loopback_host_allowed(host_header: str | None) -> bool:
+    if host_header is None:
+        return False
+    try:
+        hostname = urlsplit(f"//{host_header.strip()}").hostname
+    except ValueError:
+        return False
+    if hostname is None:
+        return False
+    normalized = hostname.rstrip(".").lower()
+    if normalized == "localhost":
+        return True
+    try:
+        return ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
+async def _close_loopback_callback(app, state: str) -> None:
+    callbacks = getattr(app.state, "loopback_oauth_callbacks", None)
+    if not isinstance(callbacks, dict):
+        return
+    server = callbacks.pop(state, None)
+    if server is None:
+        return
+    server.close()
+    await server.wait_closed()
+
+
+async def _close_all_loopback_callbacks(app) -> None:
+    callbacks = getattr(app.state, "loopback_oauth_callbacks", None)
+    if not isinstance(callbacks, dict):
+        return
+    states = list(callbacks)
+    for state in states:
+        await _close_loopback_callback(app, state)
+
+
+async def _expire_loopback_callback(app, state: str, ttl_seconds: int) -> None:
+    await asyncio.sleep(ttl_seconds)
+    await _close_loopback_callback(app, state)
+
+
+def _http_response(status: int, body: str, *, content_type: str = "text/html") -> bytes:
+    reason = {200: "OK", 400: "Bad Request", 403: "Forbidden", 404: "Not Found"}.get(
+        status, "Internal Server Error"
+    )
+    data = body.encode("utf-8")
+    headers = (
+        f"HTTP/1.1 {status} {reason}\r\n"
+        f"content-type: {content_type}; charset=utf-8\r\n"
+        f"content-length: {len(data)}\r\n"
+        "connection: close\r\n"
+        "\r\n"
+    ).encode("ascii")
+    return headers + data
+
+
+async def _handle_loopback_callback(
+    app,
+    provider: str,
+    expected_path: str,
+    expected_state: str,
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+) -> None:
+    status = 500
+    body = "Authentication failed"
+    try:
+        try:
+            raw = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=5)
+        except (asyncio.IncompleteReadError, asyncio.LimitOverrunError, TimeoutError):
+            status = 400
+            body = "Malformed callback request"
+            return
+
+        lines = raw.decode("iso-8859-1", errors="replace").split("\r\n")
+        request_line = lines[0].split()
+        if len(request_line) < 2:
+            status = 400
+            body = "Malformed callback request"
+            return
+        method, target = request_line[0], request_line[1]
+        headers: dict[str, str] = {}
+        for line in lines[1:]:
+            if not line or ":" not in line:
+                continue
+            key, value = line.split(":", 1)
+            headers[key.strip().lower()] = value.strip()
+
+        if not _loopback_host_allowed(headers.get("host")):
+            status = 403
+            body = "Forbidden callback host"
+            return
+
+        parsed = urlsplit(target)
+        if method != "GET" or parsed.path != expected_path:
+            status = 404
+            body = "Unknown callback path"
+            return
+
+        params = parse_qs(parsed.query)
+        code = params.get("code", [None])[0]
+        state = params.get("state", [None])[0]
+        if not code or not state:
+            status = 400
+            body = "Missing callback code or state"
+            return
+        if state != expected_state:
+            status = 400
+            body = "OAuth state not recognized or expired"
+            return
+
+        await _complete_oauth_for_app(app, provider, code, state)
+        status = 200
+        body = _CALLBACK_HTML
+    except Exception as exc:
+        status = 500
+        body = (
+            "<!doctype html><html><body>"
+            "<h2>Authentication failed</h2>"
+            f"<p>Provider: {escape(provider)}</p>"
+            f"<pre style='white-space:pre-wrap'>{escape(type(exc).__name__)}: "
+            f"{escape(str(exc))}</pre>"
+            "</body></html>"
+        )
+    finally:
+        writer.write(_http_response(status, body))
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+        await _close_loopback_callback(app, expected_state)
+
+
+async def _loopback_redirect_uri_for(
+    request: Request,
+    provider: str,
+    cfg: OAuthConfig,
+    state: str,
+) -> str:
+    path = cfg.redirect_path if cfg.redirect_path.startswith("/") else f"/{cfg.redirect_path}"
+    callbacks = getattr(request.app.state, "loopback_oauth_callbacks", None)
+    if not isinstance(callbacks, dict):
+        callbacks = {}
+        request.app.state.loopback_oauth_callbacks = callbacks
+    for port in cfg.loopback_redirect_ports or []:
+        try:
+            server = await asyncio.start_server(
+                lambda reader, writer: _handle_loopback_callback(
+                    request.app, provider, path, state, reader, writer
+                ),
+                host="localhost",
+                port=port,
+            )
+        except OSError:
+            continue
+        await _close_all_loopback_callbacks(request.app)
+        callbacks = getattr(request.app.state, "loopback_oauth_callbacks", None)
+        if not isinstance(callbacks, dict):
+            callbacks = {}
+            request.app.state.loopback_oauth_callbacks = callbacks
+        callbacks[state] = server
+        asyncio.create_task(_expire_loopback_callback(request.app, state, 600))
+        return f"http://localhost:{port}{path}"
+    raise HTTPException(
+        status_code=503,
+        detail={"code": "oauth_loopback_unavailable", "ports": cfg.loopback_redirect_ports},
+    )
+
+
+async def _redirect_uri_for(
+    request: Request,
+    provider: str,
+    cfg: OAuthConfig,
+    state: str,
+) -> str:
+    if cfg.loopback_redirect_ports:
+        return await _loopback_redirect_uri_for(request, provider, cfg, state)
+    return _gateway_redirect_uri_for(request, cfg)
 
 
 @router.get("/v1/auth/profiles")
@@ -84,6 +284,7 @@ async def start_oauth(
     profile_id = profile_id_for(account_id, provider, body.name)
     code_verifier, code_challenge = generate_pkce()
     state = generate_state()
+    redirect_uri = await _redirect_uri_for(request, provider, cfg, state)
 
     _pending(request).put(
         state,
@@ -93,15 +294,10 @@ async def start_oauth(
             profile_name=body.name,
             profile_id=profile_id,
             code_verifier=code_verifier,
+            redirect_uri=redirect_uri,
         ),
     )
 
-    # The Claude Code public OAuth client (and similar public clients) only
-    # accept ``http://localhost:*/callback`` as a redirect URI — using
-    # ``127.0.0.1`` or any path other than ``/callback`` triggers an
-    # "Authorization failed" error from claude.ai. We use ``localhost`` and
-    # the top-level ``/callback`` route (provider is dispatched via state).
-    redirect_uri = f"http://localhost:{request.app.state.settings.port}/callback"
     params = {
         "response_type": "code",
         "client_id": cfg.client_id,
@@ -120,6 +316,7 @@ async def start_oauth(
         account_id=account_id,
         provider=provider,
         name=body.name,
+        scopes=cfg.scopes,
         state=ProfileState.PENDING,
         defaults=body.defaults or ProfileDefaults(),
     )
@@ -147,11 +344,9 @@ async def oauth_callback(code: str, state: str, request: Request):
     state nonce is the callback credential; it maps back to the initiating
     account and profile.
 
-    Anthropic's public Claude Code OAuth client (and most OAuth providers
-    using public clients) only accepts ``http://localhost:*/callback`` as
-    the redirect URI — i.e. the path is fixed at ``/callback`` and is not
-    namespaced per provider. We dispatch to the correct provider by
-    looking up the ``state`` value in the pending-auth table.
+    Some public OAuth clients require a fixed localhost callback path. We
+    dispatch to the correct provider by looking up the ``state`` value in the
+    pending-auth table.
     """
     pending_entry = _pending(request).peek(state)
     if pending_entry is None:
@@ -177,11 +372,15 @@ async def oauth_callback(code: str, state: str, request: Request):
         )
 
 
-# Back-compat: older OAuth flows (and tests) still use the per-provider path.
-@router.get("/v1/auth/anthropic/callback")
-async def anthropic_callback(code: str, state: str, request: Request):
+@router.get("/auth/callback")
+async def oauth_nested_callback(code: str, state: str, request: Request):
+    return await oauth_callback(code, state, request)
+
+
+@router.get("/v1/auth/{provider}/callback")
+async def provider_callback(provider: str, code: str, state: str, request: Request):
     """Unauthenticated OAuth callback protected by the pending-auth state nonce."""
-    return await _generic_callback("anthropic", code, state, request)
+    return await _generic_callback(provider, code, state, request)
 
 
 async def _complete_oauth(
@@ -191,12 +390,23 @@ async def _complete_oauth(
     request: Request,
     current_account_id: str | None = None,
 ) -> None:
+    await _complete_oauth_for_app(request.app, provider, code, state, current_account_id)
+
+
+async def _complete_oauth_for_app(
+    app,
+    provider: str,
+    code: str,
+    state: str,
+    current_account_id: str | None = None,
+) -> None:
     """Run the OAuth token exchange and persist credentials.
 
     Used by both the GET browser-redirect callback and the POST manual
     paste-code endpoint. Raises HTTPException on failure.
     """
-    pending = _pending(request).peek(state)
+    pending_table = _pending_for_app(app)
+    pending = pending_table.peek(state)
     if pending is None:
         raise HTTPException(
             status_code=400,
@@ -210,31 +420,70 @@ async def _complete_oauth(
         raise HTTPException(status_code=404, detail={"code": "profile_not_found"})
     name = pending.profile_name
 
-    factory = getattr(request.app.state, f"{provider}_http_factory", None)
-    # Must match the redirect_uri sent to /authorize. Both the start-OAuth
-    # route and this exchange use the same canonical localhost+/callback
-    # form so Anthropic's redirect-URI check passes.
-    redirect_uri = f"http://localhost:{request.app.state.settings.port}/callback"
-    creds = await anthropic_auth_module.exchange_authorization_code(
-        code,
-        pending.code_verifier,
-        redirect_uri=redirect_uri,
-        state=state,
-        http_client_factory=factory,
-    )
+    plugin = _registry_for_app(app).get(provider)
+    if plugin is None:
+        raise HTTPException(
+            status_code=404, detail={"code": "unknown_provider", "provider": provider}
+        )
 
-    plugin = _registry(request).get(provider)
+    factory = getattr(app.state, f"{provider}_http_factory", None)
     strategy = plugin.oauth_strategy_for(credential_name_for(account_id, name))
+    if strategy is None or not hasattr(strategy, "set_credentials"):
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "provider_does_not_use_oauth", "provider": provider},
+        )
     # Inject the same credential store as the profile index so tests/fake keychain work.
     if hasattr(strategy, "_store"):
-        strategy._store = _index_store(request)._store
+        strategy._store = _index_store_for_app(app)._store
+
+    # Consume the OAuth state after all synchronous validation and before the
+    # first await that can race another callback using the same code.
+    pending = pending_table.pop(state)
+    if pending is None:
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "unknown_state", "message": "OAuth state not recognized or expired"},
+        )
+    try:
+        creds = await plugin.exchange_oauth_code(
+            OAuthCodeExchangeRequest(
+                code=code,
+                code_verifier=pending.code_verifier,
+                redirect_uri=pending.redirect_uri,
+                state=state,
+                http_client_factory=factory,
+            )
+        )
+    except NotImplementedError as exc:
+        await _mark_profile_error(app, account_id, provider, name)
+        await _close_loopback_callback(app, state)
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "provider_does_not_use_oauth", "provider": provider},
+        ) from exc
+    except Exception:
+        await _mark_profile_error(app, account_id, provider, name)
+        await _close_loopback_callback(app, state)
+        raise
     strategy.set_credentials(creds)
 
-    p = await _index_store(request).get(account_id, provider, name)
+    p = await _index_store_for_app(app).get(account_id, provider, name)
     if p is not None:
         p.state = ProfileState.AUTHENTICATED
-        await _index_store(request).upsert(p)
-    _pending(request).pop(state)
+        label_factory = getattr(plugin, "account_label_from_credentials", lambda _creds: None)
+        label = label_factory(creds)
+        if label is not None:
+            p.account_label = label
+        await _index_store_for_app(app).upsert(p)
+    await _close_loopback_callback(app, state)
+
+
+async def _mark_profile_error(app, account_id: str, provider: str, name: str) -> None:
+    p = await _index_store_for_app(app).get(account_id, provider, name)
+    if p is not None:
+        p.state = ProfileState.ERROR
+        await _index_store_for_app(app).upsert(p)
 
 
 async def _generic_callback(provider: str, code: str, state: str, request: Request):
@@ -255,8 +504,7 @@ async def exchange_code(
     current: CurrentAccount,
 ) -> dict:
     """Manual paste-code path for OAuth flows where the provider shows the
-    authorization code on screen instead of redirecting (e.g. claude.ai/oauth
-    with `code=true`).
+    authorization code on screen instead of redirecting.
     """
     await _complete_oauth(provider, body.code, body.state, request, str(current.id))
     return {"state": "authenticated"}

--- a/apps/aigateway/src/aigateway/routes/chat.py
+++ b/apps/aigateway/src/aigateway/routes/chat.py
@@ -6,7 +6,6 @@ import json
 import logging
 from typing import Any, cast
 
-import litellm
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from litellm.exceptions import (
@@ -146,12 +145,12 @@ async def chat_completions(request: Request, current: CurrentAccount) -> Any:
             },
         )
 
-    strategy = plugin.oauth_strategy_for(credential_name_for(account_id, profile_name))
+    strategy = plugin.oauth_strategy_for(
+        credential_name_for(account_id, profile_name),
+        credential_store=request.app.state.credential_store,
+        http_client_factory=getattr(request.app.state, f"{provider}_http_factory", None),
+    )
     if strategy is not None:
-        # Same `_store` injection pattern Tasks 7-9 introduced for parity with the
-        # tests' fake keychain. In production both reference the same singleton.
-        if hasattr(strategy, "_store"):
-            strategy._store = idx._store  # type: ignore[attr-defined]
         try:
             headers = await strategy.get_authorization_header()
         except CredentialNotFoundError as exc:
@@ -177,7 +176,7 @@ async def chat_completions(request: Request, current: CurrentAccount) -> Any:
             body["extra_headers"] = merged
 
     if body.get("stream"):
-        return StreamingResponse(_stream(body), media_type="text/event-stream")
+        return StreamingResponse(_stream(plugin, body), media_type="text/event-stream")
 
     try:
         response = await plugin.chat_completion(body)
@@ -196,10 +195,9 @@ async def chat_completions(request: Request, current: CurrentAccount) -> Any:
     return dumpable.model_dump() if hasattr(dumpable, "model_dump") else response
 
 
-async def _stream(body: dict[str, Any]):
+async def _stream(plugin: Any, body: dict[str, Any]):
     try:
-        stream: Any = await litellm.acompletion(**body)
-        async for chunk in stream:
+        async for chunk in plugin.chat_completion_stream(body):
             payload = chunk.model_dump() if hasattr(chunk, "model_dump") else chunk
             yield f"data: {json.dumps(payload)}\n\n"
         yield "data: [DONE]\n\n"

--- a/apps/aigateway/src/aigateway/routes/chat.py
+++ b/apps/aigateway/src/aigateway/routes/chat.py
@@ -4,11 +4,21 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
+from typing import Any, cast
 
 import litellm
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
+from litellm.exceptions import (
+    APIConnectionError,
+    APIError,
+    AuthenticationError,
+    BadRequestError,
+    RateLimitError,
+    ServiceUnavailableError,
+    Timeout,
+    UnsupportedParamsError,
+)
 
 from ..core.auth.middleware import CurrentAccount
 from ..core.errors import AuthError, CredentialNotFoundError
@@ -33,9 +43,18 @@ def _has_system_message(body: dict[str, Any]) -> bool:
     return any(m.get("role") == "system" for m in body.get("messages", []))
 
 
-def _apply_defaults(body: dict[str, Any], defaults: ProfileDefaults) -> dict[str, Any]:
+def _should_apply_profile_default(plugin: Any, field: str) -> bool:
+    checker = getattr(plugin, "should_apply_profile_default", None)
+    return bool(checker(field)) if callable(checker) else True
+
+
+def _apply_defaults(body: dict[str, Any], defaults: ProfileDefaults, plugin: Any) -> dict[str, Any]:
     """Body wins per field. Fields the body omits get the profile default."""
-    if defaults.system_prompt and not _has_system_message(body):
+    if (
+        defaults.system_prompt
+        and not _has_system_message(body)
+        and _should_apply_profile_default(plugin, "system_prompt")
+    ):
         body.setdefault("messages", [])
         body["messages"] = [
             {"role": "system", "content": defaults.system_prompt},
@@ -43,10 +62,37 @@ def _apply_defaults(body: dict[str, Any], defaults: ProfileDefaults) -> dict[str
         ]
     for field in _BUCKET_A_FIELDS:
         gateway_field = "timeout" if field == "timeout_seconds" else field
+        if not _should_apply_profile_default(plugin, field):
+            continue
         value = getattr(defaults, field)
         if value is not None and gateway_field not in body:
             body[gateway_field] = value
     return body
+
+
+def _retry_after_headers(exc: Exception) -> dict[str, str]:
+    response = getattr(exc, "response", None)
+    headers = getattr(response, "headers", None)
+    retry_after = headers.get("retry-after") if headers is not None else None
+    return {"Retry-After": retry_after} if retry_after else {}
+
+
+def _litellm_http_exception(exc: Exception) -> HTTPException:
+    status = int(getattr(exc, "status_code", 502) or 502)
+    code = "provider_error"
+    if status == 400:
+        code = "bad_request"
+    elif status == 401:
+        code = "auth_required"
+    elif status == 429:
+        code = "rate_limited"
+    elif status >= 500:
+        code = "provider_unavailable"
+    return HTTPException(
+        status_code=status,
+        detail={"code": code, "message": str(exc)},
+        headers=_retry_after_headers(exc),
+    )
 
 
 @router.post("/v1/chat/completions")
@@ -59,7 +105,7 @@ async def chat_completions(request: Request, current: CurrentAccount) -> Any:
     model = body.get("model", "")
     provider = model.split("/", 1)[0] if "/" in model else None
     if not provider:
-        raise HTTPException(status_code=400, detail="model must be prefixed (e.g. anthropic/...)")
+        raise HTTPException(status_code=400, detail="model must be provider-prefixed")
 
     registry: ProviderRegistry = request.app.state.providers
     plugin = registry.get(provider)
@@ -88,7 +134,17 @@ async def chat_completions(request: Request, current: CurrentAccount) -> Any:
             },
         )
 
-    body = _apply_defaults(body, profile.defaults)
+    body = plugin.prepare_chat_body(_apply_defaults(body, profile.defaults, plugin))
+
+    if body.get("stream") and not plugin.supports_chat_streaming():
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "streaming_not_supported",
+                "provider": provider,
+                "message": f"{provider} does not support streaming through this gateway yet",
+            },
+        )
 
     strategy = plugin.oauth_strategy_for(credential_name_for(account_id, profile_name))
     if strategy is not None:
@@ -114,7 +170,7 @@ async def chat_completions(request: Request, current: CurrentAccount) -> Any:
             )
         auth_value = headers.pop("Authorization", None)
         if auth_value and auth_value.lower().startswith("bearer "):
-            body.setdefault("api_key", auth_value.split(" ", 1)[1])
+            body["api_key"] = auth_value.split(" ", 1)[1]
         if headers:
             merged = dict(body.get("extra_headers") or {})
             merged.update(headers)
@@ -123,8 +179,21 @@ async def chat_completions(request: Request, current: CurrentAccount) -> Any:
     if body.get("stream"):
         return StreamingResponse(_stream(body), media_type="text/event-stream")
 
-    response: Any = await litellm.acompletion(**body)
-    return response.model_dump() if hasattr(response, "model_dump") else response
+    try:
+        response = await plugin.chat_completion(body)
+    except (
+        RateLimitError,
+        UnsupportedParamsError,
+        BadRequestError,
+        AuthenticationError,
+        APIError,
+        APIConnectionError,
+        ServiceUnavailableError,
+        Timeout,
+    ) as exc:
+        raise _litellm_http_exception(exc) from exc
+    dumpable = cast(Any, response)
+    return dumpable.model_dump() if hasattr(dumpable, "model_dump") else response
 
 
 async def _stream(body: dict[str, Any]):

--- a/apps/aigateway/tests/live/test_anthropic_live.py
+++ b/apps/aigateway/tests/live/test_anthropic_live.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -17,9 +20,42 @@ from aigateway.main import create_app
 
 pytestmark = pytest.mark.live
 
+_database_prepared = False
+
 
 def _live_enabled() -> bool:
     return os.environ.get("AIGW_LIVE") == "1"
+
+
+def _prepare_live_database() -> None:
+    global _database_prepared
+    if _database_prepared:
+        return
+
+    app_dir = Path(__file__).resolve().parents[2]
+    command = [sys.executable, "-m", "tortoise", "-c", "aigateway.db.TORTOISE_CONFIG", "migrate"]
+    try:
+        subprocess.run(
+            command,
+            cwd=app_dir,
+            env=os.environ.copy(),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        pytest.fail(
+            "failed to migrate live AIGateway database before Anthropic live test\n"
+            f"stdout:\n{exc.stdout}\n"
+            f"stderr:\n{exc.stderr}"
+        )
+
+    _database_prepared = True
+
+
+def _live_client() -> TestClient:
+    _prepare_live_database()
+    return TestClient(create_app())
 
 
 def _require_default_profile(client: TestClient) -> None:
@@ -64,10 +100,26 @@ def _live_admin_password() -> str:
     return password
 
 
+def _assert_premium_model_round_trip(client: TestClient, model: str, expected: str) -> None:
+    resp = client.post(
+        "/v1/chat/completions",
+        headers={"X-Profile": "default"},
+        json={
+            "model": f"anthropic/{model}",
+            "messages": [{"role": "user", "content": f"Reply with exactly: {expected}"}],
+            "max_tokens": 20,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    content = resp.json()["choices"][0]["message"]["content"]
+    assert content.strip()
+    assert expected in content
+
+
 @pytest.mark.skipif(not _live_enabled(), reason="AIGW_LIVE=1 not set")
 def test_anthropic_round_trip_via_default_profile() -> None:
     _live_admin_password()
-    with TestClient(create_app()) as client:
+    with _live_client() as client:
         _login_admin(client)
         _require_default_profile(client)
 
@@ -86,9 +138,27 @@ def test_anthropic_round_trip_via_default_profile() -> None:
 
 
 @pytest.mark.skipif(not _live_enabled(), reason="AIGW_LIVE=1 not set")
+def test_anthropic_premium_sonnet_round_trip_via_default_profile() -> None:
+    _live_admin_password()
+    with _live_client() as client:
+        _login_admin(client)
+        _require_default_profile(client)
+        _assert_premium_model_round_trip(client, "claude-sonnet-4-6", "sonnet-premium-ok")
+
+
+@pytest.mark.skipif(not _live_enabled(), reason="AIGW_LIVE=1 not set")
+def test_anthropic_premium_opus_round_trip_via_default_profile() -> None:
+    _live_admin_password()
+    with _live_client() as client:
+        _login_admin(client)
+        _require_default_profile(client)
+        _assert_premium_model_round_trip(client, "claude-opus-4-7", "opus-premium-ok")
+
+
+@pytest.mark.skipif(not _live_enabled(), reason="AIGW_LIVE=1 not set")
 def test_anthropic_streaming() -> None:
     _live_admin_password()
-    with TestClient(create_app()) as client:
+    with _live_client() as client:
         _login_admin(client)
         _require_default_profile(client)
 
@@ -126,7 +196,7 @@ def test_anthropic_streaming() -> None:
 @pytest.mark.skipif(not _live_enabled(), reason="AIGW_LIVE=1 not set")
 def test_anthropic_tool_calls() -> None:
     _live_admin_password()
-    with TestClient(create_app()) as client:
+    with _live_client() as client:
         _login_admin(client)
         _require_default_profile(client)
 

--- a/apps/aigateway/tests/unit/anthropic/test_anthropic_auth.py
+++ b/apps/aigateway/tests/unit/anthropic/test_anthropic_auth.py
@@ -175,15 +175,15 @@ async def test_invalidate_drops_cache() -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_credentials_persists_and_caches() -> None:
-    """set_credentials() (used by OAuth callback) writes to store + populates cache."""
+async def test_persist_credentials_persists_and_caches() -> None:
+    """persist_credentials() writes to store + populates cache after OAuth callback."""
     store = _FakeStore(payload=None)
     strat = AnthropicOAuth(
         profile_name="default",
         credential_store=store,
     )
     fresh = _fresh_creds()
-    strat.set_credentials(fresh)
+    strat.persist_credentials(fresh)
 
     headers = await strat.get_authorization_header()
     assert headers["Authorization"] == f"Bearer {fresh['access_token']}"

--- a/apps/aigateway/tests/unit/anthropic/test_anthropic_auth.py
+++ b/apps/aigateway/tests/unit/anthropic/test_anthropic_auth.py
@@ -13,7 +13,10 @@ from aigateway.plugins.anthropic_provider.auth import (
     AnthropicOAuth,
     keychain_service_for,
 )
-from aigateway.plugins.anthropic_provider.oauth_config import ANTHROPIC_TOKEN_URL
+from aigateway.plugins.anthropic_provider.oauth_config import (
+    ANTHROPIC_REFRESH_SCOPES,
+    ANTHROPIC_TOKEN_URL,
+)
 
 
 class _FakeStore(CredentialStore):
@@ -134,6 +137,7 @@ async def test_expired_credential_triggers_refresh() -> None:
     assert captured["url"] == ANTHROPIC_TOKEN_URL
     assert captured["body"]["grant_type"] == "refresh_token"
     assert captured["body"]["refresh_token"] == "rt-1"
+    assert captured["body"]["scope"] == " ".join(ANTHROPIC_REFRESH_SCOPES)
 
     assert len(store.writes) == 1
     written = json.loads(store.writes[0][2])

--- a/apps/aigateway/tests/unit/anthropic/test_chat_handler.py
+++ b/apps/aigateway/tests/unit/anthropic/test_chat_handler.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from aigateway.plugins.anthropic_provider.chat_handler import (
+    _build_billing_header,
+    chat_completion,
+    prepare_claude_code_body,
+)
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:coroutine 'Logging.async_success_handler' was never awaited:RuntimeWarning"
+)
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def post(
+        self,
+        url,
+        *,
+        headers=None,
+        json=None,
+        data=None,
+        timeout=None,
+        logging_obj=None,
+        **_kwargs,
+    ) -> httpx.Response:
+        self.calls.append({"url": url, "headers": headers, "json": json, "data": data})
+        return httpx.Response(
+            200,
+            request=httpx.Request("POST", url),
+            json={
+                "id": "msg_test",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-sonnet-4-6",
+                "content": [{"type": "text", "text": "ready"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 7, "output_tokens": 3},
+            },
+        )
+
+
+def test_prepare_claude_code_body_uses_top_level_system_escape_hatch() -> None:
+    body = {
+        "model": "anthropic/claude-sonnet-4-6",
+        "messages": [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": "Reply exactly: ready"},
+        ],
+    }
+
+    out = prepare_claude_code_body(body)
+
+    assert out["system"][0] == {
+        "type": "text",
+        "text": _build_billing_header("Reply exactly: ready"),
+    }
+    assert out["system"][0]["text"].startswith("x-anthropic-billing-header: cc_version=2.1.142.")
+    assert out["system"][0]["text"].endswith("; cc_entrypoint=cli; cch=00000;")
+    assert out["system"][1] == {"type": "text", "text": "You are concise."}
+    assert out["messages"] == [{"role": "user", "content": "Reply exactly: ready"}]
+
+
+def test_prepare_claude_code_body_is_idempotent() -> None:
+    body = {
+        "model": "anthropic/claude-sonnet-4-6",
+        "messages": [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": "Reply exactly: ready"},
+        ],
+    }
+
+    once = prepare_claude_code_body(body)
+    twice = prepare_claude_code_body(once)
+
+    assert twice["system"] == once["system"]
+    assert twice["messages"] == once["messages"]
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_preserves_billing_header_through_litellm() -> None:
+    client = FakeClient()
+
+    response = await chat_completion(
+        {
+            "model": "anthropic/claude-sonnet-4-6",
+            "api_key": "sk-ant-oat01-test",
+            "messages": [
+                {"role": "system", "content": "You are concise."},
+                {"role": "user", "content": "Reply exactly: ready"},
+            ],
+            "max_tokens": 20,
+            "client": client,
+            "no-log": True,
+        }
+    )
+
+    sent = client.calls[-1]["json"]
+    assert sent["system"][0]["text"].startswith("x-anthropic-billing-header:")
+    assert sent["system"][1] == {"type": "text", "text": "You are concise."}
+    assert sent["messages"] == [
+        {"role": "user", "content": [{"type": "text", "text": "Reply exactly: ready"}]}
+    ]
+    assert response.choices[0].message.content == "ready"
+
+
+@pytest.mark.asyncio
+async def test_tools_remain_mapped_by_litellm() -> None:
+    client = FakeClient()
+
+    await chat_completion(
+        {
+            "model": "anthropic/claude-haiku-4-5",
+            "api_key": "sk-ant-oat01-test",
+            "messages": [{"role": "user", "content": "weather"}],
+            "max_tokens": 20,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get weather.",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"location": {"type": "string"}},
+                        },
+                    },
+                }
+            ],
+            "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+            "client": client,
+            "no-log": True,
+        }
+    )
+
+    sent = client.calls[-1]["json"]
+    assert sent["tools"] == [
+        {
+            "name": "get_weather",
+            "description": "Get weather.",
+            "type": "custom",
+            "input_schema": {
+                "type": "object",
+                "properties": {"location": {"type": "string"}},
+            },
+        }
+    ]
+    assert sent["tool_choice"] == {"type": "tool", "name": "get_weather"}

--- a/apps/aigateway/tests/unit/auth/test_local_only.py
+++ b/apps/aigateway/tests/unit/auth/test_local_only.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from aigateway.config import Settings
+from aigateway.core.auth.local_only import AuthDisabledLocalOnlyMiddleware
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(AuthDisabledLocalOnlyMiddleware)
+
+    @app.get("/ok")
+    async def ok() -> dict[str, bool]:
+        return {"ok": True}
+
+    return app
+
+
+def test_auth_disabled_local_only_allows_loopback_client_and_host() -> None:
+    with TestClient(
+        _app(),
+        base_url="http://127.0.0.1:9105",
+        client=("127.0.0.1", 50000),
+    ) as client:
+        response = client.get("/ok")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+def test_auth_disabled_local_only_allows_localhost_host() -> None:
+    with TestClient(
+        _app(),
+        base_url="http://localhost:9105",
+        client=("127.0.0.1", 50000),
+    ) as client:
+        response = client.get("/ok")
+
+    assert response.status_code == 200
+
+
+def test_auth_disabled_local_only_rejects_dns_rebinding_host() -> None:
+    with TestClient(
+        _app(),
+        base_url="http://example.test:9105",
+        client=("127.0.0.1", 50000),
+    ) as client:
+        response = client.get("/ok")
+
+    assert response.status_code == 403
+    assert "loopback" in response.text
+
+
+def test_auth_disabled_local_only_rejects_non_loopback_client() -> None:
+    with TestClient(
+        _app(),
+        base_url="http://127.0.0.1:9105",
+        client=("192.168.1.50", 50000),
+    ) as client:
+        response = client.get("/ok")
+
+    assert response.status_code == 403
+    assert "loopback" in response.text
+
+
+def test_create_app_installs_local_only_middleware_when_auth_disabled() -> None:
+    from aigateway.main import create_app
+
+    app = create_app(Settings(auth_enabled=False))
+
+    assert any(
+        middleware.cls is AuthDisabledLocalOnlyMiddleware for middleware in app.user_middleware
+    )
+
+
+def test_create_app_does_not_install_local_only_middleware_when_auth_enabled() -> None:
+    from aigateway.main import create_app
+
+    app = create_app(Settings(auth_enabled=True))
+
+    assert not any(
+        middleware.cls is AuthDisabledLocalOnlyMiddleware for middleware in app.user_middleware
+    )

--- a/apps/aigateway/tests/unit/codex/test_codex_auth.py
+++ b/apps/aigateway/tests/unit/codex/test_codex_auth.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import base64
+import json
+import time
+from typing import Any
+from urllib.parse import parse_qs
+
+import httpx
+import pytest
+
+from aigateway.core.credential_store import CredentialStore
+from aigateway.core.errors import AuthError, CredentialNotFoundError
+from aigateway.plugins.codex_provider.auth import (
+    CodexOAuth,
+    account_label_from_credentials,
+    exchange_authorization_code,
+    keychain_service_for,
+)
+from aigateway.plugins.codex_provider.oauth_config import CODEX_CLIENT_ID, CODEX_TOKEN_URL
+
+
+class _FakeStore(CredentialStore):
+    def __init__(self, payload: str | None = None) -> None:
+        self.payload = payload
+        self.writes: list[tuple[str, str, str]] = []
+
+    def read(self, service: str, account: str) -> str | None:
+        return self.payload
+
+    def write(self, service: str, account: str, value: str) -> None:
+        self.writes.append((service, account, value))
+        self.payload = value
+
+    def delete(self, service: str, account: str) -> None:
+        self.payload = None
+
+
+def _jwt(payload: dict[str, Any]) -> str:
+    def encode(value: dict[str, Any] | bytes) -> str:
+        raw = value if isinstance(value, bytes) else json.dumps(value).encode()
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+    return f"{encode({'alg': 'none', 'typ': 'JWT'})}.{encode(payload)}.{encode(b'sig')}"
+
+
+def _token_payload(account_id: str = "acct-1", **extra: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "sub": "sub-1",
+        "exp": int(time.time()) + 3600,
+        "https://api.openai.com/auth": {"chatgpt_account_id": account_id},
+    }
+    payload.update(extra)
+    return payload
+
+
+def _creds(**extra: Any) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "access_token": _jwt(_token_payload()),
+        "refresh_token": "refresh-1",
+        "id_token": _jwt(_token_payload(email="user@example.com", name="User")),
+        "expires_at_ms": int((time.time() + 3600) * 1000),
+        "token_type": "Bearer",
+        "account_id": "acct-1",
+    }
+    data.update(extra)
+    return data
+
+
+def _http_factory(transport: httpx.MockTransport):
+    def factory():
+        return httpx.AsyncClient(transport=transport, timeout=httpx.Timeout(5.0))
+
+    return factory
+
+
+def test_keychain_service_uses_aigateway_namespace() -> None:
+    assert keychain_service_for("default") == "aigateway:codex:default"
+    assert keychain_service_for("work") == "aigateway:codex:work"
+
+
+@pytest.mark.asyncio
+async def test_missing_credential_raises() -> None:
+    strategy = CodexOAuth(profile_name="default", credential_store=_FakeStore(payload=None))
+
+    with pytest.raises(CredentialNotFoundError):
+        await strategy.get_authorization_header()
+
+
+@pytest.mark.asyncio
+async def test_fresh_credential_yields_codex_headers() -> None:
+    strategy = CodexOAuth(
+        profile_name="default",
+        credential_store=_FakeStore(payload=json.dumps(_creds())),
+    )
+
+    headers = await strategy.get_authorization_header()
+
+    assert headers["Authorization"].startswith("Bearer ")
+    assert headers["ChatGPT-Account-Id"] == "acct-1"
+
+
+@pytest.mark.asyncio
+async def test_unknown_expiry_does_not_force_refresh_loop() -> None:
+    called = False
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(200, json={})
+
+    strategy = CodexOAuth(
+        profile_name="default",
+        credential_store=_FakeStore(
+            payload=json.dumps(
+                _creds(
+                    access_token="opaque-access-token",
+                    id_token="opaque-id-token",
+                    expires_at_ms=0,
+                )
+            )
+        ),
+        http_client_factory=_http_factory(httpx.MockTransport(handler)),
+    )
+
+    headers = await strategy.get_authorization_header()
+
+    assert headers["Authorization"] == "Bearer opaque-access-token"
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_expired_credential_refreshes_with_scope_and_preserves_refresh_token() -> None:
+    expired = _creds(expires_at_ms=int((time.time() - 60) * 1000))
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["content_type"] = request.headers["content-type"]
+        captured["form"] = parse_qs(request.content.decode())
+        return httpx.Response(
+            200,
+            json={
+                "access_token": _jwt(_token_payload(account_id="acct-2")),
+                "id_token": _jwt(_token_payload(account_id="acct-2", email="new@example.com")),
+                "token_type": "Bearer",
+            },
+        )
+
+    store = _FakeStore(payload=json.dumps(expired))
+    strategy = CodexOAuth(
+        profile_name="default",
+        credential_store=store,
+        http_client_factory=_http_factory(httpx.MockTransport(handler)),
+    )
+
+    headers = await strategy.get_authorization_header()
+
+    assert captured["url"] == CODEX_TOKEN_URL
+    assert captured["content_type"] == "application/x-www-form-urlencoded"
+    assert captured["form"]["client_id"] == [CODEX_CLIENT_ID]
+    assert captured["form"]["grant_type"] == ["refresh_token"]
+    assert captured["form"]["refresh_token"] == ["refresh-1"]
+    assert captured["form"]["scope"] == ["openid profile email"]
+    assert headers["ChatGPT-Account-Id"] == "acct-2"
+    written = json.loads(store.writes[0][2])
+    assert written["refresh_token"] == "refresh-1"
+    assert written["account_id"] == "acct-2"
+
+
+@pytest.mark.asyncio
+async def test_refresh_http_error_raises_auth_error() -> None:
+    expired = _creds(expires_at_ms=int((time.time() - 60) * 1000))
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"error": "invalid_grant"})
+
+    strategy = CodexOAuth(
+        profile_name="default",
+        credential_store=_FakeStore(payload=json.dumps(expired)),
+        http_client_factory=_http_factory(httpx.MockTransport(handler)),
+    )
+
+    with pytest.raises(AuthError, match="401"):
+        await strategy.get_authorization_header()
+
+
+@pytest.mark.asyncio
+async def test_exchange_authorization_code_uses_form_encoded_body() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["content_type"] = request.headers["content-type"]
+        captured["form"] = parse_qs(request.content.decode())
+        return httpx.Response(
+            200,
+            json={
+                "access_token": _jwt(_token_payload()),
+                "refresh_token": "refresh-2",
+                "id_token": _jwt(_token_payload(email="user@example.com")),
+            },
+        )
+
+    creds = await exchange_authorization_code(
+        "auth-code",
+        "verifier",
+        redirect_uri="http://localhost:9105/auth/callback",
+        http_client_factory=_http_factory(httpx.MockTransport(handler)),
+    )
+
+    assert captured["url"] == CODEX_TOKEN_URL
+    assert captured["content_type"] == "application/x-www-form-urlencoded"
+    assert captured["form"]["grant_type"] == ["authorization_code"]
+    assert captured["form"]["code"] == ["auth-code"]
+    assert captured["form"]["redirect_uri"] == ["http://localhost:9105/auth/callback"]
+    assert captured["form"]["client_id"] == [CODEX_CLIENT_ID]
+    assert captured["form"]["code_verifier"] == ["verifier"]
+    assert creds["refresh_token"] == "refresh-2"
+    assert creds["account_id"] == "acct-1"
+
+
+def test_account_label_prefers_email_then_name_then_account_id_then_subject() -> None:
+    assert (
+        account_label_from_credentials(
+            _creds(id_token=_jwt(_token_payload(email="user@example.com", name="User")))
+        )
+        == "user@example.com"
+    )
+    assert (
+        account_label_from_credentials(_creds(id_token=_jwt(_token_payload(name="Named User"))))
+        == "Named User"
+    )
+    assert account_label_from_credentials(_creds(id_token=_jwt(_token_payload()))) == "acct-1"
+    assert (
+        account_label_from_credentials(
+            _creds(
+                access_token="opaque",
+                id_token=_jwt({"sub": "subject-only", "exp": int(time.time()) + 3600}),
+                account_id=None,
+            )
+        )
+        == "subject-only"
+    )

--- a/apps/aigateway/tests/unit/codex/test_litellm_handler.py
+++ b/apps/aigateway/tests/unit/codex/test_litellm_handler.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+
+import httpx
+import litellm
+import pytest
+from litellm.llms.custom_llm import CustomLLMError
+from litellm.types.utils import ModelResponse
+
+from aigateway.plugins.codex_provider.litellm_handler import (
+    CODEX_RESPONSES_URL,
+    CodexCustomLLM,
+    _model_response_from_sse,
+    ensure_litellm_codex_provider_registered,
+)
+
+
+def _http_factory(transport: httpx.MockTransport):
+    def factory():
+        return httpx.AsyncClient(transport=transport, timeout=httpx.Timeout(5.0))
+
+    return factory
+
+
+def _completed_sse(text: str = "hello") -> str:
+    payload = {
+        "type": "response.completed",
+        "response": {
+            "id": "resp_1",
+            "created_at": 123,
+            "model": "gpt-5.4-mini",
+            "output": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": text}],
+                }
+            ],
+            "usage": {"input_tokens": 3, "output_tokens": 2},
+        },
+    }
+    return f"event: response.completed\ndata: {json.dumps(payload)}\n\ndata: [DONE]\n\n"
+
+
+def _empty_completed_sse() -> str:
+    payload = {
+        "type": "response.completed",
+        "response": {
+            "id": "resp_1",
+            "created_at": 123,
+            "model": "gpt-5.4-mini",
+            "output": [],
+            "usage": {"input_tokens": 3, "output_tokens": 2},
+        },
+    }
+    return f"event: response.completed\ndata: {json.dumps(payload)}\n\ndata: [DONE]\n\n"
+
+
+def _sse_event(payload: dict[str, Any]) -> str:
+    return f"event: {payload['type']}\ndata: {json.dumps(payload)}\n\n"
+
+
+def test_build_payload_uses_default_instructions_when_no_system_message() -> None:
+    from aigateway.plugins.codex_provider.litellm_handler import _build_payload
+
+    payload = _build_payload(
+        "codex/gpt-5.4-mini",
+        [{"role": "user", "content": "hi"}],
+        {},
+    )
+
+    assert payload["instructions"] == "You are a helpful assistant."
+
+
+def test_model_response_uses_output_text_deltas_when_completed_output_empty() -> None:
+    body = "".join(
+        [
+            _sse_event({"type": "response.output_text.delta", "delta": "Hello"}),
+            _sse_event({"type": "response.output_text.delta", "delta": "!"}),
+            _empty_completed_sse(),
+        ]
+    )
+
+    response = _model_response_from_sse(body, "gpt-5.4-mini")
+
+    assert response.choices[0].message.content == "Hello!"
+
+
+def test_model_response_uses_output_item_done_when_completed_output_empty() -> None:
+    body = "".join(
+        [
+            _sse_event(
+                {
+                    "type": "response.output_item.done",
+                    "item": {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "Hello!"}],
+                    },
+                }
+            ),
+            _empty_completed_sse(),
+        ]
+    )
+
+    response = _model_response_from_sse(body, "gpt-5.4-mini")
+
+    assert response.choices[0].message.content == "Hello!"
+
+
+class _InjectedClient:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def post(self, url: str, **kwargs: Any) -> httpx.Response:
+        self.calls.append({"url": url, **kwargs})
+        return httpx.Response(
+            200,
+            text=_completed_sse("from injected client"),
+            headers={"content-type": "text/event-stream"},
+        )
+
+
+class _StreamingOnlyResponse:
+    status_code = 200
+
+    @property
+    def text(self) -> str:
+        raise AssertionError("streaming parser must not buffer response.text")
+
+    async def aiter_lines(self):
+        for line in _completed_sse("streamed only").splitlines():
+            yield line
+
+    async def aclose(self) -> None:
+        return None
+
+
+class _StreamingOnlyClient:
+    def __init__(self) -> None:
+        self.stream_requested = False
+
+    async def post(self, url: str, **kwargs: Any) -> _StreamingOnlyResponse:  # noqa: ARG002
+        self.stream_requested = kwargs.get("stream") is True
+        return _StreamingOnlyResponse()
+
+
+@pytest.mark.asyncio
+async def test_codex_handler_posts_sse_request_and_returns_model_response() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["headers"] = dict(request.headers)
+        captured["payload"] = json.loads(request.content.decode())
+        return httpx.Response(
+            200,
+            text=_completed_sse("hello from codex"),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    custom = CodexCustomLLM(http_client_factory=_http_factory(httpx.MockTransport(handler)))
+
+    response = await custom.acompletion(
+        model="codex/gpt-5.4-mini",
+        messages=[
+            {"role": "system", "content": "be terse"},
+            {"role": "user", "content": "hi"},
+        ],
+        api_base=None,
+        custom_prompt_dict={},
+        model_response=ModelResponse(),
+        print_verbose=lambda *_args, **_kwargs: None,
+        encoding=None,
+        api_key="oauth-token",
+        logging_obj=None,
+        optional_params={
+            "max_tokens": 123,
+            "temperature": 0.2,
+            "reasoning": {"effort": "medium"},
+            "include": ["custom.include"],
+        },
+        headers={"ChatGPT-Account-Id": "acct-1"},
+    )
+
+    assert captured["url"] == CODEX_RESPONSES_URL
+    assert captured["headers"]["authorization"] == "Bearer oauth-token"
+    assert captured["headers"]["chatgpt-account-id"] == "acct-1"
+    assert captured["payload"] == {
+        "model": "gpt-5.4-mini",
+        "input": [{"role": "user", "content": "hi"}],
+        "instructions": "be terse",
+        "stream": True,
+        "store": False,
+        "include": ["reasoning.encrypted_content", "custom.include"],
+        "reasoning": {"effort": "medium"},
+    }
+    assert response.model == "gpt-5.4-mini"
+    assert response.choices[0].message.content == "hello from codex"
+    usage = response.model_dump()["usage"]
+    assert usage["prompt_tokens"] == 3
+    assert usage["completion_tokens"] == 2
+
+
+@pytest.mark.asyncio
+async def test_codex_handler_ignores_api_base_override() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(200, text=_completed_sse())
+
+    custom = CodexCustomLLM(http_client_factory=_http_factory(httpx.MockTransport(handler)))
+
+    await custom.acompletion(
+        model="codex/gpt-5.4-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        api_base="https://attacker.example.test/collect",
+        custom_prompt_dict={},
+        model_response=ModelResponse(),
+        print_verbose=lambda *_args, **_kwargs: None,
+        encoding=None,
+        api_key="oauth-token",
+        logging_obj=None,
+        optional_params={},
+    )
+
+    assert captured["url"] == CODEX_RESPONSES_URL
+
+
+@pytest.mark.asyncio
+async def test_codex_handler_rejects_api_key_fallback_before_network() -> None:
+    called = False
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(200, text=_completed_sse())
+
+    custom = CodexCustomLLM(http_client_factory=_http_factory(httpx.MockTransport(handler)))
+
+    with pytest.raises(CustomLLMError) as exc_info:
+        await custom.acompletion(
+            model="codex/gpt-5.4-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            api_base=None,
+            custom_prompt_dict={},
+            model_response=ModelResponse(),
+            print_verbose=lambda *_args, **_kwargs: None,
+            encoding=None,
+            api_key="sk-proj-test",
+            logging_obj=None,
+            optional_params={},
+        )
+
+    assert exc_info.value.status_code == 400
+    assert called is False
+
+
+def test_codex_registration_is_idempotent(monkeypatch) -> None:
+    monkeypatch.setattr(litellm, "custom_provider_map", [])
+    monkeypatch.setattr(litellm, "_custom_providers", [])
+    monkeypatch.setattr(litellm, "provider_list", list(litellm.provider_list))
+    handler = CodexCustomLLM()
+
+    ensure_litellm_codex_provider_registered(handler)
+    ensure_litellm_codex_provider_registered(handler)
+
+    entries = [entry for entry in litellm.custom_provider_map if entry["provider"] == "codex"]
+    assert entries == [{"provider": "codex", "custom_handler": handler}]
+    assert "codex" in litellm._custom_providers
+    assert "codex" in litellm.provider_list
+
+
+@pytest.mark.asyncio
+async def test_codex_handler_uses_injected_litellm_client() -> None:
+    injected = _InjectedClient()
+
+    def unused_factory():
+        raise AssertionError("http_client_factory should not be used when LiteLLM injects client")
+
+    custom = CodexCustomLLM(http_client_factory=unused_factory)
+
+    response = await custom.acompletion(
+        model="codex/gpt-5.4-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        api_base=None,
+        custom_prompt_dict={},
+        model_response=ModelResponse(),
+        print_verbose=lambda *_args, **_kwargs: None,
+        encoding=None,
+        api_key="oauth-token",
+        logging_obj=None,
+        optional_params={},
+        client=cast(Any, injected),
+    )
+
+    assert response.choices[0].message.content == "from injected client"
+    assert injected.calls[0]["url"] == CODEX_RESPONSES_URL
+    assert injected.calls[0]["stream"] is True
+
+
+@pytest.mark.asyncio
+async def test_codex_handler_parses_sse_without_buffering_response_text() -> None:
+    injected = _StreamingOnlyClient()
+    custom = CodexCustomLLM(http_client_factory=lambda: None)
+
+    response = await custom.acompletion(
+        model="codex/gpt-5.4-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        api_base=None,
+        custom_prompt_dict={},
+        model_response=ModelResponse(),
+        print_verbose=lambda *_args, **_kwargs: None,
+        encoding=None,
+        api_key="oauth-token",
+        logging_obj=None,
+        optional_params={},
+        client=cast(Any, injected),
+    )
+
+    assert injected.stream_requested is True
+    assert response.choices[0].message.content == "streamed only"

--- a/apps/aigateway/tests/unit/test_auth_routes.py
+++ b/apps/aigateway/tests/unit/test_auth_routes.py
@@ -183,12 +183,20 @@ class _NoOAuthPlugin:
 class _RecordingStrategy:
     def __init__(self) -> None:
         self.creds: dict | None = None
+        self.deleted = False
+        self.refreshed = False
 
     async def get_authorization_header(self) -> dict[str, str]:
         return {}
 
-    def set_credentials(self, creds: dict) -> None:
+    def persist_credentials(self, creds: dict) -> None:
         self.creds = creds
+
+    def delete_credentials(self) -> None:
+        self.deleted = True
+
+    async def refresh_credentials(self) -> None:
+        self.refreshed = True
 
 
 class _GenericOAuthPlugin:
@@ -211,7 +219,7 @@ class _GenericOAuthPlugin:
             extra_authorize_params={"extra": "1"},
         )
 
-    def oauth_strategy_for(self, _profile_name: str) -> _RecordingStrategy:
+    def oauth_strategy_for(self, _profile_name: str, **_kwargs) -> _RecordingStrategy:
         return self.strategy
 
     async def exchange_oauth_code(self, request: OAuthCodeExchangeRequest) -> dict:
@@ -222,6 +230,9 @@ class _GenericOAuthPlugin:
             "expires_at_ms": 9999999999999,
             "token_type": "Bearer",
         }
+
+    def account_label_from_credentials(self, _credentials: dict) -> str | None:
+        return None
 
 
 class _DelayedOAuthPlugin(_GenericOAuthPlugin):
@@ -279,6 +290,28 @@ def test_start_oauth_creates_pending_profile(client_with_index) -> None:
     resp = client.get("/v1/auth/anthropic/profiles/work")
     assert resp.status_code == 200
     assert resp.json()["state"] == "pending"
+
+
+def test_start_oauth_replaces_same_profile_pending_state(client_with_index) -> None:
+    client, _ = client_with_index
+    client.app.state.anthropic_http_factory = _mock_token_factory()
+
+    first = client.post("/v1/auth/anthropic/profiles", json={"name": "work"}).json()
+    second = client.post("/v1/auth/anthropic/profiles", json={"name": "work"}).json()
+
+    stale = client.get(
+        "/v1/auth/anthropic/callback",
+        params={"code": "old-code", "state": first["state"]},
+        follow_redirects=False,
+    )
+    fresh = client.get(
+        "/v1/auth/anthropic/callback",
+        params={"code": "new-code", "state": second["state"]},
+        follow_redirects=False,
+    )
+
+    assert stale.status_code == 400
+    assert fresh.status_code == 200
 
 
 def test_profiles_are_scoped_to_current_account(
@@ -721,6 +754,47 @@ def test_refresh_missing_profile_404(client_with_index) -> None:
     resp = client.post("/v1/auth/anthropic/profiles/missing/refresh")
     assert resp.status_code == 404
     assert resp.json()["detail"]["code"] == "profile_not_found"
+
+
+@pytest.mark.asyncio
+async def test_refresh_uses_app_store_and_provider_http_factory(
+    fake_keychain, authenticated_client
+) -> None:
+    account_id = _account_id(authenticated_client)
+    credential_name = credential_name_for(account_id, "refreshme")
+
+    from aigateway.plugins.anthropic_provider.auth import keychain_service_for
+
+    fake_keychain.write(
+        keychain_service_for(credential_name),
+        "default",
+        json.dumps(
+            {
+                "access_token": "old-tok",
+                "refresh_token": "old-rt",
+                "expires_at_ms": int(time.time() * 1000) - 60_000,
+                "token_type": "Bearer",
+            }
+        ),
+    )
+    idx = ProfileIndexStore(credential_store=fake_keychain)
+    await idx.upsert(
+        Profile(
+            id=profile_id_for(account_id, "anthropic", "refreshme"),
+            account_id=account_id,
+            provider="anthropic",
+            name="refreshme",
+            state=ProfileState.AUTHENTICATED,
+        )
+    )
+    authenticated_client.app.state.anthropic_http_factory = _mock_token_factory()
+
+    resp = authenticated_client.post("/v1/auth/anthropic/profiles/refreshme/refresh")
+
+    assert resp.status_code == 200
+    blob = fake_keychain.read(keychain_service_for(credential_name), "default")
+    assert blob is not None
+    assert json.loads(blob)["access_token"] == "new-tok"
 
 
 def test_delete_removes_profile_and_tokens(client_with_index) -> None:

--- a/apps/aigateway/tests/unit/test_auth_routes.py
+++ b/apps/aigateway/tests/unit/test_auth_routes.py
@@ -4,12 +4,14 @@ import asyncio
 import base64
 import json
 import time
+from typing import cast
 from urllib.parse import parse_qs, urlparse
 
 import httpx
 import pytest
 from fastapi import HTTPException
 
+from aigateway.core.pending_auth import PendingAuthEntry
 from aigateway.core.plugin_base import OAuthCodeExchangeRequest, OAuthConfig
 from aigateway.core.profile_index import ProfileIndexStore
 from aigateway.core.profile_models import (
@@ -20,7 +22,12 @@ from aigateway.core.profile_models import (
     profile_id_for,
 )
 from aigateway.plugins.codex_provider.oauth_config import CODEX_CLIENT_ID
-from aigateway.routes.auth import _complete_oauth_for_app
+from aigateway.routes.auth import (
+    _complete_oauth_for_app,
+    _handle_loopback_callback,
+    _http_response,
+    _loopback_host_allowed,
+)
 
 
 @pytest.fixture
@@ -244,6 +251,248 @@ class _DelayedOAuthPlugin(_GenericOAuthPlugin):
         self.exchange_count += 1
         await asyncio.sleep(0.01)
         return await super().exchange_oauth_code(request)
+
+
+class _ExplodingOAuthPlugin(_GenericOAuthPlugin):
+    async def exchange_oauth_code(self, _request: OAuthCodeExchangeRequest) -> dict:
+        raise RuntimeError("<script>bad</script>")
+
+
+class _FakeReader:
+    def __init__(self, data: bytes | None = None, exc: Exception | None = None) -> None:
+        self.data = data
+        self.exc = exc
+
+    async def readuntil(self, _separator: bytes) -> bytes:
+        if self.exc is not None:
+            raise self.exc
+        assert self.data is not None
+        return self.data
+
+
+class _FakeWriter:
+    def __init__(self) -> None:
+        self.writes: list[bytes] = []
+        self.closed = False
+
+    @property
+    def response(self) -> bytes:
+        return b"".join(self.writes)
+
+    def write(self, data: bytes) -> None:
+        self.writes.append(data)
+
+    async def drain(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        pass
+
+
+class _FakeServer:
+    def __init__(self) -> None:
+        self.closed = False
+        self.waited = False
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        self.waited = True
+
+
+def _as_stream_reader(reader: _FakeReader) -> asyncio.StreamReader:
+    return cast(asyncio.StreamReader, reader)
+
+
+def _as_stream_writer(writer: _FakeWriter) -> asyncio.StreamWriter:
+    return cast(asyncio.StreamWriter, writer)
+
+
+def _raw_loopback_request(target: str, *, method: str = "GET", host: str = "localhost") -> bytes:
+    return f"{method} {target} HTTP/1.1\r\nHost: {host}\r\n\r\n".encode("ascii")
+
+
+async def _seed_pending_profile(
+    client,
+    account_id: str,
+    provider: str,
+    name: str,
+    state: str,
+) -> None:
+    client.app.state.pending_auth.put(
+        state,
+        PendingAuthEntry(
+            account_id=account_id,
+            provider=provider,
+            profile_name=name,
+            profile_id=profile_id_for(account_id, provider, name),
+            code_verifier="verifier",
+            redirect_uri="http://localhost:1455/callback",
+        ),
+    )
+    await client.app.state.profile_index.upsert(
+        Profile(
+            id=profile_id_for(account_id, provider, name),
+            account_id=account_id,
+            provider=provider,
+            name=name,
+            state=ProfileState.PENDING,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    ("host", "allowed"),
+    [
+        (None, False),
+        ("", False),
+        ("localhost", True),
+        ("localhost.", True),
+        ("127.0.0.1:1455", True),
+        ("[::1]:1455", True),
+        ("192.168.1.10:1455", False),
+        ("example.com", False),
+        ("[::1", False),
+    ],
+)
+def test_loopback_host_allowed_accepts_only_loopback(host, allowed) -> None:
+    assert _loopback_host_allowed(host) is allowed
+
+
+def test_loopback_http_response_serializes_body_and_headers() -> None:
+    response = _http_response(418, "teapot", content_type="text/plain")
+
+    assert response.startswith(b"HTTP/1.1 418 Internal Server Error\r\n")
+    assert b"content-type: text/plain; charset=utf-8\r\n" in response
+    assert b"content-length: 6\r\n" in response
+    assert response.endswith(b"\r\n\r\nteapot")
+
+
+@pytest.mark.asyncio
+async def test_handle_loopback_callback_completes_oauth(client_with_index) -> None:
+    client, _ = client_with_index
+    account_id = _account_id(client)
+    state = "loopback-state"
+    plugin = _GenericOAuthPlugin()
+    server = _FakeServer()
+    client.app.state.providers._plugins["generic"] = plugin
+    client.app.state.loopback_oauth_callbacks = {state: server}
+    await _seed_pending_profile(client, account_id, "generic", "loopback", state)
+
+    writer = _FakeWriter()
+    await _handle_loopback_callback(
+        client.app,
+        "generic",
+        "/callback",
+        state,
+        _as_stream_reader(
+            _FakeReader(_raw_loopback_request(f"/callback?code=loop-code&state={state}"))
+        ),
+        _as_stream_writer(writer),
+    )
+
+    assert writer.response.startswith(b"HTTP/1.1 200 OK\r\n")
+    assert writer.closed is True
+    assert plugin.exchange_request is not None
+    assert plugin.exchange_request.code == "loop-code"
+    assert plugin.strategy.creds is not None
+    assert plugin.strategy.creds["access_token"] == "generic-token"
+    assert server.closed is True
+    assert server.waited is True
+    assert state not in client.app.state.loopback_oauth_callbacks
+    profile = client.get("/v1/auth/generic/profiles/loopback")
+    assert profile.status_code == 200
+    assert profile.json()["state"] == "authenticated"
+
+
+@pytest.mark.parametrize(
+    ("reader", "expected_status", "expected_body"),
+    [
+        (
+            _FakeReader(exc=asyncio.IncompleteReadError(partial=b"", expected=1)),
+            b"400 Bad Request",
+            b"Malformed callback request",
+        ),
+        (
+            _FakeReader(b"GET\r\nHost: localhost\r\n\r\n"),
+            b"400 Bad Request",
+            b"Malformed callback request",
+        ),
+        (
+            _FakeReader(_raw_loopback_request("/callback?code=c&state=expected", host="evil.test")),
+            b"403 Forbidden",
+            b"Forbidden callback host",
+        ),
+        (
+            _FakeReader(_raw_loopback_request("/other?code=c&state=expected")),
+            b"404 Not Found",
+            b"Unknown callback path",
+        ),
+        (
+            _FakeReader(_raw_loopback_request("/callback?state=expected")),
+            b"400 Bad Request",
+            b"Missing callback code or state",
+        ),
+        (
+            _FakeReader(_raw_loopback_request("/callback?code=c&state=wrong")),
+            b"400 Bad Request",
+            b"OAuth state not recognized or expired",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_handle_loopback_callback_rejects_bad_requests(
+    client_with_index, reader, expected_status, expected_body
+) -> None:
+    client, _ = client_with_index
+    writer = _FakeWriter()
+
+    await _handle_loopback_callback(
+        client.app,
+        "generic",
+        "/callback",
+        "expected",
+        _as_stream_reader(reader),
+        _as_stream_writer(writer),
+    )
+
+    assert expected_status in writer.response
+    assert expected_body in writer.response
+    assert writer.closed is True
+
+
+@pytest.mark.asyncio
+async def test_handle_loopback_callback_escapes_completion_errors(client_with_index) -> None:
+    client, _ = client_with_index
+    account_id = _account_id(client)
+    state = "loopback-error-state"
+    server = _FakeServer()
+    client.app.state.providers._plugins["generic"] = _ExplodingOAuthPlugin()
+    client.app.state.loopback_oauth_callbacks = {state: server}
+    await _seed_pending_profile(client, account_id, "generic", "loopback-error", state)
+
+    writer = _FakeWriter()
+    await _handle_loopback_callback(
+        client.app,
+        "generic",
+        "/callback",
+        state,
+        _as_stream_reader(_FakeReader(_raw_loopback_request(f"/callback?code=boom&state={state}"))),
+        _as_stream_writer(writer),
+    )
+
+    assert b"HTTP/1.1 500 Internal Server Error" in writer.response
+    assert b"&lt;script&gt;bad&lt;/script&gt;" in writer.response
+    assert b"<script>bad</script>" not in writer.response
+    assert server.closed is True
+    assert server.waited is True
+    profile = client.get("/v1/auth/generic/profiles/loopback-error")
+    assert profile.status_code == 200
+    assert profile.json()["state"] == "error"
 
 
 def test_start_oauth_for_non_oauth_provider_400(client_with_index) -> None:

--- a/apps/aigateway/tests/unit/test_auth_routes.py
+++ b/apps/aigateway/tests/unit/test_auth_routes.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
+import asyncio
+import base64
+import json
+import time
+from urllib.parse import parse_qs, urlparse
+
 import httpx
 import pytest
+from fastapi import HTTPException
 
+from aigateway.core.plugin_base import OAuthCodeExchangeRequest, OAuthConfig
 from aigateway.core.profile_index import ProfileIndexStore
 from aigateway.core.profile_models import (
     Profile,
@@ -11,6 +19,8 @@ from aigateway.core.profile_models import (
     credential_name_for,
     profile_id_for,
 )
+from aigateway.plugins.codex_provider.oauth_config import CODEX_CLIENT_ID
+from aigateway.routes.auth import _complete_oauth_for_app
 
 
 @pytest.fixture
@@ -66,17 +76,21 @@ def test_start_oauth_returns_authorize_url(client_with_index) -> None:
     resp = client.post("/v1/auth/anthropic/profiles", json={"name": "work"})
     assert resp.status_code == 201
     body = resp.json()
+    parsed = urlparse(body["authorize_url"])
     assert body["profile_id"] == profile_id_for(account_id, "anthropic", "work")
-    assert body["authorize_url"].startswith("https://claude.ai/oauth/authorize")
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "claude.com"
+    assert parsed.path == "/cai/oauth/authorize"
     assert "state=" in body["authorize_url"]
     assert "code_challenge=" in body["authorize_url"]
     assert "code_challenge_method=S256" in body["authorize_url"]
     # Required by the public Claude Code OAuth app to surface the consent screen
     assert "code=true" in body["authorize_url"]
-    # Full Claude Code scope set so the issued token is treated as a user-OAuth
-    # token rather than an API token.
+    # Claude subscription OAuth must request the user scope set, not
+    # org:create_api_key, otherwise the flow is routed toward Console/API-key
+    # billing rather than Claude subscription capacity.
     assert "user%3Asessions%3Aclaude_code" in body["authorize_url"]
-    assert "org%3Acreate_api_key" in body["authorize_url"]
+    assert "org%3Acreate_api_key" not in body["authorize_url"]
     # redirect_uri must be http://localhost:*/callback (not 127.0.0.1 and not
     # a per-provider path) — the public Claude Code OAuth client only allows
     # this canonical shape.
@@ -84,9 +98,41 @@ def test_start_oauth_returns_authorize_url(client_with_index) -> None:
     assert "%2Fcallback&" in body["authorize_url"]
 
 
+def test_start_oauth_for_codex_returns_openai_authorize_url(client_with_index) -> None:
+    client, _ = client_with_index
+    account_id = _account_id(client)
+
+    resp = client.post("/v1/auth/codex/profiles", json={"name": "work"})
+
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["profile_id"] == profile_id_for(account_id, "codex", "work")
+    parsed = urlparse(body["authorize_url"])
+    query = parse_qs(parsed.query)
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "auth.openai.com"
+    assert parsed.path == "/oauth/authorize"
+    assert query["client_id"] == [CODEX_CLIENT_ID]
+    assert query["response_type"] == ["code"]
+    assert query["code_challenge_method"] == ["S256"]
+    assert query["redirect_uri"][0] in {
+        "http://localhost:1455/auth/callback",
+        "http://localhost:1457/auth/callback",
+    }
+    assert "offline_access" in query["scope"][0].split()
+    assert "api.connectors.invoke" in query["scope"][0].split()
+    assert query["id_token_add_organizations"] == ["true"]
+    assert query["codex_cli_simplified_flow"] == ["true"]
+    assert query["originator"] == ["codex_cli_rs"]
+
+    profile = client.get("/v1/auth/codex/profiles/work").json()
+    assert profile["state"] == "pending"
+    assert "offline_access" in profile["scopes"]
+
+
 def test_top_level_callback_dispatches_by_state(client_with_index) -> None:
     """The /callback route looks up the provider from the pending-auth
-    state, so the same path serves every provider — matching what claude.ai
+    state, so the same path serves every provider — matching what Claude Code
     accepts as a redirect_uri."""
     client, _ = client_with_index
     client.app.state.anthropic_http_factory = _mock_token_factory()
@@ -134,6 +180,61 @@ class _NoOAuthPlugin:
         return None
 
 
+class _RecordingStrategy:
+    def __init__(self) -> None:
+        self.creds: dict | None = None
+
+    async def get_authorization_header(self) -> dict[str, str]:
+        return {}
+
+    def set_credentials(self, creds: dict) -> None:
+        self.creds = creds
+
+
+class _GenericOAuthPlugin:
+    custom_llm_provider = "generic"
+
+    def __init__(self) -> None:
+        self.strategy = _RecordingStrategy()
+        self.exchange_request: OAuthCodeExchangeRequest | None = None
+
+    def register_models(self) -> list:
+        return []
+
+    def oauth_config(self) -> OAuthConfig:
+        return OAuthConfig(
+            authorize_url="https://example.test/oauth/authorize",
+            token_url="https://example.test/oauth/token",
+            client_id="client-id",
+            scopes=["scope-a", "scope-b"],
+            redirect_path="/callback",
+            extra_authorize_params={"extra": "1"},
+        )
+
+    def oauth_strategy_for(self, _profile_name: str) -> _RecordingStrategy:
+        return self.strategy
+
+    async def exchange_oauth_code(self, request: OAuthCodeExchangeRequest) -> dict:
+        self.exchange_request = request
+        return {
+            "access_token": "generic-token",
+            "refresh_token": "generic-refresh",
+            "expires_at_ms": 9999999999999,
+            "token_type": "Bearer",
+        }
+
+
+class _DelayedOAuthPlugin(_GenericOAuthPlugin):
+    def __init__(self) -> None:
+        super().__init__()
+        self.exchange_count = 0
+
+    async def exchange_oauth_code(self, request: OAuthCodeExchangeRequest) -> dict:
+        self.exchange_count += 1
+        await asyncio.sleep(0.01)
+        return await super().exchange_oauth_code(request)
+
+
 def test_start_oauth_for_non_oauth_provider_400(client_with_index) -> None:
     client, _ = client_with_index
     client.app.state.providers._plugins["local"] = _NoOAuthPlugin()
@@ -141,6 +242,35 @@ def test_start_oauth_for_non_oauth_provider_400(client_with_index) -> None:
     resp = client.post("/v1/auth/local/profiles", json={"name": "x"})
     assert resp.status_code == 400
     assert resp.json()["detail"]["code"] == "provider_does_not_use_oauth"
+
+
+def test_exchange_code_uses_provider_exchange_hook(client_with_index) -> None:
+    client, _ = client_with_index
+    account_id = _account_id(client)
+    plugin = _GenericOAuthPlugin()
+    client.app.state.providers._plugins["generic"] = plugin
+
+    start = client.post("/v1/auth/generic/profiles", json={"name": "work"})
+    assert start.status_code == 201
+    start_body = start.json()
+    query = parse_qs(urlparse(start_body["authorize_url"]).query)
+    redirect_uri = query["redirect_uri"][0]
+
+    resp = client.post(
+        "/v1/auth/generic/exchange-code",
+        json={"code": "generic-code", "state": start_body["state"]},
+    )
+
+    assert resp.status_code == 200
+    assert plugin.exchange_request is not None
+    assert plugin.exchange_request.code == "generic-code"
+    assert plugin.exchange_request.redirect_uri == redirect_uri
+    assert plugin.exchange_request.state == start_body["state"]
+    assert plugin.strategy.creds is not None
+    assert plugin.strategy.creds["access_token"] == "generic-token"
+    profile = client.get("/v1/auth/generic/profiles/work").json()
+    assert profile["id"] == profile_id_for(account_id, "generic", "work")
+    assert profile["state"] == "authenticated"
 
 
 def test_start_oauth_creates_pending_profile(client_with_index) -> None:
@@ -234,6 +364,35 @@ def _mock_token_factory():
     return lambda: httpx.AsyncClient(transport=transport, timeout=httpx.Timeout(5.0))
 
 
+def _jwt(payload: dict) -> str:
+    def encode(value: dict | bytes) -> str:
+        raw = value if isinstance(value, bytes) else json.dumps(value).encode()
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+    return f"{encode({'alg': 'none', 'typ': 'JWT'})}.{encode(payload)}.{encode(b'sig')}"
+
+
+def _mock_codex_token_factory():
+    token_payload = {
+        "sub": "sub-1",
+        "email": "user@example.com",
+        "exp": int(time.time()) + 3600,
+        "https://api.openai.com/auth": {"chatgpt_account_id": "acct-1"},
+    }
+    transport = httpx.MockTransport(
+        lambda req: httpx.Response(
+            200,
+            json={
+                "access_token": _jwt(token_payload),
+                "refresh_token": "codex-refresh",
+                "id_token": _jwt(token_payload),
+                "token_type": "Bearer",
+            },
+        )
+    )
+    return lambda: httpx.AsyncClient(transport=transport, timeout=httpx.Timeout(5.0))
+
+
 def _failing_token_factory():
     transport = httpx.MockTransport(
         lambda req: httpx.Response(400, json={"error": "invalid_grant"})
@@ -278,7 +437,49 @@ def test_callback_completes_auth(client_with_index) -> None:
     assert "new-tok" in blob
 
 
-def test_callback_exchange_failure_keeps_pending_state(client_with_index) -> None:
+def test_codex_nested_callback_completes_auth_with_provider_hook(client_with_index) -> None:
+    client, fake_keychain = client_with_index
+    account_id = _account_id(client)
+    client.app.state.codex_http_factory = _mock_codex_token_factory()
+
+    start = client.post("/v1/auth/codex/profiles", json={"name": "work"})
+    state = start.json()["state"]
+
+    auth_header = client.headers.pop("Authorization")
+    try:
+        cb = client.get(
+            "/auth/callback",
+            params={"code": "codex-code-1", "state": state},
+            follow_redirects=False,
+        )
+    finally:
+        client.headers["Authorization"] = auth_header
+    assert cb.status_code == 200
+
+    prof = client.get("/v1/auth/codex/profiles/work").json()
+    assert prof["state"] == "authenticated"
+    assert prof["account_label"] == "user@example.com"
+
+    from aigateway.plugins.codex_provider.auth import keychain_service_for
+
+    blob = fake_keychain.read(
+        keychain_service_for(credential_name_for(account_id, "work")), "default"
+    )
+    assert blob is not None
+    assert json.loads(blob)["refresh_token"] == "codex-refresh"
+
+
+def test_codex_import_profile_endpoint_is_absent(client_with_index) -> None:
+    client, _ = client_with_index
+
+    resp = client.post("/v1/auth/codex/profiles/import", json={"name": "default"})
+
+    assert resp.status_code == 405
+
+
+def test_callback_exchange_failure_consumes_state_and_marks_profile_error(
+    client_with_index,
+) -> None:
     client, _ = client_with_index
     client.app.state.anthropic_http_factory = _failing_token_factory()
 
@@ -302,8 +503,33 @@ def test_callback_exchange_failure_keeps_pending_state(client_with_index) -> Non
         client.headers["Authorization"] = auth_header
 
     assert failed.status_code == 500
-    assert retried.status_code == 200
+    assert retried.status_code == 400
     prof = client.get("/v1/auth/anthropic/profiles/retry").json()
+    assert prof["state"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_complete_oauth_consumes_state_before_awaiting_exchange(client_with_index) -> None:
+    client, _ = client_with_index
+    account_id = _account_id(client)
+    plugin = _DelayedOAuthPlugin()
+    client.app.state.providers._plugins["generic"] = plugin
+
+    start = client.post("/v1/auth/generic/profiles", json={"name": "race"})
+    state = start.json()["state"]
+
+    results = await asyncio.gather(
+        _complete_oauth_for_app(client.app, "generic", "code-one", state, account_id),
+        _complete_oauth_for_app(client.app, "generic", "code-two", state, account_id),
+        return_exceptions=True,
+    )
+
+    assert sum(result is None for result in results) == 1
+    errors = [result for result in results if isinstance(result, HTTPException)]
+    assert len(errors) == 1
+    assert errors[0].status_code == 400
+    assert plugin.exchange_count == 1
+    prof = client.get("/v1/auth/generic/profiles/race").json()
     assert prof["state"] == "authenticated"
 
 

--- a/apps/aigateway/tests/unit/test_bootstrap.py
+++ b/apps/aigateway/tests/unit/test_bootstrap.py
@@ -120,7 +120,11 @@ def test_lifespan_bootstraps_disabled_auth_under_anonymous_account(
     _install_bootstrap_spy(monkeypatch, main_module, mock_bootstrap)
 
     app = main_module.create_app()
-    with TestClient(app) as client:
+    with TestClient(
+        app,
+        base_url="http://127.0.0.1:9105",
+        client=("127.0.0.1", 50000),
+    ) as client:
         resp = client.get("/v1/auth/me")
         assert resp.status_code == 200
 

--- a/apps/aigateway/tests/unit/test_chat_x_profile.py
+++ b/apps/aigateway/tests/unit/test_chat_x_profile.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import json
 import time
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
+from litellm.exceptions import RateLimitError
 
 from aigateway.core.profile_index import ProfileIndexStore
 from aigateway.core.profile_models import (
@@ -15,6 +17,7 @@ from aigateway.core.profile_models import (
     profile_id_for,
 )
 from aigateway.plugins.anthropic_provider.auth import keychain_service_for
+from aigateway.plugins.codex_provider.auth import keychain_service_for as codex_keychain_service_for
 
 
 def _account_id(client) -> str:
@@ -29,6 +32,22 @@ def _seed_authenticated_profile(fake_keychain, account_id: str) -> None:
             {
                 "access_token": "tok",
                 "refresh_token": "rt",
+                "expires_at_ms": int(time.time() * 1000) + 3_600_000,
+                "token_type": "Bearer",
+            }
+        ),
+    )
+
+
+def _seed_authenticated_codex_profile(fake_keychain, account_id: str) -> None:
+    fake_keychain.write(
+        codex_keychain_service_for(credential_name_for(account_id, "default")),
+        "default",
+        json.dumps(
+            {
+                "access_token": "tok",
+                "refresh_token": "rt",
+                "id_token": "id",
                 "expires_at_ms": int(time.time() * 1000) + 3_600_000,
                 "token_type": "Bearer",
             }
@@ -93,8 +112,8 @@ async def test_chat_merges_profile_defaults(fake_keychain, authenticated_client)
 
     captured: dict = {}
 
-    async def fake_acompletion(**kwargs):
-        captured.update(kwargs)
+    async def fake_chat_completion(_self, body):
+        captured.update(body)
         from types import SimpleNamespace
 
         return SimpleNamespace(
@@ -104,7 +123,10 @@ async def test_chat_merges_profile_defaults(fake_keychain, authenticated_client)
             }
         )
 
-    with patch("aigateway.routes.chat.litellm.acompletion", fake_acompletion):
+    with patch(
+        "aigateway.plugins.anthropic_provider.plugin.AnthropicProviderPlugin.chat_completion",
+        fake_chat_completion,
+    ):
         resp = authenticated_client.post(
             "/v1/chat/completions",
             json={
@@ -118,6 +140,98 @@ async def test_chat_merges_profile_defaults(fake_keychain, authenticated_client)
         assert captured["max_tokens"] == 4096
         assert captured["reasoning_effort"] == "high"
     assert captured["api_key"] == "tok"
+
+
+@pytest.mark.asyncio
+async def test_chat_skips_anthropic_profile_reasoning_default(
+    fake_keychain, authenticated_client
+) -> None:
+    account_id = _account_id(authenticated_client)
+    _seed_authenticated_profile(fake_keychain, account_id)
+
+    idx = ProfileIndexStore(credential_store=fake_keychain)
+    await idx.upsert(
+        Profile(
+            id=profile_id_for(account_id, "anthropic", "default"),
+            account_id=account_id,
+            provider="anthropic",
+            name="default",
+            state=ProfileState.AUTHENTICATED,
+            defaults=ProfileDefaults(reasoning_effort="medium"),
+        )
+    )
+    captured: dict = {}
+
+    async def fake_chat_completion(_self, body):
+        captured.update(body)
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            model_dump=lambda: {
+                "id": "x",
+                "choices": [{"message": {"content": "ok"}}],
+            }
+        )
+
+    with patch(
+        "aigateway.plugins.anthropic_provider.plugin.AnthropicProviderPlugin.chat_completion",
+        fake_chat_completion,
+    ):
+        resp = authenticated_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "anthropic/claude-haiku-4-5",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+
+    assert resp.status_code == 200
+    assert "reasoning_effort" not in captured
+
+
+@pytest.mark.asyncio
+async def test_chat_removes_anthropic_reasoning_none(fake_keychain, authenticated_client) -> None:
+    account_id = _account_id(authenticated_client)
+    _seed_authenticated_profile(fake_keychain, account_id)
+
+    idx = ProfileIndexStore(credential_store=fake_keychain)
+    await idx.upsert(
+        Profile(
+            id=profile_id_for(account_id, "anthropic", "default"),
+            account_id=account_id,
+            provider="anthropic",
+            name="default",
+            state=ProfileState.AUTHENTICATED,
+        )
+    )
+    captured: dict = {}
+
+    async def fake_chat_completion(_self, body):
+        captured.update(body)
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            model_dump=lambda: {
+                "id": "x",
+                "choices": [{"message": {"content": "ok"}}],
+            }
+        )
+
+    with patch(
+        "aigateway.plugins.anthropic_provider.plugin.AnthropicProviderPlugin.chat_completion",
+        fake_chat_completion,
+    ):
+        resp = authenticated_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "anthropic/claude-haiku-4-5",
+                "messages": [{"role": "user", "content": "hi"}],
+                "reasoning_effort": "none",
+            },
+        )
+
+    assert resp.status_code == 200
+    assert "reasoning_effort" not in captured
 
 
 @pytest.mark.asyncio
@@ -161,3 +275,171 @@ def test_chat_requires_auth(client) -> None:
         json={"model": "anthropic/claude-haiku-4-5", "messages": []},
     )
     assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_chat_rejects_codex_stream_before_litellm(
+    fake_keychain, authenticated_client
+) -> None:
+    account_id = _account_id(authenticated_client)
+    _seed_authenticated_codex_profile(fake_keychain, account_id)
+    idx = ProfileIndexStore(credential_store=fake_keychain)
+    await idx.upsert(
+        Profile(
+            id=profile_id_for(account_id, "codex", "default"),
+            account_id=account_id,
+            provider="codex",
+            name="default",
+            state=ProfileState.AUTHENTICATED,
+        )
+    )
+    fake_acompletion = AsyncMock()
+
+    with patch("aigateway.routes.chat.litellm.acompletion", fake_acompletion):
+        resp = authenticated_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "codex/gpt-5.4-mini",
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": True,
+            },
+        )
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["code"] == "streaming_not_supported"
+    fake_acompletion.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_chat_overwrites_client_api_key_for_codex_oauth(
+    fake_keychain, authenticated_client
+) -> None:
+    account_id = _account_id(authenticated_client)
+    _seed_authenticated_codex_profile(fake_keychain, account_id)
+    idx = ProfileIndexStore(credential_store=fake_keychain)
+    await idx.upsert(
+        Profile(
+            id=profile_id_for(account_id, "codex", "default"),
+            account_id=account_id,
+            provider="codex",
+            name="default",
+            state=ProfileState.AUTHENTICATED,
+        )
+    )
+    captured: dict = {}
+
+    async def fake_acompletion(_self, body):
+        captured.update(body)
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            model_dump=lambda: {
+                "id": "x",
+                "choices": [{"message": {"content": "ok"}}],
+            }
+        )
+
+    with patch(
+        "aigateway.plugins.codex_provider.plugin.CodexProviderPlugin.chat_completion",
+        fake_acompletion,
+    ):
+        resp = authenticated_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "codex/gpt-5.4-mini",
+                "messages": [{"role": "user", "content": "hi"}],
+                "api_key": "client-supplied-token",
+            },
+        )
+
+    assert resp.status_code == 200
+    assert captured["api_key"] == "tok"
+
+
+@pytest.mark.asyncio
+async def test_chat_maps_codex_reasoning_effort_to_reasoning(
+    fake_keychain, authenticated_client
+) -> None:
+    account_id = _account_id(authenticated_client)
+    _seed_authenticated_codex_profile(fake_keychain, account_id)
+    idx = ProfileIndexStore(credential_store=fake_keychain)
+    await idx.upsert(
+        Profile(
+            id=profile_id_for(account_id, "codex", "default"),
+            account_id=account_id,
+            provider="codex",
+            name="default",
+            state=ProfileState.AUTHENTICATED,
+            defaults=ProfileDefaults(reasoning_effort="medium"),
+        )
+    )
+    captured: dict = {}
+
+    async def fake_acompletion(_self, body):
+        captured.update(body)
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            model_dump=lambda: {
+                "id": "x",
+                "choices": [{"message": {"content": "ok"}}],
+            }
+        )
+
+    with patch(
+        "aigateway.plugins.codex_provider.plugin.CodexProviderPlugin.chat_completion",
+        fake_acompletion,
+    ):
+        resp = authenticated_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "codex/gpt-5.4-mini",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+
+    assert resp.status_code == 200
+    assert captured["reasoning"] == {"effort": "medium"}
+    assert "reasoning_effort" not in captured
+
+
+@pytest.mark.asyncio
+async def test_chat_maps_litellm_rate_limit_to_429(fake_keychain, authenticated_client) -> None:
+    account_id = _account_id(authenticated_client)
+    _seed_authenticated_profile(fake_keychain, account_id)
+    idx = ProfileIndexStore(credential_store=fake_keychain)
+    await idx.upsert(
+        Profile(
+            id=profile_id_for(account_id, "anthropic", "default"),
+            account_id=account_id,
+            provider="anthropic",
+            name="default",
+            state=ProfileState.AUTHENTICATED,
+        )
+    )
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    response = httpx.Response(429, headers={"retry-after": "7"}, request=request)
+
+    async def fake_chat_completion(_self, _body):
+        raise RateLimitError(
+            "limited",
+            llm_provider="anthropic",
+            model="anthropic/claude-sonnet-4-5",
+            response=response,
+        )
+
+    with patch(
+        "aigateway.plugins.anthropic_provider.plugin.AnthropicProviderPlugin.chat_completion",
+        fake_chat_completion,
+    ):
+        resp = authenticated_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "anthropic/claude-sonnet-4-5",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+
+    assert resp.status_code == 429
+    assert resp.headers["retry-after"] == "7"
+    assert resp.json()["detail"]["code"] == "rate_limited"

--- a/apps/aigateway/tests/unit/test_chat_x_profile.py
+++ b/apps/aigateway/tests/unit/test_chat_x_profile.py
@@ -293,9 +293,12 @@ async def test_chat_rejects_codex_stream_before_litellm(
             state=ProfileState.AUTHENTICATED,
         )
     )
-    fake_acompletion = AsyncMock()
+    fake_stream = AsyncMock()
 
-    with patch("aigateway.routes.chat.litellm.acompletion", fake_acompletion):
+    with patch(
+        "aigateway.plugins.codex_provider.plugin.CodexProviderPlugin.chat_completion_stream",
+        fake_stream,
+    ):
         resp = authenticated_client.post(
             "/v1/chat/completions",
             json={
@@ -307,7 +310,51 @@ async def test_chat_rejects_codex_stream_before_litellm(
 
     assert resp.status_code == 400
     assert resp.json()["detail"]["code"] == "streaming_not_supported"
-    fake_acompletion.assert_not_called()
+    fake_stream.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_chat_streams_through_provider_plugin_boundary(
+    fake_keychain, authenticated_client
+) -> None:
+    account_id = _account_id(authenticated_client)
+    _seed_authenticated_profile(fake_keychain, account_id)
+    idx = ProfileIndexStore(credential_store=fake_keychain)
+    await idx.upsert(
+        Profile(
+            id=profile_id_for(account_id, "anthropic", "default"),
+            account_id=account_id,
+            provider="anthropic",
+            name="default",
+            state=ProfileState.AUTHENTICATED,
+        )
+    )
+    captured: dict = {}
+
+    async def fake_stream_completion(_self, body):
+        captured.update(body)
+
+        from types import SimpleNamespace
+
+        yield SimpleNamespace(model_dump=lambda: {"choices": [{"delta": {"content": "hi"}}]})
+
+    with patch(
+        "aigateway.plugins.anthropic_provider.plugin.AnthropicProviderPlugin.chat_completion_stream",
+        fake_stream_completion,
+    ):
+        resp = authenticated_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "anthropic/claude-haiku-4-5",
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": True,
+            },
+        )
+
+    assert resp.status_code == 200
+    assert 'data: {"choices": [{"delta": {"content": "hi"}}]}' in resp.text
+    assert "data: [DONE]" in resp.text
+    assert captured["api_key"] == "tok"
 
 
 @pytest.mark.asyncio

--- a/apps/aigateway/tests/unit/test_codex_provider.py
+++ b/apps/aigateway/tests/unit/test_codex_provider.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from aigateway.core.loader import load_plugins
+from aigateway.core.registry import ProviderRegistry
+from aigateway.plugins.codex_provider.auth import CodexOAuth
+from aigateway.plugins.codex_provider.oauth_config import (
+    CODEX_AUTHORIZE_URL,
+    CODEX_CLIENT_ID,
+    CODEX_REDIRECT_PATH,
+    CODEX_TOKEN_URL,
+)
+
+
+def test_codex_provider_loads_with_oauth_config_and_models() -> None:
+    registry = ProviderRegistry()
+    load_plugins(registry)
+
+    plugin = registry.get("codex")
+
+    assert plugin is not None
+    assert plugin.custom_llm_provider == "codex"
+    assert plugin.supports_chat_streaming() is False
+    cfg = plugin.oauth_config()
+    assert cfg is not None
+    assert cfg.authorize_url == CODEX_AUTHORIZE_URL
+    assert cfg.token_url == CODEX_TOKEN_URL
+    assert cfg.client_id == CODEX_CLIENT_ID
+    assert cfg.redirect_path == CODEX_REDIRECT_PATH
+    assert "offline_access" in cfg.scopes
+    names = {entry.model_name for entry in plugin.register_models()}
+    assert names == {
+        "codex/gpt-5.5",
+        "codex/gpt-5.4",
+        "codex/gpt-5.4-mini",
+        "codex/gpt-5.3-codex",
+        "codex/gpt-5.2",
+    }
+
+
+def test_codex_provider_creates_codex_oauth_strategy() -> None:
+    registry = ProviderRegistry()
+    load_plugins(registry)
+    plugin = registry.get("codex")
+    assert plugin is not None
+
+    strategy = plugin.oauth_strategy_for("default")
+
+    assert isinstance(strategy, CodexOAuth)
+    assert strategy.profile_name == "default"
+
+
+def test_models_route_includes_codex_models(authenticated_client) -> None:
+    response = authenticated_client.get("/v1/models")
+
+    assert response.status_code == 200
+    models = {entry["id"]: entry for entry in response.json()["data"]}
+    assert models["codex/gpt-5.4-mini"]["owned_by"] == "codex"
+    assert "codex/codex-auto-review" not in models

--- a/apps/aigateway/tests/unit/test_main.py
+++ b/apps/aigateway/tests/unit/test_main.py
@@ -42,6 +42,25 @@ async def test_create_app_fake_anthropic_oauth_fail_mode(monkeypatch, tmp_path) 
     assert token.json() == {"error": "invalid_grant"}
 
 
+@pytest.mark.asyncio
+async def test_create_app_fake_codex_oauth_factory(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AIGATEWAY_FAKE_KEYCHAIN", "1")
+    monkeypatch.setenv("AIGATEWAY_KEYCHAIN_FILE", str(tmp_path / "keychain.json"))
+    monkeypatch.setenv("AIGATEWAY_FAKE_CODEX_OAUTH", "1")
+
+    from aigateway.main import create_app
+
+    app = create_app()
+
+    async with app.state.codex_http_factory() as client:
+        token = await client.post("https://auth.openai.com/oauth/token")
+        unmapped = await client.post("https://example.com/oauth/token")
+
+    assert token.status_code == 200
+    assert token.json()["refresh_token"] == "fake-codex-rt"
+    assert unmapped.status_code == 404
+
+
 def test_create_app_mounts_provider_auth_router(monkeypatch) -> None:
     from aigateway import main as main_module
 

--- a/apps/aigateway/tests/unit/test_pending_auth.py
+++ b/apps/aigateway/tests/unit/test_pending_auth.py
@@ -8,6 +8,7 @@ ENTRY = PendingAuthEntry(
     profile_name="work",
     profile_id="account-1:anthropic:work",
     code_verifier="v",
+    redirect_uri="http://localhost:9105/callback",
 )
 
 
@@ -21,6 +22,7 @@ def test_pending_table_round_trip() -> None:
     assert entry.profile_name == "work"
     assert entry.profile_id == "account-1:anthropic:work"
     assert entry.code_verifier == "v"
+    assert entry.redirect_uri == "http://localhost:9105/callback"
 
 
 def test_pop_consumes_entry() -> None:

--- a/apps/aigateway/tests/unit/test_pending_auth.py
+++ b/apps/aigateway/tests/unit/test_pending_auth.py
@@ -44,3 +44,21 @@ def test_expired_entry_is_swept(monkeypatch) -> None:
 def test_unknown_state_returns_none() -> None:
     table = PendingAuthTable(ttl_seconds=600)
     assert table.pop("nonexistent") is None
+
+
+def test_pop_for_profile_removes_only_matching_profile() -> None:
+    table = PendingAuthTable(ttl_seconds=600)
+    other = PendingAuthEntry(
+        account_id="account-1",
+        provider="anthropic",
+        profile_name="personal",
+        profile_id="account-1:anthropic:personal",
+        code_verifier="v2",
+        redirect_uri="http://localhost:9105/callback",
+    )
+    table.put("state-work", ENTRY)
+    table.put("state-personal", other)
+
+    assert table.pop_for_profile("account-1", "anthropic", "work") == ["state-work"]
+    assert table.pop("state-work") is None
+    assert table.pop("state-personal") == other

--- a/apps/aigateway/tests/unit/test_plugin_loader.py
+++ b/apps/aigateway/tests/unit/test_plugin_loader.py
@@ -1,4 +1,4 @@
-"""Loader auto-discovers anthropic_provider when scanning aigateway.plugins.*."""
+"""Loader auto-discovers provider packages when scanning aigateway.plugins.*."""
 
 from __future__ import annotations
 
@@ -17,3 +17,17 @@ def test_loader_discovers_anthropic_provider() -> None:
     assert "claude-sonnet-4-5" in names
     for m in models:
         assert m.litellm_params["model"].startswith("anthropic/")
+
+
+def test_loader_discovers_codex_provider() -> None:
+    reg = ProviderRegistry()
+    load_plugins(reg)
+    plugin = reg.get("codex")
+    assert plugin is not None
+    assert plugin.custom_llm_provider == "codex"
+    models = plugin.register_models()
+    names = {m.model_name for m in models}
+    assert "codex/gpt-5.4-mini" in names
+    assert "codex/codex-auto-review" not in names
+    for m in models:
+        assert m.litellm_params["model"].startswith("codex/")

--- a/apps/aigateway/tests/unit/test_registry.py
+++ b/apps/aigateway/tests/unit/test_registry.py
@@ -64,6 +64,15 @@ def test_provider_plugin_base_strategy_factory() -> None:
         async def get_authorization_header(self):
             return {"Authorization": f"Bearer tok-{self.profile_name}"}
 
+        def persist_credentials(self, _credentials):
+            return None
+
+        def delete_credentials(self):
+            return None
+
+        async def refresh_credentials(self):
+            return None
+
     class P(ProviderPluginBase):
         custom_llm_provider = "stub"
 

--- a/apps/aigateway/uv.lock
+++ b/apps/aigateway/uv.lock
@@ -4,9 +4,10 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "aigateway"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiosqlite" },
     { name = "asyncpg" },
     { name = "bcrypt" },
     { name = "fastapi" },
@@ -21,7 +22,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "aiosqlite" },
     { name = "httpx" },
     { name = "pyright" },
     { name = "pytest" },
@@ -33,6 +33,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiosqlite", specifier = "==0.22.1" },
     { name = "asyncpg", specifier = "==0.31.0" },
     { name = "bcrypt", specifier = "==5.0.0" },
     { name = "fastapi", specifier = ">=0.115" },
@@ -47,7 +48,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "aiosqlite", specifier = "==0.22.1" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "pyright", specifier = ">=1.1.393" },
     { name = "pytest", specifier = ">=9.0" },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -93,6 +93,18 @@
         "to": "server/sf.json"
       },
       {
+        "from": "../../apps/aigateway/src",
+        "to": "aigateway/src"
+      },
+      {
+        "from": "../../apps/aigateway/pyproject.toml",
+        "to": "aigateway/pyproject.toml"
+      },
+      {
+        "from": "../../apps/aigateway/uv.lock",
+        "to": "aigateway/uv.lock"
+      },
+      {
         "from": "build-assets/${os}/${arch}/uv",
         "to": "server/bin/uv"
       },

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -4,9 +4,58 @@ import { is } from '@electron-toolkit/utils';
 import { registerAllHandlers } from './ipc';
 import { log } from './debug-log';
 import { sessionManager } from './services/session-manager';
+import { serverProcess } from './services/server-process';
+import { isAllowedExternalBrowserUrl, isAllowedPopupUrl } from './services/external-url-policy';
+import { requireTrustedIpcSender } from './ipc/sender-validation';
 
 let mainWindow: BrowserWindow | null = null;
 let phoenixWindow: BrowserWindow | null = null;
+
+function showMainWindow(reason: string): void {
+  if (!mainWindow || mainWindow.isDestroyed() || mainWindow.isVisible()) return;
+  log(`[main] show window (${reason})`);
+  mainWindow.show();
+}
+
+function registerMainWindowDiagnostics(window: BrowserWindow): void {
+  window.on('ready-to-show', () => {
+    log(`[main] ready-to-show`);
+  });
+
+  window.on('unresponsive', () => {
+    log(`[main] window unresponsive`);
+  });
+
+  window.webContents.on('dom-ready', () => {
+    log(`[renderer] dom-ready`);
+    showMainWindow('dom-ready');
+  });
+
+  window.webContents.on('did-finish-load', () => {
+    log(`[renderer] did-finish-load`);
+  });
+
+  window.webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL) => {
+    log(
+      `[renderer] did-fail-load code=${errorCode} description=${errorDescription} url=${validatedURL}`,
+    );
+    showMainWindow('did-fail-load');
+  });
+
+  window.webContents.on('render-process-gone', (_event, details) => {
+    log(`[renderer] render-process-gone reason=${details.reason} exitCode=${details.exitCode}`);
+  });
+
+  window.webContents.on('preload-error', (_event, preloadPath, error) => {
+    log(`[renderer] preload-error path=${preloadPath} message=${error.message}`);
+  });
+
+  window.webContents.on('console-message', (event) => {
+    log(
+      `[renderer:console:${event.level}] ${event.message} (${event.sourceId}:${event.lineNumber})`,
+    );
+  });
+}
 
 function createWindow(): void {
   mainWindow = new BrowserWindow({
@@ -24,20 +73,16 @@ function createWindow(): void {
   });
 
   log(`[main] BrowserWindow created`);
-
-  mainWindow.on('ready-to-show', () => {
-    log(`[main] ready-to-show`);
-    mainWindow?.show();
-    // Temporary: open DevTools in production to diagnose Finder-launch black screen
-    mainWindow?.webContents.openDevTools({ mode: 'detach' });
-  });
+  registerMainWindowDiagnostics(mainWindow);
 
   mainWindow.on('closed', () => {
     mainWindow = null;
   });
 
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url);
+    if (isAllowedExternalBrowserUrl(url)) {
+      void shell.openExternal(url);
+    }
     return { action: 'deny' };
   });
 
@@ -49,7 +94,10 @@ function createWindow(): void {
 }
 
 function registerPopupHandlers(): void {
-  ipcMain.handle('popup:open', (_event, url: string, title?: string) => {
+  ipcMain.handle('popup:open', (event, url: string, title?: string) => {
+    requireTrustedIpcSender(event);
+    if (!isAllowedPopupUrl(url)) return;
+
     // Reuse existing window if still open
     if (phoenixWindow && !phoenixWindow.isDestroyed()) {
       phoenixWindow.loadURL(url);
@@ -78,7 +126,8 @@ function registerPopupHandlers(): void {
     });
   });
 
-  ipcMain.handle('popup:close', () => {
+  ipcMain.handle('popup:close', (event) => {
+    requireTrustedIpcSender(event);
     if (phoenixWindow && !phoenixWindow.isDestroyed()) {
       phoenixWindow.close();
       phoenixWindow = null;
@@ -126,7 +175,7 @@ app.on('before-quit', (event) => {
   if (isQuitting) return;
   isQuitting = true;
   event.preventDefault();
-  sessionManager.terminateAll().finally(() => {
+  Promise.allSettled([sessionManager.terminateAll(), serverProcess.stop()]).finally(() => {
     app.quit();
   });
 });

--- a/apps/desktop/src/main/ipc/__tests__/sender-validation.test.ts
+++ b/apps/desktop/src/main/ipc/__tests__/sender-validation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { is } = vi.hoisted(() => ({ is: { dev: true } }));
+
+vi.mock('@electron-toolkit/utils', () => ({ is }));
+
+import { isTrustedIpcSenderUrl } from '../sender-validation';
+
+describe('IPC sender validation', () => {
+  it('trusts packaged file renderer URLs', () => {
+    is.dev = false;
+    const trustedRendererUrl = 'file:///Applications/ScreamingFace.app/out/renderer/index.html';
+
+    expect(isTrustedIpcSenderUrl(trustedRendererUrl, trustedRendererUrl)).toBe(true);
+    expect(
+      isTrustedIpcSenderUrl(
+        'file:///Applications/ScreamingFace.app/Contents/Resources/evil.html',
+        trustedRendererUrl,
+      ),
+    ).toBe(false);
+    expect(isTrustedIpcSenderUrl('https://example.com')).toBe(false);
+  });
+
+  it('trusts only loopback HTTP origins in dev', () => {
+    is.dev = true;
+    delete process.env['ELECTRON_RENDERER_URL'];
+
+    expect(isTrustedIpcSenderUrl('http://localhost:5173')).toBe(true);
+    expect(isTrustedIpcSenderUrl('http://127.0.0.1:5173')).toBe(true);
+    expect(isTrustedIpcSenderUrl('http://192.168.1.5:5173')).toBe(false);
+    expect(isTrustedIpcSenderUrl('https://example.com')).toBe(false);
+  });
+
+  it('honors an explicit dev renderer origin', () => {
+    is.dev = true;
+    process.env['ELECTRON_RENDERER_URL'] = 'http://127.0.0.1:5173';
+
+    expect(isTrustedIpcSenderUrl('http://127.0.0.1:5173/settings')).toBe(true);
+    expect(isTrustedIpcSenderUrl('http://127.0.0.1:5174/settings')).toBe(false);
+
+    delete process.env['ELECTRON_RENDERER_URL'];
+  });
+});

--- a/apps/desktop/src/main/ipc/backend-status.ipc.ts
+++ b/apps/desktop/src/main/ipc/backend-status.ipc.ts
@@ -51,15 +51,23 @@ export function registerBackendStatusHandlers(): void {
     },
   );
 
-  ipcMain.handle('backends:getPendingAuthState', (event, backend: string): string | null => {
-    requireTrustedIpcSender(event);
-    if (!isSafeBackendName(backend)) return null;
-    return getPendingAuthState(backend);
-  });
+  ipcMain.handle(
+    'backends:getPendingAuthState',
+    (event, backend: string, profileName?: string): string | null => {
+      requireTrustedIpcSender(event);
+      if (!isSafeBackendName(backend)) return null;
+      return getPendingAuthState(backend, profileName);
+    },
+  );
 
   ipcMain.handle(
     'backends:exchangeOAuthCode',
-    async (event, backend: string, code: string): Promise<ExchangeCodeResult> => {
+    async (
+      event,
+      backend: string,
+      code: string,
+      profileName?: string,
+    ): Promise<ExchangeCodeResult> => {
       requireTrustedIpcSender(event);
       if (!isSafeBackendName(backend)) {
         return { ok: false, message: `invalid backend name: ${backend}` };
@@ -69,9 +77,9 @@ export function registerBackendStatusHandlers(): void {
       if (!sfBaseUrl) {
         return { ok: false, message: 'SF server is not running' };
       }
-      const state = getPendingAuthState(backend);
+      const state = getPendingAuthState(backend, profileName);
       if (!state) {
-        return { ok: false, message: 'No in-flight OAuth flow for this backend' };
+        return { ok: false, message: 'No in-flight OAuth flow for this backend/profile' };
       }
       try {
         const resp = await fetch(`${sfBaseUrl}/${backend}/auth/exchange-code`, {
@@ -80,7 +88,7 @@ export function registerBackendStatusHandlers(): void {
           body: JSON.stringify({ code, state }),
         });
         if (resp.ok) {
-          clearPendingAuthState(backend);
+          clearPendingAuthState(backend, profileName);
           return { ok: true };
         }
         let message: string | undefined;

--- a/apps/desktop/src/main/ipc/backend-status.ipc.ts
+++ b/apps/desktop/src/main/ipc/backend-status.ipc.ts
@@ -6,27 +6,34 @@ import {
   clearPendingAuthState,
   type LauncherResult,
 } from '../services/oauth-launcher';
+import { isSafeBackendName } from '../services/external-url-policy';
+import { requireTrustedIpcSender } from './sender-validation';
 
-export type ExchangeCodeResult =
-  | { ok: true }
-  | { ok: false; status?: number; message?: string };
+export type ExchangeCodeResult = { ok: true } | { ok: false; status?: number; message?: string };
 
 export function registerBackendStatusHandlers(): void {
-  ipcMain.handle('backends:getStatus', () => {
+  ipcMain.handle('backends:getStatus', (event) => {
+    requireTrustedIpcSender(event);
     return backendStatusService.getStatus();
   });
 
-  ipcMain.handle('backends:refresh', () => {
+  ipcMain.handle('backends:refresh', (event) => {
+    requireTrustedIpcSender(event);
     return backendStatusService.refresh();
   });
 
-  ipcMain.handle('backends:authenticate', (_event, backend: string) => {
+  ipcMain.handle('backends:authenticate', (event, backend: string) => {
+    requireTrustedIpcSender(event);
     backendStatusService.authenticate(backend);
   });
 
   ipcMain.handle(
     'backends:authenticateOAuth',
-    async (_event, backend: string, profileName?: string): Promise<LauncherResult> => {
+    async (event, backend: string, profileName?: string): Promise<LauncherResult> => {
+      requireTrustedIpcSender(event);
+      if (!isSafeBackendName(backend)) {
+        return { kind: 'failed', reason: 'gateway_error', message: 'invalid backend name' };
+      }
       const sfBaseUrl = backendStatusService.getServerUrl();
       console.log(
         `[oauth] authenticateOAuth invoked: backend=${backend} profileName=${profileName ?? '(default)'} sfBaseUrl=${sfBaseUrl ?? 'NULL'}`,
@@ -44,13 +51,20 @@ export function registerBackendStatusHandlers(): void {
     },
   );
 
-  ipcMain.handle('backends:getPendingAuthState', (_event, backend: string): string | null => {
+  ipcMain.handle('backends:getPendingAuthState', (event, backend: string): string | null => {
+    requireTrustedIpcSender(event);
+    if (!isSafeBackendName(backend)) return null;
     return getPendingAuthState(backend);
   });
 
   ipcMain.handle(
     'backends:exchangeOAuthCode',
-    async (_event, backend: string, code: string): Promise<ExchangeCodeResult> => {
+    async (event, backend: string, code: string): Promise<ExchangeCodeResult> => {
+      requireTrustedIpcSender(event);
+      if (!isSafeBackendName(backend)) {
+        return { ok: false, message: `invalid backend name: ${backend}` };
+      }
+
       const sfBaseUrl = backendStatusService.getServerUrl();
       if (!sfBaseUrl) {
         return { ok: false, message: 'SF server is not running' };
@@ -83,7 +97,12 @@ export function registerBackendStatusHandlers(): void {
     },
   );
 
-  ipcMain.handle('backends:listProfiles', async (_event, backend: string) => {
+  ipcMain.handle('backends:listProfiles', async (event, backend: string) => {
+    requireTrustedIpcSender(event);
+    if (!isSafeBackendName(backend)) {
+      return { profiles: [], error: 'invalid_backend' };
+    }
+
     const sfBaseUrl = backendStatusService.getServerUrl();
     if (!sfBaseUrl) {
       return { profiles: [], error: 'gateway_unreachable' };
@@ -100,25 +119,27 @@ export function registerBackendStatusHandlers(): void {
     }
   });
 
-  ipcMain.handle(
-    'backends:deleteProfile',
-    async (_event, backend: string, profileName: string) => {
-      const sfBaseUrl = backendStatusService.getServerUrl();
-      if (!sfBaseUrl) {
-        return { ok: false, status: 0 };
-      }
-      try {
-        const resp = await fetch(
-          `${sfBaseUrl}/${backend}/auth/profiles/${encodeURIComponent(profileName)}`,
-          { method: 'DELETE' },
-        );
-        if (resp.status === 204) return { ok: true };
-        return { ok: false, status: resp.status };
-      } catch {
-        return { ok: false, status: 0 };
-      }
-    },
-  );
+  ipcMain.handle('backends:deleteProfile', async (event, backend: string, profileName: string) => {
+    requireTrustedIpcSender(event);
+    if (!isSafeBackendName(backend)) {
+      return { ok: false, status: 400 };
+    }
+
+    const sfBaseUrl = backendStatusService.getServerUrl();
+    if (!sfBaseUrl) {
+      return { ok: false, status: 0 };
+    }
+    try {
+      const resp = await fetch(
+        `${sfBaseUrl}/${backend}/auth/profiles/${encodeURIComponent(profileName)}`,
+        { method: 'DELETE' },
+      );
+      if (resp.status === 204) return { ok: true };
+      return { ok: false, status: resp.status };
+    } catch {
+      return { ok: false, status: 0 };
+    }
+  });
 
   // Forward status changes to all renderer windows
   backendStatusService.on('statusChanged', (status) => {

--- a/apps/desktop/src/main/ipc/config.ipc.ts
+++ b/apps/desktop/src/main/ipc/config.ipc.ts
@@ -1,12 +1,15 @@
 import { ipcMain, BrowserWindow } from 'electron';
 import { configService } from '../services/config-service';
+import { requireTrustedIpcSender } from './sender-validation';
 
 export function registerConfigHandlers(): void {
-  ipcMain.handle('config:read', () => {
+  ipcMain.handle('config:read', (event) => {
+    requireTrustedIpcSender(event);
     return configService.read();
   });
 
-  ipcMain.handle('config:write', (_event, config: Record<string, unknown>) => {
+  ipcMain.handle('config:write', (event, config: Record<string, unknown>) => {
+    requireTrustedIpcSender(event);
     configService.write(config);
   });
 

--- a/apps/desktop/src/main/ipc/plugin-manager.ipc.ts
+++ b/apps/desktop/src/main/ipc/plugin-manager.ipc.ts
@@ -1,33 +1,41 @@
 import { ipcMain, BrowserWindow } from 'electron';
 import { pluginRegistry } from '../services/plugin-registry';
 import { venvManager } from '../services/venv-manager';
+import { requireTrustedIpcSender } from './sender-validation';
 
 export function registerPluginHandlers(): void {
-  ipcMain.handle('plugins:list', () => {
+  ipcMain.handle('plugins:list', (event) => {
+    requireTrustedIpcSender(event);
     return pluginRegistry.list();
   });
 
-  ipcMain.handle('plugins:discover', () => {
+  ipcMain.handle('plugins:discover', (event) => {
+    requireTrustedIpcSender(event);
     return venvManager.discoverPlugins();
   });
 
-  ipcMain.handle('plugins:install', (_event, url: string) => {
+  ipcMain.handle('plugins:install', (event, url: string) => {
+    requireTrustedIpcSender(event);
     return pluginRegistry.install(url);
   });
 
-  ipcMain.handle('plugins:uninstall', (_event, id: string) => {
+  ipcMain.handle('plugins:uninstall', (event, id: string) => {
+    requireTrustedIpcSender(event);
     return pluginRegistry.uninstall(id);
   });
 
-  ipcMain.handle('plugins:activate', (_event, id: string) => {
+  ipcMain.handle('plugins:activate', (event, id: string) => {
+    requireTrustedIpcSender(event);
     return pluginRegistry.activate(id);
   });
 
-  ipcMain.handle('plugins:deactivate', (_event, id: string) => {
+  ipcMain.handle('plugins:deactivate', (event, id: string) => {
+    requireTrustedIpcSender(event);
     return pluginRegistry.deactivate(id);
   });
 
-  ipcMain.handle('plugins:getCatalog', () => {
+  ipcMain.handle('plugins:getCatalog', (event) => {
+    requireTrustedIpcSender(event);
     return pluginRegistry.getCatalog();
   });
 

--- a/apps/desktop/src/main/ipc/sender-validation.ts
+++ b/apps/desktop/src/main/ipc/sender-validation.ts
@@ -1,0 +1,56 @@
+import type { IpcMainInvokeEvent } from 'electron';
+import { is } from '@electron-toolkit/utils';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+export function requireTrustedIpcSender(event: IpcMainInvokeEvent): void {
+  const frameUrl = event.senderFrame?.url ?? event.sender.getURL();
+  if (!isTrustedIpcSenderUrl(frameUrl)) {
+    throw new Error('untrusted IPC sender');
+  }
+}
+
+export function isTrustedIpcSenderUrl(frameUrl: string, trustedRendererUrl?: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(frameUrl);
+  } catch {
+    return false;
+  }
+
+  if (url.protocol === 'file:') {
+    const trusted = new URL(trustedRendererUrl ?? packagedRendererFileUrl());
+    return (
+      trusted.protocol === 'file:' &&
+      url.pathname === trusted.pathname &&
+      url.search === '' &&
+      url.username === '' &&
+      url.password === ''
+    );
+  }
+
+  if (is.dev) {
+    const rendererUrl = process.env['ELECTRON_RENDERER_URL'];
+    if (rendererUrl) return sameOrigin(url, rendererUrl);
+    return url.protocol === 'http:' && isLoopbackHostname(url.hostname);
+  }
+
+  return false;
+}
+
+function packagedRendererFileUrl(): string {
+  return pathToFileURL(join(__dirname, '../renderer/index.html')).href;
+}
+
+function sameOrigin(url: URL, expectedUrlString: string): boolean {
+  try {
+    const expected = new URL(expectedUrlString);
+    return url.origin === expected.origin;
+  } catch {
+    return false;
+  }
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
+}

--- a/apps/desktop/src/main/ipc/server-process.ipc.ts
+++ b/apps/desktop/src/main/ipc/server-process.ipc.ts
@@ -3,6 +3,8 @@ import https from 'https';
 import http from 'http';
 import { serverProcess } from '../services/server-process';
 import { backendStatusService } from '../services/backend-status';
+import { isAllowedServerFetchUrl } from '../services/external-url-policy';
+import { requireTrustedIpcSender } from './sender-validation';
 
 interface FetchInit {
   method?: string;
@@ -42,24 +44,37 @@ function nodeFetch(url: string, init?: FetchInit): Promise<{ status: number; bod
 }
 
 export function registerServerHandlers(): void {
-  ipcMain.handle('server:start', () => {
+  ipcMain.handle('server:start', (event) => {
+    requireTrustedIpcSender(event);
     return serverProcess.start();
   });
 
-  ipcMain.handle('server:stop', () => {
+  ipcMain.handle('server:stop', (event) => {
+    requireTrustedIpcSender(event);
     return serverProcess.stop();
   });
 
-  ipcMain.handle('server:restart', () => {
+  ipcMain.handle('server:restart', (event) => {
+    requireTrustedIpcSender(event);
     return serverProcess.restart();
   });
 
-  ipcMain.handle('server:getStatus', () => {
+  ipcMain.handle('server:getStatus', (event) => {
+    requireTrustedIpcSender(event);
     return serverProcess.getStatus();
   });
 
   // Proxy fetch through main process to bypass self-signed cert issues
-  ipcMain.handle('server:fetch', async (_event, url: string, init?: FetchInit) => {
+  ipcMain.handle('server:fetch', async (event, url: string, init?: FetchInit) => {
+    requireTrustedIpcSender(event);
+    const { info } = serverProcess.getStatus();
+    if (!info) {
+      return { ok: false, status: 503, body: 'server_restarting' };
+    }
+    if (!isAllowedServerFetchUrl(url, info)) {
+      return { ok: false, status: 0, body: '' };
+    }
+
     try {
       const { status, body } = await nodeFetch(url, init);
       return { ok: status >= 200 && status < 300, status, body };

--- a/apps/desktop/src/main/ipc/session.ipc.ts
+++ b/apps/desktop/src/main/ipc/session.ipc.ts
@@ -1,46 +1,61 @@
 import { ipcMain, BrowserWindow } from 'electron';
-import { sessionManager } from '../services/session-manager';
+import { sessionManager, type SessionType } from '../services/session-manager';
+import { requireTrustedIpcSender } from './sender-validation';
 
 export function registerSessionHandlers(): void {
-  ipcMain.handle('session:pickDir', () => {
+  ipcMain.handle('session:pickDir', (event) => {
+    requireTrustedIpcSender(event);
     return sessionManager.pickWorkingDir();
   });
 
   ipcMain.handle(
     'session:create',
-    (_event, type: string, workingDir: string, pluginConfig?: Record<string, Record<string, unknown>>) => {
-      return sessionManager.createSession(
-        type as 'claude' | 'codex' | 'gemini' | 'claude-desktop',
-        workingDir,
-        pluginConfig,
-      );
+    (
+      event,
+      type: string,
+      workingDir: string,
+      pluginConfig?: Record<string, Record<string, unknown>>,
+    ) => {
+      requireTrustedIpcSender(event);
+      return sessionManager.createSession(type as SessionType, workingDir, pluginConfig);
     },
   );
 
-  ipcMain.handle('session:list', () => {
+  ipcMain.handle('session:list', (event) => {
+    requireTrustedIpcSender(event);
     return sessionManager.listSessions();
   });
 
-  ipcMain.handle('session:terminate', (_event, id: string) => {
+  ipcMain.handle('session:terminate', (event, id: string) => {
+    requireTrustedIpcSender(event);
     return sessionManager.terminateSession(id);
   });
 
-  ipcMain.handle('session:terminateAll', () => {
+  ipcMain.handle('session:terminateAll', (event) => {
+    requireTrustedIpcSender(event);
     return sessionManager.terminateAll();
   });
 
-  ipcMain.handle('session:remove', (_event, id: string) => {
+  ipcMain.handle('session:remove', (event, id: string) => {
+    requireTrustedIpcSender(event);
     sessionManager.removeSession(id);
   });
 
   ipcMain.handle(
     'session:update',
-    (_event, id: string, workingDir: string, pluginConfig?: Record<string, Record<string, unknown>>) => {
+    (
+      event,
+      id: string,
+      workingDir: string,
+      pluginConfig?: Record<string, Record<string, unknown>>,
+    ) => {
+      requireTrustedIpcSender(event);
       return sessionManager.updateSession(id, workingDir, pluginConfig);
     },
   );
 
-  ipcMain.handle('session:restart', (_event, id: string) => {
+  ipcMain.handle('session:restart', (event, id: string) => {
+    requireTrustedIpcSender(event);
     return sessionManager.restartSession(id);
   });
 

--- a/apps/desktop/src/main/ipc/venv-manager.ipc.ts
+++ b/apps/desktop/src/main/ipc/venv-manager.ipc.ts
@@ -1,30 +1,35 @@
 import { ipcMain, BrowserWindow } from 'electron';
 import { venvManager } from '../services/venv-manager';
 import { log } from '../debug-log';
+import { requireTrustedIpcSender } from './sender-validation';
 
 export function registerVenvHandlers(): void {
-  ipcMain.handle('venv:detect', async () => {
+  ipcMain.handle('venv:detect', async (event) => {
+    requireTrustedIpcSender(event);
     log(`[ipc] venv:detect received`);
     const result = await venvManager.detect();
     log(`[ipc] venv:detect returning ${JSON.stringify(result)}`);
     return result;
   });
 
-  ipcMain.handle('venv:create', async () => {
+  ipcMain.handle('venv:create', async (event) => {
+    requireTrustedIpcSender(event);
     log(`[ipc] venv:create received`);
     const result = await venvManager.create();
     log(`[ipc] venv:create returning ${result}`);
     return result;
   });
 
-  ipcMain.handle('venv:sync', async (_event, extra?: string) => {
+  ipcMain.handle('venv:sync', async (event, extra?: string) => {
+    requireTrustedIpcSender(event);
     log(`[ipc] venv:sync received, extra=${extra}`);
     const result = await venvManager.sync(extra);
     log(`[ipc] venv:sync returning ${result}`);
     return result;
   });
 
-  ipcMain.handle('venv:listPackages', () => {
+  ipcMain.handle('venv:listPackages', (event) => {
+    requireTrustedIpcSender(event);
     return venvManager.listPackages();
   });
 

--- a/apps/desktop/src/main/services/__tests__/backend-status.test.ts
+++ b/apps/desktop/src/main/services/__tests__/backend-status.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+import { escapeAppleScriptString } from '../backend-status';
+
+describe('backend status service', () => {
+  it('escapes cli commands before AppleScript interpolation', () => {
+    expect(escapeAppleScriptString('say "hi" && printf \\ok')).toBe(
+      'say \\"hi\\" && printf \\\\ok',
+    );
+    expect(escapeAppleScriptString('first\nsecond\rthird')).toBe('first\\nsecond\\rthird');
+  });
+});

--- a/apps/desktop/src/main/services/__tests__/config-service.test.ts
+++ b/apps/desktop/src/main/services/__tests__/config-service.test.ts
@@ -1,0 +1,40 @@
+import { existsSync, mkdtempSync, readdirSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import { describe, expect, it, vi } from 'vitest';
+
+const electronMocks = vi.hoisted(() => ({
+  app: {
+    getAppPath: vi.fn(() => '/repo/apps/desktop'),
+    getPath: vi.fn(() => '/tmp/sf-user-data'),
+  },
+}));
+
+vi.mock('electron', () => ({ app: electronMocks.app }));
+vi.mock('@electron-toolkit/utils', () => ({ is: { dev: true } }));
+
+import { ConfigService } from '../config-service';
+
+describe('ConfigService', () => {
+  it('defers Electron path resolution until first use', () => {
+    new ConfigService();
+
+    expect(electronMocks.app.getAppPath).not.toHaveBeenCalled();
+    expect(electronMocks.app.getPath).not.toHaveBeenCalled();
+  });
+
+  it('writes config through a same-directory temp file and rename', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'sf-config-'));
+    const configPath = join(dir, 'sf.json');
+    const service = new ConfigService();
+
+    service.setConfigPath(configPath);
+    service.write({ version: '0.1.0', plugins: [] });
+
+    expect(readFileSync(configPath, 'utf-8')).toBe(
+      JSON.stringify({ version: '0.1.0', plugins: [] }, null, 2) + '\n',
+    );
+    expect(readdirSync(dir).filter((name) => name.endsWith('.tmp'))).toEqual([]);
+    expect(existsSync(resolve(dir, 'sf.json'))).toBe(true);
+  });
+});

--- a/apps/desktop/src/main/services/__tests__/external-url-policy.test.ts
+++ b/apps/desktop/src/main/services/__tests__/external-url-policy.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isAllowedExternalBrowserUrl,
+  isAllowedOAuthAuthorizeUrl,
+  isAllowedPopupUrl,
+  isAllowedServerFetchUrl,
+  isSafeBackendName,
+} from '../external-url-policy';
+
+function authorizeUrl(host: string, pathname: string, params: Record<string, string>): string {
+  return `https://${host}${pathname}?${new URLSearchParams(params).toString()}`;
+}
+
+describe('external URL policy', () => {
+  it('allows only safe HTTPS renderer external links', () => {
+    expect(isAllowedExternalBrowserUrl('https://docs.example.test/project')).toBe(true);
+    expect(isAllowedExternalBrowserUrl('https://source.example.test/org/project')).toBe(true);
+
+    expect(isAllowedExternalBrowserUrl('file:///Users/example/.ssh/id_rsa')).toBe(false);
+    expect(isAllowedExternalBrowserUrl('mailto:test@example.com')).toBe(false);
+    expect(isAllowedExternalBrowserUrl('https://user:pass@example.test/project')).toBe(false);
+  });
+
+  it('allows OAuth authorize URLs with a gateway-owned loopback callback shape', () => {
+    expect(
+      isAllowedOAuthAuthorizeUrl(
+        authorizeUrl('auth.openai.com', '/oauth/authorize', {
+          response_type: 'code',
+          client_id: 'public-client-id',
+          redirect_uri: 'http://localhost:1455/auth/callback',
+          scope: 'read write',
+          code_challenge: 'challenge',
+          code_challenge_method: 'S256',
+          state: 'state',
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isAllowedOAuthAuthorizeUrl(
+        authorizeUrl('chatgpt.com', '/oauth/authorize', {
+          response_type: 'code',
+          client_id: 'public-client-id',
+          redirect_uri: 'http://localhost:1457/auth/callback',
+          scope: 'read write',
+          code_challenge: 'challenge',
+          code_challenge_method: 'S256',
+          state: 'state',
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isAllowedOAuthAuthorizeUrl(
+        authorizeUrl('claude.com', '/cai/oauth/authorize', {
+          response_type: 'code',
+          client_id: 'public-client-id',
+          redirect_uri: 'http://localhost:9105/callback',
+          scope: 'read write',
+          code_challenge: 'challenge',
+          code_challenge_method: 'S256',
+          state: 'state',
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isAllowedOAuthAuthorizeUrl(
+        authorizeUrl('claude.ai', '/oauth/authorize', {
+          response_type: 'code',
+          client_id: 'public-client-id',
+          redirect_uri: 'http://localhost:9105/callback',
+          scope: 'read write',
+          code_challenge: 'challenge',
+          code_challenge_method: 'S256',
+          state: 'state',
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects malformed OAuth authorize URLs and non-loopback callbacks', () => {
+    const base = {
+      response_type: 'code',
+      client_id: 'public-client-id',
+      redirect_uri: 'http://localhost:9105/auth/callback',
+      scope: 'read write',
+      code_challenge: 'challenge',
+      code_challenge_method: 'S256',
+      state: 'state',
+    };
+
+    expect(
+      isAllowedOAuthAuthorizeUrl(
+        authorizeUrl('identity.example.test', '/oauth/authorize', {
+          ...base,
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isAllowedOAuthAuthorizeUrl(
+        authorizeUrl('auth.openai.com', '/oauth/authorize', {
+          ...base,
+          redirect_uri: 'https://evil.test/auth/callback',
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isAllowedOAuthAuthorizeUrl(
+        authorizeUrl('auth.openai.com', '/oauth/authorize', {
+          ...base,
+          code_challenge_method: 'plain',
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isAllowedOAuthAuthorizeUrl(
+        authorizeUrl('auth.openai.com', '/oauth/authorize', {
+          ...base,
+          redirect_uri: 'http://localhost:22/auth/callback',
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isAllowedOAuthAuthorizeUrl(
+        authorizeUrl('auth.openai.com', '/oauth/authorize', {
+          ...base,
+          redirect_uri: 'http://localhost:1455/callback',
+        }),
+      ),
+    ).toBe(false);
+    expect(isAllowedOAuthAuthorizeUrl(authorizeUrl('auth.openai.com', '/login', base))).toBe(false);
+  });
+
+  it('allows only safe backend path slugs', () => {
+    expect(isSafeBackendName('browser-backend')).toBe(true);
+    expect(isSafeBackendName('backend123')).toBe(true);
+
+    expect(isSafeBackendName('../backend')).toBe(false);
+    expect(isSafeBackendName('backend/profile')).toBe(false);
+    expect(isSafeBackendName('Backend')).toBe(false);
+  });
+
+  it('allows server fetches only to the live loopback SF endpoint', () => {
+    const serverInfo = { scheme: 'https', host: '127.0.0.1', port: 8000 };
+
+    expect(isAllowedServerFetchUrl('https://127.0.0.1:8000/plugins', serverInfo)).toBe(true);
+    expect(isAllowedServerFetchUrl('https://localhost:8000/plugins', serverInfo)).toBe(true);
+
+    expect(isAllowedServerFetchUrl('https://127.0.0.1:8001/plugins', serverInfo)).toBe(false);
+    expect(isAllowedServerFetchUrl('http://127.0.0.1:8000/plugins', serverInfo)).toBe(false);
+    expect(isAllowedServerFetchUrl('https://192.168.1.5:8000/plugins', serverInfo)).toBe(false);
+    expect(isAllowedServerFetchUrl('file:///tmp/x', serverInfo)).toBe(false);
+  });
+
+  it('allows popup windows only for local Phoenix tracing', () => {
+    expect(isAllowedPopupUrl('http://localhost:6006')).toBe(true);
+    expect(isAllowedPopupUrl('http://127.0.0.1:6006/projects')).toBe(true);
+
+    expect(isAllowedPopupUrl('http://localhost:6007')).toBe(false);
+    expect(isAllowedPopupUrl('https://localhost:6006')).toBe(false);
+    expect(isAllowedPopupUrl('https://example.com')).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/services/__tests__/oauth-launcher.test.ts
+++ b/apps/desktop/src/main/services/__tests__/oauth-launcher.test.ts
@@ -6,6 +6,30 @@ vi.mock('electron', () => ({ shell: { openExternal } }));
 
 import { runOAuthLauncher } from '../oauth-launcher';
 
+const AUTHORIZE_URL =
+  'https://claude.com/cai/oauth/authorize?' +
+  new URLSearchParams({
+    response_type: 'code',
+    client_id: 'public-client-id',
+    redirect_uri: 'http://localhost:9105/callback',
+    scope: 'read write',
+    code_challenge: 'challenge',
+    code_challenge_method: 'S256',
+    state: 's1',
+  }).toString();
+
+const ALTERNATE_AUTHORIZE_URL =
+  'https://auth.openai.com/oauth/authorize?' +
+  new URLSearchParams({
+    response_type: 'code',
+    client_id: 'alternate-public-client-id',
+    redirect_uri: 'http://localhost:1455/auth/callback',
+    scope: 'openid profile',
+    code_challenge: 'challenge',
+    code_challenge_method: 'S256',
+    state: 's1',
+  }).toString();
+
 beforeEach(() => {
   openExternal.mockClear();
 });
@@ -26,7 +50,7 @@ describe('runOAuthLauncher', () => {
   it('opens the authorize URL and resolves on AUTHENTICATED status', async () => {
     const fetchMock = makeFetch([
       () =>
-        new Response(JSON.stringify({ authorize_url: 'https://x/authorize', state: 's1' }), {
+        new Response(JSON.stringify({ authorize_url: AUTHORIZE_URL, state: 's1' }), {
           status: 200,
           headers: { 'content-type': 'application/json' },
         }),
@@ -44,20 +68,46 @@ describe('runOAuthLauncher', () => {
 
     const result = await runOAuthLauncher({
       sfBaseUrl: 'http://127.0.0.1:1234',
-      backendName: 'claude',
+      backendName: 'browser-backend',
       pollIntervalMs: 1,
       timeoutMs: 5_000,
       fetchImpl: fetchMock as unknown as typeof fetch,
     });
 
-    expect(openExternal).toHaveBeenCalledWith('https://x/authorize');
+    expect(openExternal).toHaveBeenCalledWith(AUTHORIZE_URL);
+    expect(result.kind).toBe('complete');
+  });
+
+  it('opens another safe authorize URL for another backend slug', async () => {
+    const fetchMock = makeFetch([
+      () =>
+        new Response(JSON.stringify({ authorize_url: ALTERNATE_AUTHORIZE_URL, state: 's1' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      () =>
+        new Response(JSON.stringify({ state: 'authenticated' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    ]);
+
+    const result = await runOAuthLauncher({
+      sfBaseUrl: 'http://127.0.0.1:1234',
+      backendName: 'other-backend',
+      pollIntervalMs: 1,
+      timeoutMs: 5_000,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(openExternal).toHaveBeenCalledWith(ALTERNATE_AUTHORIZE_URL);
     expect(result.kind).toBe('complete');
   });
 
   it('returns timeout when status never reaches authenticated', async () => {
     const fetchMock = makeFetch([
       () =>
-        new Response(JSON.stringify({ authorize_url: 'https://x/authorize', state: 's1' }), {
+        new Response(JSON.stringify({ authorize_url: AUTHORIZE_URL, state: 's1' }), {
           status: 200,
           headers: { 'content-type': 'application/json' },
         }),
@@ -72,7 +122,7 @@ describe('runOAuthLauncher', () => {
 
     const result = await runOAuthLauncher({
       sfBaseUrl: 'http://127.0.0.1:1234',
-      backendName: 'claude',
+      backendName: 'browser-backend',
       pollIntervalMs: 1,
       timeoutMs: 10,
       fetchImpl: fetchMock as unknown as typeof fetch,
@@ -84,7 +134,7 @@ describe('runOAuthLauncher', () => {
   it('short-circuits to provider_error when status is error', async () => {
     const fetchMock = makeFetch([
       () =>
-        new Response(JSON.stringify({ authorize_url: 'https://x/authorize', state: 's1' }), {
+        new Response(JSON.stringify({ authorize_url: AUTHORIZE_URL, state: 's1' }), {
           status: 200,
           headers: { 'content-type': 'application/json' },
         }),
@@ -96,7 +146,7 @@ describe('runOAuthLauncher', () => {
     ]);
     const result = await runOAuthLauncher({
       sfBaseUrl: 'http://127.0.0.1:1234',
-      backendName: 'claude',
+      backendName: 'browser-backend',
       pollIntervalMs: 1,
       timeoutMs: 5_000,
       fetchImpl: fetchMock as unknown as typeof fetch,
@@ -110,7 +160,7 @@ describe('runOAuthLauncher', () => {
     const fetchMock = vi.fn(async (url: string) => {
       calls.push(url);
       if (calls.length === 1) {
-        return new Response(JSON.stringify({ authorize_url: 'https://x/authorize', state: 's1' }), {
+        return new Response(JSON.stringify({ authorize_url: AUTHORIZE_URL, state: 's1' }), {
           status: 200,
           headers: { 'content-type': 'application/json' },
         });
@@ -123,15 +173,15 @@ describe('runOAuthLauncher', () => {
 
     await runOAuthLauncher({
       sfBaseUrl: 'http://127.0.0.1:1234',
-      backendName: 'claude',
+      backendName: 'browser-backend',
       profileName: 'work',
       pollIntervalMs: 1,
       timeoutMs: 5_000,
       fetchImpl: fetchMock as unknown as typeof fetch,
     });
 
-    expect(calls[0]).toBe('http://127.0.0.1:1234/claude/auth/start?name=work');
-    expect(calls[1]).toBe('http://127.0.0.1:1234/claude/auth/status?name=work');
+    expect(calls[0]).toBe('http://127.0.0.1:1234/browser-backend/auth/start?name=work');
+    expect(calls[1]).toBe('http://127.0.0.1:1234/browser-backend/auth/status?name=work');
   });
 
   it('returns gateway_error when /auth/start returns 502', async () => {
@@ -144,11 +194,67 @@ describe('runOAuthLauncher', () => {
     ]);
     const result = await runOAuthLauncher({
       sfBaseUrl: 'http://127.0.0.1:1234',
-      backendName: 'claude',
+      backendName: 'browser-backend',
       pollIntervalMs: 1,
       timeoutMs: 5_000,
       fetchImpl: fetchMock as unknown as typeof fetch,
     });
+    expect(openExternal).not.toHaveBeenCalled();
+    expect(result.kind).toBe('failed');
+    if (result.kind === 'failed') expect(result.reason).toBe('gateway_error');
+  });
+
+  it('rejects invalid browser OAuth backend slugs before calling SF', async () => {
+    const fetchMock = vi.fn();
+
+    const result = await runOAuthLauncher({
+      sfBaseUrl: 'http://127.0.0.1:1234',
+      backendName: '../backend',
+      pollIntervalMs: 1,
+      timeoutMs: 5_000,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(openExternal).not.toHaveBeenCalled();
+    expect(result.kind).toBe('failed');
+    if (result.kind === 'failed') expect(result.reason).toBe('gateway_error');
+  });
+
+  it('rejects unexpected authorize URLs from SF', async () => {
+    const maliciousAuthorizeUrl =
+      'https://identity.example.test/oauth/authorize?' +
+      new URLSearchParams({
+        response_type: 'code',
+        client_id: 'public-client-id',
+        redirect_uri: 'http://localhost:9105/auth/callback',
+        scope: 'read write',
+        code_challenge: 'challenge',
+        code_challenge_method: 'S256',
+        state: 's1',
+      }).toString();
+    const fetchMock = makeFetch([
+      () =>
+        new Response(
+          JSON.stringify({
+            authorize_url: maliciousAuthorizeUrl,
+            state: 's1',
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          },
+        ),
+    ]);
+
+    const result = await runOAuthLauncher({
+      sfBaseUrl: 'http://127.0.0.1:1234',
+      backendName: 'browser-backend',
+      pollIntervalMs: 1,
+      timeoutMs: 5_000,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
     expect(openExternal).not.toHaveBeenCalled();
     expect(result.kind).toBe('failed');
     if (result.kind === 'failed') expect(result.reason).toBe('gateway_error');

--- a/apps/desktop/src/main/services/__tests__/oauth-launcher.test.ts
+++ b/apps/desktop/src/main/services/__tests__/oauth-launcher.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 const { openExternal } = vi.hoisted(() => ({ openExternal: vi.fn(async () => {}) }));
 vi.mock('electron', () => ({ shell: { openExternal } }));
 
-import { runOAuthLauncher } from '../oauth-launcher';
+import { clearPendingAuthState, getPendingAuthState, runOAuthLauncher } from '../oauth-launcher';
 
 const AUTHORIZE_URL =
   'https://claude.com/cai/oauth/authorize?' +
@@ -32,6 +32,10 @@ const ALTERNATE_AUTHORIZE_URL =
 
 beforeEach(() => {
   openExternal.mockClear();
+  clearPendingAuthState('browser-backend');
+  clearPendingAuthState('browser-backend', 'work');
+  clearPendingAuthState('browser-backend', 'personal');
+  clearPendingAuthState('other-backend');
 });
 afterEach(() => {
   vi.useRealTimers();
@@ -182,6 +186,41 @@ describe('runOAuthLauncher', () => {
 
     expect(calls[0]).toBe('http://127.0.0.1:1234/browser-backend/auth/start?name=work');
     expect(calls[1]).toBe('http://127.0.0.1:1234/browser-backend/auth/status?name=work');
+  });
+
+  it('keeps pending auth states scoped by backend and profile', async () => {
+    const workFetch = makeFetch([
+      () =>
+        new Response(JSON.stringify({ authorize_url: AUTHORIZE_URL, state: 'state-work' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    ]);
+    const personalFetch = makeFetch([
+      () =>
+        new Response(JSON.stringify({ authorize_url: AUTHORIZE_URL, state: 'state-personal' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    ]);
+
+    await runOAuthLauncher({
+      sfBaseUrl: 'http://127.0.0.1:1234',
+      backendName: 'browser-backend',
+      profileName: 'work',
+      timeoutMs: 0,
+      fetchImpl: workFetch as unknown as typeof fetch,
+    });
+    await runOAuthLauncher({
+      sfBaseUrl: 'http://127.0.0.1:1234',
+      backendName: 'browser-backend',
+      profileName: 'personal',
+      timeoutMs: 0,
+      fetchImpl: personalFetch as unknown as typeof fetch,
+    });
+
+    expect(getPendingAuthState('browser-backend', 'work')).toBe('state-work');
+    expect(getPendingAuthState('browser-backend', 'personal')).toBe('state-personal');
   });
 
   it('returns gateway_error when /auth/start returns 502', async () => {

--- a/apps/desktop/src/main/services/__tests__/runtime-config-migration.test.ts
+++ b/apps/desktop/src/main/services/__tests__/runtime-config-migration.test.ts
@@ -1,0 +1,122 @@
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+
+import { migrateDesktopRuntimeConfig } from '../runtime-config-migration';
+
+const USER_DATA = '/tmp/sf-user-data';
+
+describe('migrateDesktopRuntimeConfig', () => {
+  it('replaces active direct Codex backend with gateway-backed Codex', () => {
+    const migrated = migrateDesktopRuntimeConfig(
+      {
+        version: '0.1.0',
+        server: { host: '0.0.0.0', port: 8000, ssl: true },
+        plugins: ['tracing', 'codex-backend-api', 'gemini-backend-api'],
+        plugin_config: {
+          'codex-backend-api': {
+            default_model: 'o4-mini',
+            timeout_seconds: 120,
+          },
+          'gemini-backend-api': { default_model: 'gemini-2.5-pro' },
+        },
+      },
+      USER_DATA,
+    );
+
+    expect(migrated.plugins).toEqual([
+      'tracing',
+      'aigw-codex-backend',
+      'gemini-backend-api',
+      'aigw-runner',
+      'aigw-base',
+    ]);
+    expect(migrated.server).toEqual({ host: '127.0.0.1', port: 8000, ssl: true });
+    expect(migrated.plugin_config).toMatchObject({
+      'aigw-codex-backend': {
+        default_model: 'codex/gpt-5.4-mini',
+        timeout_seconds: 120,
+        gateway_url: 'http://127.0.0.1:9105',
+        auth_profile: 'default',
+      },
+      'gemini-backend-api': { default_model: 'gemini-2.5-pro' },
+    });
+    expect(
+      (migrated.plugin_config as Record<string, unknown>)['codex-backend-api'],
+    ).toBeUndefined();
+  });
+
+  it('preserves an existing gateway Codex config when both backend names are present', () => {
+    const migrated = migrateDesktopRuntimeConfig(
+      {
+        plugins: ['aigw-codex-backend', 'codex-backend-api'],
+        plugin_config: {
+          'aigw-codex-backend': {
+            default_model: 'codex/gpt-5.5',
+            auth_profile: 'work',
+          },
+          'codex-backend-api': {
+            default_model: 'o4-mini',
+            auth_profile: 'legacy',
+          },
+        },
+      },
+      USER_DATA,
+    );
+
+    expect(migrated.plugins).toEqual(['aigw-codex-backend', 'aigw-runner', 'aigw-base']);
+    expect(migrated.plugin_config).toMatchObject({
+      'aigw-codex-backend': {
+        default_model: 'codex/gpt-5.5',
+        auth_profile: 'work',
+      },
+    });
+    expect(
+      (migrated.plugin_config as Record<string, unknown>)['codex-backend-api'],
+    ).toBeUndefined();
+  });
+
+  it('does not inject Codex when direct Codex was not active', () => {
+    const migrated = migrateDesktopRuntimeConfig(
+      {
+        plugins: ['gemini-backend-api'],
+        plugin_config: {
+          'codex-backend-api': { default_model: 'o4-mini' },
+          'gemini-backend-api': { default_model: 'gemini-2.5-pro' },
+        },
+      },
+      USER_DATA,
+    );
+
+    expect(migrated.plugins).toEqual(['gemini-backend-api', 'aigw-runner', 'aigw-base']);
+    expect(
+      (migrated.plugin_config as Record<string, unknown>)['aigw-codex-backend'],
+    ).toBeUndefined();
+    expect(migrated.plugin_config).toMatchObject({
+      'codex-backend-api': { default_model: 'o4-mini' },
+    });
+  });
+
+  it('sets deterministic gateway runner defaults without lowering explicit timeout', () => {
+    const migrated = migrateDesktopRuntimeConfig(
+      {
+        plugins: [],
+        plugin_config: {
+          'aigw-runner': {
+            startup_timeout_seconds: 90,
+            auth_enabled: true,
+          },
+        },
+      },
+      USER_DATA,
+    );
+
+    expect(migrated.plugin_config).toMatchObject({
+      'aigw-runner': {
+        aigateway_dir: join(USER_DATA, 'aigateway'),
+        database_path: join(USER_DATA, 'aigateway', 'aigateway.db'),
+        auth_enabled: false,
+        startup_timeout_seconds: 90,
+      },
+    });
+  });
+});

--- a/apps/desktop/src/main/services/__tests__/session-manager.test.ts
+++ b/apps/desktop/src/main/services/__tests__/session-manager.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => '/tmp/sf-user-data'),
+    getAppPath: vi.fn(() => '/repo/apps/desktop'),
+  },
+  dialog: {},
+  BrowserWindow: {},
+}));
+
+vi.mock('@electron-toolkit/utils', () => ({ is: { dev: true } }));
+
+import { frontendPluginNameForSession } from '../session-manager';
+
+describe('session-manager frontend plugin mapping', () => {
+  it('uses provider-specific frontend plugins for session types', () => {
+    expect(frontendPluginNameForSession('claude')).toBe('claude-frontend');
+    expect(frontendPluginNameForSession('claude-desktop')).toBe('claude-frontend');
+    expect(frontendPluginNameForSession('codex')).toBe('codex-frontend');
+    expect(frontendPluginNameForSession('gemini')).toBe('gemini-frontend');
+  });
+});

--- a/apps/desktop/src/main/services/backend-status.ts
+++ b/apps/desktop/src/main/services/backend-status.ts
@@ -78,7 +78,7 @@ class BackendStatusService extends EventEmitter {
       // macOS: use osascript to open Terminal.app with the command
       execFile('osascript', [
         '-e',
-        `tell application "Terminal" to do script "${command}"`,
+        `tell application "Terminal" to do script "${escapeAppleScriptString(command)}"`,
         '-e',
         'tell application "Terminal" to activate',
       ]);
@@ -177,3 +177,11 @@ class BackendStatusService extends EventEmitter {
 }
 
 export const backendStatusService = new BackendStatusService();
+
+export function escapeAppleScriptString(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\r/g, '\\r')
+    .replace(/\n/g, '\\n');
+}

--- a/apps/desktop/src/main/services/config-service.ts
+++ b/apps/desktop/src/main/services/config-service.ts
@@ -1,8 +1,23 @@
-import { readFileSync, writeFileSync, copyFileSync, existsSync, watchFile, unwatchFile } from 'fs';
-import { join, resolve } from 'path';
+import {
+  closeSync,
+  readFileSync,
+  writeFileSync,
+  copyFileSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  renameSync,
+  rmSync,
+  watchFile,
+  unwatchFile,
+} from 'fs';
+import { basename, dirname, join, resolve } from 'path';
 import { EventEmitter } from 'events';
 import { app } from 'electron';
 import { is } from '@electron-toolkit/utils';
+
+import { migrateDesktopRuntimeConfig } from './runtime-config-migration';
 
 function resolveServerDir(): string {
   if (!is.dev) {
@@ -17,7 +32,9 @@ function resolveServerDir(): string {
 function resolveConfigPath(serverDir: string): string {
   if (!is.dev) {
     // Production: config lives in writable user data directory
-    const userDataConfig = join(app.getPath('userData'), 'sf.json');
+    const userDataDir = app.getPath('userData');
+    mkdirSync(userDataDir, { recursive: true });
+    const userDataConfig = join(userDataDir, 'sf.json');
     if (!existsSync(userDataConfig)) {
       const templatePath = join(serverDir, 'sf.json');
       if (existsSync(templatePath)) {
@@ -33,35 +50,51 @@ function resolveConfigPath(serverDir: string): string {
 let SERVER_DIR: string;
 let CONFIG_PATH: string;
 
-class ConfigService extends EventEmitter {
-  private configPath: string;
+export class ConfigService extends EventEmitter {
+  private configPath?: string;
+  private initialized = false;
 
   constructor() {
     super();
-    // Defer resolution until app is ready
+  }
+
+  private ensureInitialized(): void {
+    if (this.initialized) {
+      return;
+    }
     SERVER_DIR = resolveServerDir();
-    CONFIG_PATH = resolveConfigPath(SERVER_DIR);
-    this.configPath = CONFIG_PATH;
+    if (!this.configPath) {
+      CONFIG_PATH = resolveConfigPath(SERVER_DIR);
+      this.configPath = CONFIG_PATH;
+    }
+    this.initialized = true;
+    if (!is.dev) {
+      this.migrateDesktopRuntimeConfig();
+    }
   }
 
   get serverDir(): string {
+    this.ensureInitialized();
     return SERVER_DIR;
   }
 
   setConfigPath(path: string): void {
-    unwatchFile(this.configPath);
+    if (this.configPath) {
+      unwatchFile(this.configPath);
+    }
     this.configPath = path;
     this.watch();
   }
 
   read(): Record<string, unknown> {
+    const configPath = this.getConfigPath();
     try {
-      const raw = readFileSync(this.configPath, 'utf-8');
+      const raw = readFileSync(configPath, 'utf-8');
       return JSON.parse(raw);
     } catch {
       return {
         version: '0.1.0',
-        server: { host: '0.0.0.0', port: 8000, reload: false, ssl: true },
+        server: { host: '127.0.0.1', port: 8000, reload: false, ssl: true },
         plugins: [],
         plugin_config: {},
       };
@@ -69,19 +102,57 @@ class ConfigService extends EventEmitter {
   }
 
   write(config: Record<string, unknown>): void {
-    writeFileSync(this.configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+    const configPath = this.getConfigPath();
+    writeJsonAtomically(configPath, JSON.stringify(config, null, 2) + '\n');
     this.emit('changed', config);
   }
 
   watch(): void {
-    watchFile(this.configPath, { interval: 1000 }, () => {
+    const configPath = this.getConfigPath();
+    watchFile(configPath, { interval: 1000, persistent: false }, () => {
       const config = this.read();
       this.emit('changed', config);
     });
   }
 
   getConfigPath(): string {
+    this.ensureInitialized();
+    if (!this.configPath) {
+      throw new Error('Config path is not initialized');
+    }
     return this.configPath;
+  }
+
+  private migrateDesktopRuntimeConfig(): void {
+    const config = this.read();
+    const migrated = migrateDesktopRuntimeConfig(config, app.getPath('userData'));
+
+    if (JSON.stringify(migrated) !== JSON.stringify(config)) {
+      this.write(migrated);
+    }
+  }
+}
+
+function writeJsonAtomically(configPath: string, contents: string): void {
+  mkdirSync(dirname(configPath), { recursive: true });
+  const tempPath = join(
+    dirname(configPath),
+    `.${basename(configPath)}.${process.pid}.${Date.now()}.tmp`,
+  );
+  let fd: number | undefined;
+  try {
+    fd = openSync(tempPath, 'w', 0o600);
+    writeFileSync(fd, contents, 'utf-8');
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = undefined;
+    renameSync(tempPath, configPath);
+  } catch (error) {
+    if (fd !== undefined) {
+      closeSync(fd);
+    }
+    rmSync(tempPath, { force: true });
+    throw error;
   }
 }
 

--- a/apps/desktop/src/main/services/external-url-policy.ts
+++ b/apps/desktop/src/main/services/external-url-policy.ts
@@ -1,0 +1,160 @@
+const BACKEND_NAME_RE = /^[a-z0-9-]+$/;
+
+const OAUTH_AUTHORIZE_POLICIES = new Map<
+  string,
+  { authorizePath: string; redirectPath: string; ports: Set<string> }
+>([
+  [
+    'auth.openai.com',
+    {
+      authorizePath: '/oauth/authorize',
+      redirectPath: '/auth/callback',
+      ports: new Set(['1455', '1457']),
+    },
+  ],
+  [
+    'chatgpt.com',
+    {
+      authorizePath: '/oauth/authorize',
+      redirectPath: '/auth/callback',
+      ports: new Set(['1455', '1457']),
+    },
+  ],
+  [
+    'claude.com',
+    { authorizePath: '/cai/oauth/authorize', redirectPath: '/callback', ports: new Set(['9105']) },
+  ],
+  [
+    'claude.ai',
+    { authorizePath: '/oauth/authorize', redirectPath: '/callback', ports: new Set(['9105']) },
+  ],
+]);
+
+type LocalServerInfo = {
+  scheme: string;
+  host: string;
+  port: number;
+};
+
+export function isSafeBackendName(backendName: string): boolean {
+  return BACKEND_NAME_RE.test(backendName);
+}
+
+export function isAllowedOAuthAuthorizeUrl(urlString: string): boolean {
+  const url = parseHttpsUrl(urlString);
+  if (!url) return false;
+  const policy = OAUTH_AUTHORIZE_POLICIES.get(url.hostname);
+  if (!policy) return false;
+  if (url.pathname !== policy.authorizePath) return false;
+
+  const params = url.searchParams;
+  if (!hasSingleParam(params, 'response_type', 'code')) return false;
+  if (!hasSingleParam(params, 'client_id')) return false;
+  if (!hasSingleParam(params, 'redirect_uri')) return false;
+  if (!hasSingleParam(params, 'scope')) return false;
+  if (!hasSingleParam(params, 'state')) return false;
+  if (!hasSingleParam(params, 'code_challenge')) return false;
+  if (!hasSingleParam(params, 'code_challenge_method', 'S256')) return false;
+
+  const redirectUri = params.get('redirect_uri');
+  if (!redirectUri || !isLoopbackRedirectUri(redirectUri, policy)) {
+    return false;
+  }
+
+  return true;
+}
+
+export function isAllowedExternalBrowserUrl(urlString: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(urlString);
+  } catch {
+    return false;
+  }
+
+  return url.protocol === 'https:' && url.username === '' && url.password === '';
+}
+
+export function isAllowedServerFetchUrl(
+  urlString: string,
+  serverInfo: LocalServerInfo | null,
+): boolean {
+  if (!serverInfo) return false;
+
+  let url: URL;
+  try {
+    url = new URL(urlString);
+  } catch {
+    return false;
+  }
+
+  const expectedProtocol = `${serverInfo.scheme}:`;
+  if (url.protocol !== expectedProtocol) return false;
+  if (url.username || url.password) return false;
+  if (!isLoopbackHostname(url.hostname)) return false;
+  if (!isLoopbackOrWildcardHostname(serverInfo.host)) return false;
+  return url.port === String(serverInfo.port);
+}
+
+export function isAllowedPopupUrl(urlString: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(urlString);
+  } catch {
+    return false;
+  }
+
+  return (
+    url.protocol === 'http:' &&
+    isLoopbackHostname(url.hostname) &&
+    url.port === '6006' &&
+    url.username === '' &&
+    url.password === ''
+  );
+}
+
+function parseHttpsUrl(urlString: string): URL | null {
+  try {
+    const url = new URL(urlString);
+    if (url.protocol !== 'https:') return null;
+    if (url.username || url.password || url.port) return null;
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+function hasSingleParam(params: URLSearchParams, name: string, expectedValue?: string): boolean {
+  const values = params.getAll(name);
+  if (values.length !== 1 || values[0] === '') return false;
+  return expectedValue === undefined || values[0] === expectedValue;
+}
+
+function isLoopbackRedirectUri(
+  redirectUri: string,
+  policy: { redirectPath: string; ports: Set<string> },
+): boolean {
+  try {
+    const url = new URL(redirectUri);
+    return (
+      url.protocol === 'http:' &&
+      url.hostname === 'localhost' &&
+      policy.ports.has(url.port) &&
+      url.pathname === policy.redirectPath &&
+      url.search === '' &&
+      url.hash === '' &&
+      url.username === '' &&
+      url.password === ''
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
+}
+
+function isLoopbackOrWildcardHostname(hostname: string): boolean {
+  return isLoopbackHostname(hostname) || hostname === '0.0.0.0';
+}

--- a/apps/desktop/src/main/services/oauth-launcher.ts
+++ b/apps/desktop/src/main/services/oauth-launcher.ts
@@ -9,6 +9,7 @@
  */
 
 import { shell } from 'electron';
+import { isAllowedOAuthAuthorizeUrl, isSafeBackendName } from './external-url-policy';
 
 /**
  * In-memory cache of the most-recent OAuth `state` value per backend.
@@ -55,6 +56,14 @@ export interface LauncherOptions {
 }
 
 export async function runOAuthLauncher(opts: LauncherOptions): Promise<LauncherResult> {
+  if (!isSafeBackendName(opts.backendName)) {
+    return {
+      kind: 'failed',
+      reason: 'gateway_error',
+      message: `invalid browser OAuth backend: ${opts.backendName}`,
+    };
+  }
+
   const fetchImpl = opts.fetchImpl ?? fetch;
   const pollIntervalMs = opts.pollIntervalMs ?? 2000;
   const timeoutMs = opts.timeoutMs ?? 10 * 60 * 1000;
@@ -85,11 +94,18 @@ export async function runOAuthLauncher(opts: LauncherOptions): Promise<LauncherR
       message: `start returned ${startResp.status}: ${body.slice(0, 200)}`,
     };
   }
-  const startBody = (await startResp.json()) as { authorize_url: string; state?: string };
+  const startBody = (await startResp.json()) as { authorize_url?: string; state?: string };
+  if (!startBody.authorize_url || !isAllowedOAuthAuthorizeUrl(startBody.authorize_url)) {
+    return {
+      kind: 'failed',
+      reason: 'gateway_error',
+      message: 'blocked unexpected OAuth authorize URL',
+    };
+  }
   if (startBody.state) {
     pendingStateByBackend.set(opts.backendName, startBody.state);
   }
-  console.log(`[oauth-launcher] opening browser: ${startBody.authorize_url}`);
+  console.log(`[oauth-launcher] opening browser for ${opts.backendName}`);
   await shell.openExternal(startBody.authorize_url);
 
   const deadline = Date.now() + timeoutMs;

--- a/apps/desktop/src/main/services/oauth-launcher.ts
+++ b/apps/desktop/src/main/services/oauth-launcher.ts
@@ -12,7 +12,7 @@ import { shell } from 'electron';
 import { isAllowedOAuthAuthorizeUrl, isSafeBackendName } from './external-url-policy';
 
 /**
- * In-memory cache of the most-recent OAuth `state` value per backend.
+ * In-memory cache of OAuth `state` values per backend/profile.
  *
  * Populated when a launcher run successfully gets an `authorize_url` from
  * `/auth/start`. Read by the manual paste-code IPC path so the renderer
@@ -22,14 +22,18 @@ import { isAllowedOAuthAuthorizeUrl, isSafeBackendName } from './external-url-po
  * timeout) so the user can still paste the code after the long poll gives
  * up. It is cleared on successful exchange.
  */
-const pendingStateByBackend = new Map<string, string>();
+const pendingStateByBackendProfile = new Map<string, string>();
 
-export function getPendingAuthState(backendName: string): string | null {
-  return pendingStateByBackend.get(backendName) ?? null;
+function pendingAuthKey(backendName: string, profileName?: string): string {
+  return `${backendName}\0${profileName ?? ''}`;
 }
 
-export function clearPendingAuthState(backendName: string): void {
-  pendingStateByBackend.delete(backendName);
+export function getPendingAuthState(backendName: string, profileName?: string): string | null {
+  return pendingStateByBackendProfile.get(pendingAuthKey(backendName, profileName)) ?? null;
+}
+
+export function clearPendingAuthState(backendName: string, profileName?: string): void {
+  pendingStateByBackendProfile.delete(pendingAuthKey(backendName, profileName));
 }
 
 export type LauncherResult =
@@ -103,7 +107,10 @@ export async function runOAuthLauncher(opts: LauncherOptions): Promise<LauncherR
     };
   }
   if (startBody.state) {
-    pendingStateByBackend.set(opts.backendName, startBody.state);
+    pendingStateByBackendProfile.set(
+      pendingAuthKey(opts.backendName, opts.profileName),
+      startBody.state,
+    );
   }
   console.log(`[oauth-launcher] opening browser for ${opts.backendName}`);
   await shell.openExternal(startBody.authorize_url);
@@ -135,7 +142,7 @@ export async function runOAuthLauncher(opts: LauncherOptions): Promise<LauncherR
     }
     const body = (await statusResp.json()) as { state: string; error?: string };
     if (body.state === 'authenticated') {
-      pendingStateByBackend.delete(opts.backendName);
+      clearPendingAuthState(opts.backendName, opts.profileName);
       return { kind: 'complete' };
     }
     if (body.state === 'error') {

--- a/apps/desktop/src/main/services/runtime-config-migration.ts
+++ b/apps/desktop/src/main/services/runtime-config-migration.ts
@@ -1,0 +1,93 @@
+import { join } from 'path';
+
+const DIRECT_CODEX_BACKEND = 'codex-backend-api';
+const GATEWAY_CODEX_BACKEND = 'aigw-codex-backend';
+const DEFAULT_CODEX_MODEL = 'codex/gpt-5.4-mini';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function migratePluginList(plugins: string[]): string[] {
+  const nextPlugins: string[] = [];
+
+  for (const plugin of plugins) {
+    if (plugin === DIRECT_CODEX_BACKEND) {
+      if (!nextPlugins.includes(GATEWAY_CODEX_BACKEND)) {
+        nextPlugins.push(GATEWAY_CODEX_BACKEND);
+      }
+      continue;
+    }
+    if (plugin === GATEWAY_CODEX_BACKEND && nextPlugins.includes(GATEWAY_CODEX_BACKEND)) {
+      continue;
+    }
+    nextPlugins.push(plugin);
+  }
+
+  for (const required of ['aigw-runner', 'aigw-base']) {
+    if (!nextPlugins.includes(required)) nextPlugins.push(required);
+  }
+
+  return nextPlugins;
+}
+
+function migrateCodexBackendConfig(value: unknown): Record<string, unknown> {
+  const migrated = isRecord(value) ? { ...value } : {};
+  const model = migrated.default_model;
+  if (typeof model !== 'string' || !model.startsWith('codex/')) {
+    migrated.default_model = DEFAULT_CODEX_MODEL;
+  }
+  if (typeof migrated.gateway_url !== 'string') {
+    migrated.gateway_url = 'http://127.0.0.1:9105';
+  }
+  if (typeof migrated.auth_profile !== 'string') {
+    migrated.auth_profile = 'default';
+  }
+  return migrated;
+}
+
+export function migrateDesktopRuntimeConfig(
+  config: Record<string, unknown>,
+  userDataDir: string,
+): Record<string, unknown> {
+  const plugins = Array.isArray(config.plugins)
+    ? config.plugins.filter((plugin): plugin is string => typeof plugin === 'string')
+    : [];
+  const hadDirectCodexBackend = plugins.includes(DIRECT_CODEX_BACKEND);
+  const nextPlugins = migratePluginList(plugins);
+
+  const serverConfig = isRecord(config.server) ? { ...config.server } : {};
+  serverConfig.host = '127.0.0.1';
+
+  const pluginConfig = isRecord(config.plugin_config) ? { ...config.plugin_config } : {};
+  const gatewayDir = join(userDataDir, 'aigateway');
+  const runnerConfig = isRecord(pluginConfig['aigw-runner']) ? pluginConfig['aigw-runner'] : {};
+  const startupTimeout = runnerConfig.startup_timeout_seconds;
+  pluginConfig['aigw-runner'] = {
+    ...runnerConfig,
+    aigateway_dir: gatewayDir,
+    database_path: join(gatewayDir, 'aigateway.db'),
+    auth_enabled: false,
+    startup_timeout_seconds:
+      typeof startupTimeout === 'number' && startupTimeout >= 60 ? startupTimeout : 60,
+  };
+
+  if (
+    hadDirectCodexBackend &&
+    Object.prototype.hasOwnProperty.call(pluginConfig, DIRECT_CODEX_BACKEND)
+  ) {
+    if (!isRecord(pluginConfig[GATEWAY_CODEX_BACKEND])) {
+      pluginConfig[GATEWAY_CODEX_BACKEND] = migrateCodexBackendConfig(
+        pluginConfig[DIRECT_CODEX_BACKEND],
+      );
+    }
+    delete pluginConfig[DIRECT_CODEX_BACKEND];
+  }
+
+  return {
+    ...config,
+    server: serverConfig,
+    plugins: nextPlugins,
+    plugin_config: pluginConfig,
+  };
+}

--- a/apps/desktop/src/main/services/server-process.ts
+++ b/apps/desktop/src/main/services/server-process.ts
@@ -7,6 +7,7 @@ import http from 'http';
 import { app } from 'electron';
 import { is } from '@electron-toolkit/utils';
 import { configService } from './config-service';
+import { resolveUv } from './uv-resolver';
 
 const execFileAsync = promisify(execFileCb);
 
@@ -53,6 +54,29 @@ class ServerProcess extends EventEmitter {
     return this.serverDir;
   }
 
+  private get gatewayProjectDir(): string {
+    if (!is.dev) {
+      return join(app.getPath('userData'), 'aigateway');
+    }
+    return join(this.serverDir, '..', 'aigateway');
+  }
+
+  private get gatewayDatabasePath(): string {
+    return join(app.getPath('userData'), 'aigateway', 'aigateway.db');
+  }
+
+  private serverEnv(): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = (({ VIRTUAL_ENV: _drop, ...inherited }) => inherited)(
+      process.env,
+    );
+    env.SF_AIGW_RUNNER__AIGATEWAY_DIR = this.gatewayProjectDir;
+    env.SF_AIGW_RUNNER__DATABASE_PATH = this.gatewayDatabasePath;
+    env.SF_AIGW_RUNNER__AUTH_ENABLED = 'false';
+    const uvBin = resolveUv();
+    if (uvBin) env.SF_AIGW_RUNNER__UV_BIN = uvBin;
+    return env;
+  }
+
   private setStatus(s: ServerStatus): void {
     this.status = s;
     this.emit('status', s);
@@ -89,7 +113,7 @@ class ServerProcess extends EventEmitter {
     try {
       const { stdout } = await execFileAsync('osascript', [
         '-e',
-        'display dialog "ScreamingFace needs administrator privileges for the claude-intercept plugin." default answer "" with hidden answer with title "ScreamingFace" buttons {"Cancel", "OK"} default button "OK"',
+        'display dialog "ScreamingFace needs administrator privileges for an enabled plugin." default answer "" with hidden answer with title "ScreamingFace" buttons {"Cancel", "OK"} default button "OK"',
         '-e',
         'text returned of result',
       ]);
@@ -108,7 +132,8 @@ class ServerProcess extends EventEmitter {
 
     const config = configService.read();
     const configJson = JSON.stringify(config);
-    const args = ['run', '--subprocess', '--config-json', configJson];
+    const args = ['run', '--subprocess', '--config-json', configJson, '--host', '127.0.0.1'];
+    const env = this.serverEnv();
 
     // If a plugin requires root and we're not already root, elevate via sudo
     const elevate = this.needsRoot() && process.getuid?.() !== 0;
@@ -125,7 +150,7 @@ class ServerProcess extends EventEmitter {
       // Use sudo -S to read password from stdin; stdout/stderr stream normally
       child = spawn('sudo', ['-S', this.sfBin, ...args], {
         cwd: this.serverCwd,
-        env: { ...process.env },
+        env,
         stdio: ['pipe', 'pipe', 'pipe'],
       });
 
@@ -134,7 +159,7 @@ class ServerProcess extends EventEmitter {
     } else {
       child = spawn(this.sfBin, args, {
         cwd: this.serverCwd,
-        env: { ...process.env },
+        env,
         stdio: ['ignore', 'pipe', 'pipe'],
       });
     }

--- a/apps/desktop/src/main/services/session-manager.ts
+++ b/apps/desktop/src/main/services/session-manager.ts
@@ -47,6 +47,20 @@ const PORT_RANGE_START = 9101;
 const PORT_RANGE_SIZE = 100;
 const PROXY_READY_TIMEOUT_MS = 15_000;
 
+export function frontendPluginNameForSession(type: SessionType): string {
+  switch (type) {
+    case 'codex':
+      return 'codex-frontend';
+    case 'gemini':
+      return 'gemini-frontend';
+    case 'claude':
+    case 'claude-desktop':
+      return 'claude-frontend';
+    default:
+      return 'claude-frontend';
+  }
+}
+
 class SessionManager extends EventEmitter {
   private sessions: Map<string, ActiveSession> = new Map();
 
@@ -182,10 +196,11 @@ class SessionManager extends EventEmitter {
     pluginConfig?: Record<string, Record<string, unknown>>,
   ): Promise<void> {
     // SF server needs its own port (internal only), separate from the
-    // claude-frontend proxy port that the CLI connects to.
+    // frontend proxy port that the CLI connects to.
     const serverPort = await this.allocateRandomPort();
     const config = configService.read();
     const defaults = (config.plugin_config as Record<string, Record<string, unknown>>) || {};
+    const frontendPlugin = frontendPluginNameForSession(session.type);
 
     const proxyConfig = {
       version: config.version || '0.1.0',
@@ -195,20 +210,16 @@ class SessionManager extends EventEmitter {
         reload: false,
         ssl: false,
       },
-      plugins: [
-        'tracing',
-        'claude-frontend',
-        'url4-specs',
-      ],
+      plugins: ['tracing', frontendPlugin, 'url4-specs'],
       plugin_config: {
-        'tracing': {
+        tracing: {
           ...(defaults['tracing'] || {}),
           phoenix_launch: false, // connect to shared Phoenix, don't spawn per-session
         },
-        'claude-frontend': {
-          ...(defaults['claude-frontend'] || {}),
+        [frontendPlugin]: {
+          ...(defaults[frontendPlugin] || {}),
           // User overrides from dialog:
-          ...(pluginConfig?.['claude-frontend'] || {}),
+          ...(pluginConfig?.[frontendPlugin] || {}),
           // Forced by session-manager (cannot be overridden):
           listen_host: '127.0.0.1',
           listen_port: session.port,
@@ -220,8 +231,9 @@ class SessionManager extends EventEmitter {
           // configured port was busy (e.g. another local dev process held
           // it), and a stale backend_url makes /data 404 when the proxy
           // tries to store $prompt blobs.
-          backend_url: backendStatusService.getServerUrl()
-            ?? `${(config.server as Record<string, unknown>).ssl ? 'https' : 'http'}://127.0.0.1:${(config.server as Record<string, unknown>).port || 8000}`,
+          backend_url:
+            backendStatusService.getServerUrl() ??
+            `${(config.server as Record<string, unknown>).ssl ? 'https' : 'http'}://127.0.0.1:${(config.server as Record<string, unknown>).port || 8000}`,
         },
         'url4-specs': defaults['url4-specs'] || {},
       },
@@ -230,8 +242,10 @@ class SessionManager extends EventEmitter {
     const args = [
       'run',
       '--subprocess',
-      '--session-id', session.id,
-      '--config-json', JSON.stringify(proxyConfig),
+      '--session-id',
+      session.id,
+      '--config-json',
+      JSON.stringify(proxyConfig),
     ];
 
     return new Promise<void>((resolve, reject) => {
@@ -291,11 +305,16 @@ class SessionManager extends EventEmitter {
 
   private cliCommand(type: SessionType): string {
     switch (type) {
-      case 'claude': return 'claude';
-      case 'codex': return 'codex';
-      case 'gemini': return 'gemini';
-      case 'claude-desktop': return 'claude';
-      default: return 'claude';
+      case 'claude':
+        return 'claude';
+      case 'codex':
+        return 'codex';
+      case 'gemini':
+        return 'gemini';
+      case 'claude-desktop':
+        return 'claude';
+      default:
+        return 'claude';
     }
   }
 
@@ -383,14 +402,28 @@ end tell`;
         const pid = parseInt(readFileSync(pidPath, 'utf-8').trim(), 10);
         if (!isNaN(pid)) {
           this.emit('log', session.id, `Killing CLI process (PID ${pid})`);
-          try { process.kill(pid, 'SIGTERM'); } catch { /* already dead */ }
+          try {
+            process.kill(pid, 'SIGTERM');
+          } catch {
+            /* already dead */
+          }
 
           // Wait then force-kill
           await new Promise((r) => setTimeout(r, 2000));
-          try { process.kill(pid, 'SIGKILL'); } catch { /* already dead */ }
+          try {
+            process.kill(pid, 'SIGKILL');
+          } catch {
+            /* already dead */
+          }
         }
-      } catch { /* read/parse failed */ }
-      try { unlinkSync(pidPath); } catch { /* */ }
+      } catch {
+        /* read/parse failed */
+      }
+      try {
+        unlinkSync(pidPath);
+      } catch {
+        /* */
+      }
     } else {
       this.emit('log', session.id, 'No PID file found — CLI may need manual close');
     }
@@ -418,7 +451,11 @@ end tell`;
 
     // 3. Clean up temp script
     if (session.scriptPath) {
-      try { unlinkSync(session.scriptPath); } catch { /* */ }
+      try {
+        unlinkSync(session.scriptPath);
+      } catch {
+        /* */
+      }
       session.scriptPath = null;
     }
   }
@@ -438,7 +475,11 @@ end tell`;
       session.proxy.kill('SIGTERM');
       await new Promise<void>((resolve) => {
         const timer = setTimeout(() => {
-          try { session.proxy?.kill('SIGKILL'); } catch { /* */ }
+          try {
+            session.proxy?.kill('SIGKILL');
+          } catch {
+            /* */
+          }
           resolve();
         }, 5000);
         session.proxy!.once('close', () => {

--- a/apps/desktop/src/main/services/venv-manager.ts
+++ b/apps/desktop/src/main/services/venv-manager.ts
@@ -1,5 +1,13 @@
 import { spawn, execFile, execFileSync } from 'child_process';
-import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import {
+  copyFileSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
 import { join } from 'path';
 import { EventEmitter } from 'events';
 import { app } from 'electron';
@@ -19,6 +27,7 @@ export type VenvStatus = 'unknown' | 'checking' | 'missing' | 'creating' | 'read
 class VenvManager extends EventEmitter {
   private status: VenvStatus = 'unknown';
   private uvBin: string | null = null;
+  private syncing = false;
 
   private get serverDir(): string {
     return configService.serverDir;
@@ -38,6 +47,24 @@ class VenvManager extends EventEmitter {
 
   private get pythonBin(): string {
     return join(this.venvDir, 'bin', 'python');
+  }
+
+  private get bundledPythonBin(): string | null {
+    if (is.dev) return null;
+    const bundledPython = join(process.resourcesPath, 'server', 'python', 'bin', 'python3.12');
+    return existsSync(bundledPython) ? bundledPython : null;
+  }
+
+  private get gatewayProjectDir(): string {
+    return join(app.getPath('userData'), 'aigateway');
+  }
+
+  private get gatewayVenvDir(): string {
+    return join(this.gatewayProjectDir, '.venv');
+  }
+
+  private get gatewayPythonBin(): string {
+    return join(this.gatewayVenvDir, 'bin', 'python');
   }
 
   private setStatus(s: VenvStatus): void {
@@ -73,7 +100,7 @@ class VenvManager extends EventEmitter {
         const pyVer = execFileSync(this.pythonBin, ['--version'], { encoding: 'utf-8' });
         log(`[venv] python --version: ${pyVer.trim()}`);
         this.setStatus('ready');
-        const needsSync = this.needsResync();
+        const needsSync = this.needsResync() || (!is.dev && !existsSync(this.gatewayPythonBin));
         log(`[venv] needsResync=${needsSync}`);
         return { status: 'ready', uvFound: true, needsSync, autoBootstrap: false };
       } catch {
@@ -99,8 +126,8 @@ class VenvManager extends EventEmitter {
 
     // Use bundled Python interpreter in production
     if (!is.dev) {
-      const bundledPython = join(process.resourcesPath, 'server', 'python', 'bin', 'python3.12');
-      if (existsSync(bundledPython)) {
+      const bundledPython = this.bundledPythonBin;
+      if (bundledPython) {
         args.push('--python', bundledPython);
       }
     }
@@ -114,55 +141,74 @@ class VenvManager extends EventEmitter {
 
   async sync(extra?: string): Promise<boolean> {
     log(`[venv] sync() called, extra=${extra}`);
+    if (this.syncing) {
+      log(`[venv] sync already in progress`);
+      return false;
+    }
     if (!this.uvBin) {
       this.setStatus('error');
       return false;
     }
 
-    let extraEnv: Record<string, string> | undefined;
+    this.syncing = true;
+    try {
+      let extraEnv: Record<string, string> | undefined;
 
-    // In production, copy pyproject.toml + uv.lock to the writable projectDir
-    // so uv sync can run from there (the bundle is read-only)
-    if (!is.dev) {
-      log(`[venv] sync: copying project files...`);
-      this.copyProjectFiles();
+      // In production, copy pyproject.toml + uv.lock to the writable projectDir
+      // so uv sync can run from there (the bundle is read-only)
+      if (!is.dev) {
+        log(`[venv] sync: copying project files...`);
+        this.copyProjectFiles();
 
-      // Extract bundled wheel cache (async) and set up offline env vars
-      const cacheDir = join(app.getPath('userData'), 'uv-cache');
-      log(`[venv] sync: extracting cache to ${cacheDir}`);
-      try {
-        await this.extractCacheIfNeeded(cacheDir);
-        log(`[venv] sync: cache extraction done`);
-      } catch (err) {
-        log(`[venv] sync: cache extraction failed: ${err}`);
-        // Non-fatal: uv will fall back to downloading
+        // Extract bundled wheel cache (async) and set up offline env vars
+        const cacheDir = join(app.getPath('userData'), 'uv-cache');
+        log(`[venv] sync: extracting cache to ${cacheDir}`);
+        try {
+          await this.extractCacheIfNeeded(cacheDir);
+          log(`[venv] sync: cache extraction done`);
+        } catch (err) {
+          log(`[venv] sync: cache extraction failed: ${err}`);
+          // Non-fatal: uv will fall back to downloading
+        }
+        extraEnv = { UV_CACHE_DIR: cacheDir, UV_OFFLINE: '1' };
       }
-      extraEnv = { UV_CACHE_DIR: cacheDir, UV_OFFLINE: '1' };
+
+      const args = [this.uvBin, 'sync'];
+      if (!is.dev) {
+        const bundledPython = this.bundledPythonBin;
+        if (bundledPython) args.push('--python', bundledPython);
+        args.push('--no-install-project');
+      }
+      if (extra) args.push('--extra', extra);
+
+      log(`[venv] sync: spawning ${args.join(' ')}`);
+      // In production, suppress ready until the project install completes
+      const ok = await this.runUvCommand(args, extraEnv, { suppressReady: !is.dev });
+      log(`[venv] sync() result=${ok}`);
+
+      // Install the project package (sf entry point) from the bundled source.
+      // Don't pass extraEnv here — UV_OFFLINE blocks hatchling download needed for build.
+      // This runUvCommand WILL emit ready (no suppressReady) — the final signal.
+      if (ok && !is.dev) {
+        const serverSrc = join(process.resourcesPath, 'server');
+        const installArgs = [this.uvBin, 'pip', 'install', '--no-deps', serverSrc];
+        log(`[venv] installing project from ${serverSrc}`);
+        const installOk = await this.runUvCommand(installArgs, undefined, { suppressReady: true });
+        log(`[venv] project install result=${installOk}`);
+        if (!installOk) return false;
+
+        const gatewayOk = await this.syncGatewayProject(extraEnv);
+        log(`[venv] gateway project sync result=${gatewayOk}`);
+        if (!gatewayOk) return false;
+
+        this.writeVersionStamp();
+        this.setStatus('ready');
+      }
+
+      return ok;
+    } finally {
+      this.syncing = false;
     }
-
-    const args = [this.uvBin, 'sync'];
-    if (!is.dev) args.push('--no-install-project');
-    if (extra) args.push('--extra', extra);
-
-    log(`[venv] sync: spawning ${args.join(' ')}`);
-    // In production, suppress ready until the project install completes
-    const ok = await this.runUvCommand(args, extraEnv, { suppressReady: !is.dev });
-    log(`[venv] sync() result=${ok}`);
-
-    // Install the project package (sf entry point) from the bundled source.
-    // Don't pass extraEnv here — UV_OFFLINE blocks hatchling download needed for build.
-    // This runUvCommand WILL emit ready (no suppressReady) — the final signal.
-    if (ok && !is.dev) {
-      const serverSrc = join(process.resourcesPath, 'server');
-      const installArgs = [this.uvBin, 'pip', 'install', '--no-deps', serverSrc];
-      log(`[venv] installing project from ${serverSrc}`);
-      const installOk = await this.runUvCommand(installArgs);
-      log(`[venv] project install result=${installOk}`);
-      if (!installOk) return false;
-      this.writeVersionStamp();
-    }
-
-    return ok;
   }
 
   async listPackages(): Promise<Array<{ name: string; version: string }>> {
@@ -212,18 +258,18 @@ class VenvManager extends EventEmitter {
   private runUvCommand(
     args: string[],
     extraEnv?: Record<string, string>,
-    opts?: { suppressReady?: boolean },
+    opts?: { suppressReady?: boolean; cwd?: string; venvDir?: string },
   ): Promise<boolean> {
     return new Promise((resolve) => {
       const [cmd, ...rest] = args;
       const env: Record<string, string | undefined> = {
         ...process.env,
-        VIRTUAL_ENV: this.venvDir,
+        VIRTUAL_ENV: opts?.venvDir ?? this.venvDir,
         ...extraEnv,
       };
 
       const child = spawn(cmd, rest, {
-        cwd: this.projectDir,
+        cwd: opts?.cwd ?? this.projectDir,
         env,
       });
 
@@ -240,12 +286,14 @@ class VenvManager extends EventEmitter {
           if (!opts?.suppressReady) this.setStatus('ready');
           resolve(true);
         } else {
+          log(`[venv] command failed (${code}): ${cmd} ${rest.join(' ')}`);
           this.setStatus('error');
           resolve(false);
         }
       });
 
-      child.on('error', () => {
+      child.on('error', (err) => {
+        log(`[venv] command error: ${err.message}`);
         this.setStatus('error');
         resolve(false);
       });
@@ -264,18 +312,65 @@ class VenvManager extends EventEmitter {
     }
   }
 
+  private async syncGatewayProject(extraEnv?: Record<string, string>): Promise<boolean> {
+    if (!this.uvBin) return false;
+    this.copyGatewayProjectFiles();
+
+    const syncArgs = [this.uvBin, 'sync'];
+    const bundledPython = this.bundledPythonBin;
+    if (bundledPython) syncArgs.push('--python', bundledPython);
+    syncArgs.push('--no-install-project');
+
+    const syncOk = await this.runUvCommand(syncArgs, extraEnv, {
+      suppressReady: true,
+      cwd: this.gatewayProjectDir,
+      venvDir: this.gatewayVenvDir,
+    });
+    if (!syncOk) return false;
+
+    return this.runUvCommand(
+      [this.uvBin, 'pip', 'install', '--no-deps', this.gatewayProjectDir],
+      undefined,
+      {
+        suppressReady: true,
+        cwd: this.gatewayProjectDir,
+        venvDir: this.gatewayVenvDir,
+      },
+    );
+  }
+
+  private copyGatewayProjectFiles(): void {
+    mkdirSync(this.gatewayProjectDir, { recursive: true });
+    const srcRoot = join(process.resourcesPath, 'aigateway');
+    for (const file of ['pyproject.toml', 'uv.lock']) {
+      const src = join(srcRoot, file);
+      const dst = join(this.gatewayProjectDir, file);
+      if (existsSync(src)) copyFileSync(src, dst);
+    }
+    const src = join(srcRoot, 'src');
+    const dst = join(this.gatewayProjectDir, 'src');
+    if (existsSync(src)) cpSync(src, dst, { recursive: true, force: true });
+  }
+
   private extractCacheIfNeeded(cacheDir: string): Promise<void> {
-    if (existsSync(cacheDir)) return Promise.resolve();
+    const completeSentinel = join(cacheDir, '.cache-complete');
+    if (existsSync(completeSentinel)) return Promise.resolve();
     const tarball = join(process.resourcesPath, 'server', 'cache.tar.gz');
     if (!existsSync(tarball)) return Promise.resolve();
+    if (existsSync(cacheDir)) rmSync(cacheDir, { recursive: true, force: true });
 
     return new Promise((resolve, reject) => {
       mkdirSync(cacheDir, { recursive: true });
       this.emit('progress', 'Extracting package cache...\n');
       const child = spawn('tar', ['xzf', tarball, '-C', cacheDir]);
-      child.on('close', (code) =>
-        code === 0 ? resolve() : reject(new Error(`tar exited ${code}`)),
-      );
+      child.on('close', (code) => {
+        if (code === 0) {
+          writeFileSync(completeSentinel, 'ok\n', 'utf-8');
+          resolve();
+        } else {
+          reject(new Error(`tar exited ${code}`));
+        }
+      });
       child.on('error', reject);
     });
   }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -52,10 +52,10 @@ const api: ElectronAPI = {
     authenticate: (backend) => ipcRenderer.invoke('backends:authenticate', backend),
     authenticateOAuth: (backend, profileName?) =>
       ipcRenderer.invoke('backends:authenticateOAuth', backend, profileName),
-    getPendingAuthState: (backend) =>
-      ipcRenderer.invoke('backends:getPendingAuthState', backend),
-    exchangeOAuthCode: (backend, code) =>
-      ipcRenderer.invoke('backends:exchangeOAuthCode', backend, code),
+    getPendingAuthState: (backend, profileName?) =>
+      ipcRenderer.invoke('backends:getPendingAuthState', backend, profileName),
+    exchangeOAuthCode: (backend, code, profileName?) =>
+      ipcRenderer.invoke('backends:exchangeOAuthCode', backend, code, profileName),
     listProfiles: (backend) => ipcRenderer.invoke('backends:listProfiles', backend),
     deleteProfile: (backend, profileName) =>
       ipcRenderer.invoke('backends:deleteProfile', backend, profileName),

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -150,8 +150,12 @@ export interface ElectronAPI {
     authenticateOAuth: (backend: string, profileName?: string) => Promise<OAuthLauncherResult>;
     listProfiles: (backend: string) => Promise<ListProfilesResult>;
     deleteProfile: (backend: string, profileName: string) => Promise<DeleteProfileResult>;
-    getPendingAuthState: (backend: string) => Promise<string | null>;
-    exchangeOAuthCode: (backend: string, code: string) => Promise<ExchangeOAuthCodeResult>;
+    getPendingAuthState: (backend: string, profileName?: string) => Promise<string | null>;
+    exchangeOAuthCode: (
+      backend: string,
+      code: string,
+      profileName?: string,
+    ) => Promise<ExchangeOAuthCodeResult>;
     onStatusChanged: (callback: (status: BackendStatusMap) => void) => () => void;
     onAlert: (callback: (alert: BackendAlert) => void) => () => void;
   };

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -10,9 +10,61 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Rubik:wght@400;500;600;700&family=Sometype+Mono:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
+    <style>
+      html,
+      body,
+      #root {
+        height: 100%;
+      }
+
+      body {
+        margin: 0;
+        background: #14121a;
+        color: #fcfcfd;
+        font-family: Inter, system-ui, sans-serif;
+      }
+
+      .boot-screen {
+        align-items: center;
+        display: flex;
+        height: 100%;
+        justify-content: center;
+      }
+
+      .boot-card {
+        background: #1e1b26;
+        border: 1px solid #2e2a3a;
+        border-radius: 14px;
+        box-shadow: 0 24px 70px rgb(0 0 0 / 0.28);
+        min-width: 260px;
+        padding: 24px;
+      }
+
+      .boot-title {
+        color: #f8c073;
+        font-family: Rubik, system-ui, sans-serif;
+        font-size: 15px;
+        font-weight: 700;
+        letter-spacing: 0.01em;
+        margin: 0 0 8px;
+      }
+
+      .boot-copy {
+        color: #8a8699;
+        font-size: 13px;
+        margin: 0;
+      }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <div class="boot-screen">
+        <div class="boot-card">
+          <p class="boot-title">screamingface</p>
+          <p class="boot-copy">Starting desktop control plane...</p>
+        </div>
+      </div>
+    </div>
     <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/apps/desktop/src/renderer/src/components/server/BackendStatusPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/server/BackendStatusPanel.tsx
@@ -89,10 +89,7 @@ function ProfileRow({
     setBusy(true);
     setError(null);
     try {
-      const result = await window.electronAPI.backends.authenticateOAuth(
-        backendName,
-        profile.name,
-      );
+      const result = await window.electronAPI.backends.authenticateOAuth(backendName, profile.name);
       if (result.kind === 'failed') {
         const reason = result.message ? `${result.reason}: ${result.message}` : result.reason;
         setError(`Re-auth failed — ${reason}`);
@@ -161,9 +158,7 @@ function ProfileRow({
           Delete
         </button>
       </div>
-      {error && (
-        <p className="basis-full text-xs text-destructive mt-1">{error}</p>
-      )}
+      {error && <p className="basis-full text-xs text-destructive mt-1">{error}</p>}
     </div>
   );
 }
@@ -175,7 +170,7 @@ function ProfilesSubPanel({ name }: { name: string }) {
   const [newName, setNewName] = useState('');
   const [addError, setAddError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const [hasPendingAuth, setHasPendingAuth] = useState(false);
+  const [pendingProfileName, setPendingProfileName] = useState<string | null>(null);
   const [pasteCode, setPasteCode] = useState('');
   const [pasteBusy, setPasteBusy] = useState(false);
   const [pasteError, setPasteError] = useState<string | null>(null);
@@ -186,20 +181,37 @@ function ProfilesSubPanel({ name }: { name: string }) {
     setLoaded(true);
   }, [name]);
 
-  const checkPending = useCallback(async () => {
-    const s = await window.electronAPI.backends.getPendingAuthState(name);
-    setHasPendingAuth(!!s);
-  }, [name]);
+  const checkPending = useCallback(
+    async (profileName?: string) => {
+      const candidates = profileName ? [profileName] : profiles.map((p) => p.name);
+      for (const candidate of candidates) {
+        const s = await window.electronAPI.backends.getPendingAuthState(name, candidate);
+        if (s) {
+          setPendingProfileName(candidate);
+          return;
+        }
+      }
+      setPendingProfileName(null);
+    },
+    [name, profiles],
+  );
 
   useEffect(() => {
     void refresh();
+  }, [refresh]);
+
+  useEffect(() => {
     void checkPending();
-  }, [refresh, checkPending]);
+  }, [checkPending]);
 
   const onPasteSubmit = async (e?: React.FormEvent): Promise<void> => {
     e?.preventDefault();
     if (pasteBusy) return;
     const code = pasteCode.trim();
+    if (!pendingProfileName) {
+      setPasteError('No in-flight OAuth flow');
+      return;
+    }
     if (!code) {
       setPasteError('Paste the authorization code');
       return;
@@ -207,13 +219,19 @@ function ProfilesSubPanel({ name }: { name: string }) {
     setPasteBusy(true);
     setPasteError(null);
     try {
-      const result = await window.electronAPI.backends.exchangeOAuthCode(name, code);
+      const result = await window.electronAPI.backends.exchangeOAuthCode(
+        name,
+        code,
+        pendingProfileName,
+      );
       if (result.ok) {
         setPasteCode('');
-        setHasPendingAuth(false);
+        setPendingProfileName(null);
         await refresh();
       } else {
-        setPasteError(result.message ?? `Exchange failed${result.status ? ` (${result.status})` : ''}`);
+        setPasteError(
+          result.message ?? `Exchange failed${result.status ? ` (${result.status})` : ''}`,
+        );
       }
     } catch (err) {
       setPasteError(err instanceof Error ? err.message : String(err));
@@ -250,7 +268,8 @@ function ProfilesSubPanel({ name }: { name: string }) {
       // paste-code fallback form can become available before the long
       // poll resolves.
       const pendingPoll = setInterval(() => {
-        void checkPending();
+        void checkPending(candidate);
+        void refresh();
       }, 500);
       try {
         const result = await window.electronAPI.backends.authenticateOAuth(name, candidate);
@@ -335,13 +354,15 @@ function ProfilesSubPanel({ name }: { name: string }) {
         </button>
       )}
       {addError && <p className="text-xs text-destructive mt-1">{addError}</p>}
-      {hasPendingAuth && (
+      {pendingProfileName && (
         <form
           onSubmit={onPasteSubmit}
           className="flex items-center gap-2 py-1.5 mt-2 border-t border-border pt-2"
           aria-label="Paste authorization code"
         >
-          <span className="text-xs text-muted-foreground">Pasted authorization code?</span>
+          <span className="text-xs text-muted-foreground">
+            Pasted authorization code for {pendingProfileName}?
+          </span>
           <input
             type="text"
             value={pasteCode}

--- a/apps/desktop/src/renderer/src/components/server/__tests__/BackendStatusPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/components/server/__tests__/BackendStatusPanel.test.tsx
@@ -116,9 +116,12 @@ describe('BackendStatusPanel auth_kind=browser sub-panel', () => {
   });
 
   it('shows paste-code form when an OAuth flow is in-flight and Submit calls exchangeOAuthCode', async () => {
+    listProfiles.mockResolvedValue({
+      profiles: [{ id: 'anthropic:work', provider: 'anthropic', name: 'work', state: 'pending' }],
+    });
     getPendingAuthState.mockResolvedValue('pending-state-xyz');
     const { container } = render(<BackendStatusPanel />);
-    await waitFor(() => expect(getPendingAuthState).toHaveBeenCalledWith('claude'));
+    await waitFor(() => expect(getPendingAuthState).toHaveBeenCalledWith('claude', 'work'));
     const form = await waitFor(() => {
       const f = container.querySelector('form[aria-label="Paste authorization code"]');
       if (!f) throw new Error('paste form not yet rendered');
@@ -128,7 +131,7 @@ describe('BackendStatusPanel auth_kind=browser sub-panel', () => {
     fireEvent.change(input, { target: { value: 'pasted-auth-code' } });
     fireEvent.click(within(form).getByRole('button', { name: /Submit/i }));
     await waitFor(() =>
-      expect(exchangeOAuthCode).toHaveBeenCalledWith('claude', 'pasted-auth-code'),
+      expect(exchangeOAuthCode).toHaveBeenCalledWith('claude', 'pasted-auth-code', 'work'),
     );
   });
 

--- a/apps/desktop/src/renderer/src/components/session/NewSessionDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/session/NewSessionDialog.tsx
@@ -33,10 +33,26 @@ interface Props {
 
 function typeLabel(type: SessionType): string {
   switch (type) {
-    case 'claude': return 'Claude Code';
-    case 'codex': return 'Codex';
-    case 'gemini': return 'Gemini CLI';
-    case 'claude-desktop': return 'Claude Desktop';
+    case 'claude':
+      return 'Claude Code';
+    case 'codex':
+      return 'Codex';
+    case 'gemini':
+      return 'Gemini CLI';
+    case 'claude-desktop':
+      return 'Claude Desktop';
+  }
+}
+
+function frontendPluginFor(type: SessionType): string {
+  switch (type) {
+    case 'codex':
+      return 'codex-frontend';
+    case 'gemini':
+      return 'gemini-frontend';
+    case 'claude':
+    case 'claude-desktop':
+      return 'claude-frontend';
   }
 }
 
@@ -81,14 +97,12 @@ export function NewSessionDialog({ type, editSession, onLaunch, onClose }: Props
   const serverUrl = serverInfo
     ? `${serverInfo.scheme}://${serverInfo.host === '0.0.0.0' ? 'localhost' : serverInfo.host}:${serverInfo.port}`
     : '';
+  const frontendPlugin = frontendPluginFor(type);
 
-  const serverFetch = useCallback(
-    async (url: string) => {
-      const res = await window.electronAPI.server.fetch(url);
-      return { ok: res.ok, json: () => JSON.parse(res.body) };
-    },
-    [],
-  );
+  const serverFetch = useCallback(async (url: string) => {
+    const res = await window.electronAPI.server.fetch(url);
+    return { ok: res.ok, json: () => JSON.parse(res.body) };
+  }, []);
 
   // Load schemas and defaults from server
   useEffect(() => {
@@ -96,8 +110,8 @@ export function NewSessionDialog({ type, editSession, onLaunch, onClose }: Props
 
     setLoading(true);
     Promise.all([
-      serverFetch(`${serverUrl}/plugins/claude-frontend/schema`),
-      serverFetch(`${serverUrl}/plugins/claude-frontend/settings`),
+      serverFetch(`${serverUrl}/plugins/${frontendPlugin}/schema`),
+      serverFetch(`${serverUrl}/plugins/${frontendPlugin}/settings`),
     ])
       .then(([schemaRes, settingsRes]) => {
         const feSchema = schemaRes.ok ? schemaRes.json() : null;
@@ -105,17 +119,17 @@ export function NewSessionDialog({ type, editSession, onLaunch, onClose }: Props
         if (feSchema?.properties) setFrontendSchema(cleanSchema(inlineRefs(feSchema)));
 
         // For edit mode: merge saved config over server defaults
-        if (editSession?.pluginConfig?.['claude-frontend']) {
+        if (editSession?.pluginConfig?.[frontendPlugin]) {
           setFrontendData({
             ...(feSettings || {}),
-            ...editSession.pluginConfig['claude-frontend'],
+            ...editSession.pluginConfig[frontendPlugin],
           });
         } else if (feSettings) {
           setFrontendData(feSettings as Record<string, unknown>);
         }
       })
       .finally(() => setLoading(false));
-  }, [serverUrl, serverFetch, editSession]);
+  }, [serverUrl, serverFetch, editSession, frontendPlugin]);
 
   const handlePickDir = async () => {
     const dir = await window.electronAPI.session.pickDir();
@@ -130,7 +144,7 @@ export function NewSessionDialog({ type, editSession, onLaunch, onClose }: Props
       delete cleanedFrontend[f];
     }
     onLaunch(type, workingDir, {
-      'claude-frontend': cleanedFrontend,
+      [frontendPlugin]: cleanedFrontend,
     });
   };
 
@@ -166,18 +180,16 @@ export function NewSessionDialog({ type, editSession, onLaunch, onClose }: Props
               }`}
             >
               <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
-              <span className="truncate">
-                {workingDir || 'Choose a directory...'}
-              </span>
+              <span className="truncate">{workingDir || 'Choose a directory...'}</span>
             </button>
             {!workingDir && (
-              <p className="mt-1 text-[10px] text-destructive/70">Required — select the directory Claude will work in</p>
+              <p className="mt-1 text-[10px] text-destructive/70">
+                Required — select the directory {typeLabel(type)} will work in
+              </p>
             )}
           </div>
 
-          {loading && (
-            <p className="text-xs text-muted-foreground">Loading plugin settings...</p>
-          )}
+          {loading && <p className="text-xs text-muted-foreground">Loading plugin settings...</p>}
 
           {/* Frontend settings */}
           {frontendSchema && !loading && (
@@ -199,7 +211,11 @@ export function NewSessionDialog({ type, editSession, onLaunch, onClose }: Props
                     'ui:submitButtonOptions': { norender: true },
                     'ui:order': [...TOP_FIELDS, '*'],
                     active_spec: { 'ui:widget': 'SpecSelectorWidget' },
-                    system_prompt: { 'ui:widget': 'textarea', 'ui:options': { rows: 4 }, classNames: 'w-full' },
+                    system_prompt: {
+                      'ui:widget': 'textarea',
+                      'ui:options': { rows: 4 },
+                      classNames: 'w-full',
+                    },
                   }}
                 />
               </div>
@@ -212,12 +228,7 @@ export function NewSessionDialog({ type, editSession, onLaunch, onClose }: Props
           <Button variant="ghost" size="sm" onClick={onClose}>
             Cancel
           </Button>
-          <Button
-            variant="default"
-            size="sm"
-            onClick={handleLaunch}
-            disabled={!canLaunch}
-          >
+          <Button variant="default" size="sm" onClick={handleLaunch} disabled={!canLaunch}>
             {isEdit ? (
               <>
                 <Save className="mr-1.5 h-3.5 w-3.5" />

--- a/apps/desktop/src/renderer/src/components/session/__tests__/NewSessionDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/session/__tests__/NewSessionDialog.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const serverFetch = vi.fn();
+const pickDir = vi.fn();
+
+(window as unknown as { electronAPI: unknown }).electronAPI = {
+  server: { fetch: serverFetch },
+  session: { pickDir },
+};
+
+Object.defineProperty(globalThis, 'crypto', {
+  value: { randomUUID: () => 'a36f68dd-e09d-4000-8000-000000000000' },
+});
+
+vi.mock('@/hooks/use-server-status', () => ({
+  useServerStatus: () => ({
+    info: { scheme: 'http', host: '127.0.0.1', port: 8001 },
+  }),
+}));
+
+vi.mock('@/components/rjsf-theme', () => ({
+  ThemedForm: ({ formData }: { formData: Record<string, unknown> }) => (
+    <pre data-testid="form-data">{JSON.stringify(formData)}</pre>
+  ),
+}));
+
+vi.mock('@/components/rjsf-utils', () => ({ inlineRefs: (schema: unknown) => schema }));
+
+import { NewSessionDialog } from '../NewSessionDialog';
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  serverFetch.mockReset();
+  pickDir.mockReset();
+  serverFetch.mockImplementation(async (url: string) => {
+    if (url.endsWith('/schema')) {
+      return {
+        ok: true,
+        body: JSON.stringify({
+          properties: {
+            upstream_url: { type: 'string', title: 'Upstream Url' },
+            default_backend_path: { type: 'string', title: 'Default Backend Path' },
+          },
+        }),
+      };
+    }
+    return {
+      ok: true,
+      body: JSON.stringify({
+        upstream_url: 'https://api.openai.com',
+        default_backend_path: '/codex',
+      }),
+    };
+  });
+});
+
+describe('NewSessionDialog', () => {
+  it('loads and launches Codex sessions with codex-frontend settings', async () => {
+    const onLaunch = vi.fn();
+
+    render(<NewSessionDialog type="codex" onLaunch={onLaunch} onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(serverFetch).toHaveBeenCalledWith(
+        'http://127.0.0.1:8001/plugins/codex-frontend/schema',
+      );
+      expect(serverFetch).toHaveBeenCalledWith(
+        'http://127.0.0.1:8001/plugins/codex-frontend/settings',
+      );
+    });
+    expect((await screen.findByTestId('form-data')).textContent).toContain(
+      'https://api.openai.com',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Launch Session/i }));
+
+    expect(onLaunch).toHaveBeenCalledWith('codex', '/tmp/sf-a36f68dde09d', {
+      'codex-frontend': {
+        upstream_url: 'https://api.openai.com',
+        default_backend_path: '/codex',
+      },
+    });
+  });
+});

--- a/apps/desktop/src/renderer/src/components/ui/toaster.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/toaster.tsx
@@ -21,7 +21,10 @@ export function Toaster() {
           onClick={() => dismiss(t.id)}
           role="status"
         >
-          {t.message}
+          {t.title && <div>{t.title}</div>}
+          {t.description && (
+            <div className="mt-1 text-[11px] font-normal opacity-80">{t.description}</div>
+          )}
         </div>
       ))}
     </div>

--- a/apps/desktop/src/renderer/src/hooks/use-toast.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-toast.ts
@@ -4,10 +4,20 @@ export type ToastVariant = 'default' | 'success' | 'error' | 'warning';
 
 export interface Toast {
   id: string;
-  message: string;
+  title?: string;
+  description?: string;
   variant: ToastVariant;
   duration: number;
 }
+
+export interface ToastOptions {
+  title?: string;
+  description?: string;
+  variant?: ToastVariant;
+  duration?: number;
+}
+
+type ToastInput = string | ToastOptions;
 
 type Listener = () => void;
 
@@ -19,11 +29,22 @@ function emit() {
   for (const l of listeners) l();
 }
 
-function addToast(message: string, variant: ToastVariant = 'default', duration = 3000): string {
+function addToast(input: ToastInput, variant: ToastVariant = 'default', duration = 3000): string {
   const id = String(++nextId);
-  toasts = [...toasts, { id, message, variant, duration }];
+  const toast =
+    typeof input === 'string'
+      ? { id, title: input, variant, duration }
+      : {
+          id,
+          title: input.title,
+          description: input.description,
+          variant: input.variant ?? variant,
+          duration: input.duration ?? duration,
+        };
+
+  toasts = [...toasts, toast];
   emit();
-  setTimeout(() => dismiss(id), duration);
+  setTimeout(() => dismiss(id), toast.duration);
   return id;
 }
 
@@ -44,8 +65,8 @@ function subscribe(listener: Listener) {
 export function useToast() {
   const items = useSyncExternalStore(subscribe, getSnapshot);
 
-  const toast = useCallback((message: string, variant?: ToastVariant, duration?: number) => {
-    return addToast(message, variant, duration);
+  const toast = useCallback((input: ToastInput, variant?: ToastVariant, duration?: number) => {
+    return addToast(input, variant, duration);
   }, []);
 
   return { toasts: items, toast, dismiss };

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -1,10 +1,58 @@
-import React from 'react';
+import React, { Component, type ErrorInfo, type ReactNode } from 'react';
 import ReactDOM from 'react-dom/client';
 import { App } from './App';
 import './globals.css';
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+interface RendererErrorBoundaryState {
+  error: Error | null;
+}
+
+class RendererErrorBoundary extends Component<{ children: ReactNode }, RendererErrorBoundaryState> {
+  state: RendererErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('[renderer] root render failed:', error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="flex h-screen items-center justify-center bg-background p-6 text-foreground">
+          <div className="max-w-xl rounded-lg border border-destructive/50 bg-card p-5 shadow-lg">
+            <p className="font-heading text-sm font-semibold text-destructive">
+              ScreamingFace failed to render
+            </p>
+            <p className="mt-2 text-xs text-muted-foreground">
+              Check the desktop debug log for renderer console details.
+            </p>
+            <pre className="mt-4 max-h-64 overflow-auto whitespace-pre-wrap rounded border border-border bg-background p-3 text-[11px] text-muted-foreground">
+              {this.state.error.stack || this.state.error.message}
+            </pre>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('Missing #root element');
+}
+
+console.info('[renderer] mounting React root');
+
+ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
-    <App />
+    <RendererErrorBoundary>
+      <App />
+    </RendererErrorBoundary>
   </React.StrictMode>,
 );

--- a/apps/server/sf.json
+++ b/apps/server/sf.json
@@ -1,7 +1,7 @@
 {
   "version": "0.1.0",
   "server": {
-    "host": "0.0.0.0",
+    "host": "127.0.0.1",
     "port": 8000,
     "reload": true,
     "ssl": false,
@@ -18,7 +18,7 @@
     "frontend-base",
     "backend-api-base",
     "python-runner",
-    "codex-backend-api",
+    "aigw-codex-backend",
     "gemini-backend-api",
     "ollama-backend-api",
     "gemini-frontend",
@@ -32,8 +32,44 @@
     "aigw-runner": {
       "port": 9105,
       "aigateway_dir": null,
-      "startup_timeout_seconds": 10.0,
+      "database_path": null,
+      "uv_bin": null,
+      "auth_enabled": false,
+      "startup_timeout_seconds": 60.0,
+      "migrations_timeout_seconds": 30.0,
       "enabled": true
+    },
+    "aigw-codex-backend": {
+      "gateway_url": "http://127.0.0.1:9105",
+      "auth_profile": "default",
+      "default_model": "codex/gpt-5.4-mini",
+      "default_effort": "medium",
+      "timeout_seconds": 300,
+      "max_budget_usd": null,
+      "permission_mode": null,
+      "dangerously_skip_permissions": false,
+      "profiles": {
+        "default": {
+          "context": null,
+          "system_prompt": null,
+          "append_system_prompt": null,
+          "model": null,
+          "output_format": null,
+          "max_budget_usd": null,
+          "effort": null,
+          "tools": null,
+          "allowed_tools": null,
+          "disallowed_tools": null,
+          "mcp_config": null,
+          "permission_mode": null,
+          "add_dirs": null,
+          "fallback_model": null,
+          "dangerously_skip_permissions": false,
+          "no_session_persistence": true,
+          "timeout_seconds": null
+        }
+      },
+      "default_profile": "default"
     },
     "aigw-claude-backend": {
       "gateway_url": "http://127.0.0.1:9105",

--- a/apps/server/src/screamingface/plugins/aigw_base/__init__.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/__init__.py
@@ -4,6 +4,7 @@ from .auth_proxy_router import build_aigw_auth_proxy_router
 from .backend import AigwBackend, AigwGatewayError
 from .interpreter import AigwInterpreter
 from .plugin_base import AigwBackendApiPluginBase
+from .profile_defaults import build_profile_defaults_from_settings
 from .settings import AigwBackendApiSettingsBase
 
 __all__ = [
@@ -13,4 +14,5 @@ __all__ = [
     "AigwGatewayError",
     "AigwInterpreter",
     "build_aigw_auth_proxy_router",
+    "build_profile_defaults_from_settings",
 ]

--- a/apps/server/src/screamingface/plugins/aigw_base/auth_proxy_router.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/auth_proxy_router.py
@@ -26,6 +26,7 @@ from typing import Any
 
 import httpx
 from fastapi import APIRouter, HTTPException, Response
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
@@ -72,7 +73,7 @@ def build_aigw_auth_proxy_router(
     factory = http_client_factory or _default_http_factory
 
     @router.post(f"{path_prefix}/auth/start")
-    async def start_auth(name: str | None = None) -> dict[str, Any]:
+    async def start_auth(name: str | None = None) -> JSONResponse:
         target = name or profile_name
         url = f"{base}/v1/auth/{gateway_provider}/profiles"
         body: dict[str, Any] = {"name": target}
@@ -101,7 +102,7 @@ def build_aigw_auth_proxy_router(
             )
         if resp.status_code >= 400:
             raise HTTPException(status_code=resp.status_code, detail=_safe_json(resp))
-        return resp.json()
+        return JSONResponse(content=resp.json(), status_code=resp.status_code)
 
     @router.get(f"{path_prefix}/auth/status")
     async def auth_status(name: str | None = None) -> dict[str, Any]:
@@ -157,7 +158,7 @@ def build_aigw_auth_proxy_router(
         return resp.json()
 
     @router.post(f"{path_prefix}/auth/exchange-code")
-    async def exchange_code(body: _ExchangeCodeBody) -> dict[str, Any]:
+    async def exchange_code(body: _ExchangeCodeBody) -> JSONResponse:
         """Forward a manually-pasted authorization code to the gateway.
 
         Used as a fallback when the OAuth provider displays the code on
@@ -187,7 +188,7 @@ def build_aigw_auth_proxy_router(
             )
         if resp.status_code >= 400:
             raise HTTPException(status_code=resp.status_code, detail=_safe_json(resp))
-        return resp.json()
+        return JSONResponse(content=resp.json(), status_code=resp.status_code)
 
     @router.delete(f"{path_prefix}/auth/profiles/{{name}}", status_code=204)
     async def delete_profile(name: str) -> Response:

--- a/apps/server/src/screamingface/plugins/aigw_base/backend.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/backend.py
@@ -50,9 +50,12 @@ class AigwBackend(Backend):
         *,
         gateway_url: str = "http://127.0.0.1:9105",
         profile_name: str = "default",
-        gateway_provider: str = "anthropic",
+        gateway_provider: str,
         http_client_factory=None,
     ) -> None:
+        if not gateway_provider:
+            msg = "gateway_provider is required for gateway-backed backends"
+            raise ValueError(msg)
         self._gateway_url = gateway_url.rstrip("/")
         self._profile_name = profile_name
         self._gateway_provider = gateway_provider

--- a/apps/server/src/screamingface/plugins/aigw_base/interpreter.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/interpreter.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from screamingface.plugins.llm_base.errors import BackendError
 from screamingface.plugins.llm_base.messages import CoreMessage, TextPart, extract_text
 from screamingface.plugins.url4_executor.interpreter import Url4Interpreter
 from screamingface.plugins.url4_executor.scope import Env
@@ -23,7 +24,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_FALLBACK_MODEL = "anthropic/claude-sonnet-4-5"
+_FALLBACK_MODEL = "gateway/default"
 
 
 class AigwInterpreter(Url4Interpreter):
@@ -33,18 +34,24 @@ class AigwInterpreter(Url4Interpreter):
         settings: AigwBackendApiSettingsBase | None = None,
         *,
         backend: AigwBackend | None = None,
+        gateway_provider: str | None = None,
     ) -> None:
         super().__init__(app)
         self.settings = settings
         if backend is not None:
             self._backend = backend
         elif settings is not None:
+            if not gateway_provider:
+                msg = "gateway_provider is required when constructing AigwInterpreter from settings"
+                raise ValueError(msg)
             self._backend = AigwBackend(
                 gateway_url=settings.gateway_url,
                 profile_name=settings.auth_profile,
+                gateway_provider=gateway_provider,
             )
         else:
-            self._backend = AigwBackend()
+            msg = "AigwInterpreter requires either backend or settings with gateway_provider"
+            raise ValueError(msg)
 
     async def process(self, sources: str, intent: str | None, env: Env | None = None) -> str:
         combined = f"{intent}\n\n{sources}" if intent and sources else (intent or sources or "")
@@ -57,10 +64,31 @@ class AigwInterpreter(Url4Interpreter):
         system = self.settings.interpreter_system_prompt if self.settings else None
         timeout = self.settings.timeout_seconds if self.settings else 300.0
 
-        result = await self._backend.run(
-            messages,
-            model=model,
-            system=system,
-            timeout_seconds=timeout,
-        )
+        try:
+            result = await self._backend.run(
+                messages,
+                model=model,
+                system=system,
+                timeout_seconds=timeout,
+            )
+        except BackendError as exc:
+            fallback_model = getattr(self.settings, "fallback_model", None)
+            if not (
+                exc.status == 429
+                and isinstance(fallback_model, str)
+                and fallback_model
+                and fallback_model != model
+            ):
+                raise
+            logger.warning(
+                "aigw interpreter primary model %s rate limited; retrying fallback model %s",
+                model,
+                fallback_model,
+            )
+            result = await self._backend.run(
+                messages,
+                model=fallback_model,
+                system=system,
+                timeout_seconds=timeout,
+            )
         return extract_text(result)

--- a/apps/server/src/screamingface/plugins/aigw_base/plugin_base.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/plugin_base.py
@@ -1,14 +1,15 @@
 """Shared lifecycle base for aigw_*_backend plugins.
 
-Subclasses each provider's `*_backend.plugin` mirror of
-`claude_backend_api/plugin.py` style: declare class-level metadata
-(name, backend_call_paths, schema_link_base, settings_class,
-create_router) and inherit `_make_interpreter` here.
+Subclasses mirror direct backend plugin style: declare class-level metadata
+(`name`, `backend_call_paths`, `schema_link_base`, `settings_class`,
+`create_router`) and inherit `_make_interpreter` here.
 """
 
 from __future__ import annotations
 
 import logging
+import os
+from ipaddress import ip_address
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import httpx
@@ -36,17 +37,59 @@ class AigwBackendApiPluginBase(BackendApiPluginBase):
     depends: ClassVar[list[str]] = ["llm-base", "backend-api-base", "aigw-base"]
     conflicts: ClassVar[list[str]] = []
 
-    # Provider key used by the AI Gateway (e.g. "anthropic", "openai").
+    # Provider key used by the AI Gateway.
     # Subclasses MUST set this if they want the auth-proxy router mounted.
     gateway_provider: ClassVar[str | None] = None
 
-    def _make_interpreter(self, app: FastAPI):
+    def _backend(self) -> AigwBackend:
         settings = cast(AigwBackendApiSettingsBase, self.settings)
+        if not self.gateway_provider:
+            msg = f"{self.name} must declare gateway_provider"
+            raise ValueError(msg)
+        key = (settings.gateway_url, settings.auth_profile, self.gateway_provider)
+        cached = getattr(self, "_aigw_backend", None)
+        if cached is not None and getattr(self, "_aigw_backend_key", None) == key:
+            return cached
         backend = AigwBackend(
             gateway_url=settings.gateway_url,
             profile_name=settings.auth_profile,
+            gateway_provider=self.gateway_provider,
         )
-        return AigwInterpreter(app=app, settings=settings, backend=backend)
+        self._aigw_backend = backend
+        self._aigw_backend_key = key
+        return backend
+
+    def _make_interpreter(self, app: FastAPI):
+        settings = cast(AigwBackendApiSettingsBase, self.settings)
+        if not self.gateway_provider:
+            msg = f"{self.name} must declare gateway_provider"
+            raise ValueError(msg)
+        return AigwInterpreter(
+            app=app,
+            settings=settings,
+            backend=self._backend(),
+            gateway_provider=self.gateway_provider,
+        )
+
+    def setup(self, app: FastAPI, hooks, classes, routes) -> None:
+        self._assert_loopback_server_bind(app)
+        router = type(self).create_router(self.settings, app, backend=self._backend())
+        routes.add_router(self.name, router, prefix="")
+
+    def _assert_loopback_server_bind(self, app: FastAPI) -> None:
+        if os.environ.get("SF_AIGW_ALLOW_LAN") == "1":
+            return
+        host = getattr(getattr(app.state, "config", None), "server", None)
+        bind_host = getattr(host, "host", "")
+        if not bind_host:
+            return
+        if _is_loopback_host(bind_host):
+            return
+        msg = (
+            f"{self.name} refuses to activate on non-loopback SF host {bind_host!r}; "
+            "set SF_AIGW_ALLOW_LAN=1 to override"
+        )
+        raise RuntimeError(msg)
 
     # ------------------------------------------------------------------ #
     # Schema customization
@@ -151,3 +194,13 @@ class AigwBackendApiPluginBase(BackendApiPluginBase):
                 if isinstance(name, str) and name:
                     names.append(name)
         return names
+
+
+def _is_loopback_host(host: str) -> bool:
+    normalized = (host or "").strip().lower()
+    if normalized == "localhost":
+        return True
+    try:
+        return ip_address(normalized).is_loopback
+    except ValueError:
+        return False

--- a/apps/server/src/screamingface/plugins/aigw_base/profile_defaults.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/profile_defaults.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Any
+
+_GATEWAY_REASONING_EFFORTS = frozenset({"low", "medium", "high"})
+
+
+def build_profile_defaults_from_settings(settings: Any) -> dict[str, Any]:
+    """Resolve SF backend settings into a gateway ProfileDefaults payload."""
+    profile = None
+    profiles = getattr(settings, "profiles", None) or {}
+    default_profile = getattr(settings, "default_profile", None)
+    if default_profile and default_profile in profiles:
+        profile = profiles[default_profile]
+
+    out: dict[str, Any] = {}
+
+    model = getattr(profile, "model", None) if profile is not None else None
+    if model is None:
+        model = getattr(settings, "default_model", None)
+    if model is not None:
+        out["model"] = model
+
+    if profile is not None:
+        system_prompt = getattr(profile, "system_prompt", None)
+        if system_prompt is not None:
+            out["system_prompt"] = system_prompt
+
+    timeout: float | None = None
+    if profile is not None:
+        timeout = getattr(profile, "timeout_seconds", None)
+    if timeout is None:
+        timeout = getattr(settings, "timeout_seconds", None)
+    if timeout is not None:
+        out["timeout_seconds"] = timeout
+
+    effort: str | None = None
+    if profile is not None:
+        effort = getattr(profile, "effort", None)
+    if effort is None:
+        effort = getattr(settings, "default_effort", None)
+    if effort in _GATEWAY_REASONING_EFFORTS:
+        out["reasoning_effort"] = effort
+
+    return out

--- a/apps/server/src/screamingface/plugins/aigw_base/tests/test_aigw_backend.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/tests/test_aigw_backend.py
@@ -27,6 +27,14 @@ def _factory(transport: httpx.MockTransport):
     return factory
 
 
+def _backend(*, http_client_factory, **kwargs) -> AigwBackend:
+    return AigwBackend(
+        gateway_provider="test-provider",
+        http_client_factory=http_client_factory,
+        **kwargs,
+    )
+
+
 def _ok_response(text: str) -> httpx.Response:
     return httpx.Response(
         200,
@@ -55,7 +63,7 @@ async def test_happy_path_extracts_text() -> None:
         captured["body"] = json.loads(req.content.decode())
         return _ok_response("pong")
 
-    backend = AigwBackend(
+    backend = _backend(
         gateway_url="http://127.0.0.1:9105",
         profile_name="default",
         http_client_factory=_factory(httpx.MockTransport(handler)),
@@ -85,7 +93,7 @@ async def test_string_content_passes_through() -> None:
     def handler(_req: httpx.Request) -> httpx.Response:
         return _ok_response("ok")
 
-    backend = AigwBackend(http_client_factory=_factory(httpx.MockTransport(handler)))
+    backend = _backend(http_client_factory=_factory(httpx.MockTransport(handler)))
     await backend.run(
         [CoreMessage(role="user", content="bare string")],
         model="anthropic/claude-haiku-4-5",
@@ -100,9 +108,7 @@ async def test_404_profile_not_found_maps_to_credential_not_found() -> None:
             json={"detail": {"code": "profile_not_found", "provider": "anthropic", "name": "x"}},
         )
 
-    backend = AigwBackend(
-        profile_name="x", http_client_factory=_factory(httpx.MockTransport(handler))
-    )
+    backend = _backend(profile_name="x", http_client_factory=_factory(httpx.MockTransport(handler)))
     with pytest.raises(CredentialNotFoundError, match="not found"):
         await backend.run(
             [CoreMessage(role="user", content="hi")],
@@ -115,7 +121,7 @@ async def test_409_pending_auth_maps_to_auth_error() -> None:
     def handler(_req: httpx.Request) -> httpx.Response:
         return httpx.Response(409, json={"detail": {"code": "profile_pending_auth"}})
 
-    backend = AigwBackend(http_client_factory=_factory(httpx.MockTransport(handler)))
+    backend = _backend(http_client_factory=_factory(httpx.MockTransport(handler)))
     with pytest.raises(AuthError, match="awaiting OAuth"):
         await backend.run(
             [CoreMessage(role="user", content="hi")],
@@ -131,7 +137,7 @@ async def test_401_auth_required_maps_to_auth_error() -> None:
             json={"detail": {"code": "auth_required", "message": "refresh failed"}},
         )
 
-    backend = AigwBackend(http_client_factory=_factory(httpx.MockTransport(handler)))
+    backend = _backend(http_client_factory=_factory(httpx.MockTransport(handler)))
     with pytest.raises(AuthError, match="refresh failed"):
         await backend.run(
             [CoreMessage(role="user", content="hi")],
@@ -144,7 +150,7 @@ async def test_500_raises_aigw_gateway_error() -> None:
     def handler(_req: httpx.Request) -> httpx.Response:
         return httpx.Response(500, text="boom")
 
-    backend = AigwBackend(http_client_factory=_factory(httpx.MockTransport(handler)))
+    backend = _backend(http_client_factory=_factory(httpx.MockTransport(handler)))
     with pytest.raises(AigwGatewayError):
         await backend.run(
             [CoreMessage(role="user", content="hi")],
@@ -157,7 +163,7 @@ async def test_unreachable_raises_backend_error() -> None:
     def handler(_req: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("connection refused")
 
-    backend = AigwBackend(http_client_factory=_factory(httpx.MockTransport(handler)))
+    backend = _backend(http_client_factory=_factory(httpx.MockTransport(handler)))
     with pytest.raises(BackendError, match="unreachable"):
         await backend.run(
             [CoreMessage(role="user", content="hi")],

--- a/apps/server/src/screamingface/plugins/aigw_base/tests/test_auth_proxy.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/tests/test_auth_proxy.py
@@ -58,7 +58,7 @@ def test_start_happy_path_passes_through_authorize_url() -> None:
 
     client = _make_client(handler)
     resp = client.post("/claude/auth/start")
-    assert resp.status_code == 200
+    assert resp.status_code == 201
     body = resp.json()
     assert body["authorize_url"] == "https://provider/authorize?x=1"
     assert body["profile_id"] == "anthropic:default"
@@ -142,7 +142,7 @@ def test_start_omits_defaults_when_none() -> None:
 
     client = _make_client(handler)  # defaults defaults to None
     resp = client.post("/claude/auth/start")
-    assert resp.status_code == 200
+    assert resp.status_code == 201
     assert captured["body"] == {"name": "default"}
     assert "defaults" not in captured["body"]
 
@@ -162,7 +162,7 @@ def test_start_forwards_defaults_when_provided() -> None:
 
     client = _make_client(handler, defaults=defaults)
     resp = client.post("/claude/auth/start")
-    assert resp.status_code == 200
+    assert resp.status_code == 201
     assert captured["body"] == {"name": "default", "defaults": defaults}
 
 
@@ -251,7 +251,7 @@ def test_start_with_name_override_targets_named_profile() -> None:
 
     client = _make_client(handler, defaults={"model": "anthropic/claude-sonnet-4-5"})
     resp = client.post("/claude/auth/start?name=work")
-    assert resp.status_code == 200
+    assert resp.status_code == 201
     # Named profile bypasses defaults forwarding
     assert captured["body"] == {"name": "work"}
 
@@ -273,7 +273,7 @@ def test_start_default_name_forwards_defaults() -> None:
 
     client = _make_client(handler, defaults={"model": "anthropic/claude-sonnet-4-5"})
     resp = client.post("/claude/auth/start")  # no ?name → uses default "default"
-    assert resp.status_code == 200
+    assert resp.status_code == 201
     assert captured["body"] == {
         "name": "default",
         "defaults": {"model": "anthropic/claude-sonnet-4-5"},
@@ -298,7 +298,7 @@ def test_start_explicit_default_name_forwards_defaults() -> None:
 
     client = _make_client(handler, defaults={"model": "anthropic/claude-sonnet-4-5"})
     resp = client.post("/claude/auth/start?name=default")
-    assert resp.status_code == 200
+    assert resp.status_code == 201
     assert captured["body"] == {
         "name": "default",
         "defaults": {"model": "anthropic/claude-sonnet-4-5"},

--- a/apps/server/src/screamingface/plugins/aigw_base/tests/test_backend_health.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/tests/test_backend_health.py
@@ -21,6 +21,7 @@ def _backend(handler) -> AigwBackend:
     return AigwBackend(
         gateway_url="http://gateway",
         profile_name="default",
+        gateway_provider="test-provider",
         http_client_factory=factory,
     )
 
@@ -28,8 +29,7 @@ def _backend(handler) -> AigwBackend:
 @pytest.mark.anyio
 async def test_health_authenticated_when_profile_is_authenticated() -> None:
     def handler(req: httpx.Request) -> httpx.Response:
-        # Health probes the gateway's *anthropic* profile by default
-        assert "/v1/auth/anthropic/profiles/default/status" in str(req.url)
+        assert "/v1/auth/test-provider/profiles/default/status" in str(req.url)
         return httpx.Response(
             200,
             json={"state": "authenticated", "account_label": None, "last_refreshed_at": None},

--- a/apps/server/src/screamingface/plugins/aigw_base/tests/test_interpreter.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/tests/test_interpreter.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 import httpx
 import pytest
+from fastapi import APIRouter, FastAPI
 
 from screamingface.plugins.aigw_base.backend import AigwBackend
 from screamingface.plugins.aigw_base.interpreter import AigwInterpreter
+from screamingface.plugins.aigw_claude_backend.plugin import (
+    AigwClaudeBackendPlugin,
+    AigwClaudeBackendSettings,
+)
 
 
 def _factory_returning(text: str):
@@ -35,7 +42,10 @@ def _factory_returning(text: str):
 
 @pytest.mark.anyio
 async def test_process_combines_intent_and_sources() -> None:
-    backend = AigwBackend(http_client_factory=_factory_returning("answer"))
+    backend = AigwBackend(
+        gateway_provider="test-provider",
+        http_client_factory=_factory_returning("answer"),
+    )
     interp = AigwInterpreter(backend=backend)
     out = await interp.process(sources="cats are mammals", intent="what are cats?")
     assert out == "answer"
@@ -43,6 +53,36 @@ async def test_process_combines_intent_and_sources() -> None:
 
 @pytest.mark.anyio
 async def test_process_returns_empty_when_no_input() -> None:
-    backend = AigwBackend(http_client_factory=_factory_returning("X"))
+    backend = AigwBackend(
+        gateway_provider="test-provider",
+        http_client_factory=_factory_returning("X"),
+    )
     interp = AigwInterpreter(backend=backend)
     assert await interp.process(sources="", intent=None) == ""
+
+
+def test_plugin_setup_and_interpreter_share_backend(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def create_router(settings, app=None, *, backend=None):  # noqa: ANN001
+        captured["backend"] = backend
+        return APIRouter()
+
+    class _Routes:
+        def add_router(self, name, router, prefix=""):  # noqa: ANN001, ARG002
+            return None
+
+    monkeypatch.setattr(AigwClaudeBackendPlugin, "create_router", staticmethod(create_router))
+    plugin = AigwClaudeBackendPlugin()
+    plugin.settings = AigwClaudeBackendSettings()
+    app = FastAPI()
+
+    plugin.setup(
+        app=app,
+        hooks=cast(Any, None),
+        classes=cast(Any, None),
+        routes=cast(Any, _Routes()),
+    )
+    interpreter = plugin._make_interpreter(app)
+
+    assert captured["backend"] is interpreter._backend

--- a/apps/server/src/screamingface/plugins/aigw_base/tests/test_loopback_guard.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/tests/test_loopback_guard.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from screamingface.core.config import AppConfig, ServerConfig
+from screamingface.plugins.aigw_claude_backend.plugin import AigwClaudeBackendPlugin
+
+
+def _app_with_host(host: str) -> FastAPI:
+    app = FastAPI()
+    app.state.config = AppConfig(server=ServerConfig(host=host))
+    return app
+
+
+def test_gateway_backed_plugin_allows_loopback_host() -> None:
+    plugin = AigwClaudeBackendPlugin()
+    plugin._assert_loopback_server_bind(FastAPI())
+    plugin._assert_loopback_server_bind(_app_with_host(""))
+    plugin._assert_loopback_server_bind(_app_with_host("127.0.0.1"))
+    plugin._assert_loopback_server_bind(_app_with_host("localhost"))
+    plugin._assert_loopback_server_bind(_app_with_host("::1"))
+
+
+def test_gateway_backed_plugin_blocks_lan_host_without_override() -> None:
+    plugin = AigwClaudeBackendPlugin()
+
+    try:
+        plugin._assert_loopback_server_bind(_app_with_host("0.0.0.0"))
+    except RuntimeError as exc:
+        assert "non-loopback" in str(exc)
+    else:
+        raise AssertionError("expected non-loopback host to be rejected")
+
+
+def test_gateway_backed_plugin_allows_lan_host_with_override(monkeypatch) -> None:
+    monkeypatch.setenv("SF_AIGW_ALLOW_LAN", "1")
+    plugin = AigwClaudeBackendPlugin()
+    plugin._assert_loopback_server_bind(_app_with_host("0.0.0.0"))

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/_defaults.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/_defaults.py
@@ -9,15 +9,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from screamingface.plugins.aigw_base import build_profile_defaults_from_settings
+
 if TYPE_CHECKING:
     from screamingface.plugins.aigw_claude_backend.plugin import AigwClaudeBackendSettings
-
-
-# The gateway's ``ProfileDefaults.reasoning_effort`` field accepts only these
-# three values. SF additionally allows ``"max"`` as an effort, but the gateway
-# does not — drop anything outside this set rather than send a value that
-# would be rejected.
-_GATEWAY_REASONING_EFFORTS = frozenset({"low", "medium", "high"})
 
 
 def _build_profile_defaults_from_settings(
@@ -30,44 +25,9 @@ def _build_profile_defaults_from_settings(
     resulting dict — never sent as ``null``. ``temperature`` and ``max_tokens``
     have no SF source and are always omitted.
     """
-    profile = None
-    profiles = getattr(settings, "profiles", None) or {}
-    default_profile = getattr(settings, "default_profile", None)
-    if default_profile and default_profile in profiles:
-        profile = profiles[default_profile]
-
-    out: dict[str, Any] = {}
-
-    # model: profile.model -> settings.default_model
-    model = getattr(profile, "model", None) if profile is not None else None
-    if model is None:
-        model = getattr(settings, "default_model", None)
-    if model is not None:
-        out["model"] = model
-
-    # system_prompt: profile.system_prompt only (no top-level equivalent)
-    if profile is not None:
-        sp = getattr(profile, "system_prompt", None)
-        if sp is not None:
-            out["system_prompt"] = sp
-
-    # timeout_seconds: profile.timeout_seconds -> settings.timeout_seconds
-    timeout: float | None = None
-    if profile is not None:
-        timeout = getattr(profile, "timeout_seconds", None)
-    if timeout is None:
-        timeout = getattr(settings, "timeout_seconds", None)
-    if timeout is not None:
-        out["timeout_seconds"] = timeout
-
-    # reasoning_effort: profile.effort -> settings.default_effort.
-    # Drop "max" (SF-only) and anything outside the gateway's enum.
-    effort: str | None = None
-    if profile is not None:
-        effort = getattr(profile, "effort", None)
-    if effort is None:
-        effort = getattr(settings, "default_effort", None)
-    if effort in _GATEWAY_REASONING_EFFORTS:
-        out["reasoning_effort"] = effort
-
+    out = build_profile_defaults_from_settings(settings)
+    # claude_backend_api never applied SF's generic `default_effort` to Claude.
+    # Leaving it out preserves that behavior and avoids enabling Anthropic
+    # thinking for every gateway-routed Claude request by accident.
+    out.pop("reasoning_effort", None)
     return out

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/plugin.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/plugin.py
@@ -50,6 +50,14 @@ class AigwClaudeBackendSettings(AigwBackendApiSettingsBase):
         ),
         examples=_CLAUDE_MODEL_SUGGESTIONS,
     )
+    fallback_model: str | None = Field(
+        default="anthropic/claude-haiku-4-5",
+        description=(
+            "Model retried once when the primary Claude model returns a 429. "
+            "Set to null to disable automatic fallback."
+        ),
+        examples=_CLAUDE_MODEL_SUGGESTIONS,
+    )
 
 
 class AigwClaudeBackendPlugin(AigwBackendApiPluginBase):

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/routes.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/routes.py
@@ -29,17 +29,28 @@ if TYPE_CHECKING:
 
 
 _DEFAULT_MODEL = "anthropic/claude-sonnet-4-5"
+_GATEWAY_PROVIDER = "anthropic"
 
 
-def create_router(settings: AigwClaudeBackendSettings, app: Any = None) -> APIRouter:
-    backend = AigwBackend(
+def create_router(
+    settings: AigwClaudeBackendSettings,
+    app: Any = None,
+    *,
+    backend: AigwBackend | None = None,
+) -> APIRouter:
+    backend = backend or AigwBackend(
         gateway_url=settings.gateway_url,
         profile_name=settings.auth_profile,
-        gateway_provider="anthropic",
+        gateway_provider=_GATEWAY_PROVIDER,
     )
 
     def build_interpreter() -> Any:
-        return AigwInterpreter(app=app, settings=settings, backend=backend)
+        return AigwInterpreter(
+            app=app,
+            settings=settings,
+            backend=backend,
+            gateway_provider=_GATEWAY_PROVIDER,
+        )
 
     router = build_backend_api_router(
         BackendApiConfig(
@@ -58,7 +69,7 @@ def create_router(settings: AigwClaudeBackendSettings, app: Any = None) -> APIRo
         build_aigw_auth_proxy_router(
             path_prefix="/claude",
             gateway_url=settings.gateway_url,
-            gateway_provider="anthropic",
+            gateway_provider=_GATEWAY_PROVIDER,
             profile_name=settings.auth_profile,
             defaults=profile_defaults or None,
         )

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/tests/test_auth_proxy_mount.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/tests/test_auth_proxy_mount.py
@@ -48,7 +48,6 @@ def test_build_profile_defaults_top_level_settings() -> None:
     assert out == {
         "model": "anthropic/claude-sonnet-4-5",
         "timeout_seconds": 300.0,
-        "reasoning_effort": "high",
     }
 
 
@@ -72,7 +71,6 @@ def test_build_profile_defaults_profile_overrides_top_level() -> None:
         "model": "anthropic/claude-opus-4-7",
         "system_prompt": "Profile prompt.",
         "timeout_seconds": 120.0,
-        "reasoning_effort": "high",
     }
 
 
@@ -141,7 +139,7 @@ def test_aigw_claude_backend_passes_defaults_to_auth_proxy() -> None:
         app.include_router(router)
         client = TestClient(app)
         resp = client.post("/claude/auth/start")
-        assert resp.status_code == 200
+        assert resp.status_code == 201
     finally:
         apr._default_http_factory = original  # type: ignore[assignment]
 
@@ -150,6 +148,5 @@ def test_aigw_claude_backend_passes_defaults_to_auth_proxy() -> None:
         "defaults": {
             "model": "anthropic/claude-sonnet-4-5",
             "timeout_seconds": 300.0,
-            "reasoning_effort": "medium",
         },
     }

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/tests/test_plugin_metadata.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/tests/test_plugin_metadata.py
@@ -38,6 +38,7 @@ def test_backend_call_paths_owns_canonical_claude_path() -> None:
 def test_default_settings() -> None:
     s = AigwClaudeBackendSettings()
     assert s.default_model == "anthropic/claude-sonnet-4-5"
+    assert s.fallback_model == "anthropic/claude-haiku-4-5"
     assert s.gateway_url == "http://127.0.0.1:9105"
     assert s.auth_profile == "default"
     assert s.timeout_seconds == 300.0

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/tests/test_url4_dispatch.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/tests/test_url4_dispatch.py
@@ -46,6 +46,39 @@ def _factory_returning(text: str, captured: dict | None = None):
     return factory
 
 
+def _fallback_factory(captured_models: list[str]):
+    def handler(req: httpx.Request) -> httpx.Response:
+        body = json.loads(req.content.decode())
+        captured_models.append(body["model"])
+        if body["model"] == "anthropic/claude-sonnet-4-5":
+            return httpx.Response(
+                429,
+                json={"detail": {"code": "rate_limited", "message": "limited"}},
+            )
+        return httpx.Response(
+            200,
+            json={
+                "id": "x",
+                "object": "chat.completion",
+                "model": body["model"],
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "fallback pong"},
+                        "finish_reason": "stop",
+                    }
+                ],
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    def factory(timeout: float):
+        return httpx.AsyncClient(transport=transport, timeout=httpx.Timeout(timeout))
+
+    return factory
+
+
 @pytest.mark.anyio
 async def test_handle_backend_call_returns_assistant_text() -> None:
     """The plugin's handle_backend_call uses the inherited _make_interpreter
@@ -55,15 +88,23 @@ async def test_handle_backend_call_returns_assistant_text() -> None:
 
     plugin = AigwClaudeBackendPlugin()
     plugin.settings = AigwClaudeBackendSettings()  # type: ignore[assignment]
+    gateway_provider = plugin.gateway_provider
+    assert gateway_provider is not None
 
     # Inject the mocked HTTP factory by replacing _make_interpreter behavior:
     # easiest path is to swap the backend on the interpreter the plugin would build.
     backend = AigwBackend(
         gateway_url=plugin.settings.gateway_url,
         profile_name=plugin.settings.auth_profile,
+        gateway_provider=gateway_provider,
         http_client_factory=factory,
     )
-    interpreter = AigwInterpreter(app=None, settings=plugin.settings, backend=backend)
+    interpreter = AigwInterpreter(
+        app=None,
+        settings=plugin.settings,
+        backend=backend,
+        gateway_provider=gateway_provider,
+    )
 
     out = await interpreter.process(sources="cats", intent="describe")
     assert out == "pong"
@@ -76,3 +117,29 @@ async def test_handle_backend_call_returns_assistant_text() -> None:
     assert user_msg["role"] == "user"
     assert "describe" in user_msg["content"]
     assert "cats" in user_msg["content"]
+
+
+@pytest.mark.anyio
+async def test_interpreter_retries_fallback_model_on_429() -> None:
+    captured_models: list[str] = []
+    settings = AigwClaudeBackendSettings()
+    backend = AigwBackend(
+        gateway_url=settings.gateway_url,
+        profile_name=settings.auth_profile,
+        gateway_provider="anthropic",
+        http_client_factory=_fallback_factory(captured_models),
+    )
+    interpreter = AigwInterpreter(
+        app=None,
+        settings=settings,
+        backend=backend,
+        gateway_provider="anthropic",
+    )
+
+    out = await interpreter.process(sources="cats", intent="describe")
+
+    assert out == "fallback pong"
+    assert captured_models == [
+        "anthropic/claude-sonnet-4-5",
+        "anthropic/claude-haiku-4-5",
+    ]

--- a/apps/server/src/screamingface/plugins/aigw_codex_backend/plugin.py
+++ b/apps/server/src/screamingface/plugins/aigw_codex_backend/plugin.py
@@ -1,0 +1,53 @@
+"""aigw-codex-backend plugin — Codex served via the local AI Gateway."""
+
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import SettingsConfigDict
+
+from screamingface.plugins.aigw_base import (
+    AigwBackendApiPluginBase,
+    AigwBackendApiSettingsBase,
+)
+from screamingface.plugins.aigw_codex_backend.routes import create_router
+
+_CODEX_MODEL_SUGGESTIONS = [
+    "codex/gpt-5.5",
+    "codex/gpt-5.4",
+    "codex/gpt-5.4-mini",
+    "codex/gpt-5.3-codex",
+    "codex/gpt-5.2",
+]
+
+
+class AigwCodexBackendSettings(AigwBackendApiSettingsBase):
+    model_config = SettingsConfigDict(
+        env_prefix="SF_AIGW_CODEX_BACKEND__",
+        env_nested_delimiter="__",
+    )
+
+    default_model: str | None = Field(
+        default="codex/gpt-5.4-mini",
+        description=(
+            "Default Codex model. The gateway routes by the prefix; "
+            "must start with 'codex/'. Pick from the dropdown or type a "
+            "custom slug if the gateway already supports it."
+        ),
+        examples=_CODEX_MODEL_SUGGESTIONS,
+    )
+
+
+class AigwCodexBackendPlugin(AigwBackendApiPluginBase):
+    name = "aigw-codex-backend"
+    description = (
+        "Codex served at /codex via the local AI Gateway. Auth, refresh, "
+        "profile storage, and provider adaptation live in the gateway; this "
+        "plugin exposes the standard SF backend routes and browser OAuth proxy."
+    )
+    tags: list[str] = ["product:openai"]
+    backend_call_paths: list[str] = ["/codex"]
+    conflicts: list[str] = ["codex-backend-api"]
+    gateway_provider = "codex"
+    settings_class = AigwCodexBackendSettings
+    schema_link_base = "/codex/"
+    create_router = staticmethod(create_router)

--- a/apps/server/src/screamingface/plugins/aigw_codex_backend/routes.py
+++ b/apps/server/src/screamingface/plugins/aigw_codex_backend/routes.py
@@ -1,0 +1,70 @@
+"""Routes for aigw-codex-backend."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from fastapi import APIRouter
+
+from screamingface.plugins.aigw_base import (
+    AigwBackend,
+    AigwInterpreter,
+    build_aigw_auth_proxy_router,
+    build_profile_defaults_from_settings,
+)
+from screamingface.plugins.llm_base.routes_shared import (
+    BackendApiConfig,
+    build_backend_api_router,
+)
+
+if TYPE_CHECKING:
+    from screamingface.plugins.aigw_codex_backend.plugin import AigwCodexBackendSettings
+
+_GATEWAY_PROVIDER = "codex"
+_PATH_PREFIX = "/codex"
+_DEFAULT_MODEL = "codex/gpt-5.4-mini"
+
+
+def create_router(
+    settings: AigwCodexBackendSettings,
+    app: Any = None,
+    *,
+    backend: AigwBackend | None = None,
+) -> APIRouter:
+    backend = backend or AigwBackend(
+        gateway_url=settings.gateway_url,
+        profile_name=settings.auth_profile,
+        gateway_provider=_GATEWAY_PROVIDER,
+    )
+
+    def build_interpreter() -> Any:
+        return AigwInterpreter(
+            app=app,
+            settings=settings,
+            backend=backend,
+            gateway_provider=_GATEWAY_PROVIDER,
+        )
+
+    router = build_backend_api_router(
+        BackendApiConfig(
+            name="aigw-codex-backend",
+            path_prefix=_PATH_PREFIX,
+            default_model=_DEFAULT_MODEL,
+            backend=backend,
+            settings=settings,
+            app=app,
+            build_interpreter=build_interpreter,
+            span_prefix="aigw_codex",
+        )
+    )
+    profile_defaults = build_profile_defaults_from_settings(settings)
+    router.include_router(
+        build_aigw_auth_proxy_router(
+            path_prefix=_PATH_PREFIX,
+            gateway_url=settings.gateway_url,
+            gateway_provider=_GATEWAY_PROVIDER,
+            profile_name=settings.auth_profile,
+            defaults=profile_defaults or None,
+        )
+    )
+    return router

--- a/apps/server/src/screamingface/plugins/aigw_codex_backend/tests/test_auth_proxy_mount.py
+++ b/apps/server/src/screamingface/plugins/aigw_codex_backend/tests/test_auth_proxy_mount.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.routing import Route
+
+from screamingface.plugins.aigw_base import auth_proxy_router as apr
+from screamingface.plugins.aigw_codex_backend.plugin import (
+    AigwCodexBackendPlugin,
+    AigwCodexBackendSettings,
+)
+
+
+def test_aigw_codex_backend_mounts_browser_auth_proxy_routes_without_import() -> None:
+    app = FastAPI()
+    settings = AigwCodexBackendSettings()
+    router = AigwCodexBackendPlugin.create_router(settings, app=app)
+    app.include_router(router)
+
+    routes = {r.path: r for r in app.routes if isinstance(r, Route)}
+    assert "/codex/auth/start" in routes
+    assert "/codex/auth/status" in routes
+    assert "/codex/auth/profiles" in routes
+    assert "/codex/auth/profiles/{name}" in routes
+    assert "/codex/auth/exchange-code" in routes
+    assert "/codex/auth/import" not in routes
+
+
+def test_aigw_codex_backend_passes_defaults_to_gateway_oauth_start() -> None:
+    settings = AigwCodexBackendSettings(
+        default_model="codex/gpt-5.4-mini",
+        default_effort="medium",
+        timeout_seconds=300.0,
+    )
+    captured: dict = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path.endswith("/profiles"):
+            captured["url"] = str(req.url)
+            captured["body"] = json.loads(req.read().decode())
+            return httpx.Response(201, json={"profile_id": "codex:default"})
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+
+    def http_factory(timeout: float) -> httpx.AsyncClient:
+        return httpx.AsyncClient(transport=transport, timeout=timeout)
+
+    original = apr._default_http_factory
+    apr._default_http_factory = http_factory  # type: ignore[assignment]
+    try:
+        app = FastAPI()
+        router = AigwCodexBackendPlugin.create_router(settings, app=app)
+        app.include_router(router)
+        response = TestClient(app).post("/codex/auth/start")
+        assert response.status_code == 201
+    finally:
+        apr._default_http_factory = original  # type: ignore[assignment]
+
+    assert captured["url"] == "http://127.0.0.1:9105/v1/auth/codex/profiles"
+    assert captured["body"] == {
+        "name": "default",
+        "defaults": {
+            "model": "codex/gpt-5.4-mini",
+            "timeout_seconds": 300.0,
+            "reasoning_effort": "medium",
+        },
+    }

--- a/apps/server/src/screamingface/plugins/aigw_codex_backend/tests/test_plugin_metadata.py
+++ b/apps/server/src/screamingface/plugins/aigw_codex_backend/tests/test_plugin_metadata.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from screamingface.plugins.aigw_codex_backend.plugin import (
+    AigwCodexBackendPlugin,
+    AigwCodexBackendSettings,
+)
+
+
+def test_plugin_name_is_canonical() -> None:
+    assert AigwCodexBackendPlugin.name == "aigw-codex-backend"
+
+
+def test_plugin_dependency_chain() -> None:
+    assert "aigw-base" in AigwCodexBackendPlugin.depends
+    assert "llm-base" in AigwCodexBackendPlugin.depends
+    assert "backend-api-base" in AigwCodexBackendPlugin.depends
+
+
+def test_plugin_conflicts_with_direct_codex_backend() -> None:
+    assert AigwCodexBackendPlugin.conflicts == ["codex-backend-api"]
+
+
+def test_backend_call_paths_owns_canonical_codex_path() -> None:
+    assert AigwCodexBackendPlugin.backend_call_paths == ["/codex"]
+
+
+def test_plugin_declares_gateway_provider() -> None:
+    assert AigwCodexBackendPlugin.gateway_provider == "codex"
+
+
+def test_default_settings() -> None:
+    settings = AigwCodexBackendSettings()
+    assert settings.default_model == "codex/gpt-5.4-mini"
+    assert settings.gateway_url == "http://127.0.0.1:9105"
+    assert settings.auth_profile == "default"
+    assert settings.timeout_seconds == 300.0
+
+
+def test_settings_env_prefix(monkeypatch) -> None:
+    monkeypatch.setenv("SF_AIGW_CODEX_BACKEND__GATEWAY_URL", "http://example:9999")
+    monkeypatch.setenv("SF_AIGW_CODEX_BACKEND__AUTH_PROFILE", "work")
+    settings = AigwCodexBackendSettings()
+    assert settings.gateway_url == "http://example:9999"
+    assert settings.auth_profile == "work"

--- a/apps/server/src/screamingface/plugins/aigw_runner/plugin.py
+++ b/apps/server/src/screamingface/plugins/aigw_runner/plugin.py
@@ -19,9 +19,11 @@ import shutil
 import subprocess
 import threading
 import time
+from collections import deque
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import httpx
 from pydantic import Field
 from pydantic_settings import SettingsConfigDict
 
@@ -55,8 +57,27 @@ class AigwRunnerSettings(PluginSettings):
         ),
     )
     startup_timeout_seconds: float = Field(
-        default=10.0,
+        default=15.0,
         description="Max seconds to wait after Popen before declaring failure.",
+    )
+    migrations_timeout_seconds: float = Field(
+        default=30.0,
+        description="Max seconds to wait for gateway database migrations.",
+    )
+    database_path: str | None = Field(
+        default=None,
+        description=(
+            "SQLite database path for the local gateway. If unset, resolves "
+            "to .sf/aigateway.db under the SF working directory."
+        ),
+    )
+    uv_bin: str | None = Field(
+        default=None,
+        description="Explicit uv executable path. If unset, uv is resolved from PATH.",
+    )
+    auth_enabled: bool = Field(
+        default=False,
+        description="Whether the spawned local gateway should enforce its own bearer auth.",
     )
     enabled: bool = Field(
         default=True,
@@ -78,6 +99,7 @@ class AigwRunnerPlugin(Plugin):
     def __init__(self) -> None:
         self._process: subprocess.Popen | None = None
         self._aigateway_dir: Path | None = None
+        self._uv_bin: str | None = None
 
     def preflight(self) -> tuple[bool, str]:
         ok, reason = super().preflight()
@@ -102,8 +124,10 @@ class AigwRunnerPlugin(Plugin):
 
         self._aigateway_dir = candidate
 
-        if shutil.which("uv") is None:
+        uv_bin = settings.uv_bin or shutil.which("uv")
+        if uv_bin is None:
             return False, "`uv` command not found in PATH — required to run the gateway"
+        self._uv_bin = uv_bin
 
         return True, ""
 
@@ -121,9 +145,43 @@ class AigwRunnerPlugin(Plugin):
             return
 
         assert self._aigateway_dir is not None  # set in preflight
+        assert self._uv_bin is not None  # set in preflight
+
+        database_url = _database_url(settings)
+        env = _gateway_env(settings, database_url)
+        migrate_cmd = [
+            self._uv_bin,
+            "run",
+            "--directory",
+            str(self._aigateway_dir),
+            "python",
+            "-m",
+            "tortoise",
+            "-c",
+            "aigateway.db.TORTOISE_CONFIG",
+            "migrate",
+        ]
+        logger.info("aigw-runner: running gateway migrations: %s", " ".join(migrate_cmd))
+        try:
+            migration = subprocess.run(  # noqa: S603
+                migrate_cmd,
+                env=env,
+                cwd=str(self._aigateway_dir),
+                timeout=settings.migrations_timeout_seconds,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError("aigw-runner: gateway migrations timed out") from exc
+        if migration.returncode != 0:
+            raise RuntimeError(
+                "aigw-runner: gateway migrations failed "
+                f"(code {migration.returncode}):\n{migration.stdout}{migration.stderr}"
+            )
 
         cmd = [
-            "uv",
+            self._uv_bin,
             "run",
             "--directory",
             str(self._aigateway_dir),
@@ -136,7 +194,6 @@ class AigwRunnerPlugin(Plugin):
             "--log-level",
             "info",
         ]
-        env = os.environ.copy()
         logger.info("aigw-runner: spawning gateway: %s", " ".join(cmd))
 
         self._process = subprocess.Popen(  # noqa: S603
@@ -146,19 +203,28 @@ class AigwRunnerPlugin(Plugin):
             stderr=subprocess.STDOUT,
             text=True,
         )
-
-        time.sleep(0.5)
-        retcode = self._process.poll()
-        if retcode is not None:
-            output = self._process.stdout.read() if self._process.stdout else ""
-            self._process = None
-            raise RuntimeError(
-                f"aigw-runner: gateway exited immediately (code {retcode}):\n{output}"
-            )
-
+        startup_output: deque[str] = deque(maxlen=200)
         threading.Thread(
-            target=_log_output, args=(self._process,), daemon=True, name="aigw-runner-log"
+            target=_log_output,
+            args=(self._process, startup_output),
+            daemon=True,
+            name="aigw-runner-log",
         ).start()
+
+        health_url = f"http://127.0.0.1:{settings.port}/healthz"
+        if not _wait_for_health(self._process, health_url, settings.startup_timeout_seconds):
+            retcode = self._process.poll()
+            if retcode is not None:
+                output = "\n".join(startup_output)
+                self._process = None
+                raise RuntimeError(
+                    f"aigw-runner: gateway exited immediately (code {retcode}):\n{output}"
+                )
+            self._stop()
+            raise RuntimeError(
+                f"aigw-runner: gateway did not become healthy at {health_url} "
+                f"within {settings.startup_timeout_seconds}s"
+            )
 
         atexit.register(self._stop)
         hooks.register("app.shutdown", self._on_shutdown, plugin_name=self.name)
@@ -190,9 +256,43 @@ class AigwRunnerPlugin(Plugin):
         self._process = None
 
 
-def _log_output(proc: subprocess.Popen) -> None:
+def _log_output(proc: subprocess.Popen, startup_output: deque[str] | None = None) -> None:
     assert proc.stdout is not None
     for line in proc.stdout:
         line = line.rstrip()
         if line:
+            if startup_output is not None:
+                startup_output.append(line)
             logger.info("[aigateway] %s", line)
+
+
+def _database_url(settings: AigwRunnerSettings) -> str:
+    if settings.database_path is not None:
+        path = Path(settings.database_path).expanduser().resolve()
+    else:
+        path = (Path.cwd() / ".sf" / "aigateway.db").resolve()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return f"sqlite://{path}"
+
+
+def _gateway_env(settings: AigwRunnerSettings, database_url: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    env["AIGATEWAY_DATABASE_URL"] = database_url
+    env["AIGATEWAY_AUTH_ENABLED"] = "true" if settings.auth_enabled else "false"
+    return env
+
+
+def _wait_for_health(proc: subprocess.Popen, url: str, timeout_seconds: float) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            return False
+        try:
+            resp = httpx.get(url, timeout=0.5)
+            if resp.status_code == 200:
+                return True
+        except httpx.HTTPError:
+            pass
+        time.sleep(0.2)
+    return False

--- a/apps/server/src/screamingface/plugins/aigw_runner/tests/test_runner.py
+++ b/apps/server/src/screamingface/plugins/aigw_runner/tests/test_runner.py
@@ -50,6 +50,14 @@ def test_preflight_fails_without_uv(fake_aigw_dir: Path) -> None:
     assert "`uv` command not found" in reason
 
 
+def test_preflight_uses_configured_uv_bin(fake_aigw_dir: Path) -> None:
+    plugin = _make_plugin(fake_aigw_dir, uv_bin="/custom/uv")
+    with patch("shutil.which", return_value=None):
+        ok, reason = plugin.preflight()
+    assert ok, reason
+    assert plugin._uv_bin == "/custom/uv"
+
+
 def test_preflight_skipped_when_disabled(fake_aigw_dir: Path) -> None:
     plugin = _make_plugin(fake_aigw_dir, enabled=False)
     ok, _ = plugin.preflight()
@@ -67,7 +75,8 @@ def test_setup_skipped_when_disabled(fake_aigw_dir: Path) -> None:
 
 
 def test_setup_spawns_subprocess_and_registers_hooks(fake_aigw_dir: Path) -> None:
-    plugin = _make_plugin(fake_aigw_dir)
+    db_path = fake_aigw_dir / "aigateway.db"
+    plugin = _make_plugin(fake_aigw_dir, database_path=str(db_path), uv_bin="/custom/uv")
 
     fake_proc = MagicMock(spec=subprocess.Popen)
     fake_proc.poll.return_value = None  # still running
@@ -79,18 +88,33 @@ def test_setup_spawns_subprocess_and_registers_hooks(fake_aigw_dir: Path) -> Non
     fake_app = MagicMock()
 
     with (
-        patch("shutil.which", return_value="/usr/local/bin/uv"),
+        patch("screamingface.plugins.aigw_runner.plugin.subprocess.run") as mock_run,
         patch(
             "screamingface.plugins.aigw_runner.plugin.subprocess.Popen",
             return_value=fake_proc,
-        ),
+        ) as mock_popen,
+        patch("screamingface.plugins.aigw_runner.plugin._wait_for_health", return_value=True),
         patch("screamingface.plugins.aigw_runner.plugin.atexit.register") as mock_atexit,
         patch("screamingface.plugins.aigw_runner.plugin.threading.Thread") as mock_thread,
     ):
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = ""
+        mock_run.return_value.stderr = ""
         plugin.preflight()
         plugin.setup(fake_app, fake_hooks, MagicMock(), MagicMock())
 
     assert plugin._process is fake_proc
+    mock_run.assert_called_once()
+    migrate_args = mock_run.call_args.args[0]
+    assert migrate_args[:4] == ["/custom/uv", "run", "--directory", str(fake_aigw_dir.resolve())]
+    migrate_env = mock_run.call_args.kwargs["env"]
+    assert migrate_env["AIGATEWAY_DATABASE_URL"] == f"sqlite://{db_path.resolve()}"
+    assert migrate_env["AIGATEWAY_AUTH_ENABLED"] == "false"
+    assert "VIRTUAL_ENV" not in migrate_env
+    mock_popen.assert_called_once()
+    popen_args = mock_popen.call_args.args[0]
+    assert popen_args[:4] == ["/custom/uv", "run", "--directory", str(fake_aigw_dir.resolve())]
+    assert mock_popen.call_args.kwargs["env"] is migrate_env
     fake_hooks.register.assert_called_once()
     register_args = fake_hooks.register.call_args
     assert register_args.args[0] == "app.shutdown"
@@ -109,14 +133,37 @@ def test_setup_raises_if_subprocess_exits_immediately(fake_aigw_dir: Path) -> No
 
     with (
         patch("shutil.which", return_value="/usr/local/bin/uv"),
+        patch("screamingface.plugins.aigw_runner.plugin.subprocess.run") as mock_run,
         patch(
             "screamingface.plugins.aigw_runner.plugin.subprocess.Popen",
             return_value=fake_proc,
         ),
+        patch("screamingface.plugins.aigw_runner.plugin._wait_for_health", return_value=False),
     ):
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = ""
+        mock_run.return_value.stderr = ""
         plugin.preflight()
         with pytest.raises(RuntimeError, match="exited immediately"):
             plugin.setup(MagicMock(), MagicMock(), MagicMock(), MagicMock())
+
+
+def test_setup_raises_when_migrations_fail(fake_aigw_dir: Path) -> None:
+    plugin = _make_plugin(fake_aigw_dir)
+
+    with (
+        patch("shutil.which", return_value="/usr/local/bin/uv"),
+        patch("screamingface.plugins.aigw_runner.plugin.subprocess.run") as mock_run,
+        patch("screamingface.plugins.aigw_runner.plugin.subprocess.Popen") as mock_popen,
+    ):
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stdout = ""
+        mock_run.return_value.stderr = "boom"
+        plugin.preflight()
+        with pytest.raises(RuntimeError, match="gateway migrations failed"):
+            plugin.setup(MagicMock(), MagicMock(), MagicMock(), MagicMock())
+
+    mock_popen.assert_not_called()
 
 
 def test_stop_terminates_process(fake_aigw_dir: Path) -> None:

--- a/apps/server/src/screamingface/plugins/claude_backend_api/adapter.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/adapter.py
@@ -51,7 +51,7 @@ from screamingface.plugins.llm_base.messages import (
 # Billing fingerprint constants — must match the Claude Code CLI's
 # src/utils/fingerprint.ts to route requests to the CLI rate limit pool.
 _FINGERPRINT_SALT = "59cf53e54c78"
-_CC_VERSION = "2.1.104"
+_CC_VERSION = "2.1.142"
 
 
 class AnthropicAdapter(Adapter):
@@ -387,5 +387,5 @@ def _build_billing_header(first_user_text: str) -> str:
     """
     fp = _compute_fingerprint(first_user_text)
     return (
-        f"x-anthropic-billing-header: cc_version={_CC_VERSION}.{fp}; cc_entrypoint=cli; cch={fp};"
+        f"x-anthropic-billing-header: cc_version={_CC_VERSION}.{fp}; cc_entrypoint=cli; cch=00000;"
     )

--- a/apps/server/src/screamingface/plugins/claude_backend_api/auth.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/auth.py
@@ -14,8 +14,8 @@ This module just implements the four provider-specific hooks:
 2. ``_is_expired`` — compare ``expiresAt`` (unix epoch in milliseconds)
    against the 60-second proactive refresh window.
 3. ``_refresh_credential`` — POST to
-   ``https://console.anthropic.com/v1/oauth/token`` with
-   ``{grant_type: "refresh_token", refresh_token, client_id}`` and
+   ``https://platform.claude.com/v1/oauth/token`` with
+   ``{grant_type: "refresh_token", refresh_token, client_id, scope}`` and
    convert the OAuth 2.0 response shape (snake_case, ``expires_in``
    seconds) back to the keychain shape (camelCase, ``expiresAt`` ms).
 4. ``_build_headers`` — the three required Anthropic headers:
@@ -45,10 +45,17 @@ from screamingface.plugins.llm_base.oauth_base import OAuthStrategy
 
 logger = logging.getLogger(__name__)
 
-# Constants validated by the SF-77 spike.
+# Constants validated against Claude Code 2.1.142.
 KEYCHAIN_SERVICE = "Claude Code-credentials"
-OAUTH_REFRESH_URL = "https://console.anthropic.com/v1/oauth/token"
+OAUTH_REFRESH_URL = "https://platform.claude.com/v1/oauth/token"
 OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"  # public Claude Code OAuth app
+OAUTH_REFRESH_SCOPES = [
+    "user:profile",
+    "user:inference",
+    "user:sessions:claude_code",
+    "user:mcp_servers",
+    "user:file_upload",
+]
 ANTHROPIC_VERSION = "2023-06-01"
 # Beta features: ``oauth-2025-04-20`` is required for OAuth bearer tokens,
 # ``claude-code-*`` gives access to the Claude Code rate-limit pool.
@@ -146,6 +153,7 @@ class ClaudeCodeOAuth(OAuthStrategy):
             "grant_type": "refresh_token",
             "refresh_token": creds["refreshToken"],
             "client_id": OAUTH_CLIENT_ID,
+            "scope": " ".join(OAUTH_REFRESH_SCOPES),
         }
         headers = {"content-type": "application/json"}
 

--- a/apps/server/src/screamingface/plugins/claude_backend_api/plugin.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/plugin.py
@@ -50,8 +50,17 @@ class ClaudeBackendApiPlugin(BackendApiPluginBase):
     )
     tags: list[str] = ["product:claude"]
     depends: list[str] = ["llm-base", "backend-api-base"]
-    conflicts: list[str] = []
+    conflicts: list[str] = ["aigw-claude-backend"]
     backend_call_paths: list[str] = ["/claude"]
+    cli_auth_command = "claude auth login"
+    backend_status_help = {
+        "rate_limited": "Claude API rate limit reached. Capacity will reset automatically.",
+        "reauth": (
+            "Claude OAuth token is missing or expired. "
+            "Click Re-authenticate to open a terminal and run 'claude auth login'."
+        ),
+        "degraded": "Claude backend is available but experiencing issues.",
+    }
     settings_class = ClaudeBackendApiSettings
 
     schema_link_base = "/claude/"

--- a/apps/server/src/screamingface/plugins/claude_backend_api/tests/test_auth.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/tests/test_auth.py
@@ -20,6 +20,7 @@ from screamingface.plugins.claude_backend_api.auth import (
     ANTHROPIC_VERSION,
     KEYCHAIN_SERVICE,
     OAUTH_CLIENT_ID,
+    OAUTH_REFRESH_SCOPES,
     OAUTH_REFRESH_URL,
     REFRESH_WINDOW_SECONDS,
     ClaudeCodeOAuth,
@@ -107,7 +108,7 @@ class TestConstants:
         assert KEYCHAIN_SERVICE == "Claude Code-credentials"
 
     def test_refresh_url(self):
-        assert OAUTH_REFRESH_URL == "https://console.anthropic.com/v1/oauth/token"
+        assert OAUTH_REFRESH_URL == "https://platform.claude.com/v1/oauth/token"
 
     def test_client_id(self):
         assert OAUTH_CLIENT_ID == "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
@@ -235,6 +236,7 @@ class TestRefresh:
         assert kwargs["json"]["grant_type"] == "refresh_token"
         assert kwargs["json"]["client_id"] == OAUTH_CLIENT_ID
         assert kwargs["json"]["refresh_token"] == "sk-ant-ort01-CURRENT_REFRESH"
+        assert kwargs["json"]["scope"] == " ".join(OAUTH_REFRESH_SCOPES)
 
         # Headers use the new token
         assert headers["Authorization"] == "Bearer sk-ant-oat01-NEW_ACCESS"

--- a/apps/server/src/screamingface/plugins/claude_backend_api/tests/test_plugin_conflicts.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/tests/test_plugin_conflicts.py
@@ -33,6 +33,9 @@ class TestPluginMetadata:
     def test_settings_class_set(self):
         assert ClaudeBackendApiPlugin.settings_class is ClaudeBackendApiSettings
 
+    def test_conflicts_with_gateway_backed_backend(self):
+        assert ClaudeBackendApiPlugin.conflicts == ["aigw-claude-backend"]
+
 
 class TestSettings:
     def test_default_settings_load_cleanly(self):

--- a/apps/server/src/screamingface/plugins/codex_backend_api/plugin.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/plugin.py
@@ -42,8 +42,17 @@ class CodexBackendApiPlugin(BackendApiPluginBase):
     )
     tags: list[str] = ["product:openai"]
     depends: list[str] = ["llm-base", "backend-api-base"]
-    conflicts: list[str] = []
+    conflicts: list[str] = ["aigw-codex-backend"]
     backend_call_paths: list[str] = ["/codex"]
+    cli_auth_command = "codex auth login"
+    backend_status_help = {
+        "rate_limited": "OpenAI API rate limit reached. Capacity will reset automatically.",
+        "reauth": (
+            "Codex OAuth token is missing, expired, or the refresh token was already used. "
+            "Click Re-authenticate to run 'codex auth login'."
+        ),
+        "degraded": "Codex backend is available but experiencing issues.",
+    }
     settings_class = CodexBackendApiSettings
 
     schema_link_base = "/codex/"

--- a/apps/server/src/screamingface/plugins/codex_backend_api/tests/test_plugin_conflicts.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/tests/test_plugin_conflicts.py
@@ -21,9 +21,8 @@ class TestPluginMetadata:
     def test_depends_on_backend_api_base(self):
         assert "backend-api-base" in CodexBackendApiPlugin.depends
 
-    def test_no_conflicts(self):
-        # codex-backend-api coexists with claude-backend-api
-        assert CodexBackendApiPlugin.conflicts == []
+    def test_conflicts_with_gateway_backed_backend(self):
+        assert CodexBackendApiPlugin.conflicts == ["aigw-codex-backend"]
 
     def test_backend_call_paths(self):
         assert CodexBackendApiPlugin.backend_call_paths == ["/codex"]

--- a/apps/server/src/screamingface/plugins/llm_base/routes.py
+++ b/apps/server/src/screamingface/plugins/llm_base/routes.py
@@ -30,9 +30,8 @@ def create_router(app: Any = None) -> APIRouter:
     async def backends_status() -> JSONResponse:
         """Unified health status for all active backend plugins.
 
-        Returns a JSON object keyed by backend name (``claude``, ``codex``,
-        ``gemini``) with health info, error classification, and
-        actionable hints for the UI.
+        Returns a JSON object keyed by backend route name with health info,
+        error classification, and actionable hints for the UI.
 
         Each entry contains:
         - ``authenticated`` (bool)
@@ -60,8 +59,8 @@ def create_router(app: Any = None) -> APIRouter:
 
             health = await _probe_health(base_url, name)
             health["action"] = _classify_action(health)
-            health["cli_command"] = _cli_command(name, health)
-            health["help_text"] = _help_text(name, health)
+            health["cli_command"] = _cli_command(plugin, health)
+            health["help_text"] = _help_text(plugin, health)
             health["auth_kind"] = _classify_auth_kind(plugin)
             results[name] = health
 
@@ -124,7 +123,7 @@ def _classify_auth_kind(plugin: Any) -> str:
     - ``"browser"`` — open the gateway-managed authorize URL in a browser
       (used by aigw-*-backend plugins via ``gateway_provider``).
     - ``"cli"``     — spawn a terminal running the plugin's CLI auth
-      command (the historical claude/codex/gemini path).
+      command.
     """
     if getattr(plugin, "gateway_provider", None):
         return "browser"
@@ -156,52 +155,33 @@ def _classify_action(health: dict[str, Any]) -> str:
     return "degraded"
 
 
-_CLI_COMMANDS: dict[str, str] = {
-    "claude": "claude auth login",
-    "codex": "codex auth login",
-    "gemini": "gemini auth login",
-}
-
-
-def _cli_command(backend: str, health: dict[str, Any]) -> str | None:
+def _cli_command(plugin: Any, health: dict[str, Any]) -> str | None:
     """Return the terminal command to fix the issue, or None if healthy."""
     action = health.get("action", "")
-    if action in ("reauth", "degraded"):
-        return _CLI_COMMANDS.get(backend)
+    if action in ("reauth", "degraded") and not getattr(plugin, "gateway_provider", None):
+        command = getattr(plugin, "cli_auth_command", None)
+        return command if isinstance(command, str) else None
     return None
 
 
-_HELP_TEXTS: dict[str, dict[str, str]] = {
-    "healthy": {},
-    "rate_limited": {
-        "claude": "Claude API rate limit reached. Capacity will reset automatically.",
-        "codex": "OpenAI API rate limit reached. Capacity will reset automatically.",
-        "gemini": "Gemini API rate limit reached. Capacity will reset automatically.",
-    },
-    "reauth": {
-        "claude": (
-            "Claude OAuth token is missing or expired. "
-            "Click Re-authenticate to open a terminal and run 'claude auth login'."
-        ),
-        "codex": (
-            "Codex OAuth token is missing, expired, or the refresh token was "
-            "already used. Click Re-authenticate to run 'codex auth login'."
-        ),
-        "gemini": (
-            "Gemini OAuth token is missing or has insufficient API scopes. "
-            "Click Re-authenticate to run 'gemini auth login'."
-        ),
-    },
-    "degraded": {
-        "claude": "Claude backend is available but experiencing issues.",
-        "codex": "Codex backend is available but experiencing issues.",
-        "gemini": "Gemini backend is available but experiencing issues.",
-    },
-}
-
-
-def _help_text(backend: str, health: dict[str, Any]) -> str | None:
+def _help_text(plugin: Any, health: dict[str, Any]) -> str | None:
     """Return user-facing help text for the current status."""
     action = health.get("action", "healthy")
-    texts = _HELP_TEXTS.get(action, {})
-    return texts.get(backend)
+    configured = getattr(plugin, "backend_status_help", None)
+    if isinstance(configured, dict):
+        text = configured.get(action)
+        if isinstance(text, str):
+            return text
+
+    if action == "rate_limited":
+        return "Backend rate limit reached. Capacity will reset automatically."
+    if action == "reauth":
+        if getattr(plugin, "gateway_provider", None):
+            return "OAuth profile is missing or expired. Click Authenticate to open a browser."
+        command = getattr(plugin, "cli_auth_command", None)
+        if isinstance(command, str):
+            return f"Credential is missing or expired. Click Re-authenticate to run '{command}'."
+        return "Credential is missing or expired."
+    if action == "degraded":
+        return "Backend is available but experiencing issues."
+    return None

--- a/apps/server/src/screamingface/plugins/llm_base/routes_shared.py
+++ b/apps/server/src/screamingface/plugins/llm_base/routes_shared.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -164,16 +165,32 @@ def build_backend_api_router(cfg: BackendApiConfig) -> APIRouter:
 
         messages = [CoreMessage(role="user", content=[TextPart(text=request.prompt)])]
 
-        start = time.monotonic()
-        try:
-            result = await backend.run(
+        async def run_backend(model_to_use: str) -> CoreMessage:
+            return await backend.run(
                 messages,
-                model=model,
+                model=model_to_use,
                 system=system,
                 max_tokens=DEFAULT_MAX_TOKENS,
                 temperature=None,
                 timeout_seconds=timeout,
             )
+
+        start = time.monotonic()
+        try:
+            fallback_model = request.fallback_model or getattr(settings, "fallback_model", None)
+            try:
+                result = await run_backend(model)
+            except BackendError as exc:
+                if not _should_try_fallback(exc, model, fallback_model):
+                    raise
+                assert isinstance(fallback_model, str)
+                logger.warning(
+                    "%s primary model %s rate limited; retrying fallback model %s",
+                    cfg.name,
+                    model,
+                    fallback_model,
+                )
+                result = await run_backend(fallback_model)
             duration = time.monotonic() - start
             stdout = extract_text(result)
             parsed: dict | list | str | None = None
@@ -208,6 +225,7 @@ def build_backend_api_router(cfg: BackendApiConfig) -> APIRouter:
             duration = time.monotonic() - start
             logger.warning("%s backend error: %s", cfg.name, exc)
             status = 429 if exc.status == 429 else 502
+            headers = _retry_after_headers(exc)
             resp = RunResponse(
                 exit_code=1,
                 stdout="",
@@ -215,7 +233,11 @@ def build_backend_api_router(cfg: BackendApiConfig) -> APIRouter:
                 duration_seconds=round(duration, 3),
                 result=None,
             )
-            return JSONResponse(content=resp.model_dump(by_alias=True), status_code=status)
+            return JSONResponse(
+                content=resp.model_dump(by_alias=True),
+                status_code=status,
+                headers=headers,
+            )
 
     @router.post(f"{prefix}/run", response_model=None, operation_id=f"{op}_run")
     async def run_endpoint(request: RunRequest) -> JSONResponse | StreamingResponse:
@@ -231,7 +253,11 @@ def build_backend_api_router(cfg: BackendApiConfig) -> APIRouter:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
         except BackendError as exc:
             status = 429 if exc.status == 429 else 502
-            raise HTTPException(status_code=status, detail=str(exc)) from exc
+            raise HTTPException(
+                status_code=status,
+                detail=str(exc),
+                headers=_retry_after_headers(exc),
+            ) from exc
         except Exception as exc:
             logger.warning("%s url4 evaluation failed: %s", cfg.name, exc, exc_info=True)
             raise HTTPException(
@@ -346,6 +372,19 @@ def build_backend_api_router(cfg: BackendApiConfig) -> APIRouter:
     return router
 
 
+def _should_try_fallback(
+    exc: BackendError,
+    model: str,
+    fallback_model: object,
+) -> bool:
+    return (
+        exc.status == 429
+        and isinstance(fallback_model, str)
+        and bool(fallback_model)
+        and fallback_model != model
+    )
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -378,3 +417,13 @@ def _reject_cli_only_fields(request: RunRequest, plugin_name: str) -> None:
             f"call the CLI-frontend plugin instead."
         ),
     )
+
+
+def _retry_after_headers(exc: BackendError) -> dict[str, str]:
+    retry_after = getattr(exc, "retry_after", None)
+    if retry_after is None:
+        return {}
+    if retry_after < 0:
+        retry_after = 0
+    # Retry-After delta-seconds is an integer; round up so clients do not retry early.
+    return {"Retry-After": str(math.ceil(retry_after))}

--- a/apps/server/src/screamingface/plugins/llm_base/tests/test_backends_status_auth_kind.py
+++ b/apps/server/src/screamingface/plugins/llm_base/tests/test_backends_status_auth_kind.py
@@ -20,8 +20,18 @@ class _BrowserPlugin:
     gateway_provider = "anthropic"
 
 
+class _CodexBrowserPlugin:
+    name = "aigw-codex-backend"
+    backend_call_paths = ["/codex"]
+    gateway_provider = "codex"
+
+
 def test_auth_kind_browser_when_plugin_has_gateway_provider() -> None:
     assert _classify_auth_kind(_BrowserPlugin) == "browser"
+
+
+def test_auth_kind_browser_for_gateway_backed_codex() -> None:
+    assert _classify_auth_kind(_CodexBrowserPlugin) == "browser"
 
 
 def test_auth_kind_cli_when_plugin_lacks_gateway_provider() -> None:

--- a/apps/server/src/screamingface/plugins/llm_base/tests/test_routes_shared.py
+++ b/apps/server/src/screamingface/plugins/llm_base/tests/test_routes_shared.py
@@ -6,15 +6,25 @@ fields explicitly at the ``/run`` route.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 
 from screamingface.plugins.backend_api_base.models import RunRequest
+from screamingface.plugins.llm_base.backend_base import Backend, HealthStatus
 from screamingface.plugins.llm_base.constants import (
     CLI_ONLY_FIELD_DEFAULTS,
     CLI_ONLY_FIELDS,
 )
-from screamingface.plugins.llm_base.routes_shared import _reject_cli_only_fields
+from screamingface.plugins.llm_base.errors import BackendError
+from screamingface.plugins.llm_base.messages import CoreMessage, ToolDefinition
+from screamingface.plugins.llm_base.routes_shared import (
+    BackendApiConfig,
+    _reject_cli_only_fields,
+    build_backend_api_router,
+)
 
 
 def _default_request(**overrides) -> RunRequest:
@@ -65,3 +75,98 @@ def test_constant_covers_runrequest_defaults() -> None:
             f"Default mismatch for {f}: model={getattr(req, f)!r} "
             f"vs constant={CLI_ONLY_FIELD_DEFAULTS[f]!r}"
         )
+
+
+class _RateLimitedBackend(Backend):
+    async def health(self, model: str | None = None) -> HealthStatus:  # noqa: ARG002
+        return HealthStatus(authenticated=True)
+
+    async def run(
+        self,
+        messages: list[CoreMessage],  # noqa: ARG002
+        *,
+        model: str,
+        system: str | None = None,  # noqa: ARG002
+        tools: list[ToolDefinition] | None = None,  # noqa: ARG002
+        max_tokens: int = 16000,  # noqa: ARG002
+        temperature: float | None = None,  # noqa: ARG002
+        timeout_seconds: float = 300.0,  # noqa: ARG002
+    ) -> CoreMessage:
+        raise BackendError("rate limited", status=429, retry_after=2.1)
+
+
+class _FallbackBackend(Backend):
+    def __init__(self) -> None:
+        self.models: list[str] = []
+
+    async def health(self, model: str | None = None) -> HealthStatus:  # noqa: ARG002
+        return HealthStatus(authenticated=True)
+
+    async def run(
+        self,
+        messages: list[CoreMessage],  # noqa: ARG002
+        *,
+        model: str,
+        system: str | None = None,  # noqa: ARG002
+        tools: list[ToolDefinition] | None = None,  # noqa: ARG002
+        max_tokens: int = 16000,  # noqa: ARG002
+        temperature: float | None = None,  # noqa: ARG002
+        timeout_seconds: float = 300.0,  # noqa: ARG002
+    ) -> CoreMessage:
+        self.models.append(model)
+        if model == "primary/model":
+            raise BackendError("rate limited", status=429, retry_after=2.1)
+        return CoreMessage(role="assistant", content="fallback ok")
+
+
+def test_backend_error_retry_after_becomes_response_header() -> None:
+    app = FastAPI()
+    settings = SimpleNamespace(default_model=None, timeout_seconds=300.0, profiles={})
+    router = build_backend_api_router(
+        BackendApiConfig(
+            name="test-backend-api",
+            path_prefix="/test",
+            default_model="test/model",
+            backend=_RateLimitedBackend(),
+            settings=settings,
+            app=app,
+            build_interpreter=lambda: None,
+            span_prefix="test",
+        )
+    )
+    app.include_router(router)
+
+    resp = TestClient(app).post("/test/run", json={"prompt": "hi"})
+
+    assert resp.status_code == 429
+    assert resp.headers["retry-after"] == "3"
+
+
+def test_run_retries_configured_fallback_model_on_429() -> None:
+    app = FastAPI()
+    backend = _FallbackBackend()
+    settings = SimpleNamespace(
+        default_model=None,
+        fallback_model="fallback/model",
+        timeout_seconds=300.0,
+        profiles={},
+    )
+    router = build_backend_api_router(
+        BackendApiConfig(
+            name="test-backend-api",
+            path_prefix="/test",
+            default_model="primary/model",
+            backend=backend,
+            settings=settings,
+            app=app,
+            build_interpreter=lambda: None,
+            span_prefix="test",
+        )
+    )
+    app.include_router(router)
+
+    resp = TestClient(app).post("/test/run", json={"prompt": "hi"})
+
+    assert resp.status_code == 200
+    assert resp.json()["so"] == "fallback ok"
+    assert backend.models == ["primary/model", "fallback/model"]

--- a/apps/server/tests/e2e/conftest.py
+++ b/apps/server/tests/e2e/conftest.py
@@ -31,6 +31,7 @@ _PROVIDER_BY_FILE: dict[str, str] = {
     "test_cat_breeds_spec.py": "claude",
     "test_aigw_claude_e2e.py": "claude",
     "test_aigw_auth_e2e.py": "claude",
+    "test_aigw_codex_auth_e2e.py": "codex",
     "test_url4_specs_live.py": "claude",
     "test_ensemble_features.py": "claude",
     "test_url4_resolution.py": "claude",

--- a/apps/server/tests/e2e/data/claude/context_packing.yaml
+++ b/apps/server/tests/e2e/data/claude/context_packing.yaml
@@ -48,10 +48,7 @@
   ticket: SF-89
   backends: [claude]
   expression: >-
-    /claude(The population of Tokyo is 14 million.
-    The population of Paris is 2 million.
-    The population of London is 9 million.)
-    !Which city has the smallest population? One word.
+    /claude?q=%28The%20population%20of%20Tokyo%20is%2014%20million.%20The%20population%20of%20Paris%20is%202%20million.%20The%20population%20of%20London%20is%209%20million.%29%21Use%20the%20provided%20population%20facts%20to%20answer%3A%20which%20city%20has%20the%20smallest%20population%3F%20Reply%20with%20one%20word%3A%20the%20city%20name.
   expect:
     max_length: 1000
     contains_any: ["Paris", "paris"]

--- a/apps/server/tests/e2e/data/codex/context_packing.yaml
+++ b/apps/server/tests/e2e/data/codex/context_packing.yaml
@@ -48,10 +48,7 @@
   ticket: SF-83
   backends: [codex]
   expression: >-
-    /codex(The population of Tokyo is 14 million.
-    The population of Paris is 2 million.
-    The population of London is 9 million.)
-    !Which city has the smallest population? One word.
+    /codex?q=%28The%20population%20of%20Tokyo%20is%2014%20million.%20The%20population%20of%20Paris%20is%202%20million.%20The%20population%20of%20London%20is%209%20million.%29%21Use%20the%20provided%20population%20facts%20to%20answer%3A%20which%20city%20has%20the%20smallest%20population%3F%20Reply%20with%20one%20word%3A%20the%20city%20name.
   expect:
     max_length: 1000
     contains_any: ["Paris", "paris"]

--- a/apps/server/tests/e2e/test_aigw_auth_e2e.py
+++ b/apps/server/tests/e2e/test_aigw_auth_e2e.py
@@ -39,10 +39,13 @@ pytestmark = pytest.mark.e2e
 _ANONYMOUS_ACCOUNT_ID = "00000000-0000-0000-0000-000000000000"
 
 
-def _free_port() -> int:
-    with socket.socket() as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
+def _reserve_loopback_socket(*, listen: bool) -> socket.socket:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    if listen:
+        sock.listen()
+    sock.set_inheritable(True)
+    return sock
 
 
 def _aigateway_dir() -> Path:
@@ -51,9 +54,11 @@ def _aigateway_dir() -> Path:
 
 
 def _boot_gateway(extra_env: dict[str, str], tmp_path: Path) -> tuple[int, subprocess.Popen[str]]:
-    port = _free_port()
+    sock = _reserve_loopback_socket(listen=True)
+    port = sock.getsockname()[1]
     env = os.environ.copy()
     env.pop("VIRTUAL_ENV", None)
+    env["AIGW_PORT"] = str(port)
     env["AIGATEWAY_FAKE_KEYCHAIN"] = "1"
     env["AIGATEWAY_KEYCHAIN_FILE"] = str(tmp_path / "fake-kc.json")
     env["AIGATEWAY_FAKE_ANTHROPIC_OAUTH"] = "1"
@@ -63,42 +68,44 @@ def _boot_gateway(extra_env: dict[str, str], tmp_path: Path) -> tuple[int, subpr
     env["AIGATEWAY_JWT_SECRET"] = "x" * 32
     env["AIGATEWAY_PROVISIONING_TOKEN"] = "p" * 32
     env.update(extra_env)
-    subprocess.run(
-        [
-            "uv",
-            "run",
-            "--directory",
-            str(_aigateway_dir()),
-            "python",
-            "-m",
-            "tortoise",
-            "-c",
-            "aigateway.db.TORTOISE_CONFIG",
-            "migrate",
-        ],
-        env=env,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    proc = subprocess.Popen(
-        [
-            "uv",
-            "run",
-            "--directory",
-            str(_aigateway_dir()),
-            "uvicorn",
-            "aigateway.main:app",
-            "--port",
-            str(port),
-            "--host",
-            "127.0.0.1",
-        ],
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-    )
+    try:
+        subprocess.run(
+            [
+                "uv",
+                "run",
+                "--directory",
+                str(_aigateway_dir()),
+                "python",
+                "-m",
+                "tortoise",
+                "-c",
+                "aigateway.db.TORTOISE_CONFIG",
+                "migrate",
+            ],
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        proc = subprocess.Popen(
+            [
+                "uv",
+                "run",
+                "--directory",
+                str(_aigateway_dir()),
+                "uvicorn",
+                "aigateway.main:app",
+                "--fd",
+                str(sock.fileno()),
+            ],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            pass_fds=(sock.fileno(),),
+        )
+    finally:
+        sock.close()
     deadline = time.monotonic() + 30
     while time.monotonic() < deadline:
         if proc.poll() is not None:
@@ -164,7 +171,7 @@ def test_full_oauth_cycle_via_sf_auth_proxy(aigw: dict) -> None:
     sf = _sf_client(gw_port)
 
     resp = sf.post("/claude/auth/start")
-    assert resp.status_code == 200, resp.text
+    assert resp.status_code == 201, resp.text
     body = resp.json()
     assert body["profile_id"] == f"{_ANONYMOUS_ACCOUNT_ID}:anthropic:default"
     assert body["authorize_url"].startswith("https://")
@@ -257,10 +264,11 @@ def test_callback_when_token_exchange_fails_marks_profile_non_authenticated(
 
 
 def test_start_when_gateway_is_down_returns_502() -> None:
-    port = _free_port()  # Nothing listening
-    sf = _sf_client(port)
+    with _reserve_loopback_socket(listen=False) as sock:
+        port = sock.getsockname()[1]
+        sf = _sf_client(port)
 
-    resp = sf.post("/claude/auth/start")
+        resp = sf.post("/claude/auth/start")
     assert resp.status_code == 502
     assert resp.json()["detail"]["code"] == "gateway_unreachable"
 

--- a/apps/server/tests/e2e/test_aigw_claude_e2e.py
+++ b/apps/server/tests/e2e/test_aigw_claude_e2e.py
@@ -52,6 +52,7 @@ Asserts on TWO levels:
 
 from __future__ import annotations
 
+import os
 import re
 import shutil
 import time

--- a/apps/server/tests/e2e/test_aigw_claude_e2e.py
+++ b/apps/server/tests/e2e/test_aigw_claude_e2e.py
@@ -70,7 +70,7 @@ from tests.e2e.infrastructure.server_manager import ServerManager
 
 _TEST_PROMPT = "Reply with the single English word: pong"
 
-pytestmark = [pytest.mark.e2e, pytest.mark.e2e_live]
+pytestmark = pytest.mark.e2e
 
 # url4 spec: substitute $prompt as the q-param of a /claude backend call.
 # The /claude endpoint is served by aigw-claude-backend; the result text is
@@ -193,53 +193,57 @@ def aigw_proxy(otlp_collector: OTLPCollector, httpbin_url: str):
         },
     }
 
+    previous_bootstrap = os.environ.get("AIGATEWAY_BOOTSTRAP_FROM_CLAUDE_CODE")
+    os.environ["AIGATEWAY_BOOTSTRAP_FROM_CLAUDE_CODE"] = "1"
     mgr = ServerManager(config, session_id="e2e-aigw-claude")
-    mgr.start(timeout=120)
+    try:
+        mgr.start(timeout=120)
 
-    if not ServerManager.wait_for_port(proxy_port, timeout=60):
-        last_logs = "\n".join(mgr.logs.dump_last()) if mgr.logs else "<no logs>"
-        mgr.stop()
-        pytest.fail(
-            f"claude-frontend not listening on port {proxy_port}\n"
-            f"Last server log lines:\n{last_logs}"
-        )
-    if not ServerManager.wait_for_port(gateway_port, timeout=60):
-        last_logs = "\n".join(mgr.logs.dump_last()) if mgr.logs else "<no logs>"
-        mgr.stop()
-        pytest.fail(
-            f"aigw-runner did not bring up gateway on port {gateway_port}\n"
-            f"Last server log lines:\n{last_logs}"
-        )
+        if not ServerManager.wait_for_port(proxy_port, timeout=60):
+            last_logs = "\n".join(mgr.logs.dump_last()) if mgr.logs else "<no logs>"
+            pytest.fail(
+                f"claude-frontend not listening on port {proxy_port}\n"
+                f"Last server log lines:\n{last_logs}"
+            )
+        if not ServerManager.wait_for_port(gateway_port, timeout=60):
+            last_logs = "\n".join(mgr.logs.dump_last()) if mgr.logs else "<no logs>"
+            pytest.fail(
+                f"aigw-runner did not bring up gateway on port {gateway_port}\n"
+                f"Last server log lines:\n{last_logs}"
+            )
 
-    # Confirm the gateway has an authenticated anthropic:default profile —
-    # otherwise the chat call will return 404 profile_not_found.
-    deadline = time.monotonic() + 15
-    profile_state: str | None = None
-    while time.monotonic() < deadline:
-        try:
-            r = httpx.get(f"http://127.0.0.1:{gateway_port}/v1/auth/profiles", timeout=3)
-            if r.status_code == 200:
-                for p in r.json().get("profiles", []):
-                    if p.get("id") == "anthropic:default":
-                        profile_state = p.get("state")
+        # Confirm the gateway has an authenticated default Anthropic profile —
+        # otherwise the chat call will return 404 profile_not_found.
+        deadline = time.monotonic() + 15
+        profile_state: str | None = None
+        while time.monotonic() < deadline:
+            try:
+                r = httpx.get(f"http://127.0.0.1:{gateway_port}/v1/auth/profiles", timeout=3)
+                if r.status_code == 200:
+                    for p in r.json().get("profiles", []):
+                        if p.get("provider") == "anthropic" and p.get("name") == "default":
+                            profile_state = p.get("state")
+                            break
+                    if profile_state is not None:
                         break
-                if profile_state is not None:
-                    break
-        except httpx.RequestError:
-            pass
-        time.sleep(0.5)
+            except httpx.RequestError:
+                pass
+            time.sleep(0.5)
 
-    if profile_state != "authenticated":
+        if profile_state != "authenticated":
+            pytest.skip(
+                f"Gateway anthropic/default profile state is {profile_state!r}. "
+                "Run `claude auth login` so the bootstrap can import credentials, "
+                "or POST /v1/auth/anthropic/profiles to seed one manually."
+            )
+
+        yield mgr, proxy_port, gateway_port
+    finally:
         mgr.stop()
-        pytest.skip(
-            f"Gateway anthropic:default profile state is {profile_state!r}. "
-            "Run `claude auth login` so the bootstrap can import credentials, "
-            "or POST /v1/auth/anthropic/profiles to seed one manually."
-        )
-
-    yield mgr, proxy_port, gateway_port
-
-    mgr.stop()
+        if previous_bootstrap is None:
+            os.environ.pop("AIGATEWAY_BOOTSTRAP_FROM_CLAUDE_CODE", None)
+        else:
+            os.environ["AIGATEWAY_BOOTSTRAP_FROM_CLAUDE_CODE"] = previous_bootstrap
 
 
 # ---------------------------------------------------------------------------
@@ -320,10 +324,6 @@ def test_claude_frontend_to_aigw_to_anthropic(
     )
 
     # ------------------------------ span chain -----------------------------
-    # Wait briefly for spans to flush through the OTLP collector.
-    otlp_collector.wait_for_spans(3, timeout=15)
-    span_names = {s.name for s in otlp_collector._spans}  # noqa: SLF001 — test-only
-
     # Each layer below MUST appear. If any is missing, someone has rerouted
     # the request and skipped a layer (e.g. mistakenly enabled the legacy
     # claude-backend-api alongside aigw-claude-backend).
@@ -343,6 +343,14 @@ def test_claude_frontend_to_aigw_to_anthropic(
         "url4_executor": "url4.evaluate",
         "aigw_backend_route": "GET /claude",
     }
+    span_names: set[str] = set()
+    deadline = time.monotonic() + 15
+    while time.monotonic() < deadline:
+        span_names = {s.name for s in otlp_collector.spans}
+        if all(any(span in name for name in span_names) for span in expected_layers.values()):
+            break
+        time.sleep(0.2)
+
     missing = {
         layer: span
         for layer, span in expected_layers.items()

--- a/apps/server/tests/e2e/test_aigw_codex_auth_e2e.py
+++ b/apps/server/tests/e2e/test_aigw_codex_auth_e2e.py
@@ -1,0 +1,241 @@
+"""End-to-end: SF aigw-codex-backend auth-proxy <-> real aigateway subprocess.
+
+This mirrors the Claude auth E2E shape but exercises the Codex provider-owned
+OAuth exchange path. It does not contact OpenAI: the gateway subprocess is
+started with test-only fake keychain and fake Codex token endpoint hooks.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from screamingface.plugins.aigw_codex_backend.plugin import (
+    AigwCodexBackendPlugin,
+    AigwCodexBackendSettings,
+)
+
+pytestmark = pytest.mark.e2e
+
+_ANONYMOUS_ACCOUNT_ID = "00000000-0000-0000-0000-000000000000"
+
+
+def _reserve_loopback_socket(*, listen: bool) -> socket.socket:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    if listen:
+        sock.listen()
+    sock.set_inheritable(True)
+    return sock
+
+
+def _aigateway_dir() -> Path:
+    return Path(__file__).resolve().parents[3] / "aigateway"
+
+
+def _boot_gateway(extra_env: dict[str, str], tmp_path: Path) -> tuple[int, subprocess.Popen[str]]:
+    sock = _reserve_loopback_socket(listen=True)
+    port = sock.getsockname()[1]
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    env["AIGW_PORT"] = str(port)
+    env["AIGATEWAY_FAKE_KEYCHAIN"] = "1"
+    env["AIGATEWAY_KEYCHAIN_FILE"] = str(tmp_path / "fake-kc.json")
+    env["AIGATEWAY_FAKE_CODEX_OAUTH"] = "1"
+    env["AIGATEWAY_DATABASE_URL"] = f"sqlite://{tmp_path / 'aigateway.sqlite3'}"
+    env["AIGATEWAY_AUTH_ENABLED"] = "0"
+    env["AIGATEWAY_ADMIN_PASSWORD"] = "test-admin-password"
+    env["AIGATEWAY_JWT_SECRET"] = "x" * 32
+    env["AIGATEWAY_PROVISIONING_TOKEN"] = "p" * 32
+    env.update(extra_env)
+    try:
+        subprocess.run(
+            [
+                "uv",
+                "run",
+                "--directory",
+                str(_aigateway_dir()),
+                "python",
+                "-m",
+                "tortoise",
+                "-c",
+                "aigateway.db.TORTOISE_CONFIG",
+                "migrate",
+            ],
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        proc = subprocess.Popen(
+            [
+                "uv",
+                "run",
+                "--directory",
+                str(_aigateway_dir()),
+                "uvicorn",
+                "aigateway.main:app",
+                "--fd",
+                str(sock.fileno()),
+            ],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            pass_fds=(sock.fileno(),),
+        )
+    finally:
+        sock.close()
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            output = proc.stdout.read() if proc.stdout else ""
+            raise RuntimeError(f"aigateway exited early (rc={proc.returncode}); output:\n{output}")
+        try:
+            r = httpx.get(f"http://127.0.0.1:{port}/healthz", timeout=1)
+            if r.status_code == 200:
+                return port, proc
+        except httpx.RequestError:
+            time.sleep(0.2)
+    proc.terminate()
+    output = ""
+    try:
+        output = proc.stdout.read() if proc.stdout else ""
+    except Exception:
+        pass
+    raise RuntimeError(f"aigateway failed to start within 30s; output:\n{output}")
+
+
+def _terminate(proc: subprocess.Popen[str]) -> None:
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+@pytest.fixture
+def aigw(tmp_path: Path) -> Iterator[dict]:
+    port, proc = _boot_gateway({}, tmp_path)
+    try:
+        yield {"port": port, "proc": proc}
+    finally:
+        _terminate(proc)
+
+
+@pytest.fixture
+def aigw_failing_oauth(tmp_path: Path) -> Iterator[dict]:
+    port, proc = _boot_gateway({"AIGATEWAY_FAKE_CODEX_OAUTH_FAIL": "1"}, tmp_path)
+    try:
+        yield {"port": port, "proc": proc}
+    finally:
+        _terminate(proc)
+
+
+def _sf_client(gateway_port: int) -> TestClient:
+    settings = AigwCodexBackendSettings(gateway_url=f"http://127.0.0.1:{gateway_port}")
+    app = FastAPI()
+    app.include_router(AigwCodexBackendPlugin.create_router(settings, app=app))
+    return TestClient(app)
+
+
+def _callback_url_from_authorize_url(authorize_url: str) -> str:
+    query = parse_qs(urlparse(authorize_url).query)
+    redirect_uri = query["redirect_uri"][0]
+    parsed = urlparse(redirect_uri)
+    return f"http://127.0.0.1:{parsed.port}{parsed.path}"
+
+
+def test_full_codex_oauth_cycle_via_sf_auth_proxy(aigw: dict) -> None:
+    gw_port = aigw["port"]
+    sf = _sf_client(gw_port)
+
+    resp = sf.post("/codex/auth/start")
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["profile_id"] == f"{_ANONYMOUS_ACCOUNT_ID}:codex:default"
+    assert body["authorize_url"].startswith("https://auth.openai.com/oauth/authorize")
+    redirect_uri = parse_qs(urlparse(body["authorize_url"]).query)["redirect_uri"][0]
+    assert redirect_uri in {
+        "http://localhost:1455/auth/callback",
+        "http://localhost:1457/auth/callback",
+    }
+    state = body["state"]
+
+    pending = sf.get("/codex/auth/status")
+    assert pending.status_code == 200
+    assert pending.json()["state"] == "pending"
+
+    cb = httpx.get(
+        _callback_url_from_authorize_url(body["authorize_url"]),
+        params={"code": "fake-codex-code", "state": state},
+        timeout=5,
+    )
+    assert cb.status_code == 200, cb.text
+
+    status = sf.get("/codex/auth/status")
+    assert status.status_code == 200
+    assert status.json()["state"] == "authenticated"
+    assert status.json()["account_label"] == "codex-user@example.com"
+
+    health = sf.get("/codex/health")
+    assert health.status_code == 200
+    assert health.json()["authenticated"] is True
+
+
+def test_codex_import_route_is_not_exposed(aigw: dict) -> None:
+    sf = _sf_client(aigw["port"])
+
+    resp = sf.post("/codex/auth/import")
+
+    assert resp.status_code == 404
+
+
+def test_callback_with_wrong_state_does_not_authenticate(aigw: dict) -> None:
+    sf = _sf_client(aigw["port"])
+
+    start = sf.post("/codex/auth/start").json()
+    cb = httpx.get(
+        _callback_url_from_authorize_url(start["authorize_url"]),
+        params={"code": "fake-codex-code", "state": "definitely-wrong"},
+        timeout=5,
+    )
+    assert cb.status_code == 400
+    assert sf.get("/codex/auth/status").json()["state"] == "pending"
+
+
+def test_callback_when_token_exchange_fails_marks_profile_non_authenticated(
+    aigw_failing_oauth: dict,
+) -> None:
+    sf = _sf_client(aigw_failing_oauth["port"])
+
+    start = sf.post("/codex/auth/start").json()
+    cb = httpx.get(
+        _callback_url_from_authorize_url(start["authorize_url"]),
+        params={"code": "fake-codex-code", "state": start["state"]},
+        timeout=5,
+    )
+    assert cb.status_code >= 400
+    status = sf.get("/codex/auth/status").json()
+    assert status["state"] in ("pending", "error")
+    assert status["state"] != "authenticated"
+
+
+def test_start_when_gateway_is_down_returns_502() -> None:
+    with _reserve_loopback_socket(listen=False) as sock:
+        sf = _sf_client(sock.getsockname()[1])
+
+        resp = sf.post("/codex/auth/start")
+
+    assert resp.status_code == 502
+    assert resp.json()["detail"]["code"] == "gateway_unreachable"

--- a/scripts/download-build-assets.sh
+++ b/scripts/download-build-assets.sh
@@ -111,6 +111,10 @@ SERVER_VENV="$REPO_ROOT/apps/server/.venv"
 if [ -d "$SERVER_VENV" ]; then
   mv "$SERVER_VENV" "$TMP_DIR/saved-venv"
 fi
+GATEWAY_VENV="$REPO_ROOT/apps/aigateway/.venv"
+if [ -d "$GATEWAY_VENV" ]; then
+  mv "$GATEWAY_VENV" "$TMP_DIR/saved-aigateway-venv"
+fi
 
 "$OUT_DIR/uv" sync \
   --no-install-project \
@@ -118,10 +122,20 @@ fi
   --directory "$REPO_ROOT/apps/server" \
   || true  # Non-fatal: cache is an optimization, not a hard requirement
 
+"$OUT_DIR/uv" sync \
+  --no-install-project \
+  --python "$OUT_DIR/python/bin/python3.12" \
+  --directory "$REPO_ROOT/apps/aigateway" \
+  || true  # Non-fatal: cache is an optimization, not a hard requirement
+
 # Clean up the venv uv sync created, restore original if it existed
 rm -rf "$SERVER_VENV"
 if [ -d "$TMP_DIR/saved-venv" ]; then
   mv "$TMP_DIR/saved-venv" "$SERVER_VENV"
+fi
+rm -rf "$GATEWAY_VENV"
+if [ -d "$TMP_DIR/saved-aigateway-venv" ]; then
+  mv "$TMP_DIR/saved-aigateway-venv" "$GATEWAY_VENV"
 fi
 
 # Package cache as tar.gz (smaller bundle, avoids macOS xattr issues with .app bundles)


### PR DESCRIPTION
Description                                                                                                                                                                                                                                                                                                              
 Adds OAuth-backed Codex support to AI Gateway and hardens the shared provider/plugin architecture used by OAuth-backed providers.                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                          
 This implements gateway-owned browser OAuth for Codex, routes Codex requests through the ChatGPT Codex backend, adds Desktop profile/auth UI support, and keeps credentials owned by AI Gateway rather than importing local Codex CLI auth files.                                                                        
                                                                                                                                                                                                                                                                                                                          
 Follow-up hardening makes OAuth credential lifecycle operations part of the public provider contract, ensures refresh uses the app-injected credential store and HTTP factory, scopes concurrent OAuth state by backend/profile, and routes streaming through the provider plugin boundary.                              
                                                                                                                                                                                                                                                                                                                          
 Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1214568364577551                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                          
 Affected Dependencies                                                                                                                                                                                                                                                                                                    
 No new external dependencies.                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                          
 How has this been tested?                                                                                                                                                                                                                                                                                                
 - cd apps/aigateway && uv run pytest -m "not live"                                                                                                                                                                                                                                                                       
 - cd apps/aigateway && uv run ruff check .                                                                                                                                                                                                                                                                               
 - cd apps/aigateway && uv run pyright                                                                                                                                                                                                                                                                                    
 - cd apps/aigateway && uv run python scripts/check_no_enterprise.py                                                                                                                                                                                                                                                      
 - cd apps/desktop && npx vitest run src/main/services/__tests__/oauth-launcher.test.ts src/renderer/src/components/server/__tests__/BackendStatusPanel.test.tsx                                                                                                                                                          
 - cd apps/desktop && npm run build                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                          
 Additional live/manual validation performed earlier on this branch:                                                                                                                                                                                                                                                      
 - Anthropic premium Sonnet/Opus through direct AI Gateway and SF server.                                                                                                                                                                                                                                                 
 - Codex AI Gateway/SF auth and chat e2e paths with fake-keychain harness.                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                          
 Checklist                                                                                                                                                                                                                                                                                                                
 - [x] I have followed the Contribution Guidelines (https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and Code of Conduct (https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)                                                                                                           
 - [x] I have commented my code following the OpenMined Styleguide (https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)                                                                                                                                                                                       
 - [x] I have labeled this PR with the relevant Type labels (https://github.com/OpenMined/.github/labels?q=Type%3A)                                                                                                                                                                                                       
 - [x] My changes are covered by tests