### PR TITLE
SF-177: add scoreboard score persistence layer

### DIFF
--- a/apps/scoreboard/README.md
+++ b/apps/scoreboard/README.md
@@ -1,6 +1,6 @@
 # scoreboard
 
-Public benchmark scoreboard service for ScreamingFace clients. It ingests benchmark scores and serves leaderboard data in follow-up tickets; this scaffold only provides the runnable service shell, health route, settings, database wiring, Tortoise migration CLI configuration, and test/tooling baseline.
+Public benchmark scoreboard service for ScreamingFace clients. It now provides the runnable service shell, health route, settings, Tortoise database wiring, score-domain models, the initial migration, and the persistence/query store. HTTP ingestion and leaderboard routes land in follow-up tickets.
 
 ## Quick Start
 
@@ -8,13 +8,14 @@ Public benchmark scoreboard service for ScreamingFace clients. It ingests benchm
 cd apps/scoreboard
 uv sync
 
-SCOREBOARD_DATABASE_URL='sqlite://:memory:' uv run uvicorn scoreboard.main:app --port 9106 --reload
+uv run tortoise migrate
+uv run uvicorn scoreboard.main:app --port 9106 --reload
 
 # Sanity check
 curl -sf http://localhost:9106/healthz
 ```
 
-`/healthz` is a liveness probe only. It does not query the database and does not prove Postgres connectivity; a real readiness probe belongs with the first concrete score model in D-SCORE-002.
+`/healthz` is a liveness probe only. It does not query the database and does not prove Postgres connectivity.
 
 ### Running Against Local Postgres
 
@@ -28,10 +29,21 @@ docker run --rm -d --name sf-scoreboard-postgres \
   -p 5432:5432 \
   postgres:16-alpine
 
+uv run tortoise migrate
 uv run uvicorn scoreboard.main:app --port 9106 --reload
 ```
 
-Tortoise's built-in migration CLI is configured through `[tool.tortoise]` in `pyproject.toml`. D-SCORE-002 will add the first concrete score models and migrations. Once migrations exist, apply them with `uv run tortoise migrate`.
+Tortoise's built-in migration CLI is configured through `[tool.tortoise]` in `pyproject.toml`. Apply migrations with `uv run tortoise migrate`; running it a second time should be a no-op.
+
+### Migration Verification
+
+```bash
+cd apps/scoreboard
+uv run tortoise migrate
+uv run tortoise migrate
+```
+
+The first run applies pending migrations. The second run should report that no migrations are pending.
 
 ## Configuration
 
@@ -53,10 +65,11 @@ Settings are read from environment variables with the `SCOREBOARD_` prefix.
 cd apps/scoreboard
 uv run pytest tests/unit/ -v
 uv run ruff check .
+uv run ruff format --check .
 uv run pyright
 ```
 
-Unit tests use SQLite so the scaffold can be validated without a local Postgres server. Postgres-backed tests can opt into the shared per-test schema fixture by setting `SCOREBOARD_TEST_DATABASE_URL`.
+Unit tests use SQLite through Tortoise's isolated `tortoise_test_context`, so the persistence layer can be validated without a local Postgres server. Postgres-backed tests can opt into a database URL by setting `SCOREBOARD_TEST_DATABASE_URL`.
 
 ## Layout
 
@@ -68,7 +81,11 @@ src/scoreboard/
   db.py              Tortoise configuration/init helpers
   routes/
     health.py        GET /healthz
-  scores/models/     Empty model package reserved for D-SCORE-002
+  scores/
+    schemas.py       Pydantic DTOs for submissions and read models
+    store.py         Tortoise-backed persistence/query store
+    models/          Benchmark, Score, and IdempotencyKey Tortoise models
+    migrations/      Tortoise built-in migrations
 tests/
   unit/
 ```

--- a/apps/scoreboard/src/scoreboard/db.py
+++ b/apps/scoreboard/src/scoreboard/db.py
@@ -1,20 +1,23 @@
 from __future__ import annotations
 
-import warnings
+import os
 from copy import deepcopy
 from typing import Any
 
 from tortoise import Tortoise
 
 DEFAULT_DATABASE_URL = "postgres://scoreboard:scoreboard@localhost:5432/scoreboard"
-EMPTY_SCORE_MODELS_WARNING = 'Module "scoreboard.scores.models" has no models'
+DEFAULT_CONFIGURED_DATABASE_URL = os.getenv(
+    "SCOREBOARD_DATABASE_URL",
+    DEFAULT_DATABASE_URL,
+)
 
 TORTOISE_CONFIG: dict[str, Any] = {
-    "connections": {"default": DEFAULT_DATABASE_URL},
+    "connections": {"default": DEFAULT_CONFIGURED_DATABASE_URL},
     "apps": {
         "models": {
-            # D-SCORE-002 adds the first concrete model to this reserved package.
             "models": ["scoreboard.scores.models"],
+            "migrations": "scoreboard.scores.migrations",
             "default_connection": "default",
         }
     },
@@ -32,15 +35,7 @@ def build_tortoise_config(database_url: str) -> dict[str, Any]:
 async def init_db(database_url: str) -> None:
     # ASGI lifespan can initialize Tortoise in a different task than request handlers.
     # The global fallback keeps that initialized context visible across those tasks.
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message=EMPTY_SCORE_MODELS_WARNING,
-            category=RuntimeWarning,
-        )
-        await Tortoise.init(
-            config=build_tortoise_config(database_url), _enable_global_fallback=True
-        )
+    await Tortoise.init(config=build_tortoise_config(database_url), _enable_global_fallback=True)
 
 
 async def close_db() -> None:

--- a/apps/scoreboard/src/scoreboard/main.py
+++ b/apps/scoreboard/src/scoreboard/main.py
@@ -9,6 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from .config import Settings
 from .db import close_db, init_db
 from .routes import health
+from .scores.store import ScoreStore
 
 
 @asynccontextmanager
@@ -26,6 +27,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     app = FastAPI(title="scoreboard", version="0.1.0", lifespan=_lifespan)
     app.state.settings = settings
+    app.state.score_store = ScoreStore()
 
     if settings.cors_origins:
         app.add_middleware(

--- a/apps/scoreboard/src/scoreboard/scores/__init__.py
+++ b/apps/scoreboard/src/scoreboard/scores/__init__.py
@@ -1,1 +1,13 @@
 """Score ingestion and leaderboard domain package."""
+
+from .schemas import BenchmarkSchema, ClientInfo, LeaderboardEntry, ScoreSchema, ScoreSubmission
+from .store import ScoreStore
+
+__all__ = [
+    "BenchmarkSchema",
+    "ClientInfo",
+    "LeaderboardEntry",
+    "ScoreSchema",
+    "ScoreStore",
+    "ScoreSubmission",
+]

--- a/apps/scoreboard/src/scoreboard/scores/migrations/0001_initial.py
+++ b/apps/scoreboard/src/scoreboard/scores/migrations/0001_initial.py
@@ -1,0 +1,116 @@
+import functools
+from json import dumps, loads
+from uuid import uuid4
+
+from tortoise import fields, migrations
+from tortoise.fields.base import OnDelete
+from tortoise.indexes import Index
+from tortoise.migrations import operations as ops
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    operations = [
+        ops.CreateModel(
+            name="Benchmark",
+            fields=[
+                (
+                    "id",
+                    fields.CharField(primary_key=True, unique=True, db_index=True, max_length=64),
+                ),
+                ("display_name", fields.CharField(max_length=255)),
+                ("description", fields.TextField(null=True, unique=False)),
+                ("dataset_url", fields.CharField(null=True, max_length=2048)),
+                ("created_at", fields.DatetimeField(auto_now=False, auto_now_add=True)),
+            ],
+            options={"table": "benchmarks", "app": "models", "pk_attr": "id"},
+            bases=["BaseBenchmark"],
+        ),
+        ops.CreateModel(
+            name="Score",
+            fields=[
+                (
+                    "id",
+                    fields.UUIDField(primary_key=True, default=uuid4, unique=True, db_index=True),
+                ),
+                ("version", fields.IntField(default=1)),
+                ("spec_id", fields.CharField(db_index=True, max_length=255)),
+                ("url4_expression", fields.TextField(unique=False)),
+                ("submitted_by", fields.CharField(null=True, max_length=255)),
+                ("submitted_at", fields.DatetimeField(auto_now=False, auto_now_add=True)),
+                ("accuracy", fields.FloatField()),
+                ("total_questions", fields.IntField()),
+                ("correct_questions", fields.IntField()),
+                (
+                    "ran_with_providers",
+                    fields.JSONField(
+                        encoder=functools.partial(dumps, separators=(",", ":")), decoder=loads
+                    ),
+                ),
+                (
+                    "ran_at_local",
+                    fields.DatetimeField(null=True, auto_now=False, auto_now_add=False),
+                ),
+                ("client_name", fields.CharField(null=True, max_length=128)),
+                ("client_version", fields.CharField(null=True, max_length=64)),
+                ("client_platform", fields.CharField(null=True, max_length=32)),
+                ("verified_by_openmined", fields.BooleanField(default=False)),
+                (
+                    "metadata",
+                    fields.JSONField(
+                        null=True,
+                        encoder=functools.partial(dumps, separators=(",", ":")),
+                        decoder=loads,
+                    ),
+                ),
+                (
+                    "benchmark",
+                    fields.ForeignKeyField(
+                        "models.Benchmark",
+                        source_field="benchmark_id",
+                        db_constraint=True,
+                        to_field="id",
+                        related_name="scores",
+                        on_delete=OnDelete.RESTRICT,
+                    ),
+                ),
+            ],
+            options={
+                "table": "scores",
+                "app": "models",
+                "indexes": [
+                    Index(fields=["benchmark_id", "accuracy"]),
+                    Index(fields=["benchmark_id", "spec_id", "submitted_at"]),
+                ],
+                "pk_attr": "id",
+            },
+            bases=["BaseScore"],
+        ),
+        ops.CreateModel(
+            name="IdempotencyKey",
+            fields=[
+                (
+                    "key",
+                    fields.CharField(primary_key=True, unique=True, db_index=True, max_length=255),
+                ),
+                (
+                    "expires_at",
+                    fields.DatetimeField(db_index=True, auto_now=False, auto_now_add=False),
+                ),
+                (
+                    "score",
+                    fields.ForeignKeyField(
+                        "models.Score",
+                        source_field="score_id",
+                        db_constraint=True,
+                        to_field="id",
+                        related_name="idempotency_keys",
+                        on_delete=OnDelete.CASCADE,
+                    ),
+                ),
+            ],
+            options={"table": "idempotency_keys", "app": "models", "pk_attr": "key"},
+            bases=["BaseIdempotencyKey"],
+        ),
+    ]

--- a/apps/scoreboard/src/scoreboard/scores/models/__init__.py
+++ b/apps/scoreboard/src/scoreboard/scores/models/__init__.py
@@ -1,6 +1,16 @@
-"""Score models land here in D-SCORE-002.
+"""Score models for the scoreboard bounded context."""
 
-Model files in this package follow the Tortoise project convention:
-one concrete model per file, an abstract ``Base*`` interface beside each
-concrete model, ``class Meta`` first, fields next, then methods.
-"""
+from .base import BaseScoreboardModel
+from .benchmark import BaseBenchmark, Benchmark
+from .idempotency_key import BaseIdempotencyKey, IdempotencyKey
+from .score import BaseScore, Score
+
+__all__ = [
+    "BaseScoreboardModel",
+    "BaseBenchmark",
+    "Benchmark",
+    "BaseScore",
+    "Score",
+    "BaseIdempotencyKey",
+    "IdempotencyKey",
+]

--- a/apps/scoreboard/src/scoreboard/scores/models/base.py
+++ b/apps/scoreboard/src/scoreboard/scores/models/base.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from tortoise import Model
+
+
+class BaseScoreboardModel(Model):
+    class Meta:
+        abstract = True

--- a/apps/scoreboard/src/scoreboard/scores/models/benchmark.py
+++ b/apps/scoreboard/src/scoreboard/scores/models/benchmark.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from tortoise import fields
+
+from .base import BaseScoreboardModel
+
+
+class BaseBenchmark(BaseScoreboardModel):
+    class Meta:
+        abstract = True
+
+    id = fields.CharField(max_length=64, primary_key=True)
+    display_name = fields.CharField(max_length=255)
+    description = fields.TextField(null=True)
+    dataset_url = fields.CharField(max_length=2048, null=True)
+    created_at = fields.DatetimeField(auto_now_add=True)
+
+
+class Benchmark(BaseBenchmark):
+    class Meta:
+        table = "benchmarks"

--- a/apps/scoreboard/src/scoreboard/scores/models/idempotency_key.py
+++ b/apps/scoreboard/src/scoreboard/scores/models/idempotency_key.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from tortoise import fields
+
+from .base import BaseScoreboardModel
+
+
+class BaseIdempotencyKey(BaseScoreboardModel):
+    class Meta:
+        abstract = True
+
+    key = fields.CharField(max_length=255, primary_key=True)
+    expires_at = fields.DatetimeField(db_index=True)
+
+
+class IdempotencyKey(BaseIdempotencyKey):
+    class Meta:
+        table = "idempotency_keys"
+
+    score = fields.ForeignKeyField(
+        "models.Score",
+        related_name="idempotency_keys",
+        on_delete=fields.OnDelete.CASCADE,
+    )

--- a/apps/scoreboard/src/scoreboard/scores/models/score.py
+++ b/apps/scoreboard/src/scoreboard/scores/models/score.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import uuid
+
+from tortoise import fields
+
+from .base import BaseScoreboardModel
+
+
+class BaseScore(BaseScoreboardModel):
+    class Meta:
+        abstract = True
+
+    id = fields.UUIDField(primary_key=True, default=uuid.uuid4)
+    version = fields.IntField(default=1)
+    spec_id = fields.CharField(max_length=255, db_index=True)
+    url4_expression = fields.TextField()
+    submitted_by = fields.CharField(max_length=255, null=True)
+    submitted_at = fields.DatetimeField(auto_now_add=True)
+    accuracy = fields.FloatField()
+    total_questions = fields.IntField()
+    correct_questions = fields.IntField()
+    ran_with_providers = fields.JSONField()
+    ran_at_local = fields.DatetimeField(null=True)
+    client_name = fields.CharField(max_length=128, null=True)
+    client_version = fields.CharField(max_length=64, null=True)
+    client_platform = fields.CharField(max_length=32, null=True)
+    verified_by_openmined = fields.BooleanField(default=False)
+    metadata = fields.JSONField(null=True)
+
+
+class Score(BaseScore):
+    class Meta:
+        table = "scores"
+        indexes = (
+            ("benchmark_id", "accuracy"),
+            ("benchmark_id", "spec_id", "submitted_at"),
+        )
+
+    benchmark = fields.ForeignKeyField(
+        "models.Benchmark",
+        related_name="scores",
+        on_delete=fields.OnDelete.RESTRICT,
+    )

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+
+
+class ClientInfo(BaseModel):
+    """Optional client metadata for a score submission."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = None
+    version: str | None = None
+    platform: str | None = None
+
+
+class ScoreSubmission(BaseModel):
+    """Input DTO for score ingestion."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: int = 1
+    benchmark_id: str
+    spec_id: str
+    url4_expression: str
+    submitted_by: str | None = None
+    accuracy: float
+    total_questions: int
+    correct_questions: int
+    ran_with_providers: list[str]
+    ran_at_local: datetime | None = None
+    client_name: str | None = None
+    client_version: str | None = None
+    client_platform: str | None = None
+    metadata: dict[str, Any] | None = None
+
+    @field_validator("url4_expression")
+    @classmethod
+    def validate_url4_expression(cls, value: str) -> str:
+        if not value:
+            raise ValueError("url4_expression must be non-empty")
+        return value
+
+    @field_validator("benchmark_id", "spec_id")
+    @classmethod
+    def validate_identifiers(cls, value: str) -> str:
+        if not value:
+            raise ValueError("identifier fields must be non-empty")
+        return value
+
+    @field_validator("accuracy")
+    @classmethod
+    def validate_accuracy(cls, value: float) -> float:
+        if not 0 <= value <= 1:
+            raise ValueError("accuracy must be between 0 and 1")
+        return value
+
+    @field_validator("total_questions")
+    @classmethod
+    def validate_total_questions(cls, value: int) -> int:
+        if value <= 0:
+            raise ValueError("total_questions must be positive")
+        return value
+
+    @field_validator("correct_questions")
+    @classmethod
+    def validate_correct_questions(cls, value: int) -> int:
+        if value < 0:
+            raise ValueError("correct_questions must be non-negative")
+        return value
+
+    @model_validator(mode="after")
+    def validate_questions(self) -> ScoreSubmission:
+        if self.correct_questions > self.total_questions:
+            raise ValueError("correct_questions cannot exceed total_questions")
+        return self
+
+
+class BenchmarkSchema(BaseModel):
+    """Read DTO for benchmarks."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    display_name: str
+    description: str | None
+    dataset_url: str | None
+    created_at: datetime
+
+
+class ScoreSchema(BaseModel):
+    """Read DTO for a score."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: UUID
+    version: int
+    benchmark_id: str
+    spec_id: str
+    url4_expression: str
+    submitted_by: str | None
+    submitted_at: datetime
+    accuracy: float
+    total_questions: int
+    correct_questions: int
+    ran_with_providers: list[str]
+    ran_at_local: datetime | None
+    client_name: str | None
+    client_version: str | None
+    client_platform: str | None
+    verified_by_openmined: bool
+    metadata: dict[str, Any] | None
+
+
+class LeaderboardEntry(BaseModel):
+    """Read DTO for a leaderboard row before route rank assignment."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    spec_id: str
+    accuracy: float
+    total_questions: int
+    ran_with_providers: list[str]
+    submitted_at: datetime
+    submitted_by: str | None
+    verified_by_openmined: bool
+    url4_expression: str

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -4,50 +4,18 @@ from datetime import UTC, datetime, timedelta
 from typing import cast
 from uuid import UUID
 
+from pypika_tortoise.analytics import RowNumber
+from pypika_tortoise.enums import Order
+from pypika_tortoise.queries import Query, QueryBuilder
 from tortoise import Tortoise
 from tortoise.exceptions import IntegrityError
+from tortoise.query_api import execute_pypika
 from tortoise.transactions import in_transaction
 
 from .models import Benchmark, IdempotencyKey, Score
 from .schemas import BenchmarkSchema, LeaderboardEntry, ScoreSchema, ScoreSubmission
 
 IDEMPOTENCY_TTL = timedelta(hours=24)
-
-
-LEADERBOARD_SQL_POSTGRES = """
-WITH ranked AS (
-    SELECT
-        spec_id,
-        accuracy,
-        total_questions,
-        ran_with_providers,
-        submitted_at,
-        submitted_by,
-        verified_by_openmined,
-        url4_expression,
-        ROW_NUMBER() OVER (
-            PARTITION BY spec_id
-            ORDER BY accuracy DESC, submitted_at DESC
-        ) AS rn
-    FROM scores
-    WHERE benchmark_id = $1
-)
-SELECT
-    spec_id,
-    accuracy,
-    total_questions,
-    ran_with_providers,
-    submitted_at,
-    submitted_by,
-    verified_by_openmined,
-    url4_expression
-FROM ranked
-WHERE rn = 1
-ORDER BY accuracy DESC
-LIMIT $2
-"""
-
-LEADERBOARD_SQL_SQLITE = LEADERBOARD_SQL_POSTGRES.replace("$1", "?").replace("$2", "?")
 
 
 def _benchmark_to_schema(model: Benchmark) -> BenchmarkSchema:
@@ -99,6 +67,49 @@ def _submission_to_kwargs(submission: ScoreSubmission) -> dict[str, object]:
         "client_platform": submission.client_platform,
         "metadata": submission.metadata,
     }
+
+
+def _build_leaderboard_query(benchmark_id: str, top_n: int) -> QueryBuilder:
+    scores = Score.get_table()
+    row_number = (
+        RowNumber()
+        .over(scores.spec_id)
+        .orderby(scores.accuracy, order=Order.desc)
+        .orderby(scores.submitted_at, order=Order.desc)
+        .as_("rn")
+    )
+    ranked = (
+        Query.from_(scores)
+        .select(
+            scores.spec_id,
+            scores.accuracy,
+            scores.total_questions,
+            scores.ran_with_providers,
+            scores.submitted_at,
+            scores.submitted_by,
+            scores.verified_by_openmined,
+            scores.url4_expression,
+            row_number,
+        )
+        .where(scores.benchmark_id == benchmark_id)
+    ).as_("ranked")
+
+    return (
+        Query.from_(ranked)
+        .select(
+            ranked.spec_id,
+            ranked.accuracy,
+            ranked.total_questions,
+            ranked.ran_with_providers,
+            ranked.submitted_at,
+            ranked.submitted_by,
+            ranked.verified_by_openmined,
+            ranked.url4_expression,
+        )
+        .where(ranked.rn == 1)
+        .orderby(ranked.accuracy, order=Order.desc)
+        .limit(top_n)
+    )
 
 
 class ScoreStore:
@@ -190,13 +201,11 @@ class ScoreStore:
 
     async def leaderboard(self, benchmark_id: str, top_n: int = 50) -> list[LeaderboardEntry]:
         conn = Tortoise.get_connection("default")
-        sql = (
-            LEADERBOARD_SQL_POSTGRES
-            if conn.capabilities.dialect == "postgres"
-            else LEADERBOARD_SQL_SQLITE
+        result = await execute_pypika(
+            _build_leaderboard_query(benchmark_id, top_n),
+            using_db=conn,
         )
-
-        rows = await conn.execute_query_dict(sql, [benchmark_id, top_n])
+        rows = result.rows
         providers_field = Score._meta.fields_map["ran_with_providers"]
         for row in rows:
             row["ran_with_providers"] = providers_field.to_python_value(

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import cast
+from uuid import UUID
+
+from tortoise import Tortoise
+from tortoise.exceptions import IntegrityError
+from tortoise.transactions import in_transaction
+
+from .models import Benchmark, IdempotencyKey, Score
+from .schemas import BenchmarkSchema, LeaderboardEntry, ScoreSchema, ScoreSubmission
+
+IDEMPOTENCY_TTL = timedelta(hours=24)
+
+
+LEADERBOARD_SQL_POSTGRES = """
+WITH ranked AS (
+    SELECT
+        spec_id,
+        accuracy,
+        total_questions,
+        ran_with_providers,
+        submitted_at,
+        submitted_by,
+        verified_by_openmined,
+        url4_expression,
+        ROW_NUMBER() OVER (
+            PARTITION BY spec_id
+            ORDER BY accuracy DESC, submitted_at DESC
+        ) AS rn
+    FROM scores
+    WHERE benchmark_id = $1
+)
+SELECT
+    spec_id,
+    accuracy,
+    total_questions,
+    ran_with_providers,
+    submitted_at,
+    submitted_by,
+    verified_by_openmined,
+    url4_expression
+FROM ranked
+WHERE rn = 1
+ORDER BY accuracy DESC
+LIMIT $2
+"""
+
+LEADERBOARD_SQL_SQLITE = LEADERBOARD_SQL_POSTGRES.replace("$1", "?").replace("$2", "?")
+
+
+def _benchmark_to_schema(model: Benchmark) -> BenchmarkSchema:
+    return BenchmarkSchema(
+        id=model.id,
+        display_name=model.display_name,
+        description=model.description,
+        dataset_url=model.dataset_url,
+        created_at=model.created_at,
+    )
+
+
+def _score_to_schema(model: Score) -> ScoreSchema:
+    return ScoreSchema(
+        id=model.id,
+        version=model.version,
+        benchmark_id=cast(str, getattr(model, "benchmark_id")),
+        spec_id=model.spec_id,
+        url4_expression=model.url4_expression,
+        submitted_by=model.submitted_by,
+        submitted_at=model.submitted_at,
+        accuracy=model.accuracy,
+        total_questions=model.total_questions,
+        correct_questions=model.correct_questions,
+        ran_with_providers=model.ran_with_providers,
+        ran_at_local=model.ran_at_local,
+        client_name=model.client_name,
+        client_version=model.client_version,
+        client_platform=model.client_platform,
+        verified_by_openmined=model.verified_by_openmined,
+        metadata=model.metadata,
+    )
+
+
+def _submission_to_kwargs(submission: ScoreSubmission) -> dict[str, object]:
+    return {
+        "benchmark_id": submission.benchmark_id,
+        "version": submission.version,
+        "spec_id": submission.spec_id,
+        "url4_expression": submission.url4_expression,
+        "submitted_by": submission.submitted_by,
+        "accuracy": submission.accuracy,
+        "total_questions": submission.total_questions,
+        "correct_questions": submission.correct_questions,
+        "ran_with_providers": submission.ran_with_providers,
+        "ran_at_local": submission.ran_at_local,
+        "client_name": submission.client_name,
+        "client_version": submission.client_version,
+        "client_platform": submission.client_platform,
+        "metadata": submission.metadata,
+    }
+
+
+class ScoreStore:
+    async def register_benchmark(
+        self,
+        benchmark_id: str,
+        display_name: str,
+        description: str | None = None,
+        dataset_url: str | None = None,
+    ) -> BenchmarkSchema:
+        benchmark = await Benchmark.create(
+            id=benchmark_id,
+            display_name=display_name,
+            description=description,
+            dataset_url=dataset_url,
+        )
+        return _benchmark_to_schema(benchmark)
+
+    async def list_benchmarks(self) -> list[BenchmarkSchema]:
+        rows = await Benchmark.all().order_by("id")
+        return [_benchmark_to_schema(benchmark) for benchmark in rows]
+
+    async def submit(
+        self,
+        submission: ScoreSubmission,
+        idempotency_key: str | None = None,
+    ) -> ScoreSchema:
+        now_ts = datetime.now(UTC)
+        if idempotency_key is not None:
+            existing = await IdempotencyKey.get_or_none(
+                key=idempotency_key,
+                expires_at__gt=now_ts,
+            ).prefetch_related("score")
+            if existing is not None:
+                return _score_to_schema(existing.score)
+
+        expires_at = now_ts + IDEMPOTENCY_TTL
+        try:
+            async with in_transaction() as connection:
+                if idempotency_key is not None:
+                    await (
+                        IdempotencyKey.filter(
+                            key=idempotency_key,
+                            expires_at__lte=now_ts,
+                        )
+                        .using_db(connection)
+                        .delete()
+                    )
+
+                score = await Score.create(
+                    using_db=connection,
+                    **_submission_to_kwargs(submission),
+                )
+
+                if idempotency_key is not None:
+                    await IdempotencyKey.create(
+                        using_db=connection,
+                        key=idempotency_key,
+                        score=score,
+                        expires_at=expires_at,
+                    )
+
+            return _score_to_schema(score)
+        except IntegrityError:
+            if idempotency_key is None:
+                raise
+
+            live = await IdempotencyKey.get_or_none(
+                key=idempotency_key,
+                expires_at__gt=datetime.now(UTC),
+            ).prefetch_related("score")
+            if live is not None:
+                return _score_to_schema(live.score)
+
+            raise
+
+    async def get_by_idempotency_key(self, key: str) -> ScoreSchema | None:
+        now_ts = datetime.now(UTC)
+        linked = await IdempotencyKey.get_or_none(
+            key=key,
+            expires_at__gt=now_ts,
+        ).prefetch_related("score")
+        if linked is None:
+            return None
+        return _score_to_schema(linked.score)
+
+    async def cleanup_expired_idempotency_keys(self, now: datetime) -> int:
+        return await IdempotencyKey.filter(expires_at__lte=now).delete()
+
+    async def leaderboard(self, benchmark_id: str, top_n: int = 50) -> list[LeaderboardEntry]:
+        conn = Tortoise.get_connection("default")
+        sql = (
+            LEADERBOARD_SQL_POSTGRES
+            if conn.capabilities.dialect == "postgres"
+            else LEADERBOARD_SQL_SQLITE
+        )
+
+        rows = await conn.execute_query_dict(sql, [benchmark_id, top_n])
+        providers_field = Score._meta.fields_map["ran_with_providers"]
+        for row in rows:
+            row["ran_with_providers"] = providers_field.to_python_value(
+                row["ran_with_providers"],
+            )
+
+        return [LeaderboardEntry(**row) for row in rows]
+
+    async def list_for_spec(
+        self,
+        benchmark_id: str,
+        spec_id: str,
+        limit: int = 50,
+    ) -> list[ScoreSchema]:
+        rows = (
+            await Score.filter(benchmark_id=benchmark_id, spec_id=spec_id)
+            .order_by("-submitted_at")
+            .limit(limit)
+        )
+        return [_score_to_schema(score) for score in rows]
+
+    async def mark_verified(self, score_id: UUID | str) -> None:
+        await Score.filter(id=score_id).update(verified_by_openmined=True)

--- a/apps/scoreboard/tests/conftest.py
+++ b/apps/scoreboard/tests/conftest.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 import asyncio
 import os
-from collections.abc import Generator
+from collections.abc import AsyncGenerator, Generator
 from pathlib import Path
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from uuid import uuid4
 
 import asyncpg  # type: ignore[import-untyped]
 import pytest
+import pytest_asyncio
 from fastapi.testclient import TestClient
+from tortoise.contrib.test import tortoise_test_context
 
 from scoreboard.config import Settings
 from scoreboard.main import create_app
@@ -66,3 +68,17 @@ def postgres_schema_database_url() -> Generator[str, None, None]:
         yield _with_schema(database_url, schema)
     finally:
         asyncio.run(_drop_schema())
+
+
+@pytest_asyncio.fixture
+async def tortoise_db(request: pytest.FixtureRequest) -> AsyncGenerator[None, None]:
+    database_url = "sqlite://:memory:"
+    if os.getenv("SCOREBOARD_TEST_DATABASE_URL"):
+        database_url = request.getfixturevalue("postgres_schema_database_url")
+
+    async with tortoise_test_context(
+        modules=["scoreboard.scores.models"],
+        db_url=database_url,
+        app_label="models",
+    ):
+        yield

--- a/apps/scoreboard/tests/unit/scores/__init__.py
+++ b/apps/scoreboard/tests/unit/scores/__init__.py
@@ -1,0 +1,1 @@
+"""Score domain unit tests."""

--- a/apps/scoreboard/tests/unit/scores/test_models.py
+++ b/apps/scoreboard/tests/unit/scores/test_models.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+from tortoise import fields
+
+from scoreboard.config import Settings
+from scoreboard.db import TORTOISE_CONFIG
+from scoreboard.main import create_app
+from scoreboard.scores.models import (
+    BaseBenchmark,
+    BaseIdempotencyKey,
+    BaseScore,
+    BaseScoreboardModel,
+    Benchmark,
+    IdempotencyKey,
+    Score,
+)
+from scoreboard.scores.store import ScoreStore
+
+
+def test_tortoise_config_registers_score_models_and_migrations() -> None:
+    app_config = TORTOISE_CONFIG["apps"]["models"]
+
+    assert "scoreboard.scores.models" in app_config["models"]
+    assert app_config["migrations"] == "scoreboard.scores.migrations"
+
+
+def test_score_model_table_names_and_indexes() -> None:
+    assert Benchmark._meta.db_table == "benchmarks"
+    assert Score._meta.db_table == "scores"
+    assert IdempotencyKey._meta.db_table == "idempotency_keys"
+    assert ("benchmark_id", "accuracy") in Score._meta.indexes
+    assert ("benchmark_id", "spec_id", "submitted_at") in Score._meta.indexes
+
+
+def test_score_model_relations_use_expected_delete_rules() -> None:
+    benchmark_field = cast(Any, Score._meta.fields_map["benchmark"])
+    score_field = cast(Any, IdempotencyKey._meta.fields_map["score"])
+
+    assert benchmark_field.on_delete is fields.OnDelete.RESTRICT
+    assert score_field.on_delete is fields.OnDelete.CASCADE
+
+
+def test_score_model_package_exports_models_and_abstract_bases() -> None:
+    assert Benchmark.__name__ == "Benchmark"
+    assert Score.__name__ == "Score"
+    assert IdempotencyKey.__name__ == "IdempotencyKey"
+    assert BaseScoreboardModel._meta.abstract is True
+    assert BaseBenchmark._meta.abstract is True
+    assert BaseScore._meta.abstract is True
+    assert BaseIdempotencyKey._meta.abstract is True
+
+
+def test_score_models_live_in_one_model_file_per_concrete_model() -> None:
+    assert Benchmark.__module__ == "scoreboard.scores.models.benchmark"
+    assert Score.__module__ == "scoreboard.scores.models.score"
+    assert IdempotencyKey.__module__ == "scoreboard.scores.models.idempotency_key"
+
+
+def test_create_app_wires_score_store_without_db_io() -> None:
+    app = create_app(Settings(database_url="sqlite://:memory:", cors_origins=[]))
+
+    assert isinstance(app.state.score_store, ScoreStore)

--- a/apps/scoreboard/tests/unit/scores/test_models.py
+++ b/apps/scoreboard/tests/unit/scores/test_models.py
@@ -4,6 +4,7 @@ from typing import Any, cast
 
 from tortoise import fields
 
+import scoreboard.scores.models as score_models
 from scoreboard.config import Settings
 from scoreboard.db import TORTOISE_CONFIG
 from scoreboard.main import create_app
@@ -43,19 +44,34 @@ def test_score_model_relations_use_expected_delete_rules() -> None:
 
 
 def test_score_model_package_exports_models_and_abstract_bases() -> None:
-    assert Benchmark.__name__ == "Benchmark"
-    assert Score.__name__ == "Score"
-    assert IdempotencyKey.__name__ == "IdempotencyKey"
-    assert BaseScoreboardModel._meta.abstract is True
-    assert BaseBenchmark._meta.abstract is True
-    assert BaseScore._meta.abstract is True
-    assert BaseIdempotencyKey._meta.abstract is True
+    expected_exports = {
+        "BaseScoreboardModel": BaseScoreboardModel,
+        "BaseBenchmark": BaseBenchmark,
+        "Benchmark": Benchmark,
+        "BaseScore": BaseScore,
+        "Score": Score,
+        "BaseIdempotencyKey": BaseIdempotencyKey,
+        "IdempotencyKey": IdempotencyKey,
+    }
+
+    for name, model_class in expected_exports.items():
+        assert getattr(score_models, name) is model_class
+        assert name in score_models.__all__
+
+    for base_model in (BaseScoreboardModel, BaseBenchmark, BaseScore, BaseIdempotencyKey):
+        assert base_model._meta.abstract is True
 
 
 def test_score_models_live_in_one_model_file_per_concrete_model() -> None:
-    assert Benchmark.__module__ == "scoreboard.scores.models.benchmark"
-    assert Score.__module__ == "scoreboard.scores.models.score"
-    assert IdempotencyKey.__module__ == "scoreboard.scores.models.idempotency_key"
+    assert {
+        Benchmark.__module__,
+        Score.__module__,
+        IdempotencyKey.__module__,
+    } == {
+        "scoreboard.scores.models.benchmark",
+        "scoreboard.scores.models.score",
+        "scoreboard.scores.models.idempotency_key",
+    }
 
 
 def test_create_app_wires_score_store_without_db_io() -> None:

--- a/apps/scoreboard/tests/unit/scores/test_schemas.py
+++ b/apps/scoreboard/tests/unit/scores/test_schemas.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pydantic import ValidationError
+
+from scoreboard.scores.schemas import ScoreSubmission
+
+
+def _valid_payload() -> dict[str, object]:
+    return {
+        "benchmark_id": "hle",
+        "spec_id": "spec-1",
+        "url4_expression": "url4://benchmark/spec-1",
+        "accuracy": 0.75,
+        "total_questions": 4,
+        "correct_questions": 3,
+        "ran_with_providers": ["openai"],
+    }
+
+
+def test_score_submission_accepts_valid_payload() -> None:
+    submission = ScoreSubmission.model_validate(_valid_payload())
+
+    assert submission.version == 1
+    assert submission.benchmark_id == "hle"
+    assert submission.ran_with_providers == ["openai"]
+
+
+def test_score_submission_rejects_accuracy_below_zero() -> None:
+    payload = _valid_payload()
+    payload["accuracy"] = -0.01
+
+    try:
+        ScoreSubmission.model_validate(payload)
+    except ValidationError as exc:
+        assert "accuracy must be between 0 and 1" in str(exc)
+    else:
+        raise AssertionError("expected validation error")
+
+
+def test_score_submission_rejects_accuracy_above_one() -> None:
+    payload = _valid_payload()
+    payload["accuracy"] = 1.01
+
+    try:
+        ScoreSubmission.model_validate(payload)
+    except ValidationError as exc:
+        assert "accuracy must be between 0 and 1" in str(exc)
+    else:
+        raise AssertionError("expected validation error")
+
+
+def test_score_submission_rejects_non_positive_total_questions() -> None:
+    payload = _valid_payload()
+    payload["total_questions"] = 0
+
+    try:
+        ScoreSubmission.model_validate(payload)
+    except ValidationError as exc:
+        assert "total_questions must be positive" in str(exc)
+    else:
+        raise AssertionError("expected validation error")
+
+
+def test_score_submission_rejects_negative_correct_questions() -> None:
+    payload = _valid_payload()
+    payload["correct_questions"] = -1
+
+    try:
+        ScoreSubmission.model_validate(payload)
+    except ValidationError as exc:
+        assert "correct_questions must be non-negative" in str(exc)
+    else:
+        raise AssertionError("expected validation error")
+
+
+def test_score_submission_rejects_correct_questions_above_total() -> None:
+    payload = _valid_payload()
+    payload["correct_questions"] = 5
+
+    try:
+        ScoreSubmission.model_validate(payload)
+    except ValidationError as exc:
+        assert "correct_questions cannot exceed total_questions" in str(exc)
+    else:
+        raise AssertionError("expected validation error")

--- a/apps/scoreboard/tests/unit/scores/test_store.py
+++ b/apps/scoreboard/tests/unit/scores/test_store.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from tortoise import Tortoise
+
+from scoreboard.scores.models import IdempotencyKey, Score
+from scoreboard.scores.schemas import ScoreSubmission
+from scoreboard.scores.store import ScoreStore
+
+pytestmark = pytest.mark.asyncio
+
+
+def _submission(
+    *,
+    spec_id: str = "spec-1",
+    accuracy: float = 0.75,
+    providers: list[str] | None = None,
+) -> ScoreSubmission:
+    correct_questions = int(accuracy * 100)
+    return ScoreSubmission(
+        benchmark_id="hle",
+        spec_id=spec_id,
+        url4_expression=f"url4://benchmark/{spec_id}/{accuracy}",
+        submitted_by="tester",
+        accuracy=accuracy,
+        total_questions=100,
+        correct_questions=correct_questions,
+        ran_with_providers=providers or ["openai"],
+        ran_at_local=datetime(2026, 5, 21, 12, 0, tzinfo=UTC),
+        client_name="scoreboard-test",
+        client_version="0.1.0",
+        client_platform="test",
+        metadata={"source": "unit"},
+    )
+
+
+async def _store_with_benchmark() -> ScoreStore:
+    store = ScoreStore()
+    await store.register_benchmark(
+        benchmark_id="hle",
+        display_name="Humanity's Last Exam",
+        description="Fixture benchmark",
+        dataset_url="https://example.test/hle.jsonl",
+    )
+    return store
+
+
+async def test_register_benchmark_and_list_benchmarks(tortoise_db: None) -> None:
+    store = ScoreStore()
+
+    registered = await store.register_benchmark(
+        benchmark_id="hle",
+        display_name="Humanity's Last Exam",
+        description="Fixture benchmark",
+        dataset_url="https://example.test/hle.jsonl",
+    )
+    benchmarks = await store.list_benchmarks()
+
+    assert registered.id == "hle"
+    assert benchmarks == [registered]
+
+
+async def test_submit_inserts_and_returns_score(tortoise_db: None) -> None:
+    store = await _store_with_benchmark()
+
+    score = await store.submit(_submission())
+
+    assert score.benchmark_id == "hle"
+    assert score.spec_id == "spec-1"
+    assert score.accuracy == 0.75
+    assert score.total_questions == 100
+    assert score.correct_questions == 75
+    assert score.ran_with_providers == ["openai"]
+    assert score.client_name == "scoreboard-test"
+    assert score.verified_by_openmined is False
+    assert await Score.all().count() == 1
+
+
+async def test_submit_with_live_idempotency_key_returns_existing_score(
+    tortoise_db: None,
+) -> None:
+    store = await _store_with_benchmark()
+
+    first = await store.submit(_submission(accuracy=0.5), idempotency_key="repeat-key")
+    second = await store.submit(_submission(accuracy=0.9), idempotency_key="repeat-key")
+
+    assert second.id == first.id
+    assert second.submitted_at == first.submitted_at
+    assert second.accuracy == 0.5
+    assert await Score.all().count() == 1
+
+
+async def test_submit_with_expired_idempotency_key_creates_new_score(
+    tortoise_db: None,
+) -> None:
+    store = await _store_with_benchmark()
+    first = await store.submit(_submission(accuracy=0.5), idempotency_key="expired-key")
+    await IdempotencyKey.filter(key="expired-key").update(
+        expires_at=datetime.now(UTC) - timedelta(seconds=1),
+    )
+
+    second = await store.submit(_submission(accuracy=0.9), idempotency_key="expired-key")
+
+    assert second.id != first.id
+    assert second.accuracy == 0.9
+    assert await Score.all().count() == 2
+
+
+async def test_get_by_idempotency_key_respects_expiry_and_cleanup(
+    tortoise_db: None,
+) -> None:
+    store = await _store_with_benchmark()
+    score = await store.submit(_submission(), idempotency_key="lookup-key")
+
+    assert await store.get_by_idempotency_key("lookup-key") == score
+
+    past = datetime.now(UTC) - timedelta(seconds=1)
+    await IdempotencyKey.filter(key="lookup-key").update(expires_at=past)
+
+    assert await store.get_by_idempotency_key("lookup-key") is None
+    assert await store.cleanup_expired_idempotency_keys(datetime.now(UTC)) == 1
+    assert await IdempotencyKey.all().count() == 0
+
+
+async def test_leaderboard_returns_best_score_per_spec_in_rank_order(
+    tortoise_db: None,
+) -> None:
+    store = await _store_with_benchmark()
+    await store.submit(_submission(spec_id="spec-a", accuracy=0.6, providers=["openai"]))
+    await store.submit(_submission(spec_id="spec-a", accuracy=0.9, providers=["anthropic"]))
+    await store.submit(_submission(spec_id="spec-b", accuracy=0.95, providers=["openai", "gemini"]))
+    await store.submit(_submission(spec_id="spec-c", accuracy=0.7, providers=["gemini"]))
+
+    rows = await store.leaderboard("hle", top_n=2)
+
+    assert [row.spec_id for row in rows] == ["spec-b", "spec-a"]
+    assert [row.accuracy for row in rows] == [0.95, 0.9]
+    assert rows[0].ran_with_providers == ["openai", "gemini"]
+    assert isinstance(rows[0].ran_with_providers, list)
+
+
+async def test_leaderboard_uses_newer_submission_as_accuracy_tie_breaker(
+    tortoise_db: None,
+) -> None:
+    store = await _store_with_benchmark()
+    older = await store.submit(_submission(spec_id="spec-a", accuracy=0.9, providers=["older"]))
+    newer = await store.submit(_submission(spec_id="spec-a", accuracy=0.9, providers=["newer"]))
+    await Score.filter(id=older.id).update(
+        submitted_at=datetime(2026, 5, 21, 12, 0, tzinfo=UTC),
+    )
+    await Score.filter(id=newer.id).update(
+        submitted_at=datetime(2026, 5, 21, 13, 0, tzinfo=UTC),
+    )
+
+    rows = await store.leaderboard("hle")
+
+    assert len(rows) == 1
+    assert rows[0].ran_with_providers == ["newer"]
+
+
+async def test_list_for_spec_returns_history_newest_first(tortoise_db: None) -> None:
+    store = await _store_with_benchmark()
+    older = await store.submit(_submission(spec_id="spec-history", accuracy=0.5))
+    newer = await store.submit(_submission(spec_id="spec-history", accuracy=0.8))
+    await Score.filter(id=older.id).update(
+        submitted_at=datetime(2026, 5, 21, 12, 0, tzinfo=UTC),
+    )
+    await Score.filter(id=newer.id).update(
+        submitted_at=datetime(2026, 5, 21, 13, 0, tzinfo=UTC),
+    )
+
+    rows = await store.list_for_spec("hle", "spec-history")
+
+    assert [row.id for row in rows] == [newer.id, older.id]
+
+
+async def test_mark_verified_flips_score_flag(tortoise_db: None) -> None:
+    store = await _store_with_benchmark()
+    score = await store.submit(_submission())
+
+    await store.mark_verified(score.id)
+
+    verified = await Score.get(id=score.id)
+    assert verified.verified_by_openmined is True
+
+
+async def test_postgres_concurrent_idempotency_submissions_share_winner(
+    tortoise_db: None,
+) -> None:
+    if Tortoise.get_connection("default").capabilities.dialect != "postgres":
+        pytest.skip("requires Postgres")
+
+    store = await _store_with_benchmark()
+    results = await asyncio.gather(
+        *(
+            store.submit(
+                _submission(accuracy=0.5 + (index / 100)),
+                idempotency_key="race-key",
+            )
+            for index in range(10)
+        ),
+    )
+
+    assert len({result.id for result in results}) == 1
+    assert await Score.all().count() == 1


### PR DESCRIPTION
## Description
Adds the scoreboard persistence layer for benchmark scores. This includes Tortoise models, the initial migration, score submission/read DTOs, a thin score store for idempotent submissions and leaderboard queries, and app-state wiring for follow-up HTTP routes.

Motivation: D-SCORE-003 and D-SCORE-004 need a durable server-side data model and query layer before exposing score ingestion and leaderboard endpoints.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1214568426257025

## Affected Dependencies
No new dependencies.

## How has this been tested?
- `cd apps/scoreboard && uv run pytest tests/unit/ -v`
- `cd apps/scoreboard && uv run ruff check .`
- `cd apps/scoreboard && uv run ruff format --check .`
- `cd apps/scoreboard && uv run pyright`
- Verified the initial migration applies cleanly to Postgres and that a second migration run is a no-op.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests