### PR TITLE
SF-178: add scoreboard score submission routes

### DIFF
--- a/apps/scoreboard/src/scoreboard/main.py
+++ b/apps/scoreboard/src/scoreboard/main.py
@@ -8,7 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from .config import Settings
 from .db import close_db, init_db
-from .routes import health
+from .routes import health, scores
 from .scores.store import ScoreStore
 
 
@@ -39,6 +39,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         )
 
     app.include_router(health.router)
+    app.include_router(scores.router)
     return app
 
 

--- a/apps/scoreboard/src/scoreboard/routes/scores.py
+++ b/apps/scoreboard/src/scoreboard/routes/scores.py
@@ -1,0 +1,132 @@
+"""Public score submission and score lookup routes.
+
+No authentication is required in v1. The verified_by_openmined response field is
+the trust-tier signal for consumers; submitted scores default to unverified.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Annotated, Any, cast
+from uuid import UUID
+
+from fastapi import APIRouter, Header, HTTPException, Request, Response, status
+from tortoise.exceptions import OperationalError
+
+from scoreboard.scores.models import Benchmark, Score
+from scoreboard.scores.schemas import (
+    FieldErrorDetail,
+    FieldErrorResponse,
+    MessageErrorResponse,
+    ScoreSchema,
+    ScoreSubmission,
+)
+from scoreboard.scores.store import ScoreStore
+
+router = APIRouter(prefix="/v1", tags=["scores"])
+
+ACCURACY_TOLERANCE = Decimal("0.01")
+STORE_UNAVAILABLE_DETAIL = "score store unavailable"
+
+SUBMIT_SCORE_RESPONSES: dict[int | str, dict[str, Any]] = {
+    status.HTTP_200_OK: {
+        "model": ScoreSchema,
+        "description": "Idempotency hit; returns the original persisted score.",
+    },
+    status.HTTP_400_BAD_REQUEST: {
+        "model": FieldErrorResponse,
+        "description": "Field-specific validation error.",
+    },
+    status.HTTP_404_NOT_FOUND: {
+        "model": FieldErrorResponse,
+        "description": "Unknown benchmark_id.",
+    },
+    status.HTTP_503_SERVICE_UNAVAILABLE: {
+        "model": MessageErrorResponse,
+        "description": "Score store unavailable.",
+    },
+}
+GET_SCORE_RESPONSES: dict[int | str, dict[str, Any]] = {
+    status.HTTP_404_NOT_FOUND: {
+        "model": MessageErrorResponse,
+        "description": "Score not found.",
+    },
+    status.HTTP_503_SERVICE_UNAVAILABLE: SUBMIT_SCORE_RESPONSES[
+        status.HTTP_503_SERVICE_UNAVAILABLE
+    ],
+}
+
+
+def _field_error_detail(field: str, message: str) -> dict[str, str]:
+    return FieldErrorDetail(field=field, message=message).model_dump()
+
+
+@router.post(
+    "/scores",
+    response_model=ScoreSchema,
+    status_code=status.HTTP_201_CREATED,
+    responses=SUBMIT_SCORE_RESPONSES,
+)
+async def submit_score(
+    submission: ScoreSubmission,
+    request: Request,
+    response: Response,
+    idempotency_key: Annotated[str | None, Header(alias="Idempotency-Key")] = None,
+) -> ScoreSchema:
+    """Create a public unauthenticated score submission."""
+
+    submitted_accuracy = Decimal(str(submission.accuracy))
+    expected_accuracy = Decimal(submission.correct_questions) / Decimal(submission.total_questions)
+    if abs(submitted_accuracy - expected_accuracy) > ACCURACY_TOLERANCE:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=_field_error_detail(
+                "accuracy",
+                (
+                    f"accuracy {submission.accuracy} does not match "
+                    f"correct_questions/total_questions={expected_accuracy:.6f} "
+                    f"within {ACCURACY_TOLERANCE}"
+                ),
+            ),
+        )
+
+    try:
+        if not await Benchmark.exists(id=submission.benchmark_id):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=_field_error_detail(
+                    "benchmark_id",
+                    f"unknown benchmark_id: {submission.benchmark_id!r}",
+                ),
+            )
+
+        store = cast(ScoreStore, request.app.state.score_store)
+        if idempotency_key is not None:
+            existing = await store.get_by_idempotency_key(idempotency_key)
+            if existing is not None:
+                response.status_code = status.HTTP_200_OK
+                return existing
+
+        return await store.submit(submission, idempotency_key=idempotency_key)
+    except OperationalError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=STORE_UNAVAILABLE_DETAIL,
+        ) from exc
+
+
+@router.get("/scores/{score_id}", response_model=ScoreSchema, responses=GET_SCORE_RESPONSES)
+async def get_score(score_id: UUID) -> ScoreSchema:
+    """Return a public score by id; inspect verified_by_openmined before trusting it."""
+
+    try:
+        score = await Score.get_or_none(id=score_id)
+    except OperationalError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=STORE_UNAVAILABLE_DETAIL,
+        ) from exc
+
+    if score is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="score not found")
+    return ScoreSchema.model_validate(score, from_attributes=True)

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Annotated, Any, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class ClientInfo(BaseModel):
@@ -17,15 +17,40 @@ class ClientInfo(BaseModel):
     platform: str | None = None
 
 
+class FieldErrorDetail(BaseModel):
+    """Field-specific HTTP error detail."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    field: str
+    message: str
+
+
+class FieldErrorResponse(BaseModel):
+    """HTTP error response for errors tied to a request field."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    detail: FieldErrorDetail
+
+
+class MessageErrorResponse(BaseModel):
+    """HTTP error response with a flat detail message."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    detail: str
+
+
 class ScoreSubmission(BaseModel):
     """Input DTO for score ingestion."""
 
     model_config = ConfigDict(extra="forbid")
 
-    version: int = 1
+    version: Literal[1] = 1
     benchmark_id: str
     spec_id: str
-    url4_expression: str
+    url4_expression: Annotated[str, Field(max_length=32_000)]
     submitted_by: str | None = None
     accuracy: float
     total_questions: int

--- a/apps/scoreboard/tests/unit/test_scores_routes.py
+++ b/apps/scoreboard/tests/unit/test_scores_routes.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from tortoise.exceptions import OperationalError
+
+from scoreboard.config import Settings
+from scoreboard.main import create_app
+from scoreboard.scores.models import Benchmark, IdempotencyKey
+from scoreboard.scores.store import ScoreStore
+
+pytestmark = pytest.mark.asyncio
+
+
+def _valid_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "benchmark_id": "hle",
+        "spec_id": "spec-1",
+        "url4_expression": "url4://benchmark/spec-1",
+        "submitted_by": "tester",
+        "accuracy": 0.75,
+        "total_questions": 4,
+        "correct_questions": 3,
+        "ran_with_providers": ["openai"],
+        "ran_at_local": "2026-05-21T12:00:00+00:00",
+        "client_name": "scoreboard-test",
+        "client_version": "0.1.0",
+        "client_platform": "test",
+        "metadata": {"source": "unit"},
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest_asyncio.fixture
+async def app_with_benchmark(tortoise_db: None) -> FastAPI:
+    settings = Settings(database_url="sqlite://:memory:", cors_origins=[])
+    app = create_app(settings)
+    await Benchmark.create(
+        id="hle",
+        display_name="Humanity's Last Exam",
+        description="Fixture benchmark",
+        dataset_url="https://example.test/hle.jsonl",
+    )
+    return app
+
+
+@pytest_asyncio.fixture
+async def score_client(app_with_benchmark: FastAPI) -> AsyncGenerator[AsyncClient, None]:
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_benchmark),
+        base_url="http://test",
+    ) as client:
+        yield client
+
+
+async def test_post_score_creates_new_row_201(score_client: AsyncClient) -> None:
+    response = await score_client.post("/v1/scores", json=_valid_payload())
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["id"]
+    assert body["benchmark_id"] == "hle"
+    assert body["spec_id"] == "spec-1"
+    assert body["submitted_at"]
+    assert body["verified_by_openmined"] is False
+
+
+async def test_post_score_without_idempotency_key_always_creates_new_row(
+    score_client: AsyncClient,
+) -> None:
+    first = await score_client.post(
+        "/v1/scores", json=_valid_payload(accuracy=0.5, correct_questions=2)
+    )
+    second = await score_client.post(
+        "/v1/scores", json=_valid_payload(accuracy=0.5, correct_questions=2)
+    )
+
+    assert first.status_code == 201
+    assert second.status_code == 201
+    assert second.json()["id"] != first.json()["id"]
+
+
+async def test_post_score_with_live_idempotency_key_returns_200(
+    score_client: AsyncClient,
+) -> None:
+    headers = {"Idempotency-Key": "repeat-key"}
+    first = await score_client.post("/v1/scores", json=_valid_payload(), headers=headers)
+    second = await score_client.post("/v1/scores", json=_valid_payload(), headers=headers)
+
+    assert first.status_code == 201
+    assert second.status_code == 200
+    assert second.json()["id"] == first.json()["id"]
+    assert second.json()["submitted_at"] == first.json()["submitted_at"]
+
+
+async def test_post_score_with_expired_idempotency_key_creates_new_row(
+    score_client: AsyncClient,
+) -> None:
+    headers = {"Idempotency-Key": "expired-key"}
+    first = await score_client.post("/v1/scores", json=_valid_payload(), headers=headers)
+    await IdempotencyKey.filter(key="expired-key").update(
+        expires_at=datetime.now(UTC) - timedelta(seconds=1),
+    )
+
+    assert await ScoreStore().get_by_idempotency_key("expired-key") is None
+
+    second = await score_client.post("/v1/scores", json=_valid_payload(), headers=headers)
+
+    assert first.status_code == 201
+    assert second.status_code == 201
+    assert second.json()["id"] != first.json()["id"]
+
+
+async def test_post_score_accuracy_mismatch_returns_400(score_client: AsyncClient) -> None:
+    response = await score_client.post(
+        "/v1/scores",
+        json=_valid_payload(accuracy=0.5, total_questions=100, correct_questions=10),
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["field"] == "accuracy"
+
+
+async def test_post_score_accuracy_at_edge_tolerance_passes(score_client: AsyncClient) -> None:
+    response = await score_client.post(
+        "/v1/scores",
+        json=_valid_payload(accuracy=0.82, total_questions=1000, correct_questions=810),
+    )
+
+    assert response.status_code == 201
+
+
+async def test_post_score_accuracy_just_outside_tolerance_returns_400(
+    score_client: AsyncClient,
+) -> None:
+    response = await score_client.post(
+        "/v1/scores",
+        json=_valid_payload(
+            accuracy=0.8200000000005,
+            total_questions=1000,
+            correct_questions=810,
+        ),
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["field"] == "accuracy"
+
+
+async def test_post_score_unknown_benchmark_id_returns_404(score_client: AsyncClient) -> None:
+    response = await score_client.post(
+        "/v1/scores",
+        json=_valid_payload(benchmark_id="missing"),
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["field"] == "benchmark_id"
+
+
+async def test_post_score_future_version_returns_422(score_client: AsyncClient) -> None:
+    response = await score_client.post("/v1/scores", json=_valid_payload(version=2))
+
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["loc"] == ["body", "version"]
+
+
+async def test_post_score_url4_expression_too_long_returns_422(
+    score_client: AsyncClient,
+) -> None:
+    response = await score_client.post(
+        "/v1/scores",
+        json=_valid_payload(url4_expression="x" * 32_001),
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["loc"] == ["body", "url4_expression"]
+
+
+async def test_post_score_invalid_accuracy_returns_422(score_client: AsyncClient) -> None:
+    response = await score_client.post("/v1/scores", json=_valid_payload(accuracy=1.5))
+
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["loc"] == ["body", "accuracy"]
+
+
+async def test_post_score_store_unavailable_returns_503(
+    score_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def raise_operational_error(*args: object, **kwargs: object) -> bool:
+        raise OperationalError("database is locked")
+
+    monkeypatch.setattr(Benchmark, "exists", raise_operational_error)
+
+    response = await score_client.post("/v1/scores", json=_valid_payload())
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "score store unavailable"}
+
+
+async def test_get_score_by_id_returns_row(score_client: AsyncClient) -> None:
+    created = await score_client.post("/v1/scores", json=_valid_payload())
+
+    response = await score_client.get(f"/v1/scores/{created.json()['id']}")
+
+    assert response.status_code == 200
+    assert response.json()["id"] == created.json()["id"]
+    assert response.json()["benchmark_id"] == "hle"
+
+
+async def test_get_score_unknown_id_returns_404(score_client: AsyncClient) -> None:
+    response = await score_client.get(f"/v1/scores/{uuid4()}")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "score not found"}
+
+
+async def test_openapi_schema_includes_new_endpoints(score_client: AsyncClient) -> None:
+    response = await score_client.get("/openapi.json")
+
+    assert response.status_code == 200
+    paths = response.json()["paths"]
+    post_score = paths["/v1/scores"]["post"]
+    get_score = paths["/v1/scores/{score_id}"]["get"]
+
+    assert post_score["requestBody"]["content"]["application/json"]["schema"]["$ref"].endswith(
+        "/ScoreSubmission",
+    )
+    assert post_score["responses"]["201"]["content"]["application/json"]["schema"]["$ref"].endswith(
+        "/ScoreSchema",
+    )
+    assert post_score["responses"]["200"]["content"]["application/json"]["schema"]["$ref"].endswith(
+        "/ScoreSchema",
+    )
+    assert post_score["responses"]["400"]["content"]["application/json"]["schema"]["$ref"].endswith(
+        "/FieldErrorResponse",
+    )
+    assert post_score["responses"]["404"]["content"]["application/json"]["schema"]["$ref"].endswith(
+        "/FieldErrorResponse",
+    )
+    assert post_score["responses"]["503"]["content"]["application/json"]["schema"]["$ref"].endswith(
+        "/MessageErrorResponse",
+    )
+    assert get_score["responses"]["200"]["content"]["application/json"]["schema"]["$ref"].endswith(
+        "/ScoreSchema",
+    )
+    assert get_score["responses"]["404"]["content"]["application/json"]["schema"]["$ref"].endswith(
+        "/MessageErrorResponse",
+    )
+    assert get_score["responses"]["503"]["content"]["application/json"]["schema"]["$ref"].endswith(
+        "/MessageErrorResponse",
+    )


### PR DESCRIPTION
Adds the public scoreboard write/read API needed for desktop score publishing while preserving idempotency and validation contracts.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1214568426257034

## Description
Adds `POST /v1/scores` for public score submission and `GET /v1/scores/{score_id}` for score lookup. The implementation validates benchmark existence, score accuracy consistency, idempotency semantics, version/url4 constraints, and store-unavailable errors while returning typed response schemas for OpenAPI consumers.

## Affected Dependencies
None.

## How has this been tested?
- `cd apps/scoreboard && uv run pytest tests/unit/test_scores_routes.py -v`
- `cd apps/scoreboard && uv run pytest tests/unit/ -v`
- `cd apps/scoreboard && uv run ruff check .`
- `cd apps/scoreboard && uv run ruff format --check .`
- `cd apps/scoreboard && uv run pyright`

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests