### PR TITLE
SF-213: remove extraneous Plugin.depends entries (per SF-208 audit) — v2

### DIFF
--- a/apps/server/src/screamingface/plugins/claude_env_intercept/plugin.py
+++ b/apps/server/src/screamingface/plugins/claude_env_intercept/plugin.py
@@ -30,7 +30,7 @@ class ClaudeEnvInterceptPlugin(Plugin):
     name = "claude-env-intercept"
     description = "Redirect Claude Code via env vars — no sudo, no /etc/hosts, no port 443"
     tags: list[str] = ["product:claude"]
-    depends = ["claude-frontend"]
+    depends: list[str] = []
     conflicts = ["claude-intercept", "mitmproxy-intercept"]
 
     # Keys that setup() may set via launchctl — needed for cleanup even

--- a/apps/server/src/screamingface/plugins/claude_frontend/plugin.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/plugin.py
@@ -33,7 +33,7 @@ class ClaudeFrontendPlugin(FrontendPluginBase):
     name = "claude-frontend"
     description = "Transparent proxy between Claude Code and the Anthropic API"
     tags: list[str] = ["product:claude"]
-    depends: list[str] = ["url4-specs", "url4-executor", "frontend-base"]
+    depends: list[str] = ["url4-executor", "frontend-base"]
     settings_class = ClaudeFrontendSettings
 
     cli_binary = "claude"

--- a/apps/server/src/screamingface/plugins/codex_frontend/plugin.py
+++ b/apps/server/src/screamingface/plugins/codex_frontend/plugin.py
@@ -35,7 +35,7 @@ class CodexFrontendPlugin(FrontendPluginBase):
     name = "codex-frontend"
     description = "Transparent proxy between Codex CLI and the OpenAI API"
     tags: list[str] = ["product:openai"]
-    depends: list[str] = ["url4-specs", "url4-executor", "frontend-base"]
+    depends: list[str] = ["url4-executor", "frontend-base"]
     settings_class = CodexFrontendSettings
 
     cli_binary = "codex"

--- a/apps/server/src/screamingface/plugins/codex_frontend/tests/test_plugin.py
+++ b/apps/server/src/screamingface/plugins/codex_frontend/tests/test_plugin.py
@@ -16,8 +16,9 @@ class TestPluginMetadata:
         assert CodexFrontendPlugin.name == "codex-frontend"
 
     def test_depends(self):
-        assert "url4-specs" in CodexFrontendPlugin.depends
         assert "url4-executor" in CodexFrontendPlugin.depends
+        assert "frontend-base" in CodexFrontendPlugin.depends
+        assert "url4-specs" not in CodexFrontendPlugin.depends
 
     def test_settings_class(self):
         assert CodexFrontendPlugin.settings_class is CodexFrontendSettings

--- a/apps/server/src/screamingface/plugins/gemini_frontend/plugin.py
+++ b/apps/server/src/screamingface/plugins/gemini_frontend/plugin.py
@@ -31,7 +31,7 @@ class GeminiFrontendPlugin(FrontendPluginBase):
     name = "gemini-frontend"
     description = "Transparent proxy between Gemini CLI and the Google AI API"
     tags: list[str] = ["product:gemini"]
-    depends: list[str] = ["url4-specs", "url4-executor", "frontend-base"]
+    depends: list[str] = ["url4-executor", "frontend-base"]
     settings_class = GeminiFrontendSettings
 
     cli_binary = "gemini"

--- a/apps/server/src/screamingface/plugins/gemini_frontend/tests/test_plugin.py
+++ b/apps/server/src/screamingface/plugins/gemini_frontend/tests/test_plugin.py
@@ -16,7 +16,9 @@ class TestPluginMetadata:
         assert GeminiFrontendPlugin.name == "gemini-frontend"
 
     def test_depends(self):
-        assert "url4-specs" in GeminiFrontendPlugin.depends
+        assert "url4-executor" in GeminiFrontendPlugin.depends
+        assert "frontend-base" in GeminiFrontendPlugin.depends
+        assert "url4-specs" not in GeminiFrontendPlugin.depends
 
     def test_settings_class(self):
         assert GeminiFrontendPlugin.settings_class is GeminiFrontendSettings

--- a/apps/server/src/screamingface/plugins/ollama_frontend/plugin.py
+++ b/apps/server/src/screamingface/plugins/ollama_frontend/plugin.py
@@ -41,7 +41,7 @@ class OllamaFrontendPlugin(FrontendPluginBase):
     name = "ollama-frontend"
     description = "Transparent proxy between local clients and a local/remote Ollama server"
     tags: list[str] = ["product:ollama"]
-    depends: list[str] = ["url4-specs", "url4-executor", "frontend-base"]
+    depends: list[str] = ["url4-executor", "frontend-base"]
     settings_class = OllamaFrontendSettings
 
     # Ollama is a server, not a CLI — no preflight binary check.

--- a/docs/superpowers/plans/SF-213-fix-plugin-depends-manifests.md
+++ b/docs/superpowers/plans/SF-213-fix-plugin-depends-manifests.md
@@ -1,0 +1,77 @@
+# SF-213: Fix `Plugin.depends` manifests per SF-208 audit (quick wins)
+
+**Asana:** [SF-213](https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215115079155250)
+**Branched from:** `SF-208-plugin-dependency-audit` (PR #202 — must merge first or pair-merge).
+
+**Goal:** Apply the audit's REMOVAL findings only. Adding new declared deps tightens runtime activation requirements and breaks ~25 tests with narrow `plugins=[...]` fixtures; those additions are deferred to a follow-up ticket that scopes the necessary test-fixture updates alongside.
+
+**Approach:** Edit each plugin's `plugin.py` `depends: list[str] = [...]` to drop entries no plugin imports. After all edits, re-run `tools/plugin_dependency_audit.py` and verify the residual matches expectations.
+
+## Apply: removals
+
+| Plugin (`<dir>/plugin.py`) | Remove from `depends` |
+|---|---|
+| `claude_env_intercept` | `claude-frontend` |
+| `claude_frontend` | `url4-specs` |
+| `codex_frontend` | `url4-specs` |
+| `gemini_frontend` | `url4-specs` |
+| `ollama_frontend` | `url4-specs` |
+
+## Steps
+
+- [ ] **Step 1: Apply every row of the removals table.** For each plugin: read the current `depends: list[str] = [...]` line in `apps/server/src/screamingface/plugins/<dir>/plugin.py` and splice out the listed removal. Preserve ordering of remaining items. For `claude_env_intercept`, the dropped entry leaves an empty list — keep the `depends: list[str] = []` form (typed annotation, consistent with other plugins).
+
+- [ ] **Step 2: Run the audit and assert the expected residual.**
+
+  ```bash
+  cd /Users/sergey/work/openmind/screamingface
+  uv run --directory apps/server python -m tools.plugin_dependency_audit \
+    --plugins-root src/screamingface/plugins \
+    --report ../../docs/superpowers/plans/plugin-dependency-audit.md
+  ```
+
+  Inspect the report:
+  - **Cycles section:** 2 cycles remain (the two real prod cycles — see Out of scope).
+  - **Per-plugin prod-missing:** 12 plugins still flagged (all moved to the follow-up ticket — see Out of scope).
+  - **Per-plugin extraneous:** drops from 7 to 2. Only `aigw-codex-backend` and `aigw-gemini-backend` should still show extraneous (`['backend-api-base']`), which is the known asymmetric-inheritance false positive.
+
+  Verify these counts match. Commit the refreshed report.
+
+- [ ] **Step 3: Run the server test suite (fast subset).**
+
+  ```bash
+  cd /Users/sergey/work/openmind/screamingface/apps/server
+  uv run pytest -m "not e2e and not e2e_live" -q
+  ```
+
+  Expected: green. If a plugin-metadata test pins exact `depends` content for any of the 5 edited plugins, update only that test to match the new declared list.
+
+- [ ] **Step 4: Lint gates.**
+
+  ```bash
+  cd /Users/sergey/work/openmind/screamingface/apps/server
+  uv run ruff format src/screamingface/plugins
+  uv run ruff check src/screamingface/plugins
+  ```
+
+- [ ] **Step 5: Commit and push.**
+
+  ```bash
+  git add apps/server/src/screamingface/plugins/*/plugin.py \
+          apps/server/src/screamingface/plugins/*/tests/test_plugin.py \
+          docs/superpowers/plans/plugin-dependency-audit.md \
+          docs/superpowers/plans/SF-213-fix-plugin-depends-manifests.md
+  git commit -m "SF-213: remove extraneous Plugin.depends entries (per SF-208 audit)"
+  git push -u origin SF-213-fix-plugin-depends-manifests
+  ```
+
+- [ ] **Step 6: Open PR.** Base: `main`. Note in body that this depends on PR #202 (SF-208) for the audit script. **Stop — do not merge.**
+
+## Out of scope
+
+Deferred to follow-up ticket(s) that scope test-fixture updates and architectural work:
+
+- **All 12 prod-missing additions from the audit.** Adding new declared deps tightens runtime activation: any test that instantiates the plugin via a narrow `plugins=[X]` fixture starts failing because the registry refuses to activate `X` without its newly-declared transitive deps. The audit's additions table (previously in this plan) belongs in the follow-up ticket verbatim, paired with the corresponding test-fixture widening. Plugins affected: `aigw_base`, `aigw_runner`, `backend_api_base`, `claude_backend_api`, `claude_frontend`, `codex_backend_api`, `frontend_base`, `gemini_backend_api`, `llm_base`, `ollama_backend_api`, `python_runner`, `url4_executor`.
+- **The two real prod cycles** (`aigw-base ↔ url4-executor` via `backend-api-base`, and `aigw-base ↔ llm-base`). Architectural call — likely move shared types out of `aigw-base`, or invert a dep.
+- **Asymmetric inheritance handling in the audit script** (`backend-api-base` extraneous false-positives on `aigw-codex-backend` / `aigw-gemini-backend`). The audit follows inheritance for `depends` but not for the corresponding imports, producing this asymmetric false positive. Track the audit-script fix as a separate refinement.
+- **Test-only undeclared imports** (6 plugins). `Plugin.depends` is a runtime contract; test imports don't belong there.

--- a/docs/superpowers/plans/plugin-dependency-audit.md
+++ b/docs/superpowers/plans/plugin-dependency-audit.md
@@ -9,7 +9,7 @@ Audit of cross-plugin imports under `apps/server/src/screamingface/plugins` agai
 - Plugins audited: **26**
 - Plugins with **missing** prod deps (imported by production code, not declared): **12**
 - Plugins with test-only imports of undeclared plugins: **6** (informational)
-- Plugins with **extraneous** deps (declared but never imported): **7**
+- Plugins with **extraneous** deps (declared but never imported): **2**
 - Cycles detected (production edges only): **2**
 
 ## Cycles (production edges only)
@@ -157,18 +157,18 @@ Audit of cross-plugin imports under `apps/server/src/screamingface/plugins` agai
 
 ### `claude-env-intercept` (`claude_env_intercept/`)
 
-- **Declared `depends`:** ['claude-frontend']
+- **Declared `depends`:** _(none)_
 - **Missing in prod (imported by production code, not declared):** _(none)_
-- **Extraneous (declared, not imported):** ['claude-frontend']
+- **Extraneous (declared, not imported):** _(none)_
 - **Test-only imports of undeclared plugins (informational):** _(none)_
 - **Prod imports observed:** _(none)_
 - **Test imports observed:** _(none)_
 
 ### `claude-frontend` (`claude_frontend/`)
 
-- **Declared `depends`:** ['url4-specs', 'url4-executor', 'frontend-base']
+- **Declared `depends`:** ['url4-executor', 'frontend-base']
 - **Missing in prod (imported by production code, not declared):** ['llm-base']
-- **Extraneous (declared, not imported):** ['url4-specs']
+- **Extraneous (declared, not imported):** _(none)_
 - **Test-only imports of undeclared plugins (informational):** ['data-store']
 - **Prod imports observed:**
   - `frontend_base` - 3 file(s)
@@ -229,16 +229,19 @@ Audit of cross-plugin imports under `apps/server/src/screamingface/plugins` agai
 
 ### `codex-frontend` (`codex_frontend/`)
 
-- **Declared `depends`:** ['url4-specs', 'url4-executor', 'frontend-base']
+- **Declared `depends`:** ['url4-executor', 'frontend-base']
 - **Missing in prod (imported by production code, not declared):** _(none)_
-- **Extraneous (declared, not imported):** ['url4-specs']
+- **Extraneous (declared, not imported):** _(none)_
 - **Test-only imports of undeclared plugins (informational):** ['claude-frontend']
-- **Prod imports observed:**
+- <details><summary><b>Prod imports observed</b></summary>
+
   - `frontend_base` - 2 file(s)
     - `apps/server/src/screamingface/plugins/codex_frontend/plugin.py`
     - `apps/server/src/screamingface/plugins/codex_frontend/proxy.py`
   - `url4_executor` - 1 file(s)
     - `apps/server/src/screamingface/plugins/codex_frontend/proxy.py`
+
+  </details>
 - **Test imports observed:**
   - `claude_frontend` - 1 file(s)
     - `apps/server/src/screamingface/plugins/codex_frontend/tests/test_plugin.py`
@@ -315,16 +318,19 @@ Audit of cross-plugin imports under `apps/server/src/screamingface/plugins` agai
 
 ### `gemini-frontend` (`gemini_frontend/`)
 
-- **Declared `depends`:** ['url4-specs', 'url4-executor', 'frontend-base']
+- **Declared `depends`:** ['url4-executor', 'frontend-base']
 - **Missing in prod (imported by production code, not declared):** _(none)_
-- **Extraneous (declared, not imported):** ['url4-specs']
+- **Extraneous (declared, not imported):** _(none)_
 - **Test-only imports of undeclared plugins (informational):** _(none)_
-- **Prod imports observed:**
+- <details><summary><b>Prod imports observed</b></summary>
+
   - `frontend_base` - 2 file(s)
     - `apps/server/src/screamingface/plugins/gemini_frontend/plugin.py`
     - `apps/server/src/screamingface/plugins/gemini_frontend/proxy.py`
   - `url4_executor` - 1 file(s)
     - `apps/server/src/screamingface/plugins/gemini_frontend/proxy.py`
+
+  </details>
 - **Test imports observed:** _(none)_
 
 ### `llm-base` (`llm_base/`)
@@ -386,17 +392,20 @@ Audit of cross-plugin imports under `apps/server/src/screamingface/plugins` agai
 
 ### `ollama-frontend` (`ollama_frontend/`)
 
-- **Declared `depends`:** ['url4-specs', 'url4-executor', 'frontend-base']
+- **Declared `depends`:** ['url4-executor', 'frontend-base']
 - **Missing in prod (imported by production code, not declared):** _(none)_
-- **Extraneous (declared, not imported):** ['url4-specs']
+- **Extraneous (declared, not imported):** _(none)_
 - **Test-only imports of undeclared plugins (informational):** _(none)_
-- **Prod imports observed:**
+- <details><summary><b>Prod imports observed</b></summary>
+
   - `frontend_base` - 3 file(s)
     - `apps/server/src/screamingface/plugins/ollama_frontend/_observability.py`
     - `apps/server/src/screamingface/plugins/ollama_frontend/plugin.py`
     - `apps/server/src/screamingface/plugins/ollama_frontend/proxy.py`
   - `url4_executor` - 1 file(s)
     - `apps/server/src/screamingface/plugins/ollama_frontend/proxy.py`
+
+  </details>
 - **Test imports observed:** _(none)_
 
 ### `python-runner` (`python_runner/`)


### PR DESCRIPTION
Replaces #204 (which carried duplicate pre-squash commits from #202's old branch and became unmergeable after #202 was squash-merged into main). Rebuilt as a single clean cherry-pick on top of fresh main.

## Summary
Apply the audit's REMOVAL findings only — declaring fewer deps is always safe.

- Drop `url4-specs` from four frontend plugins: `claude_frontend`, `codex_frontend`, `gemini_frontend`, `ollama_frontend` (declared but never imported).
- Drop `claude-frontend` from `claude_env_intercept` (replace with `depends: list[str] = []` for type-annotation consistency).
- Update two metadata tests (`codex_frontend`, `gemini_frontend`) that asserted the dropped entry.

## Why removals only

Adding new declared deps **tightens** runtime activation: many tests instantiate plugins via narrow `plugins=[X]` fixtures and the registry refuses to activate `X` without its newly-declared transitive deps. Trial-running the full additions table broke ~25 tests across the `url4-executor → eval-runs → state` chain. The 12 additions are tracked in **SF-214** with paired fixture-widening.

## Audit residual after this PR

| Metric | After SF-208 (now on main) | After SF-213 |
|---|---|---|
| Prod-missing | 12 | 12 *(deferred to SF-214)* |
| Extraneous | 7 | **2** *(both known audit false positives — SF-216 area)* |
| Prod cycles | 2 | 2 *(architectural, separate ticket)* |

## Test plan
- [x] `uv run pytest -m "not e2e and not e2e_live" -q` → 1084 passed, 17 skipped
- [x] `ruff format` / `ruff check` clean on `src/screamingface/plugins`
- [x] Audit re-run produces the residual counts above (via `uv run sf plugin audit-deps` after #205 lands; via `uv run python -m tools.plugin_dependency_audit` if #205 hasn't merged yet)

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215115079155250
Plan: docs/superpowers/plans/SF-213-fix-plugin-depends-manifests.md