### PR TITLE
SF-210: JS/TS code complexity analysis on pre-commit (apps/desktop)

### DIFF
--- a/apps/desktop/docs/complexity-baseline.md
+++ b/apps/desktop/docs/complexity-baseline.md
@@ -1,0 +1,104 @@
+# Complexity Baseline — apps/desktop (SF-210)
+
+Captured on 2026-05-26 from commit `e33d215`.
+
+These are the high-water marks the day-1 thresholds were set to accommodate.
+Each tightening PR (one rule, one ratchet at a time) should reference this
+file and the file:line below it's reducing.
+
+Plugin: `eslint-plugin-sonarjs@4.0.3`. Rule names below are the v4 spelling.
+
+## sonarjs/cognitive-complexity
+
+- **Day-1 threshold:** `34` — set equal to the current worst file. The rule
+  fires when a function's cognitive complexity exceeds the threshold, so
+  the file at 34 sits exactly at the limit.
+- **Top offenders:**
+
+  | Cognitive complexity | File:line                                          |
+  | -------------------: | -------------------------------------------------- |
+  |                   34 | `src/main/services/oauth-launcher.ts:113`          |
+  |                   33 | `src/main/services/oauth-launcher.ts:223`          |
+  |                   28 | `src/main/services/runtime-config-migration.ts:73` |
+  |                   24 | `src/main/services/backend-status.ts:441`          |
+  |                   17 | `src/main/services/session-manager.ts:396`         |
+  |                   15 | `src/main/services/venv-manager.ts:142`            |
+  |                   14 | `src/main/services/backend-status.ts:171`          |
+  |                   13 | `src/renderer/src/components/Url4Viewer.tsx:105`   |
+  |                   12 | `src/main/services/runtime-config-migration.ts:22` |
+  |                   11 | `src/main/services/external-url-policy.ts:60`      |
+
+  Total functions over the strict baseline floor of 5: **44**.
+
+## sonarjs/no-duplicate-string
+
+- **Day-1 threshold:** `31` — one above the current worst-case literal-count.
+  The v4 rule fires when occurrences are at-or-above the configured
+  threshold, so the file at 30 needs `threshold: 31` to pass cleanly.
+- **Top offenders:**
+
+  | Duplicate count | File:line                                                                      |
+  | --------------: | ------------------------------------------------------------------------------ |
+  |              30 | `src/main/services/__tests__/oauth-launcher.test.ts:55`                        |
+  |              18 | `src/main/services/__tests__/oauth-launcher.test.ts:95`                        |
+  |              14 | `src/main/services/__tests__/oauth-launcher.test.ts:58`                        |
+  |              10 | `src/renderer/src/components/server/__tests__/BackendStatusPanel.test.tsx:293` |
+  |              10 | `src/renderer/src/components/server/__tests__/BackendStatusPanel.test.tsx:105` |
+  |               9 | `src/renderer/src/components/server/__tests__/BackendStatusPanel.test.tsx:291` |
+  |               9 | `src/main/services/__tests__/oauth-launcher.test.ts:365`                       |
+  |               8 | `src/main/services/__tests__/external-url-policy.test.ts:29`                   |
+  |               7 | `src/main/services/__tests__/external-url-policy.test.ts:31`                   |
+  |               6 | `src/renderer/src/components/server/__tests__/BackendStatusPanel.test.tsx:202` |
+
+  Total duplicate-string sites above the strict baseline floor of 3: **41**.
+
+## Other sonarjs/\* rules (`warn` only, baseline counts)
+
+These ride along at warn-level for visibility. Promote to `error` one rule
+per tightening PR.
+
+| Rule                                    | Count at baseline |
+| --------------------------------------- | ----------------: |
+| `sonarjs/publicly-writable-directories` |                 8 |
+| `sonarjs/no-os-command-from-path`       |                 7 |
+| `sonarjs/no-nested-conditional`         |                 7 |
+| `sonarjs/no-nested-functions`           |                 7 |
+| `sonarjs/void-use`                      |                 4 |
+| `sonarjs/no-nested-template-literals`   |                 3 |
+| `sonarjs/no-extra-arguments`            |                 2 |
+| `sonarjs/unused-import`                 |                 2 |
+| `sonarjs/no-clear-text-protocols`       |                 1 |
+| `sonarjs/constructor-for-side-effects`  |                 1 |
+| `sonarjs/concise-regex`                 |                 1 |
+| `sonarjs/slow-regex`                    |                 1 |
+| `sonarjs/no-duplicated-branches`        |                 1 |
+
+(Counts exclude `sonarjs/cognitive-complexity` and `sonarjs/no-duplicate-string`,
+which are the hard-enforced gates above. The sonarjs v4 recommended set
+contains 269 rules in total; rules with zero current violations are not
+listed.)
+
+## Tightening roadmap
+
+The intent is to ratchet thresholds down one rule at a time, each as its own
+ticket + PR referencing this baseline:
+
+1. **cognitive-complexity:** 34 → 25 → 20 → 15 (industry default) → 10.
+   First two ratchets need a refactor of `oauth-launcher.ts` (two functions
+   at 33-34) and `runtime-config-migration.ts:73` (28).
+2. **no-duplicate-string:** 31 → 15 → 10 → 5. First ratchet means extracting
+   constants in the oauth-launcher test suite (30, 18, 14 hits there).
+3. **Promote one warn-level rule to error per follow-up PR.** Recommended
+   order based on count and refactor cost:
+   - `sonarjs/no-nested-conditional` (7) — usually trivial to flatten.
+   - `sonarjs/no-nested-functions` (7) — likely needs small extractions.
+   - `sonarjs/void-use` (4).
+   - `sonarjs/no-os-command-from-path` (7) — security-flavoured; needs care.
+   - `sonarjs/publicly-writable-directories` (8) — Electron-specific paths,
+     may justify a per-line `eslint-disable` rather than a refactor.
+
+Each tightening PR should:
+
+- Quote the "from N → to M" delta from this file.
+- Update this file with the new high-water mark.
+- Stay under ~10 files changed; if larger, split.

--- a/apps/desktop/eslint.config.mjs
+++ b/apps/desktop/eslint.config.mjs
@@ -2,6 +2,7 @@ import tsPlugin from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
 import reactPlugin from 'eslint-plugin-react';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
+import sonarjsPlugin from 'eslint-plugin-sonarjs';
 
 export default [
   {
@@ -21,12 +22,27 @@ export default [
       '@typescript-eslint': tsPlugin,
       react: reactPlugin,
       'react-hooks': reactHooksPlugin,
+      sonarjs: sonarjsPlugin,
     },
     rules: {
       ...tsPlugin.configs.recommended.rules,
       ...reactHooksPlugin.configs.recommended.rules,
+      // sonarjs recommended set as warnings — baseline visibility, no commit blocking
+      ...Object.fromEntries(
+        Object.entries(sonarjsPlugin.configs.recommended.rules).map(([k, v]) => [
+          k,
+          Array.isArray(v) ? ['warn', ...v.slice(1)] : 'warn',
+        ]),
+      ),
       'react/react-in-jsx-scope': 'off',
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+      // Hard-enforced complexity gates — set at current high-water marks so
+      // day 1 passes. See apps/desktop/docs/complexity-baseline.md for the
+      // tightening roadmap.
+      'sonarjs/cognitive-complexity': ['error', 34],
+      'sonarjs/no-duplicate-string': ['error', { threshold: 31 }],
+      'sonarjs/no-identical-functions': 'error',
+      'sonarjs/no-collapsible-if': 'error',
     },
     settings: {
       react: { version: 'detect' },

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -36,6 +36,7 @@
         "eslint": "^9.27.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-sonarjs": "^4.0.3",
         "husky": "^9.1.7",
         "jsdom": "^29.1.1",
         "lint-staged": "^16.1.0",
@@ -160,6 +161,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -803,6 +805,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -851,6 +854,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1043,6 +1047,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1511,7 +1516,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1533,7 +1537,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1550,7 +1553,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1565,7 +1567,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2779,6 +2780,7 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -2947,6 +2949,7 @@
       "resolved": "https://registry.npmjs.org/@rjsf/utils/-/utils-6.4.1.tgz",
       "integrity": "sha512-5NL3jwt3rIS5/WRTrKt++y40FS/ScKGVwYJ3jIrHSQHSwBdLnd4cHf2zcnA97L1Klj8I6tvS/ugh+blf/Diwuw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@x0k/json-schema-merge": "^1.0.2",
         "fast-uri": "^3.1.0",
@@ -3896,8 +3899,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4056,6 +4058,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4066,6 +4069,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4146,6 +4150,7 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -4561,6 +4566,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4594,6 +4600,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5249,9 +5256,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5293,6 +5300,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5440,6 +5448,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/bundle-name": {
@@ -6080,8 +6101,7 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -6529,6 +6549,7 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -6623,8 +6644,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -6724,6 +6744,7 @@
       "integrity": "sha512-3rzz/hVIpF726W9g7nleQzyF2IOEZbzZnUTUYGhMaEfsoab8fDyOYAWbdBdo4+DczS1Ifz11rdYo8IAAGcRx/g==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^24.9.0",
@@ -6946,7 +6967,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -6967,7 +6987,6 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -7350,6 +7369,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7489,6 +7509,43 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.0.3.tgz",
+      "integrity": "sha512-5drkJKLC9qQddIiaATV0e8+ygbUc7b0Ti6VB7M2d3jmKNh3X0RaiIJYTs3dr9xnlhlrxo+/s1FoO3Jgv6O/c7g==",
+      "dev": true,
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "builtin-modules": "^3.3.0",
+        "bytes": "^3.1.2",
+        "functional-red-black-tree": "^1.0.1",
+        "globals": "^17.4.0",
+        "jsx-ast-utils-x": "^0.1.0",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^10.2.5",
+        "scslre": "^0.3.0",
+        "semver": "^7.7.4",
+        "ts-api-utils": "^2.5.0",
+        "typescript": ">=5"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/globals": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-scope": {
@@ -8364,6 +8421,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
@@ -8791,6 +8855,7 @@
       "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9926,6 +9991,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jsx-ast-utils-x": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils-x/-/jsx-ast-utils-x-0.1.0.tgz",
+      "integrity": "sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -10548,7 +10623,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -10764,13 +10838,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -10948,7 +11022,6 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -11953,7 +12026,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -11971,7 +12043,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -12021,7 +12092,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -12037,7 +12107,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -12048,7 +12117,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -12061,8 +12129,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
@@ -12290,6 +12357,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12299,6 +12367,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -12381,6 +12450,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/refa": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/refa/-/refa-0.12.1.tgz",
+      "integrity": "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -12402,6 +12484,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp-ast-analysis": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz",
+      "integrity": "sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.1"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/regexp.prototype.flags": {
@@ -12591,7 +12687,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -12847,6 +12942,21 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/scslre": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
+      "integrity": "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.0",
+        "regexp-ast-analysis": "^0.7.0"
+      },
+      "engines": {
+        "node": "^14.0.0 || >=16.0.0"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -13954,7 +14064,6 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -14097,6 +14206,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14213,9 +14323,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14418,6 +14528,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14635,6 +14746,7 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -14728,6 +14840,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15303,6 +15416,7 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -56,6 +56,7 @@
     "eslint": "^9.27.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-sonarjs": "^4.0.3",
     "husky": "^9.1.7",
     "jsdom": "^29.1.1",
     "lint-staged": "^16.1.0",

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -16,8 +16,7 @@ export function App() {
 
   useEffect(() => {
     window.electronAPI.config.read().then(setConfig);
-    const unsub = window.electronAPI.config.onChanged(setConfig);
-    return unsub;
+    return window.electronAPI.config.onChanged(setConfig);
   }, []);
 
   const handleConfigChange = useCallback(

--- a/apps/desktop/src/renderer/src/hooks/use-plugins.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-plugins.ts
@@ -12,8 +12,7 @@ export function usePlugins() {
   }, []);
 
   const install = useCallback(async (url: string) => {
-    const manifest = await window.electronAPI.plugins.install(url);
-    return manifest;
+    return await window.electronAPI.plugins.install(url);
   }, []);
 
   const uninstall = useCallback((id: string) => window.electronAPI.plugins.uninstall(id), []);

--- a/apps/desktop/src/renderer/src/hooks/use-venv-status.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-venv-status.ts
@@ -13,14 +13,17 @@ export function useVenvStatus() {
       setUvFound(result.uvFound);
 
       // Auto-bootstrap in production: create venv + sync when missing
-      if (result.autoBootstrap && result.status === 'missing' && result.uvFound) {
-        if (!bootstrapping.current) {
-          bootstrapping.current = true;
-          window.electronAPI.venv.create().then((ok) => {
-            if (ok) window.electronAPI.venv.sync();
-            bootstrapping.current = false;
-          });
-        }
+      if (
+        result.autoBootstrap &&
+        result.status === 'missing' &&
+        result.uvFound &&
+        !bootstrapping.current
+      ) {
+        bootstrapping.current = true;
+        window.electronAPI.venv.create().then((ok) => {
+          if (ok) window.electronAPI.venv.sync();
+          bootstrapping.current = false;
+        });
       }
 
       // Auto re-sync after app update (version stamp mismatch)

--- a/apps/desktop/src/renderer/src/views/DashboardView.tsx
+++ b/apps/desktop/src/renderer/src/views/DashboardView.tsx
@@ -31,11 +31,10 @@ export function DashboardView({ server }: DashboardViewProps) {
       const plugins = (config.plugins as string[]) || [];
       setTracingEnabled(plugins.includes('tracing'));
     });
-    const unsub = window.electronAPI.config.onChanged((config) => {
+    return window.electronAPI.config.onChanged((config) => {
       const plugins = (config.plugins as string[]) || [];
       setTracingEnabled(plugins.includes('tracing'));
     });
-    return unsub;
   }, []);
 
   const openPhoenix = () => {

--- a/apps/desktop/src/renderer/src/views/SettingsView.tsx
+++ b/apps/desktop/src/renderer/src/views/SettingsView.tsx
@@ -207,10 +207,9 @@ export function SettingsView() {
         initialLoadRef.current = false;
       }, 100);
     });
-    const unsub = window.electronAPI.config.onChanged((c) => {
+    return window.electronAPI.config.onChanged((c) => {
       setConfig(c as AppConfig);
     });
-    return unsub;
   }, []);
 
   const markDirty = useCallback(() => {
@@ -419,14 +418,11 @@ export function SettingsView() {
                 }
                 return h % RAINBOW_COLORS.length;
               };
-              const groupColor = (group: string): string =>
-                RAINBOW_COLORS[colorIndex(group)];
+              const groupColor = (group: string): string => RAINBOW_COLORS[colorIndex(group)];
 
               // Sort groups in rainbow order (by hue index) so the UI walks
               // red → orange → … → violet top-to-bottom.
-              const groupOrder = Object.keys(groups).sort(
-                (a, b) => colorIndex(a) - colorIndex(b),
-              );
+              const groupOrder = Object.keys(groups).sort((a, b) => colorIndex(a) - colorIndex(b));
 
               return groupOrder.map((group) => (
                 <div key={group} className="mb-4">

--- a/docs/superpowers/plans/SF-210-jsts-complexity-precommit.md
+++ b/docs/superpowers/plans/SF-210-jsts-complexity-precommit.md
@@ -1,0 +1,396 @@
+# SF-210: JS/TS code complexity analysis on pre-commit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire JS/TS code-complexity analysis into the `apps/desktop` lint chain (and through it, the existing husky pre-commit hook) with thresholds set just above current high-water marks so day 1 is green and future regressions are blocked.
+
+**Architecture:** Extend the existing ESLint flat config in `apps/desktop/eslint.config.mjs` with `eslint-plugin-sonarjs`. Use sonarjs's `cognitive-complexity` (preferred over plain cyclomatic — better signal for real-world code) plus a small set of structural-quality rules. Run an unrestricted baseline pass, document the worst-case values per metric, then set thresholds = ceil(worst-case). The husky pre-commit hook already runs `lint-staged` → `eslint --fix` on staged TS/TSX, so adding rules is enough — no hook plumbing changes.
+
+**Tech Stack:** TypeScript 5 / React 19 / Electron / ESLint 9 (flat config) / `eslint-plugin-sonarjs` ^3.x / husky 9 / lint-staged 16 — all already installed except sonarjs.
+
+**Asana:** [SF-210](https://app.asana.com/1/1185126988600652/task/1214965778747000), due 2026-05-25.
+
+**Branch:** `SF-210-jsts-complexity-precommit` (already created from `origin/main`).
+
+**Out of scope (separate tickets):** Python complexity (ruff `C901` / `xenon` at apps/server/.pre-commit-config.yaml), any `web-iterations/` JS/TS (archived demo iterations — see survey notes), gradual-tightening refactor PRs (one PR per tightening, opened once this baseline lands).
+
+---
+
+## File Structure
+
+- Modify: `apps/desktop/package.json` — add `eslint-plugin-sonarjs` to devDependencies; add `lint:complexity` and `lint:complexity:report` npm scripts.
+- Modify: `apps/desktop/eslint.config.mjs` — register the sonarjs plugin; add a rules block with the thresholds plus the small complementary rule set.
+- Create: `apps/desktop/docs/complexity-baseline.md` — snapshot of worst-case values per metric so future tightening PRs have a "from → to" reference.
+- Create: `docs/superpowers/plans/SF-210-jsts-complexity-precommit.md` — this plan (already created).
+
+That's it. No husky/lint-staged config changes — the new rules ride on the existing eslint pre-commit invocation.
+
+## Rule choice rationale
+
+`eslint-plugin-sonarjs` is the standard for SonarSource-derived rules in JS/TS-land, used by SonarQube/SonarCloud. Picked over alternatives:
+- **vs. ESLint's built-in `complexity` rule:** sonarjs's `cognitive-complexity` correlates better with what humans actually find hard to read (nesting + flow-breaking constructs weighted higher than simple branching). Built-in `complexity` is cyclomatic only.
+- **vs. `ts-complex` / `code-complexity` / `madge` CLI tools:** those run out-of-band and need separate plumbing to enforce; sonarjs runs through the existing `eslint --fix` step on staged files, no new orchestration.
+- **vs. `eslint-plugin-complexity`:** smaller scope, not maintained as actively.
+
+Initial enforced rules (all sonarjs):
+- `sonarjs/cognitive-complexity` — function-level cognitive load
+- `sonarjs/no-identical-functions` — dedup
+- `sonarjs/no-duplicate-string` — copy-paste detector
+- `sonarjs/no-collapsible-if` — flatten unnecessary nesting
+
+Everything else from sonarjs's recommended set goes to **warn** for now so we get signal without breaking commits.
+
+---
+
+## Task 1: Add sonarjs dependency and validate it loads
+
+**Files:**
+- Modify: `apps/desktop/package.json`
+
+- [ ] **Step 1: Install the plugin**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface/apps/desktop
+npm install --save-dev eslint-plugin-sonarjs
+```
+
+Expected: `package.json` gets a new line in `devDependencies` like `"eslint-plugin-sonarjs": "^3.0.x"`, `package-lock.json` updated.
+
+- [ ] **Step 2: Verify plugin loads via a sentinel rule**
+
+Temporarily add to `apps/desktop/eslint.config.mjs` after the existing imports:
+
+```js
+import sonarjsPlugin from 'eslint-plugin-sonarjs';
+```
+
+And inside the config object, add to `plugins`:
+```js
+sonarjs: sonarjsPlugin,
+```
+
+And to `rules`:
+```js
+'sonarjs/no-collapsible-if': 'error',
+```
+
+Run:
+```bash
+cd /Users/sergey/work/openmind/screamingface/apps/desktop
+npx eslint src --max-warnings 0 --no-fix 2>&1 | tail -30
+```
+
+Expected: ESLint loads without "plugin not found" errors. May report sonarjs findings — that's fine for now, we're only checking the plugin loads.
+
+- [ ] **Step 3: Commit the dependency**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface
+git add apps/desktop/package.json apps/desktop/package-lock.json
+git commit -m "SF-210: add eslint-plugin-sonarjs to apps/desktop"
+```
+
+---
+
+## Task 2: Run unrestricted baseline to find worst-case values
+
+**Files:**
+- Modify: `apps/desktop/eslint.config.mjs` (temporary baseline config)
+
+- [ ] **Step 1: Switch to baseline-mode config**
+
+Replace the temporary single-rule block from Task 1 with this rules-section (still inside the same config block):
+
+```js
+rules: {
+  ...tsPlugin.configs.recommended.rules,
+  ...reactHooksPlugin.configs.recommended.rules,
+  ...sonarjsPlugin.configs.recommended.rules,
+  'react/react-in-jsx-scope': 'off',
+  '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+  // Baseline collection: turn the metrics we care about to strict thresholds
+  // so we see every violation. We'll relax these in Task 3.
+  'sonarjs/cognitive-complexity': ['error', 5],
+  'sonarjs/no-duplicate-string': ['error', { threshold: 3 }],
+},
+```
+
+- [ ] **Step 2: Run lint and capture the violations**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface/apps/desktop
+npx eslint src --no-fix --format json > /tmp/sf210-baseline.json 2>&1 || true
+```
+
+The `|| true` keeps the shell happy when there are errors (expected).
+
+- [ ] **Step 3: Extract worst-case values per metric**
+
+```bash
+python3 <<'PY'
+import json, re
+data = json.load(open('/tmp/sf210-baseline.json'))
+cc = []       # cognitive-complexity values
+dup = []      # duplicate-string values
+other = {}    # other sonarjs rule -> count
+for f in data:
+    for m in f.get('messages', []):
+        rule = m.get('ruleId') or ''
+        if rule == 'sonarjs/cognitive-complexity':
+            # Message looks like: 'Refactor this function to reduce its Cognitive Complexity from 23 to the 5 allowed.'
+            mm = re.search(r'from (\d+) to the', m['message'])
+            if mm: cc.append((int(mm.group(1)), f['filePath'], m.get('line')))
+        elif rule == 'sonarjs/no-duplicate-string':
+            mm = re.search(r'(\d+) times', m['message'])
+            if mm: dup.append((int(mm.group(1)), f['filePath'], m.get('line')))
+        elif rule.startswith('sonarjs/'):
+            other[rule] = other.get(rule, 0) + 1
+
+cc.sort(reverse=True)
+dup.sort(reverse=True)
+print('=== cognitive-complexity worst 10 ===')
+for v, f, l in cc[:10]:
+    print(f'  {v:4d}  {f.split("apps/desktop/")[-1]}:{l}')
+print('  max:', cc[0][0] if cc else 0)
+print()
+print('=== no-duplicate-string worst 10 ===')
+for v, f, l in dup[:10]:
+    print(f'  {v:4d}  {f.split("apps/desktop/")[-1]}:{l}')
+print('  max:', dup[0][0] if dup else 0)
+print()
+print('=== other sonarjs rule counts ===')
+for r, c in sorted(other.items(), key=lambda x: -x[1]):
+    print(f'  {c:4d}  {r}')
+PY
+```
+
+Expected: a list of worst offenders. Record the **max** cognitive-complexity and **max** duplicate-string count — those become the day-1 thresholds.
+
+- [ ] **Step 4: Don't commit yet** — the baseline rules are intentionally too strict and will fail the commit hook. Move straight to Task 3.
+
+---
+
+## Task 3: Write the baseline doc and set day-1 thresholds
+
+**Files:**
+- Create: `apps/desktop/docs/complexity-baseline.md`
+- Modify: `apps/desktop/eslint.config.mjs`
+
+- [ ] **Step 1: Write the baseline doc**
+
+Create `apps/desktop/docs/complexity-baseline.md` with the actual numbers captured in Task 2 Step 3. Template:
+
+```markdown
+# Complexity Baseline — apps/desktop (SF-210)
+
+Captured on YYYY-MM-DD from commit `<short-sha-of-the-current-HEAD>`.
+
+These are the high-water marks the day-1 thresholds were set to accommodate. Each tightening PR (one rule, one ratchet at a time) should reference this file and the file:line below it's reducing.
+
+## sonarjs/cognitive-complexity
+
+- **Day-1 threshold:** <max + 0, since we want exact ceiling — the file at the max value IS at the limit>
+- **Top offenders:**
+  | Cognitive complexity | File:line |
+  |---:|---|
+  | <N> | `<relative-path>:<line>` |
+  | <N-1> | ... |
+  | ... | up to 10 rows |
+
+## sonarjs/no-duplicate-string
+
+- **Day-1 threshold:** <max literal-count + 0>
+- **Top offenders:**
+  | Duplicate count | File:line |
+  |---:|---|
+  | ... |
+
+## Other sonarjs/* rules (`warn` only, baseline counts)
+
+| Rule | Count at baseline |
+|---|---:|
+| sonarjs/<rule-id> | <N> |
+| ... |
+
+## Tightening roadmap
+
+The intent is to ratchet thresholds down one rule at a time:
+1. cognitive-complexity: target 15 (industry default), then 10
+2. no-duplicate-string: target 5
+3. Promote one warn-level rule to error per follow-up PR
+
+Each tightening is its own ticket + PR. See SF-210's PR body for the tracked sequence.
+```
+
+Use exact numbers from Task 2.
+
+- [ ] **Step 2: Set day-1 thresholds in eslint.config.mjs**
+
+Replace the rules block from Task 2 with the production version. The thresholds use the worst values you observed; the recommended set goes to `warn`.
+
+```js
+rules: {
+  ...tsPlugin.configs.recommended.rules,
+  ...reactHooksPlugin.configs.recommended.rules,
+  // sonarjs recommended set as warnings — baseline visibility, no commit blocking
+  ...Object.fromEntries(
+    Object.entries(sonarjsPlugin.configs.recommended.rules).map(([k, v]) => [
+      k,
+      Array.isArray(v) ? ['warn', ...v.slice(1)] : 'warn',
+    ]),
+  ),
+  'react/react-in-jsx-scope': 'off',
+  '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+  // Hard-enforced complexity gates — set just above current worst-case so
+  // day 1 passes. See apps/desktop/docs/complexity-baseline.md for current
+  // high-water marks and the tightening roadmap.
+  'sonarjs/cognitive-complexity': ['error', <WORST_CC>],
+  'sonarjs/no-duplicate-string': ['error', { threshold: <WORST_DUP> }],
+  'sonarjs/no-identical-functions': 'error',
+  'sonarjs/no-collapsible-if': 'error',
+},
+```
+
+Replace `<WORST_CC>` and `<WORST_DUP>` with the integers captured in Task 2. If for some unlikely reason there are zero violations of either, use industry defaults: 15 for cognitive-complexity, 5 for duplicate-string.
+
+- [ ] **Step 3: Run lint to confirm day-1 passes**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface/apps/desktop
+npx eslint src --no-fix
+```
+
+Expected: exit code 0. Warnings allowed (these are the recommended-set rules in warn mode); errors must be zero. If errors exist, the threshold isn't high enough — bump it up by one or investigate which file was missed.
+
+- [ ] **Step 4: Run npm run lint to confirm it integrates cleanly**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface/apps/desktop
+npm run lint
+```
+
+Expected: completes without exiting non-zero. `eslint . --fix` may auto-fix some sonarjs findings (e.g. `no-collapsible-if` could merge `if (a) { if (b) ... }`). Inspect any auto-fixes via `git diff`; if they look correct keep them, otherwise revert and add the affected file to `.eslintignore` for now (note in the baseline doc).
+
+- [ ] **Step 5: Commit the config + baseline doc**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface
+git add apps/desktop/eslint.config.mjs apps/desktop/docs/complexity-baseline.md
+# Include any clean auto-fixes from Step 4:
+git add -u apps/desktop/src
+git commit -m "SF-210: enforce sonarjs complexity gates in apps/desktop eslint"
+```
+
+---
+
+## Task 4: Validate the pre-commit hook picks up the new rules
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Stage a deliberately-bad TS file and try to commit**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface
+cat > /tmp/sf210-canary.ts <<'TS'
+// Intentionally exceeds cognitive complexity to verify the pre-commit hook blocks it.
+export function tangled(a: number, b: number, c: number, d: number): number {
+  let total = 0;
+  if (a > 0) { if (b > 0) { if (c > 0) { if (d > 0) { for (let i = 0; i < a; i++) { for (let j = 0; j < b; j++) { if (i + j > c) { total += i * j; } else if (i - j > d) { total -= i; } else { total += 1; } } } } } } }
+  return total;
+}
+TS
+cp /tmp/sf210-canary.ts apps/desktop/src/renderer/src/__canary__.ts
+git add apps/desktop/src/renderer/src/__canary__.ts
+git commit -m "SF-210: canary — DO NOT MERGE" 2>&1 | tail -20
+```
+
+Expected: commit is rejected by the husky pre-commit hook with a sonarjs/cognitive-complexity error pointing at `__canary__.ts`.
+
+- [ ] **Step 2: Clean up the canary**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface
+git reset HEAD apps/desktop/src/renderer/src/__canary__.ts
+rm apps/desktop/src/renderer/src/__canary__.ts
+git status --short
+```
+
+Expected: no canary file remaining, no staged changes left over from it.
+
+- [ ] **Step 3: Confirm the existing CI test workflow still passes locally**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface/apps/desktop
+npm test 2>&1 | tail -10
+```
+
+If `npm test` isn't defined or runs unrelated work, skip; the gate that actually matters is the next commit going through pre-commit cleanly.
+
+- [ ] **Step 4: Make a no-op commit to confirm the hook is green on healthy code**
+
+If steps 1-3 left no changes, skip. Otherwise, make one trivial whitespace-touch in a low-complexity file and try a real commit (then immediately undo it). The point is to see lint-staged report green on real code.
+
+---
+
+## Task 5: Push and open PR
+
+**Files:** none (process).
+
+- [ ] **Step 1: Push branch**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface
+git push -u origin SF-210-jsts-complexity-precommit
+```
+
+- [ ] **Step 2: Open PR (do not merge)**
+
+```bash
+gh pr create --base main --head SF-210-jsts-complexity-precommit \
+  --title "SF-210: JS/TS code complexity analysis on pre-commit" \
+  --body "$(cat <<'EOF'
+## Summary
+- Add `eslint-plugin-sonarjs` to `apps/desktop`.
+- Hard-enforce `sonarjs/cognitive-complexity`, `sonarjs/no-duplicate-string`, `sonarjs/no-identical-functions`, `sonarjs/no-collapsible-if` at the day-1 high-water mark.
+- Run the rest of the sonarjs recommended set at warn level for visibility.
+- Commit a baseline doc (`apps/desktop/docs/complexity-baseline.md`) listing the worst current offenders so each follow-up tightening PR has a clear "from → to" target.
+
+The rules run through the existing lint-staged → eslint --fix chain in the husky pre-commit hook — no new hook plumbing.
+
+## Scope
+- IN: `apps/desktop` (the only active JS/TS surface in the repo).
+- OUT: `web-iterations/*` (archived demo iterations, no CI, no recent commits). Python complexity is a separate ticket.
+
+## Tightening roadmap
+Each ratchet is a separate PR:
+1. cognitive-complexity → 15 (industry default), then → 10.
+2. no-duplicate-string → 5.
+3. Promote one warn-level rule to error per follow-up.
+
+See `apps/desktop/docs/complexity-baseline.md` for the current numbers.
+
+## Test plan
+- [x] `npm run lint` exits 0 on current `apps/desktop/src`.
+- [x] Canary file with cognitive-complexity > threshold is rejected by the pre-commit hook.
+- [ ] Reviewer checks the baseline doc reflects reality (worst values match a fresh local lint run).
+
+Asana: https://app.asana.com/1/1185126988600652/task/1214965778747000
+Plan: docs/superpowers/plans/SF-210-jsts-complexity-precommit.md
+EOF
+)"
+```
+
+Stop here. Per project rules: do not merge.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:**
+  - Step 1 of the ticket (inventory): the pre-plan survey already covered this; result was "scope = apps/desktop only".
+  - Step 2 (baseline + thresholds the code passes today): Task 2 + Task 3 Steps 1-3.
+  - Step 3 (wire into pre-commit): no new wiring needed — the existing husky → lint-staged → eslint chain in `apps/desktop/.husky/pre-commit` picks up the new rules automatically. Task 4 verifies this.
+  - Step 4 (tighten in steps, each becomes a refactor PR): out of scope for this PR per the "Out of scope" note up top; the roadmap and baseline doc set the structure so each future PR knows what to target.
+- **No placeholders:** The only `<WORST_CC>` / `<WORST_DUP>` placeholders are intentional — they're real integers the engineer reads off the Task 2 Step 3 output and substitutes in Task 3 Step 2. Each placeholder has an explicit fallback rule (industry default) if Task 2 produces zero violations.
+- **Type consistency:** Plugin name `sonarjsPlugin`, npm package `eslint-plugin-sonarjs`, rule prefix `sonarjs/*` used consistently throughout.
+- **Scope discipline:** No edits outside `apps/desktop/{package.json,package-lock.json,eslint.config.mjs,docs/}` and the plan file. Husky/lint-staged configs untouched. No `web-iterations/` changes.


### PR DESCRIPTION
## Summary
Wire JS/TS code-complexity analysis into `apps/desktop`. Day-1 thresholds are set just above current high-water marks so the existing tree passes; future regressions are blocked through the existing husky → lint-staged → eslint chain.

- Add `eslint-plugin-sonarjs@^4.0.3` to `apps/desktop`.
- Hard-enforce 4 rules:
  - `sonarjs/cognitive-complexity: ['error', 34]` (worst is `oauth-launcher.ts:113` at 34)
  - `sonarjs/no-duplicate-string: ['error', { threshold: 31 }]`
  - `sonarjs/no-identical-functions: 'error'`
  - `sonarjs/no-collapsible-if: 'error'`
- Run the rest of the sonarjs recommended set at `warn` level for visibility.
- Commit `apps/desktop/docs/complexity-baseline.md` listing the top offenders + the tightening roadmap so each follow-up PR has a clear "from → to" target.
- Auto-fixed 4 source files (`prefer-immediate-return`) and manually flattened 1 nested-if (`use-venv-status.ts`).

The rules ride through the existing lint-staged → eslint --fix step in `apps/desktop/.husky/pre-commit` — no new hook plumbing.

## Scope
- IN: `apps/desktop` (the only active JS/TS surface — 79 TS/TSX files).
- OUT: `web-iterations/*` (archived demo iterations, no CI, no recent commits). Python complexity is tracked separately.

## Top 3 cognitive-complexity offenders (day-1 baseline)
| CC | File:line |
|---:|---|
| 34 | `src/main/services/oauth-launcher.ts:113` |
| 33 | `src/main/services/oauth-launcher.ts:223` |
| 28 | `src/main/services/runtime-config-migration.ts:73` |

Full list in `apps/desktop/docs/complexity-baseline.md`.

## Tightening roadmap (each = separate PR)
1. cognitive-complexity → 15 (industry default), then → 10.
2. no-duplicate-string → 5.
3. Promote one warn-level rule to error per follow-up.

## Test plan
- [x] `npx eslint src --no-fix` exits 0 for sonarjs rules (one pre-existing `@typescript-eslint/no-explicit-any` in `rjsf-theme.tsx:112` predates this PR and is unrelated)
- [x] Canary file with collapsible-ifs was rejected by the husky pre-commit hook — confirmed gate works
- [x] `git status` clean after canary removal
- [ ] Reviewer: spot-check `apps/desktop/docs/complexity-baseline.md` against a fresh local `npm run lint`

## Known pre-existing issue (not SF-210)
`apps/desktop/src/renderer/src/components/rjsf-theme.tsx:112` has a pre-existing `@typescript-eslint/no-explicit-any` error already on main. Left alone — out of scope for SF-210. Would surface on the next commit that touches that file. Worth a separate small ticket if you want to clean it up.

Asana: https://app.asana.com/1/1185126988600652/task/1214965778747000
Plan: docs/superpowers/plans/SF-210-jsts-complexity-precommit.md