### PR TITLE
SF-186: add AIGateway k3s deployment

### DIFF
--- a/.github/workflows/release-aigateway.yml
+++ b/.github/workflows/release-aigateway.yml
@@ -68,8 +68,45 @@ jobs:
             org.opencontainers.image.version=${{ needs.verify.outputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}
 
+  chart:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+      - name: Lint and render charts
+        run: |
+          helm lint apps/aigateway/charts/db
+          helm lint apps/aigateway/charts/aigateway
+          helm template aigw-db apps/aigateway/charts/db \
+            --namespace aigw \
+            --values apps/aigateway/charts/db-aigateway.values.yaml >/tmp/aigw-db.yaml
+          helm template aigw apps/aigateway/charts/aigateway \
+            --namespace aigw >/tmp/aigw.yaml
+          helm template aigw apps/aigateway/charts/aigateway \
+            --namespace aigw \
+            --values apps/aigateway/charts/aigateway/values-prod.yaml >/tmp/aigw-prod.yaml
+      - name: Package Helm chart
+        env:
+          VERSION: ${{ needs.verify.outputs.version }}
+        run: |
+          mkdir -p dist/charts
+          helm package apps/aigateway/charts/aigateway \
+            --version "$VERSION" \
+            --app-version "$VERSION" \
+            --destination dist/charts
+      - name: Log in to GHCR for Helm
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GITHUB_TOKEN" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+      - name: Push Helm chart
+        env:
+          VERSION: ${{ needs.verify.outputs.version }}
+        run: helm push "dist/charts/aigateway-$VERSION.tgz" oci://ghcr.io/openmined/screamingface/charts
+
   release:
-    needs: [verify, image]
+    needs: [verify, image, chart]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -84,6 +121,11 @@ jobs:
             ```
             docker pull ghcr.io/openmined/screamingface-aigateway:${{ needs.verify.outputs.version }}
             ```
+
+            Helm chart:
+            ```
+            helm pull oci://ghcr.io/openmined/screamingface/charts/aigateway --version ${{ needs.verify.outputs.version }}
+            ```
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to sf-installer (public)
@@ -93,7 +135,11 @@ jobs:
           VERSION: ${{ needs.verify.outputs.version }}
         run: |
           gh release delete "$TAG" --repo OpenMined/sf-installer --yes 2>/dev/null || true
+          NOTES=$(printf 'AI Gateway container image: `%s`\nAI Gateway Helm chart: `%s`\n' \
+            "ghcr.io/openmined/screamingface-aigateway:$VERSION" \
+            "oci://ghcr.io/openmined/screamingface/charts/aigateway --version $VERSION"
+          )
           gh release create "$TAG" \
             --repo OpenMined/sf-installer \
             --title "ScreamingFace AI Gateway $VERSION" \
-            --notes "AI Gateway container image: \`ghcr.io/openmined/screamingface-aigateway:$VERSION\`"
+            --notes "$NOTES"

--- a/apps/aigateway/Dockerfile
+++ b/apps/aigateway/Dockerfile
@@ -19,7 +19,13 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 FROM python:3.12-slim-bookworm AS runtime
 
-ENV PATH="/app/.venv/bin:$PATH" \
+LABEL org.opencontainers.image.source="https://github.com/openmined/screamingface" \
+      org.opencontainers.image.description="ScreamingFace AI Gateway" \
+      org.opencontainers.image.licenses="MIT"
+
+ENV AIGW_HOST=0.0.0.0 \
+    AIGW_PORT=9105 \
+    PATH="/app/.venv/bin:$PATH" \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
@@ -31,6 +37,9 @@ COPY --from=builder --chown=app:app /app /app
 
 USER app
 
-EXPOSE 8000
+EXPOSE 9105
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:9105/healthz', timeout=3).read()" || exit 1
 
 ENTRYPOINT ["aigateway"]

--- a/apps/aigateway/charts/aigateway/Chart.yaml
+++ b/apps/aigateway/charts/aigateway/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: aigateway
+description: ScreamingFace AI Gateway
+type: application
+version: 0.1.0
+appVersion: "0.2.0"

--- a/apps/aigateway/charts/aigateway/README.md
+++ b/apps/aigateway/charts/aigateway/README.md
@@ -1,0 +1,52 @@
+# aigateway
+
+Helm chart for ScreamingFace AI Gateway.
+
+Install the demo database chart first, then install this app chart:
+
+```bash
+helm install aigw-db apps/aigateway/charts/db \
+  --namespace aigw \
+  --create-namespace \
+  --wait \
+  --values apps/aigateway/charts/db-aigateway.values.yaml
+helm install aigw apps/aigateway/charts/aigateway --namespace aigw --wait
+```
+
+The app chart is database-agnostic. It consumes `AIGATEWAY_DATABASE_URL` from `database.existingSecret`, which defaults to the `aigw-db` Secret created by `charts/db`.
+
+## Public URL
+
+Set `publicUrl` to the externally reachable gateway origin when using hosted OAuth callbacks:
+
+```bash
+helm upgrade --install aigw apps/aigateway/charts/aigateway \
+  --namespace aigw \
+  --set publicUrl=https://aigateway.example.com \
+  --set "ingress.hosts[0].host=aigateway.example.com" \
+  --set "ingress.hosts[0].paths[0].path=/" \
+  --set "ingress.hosts[0].paths[0].pathType=Prefix"
+```
+
+Quote indexed `--set` keys in shells such as zsh. If you override a list item, set the full `host` and `paths` structure.
+
+For temporary k3s smoke tests without real DNS, a host such as `aigateway.40.76.107.241.nip.io` resolves to `40.76.107.241` and works with host-based Ingress rules.
+
+## Production
+
+`values-prod.yaml` expects externally managed Secrets and production ingress settings:
+
+```bash
+helm template apps/aigateway/charts/aigateway \
+  --values apps/aigateway/charts/aigateway/values-prod.yaml
+```
+
+Production database infrastructure should be managed separately, for example CloudNativePG or managed Postgres.
+
+Published releases include the app chart in GHCR:
+
+```bash
+helm install aigw oci://ghcr.io/openmined/screamingface/charts/aigateway \
+  --version 0.2.0 \
+  --namespace aigw
+```

--- a/apps/aigateway/charts/aigateway/templates/_helpers.tpl
+++ b/apps/aigateway/charts/aigateway/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{- define "aigateway.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "aigateway.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "aigateway.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "aigateway.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "aigateway.labels" -}}
+helm.sh/chart: {{ include "aigateway.chart" . }}
+app.kubernetes.io/name: {{ include "aigateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: screamingface
+{{- end -}}
+
+{{- define "aigateway.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "aigateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "aigateway.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "aigateway.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "aigateway.image" -}}
+{{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
+{{- end -}}
+
+{{- define "aigateway.authSecretName" -}}
+{{- required "auth.existingSecret is required" .Values.auth.existingSecret -}}
+{{- end -}}

--- a/apps/aigateway/charts/aigateway/templates/configmap.yaml
+++ b/apps/aigateway/charts/aigateway/templates/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "aigateway.fullname" . }}
+  labels:
+    {{- include "aigateway.labels" . | nindent 4 }}
+data:
+  AIGW_HOST: {{ .Values.config.host | quote }}
+  AIGW_PORT: {{ .Values.config.port | quote }}
+  AIGW_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  AIGATEWAY_AUTH_ENABLED: {{ .Values.config.authEnabled | quote }}
+  AIGATEWAY_JWT_TTL_SECONDS: {{ .Values.config.jwtTtlSeconds | quote }}
+  AIGATEWAY_PUBLIC_URL: {{ .Values.publicUrl | quote }}

--- a/apps/aigateway/charts/aigateway/templates/deployment.yaml
+++ b/apps/aigateway/charts/aigateway/templates/deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "aigateway.fullname" . }}
+  labels:
+    {{- include "aigateway.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "aigateway.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "aigateway.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "aigateway.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: aigateway
+          image: {{ include "aigateway.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.config.port }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "aigateway.fullname" . }}
+          env:
+            - name: AIGATEWAY_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "database.existingSecret is required" .Values.database.existingSecret }}
+                  key: {{ .Values.database.existingSecretKey }}
+            - name: AIGATEWAY_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "aigateway.authSecretName" . }}
+                  key: {{ .Values.auth.jwtSecretKey }}
+            - name: AIGATEWAY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "aigateway.authSecretName" . }}
+                  key: {{ .Values.auth.adminPasswordKey }}
+            - name: AIGATEWAY_PROVISIONING_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "aigateway.authSecretName" . }}
+                  key: {{ .Values.auth.provisioningTokenKey }}
+                  optional: true
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/apps/aigateway/charts/aigateway/templates/ingress.yaml
+++ b/apps/aigateway/charts/aigateway/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "aigateway.fullname" . }}
+  labels:
+    {{- include "aigateway.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "aigateway.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/apps/aigateway/charts/aigateway/templates/job-migrate.yaml
+++ b/apps/aigateway/charts/aigateway/templates/job-migrate.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.migration.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "aigateway.fullname" . }}-migrate
+  labels:
+    {{- include "aigateway.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- with .Values.migration.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  backoffLimit: {{ .Values.migration.backoffLimit }}
+  ttlSecondsAfterFinished: {{ .Values.migration.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        {{- include "aigateway.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: migrate
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ .Values.migration.serviceAccountName | quote }}
+      containers:
+        - name: tortoise-migrate
+          image: {{ include "aigateway.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - python
+            - -m
+            - tortoise
+            - -c
+            - aigateway.db.TORTOISE_CONFIG
+            - migrate
+          env:
+            - name: AIGATEWAY_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "database.existingSecret is required" .Values.database.existingSecret }}
+                  key: {{ .Values.database.existingSecretKey }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+{{- end }}

--- a/apps/aigateway/charts/aigateway/templates/networkpolicy.yaml
+++ b/apps/aigateway/charts/aigateway/templates/networkpolicy.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "aigateway.fullname" . }}
+  labels:
+    {{- include "aigateway.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "aigateway.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: {{ .Values.config.port }}
+      {{- if .Values.networkPolicy.ingressCIDRs }}
+      from:
+        {{- range .Values.networkPolicy.ingressCIDRs }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
+      {{- end }}
+  egress:
+    - {}
+{{- end }}

--- a/apps/aigateway/charts/aigateway/templates/secret.yaml
+++ b/apps/aigateway/charts/aigateway/templates/secret.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.auth.createSecret }}
+{{- $secretName := include "aigateway.authSecretName" . -}}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $jwtSecret := .Values.auth.jwtSecret -}}
+{{- if not $jwtSecret -}}
+{{- if and $existingSecret $existingSecret.data (index $existingSecret.data .Values.auth.jwtSecretKey) -}}
+{{- $jwtSecret = (index $existingSecret.data .Values.auth.jwtSecretKey | b64dec) -}}
+{{- else -}}
+{{- $jwtSecret = randAlphaNum 64 -}}
+{{- end -}}
+{{- end -}}
+{{- $adminPassword := .Values.auth.adminPassword -}}
+{{- if not $adminPassword -}}
+{{- if and $existingSecret $existingSecret.data (index $existingSecret.data .Values.auth.adminPasswordKey) -}}
+{{- $adminPassword = (index $existingSecret.data .Values.auth.adminPasswordKey | b64dec) -}}
+{{- else -}}
+{{- $adminPassword = randAlphaNum 24 -}}
+{{- end -}}
+{{- end -}}
+{{- $provisioningToken := .Values.auth.provisioningToken -}}
+{{- if and (not $provisioningToken) $existingSecret $existingSecret.data (index $existingSecret.data .Values.auth.provisioningTokenKey) -}}
+{{- $provisioningToken = (index $existingSecret.data .Values.auth.provisioningTokenKey | b64dec) -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    {{- include "aigateway.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.auth.jwtSecretKey }}: {{ $jwtSecret | quote }}
+  {{ .Values.auth.adminPasswordKey }}: {{ $adminPassword | quote }}
+  {{- if $provisioningToken }}
+  {{ .Values.auth.provisioningTokenKey }}: {{ $provisioningToken | quote }}
+  {{- end }}
+{{- end }}

--- a/apps/aigateway/charts/aigateway/templates/service.yaml
+++ b/apps/aigateway/charts/aigateway/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "aigateway.fullname" . }}
+  labels:
+    {{- include "aigateway.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+  selector:
+    {{- include "aigateway.selectorLabels" . | nindent 4 }}

--- a/apps/aigateway/charts/aigateway/templates/serviceaccount.yaml
+++ b/apps/aigateway/charts/aigateway/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "aigateway.serviceAccountName" . }}
+  labels:
+    {{- include "aigateway.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/apps/aigateway/charts/aigateway/templates/tests/test-connection.yaml
+++ b/apps/aigateway/charts/aigateway/templates/tests/test-connection.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "aigateway.fullname" . }}-test-connection
+  labels:
+    {{- include "aigateway.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  restartPolicy: Never
+  containers:
+    - name: curl
+      image: curlimages/curl:8.11.1
+      command:
+        - sh
+        - -c
+        - curl -fsS "http://{{ include "aigateway.fullname" . }}:{{ .Values.service.port }}/healthz"

--- a/apps/aigateway/charts/aigateway/values-prod.yaml
+++ b/apps/aigateway/charts/aigateway/values-prod.yaml
@@ -1,0 +1,29 @@
+replicaCount: 3
+
+publicUrl: https://gateway.screamingface.ai
+
+auth:
+  createSecret: true
+  existingSecret: aigw-auth
+
+database:
+  existingSecret: aigw-db
+  existingSecretKey: database-url
+
+ingress:
+  enabled: true
+  className: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: gateway.screamingface.ai
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: aigw-tls
+      hosts:
+        - gateway.screamingface.ai
+
+networkPolicy:
+  enabled: true

--- a/apps/aigateway/charts/aigateway/values.yaml
+++ b/apps/aigateway/charts/aigateway/values.yaml
@@ -1,0 +1,109 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/openmined/screamingface-aigateway
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  runAsNonRoot: true
+  runAsUser: 1000
+
+config:
+  host: 0.0.0.0
+  port: 9105
+  logLevel: info
+  authEnabled: true
+  jwtTtlSeconds: 86400
+
+publicUrl: https://gateway.screamingface.ai
+
+database:
+  existingSecret: aigw-db
+  existingSecretKey: database-url
+
+auth:
+  createSecret: true
+  existingSecret: aigw-auth
+  jwtSecret: ""
+  jwtSecretKey: jwt-secret
+  adminPassword: ""
+  adminPasswordKey: admin-password
+  provisioningToken: ""
+  provisioningTokenKey: provisioning-token
+
+service:
+  type: ClusterIP
+  port: 9105
+
+ingress:
+  enabled: true
+  className: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-staging
+  hosts:
+    - host: gateway.screamingface.ai
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: aigw-tls-staging
+      hosts:
+        - gateway.screamingface.ai
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 1000m
+    memory: 512Mi
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 20
+  timeoutSeconds: 5
+
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+
+migration:
+  enabled: true
+  serviceAccountName: default
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 600
+  annotations: {}
+
+networkPolicy:
+  enabled: false
+  ingressCIDRs: []
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/apps/aigateway/charts/db-aigateway.values.yaml
+++ b/apps/aigateway/charts/db-aigateway.values.yaml
@@ -1,0 +1,8 @@
+fullnameOverride: aigw-db
+
+auth:
+  username: aigateway
+  database: aigateway
+
+secret:
+  name: aigw-db

--- a/apps/aigateway/charts/db/Chart.yaml
+++ b/apps/aigateway/charts/db/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: postgres
+description: Single-instance PostgreSQL chart for development and demos
+type: application
+version: 0.1.0
+appVersion: "16"

--- a/apps/aigateway/charts/db/README.md
+++ b/apps/aigateway/charts/db/README.md
@@ -1,0 +1,24 @@
+# postgres
+
+Small single-instance PostgreSQL chart for development and demos.
+
+## Install
+
+```bash
+helm install my-db ./charts/db --namespace my-namespace --create-namespace
+```
+
+## Resources
+
+- `Secret/<release-name>`: `username`, `password`, `database`, and `database-url`.
+- `Service/<release-name>`: cluster-internal Postgres service on port `5432`.
+- `PersistentVolumeClaim/<release-name>-data`: data volume.
+- `Deployment/<release-name>`: single `postgres:16-alpine` pod.
+
+## Notes
+
+- This is demo infrastructure only: no HA, no backups, no PITR, and no automated major-version upgrade policy.
+- The generated password is URL-safe and is preserved on upgrade when Helm can read the existing Secret from the cluster.
+- If `auth.password` is set manually, use a URL-safe value because the chart also writes a database URL Secret.
+- Postgres is cluster-internal only. Do not expose it through Ingress or a public LoadBalancer.
+- Deleting the PVC deletes the database.

--- a/apps/aigateway/charts/db/templates/NOTES.txt
+++ b/apps/aigateway/charts/db/templates/NOTES.txt
@@ -1,0 +1,9 @@
+Postgres has been installed.
+
+Service:
+  {{ include "postgres.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+Database URL Secret:
+  {{ include "postgres.secretName" . }} / {{ .Values.secret.databaseUrlKey }}
+
+Configure applications with this Secret name and key.

--- a/apps/aigateway/charts/db/templates/_helpers.tpl
+++ b/apps/aigateway/charts/db/templates/_helpers.tpl
@@ -1,0 +1,37 @@
+{{- define "postgres.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "postgres.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "postgres.name" . -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "postgres.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "postgres.labels" -}}
+helm.sh/chart: {{ include "postgres.chart" . }}
+app.kubernetes.io/name: {{ include "postgres.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "postgres.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "postgres.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "postgres.secretName" -}}
+{{- default (include "postgres.fullname" .) .Values.secret.name -}}
+{{- end -}}

--- a/apps/aigateway/charts/db/templates/deployment.yaml
+++ b/apps/aigateway/charts/db/templates/deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "postgres.fullname" . }}
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "postgres.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "postgres.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: postgres
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: postgres
+              containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "postgres.secretName" . }}
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "postgres.secretName" . }}
+                  key: password
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "postgres.secretName" . }}
+                  key: database
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "postgres.fullname" . }}-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}

--- a/apps/aigateway/charts/db/templates/pvc.yaml
+++ b/apps/aigateway/charts/db/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "postgres.fullname" . }}-data
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/apps/aigateway/charts/db/templates/secret.yaml
+++ b/apps/aigateway/charts/db/templates/secret.yaml
@@ -1,0 +1,23 @@
+{{- $secretName := include "postgres.secretName" . -}}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $password := .Values.auth.password -}}
+{{- if not $password -}}
+{{- if and $existingSecret $existingSecret.data (index $existingSecret.data "password") -}}
+{{- $password = (index $existingSecret.data "password" | b64dec) -}}
+{{- else -}}
+{{- $password = randAlphaNum 48 -}}
+{{- end -}}
+{{- end -}}
+{{- $databaseUrl := printf "%s://%s:%s@%s.%s.svc.cluster.local:%d/%s" .Values.secret.scheme .Values.auth.username $password (include "postgres.fullname" .) .Release.Namespace (.Values.service.port | int) .Values.auth.database -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  username: {{ .Values.auth.username | quote }}
+  password: {{ $password | quote }}
+  database: {{ .Values.auth.database | quote }}
+  {{ .Values.secret.databaseUrlKey }}: {{ $databaseUrl | quote }}

--- a/apps/aigateway/charts/db/templates/service.yaml
+++ b/apps/aigateway/charts/db/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "postgres.fullname" . }}
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: postgres
+      port: {{ .Values.service.port }}
+      targetPort: postgres
+  selector:
+    {{- include "postgres.selectorLabels" . | nindent 4 }}

--- a/apps/aigateway/charts/db/values.yaml
+++ b/apps/aigateway/charts/db/values.yaml
@@ -1,0 +1,45 @@
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repository: postgres
+  tag: 16-alpine
+  pullPolicy: IfNotPresent
+
+auth:
+  username: app
+  password: ""
+  database: app
+
+secret:
+  name: ""
+  databaseUrlKey: database-url
+  scheme: postgres
+
+service:
+  port: 5432
+
+persistence:
+  enabled: true
+  storageClass: local-path
+  accessModes:
+    - ReadWriteOnce
+  size: 4Gi
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+
+readinessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+
+livenessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 20
+  timeoutSeconds: 5

--- a/apps/aigateway/src/aigateway/config.py
+++ b/apps/aigateway/src/aigateway/config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from urllib.parse import urlsplit
+
 from pydantic import Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -28,6 +30,7 @@ class Settings(BaseSettings):
     )
     auth_enabled: bool = Field(default=True, validation_alias="AIGATEWAY_AUTH_ENABLED")
     jwt_ttl_seconds: int = Field(default=86_400, validation_alias="AIGATEWAY_JWT_TTL_SECONDS")
+    public_url: str | None = Field(default=None, validation_alias="AIGATEWAY_PUBLIC_URL")
 
     @field_validator("jwt_secret", "provisioning_token")
     @classmethod
@@ -47,3 +50,18 @@ class Settings(BaseSettings):
         if not 8 <= size <= 72:
             raise ValueError("password must be 8-72 UTF-8 bytes")
         return value
+
+    @field_validator("public_url")
+    @classmethod
+    def _validate_public_url(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        normalized = value.strip().rstrip("/")
+        if not normalized:
+            return None
+        parsed = urlsplit(normalized)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("public_url must be an absolute http(s) URL")
+        if parsed.query or parsed.fragment:
+            raise ValueError("public_url must not include query or fragment")
+        return normalized

--- a/apps/aigateway/src/aigateway/routes/auth.py
+++ b/apps/aigateway/src/aigateway/routes/auth.py
@@ -120,6 +120,9 @@ def _pending_for_app(app):
 
 def _gateway_redirect_uri_for(request: Request, cfg: OAuthConfig) -> str:
     path = cfg.redirect_path if cfg.redirect_path.startswith("/") else f"/{cfg.redirect_path}"
+    public_url = request.app.state.settings.public_url
+    if public_url:
+        return f"{public_url}{path}"
     port = _request_host_port(request) or request.app.state.settings.port
     return f"http://localhost:{port}{path}"
 
@@ -300,6 +303,8 @@ async def _redirect_uri_for(
     cfg: OAuthConfig,
     state: str,
 ) -> str:
+    if request.app.state.settings.public_url:
+        return _gateway_redirect_uri_for(request, cfg)
     if cfg.loopback_redirect_ports:
         return await _loopback_redirect_uri_for(request, provider, cfg, state)
     return _gateway_redirect_uri_for(request, cfg)

--- a/apps/aigateway/tests/unit/auth/test_settings_redaction.py
+++ b/apps/aigateway/tests/unit/auth/test_settings_redaction.py
@@ -27,6 +27,22 @@ def test_auth_enabled_defaults_true_and_parses_env_zero(monkeypatch, tmp_path) -
     assert Settings().auth_enabled is False
 
 
+def test_public_url_parses_env_and_strips_trailing_slash(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AIGATEWAY_PUBLIC_URL", "https://aigateway.example.com/base/")
+
+    assert Settings().public_url == "https://aigateway.example.com/base"
+
+
+def test_invalid_public_url_rejected() -> None:
+    try:
+        Settings(public_url="localhost:9105")
+    except ValueError as exc:
+        assert "public_url must be an absolute http(s) URL" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("invalid public_url was accepted")
+
+
 def test_short_secret_rejected() -> None:
     try:
         Settings(jwt_secret=SecretStr("short"))

--- a/apps/aigateway/tests/unit/test_auth_routes.py
+++ b/apps/aigateway/tests/unit/test_auth_routes.py
@@ -136,6 +136,17 @@ def test_start_oauth_invalid_host_falls_back_to_app_port(client_with_index) -> N
     assert query["redirect_uri"] == [f"http://localhost:{client.app.state.settings.port}/callback"]
 
 
+def test_start_oauth_uses_public_url_for_gateway_callback(client_with_index) -> None:
+    client, _ = client_with_index
+    client.app.state.settings.public_url = "https://aigateway.example.com/base"
+
+    resp = client.post("/v1/auth/anthropic/profiles", json={"name": "public-url"})
+
+    assert resp.status_code == 201
+    query = parse_qs(urlparse(resp.json()["authorize_url"]).query)
+    assert query["redirect_uri"] == ["https://aigateway.example.com/base/callback"]
+
+
 def test_start_oauth_for_codex_returns_openai_authorize_url(client_with_index) -> None:
     client, _ = client_with_index
     account_id = _account_id(client)
@@ -166,6 +177,19 @@ def test_start_oauth_for_codex_returns_openai_authorize_url(client_with_index) -
     profile = client.get("/v1/auth/codex/profiles/work").json()
     assert profile["state"] == "pending"
     assert "offline_access" in profile["scopes"]
+
+
+def test_start_oauth_public_url_overrides_loopback_redirect_ports_for_codex(
+    client_with_index,
+) -> None:
+    client, _ = client_with_index
+    client.app.state.settings.public_url = "https://aigateway.example.com"
+
+    resp = client.post("/v1/auth/codex/profiles", json={"name": "public-codex"})
+
+    assert resp.status_code == 201
+    query = parse_qs(urlparse(resp.json()["authorize_url"]).query)
+    assert query["redirect_uri"] == ["https://aigateway.example.com/auth/callback"]
 
 
 def test_start_oauth_loopback_unavailable_returns_503(client_with_index, monkeypatch) -> None:

--- a/apps/aigateway/tests/unit/test_oauth_connections_routes.py
+++ b/apps/aigateway/tests/unit/test_oauth_connections_routes.py
@@ -134,6 +134,19 @@ def test_anthropic_connection_uses_request_host_port_for_callback(
     assert query["redirect_uri"] == ["http://localhost:9106/callback"]
 
 
+def test_anthropic_connection_uses_public_url_for_callback(authenticated_client) -> None:
+    authenticated_client.app.state.settings.public_url = "https://aigateway.example.com"
+
+    start = authenticated_client.post(
+        "/v1/oauth/connections",
+        json={"provider": "anthropic", "label": "public-anthropic"},
+    )
+
+    assert start.status_code == 201
+    query = parse_qs(urlparse(start.json()["authorize_url"]).query)
+    assert query["redirect_uri"] == ["https://aigateway.example.com/callback"]
+
+
 def test_anthropic_connection_lifecycle_and_label_conflict(
     authenticated_client, fake_keychain
 ) -> None:

--- a/infra/k3s/.gitignore
+++ b/infra/k3s/.gitignore
@@ -1,0 +1,4 @@
+collections/
+*.retry
+*.secret.yml
+kubeconfig*

--- a/infra/k3s/README.md
+++ b/infra/k3s/README.md
@@ -1,0 +1,45 @@
+# K3s Bootstrap
+
+Ansible bootstrap for the SF single-node k3s VM at `40.76.107.241`.
+
+## Host
+
+- Azure VM: `screaming-lisbon`
+- SSH: `adminuser@40.76.107.241`
+- Private IP: `10.5.0.4`
+- OS: Ubuntu 24.04 LTS, amd64
+- Privilege: passwordless sudo
+
+## Install
+
+Run from this directory:
+
+```bash
+uvx --from ansible-core ansible-galaxy collection install -r requirements.yaml -p collections
+uvx --from ansible-core ansible-playbook -i inventory.screaming-lisbon.yml k3s.orchestration.site
+```
+
+For a future multi-node cluster or externally managed join token, put the token in an ignored secret vars file and pass it with `-e`:
+
+```yaml
+# cluster.secret.yml
+token: "<stable cluster token>"
+```
+
+```bash
+uvx --from ansible-core ansible-playbook -i inventory.screaming-lisbon.yml -e @cluster.secret.yml k3s.orchestration.site
+```
+
+## Notes
+
+- Local `ansible` is not required; the commands above use `uvx`.
+- `api_endpoint` is the VM private IP because `k3s-ansible` checks control-plane readiness from the VM. Your Mac should use the `sf-k3s` context through the SSH tunnel instead.
+- Port `6443` is not reachable publicly through Azure networking. Use an SSH tunnel for kubectl access unless the Azure NSG is intentionally opened to a restricted admin IP:
+
+```bash
+ssh -N -L 16443:127.0.0.1:6443 adminuser@40.76.107.241
+kubectl config set-cluster k3s-ansible --server=https://127.0.0.1:16443
+kubectl --context sf-k3s get nodes
+```
+
+- The k3s-ansible collection fetches kubeconfig to ignored local file `kubeconfig.screaming-lisbon`; it should not overwrite your global `~/.kube/config` on repeat runs.

--- a/infra/k3s/ansible.cfg
+++ b/infra/k3s/ansible.cfg
@@ -1,0 +1,4 @@
+[defaults]
+collections_path = ./collections
+interpreter_python = auto_silent
+retry_files_enabled = False

--- a/infra/k3s/inventory.screaming-lisbon.yml
+++ b/infra/k3s/inventory.screaming-lisbon.yml
@@ -1,0 +1,20 @@
+k3s_cluster:
+  children:
+    server:
+      hosts:
+        screaming-lisbon:
+          ansible_host: 40.76.107.241
+          ansible_ssh_common_args: "-o StrictHostKeyChecking=accept-new"
+
+  vars:
+    ansible_user: adminuser
+    ansible_become: true
+    ansible_become_method: sudo
+    k3s_version: v1.35.3+k3s1
+    cluster_context: sf-k3s
+    api_endpoint: 10.5.0.4
+    kubeconfig: ./kubeconfig.screaming-lisbon
+    server_config_yaml: |
+      tls-san:
+        - 10.5.0.4
+        - 40.76.107.241

--- a/infra/k3s/requirements.yaml
+++ b/infra/k3s/requirements.yaml
@@ -1,0 +1,4 @@
+collections:
+  - name: https://github.com/k3s-io/k3s-ansible.git
+    type: git
+    version: 1.2.0


### PR DESCRIPTION
Asana: https://app.asana.com/0/1213628819033917/1214568321070251/f

Adds Helm charts, k3s bootstrap docs, release chart publishing, and hosted public URL support for AIGateway.

## Description
Adds Kubernetes deployment support for AIGateway with a dedicated application Helm chart and a separate generic Postgres demo chart for k3s smoke/demo usage. The release workflow now lints, renders, packages, and publishes the AIGateway Helm chart to GHCR OCI alongside the container image. The AIGateway runtime image now binds to `0.0.0.0:9105`, exposes `/healthz`, and supports `AIGATEWAY_PUBLIC_URL` for hosted OAuth callback URLs.

This intentionally excludes cert-manager manifests and the standalone deployment runbook from the commit.

## Affected Dependencies
- Helm is required for chart linting, rendering, packaging, and OCI publishing.
- Kubernetes/k3s is required for running the generated manifests.
- The demo DB chart uses `postgres:16-alpine` for local k3s/demo deployments.

## How has this been tested?
- `helm lint apps/aigateway/charts/db`
- `helm lint apps/aigateway/charts/aigateway`
- `helm template aigw-db apps/aigateway/charts/db --namespace aigw --values apps/aigateway/charts/db-aigateway.values.yaml >/tmp/aigw-db.yaml`
- `helm template aigw apps/aigateway/charts/aigateway --namespace aigw >/tmp/aigw.yaml`
- `helm template aigw apps/aigateway/charts/aigateway --namespace aigw --values apps/aigateway/charts/aigateway/values-prod.yaml >/tmp/aigw-prod.yaml`
- `cd apps/aigateway && uv run pytest tests/unit/auth/test_settings_redaction.py tests/unit/test_auth_routes.py tests/unit/test_oauth_connections_routes.py -q`
- `cd apps/aigateway && uv run ruff check src/aigateway/config.py src/aigateway/routes/auth.py tests/unit/auth/test_settings_redaction.py tests/unit/test_auth_routes.py tests/unit/test_oauth_connections_routes.py`
- `cd apps/aigateway && uv run pyright`
- `git diff --cached --check`

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests