### PR TITLE
SF-227: fix URL4 backend call highlighting

### DIFF
--- a/apps/server/src/screamingface/plugins/url4_executor/highlight.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/highlight.py
@@ -7,7 +7,16 @@ that the frontend renders as colored spans.
 from __future__ import annotations
 
 from screamingface.plugins.url4_executor.decoder import split_intent
-from screamingface.plugins.url4_executor.url4 import Url4List, Url4Text, Url4Url, parse
+from screamingface.plugins.url4_executor.url4 import (
+    Url4BackendCall,
+    Url4Binding,
+    Url4ExpandedSource,
+    Url4List,
+    Url4RelUrl,
+    Url4Text,
+    Url4Url,
+    parse,
+)
 
 
 def tokenize(expr: str) -> list[dict]:
@@ -27,8 +36,34 @@ def tokenize(expr: str) -> list[dict]:
 def _walk(node, depth: int) -> list[dict]:
     if isinstance(node, Url4Url):
         return [{"type": "url", "value": node.value, "depth": depth}]
+    if isinstance(node, Url4RelUrl):
+        return [{"type": "url", "value": node.value, "depth": depth}]
     if isinstance(node, Url4Text):
         return [{"type": "text", "value": node.value, "depth": depth}]
+    if isinstance(node, Url4BackendCall):
+        backend_tokens: list[dict] = []
+        if node.name:
+            backend_tokens.append({"type": "text", "value": f"{node.name}:", "depth": depth})
+        if node.weight is not None:
+            backend_tokens.append({"type": "text", "value": f"{node.weight:g}:", "depth": depth})
+        backend_tokens.append({"type": "url", "value": node.path, "depth": depth})
+        backend_tokens.append({"type": "paren", "value": "(", "depth": depth})
+        if node.packed_context:
+            backend_tokens.append(
+                {"type": "text", "value": node.packed_context, "depth": depth + 1}
+            )
+        backend_tokens.append({"type": "paren", "value": ")", "depth": depth})
+        if node.intent is not None:
+            backend_tokens.append({"type": "intent_sep", "value": "!", "depth": depth})
+            backend_tokens.extend(_walk_intent(node.intent, depth))
+        return backend_tokens
+    if isinstance(node, Url4ExpandedSource):
+        return [{"type": "text", "value": "*", "depth": depth}, *_walk(node.inner, depth)]
+    if isinstance(node, Url4Binding):
+        return [
+            {"type": "text", "value": f"{node.name}{node.kind}", "depth": depth},
+            *_walk(node.value, depth),
+        ]
     if isinstance(node, Url4List):
         tokens: list[dict] = [{"type": "paren", "value": "(", "depth": depth}]
         for i, item in enumerate(node.items):
@@ -39,3 +74,9 @@ def _walk(node, depth: int) -> list[dict]:
         tokens.append({"type": "paren", "value": ")", "depth": depth})
         return tokens
     raise TypeError(f"Unknown node type: {type(node)}")
+
+
+def _walk_intent(node, depth: int) -> list[dict]:
+    if isinstance(node, Url4Text):
+        return [{"type": "intent", "value": node.value, "depth": depth}]
+    return _walk(node, depth)

--- a/apps/server/src/screamingface/plugins/url4_executor/tests/test_highlight_route.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/tests/test_highlight_route.py
@@ -43,6 +43,16 @@ def test_ensemble_highlight_handles_paren_list() -> None:
     assert "url" in types
 
 
+def test_ensemble_highlight_handles_backend_call() -> None:
+    client = _client()
+    resp = client.get("/ensemble/highlight", params={"q": "/claude()!hello kitty"})
+    assert resp.status_code == 200
+    tokens = resp.json()["tokens"]
+
+    assert {"type": "url", "value": "/claude", "depth": 0} in tokens
+    assert {"type": "intent", "value": "hello kitty", "depth": 0} in tokens
+
+
 def test_ensemble_highlight_missing_q_returns_400() -> None:
     client = _client()
     resp = client.get("/ensemble/highlight")

--- a/apps/server/src/screamingface/plugins/url4_executor/tests/test_url4_highlight.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/tests/test_url4_highlight.py
@@ -83,3 +83,42 @@ def test_intent_only_url() -> None:
         {"type": "intent_sep", "value": "!", "depth": 0},
         {"type": "intent", "value": "do-thing", "depth": 0},
     ]
+
+
+def test_backend_call_with_intent() -> None:
+    tokens = tokenize("/claude()!hello kitty")
+    assert tokens == [
+        {"type": "url", "value": "/claude", "depth": 0},
+        {"type": "paren", "value": "(", "depth": 0},
+        {"type": "paren", "value": ")", "depth": 0},
+        {"type": "intent_sep", "value": "!", "depth": 0},
+        {"type": "intent", "value": "hello kitty", "depth": 0},
+    ]
+
+
+def test_backend_call_list_with_outer_intent() -> None:
+    tokens = tokenize("(/claude()!hello, /gemini()!hello)!reduce")
+    types = [token["type"] for token in tokens]
+    values = [token["value"] for token in tokens]
+
+    assert types == [
+        "paren",
+        "url",
+        "paren",
+        "paren",
+        "intent_sep",
+        "intent",
+        "comma",
+        "ws",
+        "url",
+        "paren",
+        "paren",
+        "intent_sep",
+        "intent",
+        "paren",
+        "intent_sep",
+        "intent",
+    ]
+    assert "/claude" in values
+    assert "/gemini" in values
+    assert values[-1] == "reduce"


### PR DESCRIPTION
## Description
Fixes `/ensemble/highlight` for URL4 backend-call expressions such as `/claude()!prompt` and `/gemini()!prompt`.

Execution already supported these expressions through `/ensemble`, but the highlighter only handled older URL4 AST node types and returned a 400 for `Url4BackendCall`. The highlighter now handles current URL4 AST nodes while reusing existing token types, so the Desktop URL4 viewer can render backend-call expressions without a renderer change.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215193410970330

## Affected Dependencies
None.

## How has this been tested?
- `cd apps/server && uv run pytest src/screamingface/plugins/url4_executor/tests/test_url4_highlight.py src/screamingface/plugins/url4_executor/tests/test_highlight_route.py src/screamingface/plugins/url4_executor/tests/test_url4.py::test_parse_backend_call_with_text_intent -q`
- `cd apps/server && uv run pre-commit run --config .pre-commit-config.yaml --files src/screamingface/plugins/url4_executor/highlight.py src/screamingface/plugins/url4_executor/tests/test_highlight_route.py src/screamingface/plugins/url4_executor/tests/test_url4_highlight.py`
- Live local SF smoke: `/ensemble/highlight` and `/ensemble` returned 200 for `/claude()!hello kitty` and `/gemini()!hello kitty` probes.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests