### PR TITLE
SF-228: enable Tortoise global fallback so DB reads work under uvicorn

### DIFF
--- a/apps/server/src/screamingface/plugins/state/plugin.py
+++ b/apps/server/src/screamingface/plugins/state/plugin.py
@@ -82,7 +82,12 @@ class StatePlugin(Plugin):
             if self.registry.is_empty:
                 logger.info("state plugin: no models registered, skipping Tortoise.init")
                 return
-            await Tortoise.init(config=config)
+            # _enable_global_fallback: under uvicorn, Tortoise.init runs in the
+            # lifespan-startup task, but each request runs in a separate task with
+            # no active TortoiseContext. Without the global fallback, every DB query
+            # from a request handler raises "No TortoiseContext is currently active".
+            # In-process tests share the task/context, so they don't surface this.
+            await Tortoise.init(config=config, _enable_global_fallback=True)
             await Tortoise.generate_schemas(safe=True)
             self.registry.mark_initialized()
             app.state.state_ready = True


### PR DESCRIPTION
## Summary
Every Tortoise-backed read endpoint on the live SF server returned **HTTP 500** (surfaced via the desktop Eval Studio: `GET /eval_runs` → 500), affecting *all* DB-backed endpoints.

**Root cause:** `state/plugin.py` called `Tortoise.init(config=config)` without `_enable_global_fallback=True`. Tortoise 1.x stores the DB connection in a per-task `ContextVar`. Under uvicorn, `Tortoise.init()` runs in the lifespan-startup task, but each request runs in a **separate** task with no active `TortoiseContext`, so `get_connection()` raised `RuntimeError: No TortoiseContext is currently active`. In-process tests (httpx `ASGITransport`) share the task/context, so the suite never caught it.

**Fix (1 line):** pass `_enable_global_fallback=True` to `Tortoise.init()`.

## Verification
- Launched the real app via uvicorn against a temp DB:
  - `GET /eval_runs?limit=50&offset=0` → **200 `[]`** (was 500)
  - `GET /eval_runs/{random-id}` → **404** (was 500)
  - no errors logged
- `pytest` state + eval_runs → **48 passed**
- ruff format / ruff check / pyright → clean

## Notes
- Pre-existing bug on `main`, unrelated to any feature branch.
- Prerequisite for SF-167 (RunView) manual verification, which depends on `/eval_runs` working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)