### PR TITLE
SF-230: resolve $prompt url4 in-process (fix /ensemble 401 self-loop)

### DIFF
--- a/apps/server/src/screamingface/plugins/claude_frontend/_url4_context.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/_url4_context.py
@@ -138,7 +138,23 @@ async def _resolve_expression(
     backend_url: str | None,
     tracer: Any,
 ) -> str:
-    """Evaluate a url4 expression and return the final text."""
+    """Evaluate a url4 expression and return the final text.
+
+    Prefers in-process evaluation whenever an ``app`` reference is available —
+    the HTTP path (``backend_url`` set) only fires when there's no in-process
+    app. This avoids a self-loop where the proxy calls back into its own SF
+    ``/ensemble`` over HTTP: that endpoint requires the desktop secret (which
+    this internal caller doesn't supply -> 401) and also breaks on a stale
+    ``backend_url``. Mirrors :func:`_store_prompt_blob`'s in-process-first
+    preference. The in-process interpreter is the same one ``GET /ensemble``
+    uses, so the result is equivalent.
+    """
+    if app is not None:
+        from screamingface.plugins.url4_executor.interpreter import Url4Interpreter
+
+        interpreter = Url4Interpreter(app=app)
+        return await interpreter.evaluate(expression)
+
     if backend_url:
         ens_url = f"{backend_url}/ensemble"
         with tracer.start_client_span("GET /ensemble"):
@@ -162,11 +178,9 @@ async def _resolve_expression(
             )
         return final_text
 
-    # In-process fallback
-    from screamingface.plugins.url4_executor.interpreter import Url4Interpreter
-
-    interpreter = Url4Interpreter(app=app)
-    return await interpreter.evaluate(expression)
+    raise RuntimeError(
+        "_resolve_expression requires either an in-process app or a non-empty backend_url"
+    )
 
 
 async def resolve_prompt_expression(

--- a/apps/server/src/screamingface/plugins/claude_frontend/tests/test_resolve_expression.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/tests/test_resolve_expression.py
@@ -1,0 +1,133 @@
+"""Regression tests for _resolve_expression — covers the /ensemble 401 self-loop.
+
+When the claude-frontend proxy resolves a ``$prompt`` url4 expression it
+evaluates the substituted expression via :func:`_resolve_expression`. Two
+paths:
+
+1. In-process: ``Url4Interpreter(app=app).evaluate(...)`` (same interpreter
+   ``GET /ensemble`` uses).
+2. HTTP: GET ``{backend_url}/ensemble`` (only correct out-of-process).
+
+The HTTP path self-loops back into the proxy's own SF. Since SF-174 guarded
+``/ensemble`` with the desktop secret, that self-call returns 401 when
+``SF_DESKTOP_SECRET`` is set (the desktop always sets it). The fix: prefer the
+in-process path whenever ``app`` is available — mirroring ``_store_prompt_blob``.
+These tests pin that behavior.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+import pytest
+
+import screamingface.plugins.url4_executor.interpreter as interpreter_mod
+from screamingface.plugins.claude_frontend._url4_context import _resolve_expression
+
+
+class _NullSpan:
+    def __enter__(self) -> _NullSpan:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        return None
+
+
+class _NullTracer:
+    @contextmanager
+    def start_client_span(self, _name: str) -> Any:
+        yield _NullSpan()
+
+    def set_attrs(self, _attrs: dict[str, Any]) -> None:
+        return None
+
+
+class _FakeInterpreter:
+    """Stands in for Url4Interpreter; records the app and returns a fixed text."""
+
+    last_app: Any = None
+
+    def __init__(self, app: Any = None) -> None:
+        _FakeInterpreter.last_app = app
+
+    async def evaluate(self, expr: str) -> str:
+        return f"inprocess:{expr}"
+
+
+@pytest.mark.anyio
+async def test_inprocess_path_used_when_app_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With an app, evaluation goes through the in-process interpreter, not HTTP."""
+    monkeypatch.setattr(interpreter_mod, "Url4Interpreter", _FakeInterpreter)
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    result = await _resolve_expression(
+        "(https://x)!intent", app=app, backend_url=None, tracer=_NullTracer()
+    )
+
+    assert result == "inprocess:(https://x)!intent"
+    assert _FakeInterpreter.last_app is app
+
+
+@pytest.mark.anyio
+async def test_inprocess_preferred_even_when_backend_url_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The bug: backend_url set + /ensemble now secret-protected -> 401 on the
+    HTTP self-loop. We prefer in-process whenever an app is present, so a set
+    backend_url doesn't drag us into the self-call."""
+    monkeypatch.setattr(interpreter_mod, "Url4Interpreter", _FakeInterpreter)
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    # If the HTTP path were taken it would try to reach this dead address.
+    result = await _resolve_expression(
+        "(https://x)!intent",
+        app=app,
+        backend_url="http://127.0.0.1:1/garbage",
+        tracer=_NullTracer(),
+    )
+
+    assert result == "inprocess:(https://x)!intent"
+
+
+@pytest.mark.anyio
+async def test_http_path_used_when_no_inprocess_app() -> None:
+    """Out-of-process (no app): the HTTP /ensemble fallback is the only option."""
+    captured: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["url"] = str(req.url)
+        captured["method"] = req.method
+        return httpx.Response(200, text="ensemble-result")
+
+    transport = httpx.MockTransport(handler)
+
+    import screamingface.plugins.claude_frontend._url4_context as mod
+
+    real_client_cls = mod.httpx.AsyncClient
+
+    class _Client(real_client_cls):  # type: ignore[misc, valid-type]
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    mod.httpx.AsyncClient = _Client  # type: ignore[misc]
+    try:
+        result = await _resolve_expression(
+            "(https://x)", app=None, backend_url="http://gateway", tracer=_NullTracer()
+        )
+    finally:
+        mod.httpx.AsyncClient = real_client_cls  # type: ignore[misc]
+
+    assert result == "ensemble-result"
+    assert captured["url"] == "http://gateway/ensemble?q=%28https%3A%2F%2Fx%29"
+    assert captured["method"] == "GET"
+
+
+@pytest.mark.anyio
+async def test_raises_when_no_app_and_no_backend_url() -> None:
+    """No app and no backend_url is a programming error — raise loudly."""
+    with pytest.raises(RuntimeError, match="requires either"):
+        await _resolve_expression("x", app=None, backend_url=None, tracer=_NullTracer())


### PR DESCRIPTION
## Summary
Resolving a `$prompt` URL4 expression failed with **HTTP 401 Unauthorized**:

```
claude_frontend/_url4_context.py:154 _resolve_expression()
  -> GET http://127.0.0.1:8000/ensemble?q=... -> 401
```

**Root cause:** `_resolve_expression` preferred the HTTP path and self-looped into the proxy's *own* SF `GET /ensemble`. SF-174 guarded `/ensemble` with `Depends(require_desktop_secret)`, so when `SF_DESKTOP_SECRET` is set (the desktop app always sets it when spawning the server) the self-call must carry `X-SF-Desktop-Secret` — which this internal caller doesn't. The sibling `_store_prompt_blob` already prefers the in-process path for exactly this reason (its docstring: "avoids self-loops where the proxy talks back to its own SF over HTTP"); `_resolve_expression` was never updated to match.

**Fix:** prefer in-process evaluation via `Url4Interpreter(app=app)` (the same interpreter `GET /ensemble` uses) whenever an `app` reference is available; fall back to the HTTP path only when there's no in-process app. This avoids both the desktop-secret 401 and stale-`backend_url` failures.

## Tests
- New `test_resolve_expression.py`: in-process preferred (even with `backend_url` set), HTTP fallback when no app, raises when neither — 4 tests.
- Full `claude_frontend` suite: **44 passed**. ruff + pyright clean.

## Notes
- Pre-existing `main` bug (regression from SF-174), unrelated to any feature branch. Found while manually testing the URL4 flow / SF-167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)