### PR TITLE
SF-232: AIGateway reactive overload backpressure (retry 429/529/503)

### DIFF
--- a/apps/aigateway/src/aigateway/config.py
+++ b/apps/aigateway/src/aigateway/config.py
@@ -32,6 +32,16 @@ class Settings(BaseSettings):
     jwt_ttl_seconds: int = Field(default=86_400, validation_alias="AIGATEWAY_JWT_TTL_SECONDS")
     public_url: str | None = Field(default=None, validation_alias="AIGATEWAY_PUBLIC_URL")
 
+    retry_max_attempts: int = Field(default=3, validation_alias="AIGW_RETRY_MAX_ATTEMPTS")
+    retry_backoff_base_seconds: float = Field(
+        default=0.5, validation_alias="AIGW_RETRY_BACKOFF_BASE"
+    )
+    retry_backoff_max_seconds: float = Field(default=8.0, validation_alias="AIGW_RETRY_BACKOFF_MAX")
+    retry_max_total_wait_seconds: float = Field(
+        default=30.0, validation_alias="AIGW_RETRY_MAX_WAIT"
+    )
+    retry_jitter_seconds: float = Field(default=0.25, validation_alias="AIGW_RETRY_JITTER")
+
     @field_validator("jwt_secret", "provisioning_token")
     @classmethod
     def _validate_secret_length(cls, value: SecretStr | None) -> SecretStr | None:

--- a/apps/aigateway/src/aigateway/core/retry.py
+++ b/apps/aigateway/src/aigateway/core/retry.py
@@ -1,0 +1,117 @@
+"""Reactive backpressure: retry rate-limited / overloaded upstream dispatches.
+
+Status-code driven (duck-typed on ``status_code``), so it covers LiteLLM's
+``RateLimitError`` / ``ServiceUnavailableError`` (which carry ``status_code``)
+and any exception exposing one of the retryable codes. Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, TypeVar
+
+if TYPE_CHECKING:
+    from ..config import Settings
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# 429 rate-limited, 503 service-unavailable, 529 overloaded (Anthropic).
+RETRYABLE_STATUS_CODES = frozenset({429, 503, 529})
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    max_retries: int = 3
+    backoff_base_seconds: float = 0.5
+    backoff_max_seconds: float = 8.0
+    max_total_wait_seconds: float = 30.0
+    jitter_seconds: float = 0.25
+
+    @classmethod
+    def from_settings(cls, settings: Settings) -> RetryPolicy:
+        return cls(
+            max_retries=settings.retry_max_attempts,
+            backoff_base_seconds=settings.retry_backoff_base_seconds,
+            backoff_max_seconds=settings.retry_backoff_max_seconds,
+            max_total_wait_seconds=settings.retry_max_total_wait_seconds,
+            jitter_seconds=settings.retry_jitter_seconds,
+        )
+
+
+def _status_code(exc: BaseException) -> int | None:
+    code = getattr(exc, "status_code", None)
+    # bool is an int subclass; reject it explicitly.
+    if isinstance(code, bool) or not isinstance(code, int):
+        return None
+    return code
+
+
+def is_retryable_status(exc: BaseException) -> bool:
+    return _status_code(exc) in RETRYABLE_STATUS_CODES
+
+
+def parse_retry_after_seconds(exc: BaseException) -> float | None:
+    """Read an integer ``Retry-After`` (delta-seconds) off the exception's response.
+
+    Returns ``None`` for absent/malformed/HTTP-date values so the caller falls
+    back to exponential backoff. Never raises.
+    """
+    response = getattr(exc, "response", None)
+    headers = getattr(response, "headers", None)
+    if headers is None:
+        return None
+    raw = headers.get("retry-after")
+    if raw is None:
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None  # HTTP-date form unsupported -> backoff fallback
+    return max(0.0, value)
+
+
+async def with_overload_retry(
+    dispatch: Callable[[], Awaitable[T]],
+    *,
+    policy: RetryPolicy,
+    sleep: Callable[[float], Awaitable[Any]] = asyncio.sleep,
+) -> T:
+    """Run ``dispatch``; retry on retryable overload statuses with backoff.
+
+    Honors ``Retry-After`` when present, else exponential backoff + jitter.
+    Bounded by ``max_retries`` and a cumulative ``max_total_wait_seconds``
+    budget. Re-raises the original exception on exhaustion or non-retryable
+    errors.
+    """
+    attempt = 0
+    total_waited = 0.0
+    while True:
+        try:
+            return await dispatch()
+        except Exception as exc:
+            if not is_retryable_status(exc) or attempt >= policy.max_retries:
+                raise
+            delay = parse_retry_after_seconds(exc)
+            if delay is None:
+                delay = min(
+                    policy.backoff_base_seconds * 2**attempt,
+                    policy.backoff_max_seconds,
+                ) + random.uniform(0.0, policy.jitter_seconds)
+            if total_waited + delay > policy.max_total_wait_seconds:
+                raise
+            attempt += 1
+            total_waited += delay
+            logger.warning(
+                "aigw upstream overload (status=%s); retry %d/%d after %.2fs",
+                _status_code(exc),
+                attempt,
+                policy.max_retries,
+                delay,
+            )
+            await sleep(delay)

--- a/apps/aigateway/src/aigateway/core/retry.py
+++ b/apps/aigateway/src/aigateway/core/retry.py
@@ -12,14 +12,12 @@ import logging
 import random
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from ..config import Settings
 
 logger = logging.getLogger(__name__)
-
-T = TypeVar("T")
 
 # 429 rate-limited, 503 service-unavailable, 529 overloaded (Anthropic).
 RETRYABLE_STATUS_CODES = frozenset({429, 503, 529})
@@ -76,7 +74,7 @@ def parse_retry_after_seconds(exc: BaseException) -> float | None:
     return max(0.0, value)
 
 
-async def with_overload_retry(
+async def with_overload_retry[T](
     dispatch: Callable[[], Awaitable[T]],
     *,
     policy: RetryPolicy,

--- a/apps/aigateway/src/aigateway/routes/chat.py
+++ b/apps/aigateway/src/aigateway/routes/chat.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 from typing import Any, cast
 
 from fastapi import APIRouter, HTTPException, Request
@@ -26,6 +27,7 @@ from ..core.oauth.store import OAuthConnectionStore, credential_key_for
 from ..core.profile_index import ProfileIndexStore
 from ..core.profile_models import Profile, ProfileDefaults, ProfileState, credential_name_for
 from ..core.registry import ProviderRegistry
+from ..core.retry import RetryPolicy, parse_retry_after_seconds, with_overload_retry
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -196,10 +198,11 @@ def _apply_defaults(body: dict[str, Any], defaults: ProfileDefaults, plugin: Any
 
 
 def _retry_after_headers(exc: Exception) -> dict[str, str]:
-    response = getattr(exc, "response", None)
-    headers = getattr(response, "headers", None)
-    retry_after = headers.get("retry-after") if headers is not None else None
-    return {"Retry-After": retry_after} if retry_after else {}
+    seconds = parse_retry_after_seconds(exc)
+    if seconds is None:
+        return {}
+    # delta-seconds is an integer; round up so clients do not retry early.
+    return {"Retry-After": str(math.ceil(seconds))}
 
 
 def _litellm_http_exception(exc: Exception) -> HTTPException:
@@ -312,11 +315,16 @@ async def chat_completions(request: Request, current: CurrentAccount) -> Any:
         if connection is not None:
             await _oauth_connection_store(request).touch_last_used(connection)
 
+    # NOTE: overload retry covers the non-streaming path only; streaming responses
+    # commit a 200 status before dispatch, so a mid-stream 429/503 cannot be retried.
     if body.get("stream"):
         return StreamingResponse(_stream(plugin, body), media_type="text/event-stream")
 
     try:
-        response = await plugin.chat_completion(body)
+        response = await with_overload_retry(
+            lambda: plugin.chat_completion(body),
+            policy=RetryPolicy.from_settings(request.app.state.settings),
+        )
     except HTTPException as exc:
         if connection is not None and _should_mark_profile_error_on_dispatch_status(
             plugin, exc.status_code

--- a/apps/aigateway/tests/unit/test_chat_x_profile.py
+++ b/apps/aigateway/tests/unit/test_chat_x_profile.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import json
 import time
 from functools import partial
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 from uuid import UUID, uuid4
 
 import httpx
 import pytest
-from litellm.exceptions import RateLimitError
+from litellm.exceptions import RateLimitError, ServiceUnavailableError
 
 from aigateway.core.auth.middleware import ANONYMOUS_ACCOUNT_ID
 from aigateway.core.oauth.store import OAuthConnectionStore, credential_key_for
@@ -736,7 +737,10 @@ async def test_chat_maps_litellm_rate_limit_to_429(credential_blobs, authenticat
     request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
     response = httpx.Response(429, headers={"retry-after": "7"}, request=request)
 
+    calls = {"n": 0}
+
     async def fake_chat_completion(_self, _body):
+        calls["n"] += 1
         raise RateLimitError(
             "limited",
             llm_provider="anthropic",
@@ -744,9 +748,12 @@ async def test_chat_maps_litellm_rate_limit_to_429(credential_blobs, authenticat
             response=response,
         )
 
-    with patch(
-        "aigateway.plugins.anthropic_provider.plugin.AnthropicProviderPlugin.chat_completion",
-        fake_chat_completion,
+    with (
+        patch(
+            "aigateway.plugins.anthropic_provider.plugin.AnthropicProviderPlugin.chat_completion",
+            fake_chat_completion,
+        ),
+        patch("aigateway.core.retry.asyncio.sleep", new_callable=AsyncMock),
     ):
         resp = authenticated_client.post(
             "/v1/chat/completions",
@@ -759,3 +766,145 @@ async def test_chat_maps_litellm_rate_limit_to_429(credential_blobs, authenticat
     assert resp.status_code == 429
     assert resp.headers["retry-after"] == "7"
     assert resp.json()["detail"]["code"] == "rate_limited"
+    assert calls["n"] == 4  # 1 initial + 3 retries (default AIGW_RETRY_MAX_ATTEMPTS=3)
+
+
+def _seed_anthropic_profile(credential_blobs, account_id: str):
+    _seed_authenticated_profile(credential_blobs, account_id)
+    idx = ProfileIndexStore(credential_store=credential_blobs.store)
+    return idx.upsert(
+        Profile(
+            id=profile_id_for(account_id, "anthropic", "default"),
+            account_id=account_id,
+            provider="anthropic",
+            name="default",
+            state=ProfileState.AUTHENTICATED,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_chat_retries_rate_limit_then_succeeds(
+    credential_blobs, authenticated_client
+) -> None:
+    account_id = _account_id(authenticated_client)
+    await _seed_anthropic_profile(credential_blobs, account_id)
+
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    response = httpx.Response(429, headers={"retry-after": "1"}, request=request)
+    calls = {"n": 0}
+
+    async def flaky_chat_completion(_self, _body):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RateLimitError(
+                "limited",
+                llm_provider="anthropic",
+                model="anthropic/claude-sonnet-4-5",
+                response=response,
+            )
+        return SimpleNamespace(
+            model_dump=lambda: {"id": "x", "choices": [{"message": {"content": "ok"}}]}
+        )
+
+    with (
+        patch(
+            "aigateway.plugins.anthropic_provider.plugin.AnthropicProviderPlugin.chat_completion",
+            flaky_chat_completion,
+        ),
+        patch("aigateway.core.retry.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        resp = authenticated_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "anthropic/claude-sonnet-4-5",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+
+    assert resp.status_code == 200
+    assert calls["n"] == 2  # gateway absorbed the 429
+
+
+@pytest.mark.asyncio
+async def test_chat_retries_service_unavailable_then_succeeds(
+    credential_blobs, authenticated_client
+) -> None:
+    account_id = _account_id(authenticated_client)
+    await _seed_anthropic_profile(credential_blobs, account_id)
+
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    response = httpx.Response(503, request=request)
+    calls = {"n": 0}
+
+    async def flaky_chat_completion(_self, _body):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ServiceUnavailableError(
+                "overloaded",
+                llm_provider="anthropic",
+                model="anthropic/claude-sonnet-4-5",
+                response=response,
+            )
+        return SimpleNamespace(
+            model_dump=lambda: {"id": "x", "choices": [{"message": {"content": "ok"}}]}
+        )
+
+    with (
+        patch(
+            "aigateway.plugins.anthropic_provider.plugin.AnthropicProviderPlugin.chat_completion",
+            flaky_chat_completion,
+        ),
+        patch("aigateway.core.retry.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        resp = authenticated_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "anthropic/claude-sonnet-4-5",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+
+    assert resp.status_code == 200
+    assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_chat_persistent_rate_limit_still_returns_429(
+    credential_blobs, authenticated_client
+) -> None:
+    account_id = _account_id(authenticated_client)
+    await _seed_anthropic_profile(credential_blobs, account_id)
+
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    response = httpx.Response(429, headers={"retry-after": "1"}, request=request)
+    calls = {"n": 0}
+
+    async def always_limited(_self, _body):
+        calls["n"] += 1
+        raise RateLimitError(
+            "limited",
+            llm_provider="anthropic",
+            model="anthropic/claude-sonnet-4-5",
+            response=response,
+        )
+
+    with (
+        patch(
+            "aigateway.plugins.anthropic_provider.plugin.AnthropicProviderPlugin.chat_completion",
+            always_limited,
+        ),
+        patch("aigateway.core.retry.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        resp = authenticated_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "anthropic/claude-sonnet-4-5",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+
+    assert resp.status_code == 429
+    assert resp.headers["retry-after"] == "1"
+    assert resp.json()["detail"]["code"] == "rate_limited"
+    assert calls["n"] == 4  # 1 initial + 3 retries (default AIGW_RETRY_MAX_ATTEMPTS=3)

--- a/apps/aigateway/tests/unit/test_config_retry.py
+++ b/apps/aigateway/tests/unit/test_config_retry.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from aigateway.config import Settings
+
+
+def test_retry_settings_defaults() -> None:
+    s = Settings()
+    assert s.retry_max_attempts == 3
+    assert s.retry_backoff_base_seconds == 0.5
+    assert s.retry_backoff_max_seconds == 8.0
+    assert s.retry_max_total_wait_seconds == 30.0
+    assert s.retry_jitter_seconds == 0.25
+
+
+def test_retry_settings_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("AIGW_RETRY_MAX_ATTEMPTS", "0")
+    monkeypatch.setenv("AIGW_RETRY_MAX_WAIT", "12.5")
+    s = Settings()
+    assert s.retry_max_attempts == 0
+    assert s.retry_max_total_wait_seconds == 12.5

--- a/apps/aigateway/tests/unit/test_retry.py
+++ b/apps/aigateway/tests/unit/test_retry.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from aigateway.core.retry import (
+    RetryPolicy,
+    is_retryable_status,
+    parse_retry_after_seconds,
+    with_overload_retry,
+)
+
+
+class _StatusError(Exception):
+    """Minimal stand-in for a LiteLLM exception carrying status_code + response."""
+
+    def __init__(self, status_code: int, retry_after: str | None = None) -> None:
+        super().__init__(f"status {status_code}")
+        self.status_code = status_code
+        if retry_after is not None:
+            request = httpx.Request("POST", "https://example.test/v1/chat/completions")
+            self.response = httpx.Response(
+                status_code, headers={"retry-after": retry_after}, request=request
+            )
+
+
+def _policy(**kw) -> RetryPolicy:
+    base = dict(
+        max_retries=3,
+        backoff_base_seconds=0.5,
+        backoff_max_seconds=8.0,
+        max_total_wait_seconds=30.0,
+        jitter_seconds=0.0,  # deterministic in tests
+    )
+    base.update(kw)
+    return RetryPolicy(**base)
+
+
+async def _noop_sleep(_seconds: float) -> None:
+    return None
+
+
+@pytest.mark.parametrize("status", [429, 503, 529])
+def test_is_retryable_true_for_overload_statuses(status: int) -> None:
+    assert is_retryable_status(_StatusError(status)) is True
+
+
+@pytest.mark.parametrize("status", [400, 401, 500, 502])
+def test_is_retryable_false_for_other_statuses(status: int) -> None:
+    assert is_retryable_status(_StatusError(status)) is False
+
+
+def test_is_retryable_false_without_status_code() -> None:
+    assert is_retryable_status(ValueError("boom")) is False
+
+
+def test_parse_retry_after_reads_integer_seconds() -> None:
+    assert parse_retry_after_seconds(_StatusError(429, retry_after="7")) == 7.0
+
+
+def test_parse_retry_after_malformed_returns_none() -> None:
+    assert parse_retry_after_seconds(_StatusError(429, retry_after="not-a-number")) is None
+
+
+def test_parse_retry_after_absent_returns_none() -> None:
+    assert parse_retry_after_seconds(_StatusError(429)) is None
+
+
+@pytest.mark.asyncio
+async def test_overload_then_success_returns_value() -> None:
+    calls = {"n": 0}
+    slept: list[float] = []
+
+    async def dispatch() -> str:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _StatusError(429, retry_after="2")
+        return "ok"
+
+    async def sleep(seconds: float) -> None:
+        slept.append(seconds)
+
+    result = await with_overload_retry(dispatch, policy=_policy(), sleep=sleep)
+    assert result == "ok"
+    assert calls["n"] == 2
+    assert slept == [2.0]  # Retry-After honored
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [429, 503, 529])
+async def test_each_overload_status_is_retried(status: int) -> None:
+    calls = {"n": 0}
+
+    async def dispatch() -> str:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _StatusError(status, retry_after="1")
+        return "ok"
+
+    result = await with_overload_retry(dispatch, policy=_policy(), sleep=_noop_sleep)
+    assert result == "ok"
+    assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_always_overload_raises_original_after_max_retries() -> None:
+    calls = {"n": 0}
+    err = _StatusError(429, retry_after="1")
+
+    async def dispatch() -> str:
+        calls["n"] += 1
+        raise err
+
+    with pytest.raises(_StatusError) as excinfo:
+        await with_overload_retry(dispatch, policy=_policy(max_retries=3), sleep=_noop_sleep)
+    assert excinfo.value is err
+    assert calls["n"] == 4  # 1 initial + 3 retries
+
+
+@pytest.mark.asyncio
+async def test_exponential_backoff_when_no_retry_after() -> None:
+    slept: list[float] = []
+
+    async def dispatch() -> str:
+        raise _StatusError(429)  # no Retry-After header
+
+    async def sleep(seconds: float) -> None:
+        slept.append(seconds)
+
+    with pytest.raises(_StatusError):
+        await with_overload_retry(
+            dispatch,
+            policy=_policy(max_retries=4, backoff_base_seconds=1.0, backoff_max_seconds=4.0),
+            sleep=sleep,
+        )
+    # base*2**attempt = 1, 2, 4, 8 -> capped at backoff_max_seconds (4)
+    assert slept == [1.0, 2.0, 4.0, 4.0]
+
+
+@pytest.mark.asyncio
+async def test_budget_stops_retrying_early() -> None:
+    calls = {"n": 0}
+    slept: list[float] = []
+
+    async def dispatch() -> str:
+        calls["n"] += 1
+        raise _StatusError(429, retry_after="10")
+
+    async def sleep(seconds: float) -> None:
+        slept.append(seconds)
+
+    with pytest.raises(_StatusError):
+        await with_overload_retry(
+            dispatch,
+            policy=_policy(max_retries=5, max_total_wait_seconds=15.0),
+            sleep=sleep,
+        )
+    # waits 10 (total 10), next 10 would exceed 15 -> stop. 1 initial + 1 retry = 2 calls.
+    assert slept == [10.0]
+    assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_max_retries_zero_disables_retry() -> None:
+    calls = {"n": 0}
+
+    async def dispatch() -> str:
+        calls["n"] += 1
+        raise _StatusError(429, retry_after="1")
+
+    with pytest.raises(_StatusError):
+        await with_overload_retry(dispatch, policy=_policy(max_retries=0), sleep=_noop_sleep)
+    assert calls["n"] == 1  # no retry
+
+
+@pytest.mark.asyncio
+async def test_non_retryable_propagates_immediately() -> None:
+    calls = {"n": 0}
+
+    async def dispatch() -> str:
+        calls["n"] += 1
+        raise _StatusError(400)
+
+    with pytest.raises(_StatusError):
+        await with_overload_retry(dispatch, policy=_policy(), sleep=_noop_sleep)
+    assert calls["n"] == 1

--- a/apps/aigateway/tests/unit/test_retry.py
+++ b/apps/aigateway/tests/unit/test_retry.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import httpx
 import pytest
 
@@ -24,8 +26,8 @@ class _StatusError(Exception):
             )
 
 
-def _policy(**kw) -> RetryPolicy:
-    base = dict(
+def _policy(**kw: Any) -> RetryPolicy:
+    base: dict[str, Any] = dict(
         max_retries=3,
         backoff_base_seconds=0.5,
         backoff_max_seconds=8.0,


### PR DESCRIPTION
## Summary
Makes AIGateway **absorb transient upstream overload** (HTTP 429/529/503) by retrying the chat dispatch with `Retry-After`-aware backoff before forwarding the error. Today the gateway forwards overload responses immediately, so transient provider rate-limits surface as hard url4 failures.

- New stdlib-only helper `core/retry.py`: `RetryPolicy`, `is_retryable_status`, `parse_retry_after_seconds`, `with_overload_retry` (duck-typed on `status_code`).
- 5 tunable `AIGW_RETRY_*` settings (attempts, backoff base/max, total-wait budget, jitter).
- `routes/chat.py` wraps the single non-streaming dispatch; `_retry_after_headers` now reuses the shared parser (DRY).
- On exhaustion the **original** exception is re-raised, so existing error mapping/profile-error marking is unchanged. `AIGW_RETRY_MAX_ATTEMPTS=0` restores today's immediate-error behavior (kill-switch).
- Streaming is out of scope (a 200 commits before dispatch); marked as a deliberate follow-up.

Spec: `docs/superpowers/specs/2026-05-29-aigateway-429-backpressure-design.md`
Plan: `docs/superpowers/plans/2026-05-29-aigateway-429-backpressure.md`
Asana: SF-232 — https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215231263845954

> **Stacked PR:** based on `SF-231-url4-resolve-locus-and-secret` (per request). Will auto-retarget to `main` once that merges. Review only the aigateway commits here.

## Test plan
- [x] `test_retry.py` — helper in isolation (retryable statuses, Retry-After honored, exponential backoff + cap, budget cut-off, kill-switch, malformed header, non-retryable passthrough). 20 passed.
- [x] `test_config_retry.py` — defaults + `AIGW_RETRY_*` env overrides.
- [x] `test_chat_x_profile.py` — 429-then-200 and 503-then-200 absorbed; persistent 429 still returns 429 + `Retry-After` after `max_retries+1` attempts; existing rate-limit regression stays green.
- [x] Full aigateway unit suite: 371 passed, 24 skipped.
- [x] `ruff check .` + `ruff format --check .` clean.
- [ ] Manual smoke: force a 429 against a stubbed/low-quota provider, confirm `aigw upstream overload … retry N/3 after …s` log + eventual success; `AIGW_RETRY_MAX_ATTEMPTS=0` reverts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)