### PR TITLE
SF-187: add public leaderboard portal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,11 @@ __pycache__/
 .venv/
 venv/
 
+# Local databases
+*.sqlite3
+*.sqlite3-shm
+*.sqlite3-wal
+
 # Local build output
 release/
 

--- a/apps/desktop/.husky/pre-commit
+++ b/apps/desktop/.husky/pre-commit
@@ -4,7 +4,7 @@
 # JS/TS gates — lint-staged + eslint + prettier (only fires on staged JS/TS).
 ( cd apps/desktop && npx lint-staged ) || exit 1
 
-# Python gates — ruff + ruff-format + pyright (only if any .py is staged).
+# Python gates — ruff + ruff-format + scoped type/tests (only if any .py is staged).
 if git diff --cached --name-only --diff-filter=ACMR | grep -qE '\.py$'; then
     ( cd apps/server && uv run pre-commit run --config .pre-commit-config.yaml ) || exit 1
 fi

--- a/apps/scoreboard/README.md
+++ b/apps/scoreboard/README.md
@@ -15,20 +15,23 @@ uv run uvicorn scoreboard.main:app --port 9106 --reload
 curl -sf http://localhost:9106/healthz
 ```
 
-`/healthz` is a liveness probe only. It does not query the database and does not prove Postgres connectivity.
+By default, local runs use a SQLite database file named `scoreboard.sqlite3` in the current working directory. Delete that file to reset local data. If you previously exported `SCOREBOARD_DATABASE_URL`, unset it first with `unset SCOREBOARD_DATABASE_URL` to use the default.
+
+`/healthz` is a liveness probe only. It does not query the database and does not prove database connectivity.
 
 ### Running Against Local Postgres
 
-The default `SCOREBOARD_DATABASE_URL` expects a local Postgres database at `postgres://scoreboard:scoreboard@localhost:5432/scoreboard`.
+Set `SCOREBOARD_DATABASE_URL` when you want to run against Postgres instead of the default local SQLite file.
 
 ```bash
 docker run --rm -d --name sf-scoreboard-postgres \
   -e POSTGRES_USER=scoreboard \
   -e POSTGRES_PASSWORD=scoreboard \
   -e POSTGRES_DB=scoreboard \
-  -p 5432:5432 \
+  -p 5434:5432 \
   postgres:16-alpine
 
+export SCOREBOARD_DATABASE_URL='postgres://scoreboard:scoreboard@localhost:5434/scoreboard'
 uv run tortoise migrate
 uv run uvicorn scoreboard.main:app --port 9106 --reload
 ```
@@ -54,7 +57,7 @@ Settings are read from environment variables with the `SCOREBOARD_` prefix.
 | `SCOREBOARD_HOST` | `127.0.0.1` | Host used by the `scoreboard` console script. |
 | `SCOREBOARD_PORT` | `9106` | Port used by the `scoreboard` console script. |
 | `SCOREBOARD_LOG_LEVEL` | `info` | Uvicorn log level. |
-| `SCOREBOARD_DATABASE_URL` | `postgres://scoreboard:scoreboard@localhost:5432/scoreboard` | Tortoise database URL. |
+| `SCOREBOARD_DATABASE_URL` | `sqlite://./scoreboard.sqlite3` | Tortoise database URL. |
 | `SCOREBOARD_CORS_ORIGINS` | `["*"]` | JSON list of allowed CORS origins. |
 
 `SCOREBOARD_CORS_ORIGINS` defaults to `["*"]` because the scaffold has no authenticated routes and never sets cookies. D-SCORE-007 will tighten this once the leaderboard write path lands.
@@ -69,7 +72,7 @@ uv run ruff format --check .
 uv run pyright
 ```
 
-Unit tests use SQLite through Tortoise's isolated `tortoise_test_context`, so the persistence layer can be validated without a local Postgres server. Postgres-backed tests can opt into a database URL by setting `SCOREBOARD_TEST_DATABASE_URL`.
+The runtime default uses SQLite for local runs, and unit tests use SQLite through Tortoise's isolated `tortoise_test_context`, so the persistence layer can be validated without a local Postgres server. Postgres-backed tests can opt into a database URL by setting `SCOREBOARD_TEST_DATABASE_URL`.
 
 ## Layout
 

--- a/apps/scoreboard/src/scoreboard/config.py
+++ b/apps/scoreboard/src/scoreboard/config.py
@@ -1,7 +1,22 @@
 from __future__ import annotations
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+DEFAULT_DATABASE_URL = "sqlite://./scoreboard.sqlite3"
+
+
+def normalize_database_url(database_url: str) -> str:
+    sqlite_absolute_prefix = "sqlite:///"
+    if not database_url.startswith(sqlite_absolute_prefix):
+        return database_url
+
+    path = database_url.removeprefix(sqlite_absolute_prefix)
+    if not path or "/" in path:
+        return database_url
+
+    # Accept the common SQLite relative-file spelling instead of writing to /.
+    return f"sqlite://./{path}"
 
 
 class Settings(BaseSettings):
@@ -14,5 +29,10 @@ class Settings(BaseSettings):
     host: str = "127.0.0.1"
     port: int = 9106
     log_level: str = "info"
-    database_url: str = "postgres://scoreboard:scoreboard@localhost:5432/scoreboard"
+    database_url: str = DEFAULT_DATABASE_URL
     cors_origins: list[str] = Field(default_factory=lambda: ["*"])
+
+    @field_validator("database_url")
+    @classmethod
+    def _normalize_database_url(cls, database_url: str) -> str:
+        return normalize_database_url(database_url)

--- a/apps/scoreboard/src/scoreboard/db.py
+++ b/apps/scoreboard/src/scoreboard/db.py
@@ -6,10 +6,10 @@ from typing import Any
 
 from tortoise import Tortoise
 
-DEFAULT_DATABASE_URL = "postgres://scoreboard:scoreboard@localhost:5432/scoreboard"
-DEFAULT_CONFIGURED_DATABASE_URL = os.getenv(
-    "SCOREBOARD_DATABASE_URL",
-    DEFAULT_DATABASE_URL,
+from .config import DEFAULT_DATABASE_URL, normalize_database_url
+
+DEFAULT_CONFIGURED_DATABASE_URL = normalize_database_url(
+    os.getenv("SCOREBOARD_DATABASE_URL", DEFAULT_DATABASE_URL)
 )
 
 TORTOISE_CONFIG: dict[str, Any] = {

--- a/apps/scoreboard/tests/unit/test_config.py
+++ b/apps/scoreboard/tests/unit/test_config.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+
+from scoreboard.config import DEFAULT_DATABASE_URL, Settings, normalize_database_url
+
+
+def test_database_url_defaults_to_local_sqlite(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SCOREBOARD_DATABASE_URL", raising=False)
+
+    settings = Settings()
+
+    assert DEFAULT_DATABASE_URL == "sqlite://./scoreboard.sqlite3"
+    assert settings.database_url == DEFAULT_DATABASE_URL
+
+
+def test_database_url_can_use_postgres_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    database_url = "postgres://scoreboard:scoreboard@localhost:5434/scoreboard"
+    monkeypatch.setenv("SCOREBOARD_DATABASE_URL", database_url)
+
+    settings = Settings()
+
+    assert settings.database_url == database_url
+
+
+def test_sqlite_root_url_with_bare_filename_is_treated_as_relative(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SCOREBOARD_DATABASE_URL", "sqlite:///scoreboard-local.sqlite3")
+
+    settings = Settings()
+
+    assert settings.database_url == "sqlite://./scoreboard-local.sqlite3"
+    assert normalize_database_url("sqlite:///scoreboard-local.sqlite3") == settings.database_url
+
+
+def test_sqlite_absolute_url_keeps_absolute_path() -> None:
+    assert normalize_database_url("sqlite:////tmp/scoreboard.sqlite3") == (
+        "sqlite:////tmp/scoreboard.sqlite3"
+    )

--- a/apps/server/.pre-commit-config.yaml
+++ b/apps/server/.pre-commit-config.yaml
@@ -7,9 +7,22 @@ repos:
       - id: ruff-format
   - repo: local
     hooks:
-      - id: pyright
-        name: pyright
+      - id: pyright-server
+        name: pyright (server)
         entry: uv run --directory apps/server pyright
         language: system
+        files: ^apps/server/.*\.py$
+        pass_filenames: false
+      - id: pyright-scoreboard
+        name: pyright (scoreboard)
+        entry: uv run --directory apps/scoreboard pyright
+        language: system
+        files: ^apps/scoreboard/.*\.py$
+        pass_filenames: false
+      - id: pytest-scoreboard
+        name: pytest (scoreboard unit)
+        entry: uv run --directory apps/scoreboard pytest tests/unit/ -q
+        language: system
         types: [python]
+        files: ^apps/scoreboard/(src|tests)/.*\.py$
         pass_filenames: false

--- a/web/portal/benchmark.html
+++ b/web/portal/benchmark.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Benchmark Leaderboard — ScreamingFace</title>
-  <meta name="description" content="Top community-submitted ScreamingFace ensemble results for a single benchmark.">
+  <meta name="description" content="A ScreamingFace benchmark leaderboard with accuracy, question counts, providers, verification status, and local rerun links.">
   <meta name="robots" content="noindex, nofollow">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>😱</text></svg>">
   <link rel="stylesheet" href="styles.css">
@@ -21,9 +21,24 @@
       <section class="section">
         <div class="section-inner">
           <div class="notice" role="note">
-            This is a community-submitted, unverified leaderboard. Entries marked
-            “Verified” have been independently reproduced by the OpenMined team;
-            the absence of a badge means an entry has not been verified.
+            Treat this as a public scoreboard, not a trust oracle. "Verified" means
+            OpenMined independently reproduced the run; unbadged rows are community
+            submissions that still need reproduction.
+          </div>
+
+          <div id="leaderboard-summary" class="summary-grid" aria-label="Leaderboard summary" hidden>
+            <div class="summary-card">
+              <span class="proof-kicker">Best accuracy</span>
+              <strong id="summary-best">-</strong>
+            </div>
+            <div class="summary-card">
+              <span class="proof-kicker">Specs shown</span>
+              <strong id="summary-specs">-</strong>
+            </div>
+            <div class="summary-card">
+              <span class="proof-kicker">Verified rows</span>
+              <strong id="summary-verified">-</strong>
+            </div>
           </div>
 
           <div id="leaderboard-status" class="state" role="status" aria-live="polite">Loading…</div>

--- a/web/portal/benchmark.html
+++ b/web/portal/benchmark.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Benchmark Leaderboard — ScreamingFace</title>
+  <meta name="description" content="Top community-submitted ScreamingFace ensemble results for a single benchmark.">
+  <meta name="robots" content="noindex, nofollow">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>😱</text></svg>">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="page">
+    <main class="main">
+      <section class="hero">
+        <h1 id="benchmark-name">Leaderboard</h1>
+        <p id="benchmark-desc"></p>
+        <p><a href="index.html">← All benchmarks</a></p>
+      </section>
+
+      <section class="section">
+        <div class="section-inner">
+          <div class="notice" role="note">
+            This is a community-submitted, unverified leaderboard. Entries marked
+            “Verified” have been independently reproduced by the OpenMined team;
+            the absence of a badge means an entry has not been verified.
+          </div>
+
+          <div id="leaderboard-status" class="state" role="status" aria-live="polite">Loading…</div>
+
+          <div id="leaderboard-wrap" class="table-wrap" hidden>
+            <table class="leaderboard-table">
+              <thead id="leaderboard-head"></thead>
+              <tbody id="leaderboard-body"></tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <span>😱 screamingface, built by <a href="https://openmined.org">OpenMined</a></span>
+      <a href="https://github.com/OpenMined/screamingface">GitHub</a>
+    </footer>
+  </div>
+
+  <script src="main.js" defer></script>
+  <script src="benchmark.js" defer></script>
+</body>
+</html>

--- a/web/portal/benchmark.js
+++ b/web/portal/benchmark.js
@@ -1,0 +1,157 @@
+/* ScreamingFace Leaderboard Portal — benchmark (top-N) page.
+ *
+ * Reads ?id=<benchmark_id>, fetches /v1/leaderboard/{id}, and renders a
+ * client-side sortable table. Default sort is accuracy DESC. The Rank column
+ * always shows the backend-provided rank (best-per-spec), even when the user
+ * sorts by another column — we only reorder rows for display, never recompute
+ * the backend's best-per-spec selection (which breaks accuracy ties by newest
+ * submission).
+ */
+(function (P) {
+  "use strict";
+
+  // Column definitions. `sort` null => not sortable. `dir` is the default
+  // direction applied the first time a column is selected.
+  var COLUMNS = [
+    { key: "rank", label: "Rank", sort: "number", dir: "asc", cls: "num" },
+    { key: "spec_id", label: "Spec", sort: "string", dir: "asc" },
+    { key: "ran_with_providers", label: "Backends", sort: null },
+    { key: "accuracy", label: "Accuracy", sort: "number", dir: "desc", cls: "num" },
+    { key: "total_questions", label: "Questions", sort: "number", dir: "desc", cls: "num" },
+    { key: "submitted_at", label: "Submitted", sort: "date", dir: "desc" },
+    { key: "verified_by_openmined", label: "Verified", sort: "bool", dir: "desc" },
+    { key: "__run", label: "Run Locally", sort: null, cls: "col-run" },
+  ];
+
+  var state = { entries: [], benchmarkId: null, sortKey: "accuracy", sortDir: "desc" };
+
+  function compare(a, b, key, type, dir) {
+    var av = a[key], bv = b[key], res = 0;
+    if (type === "string") {
+      res = String(av).localeCompare(String(bv));
+    } else if (type === "bool") {
+      res = (av === true ? 1 : 0) - (bv === true ? 1 : 0);
+    } else if (type === "date") {
+      res = new Date(av).getTime() - new Date(bv).getTime();
+    } else { // number
+      res = (av || 0) - (bv || 0);
+    }
+    return dir === "desc" ? -res : res;
+  }
+
+  function sortedEntries() {
+    var col = COLUMNS.filter(function (c) { return c.key === state.sortKey; })[0];
+    if (!col || !col.sort) return state.entries.slice();
+    var copy = state.entries.slice();
+    copy.sort(function (a, b) { return compare(a, b, state.sortKey, col.sort, state.sortDir); });
+    return copy;
+  }
+
+  function renderHead(headNode) {
+    P.clear(headNode);
+    var tr = document.createElement("tr");
+    COLUMNS.forEach(function (col) {
+      var th = document.createElement("th");
+      if (col.cls) th.className = col.cls;
+      if (!col.sort) {
+        th.textContent = col.label;
+      } else {
+        var active = col.key === state.sortKey;
+        th.setAttribute("aria-sort", active ? (state.sortDir === "desc" ? "descending" : "ascending") : "none");
+        var btn = P.el("button", "sort-button");
+        btn.type = "button";
+        btn.appendChild(document.createTextNode(col.label + " "));
+        btn.appendChild(P.el("span", "arrow", active ? (state.sortDir === "desc" ? "▼" : "▲") : "↕"));
+        btn.addEventListener("click", function () {
+          if (state.sortKey === col.key) {
+            state.sortDir = state.sortDir === "desc" ? "asc" : "desc";
+          } else {
+            state.sortKey = col.key;
+            state.sortDir = col.dir;
+          }
+          renderHead(headNode);
+          renderBody(document.getElementById("leaderboard-body"));
+        });
+        th.appendChild(btn);
+      }
+      tr.appendChild(th);
+    });
+    headNode.appendChild(tr);
+  }
+
+  function renderBody(bodyNode) {
+    P.clear(bodyNode);
+    sortedEntries().forEach(function (entry) {
+      var tr = document.createElement("tr");
+
+      tr.appendChild(P.el("td", "num", entry.rank));
+
+      var specTd = P.el("td", "wrap");
+      specTd.appendChild(P.link("mono", "spec.html?benchmark=" + encodeURIComponent(state.benchmarkId) + "&spec=" + encodeURIComponent(entry.spec_id), entry.spec_id));
+      tr.appendChild(specTd);
+
+      tr.appendChild(P.el("td", "wrap", P.formatProviders(entry.ran_with_providers)));
+      tr.appendChild(P.el("td", "num", P.formatPercent(entry.accuracy)));
+      tr.appendChild(P.el("td", "num", P.formatQuestions(entry.total_questions)));
+      tr.appendChild(P.el("td", null, P.formatDate(entry.submitted_at)));
+
+      var verTd = document.createElement("td");
+      verTd.appendChild(P.createVerifiedBadge(entry.verified_by_openmined));
+      tr.appendChild(verTd);
+
+      var runTd = document.createElement("td");
+      runTd.className = "col-run";
+      runTd.appendChild(P.createRunLink(entry.spec_id, entry.url4_expression, { compact: true }));
+      tr.appendChild(runTd);
+
+      bodyNode.appendChild(tr);
+    });
+  }
+
+  function init() {
+    var statusNode = document.getElementById("leaderboard-status");
+    var wrap = document.getElementById("leaderboard-wrap");
+    var nameNode = document.getElementById("benchmark-name");
+    var descNode = document.getElementById("benchmark-desc");
+
+    var id;
+    try {
+      id = P.requireParam("id");
+    } catch (e) {
+      P.showError(statusNode, "No benchmark specified. Return to the benchmark list.");
+      return;
+    }
+    state.benchmarkId = id;
+
+    P.showLoading(statusNode, "Loading leaderboard…");
+    wrap.hidden = true;
+
+    P.fetchJson("/v1/leaderboard/" + encodeURIComponent(id) + "?top=50").then(
+      function (data) {
+        var b = data && data.benchmark;
+        if (b) {
+          nameNode.textContent = b.display_name || b.id;
+          descNode.textContent = b.description || "";
+          document.title = (b.display_name || b.id) + " — ScreamingFace";
+        }
+        state.entries = (data && data.entries) || [];
+        if (state.entries.length === 0) {
+          P.showEmpty(statusNode, "No submissions yet. Be the first.");
+          return;
+        }
+        renderHead(document.getElementById("leaderboard-head"));
+        renderBody(document.getElementById("leaderboard-body"));
+        P.setStatus(statusNode, null);
+        wrap.hidden = false;
+      },
+      function (err) {
+        P.showError(statusNode, P.describeError(err, {
+          notFound: "Benchmark not found.",
+          generic: "Could not load leaderboard — try again later.",
+        }));
+      }
+    );
+  }
+
+  P.ready(init);
+})(window.ScorePortal);

--- a/web/portal/benchmark.js
+++ b/web/portal/benchmark.js
@@ -108,6 +108,22 @@
     });
   }
 
+  function renderSummary(entries) {
+    var summaryNode = document.getElementById("leaderboard-summary");
+    if (!summaryNode) return;
+    if (!entries.length) {
+      summaryNode.hidden = true;
+      return;
+    }
+
+    var best = Math.max.apply(null, entries.map(function (entry) { return entry.accuracy; }));
+    var verified = entries.filter(function (entry) { return entry.verified_by_openmined === true; }).length;
+    document.getElementById("summary-best").textContent = P.formatPercent(best);
+    document.getElementById("summary-specs").textContent = P.formatCount(entries.length, "spec", "specs");
+    document.getElementById("summary-verified").textContent = P.formatCount(verified, "row", "rows");
+    summaryNode.hidden = false;
+  }
+
   function init() {
     var statusNode = document.getElementById("leaderboard-status");
     var wrap = document.getElementById("leaderboard-wrap");
@@ -139,6 +155,7 @@
           P.showEmpty(statusNode, "No submissions yet. Be the first.");
           return;
         }
+        renderSummary(state.entries);
         renderHead(document.getElementById("leaderboard-head"));
         renderBody(document.getElementById("leaderboard-body"));
         P.setStatus(statusNode, null);

--- a/web/portal/index.html
+++ b/web/portal/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ScreamingFace Leaderboards</title>
+  <meta name="description" content="Community-submitted benchmark leaderboards for ScreamingFace — an AI ensemble that combines Claude Code, Gemini CLI, Codex, and Ollama.">
+  <meta name="robots" content="noindex, nofollow">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>😱</text></svg>">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="page">
+    <main class="main">
+      <section class="hero">
+        <div class="emoji">😱</div>
+        <h1>ScreamingFace Leaderboards</h1>
+        <p>Community-submitted benchmark results from the ScreamingFace ensemble — Claude Code, Gemini CLI, Codex, and Ollama, combined to beat state-of-the-art.</p>
+        <p><a href="/">Install →</a></p>
+      </section>
+
+      <section class="section">
+        <div class="section-inner">
+          <div id="benchmark-status" class="state" role="status" aria-live="polite">Loading…</div>
+          <section id="benchmark-list" class="card-grid" aria-label="Benchmarks" hidden></section>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <span>😱 screamingface, built by <a href="https://openmined.org">OpenMined</a></span>
+      <a href="https://github.com/OpenMined/screamingface">GitHub</a>
+    </footer>
+  </div>
+
+  <script src="main.js" defer></script>
+</body>
+</html>

--- a/web/portal/index.html
+++ b/web/portal/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ScreamingFace Leaderboards</title>
-  <meta name="description" content="Community-submitted benchmark leaderboards for ScreamingFace — an AI ensemble that combines Claude Code, Gemini CLI, Codex, and Ollama.">
+  <title>ScreamingFace Benchmark Receipts</title>
+  <meta name="description" content="Public ScreamingFace benchmark results with accuracy, providers, verification status, and local rerun links.">
   <meta name="robots" content="noindex, nofollow">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>😱</text></svg>">
   <link rel="stylesheet" href="styles.css">
@@ -14,9 +14,26 @@
     <main class="main">
       <section class="hero">
         <div class="emoji">😱</div>
-        <h1>ScreamingFace Leaderboards</h1>
-        <p>Community-submitted benchmark results from the ScreamingFace ensemble — Claude Code, Gemini CLI, Codex, and Ollama, combined to beat state-of-the-art.</p>
-        <p><a href="/">Install →</a></p>
+        <h1>ScreamingFace benchmark receipts.</h1>
+        <p>Public results for specs you can inspect and rerun locally. Accuracy, providers, verification status, and the exact run link stay attached to every row.</p>
+        <p><a href="/">Install screamingface - one command</a></p>
+        <div class="proof-grid" aria-label="Leaderboard proof points">
+          <div class="proof-card">
+            <span class="proof-kicker">Live data</span>
+            <strong id="benchmark-count">-</strong>
+            <span id="benchmark-count-label">benchmarks indexed</span>
+          </div>
+          <div class="proof-card">
+            <span class="proof-kicker">Verification</span>
+            <strong>Badge, not belief</strong>
+            <span>Only independently reproduced runs get marked Verified.</span>
+          </div>
+          <div class="proof-card">
+            <span class="proof-kicker">Reproducibility</span>
+            <strong>Run Locally</strong>
+            <span>Leaderboard rows keep their URL4 expression for reruns.</span>
+          </div>
+        </div>
       </section>
 
       <section class="section">

--- a/web/portal/main.js
+++ b/web/portal/main.js
@@ -169,6 +169,10 @@ window.ScorePortal = (function () {
     if (value === null || value === undefined || value === "") return EM_DASH;
     return String(value);
   }
+  function formatCount(value, singular, plural) {
+    var count = typeof value === "number" && !isNaN(value) ? value : 0;
+    return count.toLocaleString() + " " + (count === 1 ? singular : plural);
+  }
 
   /* ---- badges & deep links -------------------------------------------- */
   // Returns a green "Verified" pill only when verified_by_openmined === true;
@@ -205,6 +209,7 @@ window.ScorePortal = (function () {
   function benchmarkCard(b) {
     var card = el("article", "card");
     card.appendChild(el("h2", "card-title", b.display_name || b.id));
+    card.appendChild(el("p", "card-id mono", b.id));
 
     if (b.description) {
       card.appendChild(el("p", "card-meta", b.description));
@@ -226,6 +231,14 @@ window.ScorePortal = (function () {
     return card;
   }
 
+  function updateBenchmarkCount(count) {
+    var countNode = document.getElementById("benchmark-count");
+    var labelNode = document.getElementById("benchmark-count-label");
+    if (!countNode || !labelNode) return;
+    countNode.textContent = String(count);
+    labelNode.textContent = count === 1 ? "benchmark indexed" : "benchmarks indexed";
+  }
+
   function initIndex() {
     var statusNode = document.getElementById("benchmark-status");
     var listNode = document.getElementById("benchmark-list");
@@ -235,8 +248,9 @@ window.ScorePortal = (function () {
     fetchJson("/v1/benchmarks").then(
       function (data) {
         var benchmarks = (data && data.benchmarks) || [];
+        updateBenchmarkCount(benchmarks.length);
         if (benchmarks.length === 0) {
-          showEmpty(statusNode, "No benchmarks yet.");
+          showEmpty(statusNode, "No public benchmarks yet. The API is live; rows will appear here as soon as benchmark specs are registered.");
           return;
         }
         clear(listNode);
@@ -270,6 +284,7 @@ window.ScorePortal = (function () {
     formatDate: formatDate,
     formatProviders: formatProviders,
     formatSubmitter: formatSubmitter,
+    formatCount: formatCount,
     createVerifiedBadge: createVerifiedBadge,
     buildRunHref: buildRunHref,
     createRunLink: createRunLink,

--- a/web/portal/main.js
+++ b/web/portal/main.js
@@ -1,0 +1,287 @@
+/* ScreamingFace Leaderboard Portal — shared utilities + index page.
+ *
+ * One global namespace, no modules/build tooling. `main.js` owns generic
+ * fetching/formatting/DOM/badge/deep-link helpers (the "port" that
+ * `benchmark.js` and `spec.js` depend on) plus the index-page rendering.
+ *
+ * Security posture: every value that originates from the API is community
+ * submitted and therefore untrusted. It is written to the DOM exclusively via
+ * textContent / createTextNode and attribute setters — never innerHTML — so a
+ * malicious spec_id / url4_expression / submitter cannot inject markup.
+ */
+window.ScorePortal = (function () {
+  "use strict";
+
+  var EM_DASH = "—";
+
+  /* ---- API base resolution -------------------------------------------- */
+  // 1. Build-time injection (deployed asset sets window.SCOREBOARD_API_BASE
+  //    via an inline script before main.js loads — handled by D-SCORE-007).
+  // 2. Local dev fallback.
+  function getApiBase() {
+    if (window.SCOREBOARD_API_BASE) {
+      return String(window.SCOREBOARD_API_BASE).replace(/\/$/, "");
+    }
+    return "http://localhost:9106";
+  }
+
+  /* ---- fetch ----------------------------------------------------------- */
+  // Throws an Error carrying `.status` (0 for network/parse failures) so each
+  // page can map it to a specific user-facing message.
+  function fetchJson(path) {
+    var url = getApiBase() + path;
+    return fetch(url, { headers: { Accept: "application/json" } }).then(
+      function (response) {
+        if (!response.ok) {
+          var err = new Error("Request failed with status " + response.status);
+          err.status = response.status;
+          return response
+            .text()
+            .catch(function () { return ""; })
+            .then(function (body) {
+              err.body = body;
+              throw err;
+            });
+        }
+        return response.text().then(function (body) {
+          if (!body) return null;
+          try {
+            return JSON.parse(body);
+          } catch (e) {
+            var perr = new Error("Invalid JSON response");
+            perr.status = 0;
+            throw perr;
+          }
+        });
+      },
+      function (networkErr) {
+        var err = new Error(networkErr && networkErr.message ? networkErr.message : "Network error");
+        err.status = 0;
+        throw err;
+      }
+    );
+  }
+
+  /* ---- query params ---------------------------------------------------- */
+  function getParam(name) {
+    return new URLSearchParams(window.location.search).get(name);
+  }
+  function requireParam(name) {
+    var value = getParam(name);
+    if (value === null || value === "") {
+      var err = new Error("Missing required query parameter: " + name);
+      err.missingParam = name;
+      throw err;
+    }
+    return value;
+  }
+
+  /* ---- DOM helpers ----------------------------------------------------- */
+  function clear(node) {
+    if (!node) return;
+    while (node.firstChild) node.removeChild(node.firstChild);
+  }
+  // Create an element with an optional class and text content (text only).
+  function el(tag, className, textValue) {
+    var node = document.createElement(tag);
+    if (className) node.className = className;
+    if (textValue !== undefined && textValue !== null) {
+      node.textContent = String(textValue);
+    }
+    return node;
+  }
+  function link(className, href, label) {
+    var a = document.createElement("a");
+    if (className) a.className = className;
+    a.setAttribute("href", href);
+    a.textContent = String(label);
+    return a;
+  }
+  // Returns a normalized http(s) URL string, or null for anything else.
+  // Untrusted, API-provided absolute URLs (e.g. a benchmark's dataset_url) must
+  // pass through this before becoming an anchor href, so a javascript:, data:,
+  // or vbscript: URL can never be made clickable. Our own links are either
+  // relative (…html?…, "/") or the hardcoded sf://run scheme, and do not use
+  // this — only externally-sourced absolute URLs do.
+  function httpUrlOrNull(value) {
+    if (!value) return null;
+    try {
+      var u = new URL(String(value), window.location.href);
+      return u.protocol === "http:" || u.protocol === "https:" ? u.href : null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /* ---- status / loading / error / empty -------------------------------- */
+  // A status region is a single element that toggles between loading/error/
+  // empty states. Passing kind === null hides it (data is ready to show).
+  function setStatus(node, kind, message) {
+    if (!node) return;
+    if (kind === null) {
+      node.hidden = true;
+      node.className = "state";
+      node.textContent = "";
+      return;
+    }
+    node.hidden = false;
+    node.className = "state state-" + kind;
+    node.textContent = message;
+    node.setAttribute("role", kind === "error" ? "alert" : "status");
+  }
+  function showLoading(node, message) { setStatus(node, "loading", message || "Loading…"); }
+  function showError(node, message) { setStatus(node, "error", message || "Something went wrong."); }
+  function showEmpty(node, message) { setStatus(node, "empty", message || "Nothing here yet."); }
+
+  // Translate a fetch error into a page-appropriate message.
+  function describeError(err, opts) {
+    opts = opts || {};
+    if (err && err.missingParam) return opts.missingParam || ("Missing “" + err.missingParam + "”.");
+    if (err && err.status === 404) return opts.notFound || "Not found.";
+    return opts.generic || "Could not load — try again later.";
+  }
+
+  /* ---- formatters ------------------------------------------------------ */
+  function formatPercent(value) {
+    if (typeof value !== "number" || isNaN(value)) return EM_DASH;
+    return (value * 100).toFixed(1) + "%";
+  }
+  function formatQuestions(total) {
+    if (typeof total !== "number" || isNaN(total)) return EM_DASH;
+    return total.toLocaleString();
+  }
+  function formatDate(value) {
+    if (!value) return EM_DASH;
+    var d = new Date(value);
+    if (isNaN(d.getTime())) return EM_DASH;
+    return d.toLocaleString(undefined, {
+      year: "numeric", month: "short", day: "numeric",
+      hour: "2-digit", minute: "2-digit",
+    });
+  }
+  function formatProviders(list) {
+    if (!Array.isArray(list) || list.length === 0) return EM_DASH;
+    return list.join(", ");
+  }
+  // Privacy note: a null submitter renders as an em dash. Never "Anonymous" —
+  // let the absence speak for itself.
+  function formatSubmitter(value) {
+    if (value === null || value === undefined || value === "") return EM_DASH;
+    return String(value);
+  }
+
+  /* ---- badges & deep links -------------------------------------------- */
+  // Returns a green "Verified" pill only when verified_by_openmined === true;
+  // otherwise an empty text node (no badge — absence means unverified).
+  function createVerifiedBadge(isVerified) {
+    if (isVerified === true) return el("span", "badge-verified", "✓ Verified");
+    return document.createTextNode(EM_DASH);
+  }
+  // sf://run?spec=...&expression=... with each value URL-encoded separately.
+  // Never concatenate a raw url4_expression — it can contain / ( ) ! $.
+  function buildRunHref(specId, expression) {
+    return (
+      "sf://run?spec=" + encodeURIComponent(specId) +
+      "&expression=" + encodeURIComponent(expression)
+    );
+  }
+  function createRunLink(specId, expression, opts) {
+    opts = opts || {};
+    var a = link((opts.compact ? "run-link compact" : "run-link"), buildRunHref(specId, expression), opts.label || "Run Locally");
+    a.setAttribute("aria-label", "Run " + specId + " locally in ScreamingFace");
+    return a;
+  }
+
+  /* ---- ready ----------------------------------------------------------- */
+  function ready(fn) {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", fn);
+    } else {
+      fn();
+    }
+  }
+
+  /* ---- index page ------------------------------------------------------ */
+  function benchmarkCard(b) {
+    var card = el("article", "card");
+    card.appendChild(el("h2", "card-title", b.display_name || b.id));
+
+    if (b.description) {
+      card.appendChild(el("p", "card-meta", b.description));
+    } else {
+      card.appendChild(el("p", "card-meta empty", "No description."));
+    }
+
+    var links = el("div", "card-links");
+    links.appendChild(link("", "benchmark.html?id=" + encodeURIComponent(b.id), "View leaderboard →"));
+    // dataset_url is API-provided/untrusted: only render it when it is a real
+    // http(s) URL, so a javascript:/data: scheme can never reach the href.
+    var datasetHref = httpUrlOrNull(b.dataset_url);
+    if (datasetHref) {
+      var dataset = link("", datasetHref, "Dataset");
+      dataset.setAttribute("rel", "noopener noreferrer nofollow");
+      links.appendChild(dataset);
+    }
+    card.appendChild(links);
+    return card;
+  }
+
+  function initIndex() {
+    var statusNode = document.getElementById("benchmark-status");
+    var listNode = document.getElementById("benchmark-list");
+    showLoading(statusNode, "Loading benchmarks…");
+    listNode.hidden = true;
+
+    fetchJson("/v1/benchmarks").then(
+      function (data) {
+        var benchmarks = (data && data.benchmarks) || [];
+        if (benchmarks.length === 0) {
+          showEmpty(statusNode, "No benchmarks yet.");
+          return;
+        }
+        clear(listNode);
+        benchmarks.forEach(function (b) { listNode.appendChild(benchmarkCard(b)); });
+        setStatus(statusNode, null);
+        listNode.hidden = false;
+      },
+      function (err) {
+        showError(statusNode, describeError(err, { generic: "Could not load benchmarks — try again later." }));
+      }
+    );
+  }
+
+  /* ---- public surface -------------------------------------------------- */
+  var api = {
+    getApiBase: getApiBase,
+    fetchJson: fetchJson,
+    getParam: getParam,
+    requireParam: requireParam,
+    clear: clear,
+    el: el,
+    link: link,
+    httpUrlOrNull: httpUrlOrNull,
+    setStatus: setStatus,
+    showLoading: showLoading,
+    showError: showError,
+    showEmpty: showEmpty,
+    describeError: describeError,
+    formatPercent: formatPercent,
+    formatQuestions: formatQuestions,
+    formatDate: formatDate,
+    formatProviders: formatProviders,
+    formatSubmitter: formatSubmitter,
+    createVerifiedBadge: createVerifiedBadge,
+    buildRunHref: buildRunHref,
+    createRunLink: createRunLink,
+    ready: ready,
+    EM_DASH: EM_DASH,
+  };
+
+  // Self-bootstrap the index page when its container is present. benchmark.html
+  // and spec.html have no #benchmark-list, so this is a no-op there.
+  ready(function () {
+    if (document.getElementById("benchmark-list")) initIndex();
+  });
+
+  return api;
+})();

--- a/web/portal/spec.html
+++ b/web/portal/spec.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Spec History — ScreamingFace</title>
-  <meta name="description" content="Submission history for a single ScreamingFace ensemble spec on a benchmark.">
+  <meta name="description" content="Submission history for a single ScreamingFace benchmark spec, including accuracy, verification status, and local rerun support.">
   <meta name="robots" content="noindex, nofollow">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>😱</text></svg>">
   <link rel="stylesheet" href="styles.css">
@@ -20,6 +20,12 @@
 
       <section class="section">
         <div class="section-inner">
+          <div class="notice" role="note">
+            History is newest-first. The Run Locally link uses the newest submission
+            for this spec, so you can reproduce the latest public claim before
+            trusting it.
+          </div>
+
           <div id="spec-status" class="state" role="status" aria-live="polite">Loading…</div>
 
           <div id="spec-content" hidden>

--- a/web/portal/spec.html
+++ b/web/portal/spec.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Spec History — ScreamingFace</title>
+  <meta name="description" content="Submission history for a single ScreamingFace ensemble spec on a benchmark.">
+  <meta name="robots" content="noindex, nofollow">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>😱</text></svg>">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="page">
+    <main class="main">
+      <section class="hero">
+        <h1 id="spec-id" class="mono hero-id">Spec</h1>
+        <p id="spec-benchmark"></p>
+        <p><a id="back-link" href="index.html">← Back to leaderboard</a></p>
+      </section>
+
+      <section class="section">
+        <div class="section-inner">
+          <div id="spec-status" class="state" role="status" aria-live="polite">Loading…</div>
+
+          <div id="spec-content" hidden>
+            <div class="history-meta">
+              <span class="stat">Best accuracy <strong id="best-accuracy">—</strong></span>
+              <span class="stat" id="submission-count"></span>
+            </div>
+
+            <div id="run-region" class="run-region" hidden></div>
+
+            <div class="table-wrap">
+              <table class="leaderboard-table">
+                <thead>
+                  <tr>
+                    <th>When</th>
+                    <th>By</th>
+                    <th class="num">Accuracy</th>
+                    <th class="num">Questions</th>
+                    <th>Verified</th>
+                  </tr>
+                </thead>
+                <tbody id="history-body"></tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <span>😱 screamingface, built by <a href="https://openmined.org">OpenMined</a></span>
+      <a href="https://github.com/OpenMined/screamingface">GitHub</a>
+    </footer>
+  </div>
+
+  <script src="main.js" defer></script>
+  <script src="spec.js" defer></script>
+</body>
+</html>

--- a/web/portal/spec.js
+++ b/web/portal/spec.js
@@ -1,0 +1,119 @@
+/* ScreamingFace Leaderboard Portal — spec history page.
+ *
+ * Reads ?benchmark=<id>&spec=<spec_id>. The history endpoint deliberately
+ * omits url4_expression, so the top "Run Locally" link is built from the most
+ * recent submission's score detail via GET /v1/scores/{submissions[0].id}
+ * (submissions are newest-first). That id is the same Score UUID the scores
+ * route accepts, so no backend change is needed. Per task line 41 this link
+ * intentionally uses the NEWEST submission, which may differ from the
+ * best-per-spec url4 shown on the leaderboard row.
+ */
+(function (P) {
+  "use strict";
+
+  function historyRow(s) {
+    var tr = document.createElement("tr");
+    tr.appendChild(P.el("td", null, P.formatDate(s.submitted_at)));
+    tr.appendChild(P.el("td", "wrap", P.formatSubmitter(s.submitted_by)));
+    tr.appendChild(P.el("td", "num", P.formatPercent(s.accuracy)));
+    tr.appendChild(P.el("td", "num", P.formatQuestions(s.total_questions)));
+    var verTd = document.createElement("td");
+    verTd.appendChild(P.createVerifiedBadge(s.verified_by_openmined));
+    tr.appendChild(verTd);
+    return tr;
+  }
+
+  // Best-effort: resolve the benchmark's display name from /v1/benchmarks.
+  // Falls back to the raw id if the list cannot be loaded or has no match.
+  function resolveBenchmarkName(benchmarkId) {
+    return P.fetchJson("/v1/benchmarks").then(
+      function (data) {
+        var list = (data && data.benchmarks) || [];
+        var match = list.filter(function (b) { return b.id === benchmarkId; })[0];
+        return match ? (match.display_name || match.id) : benchmarkId;
+      },
+      function () { return benchmarkId; }
+    );
+  }
+
+  function renderRunLink(regionNode, specId, latestId) {
+    P.fetchJson("/v1/scores/" + encodeURIComponent(latestId)).then(
+      function (score) {
+        if (score && score.url4_expression) {
+          P.clear(regionNode);
+          regionNode.appendChild(P.createRunLink(specId, score.url4_expression, { label: "Run Locally" }));
+          regionNode.hidden = false;
+        } else {
+          regionNode.hidden = true;
+        }
+      },
+      function () {
+        // Hide the button and show a quiet note rather than a hard error.
+        P.clear(regionNode);
+        regionNode.appendChild(P.el("p", "quiet", "Run link unavailable for the latest submission."));
+        regionNode.hidden = false;
+      }
+    );
+  }
+
+  function init() {
+    var statusNode = document.getElementById("spec-status");
+    var contentNode = document.getElementById("spec-content");
+    var specIdNode = document.getElementById("spec-id");
+    var benchNode = document.getElementById("spec-benchmark");
+    var backLink = document.getElementById("back-link");
+
+    var benchmarkId, specId;
+    try {
+      benchmarkId = P.requireParam("benchmark");
+      specId = P.requireParam("spec");
+    } catch (e) {
+      P.showError(statusNode, "Missing benchmark or spec. Return to the leaderboard.");
+      return;
+    }
+
+    specIdNode.textContent = specId;
+    backLink.setAttribute("href", "benchmark.html?id=" + encodeURIComponent(benchmarkId));
+    document.title = specId + " — ScreamingFace";
+
+    P.showLoading(statusNode, "Loading spec history…");
+    contentNode.hidden = true;
+
+    resolveBenchmarkName(benchmarkId).then(function (name) {
+      benchNode.textContent = name;
+    });
+
+    P.fetchJson("/v1/leaderboard/" + encodeURIComponent(benchmarkId) + "/" + encodeURIComponent(specId) + "/history?limit=20").then(
+      function (data) {
+        var submissions = (data && data.submissions) || [];
+        if (submissions.length === 0) {
+          P.showEmpty(statusNode, "No submissions for this spec yet.");
+          return;
+        }
+
+        var best = Math.max.apply(null, submissions.map(function (s) { return s.accuracy; }));
+        document.getElementById("best-accuracy").textContent = P.formatPercent(best);
+        document.getElementById("submission-count").textContent =
+          submissions.length + (submissions.length === 1 ? " submission" : " submissions");
+
+        var body = document.getElementById("history-body");
+        P.clear(body);
+        submissions.forEach(function (s) { body.appendChild(historyRow(s)); });
+
+        P.setStatus(statusNode, null);
+        contentNode.hidden = false;
+
+        // Newest submission is submissions[0] (backend orders newest-first).
+        renderRunLink(document.getElementById("run-region"), specId, submissions[0].id);
+      },
+      function (err) {
+        P.showError(statusNode, P.describeError(err, {
+          notFound: "Benchmark not found.",
+          generic: "Could not load spec history — try again later.",
+        }));
+      }
+    );
+  }
+
+  P.ready(init);
+})(window.ScorePortal);

--- a/web/portal/styles.css
+++ b/web/portal/styles.css
@@ -1,0 +1,184 @@
+/* ScreamingFace Leaderboard Portal — shared styles.
+   Visual tokens and layout language reused from web/public/index.html so the
+   portal sits in the same visual lane as the marketing page. No external
+   fonts, no CDN, no framework. */
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+:root {
+  --bg: #faf9fb;
+  --fg: #14121a;
+  --card: #f0eef5;
+  --border: #d4d0e4;
+  --muted: #14121a;
+  --primary: #c8842a;
+  --secondary-bg: rgba(228, 225, 239, 0.6);
+  --verified: #1f7a4d;
+  --verified-bg: #1f7a4d;
+  --danger: #b84e5e;
+  --font-sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+}
+
+html, body {
+  font-family: var(--font-sans);
+  font-size: 16px;
+  color: var(--fg);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--primary); text-decoration: underline; text-underline-offset: 2px; }
+a:hover { opacity: 0.8; }
+code, pre, kbd, .mono { font-family: var(--font-mono); }
+h1, h2, h3 { text-wrap: balance; }
+p { text-wrap: pretty; }
+
+/* Layout */
+.page { min-height: 100vh; display: flex; flex-direction: column; }
+.main { flex: 1; }
+
+.hero { padding: 48px 20px 32px; max-width: 896px; margin: 0 auto; text-align: center; }
+.hero .emoji { font-size: 64px; margin-bottom: 16px; user-select: none; }
+.hero h1 { font-size: 44px; font-weight: 600; letter-spacing: -0.02em; line-height: 1.1; margin-bottom: 16px; }
+.hero p { max-width: 600px; margin: 0 auto 12px; line-height: 1.6; }
+.hero .hero-id { font-size: 28px; }
+
+.section { padding: 8px 20px 56px; }
+.section-inner { max-width: 960px; margin: 0 auto; }
+
+/* Benchmark cards */
+.card-grid { display: grid; grid-template-columns: 1fr; gap: 20px; }
+@media (min-width: 768px) { .card-grid { grid-template-columns: repeat(2, 1fr); } }
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 15px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.card-title { font-size: 20px; font-weight: 600; letter-spacing: -0.01em; }
+.card-meta { line-height: 1.55; }
+.card-meta.empty { opacity: 0.6; font-style: italic; }
+.card-links { margin-top: 6px; display: flex; flex-wrap: wrap; gap: 16px; align-items: center; }
+
+/* Notice banner */
+.notice {
+  background: var(--secondary-bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px 18px;
+  margin-bottom: 24px;
+  line-height: 1.55;
+  font-size: 14px;
+}
+
+/* Table */
+.table-wrap {
+  border: 1px solid var(--border);
+  border-radius: 15px;
+  overflow-x: auto;
+  background: var(--card);
+}
+.leaderboard-table { width: 100%; border-collapse: collapse; font-size: 14px; }
+.leaderboard-table th, .leaderboard-table td {
+  padding: 12px 14px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+  vertical-align: middle;
+}
+.leaderboard-table thead th { background: var(--secondary-bg); font-weight: 600; position: sticky; top: 0; }
+.leaderboard-table tbody tr:last-child td { border-bottom: none; }
+.leaderboard-table td.num, .leaderboard-table th.num { text-align: right; font-variant-numeric: tabular-nums; }
+.leaderboard-table td.wrap { white-space: normal; }
+
+.sort-button {
+  background: none;
+  border: none;
+  font: inherit;
+  font-weight: 600;
+  color: var(--fg);
+  cursor: pointer;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.sort-button:hover { color: var(--primary); }
+.sort-button .arrow { font-size: 10px; opacity: 0; }
+th[aria-sort="ascending"] .sort-button .arrow,
+th[aria-sort="descending"] .sort-button .arrow { opacity: 1; }
+
+/* Verified badge */
+.badge-verified {
+  display: inline-block;
+  background: var(--verified-bg);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 3px 9px;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+/* Buttons / run links */
+.button, .run-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  padding: 8px 16px;
+  border-radius: 8px;
+  background: var(--fg);
+  color: var(--bg);
+  font-size: 14px;
+  font-weight: 500;
+  text-decoration: none;
+  border: 1px solid var(--fg);
+  cursor: pointer;
+}
+.button:hover, .run-link:hover { opacity: 0.9; }
+.button-secondary {
+  background: transparent;
+  color: var(--fg);
+  border: 1px solid var(--border);
+}
+.run-link.compact { min-height: 32px; padding: 5px 12px; font-size: 13px; }
+
+/* History list (spec page) */
+.history-meta { display: flex; flex-wrap: wrap; gap: 18px; align-items: baseline; margin-bottom: 20px; }
+.history-meta .stat { font-size: 14px; }
+.history-meta .stat strong { font-size: 22px; font-weight: 600; }
+.run-region { margin-bottom: 24px; display: flex; flex-direction: column; gap: 8px; }
+.run-region .quiet { font-size: 13px; opacity: 0.7; }
+
+/* Status regions */
+.state { padding: 28px 4px; line-height: 1.6; }
+.state[hidden] { display: none; }
+.state-loading { opacity: 0.75; }
+.state-error { color: var(--danger); }
+.state-empty { opacity: 0.7; }
+
+[hidden] { display: none !important; }
+
+/* Footer */
+.footer {
+  padding: 24px 20px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-top: 1px solid var(--border);
+  font-size: 14px;
+}
+@media (max-width: 639px) {
+  .footer { flex-direction: column; text-align: center; }
+  .hero h1 { font-size: 34px; }
+  /* On narrow screens the sf:// deep-links are not useful; collapse that column. */
+  .leaderboard-table .col-run { display: none; }
+}

--- a/web/portal/styles.css
+++ b/web/portal/styles.css
@@ -38,11 +38,47 @@ p { text-wrap: pretty; }
 .page { min-height: 100vh; display: flex; flex-direction: column; }
 .main { flex: 1; }
 
-.hero { padding: 48px 20px 32px; max-width: 896px; margin: 0 auto; text-align: center; }
+.hero { padding: 48px 20px 32px; max-width: 960px; margin: 0 auto; text-align: center; }
 .hero .emoji { font-size: 64px; margin-bottom: 16px; user-select: none; }
 .hero h1 { font-size: 44px; font-weight: 600; letter-spacing: -0.02em; line-height: 1.1; margin-bottom: 16px; }
 .hero p { max-width: 600px; margin: 0 auto 12px; line-height: 1.6; }
 .hero .hero-id { font-size: 28px; }
+
+/* Proof points */
+.proof-grid, .summary-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 14px;
+  margin: 28px auto 0;
+  text-align: left;
+}
+.proof-grid { max-width: 860px; }
+.summary-grid { grid-template-columns: 1fr; margin: 0 0 24px; }
+@media (min-width: 760px) {
+  .proof-grid, .summary-grid { grid-template-columns: repeat(3, 1fr); }
+}
+.proof-card, .summary-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 15px;
+  padding: 18px;
+}
+.proof-kicker {
+  display: block;
+  margin-bottom: 8px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  opacity: 0.68;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.proof-card strong, .summary-card strong {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 22px;
+  line-height: 1.2;
+}
+.proof-card span:last-child, .summary-card span:last-child { line-height: 1.45; }
 
 .section { padding: 8px 20px 56px; }
 .section-inner { max-width: 960px; margin: 0 auto; }
@@ -61,6 +97,7 @@ p { text-wrap: pretty; }
   gap: 10px;
 }
 .card-title { font-size: 20px; font-weight: 600; letter-spacing: -0.01em; }
+.card-id { font-size: 12px; opacity: 0.68; overflow-wrap: anywhere; }
 .card-meta { line-height: 1.55; }
 .card-meta.empty { opacity: 0.6; font-style: italic; }
 .card-links { margin-top: 6px; display: flex; flex-wrap: wrap; gap: 16px; align-items: center; }


### PR DESCRIPTION
Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1214568119303669

## Description
Adds a static public leaderboard portal under `web/portal` with a benchmark index, per-benchmark leaderboard, and per-spec submission history. The portal reads from the scoreboard API, handles empty/error states, supports local run links, and avoids rendering unsafe dataset URLs.

This also makes local scoreboard runs easier by defaulting the scoreboard database URL to a local SQLite file while preserving Postgres through `SCOREBOARD_DATABASE_URL`.

## Affected Dependencies
No new dependencies.

## How has this been tested?
- `node --check web/portal/main.js`
- `node --check web/portal/benchmark.js`
- `node --check web/portal/spec.js`
- `cd apps/scoreboard && uv run pytest tests/unit/ -q`
- `cd apps/scoreboard && uv run pyright`
- `cd apps/scoreboard && uv run ruff check src/scoreboard/config.py src/scoreboard/db.py tests/unit/test_config.py`
- `cd apps/scoreboard && uv run ruff format --check src/scoreboard/config.py src/scoreboard/db.py tests/unit/test_config.py`
- `cd apps/server && uv run pre-commit run --config .pre-commit-config.yaml --files ../../apps/scoreboard/src/scoreboard/config.py ../../apps/scoreboard/tests/unit/test_config.py`
- `cd apps/server && uv run pre-commit run --config .pre-commit-config.yaml --files ../../apps/server/src/screamingface/core/config.py`
- Verified a fresh SQLite migration applies successfully with `uv run tortoise migrate`.
- Verified the local portal loads against a local scoreboard service and renders empty/not-found states from the API.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests

<img width="1318" height="716" alt="image" src="https://github.com/user-attachments/assets/f10fee3a-9530-469b-bd05-3ac732ff9778" />
