### PR TITLE
SF-34 fast-follow: quoted-intent grammar rule (commas in prompts; fixes MainOne)

### DIFF
--- a/apps/server/src/screamingface/plugins/url4_executor/tests/test_quoted_intent.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/tests/test_quoted_intent.py
@@ -1,0 +1,35 @@
+# pyright: reportAttributeAccessIssue=false, reportOptionalMemberAccess=false
+from screamingface.plugins.url4_executor.url4_ast import Url4BackendCall, Url4List, Url4Text
+from screamingface.plugins.url4_executor.url4_grammar import parse
+
+
+def test_quoted_intent_with_comma_parses_whole():
+    node = parse("/claude(q)!'Answer this. Return only the answer, no other text.'")
+    assert isinstance(node, Url4BackendCall)
+    assert isinstance(node.intent, Url4Text)
+    assert node.intent.value == "'Answer this. Return only the answer, no other text.'"
+
+
+def test_quoted_intent_in_fanout_list_does_not_split_on_inner_commas():
+    # MainOne-shaped: two backend calls with comma-laden quoted intents.
+    node = parse("(/claude(q)!'Pick A, B, or C.', /codex(q)!'Pick A, B, or C.')")
+    assert isinstance(node, Url4List)
+    assert len(node.items) == 2  # NOT split on the commas inside the quotes
+    assert all(isinstance(i, Url4BackendCall) for i in node.items)
+    assert node.items[0].intent.value == "'Pick A, B, or C.'"
+
+
+def test_double_quoted_intent_with_comma():
+    node = parse('/claude(q)!"one, two, three"')
+    assert node.intent.value == '"one, two, three"'
+
+
+def test_comma_free_quoted_intent_unchanged():
+    # behavior parity: a comma-free quoted intent still parses as before
+    node = parse("/claude(q)!'hello world'")
+    assert node.intent.value == "'hello world'"
+
+
+def test_bare_text_intent_still_works():
+    node = parse("/claude(q)!plain text")
+    assert node.intent.value == "plain text"

--- a/apps/server/src/screamingface/plugins/url4_executor/url4_grammar.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/url4_grammar.py
@@ -138,6 +138,7 @@ GRAMMAR = r"""
         = url
         | relurl
         | json_blob
+        | quoted
         | text
         ;
 
@@ -151,6 +152,10 @@ GRAMMAR = r"""
     # nested {}. Lets a backend-call intent carry a multi-key JSON payload
     # whose internal commas would otherwise split the enclosing list.
     json_blob = value:/\{(?:[^{}]|\{[^{}]*\})*\}/ ;
+
+    # A quoted-string intent: '…' or "…" — commas inside are part of the
+    # string, not list separators. Twin of json_blob for quoted prompts.
+    quoted = value:/'[^']*'|"[^"]*"/ ;
 """
 
 
@@ -165,6 +170,9 @@ class Url4Semantics:
         return Url4Text(value=ast.value.strip())
 
     def json_blob(self, ast):
+        return Url4Text(value=ast.value.strip())
+
+    def quoted(self, ast):
         return Url4Text(value=ast.value.strip())
 
     def backend_call(self, ast):


### PR DESCRIPTION
## Summary
Adds a `quoted` rule to the URL4 intent atom so a backend-call intent can be a quoted string containing **commas** — e.g. `!'Answer this. Return only the answer, no other text.'`. Today such intents truncate at the comma (the intent atom only had `text = /[^,()]+/`).

Twin of the existing `json_blob` rule (which did the same for `{…}` payloads).

## Why it matters beyond the scored query
**This also fixes MainOne/MainTwo**, whose stored prompts contain commas inside quotes (`Format: {"A": 0.7, "B": 0.2, …}. Return only the JSON object.`) and therefore mis-parse today (the fanout list splits on the prompt's internal commas).

## Change (additive — only triggers for `'…'` / `"…"` intents)
- `atom_no_bc`: add `| quoted` before `| text`
- `quoted = value:/'[^']*'|"[^"]*"/ ;`
- semantic action returns `Url4Text(value=…strip())` — identical shape to how a comma-free quoted intent parses today (downstream `resolve_intent` still strips the quotes), so behavior is unchanged except commas are now retained.

## Tests
5 new (`test_quoted_intent.py`), incl. a MainOne-shaped fanout with comma-laden quoted intents. Full url4_executor suite: **252 green, no regressions**.

## Stacking
Stacked on #230 (base = `SF-34-url4-scored-ensemble-query`). The change is self-contained and could also be cherry-picked straight to `main` (it fixes MainOne independently of the scored query).

🤖 Generated with [Claude Code](https://claude.com/claude-code)