### PR TITLE
SF-188: add scoreboard deployment

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - "web/public/**"
+      - "web/portal/**"
+      - ".github/workflows/deploy-website.yml"
 
   workflow_dispatch:
 
@@ -27,9 +29,37 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Prepare Pages artifact
+        env:
+          SCOREBOARD_API_BASE: ${{ vars.SCOREBOARD_API_BASE || 'https://scoreboard.screamingface.ai' }}
+        run: |
+          rm -rf /tmp/sf-pages
+          mkdir -p /tmp/sf-pages/portal
+          cp -R web/public/. /tmp/sf-pages/
+          cp -R web/portal/. /tmp/sf-pages/portal/
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          api_base = os.environ["SCOREBOARD_API_BASE"].rstrip("/")
+          snippet = f"<script>window.SCOREBOARD_API_BASE = {json.dumps(api_base)};</script>"
+          marker = '<script src="main.js" defer></script>'
+
+          portal_dir = Path("/tmp/sf-pages/portal")
+          for name in ("index.html", "benchmark.html", "spec.html"):
+              path = portal_dir / name
+              text = path.read_text()
+              if snippet in text:
+                  continue
+              if marker not in text:
+                  raise SystemExit(f"missing main.js marker in {path}")
+              path.write_text(text.replace(marker, f"{snippet}\n  {marker}", 1))
+          PY
+
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: web/public
+          path: /tmp/sf-pages
 
       - uses: actions/deploy-pages@v4
         id: deployment

--- a/.github/workflows/release-scoreboard.yml
+++ b/.github/workflows/release-scoreboard.yml
@@ -1,0 +1,130 @@
+name: Release Scoreboard
+
+on:
+  push:
+    tags: ["scoreboard-v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. scoreboard-v0.1.0)"
+        required: true
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      tag: ${{ steps.v.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: v
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          VERSION="${TAG#scoreboard-v}"
+          MANIFEST=$(awk -F'"' '/^version[[:space:]]*=/{print $2; exit}' apps/scoreboard/pyproject.toml)
+          if [ "$MANIFEST" != "$VERSION" ]; then
+            echo "::error::tag $TAG implies version $VERSION but apps/scoreboard/pyproject.toml reports $MANIFEST"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  image:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/scoreboard/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/openmined/screamingface-scoreboard:${{ needs.verify.outputs.version }}
+            ghcr.io/openmined/screamingface-scoreboard:latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ needs.verify.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+  chart:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+      - name: Lint and render charts
+        run: |
+          helm lint apps/scoreboard/charts/db
+          helm lint apps/scoreboard/charts/scoreboard
+          helm template scoreboard-db apps/scoreboard/charts/db \
+            --namespace scoreboard \
+            --values apps/scoreboard/charts/db-scoreboard.values.yaml >/tmp/scoreboard-db.yaml
+          helm template scoreboard apps/scoreboard/charts/scoreboard \
+            --namespace scoreboard >/tmp/scoreboard.yaml
+          helm template scoreboard apps/scoreboard/charts/scoreboard \
+            --namespace scoreboard \
+            --values apps/scoreboard/charts/scoreboard/values-prod.yaml >/tmp/scoreboard-prod.yaml
+      - name: Package Helm chart
+        env:
+          VERSION: ${{ needs.verify.outputs.version }}
+        run: |
+          mkdir -p dist/charts
+          helm package apps/scoreboard/charts/scoreboard \
+            --version "$VERSION" \
+            --app-version "$VERSION" \
+            --destination dist/charts
+      - name: Log in to GHCR for Helm
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GITHUB_TOKEN" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+      - name: Push Helm chart
+        env:
+          VERSION: ${{ needs.verify.outputs.version }}
+        run: helm push "dist/charts/scoreboard-$VERSION.tgz" oci://ghcr.io/openmined/screamingface/charts
+
+  release:
+    needs: [verify, image, chart]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.verify.outputs.tag }}
+          name: ScreamingFace Scoreboard ${{ needs.verify.outputs.version }}
+          draft: true
+          body: |
+            Container image:
+            ```
+            docker pull ghcr.io/openmined/screamingface-scoreboard:${{ needs.verify.outputs.version }}
+            ```
+
+            Helm chart:
+            ```
+            helm pull oci://ghcr.io/openmined/screamingface/charts/scoreboard --version ${{ needs.verify.outputs.version }}
+            ```
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/scoreboard/DEPLOYMENT.md
+++ b/apps/scoreboard/DEPLOYMENT.md
@@ -1,0 +1,218 @@
+# Scoreboard Deployment
+
+This runbook deploys `apps/scoreboard` as a containerized FastAPI service on Kubernetes. The app chart is database-agnostic: it reads `SCOREBOARD_DATABASE_URL` from a Secret, runs Tortoise migrations as a Helm pre-install/pre-upgrade Job, and seeds configured benchmarks as a post-install/post-upgrade Job.
+
+## Artifacts
+
+- Container image: `ghcr.io/openmined/screamingface-scoreboard:<version>`.
+- App chart: `oci://ghcr.io/openmined/screamingface/charts/scoreboard`.
+- Demo database chart in this repo: `apps/scoreboard/charts/db`.
+
+The demo database chart is a single `postgres:16-alpine` Deployment with a PVC. It is useful for k3s smoke tests and demos, but it has no HA, backups, PITR, or managed upgrade policy.
+
+## Local k3s Smoke Image
+
+Build an amd64 image for a single-node Linux k3s server:
+
+```bash
+docker buildx build \
+  --platform linux/amd64 \
+  -f apps/scoreboard/Dockerfile \
+  -t ghcr.io/openmined/screamingface-scoreboard:sf188-local \
+  --load \
+  .
+```
+
+Check the image size target from the SCORE-007 acceptance criteria:
+
+```bash
+SIZE_BYTES=$(docker image inspect ghcr.io/openmined/screamingface-scoreboard:sf188-local --format '{{.Size}}')
+test "$SIZE_BYTES" -lt 209715200
+```
+
+Import the local image into k3s containerd when you do not want to push a temporary tag:
+
+```bash
+docker save ghcr.io/openmined/screamingface-scoreboard:sf188-local \
+  | ssh adminuser@40.76.107.241 \
+      "sudo k3s ctr -n k8s.io images import --platform linux/amd64 -"
+```
+
+Verify it is available to pods:
+
+```bash
+ssh adminuser@40.76.107.241 \
+  "sudo k3s ctr -n k8s.io images ls | grep screamingface-scoreboard"
+```
+
+## Demo Database
+
+Install the generic Postgres chart with the scoreboard values overlay:
+
+```bash
+helm upgrade --install scoreboard-db apps/scoreboard/charts/db \
+  --namespace scoreboard \
+  --create-namespace \
+  --values apps/scoreboard/charts/db-scoreboard.values.yaml \
+  --wait
+```
+
+The chart creates `Secret/scoreboard-db` with `username`, `password`, `database`, and `database-url`. The app chart consumes only the `database-url` key.
+
+For production, replace this chart with managed Postgres or a Postgres operator. Create a Secret with a `database-url` key and point `database.existingSecret` at it.
+
+## App Install
+
+Use a real HTTPS hostname in production. For a temporary k3s smoke test, `nip.io` can map a hostname to an IP without creating DNS records. For example, `scoreboard.40.76.107.241.nip.io` resolves to `40.76.107.241` and works with Traefik host-based Ingress.
+
+```bash
+helm upgrade --install scoreboard apps/scoreboard/charts/scoreboard \
+  --namespace scoreboard \
+  --set image.tag=sf188-local \
+  --set ingress.className=traefik \
+  --set "ingress.hosts[0].host=scoreboard.40.76.107.241.nip.io" \
+  --set "ingress.hosts[0].paths[0].path=/" \
+  --set "ingress.hosts[0].paths[0].pathType=Prefix" \
+  --set 'cors.origins[0]=*' \
+  --wait
+```
+
+Quote indexed `--set` keys in shells such as zsh. If you override a list item, set the full `host` and `paths` structure.
+
+## Production Install
+
+For production, use managed Postgres and a Secret with a `database-url` key:
+
+```bash
+kubectl -n scoreboard create secret generic scoreboard-db \
+  --from-literal=database-url='postgres://scoreboard:<password>@<host>:5432/scoreboard'
+
+helm upgrade --install scoreboard oci://ghcr.io/openmined/screamingface/charts/scoreboard \
+  --version 0.1.0 \
+  --namespace scoreboard \
+  --values apps/scoreboard/charts/scoreboard/values-prod.yaml \
+  --set database.existingSecret=scoreboard-db \
+  --set database.existingSecretKey=database-url \
+  --wait
+```
+
+`values-prod.yaml` sets three app replicas, Traefik ingress, TLS annotations, production CORS for `https://screamingface.ai`, and NetworkPolicy enabled. Adjust `ingress.className` if the production cluster uses a different ingress controller.
+
+## Benchmark Seeding
+
+The app chart runs `python -m scoreboard.seed` after install and upgrade. Seed data comes from `.Values.seedBenchmarks.benchmarks` and is passed through `SCOREBOARD_SEED_BENCHMARKS_JSON`.
+
+The default seed registers the HLE benchmark:
+
+```yaml
+seedBenchmarks:
+  enabled: true
+  benchmarks:
+    - id: hle
+      display_name: News Hallucinations
+      description: OpenMined HLE benchmark
+      dataset_url: https://github.com/openmined/HLE.jsonl
+```
+
+Re-running the Job is safe because benchmark registration is an upsert. Disable seeding with `--set seedBenchmarks.enabled=false`.
+
+## Smoke Checks
+
+Run the Helm test and check public health:
+
+```bash
+helm test scoreboard --namespace scoreboard --timeout 3m
+curl -fsS http://scoreboard.40.76.107.241.nip.io/healthz
+curl -fsS http://scoreboard.40.76.107.241.nip.io/v1/benchmarks
+```
+
+Submit a smoke score with an idempotency key:
+
+```bash
+curl -fsS -X POST http://scoreboard.40.76.107.241.nip.io/v1/scores \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: score-007-smoke-1" \
+  -d '{"version":1,"benchmark_id":"hle","spec_id":"score-007-smoke","url4_expression":"url4://smoke","submitted_by":"score-007","accuracy":0.5,"total_questions":2,"correct_questions":1,"ran_with_providers":["smoke"],"client_name":"curl","client_version":"0.1.0","client_platform":"k3s"}'
+
+curl -fsS http://scoreboard.40.76.107.241.nip.io/v1/leaderboard/hle
+```
+
+The SCORE-007 initial task mentions POSTing from SF desktop, but current D-SCORE-006 in this repo is AIGateway desktop login, not scoreboard score publishing. Use the public API smoke above until a desktop submission task exists.
+
+## Portal And CORS
+
+The static portal under `web/portal` reads `window.SCOREBOARD_API_BASE` before falling back to `http://localhost:9106`. The Pages deploy workflow injects that value into the published artifact.
+
+Production CORS must include the portal origin, not the path:
+
+```yaml
+cors:
+  origins:
+    - https://screamingface.ai
+```
+
+After a Pages deploy, open `https://screamingface.ai/portal/` and verify the browser console has no CORS failures while fetching `/v1/benchmarks`.
+
+## Migrations
+
+The app chart runs:
+
+```bash
+python -m tortoise -c scoreboard.db.TORTOISE_CONFIG migrate
+```
+
+This runs in a Helm hook Job before app Deployment rollout. Do not run `Tortoise.generate_schemas()` in production and do not run migrations in app startup.
+
+## Upgrade And Rollback
+
+Upgrade:
+
+```bash
+helm upgrade scoreboard apps/scoreboard/charts/scoreboard \
+  --namespace scoreboard \
+  --reuse-values \
+  --set image.tag=<new-tag> \
+  --wait
+```
+
+Rollback:
+
+```bash
+helm history scoreboard --namespace scoreboard
+helm rollback scoreboard <revision> --namespace scoreboard --wait
+```
+
+Helm rollback does not roll back database schema migrations. Keep migrations forward-compatible where possible.
+
+## Troubleshooting
+
+Inspect resources:
+
+```bash
+kubectl -n scoreboard get pods,job,svc,ingress,pvc
+helm status scoreboard --namespace scoreboard
+```
+
+Inspect logs:
+
+```bash
+kubectl -n scoreboard logs job/scoreboard-scoreboard-migrate
+kubectl -n scoreboard logs job/scoreboard-scoreboard-seed-benchmarks
+kubectl -n scoreboard logs deploy/scoreboard-scoreboard
+```
+
+Check the database Secret:
+
+```bash
+kubectl -n scoreboard get secret scoreboard-db -o jsonpath='{.data.database-url}' | base64 --decode
+```
+
+If GHCR image pulls fail, create an image pull Secret and set `imagePullSecrets[0].name=<secret-name>`.
+
+## Operations Notes
+
+- The container listens on `0.0.0.0:9106` and exposes `/healthz`.
+- `/healthz` is a liveness endpoint and does not query the database; Helm test also calls `/v1/benchmarks` for a DB-backed check.
+- The migration and seed Jobs use the same image and database Secret as the app Deployment.
+- The demo DB PVC owns the database state; deleting it deletes the database.
+- Backups, HA Postgres, PodMonitor, and HPA are follow-up infrastructure work.

--- a/apps/scoreboard/Dockerfile
+++ b/apps/scoreboard/Dockerfile
@@ -1,0 +1,44 @@
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+
+ENV UV_LINK_MODE=copy \
+    UV_PYTHON_DOWNLOADS=never
+
+WORKDIR /app
+
+COPY apps/scoreboard/pyproject.toml apps/scoreboard/uv.lock /app/
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-install-project --no-dev
+
+COPY apps/scoreboard/src /app/src
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev
+
+
+FROM python:3.12-slim-bookworm AS runtime
+
+LABEL org.opencontainers.image.source="https://github.com/openmined/screamingface" \
+      org.opencontainers.image.description="ScreamingFace benchmark scoreboard" \
+      org.opencontainers.image.licenses="MIT"
+
+ENV SCOREBOARD_HOST=0.0.0.0 \
+    SCOREBOARD_PORT=9106 \
+    PATH="/app/.venv/bin:$PATH" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN useradd --uid 10001 --create-home --shell /usr/sbin/nologin scoreboard
+
+COPY --from=builder --chown=scoreboard:scoreboard /app /app
+
+USER scoreboard
+
+EXPOSE 9106
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:9106/healthz', timeout=3).read()" || exit 1
+
+ENTRYPOINT ["scoreboard"]

--- a/apps/scoreboard/charts/db-scoreboard.values.yaml
+++ b/apps/scoreboard/charts/db-scoreboard.values.yaml
@@ -1,0 +1,8 @@
+fullnameOverride: scoreboard-db
+
+auth:
+  username: scoreboard
+  database: scoreboard
+
+secret:
+  name: scoreboard-db

--- a/apps/scoreboard/charts/db/Chart.yaml
+++ b/apps/scoreboard/charts/db/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: postgres
+description: Single-instance PostgreSQL chart for development and demos
+type: application
+version: 0.1.0
+appVersion: "16"

--- a/apps/scoreboard/charts/db/README.md
+++ b/apps/scoreboard/charts/db/README.md
@@ -1,0 +1,17 @@
+# postgres
+
+Single-instance PostgreSQL chart for scoreboard development and k3s demos.
+
+Install with the scoreboard overlay:
+
+```bash
+helm upgrade --install scoreboard-db apps/scoreboard/charts/db \
+  --namespace scoreboard \
+  --create-namespace \
+  --values apps/scoreboard/charts/db-scoreboard.values.yaml \
+  --wait
+```
+
+The chart creates a Secret with `username`, `password`, `database`, and `database-url` keys. The scoreboard app chart consumes only `database-url`.
+
+This chart is not production database infrastructure. It has no HA, backups, PITR, or managed upgrade policy. Use managed Postgres or a Postgres operator for production.

--- a/apps/scoreboard/charts/db/templates/_helpers.tpl
+++ b/apps/scoreboard/charts/db/templates/_helpers.tpl
@@ -1,0 +1,37 @@
+{{- define "postgres.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "postgres.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "postgres.name" . -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "postgres.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "postgres.labels" -}}
+helm.sh/chart: {{ include "postgres.chart" . }}
+app.kubernetes.io/name: {{ include "postgres.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "postgres.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "postgres.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "postgres.secretName" -}}
+{{- default (include "postgres.fullname" .) .Values.secret.name -}}
+{{- end -}}

--- a/apps/scoreboard/charts/db/templates/deployment.yaml
+++ b/apps/scoreboard/charts/db/templates/deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "postgres.fullname" . }}
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "postgres.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "postgres.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: postgres
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: postgres
+              containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "postgres.secretName" . }}
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "postgres.secretName" . }}
+                  key: password
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "postgres.secretName" . }}
+                  key: database
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "postgres.fullname" . }}-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}

--- a/apps/scoreboard/charts/db/templates/pvc.yaml
+++ b/apps/scoreboard/charts/db/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.persistence.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "postgres.fullname" . }}-data
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/apps/scoreboard/charts/db/templates/secret.yaml
+++ b/apps/scoreboard/charts/db/templates/secret.yaml
@@ -1,0 +1,23 @@
+{{- $secretName := include "postgres.secretName" . -}}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $password := .Values.auth.password -}}
+{{- if not $password -}}
+{{- if and $existingSecret $existingSecret.data (index $existingSecret.data "password") -}}
+{{- $password = (index $existingSecret.data "password" | b64dec) -}}
+{{- else -}}
+{{- $password = randAlphaNum 48 -}}
+{{- end -}}
+{{- end -}}
+{{- $databaseUrl := printf "%s://%s:%s@%s.%s.svc.cluster.local:%d/%s" .Values.secret.scheme .Values.auth.username $password (include "postgres.fullname" .) .Release.Namespace (.Values.service.port | int) .Values.auth.database -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  username: {{ .Values.auth.username | quote }}
+  password: {{ $password | quote }}
+  database: {{ .Values.auth.database | quote }}
+  {{ .Values.secret.databaseUrlKey }}: {{ $databaseUrl | quote }}

--- a/apps/scoreboard/charts/db/templates/service.yaml
+++ b/apps/scoreboard/charts/db/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "postgres.fullname" . }}
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: postgres
+      port: {{ .Values.service.port }}
+      targetPort: postgres
+  selector:
+    {{- include "postgres.selectorLabels" . | nindent 4 }}

--- a/apps/scoreboard/charts/db/values.yaml
+++ b/apps/scoreboard/charts/db/values.yaml
@@ -1,0 +1,45 @@
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repository: postgres
+  tag: 16-alpine
+  pullPolicy: IfNotPresent
+
+auth:
+  username: app
+  password: ""
+  database: app
+
+secret:
+  name: ""
+  databaseUrlKey: database-url
+  scheme: postgres
+
+service:
+  port: 5432
+
+persistence:
+  enabled: true
+  storageClass: local-path
+  accessModes:
+    - ReadWriteOnce
+  size: 4Gi
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+
+readinessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+
+livenessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 20
+  timeoutSeconds: 5

--- a/apps/scoreboard/charts/scoreboard/Chart.yaml
+++ b/apps/scoreboard/charts/scoreboard/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: scoreboard
+description: ScreamingFace benchmark scoreboard
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/apps/scoreboard/charts/scoreboard/README.md
+++ b/apps/scoreboard/charts/scoreboard/README.md
@@ -1,0 +1,50 @@
+# scoreboard
+
+Helm chart for the ScreamingFace benchmark scoreboard.
+
+Install the demo database chart first, then install this app chart:
+
+```bash
+helm upgrade --install scoreboard-db apps/scoreboard/charts/db \
+  --namespace scoreboard \
+  --create-namespace \
+  --wait \
+  --values apps/scoreboard/charts/db-scoreboard.values.yaml
+
+helm upgrade --install scoreboard apps/scoreboard/charts/scoreboard \
+  --namespace scoreboard \
+  --wait
+```
+
+The app chart is database-agnostic. It consumes `SCOREBOARD_DATABASE_URL` from `database.existingSecret`, which defaults to the `scoreboard-db` Secret created by `charts/db`.
+
+## Benchmarks
+
+The post-install/post-upgrade seed Job runs `python -m scoreboard.seed` and passes `.Values.seedBenchmarks.benchmarks` as JSON. Re-running the Job is safe because benchmark registration is idempotent.
+
+Disable seeding with:
+
+```bash
+helm upgrade --install scoreboard apps/scoreboard/charts/scoreboard \
+  --namespace scoreboard \
+  --set seedBenchmarks.enabled=false
+```
+
+## CORS
+
+Production CORS should include the portal origin:
+
+```yaml
+cors:
+  origins:
+    - https://screamingface.ai
+```
+
+## Production
+
+`values-prod.yaml` expects externally managed Postgres through a Secret with a `database-url` key, three app replicas, nginx ingress, TLS, and NetworkPolicy enabled:
+
+```bash
+helm template scoreboard apps/scoreboard/charts/scoreboard \
+  --values apps/scoreboard/charts/scoreboard/values-prod.yaml
+```

--- a/apps/scoreboard/charts/scoreboard/templates/_helpers.tpl
+++ b/apps/scoreboard/charts/scoreboard/templates/_helpers.tpl
@@ -1,0 +1,41 @@
+{{- define "scoreboard.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "scoreboard.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "scoreboard.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "scoreboard.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "scoreboard.labels" -}}
+helm.sh/chart: {{ include "scoreboard.chart" . }}
+app.kubernetes.io/name: {{ include "scoreboard.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: screamingface
+{{- end -}}
+
+{{- define "scoreboard.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "scoreboard.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "scoreboard.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "scoreboard.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "scoreboard.image" -}}
+{{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
+{{- end -}}

--- a/apps/scoreboard/charts/scoreboard/templates/configmap.yaml
+++ b/apps/scoreboard/charts/scoreboard/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "scoreboard.fullname" . }}
+  labels:
+    {{- include "scoreboard.labels" . | nindent 4 }}
+data:
+  SCOREBOARD_HOST: {{ .Values.config.host | quote }}
+  SCOREBOARD_PORT: {{ .Values.config.port | quote }}
+  SCOREBOARD_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  SCOREBOARD_CORS_ORIGINS: {{ .Values.cors.origins | toJson | quote }}

--- a/apps/scoreboard/charts/scoreboard/templates/deployment.yaml
+++ b/apps/scoreboard/charts/scoreboard/templates/deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "scoreboard.fullname" . }}
+  labels:
+    {{- include "scoreboard.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "scoreboard.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "scoreboard.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "scoreboard.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: scoreboard
+          image: {{ include "scoreboard.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.config.port }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "scoreboard.fullname" . }}
+          env:
+            - name: SCOREBOARD_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "database.existingSecret is required" .Values.database.existingSecret }}
+                  key: {{ .Values.database.existingSecretKey }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/apps/scoreboard/charts/scoreboard/templates/ingress.yaml
+++ b/apps/scoreboard/charts/scoreboard/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "scoreboard.fullname" . }}
+  labels:
+    {{- include "scoreboard.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "scoreboard.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/apps/scoreboard/charts/scoreboard/templates/job-migrate.yaml
+++ b/apps/scoreboard/charts/scoreboard/templates/job-migrate.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.migration.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "scoreboard.fullname" . }}-migrate
+  labels:
+    {{- include "scoreboard.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- with .Values.migration.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  backoffLimit: {{ .Values.migration.backoffLimit }}
+  ttlSecondsAfterFinished: {{ .Values.migration.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        {{- include "scoreboard.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: migrate
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ .Values.migration.serviceAccountName | quote }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: tortoise-migrate
+          image: {{ include "scoreboard.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - python
+            - -m
+            - tortoise
+            - -c
+            - scoreboard.db.TORTOISE_CONFIG
+            - migrate
+          env:
+            - name: SCOREBOARD_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "database.existingSecret is required" .Values.database.existingSecret }}
+                  key: {{ .Values.database.existingSecretKey }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+{{- end }}

--- a/apps/scoreboard/charts/scoreboard/templates/job-seed-benchmarks.yaml
+++ b/apps/scoreboard/charts/scoreboard/templates/job-seed-benchmarks.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.seedBenchmarks.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "scoreboard.fullname" . }}-seed-benchmarks
+  labels:
+    {{- include "scoreboard.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- with .Values.seedBenchmarks.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  backoffLimit: {{ .Values.seedBenchmarks.backoffLimit }}
+  ttlSecondsAfterFinished: {{ .Values.seedBenchmarks.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        {{- include "scoreboard.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: seed-benchmarks
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ .Values.seedBenchmarks.serviceAccountName | quote }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: seed-benchmarks
+          image: {{ include "scoreboard.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - python
+            - -m
+            - scoreboard.seed
+          env:
+            - name: SCOREBOARD_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "database.existingSecret is required" .Values.database.existingSecret }}
+                  key: {{ .Values.database.existingSecretKey }}
+            - name: SCOREBOARD_SEED_BENCHMARKS_JSON
+              value: {{ .Values.seedBenchmarks.benchmarks | toJson | quote }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+{{- end }}

--- a/apps/scoreboard/charts/scoreboard/templates/networkpolicy.yaml
+++ b/apps/scoreboard/charts/scoreboard/templates/networkpolicy.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "scoreboard.fullname" . }}
+  labels:
+    {{- include "scoreboard.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "scoreboard.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: {{ .Values.config.port }}
+      {{- if .Values.networkPolicy.ingressCIDRs }}
+      from:
+        {{- range .Values.networkPolicy.ingressCIDRs }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
+      {{- end }}
+  egress:
+    - {}
+{{- end }}

--- a/apps/scoreboard/charts/scoreboard/templates/service.yaml
+++ b/apps/scoreboard/charts/scoreboard/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "scoreboard.fullname" . }}
+  labels:
+    {{- include "scoreboard.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+  selector:
+    {{- include "scoreboard.selectorLabels" . | nindent 4 }}

--- a/apps/scoreboard/charts/scoreboard/templates/serviceaccount.yaml
+++ b/apps/scoreboard/charts/scoreboard/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "scoreboard.serviceAccountName" . }}
+  labels:
+    {{- include "scoreboard.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/apps/scoreboard/charts/scoreboard/templates/tests/test-connection.yaml
+++ b/apps/scoreboard/charts/scoreboard/templates/tests/test-connection.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "scoreboard.fullname" . }}-test-connection
+  labels:
+    {{- include "scoreboard.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  restartPolicy: Never
+  containers:
+    - name: curl
+      image: curlimages/curl:8.11.1
+      command:
+        - sh
+        - -c
+        - |
+          curl -fsS "http://{{ include "scoreboard.fullname" . }}:{{ .Values.service.port }}/healthz"
+          curl -fsS "http://{{ include "scoreboard.fullname" . }}:{{ .Values.service.port }}/v1/benchmarks"

--- a/apps/scoreboard/charts/scoreboard/values-prod.yaml
+++ b/apps/scoreboard/charts/scoreboard/values-prod.yaml
@@ -1,0 +1,35 @@
+replicaCount: 3
+
+cors:
+  origins:
+    - https://screamingface.ai
+
+database:
+  existingSecret: scoreboard-db
+  existingSecretKey: database-url
+
+ingress:
+  enabled: true
+  className: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: scoreboard.screamingface.ai
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: scoreboard-tls
+      hosts:
+        - scoreboard.screamingface.ai
+
+networkPolicy:
+  enabled: true
+
+resources:
+  requests:
+    cpu: 200m
+    memory: 128Mi
+  limits:
+    cpu: 1000m
+    memory: 512Mi

--- a/apps/scoreboard/charts/scoreboard/values.yaml
+++ b/apps/scoreboard/charts/scoreboard/values.yaml
@@ -1,0 +1,107 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/openmined/screamingface-scoreboard
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  runAsNonRoot: true
+  runAsUser: 10001
+
+config:
+  host: 0.0.0.0
+  port: 9106
+  logLevel: info
+
+cors:
+  origins:
+    - "*"
+
+database:
+  existingSecret: scoreboard-db
+  existingSecretKey: database-url
+
+service:
+  type: ClusterIP
+  port: 9106
+
+ingress:
+  enabled: true
+  className: traefik
+  annotations: {}
+  hosts:
+    - host: scoreboard.screamingface.ai
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 20
+  timeoutSeconds: 5
+
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+
+migration:
+  enabled: true
+  serviceAccountName: default
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 600
+  annotations: {}
+
+seedBenchmarks:
+  enabled: true
+  serviceAccountName: default
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 600
+  annotations: {}
+  benchmarks:
+    - id: hle
+      display_name: News Hallucinations
+      description: OpenMined HLE benchmark
+      dataset_url: https://github.com/openmined/HLE.jsonl
+
+networkPolicy:
+  enabled: false
+  ingressCIDRs: []
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -120,11 +120,13 @@ class ScoreStore:
         description: str | None = None,
         dataset_url: str | None = None,
     ) -> BenchmarkSchema:
-        benchmark = await Benchmark.create(
+        benchmark, _ = await Benchmark.update_or_create(
+            defaults={
+                "display_name": display_name,
+                "description": description,
+                "dataset_url": dataset_url,
+            },
             id=benchmark_id,
-            display_name=display_name,
-            description=description,
-            dataset_url=dataset_url,
         )
         return _benchmark_to_schema(benchmark)
 

--- a/apps/scoreboard/src/scoreboard/seed.py
+++ b/apps/scoreboard/src/scoreboard/seed.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from collections.abc import Sequence
+
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError
+
+from .config import Settings
+from .db import close_db, init_db
+from .scores.schemas import BenchmarkSchema
+from .scores.store import ScoreStore
+
+SEED_BENCHMARKS_ENV = "SCOREBOARD_SEED_BENCHMARKS_JSON"
+
+
+class SeedBenchmark(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(min_length=1, max_length=64)
+    display_name: str = Field(min_length=1, max_length=255)
+    description: str | None = None
+    dataset_url: str | None = None
+
+
+_BENCHMARKS_ADAPTER = TypeAdapter(list[SeedBenchmark])
+
+
+def load_benchmarks_json(raw_json: str) -> list[SeedBenchmark]:
+    try:
+        payload = json.loads(raw_json)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid benchmark seed JSON: {exc.msg}") from exc
+
+    try:
+        return _BENCHMARKS_ADAPTER.validate_python(payload)
+    except ValidationError as exc:
+        raise ValueError(f"invalid benchmark seed payload: {exc}") from exc
+
+
+async def seed_benchmarks(benchmarks: Sequence[SeedBenchmark]) -> list[BenchmarkSchema]:
+    store = ScoreStore()
+    seeded: list[BenchmarkSchema] = []
+    for benchmark in benchmarks:
+        seeded.append(
+            await store.register_benchmark(
+                benchmark_id=benchmark.id,
+                display_name=benchmark.display_name,
+                description=benchmark.description,
+                dataset_url=benchmark.dataset_url,
+            )
+        )
+    return seeded
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Seed scoreboard benchmark definitions.")
+    parser.add_argument(
+        "--benchmarks-json",
+        default=None,
+        help=f"JSON benchmark list. Defaults to ${SEED_BENCHMARKS_ENV}; empty list if unset.",
+    )
+    return parser
+
+
+async def _run(raw_json: str) -> None:
+    benchmarks = load_benchmarks_json(raw_json)
+    if not benchmarks:
+        print("no benchmarks configured")
+        return
+
+    settings = Settings()
+    await init_db(settings.database_url)
+    try:
+        seeded = await seed_benchmarks(benchmarks)
+        for benchmark in seeded:
+            print(f"seeded benchmark {benchmark.id}")
+    finally:
+        await close_db()
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    raw_json = args.benchmarks_json or os.getenv(SEED_BENCHMARKS_ENV, "[]")
+    try:
+        asyncio.run(_run(raw_json))
+    except ValueError as exc:
+        parser.error(str(exc))
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/scoreboard/tests/unit/scores/test_store.py
+++ b/apps/scoreboard/tests/unit/scores/test_store.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 from tortoise import Tortoise
 
-from scoreboard.scores.models import IdempotencyKey, Score
+from scoreboard.scores.models import Benchmark, IdempotencyKey, Score
 from scoreboard.scores.schemas import ScoreSubmission
 from scoreboard.scores.store import ScoreStore
 
@@ -61,6 +61,31 @@ async def test_register_benchmark_and_list_benchmarks(tortoise_db: None) -> None
 
     assert registered.id == "hle"
     assert benchmarks == [registered]
+
+
+async def test_register_benchmark_updates_existing_row(tortoise_db: None) -> None:
+    store = ScoreStore()
+
+    await store.register_benchmark(
+        benchmark_id="hle",
+        display_name="Humanity's Last Exam",
+        description="Fixture benchmark",
+        dataset_url="https://example.test/hle.jsonl",
+    )
+    updated = await store.register_benchmark(
+        benchmark_id="hle",
+        display_name="News Hallucinations",
+        description="OpenMined HLE benchmark",
+        dataset_url="https://github.com/openmined/HLE.jsonl",
+    )
+    benchmarks = await store.list_benchmarks()
+
+    assert await Benchmark.all().count() == 1
+    assert updated.id == "hle"
+    assert updated.display_name == "News Hallucinations"
+    assert updated.description == "OpenMined HLE benchmark"
+    assert updated.dataset_url == "https://github.com/openmined/HLE.jsonl"
+    assert benchmarks == [updated]
 
 
 async def test_submit_inserts_and_returns_score(tortoise_db: None) -> None:

--- a/apps/scoreboard/tests/unit/test_seed.py
+++ b/apps/scoreboard/tests/unit/test_seed.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+from scoreboard.scores.models import Benchmark
+from scoreboard.scores.store import ScoreStore
+from scoreboard.seed import load_benchmarks_json, seed_benchmarks
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_seed_benchmarks_inserts_and_updates(tortoise_db: None) -> None:
+    first = load_benchmarks_json(
+        '[{"id":"hle","display_name":"Humanity\'s Last Exam","description":"Fixture benchmark"}]'
+    )
+    second = load_benchmarks_json(
+        '[{"id":"hle","display_name":"News Hallucinations","dataset_url":"https://github.com/openmined/HLE.jsonl"}]'
+    )
+
+    seeded = await seed_benchmarks(first)
+    reseeded = await seed_benchmarks(second)
+    benchmarks = await ScoreStore().list_benchmarks()
+
+    assert await Benchmark.all().count() == 1
+    assert seeded[0].id == "hle"
+    assert reseeded[0].display_name == "News Hallucinations"
+    assert benchmarks == reseeded
+
+
+async def test_load_benchmarks_json_rejects_invalid_payload() -> None:
+    with pytest.raises(ValueError, match="invalid benchmark seed payload"):
+        load_benchmarks_json('{"id":"hle"}')


### PR DESCRIPTION
## Summary
- Adds the scoreboard Dockerfile, release workflow, deployment runbook, demo Postgres chart, and app Helm chart.
- Adds Tortoise migration and benchmark seed Helm hooks, plus idempotent benchmark registration for safe reseeding.
- Updates the Pages deploy workflow to publish `web/portal` and inject `window.SCOREBOARD_API_BASE`.

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest -q`
- `helm lint charts/db`
- `helm lint charts/scoreboard`
- `helm template scoreboard charts/scoreboard --namespace scoreboard --values charts/scoreboard/values-prod.yaml`
- Live k3s deploy verified: Helm revision 5, three ready pods, `helm test scoreboard -n scoreboard`, HTTPS `/healthz`, `/v1/benchmarks`, and `/v1/leaderboard/hle`

## Asana
https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1214568119698113