### PR TITLE
SF-229: harden direct AIGateway token path

### DIFF
--- a/apps/aigateway/src/aigateway/core/oauth/token_service.py
+++ b/apps/aigateway/src/aigateway/core/oauth/token_service.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Protocol, cast
+from uuid import UUID
+
+from aigateway.core.errors import AuthError, CredentialNotFoundError, ReauthRequiredError
+from aigateway.core.oauth.models import OAuthConnection
+from aigateway.core.oauth.store import credential_key_for
+
+
+class OAuthConnectionStoreLike(Protocol):
+    async def get(self, account_id: str | UUID, connection_id: UUID) -> Any | None: ...
+
+    async def mark_error(self, connection: Any, message: str) -> Any: ...
+
+    async def touch_last_refreshed(self, connection: Any) -> Any: ...
+
+    async def touch_last_used(self, connection: Any) -> Any: ...
+
+
+class ProviderRegistryLike(Protocol):
+    def get(self, provider: str) -> Any | None: ...
+
+
+class TokenWithExpiryStrategy(Protocol):
+    async def get_token_with_expiry(self) -> tuple[str, int, bool]: ...
+
+
+@dataclass(frozen=True)
+class OAuthConnectionToken:
+    connection: OAuthConnection
+    access_token: str
+    expires_at_ms: int
+    refreshed: bool
+
+
+class OAuthConnectionTokenError(Exception):
+    def __init__(self, status_code: int, detail: dict[str, Any]) -> None:
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(str(detail))
+
+
+class OAuthConnectionTokenService:
+    def __init__(self) -> None:
+        self._locks: dict[str, asyncio.Lock] = {}
+        self._locks_guard = asyncio.Lock()
+
+    async def get_token(
+        self,
+        *,
+        account_id: str | UUID,
+        connection_id: UUID,
+        store: OAuthConnectionStoreLike,
+        providers: ProviderRegistryLike,
+        credential_store: Any,
+        http_client_factory_for,
+    ) -> OAuthConnectionToken:
+        lock = await self._lock_for(account_id, connection_id)
+        async with lock:
+            return await self._get_token_locked(
+                account_id=account_id,
+                connection_id=connection_id,
+                store=store,
+                providers=providers,
+                credential_store=credential_store,
+                http_client_factory_for=http_client_factory_for,
+            )
+
+    async def _get_token_locked(
+        self,
+        *,
+        account_id: str | UUID,
+        connection_id: UUID,
+        store: OAuthConnectionStoreLike,
+        providers: ProviderRegistryLike,
+        credential_store: Any,
+        http_client_factory_for,
+    ) -> OAuthConnectionToken:
+        connection = await store.get(account_id, connection_id)
+        if connection is None:
+            raise OAuthConnectionTokenError(404, {"code": "connection_not_found"})
+        if connection.status != "active":
+            raise OAuthConnectionTokenError(409, {"code": "connection_not_active"})
+
+        plugin = providers.get(connection.provider)
+        if plugin is None:
+            raise OAuthConnectionTokenError(404, {"code": "unknown_provider"})
+        strategy = plugin.oauth_strategy_for(
+            credential_key_for(account_id, connection.id),
+            credential_store=credential_store,
+            http_client_factory=http_client_factory_for(connection.provider),
+        )
+        if strategy is None:
+            raise OAuthConnectionTokenError(400, {"code": "provider_does_not_use_oauth"})
+        token_strategy = cast(TokenWithExpiryStrategy, strategy)
+
+        try:
+            access_token, expires_at_ms, refreshed = await token_strategy.get_token_with_expiry()
+        except (CredentialNotFoundError, ReauthRequiredError) as exc:
+            # Credential missing, or the refresh token was rejected by the provider
+            # (revoked / invalid_grant). The connection cannot recover without a new
+            # browser auth, so mark it errored and tell the caller to re-auth.
+            await store.mark_error(connection, str(exc))
+            raise OAuthConnectionTokenError(
+                401, {"code": "auth_required", "message": str(exc)}
+            ) from exc
+        except AuthError as exc:
+            # Transient upstream refresh failure (network error, provider 5xx). Leave
+            # the connection active and surface 503 so callers back off and retry.
+            raise OAuthConnectionTokenError(
+                503, {"code": "upstream_refresh_failed", "message": str(exc)}
+            ) from exc
+
+        if refreshed:
+            await store.touch_last_refreshed(connection)
+        await store.touch_last_used(connection)
+        return OAuthConnectionToken(
+            connection=connection,
+            access_token=access_token,
+            expires_at_ms=expires_at_ms,
+            refreshed=refreshed,
+        )
+
+    async def _lock_for(self, account_id: str | UUID, connection_id: UUID) -> asyncio.Lock:
+        key = f"{account_id}:{connection_id}"
+        async with self._locks_guard:
+            lock = self._locks.get(key)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._locks[key] = lock
+            return lock
+
+
+def oauth_connection_token_service(app: Any) -> OAuthConnectionTokenService:
+    state = getattr(app, "state", None)
+    if state is None:
+        raise RuntimeError("AIGateway app state is unavailable")
+    service = getattr(state, "oauth_connection_token_service", None)
+    if not isinstance(service, OAuthConnectionTokenService):
+        service = OAuthConnectionTokenService()
+        state.oauth_connection_token_service = service
+    return service

--- a/apps/aigateway/src/aigateway/routes/oauth_connections.py
+++ b/apps/aigateway/src/aigateway/routes/oauth_connections.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, HTTPException, Request
 from tortoise.exceptions import IntegrityError
 
 from aigateway.core.auth.middleware import CurrentAccount
-from aigateway.core.errors import AuthError, CredentialNotFoundError, ReauthRequiredError
+from aigateway.core.errors import AuthError, CredentialNotFoundError
 from aigateway.core.oauth.schemas import (
     CreateOAuthConnectionRequest,
     OAuthConnectionListResponse,
@@ -20,6 +20,10 @@ from aigateway.core.oauth.store import (
     OAuthConnectionStore,
     credential_key_for,
     response_from_connection,
+)
+from aigateway.core.oauth.token_service import (
+    OAuthConnectionTokenError,
+    oauth_connection_token_service,
 )
 from aigateway.core.oauth_pkce import generate_pkce, generate_state
 from aigateway.core.pending_auth import PendingAuthEntry
@@ -189,44 +193,22 @@ async def get_connection_token(
     """
     from datetime import UTC, datetime
 
-    store = _store(request)
-    connection = await store.get(str(current.id), connection_id)
-    if connection is None:
-        raise HTTPException(status_code=404, detail={"code": "connection_not_found"})
-    if connection.status != "active":
-        raise HTTPException(status_code=409, detail={"code": "connection_not_active"})
-    plugin = request.app.state.providers.get(connection.provider)
-    if plugin is None:
-        raise HTTPException(status_code=404, detail={"code": "unknown_provider"})
-    strategy = plugin.oauth_strategy_for(
-        credential_key_for(current.id, connection.id),
-        credential_store=request.app.state.credential_store,
-        http_client_factory=getattr(request.app.state, f"{connection.provider}_http_factory", None),
-    )
-    if strategy is None:
-        raise HTTPException(status_code=400, detail={"code": "provider_does_not_use_oauth"})
     try:
-        access_token, expires_at_ms, refreshed = await strategy.get_token_with_expiry()
-    except (CredentialNotFoundError, ReauthRequiredError) as exc:
-        # Credential missing, or the refresh token was rejected by the provider
-        # (revoked / invalid_grant). The connection cannot recover without a new
-        # browser auth, so mark it errored and tell the caller to re-auth.
-        await store.mark_error(connection, str(exc))
-        raise HTTPException(
-            status_code=401, detail={"code": "auth_required", "message": str(exc)}
-        ) from exc
-    except AuthError as exc:
-        # Transient upstream refresh failure (network error, provider 5xx). Leave
-        # the connection active and surface 503 so callers back off and retry.
-        raise HTTPException(
-            status_code=503, detail={"code": "upstream_refresh_failed", "message": str(exc)}
-        ) from exc
-    if refreshed:
-        await store.touch_last_refreshed(connection)
-    await store.touch_last_used(connection)
+        token = await oauth_connection_token_service(request.app).get_token(
+            account_id=current.id,
+            connection_id=connection_id,
+            store=_store(request),
+            providers=request.app.state.providers,
+            credential_store=request.app.state.credential_store,
+            http_client_factory_for=lambda provider: getattr(
+                request.app.state, f"{provider}_http_factory", None
+            ),
+        )
+    except OAuthConnectionTokenError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
     return OAuthConnectionTokenResponse(
-        access_token=access_token,
-        expires_at=datetime.fromtimestamp(expires_at_ms / 1000, tz=UTC),
+        access_token=token.access_token,
+        expires_at=datetime.fromtimestamp(token.expires_at_ms / 1000, tz=UTC),
     )
 
 

--- a/apps/aigateway/tests/unit/test_oauth_connection_token_service.py
+++ b/apps/aigateway/tests/unit/test_oauth_connection_token_service.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from aigateway.core.oauth.token_service import OAuthConnectionTokenService
+
+
+class _FakeStore:
+    def __init__(self, connection) -> None:  # noqa: ANN001
+        self.connection = connection
+        self.last_refreshed_touches = 0
+        self.last_used_touches = 0
+
+    async def get(self, account_id, connection_id):  # noqa: ANN001
+        assert account_id == "acct-1"
+        assert connection_id == self.connection.id
+        return self.connection
+
+    async def mark_error(self, connection, message: str):  # noqa: ANN001
+        connection.status = "error"
+        connection.error_message = message
+        return connection
+
+    async def touch_last_refreshed(self, connection):  # noqa: ANN001
+        self.last_refreshed_touches += 1
+        return connection
+
+    async def touch_last_used(self, connection):  # noqa: ANN001
+        self.last_used_touches += 1
+        return connection
+
+
+class _FakeStrategy:
+    active_calls = 0
+    max_active_calls = 0
+    total_calls = 0
+
+    async def get_token_with_expiry(self) -> tuple[str, int, bool]:
+        type(self).active_calls += 1
+        type(self).total_calls += 1
+        type(self).max_active_calls = max(type(self).max_active_calls, type(self).active_calls)
+        try:
+            await asyncio.sleep(0.02)
+            return (
+                f"token-{type(self).total_calls}",
+                int((time.time() + 3600) * 1000),
+                True,
+            )
+        finally:
+            type(self).active_calls -= 1
+
+
+class _FakePlugin:
+    def oauth_strategy_for(self, profile_name: str, **kwargs):  # noqa: ANN003
+        assert profile_name.endswith(str(_CONNECTION_ID))
+        assert kwargs["credential_store"] is _CREDENTIAL_STORE
+        return _FakeStrategy()
+
+
+class _FakeProviders:
+    def get(self, provider: str):
+        assert provider == "anthropic"
+        return _FakePlugin()
+
+
+_CONNECTION_ID = uuid4()
+_CREDENTIAL_STORE = object()
+
+
+@pytest.mark.asyncio
+async def test_token_service_serializes_refresh_for_same_connection() -> None:
+    _FakeStrategy.active_calls = 0
+    _FakeStrategy.max_active_calls = 0
+    _FakeStrategy.total_calls = 0
+    connection = SimpleNamespace(id=_CONNECTION_ID, provider="anthropic", status="active")
+    store = _FakeStore(connection)
+    service = OAuthConnectionTokenService()
+
+    first, second = await asyncio.gather(
+        service.get_token(
+            account_id="acct-1",
+            connection_id=_CONNECTION_ID,
+            store=store,
+            providers=_FakeProviders(),
+            credential_store=_CREDENTIAL_STORE,
+            http_client_factory_for=lambda _provider: None,
+        ),
+        service.get_token(
+            account_id="acct-1",
+            connection_id=_CONNECTION_ID,
+            store=store,
+            providers=_FakeProviders(),
+            credential_store=_CREDENTIAL_STORE,
+            http_client_factory_for=lambda _provider: None,
+        ),
+    )
+
+    assert {first.access_token, second.access_token} == {"token-1", "token-2"}
+    assert _FakeStrategy.total_calls == 2
+    assert _FakeStrategy.max_active_calls == 1
+    assert store.last_refreshed_touches == 2
+    assert store.last_used_touches == 2

--- a/apps/server/src/screamingface/plugins/claude_backend_api/auth.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/auth.py
@@ -157,9 +157,8 @@ class ClaudeCodeOAuth(OAuthStrategy):
         for _build_headers (which only reads accessToken). We stamp sensible
         defaults so the rest of the strategy machinery has a complete dict.
 
-        expiresAt is set far in the future so _is_expired never triggers a
-        second fetch — AigwTokenSource handles its own cache + refresh
-        internally. The OAuthStrategy cache just needs to stay "fresh".
+        OAuthStrategy does not cache aigw-shaped creds; AigwTokenSource owns
+        cache + refresh and this shape only feeds _build_headers.
         """
         import time
 

--- a/apps/server/src/screamingface/plugins/claude_backend_api/routes.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/routes.py
@@ -33,7 +33,9 @@ _DEFAULT_MODEL = "claude-sonnet-4-6"
 
 
 def create_router(settings: ClaudeBackendApiSettings, app: Any = None) -> APIRouter:
-    backend = AnthropicBackend()
+    from screamingface.plugins.claude_backend_api.plugin import _maybe_aigw_source
+
+    backend = AnthropicBackend(aigw_source=_maybe_aigw_source(settings, app))
 
     def build_interpreter() -> Any:
         # Lazy import — interpreter imports from this module.

--- a/apps/server/src/screamingface/plugins/codex_backend_api/auth.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/auth.py
@@ -58,20 +58,36 @@ TOKEN_EXCHANGE_SUBJECT_TYPE = "urn:ietf:params:oauth:token-type:id_token"
 REFRESH_WINDOW_SECONDS = 60
 
 
-def _decode_jwt_exp(token: str) -> float | None:
-    """Return the unsigned JWT ``exp`` claim (seconds since epoch), or None."""
+def _decode_jwt_payload(token: str) -> dict:
+    """Return unsigned JWT claims, or an empty dict for opaque/malformed tokens."""
     parts = token.split(".")
     if len(parts) < 2:
-        return None
+        return {}
     payload_b64 = parts[1]
     padding = 4 - len(payload_b64) % 4
     if padding != 4:
         payload_b64 += "=" * padding
     try:
         payload = json.loads(base64.urlsafe_b64decode(payload_b64))
-        return float(payload["exp"])
     except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _decode_jwt_exp(token: str) -> float | None:
+    """Return the unsigned JWT ``exp`` claim (seconds since epoch), or None."""
+    exp = _decode_jwt_payload(token).get("exp")
+    if isinstance(exp, int | float):
+        return float(exp)
+    return None
+
+
+def _decode_chatgpt_account_id(token: str) -> str | None:
+    auth_claims = _decode_jwt_payload(token).get("https://api.openai.com/auth")
+    if not isinstance(auth_claims, dict):
         return None
+    account_id = auth_claims.get("chatgpt_account_id")
+    return account_id if isinstance(account_id, str) and account_id else None
 
 
 class CodexOAuth(OAuthStrategy):
@@ -161,11 +177,15 @@ class CodexOAuth(OAuthStrategy):
         Codex's _build_headers only reads access_token. The refresh_token /
         id_token fields aren't used on the aigw path because aigw owns refresh.
         """
-        return {
+        creds = {
             "access_token": access_token,
             "refresh_token": "",
             "id_token": "",
         }
+        account_id = _decode_chatgpt_account_id(access_token)
+        if account_id:
+            creds["account_id"] = account_id
+        return creds
 
     async def _refresh_credential(self, creds: dict) -> dict:
         body = {
@@ -229,9 +249,14 @@ class CodexOAuth(OAuthStrategy):
 
     def get_account_id(self) -> str:
         """Return the ``chatgpt_account_id`` from the cached tokens."""
-        if self._cached is None:
-            self._cached = self._read_credential()
-        return self._cached.get("account_id", "")
+        cached = getattr(self, "_cached", None)
+        if cached is None:
+            if self._aigw_source is not None:
+                return ""
+            cached = self._read_credential()
+            self._cached = cached
+        account_id = cached.get("account_id", "")
+        return account_id if isinstance(account_id, str) else ""
 
     # Backward-compat alias — legacy tests still call ``_read_from_file``.
     _read_from_file = _read_credential

--- a/apps/server/src/screamingface/plugins/codex_backend_api/routes.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/routes.py
@@ -20,7 +20,9 @@ _DEFAULT_MODEL = "o4-mini"
 
 
 def create_router(settings: CodexBackendApiSettings, app: Any = None) -> APIRouter:
-    backend = OpenAIBackend()
+    from screamingface.plugins.codex_backend_api.plugin import _maybe_aigw_source
+
+    backend = OpenAIBackend(aigw_source=_maybe_aigw_source(settings, app))
 
     def build_interpreter() -> Any:
         from screamingface.plugins.codex_backend_api.interpreter import (

--- a/apps/server/src/screamingface/plugins/codex_backend_api/tests/test_auth.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/tests/test_auth.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import base64
 import json
 import time
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -31,8 +32,13 @@ from screamingface.plugins.llm_base.errors import AuthError, CredentialNotFoundE
 
 def _make_jwt(exp: float) -> str:
     """Build a minimal JWT with the given exp claim (no real signature)."""
+    return _make_jwt_from_payload({"exp": exp})
+
+
+def _make_jwt_from_payload(payload_dict: dict) -> str:
+    """Build a minimal JWT with the given claims (no real signature)."""
     header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256"}).encode()).rstrip(b"=")
-    payload = base64.urlsafe_b64encode(json.dumps({"exp": exp}).encode()).rstrip(b"=")
+    payload = base64.urlsafe_b64encode(json.dumps(payload_dict).encode()).rstrip(b"=")
     sig = base64.urlsafe_b64encode(b"fake-signature").rstrip(b"=")
     return f"{header.decode()}.{payload.decode()}.{sig.decode()}"
 
@@ -355,3 +361,17 @@ async def test_codex_oauth_uses_aigw_source_when_set():
 
     assert headers == {"Authorization": "Bearer aigw-codex-token"}
     fake.fetch_token.assert_awaited_once()
+
+
+def test_codex_oauth_aigw_shape_extracts_chatgpt_account_id():
+    token = _make_jwt_from_payload(
+        {
+            "exp": time.time() + 3600,
+            "https://api.openai.com/auth": {"chatgpt_account_id": "acct-aigw"},
+        }
+    )
+    auth = CodexOAuth(aigw_source=object())  # type: ignore[arg-type]
+
+    creds = auth._aigw_creds_shape(token, datetime.now())
+
+    assert creds["account_id"] == "acct-aigw"

--- a/apps/server/src/screamingface/plugins/gemini_backend_api/auth.py
+++ b/apps/server/src/screamingface/plugins/gemini_backend_api/auth.py
@@ -121,8 +121,8 @@ class GeminiAuth(OAuthStrategy):
     def _is_expired(self, creds: dict) -> bool:
         """``expiry_date`` is unix epoch in **milliseconds**."""
         if self._aigw_source is not None:
-            # On the aigw path the helper owns expiry; OAuthStrategy's cache
-            # only needs to stay notionally "fresh".
+            # OAuthStrategy bypasses its outer cache on the aigw path; this is
+            # retained as a guard for tests and direct private-hook callers.
             return False
         # existing logic
         expiry_ms = creds.get("expiry_date", 0)

--- a/apps/server/src/screamingface/plugins/gemini_backend_api/routes.py
+++ b/apps/server/src/screamingface/plugins/gemini_backend_api/routes.py
@@ -20,9 +20,12 @@ _DEFAULT_MODEL = "gemini-2.5-flash"
 
 
 def create_router(settings: GeminiBackendApiSettings, app: Any = None) -> APIRouter:
+    from screamingface.plugins.gemini_backend_api.plugin import _maybe_aigw_source
+
     backend = GeminiBackend(
         fallback_models=list(settings.fallback_models),
         max_total_wait_seconds=settings.max_total_429_wait_seconds,
+        aigw_source=_maybe_aigw_source(settings, app),
     )
 
     def build_interpreter() -> Any:

--- a/apps/server/src/screamingface/plugins/llm_base/aigw_token_source.py
+++ b/apps/server/src/screamingface/plugins/llm_base/aigw_token_source.py
@@ -80,6 +80,9 @@ class AigwTokenSource:
             self._cache = entry
             return entry.access_token
 
+    def invalidate_cache(self) -> None:
+        self._cache = None
+
     @property
     def connection_id(self) -> str:
         return self._connection_id
@@ -90,9 +93,10 @@ class AigwTokenSource:
         client_kwargs: dict = {"timeout": self._timeout}
         if self._transport is not None:
             client_kwargs["transport"] = self._transport
+        headers = {"Authorization": f"Bearer {jwt}"} if jwt else {}
         try:
             async with httpx.AsyncClient(**client_kwargs) as client:
-                resp = await client.get(url, headers={"Authorization": f"Bearer {jwt}"})
+                resp = await client.get(url, headers=headers)
         except httpx.RequestError as exc:
             raise AigwTokenError(f"aigw unreachable at {url}: {exc}") from exc
 
@@ -133,6 +137,11 @@ async def aigw_jwt_from_env() -> str:
 
 async def aigw_jwt_from_gateway_session(app: Any) -> str:
     """JWT provider for SF's in-memory Desktop -> AIGateway session."""
+
+    from screamingface.plugins.aigw_base.config import resolve_aigw_runtime_config
+
+    if resolve_aigw_runtime_config(app).mode == "local_managed":
+        return ""
 
     app_state = getattr(app, "state", None)
     if app_state is not None:

--- a/apps/server/src/screamingface/plugins/llm_base/oauth_base.py
+++ b/apps/server/src/screamingface/plugins/llm_base/oauth_base.py
@@ -62,6 +62,10 @@ class OAuthStrategy(AuthStrategy):
         if override is not None:
             return override
 
+        if self._aigw_source is not None:
+            self._cached = await self._fetch_via_aigw()
+            return self._build_headers(self._cached)
+
         # Fast path: cache hit, still fresh.
         if self._cached is not None and not self._is_expired(self._cached):
             return self._build_headers(self._cached)
@@ -79,6 +83,13 @@ class OAuthStrategy(AuthStrategy):
 
     async def refresh(self) -> None:
         """Force a refresh regardless of cached expiry."""
+        if self._aigw_source is not None:
+            self._cached = None
+            if hasattr(self._aigw_source, "invalidate_cache"):
+                self._aigw_source.invalidate_cache()
+            self._cached = await self._fetch_via_aigw()
+            return
+
         async with self._lock:
             if self._cached is None:
                 self._cached = await self._load_credential()
@@ -87,6 +98,8 @@ class OAuthStrategy(AuthStrategy):
     def invalidate_cache(self) -> None:
         """Drop in-memory state. The next header build re-reads the store."""
         self._cached = None
+        if self._aigw_source is not None and hasattr(self._aigw_source, "invalidate_cache"):
+            self._aigw_source.invalidate_cache()
 
     # ------------------------------------------------------------------
     # Subclass hooks

--- a/apps/server/src/screamingface/plugins/llm_base/tests/test_aigw_direct_route_wiring.py
+++ b/apps/server/src/screamingface/plugins/llm_base/tests/test_aigw_direct_route_wiring.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from screamingface.plugins.claude_backend_api.auth import ClaudeCodeOAuth
+from screamingface.plugins.claude_backend_api.plugin import ClaudeBackendApiSettings
+from screamingface.plugins.claude_backend_api.routes import create_router as create_claude_router
+from screamingface.plugins.codex_backend_api.auth import CodexOAuth
+from screamingface.plugins.codex_backend_api.plugin import CodexBackendApiSettings
+from screamingface.plugins.codex_backend_api.routes import create_router as create_codex_router
+from screamingface.plugins.gemini_backend_api.auth import GeminiAuth
+from screamingface.plugins.gemini_backend_api.plugin import GeminiBackendApiSettings
+from screamingface.plugins.gemini_backend_api.routes import create_router as create_gemini_router
+from screamingface.plugins.llm_base.aigw_token_source import AigwTokenSource
+
+
+def _external_app() -> SimpleNamespace:
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            config=SimpleNamespace(
+                plugin_config={
+                    "aigw-base": {
+                        "mode": "external",
+                        "gateway_url": "http://aigw.test",
+                    }
+                }
+            ),
+            plugins=SimpleNamespace(active_plugins={}),
+        )
+    )
+    from screamingface.plugins.aigw_base.client import gateway_session_state
+
+    gateway_session_state(app).set_token("gateway-jwt", datetime.now(UTC) + timedelta(minutes=5))
+    return app
+
+
+def _find_backend(value: Any, seen: set[int] | None = None) -> Any:
+    seen = seen or set()
+    if id(value) in seen:
+        return None
+    seen.add(id(value))
+    if hasattr(value, "_auth"):
+        return value
+    backend = getattr(value, "backend", None)
+    if backend is not None and hasattr(backend, "_auth"):
+        return backend
+    closure = getattr(value, "__closure__", None)
+    if closure:
+        for cell in closure:
+            try:
+                found = _find_backend(cell.cell_contents, seen)
+            except ValueError:
+                continue
+            if found is not None:
+                return found
+    return None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("name", "router_factory", "settings", "auth_cls", "expected_header"),
+    [
+        (
+            "claude",
+            create_claude_router,
+            ClaudeBackendApiSettings(connection_id="conn-1", aigw_url="http://aigw.test"),
+            ClaudeCodeOAuth,
+            "Bearer route-token",
+        ),
+        (
+            "codex",
+            create_codex_router,
+            CodexBackendApiSettings(connection_id="conn-1", aigw_url="http://aigw.test"),
+            CodexOAuth,
+            "Bearer route-token",
+        ),
+        (
+            "gemini",
+            create_gemini_router,
+            GeminiBackendApiSettings(connection_id="conn-1", aigw_url="http://aigw.test"),
+            GeminiAuth,
+            "Bearer route-token",
+        ),
+    ],
+)
+async def test_direct_route_backends_use_aigw_source_instead_of_local_credentials(
+    monkeypatch,
+    name: str,
+    router_factory,
+    settings,
+    auth_cls,
+    expected_header: str,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+    def fail_local_read(self):  # noqa: ANN001
+        raise AssertionError("local credential path must not be reached")
+
+    async def fetch_token(self: AigwTokenSource) -> str:  # noqa: ARG001
+        return "route-token"
+
+    monkeypatch.setattr(auth_cls, "_read_credential", fail_local_read)
+    monkeypatch.setattr(AigwTokenSource, "fetch_token", fetch_token)
+
+    router = router_factory(settings, app=_external_app())
+    for path in (f"/{name}/run", f"/{name}"):
+        route = next(route for route in router.routes if route.path == path)
+        backend = _find_backend(route.endpoint)
+        assert backend is not None
+        assert backend._auth._aigw_source is not None
+        assert backend._auth._aigw_source.connection_id == "conn-1"
+        headers = await backend._auth.get_authorization_header()
+        assert headers["Authorization"] == expected_header

--- a/apps/server/src/screamingface/plugins/llm_base/tests/test_aigw_token_source.py
+++ b/apps/server/src/screamingface/plugins/llm_base/tests/test_aigw_token_source.py
@@ -38,6 +38,17 @@ def _mk_source(handler, *, jwt: str = "jwt-A") -> AigwTokenSource:
     )
 
 
+def _mode_app(mode: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        state=SimpleNamespace(
+            config=SimpleNamespace(
+                plugin_config={"aigw-base": {"mode": mode, "gateway_url": "http://aigw.test"}}
+            ),
+            plugins=SimpleNamespace(active_plugins={}),
+        )
+    )
+
+
 @pytest.mark.asyncio
 async def test_fetches_and_returns_access_token():
     def handler(req: httpx.Request) -> httpx.Response:
@@ -47,6 +58,26 @@ async def test_fetches_and_returns_access_token():
 
     src = _mk_source(handler)
     assert await src.fetch_token() == "tok-A"
+
+
+@pytest.mark.asyncio
+async def test_local_managed_mode_omits_gateway_jwt(monkeypatch):
+    monkeypatch.delenv("SF_AIGW_JWT", raising=False)
+    sent_authorization: list[str | None] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        sent_authorization.append(req.headers.get("authorization"))
+        return httpx.Response(200, json=_ok_payload(access_token="tok-local"))
+
+    src = AigwTokenSource(
+        connection_id="conn-1",
+        aigw_url="http://aigw.test",
+        aigw_jwt_provider=aigw_jwt_provider_for_app(_mode_app("local_managed")),
+        http_transport=httpx.MockTransport(handler),
+    )
+
+    assert await src.fetch_token() == "tok-local"
+    assert sent_authorization == [None]
 
 
 @pytest.mark.asyncio
@@ -168,7 +199,7 @@ async def test_jwt_provider_called_each_fetch_attempt():
 @pytest.mark.asyncio
 async def test_app_jwt_provider_reads_gateway_session_state(monkeypatch):
     monkeypatch.delenv("SF_AIGW_JWT", raising=False)
-    app = SimpleNamespace(state=SimpleNamespace())
+    app = _mode_app("external")
     gateway_session_state(app).set_token("session-jwt", datetime.now(UTC) + timedelta(minutes=5))
 
     provider = aigw_jwt_provider_for_app(app)
@@ -179,7 +210,7 @@ async def test_app_jwt_provider_reads_gateway_session_state(monkeypatch):
 @pytest.mark.asyncio
 async def test_app_jwt_provider_falls_back_to_env(monkeypatch):
     monkeypatch.setenv("SF_AIGW_JWT", "env-jwt")
-    app = SimpleNamespace(state=SimpleNamespace())
+    app = _mode_app("external")
 
     provider = aigw_jwt_provider_for_app(app)
 
@@ -189,9 +220,18 @@ async def test_app_jwt_provider_falls_back_to_env(monkeypatch):
 @pytest.mark.asyncio
 async def test_app_jwt_provider_raises_relogin_error_without_session_or_env(monkeypatch):
     monkeypatch.delenv("SF_AIGW_JWT", raising=False)
-    app = SimpleNamespace(state=SimpleNamespace())
+    app = _mode_app("external")
 
     provider = aigw_jwt_provider_for_app(app)
 
     with pytest.raises(AigwAuthError, match="sign in from Desktop"):
         await provider()
+
+
+@pytest.mark.asyncio
+async def test_local_managed_app_jwt_provider_returns_empty_token(monkeypatch):
+    monkeypatch.delenv("SF_AIGW_JWT", raising=False)
+
+    provider = aigw_jwt_provider_for_app(_mode_app("local_managed"))
+
+    assert await provider() == ""

--- a/apps/server/src/screamingface/plugins/llm_base/tests/test_oauth_base_aigw.py
+++ b/apps/server/src/screamingface/plugins/llm_base/tests/test_oauth_base_aigw.py
@@ -42,6 +42,20 @@ async def test_aigw_source_replaces_keychain_read():
 
 
 @pytest.mark.asyncio
+async def test_aigw_source_remains_authoritative_for_each_header_request():
+    fake_source = AsyncMock(spec=AigwTokenSource)
+    fake_source.fetch_token.side_effect = ["aigw-token-1", "aigw-token-2"]
+    strat = _FakeStrategy(aigw_source=fake_source)
+
+    first = await strat.get_authorization_header()
+    second = await strat.get_authorization_header()
+
+    assert first == {"Authorization": "Bearer aigw-token-1"}
+    assert second == {"Authorization": "Bearer aigw-token-2"}
+    assert fake_source.fetch_token.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_aigw_source_unset_uses_existing_path():
     """Sanity: without aigw_source the existing abstract hooks are called."""
 


### PR DESCRIPTION
Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215215320128086

## Description
Fixes the direct backend AIGateway OAuth connection path for Claude, Codex, and Gemini.

This PR wires route-created direct API backends to AIGateway OAuth Connections when `connection_id` is configured, so `/claude/run`, `/codex/run`, `/gemini/run`, and direct URL4 routes use AIGateway tokens instead of falling back to local CLI/keychain credentials. It also makes `AigwTokenSource` the source of truth for AIGateway token expiry/cache behavior so stale provider access tokens are not kept alive by the outer SF OAuth cache.

On the AIGateway side, `/v1/oauth/connections/{connection_id}/token` now delegates token retrieval to a small token service that serializes concurrent refreshes per account/connection within the gateway process.

## Affected Dependencies
None.

## How has this been tested?
- `cd apps/server && uv run pytest src/screamingface/plugins/llm_base/tests src/screamingface/plugins/claude_backend_api/tests/test_auth.py src/screamingface/plugins/codex_backend_api/tests/test_auth.py src/screamingface/plugins/gemini_backend_api/tests/test_auth.py -q`
- `cd apps/aigateway && uv run pytest -m "not live" -q`
- `cd apps/server && uv run ruff check src/screamingface/plugins/claude_backend_api/routes.py src/screamingface/plugins/codex_backend_api/routes.py src/screamingface/plugins/gemini_backend_api/routes.py src/screamingface/plugins/llm_base/oauth_base.py src/screamingface/plugins/llm_base/aigw_token_source.py src/screamingface/plugins/codex_backend_api/auth.py src/screamingface/plugins/claude_backend_api/auth.py src/screamingface/plugins/gemini_backend_api/auth.py src/screamingface/plugins/llm_base/tests/test_oauth_base_aigw.py src/screamingface/plugins/llm_base/tests/test_aigw_token_source.py src/screamingface/plugins/llm_base/tests/test_aigw_direct_route_wiring.py src/screamingface/plugins/codex_backend_api/tests/test_auth.py`
- `cd apps/aigateway && uv run ruff check src/aigateway/core/oauth/token_service.py src/aigateway/routes/oauth_connections.py tests/unit/test_oauth_connection_token_service.py tests/unit/test_oauth_connections_routes.py`
- `cd apps/aigateway && uv run pyright`

Results:
- Server auth/AIGW tests: `200 passed`
- AIGateway non-live tests: `399 passed, 1 skipped, 23 deselected`
- Ruff checks: passed
- AIGateway pyright: passed

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
