### PR TITLE
fix(url4): surface on_error=collect failures via X-SF-Collected-Errors header + span attr (SF-236)

### DIFF
--- a/apps/server/src/screamingface/plugins/url4_executor/ensemble.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/ensemble.py
@@ -93,6 +93,10 @@ class EnsembleInterpreter(Url4Interpreter):
     def __init__(self, app: Any = None, *, processor: str | None = None) -> None:
         super().__init__(app)
         self._processor = processor or DEFAULT_PROCESSOR
+        # Count of per-row exceptions captured under ``;foreach.on_error=collect``
+        # across the whole request. Accumulated (not reset) because ``evaluate``
+        # recurses per row; the route reads it once after ``evaluate`` returns.
+        self._collected_errors = 0
 
     async def process(self, sources: str, intent: str | None, env: Env | None = None) -> str:
         """Fallback for non-ensemble expressions. Delegates to base class."""
@@ -234,12 +238,16 @@ class EnsembleInterpreter(Url4Interpreter):
 
             if directives.on_error == "collect":
                 raw = await asyncio.gather(*[_guarded(i) for i in items], return_exceptions=True)
+                error_count = sum(isinstance(r, BaseException) for r in raw)
                 results = [
                     r
                     if not isinstance(r, BaseException)
                     else json.dumps({"error": {"kind": type(r).__name__, "message": str(r)}})
                     for r in raw
                 ]
+                # Accumulate so nested/multiple collections in one request sum.
+                self._collected_errors += error_count
+                set_span_attrs({"url4.collection.errors_collected": error_count})
             else:
                 results = list(await asyncio.gather(*[_guarded(i) for i in items]))
             set_span_attrs({"url4.collection.result_count": len(results)})

--- a/apps/server/src/screamingface/plugins/url4_executor/routes.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/routes.py
@@ -152,15 +152,24 @@ def create_router(app=None) -> APIRouter:  # type: ignore[no-untyped-def]
             }
         )
 
+        response: JSONResponse | PlainTextResponse
         if ast:
             source_expr, intent, _broadcast = split_intent(q)
             tree = parse(source_expr) if source_expr else None
-            return JSONResponse(
+            response = JSONResponse(
                 content={
                     "ast": _ast_to_dict(tree) if tree else None,
                     "result": result,
                 }
             )
-        return PlainTextResponse(content=result)
+        else:
+            response = PlainTextResponse(content=result)
+
+        # SF-236: surface ;foreach.on_error=collect failures so they are not
+        # silently dropped downstream. HTTP stays 200 (collect mode is robust).
+        collected_errors = getattr(interpreter, "_collected_errors", 0)
+        if collected_errors:
+            response.headers["X-SF-Collected-Errors"] = str(collected_errors)
+        return response
 
     return router

--- a/apps/server/src/screamingface/plugins/url4_executor/tests/test_collected_errors_visible.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/tests/test_collected_errors_visible.py
@@ -1,0 +1,123 @@
+"""SF-236 / WI-2: collected errors must be visible to the caller.
+
+When a collection runs with ``;foreach.on_error=collect``, per-row
+exceptions are caught and turned into ``{"error": ...}`` JSON elements
+instead of aborting the run (HTTP stays 200). Before this change nothing
+signalled to the caller that errors had been collected. We now surface
+the count on:
+
+- the ``url4.collection_iterate`` span (attribute
+  ``url4.collection.errors_collected``), and
+- an HTTP response header ``X-SF-Collected-Errors`` on ``/ensemble``.
+
+These tests drive the real ``/ensemble`` route in-process via
+``httpx.ASGITransport`` (modelled on ``eval_runs`` e2e tests), injecting
+fake backend plugins into ``app.state.plugins.active_plugins`` (modelled
+on the fan-out failure tests). One fake plugin serves the collection
+JSON array; another evaluates each row and RAISES for one specific item.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from screamingface.core.app import create_app
+from screamingface.core.config import AppConfig
+from screamingface.plugins.url4_executor.ensemble import EnsembleInterpreter
+
+
+class _DataPlugin:
+    """Serves the collection source: returns its packed context verbatim.
+
+    The collection source ``/data([1, 2, 3])`` carries the JSON array as
+    its packed context, which ``handle_backend_call`` receives as
+    ``sources`` and echoes back so ``parse_collection`` can split it.
+    """
+
+    name = "data"
+    backend_call_paths = ["/data"]
+
+    async def handle_backend_call(self, intent, *, sources="", app, env=None):
+        del intent, app, env
+        return sources
+
+
+class _FailOnTwoPlugin:
+    """Per-row evaluator that raises for item ``2`` and succeeds otherwise."""
+
+    name = "x"
+    backend_call_paths = ["/x"]
+
+    async def handle_backend_call(self, intent, *, sources="", app, env=None):
+        del intent, app, env
+        if sources == "2":
+            raise RuntimeError("boom")
+        return f"ok-{sources}"
+
+
+def _inject(app, *plugins) -> None:
+    # ``active_plugins`` is a property returning a COPY; mutate the backing
+    # ``_active`` dict so the route's plugin lookup actually sees the fakes.
+    for p in plugins:
+        app.state.plugins._active[p.name] = p
+
+
+@pytest.fixture
+async def app_url4():
+    config = AppConfig(plugins=["url4-executor"], plugin_config={})
+    app = create_app(config)
+    async with app.router.lifespan_context(app):
+        yield app
+
+
+async def _get(app, q: str) -> httpx.Response:
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t", timeout=60) as c:
+        return await c.get("/ensemble", params={"q": q})
+
+
+@pytest.mark.asyncio
+async def test_collected_errors_header_set_when_one_row_errors(app_url4) -> None:
+    _inject(app_url4, _DataPlugin(), _FailOnTwoPlugin())
+    # Collection source is a backend call returning the array; row 2 raises.
+    q = "/data([1, 2, 3])*(/x($item)) ;foreach.on_error=collect"
+
+    resp = await _get(app_url4, q)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["X-SF-Collected-Errors"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_no_header_when_no_errors(app_url4) -> None:
+    class _AlwaysOkPlugin:
+        name = "x"
+        backend_call_paths = ["/x"]
+
+        async def handle_backend_call(self, intent, *, sources="", app, env=None):
+            del intent, app, env
+            return f"ok-{sources}"
+
+    _inject(app_url4, _DataPlugin(), _AlwaysOkPlugin())
+    q = "/data([1, 2, 3])*(/x($item)) ;foreach.on_error=collect"
+
+    resp = await _get(app_url4, q)
+
+    assert resp.status_code == 200, resp.text
+    assert "X-SF-Collected-Errors" not in resp.headers
+
+
+@pytest.mark.asyncio
+async def test_interpreter_accumulates_collected_errors_count() -> None:
+    """Focused unit check: the interpreter counts collected errors and the
+    count survives on the (per-request) interpreter instance.
+    """
+    from screamingface.plugins.url4_executor.tests.test_ensemble import _make_app
+
+    app = _make_app(_DataPlugin(), _FailOnTwoPlugin())  # pyright: ignore[reportArgumentType]
+    interp = EnsembleInterpreter(app=app)
+    assert interp._collected_errors == 0  # initialized in __init__
+
+    await interp.evaluate("/data([1, 2, 3])*(/x($item)) ;foreach.on_error=collect")
+    assert interp._collected_errors == 1


### PR DESCRIPTION
## SF-236 / WI-2 — surface `on_error=collect` failures (demo silent-failure #2)

Part of the **demo-path silent-failures** cluster. Plan: `docs/superpowers/plans/2026-06-04-demo-path-silent-failures.md`.

### Problem
With `;foreach.on_error=collect`, a per-row exception is turned into a JSON error element in the result array, but nothing signalled it: HTTP 200, `url4.collection_iterate` span UNSET, and `calculate_accuracy.py` silently drops error rows from the denominator. One bad row made a whole run look green with quietly-biased accuracy (observed in trace `1652633c…`).

### Fix (visibility only — HTTP stays 200)
- `EnsembleInterpreter.__init__`: `self._collected_errors = 0`; the `on_error=collect` branch accumulates `+= error_count` (fresh interpreter per request, so counts don't bleed; never reset in `evaluate()`'s recursion).
- Span attribute `url4.collection.errors_collected` on the collection span (alongside the existing `result_count`).
- `/ensemble` response header `X-SF-Collected-Errors: <N>`, set on both the PlainText and JSON paths, only when N > 0.

### Tests
- `tests/test_collected_errors_visible.py` — 3 cases (one row errors → 200 + `X-SF-Collected-Errors: 1`; no errors → header absent; interpreter-level accumulation == 1).
- Regression: `257 passed` across `url4_executor/`; server-venv pyright `0 errors`; pre-commit clean.

### Scope / follow-ups
- **Visibility only.** `calculate_accuracy.py`, the grammar, and persistence are untouched. Persisting failed rows as `eval_question` (so Eval Studio accuracy is honest under failures) is a deliberate **deferred follow-up**.
- Pre-existing, orthogonal: the `ast=true` debug response can't carry the header for collection expressions because that path's `parse(source_expr)` doesn't handle collection-iteration syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
