### PR TITLE
fix(frontend): blocking + fail-loud url4 resolve — scream on resolve failure (SF-237)

### DIFF
--- a/apps/server/src/screamingface/plugins/claude_frontend/_url4_context.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/_url4_context.py
@@ -23,6 +23,7 @@ Extracted from ``proxy.py`` during SF-107.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import traceback
 from typing import Any
@@ -42,6 +43,35 @@ def _truncate(text: str, limit: int = PROMPT_PREVIEW_LIMIT) -> str:
     if len(text) <= limit:
         return text
     return text[:limit] + f"\n... ({len(text) - limit} more chars)"
+
+
+# Header emitted by the scoring server (PR #243) when ``on_error=collect`` ran
+# and at least one backend errored. A degraded 200 carrying collected errors is
+# a *failure* for the frontend, not a success — surface it loudly.
+_COLLECTED_ERRORS_HEADER = "X-SF-Collected-Errors"
+
+
+def _raise_if_degraded(resp: httpx.Response) -> None:
+    """Best-effort degraded-200 detection.
+
+    If ``/ensemble`` returns a 200 but reports collected backend errors via
+    ``X-SF-Collected-Errors`` (> 0), raise so the caller screams. No-op when the
+    header is absent — it lands with PR #243, so on this branch this is inert
+    until that merges. Never parses the JSON body (that would couple the
+    frontend to the scoring-script shape).
+    """
+    raw = resp.headers.get(_COLLECTED_ERRORS_HEADER)
+    if raw is None:
+        return
+    try:
+        n_errors = int(raw)
+    except (TypeError, ValueError):
+        return
+    if n_errors > 0:
+        raise RuntimeError(
+            f"/ensemble returned a degraded result with {n_errors} collected "
+            f"backend error(s) ({_COLLECTED_ERRORS_HEADER}={raw})"
+        )
 
 
 def _build_error_response(
@@ -137,6 +167,7 @@ async def _resolve_expression(
     app: Any,
     backend_url: str | None,
     tracer: Any,
+    resolve_timeout: float = 1200.0,
 ) -> str:
     """Evaluate a url4 expression and return the final text.
 
@@ -151,12 +182,17 @@ async def _resolve_expression(
 
     The guard mirrors :func:`_store_prompt_blob` exactly; diverging the two is
     what caused store/resolve to target different stores (a 404 on ``/data``).
+
+    ``resolve_timeout`` bounds both branches (matching the static-spec
+    ``resolve_timeout``): the in-process interpreter is wrapped in
+    ``asyncio.wait_for`` and the HTTP branch caps ``httpx.Timeout``. On timeout
+    the raise propagates to :func:`resolve_prompt_expression`, which screams.
     """
     if app is not None and getattr(getattr(app, "state", None), "blob_store", None) is not None:
         from screamingface.plugins.url4_executor.interpreter import Url4Interpreter
 
         interpreter = Url4Interpreter(app=app)
-        return await interpreter.evaluate(expression)
+        return await asyncio.wait_for(interpreter.evaluate(expression), resolve_timeout)
 
     if backend_url:
         ens_url = f"{backend_url}/ensemble"
@@ -168,9 +204,12 @@ async def _resolve_expression(
                     "url4.expression": _truncate(expression, 500),
                 }
             )
-            async with httpx.AsyncClient(timeout=httpx.Timeout(300.0), verify=False) as ec:
+            async with httpx.AsyncClient(
+                timeout=httpx.Timeout(resolve_timeout), verify=False
+            ) as ec:
                 ens_resp = await ec.get(ens_url, params={"q": expression})
                 ens_resp.raise_for_status()
+                _raise_if_degraded(ens_resp)  # best-effort (PR #243 header)
                 final_text = ens_resp.text
             tracer.set_attrs(
                 {
@@ -242,6 +281,7 @@ async def resolve_prompt_expression(
                 app=app,
                 backend_url=backend_url,
                 tracer=tracer,
+                resolve_timeout=getattr(settings, "resolve_timeout", 1200.0),
             )
 
             if prompt_span and prompt_span.is_recording():
@@ -289,16 +329,16 @@ def resolve_static_context(
     plugin: Any,
     embed_context: Any,
 ) -> JSONResponse | None:
-    """No ``$prompt`` — use plugin-cached resolved context.
+    """No ``$prompt`` — resolve and inject the plugin's url4 context.
 
-    Reads the plugin's cached context **non-blocking** (``get_cached_context``):
-    it returns immediately with cached text or ``None`` and warms in the
-    background, so the chat is never blocked on a (potentially 5-minute)
-    ensemble resolve. The trade-off: a cold spec resolves on a *subsequent*
-    request, not the first one.
+    **Blocking + fail-loud**: this calls :meth:`resolve_context`, which blocks
+    up to ``resolve_timeout`` on the ``/ensemble`` resolve and **re-raises** on
+    any failure (timeout, ``/ensemble`` 5xx, negative-cache cooldown). The
+    ``except`` below turns that raise into a visible ``[url4 error]`` response
+    so the CLI screams instead of silently proceeding without context.
     """
     try:
-        resolved_context = plugin.get_cached_context() if plugin else None
+        resolved_context = plugin.resolve_context() if plugin else None
     except Exception as exc:
         logger.warning("Static context resolution failed", exc_info=True)
         return _build_error_response(

--- a/apps/server/src/screamingface/plugins/claude_frontend/_url4_context.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/_url4_context.py
@@ -289,9 +289,16 @@ def resolve_static_context(
     plugin: Any,
     embed_context: Any,
 ) -> JSONResponse | None:
-    """No ``$prompt`` — use plugin-cached resolved context."""
+    """No ``$prompt`` — use plugin-cached resolved context.
+
+    Reads the plugin's cached context **non-blocking** (``get_cached_context``):
+    it returns immediately with cached text or ``None`` and warms in the
+    background, so the chat is never blocked on a (potentially 5-minute)
+    ensemble resolve. The trade-off: a cold spec resolves on a *subsequent*
+    request, not the first one.
+    """
     try:
-        resolved_context = plugin.resolve_context() if plugin else None
+        resolved_context = plugin.get_cached_context() if plugin else None
     except Exception as exc:
         logger.warning("Static context resolution failed", exc_info=True)
         return _build_error_response(

--- a/apps/server/src/screamingface/plugins/claude_frontend/tests/test_claude_frontend_models.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/tests/test_claude_frontend_models.py
@@ -318,8 +318,8 @@ class _FakePlugin:
             return "static-spec"  # Non-$prompt expression → triggers static resolve
         return None
 
-    def get_cached_context(self) -> str | None:
-        # Non-blocking cached read used by the static hot path (SF-237).
+    def resolve_context(self) -> str | None:
+        # Blocking resolve used by the static path (SF-237: blocking + screaming).
         return self._context
 
 
@@ -467,3 +467,47 @@ class TestProxyContextInjection:
         assert len(sent_body["system"]) == 2
         assert sent_body["system"][0]["text"] == "original"
         assert sent_body["system"][-1]["text"] == f"{self.prefix}cached url4 docs"
+
+
+# ---------------------------------------------------------------------------
+# Static resolve is blocking + screaming (SF-237)
+# ---------------------------------------------------------------------------
+
+
+class _RaisingPlugin:
+    """Plugin whose blocking ``resolve_context`` fails (e.g. resolve timeout)."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    def resolve_context(self) -> str | None:
+        raise self._exc
+
+
+class _StaticSettings:
+    active_spec = "spec-a"
+    embed_target = "system"
+    embed_mode = "concat"
+
+
+class TestStaticResolveScreams:
+    def test_timeout_returns_url4_error_response(self) -> None:
+        from fastapi.responses import JSONResponse
+
+        from screamingface.plugins.claude_frontend._url4_context import resolve_static_context
+
+        embedded: list[str] = []
+        result = resolve_static_context(
+            {"model": "m"},
+            raw_expression="(https://x)!'y'",
+            settings=_StaticSettings(),
+            plugin=_RaisingPlugin(TimeoutError("Spec resolution timed out after 1200s")),
+            embed_context=lambda _b, text, _s: embedded.append(text),
+        )
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 200
+        text = bytes(result.body).decode("utf-8")
+        assert "[url4 error]" in text
+        assert "TimeoutError" in text
+        assert embedded == []  # nothing injected on failure

--- a/apps/server/src/screamingface/plugins/claude_frontend/tests/test_claude_frontend_models.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/tests/test_claude_frontend_models.py
@@ -315,10 +315,11 @@ class _FakePlugin:
 
     def get_active_expression(self) -> str | None:
         if self._context:
-            return "static-spec"  # Non-$prompt expression → triggers resolve_context()
+            return "static-spec"  # Non-$prompt expression → triggers static resolve
         return None
 
-    def resolve_context(self) -> str | None:
+    def get_cached_context(self) -> str | None:
+        # Non-blocking cached read used by the static hot path (SF-237).
         return self._context
 
 

--- a/apps/server/src/screamingface/plugins/claude_frontend/tests/test_resolve_expression.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/tests/test_resolve_expression.py
@@ -138,3 +138,95 @@ async def test_raises_when_no_blob_store_app_and_no_backend_url() -> None:
         await _resolve_expression(
             "x", app=_app_without_blob_store(), backend_url=None, tracer=_NullTracer()
         )
+
+
+class _SlowInterpreter:
+    """In-process interpreter whose ``evaluate`` outlives a tiny timeout."""
+
+    def __init__(self, app: Any = None) -> None:
+        self._app = app
+
+    async def evaluate(self, _expr: str) -> str:
+        import asyncio
+
+        await asyncio.sleep(5)
+        return "never"
+
+
+@pytest.mark.anyio
+async def test_inprocess_resolve_times_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SF-237: the in-process branch is bounded by ``resolve_timeout`` — a slow
+    interpreter raises ``TimeoutError`` (so the caller can scream)."""
+    import asyncio
+
+    monkeypatch.setattr(interpreter_mod, "Url4Interpreter", _SlowInterpreter)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await _resolve_expression(
+            "(https://x)!intent",
+            app=_app_with_blob_store(),
+            backend_url=None,
+            tracer=_NullTracer(),
+            resolve_timeout=0.05,
+        )
+
+
+class _FakeBlobStore:
+    def store(self, _data: bytes, _content_type: str) -> str:
+        return "blobkey"
+
+
+class _RecordingSpan:
+    def is_recording(self) -> bool:
+        return False
+
+    def set_attribute(self, *_args: Any) -> None:
+        return None
+
+    def record_exception(self, *_args: Any) -> None:
+        return None
+
+
+class _PromptTracer(_NullTracer):
+    @contextmanager
+    def start_current_span(self, _name: str) -> Any:
+        yield _RecordingSpan()
+
+    def set_attrs(self, _attrs: dict[str, Any], *, span: Any = None) -> None:  # type: ignore[override]
+        return None
+
+
+@pytest.mark.anyio
+async def test_resolve_prompt_expression_screams_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A resolve timeout in the ``$prompt`` path returns a ``_build_error_response``."""
+    from fastapi.responses import JSONResponse
+
+    from screamingface.plugins.claude_frontend._url4_context import resolve_prompt_expression
+
+    monkeypatch.setattr(interpreter_mod, "Url4Interpreter", _SlowInterpreter)
+
+    app = SimpleNamespace(state=SimpleNamespace(blob_store=_FakeBlobStore()))
+    settings = SimpleNamespace(
+        backend_url=None,
+        active_spec="spec-a",
+        resolve_timeout=0.05,
+        embed_target="user",
+        embed_mode="concat",
+    )
+
+    result = await resolve_prompt_expression(
+        {"model": "m"},
+        raw_expression="(https://x)!$prompt",
+        settings=settings,
+        plugin=None,
+        app=app,
+        tracer=_PromptTracer(),
+        last_user_text="hello",
+        embed_context=lambda _b, _t, _s: None,
+    )
+
+    assert isinstance(result, JSONResponse)
+    assert result.status_code == 200
+    assert "[url4 error]" in bytes(result.body).decode("utf-8")

--- a/apps/server/src/screamingface/plugins/codex_frontend/tests/test_resolve_screams.py
+++ b/apps/server/src/screamingface/plugins/codex_frontend/tests/test_resolve_screams.py
@@ -1,0 +1,74 @@
+"""Fail-loud contract for codex-frontend static-spec resolution.
+
+If ``plugin.resolve_context()`` raises while resolving a static (non-$prompt)
+url4 spec, the proxy must NOT 500 or silently drop the error — it must return a
+``JSONResponse(200)`` whose assistant output text contains ``[url4 error]`` and
+surfaces the underlying exception message.
+
+This is the regression net for the ``try/except`` around ``resolve_context`` in
+``codex_frontend/proxy.py``: removing it makes this test fail.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from screamingface.plugins.codex_frontend.plugin import CodexFrontendSettings
+from screamingface.plugins.codex_frontend.proxy import create_router
+
+_BOOM = "ensemble exploded"
+
+
+class _ExplodingPlugin:
+    """Plugin whose static resolve always raises."""
+
+    def __init__(self, expression: str) -> None:
+        self._expression = expression
+
+    def get_active_expression(self) -> str | None:
+        return self._expression
+
+    def resolve_context(self) -> str | None:
+        raise RuntimeError(_BOOM)
+
+
+def _app(settings: CodexFrontendSettings, plugin: Any) -> FastAPI:
+    app = FastAPI()
+    app.include_router(create_router(settings, plugin=plugin))
+    return app
+
+
+def _error_text(payload: dict[str, Any]) -> str:
+    """Concatenate the assistant output text from a Responses-API body."""
+    parts: list[str] = []
+    for item in payload.get("output", []):
+        for chunk in item.get("content", []):
+            txt = chunk.get("text")
+            if isinstance(txt, str):
+                parts.append(txt)
+    return "\n".join(parts)
+
+
+def test_static_resolve_failure_screams() -> None:
+    settings = CodexFrontendSettings(
+        upstream_url="https://api.openai.com",
+        active_spec="boom-spec",
+        embed_target="user",
+        embed_mode="replace",
+    )
+    # Non-$prompt expression → static-resolve branch (calls resolve_context()).
+    plugin = _ExplodingPlugin(expression="(https://docs.example.com)!'answer'")
+    client = TestClient(_app(settings, plugin))
+
+    r = client.post(
+        "/v1/responses",
+        json={"model": "o4-mini", "input": "Hi", "stream": False},
+    )
+
+    assert r.status_code == 200
+    text = _error_text(r.json())
+    assert "[url4 error]" in text
+    assert _BOOM in text

--- a/apps/server/src/screamingface/plugins/frontend_base/plugin_base.py
+++ b/apps/server/src/screamingface/plugins/frontend_base/plugin_base.py
@@ -20,7 +20,6 @@ import socket
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures import TimeoutError as FutureTimeoutError
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
@@ -41,12 +40,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Bounded, shared pool for all url4 spec resolution (background warms and the
-# blocking ``_fetch_sync`` body). Two workers keep concurrency bounded so a
-# stuck ensemble can't spawn an unbounded number of daemon threads. A
-# ``_warm()`` running ``resolve_context`` → ``_fetch_sync`` re-submits to this
-# SAME pool; the per-plugin ``_warming`` flag (one warm at a time) plus
-# ``max_workers=2`` keep that nesting from starving the pool.
+# Bounded, shared pool used ONLY for background ``_warm`` submission. Two
+# workers keep concurrency bounded so a stuck ensemble can't spawn an unbounded
+# number of warm threads. ``_fetch_sync`` deliberately does NOT use this pool
+# (it owns/borrows its own event loop), so a warm never nests a second pool
+# task and warms can never starve each other.
 _RESOLVE_POOL = ThreadPoolExecutor(max_workers=2, thread_name_prefix="url4-resolve")
 
 
@@ -384,27 +382,58 @@ class FrontendPluginBase(Plugin):
     def _fetch_sync(self, expression: str, timeout: float) -> str:
         """Resolve a url4 expression by calling the /ensemble endpoint.
 
-        Runs the async ``_fetch`` in a fresh event loop on the bounded
-        ``_RESOLVE_POOL`` and waits at most ``timeout`` seconds. On timeout the
-        future is cancelled and ``TimeoutError`` is raised — no leaked daemon
-        thread. A real upstream error (non-timeout) raised inside ``_fetch`` is
-        re-raised as-is by ``future.result()`` so the caller still sees it.
+        Loop-aware and pool-free — this NEVER submits to ``_RESOLVE_POOL``, so a
+        background warm (which already runs on a pool thread) can't self-starve
+        by nesting a second pool task.
+
+        ``asyncio.wait_for(_fetch(...), timeout)`` bounds the resolve and cancels
+        the in-flight httpx request on timeout. Two execution paths:
+
+        - **No running loop** (e.g. the claude background-warm pool thread): run
+          the coroutine directly via ``asyncio.run``.
+        - **A loop is already running in THIS thread** (codex/gemini/ollama call
+          ``resolve_context`` synchronously inside their async proxy handler):
+          ``asyncio.run`` would raise, so offload to a private throwaway thread
+          with its own loop. ``Thread.join(timeout)`` plus the inner
+          ``wait_for`` mean the worker exits within ``timeout`` — no leaked
+          thread. A real upstream (non-timeout) error propagates as-is.
         """
         base = self._get_backend_url()
 
-        def _run() -> str:
-            loop = asyncio.new_event_loop()
-            try:
-                return loop.run_until_complete(_fetch(base, expression))
-            finally:
-                loop.close()
+        async def _runner() -> str:
+            return await asyncio.wait_for(_fetch(base, expression), timeout)
 
-        future = _RESOLVE_POOL.submit(_run)
         try:
-            return future.result(timeout=timeout)
-        except FutureTimeoutError:
-            future.cancel()
-            raise TimeoutError(f"Spec resolution timed out after {timeout}s") from None
+            asyncio.get_running_loop()
+        except RuntimeError:
+            # No running loop — own the loop directly.
+            try:
+                return asyncio.run(_runner())
+            except TimeoutError as exc:
+                raise TimeoutError(f"Spec resolution timed out after {timeout}s") from exc
+
+        # A loop is already running in THIS thread. Offload to a private
+        # throwaway thread with its own loop so ``asyncio.run`` is legal.
+        box_r: list[str] = []
+        box_e: list[BaseException] = []
+
+        def _worker() -> None:
+            try:
+                box_r.append(asyncio.run(_runner()))
+            except BaseException as e:  # noqa: BLE001 — surfaced to the caller below
+                box_e.append(e)
+
+        t = threading.Thread(target=_worker, name="url4-fetch", daemon=True)
+        t.start()
+        t.join(timeout=timeout + 1)  # inner asyncio.wait_for already enforces ``timeout``
+        if box_e:
+            exc = box_e[0]
+            if isinstance(exc, asyncio.TimeoutError):
+                raise TimeoutError(f"Spec resolution timed out after {timeout}s") from exc
+            raise exc
+        if not box_r:
+            raise TimeoutError(f"Spec resolution timed out after {timeout}s")
+        return box_r[0]
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/apps/server/src/screamingface/plugins/frontend_base/plugin_base.py
+++ b/apps/server/src/screamingface/plugins/frontend_base/plugin_base.py
@@ -19,6 +19,8 @@ import shutil
 import socket
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
@@ -38,6 +40,14 @@ if TYPE_CHECKING:
     from screamingface.core.routes import RouteRegistry
 
 logger = logging.getLogger(__name__)
+
+# Bounded, shared pool for all url4 spec resolution (background warms and the
+# blocking ``_fetch_sync`` body). Two workers keep concurrency bounded so a
+# stuck ensemble can't spawn an unbounded number of daemon threads. A
+# ``_warm()`` running ``resolve_context`` → ``_fetch_sync`` re-submits to this
+# SAME pool; the per-plugin ``_warming`` flag (one warm at a time) plus
+# ``max_workers=2`` keep that nesting from starving the pool.
+_RESOLVE_POOL = ThreadPoolExecutor(max_workers=2, thread_name_prefix="url4-resolve")
 
 
 class FrontendSettingsBase(PluginSettings):
@@ -84,6 +94,10 @@ class FrontendSettingsBase(PluginSettings):
         default=300.0,
         description="Max seconds to wait for url4 spec resolution on first request.",
     )
+    resolve_failure_ttl: float = Field(
+        default=60.0,
+        description="seconds to suppress re-resolving a spec after a failure",
+    )
     embed_target: Literal["system", "user"] = Field(
         default="user",
         description="Where to inject url4-resolved context: 'system' or 'user'.",
@@ -129,6 +143,8 @@ class FrontendPluginBase(Plugin):
         self._cache: dict[str, str] = {}  # spec_name → resolved text
         self._resolved_context: str | None = None
         self._active_key: str | None = None  # tracks which specs produced the cache
+        self._neg_cache: dict[str, float] = {}  # spec_name → monotonic expiry
+        self._warming = False  # a background warm is in flight
         self._lock = threading.Lock()
         self._app: Any = None
 
@@ -269,17 +285,25 @@ class FrontendPluginBase(Plugin):
                     resolved_parts.append(self._cache[name])
                     logger.info("Cache hit for spec %r (%d chars)", name, len(self._cache[name]))
                     continue
+                # Negative cache: a recent failure/timeout suppresses re-running
+                # the (potentially 5-minute) ensemble until the TTL expires.
+                neg_expiry = self._neg_cache.get(name)
+                if neg_expiry is not None and time.monotonic() < neg_expiry:
+                    logger.info("Negative-cache hit for spec %r; skipping resolve", name)
+                    continue
                 with _traced_resolve(name) as span:
                     try:
                         result = self._fetch_sync(url, timeout)
                         if result:
                             self._cache[name] = result
+                            self._neg_cache.pop(name, None)
                             resolved_parts.append(result)
                             logger.info("Resolved spec %r (%d chars)", name, len(result))
                     except Exception as exc:
                         # Record on the span so the failure is visible in Phoenix —
                         # the resolution is non-fatal (the chat proceeds without
                         # context), so we deliberately don't re-raise.
+                        self._neg_cache[name] = time.monotonic() + settings.resolve_failure_ttl
                         logger.warning("Failed to resolve spec %r", name, exc_info=True)
                         _mark_span_error(span, exc, name)
 
@@ -296,6 +320,56 @@ class FrontendPluginBase(Plugin):
 
             return self._resolved_context
 
+    def get_cached_context(self) -> str | None:
+        """Non-blocking read of resolved url4 context for the request hot path.
+
+        Returns the cached context when warm (same spec set already resolved),
+        otherwise ``None`` — it NEVER blocks the chat on resolution. A cold read
+        schedules a single background warm via :meth:`_maybe_warm`; the resolved
+        context then shows up on a *subsequent* request, not this one.
+
+        Specs containing ``$prompt`` are excluded — those need per-request
+        substitution in the proxy and aren't resolvable here.
+        """
+        spec_urls = [(n, e) for n, e in self._get_spec_urls() if "$prompt" not in e]
+        if not spec_urls:
+            return None
+
+        active_key = ",".join(n for n, _ in spec_urls)
+        # Lock-free fast read — same fields ``resolve_context``'s fast path reads.
+        if self._active_key == active_key and self._resolved_context is not None:
+            return self._resolved_context
+
+        # Cold: kick off a single background warm and return None now.
+        self._maybe_warm()
+        return None
+
+    def _maybe_warm(self) -> None:
+        """Schedule one background warm if none is already in flight.
+
+        The critical section is intentionally tiny — flag-check + submit only.
+        The actual fetch lock lives inside :meth:`resolve_context`, acquired
+        later in the pool thread, so this never holds a lock across a fetch.
+        """
+        with self._lock:
+            if self._warming:
+                return
+            self._warming = True
+            _RESOLVE_POOL.submit(self._warm)
+
+    def _warm(self) -> None:
+        """Background warm: run the blocking resolve off the hot path.
+
+        Always clears ``_warming`` (try/finally) so a failed resolve never
+        wedges resolution permanently.
+        """
+        try:
+            self.resolve_context()
+        except Exception:
+            logger.warning("Background url4 warm failed", exc_info=True)
+        finally:
+            self._warming = False
+
     def _get_backend_url(self) -> str:
         """Return the base URL for backend/ensemble/data calls."""
         settings: FrontendSettingsBase = self.settings  # type: ignore[assignment]
@@ -308,32 +382,29 @@ class FrontendPluginBase(Plugin):
         return f"{scheme}://localhost:{port}"
 
     def _fetch_sync(self, expression: str, timeout: float) -> str:
-        """Resolve a url4 expression by calling the /ensemble endpoint."""
+        """Resolve a url4 expression by calling the /ensemble endpoint.
+
+        Runs the async ``_fetch`` in a fresh event loop on the bounded
+        ``_RESOLVE_POOL`` and waits at most ``timeout`` seconds. On timeout the
+        future is cancelled and ``TimeoutError`` is raised — no leaked daemon
+        thread. A real upstream error (non-timeout) raised inside ``_fetch`` is
+        re-raised as-is by ``future.result()`` so the caller still sees it.
+        """
         base = self._get_backend_url()
-        result_holder: list[str] = []
 
-        error_holder: list[BaseException] = []
-
-        def _run() -> None:
+        def _run() -> str:
             loop = asyncio.new_event_loop()
             try:
-                result_holder.append(loop.run_until_complete(_fetch(base, expression)))
-            except BaseException as exc:  # noqa: BLE001 — re-raised to the caller below
-                error_holder.append(exc)
+                return loop.run_until_complete(_fetch(base, expression))
             finally:
                 loop.close()
 
-        thread = threading.Thread(target=_run, name="url4-fetch", daemon=True)
-        thread.start()
-        thread.join(timeout=timeout)
-
-        # Surface the real failure (e.g. /ensemble 502 with the url4 error)
-        # instead of masking everything as a timeout.
-        if error_holder:
-            raise error_holder[0]
-        if not result_holder:
-            raise TimeoutError(f"Spec resolution timed out after {timeout}s")
-        return result_holder[0]
+        future = _RESOLVE_POOL.submit(_run)
+        try:
+            return future.result(timeout=timeout)
+        except FutureTimeoutError:
+            future.cancel()
+            raise TimeoutError(f"Spec resolution timed out after {timeout}s") from None
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/apps/server/src/screamingface/plugins/frontend_base/plugin_base.py
+++ b/apps/server/src/screamingface/plugins/frontend_base/plugin_base.py
@@ -257,6 +257,11 @@ class FrontendPluginBase(Plugin):
         then **re-raised** so the caller can surface a visible error. A
         repeat call within the TTL re-raises immediately (fail-fast)
         instead of re-running the ensemble.
+
+        Blocking: this monopolizes the calling session's event loop for up
+        to ``resolve_timeout`` (default 1200s) while resolving — intentional
+        for the single-client, per-session proxy model where each session
+        serves one client and nothing else needs that loop meanwhile.
         """
         spec_urls = self._get_spec_urls()
         spec_urls = [(n, e) for n, e in spec_urls if "$prompt" not in e]
@@ -342,14 +347,17 @@ class FrontendPluginBase(Plugin):
         gets ``timeout`` so its HTTP cap matches the resolve budget. Two
         execution paths:
 
-        - **No running loop** (e.g. a claude proxy worker thread): run the
-          coroutine directly via ``asyncio.run``.
-        - **A loop is already running in THIS thread** (codex/gemini/ollama call
-          ``resolve_context`` synchronously inside their async proxy handler):
-          ``asyncio.run`` would raise, so offload to a private throwaway thread
-          with its own loop. ``Thread.join(timeout)`` plus the inner
-          ``wait_for`` mean the worker exits within ``timeout`` — no leaked
-          thread. A real upstream (non-timeout) error propagates as-is.
+        - **A loop is already running in THIS thread** — the production path.
+          All four frontends call ``resolve_context`` synchronously from an
+          ``async def`` proxy handler running on the event-loop thread, so a
+          loop is already running and ``asyncio.run`` would raise. We therefore
+          offload to a private throwaway thread with its own loop.
+          ``Thread.join(timeout)`` plus the inner ``wait_for`` mean the worker
+          exits within ``timeout`` — no leaked thread. A real upstream
+          (non-timeout) error propagates as-is.
+        - **No running loop** — a fallback for non-async callers (e.g. tests or
+          a synchronous entrypoint): run the coroutine directly via
+          ``asyncio.run``.
         """
         base = self._get_backend_url()
 

--- a/apps/server/src/screamingface/plugins/frontend_base/plugin_base.py
+++ b/apps/server/src/screamingface/plugins/frontend_base/plugin_base.py
@@ -19,7 +19,6 @@ import shutil
 import socket
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
@@ -39,13 +38,6 @@ if TYPE_CHECKING:
     from screamingface.core.routes import RouteRegistry
 
 logger = logging.getLogger(__name__)
-
-# Bounded, shared pool used ONLY for background ``_warm`` submission. Two
-# workers keep concurrency bounded so a stuck ensemble can't spawn an unbounded
-# number of warm threads. ``_fetch_sync`` deliberately does NOT use this pool
-# (it owns/borrows its own event loop), so a warm never nests a second pool
-# task and warms can never starve each other.
-_RESOLVE_POOL = ThreadPoolExecutor(max_workers=2, thread_name_prefix="url4-resolve")
 
 
 class FrontendSettingsBase(PluginSettings):
@@ -89,7 +81,7 @@ class FrontendSettingsBase(PluginSettings):
         description="Default backend path for ensemble fan-out.",
     )
     resolve_timeout: float = Field(
-        default=300.0,
+        default=1200.0,
         description="Max seconds to wait for url4 spec resolution on first request.",
     )
     resolve_failure_ttl: float = Field(
@@ -142,7 +134,6 @@ class FrontendPluginBase(Plugin):
         self._resolved_context: str | None = None
         self._active_key: str | None = None  # tracks which specs produced the cache
         self._neg_cache: dict[str, float] = {}  # spec_name → monotonic expiry
-        self._warming = False  # a background warm is in flight
         self._lock = threading.Lock()
         self._app: Any = None
 
@@ -254,12 +245,18 @@ class FrontendPluginBase(Plugin):
         return spec_urls[0][1]
 
     def resolve_context(self) -> str | None:
-        """Resolve active specs lazily.
+        """Resolve active specs lazily, **blocking** until done or failed.
 
         Cache hit (same spec set) returns cached text; cache miss
         fetches via :meth:`_fetch_sync` and stores. Specs containing
         ``$prompt`` are skipped — they need per-request substitution
         in the proxy.
+
+        Fail-loud: if a spec resolve raises (timeout, ``/ensemble`` 5xx,
+        …) the failure is negative-cached for ``resolve_failure_ttl`` and
+        then **re-raised** so the caller can surface a visible error. A
+        repeat call within the TTL re-raises immediately (fail-fast)
+        instead of re-running the ensemble.
         """
         spec_urls = self._get_spec_urls()
         spec_urls = [(n, e) for n, e in spec_urls if "$prompt" not in e]
@@ -283,12 +280,16 @@ class FrontendPluginBase(Plugin):
                     resolved_parts.append(self._cache[name])
                     logger.info("Cache hit for spec %r (%d chars)", name, len(self._cache[name]))
                     continue
-                # Negative cache: a recent failure/timeout suppresses re-running
-                # the (potentially 5-minute) ensemble until the TTL expires.
+                # Negative cache: a recent failure/timeout fails fast — re-raise
+                # immediately instead of re-running the (potentially long)
+                # ensemble until the TTL expires.
                 neg_expiry = self._neg_cache.get(name)
                 if neg_expiry is not None and time.monotonic() < neg_expiry:
-                    logger.info("Negative-cache hit for spec %r; skipping resolve", name)
-                    continue
+                    cooldown = neg_expiry - time.monotonic()
+                    logger.info("Negative-cache hit for spec %r; failing fast", name)
+                    raise RuntimeError(
+                        f"spec {name!r} resolution failed recently (cooldown {cooldown:.0f}s)"
+                    )
                 with _traced_resolve(name) as span:
                     try:
                         result = self._fetch_sync(url, timeout)
@@ -298,12 +299,13 @@ class FrontendPluginBase(Plugin):
                             resolved_parts.append(result)
                             logger.info("Resolved spec %r (%d chars)", name, len(result))
                     except Exception as exc:
-                        # Record on the span so the failure is visible in Phoenix —
-                        # the resolution is non-fatal (the chat proceeds without
-                        # context), so we deliberately don't re-raise.
+                        # Negative-cache the failure (so a repeat fails fast) and
+                        # record it on the span for Phoenix, then re-raise so the
+                        # caller surfaces a visible error in the CLI.
                         self._neg_cache[name] = time.monotonic() + settings.resolve_failure_ttl
                         logger.warning("Failed to resolve spec %r", name, exc_info=True)
                         _mark_span_error(span, exc, name)
+                        raise
 
             if resolved_parts:
                 self._resolved_context = "\n\n".join(resolved_parts)
@@ -317,56 +319,6 @@ class FrontendPluginBase(Plugin):
                 self._active_key = active_key
 
             return self._resolved_context
-
-    def get_cached_context(self) -> str | None:
-        """Non-blocking read of resolved url4 context for the request hot path.
-
-        Returns the cached context when warm (same spec set already resolved),
-        otherwise ``None`` — it NEVER blocks the chat on resolution. A cold read
-        schedules a single background warm via :meth:`_maybe_warm`; the resolved
-        context then shows up on a *subsequent* request, not this one.
-
-        Specs containing ``$prompt`` are excluded — those need per-request
-        substitution in the proxy and aren't resolvable here.
-        """
-        spec_urls = [(n, e) for n, e in self._get_spec_urls() if "$prompt" not in e]
-        if not spec_urls:
-            return None
-
-        active_key = ",".join(n for n, _ in spec_urls)
-        # Lock-free fast read — same fields ``resolve_context``'s fast path reads.
-        if self._active_key == active_key and self._resolved_context is not None:
-            return self._resolved_context
-
-        # Cold: kick off a single background warm and return None now.
-        self._maybe_warm()
-        return None
-
-    def _maybe_warm(self) -> None:
-        """Schedule one background warm if none is already in flight.
-
-        The critical section is intentionally tiny — flag-check + submit only.
-        The actual fetch lock lives inside :meth:`resolve_context`, acquired
-        later in the pool thread, so this never holds a lock across a fetch.
-        """
-        with self._lock:
-            if self._warming:
-                return
-            self._warming = True
-            _RESOLVE_POOL.submit(self._warm)
-
-    def _warm(self) -> None:
-        """Background warm: run the blocking resolve off the hot path.
-
-        Always clears ``_warming`` (try/finally) so a failed resolve never
-        wedges resolution permanently.
-        """
-        try:
-            self.resolve_context()
-        except Exception:
-            logger.warning("Background url4 warm failed", exc_info=True)
-        finally:
-            self._warming = False
 
     def _get_backend_url(self) -> str:
         """Return the base URL for backend/ensemble/data calls."""
@@ -382,15 +334,16 @@ class FrontendPluginBase(Plugin):
     def _fetch_sync(self, expression: str, timeout: float) -> str:
         """Resolve a url4 expression by calling the /ensemble endpoint.
 
-        Loop-aware and pool-free — this NEVER submits to ``_RESOLVE_POOL``, so a
-        background warm (which already runs on a pool thread) can't self-starve
-        by nesting a second pool task.
+        Loop-aware and pool-free — it owns/borrows its own event loop and never
+        leaks a thread.
 
         ``asyncio.wait_for(_fetch(...), timeout)`` bounds the resolve and cancels
-        the in-flight httpx request on timeout. Two execution paths:
+        the in-flight httpx request on timeout. The inner :func:`_fetch` also
+        gets ``timeout`` so its HTTP cap matches the resolve budget. Two
+        execution paths:
 
-        - **No running loop** (e.g. the claude background-warm pool thread): run
-          the coroutine directly via ``asyncio.run``.
+        - **No running loop** (e.g. a claude proxy worker thread): run the
+          coroutine directly via ``asyncio.run``.
         - **A loop is already running in THIS thread** (codex/gemini/ollama call
           ``resolve_context`` synchronously inside their async proxy handler):
           ``asyncio.run`` would raise, so offload to a private throwaway thread
@@ -401,7 +354,7 @@ class FrontendPluginBase(Plugin):
         base = self._get_backend_url()
 
         async def _runner() -> str:
-            return await asyncio.wait_for(_fetch(base, expression), timeout)
+            return await asyncio.wait_for(_fetch(base, expression, timeout), timeout)
 
         try:
             asyncio.get_running_loop()
@@ -509,9 +462,13 @@ class FrontendPluginBase(Plugin):
         self._thread = None
 
 
-async def _fetch(base_url: str, expression: str) -> str:
-    """Call /ensemble with a url4 expression and return plain text."""
-    async with httpx.AsyncClient(timeout=300, verify=False) as client:
+async def _fetch(base_url: str, expression: str, timeout: float) -> str:
+    """Call /ensemble with a url4 expression and return plain text.
+
+    ``timeout`` caps the inner HTTP request so it matches the resolve budget
+    (``resolve_timeout``) rather than a hardcoded value.
+    """
+    async with httpx.AsyncClient(timeout=timeout, verify=False) as client:
         resp = await client.get(f"{base_url}/ensemble", params={"q": expression})
         resp.raise_for_status()
         return resp.text

--- a/apps/server/src/screamingface/plugins/frontend_base/tests/test_resolve_cache.py
+++ b/apps/server/src/screamingface/plugins/frontend_base/tests/test_resolve_cache.py
@@ -8,9 +8,13 @@ Three fixes are pinned here:
 2. **Non-blocking hot path** — ``get_cached_context()`` returns immediately
    (cached text or ``None``); it never blocks the chat on resolution. A cold
    read schedules a single background warm.
-3. **Bounded/cancellable fetch** — ``_fetch_sync`` uses a bounded pool so a
-   timeout raises ``TimeoutError`` (and cancels) instead of leaking a thread,
-   while a real upstream error is surfaced as-is.
+3. **Loop-aware, pool-free fetch** — ``_fetch_sync`` bounds the resolve with
+   ``asyncio.wait_for`` (cancelling the in-flight request on timeout → raises
+   ``TimeoutError``) while surfacing a real upstream error as-is. It never
+   submits to ``_RESOLVE_POOL`` and works both with and without an already
+   running event loop in the calling thread.
+4. **No warm self-starvation** — concurrent warms on separate plugin instances
+   resolve independently and quickly, because warms don't nest pool tasks.
 """
 
 from __future__ import annotations
@@ -198,6 +202,93 @@ def test_fetch_sync_surfaces_upstream_error() -> None:
             plugin._fetch_sync("(https://x)!'y'", timeout=5)
     finally:
         mod._fetch = original  # type: ignore[assignment]
+
+
+def test_fetch_sync_works_inside_running_loop() -> None:
+    """BLOCKER 2: ``_fetch_sync`` must work when a loop is already running.
+
+    codex/gemini/ollama call ``resolve_context`` (→ ``_fetch_sync``)
+    synchronously from inside their ``async def`` proxy handler, i.e. with the
+    uvicorn loop already running in the same thread. A bare ``asyncio.run`` in
+    ``_fetch_sync`` would raise ``RuntimeError: cannot be called from a running
+    event loop``; the loop-detection branch must offload to a private thread.
+    """
+    plugin = _make_plugin(spec_urls=[("spec-a", "(https://x)!'y'")])
+
+    import screamingface.plugins.frontend_base.plugin_base as mod
+
+    async def _ok_fetch(_base: str, _expr: str) -> str:
+        return "resolved inside loop"
+
+    original = mod._fetch
+    mod._fetch = _ok_fetch  # type: ignore[assignment]
+    plugin._get_backend_url = lambda: "http://localhost:8000"  # type: ignore[method-assign]
+
+    async def _call_from_loop() -> str:
+        # Sanity-check the precondition: a loop really is running in this thread.
+        asyncio.get_running_loop()
+        return plugin._fetch_sync("(https://x)!'y'", timeout=5)
+
+    try:
+        result = asyncio.run(_call_from_loop())
+    finally:
+        mod._fetch = original  # type: ignore[assignment]
+
+    assert result == "resolved inside loop"
+
+
+# ---------------------------------------------------------------------------
+# (3b) Concurrent warms must not self-starve (BLOCKER 1)
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_warms_do_not_starve() -> None:
+    """BLOCKER 1: two warms on separate plugins must both resolve fast.
+
+    The old ``_fetch_sync`` re-submitted to the SAME ``max_workers=2``
+    ``_RESOLVE_POOL`` and blocked on the nested future. Two concurrent warms
+    then occupied both workers while their nested fetches had nowhere to run,
+    so both stalled for the full ``resolve_timeout``. With ``_fetch_sync`` off
+    the pool, both warms complete in well under the timeout.
+    """
+    import screamingface.plugins.frontend_base.plugin_base as mod
+
+    async def _fast_fetch(_base: str, _expr: str) -> str:
+        return "resolved fast"
+
+    original = mod._fetch
+    mod._fetch = _fast_fetch  # type: ignore[assignment]
+
+    # Small resolve_timeout: if a warm ever stalled on pool starvation it would
+    # block for this long; the poll below (~3s) is the real assertion budget.
+    plugins = []
+    for i in range(2):
+        p = _make_plugin(
+            spec_urls=[(f"spec-{i}", f"(https://x{i})!'y'")],
+            resolve_timeout=10.0,
+        )
+        p._get_backend_url = lambda: "http://localhost:8000"  # type: ignore[method-assign]
+        plugins.append(p)
+
+    try:
+        # Fire both warms concurrently via the real background-warm path.
+        for p in plugins:
+            p._maybe_warm()
+
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline:
+            if all(p._resolved_context is not None for p in plugins):
+                break
+            time.sleep(0.01)
+    finally:
+        mod._fetch = original  # type: ignore[assignment]
+
+    for i, p in enumerate(plugins):
+        assert p._resolved_context == "resolved fast", (
+            f"plugin {i} did not warm in time (self-starvation regression?)"
+        )
+        # Warm flag cleared once resolution completed.
+        assert p._warming is False
 
 
 # ---------------------------------------------------------------------------

--- a/apps/server/src/screamingface/plugins/frontend_base/tests/test_resolve_cache.py
+++ b/apps/server/src/screamingface/plugins/frontend_base/tests/test_resolve_cache.py
@@ -1,28 +1,23 @@
-"""Tests for the non-blocking url4 resolve path (WI-3 / SF-237).
+"""Tests for the blocking + fail-loud url4 resolve path (SF-237).
 
-Three fixes are pinned here:
+Three behaviors are pinned here:
 
-1. **Negative cache** — a failed/timed-out resolve is remembered for a short
-   TTL so subsequent requests don't re-run the (5-minute) ensemble until it
-   expires.
-2. **Non-blocking hot path** — ``get_cached_context()`` returns immediately
-   (cached text or ``None``); it never blocks the chat on resolution. A cold
-   read schedules a single background warm.
+1. **Blocking + fail-loud** — ``resolve_context()`` blocks on the resolve and
+   **re-raises** on failure (timeout, ``/ensemble`` 5xx, …) instead of
+   swallowing it, so the caller can surface a visible error.
+2. **Negative cache (fail-fast)** — a failed/timed-out resolve is remembered for
+   a short TTL; a repeat within the TTL re-raises immediately **without**
+   re-running the (potentially long) ensemble. After the TTL it retries.
 3. **Loop-aware, pool-free fetch** — ``_fetch_sync`` bounds the resolve with
    ``asyncio.wait_for`` (cancelling the in-flight request on timeout → raises
-   ``TimeoutError``) while surfacing a real upstream error as-is. It never
-   submits to ``_RESOLVE_POOL`` and works both with and without an already
-   running event loop in the calling thread.
-4. **No warm self-starvation** — concurrent warms on separate plugin instances
-   resolve independently and quickly, because warms don't nest pool tasks.
+   ``TimeoutError``) while surfacing a real upstream error as-is. It works both
+   with and without an already running event loop in the calling thread.
 """
 
 from __future__ import annotations
 
 import asyncio
-import threading
 import time
-from typing import ClassVar
 
 import pytest
 
@@ -55,11 +50,13 @@ def _make_plugin(
 
 
 # ---------------------------------------------------------------------------
-# (1) Negative cache
+# (1) Blocking + fail-loud + (2) negative cache fail-fast
 # ---------------------------------------------------------------------------
 
 
-def test_negative_cache_suppresses_repeat_resolve() -> None:
+def test_resolve_failure_raises_and_neg_caches() -> None:
+    """A failing fetch makes ``resolve_context`` RAISE and neg-cache the spec;
+    a second call within the TTL re-raises WITHOUT re-running the fetch."""
     plugin = _make_plugin(spec_urls=[("spec-a", "(https://x)!'y'")])
 
     calls = {"n": 0}
@@ -70,8 +67,13 @@ def test_negative_cache_suppresses_repeat_resolve() -> None:
 
     plugin._fetch_sync = _boom  # type: ignore[method-assign]
 
-    assert plugin.resolve_context() is None
-    assert plugin.resolve_context() is None  # second call must be suppressed
+    with pytest.raises(RuntimeError, match="ensemble exploded"):
+        plugin.resolve_context()
+    assert "spec-a" in plugin._neg_cache
+
+    # Second call within TTL fails fast — no re-run of _fetch_sync.
+    with pytest.raises(RuntimeError, match="failed recently"):
+        plugin.resolve_context()
     assert calls["n"] == 1
 
 
@@ -89,10 +91,12 @@ def test_negative_cache_retries_after_ttl() -> None:
 
     plugin._fetch_sync = _boom  # type: ignore[method-assign]
 
-    assert plugin.resolve_context() is None
+    with pytest.raises(RuntimeError, match="ensemble exploded"):
+        plugin.resolve_context()
     time.sleep(0.1)  # past the TTL
-    assert plugin.resolve_context() is None
-    assert calls["n"] == 2
+    with pytest.raises(RuntimeError, match="ensemble exploded"):
+        plugin.resolve_context()
+    assert calls["n"] == 2  # retried (not fail-fast) after the TTL
 
 
 def test_success_clears_negative_cache() -> None:
@@ -107,56 +111,14 @@ def test_success_clears_negative_cache() -> None:
     assert "spec-a" not in plugin._neg_cache
 
 
-# ---------------------------------------------------------------------------
-# (2) Non-blocking hot path
-# ---------------------------------------------------------------------------
-
-
-def test_get_cached_context_returns_cached_without_blocking() -> None:
-    plugin = _make_plugin(spec_urls=[("spec-a", "(https://x)!'y'")])
-    plugin._resolved_context = "warm context"
-    plugin._active_key = "spec-a"
-
-    start = time.monotonic()
-    assert plugin.get_cached_context() == "warm context"
-    assert time.monotonic() - start < 0.5
-
-
-def test_get_cached_context_cold_returns_none_and_warms() -> None:
-    plugin = _make_plugin(spec_urls=[("spec-a", "(https://x)!'y'")])
-
-    entered = threading.Event()
-    release = threading.Event()
-
-    def _slow(_expr: str, _timeout: float) -> str:
-        entered.set()
-        # Block the warm so we can assert get_cached_context didn't wait on it.
-        release.wait(timeout=5)
-        return "eventually"
-
-    plugin._fetch_sync = _slow  # type: ignore[method-assign]
-
-    start = time.monotonic()
-    result = plugin.get_cached_context()
-    elapsed = time.monotonic() - start
-
-    assert result is None
-    assert elapsed < 1.0  # must not block on the 5s fetch
-    # A background warm was scheduled and is running the fetch.
-    assert entered.wait(timeout=2)
-    assert plugin._warming is True
-    release.set()
-
-
-def test_get_cached_context_none_when_no_specs() -> None:
+def test_resolve_context_none_when_no_specs() -> None:
     plugin = _make_plugin(spec_urls=[])
-    assert plugin.get_cached_context() is None
+    assert plugin.resolve_context() is None
 
 
-def test_get_cached_context_skips_prompt_specs() -> None:
+def test_resolve_context_skips_prompt_specs() -> None:
     plugin = _make_plugin(spec_urls=[("spec-p", "(https://x)!$prompt")])
-    assert plugin.get_cached_context() is None
-    assert plugin._warming is False  # nothing warmable → no warm scheduled
+    assert plugin.resolve_context() is None
 
 
 # ---------------------------------------------------------------------------
@@ -169,7 +131,7 @@ def test_fetch_sync_times_out() -> None:
 
     import screamingface.plugins.frontend_base.plugin_base as mod
 
-    async def _slow_fetch(_base: str, _expr: str) -> str:
+    async def _slow_fetch(_base: str, _expr: str, _timeout: float) -> str:
         await asyncio.sleep(5)
         return "never"
 
@@ -191,7 +153,7 @@ def test_fetch_sync_surfaces_upstream_error() -> None:
     class _UpstreamError(RuntimeError):
         pass
 
-    async def _err_fetch(_base: str, _expr: str) -> str:
+    async def _err_fetch(_base: str, _expr: str, _timeout: float) -> str:
         raise _UpstreamError("ensemble 502")
 
     original = mod._fetch
@@ -205,7 +167,7 @@ def test_fetch_sync_surfaces_upstream_error() -> None:
 
 
 def test_fetch_sync_works_inside_running_loop() -> None:
-    """BLOCKER 2: ``_fetch_sync`` must work when a loop is already running.
+    """``_fetch_sync`` must work when a loop is already running.
 
     codex/gemini/ollama call ``resolve_context`` (→ ``_fetch_sync``)
     synchronously from inside their ``async def`` proxy handler, i.e. with the
@@ -217,7 +179,7 @@ def test_fetch_sync_works_inside_running_loop() -> None:
 
     import screamingface.plugins.frontend_base.plugin_base as mod
 
-    async def _ok_fetch(_base: str, _expr: str) -> str:
+    async def _ok_fetch(_base: str, _expr: str, _timeout: float) -> str:
         return "resolved inside loop"
 
     original = mod._fetch
@@ -238,61 +200,7 @@ def test_fetch_sync_works_inside_running_loop() -> None:
 
 
 # ---------------------------------------------------------------------------
-# (3b) Concurrent warms must not self-starve (BLOCKER 1)
-# ---------------------------------------------------------------------------
-
-
-def test_concurrent_warms_do_not_starve() -> None:
-    """BLOCKER 1: two warms on separate plugins must both resolve fast.
-
-    The old ``_fetch_sync`` re-submitted to the SAME ``max_workers=2``
-    ``_RESOLVE_POOL`` and blocked on the nested future. Two concurrent warms
-    then occupied both workers while their nested fetches had nowhere to run,
-    so both stalled for the full ``resolve_timeout``. With ``_fetch_sync`` off
-    the pool, both warms complete in well under the timeout.
-    """
-    import screamingface.plugins.frontend_base.plugin_base as mod
-
-    async def _fast_fetch(_base: str, _expr: str) -> str:
-        return "resolved fast"
-
-    original = mod._fetch
-    mod._fetch = _fast_fetch  # type: ignore[assignment]
-
-    # Small resolve_timeout: if a warm ever stalled on pool starvation it would
-    # block for this long; the poll below (~3s) is the real assertion budget.
-    plugins = []
-    for i in range(2):
-        p = _make_plugin(
-            spec_urls=[(f"spec-{i}", f"(https://x{i})!'y'")],
-            resolve_timeout=10.0,
-        )
-        p._get_backend_url = lambda: "http://localhost:8000"  # type: ignore[method-assign]
-        plugins.append(p)
-
-    try:
-        # Fire both warms concurrently via the real background-warm path.
-        for p in plugins:
-            p._maybe_warm()
-
-        deadline = time.monotonic() + 3.0
-        while time.monotonic() < deadline:
-            if all(p._resolved_context is not None for p in plugins):
-                break
-            time.sleep(0.01)
-    finally:
-        mod._fetch = original  # type: ignore[assignment]
-
-    for i, p in enumerate(plugins):
-        assert p._resolved_context == "resolved fast", (
-            f"plugin {i} did not warm in time (self-starvation regression?)"
-        )
-        # Warm flag cleared once resolution completed.
-        assert p._warming is False
-
-
-# ---------------------------------------------------------------------------
-# (4) Hot-path call site (resolve_static_context)
+# (4) Hot-path call site (resolve_static_context) — blocking + screaming
 # ---------------------------------------------------------------------------
 
 
@@ -302,18 +210,12 @@ class _FakeSettings:
     embed_mode = "concat"
 
 
-class _FakeCachedPlugin:
-    blocking_called: ClassVar[bool] = False
-
-    def __init__(self, cached: str | None) -> None:
-        self._cached = cached
-
-    def get_cached_context(self) -> str | None:
-        return self._cached
+class _FakeBlockingPlugin:
+    def __init__(self, context: str | None) -> None:
+        self._context = context
 
     def resolve_context(self) -> str | None:
-        type(self).blocking_called = True
-        raise AssertionError("hot path must not call the blocking resolve_context")
+        return self._context
 
 
 def test_resolve_static_context_none_proceeds() -> None:
@@ -323,23 +225,22 @@ def test_resolve_static_context_none_proceeds() -> None:
         {"model": "m"},
         raw_expression="(https://x)!'y'",
         settings=_FakeSettings(),
-        plugin=_FakeCachedPlugin(None),
+        plugin=_FakeBlockingPlugin(None),
         embed_context=lambda _b, text, _s: embedded.append(text),
     )
 
     assert result is None
     assert embedded == []
-    assert _FakeCachedPlugin.blocking_called is False
 
 
-def test_resolve_static_context_embeds_cached() -> None:
+def test_resolve_static_context_embeds_resolved() -> None:
     embedded: list[str] = []
 
     result = resolve_static_context(
         {"model": "m"},
         raw_expression="(https://x)!'y'",
         settings=_FakeSettings(),
-        plugin=_FakeCachedPlugin("cached docs"),
+        plugin=_FakeBlockingPlugin("cached docs"),
         embed_context=lambda _b, text, _s: embedded.append(text),
     )
 

--- a/apps/server/src/screamingface/plugins/frontend_base/tests/test_resolve_cache.py
+++ b/apps/server/src/screamingface/plugins/frontend_base/tests/test_resolve_cache.py
@@ -1,0 +1,256 @@
+"""Tests for the non-blocking url4 resolve path (WI-3 / SF-237).
+
+Three fixes are pinned here:
+
+1. **Negative cache** — a failed/timed-out resolve is remembered for a short
+   TTL so subsequent requests don't re-run the (5-minute) ensemble until it
+   expires.
+2. **Non-blocking hot path** — ``get_cached_context()`` returns immediately
+   (cached text or ``None``); it never blocks the chat on resolution. A cold
+   read schedules a single background warm.
+3. **Bounded/cancellable fetch** — ``_fetch_sync`` uses a bounded pool so a
+   timeout raises ``TimeoutError`` (and cancels) instead of leaking a thread,
+   while a real upstream error is surfaced as-is.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from typing import ClassVar
+
+import pytest
+
+from screamingface.plugins.claude_frontend._url4_context import resolve_static_context
+from screamingface.plugins.frontend_base.plugin_base import (
+    FrontendPluginBase,
+    FrontendSettingsBase,
+)
+
+
+class _ConcreteFrontend(FrontendPluginBase):
+    name = "test-frontend"
+    settings_class = FrontendSettingsBase
+
+
+def _make_plugin(
+    *,
+    spec_urls: list[tuple[str, str]],
+    resolve_failure_ttl: float = 60.0,
+    resolve_timeout: float = 300.0,
+) -> _ConcreteFrontend:
+    plugin = _ConcreteFrontend()
+    plugin.settings = FrontendSettingsBase(
+        resolve_failure_ttl=resolve_failure_ttl,
+        resolve_timeout=resolve_timeout,
+    )
+    # Pin the active spec set; avoids touching config/disk.
+    plugin._get_spec_urls = lambda: list(spec_urls)  # type: ignore[method-assign]
+    return plugin
+
+
+# ---------------------------------------------------------------------------
+# (1) Negative cache
+# ---------------------------------------------------------------------------
+
+
+def test_negative_cache_suppresses_repeat_resolve() -> None:
+    plugin = _make_plugin(spec_urls=[("spec-a", "(https://x)!'y'")])
+
+    calls = {"n": 0}
+
+    def _boom(_expr: str, _timeout: float) -> str:
+        calls["n"] += 1
+        raise RuntimeError("ensemble exploded")
+
+    plugin._fetch_sync = _boom  # type: ignore[method-assign]
+
+    assert plugin.resolve_context() is None
+    assert plugin.resolve_context() is None  # second call must be suppressed
+    assert calls["n"] == 1
+
+
+def test_negative_cache_retries_after_ttl() -> None:
+    plugin = _make_plugin(
+        spec_urls=[("spec-a", "(https://x)!'y'")],
+        resolve_failure_ttl=0.05,
+    )
+
+    calls = {"n": 0}
+
+    def _boom(_expr: str, _timeout: float) -> str:
+        calls["n"] += 1
+        raise RuntimeError("ensemble exploded")
+
+    plugin._fetch_sync = _boom  # type: ignore[method-assign]
+
+    assert plugin.resolve_context() is None
+    time.sleep(0.1)  # past the TTL
+    assert plugin.resolve_context() is None
+    assert calls["n"] == 2
+
+
+def test_success_clears_negative_cache() -> None:
+    plugin = _make_plugin(spec_urls=[("spec-a", "(https://x)!'y'")])
+
+    def _ok(_expr: str, _timeout: float) -> str:
+        return "resolved text"
+
+    plugin._fetch_sync = _ok  # type: ignore[method-assign]
+
+    assert plugin.resolve_context() == "resolved text"
+    assert "spec-a" not in plugin._neg_cache
+
+
+# ---------------------------------------------------------------------------
+# (2) Non-blocking hot path
+# ---------------------------------------------------------------------------
+
+
+def test_get_cached_context_returns_cached_without_blocking() -> None:
+    plugin = _make_plugin(spec_urls=[("spec-a", "(https://x)!'y'")])
+    plugin._resolved_context = "warm context"
+    plugin._active_key = "spec-a"
+
+    start = time.monotonic()
+    assert plugin.get_cached_context() == "warm context"
+    assert time.monotonic() - start < 0.5
+
+
+def test_get_cached_context_cold_returns_none_and_warms() -> None:
+    plugin = _make_plugin(spec_urls=[("spec-a", "(https://x)!'y'")])
+
+    entered = threading.Event()
+    release = threading.Event()
+
+    def _slow(_expr: str, _timeout: float) -> str:
+        entered.set()
+        # Block the warm so we can assert get_cached_context didn't wait on it.
+        release.wait(timeout=5)
+        return "eventually"
+
+    plugin._fetch_sync = _slow  # type: ignore[method-assign]
+
+    start = time.monotonic()
+    result = plugin.get_cached_context()
+    elapsed = time.monotonic() - start
+
+    assert result is None
+    assert elapsed < 1.0  # must not block on the 5s fetch
+    # A background warm was scheduled and is running the fetch.
+    assert entered.wait(timeout=2)
+    assert plugin._warming is True
+    release.set()
+
+
+def test_get_cached_context_none_when_no_specs() -> None:
+    plugin = _make_plugin(spec_urls=[])
+    assert plugin.get_cached_context() is None
+
+
+def test_get_cached_context_skips_prompt_specs() -> None:
+    plugin = _make_plugin(spec_urls=[("spec-p", "(https://x)!$prompt")])
+    assert plugin.get_cached_context() is None
+    assert plugin._warming is False  # nothing warmable → no warm scheduled
+
+
+# ---------------------------------------------------------------------------
+# (3) Bounded / cancellable _fetch_sync
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_sync_times_out() -> None:
+    plugin = _make_plugin(spec_urls=[("spec-a", "(https://x)!'y'")])
+
+    import screamingface.plugins.frontend_base.plugin_base as mod
+
+    async def _slow_fetch(_base: str, _expr: str) -> str:
+        await asyncio.sleep(5)
+        return "never"
+
+    original = mod._fetch
+    mod._fetch = _slow_fetch  # type: ignore[assignment]
+    plugin._get_backend_url = lambda: "http://localhost:8000"  # type: ignore[method-assign]
+    try:
+        with pytest.raises(TimeoutError):
+            plugin._fetch_sync("(https://x)!'y'", timeout=0.2)
+    finally:
+        mod._fetch = original  # type: ignore[assignment]
+
+
+def test_fetch_sync_surfaces_upstream_error() -> None:
+    plugin = _make_plugin(spec_urls=[("spec-a", "(https://x)!'y'")])
+
+    import screamingface.plugins.frontend_base.plugin_base as mod
+
+    class _UpstreamError(RuntimeError):
+        pass
+
+    async def _err_fetch(_base: str, _expr: str) -> str:
+        raise _UpstreamError("ensemble 502")
+
+    original = mod._fetch
+    mod._fetch = _err_fetch  # type: ignore[assignment]
+    plugin._get_backend_url = lambda: "http://localhost:8000"  # type: ignore[method-assign]
+    try:
+        with pytest.raises(_UpstreamError, match="ensemble 502"):
+            plugin._fetch_sync("(https://x)!'y'", timeout=5)
+    finally:
+        mod._fetch = original  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# (4) Hot-path call site (resolve_static_context)
+# ---------------------------------------------------------------------------
+
+
+class _FakeSettings:
+    active_spec = "spec-a"
+    embed_target = "system"
+    embed_mode = "concat"
+
+
+class _FakeCachedPlugin:
+    blocking_called: ClassVar[bool] = False
+
+    def __init__(self, cached: str | None) -> None:
+        self._cached = cached
+
+    def get_cached_context(self) -> str | None:
+        return self._cached
+
+    def resolve_context(self) -> str | None:
+        type(self).blocking_called = True
+        raise AssertionError("hot path must not call the blocking resolve_context")
+
+
+def test_resolve_static_context_none_proceeds() -> None:
+    embedded: list[str] = []
+
+    result = resolve_static_context(
+        {"model": "m"},
+        raw_expression="(https://x)!'y'",
+        settings=_FakeSettings(),
+        plugin=_FakeCachedPlugin(None),
+        embed_context=lambda _b, text, _s: embedded.append(text),
+    )
+
+    assert result is None
+    assert embedded == []
+    assert _FakeCachedPlugin.blocking_called is False
+
+
+def test_resolve_static_context_embeds_cached() -> None:
+    embedded: list[str] = []
+
+    result = resolve_static_context(
+        {"model": "m"},
+        raw_expression="(https://x)!'y'",
+        settings=_FakeSettings(),
+        plugin=_FakeCachedPlugin("cached docs"),
+        embed_context=lambda _b, text, _s: embedded.append(text),
+    )
+
+    assert result is None
+    assert embedded == ["cached docs"]

--- a/apps/server/src/screamingface/plugins/gemini_frontend/tests/test_resolve_screams.py
+++ b/apps/server/src/screamingface/plugins/gemini_frontend/tests/test_resolve_screams.py
@@ -1,0 +1,74 @@
+"""Fail-loud contract for gemini-frontend static-spec resolution.
+
+If ``plugin.resolve_context()`` raises while resolving a static (non-$prompt)
+url4 spec, the proxy must NOT 500 or silently drop the error — it must return a
+``JSONResponse(200)`` whose candidate text contains ``[url4 error]`` and
+surfaces the underlying exception message.
+
+This is the regression net for the ``try/except`` around ``resolve_context`` in
+``gemini_frontend/proxy.py``: removing it makes this test fail.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from screamingface.plugins.gemini_frontend.plugin import GeminiFrontendSettings
+from screamingface.plugins.gemini_frontend.proxy import create_router
+
+_BOOM = "ensemble exploded"
+
+
+class _ExplodingPlugin:
+    """Plugin whose static resolve always raises."""
+
+    def __init__(self, expression: str) -> None:
+        self._expression = expression
+
+    def get_active_expression(self) -> str | None:
+        return self._expression
+
+    def resolve_context(self) -> str | None:
+        raise RuntimeError(_BOOM)
+
+
+def _app(settings: GeminiFrontendSettings, plugin: Any) -> FastAPI:
+    app = FastAPI()
+    app.include_router(create_router(settings, plugin=plugin))
+    return app
+
+
+def _error_text(payload: dict[str, Any]) -> str:
+    parts: list[str] = []
+    for cand in payload.get("candidates", []):
+        for part in cand.get("content", {}).get("parts", []):
+            txt = part.get("text")
+            if isinstance(txt, str):
+                parts.append(txt)
+    return "\n".join(parts)
+
+
+def test_static_resolve_failure_screams() -> None:
+    settings = GeminiFrontendSettings(
+        upstream_url="https://generativelanguage.googleapis.com",
+        active_spec="boom-spec",
+        embed_target="user",
+        embed_mode="replace",
+    )
+    # Non-$prompt expression → static-resolve branch (calls resolve_context()).
+    plugin = _ExplodingPlugin(expression="(https://docs.example.com)!'answer'")
+    client = TestClient(_app(settings, plugin))
+
+    # POST to generateContent (non-streaming: path lacks "streamGenerateContent").
+    r = client.post(
+        "/v1beta/models/gemini-pro:generateContent",
+        json={"contents": [{"role": "user", "parts": [{"text": "Hi"}]}]},
+    )
+
+    assert r.status_code == 200
+    text = _error_text(r.json())
+    assert "[url4 error]" in text
+    assert _BOOM in text

--- a/apps/server/src/screamingface/plugins/ollama_frontend/tests/test_resolve_screams.py
+++ b/apps/server/src/screamingface/plugins/ollama_frontend/tests/test_resolve_screams.py
@@ -1,0 +1,67 @@
+"""Fail-loud contract for ollama-frontend static-spec resolution.
+
+If ``plugin.resolve_context()`` raises while resolving a static (non-$prompt)
+url4 spec, the proxy must NOT 500 or silently drop the error — it must return a
+``JSONResponse(200)`` whose assistant message text contains ``[url4 error]`` and
+surfaces the underlying exception message.
+
+This is the regression net for the ``try/except`` around ``resolve_context`` in
+``ollama_frontend/proxy.py``: removing it makes this test fail.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from screamingface.plugins.ollama_frontend.plugin import OllamaFrontendSettings
+from screamingface.plugins.ollama_frontend.proxy import create_router
+
+_BOOM = "ensemble exploded"
+
+
+class _ExplodingPlugin:
+    """Plugin whose static resolve always raises."""
+
+    def __init__(self, expression: str) -> None:
+        self._expression = expression
+
+    def get_active_expression(self) -> str | None:
+        return self._expression
+
+    def resolve_context(self) -> str | None:
+        raise RuntimeError(_BOOM)
+
+
+def _app(settings: OllamaFrontendSettings, plugin: Any) -> FastAPI:
+    app = FastAPI()
+    app.include_router(create_router(settings, plugin=plugin))
+    return app
+
+
+def test_static_resolve_failure_screams() -> None:
+    settings = OllamaFrontendSettings(
+        upstream_url="http://localhost:11434",
+        active_spec="boom-spec",
+        embed_target="user",
+        embed_mode="replace",
+    )
+    # Non-$prompt expression → static-resolve branch (calls resolve_context()).
+    plugin = _ExplodingPlugin(expression="(https://docs.example.com)!'answer'")
+    client = TestClient(_app(settings, plugin))
+
+    r = client.post(
+        "/api/chat",
+        json={
+            "model": "llama3",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "stream": False,
+        },
+    )
+
+    assert r.status_code == 200
+    text = r.json()["message"]["content"]
+    assert "[url4 error]" in text
+    assert _BOOM in text

--- a/docs/superpowers/plans/2026-06-04-frontend-resolve-blocking-screaming.md
+++ b/docs/superpowers/plans/2026-06-04-frontend-resolve-blocking-screaming.md
@@ -1,0 +1,76 @@
+# Frontend Resolve: "Blocking and Screaming" Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`).
+
+**Goal:** Rework the claude-frontend url4 spec resolution so it **blocks** on `/ensemble` (up to `resolve_timeout`, default raised to **1200s**) and, on any failure (TimeoutError, `/ensemble` 502, or a degraded `on_error=collect` 200), **surfaces a visible error to the CLI** via `_build_error_response` — never a silent context-less passthrough.
+
+**Architecture:** This reverses PR #244 (SF-237)'s non-blocking + background-warm + silent direction, while **keeping** its two good parts: the **negative cache** (a failed spec fails-fast — re-raises the cached error within the TTL instead of re-running the ensemble) and the **bounded/loop-aware `_fetch_sync`** (no thread leak, cancels on timeout). The `$prompt` path already screams; we only unify its timeout. Branch: this lands on `SF-237-nonblocking-url4-resolve` (updates PR #244) — retitle the PR to "fail-loud".
+
+**Tech Stack:** Python, FastAPI/Starlette proxy, httpx, `frontend_base.FrontendPluginBase`, pytest. Test via `cd apps/server && uv run pytest <path> -v`; pre-commit (ruff 0.9.0 + pyright) before push.
+
+---
+
+## Behavior matrix (target)
+
+| Outcome of `/ensemble` resolve | Today (#244) | Target ("blocking + screaming") |
+|---|---|---|
+| Times out (`resolve_timeout`) | background, swallowed → no context, silent | block, then **`_build_error_response`** in CLI |
+| `/ensemble` 502 (`on_error=abort`) | swallowed → silent | **`_build_error_response`** in CLI |
+| Degraded 200 (`on_error=collect`, errors collected) | injected as context (garbage) | treated as failure → **scream** (best-effort, see Task 4) |
+| Success | inject context | inject context (unchanged) |
+| Repeat within `resolve_failure_ttl` after a failure | warm again / swallow | **re-raise cached error immediately** (fail-fast, no re-run) |
+
+## File structure
+
+| Path | Change |
+|---|---|
+| `apps/server/src/screamingface/plugins/frontend_base/plugin_base.py` | `resolve_timeout` 300→1200; `resolve_context` re-raises on failure + raises cached error when neg-cached; **remove** `get_cached_context`/`_maybe_warm`/`_warm` + `_RESOLVE_POOL`; `_fetch` honors `resolve_timeout` |
+| `apps/server/src/screamingface/plugins/claude_frontend/_url4_context.py` | `resolve_static_context` calls blocking `resolve_context()` again (its existing `except` now screams); unify `_resolve_expression` timeout to `resolve_timeout`; best-effort degraded-200 detection |
+| `apps/server/src/screamingface/plugins/frontend_base/tests/test_resolve_cache.py` | drop warm/concurrency tests; keep+adapt neg-cache; add "failure propagates" |
+| `apps/server/src/screamingface/plugins/claude_frontend/tests/*` | add "resolve failure → `_build_error_response`" |
+
+## Tasks
+
+### Task 1 — `resolve_context`: block, neg-cache, and re-raise (stop swallowing)
+**Files:** `frontend_base/plugin_base.py`
+- [ ] `FrontendSettingsBase.resolve_timeout` default `300.0` → `1200.0`.
+- [ ] In `resolve_context`'s per-spec loop:
+  - When a spec is **negative-cached and unexpired**, instead of `continue` (silent skip), **raise** a `RuntimeError(f"spec {name!r} resolution failed recently (cooldown {…}s)")` so the caller screams fast without re-running.
+  - In the `except Exception as exc:` block: keep `self._neg_cache[name] = time.monotonic() + settings.resolve_failure_ttl` and `_mark_span_error(...)`, then **`raise`** (remove the "deliberately don't re-raise" comment + swallow). On success keep `self._neg_cache.pop(name, None)`.
+- [ ] Test (extend `test_resolve_cache.py`): a `_fetch_sync` that raises → `resolve_context()` **raises** (not returns None); the spec is neg-cached; a second call within TTL raises **without** calling `_fetch_sync` again (assert call count 1); after TTL it retries.
+
+### Task 2 — Remove the background-warm machinery
+**Files:** `frontend_base/plugin_base.py`
+- [ ] Delete `get_cached_context`, `_maybe_warm`, `_warm`, the `self._warming` field, and `_RESOLVE_POOL` (now unused — `_fetch_sync` never used it). Keep `self._neg_cache` and `self._cache`.
+- [ ] Remove now-dead imports (`ThreadPoolExecutor`) if unused.
+- [ ] Delete the warm/concurrency tests in `test_resolve_cache.py` (`test_concurrent_warms_*`, `get_cached_context` tests).
+
+### Task 3 — `resolve_static_context`: block + scream
+**Files:** `claude_frontend/_url4_context.py`
+- [ ] Change `resolved_context = plugin.get_cached_context() if plugin else None` back to `plugin.resolve_context() if plugin else None`. The existing `except Exception as exc: return _build_error_response(...)` now catches the re-raised failure → the CLI shows `[url4 error] … Traceback`. (No other change needed for timeout/502 screaming.)
+- [ ] Test (`claude_frontend/tests/`): with a plugin whose `resolve_context` raises `TimeoutError`, `resolve_static_context(...)` returns a `JSONResponse` status 200 whose text contains `[url4 error]` and the exception class.
+
+### Task 4 — Degraded-200 = failure (best-effort)
+**Files:** `claude_frontend/_url4_context.py` (and/or `_fetch`)
+- [ ] If the `/ensemble` response carries `X-SF-Collected-Errors` (header from #243) with a value > 0, treat the resolve as failed and scream. Since #243 may not be merged into this branch, guard it: only act if the header is present. If absent, no degraded detection (document as a follow-up that depends on #243). Do **not** parse the JSON body for `n_errors` here (couples the frontend to the scoring script shape) — prefer the header.
+- [ ] Note in the PR body: full degraded-200 screaming lands once #243 (the `X-SF-Collected-Errors` header) merges.
+
+### Task 5 — Unify the `$prompt` path timeout
+**Files:** `claude_frontend/_url4_context.py` (`_resolve_expression`)
+- [ ] Remote branch: replace `httpx.Timeout(300.0)` with `httpx.Timeout(settings_resolve_timeout)` (thread the resolve_timeout in; `resolve_prompt_expression` has `settings`). 
+- [ ] In-process branch (`interpreter.evaluate(expression)`): wrap in `asyncio.wait_for(interpreter.evaluate(expression), resolve_timeout)` so it can't hang unboundedly. On `asyncio.TimeoutError`, let it propagate — `resolve_prompt_expression` already returns `_build_error_response` (it already screams). 
+- [ ] Test: `_resolve_expression` in-process that exceeds a tiny timeout → raises → `resolve_prompt_expression` returns a `_build_error_response`.
+
+### Task 6 — `_fetch` honors `resolve_timeout`
+**Files:** `frontend_base/plugin_base.py`
+- [ ] `_fetch(base_url, expression, timeout)` uses `httpx.AsyncClient(timeout=timeout, …)` and `_fetch_sync` passes its `timeout` through (so the inner HTTP cap matches the 1200 budget, not a hardcoded 300). Keep the loop-aware `asyncio.wait_for(_fetch(...), timeout)` from #244.
+
+### Task 7 — Gates + PR
+- [ ] `cd apps/server && uv run pytest src/screamingface/plugins/frontend_base/ src/screamingface/plugins/claude_frontend/ src/screamingface/plugins/codex_frontend/ src/screamingface/plugins/gemini_frontend/ src/screamingface/plugins/ollama_frontend/ -q` — all green (the base change is shared; other frontends must still pass).
+- [ ] `uv run pre-commit run --files <touched>` (ruff 0.9.0 + pyright); re-stage if reformatted.
+- [ ] Commit; push to `SF-237-nonblocking-url4-resolve`; **retitle PR #244** to "fix(frontend): blocking + fail-loud url4 resolve (negative cache + bounded fetch) (SF-237)" and update the body to describe the new direction. Do NOT merge.
+
+## Risks & decisions
+- **CLI hang vs visibility:** blocking means the CLI waits up to `resolve_timeout` (or until backends 600s × serialization). That's the user's explicit choice ("blocking and screaming"). The negative cache caps the damage to one slow attempt per TTL; CC's own client timeout may fire first (then CC shows its own timeout — acceptable).
+- **Other frontends (codex/ollama/gemini)** share `frontend_base`. They call `resolve_context()` synchronously already; making it re-raise means a resolve failure now screams for them too (their proxy paths must build an error response or the exception must be handled). Verify each frontend's proxy path surfaces or tolerates the raise; if a frontend has no `_build_error_response` equivalent, it must catch and degrade — confirm in Task 7's regression.
+- **Degraded-200** full handling depends on #243's header (Task 4 best-effort).


### PR DESCRIPTION
## SF-237 — blocking + fail-loud url4 resolve

> Reworked from the original non-blocking approach per discussion — see commits e3d9163 (plan) → a0c903e (rework) → c8b7382 (tests + docs).

### Direction
The `*_frontend` url4 spec resolution now **blocks** on `/ensemble` and **screams** on failure: a timeout / 502 / resolve error surfaces as a **visible `[url4 error]` message in the CLI** (`_build_error_response`), instead of silently proceeding without context. This replaces the earlier non-blocking + background-warm + **silent** approach (which made failures invisible — the opposite of what a demo wants).

### What it does
- **Block + scream:** `resolve_context` re-raises on failure; every frontend's proxy (claude/codex/gemini/ollama) already wraps the call and returns a provider-shaped 200 whose body is the url4 error + traceback → visible in the CLI.
- **Negative cache (kept from #244):** a failed spec fails-fast — a repeat within `resolve_failure_ttl` re-raises the cached error immediately (no ensemble re-run).
- **Bounded, loop-aware fetch (kept from #244):** `_fetch_sync` is leak-free; runs the fetch on a throwaway thread when called from the async handler (the production path), `asyncio.run` fallback otherwise.
- **Timeouts unified:** `resolve_timeout` default **300 → 1200**; `_fetch` honors it (was hardcoded 300); the `$prompt` path uses `resolve_timeout` for both in-process (`asyncio.wait_for`) and HTTP (`httpx.Timeout`) branches.
- **Removed** the background-warm machinery (`get_cached_context`/`_maybe_warm`/`_warm`/`_RESOLVE_POOL`).

### Tests
- `105 passed` across all five frontend dirs; server pyright 0 errors; pre-commit (ruff 0.9.0 + pyright) clean.
- New `test_resolve_screams.py` pins the fail-loud contract for codex/gemini/ollama (verified: removing a frontend's `try/except` turns the test red).

### Notes / follow-ups
- **Blocking is intentional** (single-client, per-session proxy model): a stuck `/ensemble` monopolizes that session's worker for up to `resolve_timeout` (1200s) — documented in code.
- **Degraded-200** (an `on_error=collect` 200 that's actually an error report) is best-effort on the `$prompt` HTTP branch via the `X-SF-Collected-Errors` header; full handling on the static path lands with #243 (which adds that header).

Plan: `docs/superpowers/plans/2026-06-04-frontend-resolve-blocking-screaming.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
