### PR TITLE
fix(llm-base): exclude non-credentialed backends from /backends/status sweep (SF-238)

### DIFF
--- a/apps/server/src/screamingface/plugins/llm_base/routes.py
+++ b/apps/server/src/screamingface/plugins/llm_base/routes.py
@@ -74,6 +74,14 @@ async def _collect_backend_status(app: Any = None) -> dict[str, Any]:
     for plugin in plugins.values():
         if not plugin.backend_call_paths:
             continue
+        # Only credentialed LLM backends belong in the auth/status sweep. A
+        # utility backend (e.g. python-runner) declares backend_call_paths so
+        # url4 can route to it but has no gateway provider or CLI auth command,
+        # so probing it for credentials is meaningless (404 -> false "reauth").
+        if not (
+            getattr(plugin, "gateway_provider", None) or getattr(plugin, "cli_auth_command", None)
+        ):
+            continue
         path = plugin.backend_call_paths[0]
         name = path.lstrip("/")
 

--- a/apps/server/src/screamingface/plugins/llm_base/tests/test_backends_status_v2.py
+++ b/apps/server/src/screamingface/plugins/llm_base/tests/test_backends_status_v2.py
@@ -72,3 +72,42 @@ async def test_external_auth_disabled_gateway_fails_closed(monkeypatch) -> None:
     assert payload["gateway"]["authenticated"] is False
     assert "provider_auth" not in payload
     assert "backends" not in payload
+
+
+def _plugin(path: str, **attrs: object) -> SimpleNamespace:
+    return SimpleNamespace(backend_call_paths=[path], **attrs)
+
+
+@pytest.mark.anyio
+async def test_collect_backend_status_excludes_non_credentialed_backends(monkeypatch) -> None:
+    """Utility backends (no gateway_provider, no cli_auth_command) are skipped.
+
+    The url4 ``python-runner`` declares ``backend_call_paths=["/python"]`` so it
+    can be routed to, but it is not a credentialed LLM backend — probing it for
+    auth status is meaningless. Only real LLM backends (CLI-auth or
+    gateway-managed OAuth) belong in the sweep.
+    """
+
+    async def fake_probe(_base_url: str, backend: str) -> dict:
+        return {"authenticated": True}
+
+    monkeypatch.setattr(status_routes, "_probe_health", fake_probe)
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            config=SimpleNamespace(server=SimpleNamespace(host="127.0.0.1", port=8000)),
+            plugins=SimpleNamespace(
+                active_plugins={
+                    "python-runner": _plugin("/python"),
+                    "provider-backend-api": _plugin("/provider", cli_auth_command="provider login"),
+                    "aigw-alt-backend": _plugin("/alternate", gateway_provider="alternate"),
+                }
+            ),
+        )
+    )
+
+    results = await status_routes._collect_backend_status(app)
+
+    assert "python" not in results
+    assert "provider" in results
+    assert "alternate" in results


### PR DESCRIPTION
## SF-238 / WI-4 — exclude non-credentialed backends from /backends/status (demo silent-failure #1)

Part of the **demo-path silent-failures** cluster. Plan: `docs/superpowers/plans/2026-06-04-demo-path-silent-failures.md`.

### Problem
The desktop backend-status panel (`GET /backends/status`) treats **every** active plugin with `backend_call_paths` as a credentialed LLM backend. The utility `python-runner` declares `backend_call_paths=["/python"]` (so url4 can route `/python(...)` script calls to it) but is not an LLM provider — no `/python/health`, no `gateway_provider`, no `cli_auth_command`. So the sweep probes `GET /python/health` → 404 → classifies it `reauth` → shows the misleading **"Credential is missing or expired."** for `/python`.

### Fix
One guard in `_collect_backend_status`: skip any plugin lacking both `gateway_provider` and `cli_auth_command`. That's the exact discriminator the rest of the file already keys off (`_classify_auth_kind`, `_cli_command`, `_provider_auth_status`) — real LLM backends always have one (all `aigw-*` via `gateway_provider`, CLI backends via `cli_auth_command`).

### Tests
- `test_backends_status_v2.py`: new `test_collect_backend_status_excludes_non_credentialed_backends` — a `python-runner`-style plugin is absent from the sweep while gateway-provider and cli-auth plugins remain present.
- Regression: `113 passed` across `llm_base/`; server-venv pyright `0 errors`; pre-commit clean. No existing test asserted utility backends appear, so none needed changing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
