### PR TITLE
SF-240: claude_frontend terminal ensemble endpoint (M1 shared infra + M2)

### DIFF
--- a/apps/server/src/screamingface/plugins/claude_frontend/_url4_context.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/_url4_context.py
@@ -50,12 +50,17 @@ def _build_error_response(
     spec_name: str,
     raw_expression: str,
     exc: Exception,
+    model: str,
 ) -> dict[str, Any]:
     """Build an Anthropic-shaped error envelope dict (not a ``JSONResponse``).
 
     Error text lands in ``content[0].text`` so the CLI renders it (#244). The
     handler wraps this in a ``JSONResponse`` (unary) or feeds ``content[0].text``
     to ``stream_anthropic_sse`` (streaming).
+
+    ``model`` echoes the request body's model, matching the success envelope
+    (``build_anthropic_message``) and the spec's pinned error envelope. ``usage``
+    is the 4-key superset-of-zeros, identical to the success builder.
     """
     error_text = extract_error_text(exc, spec_name, raw_expression)
     return {
@@ -63,10 +68,15 @@ def _build_error_response(
         "type": "message",
         "role": "assistant",
         "content": [{"type": "text", "text": error_text}],
-        "model": "unknown",
+        "model": model,
         "stop_reason": "end_turn",
         "stop_sequence": None,
-        "usage": {"input_tokens": 0, "output_tokens": 0},
+        "usage": {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        },
     }
 
 
@@ -174,7 +184,7 @@ async def _resolve_expression(
 
 
 async def resolve_prompt_expression(
-    body: dict[str, Any],  # noqa: ARG001 — kept for signature symmetry with the static path
+    body: dict[str, Any],
     *,
     raw_expression: str,
     settings: Any,
@@ -256,17 +266,19 @@ async def resolve_prompt_expression(
                 spec_name=settings.active_spec or "unknown",
                 raw_expression=raw_expression,
                 exc=exc,
+                model=body.get("model", "claude-opus-4-1-20250805"),
             )
 
 
 def resolve_static_context(
-    body: dict[str, Any],  # noqa: ARG001 — kept for signature symmetry with the $prompt path
+    body: dict[str, Any],
     *,
     raw_expression: str,
     settings: Any,
     plugin: Any,
 ) -> tuple[str | None, dict[str, Any] | None]:
     """No ``$prompt`` — use plugin-cached resolved context. Fail-loud on None/empty (O5b)."""
+    model = body.get("model", "claude-opus-4-1-20250805")
     try:
         resolved_context = plugin.resolve_context() if plugin else None
         if not resolved_context:
@@ -274,6 +286,7 @@ def resolve_static_context(
                 spec_name=settings.active_spec or "unknown",
                 raw_expression=raw_expression,
                 exc=RuntimeError("Static spec resolved to empty"),
+                model=model,
             )
         logger.info("Static context resolved: %d chars", len(resolved_context))
         return resolved_context, None
@@ -283,4 +296,5 @@ def resolve_static_context(
             spec_name=settings.active_spec or "unknown",
             raw_expression=raw_expression,
             exc=exc,
+            model=model,
         )

--- a/apps/server/src/screamingface/plugins/claude_frontend/_url4_context.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/_url4_context.py
@@ -3,33 +3,34 @@
 Two resolution paths live here:
 
 - **``$prompt`` substitution** (:func:`resolve_prompt_expression`) —
-  the active spec contains the ``$prompt`` sentinel. The user's last
-  message text is stored as a blob, the sentinel is substituted with
-  the blob URL, the full expression is evaluated through url4, and
-  the result is embedded back into the outgoing request.
+  the active spec contains the ``$prompt`` sentinel. The serialized
+  conversation transcript is stored as a blob, the sentinel is
+  substituted with the blob URL, and the full expression is evaluated
+  through url4 to a terminal result string.
 
 - **Static resolution** (:func:`resolve_static_context`) — the active
   spec has no ``$prompt``. The plugin's cached resolved context is
-  embedded directly.
+  returned directly.
 
-Both paths return ``None`` on success (request body is mutated in
-place) and a :class:`JSONResponse` error on failure — the proxy
-short-circuits with that response instead of forwarding. Error
-responses are shaped as fake-200 Anthropic messages so Claude Code
-surfaces the error text in the chat UI.
+Both paths return a ``(resolved_text, error_dict)`` tuple: on success
+``(text, None)``; on any failure (including an empty/None result —
+fail-loud, O5b) ``(None, error_envelope_dict)``. The handler renders
+the success text via M1's builders/streamers, or feeds the error
+envelope's text through the SAME builder/streamer as a visible fake-200
+(blocking-and-screaming, PR #244). No body mutation; no embed_context.
 
-Extracted from ``proxy.py`` during SF-107.
+Extracted from ``proxy.py`` during SF-107; rewritten to the tuple
+contract during SF-240 (M2).
 """
 
 from __future__ import annotations
 
 import logging
-import traceback
 from typing import Any
 
 import httpx
-from fastapi.responses import JSONResponse
 
+from screamingface.plugins.frontend_base.terminal_response import extract_error_text
 from screamingface.plugins.llm_base.constants import PROMPT_PREVIEW_LIMIT
 
 logger = logging.getLogger(__name__)
@@ -45,43 +46,28 @@ def _truncate(text: str, limit: int = PROMPT_PREVIEW_LIMIT) -> str:
 
 
 def _build_error_response(
-    body: dict[str, Any],
     *,
     spec_name: str,
-    header: str,
     raw_expression: str,
-    substituted: str | None,
     exc: Exception,
-) -> JSONResponse:
-    """Build a fake-200 Anthropic response whose text is the url4 error."""
-    tb_str = "".join(traceback.format_exception(exc))
-    lines: list[str] = [
-        f"[url4 error] {header} for spec '{spec_name}'",
-        "",
-        f"Expression: {_truncate(raw_expression, 200)}",
-    ]
-    if substituted is not None:
-        lines.append(f"Substituted: {_truncate(substituted, 200)}")
-    lines += [
-        "",
-        f"Error: {exc.__class__.__name__}: {exc}",
-        "",
-        "Traceback:",
-        tb_str,
-    ]
-    return JSONResponse(
-        content={
-            "id": f"sf_error_{id(exc):x}",
-            "type": "message",
-            "role": "assistant",
-            "content": [{"type": "text", "text": "\n".join(lines)}],
-            "model": body.get("model", "unknown"),
-            "stop_reason": "end_turn",
-            "stop_sequence": None,
-            "usage": {"input_tokens": 0, "output_tokens": 0},
-        },
-        status_code=200,
-    )
+) -> dict[str, Any]:
+    """Build an Anthropic-shaped error envelope dict (not a ``JSONResponse``).
+
+    Error text lands in ``content[0].text`` so the CLI renders it (#244). The
+    handler wraps this in a ``JSONResponse`` (unary) or feeds ``content[0].text``
+    to ``stream_anthropic_sse`` (streaming).
+    """
+    error_text = extract_error_text(exc, spec_name, raw_expression)
+    return {
+        "id": f"sf_error_{id(exc):x}",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": error_text}],
+        "model": "unknown",
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "usage": {"input_tokens": 0, "output_tokens": 0},
+    }
 
 
 async def _store_prompt_blob(
@@ -188,31 +174,30 @@ async def _resolve_expression(
 
 
 async def resolve_prompt_expression(
-    body: dict[str, Any],
+    body: dict[str, Any],  # noqa: ARG001 — kept for signature symmetry with the static path
     *,
     raw_expression: str,
     settings: Any,
     plugin: Any,  # noqa: ARG001 — reserved for future plugin-scoped hooks
     app: Any,
     tracer: Any,
-    last_user_text: str,
-    embed_context: Any,
-) -> JSONResponse | None:
-    """Substitute ``$prompt``, resolve, embed the result back into body.
+    prompt_text: str,
+) -> tuple[str | None, dict[str, Any] | None]:
+    """Substitute ``$prompt`` with a transcript blob, resolve, return ``(text, error)``.
 
-    ``tracer`` is a :class:`frontend_base.ProxyTracer`. Returns ``None``
-    on success (body mutated in place) or a :class:`JSONResponse` if
-    anything in the pipeline raises; the proxy uses that return value
-    to short-circuit with a fake-200 error response.
+    Decision A: ``prompt_text`` is the FULL serialized transcript (built by the
+    handler via ``serialize_transcript``). On success returns ``(resolved_text, None)``;
+    on any failure — including an empty result (O5b, fail-loud) — returns
+    ``(None, error_envelope_dict)``. ``tracer`` is a :class:`frontend_base.ProxyTracer`.
+    No body mutation; no embed_context.
     """
-    substituted: str | None = None
     with tracer.start_current_span("url4.$prompt") as prompt_span:
         try:
             if prompt_span and prompt_span.is_recording():
                 tracer.set_attrs(
                     {
                         "url4.raw_expression": raw_expression,
-                        "url4.user_text_length": len(last_user_text),
+                        "url4.prompt_text_length": len(prompt_text),
                     },
                     span=prompt_span,
                 )
@@ -220,7 +205,7 @@ async def resolve_prompt_expression(
             backend_url = settings.backend_url.rstrip("/") if settings.backend_url else None
 
             blob_key = await _store_prompt_blob(
-                last_user_text,
+                prompt_text,
                 app=app,
                 backend_url=backend_url,
                 tracer=tracer,
@@ -244,6 +229,10 @@ async def resolve_prompt_expression(
                 tracer=tracer,
             )
 
+            if not final_text:
+                # O5b: an empty resolution is fail-loud.
+                raise RuntimeError("$prompt resolved to empty")
+
             if prompt_span and prompt_span.is_recording():
                 tracer.set_attrs(
                     {
@@ -254,16 +243,8 @@ async def resolve_prompt_expression(
                     span=prompt_span,
                 )
 
-            if final_text:
-                embed_context(body, final_text, settings)
-                logger.info(
-                    "$prompt: blob=%s resolved %d chars → target=%s mode=%s",
-                    blob_key,
-                    len(final_text),
-                    settings.embed_target,
-                    settings.embed_mode,
-                )
-            return None
+            logger.info("$prompt: blob=%s resolved %d chars", blob_key, len(final_text))
+            return final_text, None
 
         except Exception as exc:
             if prompt_span and prompt_span.is_recording():
@@ -271,44 +252,35 @@ async def resolve_prompt_expression(
                 prompt_span.set_attribute("url4.error", str(exc))
                 prompt_span.record_exception(exc)
             logger.warning("$prompt substitution failed", exc_info=True)
-            return _build_error_response(
-                body,
+            return None, _build_error_response(
                 spec_name=settings.active_spec or "unknown",
-                header="Resolution failed",
                 raw_expression=raw_expression,
-                substituted=substituted,
                 exc=exc,
             )
 
 
 def resolve_static_context(
-    body: dict[str, Any],
+    body: dict[str, Any],  # noqa: ARG001 — kept for signature symmetry with the $prompt path
     *,
     raw_expression: str,
     settings: Any,
     plugin: Any,
-    embed_context: Any,
-) -> JSONResponse | None:
-    """No ``$prompt`` — use plugin-cached resolved context."""
+) -> tuple[str | None, dict[str, Any] | None]:
+    """No ``$prompt`` — use plugin-cached resolved context. Fail-loud on None/empty (O5b)."""
     try:
         resolved_context = plugin.resolve_context() if plugin else None
+        if not resolved_context:
+            return None, _build_error_response(
+                spec_name=settings.active_spec or "unknown",
+                raw_expression=raw_expression,
+                exc=RuntimeError("Static spec resolved to empty"),
+            )
+        logger.info("Static context resolved: %d chars", len(resolved_context))
+        return resolved_context, None
     except Exception as exc:
         logger.warning("Static context resolution failed", exc_info=True)
-        return _build_error_response(
-            body,
+        return None, _build_error_response(
             spec_name=settings.active_spec or "unknown",
-            header="Static context resolution failed",
             raw_expression=raw_expression,
-            substituted=None,
             exc=exc,
         )
-
-    if resolved_context:
-        embed_context(body, resolved_context, settings)
-        logger.info(
-            "Injected cached url4 context (%d chars) embed_target=%s embed_mode=%s",
-            len(resolved_context),
-            settings.embed_target,
-            settings.embed_mode,
-        )
-    return None

--- a/apps/server/src/screamingface/plugins/claude_frontend/proxy.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/proxy.py
@@ -147,8 +147,9 @@ def create_router(
 
         resolved_text: str | None = None
         error_dict: dict[str, Any] | None = None
-        if is_prompt_spec:
-            assert raw_expression is not None
+        if raw_expression and "$prompt" in raw_expression:
+            # Branch on the raw value (not the ``is_prompt_spec`` bool) so pyright
+            # narrows ``raw_expression`` to ``str`` here — no production ``assert``.
             resolved_text, error_dict = await resolve_prompt_expression(
                 body,
                 raw_expression=raw_expression,

--- a/apps/server/src/screamingface/plugins/claude_frontend/proxy.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/proxy.py
@@ -1,19 +1,23 @@
-"""Claude API proxy router — streaming and non-streaming support.
+"""Claude API proxy router — TERMINAL ensemble inference.
 
-The hot path is :func:`proxy_messages`. Its three responsibilities are
-implemented as focused helpers and orchestrated from a thin handler:
+The hot path is :func:`proxy_messages`. It is now a TERMINAL endpoint: it
+resolves the active url4 spec in-process and synthesizes the Anthropic
+Messages response envelope (unary) / SSE stream (streaming). It no longer
+forwards inference requests to the real Anthropic upstream.
 
 - Session enrichment + save — :mod:`._session`
 - URL4 ``$prompt`` / static context resolution — :mod:`._url4_context`
-- Upstream forwarding (streaming + non-streaming) — inline below
+  (returns ``(resolved_text, error_dict)``)
+- Wire-format rendering — M1's ``build_anthropic_message`` /
+  ``stream_anthropic_sse`` from :mod:`frontend_base.terminal_response`.
 
-All tracing, SSE reconstruction, and message-surgery utilities live in
-this file (they're small and specific to the Anthropic wire format).
+Non-inference management routes (the ``/v1/{path}`` catchall, incl.
+``POST /v1/messages/count_tokens``, and the ``/api/{path}`` passthrough)
+STILL forward to the real upstream unchanged.
 """
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import ssl
@@ -24,14 +28,17 @@ import httpx
 from fastapi import APIRouter, Request, Response
 from fastapi.responses import JSONResponse, StreamingResponse
 
-from screamingface.plugins.claude_frontend._observability import trace_request_context
 from screamingface.plugins.claude_frontend._session import SessionHook
-from screamingface.plugins.claude_frontend._sse import parse_sse_response
 from screamingface.plugins.claude_frontend._url4_context import (
     resolve_prompt_expression,
     resolve_static_context,
 )
 from screamingface.plugins.frontend_base import make_tracer, redact_headers, truncate
+from screamingface.plugins.frontend_base.terminal_response import (
+    build_anthropic_message,
+    serialize_transcript,
+    stream_anthropic_sse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -51,9 +58,6 @@ FORWARD_HEADERS = {
 _SENSITIVE_HEADERS = {"x-api-key", "authorization"}
 _PLUGIN_NAME = "claude-frontend"
 
-# Always-on request dumps are noisy; opt-in via env var.
-_DEBUG_DUMP_ENV = "SF_PROXY_DEBUG_DUMP"
-
 _tracer = make_tracer(_PLUGIN_NAME)
 
 
@@ -64,93 +68,28 @@ def _record_trace_id(request: Request) -> str | None:
     return trace_id
 
 
-def _trace_request_context(body: dict[str, Any]) -> None:
-    """Thin wrapper preserving the existing call site name."""
-    trace_request_context(body, _tracer)
+def _extract_turns(body: dict[str, Any]) -> list[tuple[str, str]]:
+    """Extract conversation turns as ``(role, text)`` tuples for the ``$prompt`` blob.
 
-
-def _extract_last_user_text(messages: list[dict[str, Any]]) -> str | None:
-    """Extract the user's actual prompt from the last user message.
-
-    Claude Code packs ``<system-reminder>`` blocks (MCP instructions,
-    skills, etc.) inside user messages alongside the real prompt. We
-    skip any text block starting with ``<system-reminder>``.
+    Decision A (conversation-aware): the FULL transcript is serialized, not just the
+    last user turn. Each Anthropic ``messages`` entry contributes one ``(role, text)``
+    tuple; list-shaped content concatenates its ``text`` blocks.
     """
-    for msg in reversed(messages):
-        if msg.get("role") != "user":
-            continue
-        content = msg.get("content")
-        if isinstance(content, str):
-            if content.lstrip().startswith("<system-reminder>"):
-                return None
-            return content
+    turns: list[tuple[str, str]] = []
+    for msg in body.get("messages", []):
+        role = msg.get("role", "user")
+        content = msg.get("content", "")
         if isinstance(content, list):
-            texts = [
-                b.get("text", "")
-                for b in content
-                if isinstance(b, dict)
-                and b.get("type") == "text"
-                and not b.get("text", "").lstrip().startswith("<system-reminder>")
-            ]
-            return texts[-1] if texts else None
-    return None
-
-
-def _replace_last_user_message(messages: list[dict[str, Any]], new_text: str) -> None:
-    """Replace only the user's actual text in the last user message.
-
-    Preserves ``<system-reminder>`` blocks, ``cache_control`` markers,
-    ``tool_result`` blocks, and any other content blocks.
-    """
-    for i in range(len(messages) - 1, -1, -1):
-        if messages[i].get("role") != "user":
-            continue
-        content = messages[i].get("content")
-        if isinstance(content, str):
-            messages[i] = {"role": "user", "content": new_text}
-            return
-        if isinstance(content, list):
-            for j in range(len(content) - 1, -1, -1):
-                block = content[j]
-                if (
-                    isinstance(block, dict)
-                    and block.get("type") == "text"
-                    and not block.get("text", "").lstrip().startswith("<system-reminder>")
-                ):
-                    content[j] = {"type": "text", "text": new_text}
-                    return
-            content.append({"type": "text", "text": new_text})
-        return
-
-
-def _inject_system_context(body: dict[str, Any], text: str) -> None:
-    existing = body.get("system")
-    if existing is None:
-        body["system"] = [{"type": "text", "text": text}]
-    elif isinstance(existing, str):
-        body["system"] = existing + "\n\n" + text
-    elif isinstance(existing, list):
-        existing.append({"type": "text", "text": text})
-
-
-def _embed_context(
-    body: dict[str, Any],
-    resolved_context: str,
-    settings: ClaudeFrontendSettings,
-) -> None:
-    """Embed resolved url4 context per plugin settings."""
-    if settings.embed_target == "user":
-        messages = body.get("messages", [])
-        last_user_text = _extract_last_user_text(messages)
-        if last_user_text:
-            if settings.embed_mode == "concat":
-                combined = f"{last_user_text}\n\n{resolved_context}"
-            else:
-                combined = resolved_context
-            _replace_last_user_message(messages, combined)
-    else:
-        wrapped = f"{settings.system_prompt}\n\n{resolved_context}"
-        _inject_system_context(body, wrapped)
+            text = "".join(
+                part.get("text", "")
+                for part in content
+                if isinstance(part, dict) and part.get("type") == "text"
+            )
+        else:
+            text = content if isinstance(content, str) else str(content)
+        if text:
+            turns.append((role, text))
+    return turns
 
 
 def create_router(
@@ -185,7 +124,13 @@ def create_router(
 
     @router.post("/v1/messages", response_model=None, operation_id="proxy_messages")
     async def proxy_messages(request: Request) -> Response:
+        """Terminal inference: resolve the active spec, synthesize the Anthropic
+        response in-process, and return it. No upstream inference forward.
+        """
         body = await request.json()
+        is_streaming = body.get("stream", False)
+        model = body.get("model", "claude-opus-4-1-20250805")
+        _record_trace_id(request)
 
         # Stage 1: session enrichment
         session = SessionHook.from_request(
@@ -195,94 +140,68 @@ def create_router(
         )
         body = await session.enrich(body, tracer=_tracer)
 
-        # Stage 2: url4 context injection (either path may short-circuit)
+        # Stage 2: url4 resolution → (resolved_text, error_dict)
         raw_expression = plugin.get_active_expression() if plugin else None
-        if raw_expression and "$prompt" in raw_expression:
-            last_user_text = _extract_last_user_text(body.get("messages", []))
-            if last_user_text:
-                short_circuit = await resolve_prompt_expression(
-                    body,
-                    raw_expression=raw_expression,
-                    settings=settings,
-                    plugin=plugin,
-                    app=app,
-                    tracer=_tracer,
-                    last_user_text=last_user_text,
-                    embed_context=_embed_context,
-                )
-                if short_circuit is not None:
-                    return short_circuit
-        elif raw_expression:
-            short_circuit = resolve_static_context(
+        is_prompt_spec = bool(raw_expression and "$prompt" in raw_expression)
+        prompt_blob = serialize_transcript(_extract_turns(body)) if is_prompt_spec else ""
+
+        resolved_text: str | None = None
+        error_dict: dict[str, Any] | None = None
+        if is_prompt_spec:
+            assert raw_expression is not None
+            resolved_text, error_dict = await resolve_prompt_expression(
                 body,
                 raw_expression=raw_expression,
                 settings=settings,
                 plugin=plugin,
-                embed_context=_embed_context,
+                app=app,
+                tracer=_tracer,
+                prompt_text=prompt_blob,
             )
-            if short_circuit is not None:
-                return short_circuit
+        elif raw_expression:
+            resolved_text, error_dict = resolve_static_context(
+                body,
+                raw_expression=raw_expression,
+                settings=settings,
+                plugin=plugin,
+            )
 
-        # Stage 3: trace the final body and forward to Anthropic
-        if _tracer.enabled:
-            with _tracer.start_current_span("anthropic.request_body") as body_span:
-                _tracer.set_attrs(
-                    {
-                        "description": "Final request body sent to Anthropic API "
-                        "(after url4 injection)",
-                    },
-                    span=body_span,
-                )
-                _trace_request_context(body)
-        else:
-            _trace_request_context(body)
-
-        headers = _build_headers(request)
-        qs = str(request.url.query)
-        url = f"{upstream_url}/v1/messages"
-        if qs:
-            url = f"{url}?{qs}"
-        timeout = httpx.Timeout(connect=10.0, read=600.0, write=10.0, pool=10.0)
-        trace_id = _record_trace_id(request)
-
-        _tracer.set_attrs({"request.body": truncate(json.dumps(body))})
-        _tracer.set_headers("request.headers", redact_headers(headers, _SENSITIVE_HEADERS))
-
-        is_streaming = body.get("stream", False)
-        _maybe_dump_request(body)
         logger.info(
-            "PROXY >>> forwarding to %s | stream=%s | sys_len=%s | msgs=%s | trace=%s",
-            url,
-            is_streaming,
-            len(json.dumps(body.get("system", ""))) if body.get("system") else 0,
-            len(body.get("messages", [])),
-            trace_id,
-        )
-        logger.info(
-            "[E2E-TRACE] PROXY received %s /v1/messages | forwarding to %s",
+            "[E2E-TRACE] PROXY received %s /v1/messages | terminal (no upstream) | stream=%s",
             request.method,
-            url,
+            is_streaming,
         )
+
+        # Stage 3: error path (fake-200, branched on is_streaming) — #244 visibility
+        if error_dict is not None:
+            error_text = error_dict["content"][0]["text"]
+            if is_streaming:
+                return StreamingResponse(
+                    stream_anthropic_sse(error_text, model),
+                    media_type="text/event-stream",
+                )
+            return JSONResponse(content=error_dict, status_code=200)
+
+        # Stage 4: success. ``resolved_text`` is None only when there is no active
+        # spec — synthesize an empty envelope (no upstream call) per Decision.
+        result_text = resolved_text or ""
+        _tracer.set_attrs({"url4.result_length": len(result_text)})
+
+        response_dict = build_anthropic_message(result_text, model, prompt_text=prompt_blob)
 
         if is_streaming:
-            return await _forward_streaming(
-                url=url,
-                headers=headers,
-                body=body,
-                timeout=timeout,
-                ssl_ctx=ssl_ctx,
-                trace_id=trace_id,
-                session=session,
-            )
-        return await _forward_unary(
-            url=url,
-            headers=headers,
-            body=body,
-            timeout=timeout,
-            ssl_ctx=ssl_ctx,
-            trace_id=trace_id,
-            session=session,
-        )
+            await session.save(response_dict, streaming=True, tracer=_tracer)
+
+            async def gen():
+                async for chunk in stream_anthropic_sse(
+                    result_text, model, prompt_text=prompt_blob
+                ):
+                    yield chunk
+
+            return StreamingResponse(gen(), media_type="text/event-stream")
+
+        await session.save(response_dict, streaming=False, tracer=_tracer)
+        return JSONResponse(content=response_dict, status_code=200)
 
     @router.get("/v1/{path:path}", response_model=None, operation_id="proxy_catchall_get")
     @router.post("/v1/{path:path}", response_model=None, operation_id="proxy_catchall_post")
@@ -378,138 +297,3 @@ def create_router(
         )
 
     return router
-
-
-# ---------------------------------------------------------------------------
-# Stage 3 helpers — upstream forwarding
-# ---------------------------------------------------------------------------
-
-
-def _maybe_dump_request(body: dict[str, Any]) -> None:
-    """Dump the outgoing request body to /tmp for debugging — opt-in."""
-    if not os.environ.get(_DEBUG_DUMP_ENV):
-        return
-    import tempfile
-    from pathlib import Path
-
-    debug_dir = Path(tempfile.gettempdir()) / "sf-proxy-debug"
-    debug_dir.mkdir(exist_ok=True)
-    debug_file = debug_dir / "last_request.json"
-    debug_file.write_text(json.dumps(body, indent=2, ensure_ascii=False))
-    logger.info("PROXY >>> dumped request body to %s", debug_file)
-
-
-async def _forward_streaming(
-    *,
-    url: str,
-    headers: dict[str, str],
-    body: dict[str, Any],
-    timeout: httpx.Timeout,
-    ssl_ctx: ssl.SSLContext,
-    trace_id: str | None,
-    session: SessionHook,
-) -> StreamingResponse:
-    """Stream Anthropic's SSE response through, saving the session turn on completion."""
-    client = httpx.AsyncClient(timeout=timeout, verify=ssl_ctx)
-    upstream_span = _tracer.start_client_span_detached("anthropic.POST /v1/messages")
-    if upstream_span:
-        _tracer.set_attrs({"http.method": "POST", "http.url": url}, span=upstream_span)
-        if trace_id:
-            _tracer.set_attrs({"sf.trace_id": trace_id}, span=upstream_span)
-        _tracer.set_headers(
-            "request.headers", redact_headers(headers, _SENSITIVE_HEADERS), span=upstream_span
-        )
-        _tracer.set_attrs({"request.body": truncate(json.dumps(body))}, span=upstream_span)
-        logger.info("TRACE: created upstream span %s", upstream_span.get_span_context().span_id)
-
-    async def stream_response():
-        chunks: list[bytes] = []
-        try:
-            logger.info("STREAM >>> opening upstream connection to Anthropic")
-            async with client.stream("POST", url, json=body, headers=headers) as resp:
-                logger.info(
-                    "STREAM >>> upstream responded: status=%s content-type=%s",
-                    resp.status_code,
-                    resp.headers.get("content-type", "?"),
-                )
-                if upstream_span:
-                    _tracer.set_attrs({"http.status_code": resp.status_code}, span=upstream_span)
-                    _tracer.set_headers("response.headers", dict(resp.headers), span=upstream_span)
-                chunk_count = 0
-                async for chunk in resp.aiter_bytes():
-                    chunk_count += 1
-                    chunks.append(chunk)
-                    if chunk_count <= 3:
-                        logger.info(
-                            "STREAM >>> chunk #%d (%d bytes): %s",
-                            chunk_count,
-                            len(chunk),
-                            chunk[:200],
-                        )
-                    yield chunk
-                logger.info(
-                    "STREAM >>> finished: %d chunks, %d total bytes",
-                    chunk_count,
-                    sum(len(c) for c in chunks),
-                )
-                logger.info("[E2E-TRACE] PROXY response status=%d", resp.status_code)
-        except Exception as exc:
-            logger.error("STREAM >>> ERROR during streaming: %s", exc, exc_info=True)
-            raise
-        finally:
-            if chunks:
-                raw = b"".join(chunks).decode(errors="replace")
-                if upstream_span:
-                    _tracer.set_attrs({"response.body": truncate(raw)}, span=upstream_span)
-                _tracer.set_attrs({"response.body": truncate(raw)})
-                if session.enabled:
-                    response_data = parse_sse_response(raw)
-                    if response_data:
-                        await session.save(response_data, streaming=True, tracer=_tracer)
-            if upstream_span:
-                upstream_span.end()
-            await client.aclose()
-            logger.info("STREAM >>> client closed")
-
-    return StreamingResponse(stream_response(), media_type="text/event-stream")
-
-
-async def _forward_unary(
-    *,
-    url: str,
-    headers: dict[str, str],
-    body: dict[str, Any],
-    timeout: httpx.Timeout,
-    ssl_ctx: ssl.SSLContext,
-    trace_id: str | None,
-    session: SessionHook,
-) -> JSONResponse:
-    """Non-streaming POST, parse JSON, save session turn."""
-    with _tracer.start_client_span(f"POST {url}") as span:
-        if span:
-            _tracer.set_attrs({"http.method": "POST", "http.url": url}, span=span)
-            if trace_id:
-                _tracer.set_attrs({"sf.trace_id": trace_id}, span=span)
-            _tracer.set_headers(
-                "request.headers", redact_headers(headers, _SENSITIVE_HEADERS), span=span
-            )
-            _tracer.set_attrs({"request.body": truncate(json.dumps(body))}, span=span)
-        async with httpx.AsyncClient(timeout=timeout, verify=ssl_ctx) as client:
-            resp = await client.post(url, json=body, headers=headers)
-        if span:
-            _tracer.set_attrs(
-                {
-                    "http.status_code": resp.status_code,
-                    "response.body": truncate(resp.text),
-                },
-                span=span,
-            )
-            _tracer.set_headers("response.headers", dict(resp.headers), span=span)
-
-    _tracer.set_attrs({"response.body": truncate(resp.text), "http.status_code": resp.status_code})
-    _tracer.set_headers("response.headers", dict(resp.headers))
-    logger.info("[E2E-TRACE] PROXY response status=%d", resp.status_code)
-
-    response_data = resp.json()
-    await session.save(response_data, streaming=False, tracer=_tracer)
-    return JSONResponse(content=response_data, status_code=resp.status_code)

--- a/apps/server/src/screamingface/plugins/claude_frontend/tests/test_claude_frontend_models.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/tests/test_claude_frontend_models.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
-import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -305,7 +304,11 @@ class TestPrependSystemContext:
 
 
 # ---------------------------------------------------------------------------
-# Proxy integration tests (cached context injection)
+# Proxy integration tests (TERMINAL synthesis — no upstream inference forward)
+#
+# Migrated from the pre-SF-240 "context injection into the forwarded upstream
+# system prompt" assertions. The inference route is now terminal: the resolved
+# url4 context becomes the response BODY, and no httpx.AsyncClient.post fires.
 # ---------------------------------------------------------------------------
 
 
@@ -326,7 +329,7 @@ class _FakePlugin:
 def proxy_app_with_context() -> FastAPI:
     settings = ClaudeFrontendSettings(
         upstream_url="https://api.anthropic.com",
-        embed_target="system",
+        active_spec="static-spec",
     )
     app = FastAPI()
     router = create_router(settings, plugin=_FakePlugin("cached url4 docs"))
@@ -338,29 +341,17 @@ def proxy_app_with_context() -> FastAPI:
 def proxy_app_no_context() -> FastAPI:
     settings = ClaudeFrontendSettings(upstream_url="https://api.anthropic.com")
     app = FastAPI()
-    router = create_router(settings)
+    router = create_router(settings, plugin=_FakePlugin(None))
     app.include_router(router)
     return app
 
 
-_DEFAULT_SYS_PROMPT = (
-    "You are a helpful assistant. Answer the user's question based only on "
-    "the provided context. Be concise and factual."
-)
-_INJECT_PREFIX = _DEFAULT_SYS_PROMPT + "\n\n"
-
-
-class TestProxyContextInjection:
-    prefix = _INJECT_PREFIX
-
-    def test_injects_cached_context(self, proxy_app_with_context: FastAPI) -> None:
+class TestProxyTerminalSynthesis:
+    def test_resolved_context_becomes_response_body(self, proxy_app_with_context: FastAPI) -> None:
+        """The static-resolved url4 context is synthesized as the response text."""
         client = TestClient(proxy_app_with_context)
-        mock_response = httpx.Response(200, json={"id": "msg_1", "content": []})
-
-        with patch(
-            "httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response
-        ) as mock_post:
-            client.post(
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+            resp = client.post(
                 "/v1/messages",
                 json={
                     "model": "claude-sonnet-4-20250514",
@@ -370,19 +361,17 @@ class TestProxyContextInjection:
                 },
                 headers={"x-api-key": "test-key"},
             )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["type"] == "message"
+        assert data["content"][0]["text"] == "cached url4 docs"
+        assert not mock_post.called
 
-        call_kwargs = mock_post.call_args
-        sent_body = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json", {})
-        assert sent_body["system"] == f"Be helpful\n\n{self.prefix}cached url4 docs"
-
-    def test_no_context_passthrough(self, proxy_app_no_context: FastAPI) -> None:
+    def test_no_context_synthesizes_empty_no_upstream(self, proxy_app_no_context: FastAPI) -> None:
+        """No active spec → empty synthesized envelope, no upstream inference call."""
         client = TestClient(proxy_app_no_context)
-        mock_response = httpx.Response(200, json={"id": "msg_2", "content": []})
-
-        with patch(
-            "httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response
-        ) as mock_post:
-            client.post(
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+            resp = client.post(
                 "/v1/messages",
                 json={
                     "model": "claude-sonnet-4-20250514",
@@ -392,77 +381,29 @@ class TestProxyContextInjection:
                 },
                 headers={"x-api-key": "test-key"},
             )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["type"] == "message"
+        assert data["content"][0]["text"] == ""
+        assert not mock_post.called
 
-        call_kwargs = mock_post.call_args
-        sent_body = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json", {})
-        assert sent_body["system"] == "Be helpful"
-
-    def test_extra_fields_survive_round_trip(self, proxy_app_with_context: FastAPI) -> None:
+    def test_streaming_synthesizes_resolved_context_no_upstream(
+        self, proxy_app_with_context: FastAPI
+    ) -> None:
         client = TestClient(proxy_app_with_context)
-        mock_response = httpx.Response(200, json={"id": "msg_3", "content": []})
-
-        with patch(
-            "httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response
-        ) as mock_post:
-            client.post(
+        with patch("httpx.AsyncClient.stream") as mock_stream:
+            resp = client.post(
                 "/v1/messages",
                 json={
                     "model": "claude-sonnet-4-20250514",
                     "max_tokens": 1024,
                     "messages": [{"role": "user", "content": "Hi"}],
-                    "unknown_field": "should survive",
+                    "stream": True,
                 },
                 headers={"x-api-key": "test-key"},
             )
-
-        call_kwargs = mock_post.call_args
-        sent_body = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json", {})
-        assert sent_body["unknown_field"] == "should survive"
-
-    def test_context_injected_into_none_system(self, proxy_app_with_context: FastAPI) -> None:
-        client = TestClient(proxy_app_with_context)
-        mock_response = httpx.Response(200, json={"id": "msg_4", "content": []})
-
-        with patch(
-            "httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response
-        ) as mock_post:
-            client.post(
-                "/v1/messages",
-                json={
-                    "model": "claude-sonnet-4-20250514",
-                    "max_tokens": 1024,
-                    "messages": [{"role": "user", "content": "Hi"}],
-                    # No system prompt
-                },
-                headers={"x-api-key": "test-key"},
-            )
-
-        call_kwargs = mock_post.call_args
-        sent_body = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json", {})
-        assert isinstance(sent_body["system"], list)
-        assert sent_body["system"][0]["text"] == f"{self.prefix}cached url4 docs"
-
-    def test_context_injected_into_list_system(self, proxy_app_with_context: FastAPI) -> None:
-        client = TestClient(proxy_app_with_context)
-        mock_response = httpx.Response(200, json={"id": "msg_5", "content": []})
-
-        with patch(
-            "httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response
-        ) as mock_post:
-            client.post(
-                "/v1/messages",
-                json={
-                    "model": "claude-sonnet-4-20250514",
-                    "max_tokens": 1024,
-                    "messages": [{"role": "user", "content": "Hi"}],
-                    "system": [{"type": "text", "text": "original"}],
-                },
-                headers={"x-api-key": "test-key"},
-            )
-
-        call_kwargs = mock_post.call_args
-        sent_body = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json", {})
-        assert isinstance(sent_body["system"], list)
-        assert len(sent_body["system"]) == 2
-        assert sent_body["system"][0]["text"] == "original"
-        assert sent_body["system"][-1]["text"] == f"{self.prefix}cached url4 docs"
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        assert "cached url4 docs" in resp.text
+        assert "message_stop" in resp.text
+        assert not mock_stream.called

--- a/apps/server/src/screamingface/plugins/claude_frontend/tests/test_e2e_claude_frontend.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/tests/test_e2e_claude_frontend.py
@@ -1,327 +1,149 @@
-"""Live E2E test for claude-frontend proxy with real url4 context injection.
+"""E2E tests for the claude-frontend TERMINAL inference path.
 
-Starts the real server with:
-  - url4-spec "httpbin-robots" → fetches https://httpbin.org/robots.txt
-  - claude-frontend upstream → https://httpbin.org/anything (echoes request body)
+After the SF-240 terminal rewrite, ``POST /v1/messages`` resolves the active url4
+spec in-process and synthesizes the Anthropic response envelope/stream itself — it
+NEVER forwards inference to ``api.anthropic.com``. These tests drive a ``$prompt``
+spec end-to-end with the real ``$prompt`` locus (``_store_prompt_blob`` /
+``_resolve_expression``) mocked, and assert the synthesized response carries the
+ensemble result with no upstream inference call.
 
-Verifies that the cached url4 content ("User-agent") appears in the system
-prompt of the forwarded /v1/messages request.
-
-Run: cd apps/server && uv run python tests/test_e2e_claude_frontend.py
+(The previous httpbin live-server harness asserted url4 context injected into a
+forwarded upstream request body; that behavior no longer exists, so it was removed.)
 """
 
 from __future__ import annotations
 
-import json
-import os
-import subprocess
-import sys
-import threading
-import time
-from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
-import httpx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
-SERVER_DIR = Path(__file__).resolve().parents[5]  # apps/server/
-
-# Inline config: only enable the plugins we need, point upstream at httpbin
-E2E_CONFIG = json.dumps(
-    {
-        "version": "0.1.0",
-        "server": {
-            "host": "0.0.0.0",
-            "port": 8000,
-            "reload": False,
-            "ssl": False,
-        },
-        "plugins": [
-            "url4-executor",
-            "url4-specs",
-            "claude-frontend",
-        ],
-        "plugin_config": {
-            "claude-frontend": {
-                "active_spec": "httpbin-robots",
-                "upstream_url": "https://httpbin.org/anything",
-                "listen_host": "127.0.0.1",
-                "listen_port": 9101,
-            },
-            "url4-specs": {
-                "specs": {
-                    "httpbin-robots": {
-                        "expression": "(https://httpbin.org/robots.txt)!"
-                        "'You are an API testing assistant'",
-                    },
-                },
-            },
-        },
-    }
-)
-
-SERVER_CMD = [
-    "sf",
-    "run",
-    "--no-ssl",
-    "--no-reload",
-    "--config-json",
-    E2E_CONFIG,
-]
-
-PROXY_BASE = "http://127.0.0.1:9101"
-TIMEOUT = 15
+from screamingface.plugins.claude_frontend.plugin import ClaudeFrontendSettings
+from screamingface.plugins.claude_frontend.proxy import create_router
 
 
-class LogCollector:
-    """Thread-safe collector that reads subprocess output and stores lines."""
-
-    def __init__(self, proc: subprocess.Popen) -> None:
-        self.lines: list[str] = []
-        self._lock = threading.Lock()
-        self._thread = threading.Thread(target=self._read, args=(proc,), daemon=True)
-        self._thread.start()
-
-    def _read(self, proc: subprocess.Popen) -> None:
-        assert proc.stdout is not None
-        for raw_line in proc.stdout:
-            line = raw_line.rstrip()
-            with self._lock:
-                self.lines.append(line)
-
-    def wait_for_ready(self, timeout: float = 30) -> dict | None:
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            with self._lock:
-                for line in self.lines:
-                    if '"event"' in line and '"ready"' in line:
-                        try:
-                            return json.loads(line)
-                        except json.JSONDecodeError:
-                            continue
-            time.sleep(0.3)
-        return None
-
-    def find_line(self, needle: str) -> str | None:
-        with self._lock:
-            for line in self.lines:
-                if needle in line:
-                    return line
-        return None
-
-    def dump_all(self) -> list[str]:
-        with self._lock:
-            return list(self.lines)
+def _prompt_plugin() -> MagicMock:
+    """Plugin whose active spec contains the ``$prompt`` sentinel."""
+    plugin = MagicMock()
+    plugin.get_active_expression.return_value = '/claude($prompt)!"[end]" | /collect'
+    return plugin
 
 
-def wait_for_proxy(host: str = "127.0.0.1", port: int = 9101, timeout: float = 10) -> bool:
-    """Wait for the claude-frontend proxy port to be listening."""
-    import socket
-
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            if sock.connect_ex((host, port)) == 0:
-                return True
-        time.sleep(0.2)
-    return False
-
-
-def main() -> int:
-    print("=== E2E Claude Frontend Tests ===\n")
-
-    # 1. Start server
-    print("[1/4] Starting SF server with inline config...")
-    server = subprocess.Popen(
-        SERVER_CMD,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        env={**os.environ, "_SF_SUBPROCESS": "1"},
-        cwd=str(SERVER_DIR),
+def test_e2e_prompt_spec_unary_no_upstream() -> None:
+    settings = ClaudeFrontendSettings(
+        upstream_url="https://api.anthropic.com",
+        active_spec="test-spec",
+        backend_url="http://localhost:8000",
     )
-    logs = LogCollector(server)
+    app = FastAPI()
+    app.include_router(create_router(settings, plugin=_prompt_plugin()))
+    client = TestClient(app)
 
-    try:
-        # 2. Wait for ready
-        print("[2/4] Waiting for server ready...")
-        ready = logs.wait_for_ready(timeout=30)
-        if not ready:
-            print("ERROR: Server did not emit ready event within 30s")
-            print("       Last 20 log lines:")
-            for line in logs.dump_all()[-20:]:
-                print(f"         {line}")
-            return 1
+    with (
+        patch(
+            "screamingface.plugins.claude_frontend._url4_context._store_prompt_blob",
+            new_callable=AsyncMock,
+            return_value="blob123",
+        ),
+        patch(
+            "screamingface.plugins.claude_frontend._url4_context._resolve_expression",
+            new_callable=AsyncMock,
+            return_value="Ensemble answer: the test passed",
+        ),
+        patch("httpx.AsyncClient") as mock_client,
+    ):
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "claude-opus-4-1-20250805",
+                "messages": [{"role": "user", "content": "What is 2+2?"}],
+            },
+        )
 
-        host = ready.get("host", "0.0.0.0")
-        if host == "0.0.0.0":
-            host = "localhost"
-        port = ready["port"]
-        print(f"       Server ready at http://{host}:{port} (pid {ready.get('pid')})")
-
-        # Check for cached context in logs
-        cached_line = logs.find_line("Cached")
-        if cached_line:
-            print(f"       {cached_line.strip()}")
-        else:
-            print("       WARNING: No 'Cached' log line found (context may not have resolved)")
-
-        # Wait for proxy port
-        if not wait_for_proxy():
-            print("ERROR: claude-frontend proxy not listening on :9101 within 10s")
-            return 1
-        print(f"       Proxy listening at {PROXY_BASE}")
-
-        # 3. Run checks
-        print("[3/4] Running checks...\n")
-        results: list[tuple[str, bool, str]] = []
-
-        # --- Check 1: Context injection with string system prompt ---
-        try:
-            resp = httpx.post(
-                f"{PROXY_BASE}/v1/messages",
-                json={
-                    "model": "claude-sonnet-4-20250514",
-                    "max_tokens": 1024,
-                    "messages": [{"role": "user", "content": "Hello"}],
-                    "system": "Be helpful",
-                },
-                headers={"x-api-key": "test-key"},
-                timeout=TIMEOUT,
-            )
-            if resp.status_code == 200:
-                echoed = resp.json()
-                # httpbin echoes the POST body under "json" key
-                forwarded_body = echoed.get("json", {})
-                system_prompt = forwarded_body.get("system", "")
-
-                has_robots = "User-agent" in str(system_prompt)
-                has_original = "Be helpful" in str(system_prompt)
-                has_intent = "API testing assistant" in str(system_prompt)
-
-                sys_str = str(system_prompt)[:150]
-                name = "context_injection_string_system"
-                if has_robots and has_original and has_intent:
-                    results.append((name, True, f"all present — {sys_str}"))
-                elif has_robots and has_original:
-                    results.append((name, False, f"src+orig but no intent — {sys_str}"))
-                elif has_robots:
-                    results.append((name, False, f"sources only — {sys_str}"))
-                elif has_original:
-                    results.append((name, False, f"original only — {sys_str}"))
-                else:
-                    results.append((name, False, f"neither found — {sys_str}"))
-            else:
-                results.append(
-                    (
-                        "context_injection_string_system",
-                        False,
-                        f"unexpected status {resp.status_code}: {resp.text[:200]}",
-                    )
-                )
-        except Exception as exc:
-            results.append(("context_injection_string_system", False, f"request error: {exc}"))
-
-        # --- Check 2: Context injection with no system prompt ---
-        try:
-            resp = httpx.post(
-                f"{PROXY_BASE}/v1/messages",
-                json={
-                    "model": "claude-sonnet-4-20250514",
-                    "max_tokens": 1024,
-                    "messages": [{"role": "user", "content": "Hello"}],
-                },
-                headers={"x-api-key": "test-key"},
-                timeout=TIMEOUT,
-            )
-            if resp.status_code == 200:
-                echoed = resp.json()
-                forwarded_body = echoed.get("json", {})
-                system_prompt = forwarded_body.get("system", "")
-
-                sp = str(system_prompt)
-                has_src = "User-agent" in sp
-                has_int = "API testing assistant" in sp
-                if has_src and has_int:
-                    results.append(
-                        ("context_injection_no_system", True, f"both intent+source — {sp[:100]}")
-                    )
-                else:
-                    results.append(
-                        (
-                            "context_injection_no_system",
-                            False,
-                            f"missing src={has_src} int={has_int} — {sp[:150]}",
-                        )
-                    )
-            else:
-                results.append(
-                    (
-                        "context_injection_no_system",
-                        False,
-                        f"unexpected status {resp.status_code}: {resp.text[:200]}",
-                    )
-                )
-        except Exception as exc:
-            results.append(("context_injection_no_system", False, f"request error: {exc}"))
-
-        # --- Check 3: Extra fields pass through ---
-        try:
-            resp = httpx.post(
-                f"{PROXY_BASE}/v1/messages",
-                json={
-                    "model": "claude-sonnet-4-20250514",
-                    "max_tokens": 1024,
-                    "messages": [{"role": "user", "content": "Hello"}],
-                    "custom_field": "should_survive",
-                },
-                headers={"x-api-key": "test-key"},
-                timeout=TIMEOUT,
-            )
-            if resp.status_code == 200:
-                echoed = resp.json()
-                forwarded_body = echoed.get("json", {})
-                if forwarded_body.get("custom_field") == "should_survive":
-                    results.append(("extra_fields_passthrough", True, "custom_field preserved"))
-                else:
-                    results.append(
-                        (
-                            "extra_fields_passthrough",
-                            False,
-                            f"custom_field lost — body: {json.dumps(forwarded_body)[:200]}",
-                        )
-                    )
-            else:
-                results.append(
-                    (
-                        "extra_fields_passthrough",
-                        False,
-                        f"unexpected status {resp.status_code}",
-                    )
-                )
-        except Exception as exc:
-            results.append(("extra_fields_passthrough", False, f"request error: {exc}"))
-
-    finally:
-        # 4. Teardown
-        print("\n[4/4] Shutting down server...")
-        server.terminate()
-        try:
-            server.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            server.kill()
-            server.wait(timeout=5)
-
-    # Report
-    print("\n=== Results ===")
-    all_pass = True
-    for name, passed, detail in results:
-        status = "PASS" if passed else "FAIL"
-        if not passed:
-            all_pass = False
-        print(f"  [{status}] {name} — {detail}")
-
-    print(f"\n{'ALL CHECKS PASSED' if all_pass else 'SOME CHECKS FAILED'}")
-    return 0 if all_pass else 1
+    assert resp.status_code == 200
+    assert resp.json()["content"][0]["text"] == "Ensemble answer: the test passed"
+    assert not mock_client.called or all(
+        "api.anthropic.com" not in str(c) for c in mock_client.call_args_list
+    )
 
 
-if __name__ == "__main__":
-    sys.exit(main())
+def test_e2e_prompt_spec_streaming_no_upstream() -> None:
+    settings = ClaudeFrontendSettings(
+        upstream_url="https://api.anthropic.com",
+        active_spec="test-spec",
+        backend_url="http://localhost:8000",
+    )
+    app = FastAPI()
+    app.include_router(create_router(settings, plugin=_prompt_plugin()))
+    client = TestClient(app)
+
+    with (
+        patch(
+            "screamingface.plugins.claude_frontend._url4_context._store_prompt_blob",
+            new_callable=AsyncMock,
+            return_value="blob123",
+        ),
+        patch(
+            "screamingface.plugins.claude_frontend._url4_context._resolve_expression",
+            new_callable=AsyncMock,
+            return_value="Streamed result",
+        ),
+        patch("httpx.AsyncClient.stream") as mock_stream,
+    ):
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "claude-opus-4-1-20250805",
+                "messages": [{"role": "user", "content": "Stream this"}],
+                "stream": True,
+            },
+        )
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    assert "message_stop" in resp.text
+    assert "Streamed result" in resp.text
+    assert not mock_stream.called
+
+
+def test_e2e_prompt_spec_full_transcript_blob() -> None:
+    """Decision A: the $prompt blob is the FULL serialized transcript (all turns)."""
+    settings = ClaudeFrontendSettings(
+        upstream_url="https://api.anthropic.com",
+        active_spec="test-spec",
+        backend_url="http://localhost:8000",
+    )
+    app = FastAPI()
+    app.include_router(create_router(settings, plugin=_prompt_plugin()))
+    client = TestClient(app)
+
+    store_mock = AsyncMock(return_value="blob123")
+    with (
+        patch(
+            "screamingface.plugins.claude_frontend._url4_context._store_prompt_blob",
+            store_mock,
+        ),
+        patch(
+            "screamingface.plugins.claude_frontend._url4_context._resolve_expression",
+            new_callable=AsyncMock,
+            return_value="ok",
+        ),
+    ):
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "claude-opus-4-1-20250805",
+                "messages": [
+                    {"role": "user", "content": "first question"},
+                    {"role": "assistant", "content": "first answer"},
+                    {"role": "user", "content": "second question"},
+                ],
+            },
+        )
+
+    assert resp.status_code == 200
+    assert store_mock.await_args is not None
+    stored_text = store_mock.await_args.args[0]
+    assert "User: first question" in stored_text
+    assert "Assistant: first answer" in stored_text
+    assert "User: second question" in stored_text

--- a/apps/server/src/screamingface/plugins/claude_frontend/tests/test_proxy.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/tests/test_proxy.py
@@ -1,8 +1,14 @@
-"""Tests for the claude-frontend proxy routes."""
+"""Tests for the claude-frontend proxy routes.
+
+Inference (``POST /v1/messages``) is now TERMINAL: it synthesizes the Anthropic
+response in-process and does NOT forward to the real upstream. The header-forwarding
+and env-key tests therefore exercise the ``/v1/{path}`` catchall (which DOES still
+forward upstream) instead of the inference route.
+"""
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -13,88 +19,73 @@ from screamingface.plugins.claude_frontend.plugin import ClaudeFrontendSettings
 from screamingface.plugins.claude_frontend.proxy import create_router
 
 
-@pytest.fixture
-def proxy_app() -> FastAPI:
-    """Create a standalone FastAPI app with the proxy router (no full server startup)."""
+def test_proxy_non_streaming() -> None:
+    """Non-streaming inference synthesizes a response; no upstream inference call.
+
+    With ``get_active_expression()`` returning ``None`` (no active spec), no resolution
+    happens and the handler synthesizes an empty Anthropic envelope rather than
+    forwarding to ``api.anthropic.com``.
+    """
+    mock_plugin = MagicMock()
+    mock_plugin.get_active_expression.return_value = None
     settings = ClaudeFrontendSettings(
-        upstream_url="https://api.anthropic.com",
+        upstream_url="https://api.anthropic.com", active_spec="test-spec"
     )
     app = FastAPI()
-    router = create_router(settings)
-    app.include_router(router)
-    return app
-
-
-@pytest.fixture
-def proxy_client(proxy_app: FastAPI) -> TestClient:
-    return TestClient(proxy_app)
-
-
-def test_proxy_non_streaming(proxy_client: TestClient) -> None:
-    mock_response = httpx.Response(
-        200,
-        json={"id": "msg_123", "content": [{"type": "text", "text": "Hello"}]},
-    )
-
-    with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response):
-        resp = proxy_client.post(
+    app.include_router(create_router(settings, plugin=mock_plugin))
+    client = TestClient(app)
+    with patch("httpx.AsyncClient.post") as mock_post:
+        resp = client.post(
             "/v1/messages",
             json={
                 "model": "claude-sonnet-4-20250514",
                 "messages": [{"role": "user", "content": "Hi"}],
             },
-            headers={"x-api-key": "test-key", "anthropic-version": "2023-06-01"},
         )
-
     assert resp.status_code == 200
     data = resp.json()
-    assert data["id"] == "msg_123"
+    assert data["type"] == "message"
+    assert data["role"] == "assistant"
+    assert data["content"][0]["text"] == ""
+    assert not mock_post.called
 
 
-def test_proxy_forwards_headers(proxy_client: TestClient) -> None:
-    mock_response = httpx.Response(200, json={"id": "msg_456"})
-
+def test_proxy_forwards_headers_on_catchall() -> None:
+    """The ``/v1/{path}`` catchall (still upstream-forwarding) preserves auth headers."""
+    settings = ClaudeFrontendSettings(upstream_url="https://api.anthropic.com")
+    app = FastAPI()
+    app.include_router(create_router(settings))
+    client = TestClient(app)
+    mock_response = httpx.Response(200, json={"data": []})
     with patch(
-        "httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response
-    ) as mock_post:
-        proxy_client.post(
-            "/v1/messages",
-            json={"model": "claude-sonnet-4-20250514", "messages": []},
-            headers={
-                "x-api-key": "sk-test",
-                "anthropic-version": "2023-06-01",
-                "anthropic-beta": "messages-2024-01-01",
-            },
+        "httpx.AsyncClient.request", new_callable=AsyncMock, return_value=mock_response
+    ) as mock_req:
+        client.get(
+            "/v1/models",
+            headers={"anthropic-version": "2023-06-01", "authorization": "Bearer test"},
         )
-
-    call_kwargs = mock_post.call_args
-    sent_headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers", {})
-    assert sent_headers["x-api-key"] == "sk-test"
-    assert sent_headers["anthropic-version"] == "2023-06-01"
-    assert sent_headers["anthropic-beta"] == "messages-2024-01-01"
+    sent_headers = mock_req.call_args.kwargs.get("headers", {})
+    assert sent_headers.get("anthropic-version") == "2023-06-01"
+    assert sent_headers.get("authorization") == "Bearer test"
 
 
-def test_proxy_does_not_inject_env_api_key(
-    proxy_client: TestClient, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """ANTHROPIC_API_KEY must NOT be auto-forwarded as x-api-key.
+def test_proxy_does_not_inject_env_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ANTHROPIC_API_KEY must NOT be auto-forwarded as x-api-key on the catchall.
 
     All Anthropic auth flows through the Claude Code OAuth path served by
     aigateway. If a client sends no auth header, the proxy MUST NOT silently
     paper over it with an env var.
     """
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-should-be-ignored")
-    mock_response = httpx.Response(200, json={"id": "msg_789"})
-
+    settings = ClaudeFrontendSettings(upstream_url="https://api.anthropic.com")
+    app = FastAPI()
+    app.include_router(create_router(settings))
+    client = TestClient(app)
+    mock_response = httpx.Response(200, json={"data": []})
     with patch(
-        "httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response
-    ) as mock_post:
-        proxy_client.post(
-            "/v1/messages",
-            json={"model": "claude-sonnet-4-20250514", "messages": []},
-        )
-
-    call_kwargs = mock_post.call_args
-    sent_headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers", {})
+        "httpx.AsyncClient.request", new_callable=AsyncMock, return_value=mock_response
+    ) as mock_req:
+        client.get("/v1/models")
+    sent_headers = mock_req.call_args.kwargs.get("headers", {})
     assert "x-api-key" not in sent_headers
     assert "authorization" not in sent_headers

--- a/apps/server/src/screamingface/plugins/claude_frontend/tests/test_proxy_terminal.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/tests/test_proxy_terminal.py
@@ -153,6 +153,43 @@ def test_static_spec_none_returns_error_envelope_fail_loud() -> None:
     assert "broken-spec" in data["content"][0]["text"]
 
 
+def test_unary_error_envelope_has_superset_usage_and_real_model() -> None:
+    """UNARY error envelope matches the success envelope: 4-key usage superset
+    (all ``0``) and ``model`` echoed from the request body (NOT ``"unknown"``)."""
+    settings = ClaudeFrontendSettings(
+        upstream_url="https://api.anthropic.com",
+        active_spec="broken-spec",
+        backend_url="http://localhost:8000",
+    )
+    app = FastAPI()
+    mock_plugin = MagicMock()
+    mock_plugin.get_active_expression.return_value = "some_expression"
+    mock_plugin.resolve_context.return_value = None  # static-spec resolution failure
+    app.include_router(create_router(settings, plugin=mock_plugin))
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/messages",
+        json={
+            "model": "claude-sonnet-4-5-20250929",
+            "messages": [{"role": "user", "content": "Test"}],
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["type"] == "message"
+    # Real model from the request body — never the hardcoded "unknown".
+    assert data["model"] == "claude-sonnet-4-5-20250929"
+    # 4-key superset-of-zeros, matching build_anthropic_message.
+    assert data["usage"] == {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+    }
+
+
 def test_no_spec_synthesizes_empty_envelope_no_upstream_call() -> None:
     """No active spec → empty synthesized envelope, no upstream inference call (#3)."""
     settings = ClaudeFrontendSettings(

--- a/apps/server/src/screamingface/plugins/claude_frontend/tests/test_proxy_terminal.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/tests/test_proxy_terminal.py
@@ -1,0 +1,256 @@
+"""Tests for claude_frontend terminal (ensemble-first) inference.
+
+1. Unary and streaming inference synthesize in-memory (no api.anthropic.com).
+2. Non-inference routes (catchall, count_tokens, /api/*) still forward upstream.
+3. Error paths (static-None, resolution failure) return 200 with visible error text.
+4. Streaming error paths terminate (message_stop frame).
+
+Per the M2 adversarial-review corrections (#3): the success/terminal tests wire a
+``_static_plugin()`` MagicMock whose ``get_active_expression()`` returns a STATIC
+(no-``$prompt``) spec and ``resolve_context()`` returns the expected text — that is the
+locus the success assertions exercise (NOT ``plugin=None``). The ``$prompt`` E2E path is
+covered in ``test_e2e_claude_frontend.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from screamingface.plugins.claude_frontend.plugin import ClaudeFrontendSettings
+from screamingface.plugins.claude_frontend.proxy import create_router
+
+
+def _static_plugin(resolved_text: str = "Ensemble result text") -> MagicMock:
+    """A plugin with a STATIC (no-$prompt) active spec whose resolve_context returns text.
+
+    This is the locus the success assertions exercise: resolve_static_context() reads
+    ``plugin.resolve_context()`` directly (no blob store, no /ensemble).
+    """
+    plugin = MagicMock()
+    plugin.get_active_expression.return_value = "(https://example.com/robots.txt)"
+    plugin.resolve_context.return_value = resolved_text
+    return plugin
+
+
+def parse_sse_frames(sse_text: str) -> list:
+    frames = []
+    current_event = None
+    current_data = None
+    for line in sse_text.split("\n"):
+        if line.startswith("event:"):
+            current_event = line.replace("event:", "").strip()
+        elif line.startswith("data:"):
+            try:
+                current_data = json.loads(line.replace("data:", "").strip())
+            except json.JSONDecodeError:
+                current_data = None
+        elif line.strip() == "" and current_data is not None:
+            frames.append((current_event, current_data))
+            current_event = None
+            current_data = None
+    return frames
+
+
+def test_unary_inference_synthesizes_response_no_upstream_call() -> None:
+    settings = ClaudeFrontendSettings(
+        upstream_url="https://api.anthropic.com",
+        active_spec="test-spec",
+        backend_url="http://localhost:8000",
+    )
+    app = FastAPI()
+    app.include_router(create_router(settings, plugin=_static_plugin("Ensemble result text")))
+    client = TestClient(app)
+
+    with patch("httpx.AsyncClient.post") as mock_httpx_post:
+        response = client.post(
+            "/v1/messages",
+            json={
+                "model": "claude-opus-4-1-20250805",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": False,
+            },
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["type"] == "message"
+    assert data["role"] == "assistant"
+    assert data["content"][0]["text"] == "Ensemble result text"
+    assert data["model"] == "claude-opus-4-1-20250805"
+    assert data["stop_reason"] == "end_turn"
+    assert "usage" in data
+    assert not mock_httpx_post.called
+
+
+def test_streaming_inference_synthesizes_sse_no_upstream_call() -> None:
+    settings = ClaudeFrontendSettings(
+        upstream_url="https://api.anthropic.com",
+        active_spec="test-spec",
+        backend_url="http://localhost:8000",
+    )
+    app = FastAPI()
+    app.include_router(create_router(settings, plugin=_static_plugin("Streamed result text")))
+    client = TestClient(app)
+
+    with patch("httpx.AsyncClient.stream") as mock_httpx_stream:
+        response = client.post(
+            "/v1/messages",
+            json={
+                "model": "claude-opus-4-1-20250805",
+                "messages": [{"role": "user", "content": "Test"}],
+                "stream": True,
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    frames = parse_sse_frames(response.text)
+    event_names = [n for n, _ in frames]
+    assert event_names == [
+        "message_start",
+        "ping",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_stop",
+        "message_delta",
+        "message_stop",
+    ]
+    delta_frame = next(d for n, d in frames if n == "content_block_delta")
+    assert delta_frame["delta"]["text"] == "Streamed result text"
+    assert not mock_httpx_stream.called
+
+
+def test_static_spec_none_returns_error_envelope_fail_loud() -> None:
+    settings = ClaudeFrontendSettings(
+        upstream_url="https://api.anthropic.com",
+        active_spec="broken-spec",
+        backend_url="http://localhost:8000",
+    )
+    app = FastAPI()
+    mock_plugin = MagicMock()
+    mock_plugin.get_active_expression.return_value = "some_expression"
+    mock_plugin.resolve_context.return_value = None
+    app.include_router(create_router(settings, plugin=mock_plugin))
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/messages",
+        json={
+            "model": "claude-opus-4-1-20250805",
+            "messages": [{"role": "user", "content": "Test"}],
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["type"] == "message"
+    assert "[url4 error]" in data["content"][0]["text"]
+    assert "broken-spec" in data["content"][0]["text"]
+
+
+def test_no_spec_synthesizes_empty_envelope_no_upstream_call() -> None:
+    """No active spec → empty synthesized envelope, no upstream inference call (#3)."""
+    settings = ClaudeFrontendSettings(
+        upstream_url="https://api.anthropic.com",
+        active_spec="test-spec",
+    )
+    mock_plugin = MagicMock()
+    mock_plugin.get_active_expression.return_value = None
+    app = FastAPI()
+    app.include_router(create_router(settings, plugin=mock_plugin))
+    client = TestClient(app)
+
+    with patch("httpx.AsyncClient.post") as mock_post:
+        response = client.post(
+            "/v1/messages",
+            json={
+                "model": "claude-opus-4-1-20250805",
+                "messages": [{"role": "user", "content": "Hi"}],
+            },
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["type"] == "message"
+    assert data["content"][0]["text"] == ""
+    assert not mock_post.called
+
+
+def test_count_tokens_forwards_upstream_not_terminated() -> None:
+    settings = ClaudeFrontendSettings(
+        upstream_url="https://api.anthropic.com", active_spec="test-spec"
+    )
+    app = FastAPI()
+    app.include_router(create_router(settings))
+    client = TestClient(app)
+    mock_response = httpx.Response(200, json={"input_tokens": 50})
+    with patch("httpx.AsyncClient.request", new_callable=AsyncMock, return_value=mock_response):
+        response = client.post(
+            "/v1/messages/count_tokens",
+            json={"messages": [{"role": "user", "content": "test"}]},
+        )
+    assert response.status_code == 200
+    assert response.json()["input_tokens"] == 50
+
+
+def test_v1_models_forwards_upstream() -> None:
+    settings = ClaudeFrontendSettings(upstream_url="https://api.anthropic.com")
+    app = FastAPI()
+    app.include_router(create_router(settings))
+    client = TestClient(app)
+    mock_response = httpx.Response(200, json={"data": [{"id": "claude-3-5-sonnet"}]})
+    with patch("httpx.AsyncClient.request", new_callable=AsyncMock, return_value=mock_response):
+        response = client.get("/v1/models")
+    assert response.status_code == 200
+    assert "data" in response.json()
+
+
+def test_api_passthrough_forwards_upstream() -> None:
+    settings = ClaudeFrontendSettings(upstream_url="https://api.anthropic.com")
+    app = FastAPI()
+    app.include_router(create_router(settings))
+    client = TestClient(app)
+    mock_response = httpx.Response(200, json={"users": []})
+    with patch("httpx.AsyncClient.request", new_callable=AsyncMock, return_value=mock_response):
+        response = client.get("/api/users")
+    assert response.status_code == 200
+    assert "users" in response.json()
+
+
+def test_streaming_error_terminates_with_message_stop_frame() -> None:
+    settings = ClaudeFrontendSettings(
+        upstream_url="https://api.anthropic.com",
+        active_spec="broken-spec",
+        backend_url="http://localhost:8000",
+    )
+    app = FastAPI()
+    mock_plugin = MagicMock()
+    mock_plugin.get_active_expression.return_value = "bad_expression"
+    mock_plugin.resolve_context.side_effect = RuntimeError("Spec eval failed")
+    app.include_router(create_router(settings, plugin=mock_plugin))
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/messages",
+        json={
+            "model": "claude-opus-4-1-20250805",
+            "messages": [{"role": "user", "content": "Test"}],
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    frames = parse_sse_frames(response.text)
+    event_names = [n for n, _ in frames]
+    assert "message_stop" in event_names
+    assert any(
+        "[url4 error]" in d.get("delta", {}).get("text", "")
+        for n, d in frames
+        if n == "content_block_delta"
+    )

--- a/apps/server/src/screamingface/plugins/claude_intercept/tests/test_intercept.py
+++ b/apps/server/src/screamingface/plugins/claude_intercept/tests/test_intercept.py
@@ -1048,12 +1048,13 @@ class TestInterceptE2E:
         assert not state_file.exists()
 
     def test_proxy_handles_intercepted_request(self, claude_intercept_app) -> None:
-        """POST /v1/messages on the frontend app gets proxied to upstream.
+        """POST /v1/messages on the frontend app is served by the terminal
+        ensemble handler — it synthesizes an Anthropic envelope and no longer
+        forwards to the real upstream.
 
         With the separate-interface architecture, proxy routes live on the
         frontend's own FastAPI app (not the main server).
         """
-        import httpx
         from fastapi import FastAPI
         from fastapi.testclient import TestClient
 
@@ -1065,14 +1066,9 @@ class TestInterceptE2E:
         frontend_app = FastAPI()
         frontend_app.include_router(create_router(settings))
 
-        mock_response = httpx.Response(
-            200,
-            json={"id": "msg_123", "content": [{"type": "text", "text": "Hello"}]},
-        )
-
         with (
             TestClient(frontend_app) as client,
-            patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response),
+            patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post,
         ):
             resp = client.post(
                 "/v1/messages",
@@ -1084,7 +1080,13 @@ class TestInterceptE2E:
                 },
             )
             assert resp.status_code == 200
-            assert resp.json()["id"] == "msg_123"
+            body = resp.json()
+            # Terminal cutover: the ensemble result is synthesized into an
+            # Anthropic message envelope; the real upstream is never called.
+            assert body["type"] == "message"
+            assert body["role"] == "assistant"
+            assert body["id"].startswith("msg_")
+            assert not mock_post.called
 
     def test_requires_root_in_plugins_endpoint(self, claude_intercept_app) -> None:
         """GET /plugins returns requires_root: true for intercept."""

--- a/apps/server/src/screamingface/plugins/frontend_base/terminal_response.py
+++ b/apps/server/src/screamingface/plugins/frontend_base/terminal_response.py
@@ -1,0 +1,553 @@
+"""Shared terminal-response builders and streamers for all four frontends.
+
+Centralizes:
+- error formatting (extract_error_text)
+- transcript serialization (serialize_transcript) — Decision A conversation-aware
+- usage estimation (estimate_tokens) + deterministic ids (deterministic_id)
+- all eight builder/streamer functions (sole location)
+
+Per-frontend modules import and re-export only — no wire-format logic outside.
+Decision A (conversation-aware): builders take optional ``prompt_text`` and
+``response_id`` so responses echo a deterministic id plus plausible non-zero usage
+derived from the serialized transcript and the resolved result text.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+import traceback
+from collections.abc import AsyncIterator
+
+import httpx
+
+
+def extract_error_text(exc: BaseException, spec_name: str, expression: str) -> str:
+    """Format error text uniformly for all providers.
+
+    Handles BOTH an ``httpx.HTTPStatusError`` (the ``/ensemble`` 502 path, whose
+    ``PlainTextResponse`` body carries ``"url4 evaluation failed: ..."``) AND a raw
+    in-process ``Url4Interpreter`` exception. Always prefixed ``"[url4 error] "`` and
+    always includes the full traceback. The frontends inject the returned text into a
+    provider-native fake-200 envelope (Decision: blocking and screaming, PR #244).
+    """
+    tb_str = "".join(traceback.format_exception(exc))
+    expr_preview = expression[:200] if expression else "(empty)"
+    lines = [
+        f"[url4 error] {spec_name}",
+        "",
+        f"Expression: {expr_preview}",
+        "",
+        f"Error: {exc.__class__.__name__}: {exc}",
+    ]
+    # /ensemble 502 path: surface the upstream PlainText body so the CLI sees the
+    # real evaluation failure, not just the opaque "502 Bad Gateway" status line.
+    if isinstance(exc, httpx.HTTPStatusError) and exc.response is not None:
+        lines += [
+            "",
+            f"Status: {exc.response.status_code}",
+            f"Body: {exc.response.text}",
+        ]
+    lines += ["", "Traceback:", tb_str]
+    return "\n".join(lines)
+
+
+def serialize_transcript(turns: list[tuple[str, str]]) -> str:
+    r"""Render conversation turns as ``"User: ...\nAssistant: ...\n..."`` (Decision A).
+
+    Args:
+        turns: list of (role, text) tuples, e.g. ``[("user", "Hello"), ("assistant", "Hi")]``.
+
+    Returns:
+        Serialized transcript string for use as the ``$prompt`` blob.
+    """
+    lines = []
+    for role, text in turns:
+        role_upper = role.capitalize()
+        lines.append(f"{role_upper}: {text}")
+    return "\n".join(lines)
+
+
+def estimate_tokens(text: str) -> int:
+    """Estimate token count: ``max(1, len(text) // 4)`` if text else ``0``."""
+    return max(1, len(text) // 4) if text else 0
+
+
+def deterministic_id(prefix: str, model: str, prompt_text: str, result_text: str) -> str:
+    """Generate a deterministic id from model + prompt + result via SHA256.
+
+    Returns ``f"{prefix}{sha256((model + prompt_text + result_text).encode()).hexdigest()[:24]}"``.
+    """
+    combined = model + prompt_text + result_text
+    digest = hashlib.sha256(combined.encode()).hexdigest()[:24]
+    return f"{prefix}{digest}"
+
+
+# ============================================================================
+# Anthropic (claude_frontend)
+# ============================================================================
+
+
+def build_anthropic_message(
+    result_text: str,
+    model: str,
+    *,
+    prompt_text: str = "",
+    response_id: str | None = None,
+) -> dict:
+    """Build the unary Anthropic Messages response envelope."""
+    msg_id = response_id or deterministic_id("msg_", model, prompt_text, result_text)
+    input_tokens = estimate_tokens(prompt_text)
+    output_tokens = estimate_tokens(result_text)
+
+    return {
+        "id": msg_id,
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": result_text}],
+        "model": model,
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "usage": {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        },
+    }
+
+
+async def stream_anthropic_sse(
+    result_text: str,
+    model: str,
+    *,
+    prompt_text: str = "",
+    response_id: str | None = None,
+) -> AsyncIterator[bytes]:
+    r"""Stream the Anthropic response as SSE (``event:`` lines, blank-line terminated).
+
+    Frame sequence:
+    message_start -> ping -> content_block_start -> content_block_delta
+    -> content_block_stop -> message_delta -> message_stop
+
+    All text rides in ONE ``text_delta``. No ``[DONE]``. Every frame is ``\n\n``-terminated.
+    """
+    msg_id = response_id or deterministic_id("msg_", model, prompt_text, result_text)
+    input_tokens = estimate_tokens(prompt_text)
+    output_tokens = estimate_tokens(result_text)
+
+    def sse_frame(event_name: str, payload: dict) -> bytes:
+        return f"event: {event_name}\ndata: {json.dumps(payload)}\n\n".encode()
+
+    yield sse_frame(
+        "message_start",
+        {
+            "type": "message_start",
+            "message": {
+                "id": msg_id,
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "model": model,
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                },
+            },
+        },
+    )
+    yield sse_frame("ping", {"type": "ping"})
+    yield sse_frame(
+        "content_block_start",
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+        },
+    )
+    yield sse_frame(
+        "content_block_delta",
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": result_text},
+        },
+    )
+    yield sse_frame(
+        "content_block_stop",
+        {
+            "type": "content_block_stop",
+            "index": 0,
+        },
+    )
+    yield sse_frame(
+        "message_delta",
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+            "usage": {"output_tokens": output_tokens},
+        },
+    )
+    yield sse_frame("message_stop", {"type": "message_stop"})
+
+
+# ============================================================================
+# OpenAI (codex_frontend)
+# ============================================================================
+
+
+def build_openai_response(
+    result_text: str,
+    model: str,
+    *,
+    prompt_text: str = "",
+    response_id: str | None = None,
+    status: str = "completed",
+) -> dict:
+    """Build the unary OpenAI Responses envelope.
+
+    NOTE (#244 error visibility): the error path uses ``status="completed"`` carrying
+    the error text, NOT ``status="failed"``, so the Codex CLI renders the visible error.
+    """
+    resp_id = response_id or deterministic_id("resp_", model, prompt_text, result_text)
+    item_id = deterministic_id("msg_", model, prompt_text, result_text)
+    created_at = int(time.time())
+    input_tokens = estimate_tokens(prompt_text)
+    output_tokens = estimate_tokens(result_text)
+
+    return {
+        "id": resp_id,
+        "object": "response",
+        "created_at": created_at,
+        "model": model,
+        "status": status,
+        "output": [
+            {
+                "id": item_id,
+                "type": "message",
+                "status": "completed",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": result_text,
+                        "annotations": [],
+                    }
+                ],
+            }
+        ],
+        "usage": {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": input_tokens + output_tokens,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        },
+    }
+
+
+async def stream_openai_sse(
+    result_text: str,
+    model: str,
+    *,
+    prompt_text: str = "",
+    response_id: str | None = None,
+    status: str = "completed",
+) -> AsyncIterator[bytes]:
+    r"""Stream the OpenAI response as SSE (full canonical 9-event sequence).
+
+    response.created -> response.in_progress -> response.output_item.added
+    -> response.content_part.added -> response.output_text.delta
+    -> response.output_text.done -> response.content_part.done
+    -> response.output_item.done -> response.completed
+
+    Every frame is ``data: {json}\n\n``. Stable ``item_id``. Monotonic ``sequence_number``.
+    No ``[DONE]``.
+    """
+    resp_id = response_id or deterministic_id("resp_", model, prompt_text, result_text)
+    item_id = deterministic_id("msg_", model, prompt_text, result_text)
+    created_at = int(time.time())
+    input_tokens = estimate_tokens(prompt_text)
+    output_tokens = estimate_tokens(result_text)
+    seq = 0
+
+    def event(payload: dict) -> bytes:
+        nonlocal seq
+        payload.setdefault("sequence_number", seq)
+        seq += 1
+        return f"data: {json.dumps(payload)}\n\n".encode()
+
+    base_resp = {
+        "id": resp_id,
+        "object": "response",
+        "created_at": created_at,
+        "model": model,
+        "output": [],
+        "usage": None,
+    }
+
+    yield event({"type": "response.created", "response": {**base_resp, "status": "in_progress"}})
+    yield event(
+        {"type": "response.in_progress", "response": {**base_resp, "status": "in_progress"}}
+    )
+    yield event(
+        {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {
+                "id": item_id,
+                "type": "message",
+                "status": "in_progress",
+                "role": "assistant",
+                "content": [],
+            },
+        }
+    )
+    yield event(
+        {
+            "type": "response.content_part.added",
+            "item_id": item_id,
+            "output_index": 0,
+            "content_index": 0,
+            "part": {"type": "output_text", "text": "", "annotations": []},
+        }
+    )
+    yield event(
+        {
+            "type": "response.output_text.delta",
+            "item_id": item_id,
+            "output_index": 0,
+            "content_index": 0,
+            "delta": result_text,
+        }
+    )
+    yield event(
+        {
+            "type": "response.output_text.done",
+            "item_id": item_id,
+            "output_index": 0,
+            "content_index": 0,
+            "text": result_text,
+        }
+    )
+    yield event(
+        {
+            "type": "response.content_part.done",
+            "item_id": item_id,
+            "output_index": 0,
+            "content_index": 0,
+            "part": {"type": "output_text", "text": result_text, "annotations": []},
+        }
+    )
+    yield event(
+        {
+            "type": "response.output_item.done",
+            "output_index": 0,
+            "item": {
+                "id": item_id,
+                "type": "message",
+                "status": "completed",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": result_text, "annotations": []}],
+            },
+        }
+    )
+    yield event(
+        {
+            "type": "response.completed",
+            "response": {
+                **base_resp,
+                "status": status,
+                "output": [
+                    {
+                        "id": item_id,
+                        "type": "message",
+                        "status": "completed",
+                        "role": "assistant",
+                        "content": [
+                            {"type": "output_text", "text": result_text, "annotations": []}
+                        ],
+                    }
+                ],
+                "usage": {
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "total_tokens": input_tokens + output_tokens,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                },
+            },
+        }
+    )
+
+
+# ============================================================================
+# Google Gemini (gemini_frontend)
+# ============================================================================
+
+
+def build_gemini_response(
+    result_text: str,
+    model: str,
+    *,
+    prompt_text: str = "",
+    response_id: str | None = None,
+) -> dict:
+    """Build the unary Gemini GenerateContentResponse envelope.
+
+    O12: includes a synthetic (deterministic) ``responseId``. ``usageMetadata`` is
+    camelCase (authoritative for gemini). ``modelVersion`` mirrors the requested model.
+    """
+    input_tokens = estimate_tokens(prompt_text)
+    output_tokens = estimate_tokens(result_text)
+    resp_id = response_id or deterministic_id("", model, prompt_text, result_text)
+
+    return {
+        "candidates": [
+            {
+                "content": {"role": "model", "parts": [{"text": result_text}]},
+                "finishReason": "STOP",
+                "index": 0,
+                "safetyRatings": [],
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": input_tokens,
+            "candidatesTokenCount": output_tokens,
+            "totalTokenCount": input_tokens + output_tokens,
+        },
+        "modelVersion": model,
+        "responseId": resp_id,
+    }
+
+
+async def stream_gemini_chunks(
+    result_text: str,
+    model: str,
+    *,
+    prompt_text: str = "",
+    response_id: str | None = None,
+    alt_sse: bool = False,
+) -> AsyncIterator[bytes]:
+    r"""Stream the Gemini response.
+
+    Default (``alt_sse=False``) yields a true JSON ARRAY ``[{...}]`` matching Gemini's
+    real ``streamGenerateContent`` REST wire format (``application/json``). With
+    ``alt_sse=True``, emits ``data: {...}\n\n`` for ``text/event-stream``. No ``[DONE]``.
+    """
+    obj = build_gemini_response(
+        result_text, model, prompt_text=prompt_text, response_id=response_id
+    )
+
+    if alt_sse:
+        yield f"data: {json.dumps(obj)}\n\n".encode()
+    else:
+        yield b"["
+        yield json.dumps(obj).encode()
+        yield b"]"
+
+
+# ============================================================================
+# Ollama (ollama_frontend)
+# ============================================================================
+
+
+def build_ollama_response(
+    result_text: str,
+    model: str,
+    *,
+    prompt_text: str = "",
+) -> dict:
+    """Build the unary Ollama ``/api/chat`` response envelope.
+
+    Ollama uses durations, not tokens; durations are zero, while the eval counts carry
+    the conversation-aware estimates.
+    """
+    created_at = "2025-06-04T00:00:00Z"
+    input_tokens = estimate_tokens(prompt_text)
+    output_tokens = estimate_tokens(result_text)
+
+    return {
+        "model": model,
+        "created_at": created_at,
+        "message": {"role": "assistant", "content": result_text},
+        "done": True,
+        "done_reason": "stop",
+        "total_duration": 0,
+        "load_duration": 0,
+        "prompt_eval_count": input_tokens,
+        "prompt_eval_duration": 0,
+        "eval_count": output_tokens,
+        "eval_duration": 0,
+    }
+
+
+async def stream_ollama_ndjson(
+    result_text: str,
+    model: str,
+    *,
+    prompt_text: str = "",
+) -> AsyncIterator[bytes]:
+    """Stream the Ollama response as NDJSON (NOT SSE).
+
+    Emits TWO complete JSON objects, each on its own line:
+    1. In-progress frame with the full ``result_text`` (``done=false``).
+    2. Terminal frame with empty content and ``done=true``, ``done_reason="stop"``.
+    Every frame carries a complete ``message`` field. Content-Type: ``application/x-ndjson``.
+    No ``data:`` prefix, no blank-line separators, no ``[DONE]``.
+    """
+    created_at = "2025-06-04T00:00:00Z"
+    input_tokens = estimate_tokens(prompt_text)
+    output_tokens = estimate_tokens(result_text)
+
+    yield (
+        json.dumps(
+            {
+                "model": model,
+                "created_at": created_at,
+                "message": {"role": "assistant", "content": result_text},
+                "done": False,
+            }
+        )
+        + "\n"
+    ).encode()
+
+    yield (
+        json.dumps(
+            {
+                "model": model,
+                "created_at": created_at,
+                "message": {"role": "assistant", "content": ""},
+                "done": True,
+                "done_reason": "stop",
+                "total_duration": 0,
+                "load_duration": 0,
+                "prompt_eval_count": input_tokens,
+                "prompt_eval_duration": 0,
+                "eval_count": output_tokens,
+                "eval_duration": 0,
+            }
+        )
+        + "\n"
+    ).encode()
+
+
+__all__ = [
+    "extract_error_text",
+    "serialize_transcript",
+    "estimate_tokens",
+    "deterministic_id",
+    "build_anthropic_message",
+    "stream_anthropic_sse",
+    "build_openai_response",
+    "stream_openai_sse",
+    "build_gemini_response",
+    "stream_gemini_chunks",
+    "build_ollama_response",
+    "stream_ollama_ndjson",
+]

--- a/apps/server/src/screamingface/plugins/frontend_base/tests/test_terminal_response.py
+++ b/apps/server/src/screamingface/plugins/frontend_base/tests/test_terminal_response.py
@@ -1,0 +1,384 @@
+"""Unit tests for terminal_response builders, streamers, and helpers.
+
+Verifies, per provider:
+- the unary envelope JSON structure pinned by the spec's Component Spec sections,
+- conversation-aware usage (non-zero when prompt/result supplied, zero when empty),
+- the EXACT streamer frame sequence — each streamer is decoded INDEPENDENTLY (SSE split
+  on ``\\n\\n`` / NDJSON split on ``\\n`` then ``json.loads`` each frame) to prove valid
+  framing rather than trusting a single concatenated blob,
+- deterministic-id stability + formula, and
+- ``extract_error_text`` formatting for BOTH an ``httpx.HTTPStatusError`` (the /ensemble
+  502 PlainText path) AND a raw exception.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import httpx
+import pytest
+
+from screamingface.plugins.frontend_base.terminal_response import (
+    build_anthropic_message,
+    build_gemini_response,
+    build_ollama_response,
+    build_openai_response,
+    deterministic_id,
+    estimate_tokens,
+    extract_error_text,
+    serialize_transcript,
+    stream_anthropic_sse,
+    stream_gemini_chunks,
+    stream_ollama_ndjson,
+    stream_openai_sse,
+)
+
+# ---------------------------------------------------------------------------
+# Independent frame decoders (do not trust the producer — re-parse the bytes)
+# ---------------------------------------------------------------------------
+
+
+def parse_sse_frames(sse_bytes: bytes) -> list[tuple[str | None, dict]]:
+    """Split an SSE byte stream on blank lines and json.loads each ``data:`` payload.
+
+    Asserts (implicitly, by raising) that every non-empty frame is well-formed and that
+    the whole stream is blank-line (``\\n\\n``) terminated.
+    """
+    text = sse_bytes.decode("utf-8")
+    # A well-formed SSE stream ends each frame with a blank line.
+    assert text.endswith("\n\n"), "SSE stream must end with a blank-line-terminated frame"
+    results: list[tuple[str | None, dict]] = []
+    for frame in text.split("\n\n"):
+        if not frame.strip():
+            continue
+        lines = frame.split("\n")
+        event_line = next((line for line in lines if line.startswith("event:")), None)
+        data_line = next((line for line in lines if line.startswith("data:")), None)
+        assert data_line is not None, f"SSE frame missing data line: {frame!r}"
+        event_name = event_line.split(":", 1)[1].strip() if event_line else None
+        data_json = data_line.split(":", 1)[1].strip()
+        results.append((event_name, json.loads(data_json)))
+    return results
+
+
+def parse_ndjson_frames(ndjson_bytes: bytes) -> list[dict]:
+    """Split an NDJSON byte stream on newlines and json.loads each line."""
+    text = ndjson_bytes.decode("utf-8")
+    assert "data: " not in text, "NDJSON must not carry an SSE data: prefix"
+    return [json.loads(line) for line in text.split("\n") if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Anthropic
+# ---------------------------------------------------------------------------
+
+
+def test_build_anthropic_message() -> None:
+    result = build_anthropic_message("Test response", "claude-3-5-sonnet", prompt_text="User: hi")
+    assert result["id"].startswith("msg_")
+    assert result["type"] == "message"
+    assert result["role"] == "assistant"
+    assert result["content"] == [{"type": "text", "text": "Test response"}]
+    assert result["model"] == "claude-3-5-sonnet"
+    assert result["stop_reason"] == "end_turn"
+    assert result["stop_sequence"] is None
+    usage = result["usage"]
+    assert usage["input_tokens"] > 0  # non-zero: prompt_text supplied (conversation-aware)
+    assert usage["output_tokens"] > 0  # non-zero: result_text supplied
+    assert usage["cache_creation_input_tokens"] == 0
+    assert usage["cache_read_input_tokens"] == 0
+
+
+def test_build_anthropic_message_empty_prompt_zero_input_tokens() -> None:
+    result = build_anthropic_message("Hi", "claude-3-5-sonnet")
+    assert result["usage"]["input_tokens"] == 0
+    assert result["usage"]["output_tokens"] > 0
+
+
+def test_build_anthropic_message_honors_response_id() -> None:
+    result = build_anthropic_message("Hi", "m", response_id="msg_fixed")
+    assert result["id"] == "msg_fixed"
+
+
+async def test_stream_anthropic_sse() -> None:
+    chunks = [c async for c in stream_anthropic_sse("Result text", "claude-3-5-sonnet")]
+    assert all(isinstance(c, bytes) for c in chunks)
+    sse_bytes = b"".join(chunks)
+    frames = parse_sse_frames(sse_bytes)
+    event_names = [name for name, _ in frames]
+    assert event_names == [
+        "message_start",
+        "ping",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_stop",
+        "message_delta",
+        "message_stop",
+    ]
+    # ping frame present, after message_start
+    ping = next(d for n, d in frames if n == "ping")
+    assert ping == {"type": "ping"}
+    # whole text in ONE text_delta
+    delta_frame = next(d for n, d in frames if n == "content_block_delta")
+    assert delta_frame["delta"]["type"] == "text_delta"
+    assert delta_frame["delta"]["text"] == "Result text"
+    # message_delta carries output usage
+    md = next(d for n, d in frames if n == "message_delta")
+    assert md["delta"]["stop_reason"] == "end_turn"
+    assert "output_tokens" in md["usage"]
+    assert b"[DONE]" not in sse_bytes
+
+
+async def test_stream_anthropic_sse_usage_is_conversation_aware() -> None:
+    chunks = [c async for c in stream_anthropic_sse("Result", "m", prompt_text="User: hello there")]
+    frames = parse_sse_frames(b"".join(chunks))
+    start = next(d for n, d in frames if n == "message_start")
+    usage = start["message"]["usage"]
+    assert usage["input_tokens"] > 0
+    assert usage["output_tokens"] > 0
+
+
+# ---------------------------------------------------------------------------
+# OpenAI (Responses)
+# ---------------------------------------------------------------------------
+
+
+def test_build_openai_response() -> None:
+    result = build_openai_response("Test response", "gpt-4o-mini", prompt_text="User: hi")
+    assert result["id"].startswith("resp_")
+    assert result["object"] == "response"
+    assert result["status"] == "completed"
+    assert isinstance(result["created_at"], int)
+    assert result["created_at"] > 0
+    assert len(result["output"]) == 1
+    item = result["output"][0]
+    assert item["id"].startswith("msg_")
+    assert item["type"] == "message"
+    assert item["status"] == "completed"
+    assert item["role"] == "assistant"
+    assert item["content"][0]["type"] == "output_text"
+    assert item["content"][0]["text"] == "Test response"
+    assert item["content"][0]["annotations"] == []
+    usage = result["usage"]
+    for k in (
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+    ):
+        assert k in usage
+    assert usage["total_tokens"] == usage["input_tokens"] + usage["output_tokens"]
+    assert usage["input_tokens"] > 0
+    assert usage["output_tokens"] > 0
+
+
+def test_build_openai_response_completed_status_for_errors() -> None:
+    # #244: even the error path uses status="completed" for CLI visibility.
+    result = build_openai_response("[url4 error] ...", "gpt-4o-mini", status="completed")
+    assert result["status"] == "completed"
+
+
+async def test_stream_openai_sse() -> None:
+    chunks = [c async for c in stream_openai_sse("Result", "gpt-4o-mini")]
+    sse_bytes = b"".join(chunks)
+    frames = parse_sse_frames(sse_bytes)
+    event_names = [d["type"] for _, d in frames]
+    assert event_names == [
+        "response.created",
+        "response.in_progress",
+        "response.output_item.added",
+        "response.content_part.added",
+        "response.output_text.delta",
+        "response.output_text.done",
+        "response.content_part.done",
+        "response.output_item.done",
+        "response.completed",
+    ]
+    # codex SSE has no `event:` line — pure `data:` frames.
+    assert all(name is None for name, _ in frames)
+    created = next(d for _, d in frames if d["type"] == "response.created")
+    assert created["response"]["status"] == "in_progress"
+    delta = next(d for _, d in frames if d["type"] == "response.output_text.delta")
+    assert delta["delta"] == "Result"  # whole text in one delta
+    completed = next(d for _, d in frames if d["type"] == "response.completed")
+    assert completed["response"]["status"] == "completed"
+    assert completed["response"]["usage"]["total_tokens"] >= 0
+    assert "total_tokens" in completed["response"]["usage"]
+    # stable item_id across item/part/delta/done frames
+    item_ids = {d["item_id"] for _, d in frames if "item_id" in d} | {
+        d["item"]["id"] for _, d in frames if "item" in d
+    }
+    assert len(item_ids) == 1
+    # monotonic sequence_number
+    seq_nums = [d["sequence_number"] for _, d in frames]
+    assert seq_nums == sorted(seq_nums)
+    assert seq_nums == list(range(len(seq_nums)))
+    assert b"[DONE]" not in sse_bytes
+
+
+# ---------------------------------------------------------------------------
+# Gemini
+# ---------------------------------------------------------------------------
+
+
+def test_build_gemini_response() -> None:
+    result = build_gemini_response("Test response", "gemini-2.5-flash", prompt_text="User: hi")
+    candidate = result["candidates"][0]
+    assert candidate["finishReason"] == "STOP"
+    assert candidate["index"] == 0
+    assert candidate["content"]["role"] == "model"
+    assert candidate["content"]["parts"][0]["text"] == "Test response"
+    usage = result["usageMetadata"]  # camelCase authoritative
+    for k in ("promptTokenCount", "candidatesTokenCount", "totalTokenCount"):
+        assert k in usage
+    assert usage["totalTokenCount"] == usage["promptTokenCount"] + usage["candidatesTokenCount"]
+    assert usage["promptTokenCount"] > 0
+    assert usage["candidatesTokenCount"] > 0
+    assert result["modelVersion"] == "gemini-2.5-flash"
+    assert "responseId" in result  # O12 synthetic response id
+
+
+async def test_stream_gemini_chunks_default_json_array() -> None:
+    chunks = [c async for c in stream_gemini_chunks("Result", "gemini-2.5-flash")]
+    body = b"".join(chunks)
+    # default is a real JSON ARRAY (application/json), NOT SSE.
+    assert b"data: " not in body
+    data = json.loads(body)
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["candidates"][0]["finishReason"] == "STOP"
+    assert data[0]["candidates"][0]["content"]["parts"][0]["text"] == "Result"
+
+
+async def test_stream_gemini_chunks_alt_sse() -> None:
+    chunks = [c async for c in stream_gemini_chunks("Result", "gemini-2.5-flash", alt_sse=True)]
+    body = b"".join(chunks)
+    assert body.startswith(b"data: ")
+    assert body.endswith(b"\n\n")
+    assert b"[DONE]" not in body
+    # decode the single SSE frame independently
+    payload = body.decode("utf-8").split("data:", 1)[1].strip()
+    obj = json.loads(payload)
+    assert obj["candidates"][0]["content"]["parts"][0]["text"] == "Result"
+
+
+# ---------------------------------------------------------------------------
+# Ollama (NDJSON)
+# ---------------------------------------------------------------------------
+
+
+def test_build_ollama_response() -> None:
+    result = build_ollama_response("Test response", "llama3.2", prompt_text="User: hi")
+    assert result["model"] == "llama3.2"
+    assert result["created_at"] == "2025-06-04T00:00:00Z"
+    assert result["message"] == {"role": "assistant", "content": "Test response"}
+    assert result["done"] is True
+    assert result["done_reason"] == "stop"
+    assert result["total_duration"] == 0
+    assert result["load_duration"] == 0
+    assert result["prompt_eval_count"] > 0  # conversation-aware (prompt_text supplied)
+    assert result["eval_count"] > 0
+
+
+async def test_stream_ollama_ndjson() -> None:
+    chunks = [c async for c in stream_ollama_ndjson("Result text", "llama3.2")]
+    ndjson_bytes = b"".join(chunks)
+    frames = parse_ndjson_frames(ndjson_bytes)
+    assert len(frames) == 2
+    # first frame: full content, not done
+    assert frames[0]["done"] is False
+    assert frames[0]["message"] == {"role": "assistant", "content": "Result text"}
+    # terminal frame: empty content, done + done_reason, still structurally complete
+    assert frames[1]["done"] is True
+    assert frames[1]["done_reason"] == "stop"
+    assert frames[1]["message"] == {"role": "assistant", "content": ""}
+    # every frame carries a complete message field (fixes abbreviated-frame major)
+    assert "message" in frames[0] and "message" in frames[1]
+    # NDJSON, not SSE
+    assert b"data: " not in ndjson_bytes
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def test_extract_error_text_raw_exception() -> None:
+    exc = ValueError("Test error message")
+    text = extract_error_text(exc, "test-spec", "some_expression")
+    assert text.startswith("[url4 error] ")
+    assert "test-spec" in text
+    assert "some_expression" in text
+    assert "ValueError" in text
+    assert "Test error message" in text
+    assert "Traceback:" in text
+
+
+def test_extract_error_text_truncates_long_expression() -> None:
+    long_expr = "x" * 500
+    text = extract_error_text(RuntimeError("boom"), "spec", long_expr)
+    # only the first 200 chars of the expression are surfaced
+    assert "x" * 200 in text
+    assert "x" * 201 not in text
+
+
+def test_extract_error_text_empty_expression() -> None:
+    text = extract_error_text(RuntimeError("boom"), "spec", "")
+    assert "(empty)" in text
+
+
+def test_extract_error_text_httpx_status_error_surfaces_502_body() -> None:
+    # The /ensemble 502 path: PlainTextResponse body must be visible, not just "502".
+    request = httpx.Request("GET", "http://localhost/ensemble")
+    response = httpx.Response(
+        502, text="url4 evaluation failed: interpreter blew up", request=request
+    )
+    with pytest.raises(httpx.HTTPStatusError) as excinfo:
+        response.raise_for_status()
+    text = extract_error_text(excinfo.value, "test-spec", "$prompt | model:foo")
+    assert text.startswith("[url4 error] ")
+    assert "HTTPStatusError" in text
+    assert "502" in text
+    assert "url4 evaluation failed: interpreter blew up" in text  # the PlainText body
+    assert "Traceback:" in text
+
+
+def test_serialize_transcript() -> None:
+    turns = [("user", "Hello"), ("assistant", "Hi there"), ("user", "How are you?")]
+    result = serialize_transcript(turns)
+    assert result == "User: Hello\nAssistant: Hi there\nUser: How are you?"
+
+
+def test_serialize_transcript_empty() -> None:
+    assert serialize_transcript([]) == ""
+
+
+def test_estimate_tokens() -> None:
+    assert estimate_tokens("") == 0
+    assert estimate_tokens("1234") == 1
+    assert estimate_tokens("12345678") == 2
+    assert estimate_tokens("a") == 1  # floor would be 0, but min is 1 for non-empty
+
+
+def test_deterministic_id_is_stable() -> None:
+    a = deterministic_id("msg_", "m", "p", "r")
+    b = deterministic_id("msg_", "m", "p", "r")
+    assert a == b
+    assert a.startswith("msg_")
+    assert deterministic_id("msg_", "m", "p", "r2") != a
+
+
+def test_deterministic_id_matches_sha256_formula() -> None:
+    expected = "msg_" + hashlib.sha256(b"mpr").hexdigest()[:24]
+    assert deterministic_id("msg_", "m", "p", "r") == expected
+    # 24 hex chars after the prefix
+    assert len(deterministic_id("", "m", "p", "r")) == 24
+
+
+def test_deterministic_id_empty_prefix() -> None:
+    # gemini responseId uses an empty prefix.
+    got = deterministic_id("", "gemini-2.5-flash", "User: hi", "answer")
+    assert len(got) == 24
+    assert all(c in "0123456789abcdef" for c in got)

--- a/apps/server/tests/e2e/infrastructure/claude_code_client.py
+++ b/apps/server/tests/e2e/infrastructure/claude_code_client.py
@@ -28,8 +28,30 @@ class ProxyResponse:
     headers: dict[str, str]
 
     @property
+    def response_text(self) -> str:
+        """Assistant text from the terminal Anthropic envelope (``body.content[0].text``).
+
+        Under the terminal cutover the proxy no longer forwards; the resolved
+        url4 text *becomes* the response. This is the canonical accessor for the
+        synthesized assistant message body.
+        """
+        content = self.body.get("content")
+        if isinstance(content, list):
+            return "".join(
+                block.get("text", "")
+                for block in content
+                if isinstance(block, dict) and block.get("type") == "text"
+            )
+        return ""
+
+    @property
     def echoed_body(self) -> dict[str, Any]:
-        """The forwarded request body echoed back by httpbin ``/anything``."""
+        """The forwarded request body echoed back by httpbin ``/anything``.
+
+        Retained for the few remaining forwarding routes (catchall / passthrough).
+        For the terminal ``/v1/messages`` path this is empty — use
+        :attr:`response_text` instead.
+        """
         return self.body.get("json", {})
 
     @property

--- a/apps/server/tests/e2e/test_cat_breeds_spec.py
+++ b/apps/server/tests/e2e/test_cat_breeds_spec.py
@@ -173,7 +173,15 @@ class TestCatBreedsFullPipeline:
         cat_proxy: tuple[ServerManager, int],
         otlp_collector: OTLPCollector,
     ):
-        """Send a prompt about cats, verify Claude processes the 3 sources."""
+        """Send a prompt about cats, verify Claude processes the 3 sources.
+
+        Terminal cutover: the proxy no longer forwards. The spec
+        ``(src1,src2,src3)!$prompt`` resolves in-process — the $prompt transcript
+        (the apartment question) is sent with the 3 sources to the Claude CLI via
+        ``/claude``, and Claude's analysis *becomes* the response. So the
+        substantive cat-breed answer is in ``response_text``, not in a forwarded
+        user message.
+        """
         _, proxy_port = cat_proxy
         client = ClaudeCodeClient(proxy_url=f"http://127.0.0.1:{proxy_port}")
 
@@ -185,19 +193,22 @@ class TestCatBreedsFullPipeline:
 
         assert resp.status_code == 200
 
-        # The response is echoed by httpbin — check the forwarded user message
-        user_text = resp.last_user_text
+        # The resolved Claude analysis IS the terminal response body.
+        answer = resp.response_text
 
-        # The user message should contain the original prompt
-        assert "apartment" in user_text.lower(), (
-            f"Original prompt missing from user message: {user_text[:300]}"
+        # Claude's analysis should be substantive (it processed the 3 sources).
+        assert len(answer) > 100, (
+            f"Response too short ({len(answer)} chars) — Claude analysis may not "
+            f"have been resolved: {answer[:300]}"
         )
 
-        # The user message should contain Claude's response about cat breeds
-        # (the /claude endpoint processes the 3 sources and returns analysis)
-        assert len(user_text) > 100, (
-            f"User message too short ({len(user_text)} chars) — "
-            f"Claude response may not have been injected: {user_text[:300]}"
+        # The analysis should be on-topic: it should mention apartments (the
+        # question) and at least one concrete cat breed from the sources.
+        lowered = answer.lower()
+        assert "apartment" in lowered, f"Response not on-topic (no 'apartment'): {answer[:300]}"
+        known_breeds = ["persian", "siamese", "bengal", "maine", "bombay", "british"]
+        assert any(b in lowered for b in known_breeds), (
+            f"Response names no known cat breed from the sources: {answer[:300]}"
         )
 
     def test_cat_breeds_trace_shows_3_fetches(

--- a/apps/server/tests/e2e/test_claude_frontend_oauth_passthrough.py
+++ b/apps/server/tests/e2e/test_claude_frontend_oauth_passthrough.py
@@ -72,6 +72,12 @@ def proxy_server() -> Generator[tuple[ServerManager, int], None, None]:
         mgr.stop()
 
 
+@pytest.mark.skip(
+    reason="Obsoleted by SF-240: claude_frontend /v1/messages is now a terminal "
+    "ensemble endpoint and no longer forwards to Anthropic on the inference route. "
+    "OAuth Bearer passthrough on non-inference routes is covered by "
+    "claude_frontend/tests/test_proxy.py."
+)
 @pytest.mark.timeout(60)
 def test_oauth_access_token_passthrough_round_trip(
     proxy_server: tuple[ServerManager, int],

--- a/apps/server/tests/e2e/test_proxy_context_injection.py
+++ b/apps/server/tests/e2e/test_proxy_context_injection.py
@@ -87,35 +87,53 @@ def static_client(static_proxy):
 
 @pytest.mark.timeout(30)
 class TestStaticContextInjection:
-    """Tests for static spec (no $prompt) — context injected into system prompt."""
+    """Tests for the static spec (no $prompt) under the terminal cutover.
+
+    The proxy no longer forwards. The static spec
+    ``(robots.txt)!'You are an API testing assistant'`` resolves in-process to
+    its terminal text (intent + fetched robots.txt) and *becomes* the response
+    body. The client-sent ``system`` and extra body fields have no upstream to
+    land in, so they are ignored — assertions now target ``response_text``.
+    """
 
     def test_context_injection_with_string_system(self, static_client: ClaudeCodeClient):
-        """url4 context + original system prompt both present in forwarded request."""
+        """url4 context (source + intent) is the resolved terminal response text.
+
+        The client ``system`` ("Be helpful") is ignored — there is no upstream to
+        merge it into — so it is no longer asserted.
+        """
         resp = static_client.send_message("Hello", system="Be helpful")
 
         assert resp.status_code == 200
 
-        system = str(resp.forwarded_system)
-        assert "User-agent" in system, f"url4 source content missing: {system[:200]}"
-        assert "Be helpful" in system, f"original system prompt missing: {system[:200]}"
-        assert "API testing assistant" in system, f"intent text missing: {system[:200]}"
+        text = resp.response_text
+        assert "User-agent" in text, f"url4 source content missing: {text[:200]}"
+        assert "API testing assistant" in text, f"intent text missing: {text[:200]}"
 
     def test_context_injection_no_system(self, static_client: ClaudeCodeClient):
-        """url4 context injected even when no system prompt provided."""
+        """url4 context is resolved into the response even when no system prompt is sent."""
         resp = static_client.send_message("Hello")
 
         assert resp.status_code == 200
 
-        system = str(resp.forwarded_system)
-        assert "User-agent" in system, f"url4 source content missing: {system[:200]}"
-        assert "API testing assistant" in system, f"intent text missing: {system[:200]}"
+        text = resp.response_text
+        assert "User-agent" in text, f"url4 source content missing: {text[:200]}"
+        assert "API testing assistant" in text, f"intent text missing: {text[:200]}"
 
-    def test_extra_fields_passthrough(self, static_client: ClaudeCodeClient):
-        """Custom fields in the request body survive proxying."""
+    def test_extra_fields_tolerated(self, static_client: ClaudeCodeClient):
+        """Unknown extra body fields are tolerated by the terminal handler.
+
+        The terminal path does not forward, so extra fields cannot be echoed
+        back. Instead assert they are accepted without error: a well-formed
+        Anthropic message envelope is still returned (status 200, ``type`` =
+        ``message``) and the resolved url4 context is present.
+        """
         resp = static_client.send_message(
             "Hello",
             extra_body={"custom_field": "should_survive"},
         )
 
         assert resp.status_code == 200
-        assert resp.echoed_body.get("custom_field") == "should_survive"
+        assert resp.body["type"] == "message"
+        assert resp.body["role"] == "assistant"
+        assert "User-agent" in resp.response_text

--- a/apps/server/tests/e2e/test_proxy_multi_turn.py
+++ b/apps/server/tests/e2e/test_proxy_multi_turn.py
@@ -10,14 +10,22 @@ pytestmark = [pytest.mark.e2e, pytest.mark.timeout(30)]
 
 
 class TestMultiTurn:
-    """Tests for multi-turn conversation patterns through the proxy."""
+    """Multi-turn conversation behavior under the terminal cutover.
+
+    The active spec is the ``$prompt`` spec ``(robots.txt)!$prompt``. The proxy
+    serializes the FULL conversation transcript (``serialize_transcript`` over
+    ``_extract_turns``) into the ``$prompt`` blob, resolves the expression
+    in-process, and the resolved text *becomes* the response. So the conversation
+    history is observable in ``response_text``, not in a forwarded ``messages``
+    array (there is no upstream).
+    """
 
     def test_multi_turn_history_preserved(self, claude_client: ClaudeCodeClient):
-        """Message array grows correctly across turns."""
-        # First turn
+        """Prior turns are preserved in the transcript that drives the response."""
+        # First turn: the resolved transcript echoes the lone user turn.
         resp1 = claude_client.send_message("First message")
         assert resp1.status_code == 200
-        assert len(resp1.forwarded_messages) == 1
+        assert "First message" in resp1.response_text
 
         # Inject assistant response for multi-turn
         claude_client.inject_assistant_response(
@@ -26,36 +34,52 @@ class TestMultiTurn:
             ]
         )
 
-        # Second turn
+        # Second turn: the full transcript (all three turns) drives the response,
+        # rendered by serialize_transcript as "User:/Assistant:" lines.
         resp2 = claude_client.send_message("Second message")
         assert resp2.status_code == 200
-        assert len(resp2.forwarded_messages) == 3  # user, assistant, user
 
-        msgs = resp2.forwarded_messages
-        assert msgs[0]["role"] == "user"
-        assert msgs[1]["role"] == "assistant"
-        assert msgs[2]["role"] == "user"
+        text = resp2.response_text
+        assert "User: First message" in text, f"first user turn missing: {text[:300]}"
+        assert "Assistant: I received your first message." in text, (
+            f"assistant turn missing: {text[:300]}"
+        )
+        assert "User: Second message" in text, f"second user turn missing: {text[:300]}"
 
-    def test_system_reminders_filtered(self, claude_client: ClaudeCodeClient):
-        """<system-reminder> blocks should not be treated as user prompt text."""
+    def test_system_reminders_not_stripped_by_extract_turns(self, claude_client: ClaudeCodeClient):
+        """<system-reminder> text is NOT filtered by ``_extract_turns``.
+
+        ``_extract_turns`` concatenates every ``type="text"`` block of a turn
+        verbatim; it has no system-reminder awareness. So both the reminder
+        content and the user's question land in the transcript and therefore in
+        ``response_text``. (This documents the real terminal behavior — the old
+        "reminders filtered" forwarding semantics no longer apply.)
+        """
         claude_client.add_system_reminder("You have access to tools: Bash, Read, Write")
 
         resp = claude_client.send_message("What can you do?")
         assert resp.status_code == 200
 
-        # The user's actual text should be in the response, not the reminder
-        content = resp.last_user_text
-        # The proxy's _extract_last_user_text filters system-reminders
-        # So the $prompt substitution should use "What can you do?" not the reminder
-        assert "What can you do?" in content or "User-agent" in content
+        text = resp.response_text
+        # Reminder text is carried through (NOT stripped):
+        assert "You have access to tools" in text, f"reminder text missing: {text[:300]}"
+        # The user's actual question is also present:
+        assert "What can you do?" in text, f"user question missing: {text[:300]}"
 
     def test_tool_use_tool_result_cycle(self, claude_client: ClaudeCodeClient):
-        """Full tool_use → tool_result round-trip through the proxy."""
-        # User asks something
+        """tool_use / tool_result blocks contribute no transcript text.
+
+        ``_extract_turns`` only collects ``type="text"`` content blocks. A turn
+        whose content is purely ``tool_use`` (assistant) or ``tool_result``
+        (user) yields empty text and is dropped from the transcript. So after a
+        user-text -> assistant-tool_use -> user-tool_result cycle, only the
+        leading user text turn survives in ``response_text``.
+        """
+        # User asks something (plain text turn)
         resp1 = claude_client.send_message("List files in current directory")
         assert resp1.status_code == 200
 
-        # Simulate assistant using a tool
+        # Simulate assistant using a tool (pure tool_use → no text)
         claude_client.inject_assistant_response(
             [
                 {
@@ -67,17 +91,21 @@ class TestMultiTurn:
             ]
         )
 
-        # User sends tool result
+        # User sends tool result (pure tool_result → no text)
         resp2 = claude_client.send_tool_result(
             "toolu_01ABC",
             "file1.txt\nfile2.py\nREADME.md",
         )
         assert resp2.status_code == 200
 
-        # Verify the full message sequence was forwarded
-        msgs = resp2.forwarded_messages
-        assert len(msgs) >= 3
-
-        # Check roles alternate correctly
-        roles = [m["role"] for m in msgs]
-        assert roles[-3:] == ["user", "assistant", "user"]
+        text = resp2.response_text
+        # The leading user text turn is preserved in the transcript:
+        assert "User: List files in current directory" in text, (
+            f"leading user turn missing: {text[:300]}"
+        )
+        # The tool_use/tool_result blocks carry no text, so the tool id and
+        # tool output never reach the transcript:
+        assert "toolu_01ABC" not in text
+        assert "file1.txt" not in text
+        # The resolved url4 source is still appended (terminal resolution ran):
+        assert "User-agent" in text, f"resolved url4 source missing: {text[:300]}"

--- a/apps/server/tests/e2e/test_proxy_prompt_flow.py
+++ b/apps/server/tests/e2e/test_proxy_prompt_flow.py
@@ -18,17 +18,29 @@ class TestPromptSubstitution:
     """Tests for $prompt url4 specs — context injected into user message."""
 
     def test_prompt_text_mode(self, claude_client: ClaudeCodeClient):
-        """$prompt in intent position: user msg replaced with 'prompt + resolved context'."""
+        """$prompt blob carries the user prompt; resolved text becomes the response.
+
+        The user text goes into the serialized transcript ($prompt blob), the
+        spec resolves in-process, and the terminal text *is* the response. So the
+        original prompt and the resolved robots.txt source are both in
+        ``response_text``.
+        """
         resp = claude_client.send_message("Summarize this for me")
 
         assert resp.status_code == 200
 
-        content = resp.last_user_text
-        assert "Summarize this" in content, f"original prompt missing: {content[:200]}"
-        assert "User-agent" in content, f"resolved robots.txt missing: {content[:200]}"
+        text = resp.response_text
+        assert "Summarize this" in text, f"original prompt missing: {text[:200]}"
+        assert "User-agent" in text, f"resolved robots.txt missing: {text[:200]}"
 
     def test_prompt_skips_tool_result(self, claude_client: ClaudeCodeClient):
-        """Last user msg is pure tool_result → $prompt substitution skipped."""
+        """A pure-tool_result final turn contributes no text to the $prompt blob.
+
+        ``_extract_turns`` collects only ``type="text"`` blocks. The final user
+        turn is purely a ``tool_result`` block, so it yields empty text and is
+        dropped from the transcript. The earlier "Hello" user turn is what drives
+        the resolved response; the tool_result content/id never appear.
+        """
         # Set up multi-turn: user → assistant (tool_use) → user (tool_result)
         claude_client.send_message("Hello", track_history=True)
         claude_client.inject_assistant_response(
@@ -41,17 +53,15 @@ class TestPromptSubstitution:
 
         assert resp.status_code == 200
 
-        # The tool_result should be preserved as-is, not substituted
-        msgs = resp.forwarded_messages
-        last_user = msgs[-1] if msgs else None
-        assert last_user is not None
-
-        content = last_user.get("content", "")
-        if isinstance(content, list):
-            has_tool_result = any(
-                b.get("type") == "tool_result" for b in content if isinstance(b, dict)
-            )
-            assert has_tool_result, f"tool_result not preserved: {content}"
+        text = resp.response_text
+        # The prior plain-text user turn survives in the transcript:
+        assert "User: Hello" in text, f"prior user turn missing: {text[:200]}"
+        # The pure tool_result turn contributed no text — its id and payload
+        # are absent from the resolved response:
+        assert "t1" not in text
+        assert "file.txt" not in text
+        # Terminal resolution still ran (robots.txt source appended):
+        assert "User-agent" in text, f"resolved url4 source missing: {text[:200]}"
 
     def test_blob_dedup(self):
         """Same prompt text → same blob key (SHA-256 content hash)."""

--- a/apps/server/tests/e2e/test_trace_structure.py
+++ b/apps/server/tests/e2e/test_trace_structure.py
@@ -42,21 +42,45 @@ class TestTraceStructure:
             f"No url4.$prompt span found. All spans: {[s.name for s in spans]}"
         )
 
-    def test_anthropic_request_body_span(
+    def test_terminal_message_span_no_upstream_request_body(
         self, claude_client: ClaudeCodeClient, otlp_collector: OTLPCollector
     ):
-        """The anthropic.request_body span should record model and message count."""
+        """Terminal /v1/messages emits the FastAPI server span + url4 spans, no upstream.
+
+        Under the terminal cutover there is no upstream inference forward, so the
+        old ``anthropic.request_body`` span no longer exists. Instead assert the
+        terminal span set: the auto-instrumented ``POST /v1/messages`` server
+        span (tagged ``sf.plugin=claude-frontend`` with the resolved
+        ``url4.result_length``) plus the in-process ``url4.evaluate`` resolution
+        span — and explicitly assert NO ``anthropic.request_body`` span.
+        """
         claude_client.send_message("Hello body trace")
 
         spans = otlp_collector.wait_for_spans(3, timeout=15)
-        body_spans = otlp_collector.find_spans(name="anthropic.request_body")
+        all_names = [s.name for s in spans]
 
-        assert len(body_spans) >= 1, (
-            f"No anthropic.request_body span found. All spans: {[s.name for s in spans]}"
+        # The upstream request-body span is GONE under the terminal cutover.
+        assert otlp_collector.find_spans(name="anthropic.request_body") == [], (
+            f"anthropic.request_body span should not exist under terminal cutover. "
+            f"All spans: {all_names}"
         )
 
-        body_span = body_spans[0]
-        assert body_span.attributes.get("sf.plugin") == "claude-frontend"
+        # The terminal server span for the inference route exists and is tagged
+        # by the frontend plugin (set via the handler's tracer.set_attrs).
+        msg_spans = otlp_collector.find_spans(name="POST /v1/messages")
+        assert len(msg_spans) >= 1, (
+            f"No 'POST /v1/messages' server span found. All spans: {all_names}"
+        )
+        msg_span = msg_spans[0]
+        assert msg_span.attributes.get("sf.plugin") == "claude-frontend"
+        assert "url4.result_length" in msg_span.attributes, (
+            f"resolved result length missing from server span. "
+            f"Attributes: {list(msg_span.attributes.keys())}"
+        )
+
+        # The in-process url4 resolution span exists (terminal resolution ran).
+        eval_spans = otlp_collector.find_spans(name="url4.evaluate")
+        assert len(eval_spans) >= 1, f"No 'url4.evaluate' span found. All spans: {all_names}"
 
     def test_prompt_span_attributes(
         self, claude_client: ClaudeCodeClient, otlp_collector: OTLPCollector

--- a/docs/superpowers/plans/2026-06-04-frontend-terminal-ensemble-implementation.md
+++ b/docs/superpowers/plans/2026-06-04-frontend-terminal-ensemble-implementation.md
@@ -1,0 +1,3460 @@
+# Frontend Terminal-Ensemble Reframing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert the four CLI frontends (claude, codex, gemini, ollama) so their inference routes terminate at an in-process url4/ensemble resolution and synthesize provider-native responses instead of proxying to real upstreams.
+
+**Architecture:** Each frontend's inference leg (and only that leg) stops forwarding to the real provider; it resolves the active url4 spec (`$prompt` dynamic or static) and synthesizes the provider's native unary/streaming envelope using a single shared `terminal_response.py` module. The `$prompt` blob is the FULL serialized transcript (conversation-aware), responses echo a deterministic id plus plausible non-zero usage, and resolution errors render as a normal completed/200 envelope whose assistant text is the visible `[url4 error] ...+traceback`. Non-inference routes keep real-upstream passthrough unchanged; the cutover is direct with no feature flag.
+
+**Tech Stack:** Python 3.12, FastAPI, pytest, ruff 0.9.0, pyright; apps/server.
+
+Spec: [`docs/superpowers/plans/2026-06-04-frontend-terminal-ensemble-spec.md`](docs/superpowers/plans/2026-06-04-frontend-terminal-ensemble-spec.md)
+
+---
+
+## Settled gating decisions (authoritative)
+
+These govern every task below; where a milestone's original draft conflicts, the decision here wins.
+
+- **A. CONVERSATION-AWARE.** The `$prompt` blob is the FULL serialized transcript (not just the last user turn). Each frontend replaces `_extract_last_user_text` with `_extract_turns(body) -> list[tuple[str, str]]` then calls the shared `serialize_transcript(turns) -> str` to build the blob. Responses echo a DETERMINISTIC id (`deterministic_id(...)`) and PLAUSIBLE non-zero usage (estimated from transcript + result length via `estimate_tokens`). Static specs still ignore the CLI prompt entirely; conversation-aware only governs the `$prompt` path.
+- **B. KEEP REAL-UPSTREAM PASSTHROUGH.** Only the INFERENCE route becomes terminal/synthetic. Non-inference routes still FORWARD to the real upstream UNCHANGED: claude `/v1/{path}` (incl. `POST /v1/messages/count_tokens`) and `/api/{path}`; codex `/v1/{path}`; gemini GET + `/v1beta/{path}` + the `:countTokens`/`:embedContent` verbs; ollama `/api/{path}` (incl. tags/show/pull/embeddings). `upstream_url` is RETAINED. No new stub routes; real provider creds still required.
+- **C. HARD-REMOVE** the now-unused settings `embed_target`, `embed_mode`, `system_prompt` from `FrontendSettingsBase` AND remove the `OllamaFrontendSettings.embed_target` override. Grep the whole repo (incl. `apps/server/sf.json` and `SF_*_FRONTEND__` env usage, tests) and remove every reference. Validation must not break after removal.
+- **D. DIRECT CUTOVER.** No feature flag. Delete the proxy/forward code on the inference leg outright; rewrite each inference handler in place. No legacy path retained.
+
+**Minor open-question defaults (apply silently unless they conflict with A–D):**
+- **O5b:** an empty `$prompt` resolution result is a FAIL-LOUD error (visible error envelope), with empty-result E2E tests on all four frontends.
+- **O10:** add a TTL / re-resolution for the static-spec resolve cache; document live `active_spec`-switch behavior.
+- **O12:** include a synthetic Gemini `responseId`.
+- **O16:** if the active spec does not terminate in a model backend call, WARN (do not hard-fail).
+- **Error visibility (#244):** render resolution errors as a NORMAL completed/200 provider envelope whose assistant text is the visible `[url4 error] ...+traceback` (most visible to the CLI). For codex this means `status="completed"` carrying the error text. NOTE: this overrides the spec's `status:"failed"` error-envelope for visibility — call it out in docs.
+
+---
+
+## File structure
+
+Every file created or modified across all milestones, with its single responsibility. Paths under `apps/server/` are relative to `/Users/sergey/work/openmind/screamingface/`.
+
+### Shared infrastructure (M1)
+- **Create** `apps/server/src/screamingface/plugins/frontend_base/terminal_response.py` — SOLE location for all eight provider builders/streamers + shared helpers (`extract_error_text`, `serialize_transcript`, `estimate_tokens`, `deterministic_id`). Per-frontend modules import/re-export only.
+- **Create** `apps/server/src/screamingface/plugins/frontend_base/tests/test_terminal_response.py` — unit tests for builders/streamers/helpers (independent SSE/NDJSON frame decode).
+- **Create** `apps/server/src/screamingface/plugins/frontend_base/tests/test_settings_removal.py` — proves `embed_target`/`embed_mode`/`system_prompt` are gone from base + ollama settings.
+- **Create** `apps/server/src/screamingface/plugins/frontend_base/tests/test_resolve_contract.py` — proves the `(resolved_text, error_dict)` tuple contract.
+- **Modify** `apps/server/src/screamingface/plugins/frontend_base/plugin_base.py` — remove the three unused settings fields from `FrontendSettingsBase`.
+
+### claude_frontend (M2)
+- **Modify** `apps/server/src/screamingface/plugins/claude_frontend/proxy.py` — rewrite `proxy_messages` terminal; delete `_forward_streaming`/`_forward_unary`/`_inject_system_context`/`_embed_context`; keep catchall + `/api/{path}` passthrough + `_extract_last_user_text`/`_replace_last_user_message`.
+- **Modify** `apps/server/src/screamingface/plugins/claude_frontend/_url4_context.py` — tuple return contract for `resolve_prompt_expression`/`resolve_static_context`; `_build_error_response` returns a dict.
+- **Create** `apps/server/src/screamingface/plugins/claude_frontend/tests/test_proxy_terminal.py` — terminal synthesis, error envelopes, passthrough regressions.
+- **Modify** `apps/server/src/screamingface/plugins/claude_frontend/tests/test_proxy.py` — migrate old forwarding tests to terminal model.
+- **Modify** `apps/server/src/screamingface/plugins/claude_frontend/tests/test_e2e_claude_frontend.py` — E2E with mocked resolution.
+
+### codex_frontend (M3)
+- **Modify** `apps/server/src/screamingface/plugins/codex_frontend/proxy.py` — rewrite `proxy_responses` terminal (OpenAI Responses); delete `_inject_system_context`/`_embed_context`/`_parse_sse_response`; keep `/v1/{path}` catchall + input-fork helpers.
+- **Create** `apps/server/src/screamingface/plugins/codex_frontend/tests/test_terminal_inference.py` — unary/streaming synthesis, error paths, passthrough.
+- **Modify** `apps/server/src/screamingface/plugins/codex_frontend/tests/test_proxy.py` — skip/remove deleted-function tests.
+
+### gemini_frontend (M4)
+- **Modify** `apps/server/src/screamingface/plugins/gemini_frontend/proxy.py` — rewrite `proxy_gemini` with verb allow-list (only `:generateContent`/`:streamGenerateContent` terminal); delete `_inject_system_context`/`_embed_context`; keep passthrough verbs + GET + `/v1beta/{path}` catchall.
+- **Modify** `apps/server/src/screamingface/plugins/gemini_frontend/plugin.py` — remove any `embed_target` override if present (covered by C grep).
+- **Create** `apps/server/src/screamingface/plugins/gemini_frontend/tests/test_terminal_unary.py` — unary synthesis + error/fail-loud.
+- **Create** `apps/server/src/screamingface/plugins/gemini_frontend/tests/test_terminal_streaming.py` — JSON-array default vs `?alt=sse`.
+- **Create** `apps/server/src/screamingface/plugins/gemini_frontend/tests/test_passthrough.py` — `:countTokens`/`:embedContent`/GET/catchall forward.
+- **Create** `apps/server/src/screamingface/plugins/gemini_frontend/tests/test_e2e.py` — E2E across unary/streaming/passthrough/error.
+- **Create** `apps/server/src/screamingface/plugins/gemini_frontend/tests/test_no_upstream_inference.py` — no `generativelanguage.googleapis.com` on inference.
+- **Modify** `apps/server/src/screamingface/plugins/gemini_frontend/tests/test_proxy.py` — migrate from upstream-forward assertions.
+
+### ollama_frontend (M5)
+- **Modify** `apps/server/src/screamingface/plugins/ollama_frontend/proxy.py` — rewrite `proxy_chat` terminal (NDJSON); add `_save_session_if_needed`; delete `_inject_system_message`/`_embed_context`; keep `/api/{path}` passthrough.
+- **Modify** `apps/server/src/screamingface/plugins/ollama_frontend/plugin.py` — remove `OllamaFrontendSettings.embed_target` override (C).
+- **Modify** `apps/server/src/screamingface/plugins/ollama_frontend/tests/test_proxy.py` — add terminal/error/passthrough tests; migrate old forwarding tests.
+
+### Config (M1/C)
+- **Modify** `apps/server/sf.json` — remove ollama-frontend `embed_target`/`embed_mode` keys.
+
+### Cross-frontend, integration, docs (M6)
+- **Create** `apps/server/tests/test_m6_cross_frontend_integration.py` — same spec → identical result across all four.
+- **Create** `apps/server/src/screamingface/plugins/{claude,codex,gemini,ollama}_frontend/tests/test_m6_no_upstream.py` — per-frontend no-upstream-on-inference.
+- **Create** `apps/server/src/screamingface/plugins/{claude,gemini,ollama}_frontend/tests/test_m6_passthrough.py` — passthrough regression.
+- **Create** `apps/server/tests/test_m6_aigw_sub_calls.py` — AIGateway #245 caps apply only to ensemble sub-calls.
+- **Create** `apps/server/tests/test_terminal_response_builders.py` — comprehensive builder/streamer coverage.
+- **Create** `apps/server/tests/test_terminal_response_errors.py` — error-path coverage.
+- **Create** `apps/server/tests/test_m6_success_criteria.py` — success-criteria checklist (optional, may live in CLAUDE.md).
+- **Modify** `README.md`, per-frontend `README.md`s, `docs/configuration.md`, `docs/error-handling.md`, `CLAUDE.md`, `CHANGELOG.md` — documentation.
+
+---
+
+## M1: Shared terminal-response infrastructure + settings hard-remove + resolve return-contract
+
+Create the shared `terminal_response.py` module (sole location for all eight provider response builders/streamers), hard-remove the unused settings fields (C), and pin the resolve tuple return contract used by M2–M5.
+
+### Task 1: Create `frontend_base/terminal_response.py` with shared helpers
+
+**Files:**
+- Create: `apps/server/src/screamingface/plugins/frontend_base/terminal_response.py`
+
+- [ ] **Step 1: Write the module**
+
+```python
+"""Shared terminal-response builders and streamers for all four frontends.
+
+Centralizes:
+- error formatting (extract_error_text)
+- transcript serialization (serialize_transcript) — Decision A conversation-aware
+- usage estimation (estimate_tokens) + deterministic ids (deterministic_id)
+- all eight builder/streamer functions (sole location)
+
+Per-frontend modules import and re-export only — no wire-format logic outside.
+Decision A (conversation-aware): builders take optional `prompt_text` and `response_id`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+import traceback
+import uuid
+from typing import AsyncIterator
+
+
+def extract_error_text(exc: Exception, spec_name: str, expression: str) -> str:
+    """Format error text uniformly for all providers.
+
+    Handles both httpx.HTTPStatusError (502 path) and raw Url4Interpreter exceptions.
+    Returns a structured text blob with exception class, message, and full traceback.
+    """
+    tb_str = "".join(traceback.format_exception(exc))
+    expr_preview = expression[:200] if expression else "(empty)"
+    return (
+        f"[url4 error] {spec_name}\n\n"
+        f"Expression: {expr_preview}\n\n"
+        f"Error: {exc.__class__.__name__}: {exc}\n\n"
+        f"Traceback:\n{tb_str}"
+    )
+
+
+def serialize_transcript(turns: list[tuple[str, str]]) -> str:
+    """Render conversation turns as 'User: ...\\nAssistant: ...\\n...' (Decision A).
+
+    Args:
+        turns: list of (role, text) tuples, e.g., [("user", "Hello"), ("assistant", "Hi")]
+
+    Returns:
+        Serialized transcript string for use as the $prompt blob.
+    """
+    lines = []
+    for role, text in turns:
+        role_upper = role.capitalize()
+        lines.append(f"{role_upper}: {text}")
+    return "\n".join(lines)
+
+
+def estimate_tokens(text: str) -> int:
+    """Estimate token count: max(1, len(text)//4) if text else 0."""
+    return max(1, len(text) // 4) if text else 0
+
+
+def deterministic_id(prefix: str, model: str, prompt_text: str, result_text: str) -> str:
+    """Generate deterministic ID from model + prompt + result using SHA256.
+
+    Returns f"{prefix}{hex_digest_first_24_chars}".
+    """
+    combined = model + prompt_text + result_text
+    digest = hashlib.sha256(combined.encode()).hexdigest()[:24]
+    return f"{prefix}{digest}"
+
+
+# ============================================================================
+# Anthropic (claude_frontend)
+# ============================================================================
+
+def build_anthropic_message(
+    result_text: str,
+    model: str,
+    *,
+    prompt_text: str = "",
+    response_id: str | None = None,
+) -> dict:
+    """Build unary Anthropic Messages response envelope."""
+    msg_id = response_id or deterministic_id("msg_", model, prompt_text, result_text)
+    input_tokens = estimate_tokens(prompt_text)
+    output_tokens = estimate_tokens(result_text)
+
+    return {
+        "id": msg_id,
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": result_text}],
+        "model": model,
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "usage": {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        },
+    }
+
+
+async def stream_anthropic_sse(
+    result_text: str,
+    model: str,
+    *,
+    prompt_text: str = "",
+    response_id: str | None = None,
+) -> AsyncIterator[bytes]:
+    """Stream Anthropic response as SSE (event: lines, blank-line terminated).
+
+    Frame sequence:
+    message_start -> ping -> content_block_start -> content_block_delta
+    -> content_block_stop -> message_delta -> message_stop
+
+    All text in ONE delta. No [DONE].
+    """
+    msg_id = response_id or deterministic_id("msg_", model, prompt_text, result_text)
+    input_tokens = estimate_tokens(prompt_text)
+    output_tokens = estimate_tokens(result_text)
+
+    def sse_frame(event_name: str, payload: dict) -> bytes:
+        return f"event: {event_name}\ndata: {json.dumps(payload)}\n\n".encode("utf-8")
+
+    yield sse_frame("message_start", {
+        "type": "message_start",
+        "message": {
+            "id": msg_id,
+            "type": "message",
+            "role": "assistant",
+            "content": [],
+            "model": model,
+            "stop_reason": None,
+            "stop_sequence": None,
+            "usage": {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+            },
+        },
+    })
+    yield sse_frame("ping", {"type": "ping"})
+    yield sse_frame("content_block_start", {
+        "type": "content_block_start",
+        "index": 0,
+        "content_block": {"type": "text", "text": ""},
+    })
+    yield sse_frame("content_block_delta", {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {"type": "text_delta", "text": result_text},
+    })
+    yield sse_frame("content_block_stop", {
+        "type": "content_block_stop",
+        "index": 0,
+    })
+    yield sse_frame("message_delta", {
+        "type": "message_delta",
+        "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+        "usage": {"output_tokens": output_tokens},
+    })
+    yield sse_frame("message_stop", {"type": "message_stop"})
+
+
+# ============================================================================
+# OpenAI (codex_frontend)
+# ============================================================================
+
+def build_openai_response(
+    result_text: str,
+    model: str,
+    *,
+    prompt_text: str = "",
+    response_id: str | None = None,
+    status: str = "completed",
+) -> dict:
+    """Build unary OpenAI Responses envelope.
+
+    NOTE (#244 error visibility): error path uses status="completed" carrying the
+    error text, NOT status="failed", so the Codex CLI renders the visible error.
+    """
+    resp_id = response_id or deterministic_id("resp_", model, prompt_text, result_text)
+    item_id = deterministic_id("msg_", model, prompt_text, result_text)
+    created_at = int(time.time())
+    input_tokens = estimate_tokens(prompt_text)
+    output_tokens = estimate_tokens(result_text)
+
+    return {
+        "id": resp_id,
+        "object": "response",
+        "created_at": created_at,
+        "model": model,
+        "status": status,
+        "output": [
+            {
+                "id": item_id,
+                "type": "message",
+                "status": "completed",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": result_text,
+                        "annotations": [],
+                    }
+                ],
+            }
+        ],
+        "usage": {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": input_tokens + output_tokens,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        },
+    }
+
+
+async def stream_openai_sse(
+    result_text: str,
+    model: str,
+    *,
+    prompt_text: str = "",
+    response_id: str | None = None,
+    status: str = "completed",
+) -> AsyncIterator[bytes]:
+    """Stream OpenAI response as SSE (full canonical 9-event sequence).
+
+    response.created -> response.in_progress -> response.output_item.added
+    -> response.content_part.added -> response.output_text.delta
+    -> response.output_text.done -> response.content_part.done
+    -> response.output_item.done -> response.completed
+
+    Every frame: data: {json}\\n\\n. Stable item_id. Monotonic sequence_number. No [DONE].
+    """
+    resp_id = response_id or deterministic_id("resp_", model, prompt_text, result_text)
+    item_id = deterministic_id("msg_", model, prompt_text, result_text)
+    created_at = int(time.time())
+    input_tokens = estimate_tokens(prompt_text)
+    output_tokens = estimate_tokens(result_text)
+    seq = 0
+
+    def event(payload: dict) -> bytes:
+        nonlocal seq
+        payload.setdefault("sequence_number", seq)
+        seq += 1
+        return f"data: {json.dumps(payload)}\n\n".encode("utf-8")
+
+    base_resp = {
+        "id": resp_id,
+        "object": "response",
+        "created_at": created_at,
+        "model": model,
+        "output": [],
+        "usage": None,
+    }
+
+    yield event({"type": "response.created", "response": {**base_resp, "status": "in_progress"}})
+    yield event({"type": "response.in_progress", "response": {**base_resp, "status": "in_progress"}})
+    yield event({
+        "type": "response.output_item.added",
+        "output_index": 0,
+        "item": {"id": item_id, "type": "message", "status": "in_progress", "role": "assistant", "content": []},
+    })
+    yield event({
+        "type": "response.content_part.added",
+        "item_id": item_id,
+        "output_index": 0,
+        "content_index": 0,
+        "part": {"type": "output_text", "text": "", "annotations": []},
+    })
+    yield event({
+        "type": "response.output_text.delta",
+        "item_id": item_id,
+        "output_index": 0,
+        "content_index": 0,
+        "delta": result_text,
+    })
+    yield event({
+        "type": "response.output_text.done",
+        "item_id": item_id,
+        "output_index": 0,
+        "content_index": 0,
+        "text": result_text,
+    })
+    yield event({
+        "type": "response.content_part.done",
+        "item_id": item_id,
+        "output_index": 0,
+        "content_index": 0,
+        "part": {"type": "output_text", "text": result_text, "annotations": []},
+    })
+    yield event({
+        "type": "response.output_item.done",
+        "output_index": 0,
+        "item": {
+            "id": item_id, "type": "message", "status": "completed", "role": "assistant",
+            "content": [{"type": "output_text", "text": result_text, "annotations": []}],
+        },
+    })
+    yield event({
+        "type": "response.completed",
+        "response": {
+            **base_resp,
+            "status": status,
+            "output": [
+                {
+                    "id": item_id, "type": "message", "status": "completed", "role": "assistant",
+                    "content": [{"type": "output_text", "text": result_text, "annotations": []}],
+                }
+            ],
+            "usage": {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "total_tokens": input_tokens + output_tokens,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+            },
+        },
+    })
+
+
+# ============================================================================
+# Google Gemini (gemini_frontend)
+# ============================================================================
+
+def build_gemini_response(
+    result_text: str,
+    model: str,
+    *,
+    prompt_text: str = "",
+    response_id: str | None = None,
+) -> dict:
+    """Build unary Gemini GenerateContentResponse envelope.
+
+    O12: includes a synthetic responseId (deterministic).
+    """
+    input_tokens = estimate_tokens(prompt_text)
+    output_tokens = estimate_tokens(result_text)
+    resp_id = response_id or deterministic_id("", model, prompt_text, result_text)
+
+    return {
+        "candidates": [
+            {
+                "content": {"role": "model", "parts": [{"text": result_text}]},
+                "finishReason": "STOP",
+                "index": 0,
+                "safetyRatings": [],
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": input_tokens,
+            "candidatesTokenCount": output_tokens,
+            "totalTokenCount": input_tokens + output_tokens,
+        },
+        "modelVersion": model,
+        "responseId": resp_id,
+    }
+
+
+async def stream_gemini_chunks(
+    result_text: str,
+    model: str,
+    *,
+    prompt_text: str = "",
+    response_id: str | None = None,
+    alt_sse: bool = False,
+) -> AsyncIterator[bytes]:
+    """Stream Gemini response.
+
+    Default (alt_sse=False) returns a true JSON ARRAY `[{...}]` matching Gemini's
+    real streamGenerateContent REST wire format (application/json).
+    With alt_sse=True, emits `data: {...}\\n\\n` for text/event-stream.
+    """
+    obj = build_gemini_response(result_text, model, prompt_text=prompt_text, response_id=response_id)
+
+    if alt_sse:
+        yield f"data: {json.dumps(obj)}\n\n".encode("utf-8")
+    else:
+        yield b"["
+        yield json.dumps(obj).encode("utf-8")
+        yield b"]"
+
+
+# ============================================================================
+# Ollama (ollama_frontend)
+# ============================================================================
+
+def build_ollama_response(
+    result_text: str,
+    model: str,
+    *,
+    prompt_text: str = "",
+) -> dict:
+    """Build unary Ollama /api/chat response envelope.
+
+    Ollama uses durations not tokens; durations are zero, eval counts use estimates.
+    """
+    created_at = "2025-06-04T00:00:00Z"
+    input_tokens = estimate_tokens(prompt_text)
+    output_tokens = estimate_tokens(result_text)
+
+    return {
+        "model": model,
+        "created_at": created_at,
+        "message": {"role": "assistant", "content": result_text},
+        "done": True,
+        "done_reason": "stop",
+        "total_duration": 0,
+        "load_duration": 0,
+        "prompt_eval_count": input_tokens,
+        "prompt_eval_duration": 0,
+        "eval_count": output_tokens,
+        "eval_duration": 0,
+    }
+
+
+async def stream_ollama_ndjson(
+    result_text: str,
+    model: str,
+    *,
+    prompt_text: str = "",
+) -> AsyncIterator[bytes]:
+    """Stream Ollama response as NDJSON (NOT SSE).
+
+    Emits TWO complete JSON objects, each on its own line:
+    1. In-progress frame with the full result_text
+    2. Terminal frame with empty content, done=true
+    Every frame carries a complete "message" field. Content-Type: application/x-ndjson.
+    """
+    created_at = "2025-06-04T00:00:00Z"
+    input_tokens = estimate_tokens(prompt_text)
+    output_tokens = estimate_tokens(result_text)
+
+    yield (json.dumps({
+        "model": model,
+        "created_at": created_at,
+        "message": {"role": "assistant", "content": result_text},
+        "done": False,
+    }) + "\n").encode("utf-8")
+
+    yield (json.dumps({
+        "model": model,
+        "created_at": created_at,
+        "message": {"role": "assistant", "content": ""},
+        "done": True,
+        "done_reason": "stop",
+        "total_duration": 0,
+        "load_duration": 0,
+        "prompt_eval_count": input_tokens,
+        "prompt_eval_duration": 0,
+        "eval_count": output_tokens,
+        "eval_duration": 0,
+    }) + "\n").encode("utf-8")
+
+
+__all__ = [
+    "extract_error_text",
+    "serialize_transcript",
+    "estimate_tokens",
+    "deterministic_id",
+    "build_anthropic_message",
+    "stream_anthropic_sse",
+    "build_openai_response",
+    "stream_openai_sse",
+    "build_gemini_response",
+    "stream_gemini_chunks",
+    "build_ollama_response",
+    "stream_ollama_ndjson",
+]
+```
+
+- [ ] **Step 2: Verify it imports**
+
+Run: `cd apps/server && uv run python -c "import screamingface.plugins.frontend_base.terminal_response as t; print(t.__all__)"`
+Expected: prints the `__all__` list with all 12 names.
+
+### Task 2: Unit tests for `terminal_response.py`
+
+**Files:**
+- Create: `apps/server/src/screamingface/plugins/frontend_base/tests/test_terminal_response.py`
+
+- [ ] **Step 1: Write the test file**
+
+```python
+"""Unit tests for terminal_response builders and streamers.
+
+Verifies envelope JSON structure per provider, usage non-zero/zeros, frame
+sequence for streamers (parse SSE / NDJSON independently), and error formatting.
+"""
+
+import json
+import pytest
+
+from screamingface.plugins.frontend_base.terminal_response import (
+    build_anthropic_message,
+    stream_anthropic_sse,
+    build_openai_response,
+    stream_openai_sse,
+    build_gemini_response,
+    stream_gemini_chunks,
+    build_ollama_response,
+    stream_ollama_ndjson,
+    extract_error_text,
+    serialize_transcript,
+    estimate_tokens,
+    deterministic_id,
+)
+
+
+def parse_sse_frames(sse_bytes: bytes) -> list:
+    text = sse_bytes.decode("utf-8")
+    results = []
+    for frame in text.split("\n\n"):
+        if not frame.strip():
+            continue
+        lines = frame.strip().split("\n")
+        event_line = next((l for l in lines if l.startswith("event:")), None)
+        data_line = next((l for l in lines if l.startswith("data:")), None)
+        if data_line:
+            event_name = event_line.replace("event:", "").strip() if event_line else None
+            data_json = data_line.replace("data:", "").strip()
+            try:
+                results.append((event_name, json.loads(data_json)))
+            except json.JSONDecodeError:
+                pass
+    return results
+
+
+def parse_ndjson_frames(ndjson_bytes: bytes) -> list:
+    text = ndjson_bytes.decode("utf-8")
+    return [json.loads(line) for line in text.strip().split("\n") if line]
+
+
+def test_build_anthropic_message():
+    result = build_anthropic_message("Test response", "claude-3-5-sonnet", prompt_text="User: hi")
+    assert result["type"] == "message"
+    assert result["role"] == "assistant"
+    assert result["content"][0]["text"] == "Test response"
+    assert result["model"] == "claude-3-5-sonnet"
+    assert result["stop_reason"] == "end_turn"
+    usage = result["usage"]
+    assert usage["input_tokens"] > 0  # non-zero (prompt_text supplied)
+    assert usage["output_tokens"] > 0
+    assert usage["cache_creation_input_tokens"] == 0
+    assert usage["cache_read_input_tokens"] == 0
+
+
+@pytest.mark.asyncio
+async def test_stream_anthropic_sse():
+    chunks = [c async for c in stream_anthropic_sse("Result text", "claude-3-5-sonnet")]
+    sse_bytes = b"".join(chunks)
+    frames = parse_sse_frames(sse_bytes)
+    event_names = [name for name, _ in frames]
+    assert event_names == ["message_start", "ping", "content_block_start", "content_block_delta",
+                           "content_block_stop", "message_delta", "message_stop"]
+    delta_frame = next(d for n, d in frames if n == "content_block_delta")
+    assert delta_frame["delta"]["text"] == "Result text"
+    assert b"[DONE]" not in sse_bytes
+
+
+def test_build_openai_response():
+    result = build_openai_response("Test response", "gpt-4o-mini")
+    assert result["object"] == "response"
+    assert result["status"] == "completed"
+    assert isinstance(result["created_at"], int)
+    assert result["created_at"] > 0
+    assert len(result["output"]) == 1
+    assert result["output"][0]["type"] == "message"
+    assert result["output"][0]["status"] == "completed"
+    assert result["output"][0]["content"][0]["text"] == "Test response"
+    usage = result["usage"]
+    for k in ("input_tokens", "output_tokens", "total_tokens", "cache_creation_input_tokens"):
+        assert k in usage
+
+
+def test_build_openai_response_completed_status_for_errors():
+    # #244: even the error path uses status="completed" for CLI visibility
+    result = build_openai_response("[url4 error] ...", "gpt-4o-mini", status="completed")
+    assert result["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_stream_openai_sse():
+    chunks = [c async for c in stream_openai_sse("Result", "gpt-4o-mini")]
+    sse_bytes = b"".join(chunks)
+    frames = parse_sse_frames(sse_bytes)
+    event_names = [name for name, _ in frames]
+    assert event_names == [
+        "response.created", "response.in_progress", "response.output_item.added",
+        "response.content_part.added", "response.output_text.delta", "response.output_text.done",
+        "response.content_part.done", "response.output_item.done", "response.completed",
+    ]
+    created = next(d for n, d in frames if n == "response.created")
+    assert created["response"]["status"] == "in_progress"
+    completed = next(d for n, d in frames if n == "response.completed")
+    assert completed["response"]["status"] == "completed"
+    seq_nums = [d.get("sequence_number") for _, d in frames]
+    assert seq_nums == sorted(seq_nums)
+    assert b"[DONE]" not in sse_bytes
+
+
+def test_build_gemini_response():
+    result = build_gemini_response("Test response", "gemini-2.5-flash")
+    assert result["candidates"][0]["finishReason"] == "STOP"
+    assert result["candidates"][0]["content"]["role"] == "model"
+    assert result["candidates"][0]["content"]["parts"][0]["text"] == "Test response"
+    usage = result["usageMetadata"]
+    for k in ("promptTokenCount", "candidatesTokenCount", "totalTokenCount"):
+        assert k in usage
+    assert result["modelVersion"] == "gemini-2.5-flash"
+    assert "responseId" in result  # O12
+
+
+@pytest.mark.asyncio
+async def test_stream_gemini_chunks_default_json_array():
+    chunks = [c async for c in stream_gemini_chunks("Result", "gemini-2.5-flash")]
+    data = json.loads(b"".join(chunks))
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["candidates"][0]["finishReason"] == "STOP"
+
+
+@pytest.mark.asyncio
+async def test_stream_gemini_chunks_alt_sse():
+    chunks = [c async for c in stream_gemini_chunks("Result", "gemini-2.5-flash", alt_sse=True)]
+    body = b"".join(chunks)
+    assert b"data: " in body
+    assert b"\n\n" in body
+
+
+def test_build_ollama_response():
+    result = build_ollama_response("Test response", "llama3.2", prompt_text="User: hi")
+    assert result["model"] == "llama3.2"
+    assert result["message"]["role"] == "assistant"
+    assert result["message"]["content"] == "Test response"
+    assert result["done"] is True
+    assert result["done_reason"] == "stop"
+    assert result["total_duration"] == 0
+    assert result["load_duration"] == 0
+    assert result["prompt_eval_count"] >= 0
+    assert result["eval_count"] > 0
+
+
+@pytest.mark.asyncio
+async def test_stream_ollama_ndjson():
+    chunks = [c async for c in stream_ollama_ndjson("Result text", "llama3.2")]
+    ndjson_bytes = b"".join(chunks)
+    frames = parse_ndjson_frames(ndjson_bytes)
+    assert len(frames) == 2
+    assert frames[0]["done"] is False
+    assert frames[0]["message"]["content"] == "Result text"
+    assert frames[1]["done"] is True
+    assert frames[1]["done_reason"] == "stop"
+    assert frames[1]["message"]["content"] == ""
+    assert "message" in frames[0] and "message" in frames[1]
+    assert b"data: " not in ndjson_bytes
+
+
+def test_extract_error_text():
+    exc = ValueError("Test error message")
+    text = extract_error_text(exc, "test-spec", "some_expression")
+    assert "[url4 error]" in text
+    assert "test-spec" in text
+    assert "some_expression" in text
+    assert "ValueError" in text
+    assert "Test error message" in text
+    assert "Traceback:" in text
+
+
+def test_serialize_transcript():
+    turns = [("user", "Hello"), ("assistant", "Hi there"), ("user", "How are you?")]
+    result = serialize_transcript(turns)
+    assert "User: Hello" in result
+    assert "Assistant: Hi there" in result
+    assert "User: How are you?" in result
+
+
+def test_estimate_tokens():
+    assert estimate_tokens("") == 0
+    assert estimate_tokens("1234") == 1
+    assert estimate_tokens("12345678") == 2
+    assert estimate_tokens("a") == 1
+
+
+def test_deterministic_id_is_stable():
+    a = deterministic_id("msg_", "m", "p", "r")
+    b = deterministic_id("msg_", "m", "p", "r")
+    assert a == b
+    assert a.startswith("msg_")
+    assert deterministic_id("msg_", "m", "p", "r2") != a
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd apps/server && uv run pytest -xvs src/screamingface/plugins/frontend_base/tests/test_terminal_response.py`
+Expected: PASS (all tests green).
+
+### Task 3: Hard-remove settings fields from `FrontendSettingsBase` (C)
+
+**Files:**
+- Modify: `apps/server/src/screamingface/plugins/frontend_base/plugin_base.py`
+
+- [ ] **Step 1: Locate the fields**
+
+Run: `cd apps/server && grep -n "embed_target\|embed_mode\|system_prompt" src/screamingface/plugins/frontend_base/plugin_base.py`
+Expected: prints the three `Field(...)` definitions (~lines 87–101).
+
+- [ ] **Step 2: Delete the three fields**
+
+Remove the `embed_target`, `embed_mode`, and `system_prompt` field definitions from `FrontendSettingsBase`. The base class must end after the last RETAINED field (`active_spec` through `resolve_timeout`). Do NOT remove `upstream_url`, `active_spec`, `resolve_timeout`, or `session_service_url`.
+
+- [ ] **Step 3: Verify removal**
+
+Run: `cd apps/server && grep -n "embed_target\|embed_mode\|system_prompt" src/screamingface/plugins/frontend_base/plugin_base.py`
+Expected: no output.
+
+### Task 4: Remove `embed_target` override from `OllamaFrontendSettings` (C)
+
+**Files:**
+- Modify: `apps/server/src/screamingface/plugins/ollama_frontend/plugin.py`
+
+- [ ] **Step 1: Locate and delete**
+
+Run: `cd apps/server && grep -n "embed_target" src/screamingface/plugins/ollama_frontend/plugin.py`
+Then delete the `embed_target: Literal["system", "user"] = Field(default="system")` override line.
+
+- [ ] **Step 2: Verify**
+
+Run: `cd apps/server && grep -n "embed_target" src/screamingface/plugins/ollama_frontend/plugin.py`
+Expected: no output.
+
+### Task 5: Remove references from `sf.json` and grep the whole repo (C)
+
+**Files:**
+- Modify: `apps/server/sf.json`
+
+- [ ] **Step 1: Repo-wide grep for every reference**
+
+Run: `cd /Users/sergey/work/openmind/screamingface && grep -rn "embed_target\|embed_mode\|system_prompt\|SF_.*FRONTEND__EMBED\|SF_.*FRONTEND__SYSTEM_PROMPT" apps/server/ --include="*.py" --include="*.json" | grep -v terminal_response.py | grep -v test_settings_removal.py`
+Expected: shows remaining references (sf.json ollama-frontend keys, any env-var docs/tests).
+
+- [ ] **Step 2: Remove the keys from `sf.json`**
+
+Delete `"embed_target": ...` and `"embed_mode": ...` from the ollama-frontend block in `apps/server/sf.json`. Remove `"system_prompt"` from any frontend block that still has it.
+
+- [ ] **Step 3: Re-grep to confirm zero references remain (except removal tests)**
+
+Run: `cd /Users/sergey/work/openmind/screamingface && grep -rn "embed_target\|embed_mode" apps/server/ --include="*.py" --include="*.json" | grep -v test_settings_removal.py | grep -v terminal_response.py`
+Expected: no output.
+
+- [ ] **Step 4: Validate sf.json still parses and settings still load**
+
+Run: `cd apps/server && uv run python -c "import json; json.load(open('sf.json')); print('ok')"`
+Expected: `ok`.
+
+### Task 6: Unit test for settings hard-removal
+
+**Files:**
+- Create: `apps/server/src/screamingface/plugins/frontend_base/tests/test_settings_removal.py`
+
+- [ ] **Step 1: Write the test file**
+
+```python
+"""Test that embed_target, embed_mode, system_prompt are removed from settings (Decision C)."""
+
+import pytest
+from pydantic import ValidationError
+
+from screamingface.plugins.frontend_base.plugin_base import FrontendSettingsBase
+from screamingface.plugins.claude_frontend.plugin import ClaudeFrontendSettings
+from screamingface.plugins.ollama_frontend.plugin import OllamaFrontendSettings
+
+
+def test_frontend_settings_base_no_embed_target():
+    assert "embed_target" not in FrontendSettingsBase.model_fields
+
+
+def test_frontend_settings_base_no_embed_mode():
+    assert "embed_mode" not in FrontendSettingsBase.model_fields
+
+
+def test_frontend_settings_base_no_system_prompt():
+    assert "system_prompt" not in FrontendSettingsBase.model_fields
+
+
+def test_claude_settings_rejected_with_embed_target():
+    with pytest.raises(ValidationError):
+        ClaudeFrontendSettings(
+            upstream_url="https://api.anthropic.com",
+            listen_port=9101,
+            embed_target="user",
+        )
+
+
+def test_ollama_settings_no_override():
+    assert "embed_target" not in OllamaFrontendSettings.model_fields
+    with pytest.raises(ValidationError):
+        OllamaFrontendSettings(
+            upstream_url="http://localhost:11434",
+            listen_port=9104,
+            embed_target="system",
+        )
+
+
+def test_ollama_settings_constructs_without_embed():
+    settings = OllamaFrontendSettings(
+        upstream_url="http://localhost:11434",
+        listen_port=9104,
+    )
+    assert settings.upstream_url == "http://localhost:11434"
+    assert settings.listen_port == 9104
+    assert not hasattr(settings, "embed_target")
+```
+
+> NOTE: These rejection tests assume the settings models forbid extra fields. If the models use `model_config = ConfigDict(extra="ignore")`, the `pytest.raises(ValidationError)` assertions will not hold; in that case change those two tests to assert the field is silently dropped (`not hasattr(settings, "embed_target")`). Verify the model's `extra` policy with `grep -n "extra=" apps/server/src/screamingface/plugins/frontend_base/plugin_base.py` before running.
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd apps/server && uv run pytest -xvs src/screamingface/plugins/frontend_base/tests/test_settings_removal.py`
+Expected: PASS.
+
+### Task 7: Pin the resolve return contract in `_url4_context.py` (docstrings only)
+
+**Files:**
+- Modify: `apps/server/src/screamingface/plugins/claude_frontend/_url4_context.py`
+
+- [ ] **Step 1: Update `__all__` and add the contract note**
+
+At the top of the file (after `__all__`), add:
+
+```python
+__all__ = ["resolve_prompt_expression", "resolve_static_context"]
+
+# NOTE: Return contract as of M1 (implemented in M2):
+# - resolve_prompt_expression: returns tuple[str | None, dict | None]
+#     On success: (resolved_text_str, None)
+#     On failure: (None, error_response_dict)  # provider-shaped envelope body
+# - resolve_static_context: same tuple contract; None/empty static result is FAIL-LOUD (O5b).
+# The handler wraps the dict in JSONResponse (unary) or routes the error text through
+# the stream_<provider> generators (streaming).
+```
+
+- [ ] **Step 2: Update the two function docstrings**
+
+Change the docstrings of `resolve_prompt_expression` and `resolve_static_context` to state the tuple contract above. Do NOT change the function bodies yet — implementation lands in M2.
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd apps/server && uv run pyright src/screamingface/plugins/claude_frontend/_url4_context.py 2>&1 | tail -5`
+Expected: no new errors introduced.
+
+### Task 8: Contract test scaffold for resolve helpers
+
+**Files:**
+- Create: `apps/server/src/screamingface/plugins/frontend_base/tests/test_resolve_contract.py`
+
+- [ ] **Step 1: Write the contract test (xfail until M2)**
+
+```python
+"""Resolve return-contract tests (Decision: tuple[str|None, dict|None]).
+
+These are xfail until M2 implements the tuple contract in _url4_context.py.
+After M2 Task 2, remove the xfail markers.
+"""
+
+import pytest
+from unittest import mock
+
+from screamingface.plugins.claude_frontend._url4_context import (
+    resolve_static_context,
+)
+
+
+@pytest.mark.xfail(reason="Tuple contract implemented in M2 Task 2", strict=False)
+def test_static_spec_none_fails_loud():
+    """Static spec None/empty returns (None, error_dict) — fail-loud (O5b)."""
+    plugin = mock.MagicMock()
+    plugin.resolve_context.return_value = None
+    settings = mock.MagicMock()
+    settings.active_spec = "static-spec"
+
+    resolved_text, error_dict = resolve_static_context(
+        {"model": "test-model"},
+        raw_expression="some_static_expression",
+        settings=settings,
+        plugin=plugin,
+    )
+    assert resolved_text is None
+    assert isinstance(error_dict, dict)
+    assert "[url4 error]" in error_dict["content"][0]["text"]
+```
+
+- [ ] **Step 2: Run (expect xfail)**
+
+Run: `cd apps/server && uv run pytest -rx src/screamingface/plugins/frontend_base/tests/test_resolve_contract.py`
+Expected: 1 xfailed.
+
+### Task 9: M1 gate — run all new tests, type-check, pre-commit, commit
+
+- [ ] **Step 1: Run all M1 tests**
+
+Run: `cd apps/server && uv run pytest -q src/screamingface/plugins/frontend_base/tests/test_terminal_response.py src/screamingface/plugins/frontend_base/tests/test_settings_removal.py src/screamingface/plugins/frontend_base/tests/test_resolve_contract.py`
+Expected: all pass (resolve_contract xfailed).
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd apps/server && uv run pyright src/screamingface/plugins/frontend_base/terminal_response.py src/screamingface/plugins/frontend_base/plugin_base.py`
+Expected: 0 errors.
+
+- [ ] **Step 3: Pre-commit (full CI gate — ruff check AND ruff format)**
+
+Run: `cd /Users/sergey/work/openmind/screamingface && pre-commit run --files apps/server/src/screamingface/plugins/frontend_base/terminal_response.py apps/server/src/screamingface/plugins/frontend_base/plugin_base.py apps/server/src/screamingface/plugins/ollama_frontend/plugin.py apps/server/sf.json`
+Expected: all hooks pass. If ruff reformats, re-stage and re-run.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface && git add -A && git commit -m "M1: shared terminal_response module + hard-remove unused settings + resolve contract"
+```
+
+---
+
+## M2: claude_frontend terminal rewrite (direct cutover)
+
+Replace the upstream proxy leg in `claude_frontend` with in-process resolution. `proxy_messages` becomes terminal; non-inference routes keep passthrough. Uses M1's `build_anthropic_message` / `stream_anthropic_sse` / `extract_error_text` / `serialize_transcript` — no redefinitions.
+
+**Deletions:** `_forward_streaming`, `_forward_unary`, `_inject_system_context`, `_embed_context`, inference-path upstream URL construction.
+**Keep:** `/v1/{path}` catchall (incl. `POST /v1/messages/count_tokens`), `/api/{path}` passthrough, `_extract_last_user_text`, `_replace_last_user_message`.
+
+### Task 1: Write failing terminal tests (unary, streaming, static-None)
+
+**Files:**
+- Create: `apps/server/src/screamingface/plugins/claude_frontend/tests/test_proxy_terminal.py`
+
+- [ ] **Step 1: Write the test file**
+
+```python
+"""Tests for claude_frontend terminal (ensemble-first) inference.
+
+1. Unary and streaming inference synthesize in-memory (no api.anthropic.com).
+2. Non-inference routes (catchall, count_tokens, /api/*) still forward upstream.
+3. Error paths (static-None, resolution failure) return 200 with visible error text.
+4. Streaming error paths terminate (message_stop frame).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from screamingface.plugins.claude_frontend.plugin import ClaudeFrontendSettings
+from screamingface.plugins.claude_frontend.proxy import create_router
+
+
+def parse_sse_frames(sse_text: str) -> list:
+    frames = []
+    current_event = None
+    current_data = None
+    for line in sse_text.split("\n"):
+        if line.startswith("event:"):
+            current_event = line.replace("event:", "").strip()
+        elif line.startswith("data:"):
+            try:
+                current_data = json.loads(line.replace("data:", "").strip())
+            except json.JSONDecodeError:
+                current_data = None
+        elif line.strip() == "" and current_data is not None:
+            frames.append((current_event, current_data))
+            current_event = None
+            current_data = None
+    return frames
+
+
+def test_unary_inference_synthesizes_response_no_upstream_call() -> None:
+    settings = ClaudeFrontendSettings(
+        upstream_url="https://api.anthropic.com", active_spec="test-spec",
+        backend_url="http://localhost:8000",
+    )
+    app = FastAPI()
+    app.include_router(create_router(settings))
+    client = TestClient(app)
+
+    with patch(
+        "screamingface.plugins.frontend_base.plugin_base._fetch_sync",
+        return_value="Ensemble result text",
+    ) as mock_fetch:
+        with patch("httpx.AsyncClient.post") as mock_httpx_post:
+            response = client.post("/v1/messages", json={
+                "model": "claude-opus-4-1-20250805",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": False,
+            })
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["type"] == "message"
+    assert data["role"] == "assistant"
+    assert data["content"][0]["text"] == "Ensemble result text"
+    assert data["model"] == "claude-opus-4-1-20250805"
+    assert data["stop_reason"] == "end_turn"
+    assert "usage" in data
+    assert mock_fetch.called
+    assert not mock_httpx_post.called
+
+
+def test_streaming_inference_synthesizes_sse_no_upstream_call() -> None:
+    settings = ClaudeFrontendSettings(
+        upstream_url="https://api.anthropic.com", active_spec="test-spec",
+        backend_url="http://localhost:8000",
+    )
+    app = FastAPI()
+    app.include_router(create_router(settings))
+    client = TestClient(app)
+
+    with patch(
+        "screamingface.plugins.frontend_base.plugin_base._fetch_sync",
+        return_value="Streamed result text",
+    ) as mock_fetch:
+        with patch("httpx.AsyncClient.stream") as mock_httpx_stream:
+            response = client.post("/v1/messages", json={
+                "model": "claude-opus-4-1-20250805",
+                "messages": [{"role": "user", "content": "Test"}],
+                "stream": True,
+            })
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    frames = parse_sse_frames(response.text)
+    event_names = [n for n, _ in frames]
+    assert event_names == ["message_start", "ping", "content_block_start", "content_block_delta",
+                           "content_block_stop", "message_delta", "message_stop"]
+    delta_frame = next(d for n, d in frames if n == "content_block_delta")
+    assert delta_frame["delta"]["text"] == "Streamed result text"
+    assert mock_fetch.called
+    assert not mock_httpx_stream.called
+
+
+def test_static_spec_none_returns_error_envelope_fail_loud() -> None:
+    settings = ClaudeFrontendSettings(
+        upstream_url="https://api.anthropic.com", active_spec="broken-spec",
+        backend_url="http://localhost:8000",
+    )
+    app = FastAPI()
+    mock_plugin = MagicMock()
+    mock_plugin.get_active_expression.return_value = "some_expression"
+    mock_plugin.resolve_context.return_value = None
+    app.include_router(create_router(settings, plugin=mock_plugin))
+    client = TestClient(app)
+
+    response = client.post("/v1/messages", json={
+        "model": "claude-opus-4-1-20250805",
+        "messages": [{"role": "user", "content": "Test"}],
+    })
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["type"] == "message"
+    assert "[url4 error]" in data["content"][0]["text"]
+    assert "broken-spec" in data["content"][0]["text"]
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/server && uv run pytest -xvs src/screamingface/plugins/claude_frontend/tests/test_proxy_terminal.py::test_unary_inference_synthesizes_response_no_upstream_call 2>&1 | head -40`
+Expected: FAIL (proxy_messages still forwards upstream).
+
+### Task 2: Implement tuple contract in `_url4_context.py`
+
+**Files:**
+- Modify: `apps/server/src/screamingface/plugins/claude_frontend/_url4_context.py`
+
+- [ ] **Step 1: Make `_build_error_response` return a dict**
+
+```python
+def _build_error_response(
+    *,
+    spec_name: str,
+    raw_expression: str,
+    exc: Exception,
+) -> dict:
+    """Build Anthropic-shaped error envelope dict (not JSONResponse).
+
+    Error text lands in content[0].text so the CLI renders it (#244).
+    """
+    from screamingface.plugins.frontend_base.terminal_response import extract_error_text
+    error_text = extract_error_text(exc, spec_name, raw_expression)
+    return {
+        "id": f"sf_error_{id(exc):x}",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": error_text}],
+        "model": "unknown",
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "usage": {"input_tokens": 0, "output_tokens": 0},
+    }
+```
+
+- [ ] **Step 2: Rewrite `resolve_prompt_expression` to return `(str|None, dict|None)`**
+
+```python
+async def resolve_prompt_expression(
+    body: dict[str, Any],
+    *,
+    raw_expression: str,
+    settings: Any,
+    plugin: Any,
+    app: Any,
+    tracer: Any,
+    prompt_text: str,
+) -> tuple[str | None, dict | None]:
+    """Substitute $prompt with a transcript blob, resolve, return (text, error_dict).
+
+    Decision A: `prompt_text` is the FULL serialized transcript (built by the handler
+    via serialize_transcript). On success returns (resolved_text, None); on any failure
+    returns (None, error_envelope_dict). No body mutation; no embed_context.
+    """
+    with tracer.start_current_span("url4.$prompt") as prompt_span:
+        try:
+            backend_url = settings.backend_url.rstrip("/") if settings.backend_url else None
+            blob_key = await _store_prompt_blob(prompt_text, app=app, backend_url=backend_url, tracer=tracer)
+            blob_url = f"/data/{blob_key}"
+            substituted = raw_expression.replace("$prompt", blob_url)
+            final_text = await _resolve_expression(substituted, app=app, backend_url=backend_url, tracer=tracer)
+            logger.info("$prompt: blob=%s resolved %d chars", blob_key, len(final_text))
+            if not final_text:
+                # O5b: empty resolution is fail-loud
+                raise RuntimeError("$prompt resolved to empty")
+            return final_text, None
+        except Exception as exc:
+            if prompt_span and prompt_span.is_recording():
+                prompt_span.set_attribute("url4.status", "error")
+                prompt_span.record_exception(exc)
+            logger.warning("$prompt substitution failed", exc_info=True)
+            return None, _build_error_response(
+                spec_name=settings.active_spec or "unknown",
+                raw_expression=raw_expression,
+                exc=exc,
+            )
+```
+
+- [ ] **Step 3: Rewrite `resolve_static_context` to return `(str|None, dict|None)`**
+
+```python
+def resolve_static_context(
+    body: dict[str, Any],
+    *,
+    raw_expression: str,
+    settings: Any,
+    plugin: Any,
+) -> tuple[str | None, dict | None]:
+    """Static spec: use plugin-cached resolved context. Fail-loud on None/empty (O5b)."""
+    try:
+        resolved_context = plugin.resolve_context() if plugin else None
+        if not resolved_context:
+            return None, _build_error_response(
+                spec_name=settings.active_spec or "unknown",
+                raw_expression=raw_expression,
+                exc=RuntimeError("Static spec resolved to empty"),
+            )
+        logger.info("Static context resolved: %d chars", len(resolved_context))
+        return resolved_context, None
+    except Exception as exc:
+        logger.warning("Static context resolution failed", exc_info=True)
+        return None, _build_error_response(
+            spec_name=settings.active_spec or "unknown",
+            raw_expression=raw_expression,
+            exc=exc,
+        )
+```
+
+- [ ] **Step 4: Type-check**
+
+Run: `cd apps/server && uv run pyright src/screamingface/plugins/claude_frontend/_url4_context.py 2>&1 | tail -5`
+Expected: 0 errors.
+
+- [ ] **Step 5: Remove the xfail from the M1 resolve-contract test**
+
+Edit `apps/server/src/screamingface/plugins/frontend_base/tests/test_resolve_contract.py` and delete the `@pytest.mark.xfail(...)` decorator from `test_static_spec_none_fails_loud`. Run:
+`cd apps/server && uv run pytest -xvs src/screamingface/plugins/frontend_base/tests/test_resolve_contract.py`
+Expected: PASS.
+
+### Task 3: Add `_extract_turns` and rewrite `proxy_messages` terminal
+
+**Files:**
+- Modify: `apps/server/src/screamingface/plugins/claude_frontend/proxy.py`
+
+- [ ] **Step 1: Add imports + `_extract_turns` helper**
+
+At the top:
+
+```python
+from screamingface.plugins.frontend_base.terminal_response import (
+    build_anthropic_message,
+    stream_anthropic_sse,
+    serialize_transcript,
+)
+```
+
+Add near `_extract_last_user_text` (Decision A — full transcript):
+
+```python
+def _extract_turns(body: dict) -> list[tuple[str, str]]:
+    """Extract conversation turns as (role, text) tuples for the $prompt blob (Decision A)."""
+    turns: list[tuple[str, str]] = []
+    for msg in body.get("messages", []):
+        role = msg.get("role", "user")
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            text = "".join(
+                part.get("text", "")
+                for part in content
+                if isinstance(part, dict) and part.get("type") == "text"
+            )
+        else:
+            text = content if isinstance(content, str) else str(content)
+        if text:
+            turns.append((role, text))
+    return turns
+```
+
+- [ ] **Step 2: Rewrite `proxy_messages`**
+
+```python
+@router.post("/v1/messages", response_model=None, operation_id="proxy_messages")
+async def proxy_messages(request: Request) -> Response:
+    """Terminal inference handler: resolve spec, synthesize response, no upstream."""
+    body = await request.json()
+    is_streaming = body.get("stream", False)
+    model = body.get("model", "claude-opus-4-1-20250805")
+
+    # Stage 1: Session enrichment
+    session = SessionHook.from_request(
+        session_id=os.environ.get("_SF_SESSION_ID") or request.headers.get("x-session-id"),
+        service_url=session_service_url,
+        hooks=hooks,
+    )
+    body = await session.enrich(body, tracer=_tracer)
+
+    # Stage 2: URL4 resolution
+    raw_expression = plugin.get_active_expression() if plugin else None
+    resolved_text, error_dict = None, None
+
+    if raw_expression and "$prompt" in raw_expression:
+        turns = _extract_turns(body)  # Decision A: full transcript
+        prompt_text = serialize_transcript(turns)
+        if prompt_text:
+            resolved_text, error_dict = await resolve_prompt_expression(
+                body, raw_expression=raw_expression, settings=settings,
+                plugin=plugin, app=app, tracer=_tracer, prompt_text=prompt_text,
+            )
+    elif raw_expression:
+        resolved_text, error_dict = resolve_static_context(
+            body, raw_expression=raw_expression, settings=settings, plugin=plugin,
+        )
+
+    # Stage 3: Error path (fake-200, branched on is_streaming) — #244 visibility
+    if error_dict is not None:
+        error_text = error_dict["content"][0]["text"]
+        if is_streaming:
+            return StreamingResponse(
+                stream_anthropic_sse(error_text, model), media_type="text/event-stream",
+            )
+        return JSONResponse(content=error_dict, status_code=200)
+
+    # Stage 4: Success
+    prompt_blob = serialize_transcript(_extract_turns(body)) if raw_expression and "$prompt" in raw_expression else ""
+    response_dict = build_anthropic_message(resolved_text, model, prompt_text=prompt_blob)
+
+    if is_streaming:
+        await session.save(response_dict, streaming=True, tracer=_tracer)
+
+        async def gen():
+            async for chunk in stream_anthropic_sse(resolved_text, model, prompt_text=prompt_blob):
+                yield chunk
+
+        return StreamingResponse(gen(), media_type="text/event-stream")
+
+    await session.save(response_dict, streaming=False, tracer=_tracer)
+    return JSONResponse(content=response_dict, status_code=200)
+```
+
+- [ ] **Step 3: Delete dead code**
+
+Delete `_inject_system_context`, `_embed_context`, `_forward_streaming`, `_forward_unary`, and the inference-path upstream URL construction. KEEP `_extract_last_user_text`, `_replace_last_user_message`, the `/v1/{path}` catchall, and the `/api/{path}` passthrough.
+
+- [ ] **Step 4: Verify syntax**
+
+Run: `cd apps/server && uv run python -m py_compile src/screamingface/plugins/claude_frontend/proxy.py`
+Expected: no output (compiles).
+
+### Task 4: Run the terminal tests to green
+
+- [ ] **Step 1: Run the three Task-1 tests**
+
+Run: `cd apps/server && uv run pytest -xvs src/screamingface/plugins/claude_frontend/tests/test_proxy_terminal.py -k "unary_inference or streaming_inference or static_spec_none"`
+Expected: 3 passed.
+
+### Task 5: Passthrough regression tests
+
+**Files:**
+- Modify: `apps/server/src/screamingface/plugins/claude_frontend/tests/test_proxy_terminal.py`
+
+- [ ] **Step 1: Append passthrough tests**
+
+```python
+def test_count_tokens_forwards_upstream_not_terminated() -> None:
+    settings = ClaudeFrontendSettings(upstream_url="https://api.anthropic.com", active_spec="test-spec")
+    app = FastAPI()
+    app.include_router(create_router(settings))
+    client = TestClient(app)
+    mock_response = httpx.Response(200, json={"input_tokens": 50})
+    with patch("httpx.AsyncClient.request", new_callable=AsyncMock, return_value=mock_response):
+        response = client.post("/v1/messages/count_tokens", json={"messages": [{"role": "user", "content": "test"}]})
+    assert response.status_code == 200
+    assert response.json()["input_tokens"] == 50
+
+
+def test_v1_models_forwards_upstream() -> None:
+    settings = ClaudeFrontendSettings(upstream_url="https://api.anthropic.com")
+    app = FastAPI()
+    app.include_router(create_router(settings))
+    client = TestClient(app)
+    mock_response = httpx.Response(200, json={"data": [{"id": "claude-3-5-sonnet"}]})
+    with patch("httpx.AsyncClient.request", new_callable=AsyncMock, return_value=mock_response):
+        response = client.get("/v1/models")
+    assert response.status_code == 200
+    assert "data" in response.json()
+
+
+def test_api_passthrough_forwards_upstream() -> None:
+    settings = ClaudeFrontendSettings(upstream_url="https://api.anthropic.com")
+    app = FastAPI()
+    app.include_router(create_router(settings))
+    client = TestClient(app)
+    mock_response = httpx.Response(200, json={"users": []})
+    with patch("httpx.AsyncClient.request", new_callable=AsyncMock, return_value=mock_response):
+        response = client.get("/api/users")
+    assert response.status_code == 200
+    assert "users" in response.json()
+```
+
+> NOTE: The exact httpx method the catchall uses (`request` vs `get`/`post`) depends on the existing catchall implementation. Before running, `grep -n "httpx" apps/server/src/screamingface/plugins/claude_frontend/proxy.py` and patch the method the catchall actually calls.
+
+- [ ] **Step 2: Run**
+
+Run: `cd apps/server && uv run pytest -xvs src/screamingface/plugins/claude_frontend/tests/test_proxy_terminal.py -k "forwards_upstream"`
+Expected: 3 passed.
+
+### Task 6: Streaming error termination test
+
+**Files:**
+- Modify: `apps/server/src/screamingface/plugins/claude_frontend/tests/test_proxy_terminal.py`
+
+- [ ] **Step 1: Append the test**
+
+```python
+def test_streaming_error_terminates_with_message_stop_frame() -> None:
+    settings = ClaudeFrontendSettings(
+        upstream_url="https://api.anthropic.com", active_spec="broken-spec",
+        backend_url="http://localhost:8000",
+    )
+    app = FastAPI()
+    mock_plugin = MagicMock()
+    mock_plugin.get_active_expression.return_value = "bad_expression"
+    mock_plugin.resolve_context.side_effect = RuntimeError("Spec eval failed")
+    app.include_router(create_router(settings, plugin=mock_plugin))
+    client = TestClient(app)
+
+    response = client.post("/v1/messages", json={
+        "model": "claude-opus-4-1-20250805",
+        "messages": [{"role": "user", "content": "Test"}],
+        "stream": True,
+    })
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    frames = parse_sse_frames(response.text)
+    event_names = [n for n, _ in frames]
+    assert "message_stop" in event_names
+    assert any(
+        "[url4 error]" in d.get("delta", {}).get("text", "")
+        for n, d in frames if n == "content_block_delta"
+    )
+```
+
+- [ ] **Step 2: Run**
+
+Run: `cd apps/server && uv run pytest -xvs src/screamingface/plugins/claude_frontend/tests/test_proxy_terminal.py::test_streaming_error_terminates_with_message_stop_frame`
+Expected: PASS.
+
+### Task 7: Migrate existing `test_proxy.py`
+
+**Files:**
+- Modify: `apps/server/src/screamingface/plugins/claude_frontend/tests/test_proxy.py`
+
+- [ ] **Step 1: Replace `test_proxy_non_streaming`**
+
+```python
+def test_proxy_non_streaming() -> None:
+    """Non-streaming inference synthesizes response; no upstream call."""
+    mock_plugin = MagicMock()
+    mock_plugin.get_active_expression.return_value = None
+    settings = ClaudeFrontendSettings(upstream_url="https://api.anthropic.com", active_spec="test-spec")
+    app = FastAPI()
+    app.include_router(create_router(settings, plugin=mock_plugin))
+    client = TestClient(app)
+    with patch("screamingface.plugins.frontend_base.plugin_base._fetch_sync", return_value="Synthesized response"):
+        with patch("httpx.AsyncClient.post") as mock_post:
+            resp = client.post("/v1/messages", json={
+                "model": "claude-sonnet-4-20250514",
+                "messages": [{"role": "user", "content": "Hi"}],
+            })
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["type"] == "message"
+    assert not mock_post.called
+```
+
+> NOTE: With `get_active_expression()` returning `None`, no resolution happens and `resolved_text` is `None`. The handler must still produce a valid envelope (empty/passthrough content). If your final handler routes no-spec requests to upstream forwarding instead, change this test to assert the no-spec passthrough behavior. Decide the no-spec policy explicitly in Task 3 and keep this test consistent.
+
+- [ ] **Step 2: Replace `test_proxy_forwards_headers` with a catchall-only header test**
+
+```python
+def test_proxy_forwards_headers_on_catchall() -> None:
+    settings = ClaudeFrontendSettings(upstream_url="https://api.anthropic.com")
+    app = FastAPI()
+    app.include_router(create_router(settings))
+    client = TestClient(app)
+    mock_response = httpx.Response(200, json={"data": []})
+    with patch("httpx.AsyncClient.request", new_callable=AsyncMock, return_value=mock_response) as mock_req:
+        client.get("/v1/models", headers={"anthropic-version": "2023-06-01", "authorization": "Bearer test"})
+    sent_headers = mock_req.call_args.kwargs.get("headers", {})
+    assert sent_headers.get("anthropic-version") == "2023-06-01"
+    assert sent_headers.get("authorization") == "Bearer test"
+```
+
+- [ ] **Step 3: Run the migrated tests**
+
+Run: `cd apps/server && uv run pytest -xvs src/screamingface/plugins/claude_frontend/tests/test_proxy.py -k "non_streaming or forwards_headers_on_catchall or does_not_inject_env_api_key"`
+Expected: all pass.
+
+### Task 8: E2E tests with mocked resolution
+
+**Files:**
+- Modify: `apps/server/src/screamingface/plugins/claude_frontend/tests/test_e2e_claude_frontend.py`
+
+- [ ] **Step 1: Append E2E tests**
+
+```python
+def test_e2e_prompt_spec_unary_no_upstream() -> None:
+    mock_plugin = MagicMock()
+    mock_plugin.get_active_expression.return_value = '/claude($prompt)!"[end]" | /collect'
+    settings = ClaudeFrontendSettings(
+        upstream_url="https://api.anthropic.com", active_spec="test-spec",
+        backend_url="http://localhost:8000",
+    )
+    app = FastAPI()
+    app.include_router(create_router(settings, plugin=mock_plugin))
+    client = TestClient(app)
+    with patch("screamingface.plugins.frontend_base.plugin_base._fetch_sync", return_value="Ensemble answer: the test passed"):
+        with patch("httpx.AsyncClient") as mock_client:
+            resp = client.post("/v1/messages", json={
+                "model": "claude-opus-4-1-20250805",
+                "messages": [{"role": "user", "content": "What is 2+2?"}],
+            })
+    assert resp.status_code == 200
+    assert resp.json()["content"][0]["text"] == "Ensemble answer: the test passed"
+    assert not mock_client.called or all("api.anthropic.com" not in str(c) for c in mock_client.call_args_list)
+
+
+def test_e2e_prompt_spec_streaming_no_upstream() -> None:
+    mock_plugin = MagicMock()
+    mock_plugin.get_active_expression.return_value = '/claude($prompt)!"done" | /collect'
+    settings = ClaudeFrontendSettings(
+        upstream_url="https://api.anthropic.com", active_spec="test-spec",
+        backend_url="http://localhost:8000",
+    )
+    app = FastAPI()
+    app.include_router(create_router(settings, plugin=mock_plugin))
+    client = TestClient(app)
+    with patch("screamingface.plugins.frontend_base.plugin_base._fetch_sync", return_value="Streamed result"):
+        resp = client.post("/v1/messages", json={
+            "model": "claude-opus-4-1-20250805",
+            "messages": [{"role": "user", "content": "Stream this"}],
+            "stream": True,
+        })
+    assert resp.status_code == 200
+    assert "message_stop" in resp.text
+```
+
+- [ ] **Step 2: Run**
+
+Run: `cd apps/server && uv run pytest -xvs src/screamingface/plugins/claude_frontend/tests/test_e2e_claude_frontend.py -k "prompt_spec"`
+Expected: pass.
+
+### Task 9: M2 gate — full suite, type-check, pre-commit, commit
+
+- [ ] **Step 1: Full claude_frontend suite**
+
+Run: `cd apps/server && uv run pytest -q src/screamingface/plugins/claude_frontend/tests/`
+Expected: all pass.
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd apps/server && uv run pyright src/screamingface/plugins/claude_frontend/proxy.py src/screamingface/plugins/claude_frontend/_url4_context.py`
+Expected: 0 errors.
+
+- [ ] **Step 3: Pre-commit**
+
+Run: `cd /Users/sergey/work/openmind/screamingface && pre-commit run --files apps/server/src/screamingface/plugins/claude_frontend/proxy.py apps/server/src/screamingface/plugins/claude_frontend/_url4_context.py apps/server/src/screamingface/plugins/claude_frontend/tests/test_proxy_terminal.py`
+Expected: pass (re-stage if ruff-format edits).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface && git add -A && git commit -m "M2: claude_frontend terminal rewrite (direct cutover, conversation-aware)"
+```
+
+---
+
+## M3: codex_frontend terminal rewrite (OpenAI Responses)
+
+Rewrite `proxy_responses` to resolve in-process and synthesize OpenAI Responses envelopes using M1's `build_openai_response` / `stream_openai_sse` / `extract_error_text` / `serialize_transcript`. Keep `/v1/{path}` catchall passthrough. **#244 override:** error path uses `status="completed"` carrying the error text.
+
+**Deletions:** `_inject_system_context`, `_embed_context`, `_parse_sse_response`, inference upstream forwarding.
+**Keep:** `_extract_last_user_text`, `_replace_user_text`, `_build_headers`, `/v1/{path}` catchall.
+
+### Task 1: Add `_extract_turns` helper + failing unary test
+
+**Files:**
+- Modify: `apps/server/src/screamingface/plugins/codex_frontend/proxy.py` (add helper)
+- Create: `apps/server/src/screamingface/plugins/codex_frontend/tests/test_terminal_inference.py`
+
+- [ ] **Step 1: Add `_extract_turns` to codex proxy.py**
+
+Add a codex-shaped transcript extractor (codex uses `input` and/or `messages`):
+
+```python
+def _extract_turns(body: dict) -> list[tuple[str, str]]:
+    """Extract conversation turns (role, text) for the $prompt blob (Decision A).
+
+    Codex `input` may be a string or a list of message items.
+    """
+    turns: list[tuple[str, str]] = []
+    inp = body.get("input")
+    if isinstance(inp, str) and inp:
+        turns.append(("user", inp))
+    elif isinstance(inp, list):
+        for item in inp:
+            if not isinstance(item, dict):
+                continue
+            role = item.get("role", "user")
+            content = item.get("content", "")
+            if isinstance(content, list):
+                text = "".join(
+                    p.get("text", "") for p in content
+                    if isinstance(p, dict) and p.get("type") in ("input_text", "output_text", "text")
+                )
+            else:
+                text = content if isinstance(content, str) else str(content)
+            if text:
+                turns.append((role, text))
+    for msg in body.get("messages", []):
+        role = msg.get("role", "user")
+        content = msg.get("content", "")
+        text = content if isinstance(content, str) else str(content)
+        if text:
+            turns.append((role, text))
+    return turns
+```
+
+- [ ] **Step 2: Create the test file with the unary success test**
+
+```python
+"""Tests for codex-frontend terminal inference (direct cutover).
+
+1. POST /v1/responses resolves the spec in-process; NO upstream call.
+2. Unary + streaming paths.
+3. Error paths render visible error text (HTTP 200, status="completed").
+4. Non-inference /v1/{path} still forwards upstream.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+
+def _make_settings():
+    settings = MagicMock()
+    settings.upstream_url = "https://api.openai.com"
+    settings.listen_port = 9102
+    settings.backend_url = None
+    settings.resolve_timeout = 1200.0
+    settings.session_service_url = None
+    settings.active_spec = "test-spec"
+    return settings
+
+
+async def _call_route(router, path, request):
+    for route in router.routes:
+        if getattr(route, "path", None) == path:
+            return await route.endpoint(request)
+    raise AssertionError(f"route {path} not found")
+
+
+@pytest.mark.asyncio
+async def test_proxy_responses_unary_success_no_upstream_call():
+    from screamingface.plugins.codex_frontend.proxy import create_router
+    settings = _make_settings()
+    plugin = MagicMock()
+    plugin.get_active_expression.return_value = "/codex(model='gpt-4o-mini')!robots.txt"
+    app = MagicMock()
+    app.state.blob_store = MagicMock()
+    app.state.blob_store.store.return_value = "blob_123"
+    hooks = MagicMock()
+    hooks.emit_async = AsyncMock(return_value=[None])
+    router = create_router(settings=settings, app=app, plugin=plugin, hooks=hooks)
+
+    request = MagicMock(spec=Request)
+    request.json = AsyncMock(return_value={"input": "GET /robots.txt", "model": "gpt-4o-mini", "stream": False})
+    request.headers = {"x-session-id": "s"}
+    request.url.query = ""
+    request.method = "POST"
+    request.app = app
+
+    with patch("screamingface.plugins.codex_frontend.proxy.httpx.AsyncClient") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        with patch("screamingface.plugins.codex_frontend.proxy.Url4Interpreter") as mock_interp:
+            mock_interp.return_value.evaluate = AsyncMock(return_value="User-agent: *\nDisallow: /")
+            response = await _call_route(router, "/v1/responses", request)
+
+    assert not mock_client.post.called
+    assert not mock_client.stream.called
+    assert isinstance(response, JSONResponse)
+    rj = json.loads(response.body)
+    assert rj["object"] == "response"
+    assert rj["status"] == "completed"
+    assert isinstance(rj["created_at"], int) and rj["created_at"] > 0
+    assert rj["output"][0]["content"][0]["text"] == "User-agent: *\nDisallow: /"
+    usage = rj["usage"]
+    assert "input_tokens" in usage and "output_tokens" in usage and "total_tokens" in usage
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `cd apps/server && uv run pytest -xvs src/screamingface/plugins/codex_frontend/tests/test_terminal_inference.py::test_proxy_responses_unary_success_no_upstream_call`
+Expected: FAIL.
+
+### Task 2: Add failing streaming + error + passthrough tests
+
+**Files:**
+- Modify: `apps/server/src/screamingface/plugins/codex_frontend/tests/test_terminal_inference.py`
+
+- [ ] **Step 1: Append streaming success test**
+
+```python
+@pytest.mark.asyncio
+async def test_proxy_responses_streaming_success_no_upstream_call():
+    from screamingface.plugins.codex_frontend.proxy import create_router
+    settings = _make_settings()
+    plugin = MagicMock()
+    plugin.get_active_expression.return_value = "/codex(model='gpt-4o-mini')!robots.txt"
+    app = MagicMock()
+    app.state.blob_store = MagicMock()
+    app.state.blob_store.store.return_value = "blob_456"
+    hooks = MagicMock()
+    hooks.emit_async = AsyncMock(return_value=[None])
+    router = create_router(settings=settings, app=app, plugin=plugin, hooks=hooks)
+
+    request = MagicMock(spec=Request)
+    request.json = AsyncMock(return_value={"input": "Stream test", "model": "gpt-4o-mini", "stream": True})
+    request.headers = {"x-session-id": "t"}
+    request.url.query = ""
+    request.method = "POST"
+    request.app = app
+
+    with patch("screamingface.plugins.codex_frontend.proxy.httpx.AsyncClient") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        with patch("screamingface.plugins.codex_frontend.proxy.Url4Interpreter") as mock_interp:
+            mock_interp.return_value.evaluate = AsyncMock(return_value="Streaming result text")
+            response = await _call_route(router, "/v1/responses", request)
+
+    assert not mock_client.stream.called and not mock_client.post.called
+    assert isinstance(response, StreamingResponse)
+    assert response.media_type == "text/event-stream"
+    chunks = [c async for c in response.body_iterator]
+    sse_text = b"".join(c if isinstance(c, bytes) else c.encode() for c in chunks).decode("utf-8")
+    event_types = []
+    for frame in sse_text.split("\n\n"):
+        for line in frame.strip().split("\n"):
+            if line.startswith("data:"):
+                try:
+                    event_types.append(json.loads(line[5:].strip()).get("type"))
+                except Exception:
+                    pass
+    assert event_types == [
+        "response.created", "response.in_progress", "response.output_item.added",
+        "response.content_part.added", "response.output_text.delta", "response.output_text.done",
+        "response.content_part.done", "response.output_item.done", "response.completed",
+    ]
+    assert "[DONE]" not in sse_text
+```
+
+- [ ] **Step 2: Append unary + streaming error tests (status="completed", #244)**
+
+```python
+@pytest.mark.asyncio
+async def test_proxy_responses_error_unary_visible_text():
+    from screamingface.plugins.codex_frontend.proxy import create_router
+    settings = _make_settings()
+    plugin = MagicMock()
+    plugin.get_active_expression.return_value = "/codex(bad_expr)!error"
+    app = MagicMock()
+    app.state.blob_store = MagicMock()
+    app.state.blob_store.store.return_value = "blob_err"
+    hooks = MagicMock()
+    hooks.emit_async = AsyncMock(return_value=[None])
+    router = create_router(settings=settings, app=app, plugin=plugin, hooks=hooks)
+
+    request = MagicMock(spec=Request)
+    request.json = AsyncMock(return_value={"input": "Will fail", "model": "gpt-4o-mini", "stream": False})
+    request.headers = {"x-session-id": "e"}
+    request.url.query = ""
+    request.method = "POST"
+    request.app = app
+
+    with patch("screamingface.plugins.codex_frontend.proxy.httpx.AsyncClient"):
+        with patch("screamingface.plugins.codex_frontend.proxy.Url4Interpreter") as mock_interp:
+            mock_interp.return_value.evaluate = AsyncMock(side_effect=ValueError("Invalid expression syntax"))
+            response = await _call_route(router, "/v1/responses", request)
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 200
+    rj = json.loads(response.body)
+    assert rj["status"] == "completed"  # #244 override (NOT "failed")
+    error_text = rj["output"][0]["content"][0]["text"]
+    assert "[url4 error]" in error_text
+    assert "ValueError" in error_text or "Invalid expression" in error_text
+
+
+@pytest.mark.asyncio
+async def test_proxy_responses_error_streaming_terminating_frame():
+    from screamingface.plugins.codex_frontend.proxy import create_router
+    settings = _make_settings()
+    plugin = MagicMock()
+    plugin.get_active_expression.return_value = "/codex()!error_spec"
+    app = MagicMock()
+    app.state.blob_store = MagicMock()
+    hooks = MagicMock()
+    hooks.emit_async = AsyncMock(return_value=[None])
+    router = create_router(settings=settings, app=app, plugin=plugin, hooks=hooks)
+
+    request = MagicMock(spec=Request)
+    request.json = AsyncMock(return_value={"input": "Streaming error", "model": "gpt-4o-mini", "stream": True})
+    request.headers = {}
+    request.url.query = ""
+    request.method = "POST"
+    request.app = app
+
+    with patch("screamingface.plugins.codex_frontend.proxy.Url4Interpreter") as mock_interp:
+        mock_interp.return_value.evaluate = AsyncMock(side_effect=RuntimeError("Spec resolution timeout"))
+        response = await _call_route(router, "/v1/responses", request)
+
+    assert isinstance(response, StreamingResponse)
+    chunks = [c async for c in response.body_iterator]
+    sse_text = b"".join(c if isinstance(c, bytes) else c.encode() for c in chunks).decode("utf-8")
+    events = []
+    for frame in sse_text.split("\n\n"):
+        for line in frame.strip().split("\n"):
+            if line.startswith("data:"):
+                try:
+                    events.append(json.loads(line[5:].strip()))
+                except Exception:
+                    pass
+    assert any(e.get("type") == "response.completed" for e in events)
+    delta = next((e for e in events if e.get("type") == "response.output_text.delta"), None)
+    assert delta is not None
+    assert "[url4 error]" in delta.get("delta", "") or "Spec resolution" in delta.get("delta", "")
+```
+
+- [ ] **Step 3: Append catchall passthrough test**
+
+```python
+@pytest.mark.asyncio
+async def test_proxy_catchall_forwards_upstream_unchanged():
+    from screamingface.plugins.codex_frontend.proxy import create_router
+    settings = _make_settings()
+    plugin = MagicMock()
+    router = create_router(settings=settings, app=None, plugin=plugin, hooks=None)
+
+    request = MagicMock(spec=Request)
+    request.method = "GET"
+    request.headers = {}
+    request.url.query = ""
+    request.body = AsyncMock(return_value=b"")
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"object": "list", "data": [{"id": "gpt-4o-mini"}]}
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.content = json.dumps(mock_response.json()).encode()
+
+    with patch("screamingface.plugins.codex_frontend.proxy.httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client_class.return_value = mock_client
+        mock_client.request = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        response = await _call_route(router, "/v1/{path:path}", _patch_path(request, "models"))
+
+    assert mock_client.request.called
+
+
+def _patch_path(request, path):
+    # helper: the catchall endpoint signature is endpoint(request, path=...)
+    request._catchall_path = path
+    return request
+```
+
+> NOTE: The catchall endpoint takes `path` as a path param. Adjust `_call_route`/`_patch_path` to call `route.endpoint(request, path="models")` for the catchall route specifically. Inspect the real signature with `grep -n "def .*path" apps/server/src/screamingface/plugins/codex_frontend/proxy.py`.
+
+- [ ] **Step 4: Run all (expect FAIL until Task 3)**
+
+Run: `cd apps/server && uv run pytest -x src/screamingface/plugins/codex_frontend/tests/test_terminal_inference.py 2>&1 | tail -20`
+Expected: failures (handler not rewritten).
+
+### Task 3: Rewrite `proxy_responses` handler
+
+**Files:**
+- Modify: `apps/server/src/screamingface/plugins/codex_frontend/proxy.py`
+
+- [ ] **Step 1: Rewrite the handler**
+
+```python
+@router.post("/v1/responses", response_model=None, operation_id="proxy_responses")
+async def proxy_responses(request: Request) -> Response:
+    """Codex inference handler: resolve spec in-process, synthesize OpenAI Responses envelope."""
+    from screamingface.plugins.frontend_base.terminal_response import (
+        build_openai_response, stream_openai_sse, extract_error_text, serialize_transcript,
+    )
+
+    body = await request.json()
+    is_streaming = body.get("stream", False)
+    model = body.get("model", "unknown")
+
+    # Session enrichment
+    session_id = os.environ.get("_SF_SESSION_ID") or request.headers.get("x-session-id")
+    original_user_msg = None
+    if session_id and settings.session_service_url and hooks:
+        original_user_msg = _extract_last_user_text(body)
+        try:
+            results = await hooks.emit_async(
+                "session.enrich_request", body=body, session_id=session_id,
+                session_service_url=settings.session_service_url,
+            )
+            for result in results:
+                if result is not None:
+                    body = result
+                    break
+        except Exception:
+            logger.warning("Session enrichment failed for %s", session_id, exc_info=True)
+
+    # URL4 resolution
+    raw_expression = plugin.get_active_expression() if plugin else None
+    resolved_text = None
+    error_exc = None
+    prompt_text = ""
+
+    if raw_expression:
+        try:
+            if "$prompt" in raw_expression:
+                turns = _extract_turns(body)            # Decision A: full transcript
+                prompt_text = serialize_transcript(turns)
+                if prompt_text:
+                    if settings.backend_url:
+                        async with httpx.AsyncClient(timeout=httpx.Timeout(30.0), verify=False) as dc:
+                            blob_resp = await dc.post(
+                                f"{settings.backend_url.rstrip('/')}/data",
+                                content=prompt_text.encode("utf-8"),
+                                headers={"content-type": "text/plain; charset=utf-8"},
+                            )
+                            blob_resp.raise_for_status()
+                            blob_key = blob_resp.json()["key"]
+                    else:
+                        blob_key = app.state.blob_store.store(
+                            prompt_text.encode("utf-8"), "text/plain; charset=utf-8"
+                        )
+                    substituted = raw_expression.replace("$prompt", f"/data/{blob_key}")
+                    if settings.backend_url:
+                        async with httpx.AsyncClient(timeout=httpx.Timeout(settings.resolve_timeout), verify=False) as ec:
+                            ens_resp = await ec.get(f"{settings.backend_url.rstrip('/')}/ensemble", params={"q": substituted})
+                            ens_resp.raise_for_status()
+                            resolved_text = ens_resp.text
+                    else:
+                        interpreter = Url4Interpreter(app=app)
+                        resolved_text = await interpreter.evaluate(substituted)
+                    if not resolved_text:
+                        raise RuntimeError("$prompt resolved to empty (fail-loud)")
+            else:
+                resolved_text = plugin.resolve_context() if plugin else None
+                if not resolved_text:
+                    raise RuntimeError("Static spec resolved to empty (fail-loud)")
+        except Exception as exc:
+            error_exc = exc
+
+    # Error path — #244: status="completed" carrying the error text
+    if error_exc is not None:
+        error_text = extract_error_text(error_exc, settings.active_spec or "unknown-spec", raw_expression or "")
+        if is_streaming:
+            return StreamingResponse(
+                stream_openai_sse(error_text, model, prompt_text=prompt_text, status="completed"),
+                media_type="text/event-stream",
+            )
+        return JSONResponse(
+            content=build_openai_response(error_text, model, prompt_text=prompt_text, status="completed"),
+            status_code=200,
+        )
+
+    # Success path
+    response_dict = build_openai_response(resolved_text or "", model, prompt_text=prompt_text)
+
+    async def _save():
+        if session_id and settings.session_service_url and hooks and original_user_msg:
+            try:
+                await hooks.emit_async(
+                    "session.save_response", session_id=session_id,
+                    session_service_url=settings.session_service_url,
+                    user_message_body=original_user_msg, response_body=response_dict,
+                )
+            except Exception:
+                logger.warning("Session save failed for %s", session_id, exc_info=True)
+
+    if is_streaming:
+        async def gen():
+            async for chunk in stream_openai_sse(resolved_text or "", model, prompt_text=prompt_text):
+                yield chunk
+        await _save()
+        return StreamingResponse(gen(), media_type="text/event-stream")
+
+    await _save()
+    return JSONResponse(content=response_dict, status_code=200)
+```
+
+- [ ] **Step 2: Delete dead code**
+
+Delete `_inject_system_context`, `_embed_context`, `_parse_sse_response`, and the inference upstream-forwarding block. KEEP `_extract_last_user_text`, `_replace_user_text`, `_build_headers`, and the `/v1/{path}` catchall. Ensure `from screamingface.plugins.url4_executor.interpreter import Url4Interpreter` is imported at module level so the test's `proxy.Url4Interpreter` patch target exists.
+
+- [ ] **Step 3: Verify syntax**
+
+Run: `cd apps/server && uv run python -m py_compile src/screamingface/plugins/codex_frontend/proxy.py`
+Expected: compiles.
+
+- [ ] **Step 4: Run all terminal tests**
+
+Run: `cd apps/server && uv run pytest -x src/screamingface/plugins/codex_frontend/tests/test_terminal_inference.py`
+Expected: all pass.
+
+### Task 4: Migrate existing `test_proxy.py`
+
+**Files:**
+- Modify: `apps/server/src/screamingface/plugins/codex_frontend/tests/test_proxy.py`
+
+- [ ] **Step 1: Remove imports of deleted functions and skip obsolete classes**
+
+Remove any `from ...proxy import _parse_sse_response, _embed_context, _inject_system_context`. For any test class targeting those, mark:
+
+```python
+import pytest
+
+@pytest.mark.skip(reason="Function deleted in M3 terminal rewrite")
+class TestParseSSEResponse: pass
+
+@pytest.mark.skip(reason="Function deleted in M3 terminal rewrite")
+class TestEmbedContext: pass
+```
+
+Keep `TestExtractLastUserText` and `TestReplaceUserText`.
+
+- [ ] **Step 2: Run**
+
+Run: `cd apps/server && uv run pytest -q src/screamingface/plugins/codex_frontend/tests/test_proxy.py`
+Expected: pass (obsolete tests skipped).
+
+### Task 5: M3 gate — type-check, pre-commit, commit
+
+- [ ] **Step 1: Type-check**
+
+Run: `cd apps/server && uv run pyright src/screamingface/plugins/codex_frontend/proxy.py`
+Expected: 0 errors.
+
+- [ ] **Step 2: Pre-commit**
+
+Run: `cd /Users/sergey/work/openmind/screamingface && pre-commit run --files apps/server/src/screamingface/plugins/codex_frontend/proxy.py apps/server/src/screamingface/plugins/codex_frontend/tests/test_terminal_inference.py apps/server/src/screamingface/plugins/codex_frontend/tests/test_proxy.py`
+Expected: pass.
+
+- [ ] **Step 3: Full codex suite + commit**
+
+```bash
+cd apps/server && uv run pytest -q src/screamingface/plugins/codex_frontend/tests/
+cd /Users/sergey/work/openmind/screamingface && git add -A && git commit -m "M3: codex_frontend terminal rewrite (OpenAI Responses, conversation-aware)"
+```
+
+---
+
+## M4: gemini_frontend terminal rewrite (verb allow-list)
+
+Rewrite `proxy_gemini` so only `:generateContent` / `:streamGenerateContent` are terminal; everything else (GET, `:countTokens`, `:embedContent`, `/v1beta/{path}`) forwards upstream. Default streaming = JSON ARRAY (`application/json`); `?alt=sse` = SSE. Uses M1's `build_gemini_response` / `stream_gemini_chunks` / `extract_error_text` / `serialize_transcript`. Gemini stays **save-less**.
+
+**Deletions:** `_inject_system_context`, `_embed_context`.
+**Keep:** `_extract_last_user_text`/`_replace_user_text`, `_build_headers`, GET + non-generate verb passthrough, `/v1beta/{path}` catchall.
+
+### Task 1: Failing unary tests
+
+**Files:**
+- Create: `apps/server/src/screamingface/plugins/gemini_frontend/tests/test_terminal_unary.py`
+
+- [ ] **Step 1: Write the test file**
+
+```python
+"""gemini_frontend unary :generateContent terminal inference."""
+
+import pytest
+from unittest import mock
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from screamingface.plugins.gemini_frontend.proxy import create_router
+from screamingface.plugins.gemini_frontend.plugin import GeminiFrontendSettings
+
+
+@pytest.fixture
+def gemini_settings():
+    return GeminiFrontendSettings(
+        upstream_url="https://generativelanguage.googleapis.com",
+        listen_port=9103, backend_url="http://localhost:8000", active_spec="test-spec",
+    )
+
+
+@pytest.fixture
+def mock_plugin():
+    plugin = mock.MagicMock()
+    plugin.get_active_expression.return_value = "/echo('Static result')"
+    plugin.resolve_context.return_value = "Static resolved text"
+    return plugin
+
+
+@pytest.fixture
+def mock_hooks():
+    hooks = mock.MagicMock()
+    hooks.emit_async = mock.AsyncMock(return_value=[])
+    return hooks
+
+
+@pytest.fixture
+def app(gemini_settings, mock_plugin, mock_hooks):
+    a = FastAPI()
+    a.state.blob_store = None
+    a.include_router(create_router(settings=gemini_settings, app=a, plugin=mock_plugin, hooks=mock_hooks))
+    return a
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+def test_unary_generate_content_no_upstream_call(client):
+    with mock.patch("screamingface.plugins.gemini_frontend.proxy.Url4Interpreter") as mock_interp:
+        mock_interp.return_value.evaluate = mock.AsyncMock(return_value="Result from ensemble")
+        with mock.patch("screamingface.plugins.gemini_frontend.proxy.httpx.AsyncClient"):
+            response = client.post(
+                "/v1beta/models/gemini-2.5-flash:generateContent",
+                json={"contents": [{"role": "user", "parts": [{"text": "What is 2+2?"}]}]},
+            )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["candidates"][0]["finishReason"] == "STOP"
+    assert data["candidates"][0]["content"]["role"] == "model"
+    assert data["candidates"][0]["content"]["parts"][0]["text"] == "Result from ensemble"
+    assert "usageMetadata" in data
+    assert data["modelVersion"] == "gemini-2.5-flash"
+    assert "responseId" in data  # O12
+
+
+def test_unary_static_spec_resolved_locally(client, mock_plugin):
+    with mock.patch("screamingface.plugins.gemini_frontend.proxy.httpx.AsyncClient"):
+        response = client.post(
+            "/v1beta/models/gemini-2.5-flash:generateContent",
+            json={"contents": [{"role": "user", "parts": [{"text": "Hello"}]}]},
+        )
+    assert response.status_code == 200
+    assert response.json()["candidates"][0]["content"]["parts"][0]["text"] == "Static resolved text"
+    mock_plugin.resolve_context.assert_called_once()
+
+
+def test_unary_error_on_resolution_timeout(client):
+    with mock.patch("screamingface.plugins.gemini_frontend.proxy.Url4Interpreter") as mock_interp:
+        mock_interp.return_value.evaluate = mock.AsyncMock(side_effect=TimeoutError("Spec resolution timed out"))
+        response = client.post(
+            "/v1beta/models/gemini-2.5-flash:generateContent",
+            json={"contents": [{"role": "user", "parts": [{"text": "Test"}]}]},
+        )
+    assert response.status_code == 200
+    text = response.json()["candidates"][0]["content"]["parts"][0]["text"]
+    assert "[url4 error]" in text and "TimeoutError" in text
+
+
+def test_unary_static_none_is_fail_loud(client, mock_plugin):
+    mock_plugin.resolve_context.return_value = None
+    with mock.patch("screamingface.plugins.gemini_frontend.proxy.httpx.AsyncClient"):
+        response = client.post(
+            "/v1beta/models/gemini-2.5-flash:generateContent",
+            json={"contents": [{"role": "user", "parts": [{"text": "Test"}]}]},
+        )
+    assert response.status_code == 200
+    assert "[url4 error]" in response.json()["candidates"][0]["content"]["parts"][0]["text"]
+```
+
+> NOTE: The unary spec uses `/echo('Static result')` which contains no `$prompt`, so the static path runs and `mock_plugin.resolve_context` returns `"Static resolved text"`. The interpreter mock only matters for `$prompt` tests; both branches must route through resolution, never upstream.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/server && uv run pytest -xvs src/screamingface/plugins/gemini_frontend/tests/test_terminal_unary.py::test_unary_generate_content_no_upstream_call`
+Expected: FAIL.
+
+### Task 2: Implement `proxy_gemini` (verb allow-list + unary + streaming)
+
+**Files:**
+- Modify: `apps/server/src/screamingface/plugins/gemini_frontend/proxy.py`
+
+- [ ] **Step 1: Add imports and `_extract_turns`**
+
+```python
+from screamingface.plugins.frontend_base.terminal_response import (
+    build_gemini_response, stream_gemini_chunks, extract_error_text, serialize_transcript,
+)
+from screamingface.plugins.url4_executor.interpreter import Url4Interpreter
+
+
+def _extract_turns(body: dict) -> list[tuple[str, str]]:
+    """Extract turns (role, text) from Gemini `contents` for the $prompt blob (Decision A)."""
+    turns: list[tuple[str, str]] = []
+    for item in body.get("contents", []):
+        role = item.get("role", "user")
+        parts = item.get("parts", [])
+        text = "".join(p.get("text", "") for p in parts if isinstance(p, dict))
+        if text:
+            turns.append((role, text))
+    return turns
+```
+
+- [ ] **Step 2: Rewrite `proxy_gemini`**
+
+```python
+@router.api_route(
+    "/v1beta/models/{model_path:path}",
+    methods=["GET", "POST"],
+    response_model=None,
+    operation_id="proxy_gemini",
+)
+async def proxy_gemini(request: Request, model_path: str) -> Response:
+    """Gemini: terminal inference (:generateContent / :streamGenerateContent) vs passthrough."""
+    is_generate = model_path.endswith(":generateContent")
+    is_stream_generate = model_path.endswith(":streamGenerateContent")
+    is_inference = is_generate or is_stream_generate
+
+    # --- Passthrough (GET, :countTokens, :embedContent, etc.) ---
+    if request.method == "GET" or not is_inference:
+        url = f"{upstream_url}/v1beta/models/{model_path}"
+        qs = str(request.url.query)
+        if qs:
+            url = f"{url}?{qs}"
+        headers = _build_headers(request)
+        timeout = httpx.Timeout(connect=10.0, read=600.0, write=10.0, pool=10.0)
+        if request.method == "GET":
+            async with httpx.AsyncClient(timeout=timeout, verify=ssl_ctx) as client:
+                resp = await client.get(url, headers=headers)
+            return JSONResponse(content=resp.json(), status_code=resp.status_code)
+        body_bytes = await request.body()
+        kwargs: dict[str, Any] = {"headers": headers}
+        if body_bytes:
+            kwargs["content"] = body_bytes
+        async with httpx.AsyncClient(timeout=timeout, verify=ssl_ctx) as client:
+            resp = await client.post(url, **kwargs)
+        ct = resp.headers.get("content-type", "")
+        if "json" in ct:
+            return JSONResponse(content=resp.json(), status_code=resp.status_code)
+        return Response(content=resp.content, status_code=resp.status_code, media_type=ct)
+
+    # --- Inference path (terminal) ---
+    body = await request.json()
+    model_name = model_path.split(":")[0].split("/")[-1]
+
+    # Session enrichment (gemini stays save-less; enrich only)
+    session_id = os.environ.get("_SF_SESSION_ID") or request.headers.get("x-session-id")
+    if session_id and session_service_url and hooks:
+        try:
+            results = await hooks.emit_async(
+                "session.enrich_request", body=body, session_id=session_id,
+                session_service_url=session_service_url,
+            )
+            for result in results:
+                if result is not None:
+                    body = result
+                    break
+        except Exception:
+            logger.warning("Session enrichment failed", exc_info=True)
+
+    raw_expression = plugin.get_active_expression() if plugin else None
+    resolved_text = None
+    error_text = None
+    prompt_text = ""
+
+    if raw_expression and "$prompt" in raw_expression:
+        try:
+            turns = _extract_turns(body)               # Decision A
+            prompt_text = serialize_transcript(turns)
+            if prompt_text:
+                backend_url = settings.backend_url.rstrip("/") if settings.backend_url else None
+                if backend_url:
+                    async with httpx.AsyncClient(timeout=httpx.Timeout(30.0), verify=False) as dc:
+                        blob_resp = await dc.post(
+                            f"{backend_url}/data",
+                            content=prompt_text.encode("utf-8"),
+                            headers={"content-type": "text/plain; charset=utf-8"},
+                        )
+                        blob_resp.raise_for_status()
+                        blob_key = blob_resp.json()["key"]
+                else:
+                    blob_key = request.app.state.blob_store.store(
+                        prompt_text.encode("utf-8"), "text/plain; charset=utf-8"
+                    )
+                substituted = raw_expression.replace("$prompt", f"/data/{blob_key}")
+                if backend_url:
+                    async with httpx.AsyncClient(timeout=httpx.Timeout(settings.resolve_timeout or 1200.0), verify=False) as ec:
+                        ens_resp = await ec.get(f"{backend_url}/ensemble", params={"q": substituted})
+                        ens_resp.raise_for_status()
+                        resolved_text = ens_resp.text
+                else:
+                    resolved_text = await Url4Interpreter(app=app).evaluate(substituted)
+                if not resolved_text:
+                    raise RuntimeError("$prompt resolved to empty (fail-loud)")
+        except Exception as exc:
+            logger.warning("$prompt resolution failed", exc_info=True)
+            error_text = extract_error_text(exc, settings.active_spec or "gemini-spec", raw_expression or "")
+    elif raw_expression:
+        try:
+            resolved_text = plugin.resolve_context() if plugin else None
+            if not resolved_text:
+                raise RuntimeError("Static spec resolved to empty")
+        except Exception as exc:
+            logger.warning("Static spec resolution failed", exc_info=True)
+            error_text = extract_error_text(exc, settings.active_spec or "gemini-spec", raw_expression or "")
+
+    alt_sse = "alt=sse" in str(request.url.query)
+
+    # Error path
+    if error_text:
+        if is_stream_generate:
+            media = "text/event-stream" if alt_sse else "application/json"
+            return StreamingResponse(
+                stream_gemini_chunks(error_text, model_name, alt_sse=alt_sse), media_type=media,
+            )
+        return JSONResponse(content=build_gemini_response(error_text, model_name), status_code=200)
+
+    if not resolved_text:
+        resolved_text = ""
+
+    # Success path
+    if is_stream_generate:
+        media = "text/event-stream" if alt_sse else "application/json"
+        return StreamingResponse(
+            stream_gemini_chunks(resolved_text, model_name, prompt_text=prompt_text, alt_sse=alt_sse),
+            media_type=media,
+        )
+    return JSONResponse(content=build_gemini_response(resolved_text, model_name, prompt_text=prompt_text), status_code=200)
+```
+
+- [ ] **Step 3: Delete `_inject_system_context` and `_embed_context`**
+
+Remove both helpers. KEEP `_extract_last_user_text`, `_replace_user_text`, `_build_headers`, and the `/v1beta/{path}` catchall (non-`models` paths).
+
+- [ ] **Step 4: Run unary tests**
+
+Run: `cd apps/server && uv run pytest -xvs src/screamingface/plugins/gemini_frontend/tests/test_terminal_unary.py`
+Expected: all pass.
+
+### Task 3: Streaming tests + verify
+
+**Files:**
+- Create: `apps/server/src/screamingface/plugins/gemini_frontend/tests/test_terminal_streaming.py`
+
+- [ ] **Step 1: Write the test file**
+
+```python
+"""gemini_frontend streaming :streamGenerateContent terminal inference."""
+
+import json
+import pytest
+from unittest import mock
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from screamingface.plugins.gemini_frontend.proxy import create_router
+from screamingface.plugins.gemini_frontend.plugin import GeminiFrontendSettings
+
+
+@pytest.fixture
+def gemini_settings():
+    return GeminiFrontendSettings(
+        upstream_url="https://generativelanguage.googleapis.com",
+        listen_port=9103, backend_url="http://localhost:8000", active_spec="test-spec",
+    )
+
+
+@pytest.fixture
+def mock_plugin():
+    plugin = mock.MagicMock()
+    plugin.get_active_expression.return_value = "/echo('Streaming result')"
+    plugin.resolve_context.return_value = "Streamed text result"
+    return plugin
+
+
+@pytest.fixture
+def app(gemini_settings, mock_plugin):
+    hooks = mock.MagicMock()
+    hooks.emit_async = mock.AsyncMock(return_value=[])
+    a = FastAPI()
+    a.state.blob_store = None
+    a.include_router(create_router(settings=gemini_settings, app=a, plugin=mock_plugin, hooks=hooks))
+    return a
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+def test_streaming_default_json_array(client):
+    with mock.patch("screamingface.plugins.gemini_frontend.proxy.Url4Interpreter") as mi:
+        mi.return_value.evaluate = mock.AsyncMock(return_value="Streaming result text")
+        response = client.post(
+            "/v1beta/models/gemini-2.5-flash:streamGenerateContent",
+            json={"contents": [{"role": "user", "parts": [{"text": "Q"}]}]},
+        )
+    assert response.status_code == 200
+    assert response.headers.get("content-type") == "application/json"
+    data = json.loads(response.text)
+    assert isinstance(data, list) and len(data) == 1
+    assert data[0]["candidates"][0]["finishReason"] == "STOP"
+
+
+def test_streaming_alt_sse_format(client):
+    with mock.patch("screamingface.plugins.gemini_frontend.proxy.Url4Interpreter") as mi:
+        mi.return_value.evaluate = mock.AsyncMock(return_value="SSE result text")
+        response = client.post(
+            "/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse",
+            json={"contents": [{"role": "user", "parts": [{"text": "T"}]}]},
+        )
+    assert response.status_code == 200
+    assert response.headers.get("content-type").startswith("text/event-stream")
+    assert "data: " in response.text and "\n\n" in response.text
+
+
+def test_streaming_error_includes_terminating_frame(client):
+    with mock.patch("screamingface.plugins.gemini_frontend.proxy.Url4Interpreter") as mi:
+        mi.return_value.evaluate = mock.AsyncMock(side_effect=ValueError("Evaluation failed"))
+        response = client.post(
+            "/v1beta/models/gemini-2.5-flash:streamGenerateContent",
+            json={"contents": [{"role": "user", "parts": [{"text": "T"}]}]},
+        )
+    assert response.status_code == 200
+    data = json.loads(response.text)
+    assert "[url4 error]" in data[0]["candidates"][0]["content"]["parts"][0]["text"]
+```
+
+- [ ] **Step 2: Run**
+
+Run: `cd apps/server && uv run pytest -xvs src/screamingface/plugins/gemini_frontend/tests/test_terminal_streaming.py`
+Expected: pass.
+
+### Task 4: Passthrough + no-upstream + E2E tests
+
+**Files:**
+- Create: `apps/server/src/screamingface/plugins/gemini_frontend/tests/test_passthrough.py`
+- Create: `apps/server/src/screamingface/plugins/gemini_frontend/tests/test_no_upstream_inference.py`
+- Create: `apps/server/src/screamingface/plugins/gemini_frontend/tests/test_e2e.py`
+
+- [ ] **Step 1: Write `test_passthrough.py`**
+
+```python
+"""gemini_frontend passthrough verbs forward upstream; inference does not."""
+
+import pytest
+from unittest import mock
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from screamingface.plugins.gemini_frontend.proxy import create_router
+from screamingface.plugins.gemini_frontend.plugin import GeminiFrontendSettings
+
+
+@pytest.fixture
+def client():
+    settings = GeminiFrontendSettings(
+        upstream_url="https://generativelanguage.googleapis.com",
+        listen_port=9103, backend_url="http://localhost:8000", active_spec="test-spec",
+    )
+    plugin = mock.MagicMock()
+    plugin.get_active_expression.return_value = "/echo('Spec result')"
+    hooks = mock.MagicMock()
+    hooks.emit_async = mock.AsyncMock(return_value=[])
+    a = FastAPI()
+    a.state.blob_store = None
+    a.include_router(create_router(settings=settings, app=a, plugin=plugin, hooks=hooks))
+    return TestClient(a)
+
+
+def test_count_tokens_forwards_upstream(client):
+    with mock.patch("screamingface.plugins.gemini_frontend.proxy.httpx.AsyncClient") as mc:
+        resp = mock.AsyncMock()
+        resp.json.return_value = {"totalTokens": 42}
+        mc.return_value.__aenter__.return_value.post.return_value = resp
+        r = client.post("/v1beta/models/gemini-2.5-flash:countTokens",
+                        json={"contents": [{"role": "user", "parts": [{"text": "test"}]}]})
+    assert r.status_code == 200
+    assert r.json() == {"totalTokens": 42}
+    mc.assert_called_once()
+
+
+def test_embed_content_forwards_upstream(client):
+    with mock.patch("screamingface.plugins.gemini_frontend.proxy.httpx.AsyncClient") as mc:
+        resp = mock.AsyncMock()
+        resp.json.return_value = {"embeddings": [{"values": [0.1, 0.2]}]}
+        mc.return_value.__aenter__.return_value.post.return_value = resp
+        r = client.post("/v1beta/models/embedding-001:embedContent", json={"texts": ["hi"]})
+    assert r.status_code == 200
+    assert "embeddings" in r.json()
+
+
+def test_get_model_metadata_forwards_upstream(client):
+    with mock.patch("screamingface.plugins.gemini_frontend.proxy.httpx.AsyncClient") as mc:
+        resp = mock.AsyncMock()
+        resp.json.return_value = {"name": "models/gemini-2.5-flash"}
+        mc.return_value.__aenter__.return_value.get.return_value = resp
+        r = client.get("/v1beta/models/gemini-2.5-flash")
+    assert r.status_code == 200
+    assert r.json()["name"] == "models/gemini-2.5-flash"
+
+
+def test_generate_content_not_forwarded_upstream(client):
+    with mock.patch("screamingface.plugins.gemini_frontend.proxy.Url4Interpreter") as mi:
+        mi.return_value.evaluate = mock.AsyncMock(return_value="AI is...")
+        with mock.patch("screamingface.plugins.gemini_frontend.proxy.httpx.AsyncClient"):
+            r = client.post("/v1beta/models/gemini-2.5-flash:generateContent",
+                            json={"contents": [{"role": "user", "parts": [{"text": "What is AI?"}]}]})
+    assert r.status_code == 200
+```
+
+- [ ] **Step 2: Write `test_no_upstream_inference.py`**
+
+```python
+"""Verify gemini inference never calls generativelanguage.googleapis.com."""
+
+import pytest
+from unittest import mock
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from screamingface.plugins.gemini_frontend.proxy import create_router
+from screamingface.plugins.gemini_frontend.plugin import GeminiFrontendSettings
+
+
+@pytest.fixture
+def client():
+    settings = GeminiFrontendSettings(
+        upstream_url="https://generativelanguage.googleapis.com",
+        listen_port=9103, backend_url="http://localhost:8000", active_spec="test-spec",
+    )
+    plugin = mock.MagicMock()
+    plugin.get_active_expression.return_value = "/echo('No upstream')"
+    plugin.resolve_context.return_value = "Resolved locally"
+    hooks = mock.MagicMock()
+    hooks.emit_async = mock.AsyncMock(return_value=[])
+    a = FastAPI()
+    a.state.blob_store = None
+    a.include_router(create_router(settings=settings, app=a, plugin=plugin, hooks=hooks))
+    return TestClient(a)
+
+
+def test_generate_content_no_google_api_call(client):
+    with mock.patch("screamingface.plugins.gemini_frontend.proxy.httpx.AsyncClient") as mc:
+        with mock.patch("screamingface.plugins.gemini_frontend.proxy.Url4Interpreter") as mi:
+            mi.return_value.evaluate = mock.AsyncMock(return_value="Result")
+            r = client.post("/v1beta/models/gemini-2.5-flash:generateContent",
+                            json={"contents": [{"role": "user", "parts": [{"text": "test"}]}]})
+    assert r.status_code == 200
+    for call in mc.call_args_list:
+        assert "generativelanguage.googleapis.com" not in str(call)
+```
+
+- [ ] **Step 3: Write `test_e2e.py`** (unary static, streaming JSON-array + SSE, countTokens passthrough, timeout error)
+
+```python
+"""E2E: gemini terminal inference + passthrough."""
+
+import json
+import pytest
+from unittest import mock
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from screamingface.plugins.gemini_frontend.proxy import create_router
+from screamingface.plugins.gemini_frontend.plugin import GeminiFrontendSettings
+
+
+@pytest.fixture
+def client():
+    settings = GeminiFrontendSettings(
+        upstream_url="https://generativelanguage.googleapis.com",
+        listen_port=9103, backend_url="http://localhost:8000", active_spec="test-spec",
+    )
+    plugin = mock.MagicMock()
+    plugin.get_active_expression.return_value = "/echo('E2E test result')"
+    plugin.resolve_context.return_value = "E2E resolved text"
+    hooks = mock.MagicMock()
+    hooks.emit_async = mock.AsyncMock(return_value=[])
+    a = FastAPI()
+    a.state.blob_store = None
+    a.include_router(create_router(settings=settings, app=a, plugin=plugin, hooks=hooks))
+    return TestClient(a)
+
+
+def test_e2e_unary_static_spec(client):
+    with mock.patch("screamingface.plugins.gemini_frontend.proxy.httpx.AsyncClient"):
+        r = client.post("/v1beta/models/gemini-2.5-flash:generateContent",
+                        json={"contents": [{"role": "user", "parts": [{"text": "Hello"}]}]})
+    assert r.json()["candidates"][0]["content"]["parts"][0]["text"] == "E2E resolved text"
+
+
+def test_e2e_streaming_sse_format(client):
+    with mock.patch("screamingface.plugins.gemini_frontend.proxy.Url4Interpreter") as mi:
+        mi.return_value.evaluate = mock.AsyncMock(return_value="SSE result")
+        r = client.post("/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse",
+                        json={"contents": [{"role": "user", "parts": [{"text": "SSE"}]}]})
+    assert r.headers.get("content-type").startswith("text/event-stream")
+    assert "data: " in r.text
+
+
+def test_e2e_count_tokens_passthrough(client):
+    with mock.patch("screamingface.plugins.gemini_frontend.proxy.httpx.AsyncClient") as mc:
+        resp = mock.AsyncMock()
+        resp.json.return_value = {"totalTokens": 5}
+        mc.return_value.__aenter__.return_value.post.return_value = resp
+        r = client.post("/v1beta/models/gemini-2.5-flash:countTokens",
+                        json={"contents": [{"role": "user", "parts": [{"text": "count me"}]}]})
+    assert r.json()["totalTokens"] == 5
+
+
+def test_e2e_error_timeout(client):
+    with mock.patch("screamingface.plugins.gemini_frontend.proxy.Url4Interpreter") as mi:
+        mi.return_value.evaluate = mock.AsyncMock(side_effect=TimeoutError("Timed out after 1200s"))
+        r = client.post("/v1beta/models/gemini-2.5-flash:generateContent",
+                        json={"contents": [{"role": "user", "parts": [{"text": "t"}]}]})
+    text = r.json()["candidates"][0]["content"]["parts"][0]["text"]
+    assert "[url4 error]" in text and "TimeoutError" in text
+```
+
+- [ ] **Step 4: Run all gemini tests**
+
+Run: `cd apps/server && uv run pytest -q src/screamingface/plugins/gemini_frontend/tests/test_passthrough.py src/screamingface/plugins/gemini_frontend/tests/test_no_upstream_inference.py src/screamingface/plugins/gemini_frontend/tests/test_e2e.py`
+Expected: all pass.
+
+### Task 5: Migrate existing `test_proxy.py` and run C-grep for gemini settings
+
+**Files:**
+- Modify: `apps/server/src/screamingface/plugins/gemini_frontend/tests/test_proxy.py`
+- Modify (if needed): `apps/server/src/screamingface/plugins/gemini_frontend/plugin.py`
+
+- [ ] **Step 1: Confirm no `embed_*` override in gemini plugin (C)**
+
+Run: `cd apps/server && grep -n "embed_target\|embed_mode\|system_prompt" src/screamingface/plugins/gemini_frontend/plugin.py`
+Expected: no output. If present, delete the override line(s).
+
+- [ ] **Step 2: Migrate test_proxy.py**
+
+Keep `TestExtractLastUserText`, `TestReplaceUserText`. Delete `TestInjectSystemContext`, `TestEmbedContext` and any upstream-forward-on-inference assertions. Replace with mock-resolution synthesized-response tests.
+
+- [ ] **Step 3: Run**
+
+Run: `cd apps/server && uv run pytest -q src/screamingface/plugins/gemini_frontend/tests/test_proxy.py`
+Expected: pass.
+
+### Task 6: M4 gate — full suite, type-check, pre-commit, commit
+
+- [ ] **Step 1: Full gemini suite**
+
+Run: `cd apps/server && uv run pytest -q src/screamingface/plugins/gemini_frontend/tests/`
+Expected: all pass.
+
+- [ ] **Step 2: Type-check + pre-commit**
+
+```bash
+cd apps/server && uv run pyright src/screamingface/plugins/gemini_frontend/proxy.py
+cd /Users/sergey/work/openmind/screamingface && pre-commit run --files apps/server/src/screamingface/plugins/gemini_frontend/proxy.py
+```
+Expected: 0 errors; hooks pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface && git add -A && git commit -m "M4: gemini_frontend terminal rewrite (verb allow-list, JSON-array/SSE, save-less)"
+```
+
+---
+
+## M5: ollama_frontend terminal rewrite (NDJSON)
+
+Rewrite `proxy_chat` to resolve in-process and synthesize NDJSON using M1's `build_ollama_response` / `stream_ollama_ndjson` / `extract_error_text` / `serialize_transcript`. Keep `/api/{path}` passthrough (tags/show/pull/embeddings). Add `_save_session_if_needed`.
+
+**Deletions:** `_inject_system_message`, `_embed_context`.
+**Keep:** `_extract_last_user_text`, `/api/{path}` passthrough.
+
+### Task 1: Failing unary terminal test
+
+**Files:**
+- Modify: `apps/server/src/screamingface/plugins/ollama_frontend/tests/test_proxy.py`
+
+- [ ] **Step 1: Append the test (and ensure `json`, `patch`, `httpx`, `_FakePlugin`, `_app` are imported/defined as in the file)**
+
+```python
+@pytest.mark.asyncio
+async def test_unary_terminal_no_upstream_call() -> None:
+    settings = OllamaFrontendSettings(upstream_url="http://localhost:11434", active_spec="test-spec")
+    plugin = _FakePlugin(expression="static_context_resolved_text")
+    plugin.resolve_context = lambda: "The answer is 42"
+    app = _app(settings, plugin=plugin)
+    client = TestClient(app)
+    with patch("httpx.AsyncClient.post") as mock_post:
+        mock_post.side_effect = AssertionError("Should not call upstream!")
+        r = client.post("/api/chat", json={
+            "model": "llama3.2",
+            "messages": [{"role": "user", "content": "What is the answer?"}],
+            "stream": False,
+        })
+    assert r.status_code == 200
+    body = r.json()
+    assert body["model"] == "llama3.2"
+    assert body["message"]["role"] == "assistant"
+    assert body["message"]["content"] == "The answer is 42"
+    assert body["done"] is True
+    assert body["done_reason"] == "stop"
+    assert "eval_count" in body and "prompt_eval_count" in body
+    mock_post.assert_not_called()
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/server && uv run pytest -xvs src/screamingface/plugins/ollama_frontend/tests/test_proxy.py::test_unary_terminal_no_upstream_call`
+Expected: FAIL.
+
+### Task 2: Rewrite `proxy_chat` + add `_save_session_if_needed`
+
+**Files:**
+- Modify: `apps/server/src/screamingface/plugins/ollama_frontend/proxy.py`
+
+- [ ] **Step 1: Add module-level `_save_session_if_needed` and `_extract_turns`**
+
+```python
+def _extract_turns(body: dict) -> list[tuple[str, str]]:
+    """Extract (role, text) turns from Ollama `messages` for the $prompt blob (Decision A)."""
+    turns: list[tuple[str, str]] = []
+    for msg in body.get("messages", []):
+        role = msg.get("role", "user")
+        content = msg.get("content", "")
+        text = content if isinstance(content, str) else str(content)
+        if text:
+            turns.append((role, text))
+    return turns
+
+
+async def _save_session_if_needed(
+    session_id: str | None,
+    session_service_url: str | None,
+    hooks: Any | None,
+    original_user_msg: dict[str, Any] | None,
+    response_body: dict[str, Any],
+    streaming: bool = False,
+) -> None:
+    if session_id and session_service_url and hooks and original_user_msg:
+        with _tracer.start_current_span("session.save_response"):
+            _tracer.set_attrs({"session.id": session_id, "session.streaming": streaming})
+            try:
+                await hooks.emit_async(
+                    "session.save_response", session_id=session_id,
+                    session_service_url=session_service_url,
+                    user_message_body=original_user_msg, response_body=response_body,
+                )
+            except Exception:
+                logger.warning("Session save failed for %s", session_id, exc_info=True)
+```
+
+- [ ] **Step 2: Replace the `proxy_chat` body**
+
+```python
+@router.post("/api/chat", response_model=None, operation_id="proxy_chat")
+async def proxy_chat(request: Request) -> Response:
+    """Terminal inference: resolve url4 spec in-process, synthesize NDJSON response."""
+    from screamingface.plugins.frontend_base.terminal_response import (
+        build_ollama_response, stream_ollama_ndjson, extract_error_text, serialize_transcript,
+    )
+
+    body = await request.json()
+    is_streaming = body.get("stream", True)
+    model = body.get("model", "unknown")
+
+    session_id = os.environ.get("_SF_SESSION_ID") or request.headers.get("x-session-id")
+    original_user_msg = None
+    if session_id and session_service_url and hooks:
+        msgs = body.get("messages", [])
+        if msgs:
+            original_user_msg = msgs[-1].copy() if isinstance(msgs[-1], dict) else msgs[-1]
+        try:
+            results = await hooks.emit_async(
+                "session.enrich_request", body=body, session_id=session_id,
+                session_service_url=session_service_url,
+            )
+            for result in results:
+                if result is not None:
+                    body = result
+                    break
+        except Exception:
+            logger.warning("Session enrichment failed for %s", session_id, exc_info=True)
+
+    raw_expression = plugin.get_active_expression() if plugin else None
+    resolved_text = None
+    error_dict = None
+    prompt_text = ""
+
+    try:
+        if raw_expression and "$prompt" in raw_expression:
+            turns = _extract_turns(body)              # Decision A
+            prompt_text = serialize_transcript(turns)
+            if prompt_text:
+                backend_url = settings.backend_url.rstrip("/") if settings.backend_url else None
+                if backend_url:
+                    async with httpx.AsyncClient(timeout=httpx.Timeout(30.0), verify=False) as dc:
+                        blob_resp = await dc.post(
+                            f"{backend_url}/data",
+                            content=prompt_text.encode("utf-8"),
+                            headers={"content-type": "text/plain; charset=utf-8"},
+                        )
+                        blob_resp.raise_for_status()
+                        blob_key = blob_resp.json()["key"]
+                else:
+                    blob_key = request.app.state.blob_store.store(
+                        prompt_text.encode("utf-8"), "text/plain; charset=utf-8"
+                    )
+                substituted = raw_expression.replace("$prompt", f"/data/{blob_key}")
+                if backend_url:
+                    async with httpx.AsyncClient(timeout=httpx.Timeout(300.0), verify=False) as ec:
+                        ens_resp = await ec.get(f"{backend_url}/ensemble", params={"q": substituted})
+                        ens_resp.raise_for_status()
+                        resolved_text = ens_resp.text
+                else:
+                    from screamingface.plugins.url4_executor.interpreter import Url4Interpreter
+                    resolved_text = await Url4Interpreter(app=request.app).evaluate(substituted)
+                if not resolved_text:
+                    raise RuntimeError(f"$prompt resolved to empty for spec '{settings.active_spec or 'unknown'}'")
+        elif raw_expression:
+            resolved_text = plugin.resolve_context() if plugin else None
+            if not resolved_text:
+                raise RuntimeError(f"Static spec '{settings.active_spec or 'unknown'}' resolved to empty/None")
+    except Exception as exc:
+        error_dict = build_ollama_response(
+            extract_error_text(exc, settings.active_spec or "unknown", raw_expression or ""), model,
+        )
+
+    # Error path (fail-loud, branched on is_streaming)
+    if error_dict is not None:
+        error_text = error_dict["message"]["content"]
+        if is_streaming:
+            return StreamingResponse(stream_ollama_ndjson(error_text, model), media_type="application/x-ndjson")
+        return JSONResponse(content=error_dict, status_code=200)
+
+    # Success path
+    response_dict = build_ollama_response(resolved_text or "", model, prompt_text=prompt_text)
+    if is_streaming:
+        await _save_session_if_needed(session_id, session_service_url, hooks, original_user_msg, response_dict, streaming=True)
+        return StreamingResponse(stream_ollama_ndjson(resolved_text or "", model, prompt_text=prompt_text), media_type="application/x-ndjson")
+
+    await _save_session_if_needed(session_id, session_service_url, hooks, original_user_msg, response_dict, streaming=False)
+    return JSONResponse(content=response_dict, status_code=200)
+```
+
+- [ ] **Step 3: Delete `_inject_system_message` and `_embed_context`**
+
+Remove both. KEEP `_extract_last_user_text` and the `/api/{path}` passthrough route.
+
+- [ ] **Step 4: Run the unary test**
+
+Run: `cd apps/server && uv run pytest -xvs src/screamingface/plugins/ollama_frontend/tests/test_proxy.py::test_unary_terminal_no_upstream_call`
+Expected: PASS.
+
+### Task 3: Streaming, fail-loud, error-streaming, passthrough, $prompt tests
+
+**Files:**
+- Modify: `apps/server/src/screamingface/plugins/ollama_frontend/tests/test_proxy.py`
+
+- [ ] **Step 1: Append streaming NDJSON test**
+
+```python
+@pytest.mark.asyncio
+async def test_streaming_terminal_ndjson_no_upstream_call() -> None:
+    settings = OllamaFrontendSettings(upstream_url="http://localhost:11434", active_spec="test-spec")
+    plugin = _FakePlugin(expression="static_resolved")
+    plugin.resolve_context = lambda: "Streaming answer here"
+    app = _app(settings, plugin=plugin)
+    client = TestClient(app)
+    with patch("httpx.AsyncClient.stream") as mock_stream:
+        mock_stream.side_effect = AssertionError("Should not call upstream!")
+        r = client.post("/api/chat", json={
+            "model": "llama3.2",
+            "messages": [{"role": "user", "content": "Stream me"}],
+            "stream": True,
+        })
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("application/x-ndjson")
+    lines = r.text.strip().split("\n")
+    assert len(lines) >= 2
+    frame1, frame2 = json.loads(lines[0]), json.loads(lines[1])
+    assert frame1["message"]["content"] == "Streaming answer here" and frame1["done"] is False
+    assert frame2["done"] is True and frame2["done_reason"] == "stop" and frame2["message"]["content"] == ""
+    mock_stream.assert_not_called()
+```
+
+- [ ] **Step 2: Append fail-loud + error-streaming tests**
+
+```python
+@pytest.mark.asyncio
+async def test_fail_loud_static_spec_none() -> None:
+    settings = OllamaFrontendSettings(upstream_url="http://localhost:11434", active_spec="broken-spec")
+    plugin = _FakePlugin(expression="some_expression")
+    plugin.resolve_context = lambda: None
+    app = _app(settings, plugin=plugin)
+    client = TestClient(app)
+    with patch("httpx.AsyncClient.post") as mock_post:
+        mock_post.side_effect = AssertionError("Should not call upstream!")
+        r = client.post("/api/chat", json={
+            "model": "llama3.2", "messages": [{"role": "user", "content": "Hi"}], "stream": False,
+        })
+    assert r.status_code == 200
+    body = r.json()
+    assert "[url4 error]" in body["message"]["content"]
+    assert "broken-spec" in body["message"]["content"]
+    assert "empty/None" in body["message"]["content"]
+    assert body["done"] is True
+    mock_post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_error_path_streaming_ndjson() -> None:
+    settings = OllamaFrontendSettings(upstream_url="http://localhost:11434", active_spec="error-spec")
+    plugin = _FakePlugin(expression="failing_expression")
+    plugin.resolve_context = lambda: (_ for _ in ()).throw(ValueError("Test error"))
+    app = _app(settings, plugin=plugin)
+    client = TestClient(app)
+    with patch("httpx.AsyncClient.stream") as mock_stream:
+        mock_stream.side_effect = AssertionError("Should not call upstream!")
+        r = client.post("/api/chat", json={
+            "model": "llama3.2", "messages": [{"role": "user", "content": "Error"}], "stream": True,
+        })
+    assert r.status_code == 200
+    lines = r.text.strip().split("\n")
+    frame1, frame2 = json.loads(lines[0]), json.loads(lines[1])
+    assert "[url4 error]" in frame1["message"]["content"] and "ValueError" in frame1["message"]["content"]
+    assert frame1["done"] is False
+    assert frame2["done"] is True and frame2["message"]["content"] == ""
+    mock_stream.assert_not_called()
+```
+
+- [ ] **Step 3: Append passthrough + $prompt multi-turn tests**
+
+```python
+@pytest.mark.asyncio
+async def test_api_tags_passthrough_upstream() -> None:
+    settings = OllamaFrontendSettings(upstream_url="http://localhost:11434")
+    plugin = _FakePlugin()
+    app = _app(settings, plugin=plugin)
+    client = TestClient(app)
+    with patch("httpx.AsyncClient.request") as mock_request:
+        mock_request.return_value = httpx.Response(200, json={"models": [{"name": "llama3"}]})
+        r = client.get("/api/tags")
+    assert r.status_code == 200
+    assert r.json()["models"][0]["name"] == "llama3"
+    mock_request.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_dynamic_prompt_with_multi_turn_context() -> None:
+    settings = OllamaFrontendSettings(upstream_url="http://localhost:11434", active_spec="multi-turn-spec")
+    plugin = _FakePlugin(expression="/claude($prompt)")
+    app = _app(settings, plugin=plugin)
+    client = TestClient(app)
+    stored_key = "blob_abc123"
+    with patch.object(app.state, "blob_store") as mock_store:
+        mock_store.store.return_value = stored_key
+        with patch("screamingface.plugins.url4_executor.interpreter.Url4Interpreter.evaluate") as mock_eval:
+            mock_eval.return_value = "Ensemble result text"
+            r = client.post("/api/chat", json={
+                "model": "llama3.2",
+                "messages": [
+                    {"role": "user", "content": "First question"},
+                    {"role": "assistant", "content": "First answer"},
+                    {"role": "user", "content": "Second question"},
+                ],
+                "stream": False,
+            })
+    assert r.status_code == 200
+    assert r.json()["message"]["content"] == "Ensemble result text"
+    mock_store.store.assert_called_once()
+    stored_content = mock_store.store.call_args[0][0]
+    # Decision A: FULL transcript is stored, so all three turns appear
+    assert b"Second question" in stored_content
+    assert b"First question" in stored_content
+    assert b"First answer" in stored_content
+    called_expr = mock_eval.call_args[0][0]
+    assert f"/data/{stored_key}" in called_expr
+```
+
+> NOTE: This `$prompt` test pins Decision A — the stored blob is the FULL serialized transcript (all turns), not just the last user message. The assertion checks all three turns are present.
+
+- [ ] **Step 4: Run all new ollama tests**
+
+Run: `cd apps/server && uv run pytest -xvs src/screamingface/plugins/ollama_frontend/tests/test_proxy.py -k "terminal or fail_loud or error_path or tags_passthrough or multi_turn"`
+Expected: all pass.
+
+### Task 4: Migrate old forwarding tests + C-grep cleanup
+
+**Files:**
+- Modify: `apps/server/src/screamingface/plugins/ollama_frontend/tests/test_proxy.py`
+
+- [ ] **Step 1: Migrate/delete obsolete tests**
+
+Delete `test_inject_system_message`/`test_inject_system_context` and any inference upstream-forward assertions. Update `test_streaming_ndjson_relay` and `test_non_streaming_passthrough_no_spec` to mock resolution and assert synthesized envelopes with `mock_post.assert_not_called()`. Keep `test_authorization_forwarded_other_stripped` (passthrough header behavior).
+
+- [ ] **Step 2: Confirm no settings refs remain**
+
+Run: `cd apps/server && grep -rn "embed_target\|embed_mode\|system_prompt\|_inject_system_message\|_embed_context" src/screamingface/plugins/ollama_frontend/`
+Expected: no output.
+
+- [ ] **Step 3: Full ollama suite**
+
+Run: `cd apps/server && uv run pytest -q src/screamingface/plugins/ollama_frontend/tests/`
+Expected: all pass.
+
+### Task 5: M5 gate — type-check, pre-commit, commit, no-regression
+
+- [ ] **Step 1: Type-check + pre-commit**
+
+```bash
+cd apps/server && uv run pyright src/screamingface/plugins/ollama_frontend/proxy.py
+cd /Users/sergey/work/openmind/screamingface && pre-commit run --files apps/server/src/screamingface/plugins/ollama_frontend/proxy.py apps/server/src/screamingface/plugins/ollama_frontend/tests/test_proxy.py
+```
+Expected: 0 errors; hooks pass.
+
+- [ ] **Step 2: All-frontend regression**
+
+Run: `cd apps/server && uv run pytest -q src/screamingface/plugins/claude_frontend/tests/ src/screamingface/plugins/codex_frontend/tests/ src/screamingface/plugins/gemini_frontend/tests/ src/screamingface/plugins/ollama_frontend/tests/`
+Expected: all pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface && git add -A && git commit -m "M5: ollama_frontend terminal rewrite (direct cutover, NDJSON, conversation-aware)"
+```
+
+---
+
+## M6: cross-frontend tests, no-upstream integration, docs, final verification
+
+Validate all four frontends together, prove no upstream calls on inference (and passthrough still forwards), confirm AIGateway #245 caps apply only to ensemble sub-calls, and update docs/CHANGELOG.
+
+### Task 1: Cross-frontend integration tests
+
+**Files:**
+- Create: `apps/server/tests/test_m6_cross_frontend_integration.py`
+
+- [ ] **Step 1: Ground the test client fixtures**
+
+Run: `cd apps/server && grep -rn "def create_router" src/screamingface/plugins/*/proxy.py`
+Use the discovered signatures to build per-frontend `TestClient` fixtures (claude/codex/gemini/ollama) with a shared mocked resolution that returns a deterministic result, mirroring the per-frontend fixtures from M2–M5.
+
+- [ ] **Step 2: Write static-spec consistency test**
+
+```python
+"""Same active spec resolved through all four frontends returns identical text."""
+
+import pytest
+
+
+def _claude_text(resp): return resp.json()["content"][0]["text"]
+def _codex_text(resp): return resp.json()["output"][0]["content"][0]["text"]
+def _gemini_text(resp): return resp.json()["candidates"][0]["content"]["parts"][0]["text"]
+def _ollama_text(resp): return resp.json()["message"]["content"]
+
+
+def test_static_spec_all_four_frontends_same_result(
+    claude_client, codex_client, gemini_client, ollama_client
+):
+    # Each client fixture is wired so resolution returns "Hello from ensemble".
+    claude_resp = claude_client.post("/v1/messages", json={
+        "model": "claude-opus-4-1-20250805", "messages": [{"role": "user", "content": "hi"}]})
+    codex_resp = codex_client.post("/v1/responses", json={"model": "gpt-4", "input": "hi"})
+    gemini_resp = gemini_client.post("/v1beta/models/gemini-2.0-flash:generateContent",
+                                     json={"contents": [{"role": "user", "parts": [{"text": "hi"}]}]})
+    ollama_resp = ollama_client.post("/api/chat", json={
+        "model": "llama2", "messages": [{"role": "user", "content": "hi"}], "stream": False})
+
+    assert _claude_text(claude_resp) == "Hello from ensemble"
+    assert _codex_text(codex_resp) == "Hello from ensemble"
+    assert _gemini_text(gemini_resp) == "Hello from ensemble"
+    assert _ollama_text(ollama_resp) == "Hello from ensemble"
+```
+
+- [ ] **Step 3: Write `$prompt` dynamic consistency test**
+
+```python
+def test_dynamic_prompt_spec_all_four_frontends_same_result(
+    claude_client, codex_client, gemini_client, ollama_client
+):
+    # Resolution mock echoes the blob content + " — processed"; all four send "test input".
+    claude_resp = claude_client.post("/v1/messages", json={
+        "model": "claude-opus-4-1-20250805", "messages": [{"role": "user", "content": "test input"}]})
+    codex_resp = codex_client.post("/v1/responses", json={"model": "gpt-4", "input": "test input"})
+    gemini_resp = gemini_client.post("/v1beta/models/gemini-2.0-flash:generateContent",
+                                     json={"contents": [{"role": "user", "parts": [{"text": "test input"}]}]})
+    ollama_resp = ollama_client.post("/api/chat", json={
+        "model": "llama2", "messages": [{"role": "user", "content": "test input"}], "stream": False})
+
+    for resp_text in (_claude_text(claude_resp), _codex_text(codex_resp),
+                      _gemini_text(gemini_resp), _ollama_text(ollama_resp)):
+        assert resp_text == "test input — processed"
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd apps/server && uv run pytest -xvs tests/test_m6_cross_frontend_integration.py`
+Expected: pass.
+
+### Task 2: Per-frontend no-upstream-on-inference tests
+
+**Files:**
+- Create: `apps/server/src/screamingface/plugins/claude_frontend/tests/test_m6_no_upstream.py`
+- Create: `apps/server/src/screamingface/plugins/codex_frontend/tests/test_m6_no_upstream.py`
+- Create: `apps/server/src/screamingface/plugins/gemini_frontend/tests/test_m6_no_upstream.py`
+- Create: `apps/server/src/screamingface/plugins/ollama_frontend/tests/test_m6_no_upstream.py`
+
+- [ ] **Step 1: Write the four files (one assertion each)**
+
+Each: mock the resolution locus, POST the inference route, assert 200, and assert no httpx call mentions the provider host:
+- claude → `api.anthropic.com`
+- codex → `api.openai.com`
+- gemini → `generativelanguage.googleapis.com`
+- ollama → `localhost:11434`
+
+```python
+# claude example (adapt host + route per frontend)
+from unittest.mock import patch
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from screamingface.plugins.claude_frontend.plugin import ClaudeFrontendSettings
+from screamingface.plugins.claude_frontend.proxy import create_router
+
+
+def test_claude_inference_no_anthropic_upstream_call():
+    settings = ClaudeFrontendSettings(upstream_url="https://api.anthropic.com", active_spec="test-spec")
+    app = FastAPI(); app.include_router(create_router(settings)); client = TestClient(app)
+    with patch("screamingface.plugins.frontend_base.plugin_base._fetch_sync", return_value="ok"):
+        with patch("httpx.AsyncClient.post") as mp, patch("httpx.Client.post") as msp:
+            r = client.post("/v1/messages", json={
+                "model": "claude-opus-4-1-20250805", "messages": [{"role": "user", "content": "t"}]})
+    assert r.status_code == 200
+    for call in mp.call_args_list + msp.call_args_list:
+        assert "api.anthropic.com" not in str(call)
+```
+
+- [ ] **Step 2: Run all four**
+
+Run: `cd apps/server && uv run pytest -q src/screamingface/plugins/*/tests/test_m6_no_upstream.py`
+Expected: pass.
+
+### Task 3: Passthrough regression tests
+
+**Files:**
+- Create: `apps/server/src/screamingface/plugins/claude_frontend/tests/test_m6_passthrough.py`
+- Create: `apps/server/src/screamingface/plugins/gemini_frontend/tests/test_m6_passthrough.py`
+- Create: `apps/server/src/screamingface/plugins/ollama_frontend/tests/test_m6_passthrough.py`
+
+- [ ] **Step 1: Write the regression tests**
+
+- claude `POST /v1/messages/count_tokens` → forwards (catchall).
+- gemini `:countTokens` and `:embedContent` → forward.
+- ollama `/api/tags` (GET) and `/api/show` (POST) → forward.
+
+Mirror the mocking style used in M2 Task 5 / M4 Task 4 / M5 Task 3 (patch the actual httpx method the route uses; assert it was called and the response relays the upstream body).
+
+- [ ] **Step 2: Run**
+
+Run: `cd apps/server && uv run pytest -q src/screamingface/plugins/claude_frontend/tests/test_m6_passthrough.py src/screamingface/plugins/gemini_frontend/tests/test_m6_passthrough.py src/screamingface/plugins/ollama_frontend/tests/test_m6_passthrough.py`
+Expected: pass.
+
+### Task 4: AIGateway #245 sub-call grounding test
+
+**Files:**
+- Create: `apps/server/tests/test_m6_aigw_sub_calls.py`
+
+- [ ] **Step 1: Ground the ensemble route + AIGateway middleware**
+
+Run: `cd apps/server && grep -rn "ensemble" src/screamingface/plugins/url4_executor/ | head; grep -rn "AIGateway\|MAX_CONCURRENCY\|concurrency" src/ | grep -i aigw | head`
+Document which middleware enforces the per-provider cap and which sub-routes (`/claude`, `/codex`, `/gemini`, `/ollama`) it wraps.
+
+- [ ] **Step 2: Write the assertion test**
+
+Write a test that drives `/ensemble` with multiple concurrent `/claude` sub-calls through a mocked AIGateway dispatch and asserts the anthropic cap (=1) is honored. If the cap is only observable via config rather than runtime in unit scope, assert the config value and document the runtime trace verification step inline as a comment.
+
+- [ ] **Step 3: Run**
+
+Run: `cd apps/server && uv run pytest -xvs tests/test_m6_aigw_sub_calls.py`
+Expected: pass (or documented config assertion).
+
+### Task 5: Comprehensive builder/streamer + error-path tests
+
+**Files:**
+- Create: `apps/server/tests/test_terminal_response_builders.py`
+- Create: `apps/server/tests/test_terminal_response_errors.py`
+
+- [ ] **Step 1: Builders/streamers coverage**
+
+Cover all eight builders/streamers plus newline preservation: parse SSE on `\n\n`, NDJSON on `\n`, each frame JSON-decodes independently; assert frame order, `status:"in_progress"` (codex), stable `item_id`, monotonic `sequence_number`, camelCase Gemini `usageMetadata`, gemini JSON-array default vs `alt_sse`, ollama every-frame-`message`. Reuse the parse helpers from M1's `test_terminal_response.py`.
+
+```python
+import json
+import pytest
+from screamingface.plugins.frontend_base.terminal_response import (
+    stream_anthropic_sse, stream_ollama_ndjson,
+)
+
+
+@pytest.mark.asyncio
+async def test_newline_preservation_anthropic():
+    chunks = [c async for c in stream_anthropic_sse("line1\nline2", "claude-3-5-sonnet")]
+    text = b"".join(chunks).decode()
+    assert "line1\\nline2" in text  # JSON-escaped newline survives in the delta
+
+
+@pytest.mark.asyncio
+async def test_newline_preservation_ollama():
+    chunks = [c async for c in stream_ollama_ndjson("a\nb", "llama3.2")]
+    frame1 = json.loads(b"".join(chunks).decode().strip().split("\n")[0])
+    assert frame1["message"]["content"] == "a\nb"
+```
+
+- [ ] **Step 2: Error-path coverage**
+
+Cover `extract_error_text` for httpx 502, raw interpreter exception, TimeoutError (`timed out`), and each provider's error envelope. For codex, assert error envelope uses `status="completed"` (#244 override).
+
+```python
+import httpx
+from screamingface.plugins.frontend_base.terminal_response import (
+    extract_error_text, build_openai_response,
+)
+
+
+def test_extract_error_text_httpx_502():
+    req = httpx.Request("GET", "http://x/ensemble")
+    exc = httpx.HTTPStatusError("502", request=req, response=httpx.Response(502, request=req))
+    text = extract_error_text(exc, "spec", "/claude($prompt)")
+    assert "[url4 error]" in text and "HTTPStatusError" in text
+
+
+def test_build_openai_response_error_envelope_status_completed():
+    env = build_openai_response("[url4 error] boom", "gpt-4o-mini", status="completed")
+    assert env["status"] == "completed"  # #244 visibility override
+    assert "[url4 error]" in env["output"][0]["content"][0]["text"]
+```
+
+- [ ] **Step 3: Run**
+
+Run: `cd apps/server && uv run pytest -q tests/test_terminal_response_builders.py tests/test_terminal_response_errors.py`
+Expected: pass.
+
+### Task 6: Full server suite + type-check + pre-commit
+
+- [ ] **Step 1: Full suite**
+
+Run: `cd /Users/sergey/work/openmind/screamingface && (cd apps/server && uv run pytest -q tests/ src/screamingface/plugins/*/tests/)`
+Expected: all pass; no upstream httpx calls on inference; passthrough routes forward.
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd apps/server && uv run pyright src/ 2>&1 | tail -10`
+Expected: 0 errors in inference handlers, `terminal_response.py`, `plugin_base.py`.
+
+- [ ] **Step 3: Pre-commit (all files)**
+
+Run: `cd /Users/sergey/work/openmind/screamingface && pre-commit run --all-files`
+Expected: all hooks pass.
+
+### Task 7: Documentation updates
+
+**Files:**
+- Modify: `README.md`
+- Modify: `apps/server/src/screamingface/plugins/{claude,codex,gemini,ollama}_frontend/README.md` (create if missing)
+- Modify: `docs/configuration.md`
+- Modify: `docs/error-handling.md` (create if missing)
+- Modify: `CLAUDE.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: README + per-frontend READMEs**
+
+Rename "Transparent Proxy" → "Ensemble-Terminal Frontend Proxy". State that inference routes no longer forward to real upstreams; each frontend resolves the active url4 spec (HTTP `/ensemble` or in-process `Url4Interpreter`) and synthesizes the provider-native envelope; non-inference routes still forward. Per-frontend wire formats: claude Anthropic SSE; codex OpenAI SSE; gemini JSON array (default) or SSE (`?alt=sse`); ollama NDJSON. For gemini, list the passthrough verbs (`:countTokens`, `:embedContent`, `:batchEmbedContents`, GET) vs terminal verbs (`:generateContent`, `:streamGenerateContent`). Note all four support the `$prompt` conversation-aware input fork.
+
+- [ ] **Step 2: configuration.md (Decision C)**
+
+Document that `embed_target`, `embed_mode`, `system_prompt` are REMOVED (hard-removed, not just deprecated). Retained: `upstream_url` (passthrough), `active_spec`, `resolve_timeout`, `session_service_url`. Note O10: static-spec resolve cache has a TTL / re-resolution and document live `active_spec`-switch behavior.
+
+- [ ] **Step 3: error-handling.md**
+
+Document the fake-200 error contract: timeout / 502 / in-process exception / static-spec None/empty → HTTP 200 with visible `[url4 error] ...+traceback` (never 5xx). Two resolution loci (HTTP `/ensemble` returns 502 on failure vs in-process `Url4Interpreter.evaluate()` raising directly). Blocking up to `resolve_timeout` (default 1200s). Link PR #244. State streaming errors emit a full terminating frame sequence. Call out the codex #244 override: error envelope uses `status="completed"` (NOT `status="failed"`) for CLI visibility. Note O16: a spec that does not terminate in a model backend call WARNs (does not hard-fail).
+
+- [ ] **Step 4: CLAUDE.md "Inference Routes" section**
+
+Add before/after table, two resolution loci, AIGateway #245 caps apply to ensemble sub-calls only, static-spec fail-loud behavior change (Decision O5b / #244), passthrough route list, and the Decision A note that the `$prompt` blob is the FULL serialized transcript.
+
+- [ ] **Step 5: CHANGELOG.md M6 entry**
+
+```markdown
+## [M6] Cross-frontend Terminal Ensemble Rewrite (2026-06-04)
+
+### Breaking Changes
+- Static specs (no `$prompt`) that resolve to empty/None now return an error envelope (HTTP 200) instead of proceeding silently (#244, Decision O5b).
+- Settings `embed_target`, `embed_mode`, `system_prompt` HARD-REMOVED from frontend settings (Decision C).
+
+### Features
+- Terminal inference for all four frontends: resolve the active url4 spec in-process (or via `/ensemble`) and synthesize provider-native envelopes; no calls to real upstreams on inference.
+- Conversation-aware `$prompt`: the blob is the FULL serialized transcript (Decision A); responses echo deterministic ids + plausible non-zero usage.
+- Error contract: resolution failures return HTTP 200 with visible error text + traceback (never 5xx); streaming errors emit a terminating frame. Codex error envelope uses status="completed" for CLI visibility.
+- Wire-format synthesis: claude SSE (with ping); codex SSE (9-event canonical); gemini JSON array default + SSE on `?alt=sse`; ollama NDJSON.
+
+### Non-breaking
+- Non-inference passthrough unchanged: claude `count_tokens`, gemini `:countTokens`/`:embedContent`, ollama `/api/{tags,show,pull,embeddings}` still forward upstream.
+- AIGateway concurrency caps (#245) still apply to ensemble sub-calls only.
+
+### Docs
+- Renamed "Transparent Proxy" → "Ensemble-Terminal Frontend Proxy"; added CLAUDE.md "Inference Routes" section, error-handling.md, configuration.md updates.
+```
+
+- [ ] **Step 6: Commit docs**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface && git add -A && git commit -m "M6: cross-frontend tests, no-upstream integration, AIGW grounding, docs"
+```
+
+### Task 8: Success-criteria verification + final smoke
+
+**Files:**
+- Create (optional): `apps/server/tests/test_m6_success_criteria.py`
+
+- [ ] **Step 1: Run the full verification gate one more time**
+
+Run: `cd /Users/sergey/work/openmind/screamingface && (cd apps/server && uv run pytest -q tests/ src/screamingface/plugins/*/tests/) && (cd apps/server && uv run pyright src/ 2>&1 | tail -3) && pre-commit run --all-files`
+Expected: all green.
+
+- [ ] **Step 2: Manual smoke test across the four CLIs (post-commit)**
+
+For each CLI (claude, codex, gemini, ollama): exercise static spec, `$prompt` spec, an induced resolution error (timeout), and streaming. For gemini also test `:countTokens` passthrough and both streaming formats (JSON array + `?alt=sse`); for ollama also test `/api/tags` passthrough. Confirm no real-provider errors surface (ensemble is the only upstream path) and error cases render the `[url4 error]` text in the CLI.
+
+- [ ] **Step 3: Confirm checklist in CLAUDE.md is accurate, then final commit if anything changed**
+
+```bash
+cd /Users/sergey/work/openmind/screamingface && git add -A && git commit -m "M6: final verification + success-criteria checklist" || echo "nothing to commit"
+```
+
+---
+
+## Adversarial-review corrections (apply during execution)
+
+> **These corrections come from an adversarial critique run AFTER the milestone task bodies below were assembled. They are NOT yet folded into the tasks above. Where a correction conflicts with a task body, THE CORRECTION WINS.** The most important structural one: **M1 stays purely additive (new `terminal_response.py` module + tests only); the settings HARD-REMOVE and the O10/O16 code tasks are sequenced into M6 Task 0/4/5** so each milestone gate is independently green.
+
+Checked the assembled plan against the six milestone task lists, the settled gating decisions, and ALL fourteen critic issues. Each blocker/major is fixed inline; minors addressed.
+
+**Blockers (all fixed):**
+1. **M1 C-gate fails while embed reads remain.** RESEQUENCED: Decision C hard-remove moved to **M6 Task 0**, after M2–M5 delete every `settings.embed_*` read. M6 Task 0 Step 1 greps to PROVE zero read-sites remain BEFORE removing the base fields, so the removal is atomic and runtime-safe. M1 is now purely additive (new module + test) and independently green.
+2. **`system_prompt` grep over-broad.** Scoped: M6 Task 0 Step 4 greps `\bsystem_prompt\b` and explicitly EXCLUDES `*_backend_api`, `aigw_base`, `llm_base`, `interpreter_system_prompt`, `append_system_prompt`. Only `FrontendSettingsBase.system_prompt` and frontend test assignments are touched.
+3. **M2 success tests incoherent (plugin=None → no resolution; wrong patch target).** Fixed: all M2 terminal tests now wire a `_static_plugin()` MagicMock whose `get_active_expression` returns a static (no-`$prompt`) spec and `resolve_context` returns the expected text — the locus the success assertions actually exercise. The `$prompt` E2E tests patch `_store_prompt_blob`/`_resolve_expression` (real $prompt locus), NOT `plugin_base._fetch_sync`. The no-spec migrated test asserts an empty synthesized envelope with no upstream call.
+4. **Unused `Literal` import.** M6 Task 0 Step 2 explicitly removes `Literal` from `plugin_base.py` after deleting the two fields that used it (and from `ollama_frontend/plugin.py` if newly unused).
+5. **pre-commit run from wrong dir.** ALL pre-commit invocations now run `cd apps/server && pre-commit run ...` (config lives at `apps/server/.pre-commit-config.yaml`), with a NOTE in M1 Task 3.
+
+**Majors (all fixed):**
+6. **Untracked breaking test/config sites.** M6 Task 0 Step 6 enumerates and fixes the exact files: `test_aigw_claude_e2e.py:257`, `test_proxy_context_injection.py:47`, `codex test_plugin.py:34-35`, `gemini test_proxy.py:65-66`, `claude test_claude_frontend_models.py:329`, and the ollama `plugin.py` docstring (Step 3).
+7. **Codex top-level imports of deleted functions crash collection.** M3 Task 4 Step 1 now DELETES the top-level import names AND the test classes (`TestParseSSEResponse`/`TestEmbedContext`/`TestInjectSystemContext`) — no skip-stubbing.
+8. **Resolve-helper signature drift / unstated embed_context removal.** M2 Task 0 greps callers (only `proxy_messages`); M2 Task 2 explicitly drops the `embed_context` callback param, adds `prompt_text`, returns the tuple, and removes embed reads in `_url4_context.py`. The orphan M1 xfail contract test was REMOVED entirely (no longer created in M1) to avoid signature-shape errors.
+9. **O10 silently downgraded to docs.** Now a CODE task: **M6 Task 4** implements TTL + active-spec invalidation in `resolve_context` with two failing tests.
+10. **Codex/gemini/ollama interpreter import not hoisted before red-phase patch.** Each frontend gets a **Task 0** that HOISTS `from ...interpreter import Url4Interpreter` to module scope BEFORE the red-phase tests patch `proxy.Url4Interpreter` (codex M3 T0, gemini M4 T2 S0, ollama M5 T0). The red-phase "expect fail" notes now say "assertion failure, not AttributeError."
+
+**O16:** also promoted to a CODE task — **M6 Task 5** adds `warn_if_no_model_backend` + tests.
+
+**Minors:**
+11. **blob_store access divergence.** Standardized on `request.app.state.blob_store` across codex/gemini/ollama handlers (matching existing code).
+12. **Unused fork helpers.** Decision D updated: M2/M3/M4/M5 each grep for `_extract_last_user_text`/`_replace_*` and DELETE those with no remaining caller (not "keep").
+13. **AIGW #245 escape hatch.** M6 Task 4 (renumbered Task 6) decides feasibility UP FRONT in Step 1; if no runtime assertion is feasible, the task is DROPPED (not a meaningless config-constant assertion), with a CLAUDE.md note citing the middleware test.
+14. **Gemini passthrough AsyncMock vs sync `resp.json()`.** All passthrough tests use `MagicMock()` response objects (via `_upstream_resp`) so `resp.json()` returns the dict synchronously, matching `proxy_gemini`'s sync `resp.json()` call.
+
+**Type/name consistency:** M2–M5 import builders/streamers/helpers from M1's `terminal_response.py` (12 symbols) — no redefinitions. Resolve helpers consistently return `tuple[str | None, dict | None]`; `_build_error_response` returns a dict. Codex error envelope uses `status="completed"` (#244). Gemini includes `responseId` (O12). Every frontend has `_extract_turns` feeding `serialize_transcript` (Decision A), and the ollama `$prompt` test pins the FULL-transcript assertion.
+
+**Independent-executability of M1:** M1 now touches NO existing code (new module + new test only), so its type-check/pre-commit/test gates pass standalone. The settings/contract churn that previously polluted M1 is consolidated into M6 Task 0 where its read-site dependencies are already satisfied.
+
+---
+
+## Self-review
+
+Checked the assembled plan against the six milestone task lists and the settled gating decisions.
+
+**1. Spec / decision coverage:**
+- **A (conversation-aware):** Each frontend now has an `_extract_turns(body)` helper (claude M2 T3, codex M3 T1, gemini M4 T2, ollama M5 T2) feeding M1's `serialize_transcript`; the ollama `$prompt` test (M5 T3) explicitly asserts the FULL transcript (all turns) is stored. M1 builders take `prompt_text` and emit non-zero usage + deterministic ids. Covered.
+- **B (passthrough):** Passthrough kept and regression-tested for claude (`count_tokens`, `/v1/models`, `/api/*`), codex (`/v1/{path}`), gemini (verb allow-list: `:countTokens`/`:embedContent`/GET/`/v1beta/{path}`), ollama (`/api/tags`, `/api/show`). M6 T3 adds dedicated regression tests. Covered.
+- **C (hard-remove settings):** M1 T3–T6 remove fields from base + ollama + sf.json with a repo-wide grep gate and a dedicated removal test; gemini grep added in M4 T5. Covered.
+- **D (direct cutover):** Each rewrite deletes forward/embed helpers outright with explicit delete steps; no feature flag anywhere. Covered.
+- **O5b (empty = fail-loud):** Enforced in resolve helpers and inference handlers (`raise RuntimeError(... empty ...)`) and tested per frontend. Covered.
+- **O10 (cache TTL / live switch):** Documented in M6 T7 configuration.md. (No code task — flagged as docs-only per the source milestone; acceptable since the source plan scoped it to documentation.)
+- **O12 (gemini responseId):** Added to `build_gemini_response` (M1) and asserted in M4 T1. Covered.
+- **O16 (warn on non-model spec):** Documented in M6 T7 error-handling.md. Covered as docs.
+- **#244 (visibility, codex status="completed"):** M1 `build_openai_response` defaults error to `status="completed"`; codex M3 T2/T3 pass `status="completed"` and assert it; called out in docs and CHANGELOG. Covered.
+
+**2. Placeholder scan:** Replaced the milestone drafts' `last_user_text` resolve-helper param with the conversation-aware `prompt_text` to honor Decision A, and updated the contract note. No TBD/TODO-as-implementation remain. Where a behavior depends on existing code I couldn't read (exact httpx method on catchalls, settings `extra` policy, `create_router` signatures), I added explicit grounding `grep` steps and NOTE callouts rather than guessing — these are verification steps, not placeholders.
+
+**3. Type/name consistency:** M2–M5 import builders/streamers/helpers from M1's `terminal_response.py` (`build_anthropic_message`, `stream_anthropic_sse`, `build_openai_response`, `stream_openai_sse`, `build_gemini_response`, `stream_gemini_chunks`, `build_ollama_response`, `stream_ollama_ndjson`, `extract_error_text`, `serialize_transcript`, `estimate_tokens`, `deterministic_id`) — no redefinitions. The resolve helpers consistently return `tuple[str | None, dict | None]`. `_build_error_response` returns a dict everywhere. The M1 resolve-contract test is xfail until M2 implements the tuple, then de-xfailed in M2 T2 Step 5 (no orphan).
+
+Reconciliations applied vs the raw milestones: (a) M2's resolve signature changed from `last_user_text` to `prompt_text` (Decision A); (b) gemini draft's `build_gemini_response` gained `responseId` (O12); (c) codex error envelope uses `status="completed"` not `"failed"` (#244); (d) ollama/codex/gemini/claude all gained `_extract_turns` for full-transcript blobs.
+
+## Execution handoff
+
+Plan complete. Save it to `docs/superpowers/plans/2026-06-04-frontend-terminal-ensemble-plan.md` (companion to the spec at `docs/superpowers/plans/2026-06-04-frontend-terminal-ensemble-spec.md`). Two execution options:
+
+1. **Subagent-Driven (recommended)** — Use superpowers:subagent-driven-development: dispatch a fresh subagent per task, two-stage review between tasks, fast iteration. Best fit here because each milestone gate is independently verifiable and the grounding-grep NOTE steps benefit from a fresh-context check.
+
+2. **Inline Execution** — Use superpowers:executing-plans: batch execution in this session with checkpoints for review at each Mn gate.
+
+Which approach?

--- a/docs/superpowers/plans/2026-06-04-frontend-terminal-ensemble-spec.md
+++ b/docs/superpowers/plans/2026-06-04-frontend-terminal-ensemble-spec.md
@@ -1,0 +1,1022 @@
+# Frontend Terminal-Ensemble Reframing — Protocol Spec
+
+## Goal / Summary
+
+The four screamingface "frontends" — `claude_frontend`, `codex_frontend`, `gemini_frontend`, and `ollama_frontend` — are backend services that each emulate a provider's HTTP API (Anthropic Messages, OpenAI Responses, Google Gemini GenerateContent, Ollama `/api/chat`) for a CLI client. This spec reframes them so the **inference route stops proxying to the real upstream provider**. Instead, each frontend resolves the active url4 spec in-process via `/ensemble` (or the in-process `Url4Interpreter`, see §"Two resolution loci"), and returns the ensemble's reduced output wrapped in that provider's exact native response envelope (JSON unary, or a synthetic streaming frame sequence in the provider's exact wire format). All four frontends are first-class terminal endpoints; non-inference management routes continue to forward upstream unchanged. This is a request/response protocol spec.
+
+## Locked Decisions
+
+1. **Terminal inference route.** claude/codex/gemini/ollama frontends STOP proxying to Anthropic/OpenAI/Google/Ollama upstreams on the inference route. Each resolves the active url4 spec and RETURNS the reduced output in that provider's native envelope. No upstream provider call from the inference route.
+2. **Per-spec input fork (kept).** If `active_spec` contains `$prompt`, substitute the CLI's latest user text as ensemble input; else the spec is server-predetermined and the CLI prompt is ignored. BOTH paths now terminate at the frontend. (Multi-turn history handling: see **O9**; static-spec multi-turn semantics: see **O6**.)
+3. **Fake-stream.** On a streaming request, synthesize the provider's frame sequence carrying the whole result in ONE delta, in that provider's EXACT wire format:
+   - **claude** = Anthropic SSE (`event:` lines, blank-line `\n\n` terminated, `ping` permitted, no `[DONE]`);
+   - **codex** = OpenAI Responses SSE (blank-line `\n\n` terminated, full canonical event sequence, no `[DONE]`);
+   - **gemini** = SSE iff `?alt=sse` (`data: {...}\n\n`), else a **JSON array** `[{...}]` of `GenerateContentResponse` chunks (`application/json`);
+   - **ollama** = NDJSON (`application/x-ndjson`, one complete JSON object per line, NOT SSE, no `data:` prefix, no `[DONE]`).
+   - Unary → JSON envelope.
+4. **Error contract = PR #244 "blocking and screaming".** Block on resolution (`resolve_timeout` default 1200s); on failure (timeout / 502 / degraded `on_error=collect` / in-process interpreter exception / **static-spec resolution failure**) return a provider-shaped fake-200 whose text is the visible url4 error+traceback. Never swallow; never return HTTP 5xx to the CLI. Keep #244 negative cache + bounded/loop-aware fetch. Error rendering branches on `is_streaming` for every provider, and the streaming error path routes through the SAME frame generator as the success path so the CLI always sees a terminating frame.
+5. **AIGateway concurrency cap preserved (#245, anthropic:1).** The ensemble's INTERNAL `/claude`,`/codex`,`/gemini`,`/ollama` sub-calls still hit providers via AIGateway — UNCHANGED. Only the inference route's direct proxy leg is removed.
+6. **Response defaults.** Echo the request's `model`; usage zeros as a **superset of zeros** (every field each provider may require, all `0`/null — see §"Usage field shapes (pinned)"); `stop_reason=end_turn` (anthropic) / `status=completed` (openai) / `finishReason=STOP` (gemini) / `done=true, done_reason="stop"` (ollama). Response ids are freshly random per call (see **O11** for id/usage-vs-multi-turn interaction).
+
+**Pinned helper names AND location** (resolving O3): all eight builders/streamers live EXCLUSIVELY in the shared module `frontend_base/terminal_response.py`. Per-frontend modules, if any, import and re-export only — they MUST NOT replicate wire-format logic.
+- claude: `build_anthropic_message(result, model)` / `stream_anthropic_sse(result, model)`
+- codex: `build_openai_response(result, model)` / `stream_openai_sse(result, model)`
+- gemini: `build_gemini_response(result, model)` / `stream_gemini_chunks(result, model, alt_sse=False)`
+- ollama: `build_ollama_response(result, model)` / `stream_ollama_ndjson(result, model)`
+
+**Formal signatures (pinned):**
+
+```python
+def build_anthropic_message(result_text: str, model: str) -> dict: ...
+async def stream_anthropic_sse(result_text: str, model: str) -> AsyncIterator[bytes]: ...
+def build_openai_response(result_text: str, model: str) -> dict: ...
+async def stream_openai_sse(result_text: str, model: str) -> AsyncIterator[bytes]: ...
+def build_gemini_response(result_text: str, model: str) -> dict: ...
+async def stream_gemini_chunks(result_text: str, model: str, alt_sse: bool = False) -> AsyncIterator[bytes]: ...
+def build_ollama_response(result_text: str, model: str) -> dict: ...
+async def stream_ollama_ndjson(result_text: str, model: str) -> AsyncIterator[bytes]: ...
+```
+
+---
+
+## Two resolution loci (in-process interpreter vs HTTP `/ensemble`)
+
+Resolution happens via **one of two loci**, and the error contract MUST cover both:
+
+1. **HTTP `/ensemble`** (`url4_executor/routes.py`): GET resolves and returns `PlainTextResponse`; on evaluation failure it raises `HTTPException(status_code=502, detail="url4 evaluation failed: ...")` (routes.py:132). The frontend's `_fetch`/`_fetch_sync` GET this route and `raise_for_status()`.
+2. **In-process `Url4Interpreter`** (when the app exposes a blob store; the common in-process case): the frontend calls `Url4Interpreter(app).evaluate(...)` directly — **no** HTTP, **no** 502 wrapping. Exceptions are raw interpreter exceptions.
+
+Because exception types differ between loci, the error contract is defined in terms of **"any exception raised during resolution"**, not "`/ensemble` returns 502". `extract_error_text()` MUST format both an httpx `HTTPStatusError` (502 path) and a raw `Url4Interpreter` exception uniformly. Flows below say "Resolve spec" to mean "via whichever locus applies."
+
+---
+
+## Architecture: Before vs After
+
+| Aspect | Before | After |
+|--------|--------|-------|
+| **Upstream call on inference** | Yes, always | No, never |
+| **URL4 resolution** | Yes, embedded into request body, then forwarded | Yes, result becomes the response text |
+| **Error handling** | HTTP 5xx/4xx from upstream | HTTP 200 fake-envelope with error text + traceback |
+| **Static-spec resolution failure** | Swallowed (returns None, request proceeds, full history still forwarded) | Fail-loud: error envelope returned (see **decision below**) |
+| **Response format** | Pass-through from upstream | Synthesized by `build_<provider>_*()` |
+| **Streaming** | Pass-through from upstream | Synthesized single-delta frame sequence in exact wire format |
+| **Model field** | From upstream response | Echoed from request |
+| **Usage fields** | From upstream response | Superset of zeros (full per-provider field set) |
+| **Non-inference routes** | Forward upstream | Forward upstream (UNCHANGED) |
+| **AIGateway concurrency caps** | Apply to `/ensemble` fan-out only | Apply to `/ensemble` fan-out only (UNCHANGED) |
+
+The context-embedding machinery (`_embed_context`, `_inject_system_context`/`_inject_system_message`) is deleted from every inference path: there is no outbound request body to mutate, so the resolved text goes **directly into the response envelope**, not into a forwarded request.
+
+**Static-spec fail-loud (resolves a contradiction).** Today `FrontendPluginBase.resolve_context()` (plugin_base.py:279–283) **catches** per-spec resolution exceptions, logs a warning, and returns `None` (so a failed static spec proceeds with no context). Under the terminal rewrite a `None`/empty static result would otherwise produce a blank HTTP 200 — silently violating the #244 contract. **Decision:** the inference handler treats a `None`/empty resolved value for a non-`$prompt` spec **as a resolution failure** and returns the provider error envelope. Implementation: either (a) the per-provider static resolver re-raises so the handler's `except` fires, or (b) the handler explicitly checks `resolved_text` is non-empty when `raw_expression` is set and synthesizes the error envelope otherwise. This is a deliberate behavior change from the current non-fatal swallow and MUST be called out in the changelog. (Empty-result-vs-error nuance for the `$prompt` path: see **O5b**.)
+
+---
+
+## Usage field shapes (pinned, supersets-of-zeros)
+
+Per Locked Decision #6, every provider emits the **superset** of usage fields it may require, all zero/null. The Anthropic `Usage` model is `extra="allow"` (models.py:134), and codex/gemini consumers ignore unknown zero fields, so supersets are safe everywhere. This resolves O1 (claude minimal-vs-extended) in favor of the superset.
+
+- **claude** (`usage`, message_start + unary + `message_delta`):
+  `{"input_tokens": 0, "output_tokens": 0, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}`
+  (In `message_delta`, emit `{"output_tokens": 0}` only, per the Anthropic wire convention.)
+- **codex** (`usage`): `{"input_tokens": 0, "output_tokens": 0, "total_tokens": 0, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}`
+- **gemini** (`usageMetadata`, camelCase): `{"promptTokenCount": 0, "candidatesTokenCount": 0, "totalTokenCount": 0}`
+- **ollama**: duration/eval fields — `{"total_duration": 0, "load_duration": 0, "prompt_eval_count": 0, "prompt_eval_duration": 0, "eval_count": 0, "eval_duration": 0}`
+
+---
+
+## Query / Request / Response Flow
+
+### Flow 1 — `$prompt`-dynamic turn (AFTER)
+
+```
+CLI Request: POST /v1/messages (or /v1/responses, /v1beta/...:generateContent, /api/chat)
+    │
+    └─→ [Frontend Inference Handler]
+         │
+         ├─→ Session enrichment (if enabled)
+         │
+         ├─→ Detect $prompt in active spec
+         │    └─→ Extract input text (see O9 for last-turn-only vs full transcript)
+         │    └─→ Store input as blob (/data/{key})
+         │    └─→ Substitute $prompt → /data/{key} in expression
+         │    └─→ Resolve via HTTP /ensemble OR in-process Url4Interpreter
+         │         (ensemble sub-calls /claude,/codex,/gemini,/ollama → AIGateway → real upstreams,
+         │          subject to per-provider concurrency caps)
+         │    └─→ Reducer collects responses → final resolved text
+         │
+         ├─→ NO forward to real upstream
+         │
+         ├─→ Build provider-native envelope from resolved text
+         │    ├─→ is_streaming=true → synthesize provider's exact frame sequence (Decision #3)
+         │    └─→ is_streaming=false → single JSON response object
+         │
+         ├─→ session.save(<builder dict>) once (see O7; same dict for unary & streaming)
+         │
+         └─→ Return provider-shaped response → CLI
+
+   NO UPSTREAM CALL on inference route.
+   Response Source: in-process ensemble result.
+```
+
+### Flow 2 — Static (no `$prompt`) turn (AFTER)
+
+```
+CLI Request: POST /v1/messages (active static spec, no $prompt)
+    │
+    └─→ [Frontend Inference Handler]
+         │
+         ├─→ Resolve static spec → cached resolved text (resolve_context())
+         │    └─→ If resolution fails OR yields None/empty → ERROR ENVELOPE (fail-loud; see §Static-spec fail-loud)
+         │
+         ├─→ Build provider-native envelope from resolved text
+         │
+         ├─→ session.save(<builder dict>) once
+         │
+         └─→ Return provider-shaped response → CLI
+
+   NO upstream call on inference route.
+   Static context is resolved at startup/first-request and cached (per spec name, process lifetime — see O10).
+   The CLI prompt is ignored (see O6 for multi-turn semantics).
+```
+
+### Flow 3 — Error flow (timeout / 502 / collected errors / in-process exception / static None)
+
+```
+CLI Request: POST <inference route>
+    │
+    └─→ [Frontend Inference Handler]
+         │
+         ├─→ Session enrichment
+         ├─→ URL4 resolution ($prompt or static), via either locus
+         │    │
+         │    └─ Any of: TimeoutError; /ensemble 502 (HTTPStatusError);
+         │       in-process Url4Interpreter exception; on_error=collect insufficient;
+         │       static spec resolves to None/empty
+         │       → Exception captured (or None-as-failure synthesized)
+         │
+         ├─→ extract_error_text(exc, spec_name, expression) → structured text+traceback
+         │
+         ├─→ Build ERROR envelope (fake-200, provider-shaped):
+         │    ├─→ is_streaming=true:
+         │    │    └─→ route the error text through the SAME success frame generator
+         │    │        (stream_<provider>_sse/ndjson) so a terminating frame is always sent
+         │    └─→ is_streaming=false:
+         │         └─→ single JSON error object with full error text in content
+         │
+         └─→ HTTP 200 provider-shaped fake response → CLI  (never HTTP 5xx)
+```
+
+**Streaming error helper contract (all four).** There is no separate "error streamer." The streaming error path extracts the error text and feeds it to the normal `stream_<provider>_*(error_text, model)` generator, guaranteeing the full terminating frame set. This also fixes a pre-existing bug: today a **streaming** request that hits a `$prompt` resolution error returns a **unary** `JSONResponse` (claude proxy.py:213–224; codex:299; gemini:250/269; ollama:260/283), which streaming clients mishandle. After the rewrite, the handler branches on `is_streaming` before emitting the error.
+
+---
+
+## Component Spec: claude_frontend
+
+**Plugin path:** `apps/server/src/screamingface/plugins/claude_frontend/`
+**Inference route:** `POST /v1/messages`
+**Emulates:** Anthropic Messages API.
+
+### Current flow (before terminal rewrite)
+
+`proxy_messages` (`/v1/messages`) is a three-stage handler: (1) session enrichment; (2) URL4 context injection (`$prompt` via `resolve_prompt_expression()` or static via `resolve_static_context()`, each calling `embed_context()` and short-circuiting to a fake-200 error envelope via `_build_error_response()`); (3) forward to Anthropic via `_forward_streaming()` (402–474) / `_forward_unary()` (477–515). Helpers: `_embed_context` (136–153), `_inject_system_context` (126–133), `_extract_last_user_text` (72–96), `_replace_last_user_message` (99–123); `_url4_context.py`: `resolve_prompt_expression` (190–282), `resolve_static_context` (284–314), `_build_error_response` (47–84).
+
+### Resolve-helper contract change (resolves the ambiguity blocker)
+
+The resolve helpers change from "mutate `body`, return `JSONResponse | None`" to an explicit two-channel result. **Pinned shape:**
+
+```python
+# _url4_context.py — new signatures
+async def resolve_prompt_expression(...) -> tuple[str | None, JSONResponse | None]:
+    """Returns (resolved_text, None) on success, or (None, error_envelope_or_dict) on failure.
+    No longer calls embed_context(); no body mutation."""
+
+def resolve_static_context(...) -> tuple[str | None, JSONResponse | None]:
+    """Returns (resolved_text, None) on success. On failure OR None/empty result,
+    returns (None, error_response). Re-raises into the tuple's error channel rather
+    than swallowing (reverses the plugin_base swallow for the inference path)."""
+```
+
+The error channel carries the **envelope dict** (not a prebuilt `JSONResponse`) so the handler can render unary vs SSE. `_build_error_response()` is refactored to **return the envelope dict**; the handler wraps it in `JSONResponse` (unary) or feeds `content[0].text` to `stream_anthropic_sse` (streaming).
+
+### Terminal rewrite — new inference handler
+
+```python
+@router.post("/v1/messages", response_model=None, operation_id="proxy_messages")
+async def proxy_messages(request: Request) -> Response:
+    body = await request.json()
+    is_streaming = body.get("stream", False)
+    model = body.get("model", "claude-opus-4-1-20250805")
+
+    # Stage 1: Session enrichment (unchanged)
+    session = SessionHook.from_request(...)
+    body = await session.enrich(body, tracer=_tracer)
+
+    # Stage 2: URL4 resolution → terminal
+    raw_expression = plugin.get_active_expression() if plugin else None
+    resolved_text, error_dict = None, None
+    if raw_expression and "$prompt" in raw_expression:
+        resolved_text, error_dict = await resolve_prompt_expression(body, ...)
+    elif raw_expression:
+        resolved_text, error_dict = resolve_static_context(...)
+
+    # Stage 3: Error path (branched on is_streaming)
+    if error_dict is not None:
+        error_text = error_dict["content"][0]["text"]
+        if is_streaming:
+            return StreamingResponse(stream_anthropic_sse(error_text, model),
+                                     media_type="text/event-stream")
+        return JSONResponse(content=error_dict)
+
+    # Stage 4: Success
+    if is_streaming:
+        async def gen():
+            async for chunk in stream_anthropic_sse(resolved_text, model):
+                yield chunk
+        # session.save receives the SAME dict the streamer encodes (not re-parsed frames)
+        await session.save(build_anthropic_message(resolved_text, model),
+                           streaming=True, tracer=_tracer)
+        return StreamingResponse(gen(), media_type="text/event-stream")
+
+    response_dict = build_anthropic_message(resolved_text, model)
+    await session.save(response_dict, streaming=False, tracer=_tracer)
+    return JSONResponse(content=response_dict)
+```
+
+**Deleted (`proxy.py`):** `_forward_streaming()` (402–474), `_forward_unary()` (477–515), `_inject_system_context()` (126–133), `_embed_context()` (136–153), upstream URL construction (240–244).
+
+**KEEP:** `_extract_last_user_text()`, `_replace_last_user_message()` (input fork). `/v1/{path}` and `/api/{path}` passthroughs (see Non-inference table).
+
+### Non-streaming envelope — `build_anthropic_message(result, model)`
+
+```json
+{
+  "id": "msg_<random_hex>",
+  "type": "message",
+  "role": "assistant",
+  "content": [{"type": "text", "text": "<result_string>"}],
+  "model": "<model_param>",
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 0,
+    "output_tokens": 0,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0
+  }
+}
+```
+
+### Synthetic SSE — `stream_anthropic_sse(result, model)`
+
+Exact wire format: `event:` lines, **blank-line (`\n\n`) terminated**, with at least one `ping` after `message_start`, no `[DONE]`. Frame order:
+`message_start` → `ping` → `content_block_start` → `content_block_delta` (whole text in ONE delta) → `content_block_stop` → `message_delta` → `message_stop`.
+
+```
+event: message_start
+data: {"type": "message_start", "message": {"id": "msg_a1b2c3d4e5f6", "type": "message", "role": "assistant", "content": [], "model": "claude-opus-4-1-20250805", "stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": 0, "output_tokens": 0, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}}}
+
+event: ping
+data: {"type": "ping"}
+
+event: content_block_start
+data: {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}
+
+event: content_block_delta
+data: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "User-agent: *\nDisallow: /"}}
+
+event: content_block_stop
+data: {"type": "content_block_stop", "index": 0}
+
+event: message_delta
+data: {"type": "message_delta", "delta": {"stop_reason": "end_turn", "stop_sequence": null}, "usage": {"output_tokens": 0}}
+
+event: message_stop
+data: {"type": "message_stop"}
+```
+
+```python
+async def stream_anthropic_sse(result: str, model: str) -> AsyncIterator[bytes]:
+    import json, uuid
+    msg_id = f"msg_{uuid.uuid4().hex[:12]}"
+
+    def sse(event_name: str, payload: dict) -> bytes:
+        return f"event: {event_name}\ndata: {json.dumps(payload)}\n\n".encode("utf-8")
+
+    yield sse("message_start", {"type": "message_start", "message": {
+        "id": msg_id, "type": "message", "role": "assistant", "content": [],
+        "model": model, "stop_reason": None, "stop_sequence": None,
+        "usage": {"input_tokens": 0, "output_tokens": 0,
+                  "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}}})
+    yield sse("ping", {"type": "ping"})
+    yield sse("content_block_start", {"type": "content_block_start", "index": 0,
+              "content_block": {"type": "text", "text": ""}})
+    yield sse("content_block_delta", {"type": "content_block_delta", "index": 0,
+              "delta": {"type": "text_delta", "text": result}})
+    yield sse("content_block_stop", {"type": "content_block_stop", "index": 0})
+    yield sse("message_delta", {"type": "message_delta",
+              "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+              "usage": {"output_tokens": 0}})
+    yield sse("message_stop", {"type": "message_stop"})
+```
+
+The same generator renders the error path (the error text becomes the single `content_block_delta`), so the CLI always receives a terminating `message_stop`.
+
+### Error envelope (`build_anthropic_message`-shaped, fake-200)
+
+```json
+{
+  "id": "sf_error_<hex>",
+  "type": "message",
+  "role": "assistant",
+  "content": [{"type": "text", "text": "[url4 error] <spec_name>\n\nExpression: <truncated>\n\nError: <exc_type>: <exc_msg>\n\nTraceback:\n<full_tb>"}],
+  "model": "<model_from_body>",
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {"input_tokens": 0, "output_tokens": 0, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
+}
+```
+
+---
+
+## Component Spec: codex_frontend
+
+**Plugin:** `codex-frontend`
+**Plugin path:** `apps/server/src/screamingface/plugins/codex_frontend/`
+**Inference route:** `POST /v1/responses`
+**Emulates:** OpenAI Responses API.
+
+### Current flow (before terminal rewrite)
+
+`proxy_responses(request)` (`proxy.py:210–418`): session enrichment; URL4 injection (`$prompt` 236–299 / static 300–324, both via `_embed_context`); upstream forward (streaming + non-streaming, 327–418) with `_parse_sse_response` (117–178) to reconstruct for session save; `/v1/{path}` catchall (420–450). `_inject_system_context` (89–95), `_embed_context` (98–114) are dead after rewrite.
+
+### Terminal rewrite — new handler
+
+```python
+async def proxy_responses(request: Request) -> Response:
+    body = await request.json()
+    is_streaming = body.get("stream", False)
+    model = body.get("model", "unknown")
+
+    session_id = extract_session_id(request)
+    enrich_body_from_hooks(body, session_id)
+
+    raw_expression = plugin.get_active_expression()
+    resolved_text, exc = None, None
+    try:
+        if raw_expression and "$prompt" in raw_expression:
+            blob_key = store_blob(extract_last_user_text(body))
+            substituted = raw_expression.replace("$prompt", f"/data/{blob_key}")
+            resolved_text = await resolve(substituted)         # /ensemble or in-process
+        elif raw_expression:
+            resolved_text = plugin.resolve_context()
+            if resolved_text is None or resolved_text == "":
+                raise RuntimeError("static spec resolved to empty (fail-loud)")
+    except Exception as e:
+        exc = e
+
+    if exc is not None:
+        error_text = extract_error_text(exc, spec_name, raw_expression or "")
+        if is_streaming:
+            return StreamingResponse(stream_openai_sse(error_text, model, status="failed"),
+                                     media_type="text/event-stream")
+        return JSONResponse(content=build_openai_response(error_text, model, status="failed"),
+                            status_code=200)
+
+    if is_streaming:
+        await hooks_save(session_id, build_openai_response(resolved_text, model))  # same dict, not re-parsed
+        return StreamingResponse(stream_openai_sse(resolved_text, model),
+                                 media_type="text/event-stream")
+    response_dict = build_openai_response(resolved_text, model)
+    await hooks_save(session_id, response_dict)
+    return JSONResponse(content=response_dict, status_code=200)
+```
+
+`build_openai_response`/`stream_openai_sse` take an optional `status="completed"` param; the error path passes `status="failed"`.
+
+### Non-streaming envelope — `build_openai_response(result, model, status="completed")`
+
+Adds `created_at` (required int unix timestamp — fixes the decode-error blocker) and a full output item with `id`, `status`, and `content`:
+
+```python
+def build_openai_response(result: str, model: str, status: str = "completed") -> dict[str, Any]:
+    import uuid, time
+    resp_id = f"resp_{uuid.uuid4().hex[:12]}"
+    item_id = f"msg_{uuid.uuid4().hex[:12]}"
+    return {
+        "id": resp_id,
+        "object": "response",
+        "created_at": int(time.time()),
+        "model": model,
+        "status": status,                       # "completed" or "failed"
+        "output": [
+            {
+                "id": item_id,
+                "type": "message",
+                "status": "completed",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": result, "annotations": []}],
+            }
+        ],
+        "usage": {
+            "input_tokens": 0, "output_tokens": 0, "total_tokens": 0,
+            "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0,
+        },
+    }
+```
+
+### Synthetic SSE — `stream_openai_sse(result, model, status="completed")`
+
+**Fixes (blockers/majors):** blank-line `\n\n` framing; the full canonical Responses event sequence including `content_part.added/.done` and `output_text.done`; `status="in_progress"` (not `"processing"`); stable `item_id` across all item/part/delta/done events; `created_at`; `sequence_number`, `output_index`, `content_index` on the relevant events; no `[DONE]`.
+
+Event order (one delta carrying the entire text):
+`response.created` → `response.in_progress` → `response.output_item.added` → `response.content_part.added` → `response.output_text.delta` → `response.output_text.done` → `response.content_part.done` → `response.output_item.done` → `response.completed`.
+
+```python
+async def stream_openai_sse(result: str, model: str, status: str = "completed") -> AsyncIterator[bytes]:
+    import json, uuid, time
+    resp_id = f"resp_{uuid.uuid4().hex[:12]}"
+    item_id = f"msg_{uuid.uuid4().hex[:12]}"
+    created = int(time.time())
+    seq = 0
+
+    def event(payload: dict) -> bytes:
+        nonlocal seq
+        payload.setdefault("sequence_number", seq)
+        seq += 1
+        return f"data: {json.dumps(payload)}\n\n".encode("utf-8")
+
+    base_resp = {"id": resp_id, "object": "response", "created_at": created,
+                 "model": model, "output": [], "usage": None}
+
+    yield event({"type": "response.created",
+                 "response": {**base_resp, "status": "in_progress"}})
+    yield event({"type": "response.in_progress",
+                 "response": {**base_resp, "status": "in_progress"}})
+    yield event({"type": "response.output_item.added", "output_index": 0,
+                 "item": {"id": item_id, "type": "message", "status": "in_progress",
+                          "role": "assistant", "content": []}})
+    yield event({"type": "response.content_part.added", "item_id": item_id,
+                 "output_index": 0, "content_index": 0,
+                 "part": {"type": "output_text", "text": "", "annotations": []}})
+    yield event({"type": "response.output_text.delta", "item_id": item_id,
+                 "output_index": 0, "content_index": 0, "delta": result})
+    yield event({"type": "response.output_text.done", "item_id": item_id,
+                 "output_index": 0, "content_index": 0, "text": result})
+    yield event({"type": "response.content_part.done", "item_id": item_id,
+                 "output_index": 0, "content_index": 0,
+                 "part": {"type": "output_text", "text": result, "annotations": []}})
+    yield event({"type": "response.output_item.done", "output_index": 0,
+                 "item": {"id": item_id, "type": "message", "status": "completed",
+                          "role": "assistant",
+                          "content": [{"type": "output_text", "text": result, "annotations": []}]}})
+    yield event({"type": "response.completed",
+                 "response": {**base_resp, "status": status,
+                              "output": [{"id": item_id, "type": "message", "status": "completed",
+                                          "role": "assistant",
+                                          "content": [{"type": "output_text", "text": result,
+                                                       "annotations": []}]}],
+                              "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0,
+                                        "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}}})
+```
+
+Validate against the codebase's `codex_backend_api/sse_parser.py` AND a real Codex CLI smoke test.
+
+### Error envelope (`status:"failed"`, HTTP 200) — full schema
+
+Identical structure to `build_openai_response` with `status="failed"` and the error text in `output[0].content[0].text`:
+
+```json
+{
+  "id": "sf_error_<hex>",
+  "object": "response",
+  "created_at": 1750000000,
+  "model": "<model>",
+  "status": "failed",
+  "output": [
+    {
+      "id": "msg_<hex>",
+      "type": "message",
+      "status": "completed",
+      "role": "assistant",
+      "content": [{"type": "output_text", "text": "[url4 error] <ClassName>: <message>\n\nExpression: <truncated>\n\nTraceback:\n...", "annotations": []}]
+    }
+  ],
+  "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
+}
+```
+
+### Deletions / retained (`codex_frontend/proxy.py`)
+
+- DELETE: `_inject_system_context()` (89–95), `_embed_context()` (98–114), `_parse_sse_response()` (117–178, no upstream stream to parse), `$prompt` path (236–299), static path (300–324), upstream forwarding + post-upstream save (327–418).
+- KEEP: `_extract_last_user_text()` (50–69), `_replace_user_text()` (72–86), `_build_headers()` (198–208, catchall only), `/v1/{path}` catchall.
+
+---
+
+## Component Spec: gemini_frontend
+
+**Plugin path:** `apps/server/src/screamingface/plugins/gemini_frontend/`
+**Inference verbs:** `POST .../{model}:generateContent` (unary), `POST .../{model}:streamGenerateContent` (streaming).
+**Passthrough verbs (CRITICAL):** `:countTokens`, `:embedContent`, `:batchEmbedContents`, any other `:`-suffixed POST verb, and all GET — these MUST forward upstream.
+**Emulates:** Google Gemini API.
+
+### Single-route verb disambiguation (fixes the route blocker)
+
+Ground truth: there is ONE handler `proxy_gemini(request, model_path)` bound to `/v1beta/models/{model_path:path}` (proxy.py:140–146). The `{model_path:path}` capture swallows the verb suffix (`:countTokens`, `:embedContent`, `:generateContent`, `:streamGenerateContent`) — ALL of these hit `proxy_gemini`, NOT the `/v1beta/{path}` catchall. Therefore the handler MUST itself branch:
+
+```python
+async def proxy_gemini(request: Request, model_path: str) -> Response:
+    is_inference = model_path.endswith(":generateContent") or model_path.endswith(":streamGenerateContent")
+    if request.method == "GET" or not is_inference:
+        # Passthrough: model metadata, :countTokens, :embedContent, :batchEmbedContents, etc.
+        return await forward_upstream(request, f"{upstream_url}/v1beta/models/{model_path}")
+
+    # Inference path (terminal)
+    is_streaming = model_path.endswith(":streamGenerateContent")
+    body = await request.json()
+    model = model_path.split(":")[0].split("/")[-1]
+    # session enrich (unchanged) ...
+    # resolve ($prompt or static, fail-loud on None/empty static) ...
+    if is_streaming:
+        alt_sse = "alt=sse" in str(request.url.query)
+        return StreamingResponse(
+            stream_gemini_chunks(resolved_text, model, alt_sse=alt_sse),
+            media_type="text/event-stream" if alt_sse else "application/json",
+        )
+    return JSONResponse(content=build_gemini_response(resolved_text, model), status_code=200)
+```
+
+**Allow-list is explicit:** only `:generateContent`/`:streamGenerateContent` terminate; everything else forwards upstream from inside `proxy_gemini`. A `:countTokens` request returns a real token count (forwarded), NOT a synthesized text answer. Add a regression test asserting `:countTokens` forwards upstream.
+
+### Non-streaming envelope — `build_gemini_response(result, model)`
+
+```json
+{
+  "candidates": [
+    {
+      "content": {"role": "model", "parts": [{"text": "<result>"}]},
+      "finishReason": "STOP",
+      "index": 0,
+      "safetyRatings": []
+    }
+  ],
+  "usageMetadata": {"promptTokenCount": 0, "candidatesTokenCount": 0, "totalTokenCount": 0},
+  "modelVersion": "<model>"
+}
+```
+
+camelCase `usageMetadata` is authoritative (resolves O1 for gemini). `modelVersion` is included (cheap, matches real output); `responseId` may be added if a CLI requires it (see **O12**).
+
+```python
+def build_gemini_response(result: str, model: str) -> dict:
+    return {
+        "candidates": [{
+            "content": {"role": "model", "parts": [{"text": result}]},
+            "finishReason": "STOP", "index": 0, "safetyRatings": []
+        }],
+        "usageMetadata": {"promptTokenCount": 0, "candidatesTokenCount": 0, "totalTokenCount": 0},
+        "modelVersion": model,
+    }
+```
+
+### Streaming — `stream_gemini_chunks(result, model, alt_sse=False)`
+
+**Resolves O4 in favor of the JSON ARRAY default** (matching Google's real `streamGenerateContent` REST wire format; fixes the body/Content-Type contradiction blocker).
+
+- **`?alt=sse`** → `text/event-stream`, `data: <obj>\n\n`, no `[DONE]`:
+  ```
+  data: {"candidates": [{"content": {"role": "model", "parts": [{"text": "<result>"}]}, "finishReason": "STOP", "index": 0, "safetyRatings": []}], "usageMetadata": {"promptTokenCount": 0, "candidatesTokenCount": 0, "totalTokenCount": 0}, "modelVersion": "<model>"}
+
+  ```
+- **default (no `?alt=sse`)** → `application/json`, a true JSON ARRAY `[ <obj> ]`:
+  ```
+  [{"candidates": [{"content": {"role": "model", "parts": [{"text": "<result>"}]}, "finishReason": "STOP", "index": 0, "safetyRatings": []}], "usageMetadata": {"promptTokenCount": 0, "candidatesTokenCount": 0, "totalTokenCount": 0}, "modelVersion": "<model>"}]
+  ```
+
+```python
+async def stream_gemini_chunks(result: str, model: str, alt_sse: bool = False) -> AsyncIterator[bytes]:
+    import json
+    obj = build_gemini_response(result, model)
+    if alt_sse:
+        yield f"data: {json.dumps(obj)}\n\n".encode("utf-8")
+    else:
+        # JSON array framing so application/json is honest
+        yield b"["
+        yield json.dumps(obj).encode("utf-8")
+        yield b"]"
+```
+
+The same generator renders the streaming error path (error text as the single chunk's `parts[0].text`, `finishReason: STOP`).
+
+### Error envelope (fake-200)
+
+```json
+{
+  "candidates": [
+    {
+      "content": {"role": "model", "parts": [{"text": "[url4 error] TimeoutError: Spec resolution timed out after 1200.0s\n\nTraceback:\n..."}]},
+      "finishReason": "STOP",
+      "index": 0,
+      "safetyRatings": []
+    }
+  ],
+  "usageMetadata": {"promptTokenCount": 0, "candidatesTokenCount": 0, "totalTokenCount": 0},
+  "modelVersion": "<model>"
+}
+```
+
+On streaming, emit a single error chunk in the negotiated format (SSE `data: {...}\n\n` iff `?alt=sse`, else `[ {...} ]`).
+
+### Session save (explicit decision — fixes the asymmetry major)
+
+Ground truth: gemini's inference path **enriches** (`session.enrich_request`, proxy.py:171) but has **NO** `save_response` today. **Decision:** gemini remains **save-less** in this work — it keeps `enrich_request` and gains NO new save. The shared-changes table and test matrix below reflect this: **no gemini session-persistence tests**. (Adding save to gemini is explicitly out of scope; tracked as **O7b** if desired later.)
+
+### Deletions / retained (`gemini_frontend/proxy.py`)
+
+- DELETE: `_embed_context()` (93–109), `_inject_system_context()` (83–91), upstream-forward block on the inference branch (282–310).
+- REPURPOSE: `$prompt` block (191–231) and static block (251–271) — drop the `_embed_context()` call; `resolved_text` flows into the builders; static None/empty → fail-loud error envelope.
+- KEEP: verb-disambiguation passthrough (GET + non-generate POST verbs → upstream), `_build_headers()` (128–138), session enrichment (167–187), `/v1beta/{path}` catchall (318–342).
+- `_extract_last_user_text()`, `_replace_user_text()` retained for the input fork.
+
+---
+
+## Component Spec: ollama_frontend
+
+**Status:** FIRST-CLASS IN SCOPE. Backend service emulating the Ollama HTTP API.
+**Plugin path:** `apps/server/src/screamingface/plugins/ollama_frontend/`
+**Inference route:** `POST /api/chat`
+**Streaming wire format:** **NDJSON (`application/x-ndjson`) — NOT SSE.** One complete JSON object per line, no `data:` prefix, no blank-line separators, no `[DONE]`.
+
+### Current flow (status quo)
+
+`proxy_chat(request)` parses JSON, runs session enrichment + url4 resolution, `_embed_context()` into the body, forwards to upstream Ollama (`client.stream` :342 NDJSON relay; `client.post` :407/:415 unary). Injection paths: static (261–291) and dynamic `$prompt` (164–260). Embedding helpers: `_inject_system_message` (67–82), `_extract_last_user_text` (47–56), `_embed_context` (84–103). `_ndjson.parse_ndjson_response()` reconstructs for session save.
+
+### Terminal rewrite — ensemble-first inference
+
+```python
+async def proxy_chat(request: Request) -> Response:
+    body = await request.json()
+    is_streaming = body.get("stream", True)   # Ollama defaults stream=true
+    model = body.get("model", "unknown")
+
+    # 1. Session enrichment (unchanged)
+    # 2. Resolve spec → string
+    raw_expression = plugin.get_active_expression() if plugin else None
+    resolved_text, exc = None, None
+    try:
+        if raw_expression and "$prompt" in raw_expression:
+            resolved_text = await _resolve_prompt_expression(...)   # /ensemble or in-process
+        elif raw_expression:
+            resolved_text = plugin.resolve_context()
+            if resolved_text is None or resolved_text == "":
+                raise RuntimeError("static spec resolved to empty (fail-loud)")
+    except Exception as e:
+        exc = e
+
+    # 3. Error path
+    if exc is not None:
+        error_text = extract_error_text(exc, spec_name, raw_expression or "")
+        if is_streaming:
+            return StreamingResponse(stream_ollama_ndjson(error_text, model),
+                                     media_type="application/x-ndjson")
+        return JSONResponse(content=build_ollama_response(error_text, model))
+
+    # 4. Success
+    if is_streaming:
+        # session.save receives the same dict the streamer encodes (not re-parsed frames)
+        await _save_session(build_ollama_response(resolved_text, model))
+        return StreamingResponse(stream_ollama_ndjson(resolved_text, model),
+                                 media_type="application/x-ndjson")
+    response_dict = build_ollama_response(resolved_text, model)
+    await _save_session(response_dict)
+    return JSONResponse(content=response_dict)
+```
+
+The error path reuses `stream_ollama_ndjson`/`build_ollama_response` with the error text as `message.content` — no abbreviated frames.
+
+### Non-streaming envelope — `build_ollama_response(result, model)`
+
+```json
+{
+  "model": "<model>",
+  "created_at": "2025-06-04T00:00:00Z",
+  "message": {"role": "assistant", "content": "<result>"},
+  "done": true,
+  "done_reason": "stop",
+  "total_duration": 0,
+  "load_duration": 0,
+  "prompt_eval_count": 0,
+  "prompt_eval_duration": 0,
+  "eval_count": 0,
+  "eval_duration": 0
+}
+```
+
+### Streaming — `stream_ollama_ndjson(result, model)` (NDJSON, not SSE)
+
+Two complete NDJSON objects, **each structurally complete** (every frame, including the terminal `done` frame, carries a `message` field — fixes the abbreviated-frame major). The whole resolved text rides in the first frame's `message.content`; the terminal frame has empty content and `done:true`.
+
+```
+{"model":"<model>","created_at":"2025-06-04T00:00:00Z","message":{"role":"assistant","content":"<result>"},"done":false}
+{"model":"<model>","created_at":"2025-06-04T00:00:00Z","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop","total_duration":0,"load_duration":0,"prompt_eval_count":0,"prompt_eval_duration":0,"eval_count":0,"eval_duration":0}
+```
+
+```python
+async def stream_ollama_ndjson(result: str, model: str) -> AsyncIterator[bytes]:
+    import json
+    created = "2025-06-04T00:00:00Z"
+    yield (json.dumps({
+        "model": model, "created_at": created,
+        "message": {"role": "assistant", "content": result},
+        "done": False,
+    }) + "\n").encode("utf-8")
+    yield (json.dumps({
+        "model": model, "created_at": created,
+        "message": {"role": "assistant", "content": ""},
+        "done": True, "done_reason": "stop",
+        "total_duration": 0, "load_duration": 0, "prompt_eval_count": 0,
+        "prompt_eval_duration": 0, "eval_count": 0, "eval_duration": 0,
+    }) + "\n").encode("utf-8")
+```
+
+> **Note (simplification, intentional):** real Ollama emits one NDJSON object per model chunk; this synthesizes the whole result in a single content frame plus a terminal `done` frame. The Ollama python/JS clients and `ollama run` accumulate `message.content` across frames and stop on `done:true`, so the single-content-frame form is accepted. Every frame is a complete JSON object on its own line; this is NOT SSE.
+
+### Error envelope (fake-200)
+
+`build_ollama_response(error_text, model)` (unary) and `stream_ollama_ndjson(error_text, model)` (streaming) — the error text rides in `message.content`; the terminal frame still carries a complete `message` field.
+
+### Deleted vs retained (`ollama_frontend/proxy.py`)
+
+- DELETE: `_embed_context()` (84–103), `_inject_system_message()` (67–82), upstream forward paths (`client.stream` :342, `client.post` :407/:415, URL/header build :304–313), session save on upstream response (363–391, 423–441 — replaced with save on the builder dict). Remove the `embed_target` default override (settings line 37).
+- KEEP: session enrichment hooks, tracer, `/api/{path}` passthrough (446–453), header forwarding, `_build_headers()` (116–127). `_extract_last_user_text()` retained for the `$prompt` input fork. `_ndjson.parse_ndjson_response()` is no longer needed on the inference path (save receives the builder dict directly) but is retained if used elsewhere.
+
+### Non-inference passthrough: `/api/{path}` (`proxy_passthrough()` :446–453)
+
+`GET /api/tags`, `GET /api/show`, `POST /api/pull`, `POST /api/embeddings` forward unchanged to `upstream_url/api/{path}`. **Model-existence divergence (documented, see O13):** synthesized `/api/chat` answers for a model that the upstream Ollama server may not host, while passthrough `/api/show`/`/api/tags` reflect the real upstream. Clients that gate chat on a successful `/api/show` may see an inconsistency. NOT in scope for the ensemble refactor.
+
+---
+
+## Component Spec: shared base & terminal_response module
+
+**Base classes:** `FrontendPluginBase`, `FrontendSettingsBase`.
+**New module:** `frontend_base/terminal_response.py` (sole owner of all eight builders/streamers + shared helpers).
+
+### Resolve return contract
+
+Core (`frontend_base/plugin_base.py`):
+- `resolve_context()` (242–297): returns resolved string or `None`; caches by spec name (process lifetime, no TTL — see **O10**); skips `$prompt` specs (deferred per-request). **Behavior change for the inference path:** a `None`/empty result for a set `raw_expression` is treated as a failure by the inference handler (fail-loud), NOT silently proceeded. The swallow at 279–283 remains for non-inference/other callers but is overridden at the inference call site.
+- `_fetch_sync()` (310–336): synchronous wrapper around `_fetch()` in a daemon thread with timeout; #244 fail-loud preserved.
+- `_fetch()` (412–417): GET `/ensemble`; `raise_for_status()`; returns plain text.
+
+**Changed responsibility:** the per-provider resolve helpers **return the resolved string (or raise / signal error)** instead of returning `None` and embedding via a side-effect. They **no longer call `embed_context()`**; the inference handler injects the text into the response envelope.
+
+### `frontend_base/terminal_response.py`
+
+Centralizes the structured error-text formatter (single source — resolves the error-format-consistency major), the usage-zeroing supersets, and all eight builders/streamers.
+
+```python
+# frontend_base/terminal_response.py
+from typing import AsyncIterator
+import json, traceback
+
+def extract_error_text(exc: Exception, spec_name: str, expression: str) -> str:
+    """SINGLE structured error text shared across ALL providers (no provider envelope).
+    Handles both httpx HTTPStatusError (502 path) and raw Url4Interpreter exceptions."""
+    tb_str = "".join(traceback.format_exception(exc))
+    return (
+        f"[url4 error] {spec_name}\n\n"
+        f"Expression: {expression[:200]}\n\n"
+        f"Error: {exc.__class__.__name__}: {exc}\n\n"
+        f"Traceback:\n{tb_str}"
+    )
+
+def zeroed_usage(provider: str) -> dict:
+    """Superset-of-zeros per provider (see §Usage field shapes)."""
+    ...
+
+# builders/streamers (signatures pinned in Locked Decisions) ...
+```
+
+**All four frontends call `extract_error_text()`** for the error body; per-frontend error formatting is removed (resolves the "pinned shared function AND per-frontend formatting" contradiction — pick the shared function).
+
+**Resolved-text injection target per provider:** Anthropic → `content[0].text`; OpenAI → `output[0].content[0].text`; Gemini → `candidates[0].content.parts[0].text`; Ollama → `message.content`.
+
+### Settings changes — `embed_target`, `embed_mode`, `system_prompt`
+
+**O2 is escalated, not pinned here** (see Open Questions). To keep the rewrite implementable regardless of the O2 outcome, the **interim, non-breaking behavior** is fixed: the inference paths **stop reading** `embed_target`/`embed_mode`/`system_prompt` (the `_embed_context` calls are deleted), but the fields **remain defined** in `FrontendSettingsBase` (and the ollama `embed_target` override is removed since it is now meaningless). Whether to then HARD-REMOVE the fields (breaking configs that set them) or SOFT-DEPRECATE (keep defined, log a warning when present, ignore) is **O2**. This avoids the internal contradiction (deleting fields the rewrite cannot proceed without deciding) by separating "stop using" (locked) from "remove the field" (O2).
+
+**Retained regardless:** `upstream_url` (non-inference passthrough), `active_spec`, `backend_url`, `resolve_timeout`, `session_service_url`, remainder of `FrontendSettingsBase`.
+
+### Summary of shared changes
+
+| Component | Change | Effect |
+|-----------|--------|--------|
+| `FrontendSettingsBase` | Stop READING `embed_target`/`embed_mode`/`system_prompt` on inference; field removal gated on O2 | Interim: defined-but-unused |
+| `FrontendPluginBase.resolve_context()` | Signature unchanged; inference call site treats None/empty (set spec) as failure | 242–297 + handler override |
+| `resolve_prompt_expression()` / `resolve_static_context()` (all) | Return resolved string (or error dict); no embed | Body refactored |
+| Per-provider `_embed_context()` / `_inject_system_*()` | Delete | No longer called |
+| Per-provider `_extract_last_user_text()` | Keep (input fork) | Usage restricted |
+| Inference handlers | Resolve → build/stream helpers; branch error on `is_streaming` | Per provider |
+| Non-inference routes | Continue upstream forwarding; bypass url4 entirely | Unchanged |
+| `frontend_base/terminal_response.py` | New module: sole owner of builders/streamers + `extract_error_text` | Shared |
+
+---
+
+## Non-inference endpoints (consolidated decision)
+
+All of these **KEEP their upstream forward** (use `upstream_url`); none touch the ensemble. **Passthrough routes MUST bypass url4 entirely and forward the request body UNMODIFIED to upstream — unchanged by the rewrite.**
+
+| Frontend | Route(s) | Methods | Decision | Anchor |
+|----------|----------|---------|----------|--------|
+| claude | `/v1/{path:path}` catchall (e.g. `GET /v1/models`, OAuth, **`POST /v1/messages/count_tokens`**) | GET, POST | KEEP upstream forward (UNCHANGED) | proxy.py:287–289 |
+| claude | `/api/{path:path}` (telemetry, org mgmt) | GET, POST, PUT, PATCH, DELETE | KEEP upstream forward (UNCHANGED) | proxy.py:347–378 |
+| codex | `/v1/{path:path}` catchall (`/v1/models`, `/v1/assistants`, `/v1/threads/...`) | GET, POST | KEEP upstream forward (UNCHANGED) | proxy.py:420–450 |
+| gemini | `:countTokens`, `:embedContent`, `:batchEmbedContents`, other non-generate `:` verbs (POST) | POST | KEEP upstream forward (handled INSIDE `proxy_gemini` via verb allow-list) | proxy.py:140–164 |
+| gemini | `GET /v1beta/models/{model_path}` (model metadata / list) | GET | KEEP upstream forward (UNCHANGED) | proxy.py:159–162 |
+| gemini | `/v1beta/{path:path}` catchall (`/v1beta/cachedContent`, etc.) | GET, POST | KEEP upstream forward (UNCHANGED) | proxy.py:318–342 |
+| ollama | `/api/{path:path}` (`/api/tags`, `/api/show`, `/api/pull`, `/api/embeddings`) | GET, POST | KEEP upstream forward (UNCHANGED) | proxy.py:446–453 |
+
+Notes:
+- **Inference routes only:** claude `POST /v1/messages`; codex `POST /v1/responses`; gemini `POST .../{model}:generateContent` and `:streamGenerateContent`; ollama `POST /api/chat`.
+- **claude `POST /v1/messages/count_tokens`** is a passthrough: it does NOT match the exact `/v1/messages` route, falls to the `/v1/{path}` catchall, and MUST continue forwarding upstream. Add a regression test asserting it is NOT terminated. The synthesized `/v1/messages` handler must not swallow it.
+- **gemini `:countTokens`/`:embedContent`** hit `proxy_gemini` (the `:path` capture), NOT the `/v1beta/{path}` catchall — so the verb allow-list inside `proxy_gemini` is what keeps them as passthrough. Regression test required.
+- `upstream_url` and `_build_headers()` are retained **solely** for these passthrough routes.
+
+---
+
+## Error & Degraded Contract (PR #244 "blocking and screaming")
+
+1. **Block** on resolution. Default `resolve_timeout = 1200s`.
+2. **Triggers (uniform, locus-agnostic):** timeout; `/ensemble` 502 (httpx `HTTPStatusError`); in-process `Url4Interpreter` exception; `on_error=collect` insufficient partials; **static spec resolving to None/empty** (fail-loud override).
+3. **Loud, fake-200:** capture the exception (or synthesize one for the None-static case), format via `terminal_response.extract_error_text()` (url4 header, expression, error class+message, full traceback), build a provider-shaped **HTTP 200** envelope with the error text in the message body. **Never raise HTTPException; never return HTTP 5xx to the CLI.**
+4. **Branch on `is_streaming` for every provider, routing the error text through the SAME success frame generator:** claude `stream_anthropic_sse`; codex `stream_openai_sse(..., status="failed")`; gemini `stream_gemini_chunks` (SSE-or-JSON-array); ollama `stream_ollama_ndjson`. This guarantees a terminating frame and fixes the pre-existing streaming-request-gets-unary-error bug.
+5. **Negative cache + bounded/loop-aware fetch (#244) preserved:** `resolve_context()` cache (242–297) and `_fetch_sync()` thread+timeout (310–336) survive intact and feed the builders.
+
+Per-provider error status: claude fake-200 `stop_reason=end_turn`; codex HTTP 200 `status:"failed"`; gemini HTTP 200 `finishReason:"STOP"`; ollama HTTP 200 `done:true, done_reason:"stop"`.
+
+---
+
+## Unchanged: AIGateway & concurrency (#245)
+
+- The inference route no longer calls the upstream provider directly, so the **direct proxy leg is removed**.
+- The ensemble's **internal sub-calls** to `/claude`, `/codex`, `/gemini`, `/ollama` still go through AIGateway and respect per-provider concurrency caps (e.g., `AIGW_PROVIDER_MAX_CONCURRENCY_OVERRIDES={"anthropic":1}` per #245). UNCHANGED.
+- `/ensemble` (`url4_executor/routes.py:84–164`) continues to return a `PlainTextResponse` with the resolved string; non-ensemble shapes fall through to the base `Url4Interpreter` (routes.py:117–122). Its dispatch to internal backend sub-routes is unchanged.
+- **Grounding note:** verify the `/claude`,`/codex`,`/gemini` internal sub-routes' AIGateway dispatch when wiring tests; the cap behavior is asserted from #245 and must be confirmed against the sub-route definitions during M6.
+- **Frontend-side request concurrency** under the new blocking model is NOT capped by this spec — see **O14**.
+
+---
+
+## Test Strategy
+
+### Unit — builders & streamers
+
+- `build_anthropic_message`: role/content/usage-superset-zeros; `stop_reason=end_turn`.
+- `stream_anthropic_sse`: parse with a real SSE line-buffer (split on `\n\n`); assert sequence `message_start → ping → content_block_start → content_block_delta → content_block_stop → message_delta → message_stop`; full text present; no `[DONE]`.
+- `build_openai_response`: `created_at` present (int); `output[0]` has `id`/`status`/`content`; usage superset.
+- `stream_openai_sse`: split on `\n\n`, assert EACH event JSON-decodes independently; full canonical 9-event order; `status:"in_progress"` (not `processing`); stable `item_id` across events; `created_at`; `sequence_number` monotonic; no `[DONE]`.
+- `build_gemini_response`: schema, `finishReason=STOP`, camelCase `usageMetadata` zeros, `modelVersion` present.
+- `stream_gemini_chunks`: default emits a **JSON array** `[{...}]` parseable by `json.loads(whole_body)` with `application/json`; `alt_sse=True` emits `data: {...}\n\n` with `text/event-stream`.
+- `build_ollama_response` / `stream_ollama_ndjson`: `Content-Type: application/x-ndjson`; two NDJSON lines; EVERY line (incl. terminal) JSON-decodes and carries a `message` field; last line `done:true, done_reason:"stop"`; model echoed.
+- Newline preservation: result with embedded `\n` survives in the delta.
+
+### Integration — no upstream calls on inference
+
+Mock the resolution locus (`frontend_base.plugin_base._fetch_sync` for the HTTP path, or `Url4Interpreter.evaluate` for in-process), not the real provider. Assert a synthesized provider envelope containing the mocked text and NO httpx call to `api.anthropic.com` / `api.openai.com` / `generativelanguage.googleapis.com` / `localhost:11434`.
+
+```python
+async def test_proxy_returns_ensemble_result():
+    with mock.patch("frontend_base.plugin_base._fetch_sync") as mock_fetch:
+        mock_fetch.return_value = "Ensemble result text"
+        resp = client.post("http://localhost:9100/v1/messages", json={...})
+        mock_fetch.assert_called_once()
+        assert "Ensemble result text" in resp.json()["content"][0]["text"]
+```
+
+### Per-frontend E2E
+
+- codex streaming → synthetic OpenAI SSE; each event decodes independently; `status:"in_progress"`/`completed`; no `[DONE]`; no `api.openai.com`.
+- ollama streaming → `application/x-ndjson`; parse NDJSON; last line `done:true, done_reason:"stop"`; no upstream.
+- gemini: unary static spec; streaming `$prompt`; streaming `?alt=sse` (SSE) vs default (JSON array); **`:countTokens` forwards upstream (not synthesized)**; GET passthrough; `/v1beta/{path}` catchall.
+- claude: **`POST /v1/messages/count_tokens` forwards upstream** (regression).
+
+### Error-path tests
+
+- `test_<provider>_ensemble_timeout_returns_fake_200`: resolution raises `TimeoutError`; HTTP 200; `[url4 error]` + `timed out` in content.
+- `test_<provider>_streaming_error_terminates`: error + `stream=true`; assert error text in the stream AND a terminating frame (`message_stop` / `response.completed` / array-close / `done:true`).
+- `test_static_spec_none_is_fail_loud`: static spec resolves to None/empty → error envelope (NOT blank 200).
+- `test_in_process_interpreter_exception`: in-process locus raises → same error envelope shape as the 502 path.
+
+### Existing-test migration
+
+Tests asserting upstream httpx calls are rewritten to mock the resolution locus and assert no upstream call. Per-frontend:
+- claude `test_proxy.py`: replace `test_proxy_non_streaming`, `test_proxy_forwards_headers`; add SSE/error-streaming tests; rewrite `test_e2e_claude_frontend.py` to assert synthesized response; add catchall tests (`/v1/models`, `/api/*`, `count_tokens`).
+- codex: add unary, streaming (independent-event-decode), streaming-error, non-streaming-error, catchall, `$prompt`, static.
+- gemini `tests/test_proxy.py`: keep `TestExtractLastUserText`/`TestReplaceUserText`; delete `TestInjectSystemContext`/`TestEmbedContext`; add unary-static, streaming-`$prompt`, `?alt=sse` vs JSON-array default, timeout-fake-200, GET passthrough, `:countTokens` passthrough, catchall; new `tests/test_response_builders.py`. **No gemini session-persistence tests** (gemini stays save-less).
+- ollama `tests/test_proxy.py`: delete `test_inject_*`; update `test_non_streaming_passthrough_no_spec`, `test_streaming_ndjson_relay`, `test_prompt_spec_substitution`; keep `test_authorization_forwarded_other_stripped`, `test_catchall_passthrough_tags`; add empty-resolved-text, synthetic-NDJSON (complete frames), timeout (streaming + unary), model-echo, usage-zero. Swap upstream-mock fixtures for a mocked `plugin.resolve_context()` / `MockPlugin`.
+
+---
+
+## Docs to update
+
+- **README / architecture:** rename "Transparent Proxy" → "Ensemble-Terminal Frontend Proxy"; state inference routes no longer forward upstream; the ensemble (or in-process interpreter) is the only upstream-facing path, via its sub-routes/AIGateway.
+- **Plugin READMEs** (all four): remove "forwards to <upstream>"; add "terminal response synthesis"; ollama doc clarifies NDJSON (NOT SSE); gemini doc enumerates inference-vs-passthrough verbs.
+- **Settings/config docs:** mark `embed_target`/`embed_mode`/`system_prompt` no longer read on inference (deprecation pending O2).
+- **Error-handling docs:** document the fake-200 contract (timeout/502/in-process/static-None → HTTP 200 with error text), the `resolve_timeout` blocking window, the two resolution loci, and link to PR #244.
+- **CLAUDE.md:** add an "Inference Routes" section (before/after, concurrency model, two loci, #244 error contract, static-spec fail-loud behavior change).
+- **CHANGELOG.md:** new entry, including the static-spec fail-loud behavior change.
+
+---
+
+## Milestone Outline
+
+- **M1 — Shared terminal-response infrastructure (1–2 days):** create `frontend_base/terminal_response.py` (`extract_error_text`, `zeroed_usage`, the eight builders/streamers with pinned signatures and wire formats); add the inference-call-site fail-loud override for None/empty static results; unit tests for error paths (timeout, 502, in-process exception, partial results) and independent-event-decode for codex SSE. **All eight builder/streamer functions live exclusively here; per-frontend modules import/re-export only.**
+- **M2 — claude_frontend (1 day):** wire `build_anthropic_message` / `stream_anthropic_sse` (with `ping`, superset usage); refactor `proxy_messages()` and the resolve-helper tuple contract; delete `_forward_*`/`_embed_context`/`_inject_system_context`; keep `/v1/{path}` (+ `count_tokens` passthrough) + `/api/{path}`; unit + E2E (no `api.anthropic.com`).
+- **M3 — codex_frontend (1 day):** wire `build_openai_response` / `stream_openai_sse` (full canonical sequence, `created_at`, `in_progress`, stable item_id, `\n\n` framing); error envelope `status:"failed"`; unit + E2E.
+- **M4 — gemini_frontend (1 day):** wire `build_gemini_response` / `stream_gemini_chunks` (JSON-array default, SSE on `?alt=sse`); implement the verb allow-list inside `proxy_gemini` (`:countTokens`/`:embedContent` passthrough); gemini stays save-less; keep GET + `/v1beta/{path}` passthroughs; unit + E2E (incl. `:countTokens` passthrough).
+- **M5 — ollama_frontend (1 day):** wire `build_ollama_response` / `stream_ollama_ndjson` (complete frames, NDJSON not SSE); delete `_embed_context` + `_inject_system_message`; remove `embed_target` override; keep `/api/{path}` passthrough; unit + E2E.
+- **M6 — Testing, docs, integration (1–2 days):** migrate all proxy tests to mock the resolution locus; negative tests (no real-upstream calls on inference); verify non-inference routes still forward (incl. claude `count_tokens`, gemini `:countTokens`); confirm AIGateway sub-route dispatch (#245 grounding); cross-frontend integration (same spec → all four return the same result in their native format); docs/CLAUDE.md/changelog incl. static-spec fail-loud.
+
+### Success criteria
+
+1. All four frontends resolve inference via the ensemble (HTTP or in-process). 2. No HTTP calls to `api.anthropic.com` / `api.openai.com` / `generativelanguage.googleapis.com` / `localhost:11434` from inference routes. 3. HTTP 200 provider-native fake responses. 4. Streaming synthesized with a single delta carrying the full result, in the exact wire format (claude SSE `\n\n`+ping; codex SSE `\n\n`+full event sequence; gemini SSE-or-JSON-array; ollama NDJSON). 5. timeout/502/in-process/static-None → HTTP 200 with visible error text (never 5xx); streaming errors terminate. 6. Coverage: builders, streamers (independent-frame-decode), error paths, no-upstream integration, verb-passthrough regressions. 7. Docs + behavior-change notes updated. 8. Non-inference routes still forward upstream (incl. `count_tokens`, `:countTokens`, `:embedContent`). 9. AIGateway caps apply only to ensemble sub-calls. 10. All E2E tests pass with the resolution locus mocked.
+
+---
+
+## Open Questions / Risks
+
+- **O1 — RESOLVED.** Usage shapes pinned as supersets-of-zeros per provider (claude includes `cache_*`; codex full set; gemini camelCase `usageMetadata`; ollama duration/eval). Anthropic `Usage` is `extra="allow"` (models.py:134), so extra zero fields are safe. Confirm each CLI tolerates the superset during M6 smoke tests.
+- **O2 — Dead-settings removal vs graceful deprecation (ESCALATED, human decision).** The inference paths stop READING `embed_target`/`embed_mode`/`system_prompt` (locked). Whether to then HARD-REMOVE the fields from `FrontendSettingsBase` (breaks configs that set them; per-session override attempts fail validation) or SOFT-DEPRECATE (keep defined, log a warning, ignore) is undecided. Pick one before final field removal; the rewrite proceeds either way under the interim "defined-but-unused" state.
+- **O3 — RESOLVED.** Single shared `terminal_response.py` owns all eight builders/streamers; per-frontend modules import/re-export only.
+- **O4 — RESOLVED.** Gemini default (non-`?alt=sse`) streaming emits a true JSON ARRAY `[{...}]` with `application/json` (matching real `streamGenerateContent`); `?alt=sse` emits `data: {...}\n\n`. Verify against the actual Gemini CLI in M4/M6.
+- **O5 — RESOLVED.** The claude `$prompt` path uses the tuple-returning resolve helper (`(resolved_text, error_dict)`); no `resolved_text = last_user_text` placeholder.
+- **O5b — Empty `$prompt` result semantics (ESCALATED, human decision).** Distinct from static-None (which is fail-loud). If a `$prompt` spec legitimately resolves to `""`, is that an empty-but-valid assistant turn or an error? Decide uniformly across providers and add empty-result E2E tests for ALL four (not just ollama). Note Codex CLI may treat an empty `output` as incomplete — verify.
+- **O6 — Static-spec + CLI-prompt / multi-turn semantics (ESCALATED, human decision).** For predetermined (no `$prompt`) specs the CLI prompt is ignored and identical content (with fresh random id + zero usage) is returned every turn. Decide: (a) declare static-spec frontends single-turn/stateless and document that follow-ups are ignored, or (b) require the static path to incorporate the latest user turn. Interacts with **O11**.
+- **O7 — Session save on streaming (PARTIALLY RESOLVED).** Locked: streaming `session.save` receives the SAME dict produced by `build_<provider>_*()` directly (NOT re-parsed synthesized frames); fired exactly once. Open: whether error-envelope turns are persisted at all — escalated.
+- **O7b — Gemini session save (ESCALATED, scoped-out by default).** Gemini currently has NO `save_response` (only `enrich_request`). This spec keeps it save-less. Adding save is net-new behavior (build the save dict from the synthesized response) and is out of scope unless explicitly requested.
+- **O8 — Feature-flagged rollout (optional, human decision).** `SF_ENSEMBLE_TERMINAL_<FRONTEND>=true` per frontend with old code retained for rollback, vs direct cutover at M6.
+- **O9 — Multi-turn history into the ensemble (ESCALATED, human decision).** All four extractors take only the LAST user message. With no upstream, prior turns are lost — the ensemble sees only the latest turn. Decide: pass the full transcript as the blob, or document frontends as single-shot with intentionally-dropped history. Without a decision, multi-turn behavior silently regresses.
+- **O10 — Resolve cache lifecycle (ESCALATED, human decision).** `resolve_context()` caches per spec name for the process lifetime with no TTL/invalidation. Document behavior across live `active_spec` changes (a stale prior spec could be re-served if switched back); consider periodic re-resolution for static specs.
+- **O11 — Deterministic-vs-random id + non-zero usage for CLI budget logic (ESCALATED, human decision).** Fresh random ids and zero usage every turn may confuse CLI context-window accounting (always 0 tokens) and conversation-state keying. Decide id policy (random vs deterministic) and whether usage should report a plausible non-zero count. Interacts with O6.
+- **O12 — Gemini `responseId` (ESCALATED, low risk).** `modelVersion` is included; whether to also emit a synthetic `responseId` depends on CLI tolerance — verify in M4.
+- **O13 — Ollama model-existence divergence (ESCALATED, human decision).** Synthesized `/api/chat` answers for a model the upstream Ollama may not host, while passthrough `/api/show`/`/api/tags` reflect the real upstream. Decide whether to synthesize `/api/show`/`/api/tags` for the active model or require the upstream to host it.
+- **O14 — Frontend-side request concurrency / disconnect (ESCALATED, human decision).** Each `$prompt` turn now BLOCKS the request for up to `resolve_timeout` (1200s) on a full ensemble fan-out; N concurrent CLI turns = N concurrent fan-outs. The fake-stream computes the whole result BEFORE the first frame, so client disconnect/cancellation does not propagate to the in-flight ensemble, and the `_fetch_sync` daemon thread (plugin_base.py:326) cannot be cancelled today. Decide: a per-frontend in-flight concurrency limit/queue, and disconnect handling (`request.is_disconnected()` / `asyncio.CancelledError`) — call out the daemon-thread non-cancellability limitation.
+- **O15 — Startup auth / model-list dependency (ESCALATED, human decision).** Non-inference OAuth/model-list/`/api/show` routes still forward to the REAL upstream, so a CLI's startup auth/validation may still require valid real-provider credentials and may reject a fictitious ensemble model alias (the echoed `model`). Determine, per CLI, which startup calls must reach a real upstream, whether real provider keys remain mandatory, and whether model-list must be synthesized to include the active alias. If the goal is to run without real provider keys, the passthrough auth/model-list routes must also be stubbed — currently out of scope.
+- **O16 — Active spec terminating in a model call (ESCALATED, low priority).** The ensemble supports non-model expressions (raw fetch, collection reduce); `/ensemble` falls through to the base interpreter for non-ensemble shapes. Confirm whether the active spec is REQUIRED to end in a model/reducer call or may resolve to arbitrary url4 output, and whether wrapping non-model text as an assistant message with zeroed usage / `finishReason=STOP` is intended.
+
+---
+
+## Review Changelog
+
+**cli-compat lens**
+- Codex SSE single-`\n` framing (blocker) — FIXED inline: every codex SSE frame is `data: {json}\n\n`; test asserts each event decodes independently.
+- Gemini default non-SSE format pinned wrong (blocker) — FIXED inline (O4 resolved): default emits a true JSON ARRAY `[{...}]` with `application/json`; `?alt=sse` emits `data: {...}\n\n`.
+- Codex missing canonical events / malformed created+completed (blocker) — FIXED inline: full 9-event sequence (`response.created`, `in_progress`, `output_item.added`, `content_part.added`, `output_text.delta`, `output_text.done`, `content_part.done`, `output_item.done`, `completed`) with `created_at`, `output:[]`, item `id`/`status`/`content`, `sequence_number`/`output_index`/`content_index`.
+- Anthropic missing `ping` / "EXACT" overclaim (blocker) — FIXED inline: `ping` frame added after `message_start`; frame language softened to `message_start, ping*, content_block_start, content_block_delta+, content_block_stop, message_delta, message_stop`.
+- Codex `created_at` missing in unary+stream (major) — FIXED inline: `created_at: int(time.time())` added everywhere.
+- Gemini SSE/array media_type coupling (major) — FIXED inline: array default → `application/json`; SSE → `text/event-stream`.
+- Ollama abbreviated error frames (major) — FIXED inline: every NDJSON frame (incl. terminal `done`) carries a complete `message` field; error path reuses the full builder/streamer.
+- Codex `status:"processing"` invalid (major) — FIXED inline: `in_progress`/`completed`.
+- Gemini Content-Type vs body contradiction (major) — FIXED inline (JSON array + `application/json`).
+- Anthropic usage cache fields (minor) — RESOLVED inline: superset-of-zeros pinned (O1).
+- Gemini `modelVersion`/`responseId` (minor) — `modelVersion` ADDED inline; `responseId` escalated to O12.
+- Codex item-id inconsistency (minor) — FIXED inline: one stable `item_id` across all events; prose and code agree.
+- Anthropic streaming-error helper unspecified (question) — FIXED inline: streaming error routes the error text through the SAME `stream_anthropic_sse` generator (terminating `message_stop` guaranteed); same pattern for all four.
+- Empty ensemble result handling (question) — ESCALATED to O5b (uniform decision + E2E for all four).
+
+**completeness lens**
+- Gemini `:countTokens`/`:embedContent` mis-routed to synthesis (blocker) — FIXED inline: explicit inference verb allow-list inside `proxy_gemini`; all other `:` verbs + GET forward upstream; regression test required.
+- Claude `count_tokens` passthrough not locked (blocker) — FIXED inline: listed as a passthrough route; route-precedence confirmed (catchall, not exact `/v1/messages`); regression test required.
+- Static-spec identical-content/zero-usage multi-turn break (blocker) — ESCALATED to O6 (+ O11 for id/usage policy); single-turn-vs-incorporate-prompt decision surfaced.
+- Session save coupled to upstream stream / re-parse (major) — FIXED inline (O7): save receives the builder dict directly, not re-parsed frames.
+- Gemini has no `save_response` today (major) — FIXED inline: gemini stays save-less (O7b); session-persistence tests removed from the gemini matrix.
+- Static-spec resolution swallow vs fail-loud (major) — FIXED inline: inference handler treats None/empty static result as a failure (fail-loud override); documented as a deliberate behavior change.
+- In-process interpreter bypasses `/ensemble` 502 (major) — FIXED inline: §"Two resolution loci"; error contract is locus-agnostic ("any exception during resolution"); `extract_error_text` handles both.
+- Multi-turn history dropped (major) — ESCALATED to O9.
+- Client disconnect / cancellation (major) — ESCALATED to O14 (incl. daemon-thread non-cancellability).
+- OAuth/auth handshake still needs real upstream (major) — ESCALATED to O15.
+- Model-list dependency on real upstream (major) — ESCALATED to O15.
+- Ollama `/api/show` vs synthesized `/api/chat` divergence (major) — DOCUMENTED inline + ESCALATED to O13.
+- Gemini default-stream array (major, dup of cli-compat) — FIXED inline (JSON array).
+- Claude unary-error-on-streaming-request bug (minor) — FIXED inline: handler branches on `is_streaming`; `_build_error_response` refactored to return the dict.
+- Empty/None resolved text (minor) — ESCALATED to O5b.
+- Resolve cache no invalidation (minor) — ESCALATED to O10.
+- Spec must terminate in a model call? (question) — ESCALATED to O16.
+- Frontend request concurrency under blocking resolve (question) — ESCALATED to O14.
+
+**grounding & internal consistency lens**
+- Resolve-helper contract ambiguity (blocker) — FIXED inline: pinned tuple `(resolved_text, error_dict)`; no body mutation; `_build_error_response` returns a dict.
+- Settings-deletion vs O2 contradiction (blocker) — FIXED inline: separated "stop reading on inference" (locked) from "remove the field" (O2); interim defined-but-unused state keeps the rewrite implementable.
+- Builder placement unpinned (blocker) — FIXED inline (O3 resolved): single shared `terminal_response.py`; per-frontend re-export only.
+- Anthropic usage shape unvalidated (major) — FIXED inline: superset-of-zeros; grounded on `Usage` `extra="allow"` (models.py:134); CLI tolerance confirmed in M6.
+- Codex error envelope incomplete (major) — FIXED inline: full `status:"failed"` schema with `created_at`/`output`/`usage`, error text in `output[0].content[0].text`.
+- Ollama "one delta" vs real per-chunk NDJSON (major) — DOCUMENTED inline as an intentional simplification; format confirmed NDJSON (not SSE), complete frames; verify against real Ollama clients in M5/M6.
+- Inconsistent error formatting across providers (major) — FIXED inline: single shared `extract_error_text()`; per-frontend formatting removed.
+- Passthrough routes not confirmed url4-bypassing (major) — FIXED inline: explicit statement that passthrough routes bypass url4 and forward the body unmodified, unchanged by the rewrite.
+- AIGateway sub-call claim ungrounded (major) — ACKNOWLEDGED inline: grounding-note added; sub-route dispatch to be confirmed in M6 (route file referenced).
+- session.save contract missing (major) — FIXED inline: pseudocode shows save (builder dict) for unary and streaming in all handlers (O7).
+- Gemini streaming format unvalidated (minor) — RESOLVED inline (O4 JSON array); CLI verification in M4/M6.
+- $prompt-vs-static UX intent (minor) — ESCALATED to O6.
+- Cache lifecycle in terminal context (minor) — ESCALATED to O10.
+- Helper signatures lacking (minor) — FIXED inline: formal signatures pinned in Locked Decisions.
+- Milestone placement ambiguity (minor) — FIXED inline: M1 states all eight functions live exclusively in `terminal_response.py`; per-frontend re-export only.
+
+**Rejected findings:** none. No finding recommended excluding `ollama_frontend` or any other frontend; all four remain first-class terminal endpoints. Ollama's streaming wire format is kept as NDJSON (`application/x-ndjson`, one complete JSON object per line) and is explicitly NOT conflated with SSE throughout.


### PR DESCRIPTION
## Summary
Reframes `claude_frontend` from a transparent proxy into a **terminal ensemble endpoint**: `POST /v1/messages` now resolves the active url4 spec in-process via `/ensemble` and returns the ensemble's reduced output wrapped in the Anthropic Messages envelope (unary) or a synthetic SSE stream — **no upstream call to api.anthropic.com on the inference route**.

This is **M1 + M2** of the four-frontend reframing (codex/gemini/ollama = M3–M6, separate PRs).

## What's included
**M1 — shared `frontend_base/terminal_response.py`** (new, additive): the 8 provider builders/streamers (`build_anthropic_message`/`stream_anthropic_sse`, plus openai/gemini/ollama) and helpers (`serialize_transcript`, `estimate_tokens`, `deterministic_id`, `extract_error_text`). Exact per-provider wire formats (Anthropic SSE with `ping`, OpenAI 9-event, Gemini JSON-array vs `?alt=sse`, Ollama NDJSON). 27 unit tests with independent frame decoding.

**M2 — `claude_frontend` terminal rewrite** (direct cutover):
- `proxy_messages` resolves then synthesizes; deletes `_forward_*` / `_embed_context` / `_inject_system_context`.
- **Conversation-aware**: full-transcript `$prompt` blob, deterministic ids, non-zero usage.
- **Error contract (#244)**: resolution failure returns a visible fake-200 carrying `[url4 error]` text (unary + streaming; the stream terminates). Empty result is fail-loud (O5b).
- **Passthrough kept**: `/v1/{path}` (incl. `POST /v1/messages/count_tokens`) and `/api/{path}` still forward upstream.
- `claude_intercept` E2E test migrated (it routes traffic into this handler).

## Decisions (settled)
Conversation-aware · keep real-upstream passthrough for non-inference routes · direct cutover (no flag) · hard-remove of `embed_*` settings deferred to M6.

## Tests
Full plugin suite: **1158 passed, 17 skipped, 0 failures**; pyright 0 errors; ruff 0.9.0 + pre-commit clean.

## Reference
- Spec: `docs/superpowers/plans/2026-06-04-frontend-terminal-ensemble-spec.md`
- Plan: `docs/superpowers/plans/2026-06-04-frontend-terminal-ensemble-implementation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
