### PR TITLE
SF-181: accept SF desktop "Publish to Leaderboard" submissions (nested client)

### DIFF
--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -57,9 +57,9 @@ class ScoreSubmission(BaseModel):
     correct_questions: int
     ran_with_providers: list[str]
     ran_at_local: datetime | None = None
-    client_name: str | None = None
-    client_version: str | None = None
-    client_platform: str | None = None
+    # Nested client metadata, matching the SF "Publish to Leaderboard" wire shape
+    # (D-SCORE-006). Persisted onto the flat client_* columns by the store.
+    client: ClientInfo | None = None
     metadata: dict[str, Any] | None = None
 
     @field_validator("url4_expression")

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -62,9 +62,9 @@ def _submission_to_kwargs(submission: ScoreSubmission) -> dict[str, object]:
         "correct_questions": submission.correct_questions,
         "ran_with_providers": submission.ran_with_providers,
         "ran_at_local": submission.ran_at_local,
-        "client_name": submission.client_name,
-        "client_version": submission.client_version,
-        "client_platform": submission.client_platform,
+        "client_name": submission.client.name if submission.client else None,
+        "client_version": submission.client.version if submission.client else None,
+        "client_platform": submission.client.platform if submission.client else None,
         "metadata": submission.metadata,
     }
 

--- a/apps/scoreboard/tests/unit/scores/test_store.py
+++ b/apps/scoreboard/tests/unit/scores/test_store.py
@@ -7,7 +7,7 @@ import pytest
 from tortoise import Tortoise
 
 from scoreboard.scores.models import Benchmark, IdempotencyKey, Score
-from scoreboard.scores.schemas import ScoreSubmission
+from scoreboard.scores.schemas import ClientInfo, ScoreSubmission
 from scoreboard.scores.store import ScoreStore
 
 pytestmark = pytest.mark.asyncio
@@ -30,9 +30,7 @@ def _submission(
         correct_questions=correct_questions,
         ran_with_providers=providers or ["openai"],
         ran_at_local=datetime(2026, 5, 21, 12, 0, tzinfo=UTC),
-        client_name="scoreboard-test",
-        client_version="0.1.0",
-        client_platform="test",
+        client=ClientInfo(name="scoreboard-test", version="0.1.0", platform="test"),
         metadata={"source": "unit"},
     )
 

--- a/apps/scoreboard/tests/unit/test_leaderboard_routes.py
+++ b/apps/scoreboard/tests/unit/test_leaderboard_routes.py
@@ -10,7 +10,7 @@ import pytest_asyncio
 from scoreboard.config import Settings
 from scoreboard.main import create_app
 from scoreboard.scores.models import Score
-from scoreboard.scores.schemas import ScoreSubmission
+from scoreboard.scores.schemas import ClientInfo, ScoreSubmission
 from scoreboard.scores.store import ScoreStore
 
 pytestmark = pytest.mark.asyncio
@@ -44,9 +44,7 @@ def _submission(
         correct_questions=correct_questions,
         ran_with_providers=providers or ["openai"],
         ran_at_local=datetime(2026, 5, 21, 12, 0, tzinfo=UTC),
-        client_name="scoreboard-test",
-        client_version="0.1.0",
-        client_platform="test",
+        client=ClientInfo(name="scoreboard-test", version="0.1.0", platform="test"),
         metadata={"source": "unit"},
     )
 

--- a/apps/scoreboard/tests/unit/test_scores_routes.py
+++ b/apps/scoreboard/tests/unit/test_scores_routes.py
@@ -30,9 +30,7 @@ def _valid_payload(**overrides: Any) -> dict[str, Any]:
         "correct_questions": 3,
         "ran_with_providers": ["openai"],
         "ran_at_local": "2026-05-21T12:00:00+00:00",
-        "client_name": "scoreboard-test",
-        "client_version": "0.1.0",
-        "client_platform": "test",
+        "client": {"name": "scoreboard-test", "version": "0.1.0", "platform": "test"},
         "metadata": {"source": "unit"},
     }
     payload.update(overrides)

--- a/apps/scoreboard/tests/unit/test_sf_payload.py
+++ b/apps/scoreboard/tests/unit/test_sf_payload.py
@@ -1,0 +1,158 @@
+"""End-to-end fixtures for the SF desktop "Publish to Leaderboard" payload (D-SCORE-006).
+
+Simulates the exact wire shape the ScreamingFace desktop app POSTs to /v1/scores,
+including the nested `client` object and the Idempotency-Key=<eval_run_id> header,
+and confirms the round-trip, idempotency, unknown-benchmark, CORS, and contract
+strictness behaviour the scoreboard side owns.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from scoreboard.config import Settings
+from scoreboard.main import create_app
+from scoreboard.scores.models import Benchmark
+
+pytestmark = pytest.mark.asyncio
+
+# A repeat "Publish" click sends the same eval_run_id, so it doubles as the
+# Idempotency-Key — clicking twice must create exactly one row.
+_EVAL_RUN_ID = "eval-run-abc123"
+
+
+def _sf_payload(**overrides: Any) -> dict[str, Any]:
+    """The documented SF desktop submission body (nested `client`)."""
+    payload: dict[str, Any] = {
+        "version": 1,
+        "benchmark_id": "hle",
+        "spec_id": "hle-ensemble-three",
+        "url4_expression": "url4://ensemble(claude,codex,gemini)/hle",
+        "accuracy": 0.81,
+        "total_questions": 1000,
+        "correct_questions": 810,
+        "ran_with_providers": ["claude", "codex", "gemini"],
+        "submitted_by": None,
+        "ran_at_local": "2026-05-04T11:55:00Z",
+        "client": {"name": "screamingface-desktop", "version": "0.4.2", "platform": "darwin"},
+        "metadata": None,
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest_asyncio.fixture
+async def app_with_benchmark(tortoise_db: None) -> FastAPI:
+    settings = Settings(database_url="sqlite://:memory:", cors_origins=[])
+    app = create_app(settings)
+    await Benchmark.create(
+        id="hle",
+        display_name="Humanity's Last Exam",
+        description="Fixture benchmark",
+        dataset_url="https://example.test/hle.jsonl",
+    )
+    return app
+
+
+@pytest_asyncio.fixture
+async def sf_client(app_with_benchmark: FastAPI) -> AsyncGenerator[AsyncClient, None]:
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_benchmark),
+        base_url="http://test",
+    ) as client:
+        yield client
+
+
+async def test_sf_payload_round_trips_201(sf_client: AsyncClient) -> None:
+    response = await sf_client.post(
+        "/v1/scores", json=_sf_payload(), headers={"Idempotency-Key": _EVAL_RUN_ID}
+    )
+
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["id"]
+    assert body["benchmark_id"] == "hle"
+    assert body["spec_id"] == "hle-ensemble-three"
+    assert body["accuracy"] == 0.81
+    assert body["total_questions"] == 1000
+    assert body["correct_questions"] == 810
+    assert body["ran_with_providers"] == ["claude", "codex", "gemini"]
+    assert body["submitted_by"] is None
+    assert body["verified_by_openmined"] is False
+    # Nested `client` on the request maps to the flat client_* read fields.
+    assert body["client_name"] == "screamingface-desktop"
+    assert body["client_version"] == "0.4.2"
+    assert body["client_platform"] == "darwin"
+
+
+async def test_repeat_publish_is_idempotent(sf_client: AsyncClient) -> None:
+    first = await sf_client.post(
+        "/v1/scores", json=_sf_payload(), headers={"Idempotency-Key": _EVAL_RUN_ID}
+    )
+    assert first.status_code == 201, first.text
+    score_id = first.json()["id"]
+
+    # Second click with the same eval_run_id must not create a duplicate.
+    second = await sf_client.post(
+        "/v1/scores", json=_sf_payload(), headers={"Idempotency-Key": _EVAL_RUN_ID}
+    )
+    assert second.status_code == 200, second.text
+    assert second.json()["id"] == score_id
+
+    fetched = await sf_client.get(f"/v1/scores/{score_id}")
+    assert fetched.status_code == 200
+    assert fetched.json()["id"] == score_id
+
+
+async def test_unknown_benchmark_returns_404(sf_client: AsyncClient) -> None:
+    response = await sf_client.post(
+        "/v1/scores",
+        json=_sf_payload(benchmark_id="not-registered"),
+        headers={"Idempotency-Key": "eval-run-unknown"},
+    )
+    assert response.status_code == 404
+    assert response.json()["detail"]["field"] == "benchmark_id"
+
+
+async def test_client_is_optional(sf_client: AsyncClient) -> None:
+    payload = _sf_payload()
+    payload.pop("client")
+    response = await sf_client.post(
+        "/v1/scores", json=payload, headers={"Idempotency-Key": "eval-run-no-client"}
+    )
+
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["client_name"] is None
+    assert body["client_version"] is None
+    assert body["client_platform"] is None
+
+
+async def test_flat_client_fields_are_rejected(sf_client: AsyncClient) -> None:
+    # The contract is nested-only; the legacy flat shape must be rejected so SF
+    # and the scoreboard cannot silently drift apart on the client metadata.
+    payload = _sf_payload()
+    payload.pop("client")
+    payload["client_name"] = "screamingface-desktop"
+    response = await sf_client.post(
+        "/v1/scores", json=payload, headers={"Idempotency-Key": "eval-run-flat"}
+    )
+    assert response.status_code == 422
+
+
+async def test_cors_allows_electron_renderer_origin() -> None:
+    # Electron renderers fetch with an Origin header (e.g. file://). With
+    # cors_origins=["*"] and credentials disabled, the API echoes ACAO: *.
+    settings = Settings(database_url="sqlite://:memory:", cors_origins=["*"])
+    app = create_app(settings)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/healthz", headers={"Origin": "file://"})
+
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == "*"

--- a/docs/superpowers/plans/SF-181-scoreboard-sf-ingestion.md
+++ b/docs/superpowers/plans/SF-181-scoreboard-sf-ingestion.md
@@ -1,0 +1,226 @@
+# D-SCORE-006 — SF → scoreboard ingestion (scoreboard side)
+
+**Owner:** Dmitry (scoreboard side). SF/Electron side = Sergey (out of scope here).
+**Phase:** 3 / Week 3 · **Estimate:** ~0.5d (scoreboard side) · **Branch:** `SF-XXX-scoreboard-sf-ingestion` (SF "next available" — assign at ticket time).
+**Depends on:** D-SCORE-002 (persistence), D-SCORE-003 (POST /v1/scores), DEMO-017 (local eval persistence, SF side).
+**Confidence:** ~96%.
+
+> **Scope decision (confirmed with user):** the submission wire shape uses a **nested
+> `client: {name, version, platform}`** object, exactly as the task description documents.
+> This is the scoreboard-side plan for the paired (A+B) task; the SF/Electron deliverables
+> (`PublishDialog`, redaction, toasts) are Sergey's and appear here only as the interface contract.
+
+---
+
+## Goal
+
+Make the public scoreboard accept the SF desktop "Publish to Leaderboard" submission, confirm CORS
+allows the Electron renderer, and add a fixture-based round-trip test that simulates the real SF
+payload. The receiving endpoint (`POST /v1/scores`), idempotency, and models already exist
+(D-SCORE-002/003); this ticket reconciles the **submission schema** with the documented SF wire
+shape and proves the round-trip.
+
+## In scope (scoreboard / this PR)
+
+- `scores/schemas.py` — `ScoreSubmission` accepts a **nested `client`** (wiring the already-present
+  but currently-unused `ClientInfo` model).
+- `scores/store.py` — map the nested `client` onto the existing flat model columns.
+- CORS — verify (and, only if needed, finalize) that the Electron renderer origin is allowed.
+- `tests/unit/test_sf_payload.py` — **new**, fixture-based end-to-end round-trip of the SF payload.
+- Update existing tests that build the submission shape (`test_scores_routes.py`, `scores/test_store.py`).
+
+## Out of scope (SF side — Sergey; documented as the contract only)
+
+- `apps/desktop/.../PublishDialog.tsx`, `use-publish-score.ts`, `url4-redaction.ts`, `EvalRunDetail.tsx`.
+- Private-spec detection / redaction (SF-side logic).
+- `spec_name` → `benchmark_id:spec_id` convention (DEMO-014, SF side).
+- `SF_SCOREBOARD_URL` default coordination (D-SCORE-007).
+- No DB schema / migration change (the `Score` table stays flat).
+
+---
+
+## Current state (validated against the code)
+
+- `POST /v1/scores` + `GET /v1/scores/{id}` exist (`routes/scores.py`, D-SCORE-003). Idempotency via
+  the `Idempotency-Key` header + `IdempotencyKey` model with a 24h TTL (D-SCORE-002). Repeat key →
+  `200` with the original score; expired key → new row.
+- Validation already enforced by the route/schema: `version` is `Literal[1]`; `url4_expression`
+  non-empty, ≤ 32 000 chars; `accuracy ∈ [0,1]`; `accuracy ≈ correct/total` within `Decimal("0.01")`
+  (else `400`); `total_questions > 0`; `correct ≤ total`; unknown `benchmark_id` → `404`;
+  `extra="forbid"` on all DTOs.
+- **CORS is already permissive:** `Settings.cors_origins` defaults to `["*"]`; `main.py` adds
+  `CORSMiddleware(allow_origins=cors_origins, allow_credentials=False, allow_methods=["*"],
+  allow_headers=["*"])`. This matches the task's "permissive `*` acceptable for v1" — **no config
+  change is required**, only verification + a test.
+- **The mismatch this ticket fixes:** the endpoint currently accepts **flat** `client_name` /
+  `client_version` / `client_platform`, but the documented SF payload sends **nested** `client:{…}`.
+  With `extra="forbid"`, the documented payload is rejected `422` today. A `ClientInfo` model
+  (name/version/platform) is already defined in `schemas.py` but **unused** — this ticket wires it in.
+
+---
+
+## Design
+
+### 1. Nested `client` on the input DTO (`scores/schemas.py`)
+
+```python
+class ScoreSubmission(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    version: Literal[1] = 1
+    benchmark_id: str
+    spec_id: str
+    url4_expression: Annotated[str, Field(max_length=32_000)]
+    submitted_by: str | None = None
+    accuracy: float
+    total_questions: int
+    correct_questions: int
+    ran_with_providers: list[str]
+    ran_at_local: datetime | None = None
+    client: ClientInfo | None = None          # <- was client_name/version/platform (flat)
+    metadata: dict[str, Any] | None = None
+    # ... existing validators unchanged ...
+```
+
+`ClientInfo` (already present, `extra="forbid"`, all fields optional) becomes live.
+
+**`ScoreSchema` (the read/response DTO) stays flat** (`client_name/version/platform`). Rationale: the
+read contract is consumed by the public leaderboard portal (D-SCORE-005); the task only specifies the
+*submission* shape. Keeping the response flat avoids rippling into the portal for no task benefit. The
+input/output asymmetry is a deliberate, scoped trade-off (revisit only if a separate ticket asks to
+nest the read DTO too).
+
+### 2. Map nested → flat columns (`scores/store.py`)
+
+The `Score` model/table stay flat (no migration). `_submission_to_kwargs` unpacks the nested client:
+
+```python
+def _submission_to_kwargs(submission: ScoreSubmission) -> dict[str, object]:
+    client = submission.client
+    return {
+        "benchmark_id": submission.benchmark_id,
+        "version": submission.version,
+        "spec_id": submission.spec_id,
+        "url4_expression": submission.url4_expression,
+        "submitted_by": submission.submitted_by,
+        "accuracy": submission.accuracy,
+        "total_questions": submission.total_questions,
+        "correct_questions": submission.correct_questions,
+        "ran_with_providers": submission.ran_with_providers,
+        "ran_at_local": submission.ran_at_local,
+        "client_name": client.name if client else None,
+        "client_version": client.version if client else None,
+        "client_platform": client.platform if client else None,
+        "metadata": submission.metadata,
+    }
+```
+
+`_score_to_schema` is unchanged (model flat → `ScoreSchema` flat).
+
+### 3. CORS (`config.py` / `main.py`)
+
+No change needed — already `allow_origins=["*"]`, `allow_credentials=False`. This works for the
+Electron renderer, whose `fetch` carries `Origin: file://`/`null`; with credentials disabled,
+Starlette echoes `Access-Control-Allow-Origin: *`. We only **assert** this in a test. (If credentials
+were ever needed, `*` + credentials is disallowed by the spec and we'd switch to explicit origins —
+not needed for the open-write v1 API.)
+
+### 4. Tests
+
+- **Update existing submission-builders to nested** (one-line-ish each, fixes all dependents):
+  - `tests/unit/test_scores_routes.py::_valid_payload` → `"client": {"name": …, "version": …, "platform": …}`.
+  - `tests/unit/scores/test_store.py` → the `ScoreSubmission(...)` builder uses `client=ClientInfo(...)`.
+  - `tests/unit/test_leaderboard_routes.py` is **untouched** (it creates `Score` rows directly = flat columns).
+- **New `tests/unit/test_sf_payload.py`** (reuse the `tortoise_db` + ASGI `AsyncClient` pattern from
+  `test_scores_routes.py`; register a benchmark in the fixture):
+  1. POST the **exact documented SF payload** (nested `client`) with `Idempotency-Key: <eval_run_id>`
+     → `201`; assert the response round-trips (incl. `client_name/version/platform` derived from the
+     nested input, `verified_by_openmined is False`).
+  2. **Idempotent:** POST again with the same `Idempotency-Key` → `200` and the **same `id`**
+     (one row); confirm via `GET /v1/scores/{id}`.
+  3. **Unknown benchmark** (not pre-registered) → `404` field error on `benchmark_id`.
+  4. **CORS:** a request carrying an `Origin` header (app built with `cors_origins=["*"]`) returns
+     `Access-Control-Allow-Origin: *`. (The shared in-memory fixture uses `cors_origins=[]` to keep
+     other tests deterministic, so this case constructs its own app with `cors_origins=["*"]`.)
+  5. **Strictness:** a payload with an unknown top-level field, or the **legacy flat** `client_name`,
+     is rejected `422` (documents that the contract is now nested-only).
+
+---
+
+## tortoise-dev / SOLID check (requested)
+
+- **No model or migration change** → the `tortoise-dev` model rules are unaffected (the scoreboard
+  models already comply: `models/` subpackage, one model per file, abstract `Base*`, `Meta` first —
+  per D-SCORE-002). The `Score` table keeps its flat `client_*` columns.
+- **SRP / layering preserved:** the change lives entirely in the DTO (`schemas.ScoreSubmission`) and
+  the DTO→model mapping (`store._submission_to_kwargs`) — the exact seam meant to absorb wire-shape
+  changes. The persistence model and the read DTO are untouched, so the storage and read contracts
+  stay stable. No raw SQL is added.
+- **DRY:** wiring the existing `ClientInfo` removes dead code rather than adding a parallel definition.
+
+---
+
+## Wire contract (for the paired session with Sergey)
+
+```
+POST /v1/scores
+Content-Type: application/json
+Idempotency-Key: <eval_run_id>
+
+{ "version": 1, "benchmark_id": "hle", "spec_id": "hle-ensemble-three",
+  "url4_expression": "...", "accuracy": 0.81, "total_questions": 1000,
+  "correct_questions": 810, "ran_with_providers": ["claude","codex","gemini"],
+  "submitted_by": null, "ran_at_local": "2026-05-04T11:55:00Z",
+  "client": { "name": "screamingface-desktop", "version": "0.4.2", "platform": "darwin" },
+  "metadata": null }
+```
+
+- SF **must** send `client` **nested** (flat `client_*` is now `422`).
+- `accuracy` must equal `correct_questions/total_questions` within `0.01`, else `400`.
+- `benchmark_id` must be **pre-registered** on the scoreboard, else `404` — coordinate which
+  benchmarks are seeded (e.g. `livetruth`, `hle`); SF publishing to an unregistered benchmark fails.
+- Response is **flat** `ScoreSchema`; SF reads `id` for the success-toast deep link
+  `<portal>/spec.html?benchmark=<benchmark_id>&spec=<spec_id>`.
+- Repeat POST with the same `Idempotency-Key` → `200` + original row (no dupes).
+
+## Acceptance criteria (scoreboard side)
+
+- [ ] `POST /v1/scores` accepts the documented nested-`client` SF payload → `201`.
+- [ ] Double POST with the same `Idempotency-Key=<eval_run_id>` → one row (`200` on repeat;
+      verifiable via `GET /v1/scores/{id}`).
+- [ ] CORS allows the renderer (`Access-Control-Allow-Origin: *` present).
+- [ ] `test_sf_payload.py` simulates the SF shape and confirms the round-trip.
+- [ ] Existing route/store tests updated to nested `client` and green.
+
+## Build sequence
+
+1. `scores/schemas.py`: `ScoreSubmission.client: ClientInfo | None` (drop the 3 flat fields).
+2. `scores/store.py`: nested→flat mapping in `_submission_to_kwargs`.
+3. Update `test_scores_routes.py::_valid_payload` and `scores/test_store.py` builders to nested.
+4. Add `tests/unit/test_sf_payload.py` (round-trip + idempotency + 404 + CORS + 422 strictness).
+5. Gates.
+
+## Validation
+
+```bash
+cd apps/scoreboard
+uv run pytest tests/unit -q
+uv run ruff check . && uv run ruff format --check .
+uv run pyright
+```
+
+(The Postgres-gated migration smoke is unaffected — no schema change.)
+
+## Risks
+
+- **Input-contract change (flat → nested).** Breaks any flat-sending client; none is deployed (SF is
+  the first client and is being built in this paired task). Existing tests are updated in the same PR,
+  so CI stays green.
+- **Benchmark must exist.** A publish to an unregistered `benchmark_id` returns `404`; ensure the
+  target benchmarks are seeded (`seed.py` / `register_benchmark`). Coordination item for the manual e2e.
+- **CORS `*` + no credentials** is correct for the open-write v1 API; revisit if auth is ever added.
+
+## Notes
+
+- SF number is "next available" — assign at ticket creation and name the branch accordingly.
+- Plan location: `docs/superpowers/plans/` (per repo convention); task brief lives at
+  `.agent-team-D-SCORE-006/initial_task_description.md`.


### PR DESCRIPTION
Reconcile the scoreboard `POST /v1/scores` contract with the ScreamingFace desktop "Publish to Leaderboard" wire shape (D-SCORE-006, scoreboard side). `ScoreSubmission` now takes a nested `client: {name, version, platform}` object — activating the previously-unused `ClientInfo` model — which the store maps onto the existing flat `client_*` columns. The response DTO stays flat, so the public leaderboard portal's read contract is unchanged; **no model or migration change**. CORS already permits the Electron renderer (`allow_origins=["*"]`, credentials off).

This is the scoreboard half of the paired D-SCORE-006 task; the SF/Electron `PublishDialog` + private-spec redaction are tracked separately.

- `scores/schemas.py`: `ScoreSubmission.client: ClientInfo | None` (response `ScoreSchema` stays flat)
- `scores/store.py`: map nested `client` → flat columns (None-safe)
- tests: migrate the 3 existing `ScoreSubmission` builders to nested; add `tests/unit/test_sf_payload.py`

## Description

Today the public scoreboard's `POST /v1/scores` accepts flat `client_name`/`client_version`/`client_platform` fields, but the documented SF desktop payload nests them under a `client` object — so the documented payload would be rejected. This PR reconciles the submission contract to the nested shape (the scoreboard half of the paired SF→scoreboard ingestion task), maps it onto the unchanged flat storage columns, and keeps the read/response DTO flat so the public leaderboard portal is unaffected. Idempotency (`Idempotency-Key=<eval_run_id>`) and benchmark validation are unchanged.

## Affected Dependencies

None — no new runtime dependency, and no database schema/migration change.

## How has this been tested?

- `cd apps/scoreboard && uv run pytest tests/unit -q` → **61 passed, 1 skipped** (the skip is the Postgres-gated migration smoke, unaffected).
- `uv run ruff check .` + `uv run ruff format --check .` clean; `uv run pyright` → 0 errors.
- New `tests/unit/test_sf_payload.py` simulates the exact SF payload: nested-`client` round-trip → `201`; idempotent repeat-publish (same `Idempotency-Key`) → `200` with the same id (verified via `GET /v1/scores/{id}`); unknown benchmark → `404`; `client` optional; legacy flat `client_*` rejected → `422`; CORS `Access-Control-Allow-Origin: *` for the renderer origin.

Reproduce:

```bash
cd apps/scoreboard
uv sync
uv run pytest tests/unit -q
```

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
