### PR TITLE
SF-245: mark claude-CLI intercept plugins as deprecated/unmaintained

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,21 @@ These are **mandatory** for all code in this repo. PRs that violate them must be
   - Discovery/wiring of plugins happens via a registry, not via direct imports in core.
 - **AIGateway credential storage:** `apps/aigateway` uses ORMStore through Tortoise (`credential_blobs`): SQLite locally, Postgres in hosted/prod. No OS keychain/libsecret/Credential Manager usage in AIGateway.
 
+## Deprecated / Unmaintained Plugins
+
+The three legacy **claude-CLI traffic-intercept** plugins below are **no longer maintained** and are **not part of the pipeline we are building**. None of them is in the active `apps/server/sf.json` plugins list.
+
+- `apps/server/src/screamingface/plugins/claude_env_intercept` (`claude-env-intercept`)
+- `apps/server/src/screamingface/plugins/mitmproxy_intercept` (`mitmproxy-intercept`)
+- `apps/server/src/screamingface/plugins/claude_intercept` (`claude-intercept`)
+
+**Rules (mandatory):**
+
+- **Never add new features to these plugins.** Do not extend them, do not route new functionality through them. New gateway behavior belongs in the active pipeline — the frontend plugins (e.g. `claude_frontend` / `frontend_base`) that serve `/v1/messages`, not in an intercept shim.
+- **Do not treat them as a reference for "how the gateway works."** They are legacy CLI-redirection strategies, separate from the live request/response path.
+- **Touch them only to deprecate, delete, or keep them compiling** (e.g. shared-helper signature changes). Bug-fix-only otherwise.
+- If a task seems to require one of these, stop and confirm with the user first — it almost certainly belongs elsewhere.
+
 ## Personas
 
 This project uses a persona system to guide copy, design, positioning, and feature decisions. **Before doing any work that involves messaging, tone, design choices, or audience targeting**, consult the persona weighting guide.


### PR DESCRIPTION
## SF-245 — deprecate the legacy claude-CLI intercept plugins (docs)

Adds a mandatory rule to the root `CLAUDE.md` so future work (human or agent) doesn't extend dead code.

### What
Marks the three legacy claude-CLI traffic-intercept plugins as **no longer maintained** and **not part of the active gateway pipeline**:

- `apps/server/src/screamingface/plugins/claude_env_intercept` (`claude-env-intercept`)
- `apps/server/src/screamingface/plugins/mitmproxy_intercept` (`mitmproxy-intercept`)
- `apps/server/src/screamingface/plugins/claude_intercept` (`claude-intercept`)

None are in the active `apps/server/sf.json` plugins list.

### Rules added
- **Never add new features** to these plugins — new gateway behavior belongs in the active frontend pipeline (`claude_frontend` / `frontend_base` serving `/v1/messages`), not in an intercept shim.
- **Don't use them as a reference** for how the gateway works.
- **Touch only to deprecate, delete, or keep compiling**; bug-fix-only otherwise.
- If a task seems to require one, **confirm with the user first**.

### Why
Surfaced during the SF-243 gateway-banner review (#257): the banner had been implemented in the dormant `claude_env_intercept`, which is coupled to one of three mutually-exclusive intercept strategies and isn't enabled in `sf.json`. This rule prevents that class of mistake going forward.

Docs-only change (15 lines in `CLAUDE.md`).

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215568144835595

🤖 Generated with [Claude Code](https://claude.com/claude-code)