### PR TITLE
SF-181: Publish to Leaderboard flow (Eval Studio → scoreboard, desktop)

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -5,6 +5,7 @@ import { registerConfigHandlers } from './config.ipc';
 import { registerSessionHandlers } from './session.ipc';
 import { registerBackendStatusHandlers } from './backend-status.ipc';
 import { registerAigwSessionHandlers } from './aigw-session.ipc';
+import { registerPublishHandlers } from './publish.ipc';
 
 export function registerAllHandlers(): void {
   registerConfigHandlers();
@@ -14,4 +15,5 @@ export function registerAllHandlers(): void {
   registerSessionHandlers();
   registerAigwSessionHandlers();
   registerBackendStatusHandlers();
+  registerPublishHandlers();
 }

--- a/apps/desktop/src/main/ipc/publish.ipc.ts
+++ b/apps/desktop/src/main/ipc/publish.ipc.ts
@@ -1,0 +1,31 @@
+// apps/desktop/src/main/ipc/publish.ipc.ts
+//
+// IPC for the "Publish to Leaderboard" flow (SF-181 / D-SCORE-006):
+//   - publish:getContext  — env/app-version/platform the renderer can't read
+//   - publish:openExternal — open the leaderboard deep link in the system browser
+import { ipcMain, shell } from 'electron';
+import { resolvePublishContext, type PublishContext } from '../services/publish-context';
+import { requireTrustedIpcSender } from './sender-validation';
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+export function registerPublishHandlers(): void {
+  ipcMain.handle('publish:getContext', (event): PublishContext => {
+    requireTrustedIpcSender(event);
+    return resolvePublishContext();
+  });
+
+  ipcMain.handle('publish:openExternal', async (event, url: string): Promise<void> => {
+    requireTrustedIpcSender(event);
+    // Only ever hand http(s) URLs to the OS — never file://, custom schemes, etc.
+    if (!isHttpUrl(url)) return;
+    await shell.openExternal(url);
+  });
+}

--- a/apps/desktop/src/main/services/publish-context.ts
+++ b/apps/desktop/src/main/services/publish-context.ts
@@ -1,0 +1,53 @@
+// apps/desktop/src/main/services/publish-context.ts
+//
+// Resolves everything the renderer needs to publish an eval result to the public
+// scoreboard but cannot read itself (env vars, app version, platform). The
+// renderer hook (use-publish-score) builds and POSTs the payload; this only
+// supplies context. Resolution order for URLs: env var → sf.json config → default.
+
+import { app } from 'electron';
+import { configService } from './config-service';
+
+/** Dev defaults. Production scoreboard/portal URLs are finalized in D-SCORE-007. */
+const DEFAULT_SCOREBOARD_URL = 'http://localhost:9106';
+const DEFAULT_PORTAL_URL = 'http://localhost:8080';
+
+export interface PublishClientInfo {
+  name: string;
+  version: string;
+  platform: string;
+}
+
+export interface PublishContext {
+  scoreboardUrl: string;
+  portalUrl: string;
+  client: PublishClientInfo;
+}
+
+function configString(key: string): string | undefined {
+  try {
+    const value = configService.read()[key];
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
+  } catch {
+    // Config not readable (e.g. before init) — fall through to env/default.
+    return undefined;
+  }
+}
+
+function resolveUrl(envKey: string, configKey: string, fallback: string): string {
+  const fromEnv = process.env[envKey];
+  if (fromEnv && fromEnv.length > 0) return fromEnv;
+  return configString(configKey) ?? fallback;
+}
+
+export function resolvePublishContext(): PublishContext {
+  return {
+    scoreboardUrl: resolveUrl('SF_SCOREBOARD_URL', 'scoreboard_url', DEFAULT_SCOREBOARD_URL),
+    portalUrl: resolveUrl('SF_PORTAL_URL', 'portal_url', DEFAULT_PORTAL_URL),
+    client: {
+      name: 'screamingface-desktop',
+      version: app.getVersion(),
+      platform: process.platform,
+    },
+  };
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -46,6 +46,10 @@ const api: ElectronAPI = {
     write: (config) => ipcRenderer.invoke('config:write', config),
     onChanged: (cb) => onEvent('config:changed', cb),
   },
+  publish: {
+    getContext: () => ipcRenderer.invoke('publish:getContext'),
+    openExternal: (url) => ipcRenderer.invoke('publish:openExternal', url),
+  },
   backends: {
     getStatus: () => ipcRenderer.invoke('backends:getStatus'),
     getPollingError: () => ipcRenderer.invoke('backends:getPollingError'),

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -202,6 +202,12 @@ export type OAuthLauncherResult =
       message?: string;
     };
 
+export interface PublishContext {
+  scoreboardUrl: string;
+  portalUrl: string;
+  client: { name: string; version: string; platform: string };
+}
+
 export interface ElectronAPI {
   popup: {
     open: (url: string, title?: string) => Promise<void>;
@@ -246,6 +252,10 @@ export interface ElectronAPI {
     read: () => Promise<Record<string, unknown>>;
     write: (config: Record<string, unknown>) => Promise<void>;
     onChanged: (callback: (config: Record<string, unknown>) => void) => () => void;
+  };
+  publish: {
+    getContext: () => Promise<PublishContext>;
+    openExternal: (url: string) => Promise<void>;
   };
   backends: {
     getStatus: () => Promise<BackendStatusResponse>;

--- a/apps/desktop/src/renderer/src/components/eval/EvalRunDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/EvalRunDetail.tsx
@@ -1,9 +1,13 @@
 // apps/desktop/src/renderer/src/components/eval/EvalRunDetail.tsx
+import { useState } from 'react';
+import { Upload } from 'lucide-react';
 import { useServerStatus } from '@/hooks/use-server-status';
 import { useEvalRunDetail } from '@/hooks/use-eval-runs';
 import { Url4Viewer } from '@/components/Url4Viewer';
+import { Button } from '@/components/ui/button';
 import { EvalStatusBadge } from './EvalStatusBadge';
 import { EvalQuestionsTable } from './EvalQuestionsTable';
+import { PublishToLeaderboardDialog } from './PublishToLeaderboardDialog';
 
 function formatPercent(accuracy: number | null): string {
   if (accuracy === null) return '—';
@@ -19,6 +23,7 @@ function formatTime(iso: string | null): string {
 export function EvalRunDetail({ runId }: { runId: string }) {
   const { info } = useServerStatus();
   const { data, loading, error } = useEvalRunDetail(runId);
+  const [publishing, setPublishing] = useState(false);
 
   const serverUrl = info
     ? `${info.scheme}://${info.host === '0.0.0.0' ? 'localhost' : info.host}:${info.port}`
@@ -38,6 +43,16 @@ export function EvalRunDetail({ runId }: { runId: string }) {
         <div className="mb-2 flex items-center gap-3">
           <h2 className="text-base font-semibold">{data.spec_name}</h2>
           <EvalStatusBadge status={data.status} />
+          {data.status === 'done' && data.accuracy !== null && !!data.total_questions && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="ml-auto"
+              onClick={() => setPublishing(true)}
+            >
+              <Upload className="h-3.5 w-3.5" /> Publish to Leaderboard
+            </Button>
+          )}
         </div>
         <div className="mb-3 rounded bg-muted/30 px-3 py-2">
           <Url4Viewer expression={data.url4_expression} serverUrl={serverUrl} />
@@ -71,6 +86,13 @@ export function EvalRunDetail({ runId }: { runId: string }) {
       <div className="flex-1 overflow-auto">
         <EvalQuestionsTable questions={data.questions} />
       </div>
+      {publishing && (
+        <PublishToLeaderboardDialog
+          run={data}
+          serverUrl={serverUrl}
+          onClose={() => setPublishing(false)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
@@ -1,0 +1,248 @@
+// apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
+import { useMemo, useState } from 'react';
+import { X, Upload, ExternalLink, AlertTriangle, CheckCircle2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Url4Viewer } from '@/components/Url4Viewer';
+import { useToast } from '@/hooks/use-toast';
+import { usePublishScore } from '@/hooks/use-publish-score';
+import {
+  parseSpecName,
+  deriveProviders,
+  hasLocalDataRefs,
+  sanitizeDataRefs,
+} from '@/lib/url4-redaction';
+import type { EvalRunDetail } from './types';
+
+interface Props {
+  run: EvalRunDetail;
+  serverUrl: string;
+  onClose: () => void;
+}
+
+function formatPercent(accuracy: number | null): string {
+  if (accuracy === null) return '—';
+  return `${(accuracy * 100).toFixed(1)}%`;
+}
+
+export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
+  const { toast } = useToast();
+  const { publish, status, error, result } = usePublishScore();
+
+  const parsed = useMemo(() => parseSpecName(run.spec_name), [run.spec_name]);
+  const hasDataRefs = useMemo(() => hasLocalDataRefs(run.url4_expression), [run.url4_expression]);
+
+  const [benchmarkId, setBenchmarkId] = useState(parsed.benchmark_id ?? '');
+  const [specId, setSpecId] = useState(parsed.spec_id);
+  const [providersText, setProvidersText] = useState(
+    deriveProviders(run.url4_expression).join(', '),
+  );
+  const [submittedBy, setSubmittedBy] = useState('');
+  // Redaction choices: only relevant when the expression references /data blobs.
+  const [sanitize, setSanitize] = useState(hasDataRefs);
+  const [ackExpose, setAckExpose] = useState(false);
+
+  const expressionToPublish = sanitize
+    ? sanitizeDataRefs(run.url4_expression)
+    : run.url4_expression;
+
+  const providers = providersText
+    .split(',')
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+
+  const submitting = status === 'submitting';
+  // Block publish until: benchmark known, and any /data refs are either sanitized
+  // or explicitly acknowledged as exposing local data.
+  const redactionResolved = !hasDataRefs || sanitize || ackExpose;
+  const canPublish = benchmarkId.trim().length > 0 && specId.trim().length > 0 && redactionResolved;
+
+  const handlePublish = async (): Promise<void> => {
+    const out = await publish({
+      run,
+      benchmarkId: benchmarkId.trim(),
+      specId: specId.trim(),
+      url4Expression: expressionToPublish,
+      providers,
+      submittedBy: submittedBy.trim() || null,
+    });
+    if (out) {
+      toast({ variant: 'success', title: 'Published to the leaderboard' });
+    } else {
+      // error state is rendered inline; surface a toast too for visibility.
+      toast({ variant: 'error', title: 'Publish failed', description: error ?? undefined });
+    }
+  };
+
+  const handleViewLeaderboard = (): void => {
+    if (result) void window.electronAPI.publish.openExternal(result.portalLink);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-16">
+      <div className="flex max-h-[80vh] w-full max-w-2xl flex-col rounded-xl border border-border bg-card shadow-2xl">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border px-6 py-4">
+          <h2 className="text-base font-semibold text-foreground">
+            Publish this run to the public leaderboard?
+          </h2>
+          <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 space-y-5 overflow-y-auto px-6 py-4">
+          {status === 'success' && result ? (
+            <div className="space-y-4 py-6 text-center">
+              <CheckCircle2 className="mx-auto h-10 w-10 text-chart-3" />
+              <p className="text-sm font-medium text-foreground">Published to the leaderboard.</p>
+              <Button variant="outline" onClick={handleViewLeaderboard}>
+                <ExternalLink className="h-4 w-4" /> View on leaderboard
+              </Button>
+            </div>
+          ) : (
+            <>
+              {/* Aggregate (read-only) */}
+              <dl className="grid grid-cols-3 gap-3 text-xs">
+                <div>
+                  <dt className="text-muted-foreground">Accuracy</dt>
+                  <dd className="font-medium tabular-nums">{formatPercent(run.accuracy)}</dd>
+                </div>
+                <div>
+                  <dt className="text-muted-foreground">Correct / Total</dt>
+                  <dd className="font-medium tabular-nums">
+                    {run.correct_questions ?? 0} / {run.total_questions ?? 0}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-muted-foreground">Providers</dt>
+                  <dd className="font-medium">{providers.join(', ') || '—'}</dd>
+                </div>
+              </dl>
+
+              {/* url4 expression (read-only) + redaction warning */}
+              <div>
+                <span className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                  URL4 expression {sanitize && hasDataRefs ? '(sanitized)' : ''}
+                </span>
+                <div className="rounded bg-muted/30 px-3 py-2">
+                  <Url4Viewer expression={expressionToPublish} serverUrl={serverUrl} />
+                </div>
+                {hasDataRefs && (
+                  <div className="mt-2 rounded border border-chart-5/40 bg-chart-5/10 px-3 py-2 text-xs">
+                    <p className="flex items-start gap-1.5 text-foreground">
+                      <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-chart-5" />
+                      This expression references local <code>/data</code> blobs that only exist on
+                      your machine. The published version won&apos;t be runnable by others.
+                    </p>
+                    <label className="mt-2 flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        checked={sanitize}
+                        onChange={(e) => {
+                          setSanitize(e.target.checked);
+                          if (e.target.checked) setAckExpose(false);
+                        }}
+                      />
+                      Sanitize — replace local data refs with <code>/data/&lt;redacted&gt;</code>
+                    </label>
+                    {!sanitize && (
+                      <label className="mt-1 flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          checked={ackExpose}
+                          onChange={(e) => setAckExpose(e.target.checked)}
+                        />
+                        I understand this exposes my local data refs
+                      </label>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              {/* benchmark / spec ids */}
+              <div className="grid grid-cols-2 gap-3">
+                <label className="block">
+                  <span className="mb-1 block text-xs font-medium text-muted-foreground">
+                    Benchmark ID <span className="text-destructive">*</span>
+                  </span>
+                  <input
+                    className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
+                    value={benchmarkId}
+                    placeholder="e.g. hle"
+                    onChange={(e) => setBenchmarkId(e.target.value)}
+                  />
+                </label>
+                <label className="block">
+                  <span className="mb-1 block text-xs font-medium text-muted-foreground">
+                    Spec ID <span className="text-destructive">*</span>
+                  </span>
+                  <input
+                    className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
+                    value={specId}
+                    onChange={(e) => setSpecId(e.target.value)}
+                  />
+                </label>
+              </div>
+
+              {/* providers (editable) */}
+              <label className="block">
+                <span className="mb-1 block text-xs font-medium text-muted-foreground">
+                  Providers (comma-separated)
+                </span>
+                <input
+                  className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
+                  value={providersText}
+                  placeholder="claude, codex, gemini"
+                  onChange={(e) => setProvidersText(e.target.value)}
+                />
+              </label>
+
+              {/* submitter */}
+              <label className="block">
+                <span className="mb-1 block text-xs font-medium text-muted-foreground">
+                  Submitter name
+                </span>
+                <input
+                  className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
+                  value={submittedBy}
+                  placeholder="leave blank for anonymous"
+                  onChange={(e) => setSubmittedBy(e.target.value)}
+                />
+              </label>
+
+              {/* privacy notice */}
+              <p className="text-[11px] leading-relaxed text-muted-foreground">
+                Your aggregate result, the URL4 expression, and the submitter name (if provided)
+                will be public. Per-question details stay on your machine.
+              </p>
+
+              {error && (
+                <div className="rounded border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                  {error}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 border-t border-border px-6 py-4">
+          {status === 'success' ? (
+            <Button onClick={onClose}>Done</Button>
+          ) : (
+            <>
+              <Button variant="outline" onClick={onClose} disabled={submitting}>
+                Cancel
+              </Button>
+              <Button onClick={handlePublish} disabled={!canPublish || submitting}>
+                <Upload className="h-4 w-4" />
+                {submitting ? 'Publishing…' : error ? 'Retry' : 'Publish'}
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { PublishToLeaderboardDialog } from '../PublishToLeaderboardDialog';
+import type { EvalRunDetail } from '../types';
+
+const publishMock = vi.fn();
+const toastMock = vi.fn();
+const hookState: {
+  status: 'idle' | 'submitting' | 'success' | 'error';
+  error: string | null;
+  result: { id: string; benchmarkId: string; specId: string; portalLink: string } | null;
+} = { status: 'idle', error: null, result: null };
+
+vi.mock('@/hooks/use-publish-score', () => ({
+  usePublishScore: () => ({
+    publish: publishMock,
+    status: hookState.status,
+    error: hookState.error,
+    result: hookState.result,
+  }),
+}));
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: toastMock }) }));
+vi.mock('@/components/Url4Viewer', () => ({
+  Url4Viewer: ({ expression }: { expression: string }) => (
+    <span data-testid="url4">{expression}</span>
+  ),
+}));
+
+function makeRun(overrides: Partial<EvalRunDetail> = {}): EvalRunDetail {
+  return {
+    id: 'eval-run-1',
+    spec_name: 'hle:hle-ensemble-three',
+    url4_expression: 'url4://ensemble(claude,codex,gemini)/hle',
+    started_at: '2026-05-04T11:00:00Z',
+    finished_at: '2026-05-04T11:55:00Z',
+    status: 'done',
+    accuracy: 0.81,
+    total_questions: 1000,
+    correct_questions: 810,
+    error: null,
+    questions: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  publishMock.mockReset();
+  toastMock.mockReset();
+  hookState.status = 'idle';
+  hookState.error = null;
+  hookState.result = null;
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    publish: { openExternal: vi.fn(async () => {}), getContext: vi.fn() },
+  };
+});
+
+describe('PublishToLeaderboardDialog', () => {
+  it('prefills benchmark/spec from a colon-delimited spec_name', () => {
+    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    expect(screen.getByPlaceholderText('e.g. hle')).toHaveValue('hle');
+    expect(screen.getByDisplayValue('hle-ensemble-three')).toBeInTheDocument();
+  });
+
+  it('requires a benchmark id when spec_name has no colon', () => {
+    render(
+      <PublishToLeaderboardDialog
+        run={makeRun({ spec_name: 'hle-claude-single' })}
+        serverUrl=""
+        onClose={vi.fn()}
+      />,
+    );
+    const benchmark = screen.getByPlaceholderText('e.g. hle');
+    expect(benchmark).toHaveValue('');
+    expect(screen.getByRole('button', { name: /publish/i })).toBeDisabled();
+    fireEvent.change(benchmark, { target: { value: 'hle' } });
+    expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled();
+  });
+
+  it('warns about /data refs and publishes the sanitized expression by default', () => {
+    const run = makeRun({ url4_expression: '(/data/abc123)!$prompt' });
+    render(<PublishToLeaderboardDialog run={run} serverUrl="" onClose={vi.fn()} />);
+    expect(screen.getByText(/references local/i)).toBeInTheDocument();
+    // sanitize defaults on → the displayed/published expression is redacted.
+    expect(screen.getByTestId('url4')).toHaveTextContent('/data/<redacted>');
+    fireEvent.click(screen.getByRole('button', { name: /publish/i }));
+    expect(publishMock).toHaveBeenCalledTimes(1);
+    expect(publishMock.mock.calls[0][0].url4Expression).toContain('/data/<redacted>');
+  });
+
+  it('blocks publish if /data refs are neither sanitized nor acknowledged', () => {
+    const run = makeRun({ url4_expression: '(/data/abc123)!$prompt' });
+    render(<PublishToLeaderboardDialog run={run} serverUrl="" onClose={vi.fn()} />);
+    const sanitize = screen.getByRole('checkbox', { name: /sanitize/i });
+    fireEvent.click(sanitize); // uncheck
+    expect(screen.getByRole('button', { name: /publish/i })).toBeDisabled();
+    fireEvent.click(screen.getByRole('checkbox', { name: /exposes my local data/i }));
+    expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled();
+  });
+
+  it('shows the success state and opens the leaderboard deep link', () => {
+    hookState.status = 'success';
+    hookState.result = {
+      id: 'score-1',
+      benchmarkId: 'hle',
+      specId: 'hle-ensemble-three',
+      portalLink: 'http://localhost:8080/spec.html?benchmark=hle&spec=hle-ensemble-three',
+    };
+    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /view on leaderboard/i }));
+    expect(
+      (
+        window as unknown as {
+          electronAPI: { publish: { openExternal: ReturnType<typeof vi.fn> } };
+        }
+      ).electronAPI.publish.openExternal,
+    ).toHaveBeenCalledWith('http://localhost:8080/spec.html?benchmark=hle&spec=hle-ensemble-three');
+  });
+});

--- a/apps/desktop/src/renderer/src/hooks/__tests__/use-publish-score.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/__tests__/use-publish-score.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+import { renderHook, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { usePublishScore, type PublishInputs } from '../use-publish-score';
+import type { EvalRunDetail } from '@/components/eval/types';
+
+const CTX = {
+  scoreboardUrl: 'http://localhost:9106',
+  portalUrl: 'http://localhost:8080',
+  client: { name: 'screamingface-desktop', version: '0.4.2', platform: 'darwin' },
+};
+
+const RUN: EvalRunDetail = {
+  id: 'eval-run-abc123',
+  spec_name: 'hle:hle-ensemble-three',
+  url4_expression: 'url4://ensemble(claude,codex,gemini)/hle',
+  started_at: '2026-05-04T11:00:00Z',
+  finished_at: '2026-05-04T11:55:00Z',
+  status: 'done',
+  accuracy: 0.81,
+  total_questions: 1000,
+  correct_questions: 810,
+  error: null,
+  questions: [],
+};
+
+const INPUTS: PublishInputs = {
+  run: RUN,
+  benchmarkId: 'hle',
+  specId: 'hle-ensemble-three',
+  url4Expression: RUN.url4_expression,
+  providers: ['claude', 'codex', 'gemini'],
+  submittedBy: null,
+};
+
+function okResponse(): Response {
+  return {
+    ok: true,
+    status: 201,
+    json: async () => ({ id: 'score-1', benchmark_id: 'hle', spec_id: 'hle-ensemble-three' }),
+  } as unknown as Response;
+}
+
+function errResponse(status: number): Response {
+  return {
+    ok: false,
+    status,
+    text: async () => 'rejected',
+    json: async () => ({}),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    publish: { getContext: vi.fn(async () => CTX), openExternal: vi.fn(async () => {}) },
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('usePublishScore', () => {
+  it('POSTs the nested-client wire shape with the eval_run id as Idempotency-Key', async () => {
+    const fetchMock = vi.fn(async () => okResponse());
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { result } = renderHook(() => usePublishScore());
+    let out: Awaited<ReturnType<typeof result.current.publish>> = null;
+    await act(async () => {
+      out = await result.current.publish(INPUTS);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://localhost:9106/v1/scores');
+    expect((init.headers as Record<string, string>)['Idempotency-Key']).toBe('eval-run-abc123');
+    const body = JSON.parse(init.body as string);
+    // Nested client, not flat — and recomputed accuracy = correct/total.
+    expect(body.client).toEqual({
+      name: 'screamingface-desktop',
+      version: '0.4.2',
+      platform: 'darwin',
+    });
+    expect(body).not.toHaveProperty('client_name');
+    expect(body.accuracy).toBeCloseTo(0.81, 5);
+    expect(body.ran_with_providers).toEqual(['claude', 'codex', 'gemini']);
+    expect(body.submitted_by).toBeNull();
+    expect(body.ran_at_local).toBe('2026-05-04T11:55:00Z');
+
+    expect(result.current.status).toBe('success');
+    expect(out).toMatchObject({
+      id: 'score-1',
+      portalLink: 'http://localhost:8080/spec.html?benchmark=hle&spec=hle-ensemble-three',
+    });
+  });
+
+  it('recomputes accuracy from totals (ignores a stale stored value)', async () => {
+    const fetchMock = vi.fn(async () => okResponse());
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const drifted: PublishInputs = {
+      ...INPUTS,
+      run: { ...RUN, accuracy: 0.9, correct_questions: 810, total_questions: 1000 },
+    };
+    const { result } = renderHook(() => usePublishScore());
+    await act(async () => {
+      await result.current.publish(drifted);
+    });
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.accuracy).toBeCloseTo(0.81, 5); // 810/1000, not the stored 0.9
+  });
+
+  it('does not retry a 4xx and surfaces actionable copy', async () => {
+    const fetchMock = vi.fn(async () => errResponse(404));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { result } = renderHook(() => usePublishScore());
+    await act(async () => {
+      await result.current.publish(INPUTS);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.current.status).toBe('error');
+    expect(result.current.error).toMatch(/not registered/i);
+  });
+
+  it('retries a transient network failure with backoff, then succeeds', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce(okResponse());
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { result } = renderHook(() => usePublishScore());
+    await act(async () => {
+      const promise = result.current.publish(INPUTS);
+      await vi.advanceTimersByTimeAsync(1100); // first backoff = 1s
+      await promise;
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.current.status).toBe('success');
+  });
+});

--- a/apps/desktop/src/renderer/src/hooks/use-publish-score.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-publish-score.ts
@@ -1,0 +1,163 @@
+// apps/desktop/src/renderer/src/hooks/use-publish-score.ts
+//
+// Publishes a local eval_run aggregate to the public scoreboard (SF-181 /
+// D-SCORE-006). Builds the exact wire shape the scoreboard accepts (nested
+// `client`, see apps/scoreboard/tests/unit/test_sf_payload.py), POSTs it with
+// an Idempotency-Key so repeat clicks don't duplicate, and retries transient
+// failures. The contract is strict (`extra="forbid"`) — send these keys only.
+
+import { useCallback, useState } from 'react';
+import type { EvalRunDetail } from '@/components/eval/types';
+
+const TIMEOUT_MS = 10_000;
+const BACKOFF_MS = [1_000, 2_000, 4_000];
+
+export type PublishStatus = 'idle' | 'submitting' | 'success' | 'error';
+
+export interface PublishInputs {
+  run: EvalRunDetail;
+  benchmarkId: string;
+  specId: string;
+  /** url4 expression to publish — already sanitized if the user chose to. */
+  url4Expression: string;
+  providers: string[];
+  /** null/empty → anonymous. */
+  submittedBy: string | null;
+}
+
+export interface PublishResult {
+  id: string;
+  benchmarkId: string;
+  specId: string;
+  /** Deep link to the leaderboard entry. */
+  portalLink: string;
+}
+
+interface ScoreResponse {
+  id: string;
+  benchmark_id: string;
+  spec_id: string;
+}
+
+/** Map a non-2xx status to actionable copy. */
+function errorForStatus(status: number, body: string): string {
+  switch (status) {
+    case 404:
+      return 'That benchmark is not registered on the scoreboard yet. Coordinate with the scoreboard owner before publishing.';
+    case 400:
+      return 'The scoreboard rejected the aggregate (accuracy must equal correct/total). This run may have inconsistent totals.';
+    case 422:
+      return 'The submission did not match the scoreboard contract. This is a bug — please report it.';
+    default:
+      return `Scoreboard returned HTTP ${status}: ${body.slice(0, 200)}`;
+  }
+}
+
+function buildBody(
+  inputs: PublishInputs,
+  client: { name: string; version: string; platform: string },
+): Record<string, unknown> {
+  const { run } = inputs;
+  const total = run.total_questions ?? 0;
+  const correct = run.correct_questions ?? 0;
+  // Recompute accuracy from the integer totals: the scoreboard 400s if `accuracy`
+  // differs from correct/total by >0.01, so never trust a stored rounded value.
+  const accuracy = total > 0 ? correct / total : 0;
+  const submittedBy =
+    inputs.submittedBy && inputs.submittedBy.trim().length > 0 ? inputs.submittedBy.trim() : null;
+  return {
+    version: 1,
+    benchmark_id: inputs.benchmarkId,
+    spec_id: inputs.specId,
+    url4_expression: inputs.url4Expression,
+    submitted_by: submittedBy,
+    accuracy,
+    total_questions: total,
+    correct_questions: correct,
+    ran_with_providers: inputs.providers,
+    ran_at_local: run.finished_at ?? run.started_at,
+    client: { name: client.name, version: client.version, platform: client.platform },
+    metadata: null,
+  };
+}
+
+async function postOnce(
+  url: string,
+  body: Record<string, unknown>,
+  idempotencyKey: string,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    return await fetch(`${url.replace(/\/$/, '')}/v1/scores`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Idempotency-Key': idempotencyKey },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+export function usePublishScore() {
+  const [status, setStatus] = useState<PublishStatus>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<PublishResult | null>(null);
+
+  const publish = useCallback(async (inputs: PublishInputs): Promise<PublishResult | null> => {
+    setStatus('submitting');
+    setError(null);
+    try {
+      const ctx = await window.electronAPI.publish.getContext();
+      const body = buildBody(inputs, ctx.client);
+      const idempotencyKey = inputs.run.id;
+
+      let lastErr: string | null = null;
+      // 1 initial attempt + up to 3 retries on transient failures.
+      for (let attempt = 0; attempt <= BACKOFF_MS.length; attempt += 1) {
+        if (attempt > 0) await sleep(BACKOFF_MS[attempt - 1]);
+        let res: Response;
+        try {
+          res = await postOnce(ctx.scoreboardUrl, body, idempotencyKey);
+        } catch {
+          lastErr = 'Could not reach the scoreboard. Check your connection and try again.';
+          continue; // network/abort — retry
+        }
+        if (res.ok) {
+          const data = (await res.json()) as ScoreResponse;
+          const portalLink = `${ctx.portalUrl.replace(/\/$/, '')}/spec.html?benchmark=${encodeURIComponent(data.benchmark_id)}&spec=${encodeURIComponent(data.spec_id)}`;
+          const out: PublishResult = {
+            id: data.id,
+            benchmarkId: data.benchmark_id,
+            specId: data.spec_id,
+            portalLink,
+          };
+          setResult(out);
+          setStatus('success');
+          return out;
+        }
+        if (res.status >= 500) {
+          lastErr = errorForStatus(res.status, await res.text());
+          continue; // server error — retry
+        }
+        // 4xx (other than 5xx) is deterministic — do not retry.
+        const errText = errorForStatus(res.status, await res.text());
+        setError(errText);
+        setStatus('error');
+        return null;
+      }
+      setError(lastErr ?? 'Publishing failed after several attempts.');
+      setStatus('error');
+      return null;
+    } catch (e) {
+      setError((e as Error).message);
+      setStatus('error');
+      return null;
+    }
+  }, []);
+
+  return { publish, status, error, result };
+}

--- a/apps/desktop/src/renderer/src/lib/__tests__/url4-redaction.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/url4-redaction.test.ts
@@ -1,0 +1,100 @@
+// apps/desktop/src/renderer/src/lib/__tests__/url4-redaction.test.ts
+import { describe, it, expect } from 'vitest';
+import {
+  findLocalDataRefs,
+  hasLocalDataRefs,
+  sanitizeDataRefs,
+  parseSpecName,
+  deriveProviders,
+} from '../url4-redaction';
+
+describe('findLocalDataRefs / hasLocalDataRefs', () => {
+  it('returns [] for an expression with no /data refs', () => {
+    const expr = 'url4://ensemble(claude,codex)/hle';
+    expect(findLocalDataRefs(expr)).toEqual([]);
+    expect(hasLocalDataRefs(expr)).toBe(false);
+  });
+
+  it('finds a single /data blob ref', () => {
+    const expr = '(/data/a1b2c3d4e5f6)!$prompt';
+    expect(findLocalDataRefs(expr)).toEqual(['/data/a1b2c3d4e5f6']);
+    expect(hasLocalDataRefs(expr)).toBe(true);
+  });
+
+  it('finds multiple /data refs including nested paths', () => {
+    const expr = '/python(/data/code/check.py)!{/data/abc123}';
+    expect(findLocalDataRefs(expr)).toEqual(['/data/code/check.py', '/data/abc123']);
+    expect(hasLocalDataRefs(expr)).toBe(true);
+  });
+
+  it('handles empty input', () => {
+    expect(findLocalDataRefs('')).toEqual([]);
+    expect(hasLocalDataRefs('')).toBe(false);
+  });
+});
+
+describe('sanitizeDataRefs', () => {
+  it('replaces every /data ref with /data/<redacted>', () => {
+    const expr = '/python(/data/code/check.py)!{/data/abc123}';
+    expect(sanitizeDataRefs(expr)).toBe('/python(/data/<redacted>)!{/data/<redacted>}');
+  });
+
+  it('leaves expressions without /data refs unchanged', () => {
+    const expr = 'url4://ensemble(claude,codex,gemini)/hle';
+    expect(sanitizeDataRefs(expr)).toBe(expr);
+  });
+
+  it('handles empty input', () => {
+    expect(sanitizeDataRefs('')).toBe('');
+  });
+});
+
+describe('parseSpecName', () => {
+  it('splits on the first colon into benchmark/spec', () => {
+    expect(parseSpecName('hle:hle-ensemble-three')).toEqual({
+      benchmark_id: 'hle',
+      spec_id: 'hle-ensemble-three',
+    });
+  });
+
+  it('splits only on the first colon', () => {
+    expect(parseSpecName('hle:spec:with:colons')).toEqual({
+      benchmark_id: 'hle',
+      spec_id: 'spec:with:colons',
+    });
+  });
+
+  it('returns null benchmark and full name as spec when there is no colon', () => {
+    expect(parseSpecName('hle-claude-single')).toEqual({
+      benchmark_id: null,
+      spec_id: 'hle-claude-single',
+    });
+  });
+
+  it('treats an empty benchmark segment as null', () => {
+    expect(parseSpecName(':spec-only')).toEqual({ benchmark_id: null, spec_id: 'spec-only' });
+  });
+});
+
+describe('deriveProviders', () => {
+  it('extracts providers from an ensemble expression in stable order', () => {
+    expect(deriveProviders('url4://ensemble(claude,codex,gemini)/hle')).toEqual([
+      'claude',
+      'codex',
+      'gemini',
+    ]);
+  });
+
+  it('is order-stable regardless of expression order', () => {
+    expect(deriveProviders('gemini,claude')).toEqual(['claude', 'gemini']);
+  });
+
+  it('returns [] when no known provider token is present', () => {
+    expect(deriveProviders('url4://benchmark/spec')).toEqual([]);
+    expect(deriveProviders('')).toEqual([]);
+  });
+
+  it('detects ollama', () => {
+    expect(deriveProviders('(ollama)!$prompt')).toEqual(['ollama']);
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/url4-redaction.ts
+++ b/apps/desktop/src/renderer/src/lib/url4-redaction.ts
@@ -1,0 +1,69 @@
+// apps/desktop/src/renderer/src/lib/url4-redaction.ts
+//
+// Pure helpers for the "Publish to Leaderboard" flow (SF-181 / D-SCORE-006).
+//
+// A published url4 expression is documentation that others may try to run. When
+// it references `/data/<ref>` blobs, those are content-addressed inline data that
+// live only on the submitter's local server — they will NOT resolve on anyone
+// else's machine and may leak local code/data. We detect those refs so the
+// publish dialog can warn and optionally redact them. (Note: `/data/<ref>` is a
+// content-hash blob reference, not a "private spec" — there is no public/private
+// spec concept in the codebase.)
+//
+// Also parses spec_name into benchmark/spec ids and derives the providers a run
+// used from the expression. All functions are pure and dependency-free.
+
+const DATA_REF_RE = /\/data\/[A-Za-z0-9_./-]+/g;
+const REDACTED_REF = '/data/<redacted>';
+const KNOWN_PROVIDERS = ['claude', 'codex', 'gemini', 'ollama'] as const;
+
+/** Every `/data/<ref>` segment in the expression (empty array if none). */
+export function findLocalDataRefs(expression: string): string[] {
+  if (!expression) return [];
+  return expression.match(DATA_REF_RE) ?? [];
+}
+
+/** True when the expression references at least one local-only `/data` blob. */
+export function hasLocalDataRefs(expression: string): boolean {
+  return findLocalDataRefs(expression).length > 0;
+}
+
+/** Replace every `/data/<ref>` with `/data/<redacted>` (still readable, not runnable). */
+export function sanitizeDataRefs(expression: string): string {
+  if (!expression) return expression;
+  return expression.replace(DATA_REF_RE, REDACTED_REF);
+}
+
+export interface ParsedSpecName {
+  /** Non-null only when spec_name carries the `<benchmark>:<spec>` convention. */
+  benchmark_id: string | null;
+  spec_id: string;
+}
+
+/**
+ * Split `spec_name` on the first colon into `<benchmark_id>:<spec_id>`. When there
+ * is no colon (today's common case), benchmark_id is null and the caller must
+ * collect it from the user; spec_id defaults to the whole name.
+ */
+export function parseSpecName(specName: string): ParsedSpecName {
+  const idx = specName.indexOf(':');
+  if (idx === -1) {
+    return { benchmark_id: null, spec_id: specName };
+  }
+  const benchmark = specName.slice(0, idx);
+  return {
+    benchmark_id: benchmark.length > 0 ? benchmark : null,
+    spec_id: specName.slice(idx + 1),
+  };
+}
+
+/**
+ * Providers referenced by the url4 expression, in a stable order. Heuristic token
+ * scan over the known provider names — the dialog shows the result and lets the
+ * user edit it, so a miss is recoverable rather than silently wrong.
+ */
+export function deriveProviders(expression: string): string[] {
+  if (!expression) return [];
+  const lower = expression.toLowerCase();
+  return KNOWN_PROVIDERS.filter((provider) => lower.includes(provider));
+}

--- a/docs/superpowers/plans/2026-06-09-SF-181-publish-to-leaderboard-desktop.md
+++ b/docs/superpowers/plans/2026-06-09-SF-181-publish-to-leaderboard-desktop.md
@@ -1,0 +1,83 @@
+# SF-181 / D-SCORE-006 — "Publish to Leaderboard" (SF desktop side)
+
+**Owner:** Sergey (SF/Electron side). **Scoreboard side:** Dmitry — already merged (#259); see `docs/superpowers/plans/SF-181-scoreboard-sf-ingestion.md`.
+**Confidence:** ≥95%.
+**Asana:** https://app.asana.com/1/1185126988600652/task/1214568426736586
+
+## Context
+
+The user-initiated path that publishes a local `eval_run` aggregate to the public scoreboard. This is the **SF-desktop half** of the A+B paired ticket. The scoreboard half is **done and merged**: `POST /v1/scores` accepts the **nested-`client`** wire shape, `Idempotency-Key` dedup, `GET /v1/scores/{id}` read-back, and CORS `*` all exist, and the contract is pinned by `apps/scoreboard/tests/unit/test_sf_payload.py`. This plan builds the desktop dialog/hook/redaction to send **exactly** what that test asserts — nothing on the scoreboard changes.
+
+Why now: Eval Studio (SF-242) lets users run local evals; there is no way to share a result to the public leaderboard. This adds that, with a privacy gate so users don't accidentally publish a url4 that references local-only data.
+
+### Decisions (confirmed with user)
+- **Redaction model:** grounded `/data/<hash>` blob-ref warning (the ticket's "private spec in `~/.screamingface/specs`" premise doesn't match reality — `/data/<id>` is a content-hash blob, no public/private spec concept exists). Warn + Sanitize / Cancel / Publish-anyway.
+- **benchmark_id/spec_id:** parse `spec_name` on `:` if present; otherwise show editable required fields (`spec_id` prefilled = `spec_name`).
+- **Scope:** SF-desktop only. Do **not** recreate `test_sf_payload.py` (already merged); build the payload to satisfy it.
+
+## The pinned contract (from `test_sf_payload.py` + `scores/schemas.py`)
+
+`POST <scoreboard>/v1/scores`, header `Idempotency-Key: <eval_run.id>`, body (`extra="forbid"` — send these keys only):
+```jsonc
+{ "version": 1, "benchmark_id": "hle", "spec_id": "hle-ensemble-three",
+  "url4_expression": "...", "accuracy": 0.81, "total_questions": 1000,
+  "correct_questions": 810, "ran_with_providers": ["claude","codex","gemini"],
+  "submitted_by": null, "ran_at_local": "2026-05-04T11:55:00Z",
+  "client": { "name": "screamingface-desktop", "version": "0.4.2", "platform": "darwin" },
+  "metadata": null }
+```
+Hard constraints the desktop MUST respect:
+- **Nested `client`** (flat `client_*` → 422). No extra keys.
+- **`accuracy` must equal `correct/total` within 0.01** else 400 → **send `accuracy = correct_questions/total_questions`** (recomputed), not the stored rounded value.
+- **`benchmark_id` must be pre-registered** else 404 → surface as actionable error; coordinate seeded benchmarks with Dmitry.
+- Repeat POST with same key → **200 + same `id`** (one row).
+- Response is **flat** `ScoreSchema`; read `id`, `benchmark_id`, `spec_id` for the toast deep link.
+
+## Architecture
+
+Self-contained renderer feature. Pure redaction lib → publish hook (HTTP + idempotency + retries) → dialog → button. Native `fetch()` to a configurable scoreboard URL. No SF-server changes.
+
+### Files to create
+- **`apps/desktop/src/renderer/src/lib/url4-redaction.ts`** — pure, no React:
+  - `findLocalDataRefs(expr: string): string[]` — matches `/data/<ref>` segments (`/\/data\/[A-Za-z0-9_./-]+/g`).
+  - `hasLocalDataRefs(expr): boolean`.
+  - `sanitizeDataRefs(expr): string` — replaces each `/data/<ref>` with `/data/<redacted>`.
+  - `parseSpecName(spec_name): { benchmark_id: string | null; spec_id: string }` — split on first `:`; no colon → `{ benchmark_id: null, spec_id: spec_name }`.
+  - `deriveProviders(expr): string[]` — scan for known tokens `claude|codex|gemini|ollama` (dedup, ordered); `[]` if none.
+- **`apps/desktop/src/renderer/src/lib/__tests__/url4-redaction.test.ts`** — exhaustive pure-fn tests (incl. the test fixture's `url4://ensemble(claude,codex,gemini)/hle` → `["claude","codex","gemini"]`).
+- **`apps/desktop/src/renderer/src/hooks/use-publish-score.ts`** — `usePublishScore()` → `{ publish(args), status, error, result }`. Builds the exact nested payload (recomputed accuracy, providers, `submitted_by` null when blank, `ran_at_local = finished_at ?? started_at`, `client` from app version + `platform`), POSTs with `Idempotency-Key: <eval_run.id>`, **10s timeout, 3 retries (1s/2s/4s backoff)** on network/5xx only (never retry 4xx). Maps 404→"benchmark not registered", 400→"accuracy/aggregate mismatch", 422→"contract error". Reads scoreboard URL from config.
+- **`apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx`** — custom-overlay modal following `components/session/NewSessionDialog.tsx` (the app does **not** use shadcn Dialog). Content per ticket: read-only aggregate (accuracy, correct/total, providers), read-only url4 via the existing **`@/components/Url4Viewer`** with the redaction warning when `hasLocalDataRefs`, benchmark_id/spec_id (parsed or editable), optional submitter name ("leave blank for anonymous"), privacy notice, and Sanitize / Cancel / Publish — Publish disabled until a `/data`-ref run is either Sanitized or the "I understand this exposes local data refs" checkbox is toggled. Uses `usePublishScore` + `useToast`.
+- **`apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx`** — vitest + @testing-library (jsdom): parse vs editable IDs, redaction warning + gating, sanitize swaps the sent expression, success toast + link, error/retry. Mocks `usePublishScore`/config.
+- **`apps/desktop/src/renderer/src/hooks/__tests__/use-publish-score.test.ts`** — mock `fetch`: idempotency header present, nested-client body, recomputed accuracy, retry/backoff with fake timers, 4xx-no-retry, error mapping.
+
+### Files to modify
+- **`apps/desktop/src/renderer/src/components/eval/EvalRunDetail.tsx`** — add a "Publish to Leaderboard" button in the header row (beside `EvalStatusBadge`, ~line 44), enabled only when `status === 'done'` and `accuracy != null && total_questions`. Wire open/close + render `PublishToLeaderboardDialog`.
+- **Config / preload:** add `scoreboard_url` and `portal_url` (read via `window.electronAPI.config.read()`, overridable by `SF_SCOREBOARD_URL`; dev default `http://localhost:9106`, portal default per D-SCORE-007). Add an `app:getVersion` IPC (main already uses `app.getVersion()`), exposed on `window.electronAPI` and typed in `preload/types.ts`. `client.platform` = `process.platform` (via preload/IPC, not in the sandboxed renderer).
+
+### Reuse (don't reinvent)
+`@/components/Url4Viewer` (read-only expression), `@/hooks/use-toast` (`useToast`), `@/hooks/use-eval-runs` (`useEvalRunDetail` data), `@/hooks/use-server-status`, the `NewSessionDialog` modal pattern, `window.electronAPI.config.read()`.
+
+## Data flow
+Button (done run) → dialog opens with `useEvalRunDetail` data → `parseSpecName` + `deriveProviders` prefill → user confirms IDs / name, resolves any `/data` warning → `usePublishScore.publish()` builds nested payload (accuracy recomputed) + POSTs with idempotency key → success: toast "Published — view on leaderboard" linking `<portal>/spec.html?benchmark=<id>&spec=<id>`; failure: error toast + retry. Local `eval_run` never mutated.
+
+## Error handling
+10s timeout; 3 retries (1s/2s/4s) on network/5xx only; 4xx surfaced immediately with specific copy (404 benchmark, 400 aggregate mismatch, 422 contract). Retry button on the failure toast. Idempotency key = `eval_run.id` so retries/double-clicks never dupe.
+
+## Verification
+- **Unit (vitest):** `cd apps/desktop && npm test -- url4-redaction PublishToLeaderboardDialog use-publish-score` — all green.
+- **Contract (no change, must stay green):** `cd apps/scoreboard && uv run pytest tests/unit/test_sf_payload.py -q`. Manually diff the hook's emitted body against `_sf_payload()` in that file — keys and nesting must match exactly.
+- **Gates:** desktop lint/typecheck (`npm run lint`, `tsc`); the run renders without console errors.
+- **Manual e2e:** run scoreboard on :9106 with a benchmark seeded (e.g. `hle`); run SF desktop with `SF_SCOREBOARD_URL=http://localhost:9106`; complete a local eval; Publish; confirm one row via `GET /v1/scores/{id}`, the success toast deep link opens the portal, and a second Publish click does not dupe (200, same id). Try a run whose url4 has a `/data/<hash>` ref → warning appears; Sanitize → sent expression shows `/data/<redacted>`.
+
+## Coordination / flagged
+- **Seeded benchmarks** (Dmitry): publishing to an unregistered `benchmark_id` → 404. Confirm which benchmark ids exist before the paired e2e.
+- **`portal_url` default** is pending D-SCORE-007; use the dev default until finalized.
+- `ran_with_providers` derivation is heuristic (token scan); the editable fallback prevents sending a misleading empty list.
+
+## Build sequence
+1. `url4-redaction.ts` + tests (pure, fastest to lock down).
+2. `app:getVersion` IPC + `scoreboard_url`/`portal_url` config + preload types.
+3. `use-publish-score.ts` + tests (payload exactly matches `test_sf_payload.py`).
+4. `PublishToLeaderboardDialog.tsx` + tests.
+5. Wire the button into `EvalRunDetail.tsx`.
+6. Gates + manual e2e against a local scoreboard.


### PR DESCRIPTION
## SF-181 / D-SCORE-006 — SF-desktop "Publish to Leaderboard"

The desktop half of the paired ticket (scoreboard half already merged in #259). Adds a **Publish to Leaderboard** button on the Eval Studio run detail that POSTs a local `eval_run` aggregate to the scoreboard `/v1/scores`, matching the merged **nested-`client`** contract pinned by `apps/scoreboard/tests/unit/test_sf_payload.py`.

- `lib/url4-redaction.ts` — detect/redact local-only `/data/<hash>` blob refs, parse `spec_name`, derive providers (pure, tested)
- `hooks/use-publish-score.ts` — nested-client payload, **accuracy recomputed from correct/total** (scoreboard 400s on >0.01 drift), `Idempotency-Key=<eval_run_id>`, 10s timeout + 3 retries on transient failures, actionable 404/400/422 copy
- `PublishToLeaderboardDialog.tsx` — aggregate + url4 review, `/data` redaction gate (sanitize or acknowledge), parse-or-edit benchmark/spec ids, anonymous submitter, success deep-link
- `EvalRunDetail.tsx` — Publish button on completed runs
- main IPC `publish:getContext` / `publish:openExternal`

**Verification:** 27 new tests; scoreboard contract test stays green; full desktop suite passes.

**Coordination:** `benchmark_id` must be pre-registered on the scoreboard (404 otherwise) — confirm seeded benchmarks with the scoreboard owner before the paired e2e.

Plan: `docs/superpowers/plans/2026-06-09-SF-181-publish-to-leaderboard-desktop.md`.
Asana: https://app.asana.com/1/1185126988600652/task/1214568426736586

🤖 Generated with [Claude Code](https://claude.com/claude-code)