### PR TITLE
SF-246: exclude no-auth runners from /backends/status credential walk

### DIFF
--- a/apps/server/src/screamingface/plugin.py
+++ b/apps/server/src/screamingface/plugin.py
@@ -73,6 +73,14 @@ class Plugin:
     # ``/claude()!hello`` dispatches to it.
     backend_call_paths: list[str] = []
 
+    # Whether this plugin is a *credentialed* backend that belongs in the
+    # ``/backends/status`` credential/health walk. ``backend_call_paths`` only
+    # means "I'm a url4 dispatch target" — a no-auth runner (e.g. python-runner
+    # executes scripts and needs no credentials) declares a dispatch path but
+    # must NOT be probed for auth, or it gets misreported as
+    # "Credential is missing or expired." Such plugins set this to False.
+    requires_auth: bool = True
+
     def preflight(self) -> tuple[bool, str]:
         """Check if this plugin can activate. Return (ok, reason).
 

--- a/apps/server/src/screamingface/plugins/llm_base/routes.py
+++ b/apps/server/src/screamingface/plugins/llm_base/routes.py
@@ -74,6 +74,12 @@ async def _collect_backend_status(app: Any = None) -> dict[str, Any]:
     for plugin in plugins.values():
         if not plugin.backend_call_paths:
             continue
+        # Skip no-auth dispatch backends (e.g. python-runner): they declare a
+        # url4 backend_call path but require no credentials and expose no
+        # /health route, so probing them misreports "Credential is missing or
+        # expired." (SF-246).
+        if not getattr(plugin, "requires_auth", True):
+            continue
         path = plugin.backend_call_paths[0]
         name = path.lstrip("/")
 

--- a/apps/server/src/screamingface/plugins/llm_base/tests/test_backends_status_runner_exemption.py
+++ b/apps/server/src/screamingface/plugins/llm_base/tests/test_backends_status_runner_exemption.py
@@ -1,0 +1,58 @@
+"""SF-246: no-auth dispatch backends (e.g. python-runner) must be excluded from
+the credential/health status walk.
+
+``backend_call_paths`` is overloaded — it marks a plugin as a url4 backend-call
+target AND was the sole gate for inclusion in ``/backends/status``. A runner
+like python-runner has a dispatch path (``/python``) but no credentials and no
+``/health`` route, so it was probed, 404'd, and reported as
+"Credential is missing or expired." Plugins set ``requires_auth = False`` to opt
+out of the credential status walk.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from screamingface.plugins.llm_base import routes as status_routes
+
+
+class _CredentialedBackend:
+    name = "claude-backend-api"
+    backend_call_paths = ["/claude"]
+    # requires_auth not set → defaults to True (credentialed backend)
+
+
+class _NoAuthRunner:
+    name = "python-runner"
+    backend_call_paths = ["/python"]
+    requires_auth = False
+
+
+@pytest.mark.anyio
+async def test_collect_backend_status_skips_no_auth_runner(monkeypatch) -> None:
+    async def fake_probe(_base_url: str, _name: str) -> dict[str, object]:
+        # Simulate a plugin with no /health route (python-runner): 404 → unauthenticated.
+        return {"authenticated": False, "error": "no health endpoint"}
+
+    monkeypatch.setattr(status_routes, "_probe_health", fake_probe)
+    monkeypatch.setattr(status_routes, "_get_base_url", lambda _app: "http://test")
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            plugins=SimpleNamespace(
+                active_plugins={
+                    "claude-backend-api": _CredentialedBackend(),
+                    "python-runner": _NoAuthRunner(),
+                }
+            )
+        )
+    )
+
+    result = await status_routes._collect_backend_status(app)
+
+    # The credentialed backend is still reported (and would surface reauth).
+    assert "claude" in result
+    # The no-auth runner is excluded entirely — never classified reauth.
+    assert "python" not in result

--- a/apps/server/src/screamingface/plugins/python_runner/plugin.py
+++ b/apps/server/src/screamingface/plugins/python_runner/plugin.py
@@ -93,6 +93,9 @@ class PythonRunnerPlugin(Plugin):
     conflicts: list[str] = []
     settings_class = PythonRunnerSettings
     backend_call_paths: list[str] = ["/python"]
+    # Executes scripts; no credentials and no /health route, so it must be
+    # excluded from the /backends/status credential walk (SF-246).
+    requires_auth: bool = False
 
     async def handle_backend_call(
         self,


### PR DESCRIPTION
## SF-246 — fix false "Credential is missing or expired." for python-runner

`python-runner` declares `backend_call_paths=["/python"]` for url4 dispatch but has no credentials and no `/health` route, so `_collect_backend_status` probed it, 404'd, and reported **"Credential is missing or expired."** in the backend auth panel.

`backend_call_paths` was overloaded (it means "url4 dispatch target", not "credentialed backend"). Fix: add a `requires_auth: bool = True` flag to the `Plugin` base; skip plugins with `requires_auth=False` in `_collect_backend_status`; set `requires_auth=False` on `python-runner`.

**Audited all 8 `backend_call_paths` plugins:** the 6 model backends stay credentialed (CLI/gateway OAuth) and `ollama-backend-api` keeps a real `/health` (local reachability), so python-runner is the only correct exclusion.

**Verification:** failing test reproduces the bug → passes after fix; 470 tests green across llm_base/python_runner/ollama/url4_executor; no test expected `python` in status; ruff + pyright clean.

Asana: https://app.asana.com/1/1185126988600652/task/1215557883990253

🤖 Generated with [Claude Code](https://claude.com/claude-code)