### PR TITLE
SF-247: Monaco editor for python-runner scripts + 10px popup cap

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -11,11 +11,13 @@
         "@base-ui/react": "^1.2.0",
         "@electron-toolkit/preload": "^3.0.1",
         "@electron-toolkit/utils": "^3.0.0",
+        "@monaco-editor/react": "^4.7.0",
         "@rjsf/core": "^6.4.1",
         "@rjsf/utils": "^6.4.1",
         "@rjsf/validator-ajv8": "^6.4.1",
         "@softarc/native-federation": "^3.5.4",
         "@softarc/native-federation-runtime": "^3.5.4",
+        "monaco-editor": "^0.55.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-resizable-panels": "^2.1.9"
@@ -2757,6 +2759,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@mswjs/interceptors": {
       "version": "0.41.3",
       "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
@@ -4090,6 +4115,13 @@
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/validate-npm-package-name": {
       "version": "4.0.2",
@@ -6646,6 +6678,15 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -10678,6 +10719,18 @@
         }
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/matcher": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -11028,6 +11081,17 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
       }
     },
     "node_modules/ms": {
@@ -13592,6 +13656,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -31,11 +31,13 @@
     "@base-ui/react": "^1.2.0",
     "@electron-toolkit/preload": "^3.0.1",
     "@electron-toolkit/utils": "^3.0.0",
+    "@monaco-editor/react": "^4.7.0",
     "@rjsf/core": "^6.4.1",
     "@rjsf/utils": "^6.4.1",
     "@rjsf/validator-ajv8": "^6.4.1",
     "@softarc/native-federation": "^3.5.4",
     "@softarc/native-federation-runtime": "^3.5.4",
+    "monaco-editor": "^0.55.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-resizable-panels": "^2.1.9"

--- a/apps/desktop/src/renderer/src/components/AigwLoginDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/AigwLoginDialog.tsx
@@ -78,7 +78,7 @@ export function AigwLoginDialog({ open, session, onClose, onSignedIn }: AigwLogi
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/70 px-4 backdrop-blur-sm">
-      <div className="w-full max-w-md rounded-xl border border-border bg-card p-5 shadow-2xl">
+      <div className="w-full max-w-md rounded-[10px] border border-border bg-card p-5 shadow-2xl">
         <div className="mb-4">
           <h2 className="font-heading text-base font-semibold text-foreground">
             Sign in to AIGateway

--- a/apps/desktop/src/renderer/src/components/CodeEditorPopup.tsx
+++ b/apps/desktop/src/renderer/src/components/CodeEditorPopup.tsx
@@ -24,7 +24,7 @@ export default function CodeEditorPopup({ title, language, value, onSave, onClos
   return (
     <div className="fixed inset-0 z-50 bg-black/50">
       {/* 5% inset from every app border */}
-      <div className="absolute inset-[5%] flex flex-col overflow-hidden rounded-xl border border-border bg-card shadow-2xl">
+      <div className="absolute inset-[5%] flex flex-col overflow-hidden rounded-[10px] border border-border bg-card shadow-2xl">
         <div className="flex items-center justify-between border-b border-border px-4 py-2">
           <h2 className="text-sm font-semibold text-foreground">{title}</h2>
           <button onClick={onClose} className="text-muted-foreground hover:text-foreground">

--- a/apps/desktop/src/renderer/src/components/CodeEditorPopup.tsx
+++ b/apps/desktop/src/renderer/src/components/CodeEditorPopup.tsx
@@ -1,0 +1,65 @@
+// apps/desktop/src/renderer/src/components/CodeEditorPopup.tsx
+//
+// Full-screen-ish (5% inset) Monaco editor popup for editing a single code
+// blob. Default export so it can be React.lazy()'d — that keeps the heavy
+// monaco bundle out of the settings form until the user opens an editor.
+import { useState } from 'react';
+import Editor from '@monaco-editor/react';
+import { X, Save } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+// Side-effect: configure monaco to run bundled (no CDN) before it mounts.
+import '@/lib/monaco-setup';
+
+interface Props {
+  title: string;
+  language: string;
+  value: string;
+  onSave: (value: string) => void;
+  onClose: () => void;
+}
+
+export default function CodeEditorPopup({ title, language, value, onSave, onClose }: Props) {
+  const [draft, setDraft] = useState(value);
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/50">
+      {/* 5% inset from every app border */}
+      <div className="absolute inset-[5%] flex flex-col overflow-hidden rounded-xl border border-border bg-card shadow-2xl">
+        <div className="flex items-center justify-between border-b border-border px-4 py-2">
+          <h2 className="text-sm font-semibold text-foreground">{title}</h2>
+          <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="min-h-0 flex-1">
+          <Editor
+            language={language}
+            value={draft}
+            onChange={(v) => setDraft(v ?? '')}
+            theme="vs-dark"
+            options={{
+              minimap: { enabled: false },
+              fontSize: 13,
+              scrollBeyondLastLine: false,
+              automaticLayout: true,
+              tabSize: 4,
+            }}
+          />
+        </div>
+        <div className="flex justify-end gap-2 border-t border-border px-4 py-2">
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() => {
+              onSave(draft);
+              onClose();
+            }}
+          >
+            <Save className="h-4 w-4" /> Save
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/SpecSelector.tsx
+++ b/apps/desktop/src/renderer/src/components/SpecSelector.tsx
@@ -34,9 +34,10 @@ export function SpecSelector({ value, onChange, fallbackNames }: SpecSelectorPro
     : '';
 
   // Use fetched specs if available, otherwise fall back to enum names from schema
-  const specs = fetchedSpecs.length > 0
-    ? fetchedSpecs
-    : (fallbackNames ?? []).map((name) => ({ name, expression: '' }));
+  const specs =
+    fetchedSpecs.length > 0
+      ? fetchedSpecs
+      : (fallbackNames ?? []).map((name) => ({ name, expression: '' }));
 
   const loadSpecs = useCallback(() => {
     if (!serverUrl) return;
@@ -101,7 +102,10 @@ export function SpecSelector({ value, onChange, fallbackNames }: SpecSelectorPro
         {fetchError && (
           <div className="py-3 text-center">
             <p className="text-xs text-destructive">{fetchError}</p>
-            <button onClick={loadSpecs} className="mt-1 text-[10px] text-muted-foreground hover:text-foreground underline">
+            <button
+              onClick={loadSpecs}
+              className="mt-1 text-[10px] text-muted-foreground hover:text-foreground underline"
+            >
               Retry
             </button>
           </div>
@@ -126,9 +130,7 @@ export function SpecSelector({ value, onChange, fallbackNames }: SpecSelectorPro
               {/* Selection indicator */}
               <div
                 className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-full border ${
-                  isActive
-                    ? 'border-chart-3 bg-chart-3 text-white'
-                    : 'border-muted-foreground/30'
+                  isActive ? 'border-chart-3 bg-chart-3 text-white' : 'border-muted-foreground/30'
                 }`}
               >
                 {isActive && <Check className="h-2.5 w-2.5" />}
@@ -136,7 +138,9 @@ export function SpecSelector({ value, onChange, fallbackNames }: SpecSelectorPro
 
               {/* Spec info — row layout: name + expression side by side */}
               <div className="min-w-0 flex-1 flex items-center gap-2">
-                <span className="text-xs font-medium text-foreground whitespace-nowrap">{spec.name}</span>
+                <span className="text-xs font-medium text-foreground whitespace-nowrap">
+                  {spec.name}
+                </span>
                 {spec.expression && (
                   <span className="truncate text-[10px] text-muted-foreground font-mono">
                     {spec.expression}
@@ -164,9 +168,12 @@ export function SpecSelector({ value, onChange, fallbackNames }: SpecSelectorPro
 
       {/* Preview popup */}
       {previewSpec && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={() => setPreviewSpec(null)}>
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          onClick={() => setPreviewSpec(null)}
+        >
           <div
-            className="w-full max-w-lg rounded-xl border border-border bg-card p-5 shadow-2xl"
+            className="w-full max-w-lg rounded-[10px] border border-border bg-card p-5 shadow-2xl"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="mb-3 flex items-center justify-between">

--- a/apps/desktop/src/renderer/src/components/__tests__/rjsf-CodeDictField.test.tsx
+++ b/apps/desktop/src/renderer/src/components/__tests__/rjsf-CodeDictField.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { FieldProps } from '@rjsf/utils';
+import { CodeDictField } from '../rjsf-CodeDictField';
+
+// Stub the lazy Monaco popup so jsdom never loads monaco-editor.
+vi.mock('@/components/CodeEditorPopup', () => ({
+  default: ({ title }: { title: string }) => <div data-testid="popup">{title}</div>,
+}));
+
+function makeProps(
+  formData: Record<string, string>,
+  onChange = vi.fn(),
+): { props: FieldProps; onChange: ReturnType<typeof vi.fn> } {
+  const props = {
+    formData,
+    onChange,
+    uiSchema: { 'ui:options': { language: 'python' } },
+    schema: { type: 'object' },
+  } as unknown as FieldProps;
+  return { props, onChange };
+}
+
+describe('CodeDictField', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('lists existing scripts as <name>.py', () => {
+    const { props } = makeProps({ check: 'print(1)', score: '' });
+    render(<CodeDictField {...props} />);
+    expect(screen.getByText('check.py')).toBeInTheDocument();
+    expect(screen.getByText('score.py')).toBeInTheDocument();
+  });
+
+  it('rejects an invalid script name and does not mutate', () => {
+    const { props, onChange } = makeProps({ check: 'x' });
+    render(<CodeDictField {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /add script/i }));
+    fireEvent.change(screen.getByPlaceholderText('script_name'), { target: { value: '1bad' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Add$/ }));
+    expect(screen.getByText(/python identifier/i)).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('adds a valid new script via onChange', async () => {
+    const { props, onChange } = makeProps({ check: 'x' });
+    render(<CodeDictField {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /add script/i }));
+    fireEvent.change(screen.getByPlaceholderText('script_name'), {
+      target: { value: 'calc_score' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Add$/ }));
+    expect(onChange).toHaveBeenCalledWith({ check: 'x', calc_score: '' });
+    // Adding immediately opens the editor popup for the new script.
+    expect(await screen.findByTestId('popup')).toHaveTextContent('calc_score.py');
+  });
+
+  it('deletes a script via onChange', () => {
+    const { props, onChange } = makeProps({ check: 'x', score: 'y' });
+    render(<CodeDictField {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /delete check/i }));
+    expect(onChange).toHaveBeenCalledWith({ score: 'y' });
+  });
+
+  it('opens the Monaco popup when a script is clicked', async () => {
+    const { props } = makeProps({ check: 'print(1)' });
+    render(<CodeDictField {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: 'check.py' }));
+    expect(await screen.findByTestId('popup')).toHaveTextContent('check.py');
+  });
+});

--- a/apps/desktop/src/renderer/src/components/__tests__/rjsf-utils.test.ts
+++ b/apps/desktop/src/renderer/src/components/__tests__/rjsf-utils.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import type { RJSFSchema } from '@rjsf/utils';
+import { buildCodeEditorUiSchema } from '../rjsf-utils';
+
+describe('buildCodeEditorUiSchema', () => {
+  it('routes an x-code-editor property to CodeDictField with its language', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: {
+        scripts: {
+          type: 'object',
+          additionalProperties: { type: 'string' },
+          'x-code-editor': { language: 'python' },
+        } as RJSFSchema,
+      },
+    };
+    expect(buildCodeEditorUiSchema(schema)).toEqual({
+      scripts: { 'ui:field': 'CodeDictField', 'ui:options': { language: 'python' } },
+    });
+  });
+
+  it('returns an empty object when no property carries the hint', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+    };
+    expect(buildCodeEditorUiSchema(schema)).toEqual({});
+  });
+
+  it('defaults language to plaintext when unspecified', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: { blob: { type: 'string', 'x-code-editor': {} } as RJSFSchema },
+    };
+    expect(buildCodeEditorUiSchema(schema)).toEqual({
+      blob: { 'ui:field': 'CodeDictField', 'ui:options': { language: 'plaintext' } },
+    });
+  });
+});

--- a/apps/desktop/src/renderer/src/components/rjsf-CodeDictField.tsx
+++ b/apps/desktop/src/renderer/src/components/rjsf-CodeDictField.tsx
@@ -1,0 +1,138 @@
+// apps/desktop/src/renderer/src/components/rjsf-CodeDictField.tsx
+//
+// Custom RJSF field for a `dict[str, str]` of code, routed via the
+// `x-code-editor` schema hint. Renders a file list with add/delete and opens a
+// Monaco editor popup (lazy-loaded) to edit each entry's source. Used for
+// python-runner `scripts` (SF-247).
+import { Suspense, lazy, useState } from 'react';
+import type { FieldProps } from '@rjsf/utils';
+import { FileCode, Plus, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+const CodeEditorPopup = lazy(() => import('@/components/CodeEditorPopup'));
+
+// Mirrors the python-runner backend rule (VALID_SCRIPT_NAME): a Python identifier.
+const VALID_NAME = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+function languageOf(uiSchema: FieldProps['uiSchema']): string {
+  const opts = (uiSchema?.['ui:options'] ?? {}) as Record<string, unknown>;
+  return typeof opts.language === 'string' ? opts.language : 'plaintext';
+}
+
+export function CodeDictField(props: FieldProps) {
+  const data = (props.formData ?? {}) as Record<string, string>;
+  const language = languageOf(props.uiSchema);
+
+  const [editing, setEditing] = useState<string | null>(null);
+  const [adding, setAdding] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [nameError, setNameError] = useState<string | null>(null);
+
+  const names = Object.keys(data);
+
+  const handleAdd = (): void => {
+    const name = newName.trim();
+    if (!VALID_NAME.test(name)) {
+      setNameError(
+        'Use a Python identifier: start with a letter/underscore; letters, digits, underscores only.',
+      );
+      return;
+    }
+    if (name in data) {
+      setNameError('A script with that name already exists.');
+      return;
+    }
+    props.onChange({ ...data, [name]: '' });
+    setNewName('');
+    setAdding(false);
+    setNameError(null);
+    setEditing(name);
+  };
+
+  const handleDelete = (name: string): void => {
+    const next = { ...data };
+    delete next[name];
+    props.onChange(next);
+  };
+
+  return (
+    <div className="space-y-2">
+      <ul className="divide-y divide-border rounded-md border border-border">
+        {names.length === 0 && (
+          <li className="px-3 py-2 text-xs text-muted-foreground">No scripts yet.</li>
+        )}
+        {names.map((name) => (
+          <li key={name} className="flex items-center gap-2 px-3 py-2">
+            <button
+              type="button"
+              className="flex flex-1 items-center gap-2 text-left text-sm hover:text-primary"
+              onClick={() => setEditing(name)}
+            >
+              <FileCode className="h-4 w-4 text-muted-foreground" />
+              {name}.py
+            </button>
+            <button
+              type="button"
+              className="text-muted-foreground hover:text-destructive"
+              onClick={() => handleDelete(name)}
+              aria-label={`Delete ${name}`}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      {adding ? (
+        <div className="flex items-start gap-2">
+          <div className="flex-1">
+            <input
+              autoFocus
+              className="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm"
+              placeholder="script_name"
+              value={newName}
+              onChange={(e) => {
+                setNewName(e.target.value);
+                setNameError(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleAdd();
+              }}
+            />
+            {nameError && <p className="mt-1 text-[11px] text-destructive">{nameError}</p>}
+          </div>
+          <Button size="sm" onClick={handleAdd}>
+            Add
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => {
+              setAdding(false);
+              setNewName('');
+              setNameError(null);
+            }}
+          >
+            Cancel
+          </Button>
+        </div>
+      ) : (
+        <Button size="sm" variant="outline" onClick={() => setAdding(true)}>
+          <Plus className="h-3.5 w-3.5" /> Add script
+        </Button>
+      )}
+
+      {editing !== null && (
+        <Suspense fallback={null}>
+          <CodeEditorPopup
+            title={`${editing}.py`}
+            language={language}
+            value={data[editing] ?? ''}
+            onSave={(val) => props.onChange({ ...data, [editing]: val })}
+            onClose={() => setEditing(null)}
+          />
+        </Suspense>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/rjsf-theme.tsx
+++ b/apps/desktop/src/renderer/src/components/rjsf-theme.tsx
@@ -5,8 +5,10 @@ import type {
   ArrayFieldItemTemplateProps,
   ArrayFieldTemplateProps,
   BaseInputTemplateProps,
+  FieldProps,
   FieldTemplateProps,
   ObjectFieldTemplateProps,
+  RegistryFieldsType,
   RegistryWidgetsType,
   RJSFSchema,
   TemplatesType,
@@ -14,6 +16,7 @@ import type {
   WrapIfAdditionalTemplateProps,
 } from '@rjsf/utils';
 import { ADDITIONAL_PROPERTY_FLAG } from '@rjsf/utils';
+import { CodeDictField } from './rjsf-CodeDictField';
 import {
   Component,
   type ComponentType,
@@ -74,7 +77,6 @@ function humanizeTitle(title: string): string {
   return title.replace(/([a-z])([A-Z])/g, '$1 $2');
 }
 
-
 // ---------------------------------------------------------------------------
 // Templates
 // ---------------------------------------------------------------------------
@@ -109,7 +111,7 @@ function BaseInputTemplate(props: BaseInputTemplateProps) {
         list={listId}
         type={type === 'number' || type === 'integer' ? 'number' : 'text'}
         value={value ?? ''}
-        placeholder={placeholder || (schema as any)['x-placeholder']}
+        placeholder={placeholder || (schema as { 'x-placeholder'?: string })['x-placeholder']}
         disabled={disabled || readonly}
         autoFocus={autofocus}
         onChange={(e) => onChange(e.target.value === '' ? undefined : e.target.value)}
@@ -242,9 +244,7 @@ function ObjectFieldTemplate(props: ObjectFieldTemplateProps) {
           <p className="text-[10px] text-muted-foreground/60">{schema.description}</p>
         )}
         {properties.length === 0 && (
-          <p className="text-xs text-muted-foreground/50 py-3 text-center">
-            No entries yet
-          </p>
+          <p className="text-xs text-muted-foreground/50 py-3 text-center">No entries yet</p>
         )}
         {properties.map((p) => {
           const isExpanded = expandedKey === p.name;
@@ -575,14 +575,20 @@ const widgets: RegistryWidgetsType = {
   SpecSelectorWidget: SpecSelectorWidget as ComponentType<WidgetProps>,
 };
 
+const fields: RegistryFieldsType = {
+  CodeDictField: CodeDictField as ComponentType<FieldProps>,
+};
+
 // ---------------------------------------------------------------------------
 // Export: pre-themed Form component
 // ---------------------------------------------------------------------------
 
-export function ThemedForm<T = unknown>(props: Omit<FormProps<T>, 'templates' | 'widgets'>) {
+export function ThemedForm<T = unknown>(
+  props: Omit<FormProps<T>, 'templates' | 'widgets' | 'fields'>,
+) {
   return (
     <RJSFErrorBoundary name="ThemedForm">
-      <Form {...props} templates={templates} widgets={widgets} />
+      <Form {...props} templates={templates} widgets={widgets} fields={fields} />
     </RJSFErrorBoundary>
   );
 }

--- a/apps/desktop/src/renderer/src/components/rjsf-utils.ts
+++ b/apps/desktop/src/renderer/src/components/rjsf-utils.ts
@@ -1,6 +1,30 @@
 import type { RJSFSchema } from '@rjsf/utils';
 
 /**
+ * Build a uiSchema fragment routing any top-level property that carries an
+ * `x-code-editor` JSON-Schema annotation to the `CodeDictField` (file list +
+ * Monaco popup). The annotation's `language` is forwarded as a `ui:options`.
+ * Backend declares it via Pydantic `json_schema_extra` (e.g. python-runner
+ * `scripts`). SF-247.
+ */
+export function buildCodeEditorUiSchema(schema: RJSFSchema): Record<string, unknown> {
+  const ui: Record<string, unknown> = {};
+  const properties = (schema.properties ?? {}) as Record<string, unknown>;
+  for (const [key, propSchema] of Object.entries(properties)) {
+    if (propSchema === null || typeof propSchema !== 'object') continue;
+    const hint = (propSchema as Record<string, unknown>)['x-code-editor'];
+    if (hint && typeof hint === 'object') {
+      const language = (hint as Record<string, unknown>).language;
+      ui[key] = {
+        'ui:field': 'CodeDictField',
+        'ui:options': { language: typeof language === 'string' ? language : 'plaintext' },
+      };
+    }
+  }
+  return ui;
+}
+
+/**
  * Inline all `$ref` / `$defs` so RJSF gets a plain schema with no refs.
  * Pydantic emits `$defs` + `$ref` for nested models — RJSF *should*
  * resolve these, but in practice the custom templates sometimes receive

--- a/apps/desktop/src/renderer/src/components/session/NewSessionDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/session/NewSessionDialog.tsx
@@ -152,7 +152,7 @@ export function NewSessionDialog({ type, editSession, onLaunch, onClose }: Props
 
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-16">
-      <div className="flex max-h-[80vh] w-full max-w-2xl flex-col rounded-xl border border-border bg-card shadow-2xl">
+      <div className="flex max-h-[80vh] w-full max-w-2xl flex-col rounded-[10px] border border-border bg-card shadow-2xl">
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border px-6 py-4">
           <h2 className="text-base font-semibold text-foreground">

--- a/apps/desktop/src/renderer/src/lib/monaco-setup.ts
+++ b/apps/desktop/src/renderer/src/lib/monaco-setup.ts
@@ -1,0 +1,26 @@
+// apps/desktop/src/renderer/src/lib/monaco-setup.ts
+//
+// Side-effect module: configure Monaco to run fully bundled (no CDN) so it works
+// offline inside Electron. Import this once before mounting any Monaco editor.
+//
+// Python syntax highlighting is Monarch-based (shipped in monaco-editor's
+// basic-languages) and needs only the base editor worker — no language server.
+import { loader } from '@monaco-editor/react';
+import * as monaco from 'monaco-editor';
+import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
+
+declare global {
+  interface Window {
+    MonacoEnvironment?: monaco.Environment;
+  }
+}
+
+self.MonacoEnvironment = {
+  getWorker(): Worker {
+    return new EditorWorker();
+  },
+};
+
+// Point @monaco-editor/react at the locally-bundled monaco instead of its
+// default CDN loader.
+loader.config({ monaco });

--- a/apps/desktop/src/renderer/src/views/SessionsView.tsx
+++ b/apps/desktop/src/renderer/src/views/SessionsView.tsx
@@ -186,7 +186,7 @@ export function SessionsView() {
           onClick={() => setInstallPrompt(null)}
         >
           <div
-            className="relative w-[420px] overflow-hidden rounded-xl border border-border bg-card shadow-2xl"
+            className="relative w-[420px] overflow-hidden rounded-[10px] border border-border bg-card shadow-2xl"
             onClick={(e) => e.stopPropagation()}
           >
             {/* Gradient accent bar */}

--- a/apps/desktop/src/renderer/src/views/SettingsView.tsx
+++ b/apps/desktop/src/renderer/src/views/SettingsView.tsx
@@ -5,7 +5,7 @@ import type { RJSFSchema } from '@rjsf/utils';
 import { useServerStatus } from '../hooks/use-server-status';
 import { useToast } from '../hooks/use-toast';
 import { ThemedForm } from '../components/rjsf-theme';
-import { inlineRefs } from '../components/rjsf-utils';
+import { inlineRefs, buildCodeEditorUiSchema } from '../components/rjsf-utils';
 import type { DiscoveredPlugin } from '../../../preload/types';
 
 interface ServerConfig {
@@ -683,6 +683,7 @@ export function SettingsView() {
                                     omitExtraData
                                     uiSchema={{
                                       'ui:submitButtonOptions': { norender: true },
+                                      ...buildCodeEditorUiSchema(schema),
                                       ...([
                                         'claude-frontend',
                                         'codex-frontend',

--- a/apps/desktop/src/renderer/src/vite-env.d.ts
+++ b/apps/desktop/src/renderer/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## SF-247 — Monaco code editor for python-runner scripts in Settings

> ⚠️ **Stacked on #262 (SF-246).** Base is the SF-246 branch so this diff shows only the SF-247 commits. GitHub will retarget it to `main` automatically once #262 merges. Merge #262 first.

The python-runner `scripts` dict rendered as a single-line input. Adds a custom RJSF field routed by the backend's existing `x-code-editor` schema hint:

- **File list** of `<name>.py` with **+ Add** (Python-identifier validation, mirrors the backend rule) and delete
- Clicking a script opens a **Monaco editor popup (5% inset)** with Python syntax highlighting; edits round-trip to `sf.json`
- `@monaco-editor/react` + `monaco-editor`, **bundled (no CDN)** for offline Electron; **lazy-loaded** so the ~7MB Monaco chunk stays out of the main bundle until an editor opens
- `buildCodeEditorUiSchema` routes any `x-code-editor` property to the field; `ThemedForm` now registers a `fields` registry

Second commit: **cap big-popup corner radius at 10px** app-wide (CodeEditorPopup, AigwLoginDialog, NewSessionDialog, SessionsView, SpecSelector) — `rounded-xl` (12px) read as over-rounded.

**Verification:** 8 new tests (field + uiSchema routing); full desktop suite (123 tests) green; **production `npm run build` succeeds** (the real Monaco/worker-bundling check); eslint clean.

Asana: https://app.asana.com/1/1185126988600652/task/1215568228745923

🤖 Generated with [Claude Code](https://claude.com/claude-code)