### PR TITLE
SF-250: add Desktop Tests CI (eslint + vitest + build)

### DIFF
--- a/.github/workflows/desktop-tests.yml
+++ b/.github/workflows/desktop-tests.yml
@@ -1,0 +1,69 @@
+name: Desktop Tests
+
+on:
+  push:
+    paths:
+      - "apps/desktop/**"
+      - ".github/workflows/desktop-tests.yml"
+  pull_request:
+    paths:
+      - "apps/desktop/**"
+      - ".github/workflows/desktop-tests.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/desktop
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: apps/desktop/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint (eslint)
+        run: npx eslint .
+
+      - name: Unit tests (vitest)
+        run: npx vitest run --reporter=default --reporter=junit --outputFile=results.xml
+
+      - name: Build (electron-vite)
+        run: npm run build
+
+      - name: Test report
+        uses: dorny/test-reporter@v2
+        if: always()
+        with:
+          name: Desktop Test Results
+          path: apps/desktop/results.xml
+          reporter: java-junit
+
+  cost:
+    name: CI cost diff
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+    steps:
+      - uses: HupBaHa/cost-diff@v0.1.2
+        with:
+          current-job-id: ${{ job.check_run_id }}
+          baseline-event: push
+          comment-mode: update

--- a/apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
@@ -2,7 +2,7 @@
 import { useMemo, useState } from 'react';
 import { X, Upload, ExternalLink, AlertTriangle, CheckCircle2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Url4Viewer } from '@/components/Url4Viewer';
+import { Url4Field } from '@/components/Url4Field';
 import { useToast } from '@/hooks/use-toast';
 import { usePublishScore } from '@/hooks/use-publish-score';
 import {
@@ -126,7 +126,7 @@ export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
                   URL4 expression {sanitize && hasDataRefs ? '(sanitized)' : ''}
                 </span>
                 <div className="rounded bg-muted/30 px-3 py-2">
-                  <Url4Viewer expression={expressionToPublish} serverUrl={serverUrl} />
+                  <Url4Field value={expressionToPublish} serverUrl={serverUrl} readOnly />
                 </div>
                 {hasDataRefs && (
                   <div className="mt-2 rounded border border-chart-5/40 bg-chart-5/10 px-3 py-2 text-xs">


### PR DESCRIPTION
## SF-250 — desktop test CI

`apps/desktop` PRs had **no gating test job** (only the instant WIP check), so desktop changes could merge without remote verification — unlike the Python apps, which have `*-tests.yml`. This adds `desktop-tests.yml`.

Triggers on `apps/desktop/**` **and the workflow file itself** (so it runs on this PR):
- `npm ci`
- `npx eslint .`
- `npx vitest run` (+ junit report)
- `npm run build` (electron-vite — catches bundling/import issues incl. Monaco)
- CI cost-diff job (matches `scoreboard-tests.yml`)

Node 20, npm cache. **Verified locally:** eslint 0 errors, 137 tests pass, build succeeds.

Once this lands, desktop PRs get a real `test` check — so `--auto` (and the "wait for CI before merge" rule) will actually gate them.

Asana: https://app.asana.com/1/1185126988600652/task/1215584744746187

🤖 Generated with [Claude Code](https://claude.com/claude-code)