### PR TITLE
SF-252: bump Desktop Tests CI actions to Node 24

### DIFF
--- a/.github/workflows/desktop-tests.yml
+++ b/.github/workflows/desktop-tests.yml
@@ -24,9 +24,9 @@ jobs:
         working-directory: apps/desktop
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: npm
@@ -45,7 +45,7 @@ jobs:
         run: npm run build
 
       - name: Test report
-        uses: dorny/test-reporter@v2
+        uses: dorny/test-reporter@v3
         if: always()
         with:
           name: Desktop Test Results


### PR DESCRIPTION
Bumps the `desktop-tests.yml` actions off the deprecated Node 20 runtime to Node 24, clearing the GitHub Actions deprecation warning surfaced on the SF-250 run (Node 20 forced to Node 24 on **2026-06-16**, removed **2026-09-16**).

| action | before | after | runtime |
|---|---|---|---|
| `actions/checkout` | v4 | **v6** | node24 |
| `actions/setup-node` | v4 | **v6** | node24 |
| `dorny/test-reporter` | v2 | **v3** | node24 |

Each target major was verified to declare `using: node24` in its `action.yml`. The workflow self-tests (it triggers on its own path), so this PR's own CI run is the validation.

Follow-up to #267 (SF-250).

🤖 Generated with [Claude Code](https://claude.com/claude-code)