### PR TITLE
SF-253: favorite + delete eval runs, sort favorites to top

### DIFF
--- a/apps/desktop/src/renderer/src/components/ConfirmDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/ConfirmDialog.tsx
@@ -1,0 +1,56 @@
+// apps/desktop/src/renderer/src/components/ConfirmDialog.tsx
+//
+// Small modal confirm used for destructive actions. Matches the app's modal
+// styling (max 10px radius). Click outside or Cancel dismisses.
+import { Button } from '@/components/ui/button';
+
+interface Props {
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+  busy?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  title,
+  message,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  destructive = false,
+  busy = false,
+  onConfirm,
+  onCancel,
+}: Props) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={onCancel}
+    >
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        className="w-full max-w-sm rounded-[10px] border border-border bg-card p-5 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-base font-semibold text-foreground">{title}</h2>
+        <p className="mt-2 text-sm text-muted-foreground">{message}</p>
+        <div className="mt-5 flex justify-end gap-2">
+          <Button variant="outline" onClick={onCancel} disabled={busy}>
+            {cancelLabel}
+          </Button>
+          <Button
+            variant={destructive ? 'destructive' : 'default'}
+            onClick={onConfirm}
+            disabled={busy}
+          >
+            {confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/eval/EvalRunDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/EvalRunDetail.tsx
@@ -1,11 +1,13 @@
 // apps/desktop/src/renderer/src/components/eval/EvalRunDetail.tsx
 import { useState } from 'react';
-import { Upload, Play, Pencil } from 'lucide-react';
+import { Upload, Play, Pencil, Trash2 } from 'lucide-react';
 import { useServerStatus } from '@/hooks/use-server-status';
 import { useEvalRunDetail } from '@/hooks/use-eval-runs';
+import { useEvalRunActions } from '@/hooks/use-eval-run-actions';
 import { Url4Field } from '@/components/Url4Field';
 import { Url4Editor } from '@/components/Url4Editor';
 import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { EvalStatusBadge } from './EvalStatusBadge';
 import { EvalQuestionsTable } from './EvalQuestionsTable';
 import { PublishToLeaderboardDialog } from './PublishToLeaderboardDialog';
@@ -25,14 +27,19 @@ function formatTime(iso: string | null): string {
 export function EvalRunDetail({
   runId,
   onRunLocally,
+  onDeleted,
 }: {
   runId: string;
   onRunLocally?: (payload: RunPayload) => void;
+  onDeleted?: () => void;
 }) {
   const { info } = useServerStatus();
   const { data, loading, error } = useEvalRunDetail(runId);
+  const { deleteRun } = useEvalRunActions();
   const [publishing, setPublishing] = useState(false);
   const [editing, setEditing] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   const serverUrl = info
     ? `${info.scheme}://${info.host === '0.0.0.0' ? 'localhost' : info.host}:${info.port}`
@@ -52,6 +59,14 @@ export function EvalRunDetail({
     setEditing(false);
   };
 
+  const confirmDelete = async (): Promise<void> => {
+    setDeleting(true);
+    const ok = await deleteRun(runId);
+    setDeleting(false);
+    setConfirmingDelete(false);
+    if (ok) onDeleted?.();
+  };
+
   return (
     <div className="flex h-full w-full min-w-0 flex-col">
       <div className="min-w-0 flex-1 overflow-y-auto">
@@ -59,16 +74,21 @@ export function EvalRunDetail({
           <div className="mb-2 flex items-center gap-3">
             <h2 className="text-base font-semibold">{data.spec_name}</h2>
             <EvalStatusBadge status={data.status} />
-            {data.status === 'done' && data.accuracy !== null && !!data.total_questions && (
+            <div className="ml-auto flex items-center gap-2">
+              {data.status === 'done' && data.accuracy !== null && !!data.total_questions && (
+                <Button variant="outline" size="sm" onClick={() => setPublishing(true)}>
+                  <Upload className="h-3.5 w-3.5" /> Publish to Leaderboard
+                </Button>
+              )}
               <Button
-                variant="outline"
+                variant="ghost"
                 size="sm"
-                className="ml-auto"
-                onClick={() => setPublishing(true)}
+                className="text-muted-foreground hover:text-destructive"
+                onClick={() => setConfirmingDelete(true)}
               >
-                <Upload className="h-3.5 w-3.5" /> Publish to Leaderboard
+                <Trash2 className="h-3.5 w-3.5" /> Delete
               </Button>
-            )}
+            </div>
           </div>
           {editing ? (
             <div className="mb-3">
@@ -136,6 +156,17 @@ export function EvalRunDetail({
           run={data}
           serverUrl={serverUrl}
           onClose={() => setPublishing(false)}
+        />
+      )}
+      {confirmingDelete && (
+        <ConfirmDialog
+          title="Delete this run?"
+          message={`"${data.spec_name}" and its question results will be permanently removed. This can't be undone.`}
+          confirmLabel={deleting ? 'Deleting…' : 'Delete'}
+          destructive
+          busy={deleting}
+          onConfirm={() => void confirmDelete()}
+          onCancel={() => setConfirmingDelete(false)}
         />
       )}
     </div>

--- a/apps/desktop/src/renderer/src/components/eval/EvalRunsList.test.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/EvalRunsList.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { render, screen, fireEvent, cleanup } from '@testing-library/react';
-import { it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { it, expect, vi, afterEach, beforeEach } from 'vitest';
 import type { EvalRunSummary } from './types';
 
 const rows: EvalRunSummary[] = [
@@ -15,13 +15,41 @@ const rows: EvalRunSummary[] = [
     total_questions: 10,
     correct_questions: 9,
     error: null,
+    favorite: false,
+  },
+  {
+    id: 'r2',
+    spec_name: 'GPQA',
+    url4_expression: 'x',
+    started_at: '2026-01-02T00:00:00Z',
+    finished_at: null,
+    status: 'running',
+    accuracy: null,
+    total_questions: null,
+    correct_questions: null,
+    error: null,
+    favorite: true,
   },
 ];
 
-vi.mock('@/hooks/use-eval-runs', () => ({
-  useEvalRunsList: () => ({ data: rows, loading: false, error: null }),
+const { refresh, toggleFavorite, deleteRun } = vi.hoisted(() => ({
+  refresh: vi.fn(),
+  toggleFavorite: vi.fn().mockResolvedValue(true),
+  deleteRun: vi.fn().mockResolvedValue(true),
 }));
 
+vi.mock('@/hooks/use-eval-runs', () => ({
+  useEvalRunsList: () => ({ data: rows, loading: false, error: null, refresh }),
+}));
+vi.mock('@/hooks/use-eval-run-actions', () => ({
+  useEvalRunActions: () => ({ toggleFavorite, deleteRun }),
+}));
+
+beforeEach(() => {
+  refresh.mockClear();
+  toggleFavorite.mockClear();
+  deleteRun.mockClear();
+});
 afterEach(cleanup);
 
 import { EvalRunsList } from './EvalRunsList';
@@ -29,7 +57,7 @@ import { EvalRunsList } from './EvalRunsList';
 it('calls onRunLocally with the row spec + expression', () => {
   const onRunLocally = vi.fn();
   render(<EvalRunsList selectedId={null} onSelect={vi.fn()} onRunLocally={onRunLocally} />);
-  fireEvent.click(screen.getByRole('button', { name: /run locally/i }));
+  fireEvent.click(screen.getAllByRole('button', { name: /run locally/i })[0]);
   expect(onRunLocally).toHaveBeenCalledWith({ spec: 'HLE', expression: 'transform(url, intent)' });
 });
 
@@ -46,4 +74,47 @@ it('selects the run when the row is clicked', () => {
   render(<EvalRunsList selectedId={null} onSelect={onSelect} onRunLocally={vi.fn()} />);
   fireEvent.click(screen.getByText('HLE'));
   expect(onSelect).toHaveBeenCalledWith('r1');
+});
+
+it('reflects favorite state via the star control', () => {
+  render(<EvalRunsList selectedId={null} onSelect={vi.fn()} onRunLocally={vi.fn()} />);
+  // r1 is not favorited (label "Favorite"), r2 is (label "Unfavorite").
+  expect(screen.getByRole('button', { name: 'Favorite' })).toBeTruthy();
+  expect(screen.getByRole('button', { name: 'Unfavorite' })).toBeTruthy();
+});
+
+it('toggles favorite on the un-favorited row', async () => {
+  render(<EvalRunsList selectedId={null} onSelect={vi.fn()} onRunLocally={vi.fn()} />);
+  fireEvent.click(screen.getByRole('button', { name: 'Favorite' }));
+  await waitFor(() => expect(toggleFavorite).toHaveBeenCalledWith('r1', true));
+  expect(refresh).toHaveBeenCalled();
+});
+
+it('deletes a run only after the confirm dialog is accepted', async () => {
+  const onRunDeleted = vi.fn();
+  render(
+    <EvalRunsList
+      selectedId="r1"
+      onSelect={vi.fn()}
+      onRunLocally={vi.fn()}
+      onRunDeleted={onRunDeleted}
+    />,
+  );
+  // Clicking the row trash opens a confirm; nothing is deleted yet.
+  fireEvent.click(screen.getAllByRole('button', { name: /delete run/i })[0]);
+  expect(deleteRun).not.toHaveBeenCalled();
+  expect(screen.getByText(/delete this run/i)).toBeTruthy();
+
+  // Confirm.
+  fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+  await waitFor(() => expect(deleteRun).toHaveBeenCalledWith('r1'));
+  expect(onRunDeleted).toHaveBeenCalledWith('r1');
+});
+
+it('cancels deletion without calling deleteRun', () => {
+  render(<EvalRunsList selectedId={null} onSelect={vi.fn()} onRunLocally={vi.fn()} />);
+  fireEvent.click(screen.getAllByRole('button', { name: /delete run/i })[0]);
+  fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+  expect(deleteRun).not.toHaveBeenCalled();
+  expect(screen.queryByText(/delete this run/i)).toBeNull();
 });

--- a/apps/desktop/src/renderer/src/components/eval/EvalRunsList.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/EvalRunsList.tsx
@@ -1,6 +1,9 @@
-import { Play } from 'lucide-react';
+import { useState } from 'react';
+import { Play, Star, Trash2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useEvalRunsList } from '@/hooks/use-eval-runs';
+import { useEvalRunActions } from '@/hooks/use-eval-run-actions';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { EvalStatusBadge } from './EvalStatusBadge';
 import type { EvalRunSummary } from './types';
 import type { RunPayload } from '@/components/run/types';
@@ -9,6 +12,8 @@ interface Props {
   selectedId: string | null;
   onSelect: (id: string) => void;
   onRunLocally?: (payload: RunPayload) => void;
+  /** Called after a run is deleted so the parent can clear its selection. */
+  onRunDeleted?: (id: string) => void;
 }
 
 function formatPercent(accuracy: number | null): string {
@@ -21,8 +26,28 @@ function formatTime(iso: string): string {
   return `${d.toLocaleDateString()} ${d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
 }
 
-export function EvalRunsList({ selectedId, onSelect, onRunLocally }: Props) {
-  const { data, loading, error } = useEvalRunsList();
+export function EvalRunsList({ selectedId, onSelect, onRunLocally, onRunDeleted }: Props) {
+  const { data, loading, error, refresh } = useEvalRunsList();
+  const { toggleFavorite, deleteRun } = useEvalRunActions();
+  const [pendingDelete, setPendingDelete] = useState<EvalRunSummary | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const onToggleFavorite = async (run: EvalRunSummary): Promise<void> => {
+    if (await toggleFavorite(run.id, !run.favorite)) await refresh(true);
+  };
+
+  const confirmDelete = async (): Promise<void> => {
+    if (!pendingDelete) return;
+    setDeleting(true);
+    const id = pendingDelete.id;
+    const ok = await deleteRun(id);
+    setDeleting(false);
+    setPendingDelete(null);
+    if (ok) {
+      onRunDeleted?.(id);
+      await refresh(true);
+    }
+  };
 
   if (loading && data.length === 0) {
     return <div className="p-6 text-sm text-muted-foreground">Loading runs…</div>;
@@ -57,9 +82,27 @@ export function EvalRunsList({ selectedId, onSelect, onRunLocally }: Props) {
                 <div className="truncate font-medium text-foreground">{run.spec_name}</div>
                 <div className="text-xs text-muted-foreground">{formatTime(run.started_at)}</div>
               </div>
-              <div className="flex items-center gap-2 whitespace-nowrap">
+              <div className="flex items-center gap-1 whitespace-nowrap">
                 <EvalStatusBadge status={run.status} />
-                <div className="text-right text-sm tabular-nums">{formatPercent(run.accuracy)}</div>
+                <div className="mr-1 text-right text-sm tabular-nums">
+                  {formatPercent(run.accuracy)}
+                </div>
+                <button
+                  type="button"
+                  aria-label={run.favorite ? 'Unfavorite' : 'Favorite'}
+                  aria-pressed={run.favorite}
+                  title={run.favorite ? 'Unfavorite' : 'Favorite'}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void onToggleFavorite(run);
+                  }}
+                  className={cn(
+                    'rounded p-1 transition-colors hover:bg-accent',
+                    run.favorite ? 'text-chart-5' : 'text-muted-foreground hover:text-foreground',
+                  )}
+                >
+                  <Star className={cn('h-4 w-4', run.favorite && 'fill-current')} />
+                </button>
                 {onRunLocally && (
                   <button
                     type="button"
@@ -74,11 +117,35 @@ export function EvalRunsList({ selectedId, onSelect, onRunLocally }: Props) {
                     <Play className="h-4 w-4" />
                   </button>
                 )}
+                <button
+                  type="button"
+                  aria-label="Delete run"
+                  title="Delete run"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setPendingDelete(run);
+                  }}
+                  className="rounded p-1 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
               </div>
             </div>
           </div>
         );
       })}
+
+      {pendingDelete && (
+        <ConfirmDialog
+          title="Delete this run?"
+          message={`"${pendingDelete.spec_name}" and its question results will be permanently removed. This can't be undone.`}
+          confirmLabel={deleting ? 'Deleting…' : 'Delete'}
+          destructive
+          busy={deleting}
+          onConfirm={() => void confirmDelete()}
+          onCancel={() => setPendingDelete(null)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
@@ -38,6 +38,7 @@ function makeRun(overrides: Partial<EvalRunDetail> = {}): EvalRunDetail {
     total_questions: 1000,
     correct_questions: 810,
     error: null,
+    favorite: false,
     questions: [],
     ...overrides,
   };

--- a/apps/desktop/src/renderer/src/components/eval/types.ts
+++ b/apps/desktop/src/renderer/src/components/eval/types.ts
@@ -16,6 +16,7 @@ export interface EvalRunSummary {
   total_questions: number | null;
   correct_questions: number | null;
   error: string | null;
+  favorite: boolean;
 }
 
 export interface EvalQuestion {

--- a/apps/desktop/src/renderer/src/hooks/__tests__/use-publish-score.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/__tests__/use-publish-score.test.ts
@@ -21,6 +21,7 @@ const RUN: EvalRunDetail = {
   total_questions: 1000,
   correct_questions: 810,
   error: null,
+  favorite: false,
   questions: [],
 };
 

--- a/apps/desktop/src/renderer/src/hooks/use-eval-run-actions.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-eval-run-actions.ts
@@ -1,0 +1,66 @@
+// apps/desktop/src/renderer/src/hooks/use-eval-run-actions.ts
+//
+// Mutations on eval runs: toggle favorite (PATCH) and delete (DELETE). Both go
+// through the main-process server fetch and surface failures as error toasts.
+// Callers refresh the runs list on success.
+import { useCallback } from 'react';
+import { useServerStatus } from '@/hooks/use-server-status';
+import { useToast } from '@/hooks/use-toast';
+
+function serverBase(info: ReturnType<typeof useServerStatus>['info']): string | null {
+  if (!info) return null;
+  const host = info.host === '0.0.0.0' ? 'localhost' : info.host;
+  return `${info.scheme}://${host}:${info.port}`;
+}
+
+export function useEvalRunActions() {
+  const { info } = useServerStatus();
+  const base = serverBase(info);
+  const { toast } = useToast();
+
+  const toggleFavorite = useCallback(
+    async (id: string, favorite: boolean): Promise<boolean> => {
+      if (!base) return false;
+      try {
+        const res = await window.electronAPI.server.fetch(`${base}/eval_runs/${id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ favorite }),
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.body}`);
+        return true;
+      } catch (e) {
+        toast({
+          variant: 'error',
+          title: 'Could not update favorite',
+          description: (e as Error).message,
+        });
+        return false;
+      }
+    },
+    [base, toast],
+  );
+
+  const deleteRun = useCallback(
+    async (id: string): Promise<boolean> => {
+      if (!base) return false;
+      try {
+        const res = await window.electronAPI.server.fetch(`${base}/eval_runs/${id}`, {
+          method: 'DELETE',
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.body}`);
+        return true;
+      } catch (e) {
+        toast({
+          variant: 'error',
+          title: 'Could not delete run',
+          description: (e as Error).message,
+        });
+        return false;
+      }
+    },
+    [base, toast],
+  );
+
+  return { toggleFavorite, deleteRun };
+}

--- a/apps/desktop/src/renderer/src/views/EvalStudioView.test.tsx
+++ b/apps/desktop/src/renderer/src/views/EvalStudioView.test.tsx
@@ -3,7 +3,10 @@ import { render, screen, cleanup } from '@testing-library/react';
 import { it, expect, vi, afterEach } from 'vitest';
 
 vi.mock('@/hooks/use-eval-runs', () => ({
-  useEvalRunsList: () => ({ data: [], loading: false, error: null }),
+  useEvalRunsList: () => ({ data: [], loading: false, error: null, refresh: vi.fn() }),
+}));
+vi.mock('@/hooks/use-eval-run-actions', () => ({
+  useEvalRunActions: () => ({ toggleFavorite: vi.fn(), deleteRun: vi.fn() }),
 }));
 vi.mock('@/hooks/use-start-eval-run', () => ({ useStartEvalRun: () => () => null }));
 vi.mock('@/components/eval/EvalRunDetail', () => ({ EvalRunDetail: () => null }));

--- a/apps/desktop/src/renderer/src/views/EvalStudioView.tsx
+++ b/apps/desktop/src/renderer/src/views/EvalStudioView.tsx
@@ -30,6 +30,11 @@ export function EvalStudioView({ pendingRun, onPendingConsumed }: EvalStudioView
     [startEvalRun],
   );
 
+  // Clear the right panel when the selected run is deleted.
+  const handleRunDeleted = useCallback((id: string): void => {
+    setSelectedRunId((current) => (current === id ? null : current));
+  }, []);
+
   // Consume a deep-linked pending run exactly once.
   const handledPendingRef = useRef<RunPayload | null>(null);
   useEffect(() => {
@@ -115,6 +120,7 @@ export function EvalStudioView({ pendingRun, onPendingConsumed }: EvalStudioView
             selectedId={selectedRunId}
             onSelect={setSelectedRunId}
             onRunLocally={runAndSelect}
+            onRunDeleted={handleRunDeleted}
           />
         </ResizablePanel>
 
@@ -133,7 +139,11 @@ export function EvalStudioView({ pendingRun, onPendingConsumed }: EvalStudioView
           className="flex overflow-hidden"
         >
           {selectedRunId ? (
-            <EvalRunDetail runId={selectedRunId} onRunLocally={runAndSelect} />
+            <EvalRunDetail
+              runId={selectedRunId}
+              onRunLocally={runAndSelect}
+              onDeleted={() => handleRunDeleted(selectedRunId)}
+            />
           ) : (
             <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
               Select a run to see details

--- a/apps/server/src/screamingface/plugins/eval_runs/_migrations.py
+++ b/apps/server/src/screamingface/plugins/eval_runs/_migrations.py
@@ -1,0 +1,33 @@
+"""Idempotent additive schema patches for eval_runs.
+
+The state plugin uses ``Tortoise.generate_schemas(safe=True)``, which only
+creates missing *tables* — it never ALTERs an existing one. So a column added
+to ``EvalRun`` after a local DB already exists (e.g. ``favorite``) must be
+back-filled here. SQLite-scoped: the desktop app's local state DB is SQLite;
+Postgres is a deployment concern (see ``plugins/state/README.md``).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from tortoise import Tortoise
+
+logger = logging.getLogger(__name__)
+
+
+async def ensure_favorite_column() -> None:
+    """Add ``eval_run.favorite`` to a pre-existing table that lacks it.
+
+    Idempotent: a no-op when the column is already present (fresh installs get
+    it from ``generate_schemas``) or when the table does not exist yet.
+    """
+    conn = Tortoise.get_connection("default")
+    rows = await conn.execute_query_dict("PRAGMA table_info('eval_run')")
+    if not rows:
+        return  # table not created yet — generate_schemas owns first creation
+    columns = {row["name"] for row in rows}
+    if "favorite" in columns:
+        return
+    await conn.execute_query("ALTER TABLE eval_run ADD COLUMN favorite INT NOT NULL DEFAULT 0")
+    logger.info("eval_runs: added missing 'favorite' column to eval_run")

--- a/apps/server/src/screamingface/plugins/eval_runs/models/eval_run.py
+++ b/apps/server/src/screamingface/plugins/eval_runs/models/eval_run.py
@@ -26,6 +26,7 @@ class BaseEvalRun(BaseModel):
     total_questions = fields.IntField(null=True)
     correct_questions = fields.IntField(null=True)
     error = fields.TextField(null=True)
+    favorite = fields.BooleanField(default=False)
 
     def __str__(self) -> str:
         return f"{self.spec_name} ({self.status})"

--- a/apps/server/src/screamingface/plugins/eval_runs/plugin.py
+++ b/apps/server/src/screamingface/plugins/eval_runs/plugin.py
@@ -12,6 +12,7 @@ from screamingface.plugins.eval_runs._hook_payloads import (
     HOOK_RUN_FINISHED,
     HOOK_RUN_STARTED,
 )
+from screamingface.plugins.eval_runs._migrations import ensure_favorite_column
 from screamingface.plugins.eval_runs.models import EvalQuestion, EvalRun
 from screamingface.plugins.eval_runs.routes import create_router
 from screamingface.plugins.eval_runs.store import EvalRunStore
@@ -106,6 +107,14 @@ class EvalRunsPlugin(Plugin):
             )
             self._question_idx_by_run.pop(run_id, None)
 
+        async def _ensure_schema() -> None:
+            # Runs after the state plugin's generate_schemas (priority 10) so the
+            # eval_run table exists; back-fills the additive `favorite` column on
+            # local DBs created before it was introduced.
+            if getattr(app.state, "state_ready", False):
+                await ensure_favorite_column()
+
+        hooks.register("app.startup", _ensure_schema, plugin_name=self.name, priority=20)
         hooks.register(HOOK_RUN_STARTED, _on_run_started, plugin_name=self.name)
         hooks.register(HOOK_QUESTION_CHECKED, _on_question_checked, plugin_name=self.name)
         hooks.register(HOOK_RUN_FINISHED, _on_run_finished, plugin_name=self.name)

--- a/apps/server/src/screamingface/plugins/eval_runs/routes.py
+++ b/apps/server/src/screamingface/plugins/eval_runs/routes.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request, Response
 
 from screamingface.plugins.eval_runs.schemas import (
     EvalQuestionOut,
     EvalRunOut,
+    EvalRunPatchIn,
     EvalRunSummaryOut,
 )
 
@@ -46,5 +47,28 @@ def create_router() -> APIRouter:
             **summary,
             questions=[EvalQuestionOut.model_validate(q) for q in questions],
         )
+
+    @router.patch(
+        "/eval_runs/{run_id}",
+        response_model=EvalRunSummaryOut,
+        operation_id="eval_runs_patch",
+    )
+    async def patch_run(request: Request, run_id: UUID, body: EvalRunPatchIn) -> EvalRunSummaryOut:
+        store = request.app.state.eval_run_store
+        run = await store.set_favorite(run_id, body.favorite)
+        if run is None:
+            raise HTTPException(status_code=404, detail="run not found")
+        return EvalRunSummaryOut.model_validate(run)
+
+    @router.delete(
+        "/eval_runs/{run_id}",
+        status_code=204,
+        operation_id="eval_runs_delete",
+    )
+    async def delete_run(request: Request, run_id: UUID) -> Response:
+        store = request.app.state.eval_run_store
+        if not await store.delete(run_id):
+            raise HTTPException(status_code=404, detail="run not found")
+        return Response(status_code=204)
 
     return router

--- a/apps/server/src/screamingface/plugins/eval_runs/schemas.py
+++ b/apps/server/src/screamingface/plugins/eval_runs/schemas.py
@@ -39,9 +39,16 @@ class EvalRunSummaryOut(BaseModel):
     total_questions: int | None = None
     correct_questions: int | None = None
     error: str | None = None
+    favorite: bool = False
 
 
 class EvalRunOut(EvalRunSummaryOut):
     """Detail view — includes questions."""
 
     questions: list[EvalQuestionOut] = []
+
+
+class EvalRunPatchIn(BaseModel):
+    """Mutable fields on an eval run (currently just favorite)."""
+
+    favorite: bool

--- a/apps/server/src/screamingface/plugins/eval_runs/store.py
+++ b/apps/server/src/screamingface/plugins/eval_runs/store.py
@@ -12,8 +12,17 @@ class EvalRunStore(BaseStore[EvalRun]):
     model = EvalRun
 
     async def list_summaries(self, *, limit: int = 50, offset: int = 0) -> list[EvalRun]:
-        """List runs ordered by started_at DESC, without prefetching questions."""
-        return await EvalRun.all().order_by("-started_at").offset(offset).limit(limit)
+        """List runs with favorites first, then most-recent, without prefetching questions."""
+        return await EvalRun.all().order_by("-favorite", "-started_at").offset(offset).limit(limit)
 
     async def get_with_questions(self, run_id: UUID) -> EvalRun | None:
         return await EvalRun.filter(id=run_id).prefetch_related("questions").first()
+
+    async def set_favorite(self, run_id: UUID, favorite: bool) -> EvalRun | None:
+        """Toggle a run's favorite flag; returns the updated run or None if missing."""
+        run = await EvalRun.get_or_none(id=run_id)
+        if run is None:
+            return None
+        run.favorite = favorite
+        await run.save(update_fields=["favorite", "updated_at"])
+        return run

--- a/apps/server/src/screamingface/plugins/eval_runs/tests/test_migrations.py
+++ b/apps/server/src/screamingface/plugins/eval_runs/tests/test_migrations.py
@@ -1,0 +1,57 @@
+"""Tests for the additive `favorite` column back-fill."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from tortoise import Tortoise
+
+from screamingface.core.app import create_app
+from screamingface.core.config import AppConfig
+from screamingface.plugins.eval_runs._migrations import ensure_favorite_column
+from screamingface.plugins.eval_runs.store import EvalRunStore
+
+
+@pytest.fixture
+async def app_with_eval_runs(temp_state_path: Path) -> AsyncIterator[FastAPI]:
+    config = AppConfig(plugins=["state", "eval-runs"], plugin_config={})
+    app = create_app(config)
+    async with app.router.lifespan_context(app):
+        yield app
+
+
+async def _favorite_columns() -> set[str]:
+    conn = Tortoise.get_connection("default")
+    rows = await conn.execute_query_dict("PRAGMA table_info('eval_run')")
+    return {row["name"] for row in rows}
+
+
+async def test_ensure_favorite_column_is_idempotent(app_with_eval_runs: FastAPI) -> None:
+    # generate_schemas already created the column; re-running must be a no-op.
+    assert "favorite" in await _favorite_columns()
+    await ensure_favorite_column()
+    await ensure_favorite_column()
+    assert "favorite" in await _favorite_columns()
+
+
+async def test_ensure_favorite_column_backfills_legacy_table(
+    app_with_eval_runs: FastAPI,
+) -> None:
+    conn = Tortoise.get_connection("default")
+    # Simulate a pre-favorite local DB by dropping the column (SQLite 3.35+).
+    await conn.execute_query("ALTER TABLE eval_run DROP COLUMN favorite")
+    assert "favorite" not in await _favorite_columns()
+
+    await ensure_favorite_column()
+    assert "favorite" in await _favorite_columns()
+
+    # The back-filled column has the expected default and the store works.
+    store = EvalRunStore()
+    run = await store.create(spec_name="x", url4_expression="x", started_at=datetime.now(UTC))
+    assert run.favorite is False
+    listed = await store.list_summaries(limit=10)
+    assert [r.spec_name for r in listed] == ["x"]

--- a/apps/server/src/screamingface/plugins/eval_runs/tests/test_routes.py
+++ b/apps/server/src/screamingface/plugins/eval_runs/tests/test_routes.py
@@ -95,3 +95,58 @@ async def test_list_supports_limit_offset(async_client: httpx.AsyncClient) -> No
     assert r.status_code == 200
     body = r.json()
     assert len(body) == 2
+
+
+async def test_patch_sets_favorite(async_client: httpx.AsyncClient) -> None:
+    store = EvalRunStore()
+    run = await store.create(spec_name="x", url4_expression="x", started_at=datetime.now(UTC))
+    assert (await async_client.get(f"/eval_runs/{run.id}")).json()["favorite"] is False
+
+    r = await async_client.patch(f"/eval_runs/{run.id}", json={"favorite": True})
+    assert r.status_code == 200
+    assert r.json()["favorite"] is True
+    assert (await async_client.get(f"/eval_runs/{run.id}")).json()["favorite"] is True
+
+    r = await async_client.patch(f"/eval_runs/{run.id}", json={"favorite": False})
+    assert r.json()["favorite"] is False
+
+
+async def test_patch_missing_returns_404(async_client: httpx.AsyncClient) -> None:
+    r = await async_client.patch(f"/eval_runs/{uuid4()}", json={"favorite": True})
+    assert r.status_code == 404
+    assert r.json() == {"detail": "run not found"}
+
+
+async def test_list_sorts_favorites_first(async_client: httpx.AsyncClient) -> None:
+    store = EvalRunStore()
+    base = datetime(2026, 5, 13, 10, 0, 0, tzinfo=UTC)
+    runs = [
+        await store.create(
+            spec_name=f"spec-{i}",
+            url4_expression="x",
+            started_at=base.replace(hour=10 + i),
+        )
+        for i in range(3)
+    ]
+    # Favorite the oldest run; it should jump above the more-recent non-favorites.
+    await async_client.patch(f"/eval_runs/{runs[0].id}", json={"favorite": True})
+
+    body = (await async_client.get("/eval_runs")).json()
+    assert [row["spec_name"] for row in body] == ["spec-0", "spec-2", "spec-1"]
+
+
+async def test_delete_removes_run_and_questions(async_client: httpx.AsyncClient) -> None:
+    store = EvalRunStore()
+    run = await store.create(spec_name="x", url4_expression="x", started_at=datetime.now(UTC))
+    await EvalQuestion.create(run=run, idx=0, question="q", expected="e")
+
+    r = await async_client.delete(f"/eval_runs/{run.id}")
+    assert r.status_code == 204
+    assert (await async_client.get(f"/eval_runs/{run.id}")).status_code == 404
+    assert await EvalQuestion.all().count() == 0
+
+
+async def test_delete_missing_returns_404(async_client: httpx.AsyncClient) -> None:
+    r = await async_client.delete(f"/eval_runs/{uuid4()}")
+    assert r.status_code == 404
+    assert r.json() == {"detail": "run not found"}

--- a/apps/server/src/screamingface/plugins/eval_runs/tests/test_store.py
+++ b/apps/server/src/screamingface/plugins/eval_runs/tests/test_store.py
@@ -130,3 +130,44 @@ async def test_status_transition(app_with_eval_runs: FastAPI) -> None:
     )
     assert updated.status == "done"
     assert updated.accuracy == 0.75
+
+
+async def test_set_favorite_toggles(app_with_eval_runs: FastAPI) -> None:
+    store = EvalRunStore()
+    run = await store.create(spec_name="x", url4_expression="x", started_at=datetime.now(UTC))
+    assert run.favorite is False
+
+    updated = await store.set_favorite(run.id, True)
+    assert updated is not None
+    assert updated.favorite is True
+    refetched = await store.get(run.id)
+    assert refetched is not None and refetched.favorite is True
+
+    cleared = await store.set_favorite(run.id, False)
+    assert cleared is not None
+    assert cleared.favorite is False
+
+
+async def test_set_favorite_missing_returns_none(app_with_eval_runs: FastAPI) -> None:
+    from uuid import uuid4
+
+    store = EvalRunStore()
+    assert await store.set_favorite(uuid4(), True) is None
+
+
+async def test_list_summaries_favorites_first(app_with_eval_runs: FastAPI) -> None:
+    store = EvalRunStore()
+    base = datetime(2026, 5, 13, 10, 0, 0, tzinfo=UTC)
+    runs = [
+        await store.create(
+            spec_name=f"spec-{i}",
+            url4_expression="x",
+            started_at=base.replace(hour=10 + i),
+        )
+        for i in range(3)
+    ]
+    # Favorite the oldest; it should lead, then the rest by recency.
+    await store.set_favorite(runs[0].id, True)
+
+    listed = await store.list_summaries(limit=10)
+    assert [r.spec_name for r in listed] == ["spec-0", "spec-2", "spec-1"]

--- a/docs/superpowers/plans/2026-06-10-SF-253-eval-favorite-delete-sort.md
+++ b/docs/superpowers/plans/2026-06-10-SF-253-eval-favorite-delete-sort.md
@@ -1,0 +1,139 @@
+# SF-253 — Eval Studio: favorite + delete runs, sort favorites to top
+
+**Ticket:** SF-253 · https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215573724473294
+**Branch:** `SF-253-eval-favorite-delete-sort` (off latest `main`)
+**Confidence:** ~96%
+
+## Goal
+
+In Eval Studio:
+1. **Favorite** toggle (star) per run — persisted server-side.
+2. **Delete** per run — hard-removes the run + its cascaded questions, behind a confirm dialog.
+3. **Sort favorites to the top** of the runs list (then by recency, as today).
+
+## Decisions (confirmed with user)
+
+- **Favorite is server-side** — a `favorite` column on the `eval_run` record, a toggle endpoint, and DB-layer ordering. (Source of truth; the local server is per-machine anyway.)
+- **Delete is a hard server `DELETE`** behind a **confirm dialog**.
+
+## Architecture context
+
+- Runs are owned by the server `eval_runs` plugin (`apps/server/src/screamingface/plugins/eval_runs/`):
+  model `EvalRun` (`models/eval_run.py`), `EvalRunStore(BaseStore)` (`store.py`), GET-only routes (`routes.py`),
+  Pydantic DTOs (`schemas.py`). `BaseStore` already provides `update(id, **fields)` and `delete(id) -> bool` (`plugins/state/store.py`).
+- `EvalQuestion` has `on_delete=CASCADE` → deleting a run drops its questions automatically.
+- **Schema rollout:** the state plugin runs `Tortoise.generate_schemas(safe=True)` — `CREATE TABLE IF NOT EXISTS` only. It does **not** ALTER existing tables, so a new `favorite` column will be missing on already-created local `eval_run` tables and any query ordering by it would 500. We add a small idempotent additive migration (the README's "one-shot patch").
+- Desktop: `EvalRunsList` renders rows and owns `useEvalRunsList` (polls 2 s, exposes `refresh()`); `EvalStudioView` owns `selectedId`; `window.electronAPI.server.fetch(url, { method, headers, body })` supports non-GET.
+
+---
+
+## Server changes (`apps/server`)
+
+### 1. Model — add `favorite`
+`plugins/eval_runs/models/eval_run.py`, on `BaseEvalRun`:
+```python
+favorite = fields.BooleanField(default=False)
+```
+
+### 2. Schema — expose `favorite`
+`plugins/eval_runs/schemas.py`, on `EvalRunSummaryOut` (inherited by `EvalRunOut`):
+```python
+favorite: bool = False
+```
+
+### 3. Store — order favorites first + a toggle helper
+`plugins/eval_runs/store.py`:
+```python
+async def list_summaries(self, *, limit=50, offset=0) -> list[EvalRun]:
+    return await EvalRun.all().order_by("-favorite", "-started_at").offset(offset).limit(limit)
+
+async def set_favorite(self, run_id: UUID, favorite: bool) -> EvalRun | None:
+    run = await EvalRun.get_or_none(id=run_id)
+    if run is None:
+        return None
+    run.favorite = favorite
+    await run.save(update_fields=["favorite", "updated_at"])
+    return run
+```
+(Delete reuses `BaseStore.delete(run_id)`.)
+
+### 4. Routes — PATCH (toggle) + DELETE
+`plugins/eval_runs/routes.py`:
+- `PATCH /eval_runs/{run_id}` — body `{ "favorite": bool }` (new `EvalRunPatchIn` schema). Returns `EvalRunSummaryOut`; 404 if missing.
+- `DELETE /eval_runs/{run_id}` — `204 No Content` on success; 404 if `store.delete()` returns `False`.
+
+### 5. Additive column migration (existing local DBs)
+New `plugins/eval_runs/_migrations.py` with an idempotent `ensure_favorite_column()`:
+- Use the Tortoise connection to read `PRAGMA table_info('eval_run')`; if `favorite` absent, run
+  `ALTER TABLE eval_run ADD COLUMN favorite INT NOT NULL DEFAULT 0`.
+- SQLite-scoped (local app DB); Postgres is out of scope per state README.
+Register it as an `app.startup` hook in `EvalRunsPlugin.setup()` ordered to run **after** the state plugin's
+`generate_schemas` (state startup is priority 10 — register this with a priority that fires later; confirm
+ordering against `core/hooks` during impl). Fresh installs get the column from `generate_schemas`; existing
+installs get it from the ALTER. Idempotent on every boot.
+
+---
+
+## Desktop changes (`apps/desktop`)
+
+### 6. Type — `favorite`
+`components/eval/types.ts`: add `favorite: boolean` to `EvalRunSummary`.
+
+### 7. Actions hook
+New `hooks/use-eval-run-actions.ts` returning `{ toggleFavorite, deleteRun }`:
+- `toggleFavorite(id, favorite)` → `server.fetch(`${base}/eval_runs/${id}`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ favorite }) })`.
+- `deleteRun(id)` → `server.fetch(`${base}/eval_runs/${id}`, { method: 'DELETE' })`.
+- Both surface failures via `useToast`; callers `refresh()` the list on success.
+
+### 8. Confirm dialog
+Reuse shadcn `alert-dialog` if present; otherwise a minimal `components/ConfirmDialog.tsx` (matches the existing
+`rounded-[10px]` modal style, ≤10 px radius). Copy: "Delete this run? This permanently removes the run and its
+question results. This can't be undone." Buttons: Cancel / Delete (destructive).
+
+### 9. `EvalRunsList` rows — star + trash
+- **Star** button (always visible): filled `Star` when `run.favorite`, outline otherwise; `onClick` (stopPropagation)
+  → `toggleFavorite(run.id, !run.favorite)` then `refresh()`.
+- **Trash** button: opens the confirm dialog; on confirm → `deleteRun(run.id)` → `refresh()` and, if the deleted run
+  is selected, notify parent to clear selection via a new `onRunDeleted?(id)` prop.
+- Place both in the existing right-side action cluster next to the Run-locally play button. Keep row click =
+  select. No client-side sort needed — the **server returns favorites first**.
+
+### 10. `EvalRunDetail` header — delete the open run
+Add a Delete button to the detail header action row (alongside Publish/Edit) using the same confirm + `deleteRun`;
+on success call an `onDeleted?()` prop so `EvalStudioView` clears `selectedId`. (Favorite in the detail header is
+optional/nice-to-have; primary toggle lives in the list.)
+
+### 11. `EvalStudioView` wiring
+- Pass `onRunDeleted` to `EvalRunsList` and `onDeleted` to `EvalRunDetail`; clear `selectedId` when the deleted id
+  matches the selection.
+
+---
+
+## Tests
+
+### Server (`plugins/eval_runs/tests/`)
+- `PATCH` sets/clears `favorite`; 404 on unknown id; response reflects new value.
+- `DELETE` returns 204 and the run + its `EvalQuestion` rows are gone; 404 on unknown id.
+- `list_summaries` orders favorites before non-favorites, recency within each group.
+- `ensure_favorite_column()` is idempotent and adds the column to a pre-existing favorite-less table.
+
+### Desktop (vitest)
+- `use-eval-run-actions` issues the correct method/URL/body and toasts on failure.
+- `EvalRunsList`: star reflects `favorite` and calls `toggleFavorite`; trash opens confirm and calls `deleteRun`
+  only after confirm; renders server order (no client re-sort).
+- `ConfirmDialog` (if added) confirm/cancel behavior.
+- Run the full desktop suite (the SF-250 CI gate) + `npm run build`.
+
+---
+
+## Out of scope
+- Bulk select / multi-delete.
+- Favorite/delete on the public leaderboard (these are local eval runs only).
+- Postgres column migration (state README: deployment concern).
+- Undo for delete.
+
+## Sequencing
+1. Server: model + schema + store + routes + migration + server tests (green).
+2. Desktop: type + actions hook + confirm dialog + list buttons + detail delete + view wiring + desktop tests (green).
+3. Manual smoke: favorite a run (jumps to top, persists across restart), delete a run (confirm, disappears, questions gone).
+4. PR; wait for desktop CI (SF-250 gate) before merge.


### PR DESCRIPTION
Adds **favorite** and **delete** to Eval Studio runs, with favorites sorted to the top.

## Server (`eval_runs` plugin)
- `favorite` column on `EvalRun`, exposed in summary/detail schemas.
- `list_summaries` orders `("-favorite", "-started_at")` → favorites float to the top at the DB layer.
- `PATCH /eval_runs/{id}` toggles favorite; `DELETE /eval_runs/{id}` hard-deletes the run (questions cascade).
- Idempotent additive **`favorite` column back-fill** on startup — `generate_schemas(safe=True)` only creates tables, never ALTERs, so existing local DBs need the one-shot `ADD COLUMN` (SQLite-scoped; Postgres out of scope per state README).

## Desktop (Eval Studio)
- `use-eval-run-actions` hook (PATCH/DELETE via `server.fetch`, error toasts).
- **Star** + **trash** on each runs-list row; trash opens a `ConfirmDialog` before the hard delete. Delete also in the run-detail header. Deleting the selected run clears the right panel. The list renders the server's favorites-first order (no client re-sort).

## Tests
- Server pytest: toggle / delete+cascade / 404s / favorites-first ordering / migration idempotency + legacy back-fill. Full server suite green.
- Desktop vitest: star reflects + toggles favorite, confirm-gated delete + `onRunDeleted`, cancel path. Full suite (141) + `npm run build` green.

Decisions (confirmed): server-side favorite; hard delete behind a confirm. Plan: `docs/superpowers/plans/2026-06-10-SF-253-eval-favorite-delete-sort.md`.

Asana: SF-253 · https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215573724473294

🤖 Generated with [Claude Code](https://claude.com/claude-code)