### PR TITLE
SF-256: Save button in url4 edit popup (persist expression onto the run)

### DIFF
--- a/apps/desktop/src/renderer/src/components/CodeEditorPopup.tsx
+++ b/apps/desktop/src/renderer/src/components/CodeEditorPopup.tsx
@@ -22,6 +22,10 @@ interface Props {
   onEditorMount?: OnMount;
   confirmLabel?: string;
   confirmIcon?: ReactNode;
+  /** Optional second action (e.g. "Re-run"), shown left of the primary button. */
+  secondaryLabel?: string;
+  secondaryIcon?: ReactNode;
+  onSecondary?: (value: string) => void;
 }
 
 export default function CodeEditorPopup({
@@ -34,6 +38,9 @@ export default function CodeEditorPopup({
   onEditorMount,
   confirmLabel = 'Save',
   confirmIcon = <Save className="h-4 w-4" />,
+  secondaryLabel,
+  secondaryIcon,
+  onSecondary,
 }: Props) {
   const [draft, setDraft] = useState(value);
 
@@ -70,6 +77,17 @@ export default function CodeEditorPopup({
           <Button variant="outline" onClick={onClose}>
             Cancel
           </Button>
+          {onSecondary && (
+            <Button
+              variant="outline"
+              onClick={() => {
+                onSecondary(draft);
+                onClose();
+              }}
+            >
+              {secondaryIcon} {secondaryLabel}
+            </Button>
+          )}
           <Button
             onClick={() => {
               onSave(draft);

--- a/apps/desktop/src/renderer/src/components/eval/EvalRunDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/EvalRunDetail.tsx
@@ -1,6 +1,6 @@
 // apps/desktop/src/renderer/src/components/eval/EvalRunDetail.tsx
 import { useState, lazy, Suspense } from 'react';
-import { Upload, Play, Pencil, Trash2 } from 'lucide-react';
+import { Upload, Play, Pencil, Trash2, Save } from 'lucide-react';
 import type { OnMount } from '@monaco-editor/react';
 import { useServerStatus } from '@/hooks/use-server-status';
 import { useEvalRunDetail } from '@/hooks/use-eval-runs';
@@ -45,8 +45,8 @@ export function EvalRunDetail({
   onDeleted?: () => void;
 }) {
   const { info } = useServerStatus();
-  const { data, loading, error } = useEvalRunDetail(runId);
-  const { deleteRun } = useEvalRunActions();
+  const { data, loading, error, refresh } = useEvalRunDetail(runId);
+  const { deleteRun, saveExpression } = useEvalRunActions();
   const [publishing, setPublishing] = useState(false);
   const [editing, setEditing] = useState(false);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
@@ -68,6 +68,11 @@ export function EvalRunDetail({
   const triggerRun = (expression: string): void => {
     onRunLocally?.({ spec: data.spec_name, expression });
     setEditing(false);
+  };
+
+  // Persist an edited expression onto this run, then refetch so the panel updates.
+  const handleSaveExpression = async (expression: string): Promise<void> => {
+    if (await saveExpression(runId, expression)) await refresh();
   };
 
   const confirmDelete = async (): Promise<void> => {
@@ -168,9 +173,12 @@ export function EvalRunDetail({
             value={data.url4_expression}
             inset="10%"
             onEditorMount={mountUrl4Editor}
-            confirmLabel="Re-run"
-            confirmIcon={<Play className="h-4 w-4" />}
-            onSave={triggerRun}
+            confirmLabel="Save"
+            confirmIcon={<Save className="h-4 w-4" />}
+            onSave={(expr) => void handleSaveExpression(expr)}
+            secondaryLabel="Re-run"
+            secondaryIcon={<Play className="h-4 w-4" />}
+            onSecondary={triggerRun}
             onClose={() => setEditing(false)}
           />
         </Suspense>

--- a/apps/desktop/src/renderer/src/hooks/use-eval-run-actions.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-eval-run-actions.ts
@@ -62,5 +62,28 @@ export function useEvalRunActions() {
     [base, toast],
   );
 
-  return { toggleFavorite, deleteRun };
+  const saveExpression = useCallback(
+    async (id: string, url4Expression: string): Promise<boolean> => {
+      if (!base) return false;
+      try {
+        const res = await window.electronAPI.server.fetch(`${base}/eval_runs/${id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ url4_expression: url4Expression }),
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.body}`);
+        return true;
+      } catch (e) {
+        toast({
+          variant: 'error',
+          title: 'Could not save expression',
+          description: (e as Error).message,
+        });
+        return false;
+      }
+    },
+    [base, toast],
+  );
+
+  return { toggleFavorite, deleteRun, saveExpression };
 }

--- a/apps/desktop/src/renderer/src/hooks/use-eval-runs.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-eval-runs.ts
@@ -114,5 +114,5 @@ export function useEvalRunDetail(runId: string | null) {
     };
   }, [runId, base, fetchOnce]);
 
-  return { data, loading, error };
+  return { data, loading, error, refresh: fetchOnce };
 }

--- a/apps/server/src/screamingface/plugins/eval_runs/routes.py
+++ b/apps/server/src/screamingface/plugins/eval_runs/routes.py
@@ -55,7 +55,8 @@ def create_router() -> APIRouter:
     )
     async def patch_run(request: Request, run_id: UUID, body: EvalRunPatchIn) -> EvalRunSummaryOut:
         store = request.app.state.eval_run_store
-        run = await store.set_favorite(run_id, body.favorite)
+        fields = body.model_dump(exclude_unset=True)
+        run = await store.patch(run_id, **fields) if fields else await store.get(run_id)
         if run is None:
             raise HTTPException(status_code=404, detail="run not found")
         return EvalRunSummaryOut.model_validate(run)

--- a/apps/server/src/screamingface/plugins/eval_runs/schemas.py
+++ b/apps/server/src/screamingface/plugins/eval_runs/schemas.py
@@ -49,6 +49,7 @@ class EvalRunOut(EvalRunSummaryOut):
 
 
 class EvalRunPatchIn(BaseModel):
-    """Mutable fields on an eval run (currently just favorite)."""
+    """Mutable fields on an eval run. Only the fields provided are updated."""
 
-    favorite: bool
+    favorite: bool | None = None
+    url4_expression: str | None = None

--- a/apps/server/src/screamingface/plugins/eval_runs/store.py
+++ b/apps/server/src/screamingface/plugins/eval_runs/store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 from uuid import UUID
 
 from screamingface.plugins.eval_runs.models import EvalRun
@@ -18,11 +19,16 @@ class EvalRunStore(BaseStore[EvalRun]):
     async def get_with_questions(self, run_id: UUID) -> EvalRun | None:
         return await EvalRun.filter(id=run_id).prefetch_related("questions").first()
 
-    async def set_favorite(self, run_id: UUID, favorite: bool) -> EvalRun | None:
-        """Toggle a run's favorite flag; returns the updated run or None if missing."""
+    async def patch(self, run_id: UUID, **fields: Any) -> EvalRun | None:
+        """Update the given fields on a run; returns the updated run or None if missing."""
         run = await EvalRun.get_or_none(id=run_id)
         if run is None:
             return None
-        run.favorite = favorite
-        await run.save(update_fields=["favorite", "updated_at"])
+        for key, value in fields.items():
+            setattr(run, key, value)
+        await run.save(update_fields=[*fields.keys(), "updated_at"])
         return run
+
+    async def set_favorite(self, run_id: UUID, favorite: bool) -> EvalRun | None:
+        """Toggle a run's favorite flag; returns the updated run or None if missing."""
+        return await self.patch(run_id, favorite=favorite)

--- a/apps/server/src/screamingface/plugins/eval_runs/tests/test_routes.py
+++ b/apps/server/src/screamingface/plugins/eval_runs/tests/test_routes.py
@@ -117,6 +117,22 @@ async def test_patch_missing_returns_404(async_client: httpx.AsyncClient) -> Non
     assert r.json() == {"detail": "run not found"}
 
 
+async def test_patch_updates_url4_expression(async_client: httpx.AsyncClient) -> None:
+    store = EvalRunStore()
+    run = await store.create(
+        spec_name="x", url4_expression="/claude()!old", started_at=datetime.now(UTC), favorite=True
+    )
+
+    r = await async_client.patch(f"/eval_runs/{run.id}", json={"url4_expression": "/claude()!new"})
+    assert r.status_code == 200
+    assert r.json()["url4_expression"] == "/claude()!new"
+    # favorite is untouched when not included in the patch.
+    assert r.json()["favorite"] is True
+    assert (await async_client.get(f"/eval_runs/{run.id}")).json()[
+        "url4_expression"
+    ] == "/claude()!new"
+
+
 async def test_list_sorts_favorites_first(async_client: httpx.AsyncClient) -> None:
     store = EvalRunStore()
     base = datetime(2026, 5, 13, 10, 0, 0, tzinfo=UTC)


### PR DESCRIPTION
The url4 edit popup now offers **Save + Re-run** (was Re-run only).

- **Save** persists the edited url4 expression onto the run record, then refetches the detail so the panel shows it.
- **Re-run** is unchanged — runs the edited expression as a new run.

## Server
- `PATCH /eval_runs/{id}` now accepts `url4_expression` too. `EvalRunPatchIn` has optional `favorite` + `url4_expression`, applied via `model_dump(exclude_unset=True)` so only provided fields change.
- `EvalRunStore.patch(**fields)` added; `set_favorite` delegates to it.
- Test: PATCH updates the expression and leaves `favorite` untouched.

## Desktop
- `useEvalRunActions.saveExpression` (PATCH); `useEvalRunDetail` exposes `refresh()` to refetch after save.
- `CodeEditorPopup` gained an optional **secondary action** button (used for Re-run), with Save as primary — backward-compatible for the python-code caller.

Footer is now: `Cancel | Re-run | Save`. Server suite + desktop suite + build green.

Asana: SF-256 · https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215576754455741

🤖 Generated with [Claude Code](https://claude.com/claude-code)