### PR TITLE
SF-257: show "Not graded" instead of 0.0% for runs with 0 checked questions

### DIFF
--- a/apps/desktop/src/renderer/src/components/eval/EvalRunDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/EvalRunDetail.tsx
@@ -12,6 +12,7 @@ import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { EvalStatusBadge } from './EvalStatusBadge';
 import { EvalQuestionsTable } from './EvalQuestionsTable';
 import { PublishToLeaderboardDialog } from './PublishToLeaderboardDialog';
+import { formatAccuracy, isUngradedDone } from './format';
 import type { RunPayload } from '@/components/run/types';
 
 // Lazy so the heavy monaco bundle only loads when the editor popup opens.
@@ -23,11 +24,6 @@ const mountUrl4Editor: OnMount = (editor, monaco) => {
   const model = editor.getModel();
   if (model) monaco.editor.setModelLanguage(model, 'url4');
 };
-
-function formatPercent(accuracy: number | null): string {
-  if (accuracy === null) return '—';
-  return `${(accuracy * 100).toFixed(1)}%`;
-}
 
 function formatTime(iso: string | null): string {
   if (!iso) return '—';
@@ -122,7 +118,9 @@ export function EvalRunDetail({
           <dl className="grid grid-cols-4 gap-3 text-xs">
             <div>
               <dt className="text-muted-foreground">Accuracy</dt>
-              <dd className="font-medium tabular-nums">{formatPercent(data.accuracy)}</dd>
+              <dd className="font-medium tabular-nums">
+                {isUngradedDone(data) ? 'Not graded' : formatAccuracy(data)}
+              </dd>
             </div>
             <div>
               <dt className="text-muted-foreground">Correct / Total</dt>
@@ -139,6 +137,13 @@ export function EvalRunDetail({
               <dd className="tabular-nums">{formatTime(data.finished_at)}</dd>
             </div>
           </dl>
+          {isUngradedDone(data) && (
+            <div className="mt-3 rounded border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+              Not graded — this run recorded 0 checked questions. The spec has no grading step (a{' '}
+              <code>/python(check_correct.py)</code> node comparing answers to ground truth), so
+              there's no accuracy to report.
+            </div>
+          )}
           {data.error && (
             <div className="mt-3 rounded border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
               {data.error}

--- a/apps/desktop/src/renderer/src/components/eval/EvalRunsList.test.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/EvalRunsList.test.tsx
@@ -18,15 +18,17 @@ const rows: EvalRunSummary[] = [
     favorite: false,
   },
   {
+    // A finished run that graded nothing (inference-only spec) — must read
+    // "not graded", never "0.0%".
     id: 'r2',
     spec_name: 'GPQA',
     url4_expression: 'x',
     started_at: '2026-01-02T00:00:00Z',
-    finished_at: null,
-    status: 'running',
-    accuracy: null,
-    total_questions: null,
-    correct_questions: null,
+    finished_at: '2026-01-02T00:01:00Z',
+    status: 'done',
+    accuracy: 0,
+    total_questions: 0,
+    correct_questions: 0,
     error: null,
     favorite: true,
   },
@@ -63,8 +65,15 @@ it('renders compact rows (not a table) with spec name, date, status, accuracy', 
   render(<EvalRunsList selectedId={null} onSelect={vi.fn()} onRunLocally={vi.fn()} />);
   expect(screen.queryByRole('table')).toBeNull();
   expect(screen.getByText('HLE')).toBeTruthy();
-  expect(screen.getByText(/done/i)).toBeTruthy();
+  expect(screen.getAllByText(/done/i).length).toBeGreaterThan(0);
   expect(screen.getByText('90.0%')).toBeTruthy();
+});
+
+it('shows "not graded" (—) instead of 0.0% for a finished run with 0 questions', () => {
+  render(<EvalRunsList selectedId={null} onSelect={vi.fn()} onRunLocally={vi.fn()} />);
+  // r2 is done with 0/0 — it must not render a misleading 0.0%.
+  expect(screen.queryByText('0.0%')).toBeNull();
+  expect(screen.getByTitle(/not graded/i)).toBeTruthy();
 });
 
 it('selects the run when the row is clicked', () => {

--- a/apps/desktop/src/renderer/src/components/eval/EvalRunsList.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/EvalRunsList.tsx
@@ -3,6 +3,7 @@ import { cn } from '@/lib/utils';
 import { useEvalRunsList } from '@/hooks/use-eval-runs';
 import { useEvalRunActions } from '@/hooks/use-eval-run-actions';
 import { EvalStatusBadge } from './EvalStatusBadge';
+import { formatAccuracy, isUngradedDone } from './format';
 import type { EvalRunSummary } from './types';
 import type { RunPayload } from '@/components/run/types';
 
@@ -10,11 +11,6 @@ interface Props {
   selectedId: string | null;
   onSelect: (id: string) => void;
   onRunLocally?: (payload: RunPayload) => void;
-}
-
-function formatPercent(accuracy: number | null): string {
-  if (accuracy === null) return '—';
-  return `${(accuracy * 100).toFixed(1)}%`;
 }
 
 function formatTime(iso: string): string {
@@ -65,7 +61,12 @@ export function EvalRunsList({ selectedId, onSelect, onRunLocally }: Props) {
               </div>
               {/* Right indicators on one line, vertically centered: pct, status, star, run. */}
               <div className="flex items-center gap-2 whitespace-nowrap">
-                <span className="text-sm tabular-nums">{formatPercent(run.accuracy)}</span>
+                <span
+                  className="text-sm tabular-nums"
+                  title={isUngradedDone(run) ? 'Not graded — 0 checked questions' : undefined}
+                >
+                  {formatAccuracy(run)}
+                </span>
                 <EvalStatusBadge status={run.status} />
                 <button
                   type="button"

--- a/apps/desktop/src/renderer/src/components/eval/format.ts
+++ b/apps/desktop/src/renderer/src/components/eval/format.ts
@@ -1,0 +1,29 @@
+// apps/desktop/src/renderer/src/components/eval/format.ts
+//
+// Shared eval-run formatting. A finished run that recorded zero checked
+// questions (an inference-only spec with no check_correct grading node) is NOT
+// an accuracy result — showing "0.0%" reads as "0% correct". Treat it as
+// "not graded" instead.
+import type { EvalRunStatus } from './types';
+
+interface RunLike {
+  status: EvalRunStatus;
+  accuracy: number | null;
+  total_questions: number | null;
+}
+
+/** True when the run recorded at least one checked question. */
+export function isGradedRun(run: RunLike): boolean {
+  return (run.total_questions ?? 0) > 0;
+}
+
+/** A finished run that graded nothing — i.e. the spec had no check step. */
+export function isUngradedDone(run: RunLike): boolean {
+  return run.status === 'done' && !isGradedRun(run);
+}
+
+/** Accuracy label: a percentage when graded, "—" when not graded / incomplete. */
+export function formatAccuracy(run: RunLike): string {
+  if (!isGradedRun(run) || run.accuracy === null) return '—';
+  return `${(run.accuracy * 100).toFixed(1)}%`;
+}


### PR DESCRIPTION
A finished run with `total_questions == 0` — an inference-only spec with no `check_correct` grading node (e.g. **MainOne**) — used to render as **0.0%**, which reads like "0% correct". It now reads **"Not graded"**.

- **List row:** shows `—` with a `Not graded — 0 checked questions` tooltip.
- **Detail panel:** shows `Not graded` for accuracy + a short note ("0 checked questions; the spec has no `/python(check_correct.py)` grading step").
- Shared `formatAccuracy` / `isUngradedDone` helpers (`components/eval/format.ts`) replace the duplicated `formatPercent` in `EvalRunsList` and `EvalRunDetail` (DRY).

Verified live against the local server: `MainOne` → **Not graded** (0/0); `ScoredLiveTruth` → **36.4%** (12/33). Confirms the root cause that prompted this (MainOne lacks the grading node).

Desktop-only. eval tests 14 + full suite 136 + build green.

Asana: SF-257 · https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215601667506639

🤖 Generated with [Claude Code](https://claude.com/claude-code)