### PR TITLE
SF-258: URL4 Studio — dedicated CRUD page for url4 specs

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -4,6 +4,7 @@ import type { View } from '@/components/layout/Sidebar';
 import { DashboardView } from '@/views/DashboardView';
 import { SessionsView } from '@/views/SessionsView';
 import { EvalStudioView } from '@/views/EvalStudioView';
+import { Url4StudioView } from '@/views/Url4StudioView';
 import { SettingsView } from '@/views/SettingsView';
 import { PluginHost } from '@/components/plugins/PluginHost';
 import { useServerStatus } from '@/hooks/use-server-status';
@@ -76,6 +77,7 @@ export function App() {
         <EvalStudioView pendingRun={pendingRun} onPendingConsumed={() => setPendingRun(null)} />
       );
     }
+    if (currentView === 'url4-studio') return <Url4StudioView />;
     if (currentView === 'settings') return <SettingsView />;
 
     if (currentView.startsWith('plugin:')) {

--- a/apps/desktop/src/renderer/src/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/layout/Sidebar.tsx
@@ -4,6 +4,7 @@ import {
   Settings,
   Puzzle,
   Terminal,
+  Workflow,
   type LucideIcon,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -11,7 +12,13 @@ import type { BackendPollingError, PluginManifest } from '../../../../preload/ty
 import { GatewayStatusPanel } from '@/components/server/GatewayStatusPanel';
 import { isBackendStatusV2, useBackendStatus } from '@/hooks/use-backend-status';
 
-export type View = 'dashboard' | 'sessions' | 'eval-studio' | 'settings' | `plugin:${string}`;
+export type View =
+  | 'dashboard'
+  | 'sessions'
+  | 'eval-studio'
+  | 'url4-studio'
+  | 'settings'
+  | `plugin:${string}`;
 
 interface NavItem {
   id: View;
@@ -23,6 +30,7 @@ const coreItems: NavItem[] = [
   { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
   { id: 'sessions', label: 'Sessions', icon: Terminal },
   { id: 'eval-studio', label: 'Eval Studio', icon: FlaskConical },
+  { id: 'url4-studio', label: 'URL4 Studio', icon: Workflow },
   { id: 'settings', label: 'Settings', icon: Settings },
 ];
 

--- a/apps/desktop/src/renderer/src/components/url4/AddUrl4SpecDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/url4/AddUrl4SpecDialog.tsx
@@ -1,0 +1,74 @@
+// apps/desktop/src/renderer/src/components/url4/AddUrl4SpecDialog.tsx
+//
+// "New spec" dialog for URL4 Studio: name only. The expression starts empty and
+// is edited afterwards via the CodeEditorPopup in the detail pane.
+import { useState } from 'react';
+import { X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface Props {
+  existingNames: string[];
+  onClose: () => void;
+  onCreate: (name: string) => void;
+}
+
+export function AddUrl4SpecDialog({ existingNames, onClose, onCreate }: Props) {
+  const [name, setName] = useState('');
+  const trimmed = name.trim();
+  const duplicate = existingNames.includes(trimmed);
+  const canCreate = trimmed.length > 0 && !duplicate;
+
+  const handleCreate = (): void => {
+    if (!canCreate) return;
+    onCreate(trimmed);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-16">
+      <div className="flex w-full max-w-md flex-col rounded-[10px] border border-border bg-card shadow-2xl">
+        <div className="flex items-center justify-between border-b border-border px-6 py-4">
+          <h2 className="text-base font-semibold text-foreground">New URL4 spec</h2>
+          <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="px-6 py-4">
+          <label className="block">
+            <span className="mb-1 block text-xs font-medium text-muted-foreground">
+              Name <span className="text-destructive">*</span>
+            </span>
+            <input
+              autoFocus
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+              placeholder="e.g. my-ensemble"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleCreate();
+              }}
+            />
+          </label>
+          {duplicate && (
+            <p className="mt-1.5 text-xs text-destructive">
+              A spec named "{trimmed}" already exists.
+            </p>
+          )}
+          <p className="mt-1.5 text-xs text-muted-foreground">
+            The expression starts empty — edit it from the spec view.
+          </p>
+        </div>
+
+        <div className="flex items-center justify-end gap-2 border-t border-border px-6 py-4">
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleCreate} disabled={!canCreate}>
+            Create
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/url4/Url4SpecDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/url4/Url4SpecDetail.tsx
@@ -1,0 +1,157 @@
+// apps/desktop/src/renderer/src/components/url4/Url4SpecDetail.tsx
+//
+// Right pane of URL4 Studio: view form for one spec. Inline-editable name,
+// read-only expression (Url4Field), and an "Edit expression" button that opens
+// the same CodeEditorPopup Eval Studio uses (lazy + url4 highlighting). Delete
+// lives here with a confirm, mirroring EvalRunDetail.
+import { useState, lazy, Suspense } from 'react';
+import { Pencil, Trash2, Save, Check, X } from 'lucide-react';
+import type { OnMount } from '@monaco-editor/react';
+import { useServerStatus } from '@/hooks/use-server-status';
+import { registerUrl4Language } from '@/lib/url4-language';
+import { Url4Field } from '@/components/Url4Field';
+import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
+import type { Url4Spec } from '@/hooks/use-url4-specs';
+
+const CodeEditorPopup = lazy(() => import('@/components/CodeEditorPopup'));
+
+const mountUrl4Editor: OnMount = (editor, monaco) => {
+  registerUrl4Language(monaco);
+  const model = editor.getModel();
+  if (model) monaco.editor.setModelLanguage(model, 'url4');
+};
+
+interface Props {
+  spec: Url4Spec;
+  onRename: (oldName: string, newName: string) => void;
+  onDelete: (name: string) => void;
+  onSaveExpression: (name: string, expression: string) => void;
+}
+
+export function Url4SpecDetail({ spec, onRename, onDelete, onSaveExpression }: Props) {
+  const { info } = useServerStatus();
+  const serverUrl = info
+    ? `${info.scheme}://${info.host === '0.0.0.0' ? 'localhost' : info.host}:${info.port}`
+    : '';
+
+  const [editingName, setEditingName] = useState(false);
+  const [nameDraft, setNameDraft] = useState(spec.name);
+  const [editingExpr, setEditingExpr] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  const commitName = (): void => {
+    const next = nameDraft.trim();
+    setEditingName(false);
+    if (next && next !== spec.name) onRename(spec.name, next);
+    else setNameDraft(spec.name);
+  };
+
+  const startRename = (): void => {
+    setNameDraft(spec.name);
+    setEditingName(true);
+  };
+
+  return (
+    <div className="flex h-full w-full min-w-0 flex-col">
+      <div className="min-w-0 flex-1 overflow-y-auto">
+        <header className="border-b border-border px-6 py-4">
+          <div className="mb-3 flex items-center gap-3">
+            {editingName ? (
+              <>
+                <input
+                  autoFocus
+                  aria-label="Spec name"
+                  className="min-w-0 flex-1 rounded-md border border-input bg-background px-2 py-1 text-base font-semibold"
+                  value={nameDraft}
+                  onChange={(e) => setNameDraft(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') commitName();
+                    if (e.key === 'Escape') {
+                      setNameDraft(spec.name);
+                      setEditingName(false);
+                    }
+                  }}
+                  onBlur={commitName}
+                />
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="Confirm name"
+                  onClick={commitName}
+                >
+                  <Check className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="Cancel rename"
+                  onClick={() => {
+                    setNameDraft(spec.name);
+                    setEditingName(false);
+                  }}
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </>
+            ) : (
+              <>
+                <h2 className="min-w-0 flex-1 truncate text-base font-semibold">{spec.name}</h2>
+                <Button variant="ghost" size="sm" aria-label="Rename spec" onClick={startRename}>
+                  <Pencil className="h-3.5 w-3.5" /> Rename
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-muted-foreground hover:text-destructive"
+                  onClick={() => setConfirmingDelete(true)}
+                >
+                  <Trash2 className="h-3.5 w-3.5" /> Delete
+                </Button>
+              </>
+            )}
+          </div>
+
+          <span className="mb-1.5 block text-xs font-medium text-muted-foreground">
+            URL4 expression
+          </span>
+          <div className="mb-3 rounded border border-border bg-muted/30">
+            <Url4Field value={spec.expression} serverUrl={serverUrl} readOnly />
+          </div>
+          <Button variant="outline" size="sm" onClick={() => setEditingExpr(true)}>
+            <Pencil className="h-3.5 w-3.5" /> Edit expression
+          </Button>
+        </header>
+      </div>
+
+      {confirmingDelete && (
+        <ConfirmDialog
+          title="Delete this spec?"
+          message={`"${spec.name}" will be permanently removed from your URL4 specs. This can't be undone.`}
+          confirmLabel="Delete"
+          destructive
+          onConfirm={() => {
+            setConfirmingDelete(false);
+            onDelete(spec.name);
+          }}
+          onCancel={() => setConfirmingDelete(false)}
+        />
+      )}
+      {editingExpr && (
+        <Suspense fallback={null}>
+          <CodeEditorPopup
+            title={`Edit URL4 expression — ${spec.name}`}
+            language="url4"
+            value={spec.expression}
+            inset="10%"
+            onEditorMount={mountUrl4Editor}
+            confirmLabel="Save"
+            confirmIcon={<Save className="h-4 w-4" />}
+            onSave={(expr) => onSaveExpression(spec.name, expr)}
+            onClose={() => setEditingExpr(false)}
+          />
+        </Suspense>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/url4/Url4SpecsList.tsx
+++ b/apps/desktop/src/renderer/src/components/url4/Url4SpecsList.tsx
@@ -1,0 +1,86 @@
+// apps/desktop/src/renderer/src/components/url4/Url4SpecsList.tsx
+//
+// Left pane of URL4 Studio: searchable list of url4 specs. Mirrors EvalRunsList's
+// row styling; delete/rename live in the detail pane (like Eval Studio).
+import { useMemo, useState } from 'react';
+import { Search } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { Url4Spec } from '@/hooks/use-url4-specs';
+
+interface Props {
+  specs: Url4Spec[];
+  selectedName: string | null;
+  onSelect: (name: string) => void;
+  loading?: boolean;
+  error?: Error | null;
+}
+
+export function Url4SpecsList({ specs, selectedName, onSelect, loading, error }: Props) {
+  const [filter, setFilter] = useState('');
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return specs;
+    return specs.filter(
+      (s) => s.name.toLowerCase().includes(q) || s.expression.toLowerCase().includes(q),
+    );
+  }, [specs, filter]);
+
+  if (loading && specs.length === 0) {
+    return <div className="p-6 text-sm text-muted-foreground">Loading specs…</div>;
+  }
+  if (error) {
+    return (
+      <div className="p-6 text-sm text-destructive">Failed to load specs: {error.message}</div>
+    );
+  }
+  if (specs.length === 0) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center p-8 text-center text-sm text-muted-foreground">
+        <p className="mb-2 font-medium">No URL4 specs yet.</p>
+        <p className="text-xs">Use "New spec" above to create one.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col">
+      <div className="border-b border-border/50 p-2">
+        <div className="relative">
+          <Search className="pointer-events-none absolute top-1/2 left-2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+          <input
+            aria-label="Filter specs"
+            className="w-full rounded-md border border-input bg-background py-1.5 pr-2 pl-7 text-sm"
+            placeholder="Filter specs…"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+          />
+        </div>
+      </div>
+      {filtered.length === 0 ? (
+        <div className="p-6 text-center text-xs text-muted-foreground">
+          No specs match "{filter}".
+        </div>
+      ) : (
+        filtered.map((spec) => {
+          const active = spec.name === selectedName;
+          return (
+            <div
+              key={spec.name}
+              onClick={() => onSelect(spec.name)}
+              className={cn(
+                'cursor-pointer border-b border-border/50 px-6 py-3 transition-colors hover:bg-accent/40',
+                active && 'bg-accent/60',
+              )}
+            >
+              <div className="truncate font-medium text-foreground">{spec.name}</div>
+              <div className="truncate font-mono text-xs text-muted-foreground">
+                {spec.expression || '(empty)'}
+              </div>
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/url4/__tests__/AddUrl4SpecDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/url4/__tests__/AddUrl4SpecDialog.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { it, expect, vi, afterEach } from 'vitest';
+import { AddUrl4SpecDialog } from '../AddUrl4SpecDialog';
+
+afterEach(cleanup);
+
+it('creates a spec with the entered name', () => {
+  const onCreate = vi.fn();
+  render(<AddUrl4SpecDialog existingNames={['Alpha']} onClose={vi.fn()} onCreate={onCreate} />);
+  fireEvent.change(screen.getByPlaceholderText(/my-ensemble/i), { target: { value: 'Beta' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+  expect(onCreate).toHaveBeenCalledWith('Beta');
+});
+
+it('blocks an empty name', () => {
+  const onCreate = vi.fn();
+  render(<AddUrl4SpecDialog existingNames={[]} onClose={vi.fn()} onCreate={onCreate} />);
+  expect(screen.getByRole('button', { name: 'Create' })).toHaveProperty('disabled', true);
+  fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+  expect(onCreate).not.toHaveBeenCalled();
+});
+
+it('blocks a duplicate name and shows a hint', () => {
+  const onCreate = vi.fn();
+  render(<AddUrl4SpecDialog existingNames={['Alpha']} onClose={vi.fn()} onCreate={onCreate} />);
+  fireEvent.change(screen.getByPlaceholderText(/my-ensemble/i), { target: { value: 'Alpha' } });
+  expect(screen.getByText(/already exists/i)).toBeTruthy();
+  expect(screen.getByRole('button', { name: 'Create' })).toHaveProperty('disabled', true);
+});

--- a/apps/desktop/src/renderer/src/components/url4/__tests__/Url4SpecDetail.test.tsx
+++ b/apps/desktop/src/renderer/src/components/url4/__tests__/Url4SpecDetail.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent, cleanup, waitFor, within } from '@testing-library/react';
+import { it, expect, vi, afterEach } from 'vitest';
+
+vi.mock('@/hooks/use-server-status', () => ({
+  useServerStatus: () => ({ info: { scheme: 'http', host: 'localhost', port: 8000 } }),
+}));
+vi.mock('@/components/Url4Field', () => ({
+  Url4Field: ({ value }: { value: string }) => <span data-testid="url4">{value}</span>,
+}));
+// CodeEditorPopup is lazy + monaco-heavy — stub it to a Save button that emits a value.
+vi.mock('@/components/CodeEditorPopup', () => ({
+  default: ({ onSave }: { onSave: (v: string) => void }) => (
+    <button onClick={() => onSave('/codex()!edited')}>stub-save</button>
+  ),
+}));
+
+afterEach(cleanup);
+
+import { Url4SpecDetail } from '../Url4SpecDetail';
+
+const spec = { name: 'Alpha', expression: '/claude()!hi' };
+
+it('renders the name and read-only expression', () => {
+  render(
+    <Url4SpecDetail spec={spec} onRename={vi.fn()} onDelete={vi.fn()} onSaveExpression={vi.fn()} />,
+  );
+  expect(screen.getByText('Alpha')).toBeTruthy();
+  expect(screen.getByTestId('url4').textContent).toBe('/claude()!hi');
+});
+
+it('renames inline on Enter', () => {
+  const onRename = vi.fn();
+  render(
+    <Url4SpecDetail
+      spec={spec}
+      onRename={onRename}
+      onDelete={vi.fn()}
+      onSaveExpression={vi.fn()}
+    />,
+  );
+  fireEvent.click(screen.getByRole('button', { name: /rename spec/i }));
+  const input = screen.getByRole('textbox', { name: /spec name/i });
+  fireEvent.change(input, { target: { value: 'Renamed' } });
+  fireEvent.keyDown(input, { key: 'Enter' });
+  expect(onRename).toHaveBeenCalledWith('Alpha', 'Renamed');
+});
+
+it('deletes only after confirming', () => {
+  const onDelete = vi.fn();
+  render(
+    <Url4SpecDetail
+      spec={spec}
+      onRename={vi.fn()}
+      onDelete={onDelete}
+      onSaveExpression={vi.fn()}
+    />,
+  );
+  fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+  expect(onDelete).not.toHaveBeenCalled();
+  const dialog = screen.getByRole('alertdialog');
+  fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }));
+  expect(onDelete).toHaveBeenCalledWith('Alpha');
+});
+
+it('saves an edited expression from the popup', async () => {
+  const onSaveExpression = vi.fn();
+  render(
+    <Url4SpecDetail
+      spec={spec}
+      onRename={vi.fn()}
+      onDelete={vi.fn()}
+      onSaveExpression={onSaveExpression}
+    />,
+  );
+  fireEvent.click(screen.getByRole('button', { name: /edit expression/i }));
+  const saveBtn = await screen.findByText('stub-save');
+  fireEvent.click(saveBtn);
+  await waitFor(() => expect(onSaveExpression).toHaveBeenCalledWith('Alpha', '/codex()!edited'));
+});

--- a/apps/desktop/src/renderer/src/components/url4/__tests__/Url4SpecsList.test.tsx
+++ b/apps/desktop/src/renderer/src/components/url4/__tests__/Url4SpecsList.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { it, expect, vi, afterEach } from 'vitest';
+import type { Url4Spec } from '@/hooks/use-url4-specs';
+import { Url4SpecsList } from '../Url4SpecsList';
+
+const specs: Url4Spec[] = [
+  { name: 'Alpha', expression: '/claude()!hi' },
+  { name: 'Beta', expression: '/codex()!yo' },
+];
+
+afterEach(cleanup);
+
+it('renders a row per spec with name + expression preview', () => {
+  render(<Url4SpecsList specs={specs} selectedName={null} onSelect={vi.fn()} />);
+  expect(screen.getByText('Alpha')).toBeTruthy();
+  expect(screen.getByText('/claude()!hi')).toBeTruthy();
+  expect(screen.getByText('Beta')).toBeTruthy();
+});
+
+it('selects a spec on row click', () => {
+  const onSelect = vi.fn();
+  render(<Url4SpecsList specs={specs} selectedName={null} onSelect={onSelect} />);
+  fireEvent.click(screen.getByText('Alpha'));
+  expect(onSelect).toHaveBeenCalledWith('Alpha');
+});
+
+it('filters by name/expression', () => {
+  render(<Url4SpecsList specs={specs} selectedName={null} onSelect={vi.fn()} />);
+  fireEvent.change(screen.getByRole('textbox', { name: /filter specs/i }), {
+    target: { value: 'codex' },
+  });
+  expect(screen.queryByText('Alpha')).toBeNull();
+  expect(screen.getByText('Beta')).toBeTruthy();
+});
+
+it('shows the empty state when there are no specs', () => {
+  render(<Url4SpecsList specs={[]} selectedName={null} onSelect={vi.fn()} />);
+  expect(screen.getByText(/no url4 specs yet/i)).toBeTruthy();
+});

--- a/apps/desktop/src/renderer/src/hooks/__tests__/use-url4-specs.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/__tests__/use-url4-specs.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { it, expect, vi, beforeEach } from 'vitest';
+
+const toast = vi.fn();
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast }) }));
+vi.mock('@/hooks/use-server-status', () => ({
+  useServerStatus: () => ({ info: { scheme: 'http', host: 'localhost', port: 8000 } }),
+}));
+
+import { useUrl4Specs } from '../use-url4-specs';
+
+interface TestConfig {
+  version: string;
+  server: Record<string, unknown>;
+  plugins: string[];
+  plugin_config: Record<string, Record<string, unknown>>;
+}
+
+function baseConfig(): TestConfig {
+  return {
+    version: '1',
+    server: {},
+    plugins: ['url4-specs'],
+    plugin_config: { 'url4-specs': { specs: { Alpha: { expression: '/claude()!hi' } } } },
+  };
+}
+
+let written: TestConfig[];
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  written = [];
+  toast.mockClear();
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue({ ok: true, status: 200, body: '{}' });
+  // @ts-expect-error minimal electronAPI surface for the hook under test
+  window.electronAPI = {
+    config: {
+      read: vi.fn().mockResolvedValue(baseConfig()),
+      write: vi.fn().mockImplementation(async (c: TestConfig) => {
+        written.push(c);
+      }),
+      onChanged: vi.fn().mockReturnValue(() => {}),
+    },
+    server: { fetch: fetchMock },
+  };
+});
+
+function lastSpecs(): Record<string, { expression: string }> {
+  return written.at(-1)!.plugin_config['url4-specs'].specs as Record<
+    string,
+    { expression: string }
+  >;
+}
+
+it('loads specs from the local config', async () => {
+  const { result } = renderHook(() => useUrl4Specs());
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  expect(result.current.specs).toEqual([{ name: 'Alpha', expression: '/claude()!hi' }]);
+});
+
+it('createSpec writes a new empty-expression key, preserving order', async () => {
+  const { result } = renderHook(() => useUrl4Specs());
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  await act(async () => {
+    expect(await result.current.createSpec('Beta')).toBe(true);
+  });
+  expect(Object.keys(lastSpecs())).toEqual(['Alpha', 'Beta']);
+  expect(lastSpecs().Beta).toEqual({ expression: '' });
+});
+
+it('createSpec rejects a duplicate name without writing', async () => {
+  const { result } = renderHook(() => useUrl4Specs());
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  await act(async () => {
+    expect(await result.current.createSpec('Alpha')).toBe(false);
+  });
+  expect(written).toHaveLength(0);
+  expect(toast).toHaveBeenCalled();
+});
+
+it('renameSpec swaps the key in place and keeps the expression', async () => {
+  const { result } = renderHook(() => useUrl4Specs());
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  await act(async () => {
+    expect(await result.current.renameSpec('Alpha', 'Renamed')).toBe(true);
+  });
+  expect(Object.keys(lastSpecs())).toEqual(['Renamed']);
+  expect(lastSpecs().Renamed.expression).toBe('/claude()!hi');
+});
+
+it('deleteSpec removes the key', async () => {
+  const { result } = renderHook(() => useUrl4Specs());
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  await act(async () => {
+    expect(await result.current.deleteSpec('Alpha')).toBe(true);
+  });
+  expect(lastSpecs()).toEqual({});
+});
+
+it('saveExpression updates only the expression', async () => {
+  const { result } = renderHook(() => useUrl4Specs());
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  await act(async () => {
+    expect(await result.current.saveExpression('Alpha', '/codex()!new')).toBe(true);
+  });
+  expect(lastSpecs().Alpha).toEqual({ expression: '/codex()!new' });
+});
+
+it('aborts the write when server validation rejects', async () => {
+  fetchMock.mockResolvedValue({
+    ok: false,
+    status: 422,
+    body: JSON.stringify({ detail: 'bad spec' }),
+  });
+  const { result } = renderHook(() => useUrl4Specs());
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  await act(async () => {
+    expect(await result.current.createSpec('Beta')).toBe(false);
+  });
+  expect(written).toHaveLength(0);
+  expect(toast).toHaveBeenCalledWith(
+    expect.objectContaining({ variant: 'error', description: 'bad spec' }),
+  );
+});

--- a/apps/desktop/src/renderer/src/hooks/use-url4-specs.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-url4-specs.ts
@@ -1,0 +1,196 @@
+// apps/desktop/src/renderer/src/hooks/use-url4-specs.ts
+//
+// Read + CRUD for url4 specs (URL4 Studio). Specs live in the local app config
+// under plugin_config['url4-specs'].specs ({ [name]: { expression } }). The
+// durable source of truth is sf.json, written via window.electronAPI.config.write
+// (same path the Settings page uses); we also best-effort POST the new settings to
+// the running server's in-memory endpoint so spec resolution sees them without a
+// disk re-read. The config:changed broadcast keeps this and the Settings page in sync.
+import { useCallback, useEffect, useState } from 'react';
+import { useServerStatus } from '@/hooks/use-server-status';
+import { useToast } from '@/hooks/use-toast';
+
+export interface Url4Spec {
+  name: string;
+  expression: string;
+}
+
+interface AppConfig {
+  version: string;
+  server: Record<string, unknown>;
+  plugins: string[];
+  plugin_config: Record<string, Record<string, unknown>>;
+}
+
+type SpecMap = Record<string, { expression: string }>;
+
+const PLUGIN = 'url4-specs';
+
+function serverBase(info: ReturnType<typeof useServerStatus>['info']): string | null {
+  if (!info) return null;
+  const host = info.host === '0.0.0.0' ? 'localhost' : info.host;
+  return `${info.scheme}://${host}:${info.port}`;
+}
+
+function specMapOf(config: AppConfig | null): SpecMap {
+  const raw = (config?.plugin_config?.[PLUGIN]?.specs ?? {}) as Record<
+    string,
+    { expression?: string }
+  >;
+  return Object.fromEntries(
+    Object.entries(raw).map(([name, v]) => [name, { expression: v?.expression ?? '' }]),
+  );
+}
+
+export function useUrl4Specs() {
+  const { info } = useServerStatus();
+  const base = serverBase(info);
+  const { toast } = useToast();
+  const [config, setConfig] = useState<AppConfig | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    window.electronAPI.config
+      .read()
+      .then((c) => {
+        if (!cancelled) {
+          setConfig(c as unknown as AppConfig);
+          setLoading(false);
+        }
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          setError(e as Error);
+          setLoading(false);
+        }
+      });
+    // External edits (e.g. the Settings page) re-broadcast the whole config.
+    const unsub = window.electronAPI.config.onChanged((c) => setConfig(c as unknown as AppConfig));
+    return () => {
+      cancelled = true;
+      unsub();
+    };
+  }, []);
+
+  const specMap = specMapOf(config);
+  const specs: Url4Spec[] = Object.entries(specMap).map(([name, v]) => ({
+    name,
+    expression: v.expression,
+  }));
+
+  // Persist a new spec map: validate (best-effort) → durable config.write → dual-write in-memory.
+  const persist = useCallback(
+    async (nextSpecs: SpecMap, errTitle: string): Promise<boolean> => {
+      if (!config) return false;
+      const settings = { ...(config.plugin_config[PLUGIN] ?? {}), specs: nextSpecs };
+      const next: AppConfig = {
+        ...config,
+        plugin_config: { ...config.plugin_config, [PLUGIN]: settings },
+      };
+      try {
+        if (base) {
+          // Server validation blocks the save only on an explicit invalid response;
+          // if the server is unreachable we save anyway (config read/write is local).
+          try {
+            const res = await window.electronAPI.server.fetch(
+              `${base}/plugins/${PLUGIN}/settings/validate`,
+              {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(settings),
+              },
+            );
+            if (!res.ok) {
+              let detail = `HTTP ${res.status}`;
+              try {
+                detail = (JSON.parse(res.body) as { detail?: string }).detail ?? detail;
+              } catch {
+                /* non-JSON body */
+              }
+              toast({ variant: 'error', title: errTitle, description: detail });
+              return false;
+            }
+            // Best-effort: push to the running server's in-memory settings too.
+            void window.electronAPI.server.fetch(`${base}/plugins/${PLUGIN}/settings`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(settings),
+            });
+          } catch {
+            /* server unreachable — persist to disk anyway */
+          }
+        }
+        await window.electronAPI.config.write(next as unknown as Record<string, unknown>);
+        setConfig(next); // optimistic; the config:changed broadcast reconciles
+        return true;
+      } catch (e) {
+        toast({ variant: 'error', title: errTitle, description: (e as Error).message });
+        return false;
+      }
+    },
+    [config, base, toast],
+  );
+
+  const createSpec = useCallback(
+    async (name: string): Promise<boolean> => {
+      const trimmed = name.trim();
+      if (!trimmed) return false;
+      if (trimmed in specMap) {
+        toast({
+          variant: 'error',
+          title: 'Name in use',
+          description: `A spec named "${trimmed}" already exists.`,
+        });
+        return false;
+      }
+      return persist({ ...specMap, [trimmed]: { expression: '' } }, 'Could not create spec');
+    },
+    [specMap, persist, toast],
+  );
+
+  const renameSpec = useCallback(
+    async (oldName: string, newName: string): Promise<boolean> => {
+      const trimmed = newName.trim();
+      if (!trimmed || trimmed === oldName) return false;
+      if (trimmed in specMap) {
+        toast({
+          variant: 'error',
+          title: 'Name in use',
+          description: `A spec named "${trimmed}" already exists.`,
+        });
+        return false;
+      }
+      // Rebuild preserving order, swapping the key in place.
+      const next: SpecMap = Object.fromEntries(
+        Object.entries(specMap).map(([k, v]) => (k === oldName ? [trimmed, v] : [k, v])),
+      );
+      return persist(next, 'Could not rename spec');
+    },
+    [specMap, persist, toast],
+  );
+
+  const deleteSpec = useCallback(
+    async (name: string): Promise<boolean> => {
+      if (!(name in specMap)) return false;
+      const next = { ...specMap };
+      delete next[name];
+      return persist(next, 'Could not delete spec');
+    },
+    [specMap, persist],
+  );
+
+  const saveExpression = useCallback(
+    async (name: string, expression: string): Promise<boolean> => {
+      if (!(name in specMap)) return false;
+      return persist(
+        { ...specMap, [name]: { ...specMap[name], expression } },
+        'Could not save expression',
+      );
+    },
+    [specMap, persist],
+  );
+
+  return { specs, loading, error, createSpec, renameSpec, deleteSpec, saveExpression };
+}

--- a/apps/desktop/src/renderer/src/views/Url4StudioView.test.tsx
+++ b/apps/desktop/src/renderer/src/views/Url4StudioView.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { render, screen, cleanup } from '@testing-library/react';
+import { it, expect, vi, afterEach } from 'vitest';
+
+vi.mock('@/hooks/use-url4-specs', () => ({
+  useUrl4Specs: () => ({
+    specs: [],
+    loading: false,
+    error: null,
+    createSpec: vi.fn(),
+    renameSpec: vi.fn(),
+    deleteSpec: vi.fn(),
+    saveExpression: vi.fn(),
+  }),
+}));
+// Detail pulls in monaco via Url4Field/CodeEditorPopup — stub it out.
+vi.mock('@/components/url4/Url4SpecDetail', () => ({ Url4SpecDetail: () => null }));
+
+afterEach(cleanup);
+
+import { Url4StudioView } from './Url4StudioView';
+
+it('renders header, New spec, both pane toggles, and the empty state', () => {
+  render(<Url4StudioView />);
+  expect(screen.getByText('URL4 Studio')).toBeTruthy();
+  expect(screen.getByRole('button', { name: /new spec/i })).toBeTruthy();
+  expect(screen.getByRole('button', { name: /hide specs list/i })).toBeTruthy();
+  expect(screen.getByRole('button', { name: /hide spec details/i })).toBeTruthy();
+  expect(screen.getByText('Select a spec to see details')).toBeTruthy();
+});

--- a/apps/desktop/src/renderer/src/views/Url4StudioView.tsx
+++ b/apps/desktop/src/renderer/src/views/Url4StudioView.tsx
@@ -1,0 +1,147 @@
+import { useRef, useState } from 'react';
+import type { ImperativePanelHandle } from 'react-resizable-panels';
+import { PanelLeftClose, PanelLeftOpen, PanelRightClose, PanelRightOpen, Plus } from 'lucide-react';
+import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
+import { Button } from '@/components/ui/button';
+import { Url4SpecsList } from '@/components/url4/Url4SpecsList';
+import { Url4SpecDetail } from '@/components/url4/Url4SpecDetail';
+import { AddUrl4SpecDialog } from '@/components/url4/AddUrl4SpecDialog';
+import { useUrl4Specs } from '@/hooks/use-url4-specs';
+
+export function Url4StudioView() {
+  const { specs, loading, error, createSpec, renameSpec, deleteSpec, saveExpression } =
+    useUrl4Specs();
+  const [selectedName, setSelectedName] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const leftPanelRef = useRef<ImperativePanelHandle>(null);
+  const rightPanelRef = useRef<ImperativePanelHandle>(null);
+  const [leftCollapsed, setLeftCollapsed] = useState(false);
+  const [rightCollapsed, setRightCollapsed] = useState(false);
+
+  const selected = specs.find((s) => s.name === selectedName) ?? null;
+
+  const handleCreate = async (name: string): Promise<void> => {
+    if (await createSpec(name)) setSelectedName(name);
+  };
+  const handleRename = async (oldName: string, newName: string): Promise<void> => {
+    if (await renameSpec(oldName, newName)) setSelectedName(newName);
+  };
+  const handleDelete = async (name: string): Promise<void> => {
+    if (await deleteSpec(name)) {
+      setSelectedName((current) => (current === name ? null : current));
+    }
+  };
+
+  const toggleLeft = () => {
+    const panel = leftPanelRef.current;
+    if (!panel) return;
+    if (panel.isCollapsed()) panel.expand();
+    else panel.collapse();
+  };
+  const toggleRight = () => {
+    const panel = rightPanelRef.current;
+    if (!panel) return;
+    if (panel.isCollapsed()) panel.expand();
+    else panel.collapse();
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-start justify-between border-b border-border px-6 py-4">
+        <div>
+          <h1 className="text-lg font-semibold text-foreground">URL4 Studio</h1>
+          <p className="text-xs text-muted-foreground">
+            Named URL4 expressions you can run in Eval Studio and share
+          </p>
+        </div>
+        <div className="flex items-center gap-1">
+          <Button variant="outline" size="sm" className="mr-1" onClick={() => setCreating(true)}>
+            <Plus className="h-3.5 w-3.5" /> New spec
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={leftCollapsed ? 'Show specs list' : 'Hide specs list'}
+            aria-pressed={leftCollapsed}
+            onClick={toggleLeft}
+          >
+            {leftCollapsed ? <PanelLeftOpen /> : <PanelLeftClose />}
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={rightCollapsed ? 'Show spec details' : 'Hide spec details'}
+            aria-pressed={rightCollapsed}
+            onClick={toggleRight}
+          >
+            {rightCollapsed ? <PanelRightOpen /> : <PanelRightClose />}
+          </Button>
+        </div>
+      </div>
+
+      <ResizablePanelGroup
+        direction="horizontal"
+        autoSaveId="url4-studio-split"
+        className="min-h-0 flex-1"
+      >
+        <ResizablePanel
+          ref={leftPanelRef}
+          id="url4-specs-list"
+          order={1}
+          collapsible
+          collapsedSize={0}
+          minSize={20}
+          defaultSize={50}
+          onCollapse={() => setLeftCollapsed(true)}
+          onExpand={() => setLeftCollapsed(false)}
+          className="overflow-auto"
+        >
+          <Url4SpecsList
+            specs={specs}
+            selectedName={selectedName}
+            onSelect={setSelectedName}
+            loading={loading}
+            error={error}
+          />
+        </ResizablePanel>
+
+        <ResizableHandle withHandle />
+
+        <ResizablePanel
+          ref={rightPanelRef}
+          id="url4-spec-detail"
+          order={2}
+          collapsible
+          collapsedSize={0}
+          minSize={20}
+          defaultSize={50}
+          onCollapse={() => setRightCollapsed(true)}
+          onExpand={() => setRightCollapsed(false)}
+          className="flex overflow-hidden"
+        >
+          {selected ? (
+            <Url4SpecDetail
+              spec={selected}
+              onRename={(o, n) => void handleRename(o, n)}
+              onDelete={(n) => void handleDelete(n)}
+              onSaveExpression={(n, e) => void saveExpression(n, e)}
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
+              Select a spec to see details
+            </div>
+          )}
+        </ResizablePanel>
+      </ResizablePanelGroup>
+
+      {creating && (
+        <AddUrl4SpecDialog
+          existingNames={specs.map((s) => s.name)}
+          onClose={() => setCreating(false)}
+          onCreate={(name) => void handleCreate(name)}
+        />
+      )}
+    </div>
+  );
+}

--- a/docs/superpowers/plans/2026-06-10-url4-studio-page.md
+++ b/docs/superpowers/plans/2026-06-10-url4-studio-page.md
@@ -1,0 +1,438 @@
+# URL4 Studio — Implementation Plan
+
+**Status:** Draft for review (planning only — no code yet)
+**Author:** research agent
+**Date:** 2026-06-10
+**Confidence:** ~88% (one persistence-semantics gap to confirm with the user — see "Open questions")
+
+---
+
+## 1. Overview
+
+Today, URL4 specs (named URL4 expressions) are edited only inside the giant RJSF
+settings page, under the `url4-specs` plugin's `specs` dict field
+(`apps/desktop/src/renderer/src/views/SettingsView.tsx`). That's hard to find and
+clunky to edit.
+
+This plan adds a dedicated, top-level **URL4 Studio** screen that mirrors the
+**Eval Studio** two-pane layout:
+
+- **Left pane** — a searchable list of URL4 specs with full CRUD (create / rename / delete).
+- **Right pane** — a read-only "view form" for the selected spec: an **inline-editable name**
+  and a **read-only URL4 expression** rendered with `Url4Field` (readonly).
+- **Edit expression** — opens the *same* `CodeEditorPopup` used by Eval Studio's
+  `EvalRunDetail`, with url4 syntax highlighting via the `mountUrl4Editor` `OnMount` handler.
+  Editing the expression is **not** inline.
+- **Nav** — a new top-level sidebar entry "URL4 Studio", alongside Dashboard / Sessions /
+  Eval Studio / Settings.
+
+The data model is the `url4-specs` plugin's settings: a dict keyed by spec name whose values
+are `{ expression: string }`. CRUD = mutations on that dict, persisted exactly the way the
+RJSF settings form persists plugin settings today (write the whole `sf.json` config to disk via
+`window.electronAPI.config.write`).
+
+### How it maps onto Eval Studio
+
+| Eval Studio | URL4 Studio |
+|---|---|
+| `views/EvalStudioView.tsx` — `ResizablePanelGroup`, header w/ "New run" + collapse toggles, `selectedRunId` state | `views/Url4StudioView.tsx` — same shell; "New spec" button + collapse toggles; `selectedSpecName` state |
+| `components/eval/EvalRunsList.tsx` (left) | `components/url4/Url4SpecsList.tsx` (left) |
+| `components/eval/EvalRunDetail.tsx` (right) + `CodeEditorPopup` for expression edit | `components/url4/Url4SpecDetail.tsx` (right) + `CodeEditorPopup` for expression edit |
+| `hooks/use-eval-runs.ts` (read) + `hooks/use-eval-run-actions.ts` (mutate) | `hooks/use-url4-specs.ts` (read + CRUD, single hook — see §3) |
+| `components/eval/AddEvalRunDialog.tsx` (create) | reuse a small inline create flow (see §6) |
+
+Reference: `EvalStudioView.tsx:68-156` (shell), `EvalRunDetail.tsx:19-26,173-190`
+(lazy `CodeEditorPopup` + `mountUrl4Editor`), `EvalRunsList.tsx:44-107` (list rows).
+
+---
+
+## 2. Data model & persistence
+
+### 2.1 The spec shape (server-side)
+
+`apps/server/src/screamingface/plugins/url4_specs/plugin.py`:
+
+- `Url4Spec` (`plugin.py:20-38`) — `{ expression: str }` (with examples/placeholder metadata).
+- `Url4SpecsSettings` (`plugin.py:41-50`) — `specs: dict[str, Url4Spec]` (key = spec name).
+- Plugin `name = "url4-specs"` (`plugin.py:54`). It registers **no routes** — it is "pure
+  settings storage" (`plugin.py:77`).
+
+So a spec is `{ name, expression }` in the UI, stored on the wire as
+`specs: { [name]: { expression } }`. This matches how `SpecSelector.tsx:52-61` already parses it.
+
+### 2.2 Read endpoint
+
+`GET /plugins/url4-specs/settings` → `{ specs: { [name]: { expression } } }`.
+
+- Server handler: `apps/server/src/screamingface/core/admin_router.py:176-190` (`plugin_settings`).
+  It **re-reads `sf.json` from disk** (`load_config()`), merges with plugin defaults, and returns
+  the validated settings dump. This is the authoritative read for current specs.
+- Desktop already calls this exact URL in `SpecSelector.tsx:46` and parses the `specs` dict.
+
+### 2.3 Write / persistence — the important nuance
+
+There are **two** server settings endpoints, and only one matters for durable CRUD:
+
+- `POST /plugins/{name}/settings` (`admin_router.py:192-200`) — updates **in-memory only**
+  (`plugin.settings` + `app.state.config.plugin_config[name]`). It does **not** write `sf.json`.
+  On the next `GET …/settings` (which re-reads disk) or a server restart, in-memory-only writes
+  are lost. **Do not rely on this for persistence.**
+- `POST /plugins/{name}/settings/validate` (`admin_router.py:202-214`) — dry-run validation;
+  returns `{ valid: true }` or HTTP 422 with `detail`.
+
+**How the RJSF settings page actually persists** (the pattern we must copy):
+`SettingsView.tsx` writes the *entire* app config object to disk via
+`window.electronAPI.config.write(config)` (`SettingsView.tsx:140`), where
+`config.plugin_config['url4-specs']` holds the specs dict. The IPC handler
+`config:write` (`apps/desktop/src/main/ipc/config.ipc.ts:11-14`) calls
+`configService.write(...)`, which writes `sf.json` (`config-service.ts:156`, atomic write).
+`configService.watch()` + the `config:changed` broadcast (`config.ipc.ts:16-22`) push the new
+config back to every renderer.
+
+Before saving, the RJSF page validates plugin settings against the server
+(`SettingsView.tsx:117-145`): it POSTs each plugin's settings to
+`…/settings/validate` and aborts on failure. We mirror this.
+
+**Conclusion — the persistence contract for URL4 Studio CRUD:**
+
+1. Read current full config via `window.electronAPI.config.read()` (shape in `SettingsView.tsx:20-25`:
+   `{ version, server, plugins, plugin_config }`).
+2. Compute the new `plugin_config['url4-specs'].specs` dict (create/rename/delete/update-expression
+   = pure dict transforms).
+3. (Optional but recommended) POST the new `url4-specs` settings to
+   `…/plugins/url4-specs/settings/validate`; abort + toast on 422.
+4. Persist by writing the whole config object back: `window.electronAPI.config.write(nextConfig)`.
+5. Subscribe to `window.electronAPI.config.onChanged(...)` so the list reflects external edits
+   (e.g. someone editing the same specs in the Settings page) — same subscription used in
+   `App.tsx:24-27` and `SettingsView.tsx:202-213`.
+
+Note: a write to `plugin_config['url4-specs']` does **not** require a server restart (unlike the
+`plugins:` array, which `SettingsView.updatePlugins` restarts for — `SettingsView.tsx:254-265`).
+Settings changes are picked up by the next disk-reading `GET …/settings`. We should still POST to
+the in-memory `…/settings` endpoint *opportunistically* (best-effort) so the running server's
+`active_spec` resolution sees the new specs without waiting on its own disk re-read — but the
+durable source of truth is the `config.write` to `sf.json`. (Confirm desire for this dual-write in
+Open questions.)
+
+### 2.4 CRUD → settings-write mapping
+
+Let `specs = plugin_config['url4-specs'].specs ?? {}` (an object).
+
+- **Create**: `specs[newName] = { expression: '' }` (or a starter expression). Reject if `newName`
+  already exists (case-sensitive key collision).
+- **Rename** (`oldName` → `newName`): build a new object preserving insertion order where possible:
+  `{ ...without(oldName), [newName]: specs[oldName] }`. Reject if `newName` exists. Update
+  `selectedSpecName` to `newName`.
+- **Delete**: `delete specs[name]` (build new object without the key). Clear selection if it was
+  selected (mirror `EvalStudioView.handleRunDeleted`, `EvalStudioView.tsx:34-36`).
+- **Update expression** (`name`, `expr`): `specs[name] = { ...specs[name], expression: expr }`.
+
+Each mutation produces a new full config and persists per §2.3.
+
+### 2.5 Gaps (server changes needed?)
+
+- **No new server endpoint is required.** Read (`GET …/settings`), validate
+  (`POST …/settings/validate`), and disk persistence (`config:write` IPC) all already exist.
+- **Minor gap:** persistence is renderer-driven (write whole `sf.json`), not a REST PUT to the
+  plugin. This is *by design* in this codebase and is exactly how Settings works — so no change.
+  If the team later wants a true persisting `PUT /plugins/{name}/settings`, that's a separate,
+  out-of-scope server task. Flag, don't build.
+
+---
+
+## 3. Components to create
+
+All under `apps/desktop/src/renderer/src/`, TypeScript React, Tailwind, `@/` imports.
+
+### 3.1 `views/Url4StudioView.tsx`
+**Responsibility:** screen shell — mirror `EvalStudioView.tsx:68-156` almost verbatim.
+- `ResizablePanelGroup direction="horizontal" autoSaveId="url4-studio-split"`.
+- Header: title "URL4 Studio", subtitle (e.g. "Named URL4 expressions you can run and share"),
+  a **"New spec"** `Button` (`Plus` icon) and the two pane-collapse toggle buttons
+  (`PanelLeftClose/Open`, `PanelRightClose/Open`) with the same `aria-label`/`aria-pressed`.
+- State: `selectedSpecName: string | null`, `leftCollapsed`, `rightCollapsed`, `creating: boolean`.
+- Left panel renders `<Url4SpecsList selectedName onSelect />`.
+- Right panel renders `<Url4SpecDetail name … />` or the "Select a spec to see details" empty state.
+- Uses the `use-url4-specs` hook to get specs + CRUD callbacks; passes them down.
+
+### 3.2 `components/url4/Url4SpecsList.tsx`
+**Responsibility:** left-pane list (mirror `EvalRunsList.tsx` + the search box from
+`SpecSelector.tsx:86-95`).
+- Props: `{ specs, selectedName, onSelect, loading?, error? }`.
+- Optional filter input (reuse `SpecSelector`'s search styling) filtering by name/expression.
+- Rows: spec name (truncate) + a muted, truncated mono preview of the expression
+  (like `SpecSelector.tsx:140-149`); active styling like `EvalRunsList.tsx:52-55`.
+- Empty state: "No specs yet. Use 'New spec' above." (mirror `EvalRunsList.tsx:35-42`).
+- No per-row delete here (delete lives in the detail pane to match Eval Studio), unless we choose a
+  small trailing trash button — see §6 decision.
+
+### 3.3 `components/url4/Url4SpecDetail.tsx`
+**Responsibility:** right-pane view form (mirror `EvalRunDetail.tsx`).
+- Props: `{ name, expression, onRename, onDelete, onSaveExpression, serverUrl }`.
+- Header row: **inline-editable name** (see §5) + a **Delete** ghost button
+  (`Trash2`) like `EvalRunDetail.tsx:95-102`.
+- Read-only expression block: `<Url4Field value={expression} serverUrl={serverUrl} readOnly />`
+  inside a bordered `bg-muted/30` container (exactly `EvalRunDetail.tsx:105-107`).
+- An **"Edit expression"** `Button` (`Pencil` icon) that opens the lazy `CodeEditorPopup`
+  (see §4).
+- `ConfirmDialog` for delete (see §5), `editing` boolean for the popup.
+
+### 3.4 `hooks/use-url4-specs.ts`
+**Responsibility:** single hook = read + CRUD (combines the read/mutate split of Eval Studio into
+one, because the data source is the local config object, not a REST collection).
+- Internally:
+  - Reads full config via `window.electronAPI.config.read()` on mount and subscribes via
+    `window.electronAPI.config.onChanged(...)` (cleanup on unmount) — same as `App.tsx:24-27`.
+  - Derives `specs: { name, expression }[]` from `config.plugin_config['url4-specs']?.specs ?? {}`
+    (object → array, like `SpecSelector.tsx:54-59`).
+  - Exposes `{ specs, loading, error, createSpec, renameSpec, deleteSpec, saveExpression }`.
+  - Each mutation: validate name rules (§5), optionally POST to `…/settings/validate`, then
+    `config.write(nextConfig)`; surface failures via `useToast` (`hooks/use-toast.ts`).
+  - Server URL derived from `useServerStatus()` exactly like `use-eval-run-actions.ts:10-14`
+    (`0.0.0.0` → `localhost`).
+- Returns plain promises `Promise<boolean>` like `use-eval-run-actions.ts` so callers can await and
+  refresh selection.
+
+> Design note (SOLID/DRY): the `serverBase(info)` helper is duplicated across
+> `use-eval-runs.ts:8-12`, `use-eval-run-actions.ts:10-14`, and `SpecSelector.tsx:32-34`.
+> Consider extracting a shared `lib/server-url.ts` and using it here (small refactor; optional —
+> keep in scope only if cheap, otherwise copy the existing inline pattern to stay consistent).
+
+### 3.5 (Optional) `views/Url4StudioView.test.tsx` and component tests
+See §7.
+
+---
+
+## 4. Edit flow (reuse, don't reinvent)
+
+Copy the Eval Studio pattern verbatim (`EvalRunDetail.tsx:19-26,173-190`):
+
+```ts
+// top of Url4SpecDetail.tsx
+const CodeEditorPopup = lazy(() => import('@/components/CodeEditorPopup'));
+
+const mountUrl4Editor: OnMount = (editor, monaco) => {
+  registerUrl4Language(monaco);              // from '@/lib/url4-language'
+  const model = editor.getModel();
+  if (model) monaco.editor.setModelLanguage(model, 'url4');
+};
+```
+
+Open it when `editing` is true:
+
+```tsx
+{editing && (
+  <Suspense fallback={null}>
+    <CodeEditorPopup
+      title="Edit URL4 expression"
+      language="url4"
+      value={expression}
+      inset="10%"
+      onEditorMount={mountUrl4Editor}
+      confirmLabel="Save"
+      confirmIcon={<Save className="h-4 w-4" />}
+      onSave={(expr) => void handleSaveExpression(expr)}
+      onClose={() => setEditing(false)}
+    />
+  </Suspense>
+)}
+```
+
+- `CodeEditorPopup` props are already generalized (`CodeEditorPopup.tsx:13-44`): `inset`,
+  `onEditorMount`, `confirmLabel`, `confirmIcon`, optional secondary action. We **omit** the
+  secondary "Re-run" button (URL4 Studio doesn't run specs — running lives in Eval Studio).
+- `handleSaveExpression(expr)` calls `saveExpression(name, expr)` from the hook, then nothing else
+  is needed (the `config:changed` subscription refreshes the list/detail automatically).
+- **Inline name editing** is *not* done in the popup — only the expression. Name editing is §5.
+
+---
+
+## 5. Validation / UX
+
+### Name rules
+- **Required, non-empty** (trim). Mirror `AddEvalRunDialog`'s `canCreate` gate
+  (`AddEvalRunDialog.tsx:29`).
+- **Unique** among existing spec names (object-key collision). On collision: block + error toast
+  ("A spec named '<x>' already exists").
+- **Identifier-ish but permissive:** the server type is just `dict[str, Url4Spec]` — keys are
+  arbitrary strings, and existing examples use names freely. Recommend a soft rule: disallow only
+  empty/whitespace and leading/trailing spaces; do **not** force a strict identifier regex unless
+  the user wants it (Open question). Spec names appear in url4 expressions and `active_spec`
+  resolution, so very exotic characters could surprise users — surface a gentle warning rather than
+  a hard block. Keep it minimal for v1.
+
+### Inline name editing (detail pane)
+- Click the name (or a small pencil) → swap to a text `<input>` seeded with current name.
+- Commit on Enter / blur; cancel on Escape (revert).
+- On commit with a changed, valid, unique name → `renameSpec(old, new)`; update selection.
+- Use the app's input styling (border-input / focus ring) consistent with `AddEvalRunDialog.tsx:52-58`.
+
+### Delete
+- `ConfirmDialog` (`components/ConfirmDialog.tsx`) with `destructive`, `busy` while writing, and a
+  message like the Eval one (`EvalRunDetail.tsx:162-171`):
+  `"\"<name>\" will be permanently removed from your URL4 specs. This can't be undone."`
+
+### Empty states
+- No specs: list shows the prompt; right pane shows "Select a spec to see details" (mirrors
+  `EvalStudioView.tsx:146-150`).
+- Server not running: specs still load from local config (`config.read()` works offline). The
+  read-only `Url4Field` gracefully falls back to plain monospace text when Monaco/validation can't
+  reach the server (`Url4Field.tsx:22-26`).
+
+### Optimistic update vs refetch
+- **Source of truth is the config file + its `config:changed` broadcast.** Strategy: write config,
+  let the `onChanged` subscription re-derive `specs`. This is effectively a refetch and avoids
+  divergent local state. Optionally set local state optimistically before the write resolves for
+  snappiness, but reconcile on the broadcast. Keep it simple: write → rely on broadcast (the write
+  is local-disk fast).
+
+### Error toasts
+- All mutations use `useToast` (`hooks/use-toast.ts`); on failure show
+  `{ variant: 'error', title, description }` (object form is supported — `use-toast.ts:36-43`).
+  Note Eval actions use the object form (`use-eval-run-actions.ts:33-37`) while `SettingsView`
+  uses the `(string, variant, duration)` form — both valid; pick the object form for consistency
+  with the eval hooks we're mirroring.
+
+---
+
+## 6. Files to modify
+
+### 6.1 `components/layout/Sidebar.tsx`
+- Extend the `View` union (`Sidebar.tsx:14`):
+  `'dashboard' | 'sessions' | 'eval-studio' | 'url4-studio' | 'settings' | \`plugin:${string}\``.
+- Add a `coreItems` entry (`Sidebar.tsx:22-27`):
+  `{ id: 'url4-studio', label: 'URL4 Studio', icon: Link2 }` (or `Workflow`/`Share2` from
+  `lucide-react` — pick an icon distinct from Eval Studio's `FlaskConical`). Place it right after
+  Eval Studio.
+
+### 6.2 `App.tsx`
+- Add to `renderView()` (`App.tsx:69-103`), after the `eval-studio` branch:
+  ```tsx
+  if (currentView === 'url4-studio') return <Url4StudioView />;
+  ```
+- Import `Url4StudioView` at top (`App.tsx:6` neighborhood).
+- No deep-link plumbing needed (unlike Eval Studio's `pendingRun`).
+
+### 6.3 Create-spec flow decision
+Two options; recommend **A** for the smallest, most Eval-Studio-consistent build:
+
+- **A (recommended):** a tiny `AddUrl4SpecDialog` (or reuse an inline name prompt) that asks only
+  for a **name** (expression starts empty, edited via the popup afterward). Mirrors
+  `AddEvalRunDialog` minus the url4 field. On create → `createSpec(name)` → select it → user clicks
+  "Edit expression". Keeps the create modal trivial and reuses the popup for the real editing.
+- **B:** full create dialog with name + url4 field (closer to `AddEvalRunDialog.tsx` verbatim).
+  More code, but one-step creation. Decide with the user (Open question).
+
+---
+
+## 7. Test plan (vitest + jsdom)
+
+Mirror existing eval tests (`views/EvalStudioView.test.tsx`,
+`components/eval/__tests__/AddEvalRunDialog.test.tsx`).
+
+### Conventions to copy
+- File header `// @vitest-environment jsdom`; `@testing-library/react` + `vitest`.
+- **Mock the hook**, not the network: `vi.mock('@/hooks/use-url4-specs', ...)` returning controlled
+  `specs` + spy CRUD fns — exactly how `EvalStudioView.test.tsx:5-12` mocks `use-eval-runs` etc.
+- **Mock heavy children**: stub `Url4Field` with a labelled `<textarea>`
+  (`AddEvalRunDialog.test.tsx:12-20`); mock `@/components/CodeEditorPopup` to a simple stub that
+  renders a textarea + Save button so we can assert open + onSave without loading Monaco
+  (pattern used by `rjsf-CodeDictField.test.tsx`, `PublishToLeaderboardDialog.test.tsx`).
+- `afterEach(cleanup)`.
+
+### Cases
+1. **`Url4StudioView.test.tsx`** — renders header "URL4 Studio", "New spec" button, both pane
+   toggles by `aria-label`, and the "Select a spec to see details" empty state (mirror
+   `EvalStudioView.test.tsx:18-24`).
+2. **`Url4SpecsList`** — given mocked specs, renders a row per spec with name + expression preview;
+   filtering narrows the list; clicking a row calls `onSelect`; empty array → empty state.
+3. **CRUD wiring** (with mocked hook):
+   - Create flow opens the dialog/prompt and calls `createSpec` with the entered name; blocks empty
+     and duplicate names (assert no call + error path).
+   - Rename: enter inline edit, change text, Enter → `renameSpec(old, new)`; Escape → no call.
+   - Delete: click Delete → `ConfirmDialog` shows → Confirm → `deleteSpec(name)`; selection clears.
+4. **Edit expression popup** — clicking "Edit expression" mounts the (mocked) `CodeEditorPopup`;
+   Save calls `saveExpression(name, value)`; Cancel/close calls neither.
+5. **`use-url4-specs` unit test** (jsdom) — stub `window.electronAPI.config.read/write/onChanged`;
+   assert create/rename/delete/update produce the correct `plugin_config['url4-specs'].specs`
+   object passed to `config.write`, and that name-collision rejects without writing. (This is the
+   highest-value test — it locks the persistence contract from §2.4.)
+
+### Mocking `window.electronAPI`
+For the hook test, define a minimal `window.electronAPI = { config: { read, write, onChanged }, server: { fetch } }` in the test (return canned config; capture `write` args). For component tests, the hook is mocked so no `electronAPI` needed.
+
+---
+
+## 8. Step-by-step build sequence
+
+1. **Hook first (TDD):** write `use-url4-specs.test.ts`, then `hooks/use-url4-specs.ts` (read +
+   CRUD + persistence per §2). This nails the data contract before any UI.
+2. **List:** `components/url4/Url4SpecsList.tsx` + test (render/filter/select/empty).
+3. **Detail (view form):** `components/url4/Url4SpecDetail.tsx` — read-only `Url4Field`, inline name
+   edit, Delete + `ConfirmDialog`, "Edit expression" → lazy `CodeEditorPopup` + `mountUrl4Editor`.
+   Add tests with mocked `CodeEditorPopup`/`Url4Field`.
+4. **Create flow:** option A `AddUrl4SpecDialog` (name only) + test.
+5. **View shell:** `views/Url4StudioView.tsx` wiring list + detail + create + collapse toggles;
+   add `Url4StudioView.test.tsx`.
+6. **Nav:** extend `View` union + add `coreItems` entry in `Sidebar.tsx`; add the `url4-studio`
+   branch + import in `App.tsx`.
+7. **Manual QA:** create/rename/delete/edit a spec; confirm `sf.json` `plugin_config['url4-specs']`
+   updates on disk and the change round-trips into the Settings page (and vice-versa via
+   `config:changed`). Confirm a spec edited here appears in `SpecSelector`/Eval Studio's spec
+   picker.
+8. **Lint/typecheck/tests** for the desktop app; ensure no Monaco bundle leaks into the synchronous
+   path (it's lazy via `Url4Field` and `CodeEditorPopup`).
+
+---
+
+## 9. Out of scope
+
+- Running/evaluating specs (that stays in Eval Studio — no "Run" button in URL4 Studio).
+- A new persisting server endpoint (`PUT /plugins/{name}/settings` that writes `sf.json`). Not
+  needed; flagged in §2.5.
+- Changing the `url4-specs` plugin schema, adding fields beyond `expression`, or adding server
+  routes.
+- url4 grammar/validation changes (Kevin owns url4 grammar).
+- Removing the `specs` field from the RJSF Settings page (see §10 decision — default: **leave it**).
+- Deep-linking into URL4 Studio.
+- Sharing/copy-link UX (the plugin's `x-copy-link` metadata, `plugin.py:60-68`) — could be a nice
+  follow-up but not in v1.
+
+---
+
+## 10. Where url4 specs currently appear in settings
+
+In `SettingsView.tsx`, the `url4-specs` plugin's `specs` dict is edited via the generic RJSF
+`ThemedForm` rendered for any expanded plugin with settings (`SettingsView.tsx:637-698`); there's
+no url4-specs-specific code there (the `active_spec` `SpecSelectorWidget` override at
+`SettingsView.tsx:693` is for the *frontend* plugins, not url4-specs).
+
+**Recommendation:** **leave** the RJSF editing in place for v1 (both write the same
+`plugin_config['url4-specs']` and stay in sync via `config:changed`). Optionally add a hint in
+Settings pointing users to URL4 Studio. Removing/hiding the RJSF field is a separate, low-risk
+follow-up once URL4 Studio is the established path — out of scope here.
+
+---
+
+## 11. Confidence & open questions
+
+**Confidence: ~88%.** The layout, edit-popup reuse, read endpoint, list/detail patterns, and the
+persistence mechanism (write whole `sf.json` via `config.write`, refresh via `config:changed`) are
+all directly evidenced in the cited files. The one area to confirm is persistence semantics /
+dual-write.
+
+**Open questions for the user:**
+
+1. **Dual-write to the running server?** Persistence is via `config.write` → `sf.json` (durable).
+   Should we *also* best-effort `POST /plugins/url4-specs/settings` (in-memory) so a running server
+   resolves new specs immediately without re-reading disk, or is the next disk-read good enough?
+   (Confirm there isn't a need to restart the server for spec changes — I believe there isn't,
+   since specs aren't in the `plugins:` array.)
+2. **Create flow:** option A (name-only dialog, then edit expression via popup) — preferred — or
+   option B (name + expression in one dialog like `AddEvalRunDialog`)?
+3. **Name validation strictness:** soft rules (non-empty, unique, trimmed) — preferred — or enforce
+   a strict identifier regex?
+4. **Settings page:** leave the RJSF `specs` editor as-is (recommended), or hide/remove it once
+   URL4 Studio ships?
+5. **Per-row delete in the list** vs delete only in the detail pane (Eval Studio puts destructive
+   delete in the detail pane — I followed that; confirm).


### PR DESCRIPTION
A top-level **URL4 Studio** screen, mirroring Eval Studio's two-pane layout, so url4 specs aren't buried in the big Settings page.

- **Left:** searchable list of url4 specs.
- **Right:** view form — **inline-editable name** + **read-only expression** (`Url4Field`). **Edit expression** opens the *same* `CodeEditorPopup` Eval Studio uses (lazy + url4 highlighting). Delete behind a `ConfirmDialog`.
- **New spec** — name-only dialog; the expression is edited afterwards via the popup.
- **Nav:** new Sidebar entry (`Workflow` icon) + App route.

### Persistence (`use-url4-specs` hook)
Specs live in `plugin_config['url4-specs'].specs`. CRUD = pure dict transforms, persisted by writing the whole `sf.json` via `window.electronAPI.config.write` (the path the Settings page uses) — **no new server endpoint**. Per the agreed decisions:
- **dual-write:** best-effort `POST /plugins/url4-specs/settings` to the running server's in-memory settings (+ opportunistic `…/validate` that blocks only on an explicit invalid response; offline-tolerant).
- The `config:changed` broadcast keeps URL4 Studio and the **(left-in-place)** RJSF Settings editor in sync.

### Tests
hook CRUD→config contract (incl. duplicate-name reject + validation abort), list render/filter/select/empty, detail rename/delete-confirm/edit-save, dialog validation, view shell. Full desktop suite **155** + build green.

Plan: `docs/superpowers/plans/2026-06-10-url4-studio-page.md`
Asana: SF-258 · https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215584247444895

🤖 Generated with [Claude Code](https://claude.com/claude-code)