### PR TITLE
SF-259: pick a saved URL4 spec into a new Eval Studio run

### DIFF
--- a/apps/desktop/src/renderer/src/components/eval/AddEvalRunDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/AddEvalRunDialog.tsx
@@ -6,9 +6,10 @@
 // — we intentionally don't gate on /ensemble/highlight, which false-errors on
 // the ensemble fan-out shape that /ensemble runs fine (SF-249).
 import { useState } from 'react';
-import { X, Play } from 'lucide-react';
+import { X, Play, ListChecks } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Url4Field } from '@/components/Url4Field';
+import { Url4SpecPickerDialog } from './Url4SpecPickerDialog';
 import { useServerStatus } from '@/hooks/use-server-status';
 import type { RunPayload } from '@/components/run/types';
 
@@ -25,6 +26,7 @@ export function AddEvalRunDialog({ onClose, onCreate }: Props) {
 
   const [name, setName] = useState('');
   const [expression, setExpression] = useState('');
+  const [pickerOpen, setPickerOpen] = useState(false);
 
   const canCreate = name.trim().length > 0 && expression.trim().length > 0;
 
@@ -59,9 +61,18 @@ export function AddEvalRunDialog({ onClose, onCreate }: Props) {
           </label>
 
           <div>
-            <span className="mb-1 block text-xs font-medium text-muted-foreground">
-              URL4 expression <span className="text-destructive">*</span>
-            </span>
+            <div className="mb-1 flex items-center justify-between">
+              <span className="text-xs font-medium text-muted-foreground">
+                URL4 expression <span className="text-destructive">*</span>
+              </span>
+              <button
+                type="button"
+                onClick={() => setPickerOpen(true)}
+                className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+              >
+                <ListChecks className="h-3.5 w-3.5" /> Choose from saved specs
+              </button>
+            </div>
             <div className="rounded-md border border-border">
               <Url4Field value={expression} onChange={setExpression} serverUrl={serverUrl} />
             </div>
@@ -77,6 +88,17 @@ export function AddEvalRunDialog({ onClose, onCreate }: Props) {
           </Button>
         </div>
       </div>
+
+      {pickerOpen && (
+        <Url4SpecPickerDialog
+          onClose={() => setPickerOpen(false)}
+          onPick={(spec) => {
+            setName(spec.name);
+            setExpression(spec.expression);
+            setPickerOpen(false);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/eval/Url4SpecPickerDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/Url4SpecPickerDialog.tsx
@@ -1,0 +1,154 @@
+// apps/desktop/src/renderer/src/components/eval/Url4SpecPickerDialog.tsx
+//
+// SF-259: a modal picker of saved URL4 specs for the "New eval run" dialog.
+// Fetches the same endpoint as SpecSelector (GET {serverUrl}/plugins/url4-specs/
+// settings, response { specs: { [name]: { expression } } }) but, unlike
+// SpecSelector, hands back BOTH the name and the expression so the caller can
+// copy them into its Name + URL4-expression fields. Reuses SpecSelector's
+// list/preview/search styling. Picking calls onPick({ name, expression });
+// cancelling/closing changes nothing.
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { Search, X } from 'lucide-react';
+import { useServerStatus } from '@/hooks/use-server-status';
+
+interface Spec {
+  name: string;
+  expression: string;
+}
+
+interface Props {
+  onClose: () => void;
+  onPick: (spec: Spec) => void;
+}
+
+async function fetchFromServer(url: string): Promise<{ ok: boolean; json: () => unknown }> {
+  const res = await window.electronAPI.server.fetch(url);
+  return { ok: res.ok, json: () => JSON.parse(res.body) };
+}
+
+export function Url4SpecPickerDialog({ onClose, onPick }: Props) {
+  const [specs, setSpecs] = useState<Spec[]>([]);
+  const [filter, setFilter] = useState('');
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const hasFetched = useRef(false);
+
+  const { info: serverInfo } = useServerStatus();
+  const serverUrl = serverInfo
+    ? `${serverInfo.scheme}://${serverInfo.host === '0.0.0.0' ? 'localhost' : serverInfo.host}:${serverInfo.port}`
+    : '';
+
+  const loadSpecs = useCallback(() => {
+    if (!serverUrl) return;
+    if (!hasFetched.current) setLoading(true);
+    setFetchError(null);
+    fetchFromServer(`${serverUrl}/plugins/url4-specs/settings`)
+      .then((res) => {
+        if (!res.ok) {
+          setFetchError('Server returned error');
+          return;
+        }
+        const data = res.json() as { specs?: Record<string, { expression: string }> };
+        if (data.specs) {
+          setSpecs(
+            Object.entries(data.specs).map(([name, s]) => ({
+              name,
+              expression: s.expression,
+            })),
+          );
+          hasFetched.current = true;
+        }
+      })
+      .catch((err) => {
+        setFetchError(String(err));
+      })
+      .finally(() => setLoading(false));
+  }, [serverUrl]);
+
+  useEffect(() => {
+    loadSpecs();
+  }, [loadSpecs]);
+
+  const filtered = useMemo(() => {
+    if (!filter) return specs;
+    const q = filter.toLowerCase();
+    return specs.filter(
+      (s) => s.name.toLowerCase().includes(q) || s.expression.toLowerCase().includes(q),
+    );
+  }, [specs, filter]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-16">
+      <div className="flex max-h-[80vh] w-full max-w-lg flex-col rounded-[10px] border border-border bg-card shadow-2xl">
+        <div className="flex items-center justify-between border-b border-border px-6 py-4">
+          <h2 className="text-base font-semibold text-foreground">Choose a saved spec</h2>
+          <button
+            type="button"
+            aria-label="Close spec picker"
+            onClick={onClose}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-6 py-4">
+          {/* Search */}
+          <div className="relative mb-2">
+            <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+            <input
+              autoFocus
+              type="text"
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              placeholder="Filter specs..."
+              className="w-full rounded-md border border-input bg-background py-1.5 pl-8 pr-3 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+            />
+          </div>
+
+          {/* Spec list */}
+          <div className="space-y-1">
+            {loading && (
+              <p className="py-3 text-center text-xs text-muted-foreground">Loading specs...</p>
+            )}
+            {fetchError && (
+              <div className="py-3 text-center">
+                <p className="text-xs text-destructive">{fetchError}</p>
+                <button
+                  onClick={loadSpecs}
+                  className="mt-1 text-[10px] text-muted-foreground hover:text-foreground underline"
+                >
+                  Retry
+                </button>
+              </div>
+            )}
+            {!loading && !fetchError && filtered.length === 0 && (
+              <p className="py-3 text-center text-xs text-muted-foreground">
+                {specs.length === 0 ? 'No specs configured' : 'No matches'}
+              </p>
+            )}
+            {filtered.map((spec) => (
+              <button
+                key={spec.name}
+                type="button"
+                className="group flex w-full items-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-left transition-colors hover:border-foreground/20"
+                onClick={() => onPick(spec)}
+              >
+                <div className="min-w-0 flex-1 flex items-center gap-2">
+                  <span className="text-xs font-medium text-foreground whitespace-nowrap">
+                    {spec.name}
+                  </span>
+                  {spec.expression && (
+                    <span className="truncate text-[10px] text-muted-foreground font-mono">
+                      {spec.expression}
+                    </span>
+                  )}
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/eval/__tests__/AddEvalRunDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/__tests__/AddEvalRunDialog.test.tsx
@@ -1,8 +1,13 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { vi, describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { AddEvalRunDialog } from '../AddEvalRunDialog';
+
+const serverFetch = vi.fn();
+(window as unknown as { electronAPI: unknown }).electronAPI = {
+  server: { fetch: serverFetch },
+};
 
 vi.mock('@/hooks/use-server-status', () => ({
   useServerStatus: () => ({ info: { scheme: 'http', host: 'localhost', port: 9100 } }),
@@ -20,6 +25,23 @@ vi.mock('@/components/Url4Field', () => ({
 }));
 
 const createBtn = () => screen.getByRole('button', { name: /create & run/i });
+
+const SAVED_SPECS = {
+  alpha: { expression: 'https://a.jsonl*(/claude($item.q)!$a)' },
+  beta: { expression: '(b)!$prompt' },
+};
+
+beforeEach(() => {
+  serverFetch.mockReset();
+  serverFetch.mockResolvedValue({
+    ok: true,
+    body: JSON.stringify({ specs: SAVED_SPECS }),
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
 
 describe('AddEvalRunDialog', () => {
   it('enables Create only with a name and a non-empty expression', () => {
@@ -49,5 +71,55 @@ describe('AddEvalRunDialog', () => {
     });
     fireEvent.click(createBtn());
     expect(onCreate).toHaveBeenCalledWith({ spec: 'mine', expression: '(x)!$prompt' });
+  });
+
+  it('opens the saved-spec picker and lists fetched specs', async () => {
+    render(<AddEvalRunDialog onClose={vi.fn()} onCreate={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /choose from saved specs/i }));
+
+    expect(await screen.findByText('Choose a saved spec')).toBeInTheDocument();
+    expect(await screen.findByText('alpha')).toBeInTheDocument();
+    expect(screen.getByText('beta')).toBeInTheDocument();
+    expect(serverFetch).toHaveBeenCalledWith('http://localhost:9100/plugins/url4-specs/settings');
+  });
+
+  it('fills Name + expression when a spec is picked, then can create the run', async () => {
+    const onCreate = vi.fn();
+    render(<AddEvalRunDialog onClose={vi.fn()} onCreate={onCreate} />);
+    fireEvent.click(screen.getByRole('button', { name: /choose from saved specs/i }));
+
+    fireEvent.click(await screen.findByText('alpha'));
+
+    // Picker closes, fields are populated.
+    await waitFor(() => expect(screen.queryByText('Choose a saved spec')).not.toBeInTheDocument());
+    const nameInput = screen.getByPlaceholderText('e.g. my-ensemble') as HTMLInputElement;
+    const exprInput = screen.getByLabelText('URL4 expression') as HTMLTextAreaElement;
+    expect(nameInput.value).toBe('alpha');
+    expect(exprInput.value).toBe(SAVED_SPECS.alpha.expression);
+
+    fireEvent.click(createBtn());
+    expect(onCreate).toHaveBeenCalledWith({
+      spec: 'alpha',
+      expression: SAVED_SPECS.alpha.expression,
+    });
+  });
+
+  it('changes nothing when the picker is cancelled', async () => {
+    const onCreate = vi.fn();
+    render(<AddEvalRunDialog onClose={vi.fn()} onCreate={onCreate} />);
+    fireEvent.change(screen.getByPlaceholderText('e.g. my-ensemble'), {
+      target: { value: 'keepme' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /choose from saved specs/i }));
+    await screen.findByText('alpha');
+
+    // Close the picker without selecting anything.
+    fireEvent.click(screen.getByRole('button', { name: /close spec picker/i }));
+
+    await waitFor(() => expect(screen.queryByText('Choose a saved spec')).not.toBeInTheDocument());
+    const nameInput = screen.getByPlaceholderText('e.g. my-ensemble') as HTMLInputElement;
+    expect(nameInput.value).toBe('keepme');
+    expect(onCreate).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What

Adds a **"Choose from saved specs"** button to the Eval Studio New-run dialog (`AddEvalRunDialog`). Clicking it opens a searchable picker of saved URL4 specs (name + truncated expression preview, with a filter box). Selecting a spec copies its **name** and **expression** into the dialog's Name and URL4-expression fields, so the user can tweak and run it. Cancelling/closing the picker changes nothing.

## How

- New `components/eval/Url4SpecPickerDialog.tsx` fetches the same endpoint as `SpecSelector` (`GET {serverUrl}/plugins/url4-specs/settings`, response `{ specs: { [name]: { expression } } }`) via `window.electronAPI.server.fetch`, and returns both name **and** expression through `onPick({ name, expression })`.
- `SpecSelector`'s `onChange` only returns the name, so it is left untouched (no breaking API change). The new picker reuses its list/search/preview styling and the app's modal shell (`fixed inset-0 z-50 … rounded-[10px] border border-border bg-card`).
- `AddEvalRunDialog.tsx` gains a small `pickerOpen` state and renders the picker; `onPick` fills `name`/`expression`.

## Tests

Extends `components/eval/__tests__/AddEvalRunDialog.test.tsx` (vitest + jsdom): mocks the specs fetch with 2 canned specs and asserts the button opens the picker, the picker lists the specs, picking one fills Name + expression (and `onCreate` reflects the picked spec), and cancelling selects nothing.

## Verification

- `npx eslint .` — 0 errors
- `npx vitest run` — 139 passed (27 files)
- `npm run build` — succeeds

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215586003243391

🤖 Generated with Claude Code