### PR TITLE
SF-260: copy-to-clipboard button on url4 editors

### DIFF
--- a/apps/desktop/src/renderer/src/components/CodeEditorPopup.tsx
+++ b/apps/desktop/src/renderer/src/components/CodeEditorPopup.tsx
@@ -7,6 +7,7 @@ import { useState, type ReactNode } from 'react';
 import Editor, { type OnMount } from '@monaco-editor/react';
 import { X, Save } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { CopyButton } from '@/components/CopyButton';
 // Side-effect: configure monaco to run bundled (no CDN) before it mounts.
 import '@/lib/monaco-setup';
 
@@ -53,9 +54,12 @@ export default function CodeEditorPopup({
       >
         <div className="flex items-center justify-between border-b border-border px-4 py-2">
           <h2 className="text-sm font-semibold text-foreground">{title}</h2>
-          <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
-            <X className="h-4 w-4" />
-          </button>
+          <div className="flex items-center gap-1">
+            <CopyButton value={draft} />
+            <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
+              <X className="h-4 w-4" />
+            </button>
+          </div>
         </div>
         <div className="min-h-0 flex-1">
           <Editor

--- a/apps/desktop/src/renderer/src/components/CopyButton.tsx
+++ b/apps/desktop/src/renderer/src/components/CopyButton.tsx
@@ -1,0 +1,43 @@
+// apps/desktop/src/renderer/src/components/CopyButton.tsx
+//
+// Small icon button that copies a string to the clipboard and briefly shows a
+// check. Shared across the url4 editing surfaces.
+import { useState } from 'react';
+import { Copy, Check } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface Props {
+  value: string;
+  className?: string;
+  title?: string;
+}
+
+export function CopyButton({ value, className, title = 'Copy to clipboard' }: Props) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async (e: React.MouseEvent): Promise<void> => {
+    e.stopPropagation();
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard unavailable — no-op */
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label="Copy to clipboard"
+      title={copied ? 'Copied' : title}
+      onClick={(e) => void copy(e)}
+      className={cn(
+        'rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground',
+        className,
+      )}
+    >
+      {copied ? <Check className="h-3.5 w-3.5 text-chart-3" /> : <Copy className="h-3.5 w-3.5" />}
+    </button>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/Url4Field.tsx
+++ b/apps/desktop/src/renderer/src/components/Url4Field.tsx
@@ -5,6 +5,7 @@
 // url4 first appears; until then (and as a graceful fallback) it renders the
 // raw expression as wrapped monospace text. Read-only unless given onChange.
 import { Suspense, lazy } from 'react';
+import { CopyButton } from '@/components/CopyButton';
 
 const Url4MonacoEditor = lazy(() => import('@/components/Url4MonacoEditor'));
 
@@ -18,14 +19,19 @@ interface Url4FieldProps {
 
 export function Url4Field(props: Url4FieldProps) {
   return (
-    <Suspense
-      fallback={
-        <code className="block whitespace-pre-wrap break-words font-mono text-xs text-muted-foreground">
-          {props.value}
-        </code>
-      }
-    >
-      <Url4MonacoEditor {...props} />
-    </Suspense>
+    <div className="relative">
+      {props.value.length > 0 && (
+        <CopyButton value={props.value} className="absolute right-1 top-1 z-10 bg-card/70" />
+      )}
+      <Suspense
+        fallback={
+          <code className="block whitespace-pre-wrap break-words font-mono text-xs text-muted-foreground">
+            {props.value}
+          </code>
+        }
+      >
+        <Url4MonacoEditor {...props} />
+      </Suspense>
+    </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/__tests__/CopyButton.test.tsx
+++ b/apps/desktop/src/renderer/src/components/__tests__/CopyButton.test.tsx
@@ -1,0 +1,24 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { CopyButton } from '../CopyButton';
+
+const writeText = vi.fn().mockResolvedValue(undefined);
+
+beforeEach(() => {
+  writeText.mockClear();
+  Object.assign(navigator, { clipboard: { writeText } });
+});
+afterEach(cleanup);
+
+it('copies its value to the clipboard on click', async () => {
+  render(<CopyButton value="/claude()!hi" />);
+  fireEvent.click(screen.getByRole('button', { name: /copy to clipboard/i }));
+  await waitFor(() => expect(writeText).toHaveBeenCalledWith('/claude()!hi'));
+});
+
+it('shows a "Copied" affordance after copying', async () => {
+  render(<CopyButton value="x" />);
+  fireEvent.click(screen.getByRole('button', { name: /copy to clipboard/i }));
+  await waitFor(() => expect(screen.getByRole('button').title).toBe('Copied'));
+});


### PR DESCRIPTION
A small **copy** button on the shared url4 editing surfaces, so any url4 expression can be copied to the clipboard.

- New `CopyButton` (Copy → ✓ "Copied" feedback, `navigator.clipboard.writeText`).
- **`Url4Field`**: overlay button (top-right) copying the expression — covers *every* readonly/editable url4 surface (Eval Studio detail, URL4 Studio, publish dialog, spec picker, settings). Hidden when empty.
- **`CodeEditorPopup`**: copy button in the header copying the live draft (url4 + python editor popups).

Test: copies the value + shows the "Copied" affordance. Full desktop suite (160) + build green.

Asana: SF-260 · https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215587801880005

🤖 Generated with [Claude Code](https://claude.com/claude-code)