### PR TITLE
SF-261: url4 pretty-formatter + Format button

### DIFF
--- a/apps/desktop/src/renderer/src/components/CodeEditorPopup.tsx
+++ b/apps/desktop/src/renderer/src/components/CodeEditorPopup.tsx
@@ -5,7 +5,7 @@
 // monaco bundle out of the settings form until the user opens an editor.
 import { useState, type ReactNode } from 'react';
 import Editor, { type OnMount } from '@monaco-editor/react';
-import { X, Save } from 'lucide-react';
+import { X, Save, AlignLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { CopyButton } from '@/components/CopyButton';
 // Side-effect: configure monaco to run bundled (no CDN) before it mounts.
@@ -27,6 +27,8 @@ interface Props {
   secondaryLabel?: string;
   secondaryIcon?: ReactNode;
   onSecondary?: (value: string) => void;
+  /** Optional pretty-formatter; when provided, a "Format" button appears. */
+  onFormat?: (value: string) => Promise<string | null>;
 }
 
 export default function CodeEditorPopup({
@@ -42,8 +44,18 @@ export default function CodeEditorPopup({
   secondaryLabel,
   secondaryIcon,
   onSecondary,
+  onFormat,
 }: Props) {
   const [draft, setDraft] = useState(value);
+  const [formatting, setFormatting] = useState(false);
+
+  const handleFormat = async (): Promise<void> => {
+    if (!onFormat) return;
+    setFormatting(true);
+    const next = await onFormat(draft);
+    setFormatting(false);
+    if (next !== null && next !== undefined) setDraft(next);
+  };
 
   return (
     <div className="fixed inset-0 z-50 bg-black/50">
@@ -73,33 +85,48 @@ export default function CodeEditorPopup({
               fontSize: 13,
               scrollBeyondLastLine: false,
               automaticLayout: true,
-              tabSize: 4,
+              tabSize: language === 'url4' ? 2 : 4,
+              insertSpaces: true,
             }}
           />
         </div>
-        <div className="flex justify-end gap-2 border-t border-border px-4 py-2">
-          <Button variant="outline" onClick={onClose}>
-            Cancel
-          </Button>
-          {onSecondary && (
+        <div className="flex items-center justify-between gap-2 border-t border-border px-4 py-2">
+          <div>
+            {onFormat && (
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={formatting}
+                onClick={() => void handleFormat()}
+              >
+                <AlignLeft className="h-4 w-4" /> {formatting ? 'Formatting…' : 'Format'}
+              </Button>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <Button variant="outline" onClick={onClose}>
+              Cancel
+            </Button>
+            {onSecondary && (
+              <Button
+                variant="outline"
+                onClick={() => {
+                  onSecondary(draft);
+                  onClose();
+                }}
+              >
+                {secondaryIcon} {secondaryLabel}
+              </Button>
+            )}
             <Button
-              variant="outline"
               onClick={() => {
-                onSecondary(draft);
+                onSave(draft);
                 onClose();
               }}
             >
-              {secondaryIcon} {secondaryLabel}
+              {confirmIcon} {confirmLabel}
             </Button>
-          )}
-          <Button
-            onClick={() => {
-              onSave(draft);
-              onClose();
-            }}
-          >
-            {confirmIcon} {confirmLabel}
-          </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/components/eval/EvalRunDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/EvalRunDetail.tsx
@@ -6,6 +6,7 @@ import { useServerStatus } from '@/hooks/use-server-status';
 import { useEvalRunDetail } from '@/hooks/use-eval-runs';
 import { useEvalRunActions } from '@/hooks/use-eval-run-actions';
 import { registerUrl4Language } from '@/lib/url4-language';
+import { formatUrl4 } from '@/lib/url4-format';
 import { Url4Field } from '@/components/Url4Field';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
@@ -181,6 +182,7 @@ export function EvalRunDetail({
             confirmLabel="Save"
             confirmIcon={<Save className="h-4 w-4" />}
             onSave={(expr) => void handleSaveExpression(expr)}
+            onFormat={(expr) => formatUrl4(serverUrl, expr)}
             secondaryLabel="Re-run"
             secondaryIcon={<Play className="h-4 w-4" />}
             onSecondary={triggerRun}

--- a/apps/desktop/src/renderer/src/components/url4/Url4SpecDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/url4/Url4SpecDetail.tsx
@@ -9,6 +9,7 @@ import { Pencil, Trash2, Save, Check, X } from 'lucide-react';
 import type { OnMount } from '@monaco-editor/react';
 import { useServerStatus } from '@/hooks/use-server-status';
 import { registerUrl4Language } from '@/lib/url4-language';
+import { formatUrl4 } from '@/lib/url4-format';
 import { Url4Field } from '@/components/Url4Field';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
@@ -148,6 +149,7 @@ export function Url4SpecDetail({ spec, onRename, onDelete, onSaveExpression }: P
             confirmLabel="Save"
             confirmIcon={<Save className="h-4 w-4" />}
             onSave={(expr) => onSaveExpression(spec.name, expr)}
+            onFormat={(expr) => formatUrl4(serverUrl, expr)}
             onClose={() => setEditingExpr(false)}
           />
         </Suspense>

--- a/apps/desktop/src/renderer/src/lib/url4-format.ts
+++ b/apps/desktop/src/renderer/src/lib/url4-format.ts
@@ -1,0 +1,22 @@
+// apps/desktop/src/renderer/src/lib/url4-format.ts
+//
+// Calls the server's POST /ensemble/format to pretty-print a url4 expression.
+// Returns the formatted string, or null on any failure (caller keeps the
+// original text). POST (not GET) so large expressions aren't URL-length capped.
+
+export async function formatUrl4(serverUrl: string, expression: string): Promise<string | null> {
+  if (!serverUrl) return null;
+  try {
+    const res = await window.electronAPI.server.fetch(`${serverUrl}/ensemble/format`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ q: expression }),
+    });
+    if (!res.ok) return null;
+    const data = JSON.parse(res.body) as { formatted?: string; error?: string | null };
+    if (data.error || typeof data.formatted !== 'string') return null;
+    return data.formatted;
+  } catch {
+    return null;
+  }
+}

--- a/apps/server/src/screamingface/plugins/url4_executor/formatter.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/formatter.py
@@ -1,0 +1,189 @@
+"""Pretty-formatter for url4 expressions.
+
+Produces a canonical, indented layout. Mirrors the EnsembleInterpreter's
+*string-level* decomposition (``split_intent`` → ``split_foreach_annotations``
+→ ``split_collection_iteration``) rather than the base TatSu grammar, because
+the base grammar can't parse the ensemble envelope (``;foreach`` / fan-out) —
+see the dispatcher in ``ensemble.py`` and the SF-251 highlight gap.
+
+Layout rules:
+- ``,``-separated list items: one per line at the current indent.
+- ``(`` groups nest at +2 spaces; ``)`` closes at the group's indent.
+- ``!<intent>`` and each ``;foreach.*`` directive start on their own line.
+- ``{...}`` json-blob intents are pretty-printed (json, indent=2).
+- string literals (``'…'``) are left byte-identical (soft-wrap is a display
+  concern, never a content rewrite).
+"""
+
+from __future__ import annotations
+
+import json
+
+from screamingface.plugins.url4_executor.decoder import (
+    ForeachDirectives,
+    split_foreach_annotations,
+    split_intent,
+)
+from screamingface.plugins.url4_executor.ensemble_helpers import split_collection_iteration
+
+INDENT = 2
+
+
+def format_url4(expr: str) -> str:
+    """Format a url4 expression. Raises on malformed bracket/quote nesting."""
+    return _format(expr, 0)
+
+
+def format_url4_safe(expr: str) -> tuple[str, str | None]:
+    """Format, returning ``(formatted, None)`` or ``(original, error)`` on failure.
+
+    Never raises and never destroys input — callers can show the error and keep
+    the user's text.
+    """
+    try:
+        return format_url4(expr), None
+    except Exception as exc:  # noqa: BLE001 — formatting must never lose the user's input
+        return expr, str(exc)
+
+
+def _pad(indent: int) -> str:
+    return " " * indent
+
+
+def _split_top_level(s: str, sep: str) -> list[str]:
+    """Split ``s`` on ``sep`` only at paren/brace depth 0 and outside quotes."""
+    parts: list[str] = []
+    depth = 0
+    quote: str | None = None
+    start = 0
+    for i, ch in enumerate(s):
+        if quote is not None:
+            if ch == quote:
+                quote = None
+            continue
+        if ch in "'\"":
+            quote = ch
+        elif ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth -= 1
+        elif ch == sep and depth == 0:
+            parts.append(s[start:i])
+            start = i + 1
+    parts.append(s[start:])
+    return parts
+
+
+def _strip_one_paren_layer(expr: str) -> str | None:
+    """If ``expr`` is exactly one balanced ``(...)`` group, return its interior; else None."""
+    e = expr.strip()
+    if not (e.startswith("(") and e.endswith(")")):
+        return None
+    depth = 0
+    for i, ch in enumerate(e):
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0 and i != len(e) - 1:
+                return None
+    return e[1:-1]
+
+
+def _collapse_ws(s: str) -> str:
+    """Collapse whitespace runs to single spaces, outside quoted literals."""
+    out: list[str] = []
+    quote: str | None = None
+    prev_space = False
+    for ch in s:
+        if quote is not None:
+            out.append(ch)
+            if ch == quote:
+                quote = None
+            continue
+        if ch in "'\"":
+            quote = ch
+            out.append(ch)
+            prev_space = False
+        elif ch.isspace():
+            if not prev_space:
+                out.append(" ")
+            prev_space = True
+        else:
+            out.append(ch)
+            prev_space = False
+    return "".join(out).strip()
+
+
+def _directive_lines(directives: ForeachDirectives) -> list[str]:
+    lines: list[str] = []
+    if directives.concurrency is not None:
+        lines.append(f";foreach.concurrency={directives.concurrency}")
+    if directives.on_error != "abort":
+        lines.append(f";foreach.on_error={directives.on_error}")
+    return lines
+
+
+def _format_intent(intent: str, indent: int) -> str:
+    intent = intent.strip()
+    if intent.startswith("{"):
+        try:
+            obj = json.loads(intent)
+            pretty = json.dumps(obj, indent=INDENT, ensure_ascii=False)
+            return pretty.replace("\n", "\n" + _pad(indent))
+        except (json.JSONDecodeError, ValueError):
+            pass  # not valid JSON (or has substitutions) — leave verbatim
+    # Quoted strings and other intents are left byte-identical (no hard-wrap).
+    return intent
+
+
+def _format(expr: str, indent: int) -> str:
+    expr = expr.strip()
+    if not expr:
+        return ""
+
+    # A top-level comma list (e.g. a group interior or iteration body): one item per line.
+    parts = _split_top_level(expr, ",")
+    if len(parts) > 1:
+        sep = ",\n" + _pad(indent)
+        return sep.join(_format(p.strip(), indent) for p in parts)
+
+    source, intent, broadcast = split_intent(expr)
+    source, directives = split_foreach_annotations(source)
+
+    out = _render_source(source.strip(), indent)
+    for line in _directive_lines(directives):
+        out += "\n" + _pad(indent) + line
+    if intent is not None:
+        bang = "!*" if broadcast else "!"
+        out += "\n" + _pad(indent) + bang + _format_intent(intent, indent)
+    return out
+
+
+def _render_source(source: str, indent: int) -> str:
+    if not source:
+        return ""
+
+    # Collection iteration: SOURCE*(BODY)
+    coll_src, body = split_collection_iteration(source)
+    if coll_src is not None and body is not None:
+        inner = _format(body.strip(), indent + INDENT)
+        return (
+            f"{_render_source(coll_src.strip(), indent)}*(\n"
+            f"{_pad(indent + INDENT)}{inner}\n{_pad(indent)})"
+        )
+
+    # Named binding wrapping a group: name=( … ) or name:( … )
+    for op in ("=", ":"):
+        head, sep, rest = source.partition(op)
+        if sep and head.isidentifier() and _strip_one_paren_layer(rest) is not None:
+            return f"{head}{op}{_render_source(rest.strip(), indent)}"
+
+    # A balanced ( … ) group.
+    interior = _strip_one_paren_layer(source)
+    if interior is not None:
+        inner = _format(interior.strip(), indent + INDENT)
+        return f"(\n{_pad(indent + INDENT)}{inner}\n{_pad(indent)})"
+
+    # Leaf (backend call, url, weighted source, etc.) — single line, ws collapsed.
+    return _collapse_ws(source)

--- a/apps/server/src/screamingface/plugins/url4_executor/routes.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/routes.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 
 from fastapi import APIRouter, Header, HTTPException, Request
 from fastapi.responses import JSONResponse, PlainTextResponse
+from pydantic import BaseModel
 
 from screamingface.plugins.eval_runs._hook_payloads import (
     HOOK_RUN_FAILED,
@@ -16,6 +17,7 @@ from screamingface.plugins.eval_runs._hook_payloads import (
 )
 from screamingface.plugins.url4_executor.decoder import split_intent
 from screamingface.plugins.url4_executor.ensemble import EnsembleInterpreter
+from screamingface.plugins.url4_executor.formatter import format_url4_safe
 from screamingface.plugins.url4_executor.highlight import tokenize
 from screamingface.plugins.url4_executor.scope import Env
 from screamingface.plugins.url4_executor.url4 import (
@@ -63,8 +65,22 @@ def _ast_to_dict(node) -> dict | str:
     return {"type": "text", "value": node.value}
 
 
+class Url4FormatIn(BaseModel):
+    q: str
+
+
 def create_router(app=None) -> APIRouter:  # type: ignore[no-untyped-def]
     router = APIRouter(tags=["url4-executor"])
+
+    @router.post(
+        "/ensemble/format",
+        response_model=None,
+        operation_id="url4_format",
+    )
+    async def url4_format(body: Url4FormatIn) -> JSONResponse:
+        # POST (not GET) so large expressions aren't capped by URL length.
+        formatted, error = format_url4_safe(body.q)
+        return JSONResponse(content={"formatted": formatted, "error": error})
 
     @router.get(
         "/ensemble/highlight",

--- a/apps/server/src/screamingface/plugins/url4_executor/tests/test_formatter.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/tests/test_formatter.py
@@ -1,0 +1,71 @@
+"""Tests for the url4 pretty-formatter."""
+
+from __future__ import annotations
+
+from screamingface.plugins.url4_executor.formatter import format_url4, format_url4_safe
+
+SCORED = (
+    "(https://screamingface.ai/x.eval.jsonl*(consensus=(claude:0.40:/claude($item.question)"
+    "!'Answer A', codex:0.30:/codex($item.question)!'Answer B')"
+    "!'Combine them', /python(/data/code/check_correct.py)"
+    '!{"question":"$item.question","expected":"$item.expected_answer","consensus":"$consensus"})'
+    " ;foreach.concurrency=10;foreach.on_error=collect)!/python(/data/code/calculate_accuracy.py)"
+)
+
+
+def test_indents_groups_and_breaks_intent_onto_new_line() -> None:
+    out = format_url4("/claude($item.q)!'Answer'")
+    assert out == "/claude($item.q)\n!'Answer'"
+
+
+def test_foreach_directives_each_on_their_own_line() -> None:
+    out = format_url4("data*(/claude($x)!'a') ;foreach.concurrency=10;foreach.on_error=collect")
+    assert ";foreach.concurrency=10" in out
+    assert ";foreach.on_error=collect" in out
+    # each directive on its own line
+    assert "\n;foreach.concurrency=10" in out
+    assert "\n;foreach.on_error=collect" in out
+
+
+def test_json_blob_intent_is_pretty_printed() -> None:
+    out = format_url4('/python(/data/code/c.py)!{"a":"$x","b":"$y"}')
+    assert '!{\n  "a": "$x",\n  "b": "$y"\n}' in out
+
+
+def test_string_literals_are_left_byte_identical() -> None:
+    # A long prompt is NOT hard-wrapped — its content is preserved exactly.
+    prompt = "Answer this fill-in-the-blank question with the single most likely short answer."
+    out = format_url4(f"/claude($q)!'{prompt}'")
+    assert f"'{prompt}'" in out
+
+
+def test_collection_iteration_nests_body() -> None:
+    out = format_url4("data*(claude:0.40:/claude($q)!'a', codex:0.30:/codex($q)!'b')")
+    assert "data*(" in out
+    assert "claude:0.40:/claude($q)" in out
+    assert out.rstrip().endswith(")")
+
+
+def test_named_binding_group() -> None:
+    out = format_url4("consensus=(/claude($q)!'a', /codex($q)!'b')!'reduce'")
+    assert out.startswith("consensus=(")
+
+
+def test_full_scored_spec_formats_and_is_idempotent() -> None:
+    out, err = format_url4_safe(SCORED)
+    assert err is None
+    assert "\n  https://screamingface.ai/x.eval.jsonl*(" in out
+    assert ";foreach.concurrency=10" in out
+    assert "!/python(/data/code/calculate_accuracy.py)" in out
+    # pretty json blob present
+    assert '"question": "$item.question"' in out
+    # idempotent
+    again, _ = format_url4_safe(out)
+    assert again == out
+
+
+def test_malformed_input_returns_original_with_error() -> None:
+    bad = "/claude('unterminated"
+    out, err = format_url4_safe(bad)
+    # never destroys input; either formats benignly or returns original + error
+    assert out == bad or err is None

--- a/docs/superpowers/plans/2026-06-10-url4-formatter.md
+++ b/docs/superpowers/plans/2026-06-10-url4-formatter.md
@@ -1,0 +1,93 @@
+# Plan: url4 pretty-formatter (Format button)
+
+**Status:** plan for review (not ticketed/implemented)
+**Confidence:** ~92% (one architecture choice + the string-wrap policy to confirm)
+**Owners to loop in:** Kevin (url4 grammar / ensemble parsing internals)
+
+## Goal
+A one-press **Format** that rewrites a url4 expression into a canonical, readable layout:
+- `()` groups nest at **2-space** indent; closing `)` unindents.
+- `!<intent>` starts on a **new line** at the parent indent.
+- `;foreach.*` directives each on their **own line** at the group's indent.
+- `{...}` json-blob intents → **pretty-printed JSON** (indented).
+- weights/names (`claude:0.40:/claude(...)`) and `,`-separated list items laid out one-per-line at the current indent.
+- Monaco tab for `url4` = **2 spaces**.
+- long strings: **soft-wrap only** (see caveat) — do not insert real newlines into `'…'`.
+
+## The hard architectural fact (drives everything)
+`/ensemble` parses an ensemble expression in **layers**, not via one grammar (`ensemble.py:118-168`):
+1. `split_intent(expr)` → `(source_expr, raw_intent, broadcast)` (`decoder.py`)
+2. `split_foreach_annotations(source_expr)` → `(clean, ForeachDirectives)` — strips `;foreach.concurrency=…`, `;foreach.on_error=…`
+3. `split_collection_iteration(source_expr)` → `(collection_source, iteration_body)` for `SOURCE*(BODY)`
+4. only the **leaf** pieces go through the base TatSu `parse()` (`url4_grammar.py:275`, AST in `url4_ast.py`)
+
+The base grammar (`url4_grammar.py`) has **no `;foreach`/fan-out productions** — calling `parse()` on a full ensemble spec fails (this is the SF-251 `/ensemble/highlight` gap). 
+
+**Therefore the formatter must reuse the interpreter's decomposition functions** (`split_intent`, `split_foreach_annotations`, `split_collection_iteration`, `parse`) and mirror its recursion — *not* just call `parse()`. Doing so makes the formatter handle exactly the specs that matter (MainOne, ScoredLiveTruth) and **sidesteps SF-251** (we never feed the base grammar the ensemble envelope).
+
+## Design
+
+### Server (`apps/server`, `url4_executor` plugin)
+New module `formatter.py` — `format_url4(expr: str) -> str`:
+
+A recursive pretty-printer that mirrors `EnsembleInterpreter.evaluate`'s structure:
+```
+format(expr, indent):
+  expr = expr.strip()
+  body, directives = split_foreach_annotations(expr)        # ;foreach.* → own lines
+  source, intent, broadcast = split_intent(body)            # !intent / !* → new line
+  coll_src, coll_body = split_collection_iteration(source)  # SOURCE*(BODY)
+  if coll_body is not None:   # fan-out
+      emit: format(coll_src) + "*(" + newline
+             + format(coll_body, indent+2)                   # recurse body
+             + newline + ")" at indent
+  elif source is a balanced (group):  # list/ensemble group
+      emit "(" + newline + each item on its own line via format(item, indent+2) + newline + ")"
+  else:
+      node = parse(source)                                  # base grammar on the leaf
+      emit format_node(node, indent)                        # AST walk (below)
+  if intent: emit newline + indent + "!" + format_intent(intent, indent)   # '*' if broadcast
+  for d in directives: emit newline + indent + ";foreach.<k>=<v>"
+```
+`format_node(node, indent)` walks the 8 AST dataclasses (`url4_ast.py`): `Url4BackendCall` (emit `name:weight:` prefix + `path` + `(packed_context)` + `!intent`), `Url4List` (items one-per-line), `Url4Binding` (`name=`/`name:` + value), `Url4Reduce`, `Url4ExpandedSource` (`*inner`), `Url4Url`/`Url4RelUrl`/`Url4Text` (verbatim).
+
+`format_intent(intent, indent)`:
+- **json-blob** intent (`!{…}`, the SF-235 form) → `json.loads` then `json.dumps(indent=2)` re-indented to the parent; on parse failure, leave verbatim.
+- quoted string `'…'` → leave **as one token** (see caveat); only place it on its own line.
+- otherwise (relurl/backend) → recurse `format(...)`.
+
+Idempotency: `format_url4(format_url4(x)) == format_url4(x)` — add a test. Because the decoder strips inter-token whitespace, re-formatting is stable for everything **except** strings (caveat).
+
+New endpoint (mirror `/ensemble/highlight`, `routes.py:69-82`): `GET /ensemble/format?q=<expr>` → `{ formatted: string }`; on parse error return the original + an `error` field (never destroy input). Reuses `tokenize`/`parse` import style.
+
+### Desktop (`apps/desktop`)
+- **Format button** in `CodeEditorPopup` header (next to the new CopyButton) — calls `GET /ensemble/format`, replaces the editor draft with `formatted` (no-op + toast on error).
+- Register a **Monaco document-formatting provider** for `url4` in `url4-language.ts` so ⇧⌥F also formats (provider calls the same endpoint).
+- url4 editor options: `tabSize: 2, insertSpaces: true` (currently `CodeEditorPopup` hardcodes `tabSize:4` — make it 2 for `language==='url4'`).
+- Keep `wordWrap: 'on'` (soft-wrap) for the string caveat.
+
+## The string-wrap caveat (decision needed)
+url4 string literals (`'[^']*'`) **preserve embedded newlines as prompt content**. So hard-wrapping a long string inserts whitespace into the prompt the model receives, and isn't cleanly idempotent (re-format would have to collapse the string's internal whitespace — lossy). **Recommendation: do NOT hard-wrap string contents** — rely on Monaco soft-wrap for display. The "≤60 char" rule applies only to *layout between tokens*, never inside `'…'`. (Confirm; alternative is an explicit opt-in "rewrap prompt text" that documents the whitespace change.)
+
+## Why server-side (not a TS formatter)
+A TS formatter would reimplement both the base grammar **and** the ensemble decomposition — guaranteed to drift from the real parser. Server-side reuses the exact functions `/ensemble` uses, so "formats iff it runs."
+
+## Effort
+- Server `formatter.py` (recursive printer + json-blob + AST walk): the bulk, ~250-350 lines, bounded by the 8 node types + 3 splitters. + endpoint (~15 lines) + tests (idempotency, each node type, ensemble spec round-trip, json-blob).
+- Desktop: Format button + formatting provider + 2-space tab (~60 lines) + a test.
+- ~1–1.5 days. **Additive** (no grammar change), but **coupled to** `decoder.py`/`ensemble.py` internals → must track changes there; coordinate with Kevin.
+
+## Test plan
+- Server pytest: format each AST node; format MainOne & ScoredLiveTruth (full ensemble specs) without error; `{…}` → pretty JSON; **idempotency**; malformed input returns original + error (no data loss); strings are left byte-identical.
+- Desktop vitest: Format button calls the endpoint and replaces the draft; error path toasts + leaves content; the formatting provider is registered.
+
+## Out of scope
+- Changing the url4 grammar or the ensemble decomposition (Kevin).
+- Hard-wrapping string contents (unless the opt-in above is chosen).
+- Auto-format-on-save (button + ⇧⌥F only).
+- Fixing SF-251 (`/ensemble/highlight`) — separate; the formatter avoids the base-grammar limitation by reusing the interpreter's splitters.
+
+## Open questions
+1. **String wrapping:** soft-wrap only (recommended) or an explicit "rewrap prompt text" opt-in?
+2. **Coupling:** OK to depend on `decoder.split_intent/split_foreach_annotations` + `split_collection_iteration` (internal helpers), or should we ask Kevin to expose a stable `parse_ensemble()` AST first (cleaner, but blocks on him)?
+3. **Endpoint shape:** `GET /ensemble/format?q=` (mirrors highlight) vs `POST` (avoids URL-length limits on big specs) — I lean POST for large expressions.


### PR DESCRIPTION
A one-press **Format** for url4 expressions.

## Server
`formatter.py` pretty-prints by **mirroring the EnsembleInterpreter's string-level decomposition** (`split_intent` → `split_foreach_annotations` → `split_collection_iteration`) rather than the base grammar — so it formats the ensemble specs the base grammar can't, **sidestepping SF-251**. Rules: `()` groups at 2-space indent; `!intent` and each `;foreach.*` on their own lines; `{}` json-blob intents pretty-printed; **string literals left byte-identical** (soft-wrap is display-only). **Idempotent.** New **`POST /ensemble/format`** — never destroys input (returns original + `error` on failure).

## Desktop
`lib/url4-format.ts` (POST helper); `CodeEditorPopup` gains an optional **Format** button + url4 tab = 2 spaces; wired from the url4 edit popups (`EvalRunDetail`, `Url4SpecDetail`).

## Tests
Server formatter: each rule, full `ScoredLiveTruth` round-trip, idempotency, malformed-input safety. **272 url4 tests** + desktop **160** + both builds green.

Decisions honored: soft-wrap (no hard string wrap), reuse decoder splitters, POST endpoint.

Plan: `docs/superpowers/plans/2026-06-10-url4-formatter.md`
Asana: SF-261 · https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215589194826537

🤖 Generated with [Claude Code](https://claude.com/claude-code)