### PR TITLE
SF-262: Code Studio — dedicated CRUD page for python-runner scripts

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -5,6 +5,7 @@ import { DashboardView } from '@/views/DashboardView';
 import { SessionsView } from '@/views/SessionsView';
 import { EvalStudioView } from '@/views/EvalStudioView';
 import { Url4StudioView } from '@/views/Url4StudioView';
+import { CodeStudioView } from '@/views/CodeStudioView';
 import { SettingsView } from '@/views/SettingsView';
 import { PluginHost } from '@/components/plugins/PluginHost';
 import { useServerStatus } from '@/hooks/use-server-status';
@@ -78,6 +79,7 @@ export function App() {
       );
     }
     if (currentView === 'url4-studio') return <Url4StudioView />;
+    if (currentView === 'code-studio') return <CodeStudioView />;
     if (currentView === 'settings') return <SettingsView />;
 
     if (currentView.startsWith('plugin:')) {

--- a/apps/desktop/src/renderer/src/components/code/AddCodeScriptDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/code/AddCodeScriptDialog.tsx
@@ -1,0 +1,78 @@
+// apps/desktop/src/renderer/src/components/code/AddCodeScriptDialog.tsx
+//
+// "New script" dialog for Code Studio: name only (a Python identifier). The
+// source starts empty and is edited afterwards via the CodeEditorPopup.
+import { useState } from 'react';
+import { X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { isValidScriptName, SCRIPT_NAME_HINT } from '@/lib/script-name';
+
+interface Props {
+  existingNames: string[];
+  onClose: () => void;
+  onCreate: (name: string) => void;
+}
+
+export function AddCodeScriptDialog({ existingNames, onClose, onCreate }: Props) {
+  const [name, setName] = useState('');
+  const trimmed = name.trim();
+  const duplicate = existingNames.includes(trimmed);
+  const invalid = trimmed.length > 0 && !isValidScriptName(trimmed);
+  const canCreate = trimmed.length > 0 && !duplicate && !invalid;
+
+  const handleCreate = (): void => {
+    if (!canCreate) return;
+    onCreate(trimmed);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-16">
+      <div className="flex w-full max-w-md flex-col rounded-[10px] border border-border bg-card shadow-2xl">
+        <div className="flex items-center justify-between border-b border-border px-6 py-4">
+          <h2 className="text-base font-semibold text-foreground">New python script</h2>
+          <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="px-6 py-4">
+          <label className="block">
+            <span className="mb-1 block text-xs font-medium text-muted-foreground">
+              Name <span className="text-destructive">*</span>
+            </span>
+            <input
+              autoFocus
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+              placeholder="e.g. check_correct"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleCreate();
+              }}
+            />
+          </label>
+          {duplicate && (
+            <p className="mt-1.5 text-xs text-destructive">
+              A script named "{trimmed}" already exists.
+            </p>
+          )}
+          {invalid && <p className="mt-1.5 text-xs text-destructive">{SCRIPT_NAME_HINT}</p>}
+          <p className="mt-1.5 text-xs text-muted-foreground">
+            Servable at <code>/data/code/{trimmed || '<name>'}.py</code>. The code starts empty —
+            edit it from the script view.
+          </p>
+        </div>
+
+        <div className="flex items-center justify-end gap-2 border-t border-border px-6 py-4">
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleCreate} disabled={!canCreate}>
+            Create
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/code/CodeScriptDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/code/CodeScriptDetail.tsx
@@ -1,0 +1,142 @@
+// apps/desktop/src/renderer/src/components/code/CodeScriptDetail.tsx
+//
+// Right pane of Code Studio: view form for one python script. Inline-editable
+// name (Python identifier), read-only <pre> source preview, and an "Edit code"
+// button that opens the shared CodeEditorPopup with python highlighting (no
+// Format — that's url4-only). Delete behind a confirm. Mirrors Url4SpecDetail.
+import { useState, lazy, Suspense } from 'react';
+import { Pencil, Trash2, Save, Check, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
+import type { CodeScript } from '@/hooks/use-code-scripts';
+
+const CodeEditorPopup = lazy(() => import('@/components/CodeEditorPopup'));
+
+interface Props {
+  script: CodeScript;
+  onRename: (oldName: string, newName: string) => void;
+  onDelete: (name: string) => void;
+  onSaveSource: (name: string, source: string) => void;
+}
+
+export function CodeScriptDetail({ script, onRename, onDelete, onSaveSource }: Props) {
+  const [editingName, setEditingName] = useState(false);
+  const [nameDraft, setNameDraft] = useState(script.name);
+  const [editingCode, setEditingCode] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  const commitName = (): void => {
+    const next = nameDraft.trim();
+    setEditingName(false);
+    if (next && next !== script.name) onRename(script.name, next);
+    else setNameDraft(script.name);
+  };
+
+  return (
+    <div className="flex h-full w-full min-w-0 flex-col">
+      <div className="min-w-0 flex-1 overflow-y-auto">
+        <header className="border-b border-border px-6 py-4">
+          <div className="mb-3 flex items-center gap-3">
+            {editingName ? (
+              <>
+                <input
+                  autoFocus
+                  aria-label="Script name"
+                  className="min-w-0 flex-1 rounded-md border border-input bg-background px-2 py-1 text-base font-semibold"
+                  value={nameDraft}
+                  onChange={(e) => setNameDraft(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') commitName();
+                    if (e.key === 'Escape') {
+                      setNameDraft(script.name);
+                      setEditingName(false);
+                    }
+                  }}
+                  onBlur={commitName}
+                />
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="Confirm name"
+                  onClick={commitName}
+                >
+                  <Check className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="Cancel rename"
+                  onClick={() => {
+                    setNameDraft(script.name);
+                    setEditingName(false);
+                  }}
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </>
+            ) : (
+              <>
+                <h2 className="min-w-0 flex-1 truncate text-base font-semibold">
+                  {script.name}.py
+                </h2>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  aria-label="Rename script"
+                  onClick={() => {
+                    setNameDraft(script.name);
+                    setEditingName(true);
+                  }}
+                >
+                  <Pencil className="h-3.5 w-3.5" /> Rename
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-muted-foreground hover:text-destructive"
+                  onClick={() => setConfirmingDelete(true)}
+                >
+                  <Trash2 className="h-3.5 w-3.5" /> Delete
+                </Button>
+              </>
+            )}
+          </div>
+
+          <span className="mb-1.5 block text-xs font-medium text-muted-foreground">Source</span>
+          <pre className="mb-3 max-h-[60vh] overflow-auto rounded border border-border bg-muted/30 p-3 font-mono text-xs whitespace-pre">
+            {script.source || '(empty)'}
+          </pre>
+          <Button variant="outline" size="sm" onClick={() => setEditingCode(true)}>
+            <Pencil className="h-3.5 w-3.5" /> Edit code
+          </Button>
+        </header>
+      </div>
+
+      {confirmingDelete && (
+        <ConfirmDialog
+          title="Delete this script?"
+          message={`"${script.name}.py" will be permanently removed from your python scripts. This can't be undone.`}
+          confirmLabel="Delete"
+          destructive
+          onConfirm={() => {
+            setConfirmingDelete(false);
+            onDelete(script.name);
+          }}
+          onCancel={() => setConfirmingDelete(false)}
+        />
+      )}
+      {editingCode && (
+        <Suspense fallback={null}>
+          <CodeEditorPopup
+            title={`Edit ${script.name}.py`}
+            language="python"
+            value={script.source}
+            inset="10%"
+            onSave={(source) => onSaveSource(script.name, source)}
+            onClose={() => setEditingCode(false)}
+          />
+        </Suspense>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/code/CodeScriptsList.tsx
+++ b/apps/desktop/src/renderer/src/components/code/CodeScriptsList.tsx
@@ -1,0 +1,91 @@
+// apps/desktop/src/renderer/src/components/code/CodeScriptsList.tsx
+//
+// Left pane of Code Studio: searchable list of python-runner scripts. Mirrors
+// Url4SpecsList; subtitle is the first non-blank line of the source.
+import { useMemo, useState } from 'react';
+import { Search } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { CodeScript } from '@/hooks/use-code-scripts';
+
+interface Props {
+  scripts: CodeScript[];
+  selectedName: string | null;
+  onSelect: (name: string) => void;
+  loading?: boolean;
+  error?: Error | null;
+}
+
+function firstLine(source: string): string {
+  const line = source.split('\n').find((l) => l.trim().length > 0);
+  return line?.trim() ?? '(empty)';
+}
+
+export function CodeScriptsList({ scripts, selectedName, onSelect, loading, error }: Props) {
+  const [filter, setFilter] = useState('');
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return scripts;
+    return scripts.filter(
+      (s) => s.name.toLowerCase().includes(q) || s.source.toLowerCase().includes(q),
+    );
+  }, [scripts, filter]);
+
+  if (loading && scripts.length === 0) {
+    return <div className="p-6 text-sm text-muted-foreground">Loading scripts…</div>;
+  }
+  if (error) {
+    return (
+      <div className="p-6 text-sm text-destructive">Failed to load scripts: {error.message}</div>
+    );
+  }
+  if (scripts.length === 0) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center p-8 text-center text-sm text-muted-foreground">
+        <p className="mb-2 font-medium">No scripts yet.</p>
+        <p className="text-xs">Use "New script" above to create one.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col">
+      <div className="border-b border-border/50 p-2">
+        <div className="relative">
+          <Search className="pointer-events-none absolute top-1/2 left-2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+          <input
+            aria-label="Filter scripts"
+            className="w-full rounded-md border border-input bg-background py-1.5 pr-2 pl-7 text-sm"
+            placeholder="Filter scripts…"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+          />
+        </div>
+      </div>
+      {filtered.length === 0 ? (
+        <div className="p-6 text-center text-xs text-muted-foreground">
+          No scripts match "{filter}".
+        </div>
+      ) : (
+        filtered.map((script) => {
+          const active = script.name === selectedName;
+          return (
+            <div
+              key={script.name}
+              onClick={() => onSelect(script.name)}
+              className={cn(
+                'cursor-pointer border-b border-border/50 px-6 py-3 transition-colors hover:bg-accent/40',
+                active && 'bg-accent/60',
+              )}
+            >
+              <div className="truncate font-medium text-foreground">{script.name}.py</div>
+              <div className="truncate font-mono text-xs text-muted-foreground">
+                {firstLine(script.source)}
+              </div>
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/code/__tests__/CodeScriptsAndDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/code/__tests__/CodeScriptsAndDialog.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/react';
+import { it, expect, vi, afterEach } from 'vitest';
+import type { CodeScript } from '@/hooks/use-code-scripts';
+import { CodeScriptsList } from '../CodeScriptsList';
+import { AddCodeScriptDialog } from '../AddCodeScriptDialog';
+import { CodeScriptDetail } from '../CodeScriptDetail';
+
+// CodeScriptDetail lazy-loads the monaco popup; stub it so the detail tests stay light.
+vi.mock('@/components/CodeEditorPopup', () => ({
+  default: ({ onSave }: { onSave: (v: string) => void }) => (
+    <button onClick={() => onSave('print(2)')}>stub-save</button>
+  ),
+}));
+
+const scripts: CodeScript[] = [
+  { name: 'check_correct', source: 'def main():\n    return True' },
+  { name: 'helper', source: '# util\nx = 1' },
+];
+
+afterEach(cleanup);
+
+// --- list ---
+it('renders a row per script with .py name + first-line preview', () => {
+  render(<CodeScriptsList scripts={scripts} selectedName={null} onSelect={vi.fn()} />);
+  expect(screen.getByText('check_correct.py')).toBeTruthy();
+  expect(screen.getByText('def main():')).toBeTruthy(); // first non-blank line
+});
+
+it('selects a script on click and filters', () => {
+  const onSelect = vi.fn();
+  render(<CodeScriptsList scripts={scripts} selectedName={null} onSelect={onSelect} />);
+  fireEvent.click(screen.getByText('check_correct.py'));
+  expect(onSelect).toHaveBeenCalledWith('check_correct');
+  fireEvent.change(screen.getByRole('textbox', { name: /filter scripts/i }), {
+    target: { value: 'helper' },
+  });
+  expect(screen.queryByText('check_correct.py')).toBeNull();
+});
+
+// --- add dialog ---
+it('creates a valid identifier name', () => {
+  const onCreate = vi.fn();
+  render(
+    <AddCodeScriptDialog existingNames={['check_correct']} onClose={vi.fn()} onCreate={onCreate} />,
+  );
+  fireEvent.change(screen.getByPlaceholderText(/check_correct/i), { target: { value: 'grader' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+  expect(onCreate).toHaveBeenCalledWith('grader');
+});
+
+it('blocks an invalid (non-identifier) name', () => {
+  const onCreate = vi.fn();
+  render(<AddCodeScriptDialog existingNames={[]} onClose={vi.fn()} onCreate={onCreate} />);
+  fireEvent.change(screen.getByPlaceholderText(/check_correct/i), { target: { value: '2bad' } });
+  expect(screen.getByText(/python identifier/i)).toBeTruthy();
+  expect(screen.getByRole('button', { name: 'Create' })).toHaveProperty('disabled', true);
+});
+
+// --- detail ---
+it('renames inline and deletes after confirm; saves edited code', () => {
+  const onRename = vi.fn();
+  const onDelete = vi.fn();
+  const onSaveSource = vi.fn();
+  render(
+    <CodeScriptDetail
+      script={scripts[0]}
+      onRename={onRename}
+      onDelete={onDelete}
+      onSaveSource={onSaveSource}
+    />,
+  );
+  // rename
+  fireEvent.click(screen.getByRole('button', { name: /rename script/i }));
+  const input = screen.getByRole('textbox', { name: /script name/i });
+  fireEvent.change(input, { target: { value: 'grader' } });
+  fireEvent.keyDown(input, { key: 'Enter' });
+  expect(onRename).toHaveBeenCalledWith('check_correct', 'grader');
+  // delete (confirm)
+  fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+  const dialog = screen.getByRole('alertdialog');
+  fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }));
+  expect(onDelete).toHaveBeenCalledWith('check_correct');
+});

--- a/apps/desktop/src/renderer/src/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/layout/Sidebar.tsx
@@ -5,6 +5,7 @@ import {
   Puzzle,
   Terminal,
   Workflow,
+  FileCode2,
   type LucideIcon,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -17,6 +18,7 @@ export type View =
   | 'sessions'
   | 'eval-studio'
   | 'url4-studio'
+  | 'code-studio'
   | 'settings'
   | `plugin:${string}`;
 
@@ -31,6 +33,7 @@ const coreItems: NavItem[] = [
   { id: 'sessions', label: 'Sessions', icon: Terminal },
   { id: 'eval-studio', label: 'Eval Studio', icon: FlaskConical },
   { id: 'url4-studio', label: 'URL4 Studio', icon: Workflow },
+  { id: 'code-studio', label: 'Code Studio', icon: FileCode2 },
   { id: 'settings', label: 'Settings', icon: Settings },
 ];
 

--- a/apps/desktop/src/renderer/src/components/rjsf-CodeDictField.tsx
+++ b/apps/desktop/src/renderer/src/components/rjsf-CodeDictField.tsx
@@ -8,11 +8,9 @@ import { Suspense, lazy, useState } from 'react';
 import type { FieldProps } from '@rjsf/utils';
 import { FileCode, Plus, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { isValidScriptName, SCRIPT_NAME_HINT } from '@/lib/script-name';
 
 const CodeEditorPopup = lazy(() => import('@/components/CodeEditorPopup'));
-
-// Mirrors the python-runner backend rule (VALID_SCRIPT_NAME): a Python identifier.
-const VALID_NAME = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
 function languageOf(uiSchema: FieldProps['uiSchema']): string {
   const opts = (uiSchema?.['ui:options'] ?? {}) as Record<string, unknown>;
@@ -32,10 +30,8 @@ export function CodeDictField(props: FieldProps) {
 
   const handleAdd = (): void => {
     const name = newName.trim();
-    if (!VALID_NAME.test(name)) {
-      setNameError(
-        'Use a Python identifier: start with a letter/underscore; letters, digits, underscores only.',
-      );
+    if (!isValidScriptName(name)) {
+      setNameError(SCRIPT_NAME_HINT);
       return;
     }
     if (name in data) {

--- a/apps/desktop/src/renderer/src/hooks/__tests__/use-code-scripts.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/__tests__/use-code-scripts.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { it, expect, vi, beforeEach } from 'vitest';
+
+const toast = vi.fn();
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast }) }));
+vi.mock('@/hooks/use-server-status', () => ({
+  useServerStatus: () => ({ info: { scheme: 'http', host: 'localhost', port: 8000 } }),
+}));
+
+import { useCodeScripts } from '../use-code-scripts';
+
+interface TestConfig {
+  version: string;
+  server: Record<string, unknown>;
+  plugins: string[];
+  plugin_config: Record<string, Record<string, unknown>>;
+}
+
+function baseConfig(): TestConfig {
+  return {
+    version: '1',
+    server: {},
+    plugins: ['python-runner'],
+    plugin_config: { 'python-runner': { scripts: { check_correct: 'def main():\n    pass' } } },
+  };
+}
+
+let written: TestConfig[];
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  written = [];
+  toast.mockClear();
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue({ ok: true, status: 200, body: '{}' });
+  // @ts-expect-error minimal electronAPI surface
+  window.electronAPI = {
+    config: {
+      read: vi.fn().mockResolvedValue(baseConfig()),
+      write: vi.fn().mockImplementation(async (c: TestConfig) => {
+        written.push(c);
+      }),
+      onChanged: vi.fn().mockReturnValue(() => {}),
+    },
+    server: { fetch: fetchMock },
+  };
+});
+
+function lastScripts(): Record<string, string> {
+  return written.at(-1)!.plugin_config['python-runner'].scripts as Record<string, string>;
+}
+
+it('loads scripts from the local config', async () => {
+  const { result } = renderHook(() => useCodeScripts());
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  expect(result.current.scripts).toEqual([
+    { name: 'check_correct', source: 'def main():\n    pass' },
+  ]);
+});
+
+it('createScript writes a new empty-source key', async () => {
+  const { result } = renderHook(() => useCodeScripts());
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  await act(async () => {
+    expect(await result.current.createScript('helper')).toBe(true);
+  });
+  expect(Object.keys(lastScripts())).toEqual(['check_correct', 'helper']);
+  expect(lastScripts().helper).toBe('');
+});
+
+it('rejects an invalid (non-identifier) name without writing', async () => {
+  const { result } = renderHook(() => useCodeScripts());
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  await act(async () => {
+    expect(await result.current.createScript('bad name!')).toBe(false);
+  });
+  expect(written).toHaveLength(0);
+  expect(toast).toHaveBeenCalled();
+});
+
+it('rejects a duplicate name without writing', async () => {
+  const { result } = renderHook(() => useCodeScripts());
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  await act(async () => {
+    expect(await result.current.createScript('check_correct')).toBe(false);
+  });
+  expect(written).toHaveLength(0);
+});
+
+it('renameScript swaps the key, keeps the source', async () => {
+  const { result } = renderHook(() => useCodeScripts());
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  await act(async () => {
+    expect(await result.current.renameScript('check_correct', 'grader')).toBe(true);
+  });
+  expect(Object.keys(lastScripts())).toEqual(['grader']);
+  expect(lastScripts().grader).toBe('def main():\n    pass');
+});
+
+it('saveSource updates the source', async () => {
+  const { result } = renderHook(() => useCodeScripts());
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  await act(async () => {
+    expect(await result.current.saveSource('check_correct', 'print(1)')).toBe(true);
+  });
+  expect(lastScripts().check_correct).toBe('print(1)');
+});
+
+it('deleteScript removes the key', async () => {
+  const { result } = renderHook(() => useCodeScripts());
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  await act(async () => {
+    expect(await result.current.deleteScript('check_correct')).toBe(true);
+  });
+  expect(lastScripts()).toEqual({});
+});

--- a/apps/desktop/src/renderer/src/hooks/use-code-scripts.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-code-scripts.ts
@@ -1,0 +1,189 @@
+// apps/desktop/src/renderer/src/hooks/use-code-scripts.ts
+//
+// Read + CRUD for python-runner scripts (Code Studio). Scripts live in the app
+// config under plugin_config['python-runner'].scripts ({ [name]: source }). The
+// durable source of truth is sf.json (window.electronAPI.config.write, the path
+// the Settings page uses); we also best-effort POST the new settings to the
+// running server's in-memory endpoint. The config:changed broadcast keeps this
+// and the Settings page in sync. Mirrors use-url4-specs.ts.
+import { useCallback, useEffect, useState } from 'react';
+import { useServerStatus } from '@/hooks/use-server-status';
+import { useToast } from '@/hooks/use-toast';
+import { isValidScriptName, SCRIPT_NAME_HINT } from '@/lib/script-name';
+
+export interface CodeScript {
+  name: string;
+  source: string;
+}
+
+interface AppConfig {
+  version: string;
+  server: Record<string, unknown>;
+  plugins: string[];
+  plugin_config: Record<string, Record<string, unknown>>;
+}
+
+type ScriptMap = Record<string, string>;
+
+const PLUGIN = 'python-runner';
+
+function serverBase(info: ReturnType<typeof useServerStatus>['info']): string | null {
+  if (!info) return null;
+  const host = info.host === '0.0.0.0' ? 'localhost' : info.host;
+  return `${info.scheme}://${host}:${info.port}`;
+}
+
+function scriptMapOf(config: AppConfig | null): ScriptMap {
+  const raw = (config?.plugin_config?.[PLUGIN]?.scripts ?? {}) as Record<string, unknown>;
+  return Object.fromEntries(
+    Object.entries(raw).map(([name, src]) => [name, typeof src === 'string' ? src : '']),
+  );
+}
+
+export function useCodeScripts() {
+  const { info } = useServerStatus();
+  const base = serverBase(info);
+  const { toast } = useToast();
+  const [config, setConfig] = useState<AppConfig | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    window.electronAPI.config
+      .read()
+      .then((c) => {
+        if (!cancelled) {
+          setConfig(c as unknown as AppConfig);
+          setLoading(false);
+        }
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          setError(e as Error);
+          setLoading(false);
+        }
+      });
+    const unsub = window.electronAPI.config.onChanged((c) => setConfig(c as unknown as AppConfig));
+    return () => {
+      cancelled = true;
+      unsub();
+    };
+  }, []);
+
+  const scriptMap = scriptMapOf(config);
+  const scripts: CodeScript[] = Object.entries(scriptMap).map(([name, source]) => ({
+    name,
+    source,
+  }));
+
+  const persist = useCallback(
+    async (nextScripts: ScriptMap, errTitle: string): Promise<boolean> => {
+      if (!config) return false;
+      const settings = { ...(config.plugin_config[PLUGIN] ?? {}), scripts: nextScripts };
+      const next: AppConfig = {
+        ...config,
+        plugin_config: { ...config.plugin_config, [PLUGIN]: settings },
+      };
+      try {
+        if (base) {
+          try {
+            const res = await window.electronAPI.server.fetch(
+              `${base}/plugins/${PLUGIN}/settings/validate`,
+              {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(settings),
+              },
+            );
+            if (!res.ok) {
+              let detail = `HTTP ${res.status}`;
+              try {
+                detail = (JSON.parse(res.body) as { detail?: string }).detail ?? detail;
+              } catch {
+                /* non-JSON body */
+              }
+              toast({ variant: 'error', title: errTitle, description: detail });
+              return false;
+            }
+            void window.electronAPI.server.fetch(`${base}/plugins/${PLUGIN}/settings`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(settings),
+            });
+          } catch {
+            /* server unreachable — persist to disk anyway */
+          }
+        }
+        await window.electronAPI.config.write(next as unknown as Record<string, unknown>);
+        setConfig(next);
+        return true;
+      } catch (e) {
+        toast({ variant: 'error', title: errTitle, description: (e as Error).message });
+        return false;
+      }
+    },
+    [config, base, toast],
+  );
+
+  const rejectName = useCallback(
+    (name: string): boolean => {
+      if (!isValidScriptName(name)) {
+        toast({ variant: 'error', title: 'Invalid name', description: SCRIPT_NAME_HINT });
+        return true;
+      }
+      if (name in scriptMap) {
+        toast({
+          variant: 'error',
+          title: 'Name in use',
+          description: `A script named "${name}" already exists.`,
+        });
+        return true;
+      }
+      return false;
+    },
+    [scriptMap, toast],
+  );
+
+  const createScript = useCallback(
+    async (name: string): Promise<boolean> => {
+      const trimmed = name.trim();
+      if (rejectName(trimmed)) return false;
+      return persist({ ...scriptMap, [trimmed]: '' }, 'Could not create script');
+    },
+    [scriptMap, persist, rejectName],
+  );
+
+  const renameScript = useCallback(
+    async (oldName: string, newName: string): Promise<boolean> => {
+      const trimmed = newName.trim();
+      if (trimmed === oldName) return false;
+      if (rejectName(trimmed)) return false;
+      const next: ScriptMap = Object.fromEntries(
+        Object.entries(scriptMap).map(([k, v]) => (k === oldName ? [trimmed, v] : [k, v])),
+      );
+      return persist(next, 'Could not rename script');
+    },
+    [scriptMap, persist, rejectName],
+  );
+
+  const deleteScript = useCallback(
+    async (name: string): Promise<boolean> => {
+      if (!(name in scriptMap)) return false;
+      const next = { ...scriptMap };
+      delete next[name];
+      return persist(next, 'Could not delete script');
+    },
+    [scriptMap, persist],
+  );
+
+  const saveSource = useCallback(
+    async (name: string, source: string): Promise<boolean> => {
+      if (!(name in scriptMap)) return false;
+      return persist({ ...scriptMap, [name]: source }, 'Could not save script');
+    },
+    [scriptMap, persist],
+  );
+
+  return { scripts, loading, error, createScript, renameScript, deleteScript, saveSource };
+}

--- a/apps/desktop/src/renderer/src/lib/script-name.ts
+++ b/apps/desktop/src/renderer/src/lib/script-name.ts
@@ -1,0 +1,13 @@
+// apps/desktop/src/renderer/src/lib/script-name.ts
+//
+// Python-identifier rule for python-runner script names. Mirrors the server's
+// VALID_SCRIPT_NAME (python_runner/plugin.py) — scripts are servable at
+// /data/code/<name>.py, so names must be importable Python identifiers.
+export const VALID_SCRIPT_NAME = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+export function isValidScriptName(name: string): boolean {
+  return VALID_SCRIPT_NAME.test(name);
+}
+
+export const SCRIPT_NAME_HINT =
+  'Use a Python identifier: start with a letter/underscore; letters, digits, underscores only.';

--- a/apps/desktop/src/renderer/src/views/CodeStudioView.test.tsx
+++ b/apps/desktop/src/renderer/src/views/CodeStudioView.test.tsx
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+import { render, screen, cleanup } from '@testing-library/react';
+import { it, expect, vi, afterEach } from 'vitest';
+
+vi.mock('@/hooks/use-code-scripts', () => ({
+  useCodeScripts: () => ({
+    scripts: [],
+    loading: false,
+    error: null,
+    createScript: vi.fn(),
+    renameScript: vi.fn(),
+    deleteScript: vi.fn(),
+    saveSource: vi.fn(),
+  }),
+}));
+vi.mock('@/components/code/CodeScriptDetail', () => ({ CodeScriptDetail: () => null }));
+
+afterEach(cleanup);
+
+import { CodeStudioView } from './CodeStudioView';
+
+it('renders header, New script, both pane toggles, and the empty state', () => {
+  render(<CodeStudioView />);
+  expect(screen.getByText('Code Studio')).toBeTruthy();
+  expect(screen.getByRole('button', { name: /new script/i })).toBeTruthy();
+  expect(screen.getByRole('button', { name: /hide scripts list/i })).toBeTruthy();
+  expect(screen.getByRole('button', { name: /hide script details/i })).toBeTruthy();
+  expect(screen.getByText('Select a script to see details')).toBeTruthy();
+});

--- a/apps/desktop/src/renderer/src/views/CodeStudioView.tsx
+++ b/apps/desktop/src/renderer/src/views/CodeStudioView.tsx
@@ -1,0 +1,147 @@
+import { useRef, useState } from 'react';
+import type { ImperativePanelHandle } from 'react-resizable-panels';
+import { PanelLeftClose, PanelLeftOpen, PanelRightClose, PanelRightOpen, Plus } from 'lucide-react';
+import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
+import { Button } from '@/components/ui/button';
+import { CodeScriptsList } from '@/components/code/CodeScriptsList';
+import { CodeScriptDetail } from '@/components/code/CodeScriptDetail';
+import { AddCodeScriptDialog } from '@/components/code/AddCodeScriptDialog';
+import { useCodeScripts } from '@/hooks/use-code-scripts';
+
+export function CodeStudioView() {
+  const { scripts, loading, error, createScript, renameScript, deleteScript, saveSource } =
+    useCodeScripts();
+  const [selectedName, setSelectedName] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const leftPanelRef = useRef<ImperativePanelHandle>(null);
+  const rightPanelRef = useRef<ImperativePanelHandle>(null);
+  const [leftCollapsed, setLeftCollapsed] = useState(false);
+  const [rightCollapsed, setRightCollapsed] = useState(false);
+
+  const selected = scripts.find((s) => s.name === selectedName) ?? null;
+
+  const handleCreate = async (name: string): Promise<void> => {
+    if (await createScript(name)) setSelectedName(name);
+  };
+  const handleRename = async (oldName: string, newName: string): Promise<void> => {
+    if (await renameScript(oldName, newName)) setSelectedName(newName);
+  };
+  const handleDelete = async (name: string): Promise<void> => {
+    if (await deleteScript(name)) {
+      setSelectedName((current) => (current === name ? null : current));
+    }
+  };
+
+  const toggleLeft = () => {
+    const panel = leftPanelRef.current;
+    if (!panel) return;
+    if (panel.isCollapsed()) panel.expand();
+    else panel.collapse();
+  };
+  const toggleRight = () => {
+    const panel = rightPanelRef.current;
+    if (!panel) return;
+    if (panel.isCollapsed()) panel.expand();
+    else panel.collapse();
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-start justify-between border-b border-border px-6 py-4">
+        <div>
+          <h1 className="text-lg font-semibold text-foreground">Code Studio</h1>
+          <p className="text-xs text-muted-foreground">
+            Python scripts referenced by URL4 expressions (/data/code/&lt;name&gt;.py)
+          </p>
+        </div>
+        <div className="flex items-center gap-1">
+          <Button variant="outline" size="sm" className="mr-1" onClick={() => setCreating(true)}>
+            <Plus className="h-3.5 w-3.5" /> New script
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={leftCollapsed ? 'Show scripts list' : 'Hide scripts list'}
+            aria-pressed={leftCollapsed}
+            onClick={toggleLeft}
+          >
+            {leftCollapsed ? <PanelLeftOpen /> : <PanelLeftClose />}
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={rightCollapsed ? 'Show script details' : 'Hide script details'}
+            aria-pressed={rightCollapsed}
+            onClick={toggleRight}
+          >
+            {rightCollapsed ? <PanelRightOpen /> : <PanelRightClose />}
+          </Button>
+        </div>
+      </div>
+
+      <ResizablePanelGroup
+        direction="horizontal"
+        autoSaveId="code-studio-split"
+        className="min-h-0 flex-1"
+      >
+        <ResizablePanel
+          ref={leftPanelRef}
+          id="code-scripts-list"
+          order={1}
+          collapsible
+          collapsedSize={0}
+          minSize={20}
+          defaultSize={50}
+          onCollapse={() => setLeftCollapsed(true)}
+          onExpand={() => setLeftCollapsed(false)}
+          className="overflow-auto"
+        >
+          <CodeScriptsList
+            scripts={scripts}
+            selectedName={selectedName}
+            onSelect={setSelectedName}
+            loading={loading}
+            error={error}
+          />
+        </ResizablePanel>
+
+        <ResizableHandle withHandle />
+
+        <ResizablePanel
+          ref={rightPanelRef}
+          id="code-script-detail"
+          order={2}
+          collapsible
+          collapsedSize={0}
+          minSize={20}
+          defaultSize={50}
+          onCollapse={() => setRightCollapsed(true)}
+          onExpand={() => setRightCollapsed(false)}
+          className="flex overflow-hidden"
+        >
+          {selected ? (
+            <CodeScriptDetail
+              script={selected}
+              onRename={(o, n) => void handleRename(o, n)}
+              onDelete={(n) => void handleDelete(n)}
+              onSaveSource={(n, s) => void saveSource(n, s)}
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
+              Select a script to see details
+            </div>
+          )}
+        </ResizablePanel>
+      </ResizablePanelGroup>
+
+      {creating && (
+        <AddCodeScriptDialog
+          existingNames={scripts.map((s) => s.name)}
+          onClose={() => setCreating(false)}
+          onCreate={(name) => void handleCreate(name)}
+        />
+      )}
+    </div>
+  );
+}

--- a/docs/superpowers/plans/2026-06-10-code-studio-page.md
+++ b/docs/superpowers/plans/2026-06-10-code-studio-page.md
@@ -1,0 +1,273 @@
+# Plan: "Code Studio" page (python-runner scripts)
+
+Date: 2026-06-10
+Status: PLAN ONLY — no implementation. Awaiting explicit approval before any code change.
+
+## 1. Overview
+
+Add a new top-level desktop page, **Code Studio**, that lists the python-runner
+plugin's named scripts and lets the user CRUD them, mirroring the just-merged
+**URL4 Studio** page almost 1:1.
+
+- Left pane: searchable list of scripts (by name, with a code-snippet subtitle).
+- Right pane: a view form with an inline-editable name + a read-only code
+  preview + an **"Edit code"** button that opens the shared `CodeEditorPopup`
+  with `language="python"` (no `onFormat` — Format is url4-only).
+- CRUD: add (name-only dialog), inline rename, delete-with-confirm.
+- A new sidebar nav entry "Code Studio", placed directly after "URL4 Studio".
+
+The data source is the difference that matters: scripts live in the
+**`python-runner`** plugin settings as `scripts: dict[str, str]` (name → Python
+source), not as `{ expression }` objects. Persistence is otherwise identical to
+URL4 Studio (durable `sf.json` write + best-effort in-memory POST to the running
+server). The existing RJSF `CodeDictField` in Settings is **left in place**.
+
+### Verified facts (file:line)
+
+- Plugin name is `python-runner`; settings field is `scripts: dict[str, str]`,
+  default `load_vendored_defaults`, with `json_schema_extra={"x-code-editor": {"language": "python"}}`
+  — `apps/server/src/screamingface/plugins/python_runner/plugin.py:64-73`.
+- Name rule is `VALID_SCRIPT_NAME = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")` (a Python
+  identifier), enforced by a `field_validator` on `scripts` —
+  `apps/server/src/screamingface/plugins/python_runner/plugin.py:48`, `:75-83`.
+- The desktop already mirrors that rule: `VALID_NAME = /^[a-zA-Z_][a-zA-Z0-9_]*$/`
+  with the comment "Mirrors the python-runner backend rule (VALID_SCRIPT_NAME)" —
+  `apps/desktop/src/renderer/src/components/rjsf-CodeDictField.tsx:14-15`.
+- Generic per-plugin settings endpoints exist (so no new server route is needed):
+  `POST /plugins/{name}/settings/validate` and `POST /plugins/{name}/settings` —
+  `apps/server/src/screamingface/core/admin_router.py:192-214`. Validate returns
+  `{"valid": true}` or HTTP 422 with `detail=str(exc)`.
+- Both `url4-specs` and `python-runner` are active in `apps/server/sf.json`
+  (lines 14 and 20; settings blocks at 246 and 268).
+- `CodeEditorPopup` already supports a Copy button (always) and a Format button
+  (only when `onFormat` is passed) — `apps/desktop/src/renderer/src/components/CodeEditorPopup.tsx:31,47,95-104`.
+  Omitting `onFormat` hides Format, which is what we want for Python.
+
+## 2. Mapping onto URL4 Studio
+
+| URL4 Studio (exists) | Code Studio (new) | Change |
+|---|---|---|
+| `views/Url4StudioView.tsx` | `views/CodeStudioView.tsx` | Title "Code Studio"; "New script" button; subtitle copy; `autoSaveId="code-studio-split"`; panel ids `code-scripts-list` / `code-script-detail`; aria labels "scripts list" / "script details". |
+| `hooks/use-url4-specs.ts` | `hooks/use-code-scripts.ts` | `PLUGIN='python-runner'`; value type `string` (source) instead of `{ expression }`; field `scripts` instead of `specs`; methods `createScript/renameScript/deleteScript/saveSource`; add Python-identifier name validation on create+rename. |
+| `components/url4/Url4SpecsList.tsx` | `components/code/CodeScriptsList.tsx` | Filter on name + source; subtitle shows first line of source or "(empty)"; empty-state copy. Row shows `name.py`. |
+| `components/url4/Url4SpecDetail.tsx` | `components/code/CodeScriptDetail.tsx` | Read-only preview is a `<pre>` code block (not `Url4Field`); "Edit code" button; `CodeEditorPopup` with `language="python"`, **no** `onEditorMount`, **no** `onFormat`; title `${name}.py`. Inline rename validates Python identifier before calling `onRename`. |
+| `components/url4/AddUrl4SpecDialog.tsx` | `components/code/AddCodeScriptDialog.tsx` | Name placeholder `script_name`; add Python-identifier validation + hint; "The code starts empty…" copy. |
+| `components/layout/Sidebar.tsx` (`url4-studio` nav) | same file | Add `code-studio` to `View` union + `coreItems` entry after URL4 Studio. |
+| `App.tsx` (`url4-studio` branch) | same file | Add `code-studio` route branch after the url4 branch. |
+
+## 3. Data model & persistence
+
+### Shapes
+
+```ts
+// use-code-scripts.ts
+export interface CodeScript { name: string; source: string }
+type ScriptMap = Record<string, string>;   // name -> python source
+const PLUGIN = 'python-runner';
+```
+
+Read from `config.plugin_config['python-runner'].scripts` (a flat
+`dict[str,str]`), unlike url4's `specs` (`{[name]: {expression}}`). The
+`specMapOf`-equivalent (`scriptMapOf`) normalizes each value to a string:
+`Object.fromEntries(Object.entries(raw).map(([n,v]) => [n, typeof v === 'string' ? v : '']))`.
+
+### Persist path (identical to `use-url4-specs.ts:84-134`)
+
+For every mutation, build `settings = { ...config.plugin_config['python-runner'], scripts: nextScripts }`,
+then:
+
+1. If a server base URL is known, `POST ${base}/plugins/python-runner/settings/validate`
+   with the settings body. On non-OK, parse `detail` and `toast` an error, return
+   `false` (block the write). On network failure, fall through and save anyway.
+2. Best-effort (fire-and-forget) `POST ${base}/plugins/python-runner/settings`
+   with the same body, so the running server's in-memory `settings.scripts`
+   updates without a disk re-read (keeps `GET /data/code/<name>.py` current).
+3. `await window.electronAPI.config.write(next)` — durable write to `sf.json`.
+4. `setConfig(next)` optimistically; the `config:changed` broadcast reconciles
+   with the Settings page (and vice-versa).
+
+`serverBase()` is copied verbatim (`0.0.0.0` → `localhost`).
+
+### scripts-dict transforms
+
+- **create(name)**: trim; reject empty; **reject non-Python-identifier** (new vs
+  url4); reject duplicate (`name in scriptMap`). `persist({ ...scriptMap, [name]: '' }, 'Could not create script')`.
+- **rename(oldName, newName)**: trim; no-op if empty or unchanged;
+  **reject non-Python-identifier**; reject duplicate. Rebuild preserving order by
+  swapping the key in place (same `Object.entries(...).map` trick as
+  `use-url4-specs.ts:166-168`), value carried over. `persist(next, 'Could not rename script')`.
+- **delete(name)**: `{ ...scriptMap }; delete next[name]; persist(next, 'Could not delete script')`.
+- **saveSource(name, source)**: guard `name in scriptMap`;
+  `persist({ ...scriptMap, [name]: source }, 'Could not save code')`. (url4 stores
+  `{ ...specMap[name], expression }`; here the value is just the string.)
+
+The server's `field_validator` is the backstop: an invalid name slips past the
+client only if the server is unreachable, in which case it will be rejected on
+the next reachable validate. Client-side identifier checking matches
+`rjsf-CodeDictField.tsx:14,33-40`.
+
+## 4. Components to create / files to modify
+
+### Create
+- `apps/desktop/src/renderer/src/views/CodeStudioView.tsx`
+- `apps/desktop/src/renderer/src/hooks/use-code-scripts.ts`
+- `apps/desktop/src/renderer/src/components/code/CodeScriptsList.tsx`
+- `apps/desktop/src/renderer/src/components/code/CodeScriptDetail.tsx`
+- `apps/desktop/src/renderer/src/components/code/AddCodeScriptDialog.tsx`
+- Tests (see §6):
+  - `apps/desktop/src/renderer/src/hooks/__tests__/use-code-scripts.test.ts`
+  - `apps/desktop/src/renderer/src/views/CodeStudioView.test.tsx`
+  - `apps/desktop/src/renderer/src/components/code/__tests__/CodeScriptDetail.test.tsx`
+  - `apps/desktop/src/renderer/src/components/code/__tests__/AddCodeScriptDialog.test.tsx`
+  - `apps/desktop/src/renderer/src/components/code/__tests__/CodeScriptsList.test.tsx` (optional, mirrors `Url4SpecsList.test.tsx` if that file is expanded)
+
+### Modify
+- `apps/desktop/src/renderer/src/components/layout/Sidebar.tsx`
+  - Import a distinct lucide icon — **`FileCode2`** (Code Studio is files-of-code; `Workflow` is taken by URL4, `FileCode` is used inside `rjsf-CodeDictField`).
+  - Add `'code-studio'` to the `View` union (after `'url4-studio'`).
+  - Add `{ id: 'code-studio', label: 'Code Studio', icon: FileCode2 }` to `coreItems` after the URL4 Studio entry.
+- `apps/desktop/src/renderer/src/App.tsx`
+  - `import { CodeStudioView } from '@/views/CodeStudioView';`
+  - Add `if (currentView === 'code-studio') return <CodeStudioView />;` after the `url4-studio` branch.
+
+## 5. The edit flow
+
+`CodeScriptDetail` renders:
+- inline-editable `<h2>`/input header (copy `Url4SpecDetail.tsx:39-114`), but
+  `commitName` first checks `VALID_SCRIPT_NAME` (a shared `const` re-declared in
+  the detail + dialog + hook, matching `rjsf-CodeDictField.tsx:15`); on invalid,
+  it does not call `onRename` (the hook also re-validates as a backstop).
+- a **read-only code preview**: a `<pre><code>` monospace block showing
+  `script.source` (or "(empty)"), with a `CopyButton`. We do **not** reuse
+  `Url4Field` (it is url4-specific and Monaco-backed); a plain `<pre>` is enough
+  for a preview and avoids loading Monaco until "Edit code" is clicked.
+- an **"Edit code"** button that sets `editingCode = true`, lazily rendering:
+
+```tsx
+<CodeEditorPopup
+  title={`${script.name}.py`}
+  language="python"
+  value={script.source}
+  confirmLabel="Save"
+  confirmIcon={<Save className="h-4 w-4" />}
+  onSave={(src) => onSaveSource(script.name, src)}
+  onClose={() => setEditingCode(false)}
+  // NOTE: no onEditorMount, no onFormat → Format button stays hidden (url4-only).
+/>
+```
+
+Monaco ships Python highlighting out of the box, so no `onEditorMount`/language
+registration is needed (url4 needs it; Python does not). `CodeEditorPopup` sets
+`tabSize: 4` for non-url4 languages already (`CodeEditorPopup.tsx:88`), which
+suits Python.
+
+Delete uses the same `ConfirmDialog` pattern as `Url4SpecDetail.tsx:128-140`,
+with script-flavored copy.
+
+## 6. Name validation
+
+- Shared regex `const VALID_SCRIPT_NAME = /^[a-zA-Z_][a-zA-Z0-9_]*$/;` — identical
+  to the server's `VALID_SCRIPT_NAME` (`plugin.py:48`) and the existing client copy
+  (`rjsf-CodeDictField.tsx:15`). To stay DRY, **export it from a small shared module**
+  (e.g. `apps/desktop/src/renderer/src/lib/script-name.ts`) and have both the new
+  Code Studio components and `rjsf-CodeDictField.tsx` import it. (If reviewers prefer
+  minimal blast radius, re-declare it locally and leave `rjsf-CodeDictField` untouched
+  — call this out as an open question, §10.)
+- Validation points: AddCodeScriptDialog (disable Create + show hint),
+  CodeScriptDetail inline rename (block commit + show hint), and the hook
+  (`createScript`/`renameScript` return `false` + `toast` on invalid). Error copy
+  matches `rjsf-CodeDictField.tsx:36-38`: "Use a Python identifier: start with a
+  letter/underscore; letters, digits, underscores only."
+- This is the one behavioral departure from URL4 Studio, whose names are permissive
+  (no regex in `AddUrl4SpecDialog`/`use-url4-specs`).
+
+## 7. Leave the RJSF CodeDictField in Settings? — Yes, recommend LEAVE
+
+- The `x-code-editor` → `CodeDictField` mapping (`rjsf-utils.ts:15-19`,
+  `rjsf-theme.tsx:578`) is generic for any `x-code-editor` dict field, not
+  python-runner-specific; removing it could regress other/future plugins.
+- URL4 Studio set the precedent: it added a dedicated page while leaving Settings
+  editing intact. Code Studio should match.
+- Both surfaces write the same `sf.json` key and listen to `config:changed`, so
+  they stay in sync. No change to Settings is in scope.
+
+## 8. Test plan (vitest, mirrors url4-studio tests)
+
+Mirror the four existing url4 test files, adapting fixtures to the flat
+`scripts: dict[str,str]` shape and adding identifier-validation cases.
+
+1. **`use-code-scripts.test.ts`** (from `__tests__/use-url4-specs.test.ts`):
+   - mock `use-toast`, `use-server-status`; stub `window.electronAPI.config` +
+     `server.fetch`; `baseConfig` = `{ plugin_config: { 'python-runner': { scripts: { greet: "print('hi')" } } } }`.
+   - loads scripts from local config → `[{ name:'greet', source:"print('hi')" }]`.
+   - `createScript('hello')` writes `{...}` preserving order, new key `''`.
+   - `createScript('greet')` rejected (duplicate) — no write, toast.
+   - **`createScript('1bad')` rejected (invalid identifier)** — no write, toast (NEW).
+   - `renameScript('greet','hello')` swaps key in place, source preserved.
+   - **`renameScript('greet','1bad')` rejected (invalid identifier)** (NEW).
+   - `deleteScript('greet')` → `{}`.
+   - `saveSource('greet', 'x=1')` updates only that value.
+   - server validate 422 → aborts write, toast with parsed `detail`.
+
+2. **`CodeStudioView.test.tsx`** (from `Url4StudioView.test.tsx`): mock
+   `use-code-scripts` (empty) and stub `CodeScriptDetail`; assert header "Code
+   Studio", "New script" button, both pane toggles, and empty-state text.
+
+3. **`CodeScriptDetail.test.tsx`** (from `Url4SpecDetail.test.tsx`): stub
+   `CodeEditorPopup` to a button emitting a source string; assert name + read-only
+   preview render; inline rename on Enter calls `onRename`; **inline rename with an
+   invalid identifier does NOT call `onRename`** (NEW); delete only after confirm;
+   "Edit code" → save calls `onSaveSource(name, src)`. (No `Url4Field` mock needed
+   since the preview is a plain `<pre>`.)
+
+4. **`AddCodeScriptDialog.test.tsx`** (from `AddUrl4SpecDialog.test.tsx`): creates
+   with a valid name; blocks empty; blocks duplicate with hint; **blocks an invalid
+   identifier with a hint** (NEW).
+
+Run: `pnpm --filter <desktop-pkg> test` (or the repo's configured vitest command;
+confirm during build).
+
+## 9. Build sequence
+
+1. (If chosen) add `lib/script-name.ts` exporting `VALID_SCRIPT_NAME`; refactor
+   `rjsf-CodeDictField.tsx` to import it. Run existing CodeDictField/Settings tests.
+2. `hooks/use-code-scripts.ts` + its test → green.
+3. `components/code/AddCodeScriptDialog.tsx` + test → green.
+4. `components/code/CodeScriptsList.tsx` (+ optional test) → green.
+5. `components/code/CodeScriptDetail.tsx` + test → green.
+6. `views/CodeStudioView.tsx` + test → green.
+7. Wire `Sidebar.tsx` (`View` union + `coreItems` + `FileCode2` import) and
+   `App.tsx` (import + route branch).
+8. Run full desktop unit suite + typecheck/lint; manually verify in the running
+   app (create/rename/delete/edit a script; confirm `GET /data/code/<name>.py`
+   reflects edits and the Settings CodeDictField stays in sync via `config:changed`).
+
+## 10. Out of scope
+
+- Running/executing scripts from Code Studio (no run button; execution is the
+  server's `/python` backend path).
+- Any change to Settings beyond the optional `VALID_SCRIPT_NAME` import refactor.
+- Server-side changes (the generic admin endpoints already cover validate/update).
+- url4-specific features: language registration, `formatUrl4`/Format button,
+  `Url4Field` Monaco preview.
+- Sharing/export of scripts, vendored-default management UI.
+
+## 11. Confidence
+
+**~95%.** The URL4 Studio architecture, the python-runner settings shape, the name
+rule, and the generic admin endpoints are all confirmed in-repo at the cited
+lines. The shared-regex extraction (§6, step 1) is the only design choice with a
+reviewer-preference fork; both branches are spelled out.
+
+## 12. Open questions
+
+1. **Shared `VALID_SCRIPT_NAME`**: extract to `lib/script-name.ts` (DRY, touches
+   `rjsf-CodeDictField.tsx`) vs. re-declare locally (smaller blast radius)?
+   Recommendation: extract, per the repo's DRY mandate.
+2. **Read-only preview**: plain `<pre>` (recommended, no Monaco until "Edit code")
+   vs. a read-only Monaco view for Python syntax highlighting in the preview pane.
+   Recommendation: `<pre>` for parity-of-effort and bundle weight.
+3. **Subtitle in the list row**: show the first non-blank line of source
+   (recommended) or a script byte/line count?
+4. **Asana/branch**: this is plan-only; on approval, get the SF ticket and a
+   `SF-{n}-code-studio-page` branch before any code (per CLAUDE.md git workflow).


### PR DESCRIPTION
Code Studio: a top-level screen mirroring URL4 Studio for the python-runner scripts dict. Left list; right view form with inline-editable name + read-only source; Edit code opens CodeEditorPopup (python). Name-only add dialog; delete confirm. Python-identifier names (shared lib/script-name.ts, reused by CodeDictField). Persistence via config.write + dual-write. Sidebar entry + App route; RJSF editor left in Settings. Desktop suite 173 + build green. Plan: docs/superpowers/plans/2026-06-10-code-studio-page.md. Asana: SF-262 https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215595784758263