### PR TITLE
SF-267: design system skill from brand.screamingface.ai

### DIFF
--- a/.claude/skills/screamingface-design/SKILL.md
+++ b/.claude/skills/screamingface-design/SKILL.md
@@ -1,0 +1,145 @@
+---
+description: ScreamingFace brand & design system — the single visual law for ALL UI/UX work in this repo (website, app, cloud, demos, charts, components, copy). Use whenever building, styling, or reviewing any frontend surface; choosing colors, type, or spacing; or making a design/layout/visual decision. Overrides shadcn/Tailwind defaults. Parsed from brand.screamingface.ai.
+user_invocable: true
+---
+
+# ScreamingFace Design System
+
+This is the canonical look-and-rules for everything we ship. The audience is **policy and science leadership, not only developers**, so the surface has to **earn trust at a glance**. One system, applied everywhere — website, Electron app, cloud webapp, demos, charts, and copy.
+
+> **The direction — "infra-retro-modern."** The precision of a developer-infrastructure tool with a terminal-retro backbone: **monospace structure, hairline rules, square corners, true white and true dark.** Color is rationed — it appears only to help the reader follow the story. Retro, not messy. We argue that AI should be *honest*; the surface should feel honest too.
+
+When you touch any UI/UX, follow this skill over framework defaults. The exact tokens and component CSS are in `reference/` — read them when you need precise values.
+
+## The five principles
+
+1. **Evidence over adjectives.** Lead with the number, the run, the source. If we can't back it up, we don't say it.
+2. **Structure you can see.** Hierarchy comes from type and rules, not decoration.
+3. **Color means something.** Greys carry the page; the accent only marks the thing the reader should understand.
+4. **Legible at small sizes.** This holds dense tables and footnotes. Type is chosen for that.
+5. **Light and dark are equals.** Both are designed, not one tinted from the other.
+
+## Anti-rules — NOT vibe-coded (hard rules, not suggestions)
+
+The fastest way to look auto-generated in 2026 is to accept the defaults. **Never do the left column. Do the right.**
+
+| NEVER | INSTEAD |
+| --- | --- |
+| Gradients — **especially blue→purple**. | Flat color fills only. |
+| Rounded corners. Radius is `0`. | Square edges + hairline borders. |
+| Drop shadows, glows, glassmorphism, blur. | Depth from spacing and rules, not shadow. |
+| Gradient or glowing text. | Real type hierarchy; one accent for the story. |
+| Emoji as bullets, ✨ decoration. | The 😱 mark, once — never as decoration. |
+| **Purple. Any purple.** | The greyscale palette + the one semantic accent. |
+| Hero + three feature cards + bento grid. | Left-aligned, document-like, generous space. |
+| The default **shadcn / "clean modern SaaS" look**. | Monospace structure; deliberate, defensible choices. |
+| Lorem, fake logos, vanity metrics, undefined acronyms. | Real data, real labels, real receipts. |
+| Motion to impress. | Motion only where it clarifies. |
+
+**These override shadcn/Tailwind defaults.** When working in the React/Tailwind/shadcn app or cloud webapp: restyle primitives to these tokens (square corners, hairline borders, no shadow, semantic colors) — do **not** ship the stock component look.
+
+## Color — semantic tokens only
+
+Components reference **semantic** tokens (`var(--ink)`, `var(--gain)`…), **never raw hex and never a primitive directly.** The page is **near-monochrome on purpose.** Only two roles carry chromatic meaning:
+
+- **`--gain`** (green) = the model can read the source → correct / SOTA / the win.
+- **`--blind`** (red) = guessing without the source → the "before".
+- **`--mark`** (😱 amber) = a UI spark only. **Never** use it to encode data.
+
+Everything else is greyscale (`--bg`, `--surface`, `--surface-2`, `--ink`, `--ink-2`, `--ink-3`, `--line`, `--line-2`).
+
+| token | light | dark | role |
+| --- | --- | --- | --- |
+| `--bg` | `#ffffff` | `#0a0b0d` | page background (true white / true dark) |
+| `--surface` | `#f6f6f7` | `#131519` | raised panel / code / hover |
+| `--surface-2` | `#efeff1` | `#1a1d22` | second surface |
+| `--ink` | `#16181d` | `#e8eaed` | primary text |
+| `--ink-2` | `#585d67` | `#9aa0aa` | secondary text |
+| `--ink-3` | `#8b909a` | `#686e78` | muted / labels / captions |
+| `--line` | `#e6e7ea` | `#20232a` | hairline border |
+| `--line-2` | `#d4d6db` | `#2c303a` | stronger divider |
+| `--gain` | `#0f7a3d` | `#35d07f` | correct / SOTA / win |
+| `--gain-bg` | `#e8f3ec` | `#11241b` | SOTA row / gain note tint |
+| `--blind` | `#b23b3b` | `#f0726f` | guessing / before |
+| `--blind-bg` | `#f6e7e6` | `#2a1715` | blind tint |
+| `--mark` | `#c9821f` | `#e0a23c` | 😱 UI spark — never data |
+
+**Charts comparing many series** use the 8-color categorical palette `--cat-blue, --cat-green, --cat-amber, --cat-rust, --cat-teal, --cat-rose, --cat-brown, --cat-slate` — colorblind-aware, **no purple**, assigned **in that order**, theme-shared, and kept distinct from `--gain`/`--blind`. Full set in `reference/tokens.json` / `reference/tokens.css`.
+
+## Type — four families, strict roles
+
+| family | token | used for |
+| --- | --- | --- |
+| **EB Garamond** (old-style serif) | `--f-display` | **h1 / display only.** Timeless, credible — deliberately *not* a tech/mono serif. |
+| **IBM Plex Sans** | `--f-sans` | body prose, dense small text |
+| **IBM Plex Mono** | `--f-mono` | data, labels, code, h2, the rail, chart text |
+| **Rubik** | `--f-wordmark` | the wordmark / logo lockup **only** (OpenMined family) |
+
+**Seven sizes, one job each** (one of these maps to everything):
+
+| token | size | role |
+| --- | --- | --- |
+| `--text-display` | 38px | h1 (Garamond) |
+| `--text-metric` | 30px | big stat numbers (Mono) |
+| `--text-lead` | 20px | the one opening line (Sans) |
+| `--text-body` | 16px | all prose (Sans) |
+| `--text-sm` | 13px | captions, tables, climb, buttons |
+| `--text-micro` | 12px | chart ticks/labels, rail, footer (Mono) |
+| `--text-label` | 11px | ALL uppercase labels: eyebrow, h2, kickers, table headers (Mono) |
+
+All-caps labels use **mono + `--tracking-label` (0.1em)**. Big numbers use `font-variant-numeric: tabular-nums`. Weights are only 400 / 500 / 600.
+
+## Spacing, layout, geometry
+
+- **4px spacing scale**: `--space-1`(4) … `--space-12`(96). Use these for all padding / margin / gap.
+- **Column**: `--col` 760px (reading), `--col-wide` 1000px (dense). Content is left-aligned and document-like.
+- **Square**: `--radius-none` is `0`. **No exceptions.**
+- **Borders**: `--border-hairline` 1px (default), `--border-strong` 2px (emphasis accents, e.g. the left rule on a note).
+- **Rail**: a sticky 44px (`--rail-h`) mono header — wordmark, crumbs, theme toggle. See `.rail` in `reference/style.css`.
+
+## Component recipes
+
+Reach for these before inventing anything. Each lives in `reference/style.css`; structures are in the parsed demo/viz pages.
+
+- **`.stats`** — 3-up big-number row. The win number gets `.gain`. Use for the headline metrics ("45% → 91%").
+- **`table` + `tr.sota`** — leaderboard of reproducible runs. Mono, `--text-sm`, numeric columns get `.num` (right-aligned tabular-nums). The SOTA/best row is `tr.sota` (gain-bg tint + inset gain bar on the first cell).
+- **`.climb`** — staged horizontal-bar progression (label / track / value rows under `.stage-head` group headers). Fill variants: `.base` (frontier alone), `.ens` (ensemble), `.priv` (one model + source), `.sota` (the win). Use to show "why it climbs".
+- **`.deltawrap`** — before / `+Δ` / after big-delta panels. `.cell.before .big` is `--blind`, `.cell.after .big` is `--gain`, the `.mid` cell holds the delta. Use for "one thing changed".
+- **`figure` + `.svg-*` hooks** — charts (e.g. accuracy×cost Pareto). All chart text is mono/micro. Use the theme hooks (`.svg-ink`, `.svg-line`, `.svg-axis`, `.svg-gain`, `.svg-blind`, `.svg-base`) so SVGs follow the theme. Draw markers **after** lines; circles get a `--bg` halo via `paint-order: stroke`. Caption in `figcaption`.
+- **`.note` / `.note.gain`** — callout with a strong left rule + `.kicker` label. `.gain` variant for the positive "what this means" note.
+- **`.btn` / `.btn.ghost`** — square mono buttons (solid ink fill / outline ghost), invert on hover.
+- **`pre` with `.ok` / `.dim`** — terminal-style command blocks ("run it yourself"). `.ok` = gain, `.dim` = muted.
+
+A full canonical page shell (fonts + tokens + rail + masthead + a `.stats` block + theme toggle) is in `reference/starter.html` — copy it as the skeleton for any new static surface.
+
+## Voice (copy is design too)
+
+Per OpenMined: **concise, credible, helpful.** Write to be useful, not to sound impressive.
+
+| do | don't |
+| --- | --- |
+| Lead with the outcome, then how it works | Overclaim or speculate |
+| Show receipts — numbers, links, names | Buzzwords / corporate jargon |
+| Plain language; define acronyms once | Fear-based messaging |
+| Center the reader and the outcome | Center ourselves |
+
+**Titles must pass four tests:** can you visualize it; is it falsifiable; could anyone else say it (if yes, too generic); is it true. Draft 5–10 before choosing.
+
+## Self-check before you finish
+
+Run this against your own output — every "yes" in the left list is a violation to fix:
+
+- [ ] Any **purple** anywhere?
+- [ ] Any gradient, drop shadow, glow, blur, or glassmorphism?
+- [ ] Any **rounded corner** (radius ≠ 0)?
+- [ ] Color used for anything **other than** gain (green), blind (red), or the 😱 mark (amber)?
+- [ ] A **raw hex** or a primitive token where a semantic token belongs?
+- [ ] **EB Garamond** used anywhere but an h1? Mono used for a big display headline?
+- [ ] Lorem / fake logos / vanity or placeholder metrics / undefined acronyms left in?
+- [ ] Did you verify **both light and dark**? (They are co-equal — check the toggle.)
+- [ ] Is depth coming from shadow instead of spacing + hairlines?
+- [ ] Is the layout a hero + 3-cards + bento, or the stock shadcn "clean SaaS" look?
+
+## Source & drift
+
+Canonical source: **`brand.screamingface.ai`** (password `letmein`) and the external **`screamingface-brand`** repo. The files in `reference/` (`tokens.json`, `tokens.css`, `style.css`, `starter.html`) are a **snapshot dated 2026-06-11**. If they diverge from the live site, the live site / brand repo wins — re-pull and update this snapshot.

--- a/.claude/skills/screamingface-design/reference/starter.html
+++ b/.claude/skills/screamingface-design/reference/starter.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<!--
+  screamingface design system — STARTER / canonical page shell.
+  Copy this as the skeleton for any new static surface. It wires the four
+  fonts, the tokens, the component stylesheet, the sticky rail, the column,
+  a masthead, one .stats component, and the light/dark toggle. Everything
+  uses semantic tokens — no raw hex, no shadows, no rounded corners, no
+  purple. Open in a browser and hit the toggle to verify both themes.
+-->
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>screamingface — starter</title>
+  <!-- the four families: EB Garamond (h1), IBM Plex Sans (prose), IBM Plex Mono (data/labels), Rubik (wordmark) -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600&family=EB+Garamond:wght@500;600&family=Rubik:wght@400;500;600&display=swap">
+  <link rel="stylesheet" href="./tokens.css">
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <!-- sticky infra rail: wordmark left, crumbs, theme toggle right -->
+  <nav class="rail">
+    <span class="brand"><span class="m">😱</span> screamingface</span>
+    <span class="sep">·</span>
+    <span class="crumbs"><a href="#" class="here">starter</a></span>
+    <span class="spacer"></span>
+    <button class="toggle" id="theme">◐ dark</button>
+  </nav>
+
+  <main class="wrap">
+    <header class="masthead">
+      <span class="eyebrow">honest-agi-live · starter shell</span>
+      <h1>Private data turns a 45% model into a 91% one.</h1>
+    </header>
+    <p class="lead">One opening line in Plex Sans — lead with the outcome, then how it works. Replace with real copy; no lorem.</p>
+
+    <!-- the only accent on the page lands on the win number, via .gain -->
+    <div class="stats">
+      <div class="s"><div class="k">frontier model, alone</div><div class="v">45<span class="u">%</span></div></div>
+      <div class="s"><div class="k">+ the private source</div><div class="v gain">83<span class="u">%</span></div></div>
+      <div class="s"><div class="k">ensemble + source · SOTA</div><div class="v gain">91<span class="u">%</span></div></div>
+    </div>
+
+    <div class="foot">
+      <span>😱 honest-agi-live · starter</span>
+      <span>brand.screamingface.ai · internal</span>
+    </div>
+  </main>
+
+  <script>
+    // Light and dark are co-equal designed modes — never tint one from the other.
+    var root = document.documentElement, btn = document.getElementById('theme');
+    btn.addEventListener('click', function () {
+      var dark = root.getAttribute('data-theme') === 'dark';
+      root.setAttribute('data-theme', dark ? 'light' : 'dark');
+      btn.textContent = dark ? '◐ dark' : '◐ light';
+    });
+  </script>
+</body>
+</html>

--- a/.claude/skills/screamingface-design/reference/style.css
+++ b/.claude/skills/screamingface-design/reference/style.css
@@ -1,0 +1,243 @@
+/* =====================================================================
+   SNAPSHOT 2026-06-11 from brand.screamingface.ai — canonical source is
+   the screamingface-brand repo. Re-pull if it diverges. Reference only.
+
+   screamingface — brand system  ·  brand.screamingface.ai
+   Aesthetic: infra-retro-modern. Square, hairline, monochrome-with-one-
+   accent. Refined, not "vibe-coded" (see the anti-rules in the guide).
+
+   FULLY TOKENISED. Every value here is a var() from tokens.css (generated
+   from tokens/tokens.json by build.mjs). This file only arranges tokens
+   into the interface — it contains no raw colors, sizes, or fonts.
+
+   Type roles (the whole scale, deliberately few):
+     display  Garamond  --text-display   h1
+     metric   Mono      --text-metric    big stat numbers
+     lead     Sans      --text-lead      opening line
+     body     Sans      --text-body      prose (incl. notes)
+     sm       Sans/Mono --text-sm        captions, tables, climb, buttons
+     micro    Mono      --text-micro     chart text, rail, footer
+     label    Mono caps --text-label     eyebrow, h2, kickers, table headers
+   ===================================================================== */
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+html { -webkit-text-size-adjust: 100%; scroll-behavior: smooth; }
+
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--f-sans);
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+/* ---- top rail (infra header) -------------------------------------- */
+.rail {
+  position: sticky; top: 0; z-index: 20;
+  height: var(--rail-h); display: flex; align-items: center; gap: var(--space-4);
+  padding: 0 var(--space-5); background: var(--bg);
+  border-bottom: var(--border-hairline) solid var(--line);
+  font-family: var(--f-mono); font-size: var(--text-micro);
+}
+.rail .brand { display: flex; align-items: center; gap: var(--space-2); color: var(--ink); font-family: var(--f-wordmark); font-weight: var(--weight-regular); letter-spacing: var(--tracking-tight); }
+.rail .brand .m { font-size: var(--text-body); }
+.rail .sep { color: var(--ink-3); }
+.rail .crumbs { display: flex; gap: var(--space-4); color: var(--ink-3); }
+.rail .crumbs a { color: var(--ink-2); text-decoration: none; }
+.rail .crumbs a:hover { color: var(--ink); }
+.rail .crumbs a.here { color: var(--ink); border-bottom: var(--border-hairline) solid var(--ink); }
+.rail .spacer { margin-left: auto; }
+.rail .toggle {
+  font-family: var(--f-mono); font-size: var(--text-micro); cursor: pointer;
+  background: none; border: var(--border-hairline) solid var(--line-2); color: var(--ink-2);
+  padding: var(--space-1) var(--space-2); line-height: 1; border-radius: var(--radius-none);
+}
+.rail .toggle:hover { color: var(--ink); border-color: var(--ink-2); }
+
+/* ---- column ------------------------------------------------------- */
+.wrap { max-width: var(--col); margin: 0 auto; padding: var(--space-8) var(--space-5) var(--space-12); }
+.wrap.wide { max-width: var(--col-wide); }
+
+/* ---- type --------------------------------------------------------- */
+h1 {
+  font-family: var(--f-display); font-weight: var(--weight-semibold);
+  font-size: var(--text-display); letter-spacing: var(--tracking-normal);
+  line-height: var(--leading-tight); color: var(--ink); margin: 0 0 var(--space-4);
+}
+/* label role — the single treatment for every small caps label */
+h2, .eyebrow, .kicker, thead th, .stage-head, .deltawrap .k, .stats .k, .logo-cell .cap, .rules h4, #gate .t {
+  font-family: var(--f-mono); font-weight: var(--weight-semibold);
+  font-size: var(--text-label); letter-spacing: var(--tracking-label);
+  text-transform: uppercase; color: var(--ink-3);
+}
+h2 { margin: var(--space-9) 0 var(--space-4); padding-bottom: var(--space-2); border-bottom: var(--border-hairline) solid var(--line); }
+h3 { font-family: var(--f-sans); font-weight: var(--weight-semibold); font-size: var(--text-body); margin: var(--space-6) 0 var(--space-2); color: var(--ink); }
+
+p { margin: 0 0 var(--space-4); }
+.lead { font-family: var(--f-sans); font-size: var(--text-lead); line-height: var(--leading-snug); color: var(--ink); letter-spacing: var(--tracking-tight); }
+small, .small { font-size: var(--text-sm); }
+.meta { font-family: var(--f-mono); font-size: var(--text-micro); color: var(--ink-3); }
+.faint { color: var(--ink-3); }
+.mono { font-family: var(--f-mono); }
+strong, b { font-weight: var(--weight-semibold); color: var(--ink); }
+
+ul, ol { margin: 0 0 var(--space-4); padding-left: var(--space-5); }
+li { margin: var(--space-1) 0; }
+
+a { color: var(--ink); text-decoration: underline; text-decoration-color: var(--line-2); text-underline-offset: 3px; }
+a:hover { text-decoration-color: var(--ink); }
+
+hr { border: 0; border-top: var(--border-hairline) solid var(--line); margin: var(--space-7) 0; }
+
+code, kbd {
+  font-family: var(--f-mono); font-size: 0.85em;
+  background: var(--surface); border: var(--border-hairline) solid var(--line); padding: 0 var(--space-1); border-radius: var(--radius-none);
+}
+pre {
+  font-family: var(--f-mono); font-size: var(--text-sm); line-height: var(--leading-snug);
+  background: var(--surface); border: var(--border-hairline) solid var(--line);
+  padding: var(--space-4) var(--space-5); overflow-x: auto; margin: 0 0 var(--space-4); color: var(--ink);
+}
+pre .ok { color: var(--gain); }
+pre .dim { color: var(--ink-3); }
+
+/* ---- masthead ----------------------------------------------------- */
+.masthead { margin-bottom: var(--space-1); }
+.masthead .eyebrow { display: block; margin-bottom: var(--space-3); }
+
+/* ---- kicker / note ------------------------------------------------ */
+.kicker { display: block; margin-bottom: var(--space-2); }
+.note { border: var(--border-hairline) solid var(--line); border-left: var(--border-strong) solid var(--ink); background: var(--surface); padding: var(--space-4); margin: 0 0 var(--space-4); font-size: var(--text-body); }
+.note.gain { border-left-color: var(--gain); }
+.note.gain .kicker { color: var(--gain); }
+
+/* ---- tables ------------------------------------------------------- */
+table { width: 100%; border-collapse: collapse; font-family: var(--f-mono); font-size: var(--text-sm); margin: 0 0 var(--space-5); }
+th, td { text-align: left; padding: var(--space-2) var(--space-3); border-bottom: var(--border-hairline) solid var(--line); }
+thead th { border-bottom: var(--border-hairline) solid var(--line-2); }
+tbody tr:hover { background: var(--surface); }
+td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
+tr.sota td { background: var(--gain-bg); }
+tr.sota td:first-child { box-shadow: inset var(--border-strong) 0 0 var(--gain); }
+
+/* ---- swatches ----------------------------------------------------- */
+.swatches { display: grid; grid-template-columns: repeat(auto-fill, minmax(140px,1fr)); gap: var(--border-hairline); background: var(--line); border: var(--border-hairline) solid var(--line); }
+.swatch { background: var(--bg); }
+.swatch .chip { height: var(--space-10); border-bottom: var(--border-hairline) solid var(--line); }
+.swatch .m { font-family: var(--f-mono); font-size: var(--text-label); padding: var(--space-2); text-transform: none; letter-spacing: var(--tracking-normal); }
+.swatch .m b { display: block; }
+.swatch .m span { color: var(--ink-3); }
+
+/* big-figure unit (the % set small + muted so the number leads) */
+.v .u, .big .u { font-size: 0.45em; font-weight: var(--weight-regular); opacity: 0.5; margin-left: 2px; letter-spacing: 0; }
+
+/* token-reference inline swatch (rendered by guide.js) */
+.tok-sw { display: inline-block; width: 11px; height: 11px; border: var(--border-hairline) solid var(--line-2); vertical-align: -1px; margin-right: var(--space-2); }
+#tok-semantic td:first-child, #tok-type td:first-child, #tok-text td:first-child { color: var(--ink); }
+
+/* logo / mark */
+.logo-row { display: flex; flex-wrap: wrap; border: var(--border-hairline) solid var(--line); margin: 0 0 var(--space-4); }
+.logo-cell { padding: var(--space-6) var(--space-7); border-right: var(--border-hairline) solid var(--line); display: flex; flex-direction: column; align-items: center; gap: var(--space-3); text-align: center; flex: 1; min-width: 150px; }
+.logo-cell:last-child { border-right: 0; }
+.logo-cell .big-mark { font-size: var(--space-10); line-height: 1; user-select: none; }
+.logo-cell img { width: 72px; height: 72px; }
+.logo-cell .cap { display: block; }
+
+/* ---- anti-rules grid (do / don't) --------------------------------- */
+.rules { display: grid; grid-template-columns: 1fr 1fr; gap: var(--border-hairline); background: var(--line); border: var(--border-hairline) solid var(--line); font-size: var(--text-sm); }
+.rules > div { background: var(--bg); padding: var(--space-3); }
+.rules .no { border-top: var(--border-strong) solid var(--blind); }
+.rules .yes { border-top: var(--border-strong) solid var(--gain); }
+.rules h4 { margin-bottom: var(--space-2); }
+.rules .no h4 { color: var(--blind); }
+.rules .yes h4 { color: var(--gain); }
+.rules ul { padding-left: var(--space-4); margin: 0; }
+.rules li { font-family: var(--f-sans); }
+@media (max-width: 620px) { .rules { grid-template-columns: 1fr; } }
+
+/* ---- figure / chart ----------------------------------------------- */
+figure { margin: 0 0 var(--space-4); border: var(--border-hairline) solid var(--line); background: var(--bg); }
+figure svg { display: block; width: 100%; height: auto; }
+figcaption { font-family: var(--f-mono); font-size: var(--text-micro); color: var(--ink-3); padding: var(--space-2) var(--space-3); border-top: var(--border-hairline) solid var(--line); }
+/* all chart text is mono/micro by default; bold via inline font-weight where needed */
+figure svg text { font-family: var(--f-mono); font-size: var(--text-micro); }
+/* svg theme hooks */
+.svg-ink   { fill: var(--ink); }
+.svg-ink2  { fill: var(--ink-2); }
+.svg-ink3  { fill: var(--ink-3); }
+.svg-line  { stroke: var(--line); }
+.svg-line2 { stroke: var(--line-2); }
+.svg-axis  { stroke: var(--ink-3); }
+.svg-gain  { fill: var(--gain); }
+.svg-gain-s{ stroke: var(--gain); }
+.svg-base  { fill: var(--ink-3); }
+.svg-blind { fill: var(--blind); }
+/* Data points always sit on top of lines/gridlines with a clean halo. Markers
+   must be drawn AFTER lines and kept opaque for the halo to read. */
+figure svg circle { paint-order: stroke; stroke: var(--bg); stroke-width: 3.5px; }
+figure svg circle[fill="none"] { stroke-width: 1.3px; }  /* ring markers keep their own stroke */
+
+/* ---- climb (direction A) ------------------------------------------ */
+.climb { font-family: var(--f-mono); font-size: var(--text-sm); margin: var(--space-2) 0 var(--space-4); }
+.climb .row { display: grid; grid-template-columns: 210px 1fr 52px; align-items: center; gap: var(--space-3); padding: var(--space-1) 0; }
+.climb .lbl { color: var(--ink-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.climb .track { display: block; background: var(--surface); border: var(--border-hairline) solid var(--line); height: 18px; overflow: hidden; }
+.climb .fill { display: block; height: 100%; }
+.climb .fill.base { background: var(--ink-3); opacity: 0.5; }
+.climb .fill.ens  { background: var(--ink-3); }
+.climb .fill.priv { background: var(--gain); opacity: 0.6; }
+.climb .fill.sota { background: var(--gain); }
+.climb .val { text-align: right; font-variant-numeric: tabular-nums; color: var(--ink); }
+.stage-head { display: block; margin: var(--space-4) 0 var(--space-1); }
+
+/* ---- before/after delta (direction C) ----------------------------- */
+.deltawrap { display: grid; grid-template-columns: 1fr auto 1fr; border: var(--border-hairline) solid var(--line); font-family: var(--f-mono); margin: var(--space-1) 0 var(--space-4); }
+.deltawrap .cell { padding: var(--space-6) var(--space-5); }
+.deltawrap .cell.mid { display: flex; align-items: center; justify-content: center; border-left: var(--border-hairline) solid var(--line); border-right: var(--border-hairline) solid var(--line); background: var(--surface); font-size: var(--text-lead); color: var(--gain); }
+.deltawrap .k { display: block; }
+.deltawrap .big { font-size: var(--text-display); line-height: var(--leading-tight); margin: var(--space-2) 0 var(--space-1); font-variant-numeric: tabular-nums; font-weight: var(--weight-semibold); }
+.deltawrap .cell.before .big { color: var(--blind); }
+.deltawrap .cell.after .big { color: var(--gain); }
+@media (max-width: 620px) { .deltawrap { grid-template-columns: 1fr; } .deltawrap .cell.mid { border: 0; border-top: var(--border-hairline) solid var(--line); border-bottom: var(--border-hairline) solid var(--line); } }
+
+/* ---- stat row (demo) ---------------------------------------------- */
+.stats { display: grid; grid-template-columns: repeat(3,1fr); border: var(--border-hairline) solid var(--line); font-family: var(--f-mono); margin: 0 0 var(--space-5); }
+.stats .s { padding: var(--space-4); border-right: var(--border-hairline) solid var(--line); }
+.stats .s:last-child { border-right: 0; }
+.stats .s .v { font-size: var(--text-metric); font-weight: var(--weight-semibold); margin-top: var(--space-2); font-variant-numeric: tabular-nums; color: var(--ink); }
+.stats .s .v.gain { color: var(--gain); }
+@media (max-width: 620px) { .stats { grid-template-columns: 1fr; } .stats .s { border-right: 0; border-bottom: var(--border-hairline) solid var(--line); } }
+
+/* ---- buttons / deep-link ------------------------------------------ */
+.btn { display: inline-flex; align-items: center; gap: var(--space-2); font-family: var(--f-mono); font-size: var(--text-sm); padding: var(--space-2) var(--space-3); border: var(--border-hairline) solid var(--ink); background: var(--ink); color: var(--bg); text-decoration: none; cursor: pointer; border-radius: var(--radius-none); }
+.btn:hover { background: transparent; color: var(--ink); }
+.btn.ghost { background: transparent; color: var(--ink); }
+.btn.ghost:hover { background: var(--surface); }
+
+/* ---- footer ------------------------------------------------------- */
+.foot { margin-top: var(--space-10); padding-top: var(--space-4); border-top: var(--border-hairline) solid var(--line); font-family: var(--f-mono); font-size: var(--text-micro); color: var(--ink-3); display: flex; flex-wrap: wrap; gap: var(--space-2) var(--space-4); justify-content: space-between; }
+
+/* ---- gate --------------------------------------------------------- */
+#gate { position: fixed; inset: 0; background: var(--bg); display: flex; flex-direction: column; align-items: center; justify-content: center; gap: var(--space-4); padding: var(--space-6); z-index: 100; }
+#gate .m { font-size: var(--space-9); }
+#gate .t { color: var(--ink-3); }
+#gate form { display: flex; gap: var(--space-2); }
+#gate input { font-family: var(--f-mono); font-size: var(--text-sm); padding: var(--space-2) var(--space-3); background: var(--bg); border: var(--border-hairline) solid var(--line-2); color: var(--ink); outline: none; width: 200px; border-radius: var(--radius-none); }
+#gate input:focus { border-color: var(--ink); }
+#gate input.err { border-color: var(--blind); }
+#gate button { font-family: var(--f-mono); font-size: var(--text-sm); padding: var(--space-2) var(--space-4); background: var(--ink); color: var(--bg); border: var(--border-hairline) solid var(--ink); cursor: pointer; border-radius: var(--radius-none); }
+#gate .e { font-family: var(--f-mono); font-size: var(--text-micro); color: var(--blind); height: 14px; }
+body.locked { overflow: hidden; }
+
+@media (max-width: 620px) {
+  .wrap { padding: var(--space-7) var(--space-4) var(--space-11); }
+  h1 { font-size: var(--text-metric); }
+  .lead { font-size: var(--text-body); }
+  /* keep the full nav available on mobile: let the rail wrap instead of hiding it */
+  .rail { height: auto; flex-wrap: wrap; padding: var(--space-2) var(--space-4); gap: var(--space-1) var(--space-3); }
+  .rail .crumbs { flex-wrap: wrap; gap: var(--space-1) var(--space-3); }
+  .rail .spacer { display: none; }
+  .climb .row { grid-template-columns: 124px 1fr 44px; }
+}

--- a/.claude/skills/screamingface-design/reference/tokens.css
+++ b/.claude/skills/screamingface-design/reference/tokens.css
@@ -1,0 +1,108 @@
+/* ============================================================
+   SNAPSHOT 2026-06-11 from brand.screamingface.ai/tokens.css —
+   canonical source is the screamingface-brand repo. Re-pull if it
+   diverges. GENERATED there by build.mjs from tokens.json — DO NOT
+   hand-edit; edit tokens.json and regenerate. Reference only.
+   screamingface design tokens · honest-AGI initiative
+   ============================================================ */
+
+:root {
+  --bg: #ffffff;
+  --surface: #f6f6f7;
+  --surface-2: #efeff1;
+  --ink: #16181d;
+  --ink-2: #585d67;
+  --ink-3: #8b909a;
+  --line: #e6e7ea;
+  --line-2: #d4d6db;
+  --gain: #0f7a3d;
+  --gain-2: #128a45;
+  --gain-bg: #e8f3ec;
+  --blind: #b23b3b;
+  --blind-bg: #f6e7e6;
+  --mark: #c9821f;
+  color-scheme: light;
+
+  --f-display: "EB Garamond", "Iowan Old Style", Georgia, "Times New Roman", serif;
+  --f-sans: "IBM Plex Sans", system-ui, -apple-system, "Segoe UI", sans-serif;
+  --f-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --f-wordmark: "Rubik", system-ui, sans-serif;
+
+  /* size */
+  --col: 760px;
+  --col-wide: 1000px;
+  --rail-h: 44px;
+
+  /* text */
+  --text-display: 38px;
+  --text-metric: 30px;
+  --text-lead: 20px;
+  --text-body: 16px;
+  --text-sm: 13px;
+  --text-micro: 12px;
+  --text-label: 11px;
+
+  /* weight */
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+
+  /* tracking */
+  --tracking-tight: -0.01em;
+  --tracking-normal: 0;
+  --tracking-label: 0.1em;
+
+  /* leading */
+  --leading-tight: 1.16;
+  --leading-snug: 1.45;
+  --leading-body: 1.6;
+
+  /* space */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-7: 32px;
+  --space-8: 40px;
+  --space-9: 52px;
+  --space-10: 64px;
+  --space-11: 80px;
+  --space-12: 96px;
+
+  /* radius */
+  --radius-none: 0;
+
+  /* border */
+  --border-hairline: 1px;
+  --border-strong: 2px;
+
+  /* categorical data palette (series colors; theme-shared) */
+  --cat-blue: #4e79a7;
+  --cat-green: #59a14f;
+  --cat-amber: #d6a13c;
+  --cat-rust: #b4574a;
+  --cat-teal: #5a9b9a;
+  --cat-rose: #cf5d7a;
+  --cat-brown: #9c755f;
+  --cat-slate: #7e8794;
+}
+
+[data-theme="dark"] {
+  --bg: #0a0b0d;
+  --surface: #131519;
+  --surface-2: #1a1d22;
+  --ink: #e8eaed;
+  --ink-2: #9aa0aa;
+  --ink-3: #686e78;
+  --line: #20232a;
+  --line-2: #2c303a;
+  --gain: #35d07f;
+  --gain-2: #2bbd72;
+  --gain-bg: #11241b;
+  --blind: #f0726f;
+  --blind-bg: #2a1715;
+  --mark: #e0a23c;
+  color-scheme: dark;
+}

--- a/.claude/skills/screamingface-design/reference/tokens.json
+++ b/.claude/skills/screamingface-design/reference/tokens.json
@@ -1,0 +1,468 @@
+{
+  "$schema": "https://design-tokens.org/draft (DTCG-style; resolved by build.mjs)",
+  "$snapshot": "snapshot 2026-06-11 from brand.screamingface.ai — canonical source is the screamingface-brand repo. Re-pull if values diverge.",
+  "$description": "screamingface — canonical design tokens for the honest-AGI initiative. SINGLE SOURCE OF TRUTH. Edit here, then `node build.mjs` to regenerate public/tokens.css. Never hand-edit tokens.css. Standalone OpenMined brand system — self-contained, no external design-system dependency.",
+  "color": {
+    "primitive": {
+      "white": {
+        "$type": "color",
+        "$value": "#ffffff"
+      },
+      "paper-2": {
+        "$type": "color",
+        "$value": "#f6f6f7"
+      },
+      "paper-3": {
+        "$type": "color",
+        "$value": "#efeff1"
+      },
+      "ink-900": {
+        "$type": "color",
+        "$value": "#16181d"
+      },
+      "ink-600": {
+        "$type": "color",
+        "$value": "#585d67"
+      },
+      "ink-400": {
+        "$type": "color",
+        "$value": "#8b909a"
+      },
+      "line-200": {
+        "$type": "color",
+        "$value": "#e6e7ea"
+      },
+      "line-300": {
+        "$type": "color",
+        "$value": "#d4d6db"
+      },
+      "black": {
+        "$type": "color",
+        "$value": "#0a0b0d"
+      },
+      "d-surface": {
+        "$type": "color",
+        "$value": "#131519"
+      },
+      "d-surface-2": {
+        "$type": "color",
+        "$value": "#1a1d22"
+      },
+      "d-ink": {
+        "$type": "color",
+        "$value": "#e8eaed"
+      },
+      "d-ink-2": {
+        "$type": "color",
+        "$value": "#9aa0aa"
+      },
+      "d-ink-3": {
+        "$type": "color",
+        "$value": "#686e78"
+      },
+      "d-line": {
+        "$type": "color",
+        "$value": "#20232a"
+      },
+      "d-line-2": {
+        "$type": "color",
+        "$value": "#2c303a"
+      },
+      "green-700": {
+        "$type": "color",
+        "$value": "#0f7a3d"
+      },
+      "green-600": {
+        "$type": "color",
+        "$value": "#128a45"
+      },
+      "green-050": {
+        "$type": "color",
+        "$value": "#e8f3ec"
+      },
+      "green-400": {
+        "$type": "color",
+        "$value": "#35d07f"
+      },
+      "green-450": {
+        "$type": "color",
+        "$value": "#2bbd72"
+      },
+      "green-950": {
+        "$type": "color",
+        "$value": "#11241b"
+      },
+      "red-600": {
+        "$type": "color",
+        "$value": "#b23b3b"
+      },
+      "red-050": {
+        "$type": "color",
+        "$value": "#f6e7e6"
+      },
+      "red-400": {
+        "$type": "color",
+        "$value": "#f0726f"
+      },
+      "red-950": {
+        "$type": "color",
+        "$value": "#2a1715"
+      },
+      "amber-600": {
+        "$type": "color",
+        "$value": "#c9821f"
+      },
+      "amber-400": {
+        "$type": "color",
+        "$value": "#e0a23c"
+      }
+    },
+    "cat": {
+      "$description": "Categorical data palette for comparing many series in one chart (models, weeks, configs). 8 distinguishable, colorblind-aware mid-tones tuned to read on both white and dark. NO purple (anti-rule). Use in defined order; these are for DATA series only, distinct from semantic gain/blind. Assign via --cat-<name>.",
+      "blue": {
+        "$type": "color",
+        "$value": "#4e79a7"
+      },
+      "green": {
+        "$type": "color",
+        "$value": "#59a14f"
+      },
+      "amber": {
+        "$type": "color",
+        "$value": "#d6a13c"
+      },
+      "rust": {
+        "$type": "color",
+        "$value": "#b4574a"
+      },
+      "teal": {
+        "$type": "color",
+        "$value": "#5a9b9a"
+      },
+      "rose": {
+        "$type": "color",
+        "$value": "#cf5d7a"
+      },
+      "brown": {
+        "$type": "color",
+        "$value": "#9c755f"
+      },
+      "slate": {
+        "$type": "color",
+        "$value": "#7e8794"
+      }
+    }
+  },
+  "semantic": {
+    "$description": "Role-based tokens. These are what components reference. Two modes; build.mjs emits light to :root and dark to [data-theme=dark]. ONLY gain/blind carry chromatic meaning — gain = the model can read the source (correct / SOTA); blind = guessing without it. mark = the 😱 UI spark; never used to encode data.",
+    "light": {
+      "bg": {
+        "$type": "color",
+        "$value": "{color.primitive.white}"
+      },
+      "surface": {
+        "$type": "color",
+        "$value": "{color.primitive.paper-2}"
+      },
+      "surface-2": {
+        "$type": "color",
+        "$value": "{color.primitive.paper-3}"
+      },
+      "ink": {
+        "$type": "color",
+        "$value": "{color.primitive.ink-900}"
+      },
+      "ink-2": {
+        "$type": "color",
+        "$value": "{color.primitive.ink-600}"
+      },
+      "ink-3": {
+        "$type": "color",
+        "$value": "{color.primitive.ink-400}"
+      },
+      "line": {
+        "$type": "color",
+        "$value": "{color.primitive.line-200}"
+      },
+      "line-2": {
+        "$type": "color",
+        "$value": "{color.primitive.line-300}"
+      },
+      "gain": {
+        "$type": "color",
+        "$value": "{color.primitive.green-700}"
+      },
+      "gain-2": {
+        "$type": "color",
+        "$value": "{color.primitive.green-600}"
+      },
+      "gain-bg": {
+        "$type": "color",
+        "$value": "{color.primitive.green-050}"
+      },
+      "blind": {
+        "$type": "color",
+        "$value": "{color.primitive.red-600}"
+      },
+      "blind-bg": {
+        "$type": "color",
+        "$value": "{color.primitive.red-050}"
+      },
+      "mark": {
+        "$type": "color",
+        "$value": "{color.primitive.amber-600}"
+      },
+      "scheme": {
+        "$type": "other",
+        "$value": "light"
+      }
+    },
+    "dark": {
+      "bg": {
+        "$type": "color",
+        "$value": "{color.primitive.black}"
+      },
+      "surface": {
+        "$type": "color",
+        "$value": "{color.primitive.d-surface}"
+      },
+      "surface-2": {
+        "$type": "color",
+        "$value": "{color.primitive.d-surface-2}"
+      },
+      "ink": {
+        "$type": "color",
+        "$value": "{color.primitive.d-ink}"
+      },
+      "ink-2": {
+        "$type": "color",
+        "$value": "{color.primitive.d-ink-2}"
+      },
+      "ink-3": {
+        "$type": "color",
+        "$value": "{color.primitive.d-ink-3}"
+      },
+      "line": {
+        "$type": "color",
+        "$value": "{color.primitive.d-line}"
+      },
+      "line-2": {
+        "$type": "color",
+        "$value": "{color.primitive.d-line-2}"
+      },
+      "gain": {
+        "$type": "color",
+        "$value": "{color.primitive.green-400}"
+      },
+      "gain-2": {
+        "$type": "color",
+        "$value": "{color.primitive.green-450}"
+      },
+      "gain-bg": {
+        "$type": "color",
+        "$value": "{color.primitive.green-950}"
+      },
+      "blind": {
+        "$type": "color",
+        "$value": "{color.primitive.red-400}"
+      },
+      "blind-bg": {
+        "$type": "color",
+        "$value": "{color.primitive.red-950}"
+      },
+      "mark": {
+        "$type": "color",
+        "$value": "{color.primitive.amber-400}"
+      },
+      "scheme": {
+        "$type": "other",
+        "$value": "dark"
+      }
+    }
+  },
+  "font": {
+    "$description": "display = EB Garamond (headlines — classic old-style serif, timeless/credible, NOT a tech or mono face). sans = IBM Plex Sans (prose, dense small text). mono = IBM Plex Mono (data, labels, code, the rail — NEVER big display). wordmark = Rubik (logo lockup only).",
+    "display": {
+      "$type": "fontFamily",
+      "$value": "\"EB Garamond\", \"Iowan Old Style\", Georgia, \"Times New Roman\", serif",
+      "$description": "Headlines / h1 only. EB Garamond, a classic old-style serif (Garamond lineage). Chosen for timeless, credible, editorial gravitas, deliberately not a contemporary/tech serif (those read as modern/AI-generated). Set larger than a sans headline because of its small x-height."
+    },
+    "sans": {
+      "$type": "fontFamily",
+      "$value": "\"IBM Plex Sans\", system-ui, -apple-system, \"Segoe UI\", sans-serif"
+    },
+    "mono": {
+      "$type": "fontFamily",
+      "$value": "\"IBM Plex Mono\", ui-monospace, SFMono-Regular, Menlo, monospace"
+    },
+    "wordmark": {
+      "$type": "fontFamily",
+      "$value": "\"Rubik\", system-ui, sans-serif",
+      "$description": "The screamingface wordmark/logo lockup only — Rubik, matching the wider OpenMined brand family. Not for UI or body type."
+    }
+  },
+  "size": {
+    "$description": "Layout constants, not part of the color theme.",
+    "col": {
+      "$type": "dimension",
+      "$value": "760px"
+    },
+    "col-wide": {
+      "$type": "dimension",
+      "$value": "1000px"
+    },
+    "rail-h": {
+      "$type": "dimension",
+      "$value": "44px"
+    }
+  },
+  "text": {
+    "$description": "Type scale — one font-size per role. Compose with --f-*, --weight-*, --tracking-*, --leading-*. Seven roles, deliberately few.",
+    "display": {
+      "$type": "dimension",
+      "$value": "38px",
+      "$description": "h1 (Garamond)"
+    },
+    "metric": {
+      "$type": "dimension",
+      "$value": "30px",
+      "$description": "big stat numbers (Mono)"
+    },
+    "lead": {
+      "$type": "dimension",
+      "$value": "20px",
+      "$description": "the one opening line (Sans)"
+    },
+    "body": {
+      "$type": "dimension",
+      "$value": "16px",
+      "$description": "all prose (Sans)"
+    },
+    "sm": {
+      "$type": "dimension",
+      "$value": "13px",
+      "$description": "captions, table/data, climb (Sans or Mono)"
+    },
+    "micro": {
+      "$type": "dimension",
+      "$value": "12px",
+      "$description": "chart ticks/labels, rail, footer (Mono)"
+    },
+    "label": {
+      "$type": "dimension",
+      "$value": "11px",
+      "$description": "ALL uppercase labels: eyebrow, h2, kickers, table headers (Mono)"
+    }
+  },
+  "weight": {
+    "regular": {
+      "$type": "number",
+      "$value": "400"
+    },
+    "medium": {
+      "$type": "number",
+      "$value": "500"
+    },
+    "semibold": {
+      "$type": "number",
+      "$value": "600"
+    }
+  },
+  "tracking": {
+    "tight": {
+      "$type": "dimension",
+      "$value": "-0.01em"
+    },
+    "normal": {
+      "$type": "dimension",
+      "$value": "0"
+    },
+    "label": {
+      "$type": "dimension",
+      "$value": "0.1em",
+      "$description": "the single tracking for all caps labels"
+    }
+  },
+  "leading": {
+    "tight": {
+      "$type": "number",
+      "$value": "1.16"
+    },
+    "snug": {
+      "$type": "number",
+      "$value": "1.45"
+    },
+    "body": {
+      "$type": "number",
+      "$value": "1.6"
+    }
+  },
+  "space": {
+    "1": {
+      "$type": "dimension",
+      "$value": "4px"
+    },
+    "2": {
+      "$type": "dimension",
+      "$value": "8px"
+    },
+    "3": {
+      "$type": "dimension",
+      "$value": "12px"
+    },
+    "4": {
+      "$type": "dimension",
+      "$value": "16px"
+    },
+    "5": {
+      "$type": "dimension",
+      "$value": "20px"
+    },
+    "6": {
+      "$type": "dimension",
+      "$value": "24px"
+    },
+    "7": {
+      "$type": "dimension",
+      "$value": "32px"
+    },
+    "8": {
+      "$type": "dimension",
+      "$value": "40px"
+    },
+    "9": {
+      "$type": "dimension",
+      "$value": "52px"
+    },
+    "10": {
+      "$type": "dimension",
+      "$value": "64px"
+    },
+    "11": {
+      "$type": "dimension",
+      "$value": "80px"
+    },
+    "12": {
+      "$type": "dimension",
+      "$value": "96px"
+    },
+    "$description": "4px-based spacing scale for padding, margin, gap."
+  },
+  "radius": {
+    "$description": "The system is square. Radius is 0, on purpose (see anti-rules).",
+    "none": {
+      "$type": "dimension",
+      "$value": "0"
+    }
+  },
+  "border": {
+    "hairline": {
+      "$type": "dimension",
+      "$value": "1px"
+    },
+    "strong": {
+      "$type": "dimension",
+      "$value": "2px"
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds `.claude/skills/screamingface-design` — a project skill that auto-triggers on **any UI/UX/frontend/design/styling work repo-wide** and makes the screamingface brand system the single visual law, overriding shadcn/Tailwind defaults.

Parsed from `brand.screamingface.ai` across all sections: **brand guide, demo, live, climb, pareto, before/after, dark mode**.

## Contents

- **`SKILL.md`** — the direction ("infra-retro-modern"), five principles, the NEVER/INSTEAD anti-rules (no gradients/rounded/shadows/purple/shadcn-default), semantic + categorical color (only `--gain`/`--blind`/`--mark` carry meaning), four-family type system + 7-step scale, spacing/geometry, component recipes (`.stats`, `tr.sota`, `.climb`, `.deltawrap`, `figure`+SVG hooks, `.note`, `.btn`), voice guidelines, and a pre-finish self-check.
- **`reference/`** — dated snapshot (2026-06-11) of `tokens.json`, `tokens.css`, `style.css`, and a both-theme `starter.html`. `brand.screamingface.ai` / the `screamingface-brand` repo remain canonical.

## Scope

Skill only — no `app/`/`web/`/`cloud/` code changes. Applying the system to existing screens is follow-up work.

## Verification

- Skill is discovered (appears in the skills list with the repo-wide trigger).
- Token/CSS files pulled **verbatim** from the live source; spot-checked `--gain`, `radius 0`, the type scale, the four font families.
- `starter.html` renders correctly in **light and dark** and passes its own anti-rules.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215639770863288

🤖 Generated with [Claude Code](https://claude.com/claude-code)