### PR TITLE
SF-266: portal table alignment fix + durable livetruth receipt publishing

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "web/public/**"
       - "web/portal/**"
+      - "output_artifacts/eval_results/livetruth-latest.eval.jsonl"
       - ".github/workflows/deploy-website.yml"
 
   workflow_dispatch:
@@ -37,6 +38,10 @@ jobs:
           mkdir -p /tmp/sf-pages/portal
           cp -R web/public/. /tmp/sf-pages/
           cp -R web/portal/. /tmp/sf-pages/portal/
+          # Published data receipt at the site root: referenced by sf.json
+          # URL4 eval specs. Without it the live URL 404s after any deploy.
+          # (livetruth-masking.dataset.jsonl deliberately not published yet.)
+          cp output_artifacts/eval_results/livetruth-latest.eval.jsonl /tmp/sf-pages/
           python3 - <<'PY'
           import json
           import os

--- a/web/portal/benchmark.js
+++ b/web/portal/benchmark.js
@@ -95,7 +95,7 @@
 
       tr.appendChild(P.el("td", "num", entry.rank));
 
-      var specTd = P.el("td", "wrap");
+      var specTd = P.el("td", "cell-wrap");
       specTd.appendChild(P.link("mono", "spec.html?benchmark=" + encodeURIComponent(state.benchmarkId) + "&spec=" + encodeURIComponent(entry.spec_id), entry.spec_id));
       // Color must not be the only carrier of the sota meaning.
       if (isSota) specTd.appendChild(P.el("span", "sr-only", " (state of the art)"));

--- a/web/portal/main.js
+++ b/web/portal/main.js
@@ -230,7 +230,7 @@ window.ScorePortal = (function () {
     var tr = document.createElement("tr");
     tr.appendChild(el("td", null, b.display_name || b.id));
     tr.appendChild(el("td", "mono", b.id));
-    tr.appendChild(el("td", "wrap", b.description ? b.description : EM_DASH));
+    tr.appendChild(el("td", "cell-wrap", b.description ? b.description : EM_DASH));
 
     // dataset_url is API-provided/untrusted: only render it when it is a real
     // http(s) URL, so a javascript:/data: scheme can never reach the href.

--- a/web/portal/portal.css
+++ b/web/portal/portal.css
@@ -59,7 +59,7 @@ th[aria-sort="descending"] .sort-button .arrow { opacity: 1; }
 /* min-width keeps narrow viewports from crushing the column to a sliver —
    the .table-wrap x-scroll takes over instead. Derived from the space scale
    (2 × the largest step) so it stays tied to the token system. */
-td.wrap { white-space: normal; overflow-wrap: break-word; min-width: calc(2 * var(--space-12)); }
+td.cell-wrap { white-space: normal; overflow-wrap: break-word; min-width: calc(2 * var(--space-12)); }
 table .btn { white-space: nowrap; }
 
 /* ---- spec page run region ------------------------------------------- */

--- a/web/portal/spec.js
+++ b/web/portal/spec.js
@@ -14,7 +14,7 @@
   function historyRow(s) {
     var tr = document.createElement("tr");
     tr.appendChild(P.el("td", null, P.formatDate(s.submitted_at)));
-    tr.appendChild(P.el("td", "wrap", P.formatSubmitter(s.submitted_by)));
+    tr.appendChild(P.el("td", "cell-wrap", P.formatSubmitter(s.submitted_by)));
     tr.appendChild(P.el("td", "num", P.formatPercent(s.accuracy)));
     tr.appendChild(P.el("td", "num", P.formatQuestions(s.total_questions)));
     var verTd = document.createElement("td");

--- a/web/tests/portal_smoke.py
+++ b/web/tests/portal_smoke.py
@@ -202,6 +202,22 @@ def main() -> int:
             "T2", f"no {sink} usage in portal JS", re.search(sink, js_sources) is None
         )
 
+    # Published data receipts: sf.json URL4 specs and the scoreboard's
+    # livetruth dataset_url reference these at the site root — the deploy
+    # workflow must package them or the live URLs 404 (regression of
+    # 2026-06-11: a main deploy dropped the probe-branch-published copies).
+    workflow_text = (ROOT / ".github" / "workflows" / "deploy-website.yml").read_text()
+    # (livetruth-masking.dataset.jsonl is deliberately unpublished for now.)
+    for artifact in ("output_artifacts/eval_results/livetruth-latest.eval.jsonl",):
+        check(
+            "T21",
+            f"deploy workflow publishes {Path(artifact).name}",
+            artifact in workflow_text,
+        )
+        check(
+            "T21", f"{Path(artifact).name} tracked in repo", (ROOT / artifact).is_file()
+        )
+
     api_srv = ThreadingHTTPServer(("127.0.0.1", 0), StubApi)
     api_port = api_srv.server_address[1]
     threading.Thread(target=api_srv.serve_forever, daemon=True).start()

--- a/web/tests/portal_smoke.py
+++ b/web/tests/portal_smoke.py
@@ -369,6 +369,31 @@ def main() -> int:
                 == "Copy",
             )
 
+            # Cells must keep the brand table padding — the old `wrap` cell
+            # class collided with the brand's `.wrap` page-column class and
+            # inherited 40px/96px page padding, inflating rows to ~180px.
+            spec_pad = (
+                page.locator("#leaderboard-body tr")
+                .first.locator("td")
+                .nth(1)
+                .evaluate("el => getComputedStyle(el).padding")
+            )
+            check(
+                "T20",
+                "benchmark: spec cell keeps table padding (no .wrap collision)",
+                spec_pad == "8px 12px",
+                spec_pad,
+            )
+            row_h = page.locator("#leaderboard-body tr").first.evaluate(
+                "el => el.offsetHeight"
+            )
+            check(
+                "T20",
+                "benchmark: row height is content-sized (< 90px)",
+                row_h < 90,
+                f"{row_h}px",
+            )
+
             # ---- climb accuracy chart (viz-a direction, SF-266 phase 2a) ----
             climb = page.locator("#leaderboard-climb")
             check(


### PR DESCRIPTION
## Description

Two follow-ups to the merged portal re-skin (#281):

**1. Table alignment fix (missed the merge by minutes).** The wrapping-cell class `wrap` collides with the brand system's `.wrap` page-column class, so every wrapping cell inherited the page padding (`40px 20px 96px`) — inflating leaderboard rows to ~180px with skewed vertical alignment, which is what's live right now. Renamed the cell class to `cell-wrap` (root-cause removal). Two regression guards added: the spec cell's computed padding must equal the brand table padding, and rows must stay content-sized.

**2. Durable publication of the livetruth eval receipt.** `https://screamingface.ai/livetruth-latest.eval.jsonl` went 404 after #281's deploy: the workflow only packages `web/public` + `web/portal`, and the live copy had come from a one-off probe-branch `workflow_dispatch` (Jun 3) — so the next main deploy rebuilt the site without it. The URL is load-bearing: `sf.json`'s MainTwo URL4 eval spec points at it. The workflow now copies the receipt into the Pages artifact root and triggers on changes to it.

Deliberately **not** published for now (on hold by request): `livetruth-masking.dataset.jsonl`. Note the scoreboard's livetruth `dataset_url` still points at that URL, so the portal's Dataset link stays 404 until it's published or the `dataset_url` is updated.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215636036104464

## Affected Dependencies

None.

## How has this been tested?

- `web/tests/portal_smoke.py` extended to **71 assertions** (computed-padding + row-height guards; workflow-publishes-receipt + receipt-tracked guards). All green.
- Full Pages artifact build simulated locally: portal pages, API-base injection, and the receipt at the artifact root (valid JSONL).
- Root cause diagnosed via computed-style inspection in a real browser, fix verified by re-rendered screenshots at 1280px/375px in both themes.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
