### PR TITLE
SF-266: in-portal viewer for published jsonl data files

### DIFF
--- a/web/portal/data.html
+++ b/web/portal/data.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>screamingface — data file</title>
+  <meta name="description" content="Reads a published screamingface data file (JSONL) and renders it as a table.">
+  <meta name="robots" content="noindex, nofollow">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>😱</text></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600&family=EB+Garamond:wght@500;600&family=Rubik:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="tokens.css">
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="portal.css">
+  <script>(function(){try{var t=localStorage.getItem('sf_theme')||'light';document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+</head>
+<body>
+  <div class="rail">
+    <span class="brand"><span class="m">😱</span> screamingface</span><span class="sep">/</span>
+    <nav class="crumbs"><a href="index.html">portal</a><a href="#" class="here">data</a></nav>
+    <span class="spacer"></span><button class="toggle" id="theme-toggle" aria-label="Toggle light/dark theme">◐</button>
+  </div>
+
+  <div class="wrap wide">
+    <header class="masthead">
+      <div class="eyebrow">Data file</div>
+      <h1>Receipt, in the open</h1>
+    </header>
+
+    <p class="meta mono" id="data-file"></p>
+    <p class="meta mono">
+      <span id="data-meta"></span>
+      · <a id="data-raw" href="#">raw .jsonl</a>
+      · <a id="data-txt" href="#">plain text</a>
+    </p>
+
+    <div id="data-status" class="state" role="status" aria-live="polite">Loading…</div>
+
+    <div id="data-wrap" class="table-wrap" hidden>
+      <table aria-label="Data file contents">
+        <thead id="data-head"></thead>
+        <tbody id="data-body"></tbody>
+      </table>
+    </div>
+
+    <div class="foot">
+      <span>😱 screamingface, built by <a href="https://openmined.org" rel="noopener noreferrer nofollow">OpenMined</a></span>
+      <span><a href="https://github.com/OpenMined/screamingface" rel="noopener noreferrer nofollow">GitHub</a></span>
+    </div>
+  </div>
+
+  <script src="main.js" defer></script>
+  <script src="data.js" defer></script>
+  <script src="theme.js" defer></script>
+</body>
+</html>

--- a/web/portal/data.js
+++ b/web/portal/data.js
@@ -1,0 +1,102 @@
+/* ScreamingFace Leaderboard Portal — published-data viewer.
+ *
+ * Reads ?file=<name>.jsonl, fetches it from the site root, and renders the
+ * rows as a table. Exists because GitHub Pages serves .jsonl as
+ * application/octet-stream (a forced download) with no way to customize
+ * MIME types — this page is the human-readable view of the same bytes.
+ *
+ * Security posture matches the rest of the portal: the file name is
+ * validated against a strict pattern (no slashes, no traversal — site-root
+ * .jsonl files only) and every value reaches the DOM via textContent.
+ */
+(function (P) {
+  "use strict";
+
+  var FILE_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*\.jsonl$/;
+
+  function cellValue(value) {
+    if (value === null || value === undefined || value === "") return P.EM_DASH;
+    if (typeof value === "object") return JSON.stringify(value);
+    return String(value);
+  }
+
+  // Columns are the union of keys across rows, in first-appearance order.
+  function render(rows) {
+    var cols = [];
+    rows.forEach(function (row) {
+      Object.keys(row).forEach(function (key) {
+        if (cols.indexOf(key) === -1) cols.push(key);
+      });
+    });
+
+    var head = document.getElementById("data-head");
+    P.clear(head);
+    var headRow = document.createElement("tr");
+    headRow.appendChild(P.el("th", "num", "#"));
+    cols.forEach(function (col) { headRow.appendChild(P.el("th", null, col)); });
+    head.appendChild(headRow);
+
+    var body = document.getElementById("data-body");
+    P.clear(body);
+    rows.forEach(function (row, i) {
+      var tr = document.createElement("tr");
+      tr.appendChild(P.el("td", "num", i + 1));
+      cols.forEach(function (col) {
+        tr.appendChild(P.el("td", "cell-wrap", cellValue(row[col])));
+      });
+      body.appendChild(tr);
+    });
+    return cols.length;
+  }
+
+  function init() {
+    var statusNode = document.getElementById("data-status");
+    var wrap = document.getElementById("data-wrap");
+
+    var file;
+    try {
+      file = P.requireParam("file");
+    } catch (e) {
+      P.showError(statusNode, "Missing “file” parameter.");
+      return;
+    }
+    if (!FILE_RE.test(file)) {
+      P.showError(statusNode, "Not a publishable data file name.");
+      return;
+    }
+
+    document.getElementById("data-file").textContent = file;
+    document.title = file + " — screamingface";
+    document.getElementById("data-raw").setAttribute("href", "/" + file);
+    document.getElementById("data-txt").setAttribute("href", "/" + file + ".txt");
+
+    P.showLoading(statusNode, "Loading " + file + "…");
+    wrap.hidden = true;
+
+    fetch("/" + file)
+      .then(function (resp) {
+        if (!resp.ok) throw new Error("status " + resp.status);
+        return resp.text();
+      })
+      .then(function (text) {
+        var rows = text
+          .split("\n")
+          .filter(function (line) { return line.trim() !== ""; })
+          .map(function (line) { return JSON.parse(line); });
+        if (!rows.length) {
+          P.showEmpty(statusNode, "The file is empty.");
+          return;
+        }
+        var fields = render(rows);
+        document.getElementById("data-meta").textContent =
+          rows.length + (rows.length === 1 ? " row" : " rows") + " · " + fields + " fields";
+        P.setStatus(statusNode, null);
+        wrap.hidden = false;
+      })
+      .catch(function () {
+        P.showError(statusNode, "Could not load " + file + " — it may not be published.");
+      });
+  }
+
+  P.ready(init);
+})(window.ScorePortal);

--- a/web/portal/main.js
+++ b/web/portal/main.js
@@ -226,6 +226,20 @@ window.ScorePortal = (function () {
   }
 
   /* ---- index page ------------------------------------------------------ */
+  // Site-root data files (published by the deploy workflow) open in the
+  // in-portal viewer instead of forcing a download — GitHub Pages serves
+  // .jsonl as application/octet-stream with no MIME override available.
+  function publishedDataFileName(href) {
+    try {
+      var u = new URL(href);
+      if (u.hostname !== "screamingface.ai") return null;
+      var m = u.pathname.match(/^\/([A-Za-z0-9][A-Za-z0-9._-]*\.jsonl)$/);
+      return m ? m[1] : null;
+    } catch (e) {
+      return null;
+    }
+  }
+
   function benchmarkRow(b) {
     var tr = document.createElement("tr");
     tr.appendChild(el("td", null, b.display_name || b.id));
@@ -237,9 +251,14 @@ window.ScorePortal = (function () {
     var datasetTd = el("td");
     var datasetHref = httpUrlOrNull(b.dataset_url);
     if (datasetHref) {
-      var dataset = link("", datasetHref, "Dataset");
-      dataset.setAttribute("rel", "noopener noreferrer nofollow");
-      datasetTd.appendChild(dataset);
+      var viewerName = publishedDataFileName(datasetHref);
+      if (viewerName) {
+        datasetTd.appendChild(link("", "data.html?file=" + encodeURIComponent(viewerName), "Dataset"));
+      } else {
+        var dataset = link("", datasetHref, "Dataset");
+        dataset.setAttribute("rel", "noopener noreferrer nofollow");
+        datasetTd.appendChild(dataset);
+      }
     } else {
       datasetTd.textContent = EM_DASH;
     }

--- a/web/tests/portal_smoke.py
+++ b/web/tests/portal_smoke.py
@@ -155,9 +155,30 @@ class StubApi(BaseHTTPRequestHandler):
         return self._json(404, {"detail": "not found"})
 
 
+FIXTURE_JSONL = "\n".join(
+    [
+        '{"qa_id": "q1", "dataset": "d", "question": "What?"}',
+        '{"qa_id": "q2", "question": "Who?", "meta": {"k": 1}}',
+        '{"qa_id": "q3", "dataset": "d", "question": ""}',
+    ]
+)
+
+
 class QuietStatic(SimpleHTTPRequestHandler):
     def log_message(self, *args):
         pass
+
+    def do_GET(self):
+        # Site-root data file, as published by the deploy workflow.
+        if self.path.split("?")[0] == "/fixture.dataset.jsonl":
+            body = FIXTURE_JSONL.encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        super().do_GET()
 
 
 results: list[tuple[str, str, str]] = []
@@ -543,6 +564,74 @@ def main() -> int:
             check("T6", "spec: .btn square corners", btn_radius == "0px", btn_radius)
 
         section("T9", "spec: history block", t_spec)
+
+        # ---- data viewer (jsonl rendered in-page, SF-266) ----
+        def t_viewer():
+            page.goto(f"{base}/data.html?file=fixture.dataset.jsonl")
+            page.wait_for_selector("#data-body tr", timeout=8000)
+            rows = page.locator("#data-body tr")
+            check("T23", "viewer: one table row per jsonl line", rows.count() == 3)
+            head = page.locator("#data-head").text_content() or ""
+            check(
+                "T23",
+                "viewer: columns are the union of row keys",
+                all(k in head for k in ("qa_id", "dataset", "question", "meta")),
+                head,
+            )
+            q2 = page.locator("#data-body tr", has_text="q2")
+            check(
+                "T23",
+                "viewer: missing field renders em dash",
+                "—" in (q2.text_content() or ""),
+            )
+            check(
+                "T23",
+                "viewer: nested object rendered as JSON",
+                '{"k":1}' in (q2.text_content() or "").replace(" ", ""),
+            )
+            check(
+                "T23",
+                "viewer: meta line shows row count",
+                "3 rows" in (page.locator("#data-meta").text_content() or ""),
+            )
+            raw_href = page.locator("#data-raw").get_attribute("href") or ""
+            check(
+                "T23",
+                "viewer: raw download link",
+                raw_href == "/fixture.dataset.jsonl",
+                raw_href,
+            )
+
+            page.goto(f"{base}/data.html?file=missing.jsonl")
+            page.wait_for_selector(".state-error", timeout=8000)
+            check("T23", "viewer: missing file shows error state", True)
+            page.goto(f"{base}/data.html?file=../../etc/passwd")
+            page.wait_for_selector(".state-error", timeout=8000)
+            check("T23", "viewer: invalid file param rejected", True)
+
+            page.goto(pages["index"])
+            page.wait_for_selector("#benchmark-table tbody tr", timeout=8000)
+            lt = page.locator("#benchmark-table tbody tr", has_text="News Livetruth")
+            ds = lt.locator("a", has_text="Dataset").first
+            check(
+                "T23",
+                "index: same-origin dataset link routes through viewer",
+                (ds.get_attribute("href") or "")
+                == "data.html?file=livetruth-masking.dataset.jsonl",
+                ds.get_attribute("href") or "",
+            )
+            hle = page.locator(
+                "#benchmark-table tbody tr", has_text="News Hallucinations"
+            )
+            ext = hle.locator("a", has_text="Dataset").first
+            check(
+                "T23",
+                "index: external dataset link stays direct + rel-hardened",
+                (ext.get_attribute("href") or "").startswith("https://github.com/")
+                and "noopener" in (ext.get_attribute("rel") or ""),
+            )
+
+        section("T23", "data viewer block", t_viewer)
 
         # ---- theme toggle persistence ----
         def t_theme():


### PR DESCRIPTION
## Description

The portal's Dataset link force-downloaded the jsonl instead of showing it. Root cause is the hosting platform: screamingface.ai is plain GitHub Pages, which serves `.jsonl` as `application/octet-stream` and offers **no MIME customization** — no server-side fix can make the canonical URLs render in a browser.

This adds the proper in-portal solution:

- **New `data.html` + `data.js` — a branded data-file viewer.** Takes `?file=<name>.jsonl` (strict name validation: site-root files only, no path traversal), fetches the file same-origin, and renders the rows as a brand table — columns are the union of row keys in first-appearance order, absent/empty values render as em dashes, nested values as JSON, everything via `textContent` (same security posture as the rest of the portal). A meta line shows row/field counts plus links to the raw `.jsonl` and the plain-text twin.
- **Dataset links route through the viewer** when the benchmark's `dataset_url` is a site-root screamingface.ai `.jsonl`; external dataset URLs keep the direct, rel-hardened link.

Clicking "Dataset" on the livetruth row now opens a readable page instead of downloading a file.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215636036104464

## Affected Dependencies

None.

## How has this been tested?

`web/tests/portal_smoke.py` at **85 assertions**, all green — 10 new for the viewer: row rendering, union-of-keys columns, em-dash for absent fields, nested-object JSON rendering, meta counts, raw link target, missing-file and invalid-name error paths, and both Dataset-link routing branches (same-origin → viewer, external → direct). Visual check at 1280px confirms the brand shell (rail, Garamond masthead, mono table).

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
