### PR TITLE
SF-268: fix logo hover shake + trigger on whole sidebar header

### DIFF
--- a/apps/desktop/src/renderer/src/components/layout/BrandMark.tsx
+++ b/apps/desktop/src/renderer/src/components/layout/BrandMark.tsx
@@ -1,28 +1,37 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import screamShaking from '@/assets/scream-shaking.gif';
+
+interface BrandMarkProps {
+  /** When true, show the animated (shaking) mark instead of the resting emoji. */
+  animate?: boolean;
+}
 
 /**
  * The screamingface logo lockup: static 😱 mark + wordmark.
  *
  * Per the brand system, the static system emoji is the resting mark and the
  * animated mark "earns its place in moments that deserve it." Hovering the
- * logo is one such moment — we swap in the shaking GIF, remounting it so it
- * replays from the first frame each hover.
+ * sidebar header is one such moment — the parent drives `animate`, and we swap
+ * in the shaking GIF. Each time animation (re)starts we bump a nonce so the GIF
+ * reloads from frame one instead of showing a cached final frame.
  */
-export function BrandMark() {
-  const [animate, setAnimate] = useState(false);
+export function BrandMark({ animate = false }: BrandMarkProps) {
+  const [nonce, setNonce] = useState(0);
+  const wasAnimating = useRef(false);
+
+  useEffect(() => {
+    if (animate && !wasAnimating.current) setNonce((n) => n + 1);
+    wasAnimating.current = animate;
+  }, [animate]);
 
   return (
-    <span
-      className="flex items-center gap-2"
-      onMouseEnter={() => setAnimate(true)}
-      onMouseLeave={() => setAnimate(false)}
-    >
+    <span className="flex items-center gap-2">
       <span className="grid size-5 place-items-center" aria-hidden="true">
         {animate ? (
           <img
-            src={screamShaking}
+            key={nonce}
+            src={`${screamShaking}?n=${nonce}`}
             alt=""
             draggable={false}
             className="size-5 select-none"

--- a/apps/desktop/src/renderer/src/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/layout/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
   FileText,
   type LucideIcon,
 } from 'lucide-react';
+import { useState } from 'react';
 import { cn } from '@/lib/utils';
 import { BrandMark } from '@/components/layout/BrandMark';
 import type { BackendPollingError, PluginManifest } from '../../../../preload/types';
@@ -54,15 +55,23 @@ export function Sidebar({ currentView, onNavigate, plugins, onAigwLoginRequest }
   const { statuses, pollingError, refresh } = useBackendStatus();
   const gatewayStatus = isBackendStatusV2(statuses) ? statuses : null;
   const showPollingError = pollingError !== null && pollingError.consecutiveFailures >= 2;
+  const [logoHover, setLogoHover] = useState(false);
 
   return (
     <aside className="flex w-52 flex-col border-r border-sidebar-border bg-sidebar">
-      {/* App title — draggable region for macOS title bar */}
-      <div
-        className="flex items-center gap-2 px-4 pb-3 pt-8"
-        style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
-      >
-        <BrandMark />
+      {/* App title — outer strip stays draggable for the macOS title bar... */}
+      <div className="px-4 pb-3 pt-8" style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}>
+        {/* ...but the header row itself is interactive (no-drag) so hover events
+            fire inside the drag region. Hovering anywhere on the row plays the
+            animated mark. */}
+        <div
+          className="flex w-full items-center"
+          style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+          onMouseEnter={() => setLogoHover(true)}
+          onMouseLeave={() => setLogoHover(false)}
+        >
+          <BrandMark animate={logoHover} />
+        </div>
       </div>
 
       <nav className="flex flex-1 flex-col gap-0.5 px-2 py-2">


### PR DESCRIPTION
## Problem
The animated 😱 mark (added in #286) **never played on hover** — the sidebar logo lives inside the macOS title-bar **drag region** (`-webkit-app-region: drag`), which suppresses mouse events, so `onMouseEnter` never fired and the shaking GIF was never shown.

## Fix
- Wrap the header row in an interactive **`no-drag`** div that carries the hover handlers → events now fire.
- Make that row **full-width** so hovering **anywhere on the sidebar header** (not just the tiny mark) plays the shake (as requested).
- Keep the outer strip draggable so the window can still be moved.
- `BrandMark` is now controlled via an `animate` prop (state lifted to the header) and bumps a nonce on (re)start so the GIF replays from frame one.

## Notes
- The brand GIF is 16 frames, infinite-loop — it shakes continuously while shown.
- Builds green; no type errors.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215639975551466

🤖 Generated with [Claude Code](https://claude.com/claude-code)