### PR TITLE
SF-268: scale view headers + logo lockup 1.5x

### DIFF
--- a/apps/desktop/src/renderer/src/components/layout/BrandMark.tsx
+++ b/apps/desktop/src/renderer/src/components/layout/BrandMark.tsx
@@ -27,21 +27,21 @@ export function BrandMark({ animate = false }: BrandMarkProps) {
 
   return (
     <span className="flex items-center gap-2">
-      <span className="grid size-5 place-items-center" aria-hidden="true">
+      <span className="grid size-[1.875rem] place-items-center" aria-hidden="true">
         {animate ? (
           <img
             key={nonce}
             src={`${screamShaking}?n=${nonce}`}
             alt=""
             draggable={false}
-            className="size-5 select-none"
+            className="size-[1.875rem] select-none"
             style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
           />
         ) : (
-          <span className="text-lg leading-none">&#x1F631;</span>
+          <span className="text-[1.6875rem] leading-none">&#x1F631;</span>
         )}
       </span>
-      <span className="font-heading text-sm font-semibold text-sidebar-foreground">
+      <span className="font-heading text-[1.3125rem] font-semibold text-sidebar-foreground">
         screamingface
       </span>
     </span>

--- a/apps/desktop/src/renderer/src/views/CodeStudioView.tsx
+++ b/apps/desktop/src/renderer/src/views/CodeStudioView.tsx
@@ -50,7 +50,7 @@ export function CodeStudioView() {
     <div className="flex h-full flex-col">
       <div className="flex items-start justify-between border-b border-border px-6 py-4">
         <div>
-          <h1 className="text-lg font-semibold text-foreground">Code Studio</h1>
+          <h1 className="text-[1.6875rem] font-semibold text-foreground">Code Studio</h1>
           <p className="text-xs text-muted-foreground">
             Python scripts referenced by URL4 expressions (/data/code/&lt;name&gt;.py)
           </p>

--- a/apps/desktop/src/renderer/src/views/DashboardView.tsx
+++ b/apps/desktop/src/renderer/src/views/DashboardView.tsx
@@ -44,7 +44,7 @@ export function DashboardView({ server, onAigwLoginRequest }: DashboardViewProps
 
   return (
     <div className="mx-auto max-w-2xl space-y-4">
-      <h1 className="font-heading text-lg font-semibold text-foreground">Dashboard</h1>
+      <h1 className="font-heading text-[1.6875rem] font-semibold text-foreground">Dashboard</h1>
 
       {/* Venv status */}
       <VenvStatusCard status={venv.status} uvFound={venv.uvFound} />

--- a/apps/desktop/src/renderer/src/views/EvalStudioView.tsx
+++ b/apps/desktop/src/renderer/src/views/EvalStudioView.tsx
@@ -69,7 +69,7 @@ export function EvalStudioView({ pendingRun, onPendingConsumed }: EvalStudioView
     <div className="flex h-full flex-col">
       <div className="flex items-start justify-between border-b border-border px-6 py-4">
         <div>
-          <h1 className="text-lg font-semibold text-foreground">Eval Studio</h1>
+          <h1 className="text-[1.6875rem] font-semibold text-foreground">Eval Studio</h1>
           <p className="text-xs text-muted-foreground">
             History of evaluation runs across leaderboard entries
           </p>

--- a/apps/desktop/src/renderer/src/views/PluginView.tsx
+++ b/apps/desktop/src/renderer/src/views/PluginView.tsx
@@ -15,10 +15,9 @@ export function PluginView() {
 
   return (
     <div className="mx-auto max-w-2xl space-y-4">
-      <h1 className="font-heading text-lg font-semibold text-foreground">Plugins</h1>
+      <h1 className="font-heading text-[1.6875rem] font-semibold text-foreground">Plugins</h1>
       <p className="text-sm text-muted-foreground">
-        Load remote UI plugins from CDN URLs. Each plugin renders inside the app as a sidebar
-        entry.
+        Load remote UI plugins from CDN URLs. Each plugin renders inside the app as a sidebar entry.
       </p>
 
       <PluginBrowser onInstall={handleInstall} />

--- a/apps/desktop/src/renderer/src/views/PrivateDataView.tsx
+++ b/apps/desktop/src/renderer/src/views/PrivateDataView.tsx
@@ -18,7 +18,7 @@ export function PrivateDataView() {
     <div className="relative flex h-full flex-col">
       <div className="flex items-center justify-between border-b border-border px-6 py-4">
         <div>
-          <h1 className="text-xl">Private Data</h1>
+          <h1 className="text-[1.6875rem]">Private Data</h1>
           <p className="text-sm text-muted-foreground">
             Editable markdown entities. Reference any entry in url4 as{' '}
             <code>/private/&lt;uuid7&gt;</code>.

--- a/apps/desktop/src/renderer/src/views/SessionsView.tsx
+++ b/apps/desktop/src/renderer/src/views/SessionsView.tsx
@@ -262,7 +262,7 @@ export function SessionsView() {
       {/* Header */}
       <div className="flex items-center justify-between border-b border-border px-6 py-4">
         <div>
-          <h1 className="text-lg font-semibold text-foreground">Sessions</h1>
+          <h1 className="text-[1.6875rem] font-semibold text-foreground">Sessions</h1>
           <p className="text-xs text-muted-foreground">
             Each session runs a CLI tool in its own terminal with a dedicated proxy
           </p>

--- a/apps/desktop/src/renderer/src/views/SettingsView.tsx
+++ b/apps/desktop/src/renderer/src/views/SettingsView.tsx
@@ -316,7 +316,7 @@ export function SettingsView() {
 
   return (
     <div className="mx-auto max-w-2xl space-y-6">
-      <h1 className="font-heading text-lg font-semibold text-foreground">Settings</h1>
+      <h1 className="font-heading text-[1.6875rem] font-semibold text-foreground">Settings</h1>
 
       {/* Server settings */}
       <section className="rounded-none border border-border bg-card p-4">

--- a/apps/desktop/src/renderer/src/views/Url4StudioView.tsx
+++ b/apps/desktop/src/renderer/src/views/Url4StudioView.tsx
@@ -50,7 +50,7 @@ export function Url4StudioView() {
     <div className="flex h-full flex-col">
       <div className="flex items-start justify-between border-b border-border px-6 py-4">
         <div>
-          <h1 className="text-lg font-semibold text-foreground">URL4 Studio</h1>
+          <h1 className="text-[1.6875rem] font-semibold text-foreground">URL4 Studio</h1>
           <p className="text-xs text-muted-foreground">
             Named URL4 expressions you can run in Eval Studio and share
           </p>


### PR DESCRIPTION
## What
Per request, make all page headers and the text logo **1.5× bigger**.

- **View titles** — every `<h1>` view header scaled to exactly 1.5× (`text-lg` 1.125rem → `text-[1.6875rem]`). Normalized the one `text-xl` outlier (Private Data) so all eight view titles now match.
- **Logo lockup** (`BrandMark`) — wordmark `text-sm` → `text-[1.3125rem]`; the 😱 mark (emoji + hover GIF) and its box scaled to `1.6875rem`/`1.875rem` so the larger mark doesn't clip.

Build green.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215639975551466

🤖 Generated with [Claude Code](https://claude.com/claude-code)