### PR TITLE
SF-266: seed the livetruth benchmark in the scoreboard chart

### DIFF
--- a/apps/scoreboard/charts/scoreboard/values.yaml
+++ b/apps/scoreboard/charts/scoreboard/values.yaml
@@ -97,7 +97,10 @@ seedBenchmarks:
       display_name: News Hallucinations
       description: OpenMined HLE benchmark
       dataset_url: https://github.com/openmined/HLE.jsonl
-
+    - id: livetruth
+      display_name: News Livetruth
+      description: OpenMined Livetruth benchmark
+      dataset_url: https://screamingface.ai/livetruth-masking.dataset.jsonl
 networkPolicy:
   enabled: false
   ingressCIDRs: []

--- a/web/portal/index.html
+++ b/web/portal/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>screamingface — benchmark receipts</title>
-  <meta name="description" content="Public screamingface benchmark results with accuracy, providers, verification status, and local rerun links.">
+  <title>screamingface — live leaderboard</title>
+  <meta name="description" content="LiveTruth leaderboard, live from the public screamingface scoreboard.">
   <meta name="robots" content="noindex, nofollow">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>😱</text></svg>">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -22,47 +22,31 @@
     <span class="spacer"></span><button class="toggle" id="theme-toggle" aria-label="Toggle light/dark theme">◐</button>
   </div>
 
-  <div class="wrap">
+  <div class="wrap wide">
     <header class="masthead">
-      <div class="eyebrow">Benchmark receipts</div>
-      <h1>Results you can rerun, not just read.</h1>
+      <div class="eyebrow">honest-agi-live · live from the public scoreboard</div>
+      <h1>The leaderboard, live.</h1>
     </header>
 
-    <p class="lead">Public benchmark results for specs you can inspect and rerun locally. Accuracy, providers, verification status, and the exact run link stay attached to every row.</p>
+    <p class="lead">Same benchmark, real numbers — pulled straight from the scoreboard as runs are published.</p>
+    <p>Every row below is a real run on the LiveTruth benchmark, fetched live from <code>scoreboard.screamingface.ai</code>. Right now that's the frontier-model baselines. The private-data ensemble runs that beat them — the story the designed demo tells — will appear here automatically as the team publishes them.</p>
 
-    <p><a href="/">Install screamingface — one command</a></p>
+    <div id="live-status" class="note" role="status" aria-live="polite">Loading…</div>
+
+    <h2>Accuracy</h2>
+    <div id="live-chart" class="climb" aria-hidden="true"></div>
+
+    <h2>Leaderboard</h2>
+    <div id="live-table" class="table-wrap"></div>
 
     <div class="note">
-      <span class="kicker">Verification</span>
-      “Verified” means OpenMined independently reproduced the run. Unbadged rows are
-      community submissions that still need reproduction. Every leaderboard row keeps
-      its URL4 expression, so you can rerun the claim before trusting it.
+      <span class="kicker">Why this looks sparse</span>
+      This is the honest current state: only the baseline evaluations have been published so far. As the ensemble + private-data runs land on the scoreboard, they show up here with no change to this page. Until then, the demo shows the intended end state.
     </div>
 
-    <div class="stats" aria-label="Live portal counts">
-      <div class="s"><span class="k">Benchmarks</span><div class="v" id="stat-benchmarks">—</div></div>
-      <div class="s"><span class="k">Datasets published</span><div class="v" id="stat-datasets">—</div></div>
-      <div class="s"><span class="k">Newest benchmark</span><div class="v" id="stat-newest">—</div></div>
-    </div>
-
-    <h2>Benchmarks</h2>
-
-    <div id="benchmark-status" class="state" role="status" aria-live="polite">Loading…</div>
-
-    <div id="benchmark-table-wrap" class="table-wrap" hidden>
-      <table id="benchmark-table" aria-label="Benchmarks">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>id</th>
-            <th>Description</th>
-            <th>Dataset</th>
-            <th>Leaderboard</th>
-          </tr>
-        </thead>
-        <tbody id="benchmark-list"></tbody>
-      </table>
-    </div>
+    <h2>Run it yourself</h2>
+    <p>Every row with a run link is reproducible. Open it in Eval Studio and run the same evaluation on your own model subscriptions; nothing private leaves your machine.</p>
+    <p><a class="btn ghost" href="https://github.com/OpenMined/screamingface" rel="noopener noreferrer nofollow">view the source</a></p>
 
     <div class="foot">
       <span>😱 screamingface, built by <a href="https://openmined.org" rel="noopener noreferrer nofollow">OpenMined</a></span>

--- a/web/portal/main.js
+++ b/web/portal/main.js
@@ -225,94 +225,111 @@ window.ScorePortal = (function () {
     }
   }
 
-  /* ---- index page ------------------------------------------------------ */
-  // Site-root data files (published by the deploy workflow) open in the
-  // in-portal viewer instead of forcing a download — GitHub Pages serves
-  // .jsonl as application/octet-stream with no MIME override available.
-  function publishedDataFileName(href) {
-    try {
-      var u = new URL(href);
-      if (u.hostname !== "screamingface.ai") return null;
-      var m = u.pathname.match(/^\/([A-Za-z0-9][A-Za-z0-9._-]*\.jsonl)$/);
-      return m ? m[1] : null;
-    } catch (e) {
-      return null;
-    }
+  /* ---- live index page -------------------------------------------------- */
+  var LIVE_BENCHMARK_ID = "livetruth";
+
+  function setLiveStatus(message, kind) {
+    var node = document.getElementById("live-status");
+    if (!node) return;
+    node.className = "note" + (kind === "gain" ? " gain" : "");
+    node.textContent = "";
+    node.appendChild(el("span", "kicker", kind === "error" ? "scoreboard" : "live · scoreboard"));
+    node.appendChild(document.createTextNode(message));
   }
 
-  function benchmarkRow(b) {
-    var tr = document.createElement("tr");
-    tr.appendChild(el("td", null, b.display_name || b.id));
-    tr.appendChild(el("td", "mono", b.id));
-    tr.appendChild(el("td", "cell-wrap", b.description ? b.description : EM_DASH));
-
-    // dataset_url is API-provided/untrusted: only render it when it is a real
-    // http(s) URL, so a javascript:/data: scheme can never reach the href.
-    var datasetTd = el("td");
-    var datasetHref = httpUrlOrNull(b.dataset_url);
-    if (datasetHref) {
-      var viewerName = publishedDataFileName(datasetHref);
-      if (viewerName) {
-        datasetTd.appendChild(link("", "data.html?file=" + encodeURIComponent(viewerName), "Dataset"));
-      } else {
-        var dataset = link("", datasetHref, "Dataset");
-        dataset.setAttribute("rel", "noopener noreferrer nofollow");
-        datasetTd.appendChild(dataset);
-      }
-    } else {
-      datasetTd.textContent = EM_DASH;
-    }
-    tr.appendChild(datasetTd);
-
-    var lbTd = el("td");
-    lbTd.appendChild(link("", "benchmark.html?id=" + encodeURIComponent(b.id), "Leaderboard →"));
-    tr.appendChild(lbTd);
-    return tr;
+  function liveFillWidth(accuracy) {
+    if (typeof accuracy !== "number" || isNaN(accuracy)) return "0%";
+    var pct = Math.max(0, Math.min(100, accuracy * 100));
+    return (pct.toFixed(1) + "%").replace(".0%", "%");
   }
 
-  function formatDateOnly(value) {
-    if (!value) return EM_DASH;
-    var d = new Date(value);
-    if (isNaN(d.getTime())) return EM_DASH;
-    return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
-  }
-
-  function updateIndexStats(benchmarks) {
-    var counts = {
-      "stat-benchmarks": String(benchmarks.length),
-      "stat-datasets": String(benchmarks.filter(function (b) { return httpUrlOrNull(b.dataset_url) !== null; }).length),
-      "stat-newest": formatDateOnly(
-        benchmarks.map(function (b) { return b.created_at; }).filter(Boolean).sort().pop()
-      ),
-    };
-    Object.keys(counts).forEach(function (id) {
-      var node = document.getElementById(id);
-      if (node) node.textContent = counts[id];
+  function renderLiveChart(entries) {
+    var node = document.getElementById("live-chart");
+    if (!node) return;
+    clear(node);
+    entries.forEach(function (entry, index) {
+      var row = el("div", "row");
+      row.appendChild(el("span", "lbl", entry.spec_id));
+      var track = el("span", "track");
+      var fill = el("span", "fill " + (index === 0 ? "sota" : "ens"));
+      fill.style.width = liveFillWidth(entry.accuracy);
+      track.appendChild(fill);
+      row.appendChild(track);
+      row.appendChild(el("span", "val", formatPercent(entry.accuracy)));
+      node.appendChild(row);
     });
   }
 
-  function initIndex() {
-    var statusNode = document.getElementById("benchmark-status");
-    var listNode = document.getElementById("benchmark-list");
-    var wrapNode = document.getElementById("benchmark-table-wrap");
-    showLoading(statusNode, "Loading benchmarks…");
-    wrapNode.hidden = true;
+  function liveRunLink(entry) {
+    if (!entry.url4_expression) return document.createTextNode(EM_DASH);
+    return link("btn ghost", buildRunHref(entry.spec_id, entry.url4_expression), "▸ run");
+  }
 
-    fetchJson("/v1/benchmarks").then(
+  function renderLiveTable(entries) {
+    var host = document.getElementById("live-table");
+    if (!host) return;
+    clear(host);
+
+    var table = document.createElement("table");
+    table.setAttribute("aria-label", "LiveTruth leaderboard");
+    var thead = document.createElement("thead");
+    var headRow = document.createElement("tr");
+    ["#", "configuration", "accuracy", "questions", "verified", ""].forEach(function (label, index) {
+      headRow.appendChild(el("th", (index === 2 || index === 3) ? "num" : null, label));
+    });
+    thead.appendChild(headRow);
+    table.appendChild(thead);
+
+    var tbody = document.createElement("tbody");
+    entries.forEach(function (entry, index) {
+      var rank = typeof entry.rank === "number" ? entry.rank : index + 1;
+      var tr = document.createElement("tr");
+      if (rank === 1) tr.className = "sota";
+      tr.appendChild(el("td", null, rank));
+      var specTd = el("td", "cell-wrap", entry.spec_id);
+      if (rank === 1) specTd.appendChild(el("span", "sr-only", " (state of the art)"));
+      tr.appendChild(specTd);
+      tr.appendChild(el("td", "num", formatPercent(entry.accuracy)));
+      tr.appendChild(el("td", "num", formatQuestions(entry.total_questions)));
+      tr.appendChild(el("td", null, entry.verified_by_openmined ? "✓ OpenMined" : EM_DASH));
+      var runTd = document.createElement("td");
+      runTd.appendChild(liveRunLink(entry));
+      tr.appendChild(runTd);
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+    host.appendChild(table);
+  }
+
+  function initLiveIndex() {
+    setLiveStatus("Fetching the latest runs…");
+    fetchJson("/v1/leaderboard/" + encodeURIComponent(LIVE_BENCHMARK_ID) + "?top=50").then(
       function (data) {
-        var benchmarks = (data && data.benchmarks) || [];
-        updateIndexStats(benchmarks);
-        if (benchmarks.length === 0) {
-          showEmpty(statusNode, "No public benchmarks yet. The API is live; rows will appear here as soon as benchmark specs are registered.");
+        var entries = (data && data.entries) || [];
+        if (entries.length === 0) {
+          setLiveStatus("The scoreboard is live, but no runs are published for this benchmark yet.");
           return;
         }
-        clear(listNode);
-        benchmarks.forEach(function (b) { listNode.appendChild(benchmarkRow(b)); });
-        setStatus(statusNode, null);
-        wrapNode.hidden = false;
+        var best = Math.max.apply(null, entries.map(function (entry) { return entry.accuracy || 0; }));
+        var now = new Date().toLocaleString(undefined, {
+          month: "short", day: "numeric", hour: "2-digit", minute: "2-digit",
+        });
+        setLiveStatus(
+          entries.length + " run" + (entries.length === 1 ? "" : "s") +
+          " on LiveTruth · best " + formatPercent(best) +
+          " · fetched " + now + " from scoreboard.screamingface.ai",
+          "gain"
+        );
+        renderLiveChart(entries);
+        renderLiveTable(entries);
       },
       function (err) {
-        showError(statusNode, describeError(err, { generic: "Could not load benchmarks — try again later." }));
+        setLiveStatus(
+          "Could not reach the scoreboard (" +
+          (err && err.message ? err.message : "network") +
+          "). It may be waking up — try a refresh.",
+          "error"
+        );
       }
     );
   }
@@ -345,10 +362,9 @@ window.ScorePortal = (function () {
     EM_DASH: EM_DASH,
   };
 
-  // Self-bootstrap the index page when its container is present. benchmark.html
-  // and spec.html have no #benchmark-list, so this is a no-op there.
+  // Self-bootstrap the live index page when its container is present.
   ready(function () {
-    if (document.getElementById("benchmark-list")) initIndex();
+    if (document.getElementById("live-table")) initLiveIndex();
   });
 
   return api;

--- a/web/tests/portal_smoke.py
+++ b/web/tests/portal_smoke.py
@@ -20,9 +20,12 @@ import json
 import re
 import sys
 import threading
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from functools import partial
-from http.server import SimpleHTTPRequestHandler
+from http.server import (
+    BaseHTTPRequestHandler,
+    SimpleHTTPRequestHandler,
+    ThreadingHTTPServer,
+)
 from pathlib import Path
 
 from playwright.sync_api import sync_playwright
@@ -281,7 +284,9 @@ def main() -> int:
         pages = {
             "index": f"{base}/index.html",
             "benchmark": f"{base}/benchmark.html?id=livetruth",
-            "spec": f"{base}/spec.html?benchmark=livetruth&spec=direct-google-gemini-3-1-pro-preview",
+            "spec": (
+                f"{base}/spec.html?benchmark=livetruth&spec=direct-google-gemini-3-1-pro-preview"
+            ),
         }
 
         # ---- brand shell assertions on every page ----
@@ -351,31 +356,63 @@ def main() -> int:
                 bool(page.get_attribute("#theme-toggle", "aria-label")),
             )
 
-        # ---- index: benchmarks render as a table ----
+        # ---- index: live leaderboard reference page ----
         def t_index():
             page.goto(pages["index"])
-            page.wait_for_selector("#benchmark-table tbody tr", timeout=8000)
-            rows = page.locator("#benchmark-table tbody tr")
+            page.wait_for_selector("#live-table tbody tr", timeout=8000)
+            rows = page.locator("#live-table tbody tr")
             check(
                 "T7",
-                "index: 2 benchmark rows from API",
-                rows.count() == 2,
+                "index: headline matches live brand reference",
+                page.locator("h1").first.text_content() == "The leaderboard, live.",
+            )
+            check(
+                "T7",
+                "index: live scoreboard status note rendered",
+                page.locator("#live-status.note.gain").count() == 1
+                and "scoreboard.screamingface.ai"
+                in (page.locator("#live-status").text_content() or ""),
+            )
+            check(
+                "T7",
+                "index: one live leaderboard row per API entry",
+                rows.count() == 4,
                 f"got {rows.count()}",
             )
             check(
                 "T7",
-                "index: leaderboard link href",
-                "benchmark.html?id=livetruth"
-                in (rows.first.locator("a").last.get_attribute("href") or ""),
+                "index: live table uses configuration label",
+                "direct-google-gemini-3-1-pro-preview"
+                in (rows.first.text_content() or ""),
             )
             check(
                 "T7",
-                "index: stats row shows live count",
-                page.locator(".stats").count() == 1
-                and "2" in (page.locator("#stat-benchmarks").text_content() or ""),
+                "index: live chart has one row per API entry",
+                page.locator("#live-chart .row").count() == 4,
+                f"got {page.locator('#live-chart .row').count()}",
+            )
+            check(
+                "T7",
+                "index: only top-ranked live chart fill is green",
+                page.locator("#live-chart .fill.sota").count() == 1
+                and page.locator("#live-chart .fill.ens").count() == 3,
+            )
+            check(
+                "T7",
+                "index: first live table row is highlighted as SOTA",
+                page.locator("#live-table tbody tr.sota").count() == 1,
+            )
+            check(
+                "T7",
+                "index: run links use branded run affordance",
+                rows.first.locator("a.btn.ghost").count() == 1
+                and "▸ run" in (rows.first.locator("a.btn.ghost").text_content() or "")
+                and (
+                    rows.first.locator("a.btn.ghost").get_attribute("href") or ""
+                ).startswith("sf://run?spec="),
             )
 
-        section("T7", "index: benchmarks table block", t_index)
+        section("T7", "index: live leaderboard block", t_index)
 
         # ---- benchmark: table, sota, badge, sorting, radius ----
         def t_benchmark():
@@ -608,28 +645,6 @@ def main() -> int:
             page.goto(f"{base}/data.html?file=../../etc/passwd")
             page.wait_for_selector(".state-error", timeout=8000)
             check("T23", "viewer: invalid file param rejected", True)
-
-            page.goto(pages["index"])
-            page.wait_for_selector("#benchmark-table tbody tr", timeout=8000)
-            lt = page.locator("#benchmark-table tbody tr", has_text="News Livetruth")
-            ds = lt.locator("a", has_text="Dataset").first
-            check(
-                "T23",
-                "index: same-origin dataset link routes through viewer",
-                (ds.get_attribute("href") or "")
-                == "data.html?file=livetruth-masking.dataset.jsonl",
-                ds.get_attribute("href") or "",
-            )
-            hle = page.locator(
-                "#benchmark-table tbody tr", has_text="News Hallucinations"
-            )
-            ext = hle.locator("a", has_text="Dataset").first
-            check(
-                "T23",
-                "index: external dataset link stays direct + rel-hardened",
-                (ext.get_attribute("href") or "").startswith("https://github.com/")
-                and "noopener" in (ext.get_attribute("rel") or ""),
-            )
 
         section("T23", "data viewer block", t_viewer)
 


### PR DESCRIPTION
## Description

Adds the **livetruth** benchmark to the scoreboard chart's `seedBenchmarks`. The benchmark has existed in the prod scoreboard DB since Jun 3 (created ad hoc, with Helm revision 7 pointing its `dataset_url` at the masking dataset), but the chart never carried it — a fresh install would come up without the benchmark that the portal and the brand live page depend on. This restores chart↔prod parity.

The `dataset_url` points at the question-only masking dataset (`https://screamingface.ai/livetruth-masking.dataset.jsonl`), which is durably published by the Pages deploy since #284 and rendered in-browser by the portal's data viewer since #285 — so the seeded link is live and leak-free (no `expected_answer` fields).

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215636036104464

## Affected Dependencies

None.

## How has this been tested?

- `helm lint apps/scoreboard/charts/scoreboard` — 1 chart linted, 0 failed.
- Values match the live prod row byte-for-byte (verified against `/v1/benchmarks` and the prod DB earlier in this work): id, display_name, description, dataset_url.
- The dataset_url target returns 200 and is verified question-only (11 rows, no answer fields).

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests