### PR TITLE
SF-270: detect & surface backend-unavailable in eval runs (no silent zero-record runs)

### DIFF
--- a/apps/desktop/src/renderer/src/components/eval/EvalStatusBadge.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/EvalStatusBadge.tsx
@@ -5,6 +5,7 @@ const STATUS_STYLES: Record<EvalRunStatus, string> = {
   running: 'bg-primary/15 text-primary border-primary/30',
   done: 'bg-gain/15 text-gain border-gain/30',
   failed: 'bg-destructive/15 text-destructive border-destructive/30',
+  degraded: 'bg-primary/15 text-primary border-primary/30',
 };
 
 export function EvalStatusBadge({

--- a/apps/desktop/src/renderer/src/components/eval/types.ts
+++ b/apps/desktop/src/renderer/src/components/eval/types.ts
@@ -3,7 +3,7 @@
 // Mirrors apps/server/src/screamingface/plugins/eval_runs/schemas.py.
 // If the server schema changes, update both.
 
-export type EvalRunStatus = 'running' | 'done' | 'failed';
+export type EvalRunStatus = 'running' | 'done' | 'failed' | 'degraded';
 
 export interface EvalRunSummary {
   id: string;

--- a/apps/desktop/src/renderer/src/hooks/use-backend-status.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-backend-status.ts
@@ -38,10 +38,11 @@ export function useBackendStatus() {
     };
   }, []);
 
-  const refresh = async (): Promise<void> => {
+  const refresh = async (): Promise<BackendStatusResponse> => {
     const next = await window.electronAPI.backends.refresh();
     setStatuses(next);
     setLoaded(true);
+    return next;
   };
 
   return { statuses, pollingError, loaded, refresh };

--- a/apps/desktop/src/renderer/src/lib/__tests__/referenced-backends.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/referenced-backends.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { referencedBackends } from '../referenced-backends';
+
+describe('referencedBackends', () => {
+  it('finds the single backend in ScoredLiveTruth (claude only)', () => {
+    expect(referencedBackends("(...consensus=/claude($item.q)!'x'...)")).toEqual(['claude']);
+  });
+  it('finds all three in a 3-way ensemble', () => {
+    const e = '(claude:/claude($q)!a, codex:/codex($q)!b, gemini:/gemini($q)!c)!reduce';
+    expect(referencedBackends(e).sort()).toEqual(['claude', 'codex', 'gemini']);
+  });
+  it('excludes /python and /data (non-auth, not model backends)', () => {
+    expect(referencedBackends('/python(/data/code/check_correct.py)!{}')).toEqual([]);
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/referenced-backends.ts
+++ b/apps/desktop/src/renderer/src/lib/referenced-backends.ts
@@ -1,0 +1,14 @@
+// Which auth-requiring model backends a url4 expression dispatches to, by
+// scanning for their call-paths (/claude, /codex, /gemini, /ollama). /python,
+// /data and /private are intentionally excluded — no credentials / not models.
+// Mirrors the server's backend keying (backend_call_paths[0].lstrip('/')).
+const AUTH_BACKENDS = ['claude', 'codex', 'gemini', 'ollama'] as const;
+export type BackendName = (typeof AUTH_BACKENDS)[number];
+
+export function referencedBackends(expression: string): BackendName[] {
+  const found: BackendName[] = [];
+  for (const name of AUTH_BACKENDS) {
+    if (new RegExp(`/${name}\\b`).test(expression)) found.push(name);
+  }
+  return found;
+}

--- a/apps/desktop/src/renderer/src/views/EvalStudioView.tsx
+++ b/apps/desktop/src/renderer/src/views/EvalStudioView.tsx
@@ -6,7 +6,10 @@ import { Button } from '@/components/ui/button';
 import { EvalRunsList } from '@/components/eval/EvalRunsList';
 import { EvalRunDetail } from '@/components/eval/EvalRunDetail';
 import { AddEvalRunDialog } from '@/components/eval/AddEvalRunDialog';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { useStartEvalRun } from '@/hooks/use-start-eval-run';
+import { useBackendStatus, isBackendStatusV2 } from '@/hooks/use-backend-status';
+import { referencedBackends } from '@/lib/referenced-backends';
 import type { RunPayload } from '@/components/run/types';
 
 interface EvalStudioViewProps {
@@ -19,15 +22,47 @@ interface EvalStudioViewProps {
 export function EvalStudioView({ pendingRun, onPendingConsumed }: EvalStudioViewProps = {}) {
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
   const startEvalRun = useStartEvalRun();
+  const { refresh: refreshBackends } = useBackendStatus();
+  const [preflight, setPreflight] = useState<{ payload: RunPayload; unavailable: string[] } | null>(
+    null,
+  );
 
   // Start a run and immediately select it so the right panel shows it running
   // (the detail panel polls running runs for live progress).
-  const runAndSelect = useCallback(
+  const startRun = useCallback(
     (payload: RunPayload): void => {
       const runId = startEvalRun(payload);
       if (runId) setSelectedRunId(runId);
     },
     [startEvalRun],
+  );
+
+  // Preflight: if the spec references a model backend that isn't healthy, warn
+  // the user first (the run would otherwise silently produce no scored records).
+  // Advisory only — the user can start anyway, and a probe failure never blocks.
+  const runAndSelect = useCallback(
+    async (payload: RunPayload): Promise<void> => {
+      const needed = referencedBackends(payload.expression);
+      if (needed.length > 0) {
+        try {
+          const status = await refreshBackends();
+          const unavailable = isBackendStatusV2(status)
+            ? needed.filter((n) => {
+                const b = status.backends?.[n];
+                return !b || !b.authenticated || b.action !== 'healthy';
+              })
+            : [];
+          if (unavailable.length > 0) {
+            setPreflight({ payload, unavailable });
+            return; // wait for the user's confirm
+          }
+        } catch {
+          // status unreachable — fall through and start (don't block on a probe failure)
+        }
+      }
+      startRun(payload);
+    },
+    [refreshBackends, startRun],
   );
 
   // Clear the right panel when the selected run is deleted.
@@ -40,7 +75,7 @@ export function EvalStudioView({ pendingRun, onPendingConsumed }: EvalStudioView
   useEffect(() => {
     if (pendingRun && handledPendingRef.current !== pendingRun) {
       handledPendingRef.current = pendingRun;
-      runAndSelect(pendingRun);
+      void runAndSelect(pendingRun);
       onPendingConsumed?.();
     }
   }, [pendingRun, runAndSelect, onPendingConsumed]);
@@ -152,6 +187,23 @@ export function EvalStudioView({ pendingRun, onPendingConsumed }: EvalStudioView
       </ResizablePanelGroup>
 
       {adding && <AddEvalRunDialog onClose={() => setAdding(false)} onCreate={runAndSelect} />}
+
+      {preflight && (
+        <ConfirmDialog
+          title="Backend unavailable"
+          message={`${preflight.unavailable.join(', ')} ${
+            preflight.unavailable.length === 1 ? 'is' : 'are'
+          } unavailable. This run will likely produce no scored records. Start anyway?`}
+          confirmLabel="Start anyway"
+          cancelLabel="Cancel"
+          onConfirm={() => {
+            const p = preflight.payload;
+            setPreflight(null);
+            startRun(p);
+          }}
+          onCancel={() => setPreflight(null)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/server/src/screamingface/plugins/eval_runs/_hook_payloads.py
+++ b/apps/server/src/screamingface/plugins/eval_runs/_hook_payloads.py
@@ -28,6 +28,7 @@ class RunStartedPayload(TypedDict):
 class RunFinishedPayload(TypedDict):
     run_id: str
     finished_at: datetime
+    collected_errors: int
 
 
 class RunFailedPayload(TypedDict):

--- a/apps/server/src/screamingface/plugins/eval_runs/plugin.py
+++ b/apps/server/src/screamingface/plugins/eval_runs/plugin.py
@@ -89,13 +89,21 @@ class EvalRunsPlugin(Plugin):
             total = await EvalQuestion.filter(run_id=run_uuid).count()
             correct = await EvalQuestion.filter(run_id=run_uuid, correct=True).count()
             accuracy = (correct / total) if total else 0.0
-            await EvalRun.filter(id=run_uuid).update(
-                status="done",
-                finished_at=payload["finished_at"],
-                accuracy=accuracy,
-                total_questions=total,
-                correct_questions=correct,
-            )
+            collected_errors = int(payload.get("collected_errors", 0) or 0)
+            update: dict = {
+                "status": "done",
+                "finished_at": payload["finished_at"],
+                "accuracy": accuracy,
+                "total_questions": total,
+                "correct_questions": correct,
+            }
+            if collected_errors > 0:
+                update["status"] = "degraded"
+                update["error"] = (
+                    f"{collected_errors} row(s) errored (e.g. a model backend was "
+                    f"unavailable); {total} graded."
+                )
+            await EvalRun.filter(id=run_uuid).update(**update)
             self._question_idx_by_run.pop(run_id, None)
 
         async def _on_run_failed(**payload) -> None:

--- a/apps/server/src/screamingface/plugins/eval_runs/tests/test_degraded_status.py
+++ b/apps/server/src/screamingface/plugins/eval_runs/tests/test_degraded_status.py
@@ -1,0 +1,78 @@
+"""SF-270: a finished run is 'degraded' (not 'done') when rows were collected
+as errors (e.g. a model backend was unavailable), and 'done' when none were.
+
+Mirrors the async lifespan fixture pattern in test_hook_subscribers.py so
+Tortoise is initialized on the test's own event loop (a sync TestClient would
+init on a different loop and deadlock on cross-loop DB access)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+
+from screamingface.core.app import create_app
+from screamingface.core.config import AppConfig
+from screamingface.plugins.eval_runs._hook_payloads import (
+    HOOK_RUN_FINISHED,
+    HOOK_RUN_STARTED,
+)
+from screamingface.plugins.eval_runs.models import EvalRun
+
+
+@pytest.fixture
+def temp_state_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db = tmp_path / "state.db"
+    monkeypatch.setenv("SF_STATE__PATH", str(db))
+    return db
+
+
+@pytest.fixture
+async def app_with_eval_runs(temp_state_path: Path):
+    config = AppConfig(plugins=["state", "eval-runs"], plugin_config={})
+    app = create_app(config)
+    async with app.router.lifespan_context(app):
+        yield app
+
+
+async def _start(app: FastAPI, run_id: str, spec: str = "ScoredLiveTruth") -> None:
+    await app.state.hooks.emit_async(
+        HOOK_RUN_STARTED,
+        run_id=run_id,
+        spec_name=spec,
+        url4_expression="(...)",
+        started_at=datetime.now(UTC),
+    )
+
+
+@pytest.mark.asyncio
+async def test_finished_with_collected_errors_is_degraded(app_with_eval_runs: FastAPI) -> None:
+    run_id = str(uuid4())
+    await _start(app_with_eval_runs, run_id)
+    await app_with_eval_runs.state.hooks.emit_async(
+        HOOK_RUN_FINISHED,
+        run_id=run_id,
+        finished_at=datetime.now(UTC),
+        collected_errors=5,
+    )
+    row = await EvalRun.get(id=run_id)
+    assert row.status == "degraded"
+    assert row.error and "errored" in row.error
+
+
+@pytest.mark.asyncio
+async def test_finished_clean_is_done(app_with_eval_runs: FastAPI) -> None:
+    run_id = str(uuid4())
+    await _start(app_with_eval_runs, run_id)
+    await app_with_eval_runs.state.hooks.emit_async(
+        HOOK_RUN_FINISHED,
+        run_id=run_id,
+        finished_at=datetime.now(UTC),
+        collected_errors=0,
+    )
+    row = await EvalRun.get(id=run_id)
+    assert row.status == "done"
+    assert row.error is None

--- a/apps/server/src/screamingface/plugins/url4_executor/routes.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/routes.py
@@ -147,11 +147,13 @@ def create_router(app=None) -> APIRouter:  # type: ignore[no-untyped-def]
                 )
             raise HTTPException(status_code=502, detail=f"url4 evaluation failed: {exc}")
 
+        collected_errors = getattr(interpreter, "_collected_errors", 0)
         if run_id:
             await request.app.state.hooks.emit_async(
                 HOOK_RUN_FINISHED,
                 run_id=run_id,
                 finished_at=datetime.now(UTC),
+                collected_errors=collected_errors,
             )
 
         # Record result on the FastAPI auto-instrumented span
@@ -183,7 +185,6 @@ def create_router(app=None) -> APIRouter:  # type: ignore[no-untyped-def]
 
         # SF-236: surface ;foreach.on_error=collect failures so they are not
         # silently dropped downstream. HTTP stays 200 (collect mode is robust).
-        collected_errors = getattr(interpreter, "_collected_errors", 0)
         if collected_errors:
             response.headers["X-SF-Collected-Errors"] = str(collected_errors)
         return response

--- a/docs/superpowers/plans/2026-06-12-backend-unavailable-handling.md
+++ b/docs/superpowers/plans/2026-06-12-backend-unavailable-handling.md
@@ -1,0 +1,392 @@
+# Backend-Unavailable Handling — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans. Steps use checkbox (`- [ ]`).
+
+**Goal:** Stop eval runs from silently producing zero records when a model backend is down — warn the user before the run (preflight) and persist a `degraded` status + reason after it.
+
+**Architecture:** Server reads the already-computed `interpreter._collected_errors` and threads it into `HOOK_RUN_FINISHED`; `eval_runs` records `status="degraded"` + a reason when errors were collected. Desktop preflights the run by matching the backends the expression references against `/backends/status` health, and renders the new `degraded` status.
+
+**Tech Stack:** FastAPI, Tortoise, pytest; React 19 + TS, vitest.
+
+**Ticket:** SF-270 — https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215654793910878
+**Branch:** `SF-270-backend-unavailable-handling`. Spec: `docs/superpowers/specs/2026-06-12-backend-unavailable-handling-design.md`.
+
+---
+
+## Task 1: Server — persist `degraded` from collected errors
+
+**Files:**
+- Modify: `apps/server/src/screamingface/plugins/eval_runs/_hook_payloads.py`
+- Modify: `apps/server/src/screamingface/plugins/eval_runs/plugin.py` (`_on_run_finished`)
+- Modify: `apps/server/src/screamingface/plugins/url4_executor/routes.py` (`HOOK_RUN_FINISHED` emit)
+- Test: `apps/server/src/screamingface/plugins/eval_runs/tests/test_degraded_status.py`
+
+- [ ] **Step 1: Failing test for the handler**
+
+Create `apps/server/src/screamingface/plugins/eval_runs/tests/test_degraded_status.py`:
+```python
+"""eval run goes 'degraded' (not 'done') when rows were collected as errors."""
+from __future__ import annotations
+
+import uuid
+import pytest
+from fastapi.testclient import TestClient
+
+from screamingface.core.config import AppConfig
+from screamingface.core.app import create_app
+from screamingface.plugins.state.testing import temp_state_path  # noqa: F401  (fixture)
+
+
+@pytest.fixture
+def client(temp_state_path):
+    app = create_app(AppConfig(plugins=["state", "eval-runs"], plugin_config={}))
+    with TestClient(app) as c:
+        yield app, c
+
+
+@pytest.mark.asyncio
+async def test_finished_with_collected_errors_is_degraded(client):
+    app, _ = client
+    from screamingface.plugins.eval_runs.models import EvalRun
+    from screamingface.plugins.eval_runs._hook_payloads import (
+        HOOK_RUN_STARTED, HOOK_RUN_FINISHED,
+    )
+    from datetime import datetime, UTC
+
+    rid = str(uuid.uuid4())
+    await app.state.hooks.emit_async(
+        HOOK_RUN_STARTED, run_id=rid, spec_name="ScoredLiveTruth",
+        url4_expression="(...)", started_at=datetime.now(UTC),
+    )
+    await app.state.hooks.emit_async(
+        HOOK_RUN_FINISHED, run_id=rid, finished_at=datetime.now(UTC), collected_errors=5,
+    )
+    run = await EvalRun.get(id=uuid.UUID(rid))
+    assert run.status == "degraded"
+    assert run.error and "errored" in run.error
+
+
+@pytest.mark.asyncio
+async def test_finished_clean_is_done(client):
+    app, _ = client
+    from screamingface.plugins.eval_runs.models import EvalRun
+    from screamingface.plugins.eval_runs._hook_payloads import HOOK_RUN_STARTED, HOOK_RUN_FINISHED
+    from datetime import datetime, UTC
+
+    rid = str(uuid.uuid4())
+    await app.state.hooks.emit_async(HOOK_RUN_STARTED, run_id=rid, spec_name="x",
+                                     url4_expression="x", started_at=datetime.now(UTC))
+    await app.state.hooks.emit_async(HOOK_RUN_FINISHED, run_id=rid, finished_at=datetime.now(UTC),
+                                     collected_errors=0)
+    run = await EvalRun.get(id=uuid.UUID(rid))
+    assert run.status == "done"
+    assert run.error is None
+```
+
+- [ ] **Step 2: Run it — expect failure**
+
+Run: `cd apps/server && uv run pytest src/screamingface/plugins/eval_runs/tests/test_degraded_status.py -v`
+Expected: FAIL (handler ignores `collected_errors`; status is `done`). If the test-fixture import path differs, mirror the existing `eval_runs/tests/` files' fixture usage (they already use `temp_state_path`).
+
+- [ ] **Step 3: Extend the payload type**
+
+In `_hook_payloads.py`, add the field to `RunFinishedPayload`:
+```python
+class RunFinishedPayload(TypedDict):
+    run_id: str
+    finished_at: datetime
+    collected_errors: int
+```
+
+- [ ] **Step 4: Handle it in `_on_run_finished`**
+
+In `eval_runs/plugin.py`, replace the body of `_on_run_finished` with:
+```python
+        async def _on_run_finished(**payload) -> None:
+            run_id = payload["run_id"]
+            run_uuid = UUID(run_id)
+            total = await EvalQuestion.filter(run_id=run_uuid).count()
+            correct = await EvalQuestion.filter(run_id=run_uuid, correct=True).count()
+            accuracy = (correct / total) if total else 0.0
+            collected_errors = int(payload.get("collected_errors", 0) or 0)
+            update: dict = {
+                "status": "done",
+                "finished_at": payload["finished_at"],
+                "accuracy": accuracy,
+                "total_questions": total,
+                "correct_questions": correct,
+            }
+            if collected_errors > 0:
+                update["status"] = "degraded"
+                update["error"] = (
+                    f"{collected_errors} row(s) errored (e.g. a model backend was "
+                    f"unavailable); {total} graded."
+                )
+            await EvalRun.filter(id=run_uuid).update(**update)
+            self._question_idx_by_run.pop(run_id, None)
+```
+
+- [ ] **Step 5: Thread `collected_errors` from the route**
+
+In `url4_executor/routes.py`, the `HOOK_RUN_FINISHED` emit (the `if run_id:` block after a successful `evaluate`) becomes:
+```python
+        collected_errors = getattr(interpreter, "_collected_errors", 0)
+        if run_id:
+            await request.app.state.hooks.emit_async(
+                HOOK_RUN_FINISHED,
+                run_id=run_id,
+                finished_at=datetime.now(UTC),
+                collected_errors=collected_errors,
+            )
+```
+Leave the later SF-236 header block as-is (it re-reads `collected_errors`; reuse the variable if already defined above — remove the duplicate `collected_errors = getattr(...)` line there to avoid shadowing, keeping the `if collected_errors:` header set).
+
+- [ ] **Step 6: Run tests — expect pass**
+
+Run: `cd apps/server && uv run pytest src/screamingface/plugins/eval_runs -v`
+Expected: PASS (new degraded tests + existing eval_runs tests).
+
+- [ ] **Step 7: Commit**
+```bash
+git add apps/server/src/screamingface/plugins/eval_runs apps/server/src/screamingface/plugins/url4_executor/routes.py
+git commit -m "SF-270: persist degraded eval-run status from collected errors"
+```
+
+---
+
+## Task 2: Desktop — referenced-backends helper
+
+**Files:**
+- Create: `apps/desktop/src/renderer/src/lib/referenced-backends.ts`
+- Test: `apps/desktop/src/renderer/src/lib/__tests__/referenced-backends.test.ts`
+
+- [ ] **Step 1: Failing test**
+
+Create `apps/desktop/src/renderer/src/lib/__tests__/referenced-backends.test.ts`:
+```ts
+import { describe, expect, it } from 'vitest';
+import { referencedBackends } from '../referenced-backends';
+
+describe('referencedBackends', () => {
+  it('finds the single backend in ScoredLiveTruth (claude only)', () => {
+    expect(referencedBackends('(...consensus=/claude($item.q)!\'x\'...)')).toEqual(['claude']);
+  });
+  it('finds all three in a 3-way ensemble', () => {
+    const e = '(claude:/claude($q)!a, codex:/codex($q)!b, gemini:/gemini($q)!c)!reduce';
+    expect(referencedBackends(e).sort()).toEqual(['claude', 'codex', 'gemini']);
+  });
+  it('excludes /python and /data (non-auth, not model backends)', () => {
+    expect(referencedBackends('/python(/data/code/check_correct.py)!{}')).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+Run: `cd apps/desktop && npx vitest run src/renderer/src/lib/__tests__/referenced-backends.test.ts`
+Expected: FAIL (module missing).
+
+- [ ] **Step 3: Implement**
+
+Create `apps/desktop/src/renderer/src/lib/referenced-backends.ts`:
+```ts
+// Which auth-requiring model backends a url4 expression dispatches to, by
+// scanning for their call-paths (/claude, /codex, /gemini, /ollama). /python,
+// /data and /private are intentionally excluded — no credentials / not models.
+// Mirrors the server's backend keying (backend_call_paths[0].lstrip('/')).
+const AUTH_BACKENDS = ['claude', 'codex', 'gemini', 'ollama'] as const;
+export type BackendName = (typeof AUTH_BACKENDS)[number];
+
+export function referencedBackends(expression: string): BackendName[] {
+  const found: BackendName[] = [];
+  for (const name of AUTH_BACKENDS) {
+    if (new RegExp(`/${name}\\b`).test(expression)) found.push(name);
+  }
+  return found;
+}
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+Run: `cd apps/desktop && npx vitest run src/renderer/src/lib/__tests__/referenced-backends.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+```bash
+git add apps/desktop/src/renderer/src/lib/referenced-backends.ts apps/desktop/src/renderer/src/lib/__tests__/referenced-backends.test.ts
+git commit -m "SF-270: referenced-backends helper + tests"
+```
+
+---
+
+## Task 3: Desktop — `degraded` status type, badge, and refresh-returns-value
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/components/eval/types.ts`
+- Modify: `apps/desktop/src/renderer/src/components/eval/EvalStatusBadge.tsx`
+- Modify: `apps/desktop/src/renderer/src/hooks/use-backend-status.ts`
+
+- [ ] **Step 1: Add `degraded` to the status union**
+
+In `components/eval/types.ts`, change:
+```ts
+export type EvalRunStatus = 'running' | 'done' | 'failed' | 'degraded';
+```
+
+- [ ] **Step 2: Style the `degraded` badge (amber = warning, not hard fail)**
+
+In `EvalStatusBadge.tsx`, add to `STATUS_STYLES`:
+```ts
+  degraded: 'bg-primary/15 text-primary border-primary/30',
+```
+(Keep `running`/`done`/`failed` as-is.)
+
+- [ ] **Step 3: Make `refresh()` return the fresh statuses**
+
+In `use-backend-status.ts`, the `refresh` callback currently sets state and returns void; have it also return the value so a preflight can read it without a stale-closure re-render:
+```ts
+  const refresh = async (): Promise<BackendStatusResponse> => {
+    const next = await window.electronAPI.backends.refresh();
+    setStatuses(next);
+    return next;
+  };
+```
+(Keep the rest of the return object; `refresh` is already exported.)
+
+- [ ] **Step 4: Typecheck**
+
+Run: `cd apps/desktop && npx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "EvalStatusBadge|use-backend-status|eval/types" || echo "clean"`
+Expected: `clean`.
+
+- [ ] **Step 5: Commit**
+```bash
+git add apps/desktop/src/renderer/src/components/eval/types.ts apps/desktop/src/renderer/src/components/eval/EvalStatusBadge.tsx apps/desktop/src/renderer/src/hooks/use-backend-status.ts
+git commit -m "SF-270: degraded eval status type+badge; refresh returns statuses"
+```
+
+---
+
+## Task 4: Desktop — preflight warning before a run
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/views/EvalStudioView.tsx`
+
+Preflight gates `runAndSelect`: extract referenced backends, refresh status, and if any is unavailable, show a `ConfirmDialog` ("Start anyway?"). Confirm proceeds; Cancel aborts.
+
+- [ ] **Step 1: Add imports + preflight state**
+
+At the top of `EvalStudioView.tsx`, add imports:
+```ts
+import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { useBackendStatus, isBackendStatusV2 } from '@/hooks/use-backend-status';
+import { referencedBackends } from '@/lib/referenced-backends';
+```
+Inside the component, add:
+```ts
+  const { refresh: refreshBackends } = useBackendStatus();
+  const [preflight, setPreflight] = useState<{ payload: RunPayload; unavailable: string[] } | null>(null);
+```
+
+- [ ] **Step 2: Split out the actual start + make `runAndSelect` preflight**
+
+Replace the existing `runAndSelect` with a starter + an async preflight wrapper:
+```ts
+  const startRun = useCallback(
+    (payload: RunPayload): void => {
+      const runId = startEvalRun(payload);
+      if (runId) setSelectedRunId(runId);
+    },
+    [startEvalRun],
+  );
+
+  const runAndSelect = useCallback(
+    async (payload: RunPayload): Promise<void> => {
+      const needed = referencedBackends(payload.expression);
+      if (needed.length > 0) {
+        try {
+          const status = await refreshBackends();
+          const unavailable = isBackendStatusV2(status)
+            ? needed.filter((n) => {
+                const b = status.backends?.[n];
+                return !b || !b.authenticated || b.action !== 'healthy';
+              })
+            : [];
+          if (unavailable.length > 0) {
+            setPreflight({ payload, unavailable });
+            return; // wait for the user's confirm
+          }
+        } catch {
+          // status unreachable — fall through and start (don't block on a probe failure)
+        }
+      }
+      startRun(payload);
+    },
+    [refreshBackends, startRun],
+  );
+```
+Update the `pendingRun` effect call to `void runAndSelect(pendingRun);` (it's now async).
+
+- [ ] **Step 3: Render the confirm dialog**
+
+Near the other modals in the returned JSX (e.g. beside `{adding && <AddEvalRunDialog … />}`), add:
+```tsx
+      {preflight && (
+        <ConfirmDialog
+          title="Backend unavailable"
+          message={`${preflight.unavailable.join(', ')} ${
+            preflight.unavailable.length === 1 ? 'is' : 'are'
+          } unavailable. This run will likely produce no scored records. Start anyway?`}
+          confirmLabel="Start anyway"
+          cancelLabel="Cancel"
+          onConfirm={() => {
+            const p = preflight.payload;
+            setPreflight(null);
+            startRun(p);
+          }}
+          onCancel={() => setPreflight(null)}
+        />
+      )}
+```
+
+- [ ] **Step 4: Build**
+
+Run: `cd apps/desktop && npm run build 2>&1 | tail -2`
+Expected: `✓ built`. (If `ConfirmDialog` prop names differ, match `components/ConfirmDialog.tsx`: `title`, `message`, `confirmLabel`, `cancelLabel`, `onConfirm`, `onCancel`.)
+
+- [ ] **Step 5: Commit**
+```bash
+git add apps/desktop/src/renderer/src/views/EvalStudioView.tsx
+git commit -m "SF-270: preflight warn when a referenced backend is unavailable"
+```
+
+---
+
+## Task 5: Verification
+
+- [ ] **Step 1: Server tests**
+
+Run: `cd apps/server && uv run pytest src/screamingface/plugins/eval_runs src/screamingface/plugins/url4_executor -q`
+Expected: all PASS.
+
+- [ ] **Step 2: Desktop tests + build**
+
+Run: `cd apps/desktop && npx vitest run src/renderer/src/lib/__tests__/referenced-backends.test.ts && npm run build 2>&1 | tail -2`
+Expected: vitest PASS; build `✓ built`.
+
+- [ ] **Step 3: Manual smoke (one dev app; close any first)**
+
+`cd apps/desktop && npm run dev`. With the Claude backend logged out/unavailable: start ScoredLiveTruth → expect the **preflight dialog** ("claude is unavailable… Start anyway?"). Start anyway → when it finishes, the run shows a **degraded** badge with the "N row(s) errored…" reason. With Claude healthy → no dialog, run completes `done`.
+
+- [ ] **Step 4: Final commit (if any verification fixes)**
+```bash
+git add -A && git commit -m "SF-270: verification fixes" || echo "nothing to commit"
+```
+
+---
+
+## Self-review notes (addressed)
+
+- **Spec coverage:** preflight (Task 4, helper Task 2, refresh-returns Task 3), degraded persistence (Task 1), degraded display (Task 3 badge + existing `EvalRunDetail` error block), any-referenced-backend scope (Task 2). All covered.
+- **Stale-closure pitfall** explicitly handled by having `refresh()` return the fresh statuses (Task 3) and reading them directly in preflight (Task 4) instead of the hook's `statuses` state.
+- **Robustness preserved:** preflight is advisory (Start anyway), a status-probe failure does not block the run, and `on_error=collect` semantics are unchanged.
+- **Signature checks flagged:** ConfirmDialog props, the eval-runs test fixture, and the `_collected_errors` attribute are called out to verify against the real files during implementation.

--- a/docs/superpowers/specs/2026-06-12-backend-unavailable-handling-design.md
+++ b/docs/superpowers/specs/2026-06-12-backend-unavailable-handling-design.md
@@ -1,0 +1,69 @@
+# Design Spec — Detect & surface backend-unavailable in eval runs
+
+- **Ticket:** SF-270 — https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215654793910878
+- **Date:** 2026-06-12
+- **Status:** Design (approved decisions baked in) → implementation plan alongside
+
+## Context
+
+ScoredLiveTruth (and any spec that calls a model backend) **silently produces zero scored records when a backend is unavailable**. Root cause (confirmed):
+
+- Each row scores via `consensus=/claude($item.question)!…`. When the Claude backend is down, every `/claude` call fails.
+- The spec runs with `;foreach.on_error=collect`, which is deliberately robust: it collects per-row failures, keeps **HTTP 200**, and the run is marked **`done`** (never `failed`).
+- `check_correct` gets no real consensus → no verdict; `calculate_accuracy` excludes the error rows → `n=0, accuracy 0%, errors=N`.
+- The eval run is recorded as `done` with **zero graded records**, and nothing tells the user the backend was down. The existing `X-SF-Collected-Errors` response header (SF-236) is ignored by the fire-and-forget run starter and never persisted/shown.
+
+**Goal:** (1) **preflight** — before starting a run, warn the user if a backend the spec references is unavailable; (2) **degraded status** — after a run, if rows were collected as errors, persist the count and mark the run `degraded` with a reason, surfaced in Eval Studio. Detection covers **any backend the spec references** (decisions locked with the user).
+
+## Scope
+
+**In:** `apps/server` (url4_executor, eval_runs) + `apps/desktop` (Eval Studio run flow + display). Backends in scope: any `/claude`, `/codex`, `/gemini`, `/ollama` the expression references.
+
+**Out:** changing `on_error=collect` semantics (kept robust); ret`/`auto-retry of failed runs; non-eval url4 traffic (live frontend requests don't create eval records); web portal.
+
+## Key facts (from code research)
+
+- **Backend health source of truth:** `GET /backends/status` (v2) — `llm_base/routes.py`. Per-backend verdict via `_classify_action` → `healthy | reauth | rate_limited | degraded`, plus `authenticated: bool`. The walk already skips `requires_auth=False` runners (python). Backends are keyed by name = `backend_call_paths[0].lstrip("/")` (`claude`/`codex`/`gemini`/`ollama`).
+- **Desktop already polls it:** `use-backend-status.ts` → `useBackendStatus()` returns `{ statuses, refresh }`; `isBackendStatusV2(statuses)` then `statuses.backends[name].authenticated`/`.action`. No new server call needed for preflight.
+- **Run start funnel:** `EvalStudioView.tsx::runAndSelect` is the single path for all three start entry points (runs list, run detail, add dialog) → `useStartEvalRun()` → `GET /ensemble?q=…` with `X-SF-Run-Id`/`X-SF-Run-Spec`.
+- **Collected errors available pre-persist:** in `url4_executor/routes.py`, `interpreter._collected_errors` is computed before the `HOOK_RUN_FINISHED` emit; it's only read *after* today (for the header). It can be passed into the emit.
+- **Run model:** `EvalRun.status` is `CharField(max_length=16)` with `running|done|failed`; `"degraded"` fits. Already has `error: TextField`, `accuracy`, `total_questions`, `correct_questions`. `_on_run_finished`/`_on_run_failed` in `eval_runs/plugin.py` set status; `RunFinishedPayload` in `_hook_payloads.py` carries only `run_id`+`finished_at` today.
+- **Desktop display:** `EvalRunDetail.tsx` shows `<EvalStatusBadge status=…/>` + an `error` block; `EvalRunStatus = 'running'|'done'|'failed'` and `EvalStatusBadge` styles those three — both need a `degraded` entry. The client already carries `error` end-to-end.
+
+## Design
+
+### 1. Referenced-backend extraction (shared helper)
+A small pure helper maps a url4 expression → the set of auth-requiring backend names it calls, by scanning for the backend-call tokens `/claude`, `/codex`, `/gemini`, `/ollama` (the `requires_auth` providers; `/python`, `/data`, `/private` excluded). Implemented on the desktop (for preflight) as `lib/referenced-backends.ts`. Regex on call-paths is sufficient and matches how the server keys backends.
+
+### 2. Preflight (desktop, before run)
+In `runAndSelect` (`EvalStudioView.tsx`): before calling `startEvalRun`, compute the referenced backends; `await refresh()` then read `useBackendStatus()`; if any referenced backend is **not authenticated/healthy**, show a confirm dialog (reuse `ConfirmDialog`): _"Claude backend is unavailable (needs auth). This run will produce no scored records. Start anyway?"_ — listing each unavailable backend + its `action`/`help_text`. **Proceed only on confirm**; "Cancel" aborts (no run created). If all healthy, run immediately (no dialog).
+
+### 3. Degraded status (server, after run)
+In `url4_executor/routes.py`: read `collected_errors = getattr(interpreter, "_collected_errors", 0)` **before** the `HOOK_RUN_FINISHED` emit and pass it in. Extend `RunFinishedPayload` with `collected_errors: int = 0`. In `eval_runs/plugin.py::_on_run_finished`: when `collected_errors > 0`, set `status="degraded"` and an `error` reason like `"{collected_errors} row(s) errored (e.g. backend unavailable); {graded} graded."` instead of `"done"`. Runs with no collected errors stay `done`. (Hard failures still go through `HOOK_RUN_FAILED` → `failed`.)
+
+### 4. Degraded display (desktop)
+Add `'degraded'` to `EvalRunStatus` (`components/eval/types.ts`) and a style entry in `EvalStatusBadge.tsx` (amber/mark — it's a warning, not a hard fail). The reason renders through the existing `EvalRunDetail` `error` block with no new wiring.
+
+## Data flow
+
+1. **Preflight:** user clicks Run → `runAndSelect` extracts referenced backends → `refresh()` + check `statuses` → if any unavailable, `ConfirmDialog`; cancel aborts, confirm proceeds.
+2. **Run:** `GET /ensemble?q=…` with run headers → executor evaluates → `_collected_errors` tallied.
+3. **Persist:** `HOOK_RUN_FINISHED(run_id, finished_at, collected_errors)` → `_on_run_finished` writes `status=degraded`+reason when `collected_errors>0`, else `done`.
+4. **Display:** runs list/detail poll → `degraded` badge + reason in the error block.
+
+## Testing
+
+- **Server:** unit test `_on_run_finished` sets `degraded`+reason when `collected_errors>0`, `done` when 0. Route test: a resolve whose interpreter reports collected errors persists `degraded` (can stub the interpreter / use a small `on_error=collect` expression with a deliberately failing node).
+- **Desktop:** unit test `referenced-backends.ts` (claude-only spec → {claude}; 3-way → {claude,codex,gemini}; `/python`/`/data` excluded). Component/logic test that `runAndSelect` aborts when a referenced backend is unauthenticated and the user cancels; proceeds when healthy. `EvalStatusBadge` renders `degraded`.
+- Build + existing suites stay green.
+
+## Risks / open questions
+
+- **`_collected_errors` attribute name** is internal to the interpreter; confirm `EnsembleInterpreter` sets it on the same object the route holds (it does today via the header read). Use `getattr(..., 0)` defensively.
+- **"Unavailable" definition** = not (`authenticated && action == 'healthy'`). `rate_limited` is borderline — treat as a warnable-unavailable too (it will also collect errors). Preflight message uses the per-backend `action`/`help_text` to be specific.
+- **Degraded threshold:** any `collected_errors > 0` ⇒ degraded. (Not "all rows" — a partial outage that drops some rows is still degraded and worth surfacing. n=0 is the worst case.)
+- Preflight is **advisory** (user can proceed); it never blocks a run outright, matching the robust-by-design philosophy.
+
+## Summary
+
+Surface backend-unavailability at both ends: an advisory preflight that warns before a run produces nothing, and a persisted `degraded` run status + reason (driven by the already-computed collected-error count) shown in Eval Studio. No change to the robust `on_error=collect` semantics.


### PR DESCRIPTION
## Problem
ScoredLiveTruth (and any spec calling a model backend) **silently produced zero scored records when a backend was unavailable**: per-row `/claude` calls fail, `;foreach.on_error=collect` swallows them (HTTP 200), `calculate_accuracy` returns `n=0`, and the run is marked `done`. The `X-SF-Collected-Errors` header existed but the fire-and-forget client ignored it — so nothing told the user Claude was down.

## Fix
**1. Degraded run status (server).** Thread the already-computed `interpreter._collected_errors` into `HOOK_RUN_FINISHED`; `_on_run_finished` records `status="degraded"` + a reason (`"N row(s) errored (e.g. a model backend was unavailable); M graded."`) when errors were collected — else `done`. Hard failures still go `failed`. `on_error=collect` semantics unchanged.

**2. Preflight warning (desktop).** Before a run, `referencedBackends()` extracts the backends the expression calls (`/claude`,`/codex`,`/gemini`,`/ollama`; excludes `/python`,`/data`,`/private`) and checks them against `/backends/status`; if any is unauthenticated/unhealthy, a `ConfirmDialog` warns ("…is unavailable. Start anyway?"). Advisory — Start-anyway proceeds, Cancel aborts, a probe failure never blocks.

**3. Display (desktop).** `degraded` added to `EvalRunStatus` + an amber badge; the reason surfaces through the existing `EvalRunDetail` error block.

## Scope
Any backend the spec references. Detection covers claude/codex/gemini/ollama.

## Verification
- Server: **314 passed** (incl. new `test_degraded_status.py`).
- Desktop: **3 passed** (`referenced-backends`) + clean `npm run build`.
- `refresh()` now returns fresh statuses so the preflight avoids a stale-closure read.

Built from the approved spec/plan: `docs/superpowers/specs/2026-06-12-backend-unavailable-handling-design.md`, `docs/superpowers/plans/2026-06-12-backend-unavailable-handling.md`.

> Note: implemented mostly by hand after the orchestration workflow stalled on a cross-event-loop test fixture (a sync `TestClient` initializing Tortoise on a different loop than the async test). Rewrote the test to the proven `async with app.router.lifespan_context(app)` fixture — runs in 0.33s.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215654793910878

🤖 Generated with [Claude Code](https://claude.com/claude-code)