### PR TITLE
SF-269: add Copy-link button to Private Data

### DIFF
--- a/apps/desktop/src/renderer/src/components/private-data/PrivateDataDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/private-data/PrivateDataDetail.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense, useEffect, useState } from 'react';
+import { Check, Copy } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { CopyButton } from '@/components/CopyButton';
@@ -26,6 +27,20 @@ export function PrivateDataDetail({
   const [content, setContent] = useState('');
   const [editing, setEditing] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [linkCopied, setLinkCopied] = useState(false);
+
+  // The url4 reference for this entry — what you paste into an expression.
+  const link = `/private/${item.uuid}`;
+
+  const copyLink = async (): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(link);
+      setLinkCopied(true);
+      setTimeout(() => setLinkCopied(false), 1500);
+    } catch {
+      /* clipboard unavailable — no-op */
+    }
+  };
 
   useEffect(() => {
     setLabel(item.label ?? '');
@@ -43,6 +58,14 @@ export function PrivateDataDetail({
           className="max-w-xs"
         />
         <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={() => void copyLink()}>
+            {linkCopied ? (
+              <Check className="h-3.5 w-3.5 text-gain" />
+            ) : (
+              <Copy className="h-3.5 w-3.5" />
+            )}
+            {linkCopied ? 'Copied' : 'Copy link'}
+          </Button>
           <Button variant="outline" size="sm" onClick={() => setEditing(true)}>
             Edit content
           </Button>

--- a/apps/desktop/src/renderer/src/views/EvalStudioView.test.tsx
+++ b/apps/desktop/src/renderer/src/views/EvalStudioView.test.tsx
@@ -9,6 +9,15 @@ vi.mock('@/hooks/use-eval-run-actions', () => ({
   useEvalRunActions: () => ({ toggleFavorite: vi.fn(), deleteRun: vi.fn() }),
 }));
 vi.mock('@/hooks/use-start-eval-run', () => ({ useStartEvalRun: () => () => null }));
+vi.mock('@/hooks/use-backend-status', () => ({
+  useBackendStatus: () => ({
+    statuses: {},
+    pollingError: null,
+    loaded: true,
+    refresh: vi.fn().mockResolvedValue({}),
+  }),
+  isBackendStatusV2: () => false,
+}));
 vi.mock('@/components/eval/EvalRunDetail', () => ({ EvalRunDetail: () => null }));
 
 afterEach(cleanup);


### PR DESCRIPTION
## What
Adds a **"Copy link"** button to the Private Data detail pane (next to Edit content / Delete) that copies the entry's url4 reference `/private/<uuid7>` to the clipboard, with a brief "Copied" confirmation. That's the path you paste into a url4 expression to use the entry as a content/context source.

Build green; typecheck clean.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215643830854867

🤖 Generated with [Claude Code](https://claude.com/claude-code)