### PR TITLE
SF-266: restore portal benchmark directory landing

### DIFF
--- a/web/portal/index.html
+++ b/web/portal/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>screamingface — live leaderboard</title>
-  <meta name="description" content="LiveTruth leaderboard, live from the public screamingface scoreboard.">
+  <title>screamingface — benchmark receipts</title>
+  <meta name="description" content="Public screamingface benchmark results with accuracy, providers, verification status, and local rerun links.">
   <meta name="robots" content="noindex, nofollow">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>😱</text></svg>">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -22,34 +22,30 @@
     <span class="spacer"></span><button class="toggle" id="theme-toggle" aria-label="Toggle light/dark theme">◐</button>
   </div>
 
-  <div class="wrap wide">
+  <div class="wrap">
     <header class="masthead">
-      <div class="eyebrow">honest-agi-live · live from the public scoreboard</div>
-      <h1>The leaderboard, live.</h1>
+      <div class="eyebrow">Benchmark receipts</div>
+      <h1>Results you can rerun, not just read.</h1>
     </header>
 
-    <p class="lead">Same benchmark, real numbers — pulled straight from the scoreboard as runs are published.</p>
-    <p>Every row below is a real run on the LiveTruth benchmark, fetched live from <code>scoreboard.screamingface.ai</code>. Right now that's the frontier-model baselines. The private-data ensemble runs that beat them — the story the designed demo tells — will appear here automatically as the team publishes them.</p>
+    <p class="lead">Public benchmark results for specs you can inspect and rerun locally. Accuracy, providers, verification status, and the exact run link stay attached to every row.</p>
 
-    <div id="live-status" class="note" role="status" aria-live="polite">Loading…</div>
-
-    <h2>Accuracy</h2>
-    <div id="live-chart" class="climb" aria-hidden="true"></div>
-
-    <h2>Leaderboard</h2>
-    <div id="live-table" class="table-wrap"></div>
+    <p><a href="/">Install screamingface — one command</a></p>
 
     <div class="note">
-      <span class="kicker">Why this looks sparse</span>
-      This is the honest current state: only the baseline evaluations have been published so far. As the ensemble + private-data runs land on the scoreboard, they show up here with no change to this page. Until then, the demo shows the intended end state.
+      <span class="kicker">Verification</span>
+      “Verified” means OpenMined independently reproduced the run. Unbadged rows are
+      community submissions that still need reproduction. Every leaderboard row keeps
+      its URL4 expression, so you can rerun the claim before trusting it.
     </div>
 
-    <h2>Run it yourself</h2>
-    <p>Every row with a run link is reproducible. Open it in Eval Studio and run the same evaluation on your own model subscriptions; nothing private leaves your machine.</p>
-    <p><a class="btn ghost" href="https://github.com/OpenMined/screamingface" rel="noopener noreferrer nofollow">view the source</a></p>
+    <div class="stats" aria-label="Live portal counts">
+      <div class="s"><span class="k">Benchmarks</span><div class="v" id="stat-benchmarks">—</div></div>
+      <div class="s"><span class="k">Datasets published</span><div class="v" id="stat-datasets">—</div></div>
+      <div class="s"><span class="k">Newest benchmark</span><div class="v" id="stat-newest">—</div></div>
+    </div>
 
-    <h2>All benchmarks</h2>
-    <p>Choose another public leaderboard, or open the dataset receipt attached to a benchmark.</p>
+    <h2>Benchmarks</h2>
 
     <div id="benchmark-status" class="state" role="status" aria-live="polite">Loading…</div>
 

--- a/web/portal/main.js
+++ b/web/portal/main.js
@@ -226,82 +226,7 @@ window.ScorePortal = (function () {
     }
   }
 
-  /* ---- live index page -------------------------------------------------- */
-  var LIVE_BENCHMARK_ID = "livetruth";
-
-  function setLiveStatus(message, kind) {
-    var node = document.getElementById("live-status");
-    if (!node) return;
-    node.className = "note" + (kind === "gain" ? " gain" : "");
-    node.textContent = "";
-    node.appendChild(el("span", "kicker", kind === "error" ? "scoreboard" : "live · scoreboard"));
-    node.appendChild(document.createTextNode(message));
-  }
-
-  function liveFillWidth(accuracy) {
-    if (typeof accuracy !== "number" || isNaN(accuracy)) return "0%";
-    var pct = Math.max(0, Math.min(100, accuracy * 100));
-    return (pct.toFixed(1) + "%").replace(".0%", "%");
-  }
-
-  function renderLiveChart(entries) {
-    var node = document.getElementById("live-chart");
-    if (!node) return;
-    clear(node);
-    entries.forEach(function (entry, index) {
-      var row = el("div", "row");
-      row.appendChild(el("span", "lbl", entry.spec_id));
-      var track = el("span", "track");
-      var fill = el("span", "fill " + (index === 0 ? "sota" : "ens"));
-      fill.style.width = liveFillWidth(entry.accuracy);
-      track.appendChild(fill);
-      row.appendChild(track);
-      row.appendChild(el("span", "val", formatPercent(entry.accuracy)));
-      node.appendChild(row);
-    });
-  }
-
-  function liveRunLink(entry) {
-    if (!entry.url4_expression) return document.createTextNode(EM_DASH);
-    return link("btn ghost", buildRunHref(entry.spec_id, entry.url4_expression), "▸ run");
-  }
-
-  function renderLiveTable(entries) {
-    var host = document.getElementById("live-table");
-    if (!host) return;
-    clear(host);
-
-    var table = document.createElement("table");
-    table.setAttribute("aria-label", "LiveTruth leaderboard");
-    var thead = document.createElement("thead");
-    var headRow = document.createElement("tr");
-    ["#", "configuration", "accuracy", "questions", "verified", ""].forEach(function (label, index) {
-      headRow.appendChild(el("th", (index === 2 || index === 3) ? "num" : null, label));
-    });
-    thead.appendChild(headRow);
-    table.appendChild(thead);
-
-    var tbody = document.createElement("tbody");
-    entries.forEach(function (entry, index) {
-      var rank = typeof entry.rank === "number" ? entry.rank : index + 1;
-      var tr = document.createElement("tr");
-      if (rank === 1) tr.className = "sota";
-      tr.appendChild(el("td", null, rank));
-      var specTd = el("td", "cell-wrap", entry.spec_id);
-      if (rank === 1) specTd.appendChild(el("span", "sr-only", " (state of the art)"));
-      tr.appendChild(specTd);
-      tr.appendChild(el("td", "num", formatPercent(entry.accuracy)));
-      tr.appendChild(el("td", "num", formatQuestions(entry.total_questions)));
-      tr.appendChild(el("td", null, entry.verified_by_openmined ? "✓ OpenMined" : EM_DASH));
-      var runTd = document.createElement("td");
-      runTd.appendChild(liveRunLink(entry));
-      tr.appendChild(runTd);
-      tbody.appendChild(tr);
-    });
-    table.appendChild(tbody);
-    host.appendChild(table);
-  }
-
+  /* ---- index page ------------------------------------------------------ */
   // Site-root data files (published by the deploy workflow) open in the
   // in-portal viewer instead of forcing a download — GitHub Pages serves
   // .jsonl as application/octet-stream with no MIME override available.
@@ -346,19 +271,40 @@ window.ScorePortal = (function () {
     return tr;
   }
 
-  function initBenchmarkDirectory() {
+  function formatDateOnly(value) {
+    if (!value) return EM_DASH;
+    var d = new Date(value);
+    if (isNaN(d.getTime())) return EM_DASH;
+    return d.toLocaleDateString(PORTAL_LOCALE, { year: "numeric", month: "short", day: "numeric" });
+  }
+
+  function updateIndexStats(benchmarks) {
+    var counts = {
+      "stat-benchmarks": String(benchmarks.length),
+      "stat-datasets": String(benchmarks.filter(function (b) { return httpUrlOrNull(b.dataset_url) !== null; }).length),
+      "stat-newest": formatDateOnly(
+        benchmarks.map(function (b) { return b.created_at; }).filter(Boolean).sort().pop()
+      ),
+    };
+    Object.keys(counts).forEach(function (id) {
+      var node = document.getElementById(id);
+      if (node) node.textContent = counts[id];
+    });
+  }
+
+  function initIndex() {
     var statusNode = document.getElementById("benchmark-status");
     var listNode = document.getElementById("benchmark-list");
     var wrapNode = document.getElementById("benchmark-table-wrap");
-    if (!statusNode || !listNode || !wrapNode) return;
     showLoading(statusNode, "Loading benchmarks…");
     wrapNode.hidden = true;
 
     fetchJson("/v1/benchmarks").then(
       function (data) {
         var benchmarks = (data && data.benchmarks) || [];
+        updateIndexStats(benchmarks);
         if (benchmarks.length === 0) {
-          showEmpty(statusNode, "No public benchmarks yet.");
+          showEmpty(statusNode, "No public benchmarks yet. The API is live; rows will appear here as soon as benchmark specs are registered.");
           return;
         }
         clear(listNode);
@@ -368,39 +314,6 @@ window.ScorePortal = (function () {
       },
       function (err) {
         showError(statusNode, describeError(err, { generic: "Could not load benchmarks — try again later." }));
-      }
-    );
-  }
-
-  function initLiveIndex() {
-    setLiveStatus("Fetching the latest runs…");
-    fetchJson("/v1/leaderboard/" + encodeURIComponent(LIVE_BENCHMARK_ID) + "?top=50").then(
-      function (data) {
-        var entries = (data && data.entries) || [];
-        if (entries.length === 0) {
-          setLiveStatus("The scoreboard is live, but no runs are published for this benchmark yet.");
-          return;
-        }
-        var best = Math.max.apply(null, entries.map(function (entry) { return entry.accuracy || 0; }));
-        var now = new Date().toLocaleString(PORTAL_LOCALE, {
-          month: "short", day: "numeric", hour: "2-digit", minute: "2-digit",
-        });
-        setLiveStatus(
-          entries.length + " run" + (entries.length === 1 ? "" : "s") +
-          " on LiveTruth · best " + formatPercent(best) +
-          " · fetched " + now + " from scoreboard.screamingface.ai",
-          "gain"
-        );
-        renderLiveChart(entries);
-        renderLiveTable(entries);
-      },
-      function (err) {
-        setLiveStatus(
-          "Could not reach the scoreboard (" +
-          (err && err.message ? err.message : "network") +
-          "). It may be waking up — try a refresh.",
-          "error"
-        );
       }
     );
   }
@@ -433,10 +346,10 @@ window.ScorePortal = (function () {
     EM_DASH: EM_DASH,
   };
 
-  // Self-bootstrap the live index page when its container is present.
+  // Self-bootstrap the index page when its container is present. benchmark.html
+  // and spec.html have no #benchmark-list, so this is a no-op there.
   ready(function () {
-    if (document.getElementById("live-table")) initLiveIndex();
-    if (document.getElementById("benchmark-list")) initBenchmarkDirectory();
+    if (document.getElementById("benchmark-list")) initIndex();
   });
 
   return api;

--- a/web/tests/portal_smoke.py
+++ b/web/tests/portal_smoke.py
@@ -356,75 +356,58 @@ def main() -> int:
                 bool(page.get_attribute("#theme-toggle", "aria-label")),
             )
 
-        # ---- index: live leaderboard reference page ----
+        # ---- index: benchmark directory + drilldown ----
         def t_index():
             page.goto(pages["index"])
-            page.wait_for_selector("#live-table tbody tr", timeout=8000)
-            rows = page.locator("#live-table tbody tr")
+            page.wait_for_selector("#benchmark-table tbody tr", timeout=8000)
+            rows = page.locator("#benchmark-table tbody tr")
             check(
                 "T7",
-                "index: headline matches live brand reference",
-                page.locator("h1").first.text_content() == "The leaderboard, live.",
+                "index: headline matches benchmark directory reference",
+                page.locator("h1").first.text_content()
+                == "Results you can rerun, not just read.",
             )
             check(
                 "T7",
-                "index: live scoreboard status note rendered",
-                page.locator("#live-status.note.gain").count() == 1
-                and "scoreboard.screamingface.ai"
-                in (page.locator("#live-status").text_content() or ""),
+                "index: no inline live leaderboard block",
+                page.locator("#live-table, #live-chart, #live-status").count() == 0,
             )
-            status_text = page.locator("#live-status").text_content() or ""
+            newest_text = page.locator("#stat-newest").text_content() or ""
             check(
                 "T7",
-                "index: live status uses English date text",
-                re.search(
+                "index: benchmark stats rendered",
+                (page.locator("#stat-benchmarks").text_content() or "") == "2"
+                and (page.locator("#stat-datasets").text_content() or "") == "2"
+                and re.search(
                     r"\b(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\b",
-                    status_text,
+                    newest_text,
                 )
                 is not None
-                and re.search(r"[А-Яа-яЁё]", status_text) is None,
-                status_text,
+                and re.search(r"[А-Яа-яЁё]", newest_text) is None,
+                newest_text,
             )
             check(
                 "T7",
-                "index: one live leaderboard row per API entry",
-                rows.count() == 4,
+                "index: one directory row per benchmark",
+                rows.count() == 2,
                 f"got {rows.count()}",
             )
+            rows.filter(has_text="News Livetruth").locator(
+                "a", has_text="Leaderboard"
+            ).first.click()
+            page.wait_for_url("**/benchmark.html?id=livetruth", timeout=8000)
+            page.wait_for_selector("#leaderboard-body tr", timeout=8000)
             check(
                 "T7",
-                "index: live table uses configuration label",
-                "direct-google-gemini-3-1-pro-preview"
-                in (rows.first.text_content() or ""),
-            )
-            check(
-                "T7",
-                "index: live chart has one row per API entry",
-                page.locator("#live-chart .row").count() == 4,
-                f"got {page.locator('#live-chart .row').count()}",
-            )
-            check(
-                "T7",
-                "index: only top-ranked live chart fill is green",
-                page.locator("#live-chart .fill.sota").count() == 1
-                and page.locator("#live-chart .fill.ens").count() == 3,
-            )
-            check(
-                "T7",
-                "index: first live table row is highlighted as SOTA",
-                page.locator("#live-table tbody tr.sota").count() == 1,
-            )
-            check(
-                "T7",
-                "index: run links use branded run affordance",
-                rows.first.locator("a.btn.ghost").count() == 1
-                and "▸ run" in (rows.first.locator("a.btn.ghost").text_content() or "")
-                and (
-                    rows.first.locator("a.btn.ghost").get_attribute("href") or ""
-                ).startswith("sf://run?spec="),
+                "index: leaderboard link opens detailed page with Copy buttons",
+                page.locator("#benchmark-name").text_content() == "News Livetruth"
+                and page.locator(
+                    "#leaderboard-body td.col-run button.btn.ghost"
+                ).count()
+                == 3,
             )
 
-        section("T7", "index: live leaderboard block", t_index)
+        section("T7", "index: benchmark directory drilldown", t_index)
 
         # ---- index: all benchmarks + dataset affordances restored ----
         def t_index_directory():


### PR DESCRIPTION
## Summary
- Restore the portal index to the benchmark-directory landing from 4c7b771.
- Keep Leaderboard links drilling into benchmark.html, where the summary, accuracy chart, and Copy buttons live.
- Keep dataset viewer routing for same-origin JSONL files and the en-US date-format guard.

## Verification
- `/Users/dmitry/.claude/skills/automating-browsers-playwright/venv/bin/python web/tests/portal_smoke.py`
- `uvx ruff check web/tests/portal_smoke.py --select I,E,F --line-length 100`
- `node --check web/portal/main.js`
- `git diff --check`

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215636036104464