### PR TITLE
SF-266: widen portal benchmark landing

### DIFF
--- a/web/portal/index.html
+++ b/web/portal/index.html
@@ -22,7 +22,7 @@
     <span class="spacer"></span><button class="toggle" id="theme-toggle" aria-label="Toggle light/dark theme">◐</button>
   </div>
 
-  <div class="wrap">
+  <div class="wrap wide">
     <header class="masthead">
       <div class="eyebrow">Benchmark receipts</div>
       <h1>Results you can rerun, not just read.</h1>

--- a/web/tests/portal_smoke.py
+++ b/web/tests/portal_smoke.py
@@ -372,6 +372,11 @@ def main() -> int:
                 "index: no inline live leaderboard block",
                 page.locator("#live-table, #live-chart, #live-status").count() == 0,
             )
+            check(
+                "T7",
+                "index: uses wide branded content column",
+                page.locator(".wrap.wide").count() == 1,
+            )
             newest_text = page.locator("#stat-newest").text_content() or ""
             check(
                 "T7",


### PR DESCRIPTION
## Summary
- Use the existing brand-system `.wrap wide` content column on the portal index.
- Keep the benchmark-directory page content and flow unchanged.
- Add a smoke assertion so the index stays aligned with the detailed leaderboard page width.

## Verification
- `/Users/dmitry/.claude/skills/automating-browsers-playwright/venv/bin/python web/tests/portal_smoke.py`
- `uvx ruff check web/tests/portal_smoke.py --select I,E,F --line-length 100`
- `node --check web/portal/main.js`
- `git diff --check`

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215636036104464