### PR TITLE
SF-271: default desktop publish to production scoreboard

### DIFF
--- a/apps/desktop/src/main/services/publish-context.ts
+++ b/apps/desktop/src/main/services/publish-context.ts
@@ -8,8 +8,12 @@
 import { app } from 'electron';
 import { configService } from './config-service';
 
-/** Dev defaults. Production scoreboard/portal URLs are finalized in D-SCORE-007. */
-const DEFAULT_SCOREBOARD_URL = 'http://localhost:9106';
+/**
+ * Production scoreboard is the default so packaged builds publish without any
+ * override; local dev points elsewhere via SF_SCOREBOARD_URL or sf.json.
+ * Portal URL is still the dev placeholder pending its production value.
+ */
+const DEFAULT_SCOREBOARD_URL = 'https://scoreboard.screamingface.ai';
 const DEFAULT_PORTAL_URL = 'http://localhost:8080';
 
 export interface PublishClientInfo {

--- a/apps/desktop/src/renderer/src/hooks/__tests__/use-publish-score.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/__tests__/use-publish-score.test.ts
@@ -5,7 +5,7 @@ import { usePublishScore, type PublishInputs } from '../use-publish-score';
 import type { EvalRunDetail } from '@/components/eval/types';
 
 const CTX = {
-  scoreboardUrl: 'http://localhost:9106',
+  scoreboardUrl: 'https://scoreboard.screamingface.ai',
   portalUrl: 'http://localhost:8080',
   client: { name: 'screamingface-desktop', version: '0.4.2', platform: 'darwin' },
 };
@@ -75,7 +75,7 @@ describe('usePublishScore', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe('http://localhost:9106/v1/scores');
+    expect(url).toBe('https://scoreboard.screamingface.ai/v1/scores');
     expect((init.headers as Record<string, string>)['Idempotency-Key']).toBe('eval-run-abc123');
     const body = JSON.parse(init.body as string);
     // Nested client, not flat — and recomputed accuracy = correct/total.


### PR DESCRIPTION
## What
Sets the desktop Publish-to-Leaderboard **default scoreboard URL** to the production endpoint `https://scoreboard.screamingface.ai`, replacing the dev placeholder `http://localhost:9106` (the `D-SCORE-007` TODO in `publish-context.ts`).

Packaged builds now publish to prod out of the box. Local dev still overrides via `SF_SCOREBOARD_URL` env var or `scoreboard_url` in `sf.json` (resolution order unchanged: env → config → default).

## Changes
- `apps/desktop/src/main/services/publish-context.ts` — `DEFAULT_SCOREBOARD_URL` → `https://scoreboard.screamingface.ai`; refreshed the comment.
- `apps/desktop/src/renderer/src/hooks/__tests__/use-publish-score.test.ts` — fixture + assertion updated to the production URL.

## Out of scope
Portal default (`http://localhost:8080`) left untouched pending its production URL.

## Verification
- Full desktop vitest suite: **181 passed / 38 files**.
- `npm run build`: green.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215688107145625

🤖 Generated with [Claude Code](https://claude.com/claude-code)