### PR TITLE
SF-272: default desktop publish portal link to production

### DIFF
--- a/apps/desktop/src/main/services/publish-context.ts
+++ b/apps/desktop/src/main/services/publish-context.ts
@@ -9,12 +9,12 @@ import { app } from 'electron';
 import { configService } from './config-service';
 
 /**
- * Production scoreboard is the default so packaged builds publish without any
- * override; local dev points elsewhere via SF_SCOREBOARD_URL or sf.json.
- * Portal URL is still the dev placeholder pending its production value.
+ * Production scoreboard + portal are the defaults so packaged builds publish
+ * (and link out) without any override; local dev points elsewhere via
+ * SF_SCOREBOARD_URL / SF_PORTAL_URL or sf.json.
  */
 const DEFAULT_SCOREBOARD_URL = 'https://scoreboard.screamingface.ai';
-const DEFAULT_PORTAL_URL = 'http://localhost:8080';
+const DEFAULT_PORTAL_URL = 'https://screamingface.ai/portal/';
 
 export interface PublishClientInfo {
   name: string;

--- a/apps/desktop/src/renderer/src/hooks/__tests__/use-publish-score.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/__tests__/use-publish-score.test.ts
@@ -6,7 +6,7 @@ import type { EvalRunDetail } from '@/components/eval/types';
 
 const CTX = {
   scoreboardUrl: 'https://scoreboard.screamingface.ai',
-  portalUrl: 'http://localhost:8080',
+  portalUrl: 'https://screamingface.ai/portal/',
   client: { name: 'screamingface-desktop', version: '0.4.2', platform: 'darwin' },
 };
 
@@ -93,7 +93,7 @@ describe('usePublishScore', () => {
     expect(result.current.status).toBe('success');
     expect(out).toMatchObject({
       id: 'score-1',
-      portalLink: 'http://localhost:8080/spec.html?benchmark=hle&spec=hle-ensemble-three',
+      portalLink: 'https://screamingface.ai/portal/spec.html?benchmark=hle&spec=hle-ensemble-three',
     });
   });
 


### PR DESCRIPTION
## What
Follow-up to #297 (SF-271). Sets the desktop post-publish **portal deep link** default to the production portal `https://screamingface.ai/portal/`, replacing the dev placeholder `http://localhost:8080`.

After a successful publish the app opens `{portalUrl}/spec.html?benchmark=…&spec=…`; this now lands on prod out of the box. Resolution order unchanged: `SF_PORTAL_URL` env → `portal_url` in `sf.json` → default.

## Changes
- `apps/desktop/src/main/services/publish-context.ts` — `DEFAULT_PORTAL_URL` → `https://screamingface.ai/portal/`; comment now reflects both prod defaults.
- `apps/desktop/src/renderer/src/hooks/__tests__/use-publish-score.test.ts` — fixture + assertion updated; the path-style URL also exercises the link builder's trailing-slash stripping (`.../portal/spec.html?...`).

## Verification
- Full desktop vitest suite: **181 passed / 38 files**.
- `npm run build`: green.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215677924485331

🤖 Generated with [Claude Code](https://claude.com/claude-code)