### PR TITLE
SF-273: publish eval score from Electron main process (fix CORS block)

### DIFF
--- a/apps/desktop/src/main/ipc/publish.ipc.ts
+++ b/apps/desktop/src/main/ipc/publish.ipc.ts
@@ -2,9 +2,12 @@
 //
 // IPC for the "Publish to Leaderboard" flow (SF-181 / D-SCORE-006):
 //   - publish:getContext  — env/app-version/platform the renderer can't read
+//   - publish:submitScore — POST the score from main, exempt from renderer CORS (SF-273)
 //   - publish:openExternal — open the leaderboard deep link in the system browser
 import { ipcMain, shell } from 'electron';
 import { resolvePublishContext, type PublishContext } from '../services/publish-context';
+import { submitScore } from '../services/publish-score';
+import type { PublishOutcome, PublishScoreRequest } from '../../preload/types';
 import { requireTrustedIpcSender } from './sender-validation';
 
 function isHttpUrl(value: string): boolean {
@@ -21,6 +24,14 @@ export function registerPublishHandlers(): void {
     requireTrustedIpcSender(event);
     return resolvePublishContext();
   });
+
+  ipcMain.handle(
+    'publish:submitScore',
+    (event, request: PublishScoreRequest): Promise<PublishOutcome> => {
+      requireTrustedIpcSender(event);
+      return submitScore(request);
+    },
+  );
 
   ipcMain.handle('publish:openExternal', async (event, url: string): Promise<void> => {
     requireTrustedIpcSender(event);

--- a/apps/desktop/src/main/services/__tests__/publish-score.test.ts
+++ b/apps/desktop/src/main/services/__tests__/publish-score.test.ts
@@ -1,0 +1,125 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { PublishScoreRequest } from '../../../preload/types';
+
+// The service reads URLs + client via resolvePublishContext; stub it so the
+// test is independent of env/sf.json and asserts against fixed prod-shaped URLs.
+const CTX = {
+  scoreboardUrl: 'https://scoreboard.screamingface.ai',
+  portalUrl: 'https://screamingface.ai/portal/',
+  client: { name: 'screamingface-desktop', version: '0.4.2', platform: 'darwin' },
+};
+vi.mock('../publish-context', () => ({ resolvePublishContext: () => CTX }));
+
+import { submitScore } from '../publish-score';
+
+const REQUEST: PublishScoreRequest = {
+  benchmarkId: 'hle',
+  specId: 'hle-ensemble-three',
+  url4Expression: 'url4://ensemble(claude,codex,gemini)/hle',
+  providers: ['claude', 'codex', 'gemini'],
+  submittedBy: null,
+  runId: 'eval-run-abc123',
+  totalQuestions: 1000,
+  correctQuestions: 810,
+  ranAtLocal: '2026-05-04T11:55:00Z',
+};
+
+function okResponse(): Response {
+  return {
+    ok: true,
+    status: 201,
+    json: async () => ({ id: 'score-1', benchmark_id: 'hle', spec_id: 'hle-ensemble-three' }),
+  } as unknown as Response;
+}
+
+function errResponse(status: number): Response {
+  return {
+    ok: false,
+    status,
+    text: async () => 'rejected',
+    json: async () => ({}),
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('submitScore (main process)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('POSTs the nested-client wire shape to the prod scoreboard with the run id as Idempotency-Key', async () => {
+    const fetchMock = vi.fn(async () => okResponse());
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const outcome = await submitScore(REQUEST);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('https://scoreboard.screamingface.ai/v1/scores');
+    expect((init.headers as Record<string, string>)['Idempotency-Key']).toBe('eval-run-abc123');
+    const body = JSON.parse(init.body as string);
+    // Nested client, not flat — and recomputed accuracy = correct/total.
+    expect(body.client).toEqual({
+      name: 'screamingface-desktop',
+      version: '0.4.2',
+      platform: 'darwin',
+    });
+    expect(body).not.toHaveProperty('client_name');
+    expect(body.accuracy).toBeCloseTo(0.81, 5);
+    expect(body.ran_with_providers).toEqual(['claude', 'codex', 'gemini']);
+    expect(body.submitted_by).toBeNull();
+    expect(body.ran_at_local).toBe('2026-05-04T11:55:00Z');
+
+    expect(outcome).toEqual({
+      ok: true,
+      value: {
+        id: 'score-1',
+        benchmarkId: 'hle',
+        specId: 'hle-ensemble-three',
+        portalLink:
+          'https://screamingface.ai/portal/spec.html?benchmark=hle&spec=hle-ensemble-three',
+      },
+    });
+  });
+
+  it('recomputes accuracy from totals (ignores any drift)', async () => {
+    const fetchMock = vi.fn(async () => okResponse());
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await submitScore({ ...REQUEST, correctQuestions: 810, totalQuestions: 1000 });
+
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.accuracy).toBeCloseTo(0.81, 5); // 810/1000
+  });
+
+  it('does not retry a 4xx and returns actionable copy', async () => {
+    const fetchMock = vi.fn(async () => errResponse(404));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const outcome = await submitScore(REQUEST);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) expect(outcome.error).toMatch(/not registered/i);
+  });
+
+  it('retries a transient network failure with backoff, then succeeds', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce(okResponse());
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const promise = submitScore(REQUEST);
+    await vi.advanceTimersByTimeAsync(1100); // first backoff = 1s
+    const outcome = await promise;
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(outcome.ok).toBe(true);
+  });
+});

--- a/apps/desktop/src/main/services/publish-score.ts
+++ b/apps/desktop/src/main/services/publish-score.ts
@@ -1,0 +1,128 @@
+// apps/desktop/src/main/services/publish-score.ts
+//
+// Publishes a local eval_run aggregate to the public scoreboard (SF-181 /
+// D-SCORE-006) from the MAIN process, so the request is exempt from renderer
+// CORS (SF-273): the scoreboard need not allowlist the desktop app origin
+// (localhost in dev, file://null when packaged). Builds the exact wire shape the
+// scoreboard accepts (nested `client`, see apps/scoreboard/tests/unit/
+// test_sf_payload.py), POSTs it with an Idempotency-Key so repeat clicks don't
+// duplicate, and retries transient failures. The contract is strict
+// (`extra="forbid"`) — send these keys only.
+
+import { resolvePublishContext } from './publish-context';
+import type { PublishOutcome, PublishResult, PublishScoreRequest } from '../../preload/types';
+
+const TIMEOUT_MS = 10_000;
+const BACKOFF_MS = [1_000, 2_000, 4_000];
+
+interface ScoreResponse {
+  id: string;
+  benchmark_id: string;
+  spec_id: string;
+}
+
+/** Map a non-2xx status to actionable copy. */
+function errorForStatus(status: number, body: string): string {
+  switch (status) {
+    case 404:
+      return 'That benchmark is not registered on the scoreboard yet. Coordinate with the scoreboard owner before publishing.';
+    case 400:
+      return 'The scoreboard rejected the aggregate (accuracy must equal correct/total). This run may have inconsistent totals.';
+    case 422:
+      return 'The submission did not match the scoreboard contract. This is a bug — please report it.';
+    default:
+      return `Scoreboard returned HTTP ${status}: ${body.slice(0, 200)}`;
+  }
+}
+
+function buildBody(
+  request: PublishScoreRequest,
+  client: { name: string; version: string; platform: string },
+): Record<string, unknown> {
+  const total = request.totalQuestions ?? 0;
+  const correct = request.correctQuestions ?? 0;
+  // Recompute accuracy from the integer totals: the scoreboard 400s if `accuracy`
+  // differs from correct/total by >0.01, so never trust a stored rounded value.
+  const accuracy = total > 0 ? correct / total : 0;
+  const submittedBy =
+    request.submittedBy && request.submittedBy.trim().length > 0
+      ? request.submittedBy.trim()
+      : null;
+  return {
+    version: 1,
+    benchmark_id: request.benchmarkId,
+    spec_id: request.specId,
+    url4_expression: request.url4Expression,
+    submitted_by: submittedBy,
+    accuracy,
+    total_questions: total,
+    correct_questions: correct,
+    ran_with_providers: request.providers,
+    ran_at_local: request.ranAtLocal,
+    client: { name: client.name, version: client.version, platform: client.platform },
+    metadata: null,
+  };
+}
+
+async function postOnce(
+  url: string,
+  body: Record<string, unknown>,
+  idempotencyKey: string,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    return await fetch(`${url.replace(/\/$/, '')}/v1/scores`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Idempotency-Key': idempotencyKey },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * POST the score to the scoreboard with retries. Returns a discriminated
+ * outcome rather than throwing, so the IPC layer can pass it straight to the
+ * renderer's UI state machine.
+ */
+export async function submitScore(request: PublishScoreRequest): Promise<PublishOutcome> {
+  const ctx = resolvePublishContext();
+  const body = buildBody(request, ctx.client);
+  const idempotencyKey = request.runId;
+
+  let lastErr: string | null = null;
+  // 1 initial attempt + up to 3 retries on transient failures.
+  for (let attempt = 0; attempt <= BACKOFF_MS.length; attempt += 1) {
+    if (attempt > 0) await sleep(BACKOFF_MS[attempt - 1]);
+    let res: Response;
+    try {
+      res = await postOnce(ctx.scoreboardUrl, body, idempotencyKey);
+    } catch {
+      lastErr = 'Could not reach the scoreboard. Check your connection and try again.';
+      continue; // network/abort — retry
+    }
+    if (res.ok) {
+      const data = (await res.json()) as ScoreResponse;
+      const portalLink = `${ctx.portalUrl.replace(/\/$/, '')}/spec.html?benchmark=${encodeURIComponent(data.benchmark_id)}&spec=${encodeURIComponent(data.spec_id)}`;
+      const value: PublishResult = {
+        id: data.id,
+        benchmarkId: data.benchmark_id,
+        specId: data.spec_id,
+        portalLink,
+      };
+      return { ok: true, value };
+    }
+    if (res.status >= 500) {
+      lastErr = errorForStatus(res.status, await res.text());
+      continue; // server error — retry
+    }
+    // 4xx (other than 5xx) is deterministic — do not retry.
+    return { ok: false, error: errorForStatus(res.status, await res.text()) };
+  }
+  return { ok: false, error: lastErr ?? 'Publishing failed after several attempts.' };
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -48,6 +48,7 @@ const api: ElectronAPI = {
   },
   publish: {
     getContext: () => ipcRenderer.invoke('publish:getContext'),
+    submitScore: (request) => ipcRenderer.invoke('publish:submitScore', request),
     openExternal: (url) => ipcRenderer.invoke('publish:openExternal', url),
   },
   backends: {

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -208,6 +208,34 @@ export interface PublishContext {
   client: { name: string; version: string; platform: string };
 }
 
+/** Plain, serializable inputs the renderer sends over IPC to publish a score. */
+export interface PublishScoreRequest {
+  benchmarkId: string;
+  specId: string;
+  /** url4 expression to publish — already sanitized if the user chose to. */
+  url4Expression: string;
+  providers: string[];
+  /** null/empty → anonymous. */
+  submittedBy: string | null;
+  /** eval_run id — used as the Idempotency-Key so repeat clicks don't duplicate. */
+  runId: string;
+  totalQuestions: number;
+  correctQuestions: number;
+  /** ISO timestamp the run finished (falls back to started_at upstream). */
+  ranAtLocal: string;
+}
+
+export interface PublishResult {
+  id: string;
+  benchmarkId: string;
+  specId: string;
+  /** Deep link to the leaderboard entry. */
+  portalLink: string;
+}
+
+/** Discriminated outcome of a publish attempt — never throws across IPC. */
+export type PublishOutcome = { ok: true; value: PublishResult } | { ok: false; error: string };
+
 export interface ElectronAPI {
   popup: {
     open: (url: string, title?: string) => Promise<void>;
@@ -255,6 +283,7 @@ export interface ElectronAPI {
   };
   publish: {
     getContext: () => Promise<PublishContext>;
+    submitScore: (request: PublishScoreRequest) => Promise<PublishOutcome>;
     openExternal: (url: string) => Promise<void>;
   };
   backends: {

--- a/apps/desktop/src/renderer/src/hooks/__tests__/use-publish-score.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/__tests__/use-publish-score.test.ts
@@ -3,12 +3,7 @@ import { renderHook, act } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { usePublishScore, type PublishInputs } from '../use-publish-score';
 import type { EvalRunDetail } from '@/components/eval/types';
-
-const CTX = {
-  scoreboardUrl: 'https://scoreboard.screamingface.ai',
-  portalUrl: 'https://screamingface.ai/portal/',
-  client: { name: 'screamingface-desktop', version: '0.4.2', platform: 'darwin' },
-};
+import type { PublishOutcome } from '../../../../preload/types';
 
 const RUN: EvalRunDetail = {
   id: 'eval-run-abc123',
@@ -34,114 +29,87 @@ const INPUTS: PublishInputs = {
   submittedBy: null,
 };
 
-function okResponse(): Response {
-  return {
-    ok: true,
-    status: 201,
-    json: async () => ({ id: 'score-1', benchmark_id: 'hle', spec_id: 'hle-ensemble-three' }),
-  } as unknown as Response;
-}
+const SUCCESS: PublishOutcome = {
+  ok: true,
+  value: {
+    id: 'score-1',
+    benchmarkId: 'hle',
+    specId: 'hle-ensemble-three',
+    portalLink: 'https://screamingface.ai/portal/spec.html?benchmark=hle&spec=hle-ensemble-three',
+  },
+};
 
-function errResponse(status: number): Response {
-  return {
-    ok: false,
-    status,
-    text: async () => 'rejected',
-    json: async () => ({}),
-  } as unknown as Response;
-}
+let submitScore: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
+  submitScore = vi.fn(async () => SUCCESS);
   (window as unknown as { electronAPI: unknown }).electronAPI = {
-    publish: { getContext: vi.fn(async () => CTX), openExternal: vi.fn(async () => {}) },
+    publish: { submitScore, openExternal: vi.fn(async () => {}) },
   };
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
-  vi.useRealTimers();
 });
 
 describe('usePublishScore', () => {
-  it('POSTs the nested-client wire shape with the eval_run id as Idempotency-Key', async () => {
-    const fetchMock = vi.fn(async () => okResponse());
-    global.fetch = fetchMock as unknown as typeof fetch;
-
+  it('flattens the run into the IPC request (idempotency id, totals, ran_at) and returns the value on success', async () => {
     const { result } = renderHook(() => usePublishScore());
     let out: Awaited<ReturnType<typeof result.current.publish>> = null;
     await act(async () => {
       out = await result.current.publish(INPUTS);
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe('https://scoreboard.screamingface.ai/v1/scores');
-    expect((init.headers as Record<string, string>)['Idempotency-Key']).toBe('eval-run-abc123');
-    const body = JSON.parse(init.body as string);
-    // Nested client, not flat — and recomputed accuracy = correct/total.
-    expect(body.client).toEqual({
-      name: 'screamingface-desktop',
-      version: '0.4.2',
-      platform: 'darwin',
+    expect(submitScore).toHaveBeenCalledTimes(1);
+    expect(submitScore).toHaveBeenCalledWith({
+      benchmarkId: 'hle',
+      specId: 'hle-ensemble-three',
+      url4Expression: 'url4://ensemble(claude,codex,gemini)/hle',
+      providers: ['claude', 'codex', 'gemini'],
+      submittedBy: null,
+      runId: 'eval-run-abc123',
+      totalQuestions: 1000,
+      correctQuestions: 810,
+      ranAtLocal: '2026-05-04T11:55:00Z',
     });
-    expect(body).not.toHaveProperty('client_name');
-    expect(body.accuracy).toBeCloseTo(0.81, 5);
-    expect(body.ran_with_providers).toEqual(['claude', 'codex', 'gemini']);
-    expect(body.submitted_by).toBeNull();
-    expect(body.ran_at_local).toBe('2026-05-04T11:55:00Z');
-
     expect(result.current.status).toBe('success');
-    expect(out).toMatchObject({
-      id: 'score-1',
-      portalLink: 'https://screamingface.ai/portal/spec.html?benchmark=hle&spec=hle-ensemble-three',
-    });
+    expect(out).toEqual(SUCCESS.value);
+    expect(result.current.result).toEqual(SUCCESS.value);
   });
 
-  it('recomputes accuracy from totals (ignores a stale stored value)', async () => {
-    const fetchMock = vi.fn(async () => okResponse());
-    global.fetch = fetchMock as unknown as typeof fetch;
-    const drifted: PublishInputs = {
-      ...INPUTS,
-      run: { ...RUN, accuracy: 0.9, correct_questions: 810, total_questions: 1000 },
-    };
+  it('falls back to started_at when the run has no finished_at', async () => {
     const { result } = renderHook(() => usePublishScore());
     await act(async () => {
-      await result.current.publish(drifted);
+      await result.current.publish({ ...INPUTS, run: { ...RUN, finished_at: null } });
     });
-    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
-    expect(body.accuracy).toBeCloseTo(0.81, 5); // 810/1000, not the stored 0.9
+    const sent = submitScore.mock.calls[0][0] as { ranAtLocal: string };
+    expect(sent.ranAtLocal).toBe('2026-05-04T11:00:00Z');
   });
 
-  it('does not retry a 4xx and surfaces actionable copy', async () => {
-    const fetchMock = vi.fn(async () => errResponse(404));
-    global.fetch = fetchMock as unknown as typeof fetch;
+  it('surfaces the error string from a failed outcome without throwing', async () => {
+    submitScore.mockResolvedValueOnce({
+      ok: false,
+      error: 'That benchmark is not registered on the scoreboard yet.',
+    } satisfies PublishOutcome);
 
     const { result } = renderHook(() => usePublishScore());
+    let out: Awaited<ReturnType<typeof result.current.publish>> = 'sentinel' as never;
     await act(async () => {
-      await result.current.publish(INPUTS);
+      out = await result.current.publish(INPUTS);
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(out).toBeNull();
     expect(result.current.status).toBe('error');
     expect(result.current.error).toMatch(/not registered/i);
   });
 
-  it('retries a transient network failure with backoff, then succeeds', async () => {
-    vi.useFakeTimers();
-    const fetchMock = vi
-      .fn()
-      .mockRejectedValueOnce(new Error('network down'))
-      .mockResolvedValueOnce(okResponse());
-    global.fetch = fetchMock as unknown as typeof fetch;
-
+  it('maps a thrown IPC error to error state', async () => {
+    submitScore.mockRejectedValueOnce(new Error('ipc exploded'));
     const { result } = renderHook(() => usePublishScore());
     await act(async () => {
-      const promise = result.current.publish(INPUTS);
-      await vi.advanceTimersByTimeAsync(1100); // first backoff = 1s
-      await promise;
+      await result.current.publish(INPUTS);
     });
-
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(result.current.status).toBe('success');
+    expect(result.current.status).toBe('error');
+    expect(result.current.error).toBe('ipc exploded');
   });
 });

--- a/apps/desktop/src/renderer/src/hooks/use-publish-score.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-publish-score.ts
@@ -1,16 +1,14 @@
 // apps/desktop/src/renderer/src/hooks/use-publish-score.ts
 //
 // Publishes a local eval_run aggregate to the public scoreboard (SF-181 /
-// D-SCORE-006). Builds the exact wire shape the scoreboard accepts (nested
-// `client`, see apps/scoreboard/tests/unit/test_sf_payload.py), POSTs it with
-// an Idempotency-Key so repeat clicks don't duplicate, and retries transient
-// failures. The contract is strict (`extra="forbid"`) — send these keys only.
+// D-SCORE-006). The actual POST (wire-shape build, Idempotency-Key, retries,
+// error mapping) runs in the Electron main process via publish:submitScore, so
+// it is exempt from renderer CORS (SF-273). This hook just maps the run into the
+// IPC request and drives the UI state machine.
 
 import { useCallback, useState } from 'react';
 import type { EvalRunDetail } from '@/components/eval/types';
-
-const TIMEOUT_MS = 10_000;
-const BACKOFF_MS = [1_000, 2_000, 4_000];
+import type { PublishResult, PublishScoreRequest } from '../../../../preload/types';
 
 export type PublishStatus = 'idle' | 'submitting' | 'success' | 'error';
 
@@ -25,82 +23,23 @@ export interface PublishInputs {
   submittedBy: string | null;
 }
 
-export interface PublishResult {
-  id: string;
-  benchmarkId: string;
-  specId: string;
-  /** Deep link to the leaderboard entry. */
-  portalLink: string;
-}
+export type { PublishResult };
 
-interface ScoreResponse {
-  id: string;
-  benchmark_id: string;
-  spec_id: string;
-}
-
-/** Map a non-2xx status to actionable copy. */
-function errorForStatus(status: number, body: string): string {
-  switch (status) {
-    case 404:
-      return 'That benchmark is not registered on the scoreboard yet. Coordinate with the scoreboard owner before publishing.';
-    case 400:
-      return 'The scoreboard rejected the aggregate (accuracy must equal correct/total). This run may have inconsistent totals.';
-    case 422:
-      return 'The submission did not match the scoreboard contract. This is a bug — please report it.';
-    default:
-      return `Scoreboard returned HTTP ${status}: ${body.slice(0, 200)}`;
-  }
-}
-
-function buildBody(
-  inputs: PublishInputs,
-  client: { name: string; version: string; platform: string },
-): Record<string, unknown> {
+/** Flatten the run + form fields into the serializable IPC request. */
+function toRequest(inputs: PublishInputs): PublishScoreRequest {
   const { run } = inputs;
-  const total = run.total_questions ?? 0;
-  const correct = run.correct_questions ?? 0;
-  // Recompute accuracy from the integer totals: the scoreboard 400s if `accuracy`
-  // differs from correct/total by >0.01, so never trust a stored rounded value.
-  const accuracy = total > 0 ? correct / total : 0;
-  const submittedBy =
-    inputs.submittedBy && inputs.submittedBy.trim().length > 0 ? inputs.submittedBy.trim() : null;
   return {
-    version: 1,
-    benchmark_id: inputs.benchmarkId,
-    spec_id: inputs.specId,
-    url4_expression: inputs.url4Expression,
-    submitted_by: submittedBy,
-    accuracy,
-    total_questions: total,
-    correct_questions: correct,
-    ran_with_providers: inputs.providers,
-    ran_at_local: run.finished_at ?? run.started_at,
-    client: { name: client.name, version: client.version, platform: client.platform },
-    metadata: null,
+    benchmarkId: inputs.benchmarkId,
+    specId: inputs.specId,
+    url4Expression: inputs.url4Expression,
+    providers: inputs.providers,
+    submittedBy: inputs.submittedBy,
+    runId: run.id,
+    totalQuestions: run.total_questions ?? 0,
+    correctQuestions: run.correct_questions ?? 0,
+    ranAtLocal: run.finished_at ?? run.started_at,
   };
 }
-
-async function postOnce(
-  url: string,
-  body: Record<string, unknown>,
-  idempotencyKey: string,
-): Promise<Response> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
-  try {
-    return await fetch(`${url.replace(/\/$/, '')}/v1/scores`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'Idempotency-Key': idempotencyKey },
-      body: JSON.stringify(body),
-      signal: controller.signal,
-    });
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
-const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 export function usePublishScore() {
   const [status, setStatus] = useState<PublishStatus>('idle');
@@ -111,45 +50,13 @@ export function usePublishScore() {
     setStatus('submitting');
     setError(null);
     try {
-      const ctx = await window.electronAPI.publish.getContext();
-      const body = buildBody(inputs, ctx.client);
-      const idempotencyKey = inputs.run.id;
-
-      let lastErr: string | null = null;
-      // 1 initial attempt + up to 3 retries on transient failures.
-      for (let attempt = 0; attempt <= BACKOFF_MS.length; attempt += 1) {
-        if (attempt > 0) await sleep(BACKOFF_MS[attempt - 1]);
-        let res: Response;
-        try {
-          res = await postOnce(ctx.scoreboardUrl, body, idempotencyKey);
-        } catch {
-          lastErr = 'Could not reach the scoreboard. Check your connection and try again.';
-          continue; // network/abort — retry
-        }
-        if (res.ok) {
-          const data = (await res.json()) as ScoreResponse;
-          const portalLink = `${ctx.portalUrl.replace(/\/$/, '')}/spec.html?benchmark=${encodeURIComponent(data.benchmark_id)}&spec=${encodeURIComponent(data.spec_id)}`;
-          const out: PublishResult = {
-            id: data.id,
-            benchmarkId: data.benchmark_id,
-            specId: data.spec_id,
-            portalLink,
-          };
-          setResult(out);
-          setStatus('success');
-          return out;
-        }
-        if (res.status >= 500) {
-          lastErr = errorForStatus(res.status, await res.text());
-          continue; // server error — retry
-        }
-        // 4xx (other than 5xx) is deterministic — do not retry.
-        const errText = errorForStatus(res.status, await res.text());
-        setError(errText);
-        setStatus('error');
-        return null;
+      const outcome = await window.electronAPI.publish.submitScore(toRequest(inputs));
+      if (outcome.ok) {
+        setResult(outcome.value);
+        setStatus('success');
+        return outcome.value;
       }
-      setError(lastErr ?? 'Publishing failed after several attempts.');
+      setError(outcome.error);
       setStatus('error');
       return null;
     } catch (e) {


### PR DESCRIPTION
## Problem
Clicking **Publish** in Eval Studio failed with *"Could not reach the scoreboard. Check your connection and try again."* — but the scoreboard is healthy. The real cause is **CORS**: the publish POST ran in the renderer (`use-publish-score.ts` `fetch`), so it was subject to browser CORS. The prod scoreboard allowlists the web portal origin but not the desktop app origin:

| Origin (preflight) | Result |
|---|---|
| `http://localhost:5173` (dev renderer) | **400 `Disallowed CORS origin`** ❌ |
| `https://screamingface.ai` (web portal) | `200`, origin echoed ✅ |

The renderer blocks the request, `fetch` throws, and the hook's catch-all maps any throw to the misleading "could not reach" copy.

## Fix
Move the publish POST into the **Electron main process**, which is **not subject to CORS**. No scoreboard allowlist changes needed; works in dev and packaged builds.

- **New `main/services/publish-score.ts`** — owns the wire-shape build, `Idempotency-Key`, retry/backoff, error mapping, and portal-link construction (moved verbatim from the renderer). Returns a discriminated `PublishOutcome` instead of throwing.
- **New `publish:submitScore` IPC** — purpose-specific handler (not a generic "fetch anything" bridge, so the security boundary stays tight) + preload bridge + shared types in `preload/types.ts`.
- **Renderer hook slimmed** to a thin caller: maps the run into the IPC request and drives the UI state machine. Public API (`usePublishScore()` → `{ publish, status, error, result }`) unchanged, so `PublishToLeaderboardDialog` needs no changes.
- Side benefit: the "Could not reach" message is now only shown on a *genuine* network failure.

## Tests
- **New `main/services/__tests__/publish-score.test.ts`** — ports the network cases (wire shape, Idempotency-Key, accuracy recompute, 4xx-no-retry, transient-retry-with-backoff) to the main process.
- **Rewrote `use-publish-score.test.ts`** — mocks `publish.submitScore`, asserts input→request mapping (incl. `finished_at`→`started_at` fallback), success/error state, and thrown-IPC handling.
- Full desktop suite: **185 passed / 39 files**. `npm run build`: green (main+preload+renderer).

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215680338116171

🤖 Generated with [Claude Code](https://claude.com/claude-code)