### PR TITLE
SF-275: preflight guard for un-publishable runs in the publish dialog

### DIFF
--- a/apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
@@ -11,6 +11,7 @@ import {
   hasLocalDataRefs,
   sanitizeDataRefs,
 } from '@/lib/url4-redaction';
+import { publishBlockReason } from '@/lib/publish-guard';
 import type { EvalRunDetail } from './types';
 
 interface Props {
@@ -51,10 +52,17 @@ export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
     .filter((p) => p.length > 0);
 
   const submitting = status === 'submitting';
-  // Block publish until: benchmark known, and any /data refs are either sanitized
-  // or explicitly acknowledged as exposing local data.
+  // Preflight: deterministic scoreboard-contract violations we can catch before
+  // the round-trip (e.g. a zero-question degraded run) — block + explain up front.
+  const blockReason = useMemo(
+    () => publishBlockReason({ run, url4Expression: expressionToPublish }),
+    [run, expressionToPublish],
+  );
+  // Block publish until: run is publishable, benchmark known, and any /data refs
+  // are either sanitized or explicitly acknowledged as exposing local data.
   const redactionResolved = !hasDataRefs || sanitize || ackExpose;
-  const canPublish = benchmarkId.trim().length > 0 && specId.trim().length > 0 && redactionResolved;
+  const canPublish =
+    !blockReason && benchmarkId.trim().length > 0 && specId.trim().length > 0 && redactionResolved;
 
   const handlePublish = async (): Promise<void> => {
     const out = await publish({
@@ -102,6 +110,14 @@ export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
             </div>
           ) : (
             <>
+              {/* Preflight block — this run can't satisfy the scoreboard contract */}
+              {blockReason && (
+                <div className="flex items-start gap-1.5 rounded-none border border-primary/40 bg-primary/10 px-3 py-2 text-xs text-foreground">
+                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" />
+                  <span>{blockReason}</span>
+                </div>
+              )}
+
               {/* Aggregate (read-only) */}
               <dl className="grid grid-cols-3 gap-3 text-xs">
                 <div>

--- a/apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
@@ -98,6 +98,19 @@ describe('PublishToLeaderboardDialog', () => {
     expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled();
   });
 
+  it('blocks a zero-question run with an explanation (preflight guard)', () => {
+    const run = makeRun({ total_questions: 0, correct_questions: 0 });
+    render(<PublishToLeaderboardDialog run={run} serverUrl="" onClose={vi.fn()} />);
+    expect(screen.getByText(/no graded questions/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /publish/i })).toBeDisabled();
+  });
+
+  it('does not block a normal completed run', () => {
+    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    expect(screen.queryByText(/no graded questions/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled();
+  });
+
   it('shows the success state and opens the leaderboard deep link', () => {
     hookState.status = 'success';
     hookState.result = {

--- a/apps/desktop/src/renderer/src/lib/__tests__/publish-guard.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/publish-guard.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { publishBlockReason } from '../publish-guard';
+import type { EvalRunDetail } from '@/components/eval/types';
+
+const RUN: EvalRunDetail = {
+  id: 'r1',
+  spec_name: 'hle:hle-ensemble-three',
+  url4_expression: 'url4://ensemble(claude)/hle',
+  started_at: '2026-05-04T11:00:00Z',
+  finished_at: '2026-05-04T11:55:00Z',
+  status: 'done',
+  accuracy: 0.81,
+  total_questions: 1000,
+  correct_questions: 810,
+  error: null,
+  favorite: false,
+  questions: [],
+};
+
+const EXPR = RUN.url4_expression;
+
+describe('publishBlockReason', () => {
+  it('passes a normal completed run', () => {
+    expect(publishBlockReason({ run: RUN, url4Expression: EXPR })).toBeNull();
+  });
+
+  it('blocks a run with zero graded questions (degraded/empty)', () => {
+    const reason = publishBlockReason({
+      run: { ...RUN, total_questions: 0, correct_questions: 0 },
+      url4Expression: EXPR,
+    });
+    expect(reason).toMatch(/no graded questions/i);
+  });
+
+  it('blocks a null total_questions', () => {
+    const reason = publishBlockReason({
+      run: { ...RUN, total_questions: null as unknown as number },
+      url4Expression: EXPR,
+    });
+    expect(reason).toMatch(/no graded questions/i);
+  });
+
+  it('blocks inconsistent totals (correct > total)', () => {
+    const reason = publishBlockReason({
+      run: { ...RUN, total_questions: 2, correct_questions: 3 },
+      url4Expression: EXPR,
+    });
+    expect(reason).toMatch(/inconsistent/i);
+  });
+
+  it('blocks an empty url4 expression to publish', () => {
+    expect(publishBlockReason({ run: RUN, url4Expression: '   ' })).toMatch(/no URL4 expression/i);
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/publish-guard.ts
+++ b/apps/desktop/src/renderer/src/lib/publish-guard.ts
@@ -1,0 +1,35 @@
+// apps/desktop/src/renderer/src/lib/publish-guard.ts
+//
+// Deterministic, client-checkable reasons a run cannot be published — a preflight
+// mirror of the scoreboard ScoreSubmission validators we can evaluate without a
+// round-trip (apps/scoreboard/src/scoreboard/scores/schemas.py). Lets the publish
+// dialog block + explain up front instead of bouncing the user off a 422.
+
+import type { EvalRunDetail } from '@/components/eval/types';
+
+export interface PublishGuardInput {
+  run: EvalRunDetail;
+  /** The expression that will actually be published (post-sanitization). */
+  url4Expression: string;
+}
+
+/**
+ * Returns a user-facing reason the run can't be published, or null if it clears
+ * the deterministic checks. `accuracy` is recomputed server-side from the totals,
+ * so it can't be out of range once `total > 0` — no check needed here.
+ */
+export function publishBlockReason({ run, url4Expression }: PublishGuardInput): string | null {
+  const total = run.total_questions ?? 0;
+  const correct = run.correct_questions ?? 0;
+
+  if (total <= 0) {
+    return 'This run has no graded questions, so there is nothing to publish. Run an eval that produces scored results first (a degraded run from a backend outage scores zero rows).';
+  }
+  if (correct > total) {
+    return `This run's totals are inconsistent (correct ${correct} exceeds total ${total}), so the scoreboard would reject it.`;
+  }
+  if (url4Expression.trim().length === 0) {
+    return 'This run has no URL4 expression to publish.';
+  }
+  return null;
+}


### PR DESCRIPTION
## What
Follow-up to #300 (SF-274). Stops the user from even attempting to publish a run that would deterministically fail the scoreboard contract — so they never round-trip to a 422.

New pure helper `lib/publish-guard.ts` mirrors the `ScoreSubmission` validators we can evaluate client-side:
- `total_questions <= 0` — **no graded questions** (the common degraded/empty-run case)
- `correct_questions > total_questions` — inconsistent totals
- empty `url4_expression`

(`accuracy` is recomputed server-side from the totals, so it can't be out of range once `total > 0` — no client check needed.)

`PublishToLeaderboardDialog` now **disables Publish** and shows the reason in an amber notice (brand `--primary`/mark) when a run is un-publishable, e.g.:

> This run has no graded questions, so there is nothing to publish. Run an eval that produces scored results first.

## Tests
- New `lib/__tests__/publish-guard.test.ts` — normal run passes; zero/null totals, `correct > total`, and empty url4 each blocked.
- Extended `PublishToLeaderboardDialog.test.tsx` — zero-question run shows the notice + disables Publish; normal run does not.
- Full desktop suite: **195 passed / 40 files**. `npm run build`: green.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215685534221095

🤖 Generated with [Claude Code](https://claude.com/claude-code)