### PR TITLE
SF-276: log raw scoreboard response per publish attempt

### DIFF
--- a/apps/desktop/src/main/services/__tests__/publish-score.test.ts
+++ b/apps/desktop/src/main/services/__tests__/publish-score.test.ts
@@ -9,6 +9,8 @@ const CTX = {
   client: { name: 'screamingface-desktop', version: '0.4.2', platform: 'darwin' },
 };
 vi.mock('../publish-context', () => ({ resolvePublishContext: () => CTX }));
+// debug-log imports electron's app at module load — stub it for the node test env.
+vi.mock('../../debug-log', () => ({ log: () => {} }));
 
 import { submitScore } from '../publish-score';
 

--- a/apps/desktop/src/main/services/publish-score.ts
+++ b/apps/desktop/src/main/services/publish-score.ts
@@ -10,6 +10,7 @@
 // (`extra="forbid"`) — send these keys only.
 
 import { resolvePublishContext } from './publish-context';
+import { log } from '../debug-log';
 import type { PublishOutcome, PublishResult, PublishScoreRequest } from '../../preload/types';
 
 const TIMEOUT_MS = 10_000;
@@ -136,20 +137,31 @@ export async function submitScore(request: PublishScoreRequest): Promise<Publish
   const ctx = resolvePublishContext();
   const body = buildBody(request, ctx.client);
   const idempotencyKey = request.runId;
+  const target = `${ctx.scoreboardUrl.replace(/\/$/, '')}/v1/scores`;
+  // Diagnostics (debug.log): we have no server-side log access, so record the
+  // request shape and every attempt's raw status/body. No submitter name logged.
+  log(
+    `publish: POST ${target} run=${request.runId} benchmark=${request.benchmarkId} ` +
+      `spec=${request.specId} total=${request.totalQuestions} correct=${request.correctQuestions} ` +
+      `providers=${request.providers.join('+') || '-'}`,
+  );
 
   let lastErr: string | null = null;
   // 1 initial attempt + up to 3 retries on transient failures.
   for (let attempt = 0; attempt <= BACKOFF_MS.length; attempt += 1) {
     if (attempt > 0) await sleep(BACKOFF_MS[attempt - 1]);
+    const label = `attempt ${attempt + 1}/${BACKOFF_MS.length + 1}`;
     let res: Response;
     try {
       res = await postOnce(ctx.scoreboardUrl, body, idempotencyKey);
-    } catch {
+    } catch (e) {
       lastErr = 'Could not reach the scoreboard. Check your connection and try again.';
+      log(`publish: ${label} network/abort error: ${(e as Error).message}`);
       continue; // network/abort — retry
     }
     if (res.ok) {
       const data = (await res.json()) as ScoreResponse;
+      log(`publish: ${label} -> HTTP ${res.status} ok, score=${data.id}`);
       const portalLink = `${ctx.portalUrl.replace(/\/$/, '')}/spec.html?benchmark=${encodeURIComponent(data.benchmark_id)}&spec=${encodeURIComponent(data.spec_id)}`;
       const value: PublishResult = {
         id: data.id,
@@ -159,12 +171,16 @@ export async function submitScore(request: PublishScoreRequest): Promise<Publish
       };
       return { ok: true, value };
     }
+    // Read the body once, for both logging and the user-facing message.
+    const text = await res.text();
+    log(`publish: ${label} -> HTTP ${res.status}: ${text.slice(0, 500)}`);
     if (res.status >= 500) {
-      lastErr = errorForStatus(res.status, await res.text());
+      lastErr = errorForStatus(res.status, text);
       continue; // server error — retry
     }
     // 4xx (other than 5xx) is deterministic — do not retry.
-    return { ok: false, error: errorForStatus(res.status, await res.text()) };
+    return { ok: false, error: errorForStatus(res.status, text) };
   }
+  log(`publish: giving up after ${BACKOFF_MS.length + 1} attempts: ${lastErr ?? 'unknown'}`);
   return { ok: false, error: lastErr ?? 'Publishing failed after several attempts.' };
 }


### PR DESCRIPTION
## Why
Publish failures are intermittent — the first attempt's error differs from the second — and we have **no server-side log access** to the scoreboard. So capture the evidence on the client.

## What
The main-process publish service (`publish-score.ts`) now writes to the existing `userData/debug.log`:
- one line on entry with the request shape — `run`, `benchmark`, `spec`, `total`, `correct`, `providers` (**no submitter name**)
- one line per attempt with the raw **status + body slice** (truncated to 500 chars), or the network/abort error message
- a final line if all retries are exhausted

The response body is now read **once** per attempt and reused for both the log line and the user-facing message (previously read separately in the 5xx/4xx branches).

This makes "first error differs from second" diagnosable: the log shows exactly what the scoreboard returned each click (e.g. `HTTP 404: {"detail":{"field":"benchmark_id",...}}` vs a transient connection error).

## Where to read it
macOS: `~/Library/Application Support/ScreamingFace/debug.log` (truncated each launch). `tail -f` it while clicking Publish.

## Tests
- `publish-score.test.ts` stubs `debug-log` (it imports electron's `app` at module load) and still asserts all status/retry paths.
- Full desktop suite: **195 passed / 40 files**. `npm run build`: green.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215682952313693

🤖 Generated with [Claude Code](https://claude.com/claude-code)