### PR TITLE
SF-277: in-app Publish logs panel in Eval Studio

### DIFF
--- a/apps/desktop/src/main/ipc/publish.ipc.ts
+++ b/apps/desktop/src/main/ipc/publish.ipc.ts
@@ -3,10 +3,12 @@
 // IPC for the "Publish to Leaderboard" flow (SF-181 / D-SCORE-006):
 //   - publish:getContext  — env/app-version/platform the renderer can't read
 //   - publish:submitScore — POST the score from main, exempt from renderer CORS (SF-273)
+//   - publish:getLogs / publish:log — backlog + live stream of scoreboard attempts (SF-277)
 //   - publish:openExternal — open the leaderboard deep link in the system browser
-import { ipcMain, shell } from 'electron';
+import { BrowserWindow, ipcMain, shell } from 'electron';
 import { resolvePublishContext, type PublishContext } from '../services/publish-context';
 import { submitScore } from '../services/publish-score';
+import { getPublishLog, onPublishLog } from '../services/publish-log';
 import type { PublishOutcome, PublishScoreRequest } from '../../preload/types';
 import { requireTrustedIpcSender } from './sender-validation';
 
@@ -32,6 +34,18 @@ export function registerPublishHandlers(): void {
       return submitScore(request);
     },
   );
+
+  ipcMain.handle('publish:getLogs', (event): string[] => {
+    requireTrustedIpcSender(event);
+    return getPublishLog();
+  });
+
+  // Stream new publish/scoreboard diagnostic lines to every renderer window.
+  onPublishLog((line) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send('publish:log', line);
+    }
+  });
 
   ipcMain.handle('publish:openExternal', async (event, url: string): Promise<void> => {
     requireTrustedIpcSender(event);

--- a/apps/desktop/src/main/services/__tests__/publish-log.test.ts
+++ b/apps/desktop/src/main/services/__tests__/publish-log.test.ts
@@ -1,0 +1,28 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+// debug-log imports electron's app at module load — stub the file sink.
+const fileLog = vi.fn();
+vi.mock('../../debug-log', () => ({ log: (m: string) => fileLog(m) }));
+
+import { publishLog, getPublishLog, onPublishLog } from '../publish-log';
+
+beforeEach(() => fileLog.mockClear());
+
+describe('publish-log bus', () => {
+  it('persists to the file sink and keeps an in-memory backlog', () => {
+    publishLog('publish: hello');
+    expect(fileLog).toHaveBeenCalledWith('publish: hello');
+    const backlog = getPublishLog();
+    expect(backlog[backlog.length - 1]).toContain('publish: hello');
+  });
+
+  it('notifies live subscribers and supports unsubscribe', () => {
+    const seen: string[] = [];
+    const off = onPublishLog((line) => seen.push(line));
+    publishLog('publish: one');
+    off();
+    publishLog('publish: two');
+    expect(seen.some((l) => l.includes('one'))).toBe(true);
+    expect(seen.some((l) => l.includes('two'))).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/services/__tests__/publish-score.test.ts
+++ b/apps/desktop/src/main/services/__tests__/publish-score.test.ts
@@ -9,8 +9,8 @@ const CTX = {
   client: { name: 'screamingface-desktop', version: '0.4.2', platform: 'darwin' },
 };
 vi.mock('../publish-context', () => ({ resolvePublishContext: () => CTX }));
-// debug-log imports electron's app at module load — stub it for the node test env.
-vi.mock('../../debug-log', () => ({ log: () => {} }));
+// publish-log transitively imports electron (debug-log) at module load — stub it.
+vi.mock('../publish-log', () => ({ publishLog: () => {} }));
 
 import { submitScore } from '../publish-score';
 

--- a/apps/desktop/src/main/services/publish-log.ts
+++ b/apps/desktop/src/main/services/publish-log.ts
@@ -1,0 +1,34 @@
+// apps/desktop/src/main/services/publish-log.ts
+//
+// A small diagnostic bus for the "Publish to Leaderboard" flow. publish-score.ts
+// records each scoreboard attempt here; the lines are (a) persisted to debug.log,
+// (b) kept in a bounded in-memory backlog, and (c) streamed live to the renderer
+// so the Eval Studio "Publish logs" panel can show them without tailing a file.
+
+import { EventEmitter } from 'events';
+import { log as fileLog } from '../debug-log';
+
+const MAX_BACKLOG = 200;
+const buffer: string[] = [];
+const emitter = new EventEmitter();
+emitter.setMaxListeners(0); // any number of windows may subscribe
+
+/** Record a publish/scoreboard diagnostic line. */
+export function publishLog(message: string): void {
+  fileLog(message);
+  const line = `[${new Date().toISOString()}] ${message}`;
+  buffer.push(line);
+  if (buffer.length > MAX_BACKLOG) buffer.splice(0, buffer.length - MAX_BACKLOG);
+  emitter.emit('line', line);
+}
+
+/** Snapshot of recent lines, for a renderer that just mounted. */
+export function getPublishLog(): string[] {
+  return [...buffer];
+}
+
+/** Subscribe to live lines; returns an unsubscribe fn. */
+export function onPublishLog(listener: (line: string) => void): () => void {
+  emitter.on('line', listener);
+  return () => emitter.off('line', listener);
+}

--- a/apps/desktop/src/main/services/publish-score.ts
+++ b/apps/desktop/src/main/services/publish-score.ts
@@ -10,7 +10,7 @@
 // (`extra="forbid"`) — send these keys only.
 
 import { resolvePublishContext } from './publish-context';
-import { log } from '../debug-log';
+import { publishLog } from './publish-log';
 import type { PublishOutcome, PublishResult, PublishScoreRequest } from '../../preload/types';
 
 const TIMEOUT_MS = 10_000;
@@ -140,7 +140,7 @@ export async function submitScore(request: PublishScoreRequest): Promise<Publish
   const target = `${ctx.scoreboardUrl.replace(/\/$/, '')}/v1/scores`;
   // Diagnostics (debug.log): we have no server-side log access, so record the
   // request shape and every attempt's raw status/body. No submitter name logged.
-  log(
+  publishLog(
     `publish: POST ${target} run=${request.runId} benchmark=${request.benchmarkId} ` +
       `spec=${request.specId} total=${request.totalQuestions} correct=${request.correctQuestions} ` +
       `providers=${request.providers.join('+') || '-'}`,
@@ -156,12 +156,12 @@ export async function submitScore(request: PublishScoreRequest): Promise<Publish
       res = await postOnce(ctx.scoreboardUrl, body, idempotencyKey);
     } catch (e) {
       lastErr = 'Could not reach the scoreboard. Check your connection and try again.';
-      log(`publish: ${label} network/abort error: ${(e as Error).message}`);
+      publishLog(`publish: ${label} network/abort error: ${(e as Error).message}`);
       continue; // network/abort — retry
     }
     if (res.ok) {
       const data = (await res.json()) as ScoreResponse;
-      log(`publish: ${label} -> HTTP ${res.status} ok, score=${data.id}`);
+      publishLog(`publish: ${label} -> HTTP ${res.status} ok, score=${data.id}`);
       const portalLink = `${ctx.portalUrl.replace(/\/$/, '')}/spec.html?benchmark=${encodeURIComponent(data.benchmark_id)}&spec=${encodeURIComponent(data.spec_id)}`;
       const value: PublishResult = {
         id: data.id,
@@ -173,7 +173,7 @@ export async function submitScore(request: PublishScoreRequest): Promise<Publish
     }
     // Read the body once, for both logging and the user-facing message.
     const text = await res.text();
-    log(`publish: ${label} -> HTTP ${res.status}: ${text.slice(0, 500)}`);
+    publishLog(`publish: ${label} -> HTTP ${res.status}: ${text.slice(0, 500)}`);
     if (res.status >= 500) {
       lastErr = errorForStatus(res.status, text);
       continue; // server error — retry
@@ -181,6 +181,6 @@ export async function submitScore(request: PublishScoreRequest): Promise<Publish
     // 4xx (other than 5xx) is deterministic — do not retry.
     return { ok: false, error: errorForStatus(res.status, text) };
   }
-  log(`publish: giving up after ${BACKOFF_MS.length + 1} attempts: ${lastErr ?? 'unknown'}`);
+  publishLog(`publish: giving up after ${BACKOFF_MS.length + 1} attempts: ${lastErr ?? 'unknown'}`);
   return { ok: false, error: lastErr ?? 'Publishing failed after several attempts.' };
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -49,6 +49,8 @@ const api: ElectronAPI = {
   publish: {
     getContext: () => ipcRenderer.invoke('publish:getContext'),
     submitScore: (request) => ipcRenderer.invoke('publish:submitScore', request),
+    getLogs: () => ipcRenderer.invoke('publish:getLogs'),
+    onLog: (cb) => onEvent('publish:log', cb),
     openExternal: (url) => ipcRenderer.invoke('publish:openExternal', url),
   },
   backends: {

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -284,6 +284,10 @@ export interface ElectronAPI {
   publish: {
     getContext: () => Promise<PublishContext>;
     submitScore: (request: PublishScoreRequest) => Promise<PublishOutcome>;
+    /** Backlog of recent publish/scoreboard diagnostic lines. */
+    getLogs: () => Promise<string[]>;
+    /** Subscribe to live publish/scoreboard log lines; returns an unsubscribe fn. */
+    onLog: (callback: (line: string) => void) => () => void;
     openExternal: (url: string) => Promise<void>;
   };
   backends: {

--- a/apps/desktop/src/renderer/src/components/server/ServerLogs.tsx
+++ b/apps/desktop/src/renderer/src/components/server/ServerLogs.tsx
@@ -4,6 +4,8 @@ import { Trash2, Copy, Check, ChevronRight, ChevronDown, Maximize2, Minimize2 } 
 interface ServerLogsProps {
   logs: string[];
   onClear: () => void;
+  /** Panel heading; defaults to "Logs". */
+  title?: string;
 }
 
 type LogLevel = 'debug' | 'info' | 'warning' | 'error' | 'critical' | 'system';
@@ -103,7 +105,7 @@ function LogLine({ line }: { line: string }) {
   );
 }
 
-export function ServerLogs({ logs, onClear }: ServerLogsProps) {
+export function ServerLogs({ logs, onClear, title = 'Logs' }: ServerLogsProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [copied, setCopied] = useState(false);
@@ -152,7 +154,8 @@ export function ServerLogs({ logs, onClear }: ServerLogsProps) {
     <div className={wrapperClass}>
       <div className="flex items-center justify-between border-b border-border px-4 py-2">
         <h3 className="text-xs font-medium text-muted-foreground">
-          Logs{fullscreen && <span className="ml-2 text-[10px] opacity-50">ESC to exit</span>}
+          {title}
+          {fullscreen && <span className="ml-2 text-[10px] opacity-50">ESC to exit</span>}
         </h3>
         <div className="flex items-center gap-2">
           <button

--- a/apps/desktop/src/renderer/src/hooks/__tests__/use-publish-logs.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/__tests__/use-publish-logs.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { usePublishLogs } from '../use-publish-logs';
+
+let onLogCb: ((line: string) => void) | null = null;
+const unsub = vi.fn();
+
+beforeEach(() => {
+  onLogCb = null;
+  unsub.mockClear();
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    publish: {
+      getLogs: vi.fn(async () => ['[t0] publish: backlog line']),
+      onLog: vi.fn((cb: (line: string) => void) => {
+        onLogCb = cb;
+        return unsub;
+      }),
+    },
+  };
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('usePublishLogs', () => {
+  it('loads the backlog then appends live lines', async () => {
+    const { result } = renderHook(() => usePublishLogs());
+
+    await waitFor(() => expect(result.current.logs).toHaveLength(1));
+    expect(result.current.logs[0]).toContain('backlog');
+
+    act(() => onLogCb?.('[t1] publish: attempt 1/4 -> HTTP 404'));
+    expect(result.current.logs).toHaveLength(2);
+    expect(result.current.logs[1]).toContain('HTTP 404');
+  });
+
+  it('clears and unsubscribes on unmount', async () => {
+    const { result, unmount } = renderHook(() => usePublishLogs());
+    await waitFor(() => expect(result.current.logs.length).toBeGreaterThan(0));
+
+    act(() => result.current.clearLogs());
+    expect(result.current.logs).toEqual([]);
+
+    unmount();
+    expect(unsub).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/renderer/src/hooks/use-publish-logs.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-publish-logs.ts
@@ -1,0 +1,35 @@
+// apps/desktop/src/renderer/src/hooks/use-publish-logs.ts
+//
+// Streams the main-process publish/scoreboard diagnostic lines (SF-277) for the
+// Eval Studio "Publish logs" panel: loads the backlog on mount, then appends
+// live lines, ring-buffered to the most recent 500.
+
+import { useCallback, useEffect, useState } from 'react';
+
+const MAX_LINES = 500;
+
+export function usePublishLogs() {
+  const [logs, setLogs] = useState<string[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    // Seed with the backlog, but don't clobber any live lines that raced ahead.
+    void window.electronAPI.publish.getLogs().then((backlog) => {
+      if (active) setLogs((prev) => (prev.length === 0 ? backlog : prev));
+    });
+    const unsub = window.electronAPI.publish.onLog((line) => {
+      setLogs((prev) => {
+        const next = [...prev, line];
+        return next.length > MAX_LINES ? next.slice(-MAX_LINES) : next;
+      });
+    });
+    return () => {
+      active = false;
+      unsub();
+    };
+  }, []);
+
+  const clearLogs = useCallback(() => setLogs([]), []);
+
+  return { logs, clearLogs };
+}

--- a/apps/desktop/src/renderer/src/views/EvalStudioView.test.tsx
+++ b/apps/desktop/src/renderer/src/views/EvalStudioView.test.tsx
@@ -19,6 +19,9 @@ vi.mock('@/hooks/use-backend-status', () => ({
   isBackendStatusV2: () => false,
 }));
 vi.mock('@/components/eval/EvalRunDetail', () => ({ EvalRunDetail: () => null }));
+vi.mock('@/hooks/use-publish-logs', () => ({
+  usePublishLogs: () => ({ logs: [], clearLogs: vi.fn() }),
+}));
 
 afterEach(cleanup);
 

--- a/apps/desktop/src/renderer/src/views/EvalStudioView.tsx
+++ b/apps/desktop/src/renderer/src/views/EvalStudioView.tsx
@@ -1,14 +1,23 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ImperativePanelHandle } from 'react-resizable-panels';
-import { PanelLeftClose, PanelLeftOpen, PanelRightClose, PanelRightOpen, Plus } from 'lucide-react';
+import {
+  PanelLeftClose,
+  PanelLeftOpen,
+  PanelRightClose,
+  PanelRightOpen,
+  Plus,
+  ScrollText,
+} from 'lucide-react';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
 import { Button } from '@/components/ui/button';
 import { EvalRunsList } from '@/components/eval/EvalRunsList';
 import { EvalRunDetail } from '@/components/eval/EvalRunDetail';
 import { AddEvalRunDialog } from '@/components/eval/AddEvalRunDialog';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { ServerLogs } from '@/components/server/ServerLogs';
 import { useStartEvalRun } from '@/hooks/use-start-eval-run';
 import { useBackendStatus, isBackendStatusV2 } from '@/hooks/use-backend-status';
+import { usePublishLogs } from '@/hooks/use-publish-logs';
 import { referencedBackends } from '@/lib/referenced-backends';
 import type { RunPayload } from '@/components/run/types';
 
@@ -85,6 +94,8 @@ export function EvalStudioView({ pendingRun, onPendingConsumed }: EvalStudioView
   const [leftCollapsed, setLeftCollapsed] = useState(false);
   const [rightCollapsed, setRightCollapsed] = useState(false);
   const [adding, setAdding] = useState(false);
+  const [showLogs, setShowLogs] = useState(false);
+  const { logs: publishLogs, clearLogs: clearPublishLogs } = usePublishLogs();
 
   const toggleLeft = () => {
     const panel = leftPanelRef.current;
@@ -112,6 +123,16 @@ export function EvalStudioView({ pendingRun, onPendingConsumed }: EvalStudioView
         <div className="flex items-center gap-1">
           <Button variant="outline" size="sm" className="mr-1" onClick={() => setAdding(true)}>
             <Plus className="h-3.5 w-3.5" /> New run
+          </Button>
+          <Button
+            variant={showLogs ? 'secondary' : 'ghost'}
+            size="icon-sm"
+            aria-label={showLogs ? 'Hide publish logs' : 'Show publish logs'}
+            aria-pressed={showLogs}
+            title="Publish logs"
+            onClick={() => setShowLogs((v) => !v)}
+          >
+            <ScrollText />
           </Button>
           <Button
             variant="ghost"
@@ -185,6 +206,12 @@ export function EvalStudioView({ pendingRun, onPendingConsumed }: EvalStudioView
           )}
         </ResizablePanel>
       </ResizablePanelGroup>
+
+      {showLogs && (
+        <div className="shrink-0 px-3 pb-3">
+          <ServerLogs logs={publishLogs} onClear={clearPublishLogs} title="Publish logs" />
+        </div>
+      )}
 
       {adding && <AddEvalRunDialog onClose={() => setAdding(false)} onCreate={runAndSelect} />}
 


### PR DESCRIPTION
## Why
Repeated request: a **log view inside Eval Studio** to see what the scoreboard returns on each publish attempt — not a `debug.log` file to tail (which, in dev, lives under the package name, not `ScreamingFace`, so it looked missing).

## What
Streams the main-process publish/scoreboard diagnostic lines into the app, reusing the existing `server:log` streaming pattern and the `ServerLogs` renderer.

- **`main/services/publish-log.ts`** (new) — a small bus: bounded in-memory backlog (200) + `EventEmitter`, still writes through to `debug.log`. `publish-score.ts` now logs via `publishLog()`.
- **IPC** (`publish.ipc.ts`) — `publish:getLogs` (backlog fetch) + a `publish:log` broadcast to all windows, mirroring `server:log`.
- **`hooks/use-publish-logs.ts`** (new) — loads the backlog on mount, appends live lines, ring-buffered to 500.
- **`EvalStudioView`** — a **Publish logs** toggle (ScrollText icon) in the header reveals a bottom panel rendering `ServerLogs` (now accepts an optional `title`): autoscroll, copy, clear, fullscreen, per-line level colouring.

Now the exact per-attempt line — e.g. `publish: attempt 1/4 -> HTTP 404: {"detail":{"field":"benchmark_id",...}}` — is visible in Eval Studio, no terminal required.

## Tests
- `publish-log.test.ts` — file passthrough, backlog, subscribe/unsubscribe.
- `use-publish-logs.test.ts` — backlog load → live append → clear/unsubscribe.
- Updated `publish-score.test.ts` (mock the new bus) and `EvalStudioView.test.tsx` (mock the hook).
- Full desktop suite: **199 passed / 42 files**. `npm run build`: green.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215685543505794

🤖 Generated with [Claude Code](https://claude.com/claude-code)