### PR TITLE
SF-265: gateway-owned response cache for deterministic chat completions

### DIFF
--- a/apps/aigateway/src/aigateway/config.py
+++ b/apps/aigateway/src/aigateway/config.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from urllib.parse import urlsplit
 
-from pydantic import Field, SecretStr, field_validator
+from pydantic import Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -69,6 +69,27 @@ class Settings(BaseSettings):
         default_factory=dict,
         validation_alias="AIGW_PROVIDER_MAX_CONCURRENCY_OVERRIDES",
     )
+
+    # Opt-in persistent response cache for deterministic chat completions
+    # (SF-265). Disabled by default; behavior with the flag off is unchanged.
+    request_cache_enabled: bool = Field(
+        default=False, validation_alias="AIGW_REQUEST_CACHE_ENABLED"
+    )
+    request_cache_default_ttl_seconds: int = Field(
+        default=600, gt=0, validation_alias="AIGW_REQUEST_CACHE_TTL_SECONDS"
+    )
+    request_cache_max_ttl_seconds: int = Field(
+        default=3600, gt=0, validation_alias="AIGW_REQUEST_CACHE_MAX_TTL_SECONDS"
+    )
+    request_cache_max_response_bytes: int = Field(
+        default=1_000_000, gt=0, validation_alias="AIGW_REQUEST_CACHE_MAX_RESPONSE_BYTES"
+    )
+
+    @model_validator(mode="after")
+    def _validate_request_cache_ttls(self) -> Settings:
+        if self.request_cache_default_ttl_seconds > self.request_cache_max_ttl_seconds:
+            raise ValueError("request cache default TTL must not exceed the max TTL")
+        return self
 
     @field_validator("jwt_secret", "provisioning_token")
     @classmethod

--- a/apps/aigateway/src/aigateway/core/request_cache/__init__.py
+++ b/apps/aigateway/src/aigateway/core/request_cache/__init__.py
@@ -1,0 +1,29 @@
+"""Gateway-owned opt-in response cache for deterministic chat completions.
+
+Keying, eligibility, and persistence live here so ``routes/chat.py`` stays
+orchestration-only. Cache policy is gateway-wide (not per provider plugin),
+keys are computed before credential injection, and stored payloads are
+encrypted at rest through the active secret store.
+"""
+
+from __future__ import annotations
+
+from .keys import (
+    CacheBypass,
+    CacheControls,
+    CacheKeyResult,
+    build_cache_key,
+    parse_cache_controls,
+)
+from .store import RequestCacheStore, RequestCacheWrite, TortoiseRequestCacheStore
+
+__all__ = [
+    "CacheBypass",
+    "CacheControls",
+    "CacheKeyResult",
+    "RequestCacheStore",
+    "RequestCacheWrite",
+    "TortoiseRequestCacheStore",
+    "build_cache_key",
+    "parse_cache_controls",
+]

--- a/apps/aigateway/src/aigateway/core/request_cache/keys.py
+++ b/apps/aigateway/src/aigateway/core/request_cache/keys.py
@@ -1,0 +1,138 @@
+"""Cache key canonicalization, eligibility, and per-request control parsing.
+
+The v1 key is deliberately narrow: only ``model``, ``messages``, and a
+top-level ``system`` participate in the prompt hash. Any other
+output-affecting field makes the request ineligible (bypass) instead of
+risking a wrong hit against a response produced with different parameters.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any
+
+KEY_VERSION = "aigw-chat-cache-v1"
+
+# Part of the prompt hash. Everything else is either ignored or a bypass.
+_PROMPT_FIELDS = ("model", "messages", "system")
+# Transport/auth fields that never affect provider output. ``cache`` is the
+# gateway's own control object and is popped before eligibility runs; it is
+# listed defensively in case a caller re-injects it.
+_IGNORED_FIELDS = frozenset({"timeout", "api_key", "extra_headers", "cache"})
+
+
+@dataclass(frozen=True)
+class CacheKeyResult:
+    key_hash: str
+    prompt_hash: str
+    normalized_prompt: dict[str, Any]
+    profile_name: str
+    provider: str
+    model: str
+
+
+@dataclass(frozen=True)
+class CacheBypass:
+    reason: str
+
+
+@dataclass(frozen=True)
+class CacheControls:
+    """Parsed per-request ``cache`` body controls (LiteLLM-shaped names)."""
+
+    use_cache: bool = False
+    ttl: int | None = None
+    s_maxage: int | None = None
+    no_cache: bool = False
+    no_store: bool = False
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value if value > 0 else None
+
+
+def parse_cache_controls(body: dict[str, Any]) -> CacheControls:
+    """Pop and parse the ``cache`` control object from a request body.
+
+    The field is removed unconditionally so it can never reach provider
+    plugins; malformed values parse as "not requested".
+    """
+    raw = body.pop("cache", None)
+    if not isinstance(raw, dict):
+        return CacheControls()
+    return CacheControls(
+        use_cache=raw.get("use-cache") is True,
+        ttl=_positive_int(raw.get("ttl")),
+        s_maxage=_positive_int(raw.get("s-maxage")),
+        no_cache=raw.get("no-cache") is True,
+        no_store=raw.get("no-store") is True,
+    )
+
+
+def build_cache_key(
+    *,
+    account_id: str,
+    profile_name: str,
+    provider: str,
+    normalized_body: dict[str, Any],
+) -> CacheKeyResult | CacheBypass:
+    """Build the account/profile/provider/model-scoped cache key, or bypass.
+
+    ``normalized_body`` is the provider-facing body after profile defaults and
+    ``prepare_chat_body`` but before credential injection.
+    """
+    if not isinstance(normalized_body, dict):
+        return CacheBypass(reason="unsupported_fields")
+
+    if normalized_body.get("stream"):
+        return CacheBypass(reason="stream")
+
+    model = normalized_body.get("model")
+    messages = normalized_body.get("messages")
+    if not isinstance(model, str) or not model or not isinstance(messages, list):
+        return CacheBypass(reason="unsupported_fields")
+
+    for field in normalized_body:
+        if field in _PROMPT_FIELDS or field in _IGNORED_FIELDS:
+            continue
+        if field == "stream":  # stream=False is reachable here and harmless
+            continue
+        return CacheBypass(reason="unsupported_fields")
+
+    normalized_prompt: dict[str, Any] = {"model": model, "messages": messages}
+    if "system" in normalized_body:
+        normalized_prompt["system"] = normalized_body["system"]
+
+    prompt_hash = _sha256(_canonical_json(normalized_prompt))
+    key_hash = _sha256(
+        _canonical_json(
+            {
+                "v": KEY_VERSION,
+                "account_id": account_id,
+                "profile_name": profile_name,
+                "provider": provider,
+                "model": model,
+                "prompt_hash": prompt_hash,
+            }
+        )
+    )
+    return CacheKeyResult(
+        key_hash=key_hash,
+        prompt_hash=prompt_hash,
+        normalized_prompt=normalized_prompt,
+        profile_name=profile_name,
+        provider=provider,
+        model=model,
+    )

--- a/apps/aigateway/src/aigateway/core/request_cache/models/__init__.py
+++ b/apps/aigateway/src/aigateway/core/request_cache/models/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from .request_cache_entry import BaseRequestCacheEntry, RequestCacheEntry
+
+__all__ = ["BaseRequestCacheEntry", "RequestCacheEntry"]
+__models__ = [RequestCacheEntry]

--- a/apps/aigateway/src/aigateway/core/request_cache/models/request_cache_entry.py
+++ b/apps/aigateway/src/aigateway/core/request_cache/models/request_cache_entry.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import uuid
+
+from tortoise import fields
+from tortoise.models import Model
+
+
+class BaseRequestCacheEntry(Model):
+    class Meta:
+        abstract = True
+
+    id = fields.UUIDField(pk=True, default=uuid.uuid4)
+    key_hash = fields.CharField(max_length=64, unique=True, index=True)
+    key_version = fields.CharField(max_length=32)
+    account_id = fields.CharField(max_length=64, index=True)
+    profile_name = fields.CharField(max_length=128, index=True)
+    prompt_hash = fields.CharField(max_length=64, index=True)
+    provider = fields.CharField(max_length=64, index=True)
+    model = fields.CharField(max_length=255, index=True)
+    # Encrypted JSON of the provider response; the plaintext never touches
+    # the database. Raw prompts/messages are never persisted at all.
+    response_ciphertext = fields.TextField()
+    response_size_bytes = fields.IntField()
+    created_at = fields.DatetimeField(auto_now_add=True)
+    updated_at = fields.DatetimeField(auto_now=True)
+    expires_at = fields.DatetimeField(index=True)
+    last_hit_at = fields.DatetimeField(null=True)
+    hit_count = fields.IntField(default=0)
+
+
+class RequestCacheEntry(BaseRequestCacheEntry):
+    class Meta:
+        table = "request_cache_entries"
+        indexes = (("account_id", "profile_name", "provider", "expires_at"),)

--- a/apps/aigateway/src/aigateway/core/request_cache/store.py
+++ b/apps/aigateway/src/aigateway/core/request_cache/store.py
@@ -1,0 +1,123 @@
+"""Persistence for cache entries: encrypted-at-rest, account/profile scoped.
+
+Mirrors ``ORMStore``: the active secret store is resolved lazily at call time
+(the app lifespan installs it before any request runs), and writes use the
+safe get / create / catch-``IntegrityError`` upsert pattern.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, Protocol
+
+from tortoise.exceptions import IntegrityError
+
+from ..secrets import get_active_secret_store
+from ..secrets.mixin import SecretStoreMixin
+from .models import RequestCacheEntry
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RequestCacheWrite:
+    key_hash: str
+    key_version: str
+    account_id: str
+    profile_name: str
+    prompt_hash: str
+    provider: str
+    model: str
+    response: dict[str, Any]
+    response_size_bytes: int
+    expires_at: datetime
+
+
+class RequestCacheStore(Protocol):
+    async def get(
+        self, key_hash: str, *, max_age_seconds: int | None = None
+    ) -> dict[str, Any] | None: ...
+
+    async def set(self, entry: RequestCacheWrite) -> None: ...
+
+    async def delete_expired(self) -> int: ...
+
+
+class TortoiseRequestCacheStore:
+    """Tortoise-backed implementation of :class:`RequestCacheStore`."""
+
+    def __init__(self, secret_store: SecretStoreMixin | None = None) -> None:
+        # Lazy by default: the process-wide active store is installed by the
+        # app lifespan. Tests may inject one directly.
+        self._secret_store = secret_store
+
+    def _secrets(self) -> SecretStoreMixin:
+        return self._secret_store if self._secret_store is not None else get_active_secret_store()
+
+    async def get(
+        self, key_hash: str, *, max_age_seconds: int | None = None
+    ) -> dict[str, Any] | None:
+        row = await RequestCacheEntry.get_or_none(key_hash=key_hash)
+        if row is None:
+            return None
+
+        now = datetime.now(UTC)
+        if row.expires_at <= now:
+            return None
+        if max_age_seconds is not None and row.created_at < now - timedelta(
+            seconds=max_age_seconds
+        ):
+            return None
+
+        try:
+            plaintext = await self._secrets().decrypt(row.response_ciphertext)
+            response = json.loads(plaintext)
+            if not isinstance(response, dict):
+                raise ValueError("cached payload is not a JSON object")
+        except Exception:
+            # Corrupt or undecryptable entry: drop it so it cannot keep
+            # short-circuiting dispatch. Log by hash prefix only.
+            logger.warning("request cache entry %s… is corrupt; deleting", key_hash[:12])
+            await row.delete()
+            return None
+
+        row.hit_count += 1
+        row.last_hit_at = now
+        await row.save(update_fields=["hit_count", "last_hit_at"])
+        return response
+
+    async def set(self, entry: RequestCacheWrite) -> None:
+        payload = json.dumps(entry.response, separators=(",", ":"), ensure_ascii=False)
+        ciphertext = await self._secrets().encrypt(payload)
+        values = {
+            "key_version": entry.key_version,
+            "account_id": entry.account_id,
+            "profile_name": entry.profile_name,
+            "prompt_hash": entry.prompt_hash,
+            "provider": entry.provider,
+            "model": entry.model,
+            "response_ciphertext": ciphertext,
+            "response_size_bytes": entry.response_size_bytes,
+            "expires_at": entry.expires_at,
+        }
+
+        row = await RequestCacheEntry.get_or_none(key_hash=entry.key_hash)
+        if row is None:
+            try:
+                await RequestCacheEntry.create(key_hash=entry.key_hash, **values)
+                await self.delete_expired()
+                return
+            except IntegrityError:
+                # Lost a concurrent-create race: fall through to update.
+                row = await RequestCacheEntry.get(key_hash=entry.key_hash)
+
+        for field, value in values.items():
+            setattr(row, field, value)
+        await row.save(update_fields=list(values.keys()))
+        await self.delete_expired()
+
+    async def delete_expired(self) -> int:
+        return await RequestCacheEntry.filter(expires_at__lte=datetime.now(UTC)).delete()

--- a/apps/aigateway/src/aigateway/db.py
+++ b/apps/aigateway/src/aigateway/db.py
@@ -21,6 +21,7 @@ TORTOISE_CONFIG: dict[str, Any] = {
                 "aigateway.core.auth.models",
                 "aigateway.core.credential_blob",
                 "aigateway.core.oauth.models",
+                "aigateway.core.request_cache.models",
                 "aigateway.core.secrets.models",
             ],
             "default_connection": "default",

--- a/apps/aigateway/src/aigateway/main.py
+++ b/apps/aigateway/src/aigateway/main.py
@@ -23,6 +23,7 @@ from .core.loader import load_plugins
 from .core.pending_auth import PendingAuthTable
 from .core.profile_index import ProfileIndexStore
 from .core.registry import ProviderRegistry
+from .core.request_cache.store import TortoiseRequestCacheStore
 from .core.secrets.factory import build_secret_store, set_active_secret_store
 from .db import close_db, init_db
 from .routes import accounts, auth, auth_session, chat, health, models, oauth_connections
@@ -193,6 +194,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     credential_store = ORMStore()
     app.state.credential_store = credential_store
     app.state.profile_index = ProfileIndexStore(credential_store=credential_store)
+    # Resolves the active secret store lazily at call time (mirrors ORMStore);
+    # Tortoise itself is initialized once, by the lifespan.
+    app.state.request_cache_store = TortoiseRequestCacheStore()
 
     _configure_fake_anthropic_oauth(app)
     _configure_fake_codex_oauth(app)

--- a/apps/aigateway/src/aigateway/migrations/0006_request_cache.py
+++ b/apps/aigateway/src/aigateway/migrations/0006_request_cache.py
@@ -1,0 +1,44 @@
+from uuid import uuid4
+
+from tortoise import fields, migrations
+from tortoise.migrations import operations as ops
+
+
+class Migration(migrations.Migration):
+    dependencies = [("models", "0005_secret_store")]
+
+    operations = [
+        ops.CreateModel(
+            name="RequestCacheEntry",
+            fields=[
+                (
+                    "id",
+                    fields.UUIDField(primary_key=True, default=uuid4, unique=True, db_index=True),
+                ),
+                ("key_hash", fields.CharField(unique=True, db_index=True, max_length=64)),
+                ("key_version", fields.CharField(max_length=32)),
+                ("account_id", fields.CharField(db_index=True, max_length=64)),
+                ("profile_name", fields.CharField(db_index=True, max_length=128)),
+                ("prompt_hash", fields.CharField(db_index=True, max_length=64)),
+                ("provider", fields.CharField(db_index=True, max_length=64)),
+                ("model", fields.CharField(db_index=True, max_length=255)),
+                ("response_ciphertext", fields.TextField()),
+                ("response_size_bytes", fields.IntField()),
+                ("created_at", fields.DatetimeField(auto_now=False, auto_now_add=True)),
+                ("updated_at", fields.DatetimeField(auto_now=True, auto_now_add=False)),
+                ("expires_at", fields.DatetimeField(db_index=True)),
+                (
+                    "last_hit_at",
+                    fields.DatetimeField(null=True, auto_now=False, auto_now_add=False),
+                ),
+                ("hit_count", fields.IntField(default=0)),
+            ],
+            options={
+                "table": "request_cache_entries",
+                "app": "models",
+                "pk_attr": "id",
+                "indexes": (("account_id", "profile_name", "provider", "expires_at"),),
+            },
+            bases=["Model"],
+        ),
+    ]

--- a/apps/aigateway/src/aigateway/routes/chat.py
+++ b/apps/aigateway/src/aigateway/routes/chat.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import json
 import logging
 import math
+from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import StreamingResponse
 from litellm.exceptions import (
     APIConnectionError,
@@ -28,6 +29,15 @@ from ..core.oauth.store import OAuthConnectionStore, credential_key_for
 from ..core.profile_index import ProfileIndexStore
 from ..core.profile_models import Profile, ProfileDefaults, ProfileState, credential_name_for
 from ..core.registry import ProviderRegistry
+from ..core.request_cache.keys import (
+    KEY_VERSION,
+    CacheBypass,
+    CacheControls,
+    CacheKeyResult,
+    build_cache_key,
+    parse_cache_controls,
+)
+from ..core.request_cache.store import RequestCacheStore, RequestCacheWrite
 from ..core.retry import RetryPolicy, parse_retry_after_seconds, with_overload_retry
 
 logger = logging.getLogger(__name__)
@@ -227,6 +237,88 @@ async def _dispatch_with_backpressure(
         )
 
 
+def _resolve_cache_plan(
+    request: Request,
+    *,
+    account_id: str,
+    profile_name: str,
+    provider: str,
+    body: dict[str, Any],
+    controls: CacheControls,
+) -> tuple[CacheKeyResult | None, str, str]:
+    """Decide cache participation for this request.
+
+    Returns ``(key, status, reason)`` where ``key`` is None whenever the
+    request bypasses the cache. Status/reason feed the X-AIGW-Cache headers.
+    """
+    settings = request.app.state.settings
+    if not settings.request_cache_enabled:
+        return None, "bypass", "disabled"
+    if not controls.use_cache:
+        return None, "bypass", "not_requested"
+    built = build_cache_key(
+        account_id=account_id,
+        profile_name=profile_name,
+        provider=provider,
+        normalized_body=body,
+    )
+    if isinstance(built, CacheBypass):
+        return None, "bypass", built.reason
+    return built, "miss", ""
+
+
+def _set_cache_headers(
+    response: Response, status: str, reason: str, key: CacheKeyResult | None
+) -> None:
+    response.headers["X-AIGW-Cache"] = status
+    if reason:
+        response.headers["X-AIGW-Cache-Reason"] = reason
+    # Hash-derived prefix only — never prompt or response content.
+    if key is not None and status in {"hit", "miss"}:
+        response.headers["X-AIGW-Cache-Key"] = key.key_hash[:12]
+
+
+async def _store_cached_response(
+    request: Request,
+    *,
+    key: CacheKeyResult,
+    account_id: str,
+    result: Any,
+    controls: CacheControls,
+) -> str:
+    """Persist a fresh response when allowed; returns the cache reason."""
+    if controls.no_store:
+        return "no_store"
+    if not isinstance(result, dict):
+        return "unsupported_fields"
+    settings = request.app.state.settings
+    payload_size = len(
+        json.dumps(result, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    )
+    if payload_size > settings.request_cache_max_response_bytes:
+        return "too_large"
+    ttl = min(
+        controls.ttl or settings.request_cache_default_ttl_seconds,
+        settings.request_cache_max_ttl_seconds,
+    )
+    store: RequestCacheStore = request.app.state.request_cache_store
+    await store.set(
+        RequestCacheWrite(
+            key_hash=key.key_hash,
+            key_version=KEY_VERSION,
+            account_id=account_id,
+            profile_name=key.profile_name,
+            prompt_hash=key.prompt_hash,
+            provider=key.provider,
+            model=key.model,
+            response=result,
+            response_size_bytes=payload_size,
+            expires_at=datetime.now(UTC) + timedelta(seconds=ttl),
+        )
+    )
+    return "stored"
+
+
 def _litellm_http_exception(exc: Exception) -> HTTPException:
     status = int(getattr(exc, "status_code", 502) or 502)
     code = "provider_error"
@@ -245,48 +337,26 @@ def _litellm_http_exception(exc: Exception) -> HTTPException:
     )
 
 
-@router.post("/v1/chat/completions")
-async def chat_completions(request: Request, current: CurrentAccount) -> Any:
-    body = await request.json()
-    if not isinstance(body, dict) or "model" not in body or "messages" not in body:
-        raise HTTPException(status_code=400, detail="model and messages are required")
-
-    profile_name = (request.headers.get("X-Profile") or "default").strip() or "default"
-    model = body.get("model", "")
-    provider = model.split("/", 1)[0] if "/" in model else None
-    if not provider:
-        raise HTTPException(status_code=400, detail="model must be provider-prefixed")
-
-    registry: ProviderRegistry = request.app.state.providers
-    plugin = registry.get(provider)
-    if plugin is None:
-        raise HTTPException(status_code=400, detail=f"unknown provider: {provider}")
-
-    account_id = str(current.id)
-    profile, connection, defaults = await _credential_target_for_chat(
-        request,
-        account_id=account_id,
-        provider=provider,
-        profile_name=profile_name,
-        plugin=plugin,
-    )
-
-    body = plugin.prepare_chat_body(_apply_defaults(body, defaults, plugin))
-
-    if body.get("stream") and not plugin.supports_chat_streaming():
-        raise HTTPException(
-            status_code=400,
-            detail={
-                "code": "streaming_not_supported",
-                "provider": provider,
-                "message": f"{provider} does not support streaming through this gateway yet",
-            },
-        )
-
+async def _inject_credentials(
+    request: Request,
+    *,
+    plugin: Any,
+    provider: str,
+    account_id: str,
+    profile_name: str,
+    profile: Profile | None,
+    connection: OAuthConnection | None,
+    account_key: Any,
+    body: dict[str, Any],
+) -> str | None:
+    """Resolve the profile/connection credential strategy and inject auth
+    into ``body``; returns the resolved credential name (used to invalidate
+    provider session caches on later dispatch failures). Raises 401 (marking
+    profile/connection errored) when stored credentials are unusable."""
     strategy = None
     credential_name: str | None = None
     if connection is not None:
-        credential_name = credential_key_for(current.id, connection.id)
+        credential_name = credential_key_for(account_key, connection.id)
         strategy = plugin.oauth_strategy_for(
             credential_name,
             credential_store=request.app.state.credential_store,
@@ -337,13 +407,99 @@ async def chat_completions(request: Request, current: CurrentAccount) -> Any:
         if connection is not None:
             await _oauth_connection_store(request).touch_last_used(connection)
 
+    return credential_name
+
+
+@router.post("/v1/chat/completions")
+async def chat_completions(request: Request, response: Response, current: CurrentAccount) -> Any:
+    body = await request.json()
+    if not isinstance(body, dict) or "model" not in body or "messages" not in body:
+        raise HTTPException(status_code=400, detail="model and messages are required")
+
+    # Popped immediately so the control object can never reach providers.
+    cache_controls = parse_cache_controls(body)
+
+    profile_name = (request.headers.get("X-Profile") or "default").strip() or "default"
+    model = body.get("model", "")
+    provider = model.split("/", 1)[0] if "/" in model else None
+    if not provider:
+        raise HTTPException(status_code=400, detail="model must be provider-prefixed")
+
+    registry: ProviderRegistry = request.app.state.providers
+    plugin = registry.get(provider)
+    if plugin is None:
+        raise HTTPException(status_code=400, detail=f"unknown provider: {provider}")
+
+    account_id = str(current.id)
+    profile, connection, defaults = await _credential_target_for_chat(
+        request,
+        account_id=account_id,
+        provider=provider,
+        profile_name=profile_name,
+        plugin=plugin,
+    )
+
+    body = plugin.prepare_chat_body(_apply_defaults(body, defaults, plugin))
+
+    # Cache key is computed from the normalized body, before credential
+    # injection, so no secret-bearing field can ever participate in the key.
+    cache_key, cache_status, cache_reason = _resolve_cache_plan(
+        request,
+        account_id=account_id,
+        profile_name=profile_name,
+        provider=provider,
+        body=body,
+        controls=cache_controls,
+    )
+
+    if body.get("stream") and not plugin.supports_chat_streaming():
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "streaming_not_supported",
+                "provider": provider,
+                "message": f"{provider} does not support streaming through this gateway yet",
+            },
+        )
+
+    credential_name = await _inject_credentials(
+        request,
+        plugin=plugin,
+        provider=provider,
+        account_id=account_id,
+        profile_name=profile_name,
+        profile=profile,
+        connection=connection,
+        account_key=current.id,
+        body=body,
+    )
+
     # NOTE: overload retry covers the non-streaming path only; streaming responses
     # commit a 200 status before dispatch, so a mid-stream 429/503 cannot be retried.
     if body.get("stream"):
-        return StreamingResponse(_stream(plugin, body), media_type="text/event-stream")
+        return StreamingResponse(
+            _stream(plugin, body),
+            media_type="text/event-stream",
+            headers={"X-AIGW-Cache": "bypass", "X-AIGW-Cache-Reason": cache_reason or "stream"},
+        )
+
+    if cache_key is not None and not cache_controls.no_cache:
+        cache_store: RequestCacheStore = request.app.state.request_cache_store
+        cached = await cache_store.get(cache_key.key_hash, max_age_seconds=cache_controls.s_maxage)
+        if cached is not None:
+            _set_cache_headers(response, "hit", "", cache_key)
+            logger.info(
+                "request cache hit provider=%s model=%s account=%s profile=%s key=%s…",
+                provider,
+                cache_key.model,
+                account_id,
+                profile_name,
+                cache_key.key_hash[:12],
+            )
+            return cached
 
     try:
-        response = await _dispatch_with_backpressure(request, plugin, provider, body)
+        provider_response = await _dispatch_with_backpressure(request, plugin, provider, body)
     except HTTPException as exc:
         if connection is not None and _should_mark_profile_error_on_dispatch_status(
             plugin, exc.status_code
@@ -384,8 +540,29 @@ async def chat_completions(request: Request, current: CurrentAccount) -> Any:
         Timeout,
     ) as exc:
         raise _litellm_http_exception(exc) from exc
-    dumpable = cast(Any, response)
-    return dumpable.model_dump() if hasattr(dumpable, "model_dump") else response
+    dumpable = cast(Any, provider_response)
+    result = dumpable.model_dump() if hasattr(dumpable, "model_dump") else provider_response
+
+    if cache_key is not None:
+        cache_reason = await _store_cached_response(
+            request,
+            key=cache_key,
+            account_id=account_id,
+            result=result,
+            controls=cache_controls,
+        )
+    _set_cache_headers(response, cache_status, cache_reason, cache_key)
+    if cache_status != "bypass":
+        logger.info(
+            "request cache %s reason=%s provider=%s account=%s profile=%s key=%s…",
+            cache_status,
+            cache_reason,
+            provider,
+            account_id,
+            profile_name,
+            cache_key.key_hash[:12] if cache_key is not None else "",
+        )
+    return result
 
 
 async def _stream(plugin: Any, body: dict[str, Any]):

--- a/apps/aigateway/tests/integration/test_tortoise_migration_smoke.py
+++ b/apps/aigateway/tests/integration/test_tortoise_migration_smoke.py
@@ -56,6 +56,7 @@ def test_tortoise_migrate_creates_accounts_table() -> None:
         assert {
             "accounts",
             "credential_blobs",
+            "request_cache_entries",
             "secret_master_keys",
             "tortoise_migrations",
         } <= asyncio.run(_tables())

--- a/apps/aigateway/tests/unit/test_chat_request_cache.py
+++ b/apps/aigateway/tests/unit/test_chat_request_cache.py
@@ -1,0 +1,288 @@
+"""Route-level tests for the opt-in request cache on /v1/chat/completions.
+
+Provider-dimension isolation is proven at the key level
+(test_request_cache_keys.py): a route-level "different provider" request is
+the same as a "different model prefix" request, which is covered here by the
+different-model test.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from functools import partial
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from aigateway.core.oauth.store import OAuthConnectionStore, credential_key_for
+from aigateway.plugins.anthropic_provider.auth import credential_service_for
+
+_CHAT_PATH = "/v1/chat/completions"
+_PATCH_TARGET = (
+    "aigateway.plugins.anthropic_provider.plugin.AnthropicProviderPlugin.chat_completion"
+)
+
+
+def _account_id(client) -> str:
+    return client.get("/v1/auth/me").json()["id"]
+
+
+async def _create_active_connection(account_id: str, *, label: str = "default"):
+    store = OAuthConnectionStore()
+    connection = await store.create_pending(
+        account_id=account_id,
+        provider="anthropic",
+        label=label,
+        connection_id=uuid4(),
+    )
+    return await store.complete(connection, label=label, identity=None)
+
+
+def _seed_connection_credentials(credential_blobs, account_id: str, connection_id) -> None:
+    credential_blobs.write(
+        credential_service_for(credential_key_for(account_id, connection_id)),
+        "default",
+        json.dumps(
+            {
+                "access_token": "tok",
+                "refresh_token": "rt",
+                "expires_at_ms": int(time.time() * 1000) + 3_600_000,
+                "token_type": "Bearer",
+            }
+        ),
+    )
+
+
+def _arrange_account(client, credential_blobs, *, label: str = "default") -> str:
+    account_id = _account_id(client)
+    connection = client.portal.call(partial(_create_active_connection, account_id, label=label))
+    _seed_connection_credentials(credential_blobs, account_id, connection.id)
+    return account_id
+
+
+class _DispatchCounter:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    # Patched over the *class* method with an instance, which bypasses
+    # function-descriptor binding — so only `body` arrives.
+    async def __call__(self, body):
+        self.calls.append(dict(body))
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            model_dump=lambda: {
+                "id": f"resp-{len(self.calls)}",
+                "choices": [{"message": {"content": "SECRET-ANSWER"}}],
+            }
+        )
+
+
+def _chat_body(**overrides) -> dict:
+    body = {
+        "model": "anthropic/claude-haiku-4-5",
+        "messages": [{"role": "user", "content": "hi"}],
+        "cache": {"use-cache": True},
+    }
+    body.update(overrides)
+    return body
+
+
+@pytest.fixture
+def _cache_env(monkeypatch):
+    # Must run before the `client` fixture builds the app so Settings sees it.
+    monkeypatch.setenv("AIGW_REQUEST_CACHE_ENABLED", "true")
+
+
+@pytest.fixture
+def cache_client(_cache_env, client: TestClient) -> TestClient:
+    response = client.post(
+        "/v1/auth/login",
+        json={"username": "admin", "password": "test-admin-password"},
+    )
+    assert response.status_code == 200, response.text
+    client.headers.update({"Authorization": f"Bearer {response.json()['token']}"})
+    return client
+
+
+def test_cache_disabled_by_default_dispatches_twice(credential_blobs, authenticated_client) -> None:
+    _arrange_account(authenticated_client, credential_blobs)
+    counter = _DispatchCounter()
+    with patch(_PATCH_TARGET, counter):
+        first = authenticated_client.post(_CHAT_PATH, json=_chat_body())
+        second = authenticated_client.post(_CHAT_PATH, json=_chat_body())
+    assert first.status_code == second.status_code == 200
+    assert len(counter.calls) == 2
+    assert first.headers["X-AIGW-Cache"] == "bypass"
+    assert first.headers["X-AIGW-Cache-Reason"] == "disabled"
+
+
+def test_enabled_but_not_requested_dispatches_twice(credential_blobs, cache_client) -> None:
+    _arrange_account(cache_client, credential_blobs)
+    counter = _DispatchCounter()
+    body = _chat_body()
+    del body["cache"]
+    with patch(_PATCH_TARGET, counter):
+        cache_client.post(_CHAT_PATH, json=body)
+        resp = cache_client.post(_CHAT_PATH, json=body)
+    assert len(counter.calls) == 2
+    assert resp.headers["X-AIGW-Cache"] == "bypass"
+    assert resp.headers["X-AIGW-Cache-Reason"] == "not_requested"
+
+
+def test_opt_in_hit_skips_provider_dispatch(credential_blobs, cache_client) -> None:
+    _arrange_account(cache_client, credential_blobs)
+    counter = _DispatchCounter()
+    with patch(_PATCH_TARGET, counter):
+        first = cache_client.post(_CHAT_PATH, json=_chat_body())
+        second = cache_client.post(_CHAT_PATH, json=_chat_body())
+    assert first.status_code == second.status_code == 200
+    assert len(counter.calls) == 1, "second identical request must be served from cache"
+    assert first.headers["X-AIGW-Cache"] == "miss"
+    assert first.headers["X-AIGW-Cache-Reason"] == "stored"
+    assert second.headers["X-AIGW-Cache"] == "hit"
+    assert second.json() == first.json()
+    # The cache key header is hash-derived only.
+    assert "hi" not in second.headers.get("X-AIGW-Cache-Key", "")
+    assert len(second.headers["X-AIGW-Cache-Key"]) == 12
+
+
+def test_different_account_misses(credential_blobs, cache_client, provisioned_user_factory) -> None:
+    _arrange_account(cache_client, credential_blobs)
+    counter = _DispatchCounter()
+    with patch(_PATCH_TARGET, counter):
+        cache_client.post(_CHAT_PATH, json=_chat_body())
+
+        provisioned_user_factory("second-user")
+        login = cache_client.post(
+            "/v1/auth/login",
+            json={"username": "second-user", "password": "test-user-password"},
+        )
+        assert login.status_code == 200
+        other_headers = {"Authorization": f"Bearer {login.json()['token']}"}
+        other_account = cache_client.get("/v1/auth/me", headers=other_headers).json()["id"]
+        connection = cache_client.portal.call(_create_active_connection, other_account)
+        _seed_connection_credentials(credential_blobs, other_account, connection.id)
+
+        resp = cache_client.post(_CHAT_PATH, json=_chat_body(), headers=other_headers)
+    assert resp.status_code == 200
+    assert len(counter.calls) == 2, "another account must never hit the first account's cache"
+    assert resp.headers["X-AIGW-Cache"] == "miss"
+
+
+def test_different_profile_misses(credential_blobs, cache_client) -> None:
+    account_id = _account_id(cache_client)
+    for label in ("default", "work"):
+        connection = cache_client.portal.call(
+            partial(_create_active_connection, account_id, label=label)
+        )
+        _seed_connection_credentials(credential_blobs, account_id, connection.id)
+    counter = _DispatchCounter()
+    with patch(_PATCH_TARGET, counter):
+        first = cache_client.post(_CHAT_PATH, json=_chat_body())
+        second = cache_client.post(_CHAT_PATH, json=_chat_body(), headers={"X-Profile": "work"})
+    assert first.status_code == second.status_code == 200
+    assert len(counter.calls) == 2, "a different X-Profile must not share the cache entry"
+    assert second.headers["X-AIGW-Cache"] == "miss"
+
+
+def test_different_model_misses(credential_blobs, cache_client) -> None:
+    _arrange_account(cache_client, credential_blobs)
+    counter = _DispatchCounter()
+    with patch(_PATCH_TARGET, counter):
+        cache_client.post(_CHAT_PATH, json=_chat_body())
+        resp = cache_client.post(_CHAT_PATH, json=_chat_body(model="anthropic/claude-sonnet-4-6"))
+    assert resp.status_code == 200
+    assert len(counter.calls) == 2
+
+
+def test_no_cache_skips_lookup_but_stores(credential_blobs, cache_client) -> None:
+    _arrange_account(cache_client, credential_blobs)
+    counter = _DispatchCounter()
+    with patch(_PATCH_TARGET, counter):
+        cache_client.post(_CHAT_PATH, json=_chat_body())
+        refreshed = cache_client.post(
+            _CHAT_PATH, json=_chat_body(cache={"use-cache": True, "no-cache": True})
+        )
+        third = cache_client.post(_CHAT_PATH, json=_chat_body())
+    assert len(counter.calls) == 2, "no-cache must skip lookup and re-dispatch"
+    assert refreshed.headers["X-AIGW-Cache"] == "miss"
+    # The refreshed response was stored: the third request hits it.
+    assert third.headers["X-AIGW-Cache"] == "hit"
+    assert third.json()["id"] == "resp-2"
+
+
+def test_no_store_prevents_storage(credential_blobs, cache_client) -> None:
+    _arrange_account(cache_client, credential_blobs)
+    counter = _DispatchCounter()
+    no_store_body = _chat_body(cache={"use-cache": True, "no-store": True})
+    with patch(_PATCH_TARGET, counter):
+        first = cache_client.post(_CHAT_PATH, json=no_store_body)
+        second = cache_client.post(_CHAT_PATH, json=no_store_body)
+    assert len(counter.calls) == 2, "no-store responses must not be persisted"
+    assert first.headers["X-AIGW-Cache"] == "miss"
+    assert first.headers["X-AIGW-Cache-Reason"] == "no_store"
+    assert second.headers["X-AIGW-Cache"] == "miss"
+
+
+def test_expired_entry_dispatches_again(credential_blobs, cache_client) -> None:
+    _arrange_account(cache_client, credential_blobs)
+    counter = _DispatchCounter()
+    body = _chat_body(cache={"use-cache": True, "ttl": 1})
+    with patch(_PATCH_TARGET, counter):
+        cache_client.post(_CHAT_PATH, json=body)
+        time.sleep(1.2)
+        resp = cache_client.post(_CHAT_PATH, json=body)
+    assert len(counter.calls) == 2
+    assert resp.headers["X-AIGW-Cache"] == "miss"
+
+
+def test_stream_bypasses_cache(credential_blobs, cache_client) -> None:
+    _arrange_account(cache_client, credential_blobs)
+
+    async def fake_stream(_self, body):
+        from types import SimpleNamespace
+
+        yield SimpleNamespace(model_dump=lambda: {"choices": [{"delta": {"content": "x"}}]})
+
+    counter = _DispatchCounter()
+    with (
+        patch(_PATCH_TARGET, counter),
+        patch(
+            "aigateway.plugins.anthropic_provider.plugin.AnthropicProviderPlugin.chat_completion_stream",
+            fake_stream,
+        ),
+    ):
+        resp = cache_client.post(_CHAT_PATH, json=_chat_body(stream=True))
+        resp2 = cache_client.post(_CHAT_PATH, json=_chat_body(stream=True))
+    assert resp.status_code == resp2.status_code == 200
+    assert len(counter.calls) == 0, "streaming must use the streaming path, never the cache"
+
+
+def test_unsupported_field_bypasses(credential_blobs, cache_client) -> None:
+    _arrange_account(cache_client, credential_blobs)
+    counter = _DispatchCounter()
+    body = _chat_body(temperature=0.7)
+    with patch(_PATCH_TARGET, counter):
+        first = cache_client.post(_CHAT_PATH, json=body)
+        second = cache_client.post(_CHAT_PATH, json=body)
+    assert len(counter.calls) == 2
+    assert first.headers["X-AIGW-Cache"] == "bypass"
+    assert second.headers["X-AIGW-Cache"] == "bypass"
+    assert first.headers["X-AIGW-Cache-Reason"] == "unsupported_fields"
+
+
+def test_cache_headers_do_not_leak_content(credential_blobs, cache_client) -> None:
+    _arrange_account(cache_client, credential_blobs)
+    counter = _DispatchCounter()
+    with patch(_PATCH_TARGET, counter):
+        resp = cache_client.post(
+            _CHAT_PATH,
+            json=_chat_body(messages=[{"role": "user", "content": "SECRET-PROMPT"}]),
+        )
+    header_blob = json.dumps(dict(resp.headers))
+    assert "SECRET-PROMPT" not in header_blob
+    assert "SECRET-ANSWER" not in header_blob

--- a/apps/aigateway/tests/unit/test_request_cache_keys.py
+++ b/apps/aigateway/tests/unit/test_request_cache_keys.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import pytest
+
+from aigateway.core.request_cache.keys import (
+    CacheBypass,
+    CacheControls,
+    CacheKeyResult,
+    build_cache_key,
+    parse_cache_controls,
+)
+
+_BASE_KW = {
+    "account_id": "acct-1",
+    "profile_name": "default",
+    "provider": "anthropic",
+}
+
+
+def _body(**overrides):
+    body = {
+        "model": "anthropic/claude-haiku-4-5",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    body.update(overrides)
+    return body
+
+
+def _key(**kw) -> CacheKeyResult:
+    merged = {**_BASE_KW, "normalized_body": _body()}
+    merged.update(kw)
+    result = build_cache_key(**merged)
+    assert isinstance(result, CacheKeyResult), result
+    return result
+
+
+class TestKeyHashing:
+    def test_dict_key_order_does_not_change_hash(self) -> None:
+        a = build_cache_key(
+            **_BASE_KW,
+            normalized_body={
+                "model": "anthropic/claude-haiku-4-5",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+        b = build_cache_key(
+            **_BASE_KW,
+            normalized_body={
+                "messages": [{"content": "hi", "role": "user"}],
+                "model": "anthropic/claude-haiku-4-5",
+            },
+        )
+        assert isinstance(a, CacheKeyResult) and isinstance(b, CacheKeyResult)
+        assert a.key_hash == b.key_hash
+        assert a.prompt_hash == b.prompt_hash
+
+    def test_different_messages_change_hash(self) -> None:
+        a = _key()
+        b = _key(normalized_body=_body(messages=[{"role": "user", "content": "bye"}]))
+        assert a.key_hash != b.key_hash
+
+    def test_message_order_changes_hash(self) -> None:
+        m1 = [{"role": "user", "content": "a"}, {"role": "user", "content": "b"}]
+        m2 = [{"role": "user", "content": "b"}, {"role": "user", "content": "a"}]
+        assert (
+            _key(normalized_body=_body(messages=m1)).key_hash
+            != _key(normalized_body=_body(messages=m2)).key_hash
+        )
+
+    def test_different_model_changes_hash(self) -> None:
+        a = _key()
+        b = _key(normalized_body=_body(model="anthropic/claude-sonnet-4-6"))
+        assert a.key_hash != b.key_hash
+
+    def test_different_provider_changes_hash(self) -> None:
+        assert _key(provider="anthropic").key_hash != _key(provider="codex").key_hash
+
+    def test_different_account_changes_hash(self) -> None:
+        assert _key(account_id="acct-1").key_hash != _key(account_id="acct-2").key_hash
+
+    def test_different_profile_changes_hash(self) -> None:
+        assert _key(profile_name="default").key_hash != _key(profile_name="work").key_hash
+
+    def test_top_level_system_is_part_of_prompt(self) -> None:
+        a = _key()
+        b = _key(normalized_body=_body(system=[{"type": "text", "text": "be brief"}]))
+        assert a.prompt_hash != b.prompt_hash
+
+    def test_result_contains_no_raw_prompt_in_hashes(self) -> None:
+        result = _key(
+            normalized_body=_body(messages=[{"role": "user", "content": "SECRET-PROMPT"}])
+        )
+        assert "SECRET-PROMPT" not in result.key_hash
+        assert "SECRET-PROMPT" not in result.prompt_hash
+        assert len(result.key_hash) == 64
+        assert len(result.prompt_hash) == 64
+
+
+class TestEligibility:
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("temperature", 0.2),
+            ("max_tokens", 128),
+            ("response_format", {"type": "json_object"}),
+            ("tools", [{"type": "function"}]),
+            ("tool_choice", "auto"),
+            ("reasoning", {"effort": "high"}),
+            ("reasoning_effort", "high"),
+            ("top_p", 0.9),
+            ("stop", ["x"]),
+            ("presence_penalty", 0.1),
+            ("logit_bias", {"1": 1}),
+            ("some_unknown_field", 1),
+        ],
+    )
+    def test_output_affecting_fields_bypass(self, field, value) -> None:
+        result = build_cache_key(**_BASE_KW, normalized_body=_body(**{field: value}))
+        assert isinstance(result, CacheBypass)
+        assert result.reason == "unsupported_fields"
+
+    def test_stream_true_bypasses(self) -> None:
+        result = build_cache_key(**_BASE_KW, normalized_body=_body(stream=True))
+        assert isinstance(result, CacheBypass)
+        assert result.reason == "stream"
+
+    def test_stream_false_is_ignored(self) -> None:
+        assert isinstance(
+            build_cache_key(**_BASE_KW, normalized_body=_body(stream=False)), CacheKeyResult
+        )
+
+    @pytest.mark.parametrize("field", ["timeout", "api_key", "extra_headers"])
+    def test_transport_fields_are_ignored(self, field) -> None:
+        a = _key()
+        b = build_cache_key(**_BASE_KW, normalized_body=_body(**{field: "whatever"}))
+        assert isinstance(b, CacheKeyResult)
+        assert a.key_hash == b.key_hash
+
+    def test_non_dict_body_bypasses(self) -> None:
+        result = build_cache_key(**_BASE_KW, normalized_body=["not", "a", "dict"])  # type: ignore[arg-type]
+        assert isinstance(result, CacheBypass)
+
+    def test_non_list_messages_bypasses(self) -> None:
+        result = build_cache_key(**_BASE_KW, normalized_body=_body(messages="oops"))
+        assert isinstance(result, CacheBypass)
+
+
+class TestCacheControls:
+    def test_absent_cache_field_means_not_requested(self) -> None:
+        body = _body()
+        controls = parse_cache_controls(body)
+        assert isinstance(controls, CacheControls)
+        assert controls.use_cache is False
+        assert "cache" not in body
+
+    def test_controls_are_popped_from_body(self) -> None:
+        body = _body(cache={"use-cache": True, "ttl": 60})
+        controls = parse_cache_controls(body)
+        assert controls.use_cache is True
+        assert controls.ttl == 60
+        assert "cache" not in body  # never forwarded to providers
+
+    def test_all_fields_parse(self) -> None:
+        body = _body(
+            cache={
+                "use-cache": True,
+                "ttl": 120,
+                "s-maxage": 30,
+                "no-cache": True,
+                "no-store": True,
+            }
+        )
+        controls = parse_cache_controls(body)
+        assert (controls.use_cache, controls.ttl, controls.s_maxage) == (True, 120, 30)
+        assert (controls.no_cache, controls.no_store) == (True, True)
+
+    def test_malformed_cache_field_is_ignored(self) -> None:
+        body = _body(cache="not-a-dict")
+        controls = parse_cache_controls(body)
+        assert controls.use_cache is False
+        assert "cache" not in body

--- a/apps/aigateway/tests/unit/test_request_cache_store.py
+++ b/apps/aigateway/tests/unit/test_request_cache_store.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from tortoise import Tortoise
+
+from aigateway.core.request_cache.models import RequestCacheEntry
+from aigateway.core.request_cache.store import (
+    RequestCacheWrite,
+    TortoiseRequestCacheStore,
+)
+from aigateway.core.secrets.local import LocalSecretStore
+from aigateway.db import build_tortoise_config
+
+_TEST_KEY = bytes(range(32))
+
+
+def _write(key_hash: str = "k" * 64, *, ttl_seconds: int = 600, **overrides) -> RequestCacheWrite:
+    values = {
+        "key_hash": key_hash,
+        "key_version": "aigw-chat-cache-v1",
+        "account_id": "acct-1",
+        "profile_name": "default",
+        "prompt_hash": "p" * 64,
+        "provider": "anthropic",
+        "model": "anthropic/claude-haiku-4-5",
+        "response": {"id": "x", "choices": [{"message": {"content": "SECRET-ANSWER"}}]},
+        "response_size_bytes": 64,
+        "expires_at": datetime.now(UTC) + timedelta(seconds=ttl_seconds),
+    }
+    values.update(overrides)
+    return RequestCacheWrite(**values)
+
+
+@pytest_asyncio.fixture
+async def cache_store(tmp_path):
+    db_path = tmp_path / "cache-test.sqlite3"
+    await Tortoise.close_connections()
+    await Tortoise.init(
+        config=build_tortoise_config(f"sqlite://{db_path}"),
+        _enable_global_fallback=True,
+    )
+    await Tortoise.generate_schemas()
+    try:
+        # Inject the secret store directly (the process-wide active store is only
+        # installed by the app lifespan, which this unit fixture does not run).
+        yield TortoiseRequestCacheStore(secret_store=LocalSecretStore(_TEST_KEY))
+    finally:
+        await Tortoise.close_connections()
+
+
+@pytest.mark.asyncio
+async def test_set_then_get_round_trips_response(cache_store) -> None:
+    entry = _write()
+    await cache_store.set(entry)
+    got = await cache_store.get(entry.key_hash)
+    assert got == entry.response
+
+
+@pytest.mark.asyncio
+async def test_get_missing_returns_none(cache_store) -> None:
+    assert await cache_store.get("missing" + "0" * 57) is None
+
+
+@pytest.mark.asyncio
+async def test_expired_entry_returns_none(cache_store) -> None:
+    entry = _write(ttl_seconds=-5)
+    await cache_store.set(entry)
+    assert await cache_store.get(entry.key_hash) is None
+
+
+@pytest.mark.asyncio
+async def test_s_maxage_rejects_older_entries(cache_store) -> None:
+    entry = _write()
+    await cache_store.set(entry)
+    # Entry was just created: a generous max age accepts it...
+    assert await cache_store.get(entry.key_hash, max_age_seconds=60) == entry.response
+    # ...but a zero-second freshness window rejects it even though unexpired.
+    row = await RequestCacheEntry.get(key_hash=entry.key_hash)
+    row.created_at = datetime.now(UTC) - timedelta(seconds=30)
+    await row.save(update_fields=["created_at"])
+    assert await cache_store.get(entry.key_hash, max_age_seconds=10) is None
+
+
+@pytest.mark.asyncio
+async def test_db_row_does_not_contain_plaintext_response(cache_store) -> None:
+    entry = _write()
+    await cache_store.set(entry)
+    row = await RequestCacheEntry.get(key_hash=entry.key_hash)
+    assert "SECRET-ANSWER" not in row.response_ciphertext
+    assert json.dumps(entry.response) != row.response_ciphertext
+
+
+@pytest.mark.asyncio
+async def test_duplicate_write_updates_existing_row(cache_store) -> None:
+    first = _write()
+    await cache_store.set(first)
+    second = _write(response={"id": "y", "choices": []})
+    await cache_store.set(second)
+    assert await RequestCacheEntry.filter(key_hash=first.key_hash).count() == 1
+    assert await cache_store.get(first.key_hash) == second.response
+
+
+@pytest.mark.asyncio
+async def test_hit_metadata_updated_on_get(cache_store) -> None:
+    entry = _write()
+    await cache_store.set(entry)
+    await cache_store.get(entry.key_hash)
+    await cache_store.get(entry.key_hash)
+    row = await RequestCacheEntry.get(key_hash=entry.key_hash)
+    assert row.hit_count == 2
+    assert row.last_hit_at is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_expired_removes_only_expired(cache_store) -> None:
+    # Write both entries live, then age one directly — set() itself purges
+    # expired rows opportunistically, so an already-dead write never persists.
+    live = _write("l" * 64, ttl_seconds=600)
+    dead = _write("d" * 64, ttl_seconds=600)
+    await cache_store.set(live)
+    await cache_store.set(dead)
+    row = await RequestCacheEntry.get(key_hash=dead.key_hash)
+    row.expires_at = datetime.now(UTC) - timedelta(seconds=5)
+    await row.save(update_fields=["expires_at"])
+
+    deleted = await cache_store.delete_expired()
+    assert deleted == 1
+    assert await RequestCacheEntry.filter(key_hash=live.key_hash).exists()
+    assert not await RequestCacheEntry.filter(key_hash=dead.key_hash).exists()
+
+
+@pytest.mark.asyncio
+async def test_set_purges_already_expired_rows_opportunistically(cache_store) -> None:
+    dead = _write("d" * 64, ttl_seconds=-5)
+    await cache_store.set(dead)
+    assert not await RequestCacheEntry.filter(key_hash=dead.key_hash).exists()
+
+
+@pytest.mark.asyncio
+async def test_corrupt_ciphertext_returns_none_and_deletes(cache_store) -> None:
+    entry = _write()
+    await cache_store.set(entry)
+    row = await RequestCacheEntry.get(key_hash=entry.key_hash)
+    row.response_ciphertext = "not-valid-ciphertext"
+    await row.save(update_fields=["response_ciphertext"])
+    assert await cache_store.get(entry.key_hash) is None
+    assert not await RequestCacheEntry.filter(key_hash=entry.key_hash).exists()


### PR DESCRIPTION
## Description

Adds an **opt-in, disabled-by-default response cache** for `POST /v1/chat/completions` in AIGateway (SF-265 / D-AIGW-017).

**Motivation.** Repeated deterministic chat completions re-bill the provider and add latency. LiteLLM's global cache cannot be used here: its default key has no gateway account isolation, the Gemini/Codex custom handler paths bypass its `acompletion` cache callback, and we need explicit control over exactly what is keyed and persisted. So this is a gateway-owned cache.

**What it does.**
- **Keying** (`core/request_cache/keys.py`): one canonical-JSON SHA-256 hash scoped by `account_id` + `profile_name` + `provider` + `model`, plus a prompt hash over a deliberately narrow allowlist (`model`, `messages`, top-level `system`). Any other output-affecting field (`temperature`, `max_tokens`, `tools`, `response_format`, `reasoning`, `stream`, …) makes the request **ineligible and bypasses** the cache rather than risk a wrong hit. The per-request `cache` control object is parsed and stripped so it never reaches a provider.
- **Storage** (`core/request_cache/store.py`): a `RequestCacheStore` port with a Tortoise adapter. Response payloads are **encrypted at rest** through the active secret store (responses may contain private source-derived content); only the key hash and non-sensitive metadata are stored in plaintext — raw prompts/messages are never persisted. TTL + `s-maxage` freshness, hit metadata, opportunistic expiry purge, and self-healing on corrupt rows.
- **Route** (`routes/chat.py`): the key is computed **before** credential injection (no secret-bearing field can participate), lookup happens **after** auth is applied (a hit never bypasses auth), streaming bypasses the cache, and `X-AIGW-Cache` / `X-AIGW-Cache-Reason` / `X-AIGW-Cache-Key` headers report status using hash prefixes only (no prompt/response content leaks).
- **Config**: `AIGW_REQUEST_CACHE_ENABLED` (default `false`), default/max TTL, max response bytes. With the flag off, behavior is unchanged.

Persistence follows the existing Tortoise architecture (abstract `Base*` + concrete model, `models/` package registered in `TORTOISE_CONFIG`, migration `0006_request_cache.py`, single DB init in the FastAPI lifespan).

Closes SF-265 · Asana: https://app.asana.com/1/1185126988600652/task/1215635733439285

> Coordination note: if SF-244 (PR #280) merges first, this branch's migration renumbers to `0007` and the route-integration points (which currently match `main`) need a rebase pass.

## Affected Dependencies

None — no new packages. Uses the existing Tortoise ORM, the encrypting secret store (`SecretStoreMixin`), and LiteLLM already in the gateway.

## How has this been tested?

All from `apps/aigateway`:

```bash
uv run pytest -m "not live"          # 497 passed, 1 skipped
uv run ruff check .                  # clean
uv run pyright                       # 0 errors, 0 warnings
uv run python scripts/check_no_enterprise.py   # OK
```

New coverage (49 tests):
- **Keys** — canonical hashing is dict-order-independent; `account_id` / `profile_name` / `provider` / `model` / `messages` each change the hash; every output-affecting field bypasses; transport/auth fields are ignored; control-object parse-and-strip.
- **Store** — set/get round-trip; ciphertext at rest contains no plaintext; expiry and `s-maxage` rejection; upsert by key hash; opportunistic + explicit expiry purge; corrupt-entry deletion.
- **Route** — disabled-by-default still dispatches; opt-in second identical request is served from cache with **provider dispatch asserted absent**; different account / profile (`X-Profile`) / model all miss; `no-cache` / `no-store`; TTL expiry; streaming bypass; unsupported-field bypass; headers carry no prompt or response content.

Optional Postgres migration smoke (testcontainers): asserts `request_cache_entries` exists after `migrate`.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
