### PR TITLE
SF-264: portal Copy button copies the raw URL4 expression

### DIFF
--- a/web/portal/benchmark.js
+++ b/web/portal/benchmark.js
@@ -113,7 +113,7 @@
       var runTd = document.createElement("td");
       runTd.className = "col-run";
       // Guard like spec.js: a missing expression renders as absence, never as
-      // a malformed sf://…&expression=undefined link.
+      // a Copy button that would put "undefined" on the clipboard.
       if (entry.url4_expression) {
         runTd.appendChild(P.createCopyButton(entry.spec_id, entry.url4_expression, { compact: true }));
       } else {

--- a/web/portal/main.js
+++ b/web/portal/main.js
@@ -101,9 +101,9 @@ window.ScorePortal = (function () {
   // Returns a normalized http(s) URL string, or null for anything else.
   // Untrusted, API-provided absolute URLs (e.g. a benchmark's dataset_url) must
   // pass through this before becoming an anchor href, so a javascript:, data:,
-  // or vbscript: URL can never be made clickable. Our own links are either
-  // relative (…html?…, "/") or the hardcoded sf://run scheme, and do not use
-  // this — only externally-sourced absolute URLs do.
+  // or vbscript: URL can never be made clickable. Our own links are relative
+  // (…html?…, "/") and do not use this — only externally-sourced absolute
+  // URLs do.
   function httpUrlOrNull(value) {
     if (!value) return null;
     try {
@@ -183,30 +183,23 @@ window.ScorePortal = (function () {
     if (isVerified === true) return el("span", "badge-verified", "✓ verified");
     return document.createTextNode(EM_DASH);
   }
-  // sf://run?spec=...&expression=... with each value URL-encoded separately.
-  // Never concatenate a raw url4_expression — it can contain / ( ) ! $.
-  function buildRunHref(specId, expression) {
-    return (
-      "sf://run?spec=" + encodeURIComponent(specId) +
-      "&expression=" + encodeURIComponent(expression)
-    );
-  }
-  // Copy-to-clipboard button for the sf://run link. A button (not an sf://
-  // anchor) so it works in any browser regardless of whether the protocol
-  // handler is registered; the copied URI still opens screamingface locally.
+  // Copy-to-clipboard button that places the RAW url4_expression on the
+  // clipboard — the exact string pasted into the desktop app's Eval Studio
+  // "URL4 expression" field. We copy it verbatim (no encoding, no sf://run
+  // wrapper): a url4 spec can contain / ( ) ! $ # : and must survive intact.
   function createCopyButton(specId, expression, opts) {
     opts = opts || {};
     var label = opts.label || "Copy";
     var btn = el("button", opts.compact ? "btn ghost" : "btn", label);
     btn.type = "button";
-    btn.setAttribute("aria-label", "Copy the local run link for " + specId);
+    btn.setAttribute("aria-label", "Copy the URL4 expression for " + specId);
     btn.addEventListener("click", function () {
       function done(ok) {
         btn.textContent = ok ? "✓ copied" : "copy failed";
         setTimeout(function () { btn.textContent = label; }, 1600);
       }
       if (navigator.clipboard && navigator.clipboard.writeText) {
-        navigator.clipboard.writeText(buildRunHref(specId, expression)).then(
+        navigator.clipboard.writeText(expression).then(
           function () { done(true); },
           function () { done(false); }
         );
@@ -340,7 +333,6 @@ window.ScorePortal = (function () {
     formatSubmitter: formatSubmitter,
     formatCount: formatCount,
     createVerifiedBadge: createVerifiedBadge,
-    buildRunHref: buildRunHref,
     createCopyButton: createCopyButton,
     ready: ready,
     EM_DASH: EM_DASH,

--- a/web/portal/spec.html
+++ b/web/portal/spec.html
@@ -33,8 +33,9 @@
 
     <div class="note">
       <span class="kicker">Reproduce before trusting</span>
-      History is newest-first. The Copy button gives you the local run link for the
-      newest submission, so you can reproduce the latest public claim before trusting it.
+      History is newest-first. The Copy button copies the newest submission's URL4
+      expression — paste it into the desktop app to reproduce the latest public claim
+      before trusting it.
     </div>
 
     <div id="spec-status" class="state" role="status" aria-live="polite">Loading…</div>

--- a/web/tests/portal_smoke.py
+++ b/web/tests/portal_smoke.py
@@ -617,21 +617,31 @@ def main() -> int:
             )
             page.wait_for_selector("#run-region button.btn", timeout=8000)
             btn = page.locator("#run-region button.btn")
+            aria = btn.get_attribute("aria-label") or ""
             check(
                 "T9",
                 "spec: Copy button rendered with accessible name",
                 btn.count() == 1
                 and (btn.text_content() or "").strip() == "Copy"
-                and "direct-google" in (btn.get_attribute("aria-label") or ""),
+                and "URL4 expression" in aria
+                and "direct-google" in aria,
+                aria,
             )
             btn.click()
             clipboard = page.evaluate("() => navigator.clipboard.readText()")
+            # Behavioral contract change (D-SCORE-010): the Copy button now puts the
+            # raw url4_expression on the clipboard — the exact string pasted into the
+            # desktop Eval Studio URL4 field — not an sf://run?spec=...&expression=...
+            # deep link (which had no consumer). The '#' must stay raw (#model=),
+            # not URL-encoded (%23model%3D) as the old buildRunHref produced.
             check(
                 "T9",
-                "spec: click copies sf://run link with encoded expression",
-                clipboard.startswith("sf://run?spec=")
-                and "expression=" in clipboard
-                and "%23model%3D" in clipboard,
+                "spec: click copies the raw url4_expression verbatim (no sf:// wrapper)",
+                clipboard == SCORE["url4_expression"]
+                and "#model=" in clipboard
+                and "%23model%3D" not in clipboard
+                and not clipboard.startswith("sf://")
+                and "expression=" not in clipboard,
                 clipboard,
             )
             check(


### PR DESCRIPTION
## Description

The public portal leaderboard **Copy** button (per-row on the benchmark page and the spec page) now places the **raw `url4_expression`** on the clipboard — the exact string a user pastes into the desktop app's **Eval Studio → New eval run → URL4 expression** field.

**Motivation.** Today the button copies an `sf://run?spec=<id>&expression=<url-encoded>` deep link. Nothing consumes that scheme — the desktop app has **no `sf://` protocol handler** (no `setAsDefaultProtocolClient`, no `open-url`/`second-instance` deep-link handling, no `protocols` entry in packaging), so the copied string is undeliverable. The desktop's real ingestion path is a plain text field (a Monaco editor), so the paste-friendly payload is the bare expression.

**What it does.**
- **`main.js`** — `createCopyButton` now copies `expression` verbatim via `navigator.clipboard.writeText(expression)`. The dead `buildRunHref` helper (and its export) is removed — the `sf://run` scheme has no consumer. `aria-label` updated to `"Copy the URL4 expression for <spec>"`. The existing transient success state (`✓ copied`) and the Clipboard-API-absent failure state (`copy failed`) are unchanged.
- **`benchmark.js` / `spec.js`** — call sites unchanged in shape; behavior follows the shared helper. The missing-`url4_expression` guard still renders an em dash (no control).
- **`spec.html`** — the "Reproduce before trusting" note no longer calls the output a "local run link"; it now states the button copies the newest submission's URL4 expression to paste into the desktop app.

Copying is forward-compatible: it copies whatever the row actually holds. Today's livetruth rows store `direct-eval:` provenance strings; future ensemble submissions store runnable url4. The portal copies either, verbatim, with no URL-encoding of `#`, `/`, `:` etc.

Portal-only change — no `apps/desktop`, `apps/server`, or `apps/scoreboard` edits. Reviving an `sf://` protocol handler was explicitly out of scope.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215636036095054

## Affected Dependencies

None — no new packages. Pure presentation-layer change in the static portal (vanilla JS/HTML), read-only consumer of the existing `/v1/leaderboard` + `/v1/scores` scoreboard endpoints (both unchanged).

## How has this been tested?

The portal has no build step; the gate is the Playwright smoke suite (real Chromium, stubbed scoreboard API, end-to-end clipboard round-trip):

```bash
<playwright-venv-python> web/tests/portal_smoke.py   # 90/90 passed
```

Rewritten **T9** (spec page) now asserts the clicked clipboard:
- equals the fixture's raw `url4_expression` verbatim,
- contains raw `#model=` (not URL-encoded `%23model%3D`),
- contains **no** `sf://` prefix and **no** `expression=` wrapper,

and the accessible name reads "Copy the URL4 expression for …". TDD: the rewritten assertions were confirmed to fail against the old `sf://`-emitting code before the fix, then pass after. T17 (missing-expression em dash) and T19 (compact Copy buttons render) are unchanged.