### PR TITLE
SF-278: improve Phoenix tracing quality (backend/gateway spans, noise muting, OpenInference)

### DIFF
--- a/apps/server/src/screamingface/plugins/aigw_base/backend.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/backend.py
@@ -269,20 +269,47 @@ class AigwBackend(Backend):
         headers: dict[str, str] | None = None,
         timeout_seconds: float,
     ) -> httpx.Response:
-        if self._app is not None:
-            return await AigwGatewayClient(
-                self._app,
-                http_client_factory=self._http_factory,
-            ).request(
-                method,
-                path,
-                json=json,
-                headers=headers,
-                timeout_seconds=timeout_seconds,
-            )
+        from screamingface.plugins.llm_base._tracing import (
+            set_provider_attrs,
+            traced_provider_post,
+        )
+
         url = f"{self._gateway_url}{path}"
-        async with self._http_factory(timeout_seconds) as client:
-            return await client.request(method, url, json=json, headers=headers)
+        # Open the span first, then inject W3C trace context into the outbound
+        # headers so a locally-instrumented gateway can link into this trace.
+        # (Remote gateways simply ignore the header — see plan follow-up.)
+        with traced_provider_post("aigw", url, method=method):
+            headers = dict(headers or {})
+            try:
+                from opentelemetry.propagate import inject
+
+                inject(headers)
+            except ImportError:
+                pass
+
+            if self._app is not None:
+                resp = await AigwGatewayClient(
+                    self._app,
+                    http_client_factory=self._http_factory,
+                ).request(
+                    method,
+                    path,
+                    json=json,
+                    headers=headers,
+                    timeout_seconds=timeout_seconds,
+                )
+            else:
+                async with self._http_factory(timeout_seconds) as client:
+                    resp = await client.request(method, url, json=json, headers=headers)
+
+            set_provider_attrs(
+                {
+                    "http.status_code": resp.status_code,
+                    "aigw.profile": self._profile_name,
+                    "aigw.provider": self._gateway_provider,
+                }
+            )
+            return resp
 
 
 def _core_message_to_openai(msg: CoreMessage) -> dict:

--- a/apps/server/src/screamingface/plugins/aigw_base/backend.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/backend.py
@@ -270,6 +270,7 @@ class AigwBackend(Backend):
         timeout_seconds: float,
     ) -> httpx.Response:
         from screamingface.plugins.llm_base._tracing import (
+            record_llm_call,
             set_provider_attrs,
             traced_provider_post,
         )
@@ -309,6 +310,9 @@ class AigwBackend(Backend):
                     "aigw.provider": self._gateway_provider,
                 }
             )
+            # Only the chat-completions call is an LLM call; auth/status GETs are not.
+            if path == "/v1/chat/completions":
+                record_llm_call(self._gateway_provider, json, resp)
             return resp
 
 

--- a/apps/server/src/screamingface/plugins/aigw_base/tests/test_aigw_backend.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/tests/test_aigw_backend.py
@@ -169,3 +169,60 @@ async def test_unreachable_raises_backend_error() -> None:
             [CoreMessage(role="user", content="hi")],
             model="anthropic/claude-haiku-4-5",
         )
+
+
+# ----------------------------------------------------------------------------
+# SF-278: gateway client span + W3C traceparent propagation
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_request_injects_traceparent_and_emits_span() -> None:
+    """`_request` opens an `llm.POST aigw` span and injects W3C traceparent.
+
+    A locally-instrumented gateway can then link into this trace; remote
+    gateways simply ignore the header.
+    """
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    exporter = InMemorySpanExporter()
+    provider = trace.get_tracer_provider()
+    if not isinstance(provider, TracerProvider):
+        provider = TracerProvider()
+        trace.set_tracer_provider(provider)
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    exporter.clear()
+
+    captured: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["headers"] = dict(req.headers)
+        return _ok_response("pong")
+
+    backend = _backend(
+        gateway_url="http://127.0.0.1:9105",
+        profile_name="default",
+        http_client_factory=_factory(httpx.MockTransport(handler)),
+    )
+
+    # An active recording span is required for inject() to produce traceparent.
+    tracer = trace.get_tracer("test")
+    with tracer.start_as_current_span("root"):
+        await backend.run(
+            [CoreMessage(role="user", content=[TextPart(text="hi")])],
+            model="anthropic/claude-haiku-4-5",
+        )
+
+    assert "traceparent" in captured["headers"], (
+        f"traceparent not propagated to gateway. Headers: {sorted(captured['headers'])}"
+    )
+
+    aigw_spans = [s for s in exporter.get_finished_spans() if s.name == "llm.POST aigw"]
+    assert len(aigw_spans) == 1
+    attrs = dict(aigw_spans[0].attributes or {})
+    assert attrs["http.status_code"] == 200
+    assert attrs["aigw.provider"] == "test-provider"
+    assert attrs["aigw.profile"] == "default"

--- a/apps/server/src/screamingface/plugins/claude_frontend/proxy.py
+++ b/apps/server/src/screamingface/plugins/claude_frontend/proxy.py
@@ -217,7 +217,18 @@ def create_router(
         # Stage 4: success. ``resolved_text`` is None only when there is no active
         # spec — synthesize an empty envelope (no upstream call) per Decision.
         result_text = resolved_text or ""
-        _tracer.set_attrs({"url4.result_length": len(result_text)})
+        # OpenInference: the /v1/messages request is the root CHAIN — the user's
+        # prompt in, the synthesized answer out (so Phoenix shows input/output).
+        _tracer.set_attrs(
+            {
+                "url4.result_length": len(result_text),
+                "openinference.span.kind": "CHAIN",
+                "input.value": prompt_blob[:16000],
+                "input.mime_type": "text/plain",
+                "output.value": result_text[:16000],
+                "output.mime_type": "text/plain",
+            }
+        )
 
         response_dict = build_anthropic_message(result_text, model, prompt_text=prompt_blob)
 

--- a/apps/server/src/screamingface/plugins/eval_runs/schemas.py
+++ b/apps/server/src/screamingface/plugins/eval_runs/schemas.py
@@ -8,7 +8,9 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
 
-RunStatus = Literal["running", "done", "failed"]
+# Mirrors the statuses written by the run lifecycle in plugin.py:
+# running (start) → done | degraded (finish; degraded = some rows errored) | failed.
+RunStatus = Literal["running", "done", "degraded", "failed"]
 
 
 class EvalQuestionOut(BaseModel):

--- a/apps/server/src/screamingface/plugins/eval_runs/tests/test_routes.py
+++ b/apps/server/src/screamingface/plugins/eval_runs/tests/test_routes.py
@@ -75,6 +75,28 @@ async def test_get_detail_returns_questions_sorted_by_idx(
     assert [q["idx"] for q in body["questions"]] == [0, 1, 2]
 
 
+async def test_list_and_detail_serialize_degraded_run(async_client: httpx.AsyncClient) -> None:
+    """SF-270 introduced a 'degraded' status; the read DTO must accept it.
+
+    Regression for the /eval_runs 500: because ``RunStatus`` omitted
+    'degraded', a single degraded run failed ``EvalRunSummaryOut`` validation
+    and 500'd the whole list (and its detail view).
+    """
+    from screamingface.plugins.eval_runs.models import EvalRun
+
+    store = EvalRunStore()
+    run = await store.create(spec_name="x", url4_expression="x", started_at=datetime.now(UTC))
+    await EvalRun.filter(id=run.id).update(status="degraded", error="2 row(s) errored")
+
+    r = await async_client.get("/eval_runs")
+    assert r.status_code == 200
+    assert r.json()[0]["status"] == "degraded"
+
+    detail = await async_client.get(f"/eval_runs/{run.id}")
+    assert detail.status_code == 200
+    assert detail.json()["status"] == "degraded"
+
+
 async def test_get_detail_missing_returns_404(async_client: httpx.AsyncClient) -> None:
     r = await async_client.get(f"/eval_runs/{uuid4()}")
     assert r.status_code == 404

--- a/apps/server/src/screamingface/plugins/gemini_backend_api/backend.py
+++ b/apps/server/src/screamingface/plugins/gemini_backend_api/backend.py
@@ -409,6 +409,7 @@ class GeminiBackend(Backend):
 
     async def _do_post(self, body: dict, headers: dict[str, str], url: str) -> httpx.Response:
         from screamingface.plugins.llm_base._tracing import (
+            record_llm_call,
             set_provider_attrs,
             traced_provider_post,
         )
@@ -422,10 +423,7 @@ class GeminiBackend(Backend):
             except httpx.RequestError as exc:
                 raise BackendError(f"Gemini request failed: {exc}", status=None) from exc
             set_provider_attrs(
-                {
-                    "http.status_code": resp.status_code,
-                    "http.response.size": len(resp.content),
-                    "gen_ai.request.model": body.get("model"),
-                }
+                {"http.status_code": resp.status_code, "http.response.size": len(resp.content)}
             )
+            record_llm_call("gemini", body, resp)
             return resp

--- a/apps/server/src/screamingface/plugins/gemini_backend_api/backend.py
+++ b/apps/server/src/screamingface/plugins/gemini_backend_api/backend.py
@@ -408,10 +408,24 @@ class GeminiBackend(Backend):
         return None
 
     async def _do_post(self, body: dict, headers: dict[str, str], url: str) -> httpx.Response:
-        try:
-            async with self._http_factory() as client:
-                return await client.post(url, json=body, headers=headers)
-        except httpx.TimeoutException as exc:
-            raise BackendError(f"Gemini request timed out: {exc}", status=None) from exc
-        except httpx.RequestError as exc:
-            raise BackendError(f"Gemini request failed: {exc}", status=None) from exc
+        from screamingface.plugins.llm_base._tracing import (
+            set_provider_attrs,
+            traced_provider_post,
+        )
+
+        with traced_provider_post("gemini", url):
+            try:
+                async with self._http_factory() as client:
+                    resp = await client.post(url, json=body, headers=headers)
+            except httpx.TimeoutException as exc:
+                raise BackendError(f"Gemini request timed out: {exc}", status=None) from exc
+            except httpx.RequestError as exc:
+                raise BackendError(f"Gemini request failed: {exc}", status=None) from exc
+            set_provider_attrs(
+                {
+                    "http.status_code": resp.status_code,
+                    "http.response.size": len(resp.content),
+                    "gen_ai.request.model": body.get("model"),
+                }
+            )
+            return resp

--- a/apps/server/src/screamingface/plugins/llm_base/_tracing.py
+++ b/apps/server/src/screamingface/plugins/llm_base/_tracing.py
@@ -1,0 +1,68 @@
+"""Optional OTel HTTP-client tracing helpers for backend plugins.
+
+All functions are no-ops when opentelemetry is not installed, so backend
+modules can call them unconditionally. Mirrors
+``url4_executor/_tracing.py`` but parametrized by provider so each span
+carries the real provider identity (Anthropic, gemini, ollama, aigw, …).
+
+Lives in ``llm_base`` (the lowest backend layer) on purpose: ``frontend_base``
+already imports ``llm_base.constants``, so ``llm_base`` must not depend on
+``frontend_base``. ``aigw_base`` already depends on ``llm_base`` and reuses
+these helpers.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager, nullcontext
+from typing import Any
+
+_TRACER_NAME = "screamingface.llm-base"
+
+
+def _get_tracer():  # type: ignore[no-untyped-def]
+    try:
+        from opentelemetry import trace
+
+        return trace.get_tracer(_TRACER_NAME)
+    except ImportError:
+        return None
+
+
+@contextmanager
+def traced_provider_post(provider: str, url: str, *, method: str = "POST"):  # type: ignore[no-untyped-def]
+    """Open a CLIENT span ``llm.{method} {provider}`` for an outbound POST.
+
+    Yields the span (or ``None`` without OTel) so callers can record
+    response attributes via :func:`set_provider_attrs`. Exceptions raised
+    inside the ``with`` are recorded on the span by OTel on context exit.
+    """
+    tracer = _get_tracer()
+    if tracer is None:
+        with nullcontext() as span:
+            yield span
+        return
+    from opentelemetry.trace import SpanKind
+
+    with tracer.start_as_current_span(f"llm.{method} {provider}", kind=SpanKind.CLIENT) as span:
+        if span.is_recording():
+            span.set_attribute("sf.plugin", provider)
+            span.set_attribute("http.method", method)
+            span.set_attribute("http.url", url[:500])
+        yield span
+
+
+def set_provider_attrs(attrs: dict[str, Any], span: Any = None) -> None:
+    """Set attributes on the current (or provided) span; no-op without OTel.
+
+    ``None`` values are skipped — OTel rejects ``None`` attribute values.
+    """
+    try:
+        from opentelemetry import trace
+
+        span = span or trace.get_current_span()
+        if span and span.is_recording():
+            for k, v in attrs.items():
+                if v is not None:
+                    span.set_attribute(k, v)
+    except ImportError:
+        pass

--- a/apps/server/src/screamingface/plugins/llm_base/_tracing.py
+++ b/apps/server/src/screamingface/plugins/llm_base/_tracing.py
@@ -66,3 +66,99 @@ def set_provider_attrs(attrs: dict[str, Any], span: Any = None) -> None:
                     span.set_attribute(k, v)
     except ImportError:
         pass
+
+
+_IO_CAP = 16000
+
+
+def _cap(text: str) -> str:
+    return text if len(text) <= _IO_CAP else text[:_IO_CAP] + f"… ({len(text) - _IO_CAP} more)"
+
+
+def _extract_tokens(data: object) -> tuple[int | None, int | None]:
+    """Best-effort prompt/completion token counts across provider response shapes."""
+    if not isinstance(data, dict):
+        return None, None
+    usage = data.get("usage")
+    if isinstance(usage, dict):
+        # OpenAI/gateway: prompt_tokens/completion_tokens; Anthropic: input/output_tokens.
+        prompt = usage.get("prompt_tokens", usage.get("input_tokens"))
+        completion = usage.get("completion_tokens", usage.get("output_tokens"))
+        if prompt is not None or completion is not None:
+            return prompt, completion
+    meta = data.get("usageMetadata")  # Gemini
+    if isinstance(meta, dict):
+        return meta.get("promptTokenCount"), meta.get("candidatesTokenCount")
+    return None, None
+
+
+def record_llm_call(
+    provider: str,
+    request_body: dict | None,
+    response: object,
+    *,
+    span: Any = None,
+) -> None:
+    """Set LLM input/output/model/tokens from a request body + httpx.Response.
+
+    Provider-agnostic: serializes the request body as the input, the raw
+    response text as the output, and extracts token usage from common response
+    shapes. Best-effort and exception-safe; no-op without OTel.
+    """
+    import json
+
+    output_value: str | None = None
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    try:
+        output_value = _cap(response.text)  # type: ignore[attr-defined]
+        prompt_tokens, completion_tokens = _extract_tokens(response.json())  # type: ignore[attr-defined]
+    except Exception:  # noqa: BLE001 — tracing must never break the request path
+        pass
+    try:
+        input_value = _cap(json.dumps(request_body, default=str)) if request_body else None
+    except (TypeError, ValueError):
+        input_value = None
+    set_llm_io(
+        provider=provider,
+        input_value=input_value,
+        output_value=output_value,
+        model=(request_body or {}).get("model"),
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        span=span,
+    )
+
+
+def set_llm_io(
+    *,
+    provider: str | None = None,
+    input_value: str | None = None,
+    output_value: str | None = None,
+    model: str | None = None,
+    prompt_tokens: int | None = None,
+    completion_tokens: int | None = None,
+    span: Any = None,
+) -> None:
+    """Mark the current span as an OpenInference LLM call with input/output/model.
+
+    Classifies the span ``openinference.span.kind = "LLM"`` (so Phoenix renders
+    it as a model call) and records the request body / response / model / token
+    counts. Call this only for actual model calls — generic transport spans
+    (e.g. gateway auth-status GETs) must not be tagged LLM. ``None`` fields are
+    skipped; no-op without OTel.
+    """
+    set_provider_attrs(
+        {
+            "openinference.span.kind": "LLM",
+            "llm.provider": provider,
+            "input.value": input_value,
+            "input.mime_type": "application/json" if input_value else None,
+            "output.value": output_value,
+            "output.mime_type": "application/json" if output_value else None,
+            "llm.model_name": model,
+            "llm.token_count.prompt": prompt_tokens,
+            "llm.token_count.completion": completion_tokens,
+        },
+        span=span,
+    )

--- a/apps/server/src/screamingface/plugins/llm_base/backend_base.py
+++ b/apps/server/src/screamingface/plugins/llm_base/backend_base.py
@@ -119,20 +119,31 @@ async def post_with_default_retry(
     """
     import httpx
 
+    from screamingface.plugins.llm_base._tracing import set_provider_attrs, traced_provider_post
+
     async def _do_post(headers: dict[str, str]) -> httpx.Response:
-        try:
-            async with http_factory() as client:
-                return await client.post(url, json=body, headers=headers)
-        except httpx.TimeoutException as exc:
-            raise BackendError(
-                f"{provider_name} request timed out: {exc}",
-                status=None,
-            ) from exc
-        except httpx.RequestError as exc:
-            raise BackendError(
-                f"{provider_name} request failed: {exc}",
-                status=None,
-            ) from exc
+        with traced_provider_post(provider_name, url):
+            try:
+                async with http_factory() as client:
+                    resp = await client.post(url, json=body, headers=headers)
+            except httpx.TimeoutException as exc:
+                raise BackendError(
+                    f"{provider_name} request timed out: {exc}",
+                    status=None,
+                ) from exc
+            except httpx.RequestError as exc:
+                raise BackendError(
+                    f"{provider_name} request failed: {exc}",
+                    status=None,
+                ) from exc
+            set_provider_attrs(
+                {
+                    "http.status_code": resp.status_code,
+                    "http.response.size": len(resp.content),
+                    "gen_ai.request.model": body.get("model"),
+                }
+            )
+            return resp
 
     headers = await auth.get_authorization_header()
     headers.setdefault("content-type", "application/json")

--- a/apps/server/src/screamingface/plugins/llm_base/backend_base.py
+++ b/apps/server/src/screamingface/plugins/llm_base/backend_base.py
@@ -119,7 +119,11 @@ async def post_with_default_retry(
     """
     import httpx
 
-    from screamingface.plugins.llm_base._tracing import set_provider_attrs, traced_provider_post
+    from screamingface.plugins.llm_base._tracing import (
+        record_llm_call,
+        set_provider_attrs,
+        traced_provider_post,
+    )
 
     async def _do_post(headers: dict[str, str]) -> httpx.Response:
         with traced_provider_post(provider_name, url):
@@ -137,12 +141,9 @@ async def post_with_default_retry(
                     status=None,
                 ) from exc
             set_provider_attrs(
-                {
-                    "http.status_code": resp.status_code,
-                    "http.response.size": len(resp.content),
-                    "gen_ai.request.model": body.get("model"),
-                }
+                {"http.status_code": resp.status_code, "http.response.size": len(resp.content)}
             )
+            record_llm_call(provider_name, body, resp)
             return resp
 
     headers = await auth.get_authorization_header()

--- a/apps/server/src/screamingface/plugins/llm_base/tests/test_tracing_helper.py
+++ b/apps/server/src/screamingface/plugins/llm_base/tests/test_tracing_helper.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import httpx
 import pytest
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
@@ -9,7 +10,12 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import SpanKind
 
-from screamingface.plugins.llm_base._tracing import set_provider_attrs, traced_provider_post
+from screamingface.plugins.llm_base._tracing import (
+    record_llm_call,
+    set_llm_io,
+    set_provider_attrs,
+    traced_provider_post,
+)
 
 
 @pytest.fixture
@@ -64,3 +70,54 @@ def test_exception_inside_span_is_recorded(exporter: InMemorySpanExporter) -> No
     assert len(spans) == 1
     # OTel records the exception as a span event on context exit.
     assert any(e.name == "exception" for e in spans[0].events)
+
+
+# ---------------------------------------------------------------------------
+# OpenInference LLM semantics (SF-278, 2nd commit)
+# ---------------------------------------------------------------------------
+
+
+def test_set_llm_io_marks_llm_kind_and_fields(exporter: InMemorySpanExporter) -> None:
+    with traced_provider_post("aigw", "http://gw/v1/chat/completions"):
+        set_llm_io(
+            provider="aigw",
+            input_value='{"model":"x"}',
+            output_value="hi",
+            model="x",
+            prompt_tokens=3,
+            completion_tokens=2,
+        )
+    spans = [s for s in exporter.get_finished_spans() if s.name == "llm.POST aigw"]
+    assert len(spans) == 1
+    attrs = dict(spans[0].attributes or {})
+    assert attrs["openinference.span.kind"] == "LLM"
+    assert attrs["llm.provider"] == "aigw"
+    assert attrs["llm.model_name"] == "x"
+    assert attrs["llm.token_count.prompt"] == 3
+    assert attrs["llm.token_count.completion"] == 2
+    assert attrs["input.value"] == '{"model":"x"}'
+    assert attrs["output.value"] == "hi"
+
+
+@pytest.mark.parametrize(
+    ("usage_body", "want_prompt", "want_completion"),
+    [
+        ({"usage": {"prompt_tokens": 10, "completion_tokens": 5}}, 10, 5),  # OpenAI/gateway
+        ({"usage": {"input_tokens": 8, "output_tokens": 4}}, 8, 4),  # Anthropic
+        ({"usageMetadata": {"promptTokenCount": 7, "candidatesTokenCount": 3}}, 7, 3),  # Gemini
+    ],
+)
+def test_record_llm_call_extracts_tokens_across_shapes(
+    exporter: InMemorySpanExporter, usage_body: dict, want_prompt: int, want_completion: int
+) -> None:
+    with traced_provider_post("p", "http://x"):
+        record_llm_call("p", {"model": "m", "messages": []}, httpx.Response(200, json=usage_body))
+    spans = [s for s in exporter.get_finished_spans() if s.name == "llm.POST p"]
+    assert len(spans) == 1
+    attrs = dict(spans[0].attributes or {})
+    assert attrs["openinference.span.kind"] == "LLM"
+    assert attrs["llm.model_name"] == "m"
+    assert attrs["llm.token_count.prompt"] == want_prompt
+    assert attrs["llm.token_count.completion"] == want_completion
+    assert attrs["input.value"]  # request body serialized
+    assert attrs["output.value"]  # response text captured

--- a/apps/server/src/screamingface/plugins/llm_base/tests/test_tracing_helper.py
+++ b/apps/server/src/screamingface/plugins/llm_base/tests/test_tracing_helper.py
@@ -1,0 +1,66 @@
+"""Unit tests for the shared provider HTTP-span helper (SF-278)."""
+
+from __future__ import annotations
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanKind
+
+from screamingface.plugins.llm_base._tracing import set_provider_attrs, traced_provider_post
+
+
+@pytest.fixture
+def exporter() -> InMemorySpanExporter:
+    """Attach an in-memory exporter to the active SDK tracer provider.
+
+    Works whether or not a provider is already installed: if the global
+    provider isn't an SDK ``TracerProvider`` we create and install one.
+    """
+    exp = InMemorySpanExporter()
+    provider = trace.get_tracer_provider()
+    if not isinstance(provider, TracerProvider):
+        provider = TracerProvider()
+        trace.set_tracer_provider(provider)
+    provider.add_span_processor(SimpleSpanProcessor(exp))
+    exp.clear()
+    return exp
+
+
+def test_traced_provider_post_creates_client_span(exporter: InMemorySpanExporter) -> None:
+    with traced_provider_post("anthropic", "https://api.anthropic.com/v1/messages"):
+        set_provider_attrs(
+            {"http.status_code": 200, "gen_ai.request.model": "claude", "absent": None}
+        )
+
+    spans = [s for s in exporter.get_finished_spans() if s.name == "llm.POST anthropic"]
+    assert len(spans) == 1
+    span = spans[0]
+    attrs = dict(span.attributes or {})
+    assert span.kind == SpanKind.CLIENT
+    assert attrs["sf.plugin"] == "anthropic"
+    assert attrs["http.method"] == "POST"
+    assert str(attrs["http.url"]).startswith("https://api.anthropic.com")
+    assert attrs["http.status_code"] == 200
+    assert attrs["gen_ai.request.model"] == "claude"
+    # None-valued attributes are skipped (OTel rejects None).
+    assert "absent" not in attrs
+
+
+def test_method_param_changes_span_name(exporter: InMemorySpanExporter) -> None:
+    with traced_provider_post("aigw", "http://127.0.0.1:9105/v1/auth", method="GET"):
+        pass
+    names = [s.name for s in exporter.get_finished_spans()]
+    assert "llm.GET aigw" in names
+
+
+def test_exception_inside_span_is_recorded(exporter: InMemorySpanExporter) -> None:
+    with pytest.raises(ValueError):  # noqa: PT012, SIM117
+        with traced_provider_post("ollama", "http://localhost:11434/api/chat"):
+            raise ValueError("boom")
+    spans = [s for s in exporter.get_finished_spans() if s.name == "llm.POST ollama"]
+    assert len(spans) == 1
+    # OTel records the exception as a span event on context exit.
+    assert any(e.name == "exception" for e in spans[0].events)

--- a/apps/server/src/screamingface/plugins/ollama_backend_api/backend.py
+++ b/apps/server/src/screamingface/plugins/ollama_backend_api/backend.py
@@ -134,13 +134,27 @@ class OllamaBackend(Backend):
         )
 
     async def _do_post(self, body: dict, headers: dict[str, str]) -> httpx.Response:
-        try:
-            async with self._http_factory() as client:
-                return await client.post(self._chat_url, json=body, headers=headers)
-        except httpx.TimeoutException as exc:
-            raise BackendError(f"Request timed out: {exc}", status=None) from exc
-        except httpx.RequestError as exc:
-            raise BackendError(f"Request failed: {exc}", status=None) from exc
+        from screamingface.plugins.llm_base._tracing import (
+            set_provider_attrs,
+            traced_provider_post,
+        )
+
+        with traced_provider_post("ollama", self._chat_url):
+            try:
+                async with self._http_factory() as client:
+                    resp = await client.post(self._chat_url, json=body, headers=headers)
+            except httpx.TimeoutException as exc:
+                raise BackendError(f"Request timed out: {exc}", status=None) from exc
+            except httpx.RequestError as exc:
+                raise BackendError(f"Request failed: {exc}", status=None) from exc
+            set_provider_attrs(
+                {
+                    "http.status_code": resp.status_code,
+                    "http.response.size": len(resp.content),
+                    "gen_ai.request.model": body.get("model"),
+                }
+            )
+            return resp
 
     # ------------------------------------------------------------------
     # health()

--- a/apps/server/src/screamingface/plugins/ollama_backend_api/backend.py
+++ b/apps/server/src/screamingface/plugins/ollama_backend_api/backend.py
@@ -135,6 +135,7 @@ class OllamaBackend(Backend):
 
     async def _do_post(self, body: dict, headers: dict[str, str]) -> httpx.Response:
         from screamingface.plugins.llm_base._tracing import (
+            record_llm_call,
             set_provider_attrs,
             traced_provider_post,
         )
@@ -148,12 +149,9 @@ class OllamaBackend(Backend):
             except httpx.RequestError as exc:
                 raise BackendError(f"Request failed: {exc}", status=None) from exc
             set_provider_attrs(
-                {
-                    "http.status_code": resp.status_code,
-                    "http.response.size": len(resp.content),
-                    "gen_ai.request.model": body.get("model"),
-                }
+                {"http.status_code": resp.status_code, "http.response.size": len(resp.content)}
             )
+            record_llm_call("ollama", body, resp)
             return resp
 
     # ------------------------------------------------------------------

--- a/apps/server/src/screamingface/plugins/tracing/plugin.py
+++ b/apps/server/src/screamingface/plugins/tracing/plugin.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fnmatch
 import logging
 from typing import TYPE_CHECKING
 
@@ -18,6 +19,17 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# High-frequency, low-signal GET endpoints the desktop app polls on a timer.
+# Marked internal and dropped by default; override via SF_TRACING__MUTED_PATH_PATTERNS
+# (JSON list) or disable muting entirely with SF_TRACING__MUTE_NOISY_TRACES=false.
+# fnmatch patterns; only GET/HEAD requests are muted so mutations stay visible.
+DEFAULT_MUTED_PATH_PATTERNS: list[str] = [
+    "*/health",  # admin /health + per-backend probes (/claude/health, …)
+    "*/auth/connections",  # OAuth connection-status polling
+    "*/auth/connections/*",  # per-connection status polling
+    "/eval_runs/*",  # Eval Studio run-detail polling (the /eval_runs list stays visible)
+]
+
 
 class TracingSettings(PluginSettings):
     model_config = SettingsConfigDict(
@@ -29,6 +41,8 @@ class TracingSettings(PluginSettings):
     otlp_endpoint: str = "http://localhost:6006/v1/traces"
     phoenix_port: int = 6006
     phoenix_launch: bool = True  # auto-launch Phoenix as background thread
+    mute_noisy_traces: bool = True  # SF_TRACING__MUTE_NOISY_TRACES — drop muted-path spans
+    muted_path_patterns: list[str] = DEFAULT_MUTED_PATH_PATTERNS  # SF_TRACING__MUTED_PATH_PATTERNS
 
 
 class TracingPlugin(Plugin):
@@ -139,13 +153,23 @@ class TracingPlugin(Plugin):
             from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
             span_exporter = OTLPSpanExporter(endpoint=settings.otlp_endpoint)
-            provider.add_span_processor(_FilteringSpanProcessor(BatchSpanProcessor(span_exporter)))  # type: ignore[reportArgumentType]
+            provider.add_span_processor(
+                _FilteringSpanProcessor(
+                    BatchSpanProcessor(span_exporter),  # type: ignore[reportArgumentType]
+                    mute_internal=settings.mute_noisy_traces,
+                )
+            )
             logger.info("OTEL exporting to %s", settings.otlp_endpoint)
         elif settings.exporter == "console":
             from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
 
             span_exporter = ConsoleSpanExporter()
-            provider.add_span_processor(_FilteringSpanProcessor(SimpleSpanProcessor(span_exporter)))  # type: ignore[reportArgumentType]
+            provider.add_span_processor(
+                _FilteringSpanProcessor(
+                    SimpleSpanProcessor(span_exporter),  # type: ignore[reportArgumentType]
+                    mute_internal=settings.mute_noisy_traces,
+                )
+            )
             logger.info("OTEL exporting to console")
 
         trace.set_tracer_provider(provider)
@@ -159,7 +183,7 @@ class TracingPlugin(Plugin):
 
         FastAPIInstrumentor.instrument_app(
             app,
-            server_request_hook=_server_request_hook,
+            server_request_hook=_make_server_request_hook(settings.muted_path_patterns),
         )
 
         # Ensure httpx auto-instrumentation is disabled — we create manual spans
@@ -198,10 +222,16 @@ class TracingPlugin(Plugin):
 
 
 class _FilteringSpanProcessor:
-    """Wraps a SpanProcessor and drops spans whose names contain 'http send' or 'http receive'."""
+    """Wraps a SpanProcessor and drops noisy spans.
 
-    def __init__(self, inner) -> None:  # type: ignore[no-untyped-def]
+    Always drops the per-message ASGI ``http send`` / ``http receive`` child
+    spans. When ``mute_health`` is set, also drops spans flagged
+    ``_sf.internal`` (healthcheck probes — see :func:`_server_request_hook`).
+    """
+
+    def __init__(self, inner, *, mute_internal: bool = True) -> None:  # type: ignore[no-untyped-def]
         self._inner = inner
+        self._mute_internal = mute_internal
 
     def on_start(self, span, parent_context=None) -> None:  # type: ignore[no-untyped-def]
         self._inner.on_start(span, parent_context)
@@ -214,8 +244,8 @@ class _FilteringSpanProcessor:
         name = span.name
         if "http send" in name or "http receive" in name:
             return  # drop — noisy ASGI per-message spans
-        # Drop health check spans
-        if span.attributes and span.attributes.get("_sf.internal"):
+        # Drop muted-path spans (healthchecks, status polling) when muting is enabled.
+        if self._mute_internal and span.attributes and span.attributes.get("_sf.internal"):
             return
         self._inner.on_end(span)
 
@@ -232,15 +262,34 @@ def _truncate(text: str, limit: int = 4000) -> str:
     return text[:limit] + f"... ({len(text) - limit} more chars)"
 
 
-def _server_request_hook(span, scope) -> None:  # type: ignore[no-untyped-def]
-    """Add useful attributes to the server span from the ASGI scope."""
-    if not span or not span.is_recording():
-        return
-    path = scope.get("path", "")
-    if path == "/health":
-        # Mark as internal so the filtering processor can drop it
-        span.set_attribute("_sf.internal", True)
-        return
-    qs = scope.get("query_string", b"")
-    if qs:
-        span.set_attribute("http.query_string", qs.decode(errors="replace"))
+def _is_muted_path(path: str, method: str, patterns: list[str]) -> bool:
+    """True if a GET/HEAD ``path`` matches any fnmatch ``patterns``.
+
+    Method-restricted so mutations (POST create-connection, DELETE run, …) stay
+    visible even when their read-polling counterparts are muted.
+    """
+    if method not in ("GET", "HEAD"):
+        return False
+    return any(fnmatch.fnmatch(path, p) for p in patterns)
+
+
+def _make_server_request_hook(patterns: list[str]):  # type: ignore[no-untyped-def]
+    """Build a FastAPI server_request_hook bound to ``patterns``.
+
+    Marks muted-path spans ``_sf.internal`` (the filtering processor drops them
+    when muting is enabled) and records the query string on everything else.
+    """
+
+    def _hook(span, scope) -> None:  # type: ignore[no-untyped-def]
+        if not span or not span.is_recording():
+            return
+        path = scope.get("path", "")
+        method = scope.get("method", "GET")
+        if _is_muted_path(path, method, patterns):
+            span.set_attribute("_sf.internal", True)
+            return
+        qs = scope.get("query_string", b"")
+        if qs:
+            span.set_attribute("http.query_string", qs.decode(errors="replace"))
+
+    return _hook

--- a/apps/server/src/screamingface/plugins/tracing/tests/test_health_mute.py
+++ b/apps/server/src/screamingface/plugins/tracing/tests/test_health_mute.py
@@ -1,0 +1,139 @@
+"""Unit tests for noisy-path trace muting (SF-278).
+
+Two-phase design: the server_request_hook *marks* muted-path spans
+``_sf.internal`` at span start, and ``_FilteringSpanProcessor`` *decides*
+whether to drop them at span end based on the ``mute_internal`` flag.
+"""
+
+from __future__ import annotations
+
+from screamingface.plugins.tracing.plugin import (
+    DEFAULT_MUTED_PATH_PATTERNS,
+    _FilteringSpanProcessor,
+    _is_muted_path,
+    _make_server_request_hook,
+)
+
+
+class _FakeInner:
+    """Minimal SpanProcessor stand-in recording forwarded spans."""
+
+    def __init__(self) -> None:
+        self.ended: list[object] = []
+
+    def on_start(self, span, parent_context=None) -> None:  # noqa: ANN001, ARG002
+        pass
+
+    def on_end(self, span) -> None:  # noqa: ANN001
+        self.ended.append(span)
+
+    def shutdown(self) -> None:
+        pass
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:  # noqa: ARG002
+        return True
+
+
+class _FakeSpan:
+    def __init__(self, name: str, attributes: dict | None = None, *, recording: bool = True):
+        self.name = name
+        self.attributes = attributes if attributes is not None else {}
+        self._recording = recording
+
+    def is_recording(self) -> bool:
+        return self._recording
+
+    def set_attribute(self, key: str, value: object) -> None:
+        self.attributes[key] = value
+
+
+# ---------------------------------------------------------------------------
+# _FilteringSpanProcessor
+# ---------------------------------------------------------------------------
+
+
+def test_mutes_internal_spans_when_enabled() -> None:
+    inner = _FakeInner()
+    proc = _FilteringSpanProcessor(inner, mute_internal=True)
+    proc.on_end(_FakeSpan("GET /claude/auth/connections", {"_sf.internal": True}))
+    assert inner.ended == []
+
+
+def test_forwards_internal_spans_when_disabled() -> None:
+    inner = _FakeInner()
+    proc = _FilteringSpanProcessor(inner, mute_internal=False)
+    span = _FakeSpan("GET /claude/auth/connections", {"_sf.internal": True})
+    proc.on_end(span)
+    assert inner.ended == [span]
+
+
+def test_asgi_noise_always_dropped_regardless_of_flag() -> None:
+    for mute in (True, False):
+        inner = _FakeInner()
+        proc = _FilteringSpanProcessor(inner, mute_internal=mute)
+        proc.on_end(_FakeSpan("http send", {}))
+        proc.on_end(_FakeSpan("http receive", {}))
+        assert inner.ended == []
+
+
+def test_normal_spans_always_forwarded() -> None:
+    inner = _FakeInner()
+    proc = _FilteringSpanProcessor(inner, mute_internal=True)
+    span = _FakeSpan("POST /v1/messages", {"sf.plugin": "claude-frontend"})
+    proc.on_end(span)
+    assert inner.ended == [span]
+
+
+# ---------------------------------------------------------------------------
+# _is_muted_path (default patterns, method-aware)
+# ---------------------------------------------------------------------------
+
+
+def test_default_patterns_mute_polling_gets() -> None:
+    muted = [
+        "/health",
+        "/claude/health",
+        "/gemini/health",
+        "/claude/auth/connections",
+        "/codex/auth/connections",
+        "/claude/auth/connections/abc-123",
+        "/eval_runs/550e8400-e29b-41d4-a716-446655440000",
+    ]
+    for path in muted:
+        assert _is_muted_path(path, "GET", DEFAULT_MUTED_PATH_PATTERNS), path
+
+
+def test_default_patterns_keep_real_endpoints() -> None:
+    kept = ["/v1/messages", "/ensemble", "/eval_runs", "/backends/status", "/data/abc"]
+    for path in kept:
+        assert not _is_muted_path(path, "GET", DEFAULT_MUTED_PATH_PATTERNS), path
+
+
+def test_mutations_are_not_muted() -> None:
+    # Same paths, non-GET methods — connecting/deleting must stay visible.
+    assert not _is_muted_path("/claude/auth/connections", "POST", DEFAULT_MUTED_PATH_PATTERNS)
+    assert not _is_muted_path("/eval_runs/abc", "DELETE", DEFAULT_MUTED_PATH_PATTERNS)
+    assert not _is_muted_path(
+        "/claude/auth/connections/x/refresh", "POST", DEFAULT_MUTED_PATH_PATTERNS
+    )
+
+
+# ---------------------------------------------------------------------------
+# server_request_hook
+# ---------------------------------------------------------------------------
+
+
+def test_hook_marks_muted_paths() -> None:
+    hook = _make_server_request_hook(DEFAULT_MUTED_PATH_PATTERNS)
+    for path in ("/health", "/claude/auth/connections", "/eval_runs/abc"):
+        span = _FakeSpan("server")
+        hook(span, {"path": path, "method": "GET"})
+        assert span.attributes.get("_sf.internal") is True, path
+
+
+def test_hook_does_not_mark_real_paths_and_records_query() -> None:
+    hook = _make_server_request_hook(DEFAULT_MUTED_PATH_PATTERNS)
+    span = _FakeSpan("server")
+    hook(span, {"path": "/ensemble", "method": "GET", "query_string": b"q=hi"})
+    assert "_sf.internal" not in span.attributes
+    assert span.attributes.get("http.query_string") == "q=hi"

--- a/apps/server/src/screamingface/plugins/url4_executor/_tracing.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/_tracing.py
@@ -47,3 +47,43 @@ def set_span_attrs(attrs: dict[str, Any], span: Any = None) -> None:
                 span.set_attribute(k, v)
     except ImportError:
         pass
+
+
+# OpenInference attribute names (stable spec strings; literals avoid a hard dep
+# on openinference-semantic-conventions so this stays no-op without OTel).
+# Phoenix reads these to populate its kind / input / output columns.
+_OI_KIND = "openinference.span.kind"
+_OI_INPUT = "input.value"
+_OI_INPUT_MIME = "input.mime_type"
+_OI_OUTPUT = "output.value"
+_OI_OUTPUT_MIME = "output.mime_type"
+
+
+def set_openinference(
+    kind: str,
+    *,
+    input_value: str | None = None,
+    output_value: str | None = None,
+    mime_type: str = "text/plain",
+    span: Any = None,
+) -> None:
+    """Tag the current span with OpenInference semantics (no-op without OTel).
+
+    ``kind`` is an OpenInference span kind ("LLM", "CHAIN", "RETRIEVER", …).
+    ``input_value`` / ``output_value`` populate Phoenix's input / output columns.
+    """
+    try:
+        from opentelemetry import trace
+
+        span = span or trace.get_current_span()
+        if not (span and span.is_recording()):
+            return
+        span.set_attribute(_OI_KIND, kind)
+        if input_value is not None:
+            span.set_attribute(_OI_INPUT, input_value)
+            span.set_attribute(_OI_INPUT_MIME, mime_type)
+        if output_value is not None:
+            span.set_attribute(_OI_OUTPUT, output_value)
+            span.set_attribute(_OI_OUTPUT_MIME, mime_type)
+    except ImportError:
+        pass

--- a/apps/server/src/screamingface/plugins/url4_executor/ensemble.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/ensemble.py
@@ -114,7 +114,11 @@ class EnsembleInterpreter(Url4Interpreter):
         + tracing. Order matters: collection iteration must come before
         fan-out detection because ``source*(…)`` is a distinct shape.
         """
-        from screamingface.plugins.url4_executor._tracing import set_span_attrs, traced
+        from screamingface.plugins.url4_executor._tracing import (
+            set_openinference,
+            set_span_attrs,
+            traced,
+        )
         from screamingface.plugins.url4_executor.decoder import split_intent
         from screamingface.plugins.url4_executor.url4 import parse
 
@@ -126,6 +130,7 @@ class EnsembleInterpreter(Url4Interpreter):
             except KeyError:
                 env = env.child(__processor__=self._processor)
             set_span_attrs({"url4.expression": expr[:500]})
+            set_openinference("CHAIN", input_value=expr[:16000])
             source_expr, raw_intent, broadcast = split_intent(expr.strip())
             set_span_attrs(
                 {

--- a/apps/server/src/screamingface/plugins/url4_executor/interpreter.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/interpreter.py
@@ -66,7 +66,11 @@ class Url4Interpreter:
 
     async def evaluate(self, expr: str, env: Env | None = None) -> str:
         """Full evaluation pipeline."""
-        from screamingface.plugins.url4_executor._tracing import set_span_attrs, traced
+        from screamingface.plugins.url4_executor._tracing import (
+            set_openinference,
+            set_span_attrs,
+            traced,
+        )
 
         with traced("url4.evaluate"):
             if env is None:
@@ -76,6 +80,7 @@ class Url4Interpreter:
                     "url4.expression": expr[:500],
                 }
             )
+            set_openinference("CHAIN", input_value=expr[:16000])
 
             source_expr, raw_intent, _broadcast = split_intent(expr.strip())
             set_span_attrs({"url4.has_intent": raw_intent is not None})
@@ -113,6 +118,7 @@ class Url4Interpreter:
                     "url4.response_body": result_preview,
                 }
             )
+            set_openinference("CHAIN", output_value=result[:16000])
             return result
 
     async def process(self, sources: str, intent: str | None, env: Env | None = None) -> str:

--- a/apps/server/src/screamingface/plugins/url4_executor/routes.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/routes.py
@@ -157,7 +157,7 @@ def create_router(app=None) -> APIRouter:  # type: ignore[no-untyped-def]
             )
 
         # Record result on the FastAPI auto-instrumented span
-        from screamingface.plugins.url4_executor._tracing import set_span_attrs
+        from screamingface.plugins.url4_executor._tracing import set_openinference, set_span_attrs
 
         preview = result[:4000]
         if len(result) > 4000:
@@ -169,6 +169,9 @@ def create_router(app=None) -> APIRouter:  # type: ignore[no-untyped-def]
                 "url4.response_body": preview,
             }
         )
+        # OpenInference: the /ensemble request is the root CHAIN — full query in,
+        # final result out (the backend/LLM child spans carry the rest).
+        set_openinference("CHAIN", input_value=q[:16000], output_value=result[:16000])
 
         response: JSONResponse | PlainTextResponse
         if ast:

--- a/apps/server/src/screamingface/plugins/url4_executor/url4_resolve.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/url4_resolve.py
@@ -31,6 +31,14 @@ from screamingface.plugins.url4_executor.url4_grammar import parse
 
 logger = logging.getLogger(__name__)
 
+_OI_IO_CAP = 16000
+
+
+def _format_prompt_context(sources: str, intent: str) -> str:
+    """Render context + prompt as one OpenInference ``input.value`` string."""
+    text = f"[context]\n{sources}\n\n[prompt]\n{intent}" if sources else intent
+    return text[:_OI_IO_CAP]
+
 
 async def resolve(node: Url4Node, app: Any = None, env: Env | None = None) -> str:
     """Recursively resolve an AST node to a string.
@@ -138,7 +146,11 @@ async def _dispatch_backend_call(node: Url4BackendCall, app: Any, env: Env | Non
     intent into a plain string, then awaits the plugin's
     ``handle_backend_call(intent, app=app)`` method.
     """
-    from screamingface.plugins.url4_executor._tracing import set_span_attrs, traced
+    from screamingface.plugins.url4_executor._tracing import (
+        set_openinference,
+        set_span_attrs,
+        traced,
+    )
 
     with traced(f"url4.backend_call {node.path}", kind="client"):
         if app is None:
@@ -159,6 +171,10 @@ async def _dispatch_backend_call(node: Url4BackendCall, app: Any, env: Env | Non
                 "url4.intent_preview": intent_text[:500],
             }
         )
+        # OpenInference: a backend call is a CHAIN step — expose the full prompt +
+        # context as input so Phoenix renders it (the LLM child span carries the
+        # provider request/response).
+        set_openinference("CHAIN", input_value=_format_prompt_context(sources_text, intent_text))
 
         from screamingface.core.helpers import get_plugins_registry
 
@@ -175,6 +191,7 @@ async def _dispatch_backend_call(node: Url4BackendCall, app: Any, env: Env | Non
                 set_span_attrs(
                     {"sf.backend_plugin": plugin.name, "url4.result_length": len(result)}
                 )
+                set_openinference("CHAIN", output_value=result[:16000])
                 return result
 
         raise RuntimeError(
@@ -233,7 +250,11 @@ def _sanitize_url(url: str) -> str:
 
 async def _fetch_relative(app: Any, path: str) -> str:
     """Fetch a relative path via in-process ASGI transport (no network hop)."""
-    from screamingface.plugins.url4_executor._tracing import set_span_attrs, traced
+    from screamingface.plugins.url4_executor._tracing import (
+        set_openinference,
+        set_span_attrs,
+        traced,
+    )
 
     if not app:
         raise ValueError(f"Cannot resolve relative URL {path!r} without app context")
@@ -254,12 +275,17 @@ async def _fetch_relative(app: Any, path: str) -> str:
                     "url4.response_body": preview,
                 }
             )
+            set_openinference("RETRIEVER", input_value=path, output_value=preview)
             return body
 
 
 async def _fetch_url(url: str) -> str:
     """Fetch a URL via HTTP GET and return the response body as text."""
-    from screamingface.plugins.url4_executor._tracing import set_span_attrs, traced
+    from screamingface.plugins.url4_executor._tracing import (
+        set_openinference,
+        set_span_attrs,
+        traced,
+    )
 
     safe_url = _sanitize_url(url)
     logger.info("url4: fetching %s", safe_url[:200])
@@ -280,6 +306,7 @@ async def _fetch_url(url: str) -> str:
                     "url4.response_body": preview,
                 }
             )
+            set_openinference("RETRIEVER", input_value=safe_url[:500], output_value=preview)
             return body
 
 

--- a/apps/server/src/screamingface/plugins/url4_executor/url4_resolve.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/url4_resolve.py
@@ -138,36 +138,51 @@ async def _dispatch_backend_call(node: Url4BackendCall, app: Any, env: Env | Non
     intent into a plain string, then awaits the plugin's
     ``handle_backend_call(intent, app=app)`` method.
     """
-    if app is None:
-        raise RuntimeError(
-            f"Cannot dispatch backend call {node.path}() without an app "
-            "context. Backend-call resolution needs access to the active "
-            "plugin registry via app.state.plugins."
-        )
+    from screamingface.plugins.url4_executor._tracing import set_span_attrs, traced
 
-    intent_text = "" if node.intent is None else await resolve(node.intent, app, env)
-    intent_text = substitute_env_vars(intent_text, env)
-    sources_text = node.packed_context or ""
-
-    from screamingface.core.helpers import get_plugins_registry
-
-    plugins_registry = get_plugins_registry(app)
-
-    known_paths: list[str] = []
-    for plugin in plugins_registry.active_plugins.values():
-        paths = getattr(plugin, "backend_call_paths", [])
-        known_paths.extend(paths)
-        if node.path in paths:
-            return await plugin.handle_backend_call(
-                intent_text, sources=sources_text, app=app, env=env
+    with traced(f"url4.backend_call {node.path}", kind="client"):
+        if app is None:
+            raise RuntimeError(
+                f"Cannot dispatch backend call {node.path}() without an app "
+                "context. Backend-call resolution needs access to the active "
+                "plugin registry via app.state.plugins."
             )
 
-    raise RuntimeError(
-        f"No active plugin handles the backend call {node.path}(). "
-        f"Known backend_call_paths across active plugins: {known_paths!r}. "
-        "Activate a plugin that declares this path in its "
-        "backend_call_paths attribute."
-    )
+        # Resolve the intent inside the span so any child fetch spans nest here.
+        intent_text = "" if node.intent is None else await resolve(node.intent, app, env)
+        intent_text = substitute_env_vars(intent_text, env)
+        sources_text = node.packed_context or ""
+        set_span_attrs(
+            {
+                "url4.path": node.path,
+                "url4.intent_length": len(intent_text),
+                "url4.intent_preview": intent_text[:500],
+            }
+        )
+
+        from screamingface.core.helpers import get_plugins_registry
+
+        plugins_registry = get_plugins_registry(app)
+
+        known_paths: list[str] = []
+        for plugin in plugins_registry.active_plugins.values():
+            paths = getattr(plugin, "backend_call_paths", [])
+            known_paths.extend(paths)
+            if node.path in paths:
+                result = await plugin.handle_backend_call(
+                    intent_text, sources=sources_text, app=app, env=env
+                )
+                set_span_attrs(
+                    {"sf.backend_plugin": plugin.name, "url4.result_length": len(result)}
+                )
+                return result
+
+        raise RuntimeError(
+            f"No active plugin handles the backend call {node.path}(). "
+            f"Known backend_call_paths across active plugins: {known_paths!r}. "
+            "Activate a plugin that declares this path in its "
+            "backend_call_paths attribute."
+        )
 
 
 async def _dispatch_backend_call_with_intent(

--- a/apps/server/tests/e2e/test_ensemble_features.py
+++ b/apps/server/tests/e2e/test_ensemble_features.py
@@ -420,3 +420,54 @@ class TestCollectionSourceFetchFailure:
         assert otlp_collector.find_spans(name="url4.collection_iterate"), (
             f"collection iteration should start for a reachable source; spans={span_names}"
         )
+
+
+# ============================================================================
+# SF-278: backend dispatch + provider HTTP spans in ensemble traces
+# ============================================================================
+
+
+class TestBackendDispatchTracing:
+    def test_dispatch_span_emitted_for_backend_call(
+        self, ensemble_url: str, otlp_collector: OTLPCollector
+    ) -> None:
+        """`_dispatch_backend_call` emits `url4.backend_call /claude`.
+
+        CI-safe: the span is opened *before* the backend's credential check,
+        so it is emitted (as an error span) even with no Keychain credential.
+        We assert only on the span, not the HTTP status.
+        """
+        otlp_collector.clear()
+        _get_ensemble(ensemble_url, q="/claude()!ping")
+        otlp_collector.wait_for_spans(1, timeout=15)
+
+        dispatch = otlp_collector.find_spans(name="url4.backend_call")
+        span_names = sorted({s.name for s in otlp_collector.spans})
+        assert dispatch, f"no url4.backend_call span emitted; spans={span_names}"
+        s = dispatch[0]
+        assert s.name == "url4.backend_call /claude"
+        assert s.attributes.get("url4.path") == "/claude"
+        assert "url4.intent_length" in s.attributes
+
+
+@pytest.mark.e2e_live
+class TestProviderHttpTracing:
+    def test_provider_post_span_emitted(
+        self, ensemble_url: str, otlp_collector: OTLPCollector
+    ) -> None:
+        """A real backend call emits the deep `llm.POST Anthropic` client span.
+
+        Live-only: the provider POST only fires once a real auth header is
+        obtained (Keychain credential present).
+        """
+        otlp_collector.clear()
+        resp = _get_ensemble(ensemble_url, q="/claude()!Say the word pong. One word.")
+        assert resp.status_code == 200
+
+        otlp_collector.wait_for_spans(2, timeout=20)
+        provider = otlp_collector.find_spans(name="llm.POST Anthropic")
+        span_names = sorted({s.name for s in otlp_collector.spans})
+        assert provider, f"no llm.POST Anthropic span emitted; spans={span_names}"
+        s = provider[0]
+        assert s.attributes.get("sf.plugin") == "Anthropic"
+        assert s.attributes.get("http.status_code") == 200

--- a/apps/server/tests/e2e/test_ensemble_features.py
+++ b/apps/server/tests/e2e/test_ensemble_features.py
@@ -448,6 +448,9 @@ class TestBackendDispatchTracing:
         assert s.name == "url4.backend_call /claude"
         assert s.attributes.get("url4.path") == "/claude"
         assert "url4.intent_length" in s.attributes
+        # OpenInference: a backend call is a CHAIN with the prompt+context as input.
+        assert s.attributes.get("openinference.span.kind") == "CHAIN"
+        assert "ping" in str(s.attributes.get("input.value", ""))
 
 
 @pytest.mark.e2e_live
@@ -471,3 +474,7 @@ class TestProviderHttpTracing:
         s = provider[0]
         assert s.attributes.get("sf.plugin") == "Anthropic"
         assert s.attributes.get("http.status_code") == 200
+        # OpenInference LLM classification + captured model call.
+        assert s.attributes.get("openinference.span.kind") == "LLM"
+        assert s.attributes.get("input.value")  # request body captured
+        assert s.attributes.get("output.value")  # response captured


### PR DESCRIPTION
## Summary

Improve Phoenix tracing quality so `/ensemble` traces are complete, quiet, and render natively in Phoenix's LLM-observability UI.

**Commit 1 (`98b9ac5`) — foundation**
- `url4.backend_call` dispatch span at the single `_dispatch_backend_call` chokepoint → every fan-out leg + reducer is visible.
- Deep provider HTTP client spans via a shared `llm_base/_tracing` helper (claude/codex via `post_with_default_retry`, gemini/ollama `_do_post`).
- AI gateway: client span + W3C `traceparent` propagation in `AigwBackend._request` (local + remote SF-side; gateway-internal is a follow-up — `apps/aigateway` has no OTEL yet).
- Configurable noise muting (`SF_TRACING__MUTE_NOISY_TRACES` / `SF_TRACING__MUTED_PATH_PATTERNS`), on by default: GET/HEAD polling for `*/health`, `*/auth/connections(+/{id})`, `/eval_runs/{id}`. Method-aware so mutations stay visible.
- Drive-by: `/eval_runs` 500 fix — `RunStatus` omitted `degraded` (written by the SF-270 lifecycle); widened the Literal + regression test.

**Commit 2 (`90744a5`) — OpenInference conventions**
Spans previously carried only OTel `SpanKind` + ad-hoc attrs, so Phoenix showed `kind=unknown` with empty input/output. Now mapped to OpenInference:
- **LLM**: provider POSTs + aigw chat-completions → `kind=LLM`, `input.value`/`output.value`, `llm.model_name`/`llm.provider`, prompt/completion token counts (parsed across OpenAI/Anthropic/Gemini shapes). aigw auth/status GETs are *not* tagged LLM.
- **CHAIN**: `url4.backend_call`, `url4.evaluate` (interpreter + ensemble), root `/v1/messages` & `/ensemble`.
- **RETRIEVER**: `url4.fetch` / `url4.fetch_relative`.

## Test plan
- CI Server Tests green (ruff + 1309 unit + 139 e2e).
- Local full suite incl. live: **1436 passed, 19 skipped** (the 7 `e2e_live` run locally, skipped on CI).
- New: unit tests for noise-muting, the LLM/OI helpers (token extraction across shapes), aigw traceparent propagation; CI-safe e2e for the dispatch CHAIN span + live e2e for the provider LLM span.

## Out of scope / follow-ups
- Instrument `apps/aigateway` itself (OTEL + traceparent extraction → same OTLP endpoint) for local gateway-internal spans.
- Phoenix `annotations` (eval-run scores as feedback) — separate from instrumentation.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215683061383808

🤖 Generated with [Claude Code](https://claude.com/claude-code)
