### PR TITLE
SF-281: scope Dependabot to maintained apps (grouped) + clear web-iterations noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+# Scope Dependabot to the maintained apps only, with grouped updates.
+#
+# Without this file Dependabot auto-discovers EVERY manifest in the repo,
+# including the throwaway prototypes under web-iterations/ — which produced a
+# backlog of noise PRs. Listing explicit directories means only these trees are
+# scanned; `groups` collapses each ecosystem's bumps into a single PR.
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/apps/server"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      server-python:
+        patterns: ["*"]
+
+  - package-ecosystem: "uv"
+    directory: "/apps/aigateway"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      aigateway-python:
+        patterns: ["*"]
+
+  - package-ecosystem: "npm"
+    directory: "/apps/desktop"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      desktop-npm:
+        patterns: ["*"]
+
+  # Keep GitHub Actions pinned-version bumps current too (low volume).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
## Why
There was no `.github/dependabot.yml`, so Dependabot auto-discovered **every** manifest in the repo — including the 142-file `web-iterations/` prototype tree (referenced by no workflow/build/workspace). That generated a backlog of 19 open Dependabot PRs, 10 of them against dead prototype dirs.

## What
Add an explicit, scoped + grouped config:
- **Scanned:** `apps/server` + `apps/aigateway` (uv), `apps/desktop` (npm), and `github-actions` at root (the last keeps pinned action versions current — addresses the recurring Node 20 deprecation annotation).
- **Grouped:** each ecosystem's bumps collapse into a single PR (`patterns: ["*"]`) instead of one-per-package.
- **No longer scanned:** `web-iterations/**` — stopping the noise at the source.

## Follow-up (this batch)
- Closing the 10 stale `web-iterations` Dependabot PRs.
- Merging the 9 real-app bumps individually once each one's CI is green.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215764732737646

🤖 Generated with [Claude Code](https://claude.com/claude-code)
