### PR TITLE
SF-282: single-flight OAuth refresh on chat path (shared strategy cache)

### DIFF
--- a/apps/aigateway/src/aigateway/core/credential_strategy_cache.py
+++ b/apps/aigateway/src/aigateway/core/credential_strategy_cache.py
@@ -1,0 +1,81 @@
+"""Process-wide cache of credential strategy instances (SF-282).
+
+Concurrent ``POST /v1/chat/completions`` requests for the same credential must
+share ONE strategy instance so its ``asyncio.Lock`` single-flights the OAuth
+refresh. Without this, each request built a fresh ``BaseOAuthStrategy`` with its
+own per-instance lock, so a fan-out (e.g. a 33-row eval) refreshed the same
+rotating OAuth token N times in parallel and the provider rejected the racers
+(Anthropic returns ``429 refresh_token_conflict``).
+
+``get_or_create`` and ``evict`` are intentionally **synchronous**: asyncio is
+single-threaded and neither method contains an ``await``, so check-then-insert
+is atomic without a lock. The actual refresh single-flight is the shared
+strategy's own lock (``BaseOAuthStrategy._lock``), not this cache.
+
+The cache MUST be evicted on every credential mutation (OAuth re-auth, delete,
+manual refresh) so a cached, not-yet-expired access token cannot outlive the
+stored credential. API-key strategies hold no in-memory token (they read the
+store on every call), so api-key paths do not require eviction.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+# (provider, auth_type, credential_name) — provider distinguishes same-named
+# profiles across providers; auth_type distinguishes oauth vs api_key strategies.
+StrategyKey = tuple[str, str, str]
+
+
+class CredentialStrategyCache:
+    """Caches one credential-strategy instance per (provider, auth_type, name)."""
+
+    def __init__(self) -> None:
+        self._cache: dict[StrategyKey, Any] = {}
+
+    def get_or_create(
+        self,
+        *,
+        provider: str,
+        auth_type: str,
+        credential_name: str,
+        build: Callable[[], Any],
+    ) -> Any:
+        """Return the cached strategy for the key, building + caching on miss.
+
+        ``build`` is only invoked on a miss. A ``None`` build result is not
+        cached (matches ``credential_strategy_from`` returning ``None``).
+        """
+        key = (provider, auth_type, credential_name)
+        strategy = self._cache.get(key)
+        if strategy is None:
+            strategy = build()
+            if strategy is not None:
+                self._cache[key] = strategy
+        return strategy
+
+    def evict(self, credential_name: str) -> int:
+        """Drop every cached strategy for ``credential_name`` (any provider/auth).
+
+        Returns the count evicted. Call on any mutation of the credential.
+        """
+        stale = [key for key in self._cache if key[2] == credential_name]
+        for key in stale:
+            self._cache.pop(key, None)
+        return len(stale)
+
+    def clear(self) -> None:
+        self._cache.clear()
+
+
+def credential_strategy_cache(app: Any) -> CredentialStrategyCache:
+    """Get-or-create the app-wide cache on ``app.state`` (token-service pattern)."""
+    state = getattr(app, "state", None)
+    if state is None:
+        raise RuntimeError("AIGateway app state is unavailable")
+    cache = getattr(state, "credential_strategy_cache", None)
+    if not isinstance(cache, CredentialStrategyCache):
+        cache = CredentialStrategyCache()
+        state.credential_strategy_cache = cache
+    return cache

--- a/apps/aigateway/src/aigateway/routes/auth.py
+++ b/apps/aigateway/src/aigateway/routes/auth.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel
 from tortoise.exceptions import IntegrityError
 
 from ..core.auth.middleware import CurrentAccount
+from ..core.credential_strategy_cache import credential_strategy_cache
 from ..core.errors import AuthError, CredentialNotFoundError
 from ..core.oauth.store import (
     OAuthConnectionStore,
@@ -103,10 +104,14 @@ def _credential_strategy_for_credential_name(
     )
 
 
-def _invalidate_profile_session(plugin, account_id: str, name: str) -> None:
+def _invalidate_profile_session(app, plugin, account_id: str, name: str) -> None:
+    credential_name = credential_name_for(account_id, name)
     invalidator = getattr(plugin, "invalidate_profile_session", None)
     if callable(invalidator):
-        invalidator(credential_name_for(account_id, name))
+        invalidator(credential_name)
+    # Drop the shared cached strategy so re-auth / api-key change / delete / refresh
+    # never serve a stale in-memory token from a prior credential (SF-282).
+    credential_strategy_cache(app).evict(credential_name)
 
 
 @asynccontextmanager
@@ -124,7 +129,7 @@ async def _profile_refresh_lifecycle(
     except (CredentialNotFoundError, AuthError) as exc:
         profile.state = ProfileState.ERROR
         await _index_store(request).upsert(profile)
-        _invalidate_profile_session(plugin, account_id, name)
+        _invalidate_profile_session(request.app, plugin, account_id, name)
         raise HTTPException(
             status_code=401,
             detail={
@@ -137,7 +142,7 @@ async def _profile_refresh_lifecycle(
         profile.state = ProfileState.AUTHENTICATED
         profile.last_refreshed_at = datetime.now(UTC)
         await _index_store(request).upsert(profile)
-        _invalidate_profile_session(plugin, account_id, name)
+        _invalidate_profile_session(request.app, plugin, account_id, name)
 
 
 def _pending(request: Request):
@@ -672,7 +677,7 @@ async def _complete_oauth_for_app(
         raise
     if pending.connection_id is None:
         await strategy.persist_credentials(creds)
-        _invalidate_profile_session(plugin, pending.account_id, pending.profile_name)
+        _invalidate_profile_session(app, plugin, pending.account_id, pending.profile_name)
 
     await _mark_profile_authenticated(app, pending, plugin, creds)
     await _record_oauth_connection_completion(app, pending, plugin, creds)
@@ -760,6 +765,9 @@ async def _mark_connection_error(app, pending: PendingAuthEntry, message: str) -
     connection = await store.get(pending.account_id, pending.connection_id)
     if connection is not None:
         await store.mark_error(connection, message)
+    credential_strategy_cache(app).evict(
+        credential_key_for(pending.account_id, pending.connection_id)
+    )
 
 
 async def _persist_connection_credentials(
@@ -778,6 +786,7 @@ async def _persist_connection_credentials(
     )
     if strategy is not None:
         await strategy.persist_credentials(creds)
+    credential_strategy_cache(app).evict(credential_key_for(account_id, connection_id))
 
 
 async def _record_oauth_connection_completion(
@@ -1072,7 +1081,7 @@ async def set_profile_api_key(
 
     await strategy.persist_credentials({"auth_type": "api_key", "api_key": api_key})
     await idx.upsert(profile)
-    _invalidate_profile_session(plugin, account_id, name)
+    _invalidate_profile_session(request.app, plugin, account_id, name)
     return profile.model_dump(mode="json")
 
 
@@ -1090,7 +1099,7 @@ async def delete_profile(provider: str, name: str, request: Request, current: Cu
     )
     if strategy is not None:
         await strategy.delete_credentials()
-    _invalidate_profile_session(plugin, account_id, name)
+    _invalidate_profile_session(request.app, plugin, account_id, name)
     await _index_store(request).remove(p.id)
 
 

--- a/apps/aigateway/src/aigateway/routes/chat.py
+++ b/apps/aigateway/src/aigateway/routes/chat.py
@@ -23,6 +23,7 @@ from litellm.exceptions import (
 
 from ..core.auth.middleware import CurrentAccount
 from ..core.concurrency import effective_provider_limit, provider_slot
+from ..core.credential_strategy_cache import credential_strategy_cache
 from ..core.errors import AuthError, CredentialNotFoundError
 from ..core.oauth.models import OAuthConnection
 from ..core.oauth.store import OAuthConnectionStore, credential_key_for
@@ -214,12 +215,20 @@ def _strategy_for_credential_target(
         auth_type = profile.auth_type
     else:
         return None, None, "oauth"
-    strategy = credential_strategy_from(
-        plugin,
-        credential_name,
+    # Share ONE strategy instance per credential across concurrent requests so its
+    # asyncio.Lock single-flights the OAuth refresh (SF-282). Building is only a
+    # constructor call; the cache is evicted on every credential mutation.
+    strategy = credential_strategy_cache(request.app).get_or_create(
+        provider=provider,
         auth_type=auth_type,
-        credential_store=request.app.state.credential_store,
-        http_client_factory=getattr(request.app.state, f"{provider}_http_factory", None),
+        credential_name=credential_name,
+        build=lambda: credential_strategy_from(
+            plugin,
+            credential_name,
+            auth_type=auth_type,
+            credential_store=request.app.state.credential_store,
+            http_client_factory=getattr(request.app.state, f"{provider}_http_factory", None),
+        ),
     )
     return strategy, credential_name, auth_type
 
@@ -268,6 +277,10 @@ async def _dispatch_failure_response(
     """
     if not _should_mark_profile_error_on_dispatch_status(plugin, exc.status_code):
         return exc
+    # Drop the cached strategy so its (now bad) token isn't reused by the next
+    # request — important under fan-out where many requests share the instance.
+    if credential_name is not None:
+        credential_strategy_cache(request.app).evict(credential_name)
     detail = exc.detail if isinstance(exc.detail, dict) else {"message": str(exc.detail)}
     if connection is not None:
         await _oauth_connection_store(request).mark_error(
@@ -482,6 +495,8 @@ async def _inject_credentials(
         try:
             headers = await strategy.get_authorization_header()
         except CredentialNotFoundError as exc:
+            if credential_name is not None:
+                credential_strategy_cache(request.app).evict(credential_name)
             if connection is not None:
                 await _oauth_connection_store(request).mark_error(connection, str(exc))
             raise HTTPException(
@@ -493,6 +508,8 @@ async def _inject_credentials(
                 },
             )
         except AuthError as exc:
+            if credential_name is not None:
+                credential_strategy_cache(request.app).evict(credential_name)
             if connection is not None:
                 await _oauth_connection_store(request).mark_error(connection, str(exc))
                 if credential_name is not None:

--- a/apps/aigateway/src/aigateway/routes/oauth_connections.py
+++ b/apps/aigateway/src/aigateway/routes/oauth_connections.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, HTTPException, Request
 from tortoise.exceptions import IntegrityError
 
 from aigateway.core.auth.middleware import CurrentAccount
+from aigateway.core.credential_strategy_cache import credential_strategy_cache
 from aigateway.core.errors import AuthError, CredentialNotFoundError
 from aigateway.core.oauth.schemas import (
     CreateOAuthConnectionRequest,
@@ -174,6 +175,9 @@ async def delete_connection(connection_id: UUID, request: Request, current: Curr
         raise HTTPException(status_code=404, detail={"code": "connection_not_found"})
     await _delete_credentials(request, connection.credential_locator)
     await store.mark_revoked(connection)
+    # Evict the shared cached strategy so a deleted connection's still-valid token
+    # can't keep being served from memory (SF-282).
+    credential_strategy_cache(request.app).evict(credential_key_for(str(current.id), connection_id))
 
 
 @router.get(
@@ -240,9 +244,15 @@ async def refresh_connection(
         await strategy.refresh_credentials()
     except (CredentialNotFoundError, AuthError) as exc:
         await store.mark_error(connection, str(exc))
+        credential_strategy_cache(request.app).evict(
+            credential_key_for(str(current.id), connection.id)
+        )
         raise HTTPException(
             status_code=401, detail={"code": "auth_required", "message": str(exc)}
         ) from exc
+    # Manual refresh wrote new tokens to the store; drop the cached instance so the
+    # chat path rebuilds and reads them (SF-282).
+    credential_strategy_cache(request.app).evict(credential_key_for(str(current.id), connection.id))
     connection = await store.complete(
         connection,
         label=connection.label,

--- a/apps/aigateway/tests/unit/test_credential_strategy_cache.py
+++ b/apps/aigateway/tests/unit/test_credential_strategy_cache.py
@@ -1,0 +1,139 @@
+"""SF-282: shared credential-strategy cache single-flights OAuth refresh.
+
+Concurrent chat requests for the same credential must share ONE strategy
+instance so its lock serializes refresh — otherwise a fan-out refreshes the
+same rotating token N times and the provider rejects the racers (Anthropic
+429 refresh_token_conflict).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from aigateway.core.credential_strategy_cache import CredentialStrategyCache
+
+
+def test_get_or_create_caches_per_key() -> None:
+    cache = CredentialStrategyCache()
+    builds = 0
+
+    def build() -> object:
+        nonlocal builds
+        builds += 1
+        return object()
+
+    a = cache.get_or_create(
+        provider="anthropic", auth_type="oauth", credential_name="x", build=build
+    )
+    b = cache.get_or_create(
+        provider="anthropic", auth_type="oauth", credential_name="x", build=build
+    )
+    assert a is b
+    assert builds == 1
+
+
+def test_distinct_keys_get_distinct_instances() -> None:
+    cache = CredentialStrategyCache()
+    a = cache.get_or_create(
+        provider="anthropic", auth_type="oauth", credential_name="x", build=object
+    )
+    b = cache.get_or_create(provider="gemini", auth_type="oauth", credential_name="x", build=object)
+    c = cache.get_or_create(
+        provider="anthropic", auth_type="api_key", credential_name="x", build=object
+    )
+    d = cache.get_or_create(
+        provider="anthropic", auth_type="oauth", credential_name="y", build=object
+    )
+    assert len({id(a), id(b), id(c), id(d)}) == 4
+
+
+def test_evict_drops_all_variants_for_a_credential_name() -> None:
+    cache = CredentialStrategyCache()
+    cache.get_or_create(provider="anthropic", auth_type="oauth", credential_name="x", build=object)
+    cache.get_or_create(
+        provider="anthropic", auth_type="api_key", credential_name="x", build=object
+    )
+    kept = cache.get_or_create(
+        provider="anthropic", auth_type="oauth", credential_name="y", build=object
+    )
+
+    assert cache.evict("x") == 2
+    # "y" is untouched — same instance still returned (build not re-invoked).
+    again = cache.get_or_create(
+        provider="anthropic", auth_type="oauth", credential_name="y", build=lambda: object()
+    )
+    assert again is kept
+
+
+def test_none_build_result_is_not_cached() -> None:
+    cache = CredentialStrategyCache()
+    builds = 0
+
+    def build() -> None:
+        nonlocal builds
+        builds += 1
+        return None
+
+    assert (
+        cache.get_or_create(provider="p", auth_type="oauth", credential_name="x", build=build)
+        is None
+    )
+    cache.get_or_create(provider="p", auth_type="oauth", credential_name="x", build=build)
+    assert builds == 2  # not cached → rebuilt
+
+
+class _FakeOAuthStrategy:
+    """Minimal stand-in mirroring BaseOAuthStrategy's locked, once-only refresh."""
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._token: str | None = None
+        self.refreshes = 0
+        self._active = 0
+        self.max_concurrent_refresh = 0
+
+    async def get_authorization_header(self) -> dict[str, str]:
+        async with self._lock:
+            if self._token is None:
+                self._active += 1
+                self.max_concurrent_refresh = max(self.max_concurrent_refresh, self._active)
+                await asyncio.sleep(0.01)  # widen the refresh window
+                self.refreshes += 1
+                self._token = "tok"
+                self._active -= 1
+        return {"Authorization": f"Bearer {self._token}"}
+
+
+@pytest.mark.asyncio
+async def test_shared_instance_single_flights_refresh() -> None:
+    cache = CredentialStrategyCache()
+
+    async def one_request() -> _FakeOAuthStrategy:
+        strategy = cache.get_or_create(
+            provider="anthropic",
+            auth_type="oauth",
+            credential_name="acc:default",
+            build=_FakeOAuthStrategy,
+        )
+        await strategy.get_authorization_header()
+        return strategy
+
+    results = await asyncio.gather(*[one_request() for _ in range(25)])
+    shared = results[0]
+    assert all(r is shared for r in results), "all requests must share one cached instance"
+    assert shared.refreshes == 1, "exactly one refresh across the fan-out (single-flight)"
+    assert shared.max_concurrent_refresh == 1, "no concurrent refreshes"
+
+
+@pytest.mark.asyncio
+async def test_without_cache_each_request_refreshes_independently() -> None:
+    # Contrast: a fresh strategy per request (the old behavior) refreshes N times.
+    async def one_request() -> int:
+        strategy = _FakeOAuthStrategy()  # not shared
+        await strategy.get_authorization_header()
+        return strategy.refreshes
+
+    refresh_counts = await asyncio.gather(*[one_request() for _ in range(25)])
+    assert sum(refresh_counts) == 25, "without sharing, every request refreshes (the bug)"


### PR DESCRIPTION
## Why
Concurrent `POST /v1/chat/completions` requests each built a **fresh** `BaseOAuthStrategy` (`chat.py::_strategy_for_credential_target` → `credential_strategy_from`), so its per-instance `asyncio.Lock` didn't coordinate. Under fan-out (e.g. a 33-row `ScoredLiveTruth` eval) every request refreshed the **same rotating OAuth token** at once, and Anthropic rejected the racers with **`429 refresh_token_conflict`** → 27/33 rows errored → run went `degraded`. (Surfaced via SF-278's span Status Description.)

## What (option 1: shared strategy cache)
- New `core/credential_strategy_cache.py`: caches one strategy per `(provider, auth_type, credential_name)` on `app.state`. Concurrent requests share the instance, so its lock **single-flights** the refresh. `get_or_create`/`evict` are synchronous — single-threaded asyncio with no `await` between check and insert is atomic, so no extra lock; the refresh single-flight is the strategy's own lock.
- `chat.py::_strategy_for_credential_target` now resolves via the cache.

## Eviction (so a cached token can't outlive its credential)
- Profile re-auth / api-key set / delete / refresh → centralized in `auth._invalidate_profile_session` (now `app`-aware).
- Connection OAuth callback persist + error (`auth.py`); connection delete + refresh (`oauth_connections.py`).
- 401 / `AuthError` on the chat path (`chat.py` `_dispatch_failure_response` + `_inject_credentials`).
- API-key strategies read the store per call (no in-memory token) → no eviction needed.

## Caveat
In-memory locks coordinate within **one** process. Multi-worker hosted/prod still needs a DB advisory lock / "refresh-in-progress" marker for full cross-worker single-flight — noted for follow-up. Local single-worker (the eval scenario) is fully fixed.

## Tests
- Cache get_or_create / evict / key-isolation / none-not-cached.
- Concurrency proof: 25 fan-out requests sharing the cached instance → **exactly 1 refresh** (vs 25 without sharing).
- Full aigateway suite: **546 passed**.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215758192196958

🤖 Generated with [Claude Code](https://claude.com/claude-code)
