### PR TITLE
SF-284: derive aigw model dropdown from gateway /v1/models + extend Claude lineup

### DIFF
--- a/apps/aigateway/src/aigateway/plugins/anthropic_provider/settings.py
+++ b/apps/aigateway/src/aigateway/plugins/anthropic_provider/settings.py
@@ -19,19 +19,25 @@ def _default_scopes() -> list[str]:
 
 
 def _default_models() -> list[ModelEntry]:
+    """Claude models the gateway routes by default.
+
+    Single source of truth for the SF Settings model dropdown: the
+    aigw-claude-backend plugin derives its suggestions from this list via
+    ``GET /v1/models`` (SF-284), so it must NOT be copied SF-side.
+
+    Ordered newest-first within each tier (opus, sonnet, haiku). Older
+    snapshots are kept alongside the latest so existing configs pinned to
+    them (e.g. the ``claude-sonnet-4-5`` default) keep routing.
+    """
+    names = [
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+        "claude-sonnet-4-6",
+        "claude-sonnet-4-5",
+        "claude-haiku-4-5",
+    ]
     return [
-        ModelEntry(
-            model_name="claude-sonnet-4-5",
-            litellm_params={"model": "anthropic/claude-sonnet-4-5"},
-        ),
-        ModelEntry(
-            model_name="claude-opus-4-7",
-            litellm_params={"model": "anthropic/claude-opus-4-7"},
-        ),
-        ModelEntry(
-            model_name="claude-haiku-4-5",
-            litellm_params={"model": "anthropic/claude-haiku-4-5"},
-        ),
+        ModelEntry(model_name=name, litellm_params={"model": f"anthropic/{name}"}) for name in names
     ]
 
 

--- a/apps/aigateway/tests/unit/anthropic/test_settings.py
+++ b/apps/aigateway/tests/unit/anthropic/test_settings.py
@@ -37,11 +37,16 @@ def test_anthropic_settings_defaults_preserve_current_values(monkeypatch) -> Non
     assert settings.keychain_account == "default"
     assert settings.bootstrap_user == "alice"
     assert [model.model_name for model in settings.models] == [
-        "claude-sonnet-4-5",
+        "claude-opus-4-8",
         "claude-opus-4-7",
+        "claude-sonnet-4-6",
+        "claude-sonnet-4-5",
         "claude-haiku-4-5",
     ]
-    assert settings.models[0].litellm_params == {"model": "anthropic/claude-sonnet-4-5"}
+    # Every entry's litellm model string must be the "anthropic/"-prefixed alias
+    # so the gateway routes it to the Anthropic provider.
+    for model in settings.models:
+        assert model.litellm_params == {"model": f"anthropic/{model.model_name}"}
 
 
 def test_anthropic_settings_env_overrides(monkeypatch) -> None:

--- a/apps/server/src/screamingface/plugins/aigw_base/plugin_base.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/plugin_base.py
@@ -125,6 +125,15 @@ class AigwBackendApiPluginBase(BackendApiPluginBase):
         "dangerously_skip_permissions",
     )
 
+    # Settings fields that hold a `<provider>/<model>` string and should offer
+    # a gateway-derived suggestion dropdown. Not every subclass declares both
+    # (only aigw-claude-backend has a `fallback_model`); absent fields are
+    # skipped. Populated dynamically in `customize_schema` (SF-284).
+    _MODEL_SUGGESTION_FIELDS: ClassVar[tuple[str, ...]] = (
+        "default_model",
+        "fallback_model",
+    )
+
     def customize_schema(self, schema: dict) -> dict:
         # Skip the parent's customize_schema — it injects an enum / x-link-base
         # on `default_profile` / `profiles`, both of which we're about to drop.
@@ -137,7 +146,61 @@ class AigwBackendApiPluginBase(BackendApiPluginBase):
 
         if "auth_profile" in props:
             self._inject_auth_profile_enum(props["auth_profile"])
+        self._inject_model_suggestions(props)
         return schema
+
+    def _inject_model_suggestions(self, props: dict[str, Any]) -> None:
+        """Populate the model fields' ``examples`` from the gateway's live
+        ``/v1/models`` registry (SF-284).
+
+        The SF Settings model dropdown thus reflects exactly what the gateway
+        can route, with no hard-coded copy of the gateway's model list. We set
+        ``examples`` (a free-text datalist), never ``enum``: a brand-new
+        snapshot the gateway already supports must remain typeable before this
+        derivation is refreshed.
+        """
+        present = [name for name in self._MODEL_SUGGESTION_FIELDS if name in props]
+        if not present:
+            return
+
+        suggestions = self._fetch_gateway_model_ids()
+        if suggestions is not None:
+            for name in present:
+                props[name]["examples"] = list(suggestions)
+            return
+
+        # Gateway unreachable: fall back to each field's currently-configured
+        # value so the dropdown isn't empty offline (mirrors the auth_profile
+        # fallback). Free-text entry still works either way.
+        settings = self.settings
+        for name in present:
+            current = getattr(settings, name, None) if settings else None
+            props[name]["examples"] = [current] if current else []
+
+    def _fetch_gateway_model_ids(self) -> list[str] | None:
+        """Return this provider's gateway models as SF ``<provider>/<model>``
+        strings, or ``None`` when the gateway can't be reached.
+
+        Mirrors `_fetch_gateway_profile_names`: synchronous, bounded by
+        `_SCHEMA_FETCH_TIMEOUT_S`, and tolerant of a down gateway. ``/v1/models``
+        aggregates every loaded provider, so results are filtered to this
+        backend's `gateway_provider` (which equals the gateway's ``owned_by``).
+        """
+        if not self.gateway_provider:
+            return None
+        if self.settings is None:
+            return None
+        client = self._schema_gateway_client()
+        try:
+            payload = _gateway_json(client, "/v1/models")
+        except (AigwGatewayClientError, httpx.HTTPError, ValueError) as exc:
+            _log.debug(
+                "aigw schema: gateway model-list fetch failed (%s); "
+                "falling back to configured model values",
+                exc,
+            )
+            return None
+        return _model_ids_from_payload(payload, self.gateway_provider)
 
     def _inject_auth_profile_enum(self, auth_profile_field: dict[str, Any]) -> None:
         settings = cast(AigwBackendApiSettingsBase, self.settings)
@@ -170,20 +233,9 @@ class AigwBackendApiPluginBase(BackendApiPluginBase):
         """
         if not self.gateway_provider:
             return None
-        settings = cast(AigwBackendApiSettingsBase, self.settings)
-        if not settings:
+        if self.settings is None:
             return None
-        app = getattr(self, "_app", None)
-        transport = getattr(self, "_http_transport", None)
-        sync_factory: Callable[[float], httpx.Client] | None = None
-        if transport is not None:
-
-            def make_sync_client(timeout: float) -> httpx.Client:
-                return httpx.Client(timeout=timeout, transport=transport)
-
-            sync_factory = make_sync_client
-
-        client = AigwGatewayClient(app, sync_http_client_factory=sync_factory)
+        client = self._schema_gateway_client()
         try:
             payload = _gateway_json(
                 client,
@@ -217,6 +269,25 @@ class AigwBackendApiPluginBase(BackendApiPluginBase):
                 names.extend(connection_names)
         return _dedupe_preserving_order(names)
 
+    def _schema_gateway_client(self) -> AigwGatewayClient:
+        """Build the gateway client used during synchronous schema emission.
+
+        Tests inject ``self._http_transport`` — an ``httpx.MockTransport`` — to
+        fully simulate the gateway without a network round-trip; otherwise the
+        client talks to the real (local) gateway.
+        """
+        app = getattr(self, "_app", None)
+        transport = getattr(self, "_http_transport", None)
+        sync_factory: Callable[[float], httpx.Client] | None = None
+        if transport is not None:
+
+            def make_sync_client(timeout: float) -> httpx.Client:
+                return httpx.Client(timeout=timeout, transport=transport)
+
+            sync_factory = make_sync_client
+
+        return AigwGatewayClient(app, sync_http_client_factory=sync_factory)
+
 
 def _gateway_json(client: AigwGatewayClient, path: str) -> Any:
     resp = client.request_sync(
@@ -239,6 +310,32 @@ def _names_from_payload(payload: Any, collection_key: str, name_key: str) -> lis
             if isinstance(name, str) and name:
                 names.append(name)
     return names
+
+
+def _model_ids_from_payload(payload: Any, provider: str) -> list[str] | None:
+    """Extract this provider's model ids from an OpenAI-shaped ``/v1/models``
+    body, as SF ``<provider>/<model>`` strings.
+
+    The endpoint aggregates every loaded provider and tags each entry with
+    ``owned_by``; we keep only ``owned_by == provider`` and normalize the id to
+    the SF ``<provider>/<model>`` form the backend sends. Prefixing is
+    idempotent: gateway registries are inconsistent — anthropic ids are bare
+    (``claude-sonnet-4-5``) while codex/gemini ids already carry the prefix
+    (``codex/gpt-5.5``) — so we only prepend when it isn't already there.
+    Returns ``None`` if the payload isn't the expected ``{"data": [...]}`` shape.
+    """
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, list):
+        return None
+    prefix = f"{provider}/"
+    ids: list[str] = []
+    for item in data:
+        if not isinstance(item, dict) or item.get("owned_by") != provider:
+            continue
+        model_id = item.get("id")
+        if isinstance(model_id, str) and model_id:
+            ids.append(model_id if model_id.startswith(prefix) else f"{prefix}{model_id}")
+    return _dedupe_preserving_order(ids)
 
 
 def _dedupe_preserving_order(values: list[str]) -> list[str]:

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/plugin.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/plugin.py
@@ -23,24 +23,17 @@ if TYPE_CHECKING:
     pass
 
 
-# Suggestions for the default_model dropdown. Mirrors the gateway's
-# anthropic_provider/models.py registry. RJSF's BaseInputTemplate renders
-# a `<datalist>` from `examples`, giving the UI a typeahead dropdown that
-# still accepts free-text — useful when a new Anthropic snapshot ships
-# before this list is updated.
-_CLAUDE_MODEL_SUGGESTIONS = [
-    "anthropic/claude-sonnet-4-5",
-    "anthropic/claude-opus-4-7",
-    "anthropic/claude-haiku-4-5",
-]
-
-
 class AigwClaudeBackendSettings(AigwBackendApiSettingsBase):
     model_config = SettingsConfigDict(
         env_prefix="SF_AIGW_CLAUDE_BACKEND__",
         env_nested_delimiter="__",
     )
 
+    # The `default_model`/`fallback_model` dropdown suggestions are NOT baked in
+    # here — `AigwBackendApiPluginBase.customize_schema` derives them live from
+    # the gateway's /v1/models registry (SF-284), so the single source of truth
+    # stays in apps/aigateway/.../anthropic_provider/settings.py. RJSF renders a
+    # free-text `<datalist>` from the injected `examples`.
     default_model: str | None = Field(
         default="anthropic/claude-sonnet-4-5",
         description=(
@@ -48,7 +41,6 @@ class AigwClaudeBackendSettings(AigwBackendApiSettingsBase):
             "must start with 'anthropic/'. Pick from the dropdown or "
             "type a custom snapshot if the gateway already supports it."
         ),
-        examples=_CLAUDE_MODEL_SUGGESTIONS,
     )
     fallback_model: str | None = Field(
         default="anthropic/claude-haiku-4-5",
@@ -56,7 +48,6 @@ class AigwClaudeBackendSettings(AigwBackendApiSettingsBase):
             "Model retried once when the primary Claude model returns a 429. "
             "Set to null to disable automatic fallback."
         ),
-        examples=_CLAUDE_MODEL_SUGGESTIONS,
     )
 
 

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/tests/test_settings_schema.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/tests/test_settings_schema.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import httpx
 import pytest
@@ -67,6 +67,7 @@ def _emit_schema(plugin: AigwClaudeBackendPlugin) -> dict[str, Any]:
 def _gateway_profiles_handler(
     profiles: list[dict[str, Any]],
     connections: list[dict[str, Any]] | None = None,
+    models: list[dict[str, Any]] | None = None,
 ):
     def handler(req: httpx.Request) -> httpx.Response:
         if req.url.path.endswith("/v1/auth/anthropic/profiles"):
@@ -75,6 +76,8 @@ def _gateway_profiles_handler(
             assert req.url.params["provider"] == "anthropic"
             assert req.url.params["status"] == "active"
             return httpx.Response(200, json={"connections": connections or []})
+        if req.url.path.endswith("/v1/models"):
+            return httpx.Response(200, json={"data": models or []})
         raise AssertionError(f"unexpected gateway request: {req.url}")
 
     return handler
@@ -145,6 +148,8 @@ def test_schema_fetch_uses_gateway_session_token_in_external_mode() -> None:
             return httpx.Response(200, json={"profiles": [{"name": "work"}]})
         if req.url.path.endswith("/v1/oauth/connections"):
             return httpx.Response(200, json={"connections": []})
+        if req.url.path.endswith("/v1/models"):
+            return httpx.Response(200, json={"data": []})
         raise AssertionError(f"unexpected gateway request: {req.url}")
 
     plugin = _make_plugin(mode="external", transport=httpx.MockTransport(handler))
@@ -196,6 +201,99 @@ def test_schema_enum_is_empty_when_gateway_has_no_profiles() -> None:
     plugin = _make_plugin(transport=httpx.MockTransport(handler))
     schema = _emit_schema(plugin)
     assert schema["properties"]["auth_profile"]["enum"] == []
+
+
+# --------------------------------------------------------------------------- #
+# SF-284: default_model / fallback_model `examples` are derived from the
+# gateway's live /v1/models registry instead of a hard-coded SF-side copy.
+# --------------------------------------------------------------------------- #
+
+
+def _anthropic_models(*ids: str) -> list[dict[str, Any]]:
+    return [{"id": i, "object": "model", "owned_by": "anthropic"} for i in ids]
+
+
+def test_model_fields_have_no_static_examples_before_customization() -> None:
+    """The plugin must NOT bake a hard-coded model list into the field schema.
+
+    Guards the DRY contract: suggestions come from the gateway at schema time,
+    not a constant duplicating the gateway registry.
+    """
+    base_props = AigwClaudeBackendSettings.model_json_schema()["properties"]
+    assert not base_props["default_model"].get("examples")
+    assert not base_props["fallback_model"].get("examples")
+
+
+def test_model_examples_derived_from_gateway_models() -> None:
+    handler = _gateway_profiles_handler(
+        [{"name": "default"}],
+        models=_anthropic_models("claude-opus-4-8", "claude-sonnet-4-5", "claude-haiku-4-5"),
+    )
+    plugin = _make_plugin(transport=httpx.MockTransport(handler))
+    schema = _emit_schema(plugin)
+
+    # Bare gateway ids are prefixed with the provider key to match the SF
+    # `<provider>/<model>` form the backend sends.
+    expected = [
+        "anthropic/claude-opus-4-8",
+        "anthropic/claude-sonnet-4-5",
+        "anthropic/claude-haiku-4-5",
+    ]
+    assert schema["properties"]["default_model"]["examples"] == expected
+    assert schema["properties"]["fallback_model"]["examples"] == expected
+
+
+def test_model_examples_exclude_other_providers() -> None:
+    """/v1/models aggregates every provider; only this backend's are suggested."""
+    models = _anthropic_models("claude-opus-4-8") + [
+        {"id": "gpt-5.4-mini", "object": "model", "owned_by": "codex"},
+        {"id": "gemini-2.5-flash", "object": "model", "owned_by": "gemini-cli"},
+    ]
+    handler = _gateway_profiles_handler([{"name": "default"}], models=models)
+    plugin = _make_plugin(transport=httpx.MockTransport(handler))
+    schema = _emit_schema(plugin)
+
+    assert schema["properties"]["default_model"]["examples"] == ["anthropic/claude-opus-4-8"]
+
+
+def test_model_examples_do_not_double_prefix_already_prefixed_ids() -> None:
+    """Gateway registries are inconsistent: codex/gemini model ids already carry
+    the `<provider>/` prefix while anthropic's are bare. Prefixing must be
+    idempotent so a `codex/...` id never becomes `codex/codex/...`."""
+    models = [{"id": "anthropic/claude-opus-4-8", "object": "model", "owned_by": "anthropic"}]
+    handler = _gateway_profiles_handler([{"name": "default"}], models=models)
+    plugin = _make_plugin(transport=httpx.MockTransport(handler))
+    schema = _emit_schema(plugin)
+
+    assert schema["properties"]["default_model"]["examples"] == ["anthropic/claude-opus-4-8"]
+
+
+def test_model_examples_remain_free_text_no_enum() -> None:
+    """Suggestions use `examples` (datalist), never `enum` — a brand-new
+    snapshot the gateway already supports must still be typeable."""
+    handler = _gateway_profiles_handler(
+        [{"name": "default"}], models=_anthropic_models("claude-opus-4-8")
+    )
+    plugin = _make_plugin(transport=httpx.MockTransport(handler))
+    schema = _emit_schema(plugin)
+
+    assert "enum" not in schema["properties"]["default_model"]
+    assert "enum" not in schema["properties"]["fallback_model"]
+
+
+def test_model_examples_fall_back_to_configured_value_when_gateway_down() -> None:
+    """Offline: the dropdown shows each field's currently-configured value so
+    the user isn't staring at an empty list. Free-text still works."""
+
+    def boom(req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("gateway down")
+
+    plugin = _make_plugin(transport=httpx.MockTransport(boom))
+    schema = _emit_schema(plugin)
+
+    settings = cast(AigwClaudeBackendSettings, plugin.settings)
+    assert schema["properties"]["default_model"]["examples"] == [settings.default_model]
+    assert schema["properties"]["fallback_model"]["examples"] == [settings.fallback_model]
 
 
 if __name__ == "__main__":

--- a/apps/server/src/screamingface/plugins/aigw_codex_backend/plugin.py
+++ b/apps/server/src/screamingface/plugins/aigw_codex_backend/plugin.py
@@ -11,14 +11,6 @@ from screamingface.plugins.aigw_base import (
 )
 from screamingface.plugins.aigw_codex_backend.routes import create_router
 
-_CODEX_MODEL_SUGGESTIONS = [
-    "codex/gpt-5.5",
-    "codex/gpt-5.4",
-    "codex/gpt-5.4-mini",
-    "codex/gpt-5.3-codex",
-    "codex/gpt-5.2",
-]
-
 
 class AigwCodexBackendSettings(AigwBackendApiSettingsBase):
     model_config = SettingsConfigDict(
@@ -26,6 +18,9 @@ class AigwCodexBackendSettings(AigwBackendApiSettingsBase):
         env_nested_delimiter="__",
     )
 
+    # `default_model` suggestions are derived live from the gateway's /v1/models
+    # registry by AigwBackendApiPluginBase.customize_schema (SF-284) — not copied
+    # here. Source of truth: apps/aigateway/.../codex_provider/models.py.
     default_model: str | None = Field(
         default="codex/gpt-5.4-mini",
         description=(
@@ -33,7 +28,6 @@ class AigwCodexBackendSettings(AigwBackendApiSettingsBase):
             "must start with 'codex/'. Pick from the dropdown or type a "
             "custom slug if the gateway already supports it."
         ),
-        examples=_CODEX_MODEL_SUGGESTIONS,
     )
 
 

--- a/apps/server/src/screamingface/plugins/aigw_gemini_backend/plugin.py
+++ b/apps/server/src/screamingface/plugins/aigw_gemini_backend/plugin.py
@@ -11,13 +11,6 @@ from screamingface.plugins.aigw_base import (
 )
 from screamingface.plugins.aigw_gemini_backend.routes import create_router
 
-_GEMINI_MODEL_SUGGESTIONS = [
-    "gemini-cli/gemini-2.5-pro",
-    "gemini-cli/gemini-2.5-flash",
-    "gemini-cli/gemini-2.5-flash-lite",
-    "gemini-cli/gemini-2.0-flash",
-]
-
 
 class AigwGeminiBackendSettings(AigwBackendApiSettingsBase):
     model_config = SettingsConfigDict(
@@ -25,6 +18,9 @@ class AigwGeminiBackendSettings(AigwBackendApiSettingsBase):
         env_nested_delimiter="__",
     )
 
+    # `default_model` suggestions are derived live from the gateway's /v1/models
+    # registry by AigwBackendApiPluginBase.customize_schema (SF-284) — not copied
+    # here. Source of truth: apps/aigateway/.../gemini_provider/models.py.
     default_model: str | None = Field(
         default="gemini-cli/gemini-2.5-flash",
         description=(
@@ -32,7 +28,6 @@ class AigwGeminiBackendSettings(AigwBackendApiSettingsBase):
             "must start with 'gemini-cli/'. Pick from the dropdown or type a "
             "custom slug if the gateway already supports it."
         ),
-        examples=_GEMINI_MODEL_SUGGESTIONS,
     )
 
 

--- a/apps/server/tests/core/test_plugin_settings.py
+++ b/apps/server/tests/core/test_plugin_settings.py
@@ -157,6 +157,17 @@ def test_real_aigw_plugin_schema_lists_gateway_profiles() -> None:
                 200,
                 json={"connections": [{"label": "work-anthropic", "status": "active"}]},
             )
+        if req.url.path.endswith("/v1/models"):
+            return httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {"id": "claude-opus-4-8", "object": "model", "owned_by": "anthropic"},
+                        # A foreign-provider entry must be filtered out.
+                        {"id": "gpt-5.4-mini", "object": "model", "owned_by": "codex"},
+                    ]
+                },
+            )
         raise AssertionError(f"unexpected gateway request: {req.url}")
 
     plugin = AigwClaudeBackendPlugin()
@@ -174,13 +185,15 @@ def test_real_aigw_plugin_schema_lists_gateway_profiles() -> None:
     resp = client.get(f"/plugins/{plugin.name}/schema")
 
     assert resp.status_code == 200
-    assert resp.json()["properties"]["auth_profile"]["enum"] == [
-        "default",
-        "work-anthropic",
-    ]
+    props = resp.json()["properties"]
+    assert props["auth_profile"]["enum"] == ["default", "work-anthropic"]
+    # SF-284: model dropdown derived from /v1/models, filtered to this provider
+    # and prefixed to the SF `<provider>/<model>` form.
+    assert props["default_model"]["examples"] == ["anthropic/claude-opus-4-8"]
     assert gateway_requests == [
         "http://gateway/v1/auth/anthropic/profiles",
         "http://gateway/v1/oauth/connections?provider=anthropic&status=active",
+        "http://gateway/v1/models",
     ]
 
 


### PR DESCRIPTION
## Summary

The `aigw_*_backend` plugins each hard-coded a per-provider model suggestion list (`_CLAUDE_/_CODEX_/_GEMINI_MODEL_SUGGESTIONS`) that duplicated the gateway's model registry — a DRY violation that silently drifted from what the gateway can actually route, and was missing the latest Claude snapshots.

### Part 1 — derive, don't copy
- `AigwBackendApiPluginBase.customize_schema` now populates `default_model` / `fallback_model` **`examples`** from a live `GET /v1/models` fetch — synchronous, 2s-bounded, graceful fallback — **mirroring the existing `auth_profile` enum-injection pattern** in the same class.
- Results are filtered to the backend's `gateway_provider` (which equals the gateway's `owned_by`) and normalized to the SF `<provider>/<model>` form. **Prefixing is idempotent**: anthropic ids are bare (`claude-sonnet-4-5`) while codex/gemini ids already carry the prefix (`codex/gpt-5.5`) — a real inconsistency in the gateway registries that would otherwise produce `codex/codex/...`.
- Extracted a shared `_schema_gateway_client()` helper so the profile-list and model-list fetches don't duplicate client construction.
- **Removed all three static suggestion lists.** The gateway is now the single source of truth. Offline fallback is the field's currently-configured value, and suggestions use `examples` (free-text datalist) — never `enum` — so a brand-new snapshot the gateway already supports stays typeable.

Because the derivation lives in the **base**, claude **and** codex/gemini backends all get it for free.

### Part 2 — extend the gateway registry (superset)
- `anthropic_provider._default_models` → `claude-opus-4-8`, `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-sonnet-4-5`, `claude-haiku-4-5`. **Superset** — nothing removed, so configs pinned to existing aliases (incl. the `claude-sonnet-4-5` default) keep routing. `default_model` default is unchanged.

## Dependency direction
The SF backend depends only on the gateway's **HTTP contract** (`/v1/models`), not the gateway's Python package — core/adapter boundary preserved.

## Tests
- New: derivation from `/v1/models`, foreign-provider filtering, free-text/no-`enum`, offline fallback to configured value, double-prefix regression, and the full `/plugins/{name}/schema` HTTP-route integration.
- Updated the gateway anthropic-settings assertion to the superset (with a per-entry `anthropic/<id>` litellm-param check).
- Green: aigw suites (126), gateway unit (539), server schema integration (12), gateway anthropic settings (4). `ruff` + `pyright` clean on both packages.

## Verification before merge
Full e2e (incl. live) to be run locally before merge — CI skips live.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215769448556895

🤖 Generated with [Claude Code](https://claude.com/claude-code)