### PR TITLE
SF-286: capture traceback + kind in url4 foreach collected errors

### DIFF
--- a/apps/server/src/screamingface/plugins/url4_executor/ensemble.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/ensemble.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import traceback
 from typing import TYPE_CHECKING, Any, TypeGuard
 
 if TYPE_CHECKING:
@@ -63,6 +64,31 @@ logger = logging.getLogger(__name__)
 
 # Default reducer backend path when ?processor= is not specified.
 DEFAULT_PROCESSOR = "/claude"
+
+# Cap on the traceback tail embedded per collected error, so a fan-out of
+# failures can't bloat the response. The tail (not head) is kept because the
+# innermost frames — where the error was actually raised — are most useful.
+_COLLECTED_ERROR_TRACEBACK_CAP = 2000
+
+
+def _collected_error_payload(exc: BaseException) -> dict[str, Any]:
+    """Build the ``{"error": ...}`` element for a collected per-row exception.
+
+    ``;foreach.on_error=collect`` turns per-row failures into JSON elements
+    instead of aborting. The payload must be *diagnosable*: some exceptions
+    carry no message (e.g. a bare ``NotImplementedError`` from TatSu's parse
+    engine), which previously surfaced as ``{"kind": "...", "message": ""}`` —
+    opaque. So ``message`` falls back to ``repr(exc)`` and we attach a capped
+    traceback tail naming the raising frame (SF-286).
+    """
+    tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    return {
+        "error": {
+            "kind": type(exc).__name__,
+            "message": str(exc) or repr(exc),
+            "traceback": tb[-_COLLECTED_ERROR_TRACEBACK_CAP:],
+        }
+    }
 
 
 def _strip_one_paren_layer(expr: str) -> str | None:
@@ -244,12 +270,16 @@ class EnsembleInterpreter(Url4Interpreter):
             if directives.on_error == "collect":
                 raw = await asyncio.gather(*[_guarded(i) for i in items], return_exceptions=True)
                 error_count = sum(isinstance(r, BaseException) for r in raw)
-                results = [
-                    r
-                    if not isinstance(r, BaseException)
-                    else json.dumps({"error": {"kind": type(r).__name__, "message": str(r)}})
-                    for r in raw
-                ]
+                results = []
+                for r in raw:
+                    if not isinstance(r, BaseException):
+                        results.append(r)
+                        continue
+                    # Full traceback to server logs (the result payload only
+                    # carries a capped tail) so opaque per-row failures are
+                    # always diagnosable from stderr (SF-286).
+                    logger.warning("url4 foreach collected error: %r", r, exc_info=r)
+                    results.append(json.dumps(_collected_error_payload(r)))
                 # Accumulate so nested/multiple collections in one request sum.
                 self._collected_errors += error_count
                 set_span_attrs({"url4.collection.errors_collected": error_count})

--- a/apps/server/src/screamingface/plugins/url4_executor/tests/test_collected_errors_visible.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/tests/test_collected_errors_visible.py
@@ -108,6 +108,67 @@ async def test_no_header_when_no_errors(app_url4) -> None:
     assert "X-SF-Collected-Errors" not in resp.headers
 
 
+def test_collected_error_payload_nonempty_message_and_traceback() -> None:
+    """SF-286: a collected error must be diagnosable even when the exception
+    carries no message (e.g. a bare ``NotImplementedError`` from TatSu's parse
+    engine). Before this, the payload was ``{"kind": "...", "message": ""}`` —
+    opaque. Now: a repr fallback for the message + a captured traceback tail.
+    """
+    from screamingface.plugins.url4_executor.ensemble import _collected_error_payload
+
+    def _raises_bare() -> None:
+        raise NotImplementedError  # bare: str(exc) == ""
+
+    try:
+        _raises_bare()
+    except NotImplementedError as exc:
+        payload = _collected_error_payload(exc)
+
+    err = payload["error"]
+    assert err["kind"] == "NotImplementedError"
+    # message is non-empty: repr fallback when str(exc) is blank.
+    assert err["message"]
+    assert "NotImplementedError" in err["message"]
+    # traceback names the raising frame so the origin is locatable.
+    assert "_raises_bare" in err["traceback"]
+    assert "NotImplementedError" in err["traceback"]
+
+
+class _RaiseBarePlugin:
+    """Per-row evaluator that raises a bare (message-less) NotImplementedError
+    for item ``2`` — mirrors the TatSu parse-engine failure mode."""
+
+    name = "x"
+    backend_call_paths = ["/x"]
+
+    async def handle_backend_call(self, intent, *, sources="", app, env=None):
+        del intent, app, env
+        if sources == "2":
+            raise NotImplementedError
+        return f"ok-{sources}"
+
+
+@pytest.mark.asyncio
+async def test_collected_empty_message_error_is_diagnosable_in_body(app_url4) -> None:
+    """End-to-end: a message-less per-row exception surfaces in the response
+    body with a kind, a non-empty message, and a traceback — not an empty
+    ``NotImplementedError``."""
+    import json
+
+    _inject(app_url4, _DataPlugin(), _RaiseBarePlugin())
+    q = "/data([1, 2, 3])*(/x($item)) ;foreach.on_error=collect"
+
+    resp = await _get(app_url4, q)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["X-SF-Collected-Errors"] == "1"
+    # The errored row's JSON object is embedded in the response body.
+    assert '"kind": "NotImplementedError"' in resp.text
+    assert '"message": ""' not in resp.text  # no opaque empty-message errors
+    payload = json.loads(resp.text) if resp.text.startswith("[") else None
+    del payload  # body shape is route-defined; substring checks above suffice
+
+
 @pytest.mark.asyncio
 async def test_interpreter_accumulates_collected_errors_count() -> None:
     """Focused unit check: the interpreter counts collected errors and the


### PR DESCRIPTION
## Summary

`;foreach.on_error=collect` (url4 collection iteration) turned per-row exceptions into JSON elements but serialized only `{kind: type.__name__, message: str(exc)}` — **discarding the traceback**. A message-less exception (observed in a live eval: a **bare `NotImplementedError`** from TatSu's parse engine, `tatsu/contexts/engine.py` `_find_rule`) surfaced as `{"kind":"NotImplementedError","message":""}` — impossible to locate.

This is the **evidence-gathering fix** (debugging discipline: make the failure diagnosable before fixing it). No behavior change to success paths.

## Change

`_collected_error_payload(exc)` in `ensemble.py`, used by the `on_error=collect` path:
- `message` falls back to `repr(exc)` when `str(exc)` is empty.
- carries a **capped traceback tail** (innermost frames, 2000-char cap) in the payload.
- the **full traceback is logged server-side** (`logger.warning(..., exc_info=exc)`) so it always lands in stderr.

## Tests
- Unit: `_collected_error_payload(NotImplementedError)` → non-empty message (repr fallback) + traceback naming the raising frame + correct `kind`.
- E2E (existing harness): a per-row bare `NotImplementedError` now surfaces in the `/ensemble` body with a kind, non-empty message, and traceback — and no `"message": ""`.
- Full `url4_executor` + `eval_runs` suites: 317 passed. ruff + pyright clean.

## Follow-up (not in this PR)
The underlying parse failure this surfaces: the shared singleton TatSu `_parser` (`url4_grammar.py:272`) reused across the concurrent collection fan-out, plus unescaped `$item` interpolation into url4 source position. Root-cause fix pending the traceback this change captures from a re-run.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215776310706475

🤖 Generated with [Claude Code](https://claude.com/claude-code)