### PR TITLE
SF-287: spawn python_runner off the asyncio child watcher (fix uvloop policy mismatch)

### DIFF
--- a/apps/server/src/screamingface/plugins/frontend_base/plugin_base.py
+++ b/apps/server/src/screamingface/plugins/frontend_base/plugin_base.py
@@ -368,6 +368,15 @@ class FrontendPluginBase(Plugin):
                 host=settings.listen_host,
                 port=settings.listen_port,
                 log_level="info",
+                # Pin the standard asyncio loop. The default loop="auto" detects
+                # uvloop (installed) and calls asyncio.set_event_loop_policy(
+                # uvloop.EventLoopPolicy()) PROCESS-WIDE. That uvloop policy's
+                # get_child_watcher() raises NotImplementedError, which breaks
+                # asyncio.create_subprocess_exec on the main server's standard
+                # loop=asyncio loop (e.g. python_runner). loop="asyncio" is a
+                # no-op on the policy (uvicorn only touches it on win32), so the
+                # per-session frontend no longer contaminates the process (SF-287).
+                loop="asyncio",
             )
             self._server = uvicorn.Server(config)
             self._thread = threading.Thread(

--- a/apps/server/src/screamingface/plugins/python_runner/runner.py
+++ b/apps/server/src/screamingface/plugins/python_runner/runner.py
@@ -15,6 +15,7 @@ import hashlib
 import json
 import logging
 import os
+import subprocess
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -96,42 +97,58 @@ _MAIN_HARNESS = (
 )
 
 
+def _run_blocking(
+    argv: list[str],
+    stdin_bytes: bytes,
+    timeout: float,
+) -> tuple[int, bytes, bytes]:
+    """Run the subprocess synchronously; return (returncode, stdout, stderr).
+
+    Uses ``subprocess.run`` rather than ``asyncio.create_subprocess_exec`` on
+    purpose (SF-287): the asyncio Unix subprocess path calls
+    ``events.get_child_watcher()``, which raises a bare ``NotImplementedError``
+    whenever a uvloop event-loop policy is installed process-wide (the
+    per-session frontend uvicorn does this via ``loop="auto"``) while we run on
+    the main server's standard ``loop="asyncio"`` loop. ``subprocess.run`` never
+    touches the child watcher, so it is immune to that policy/loop mismatch —
+    and forward-compatible with Python 3.14, which removes child watchers
+    entirely. Meant to be called via :func:`asyncio.to_thread`.
+
+    Raises PythonRunnerError(kind="timeout") on timeout (the child is killed by
+    ``subprocess.run``) and PythonRunnerError(kind="io_error") on OSError.
+    """
+    try:
+        completed = subprocess.run(  # noqa: S603 — argv is built by the sandbox
+            argv,
+            input=stdin_bytes,
+            capture_output=True,
+            timeout=timeout,
+            env={"PATH": "/usr/bin", "HOME": "/tmp"},
+            check=False,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise PythonRunnerError(
+            kind="timeout",
+            message=f"Script exceeded {timeout}s timeout",
+        ) from e
+    except OSError as e:
+        raise PythonRunnerError(kind="io_error", message=str(e)) from e
+
+    return completed.returncode, completed.stdout, completed.stderr
+
+
 async def _spawn_collect(
     argv: list[str],
     stdin_bytes: bytes,
     timeout: float,
 ) -> tuple[int, bytes, bytes]:
-    """Spawn a subprocess, feed stdin, collect (returncode, stdout, stderr).
+    """Spawn a subprocess off the event loop, returning (returncode, stdout, stderr).
 
-    Raises PythonRunnerError(kind="io_error") on OSError and
-    PythonRunnerError(kind="timeout") when *timeout* is exceeded.
+    Delegates to :func:`_run_blocking` in a worker thread so the event loop
+    stays responsive while the script runs, without depending on the asyncio
+    child watcher (SF-287).
     """
-    _spawn = asyncio.create_subprocess_exec
-    try:
-        proc = await _spawn(
-            *argv,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env={"PATH": "/usr/bin", "HOME": "/tmp"},
-        )
-    except OSError as e:
-        raise PythonRunnerError(kind="io_error", message=str(e)) from e
-
-    try:
-        stdout_b, stderr_b = await asyncio.wait_for(
-            proc.communicate(input=stdin_bytes),
-            timeout=timeout,
-        )
-    except TimeoutError as e:
-        proc.kill()
-        await proc.wait()
-        raise PythonRunnerError(
-            kind="timeout",
-            message=f"Script exceeded {timeout}s timeout",
-        ) from e
-
-    return proc.returncode or 0, stdout_b, stderr_b
+    return await asyncio.to_thread(_run_blocking, argv, stdin_bytes, timeout)
 
 
 def _parse_output(

--- a/apps/server/src/screamingface/plugins/python_runner/tests/test_runner.py
+++ b/apps/server/src/screamingface/plugins/python_runner/tests/test_runner.py
@@ -144,3 +144,37 @@ async def test_timeout_raises_and_kills_subprocess(
     with pytest.raises(PythonRunnerError) as ei:
         await run_script_source(script, {}, timeout=0.5)
     assert ei.value.kind == "timeout"
+
+
+def test_spawn_works_under_uvloop_policy_on_standard_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SF-287 regression: spawning must work when a uvloop event-loop policy is
+    installed process-wide (as the per-session frontend uvicorn does via
+    loop="auto") while python_runner runs on a *standard* asyncio loop (the main
+    server's loop="asyncio").
+
+    Before the fix, ``create_subprocess_exec`` reached
+    ``events.get_child_watcher()`` → the uvloop policy → a bare
+    ``NotImplementedError``. The fix spawns via ``subprocess.run`` in a worker
+    thread, which never touches the child watcher.
+
+    A plain (non-async) test: we drive a standard ``SelectorEventLoop`` directly
+    so the loop/policy mismatch is reproduced exactly, and save/restore the
+    global policy so the rest of the suite is unaffected.
+    """
+    import asyncio
+
+    uvloop = pytest.importorskip("uvloop")
+    monkeypatch.setenv("SF_PYTHON_RUNNER__CACHE_ROOT", str(tmp_path))
+
+    saved_policy = asyncio.get_event_loop_policy()
+    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+    loop = asyncio.SelectorEventLoop()  # standard loop, like the main server
+    try:
+        result = loop.run_until_complete(run_script_source(_ECHO_SCRIPT, {"a": 1}))
+    finally:
+        loop.close()
+        asyncio.set_event_loop_policy(saved_policy)
+
+    assert result == {"ok": True, "got": {"a": 1}}

--- a/apps/server/src/screamingface/plugins/python_runner/tests/test_sandbox.py
+++ b/apps/server/src/screamingface/plugins/python_runner/tests/test_sandbox.py
@@ -6,6 +6,7 @@ Integration tests are darwin-only and rely on /usr/bin/sandbox-exec.
 from __future__ import annotations
 
 import asyncio
+import subprocess
 import sys
 import textwrap
 from pathlib import Path
@@ -239,20 +240,14 @@ def test_runner_uses_sandbox_helper_and_scrubs_env(
     monkeypatch.delenv("SF_PYTHON_RUNNER__SANDBOX", raising=False)
 
     captured: dict = {}
-    real_create = asyncio.create_subprocess_exec
 
-    async def fake_create(*argv, **kwargs):
+    def fake_run(argv, **kwargs):
         captured["argv"] = list(argv)
         captured["env"] = kwargs.get("env")
-        passthrough_kwargs = {k: v for k, v in kwargs.items() if k != "env"}
-        return await real_create(
-            sys.executable,
-            "-c",
-            "import json, sys; json.dump({}, sys.stdout)",
-            **passthrough_kwargs,
-        )
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout=b"{}", stderr=b"")
 
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create)
+    # python_runner spawns via subprocess.run (SF-287), not create_subprocess_exec.
+    monkeypatch.setattr(subprocess, "run", fake_run)
 
     asyncio.run(run_script_source("print(1)\n", {}))
 


### PR DESCRIPTION
## Summary

`python_runner` failed with a **bare `NotImplementedError`** (empty message) for most eval rows. Root cause is a cross-component event-loop-policy contamination:

1. In **session mode**, a frontend plugin starts a per-session uvicorn with the default `loop="auto"` → uvicorn detects uvloop (installed) → `asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())` **process-wide**.
2. The **main** server runs `loop="asyncio"` (standard loop). It keeps working, but the global policy is now uvloop's.
3. An eval hits `/ensemble` on that standard loop → `python_runner` → `asyncio.create_subprocess_exec` → cpython's `_make_subprocess_transport` calls `events.get_child_watcher()` → returns the uvloop policy → uvloop's `get_child_watcher()` **raises a bare `NotImplementedError`**.

Reproduced in a test: uvloop policy + standard `SelectorEventLoop` + `create_subprocess_exec` → `NotImplementedError("")`. (Made diagnosable by SF-286's traceback capture.)

## Fix

**A — durable (`python_runner/runner.py`):** spawn via `subprocess.run` inside `asyncio.to_thread` instead of `create_subprocess_exec`. Never touches the asyncio child watcher → immune to the policy/loop mismatch, and forward-compatible with **Python 3.14** (which removes child watchers entirely). Preserves timeout / io_error / returncode / stdin / scrubbed-env semantics.

**B — root-cause hygiene (`frontend_base/plugin_base.py`):** pin `uvicorn.Config(loop="asyncio")` on the per-session frontend server so it stops installing uvloop's policy process-wide. `loop="asyncio"` is a no-op on the policy off-Windows, so it protects any other asyncio-subprocess user on the main loop too.

## Tests
- **Regression:** sets uvloop's policy + drives `python_runner` on a standard loop, asserts success — reproduces the exact production failure and closes the seam.
- Updated the sandbox test to patch `subprocess.run` (the new spawn path).
- Full `python_runner` + `frontend_base` (90) and `url4_executor` + `eval_runs` (317) suites pass. ruff + pyright clean.

## Why unit tests missed it
Emergent **global mutable state** across components: each unit is correct in isolation (subprocess spawn works under the default policy on the main *and* worker threads). The bug only appears in session mode, where the frontend's `loop="auto"` uvicorn swaps the process-wide policy and python_runner then spawns on the main `loop="asyncio"` loop. No test combined those — this PR adds one.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215774223976749

🤖 Generated with [Claude Code](https://claude.com/claude-code)