### PR TITLE
SF-292: fail loudly when a collection dataset source is unavailable

### DIFF
--- a/apps/server/src/screamingface/plugins/url4_executor/collection_parser.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/collection_parser.py
@@ -44,6 +44,18 @@ def parse_collection(body: str) -> list[str]:
     if not body:
         return []
 
+    # Reject HTML loudly. An HTML page served where a data file was expected is
+    # the signature of a soft-404 / SPA fallback (e.g. a missing dataset URL
+    # resolving to the marketing site's index). Without this guard the plain-text
+    # fallback below would turn each HTML line into an "item", silently producing
+    # a 0-accuracy "degraded" run instead of a clear failure (SF-292).
+    if body[:512].lstrip().lower().startswith(("<!doctype html", "<html")):
+        raise ValueError(
+            "collection source returned an HTML page, not a data file "
+            "(JSON array, JSONL, or CSV expected) — the dataset URL is likely "
+            "missing or misrouted to an HTML fallback"
+        )
+
     # Try JSON array first
     if body.startswith("["):
         try:

--- a/apps/server/src/screamingface/plugins/url4_executor/ensemble.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/ensemble.py
@@ -250,7 +250,15 @@ class EnsembleInterpreter(Url4Interpreter):
             set_span_attrs({"url4.collection.item_count": len(items)})
 
             if not items:
-                return []
+                # A collection that resolves to zero items is never meaningful to
+                # iterate — and is the signature of a missing/unavailable remote
+                # dataset (blank body, or content that parsed to nothing). Fail
+                # loudly so the run is marked FAILED in Eval Studio rather than
+                # silently completing as a 0-question "done" run (SF-292).
+                raise ValueError(
+                    f"collection source {collection_source!r} resolved to zero items — "
+                    "the dataset is empty or the source is unavailable"
+                )
 
             directives = directives or ForeachDirectives()
 

--- a/apps/server/src/screamingface/plugins/url4_executor/tests/test_collection_concurrency.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/tests/test_collection_concurrency.py
@@ -124,3 +124,67 @@ async def test_default_abort_propagates_error(monkeypatch):
     interp = EnsembleInterpreter(app=_make_app(_FailOnTwoPlugin()))  # pyright: ignore[reportArgumentType]
     with pytest.raises(RuntimeError):
         await interp.evaluate("DATA*(/x($item))")  # default abort → first error propagates
+
+
+class _NoopPlugin:
+    name = "x"
+    backend_call_paths = ["/x"]
+
+    async def handle_backend_call(self, intent, *, sources="", app, env=None):
+        return f"ok-{sources}"
+
+
+@pytest.mark.asyncio
+async def test_empty_collection_raises(monkeypatch):
+    """A collection source that resolves to zero items must fail loudly, not
+    yield an empty (silently "done") run. This is how a missing/unavailable
+    remote dataset (blank body) surfaces as an error in Eval Studio (SF-292)."""
+    monkeypatch.setattr(
+        "screamingface.plugins.url4_executor.url4.resolve_str",
+        _fake_resolve_returning(""),
+    )
+    interp = EnsembleInterpreter(app=_make_app(_NoopPlugin()))  # pyright: ignore[reportArgumentType]
+    with pytest.raises(ValueError, match="zero items|empty"):
+        await interp.evaluate("DATA*(/x($item))")
+
+
+@pytest.mark.asyncio
+async def test_empty_json_array_collection_raises(monkeypatch):
+    """An explicit empty array is still nothing to iterate — same failure."""
+    monkeypatch.setattr(
+        "screamingface.plugins.url4_executor.url4.resolve_str",
+        _fake_resolve_returning("[]"),
+    )
+    interp = EnsembleInterpreter(app=_make_app(_NoopPlugin()))  # pyright: ignore[reportArgumentType]
+    with pytest.raises(ValueError, match="zero items|empty"):
+        await interp.evaluate("DATA*(/x($item))")
+
+
+@pytest.mark.asyncio
+async def test_html_collection_source_aborts_before_any_row_even_with_collect(monkeypatch):
+    """The real ScoredLiveTruth scenario: a reducer-shaped collection with
+    ``;foreach.on_error=collect`` whose dataset URL returns an HTML page
+    (the screamingface.ai soft-404) must FAIL FAST — the collection-source
+    failure is raised before per-row fan-out, so ``on_error=collect`` does NOT
+    swallow it and no model/python backend is ever invoked (SF-292)."""
+    html = '<!DOCTYPE html>\n<html lang="en" data-theme="light">\n<body>x</body>\n</html>'
+    calls = {"n": 0}
+
+    class _NeverCalled:
+        name = "m"
+        backend_call_paths = ["/x", "/python"]
+
+        async def handle_backend_call(self, intent, *, sources="", app, env=None):
+            calls["n"] += 1
+            return "should-not-run"
+
+    monkeypatch.setattr(
+        "screamingface.plugins.url4_executor.url4.resolve_str",
+        _fake_resolve_returning(html, collection_source="DATA"),
+    )
+    interp = EnsembleInterpreter(app=_make_app(_NeverCalled()))  # pyright: ignore[reportArgumentType]
+    with pytest.raises(ValueError, match="HTML"):
+        await interp.evaluate(
+            "(DATA*(/x($item.q)) ;foreach.on_error=collect)!/python(/data/code/reduce.py)"
+        )
+    assert calls["n"] == 0  # aborted before any per-row backend work

--- a/apps/server/src/screamingface/plugins/url4_executor/tests/test_collection_parser.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/tests/test_collection_parser.py
@@ -64,3 +64,33 @@ class TestFallback:
     def test_empty_body(self):
         assert parse_collection("") == []
         assert parse_collection("   ") == []
+
+
+class TestHtmlRejection:
+    """An HTML page is the signature of a soft-404 / SPA fallback served where a
+    data file was expected. It must fail loudly, not silently degrade to
+    line-items (which yields a "successful" 0-accuracy eval). See SF-292."""
+
+    def test_doctype_html_raises(self):
+        import pytest
+
+        body = '<!DOCTYPE html>\n<html lang="en">\n<head><title>x</title></head>\n</html>'
+        with pytest.raises(ValueError, match="HTML"):
+            parse_collection(body)
+
+    def test_html_tag_without_doctype_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="HTML"):
+            parse_collection('<html data-theme="light">\n<body>nope</body>\n</html>')
+
+    def test_leading_whitespace_before_doctype_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="HTML"):
+            parse_collection("\n  \n<!doctype HTML>\n<html></html>")
+
+    def test_plain_text_with_angle_brackets_still_parses(self):
+        # A genuine text collection containing '<' must NOT be mistaken for HTML.
+        body = "a < b\nc > d"
+        assert parse_collection(body) == ["a < b", "c > d"]


### PR DESCRIPTION
## Problem

The LiveTruth eval silently produced a 0-accuracy **degraded** run when its dataset URL (`https://screamingface.ai/livetruth-latest.eval.jsonl`) returned an **HTML SPA page** instead of JSONL (Cloudflare/DNS soft-404 — the file isn't served at that origin). `parse_collection`'s plain-text fallback turned each HTML line into a "row", so `$item.*` never interpolated and every model answered identically. **The interpolation engine was never at fault — the data source was.**

## Fix

Two guards make an unavailable remote surface as a **FAILED** run in Eval Studio instead of a silent success:

- **`parse_collection`** — raise on an HTML body (the soft-404 / SPA-fallback signature) rather than degrading to line-items.
- **`_collect_rows`** — raise when a collection resolves to **zero items** (blank body / nothing parsed) instead of returning `[]` and completing as a 0-question "done" run.

Both fire at the collection-source step, **before** per-row fan-out — so even with `;foreach.on_error=collect` the run aborts fast and **no model backend is invoked**. Real HTTP 404/500 and connection/timeout errors already failed via routes' `RUN_FAILED` path; these close the remaining silent paths.

| Remote-unavailable case | Before | After |
|---|---|---|
| HTTP 404/500, connection/timeout | failed | failed (unchanged) |
| Soft-404 HTML (200 + SPA page) | silent → degraded, 0 acc | **failed** |
| Empty / blank body → 0 rows | silent → "done, not graded" | **failed** |

A failed run renders the red `failed` badge + the error message in `EvalRunDetail` (no frontend change needed).

## Out of scope

The underlying infra (restoring the dataset at the `screamingface.ai` URL) is a Cloudflare/DNS task owned by the website side; local eval runs are unblocked by pointing the spec at a `/private` dataset.

## Test plan

- `parse_collection` rejects HTML (DOCTYPE / `<html>` / leading whitespace), still parses genuine text with `<`/`>`.
- `_collect_rows` raises on empty body and on `[]`.
- Real ScoredLiveTruth shape (reducer + `on_error=collect` + HTML source) **fails fast with 0 backend calls**.
- url4 suite green; scored-query e2e + eval_runs + python_runner green.

Asana: SF-292 — https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215840729922325

🤖 Generated with [Claude Code](https://claude.com/claude-code)