### PR TITLE
SF-291: Desktop API-key auth in the v2 connections UI

### DIFF
--- a/apps/aigateway/src/aigateway/core/api_key_strategy.py
+++ b/apps/aigateway/src/aigateway/core/api_key_strategy.py
@@ -75,8 +75,8 @@ class ApiKeyStrategy(CredentialStrategy):
         raw = await self._store.read(self._service, self._account)
         if raw is None:
             raise CredentialNotFoundError(
-                f"No API key stored for profile {self.profile_name!r}. "
-                "Set one via the profile api-key endpoint."
+                f"No API key stored for {self.profile_name!r}. "
+                "Set or replace the key for this profile or connection."
             )
         try:
             creds = json.loads(raw)

--- a/apps/aigateway/src/aigateway/core/oauth/schemas.py
+++ b/apps/aigateway/src/aigateway/core/oauth/schemas.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
+from ..profile_models import AuthType
 from .identity import AccountIdentity
 
 OAuthConnectionStatus = Literal["pending", "active", "expired", "revoked", "error"]
@@ -21,6 +22,7 @@ class OAuthConnectionResponse(BaseModel):
     provider: str
     label: str
     status: OAuthConnectionStatus
+    auth_type: AuthType = "oauth"
     account: AccountIdentity | None = None
     credential_locator: dict[str, Any]
     created_at: datetime
@@ -42,6 +44,20 @@ class CreateOAuthConnectionRequest(BaseModel):
 
 class PatchOAuthConnectionRequest(BaseModel):
     label: OAuthConnectionLabel | None = None
+
+
+class CreateApiKeyConnectionRequest(BaseModel):
+    """Create an api-key-authenticated connection (no OAuth round-trip)."""
+
+    provider: str
+    label: OAuthConnectionLabel | None = None
+    api_key: str
+
+
+class SetConnectionApiKeyRequest(BaseModel):
+    """Replace the stored API key on an existing api-key connection."""
+
+    api_key: str
 
 
 class OAuthConnectionTokenResponse(BaseModel):

--- a/apps/aigateway/src/aigateway/core/oauth/store.py
+++ b/apps/aigateway/src/aigateway/core/oauth/store.py
@@ -78,6 +78,38 @@ class OAuthConnectionStore:
             ),
         )
 
+    async def create_api_key(
+        self,
+        *,
+        account_id: str | UUID,
+        provider: str,
+        label: str,
+        connection_id: UUID,
+        credential_provider: str | None = None,
+    ) -> OAuthConnection:
+        """Create an api-key connection in the active state directly.
+
+        Unlike create_pending (OAuth: pending -> active on callback), an
+        api-key connection has no browser round-trip, so it is authenticated
+        the moment its key is stored. status has no DB default, so it is set
+        explicitly here; auth_type is set to "api_key" (the column defaults to
+        "oauth"). The credential_locator points at the same blob slot the chat
+        path reads via credential_key_for(account_id, connection_id)."""
+        await _ensure_anonymous_account(account_id)
+        return await OAuthConnection.create(
+            id=connection_id,
+            account_id=account_id,
+            provider=provider,
+            label=label,
+            status="active",
+            auth_type="api_key",
+            credential_locator=credential_locator_for(
+                credential_provider or provider,
+                account_id,
+                connection_id,
+            ),
+        )
+
     async def find_by_identity(
         self,
         account_id: str | UUID,
@@ -182,6 +214,7 @@ def response_from_connection(
         provider=connection.provider,
         label=connection.label,
         status=connection.status,
+        auth_type=connection.auth_type,
         account=account,
         credential_locator=connection.credential_locator,
         created_at=connection.created_at,

--- a/apps/aigateway/src/aigateway/core/oauth/store.py
+++ b/apps/aigateway/src/aigateway/core/oauth/store.py
@@ -158,11 +158,27 @@ class OAuthConnectionStore:
         return connection
 
     async def mark_error(self, connection: OAuthConnection, message: str) -> OAuthConnection:
-        connection.label = f"error:{connection.id}"
-        connection.identity_sub = None
         connection.status = "error"
         connection.error_message = message
-        await connection.save(update_fields=["label", "identity_sub", "status", "error_message"])
+        fields = ["status", "error_message"]
+        # OAuth connections are superseded by a fresh re-auth, so the old row's
+        # label/identity are cleared. An api-key connection is re-keyed IN PLACE
+        # (Replace key), so its label and identity must survive the error state
+        # to stay recoverable (SF-291 review RF2-1).
+        if connection.auth_type != "api_key":
+            connection.label = f"error:{connection.id}"
+            connection.identity_sub = None
+            fields += ["label", "identity_sub"]
+        await connection.save(update_fields=fields)
+        return connection
+
+    async def reactivate(self, connection: OAuthConnection) -> OAuthConnection:
+        """Return an errored connection to active after its credential is
+        replaced (SF-291 review RF2-1)."""
+        connection.status = "active"
+        connection.error_message = None
+        connection.last_refreshed_at = datetime.now(UTC)
+        await connection.save(update_fields=["status", "error_message", "last_refreshed_at"])
         return connection
 
     async def mark_revoked(

--- a/apps/aigateway/src/aigateway/core/oauth/token_service.py
+++ b/apps/aigateway/src/aigateway/core/oauth/token_service.py
@@ -84,6 +84,11 @@ class OAuthConnectionTokenService:
             raise OAuthConnectionTokenError(404, {"code": "connection_not_found"})
         if connection.status != "active":
             raise OAuthConnectionTokenError(409, {"code": "connection_not_active"})
+        if getattr(connection, "auth_type", "oauth") == "api_key":
+            # An api-key connection has no OAuth access token to mint; the
+            # OAuth strategy cannot parse its blob. Reject explicitly instead
+            # of surfacing the misleading "provider_does_not_use_oauth".
+            raise OAuthConnectionTokenError(400, {"code": "connection_not_oauth"})
 
         plugin = providers.get(connection.provider)
         if plugin is None:

--- a/apps/aigateway/src/aigateway/core/plugin_base.py
+++ b/apps/aigateway/src/aigateway/core/plugin_base.py
@@ -182,6 +182,15 @@ class ProviderPluginBase[TSettings: PluginSettings](ABC):
         """Whether `/v1/chat/completions` may create a streaming response."""
         return True
 
+    def supports_api_key(self) -> bool:
+        """Whether this provider accepts a raw API key (vs OAuth-only).
+
+        Capability flag surfaced to clients so the UI only offers API-key auth
+        where it works. The default is False; providers that implement
+        ``api_key_strategy_for`` override this to True. Codex stays False (its
+        subscription endpoint is OAuth-only and rejects raw keys)."""
+        return False
+
     def prepare_chat_body(self, body: dict[str, Any]) -> dict[str, Any]:
         """Apply provider-specific request normalization before dispatch."""
         return body

--- a/apps/aigateway/src/aigateway/main.py
+++ b/apps/aigateway/src/aigateway/main.py
@@ -7,7 +7,10 @@ import os
 import time
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
 
 from .config import Settings
 from .core.auth.bootstrap_admin import ensure_admin_account
@@ -176,11 +179,24 @@ async def _lifespan(app):
         await close_db()
 
 
+async def _redact_validation_errors(_request: Request, exc: Exception) -> JSONResponse:
+    """Return 422s without the echoed request body.
+
+    FastAPI's default validation handler includes ``input`` (the raw submitted
+    body) in each error. For api-key endpoints that body carries the raw key, so
+    echoing it back leaks the secret into error responses and logs (SF-291
+    review F1). Strip ``input`` from every error while preserving type/loc/msg."""
+    errors = exc.errors() if isinstance(exc, RequestValidationError) else []
+    cleaned = [{k: v for k, v in err.items() if k != "input"} for err in errors]
+    return JSONResponse(status_code=422, content=jsonable_encoder({"detail": cleaned}))
+
+
 def create_app(settings: Settings | None = None) -> FastAPI:
     if settings is None:
         settings = Settings()
     _attach_log_filter()
     app = FastAPI(title="aigateway", version="0.1.0", lifespan=_lifespan)
+    app.add_exception_handler(RequestValidationError, _redact_validation_errors)
     app.state.settings = settings
     if not settings.auth_enabled:
         app.add_middleware(AuthDisabledLocalOnlyMiddleware)

--- a/apps/aigateway/src/aigateway/plugins/anthropic_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/anthropic_provider/plugin.py
@@ -61,6 +61,9 @@ class AnthropicProviderPlugin(ProviderPluginBase[AnthropicPluginSettings]):
             settings=self.settings,
         )
 
+    def supports_api_key(self) -> bool:
+        return True
+
     def api_key_strategy_for(
         self,
         profile_name: str,

--- a/apps/aigateway/src/aigateway/plugins/gemini_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/gemini_provider/plugin.py
@@ -100,6 +100,9 @@ class GeminiProviderPlugin(ProviderPluginBase):
             http_client_factory=http_client_factory,
         )
 
+    def supports_api_key(self) -> bool:
+        return True
+
     def api_key_strategy_for(
         self,
         profile_name: str,

--- a/apps/aigateway/src/aigateway/routes/chat.py
+++ b/apps/aigateway/src/aigateway/routes/chat.py
@@ -233,7 +233,18 @@ def _strategy_for_credential_target(
     return strategy, credential_name, auth_type
 
 
-def _reauth_url_for(provider: str, profile_name: str, auth_type: AuthType) -> str:
+def _reauth_url_for(
+    provider: str,
+    profile_name: str,
+    auth_type: AuthType,
+    *,
+    connection_id: str | None = None,
+) -> str:
+    if connection_id is not None and auth_type == "api_key":
+        # An api-key CONNECTION re-keys via its own replace route; never send the
+        # user back to the legacy profile api-key endpoint, which would shadow
+        # connections on chat (SF-291 review F3).
+        return f"/v1/oauth/connections/{connection_id}/api-key"
     base = f"/v1/auth/{provider}/profiles/{profile_name}"
     return f"{base}/api-key" if auth_type == "api_key" else base
 
@@ -504,7 +515,12 @@ async def _inject_credentials(
                 detail={
                     "code": "auth_required",
                     "message": str(exc),
-                    "reauth_url": _reauth_url_for(provider, profile_name, auth_type),
+                    "reauth_url": _reauth_url_for(
+                        provider,
+                        profile_name,
+                        auth_type,
+                        connection_id=str(connection.id) if connection is not None else None,
+                    ),
                 },
             )
         except AuthError as exc:
@@ -528,7 +544,12 @@ async def _inject_credentials(
                 detail={
                     "code": "auth_required",
                     "message": str(exc),
-                    "reauth_url": _reauth_url_for(provider, profile_name, auth_type),
+                    "reauth_url": _reauth_url_for(
+                        provider,
+                        profile_name,
+                        auth_type,
+                        connection_id=str(connection.id) if connection is not None else None,
+                    ),
                 },
             )
         auth_value = headers.pop("Authorization", None)

--- a/apps/aigateway/src/aigateway/routes/chat.py
+++ b/apps/aigateway/src/aigateway/routes/chat.py
@@ -126,7 +126,7 @@ async def _active_oauth_connection_for_profile(
                 "code": "connection_ambiguous",
                 "provider": provider,
                 "message": (
-                    "Multiple active OAuth connections exist. Select one by setting "
+                    "Multiple active connections exist. Select one by setting "
                     "X-Profile to the connection label."
                 ),
             },

--- a/apps/aigateway/src/aigateway/routes/oauth_connections.py
+++ b/apps/aigateway/src/aigateway/routes/oauth_connections.py
@@ -199,6 +199,11 @@ async def create_api_key_connection(
             status_code=409,
             detail={"code": "label_conflict", "provider": body.provider, "label": label},
         )
+    # Persist the key BEFORE activating the row so a credential-write failure
+    # never leaves an active connection with no credential (SF-291 review F4).
+    # The blob slot is keyed by the already-generated connection_id — exactly
+    # the slot the chat path reads.
+    await strategy.persist_credentials({"auth_type": "api_key", "api_key": api_key})
     try:
         connection = await store.create_api_key(
             account_id=account_id,
@@ -207,12 +212,16 @@ async def create_api_key_connection(
             connection_id=connection_id,
             credential_provider=credential_service_provider_for(plugin, body.provider),
         )
-    except IntegrityError as exc:
-        raise HTTPException(
-            status_code=409,
-            detail={"code": "label_conflict", "provider": body.provider, "label": label},
-        ) from exc
-    await strategy.persist_credentials({"auth_type": "api_key", "api_key": api_key})
+    except Exception as exc:
+        # The row could not be created — drop the orphan blob so no credential
+        # is left without a connection pointing at it.
+        await strategy.delete_credentials()
+        if isinstance(exc, IntegrityError):
+            raise HTTPException(
+                status_code=409,
+                detail={"code": "label_conflict", "provider": body.provider, "label": label},
+            ) from exc
+        raise
     credential_strategy_cache(request.app).evict(credential_key_for(account_id, connection_id))
     return response_from_connection(connection)
 
@@ -349,6 +358,11 @@ async def refresh_connection(
         raise HTTPException(status_code=404, detail={"code": "connection_not_found"})
     if connection.status != "active":
         raise HTTPException(status_code=409, detail={"code": "connection_not_active"})
+    if connection.auth_type == "api_key":
+        # /refresh is OAuth-only. An api-key connection has nothing to refresh,
+        # and running oauth_strategy_for against its blob would raise and flip
+        # the row to error (SF-291 review F2). Reject without mutating the row.
+        raise HTTPException(status_code=400, detail={"code": "connection_not_oauth"})
     plugin = request.app.state.providers.get(connection.provider)
     if plugin is None:
         raise HTTPException(status_code=404, detail={"code": "unknown_provider"})

--- a/apps/aigateway/src/aigateway/routes/oauth_connections.py
+++ b/apps/aigateway/src/aigateway/routes/oauth_connections.py
@@ -236,13 +236,17 @@ async def set_connection_api_key(
     request: Request,
     current: CurrentAccount,
 ) -> OAuthConnectionResponse:
-    """Replace the stored API key on an existing active api-key connection."""
+    """Replace the stored API key on an api-key connection.
+
+    Accepts an active OR errored connection: replacing the key is exactly how a
+    user recovers a connection that errored on a bad/missing key, so a
+    successful replace re-activates it (SF-291 review RF2-1)."""
     account_id = str(current.id)
     store = _store(request)
     connection = await store.get(account_id, connection_id)
     if connection is None:
         raise HTTPException(status_code=404, detail={"code": "connection_not_found"})
-    if connection.auth_type != "api_key" or connection.status != "active":
+    if connection.auth_type != "api_key" or connection.status not in ("active", "error"):
         raise HTTPException(status_code=409, detail={"code": "connection_not_api_key"})
     api_key = body.api_key.strip()
     if len(api_key) < 8:
@@ -266,7 +270,9 @@ async def set_connection_api_key(
         )
     await strategy.persist_credentials({"auth_type": "api_key", "api_key": api_key})
     credential_strategy_cache(request.app).evict(credential_key_for(account_id, connection.id))
-    connection = await store.touch_last_refreshed(connection)
+    # Replacing the key clears any prior error and returns the connection to
+    # active (recovery path).
+    connection = await store.reactivate(connection)
     return response_from_connection(connection)
 
 

--- a/apps/aigateway/src/aigateway/routes/oauth_connections.py
+++ b/apps/aigateway/src/aigateway/routes/oauth_connections.py
@@ -203,7 +203,7 @@ async def create_api_key_connection(
     # never leaves an active connection with no credential (SF-291 review F4).
     # The blob slot is keyed by the already-generated connection_id — exactly
     # the slot the chat path reads.
-    await strategy.persist_credentials({"auth_type": "api_key", "api_key": api_key})
+    await _persist_api_key_credentials(strategy, api_key)
     try:
         connection = await store.create_api_key(
             account_id=account_id,
@@ -247,7 +247,13 @@ async def set_connection_api_key(
     if connection is None:
         raise HTTPException(status_code=404, detail={"code": "connection_not_found"})
     if connection.auth_type != "api_key" or connection.status not in ("active", "error"):
-        raise HTTPException(status_code=409, detail={"code": "connection_not_api_key"})
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "connection_not_api_key",
+                "message": "Connection does not use API-key authentication",
+            },
+        )
     api_key = body.api_key.strip()
     if len(api_key) < 8:
         raise HTTPException(
@@ -256,7 +262,10 @@ async def set_connection_api_key(
         )
     plugin = request.app.state.providers.get(connection.provider)
     if plugin is None:
-        raise HTTPException(status_code=404, detail={"code": "unknown_provider"})
+        raise HTTPException(
+            status_code=404,
+            detail={"code": "unknown_provider", "provider": connection.provider},
+        )
     strategy = credential_strategy_from(
         plugin,
         credential_key_for(account_id, connection.id),
@@ -268,7 +277,7 @@ async def set_connection_api_key(
             status_code=400,
             detail={"code": "api_key_not_supported", "provider": connection.provider},
         )
-    await strategy.persist_credentials({"auth_type": "api_key", "api_key": api_key})
+    await _persist_api_key_credentials(strategy, api_key)
     credential_strategy_cache(request.app).evict(credential_key_for(account_id, connection.id))
     # Replacing the key clears any prior error and returns the connection to
     # active (recovery path).
@@ -431,6 +440,19 @@ async def _delete_credentials(request: Request, locator: dict) -> None:
     account = locator.get("account")
     if isinstance(service, str) and isinstance(account, str):
         await request.app.state.credential_store.delete(service, account)
+
+
+async def _persist_api_key_credentials(strategy, api_key: str) -> None:
+    try:
+        await strategy.persist_credentials({"auth_type": "api_key", "api_key": api_key})
+    except Exception as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": "credential_store_unavailable",
+                "message": "Could not store API-key credentials. Try again.",
+            },
+        ) from exc
 
 
 def _duplicate_id(message: str | None) -> UUID | None:

--- a/apps/aigateway/src/aigateway/routes/oauth_connections.py
+++ b/apps/aigateway/src/aigateway/routes/oauth_connections.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from urllib.parse import urlencode
 from uuid import UUID, uuid4
 
@@ -33,6 +34,8 @@ from aigateway.core.pending_auth import PendingAuthEntry
 from aigateway.core.plugin_base import credential_service_provider_for, credential_strategy_from
 
 from .auth import _redirect_uri_for
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -165,12 +168,7 @@ async def create_api_key_connection(
         raise HTTPException(
             status_code=404, detail={"code": "unknown_provider", "provider": body.provider}
         )
-    api_key = body.api_key.strip()
-    if len(api_key) < 8:
-        raise HTTPException(
-            status_code=400,
-            detail={"code": "invalid_api_key", "message": "api_key is missing or too short"},
-        )
+    api_key = _validate_api_key(body.api_key)
     account_id = str(current.id)
     connection_id = uuid4()
     # Build the strategy BEFORE creating any row: a provider that does not
@@ -254,12 +252,7 @@ async def set_connection_api_key(
                 "message": "Connection does not use API-key authentication",
             },
         )
-    api_key = body.api_key.strip()
-    if len(api_key) < 8:
-        raise HTTPException(
-            status_code=400,
-            detail={"code": "invalid_api_key", "message": "api_key is missing or too short"},
-        )
+    api_key = _validate_api_key(body.api_key)
     plugin = request.app.state.providers.get(connection.provider)
     if plugin is None:
         raise HTTPException(
@@ -442,10 +435,33 @@ async def _delete_credentials(request: Request, locator: dict) -> None:
         await request.app.state.credential_store.delete(service, account)
 
 
+def _validate_api_key(raw_key: str) -> str:
+    """Normalize and length-check a raw API key (the one rule shared verbatim by
+    the create and replace endpoints). Raises 400 ``invalid_api_key`` if too
+    short. Kept tiny on purpose: each endpoint's provider/strategy resolution
+    stays inline because the two flows order those checks differently."""
+    api_key = raw_key.strip()
+    if len(api_key) < 8:
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "invalid_api_key", "message": "api_key is missing or too short"},
+        )
+    return api_key
+
+
 async def _persist_api_key_credentials(strategy, api_key: str) -> None:
     try:
         await strategy.persist_credentials({"auth_type": "api_key", "api_key": api_key})
     except Exception as exc:
+        # A caught store failure is otherwise a silent 503 — log which service
+        # failed and the exception TYPE so ops can diagnose. Deliberately NOT
+        # str(exc)/the traceback: a store implementation could echo its write
+        # argument (the key) in the message, and this path must never log a key.
+        logger.error(
+            "Failed to persist API-key credentials for service %s: %s",
+            strategy.credential_service(),
+            type(exc).__name__,
+        )
         raise HTTPException(
             status_code=503,
             detail={

--- a/apps/aigateway/src/aigateway/routes/oauth_connections.py
+++ b/apps/aigateway/src/aigateway/routes/oauth_connections.py
@@ -10,11 +10,13 @@ from aigateway.core.auth.middleware import CurrentAccount
 from aigateway.core.credential_strategy_cache import credential_strategy_cache
 from aigateway.core.errors import AuthError, CredentialNotFoundError
 from aigateway.core.oauth.schemas import (
+    CreateApiKeyConnectionRequest,
     CreateOAuthConnectionRequest,
     OAuthConnectionListResponse,
     OAuthConnectionResponse,
     OAuthConnectionTokenResponse,
     PatchOAuthConnectionRequest,
+    SetConnectionApiKeyRequest,
     StartOAuthConnectionResponse,
 )
 from aigateway.core.oauth.store import (
@@ -28,7 +30,7 @@ from aigateway.core.oauth.token_service import (
 )
 from aigateway.core.oauth_pkce import generate_pkce, generate_state
 from aigateway.core.pending_auth import PendingAuthEntry
-from aigateway.core.plugin_base import credential_service_provider_for
+from aigateway.core.plugin_base import credential_service_provider_for, credential_strategy_from
 
 from .auth import _redirect_uri_for
 
@@ -140,6 +142,123 @@ async def start_connection_oauth(
         authorize_url=f"{cfg.authorize_url}?{urlencode(params)}",
         state=state,
     )
+
+
+@router.post(
+    "/v1/oauth/connections/api-key",
+    status_code=201,
+    response_model=OAuthConnectionResponse,
+)
+async def create_api_key_connection(
+    body: CreateApiKeyConnectionRequest,
+    request: Request,
+    current: CurrentAccount,
+) -> OAuthConnectionResponse:
+    """Create an api-key-authenticated connection (no OAuth round-trip).
+
+    The key is stored (encrypted at rest) in the same credential-blob slot the
+    chat path reads for this connection, so it is usable on a real chat call
+    immediately. The key is never echoed back or logged.
+    """
+    plugin = request.app.state.providers.get(body.provider)
+    if plugin is None:
+        raise HTTPException(
+            status_code=404, detail={"code": "unknown_provider", "provider": body.provider}
+        )
+    api_key = body.api_key.strip()
+    if len(api_key) < 8:
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "invalid_api_key", "message": "api_key is missing or too short"},
+        )
+    account_id = str(current.id)
+    connection_id = uuid4()
+    # Build the strategy BEFORE creating any row: a provider that does not
+    # support api-key auth (codex) yields None here and we 400 without leaving
+    # an orphan connection. The credential_name is the same composite key the
+    # chat path uses, so persist writes exactly the slot chat reads.
+    strategy = credential_strategy_from(
+        plugin,
+        credential_key_for(account_id, connection_id),
+        auth_type="api_key",
+        credential_store=request.app.state.credential_store,
+    )
+    if strategy is None:
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "api_key_not_supported", "provider": body.provider},
+        )
+    if plugin.requires_oauth_connection_label() and not body.label:
+        raise HTTPException(
+            status_code=422, detail={"code": "label_required", "provider": body.provider}
+        )
+    label = body.label or f"api-key-{connection_id}"
+    store = _store(request)
+    if await store.find_by_label(account_id, body.provider, label) is not None:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "label_conflict", "provider": body.provider, "label": label},
+        )
+    try:
+        connection = await store.create_api_key(
+            account_id=account_id,
+            provider=body.provider,
+            label=label,
+            connection_id=connection_id,
+            credential_provider=credential_service_provider_for(plugin, body.provider),
+        )
+    except IntegrityError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "label_conflict", "provider": body.provider, "label": label},
+        ) from exc
+    await strategy.persist_credentials({"auth_type": "api_key", "api_key": api_key})
+    credential_strategy_cache(request.app).evict(credential_key_for(account_id, connection_id))
+    return response_from_connection(connection)
+
+
+@router.put(
+    "/v1/oauth/connections/{connection_id}/api-key",
+    response_model=OAuthConnectionResponse,
+)
+async def set_connection_api_key(
+    connection_id: UUID,
+    body: SetConnectionApiKeyRequest,
+    request: Request,
+    current: CurrentAccount,
+) -> OAuthConnectionResponse:
+    """Replace the stored API key on an existing active api-key connection."""
+    account_id = str(current.id)
+    store = _store(request)
+    connection = await store.get(account_id, connection_id)
+    if connection is None:
+        raise HTTPException(status_code=404, detail={"code": "connection_not_found"})
+    if connection.auth_type != "api_key" or connection.status != "active":
+        raise HTTPException(status_code=409, detail={"code": "connection_not_api_key"})
+    api_key = body.api_key.strip()
+    if len(api_key) < 8:
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "invalid_api_key", "message": "api_key is missing or too short"},
+        )
+    plugin = request.app.state.providers.get(connection.provider)
+    if plugin is None:
+        raise HTTPException(status_code=404, detail={"code": "unknown_provider"})
+    strategy = credential_strategy_from(
+        plugin,
+        credential_key_for(account_id, connection.id),
+        auth_type="api_key",
+        credential_store=request.app.state.credential_store,
+    )
+    if strategy is None:
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "api_key_not_supported", "provider": connection.provider},
+        )
+    await strategy.persist_credentials({"auth_type": "api_key", "api_key": api_key})
+    credential_strategy_cache(request.app).evict(credential_key_for(account_id, connection.id))
+    connection = await store.touch_last_refreshed(connection)
+    return response_from_connection(connection)
 
 
 @router.patch("/v1/oauth/connections/{connection_id}", response_model=OAuthConnectionResponse)

--- a/apps/aigateway/tests/unit/test_chat_x_profile.py
+++ b/apps/aigateway/tests/unit/test_chat_x_profile.py
@@ -1241,3 +1241,29 @@ def test_chat_api_key_connection_missing_blob_reauth_url_is_connection_native(
     assert detail["code"] == "auth_required"
     assert detail["reauth_url"] == f"/v1/oauth/connections/{connection.id}/api-key"
     assert "/profiles/" not in detail["reauth_url"]
+
+
+def test_chat_multiple_active_api_key_connections_is_ambiguous(authenticated_client) -> None:
+    """Two active api-key connections + X-Profile=default -> 409 connection_ambiguous.
+    The ambiguity guard is auth-type-agnostic (mirrors the OAuth case)."""
+    account_id = _account_id(authenticated_client)
+
+    async def _two_api_key_connections() -> None:
+        store = OAuthConnectionStore()
+        await store.create_api_key(
+            account_id=account_id, provider="anthropic", label="work-key", connection_id=uuid4()
+        )
+        await store.create_api_key(
+            account_id=account_id, provider="anthropic", label="home-key", connection_id=uuid4()
+        )
+
+    authenticated_client.portal.call(_two_api_key_connections)
+    resp = authenticated_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "anthropic/claude-haiku-4-5",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["code"] == "connection_ambiguous"

--- a/apps/aigateway/tests/unit/test_chat_x_profile.py
+++ b/apps/aigateway/tests/unit/test_chat_x_profile.py
@@ -1211,3 +1211,33 @@ def test_chat_api_key_connection_resolves_api_key_strategy(
 
     assert resp.status_code == 200
     assert captured["api_key"] == "sk-ant-api03-conn-key"
+
+
+def test_chat_api_key_connection_missing_blob_reauth_url_is_connection_native(
+    credential_blobs, authenticated_client
+) -> None:
+    """When an api-key CONNECTION has no/blank credential, the 401 reauth_url
+    must point at the connection's replace-key route, not the legacy profile
+    api-key endpoint (review F3 — avoid reintroducing profile shadowing)."""
+    account_id = _account_id(authenticated_client)
+    connection = authenticated_client.portal.call(_create_active_connection, account_id)
+
+    async def _flag_api_key() -> None:
+        connection.auth_type = "api_key"
+        await connection.save(update_fields=["auth_type"])
+
+    authenticated_client.portal.call(_flag_api_key)
+    # Intentionally write NO credential blob -> CredentialNotFoundError on dispatch.
+    resp = authenticated_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "anthropic/claude-haiku-4-5",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+
+    assert resp.status_code == 401
+    detail = resp.json()["detail"]
+    assert detail["code"] == "auth_required"
+    assert detail["reauth_url"] == f"/v1/oauth/connections/{connection.id}/api-key"
+    assert "/profiles/" not in detail["reauth_url"]

--- a/apps/aigateway/tests/unit/test_oauth_connection_api_key_routes.py
+++ b/apps/aigateway/tests/unit/test_oauth_connection_api_key_routes.py
@@ -11,6 +11,7 @@ and never echoed back.
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Iterator
 from contextlib import contextmanager
 
@@ -86,6 +87,18 @@ def test_create_codex_is_api_key_not_supported(authenticated_client) -> None:
 
 def test_create_short_key_rejected(authenticated_client) -> None:
     resp = _create(authenticated_client, api_key="short")
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["code"] == "invalid_api_key"
+
+
+def test_replace_short_key_rejected(authenticated_client) -> None:
+    """The replace (PUT) path enforces the same minimum-length rule as create
+    (pins the shared _validate_api_key contract on both endpoints)."""
+    created = _create(authenticated_client, label="shortput").json()
+    resp = authenticated_client.put(
+        f"/v1/oauth/connections/{created['id']}/api-key",
+        json={"api_key": "short"},
+    )
     assert resp.status_code == 400
     assert resp.json()["detail"]["code"] == "invalid_api_key"
 
@@ -310,6 +323,36 @@ def test_create_api_key_persist_failure_returns_sanitized_5xx(
     assert leak_marker not in resp.text
     listing = authenticated_client.get("/v1/oauth/connections").json()["connections"]
     assert all(c["label"] != "atomic-http" for c in listing)
+
+
+def test_persist_failure_is_logged_for_ops_without_leaking_key(
+    authenticated_client, monkeypatch, caplog
+) -> None:
+    """A credential-store failure must be observable to ops (which service
+    failed + the exception type) so a silent 503 isn't undiagnosable — but the
+    raw key and the underlying exception message (which a store could echo)
+    must NEVER reach the log."""
+    leak_marker = "sk-ant-api03-key-that-must-not-reach-logs"
+
+    async def _boom(*_a, **_k):
+        raise RuntimeError(f"store blew up with {leak_marker}")
+
+    monkeypatch.setattr(authenticated_client.app.state.credential_store, "write", _boom)
+
+    with (
+        caplog.at_level(logging.ERROR),
+        _server_errors_as_responses(authenticated_client),
+    ):
+        resp = _create(authenticated_client, label="logtest", api_key=leak_marker)
+
+    assert resp.status_code == 503
+    # Observable: ops can see a persist failure occurred and its type.
+    assert any(
+        "Failed to persist API-key credentials" in record.message for record in caplog.records
+    )
+    assert "RuntimeError" in caplog.text
+    # Safe: neither the raw key nor the store's exception message is logged.
+    assert leak_marker not in caplog.text
 
 
 def test_create_api_key_deletes_blob_when_row_create_fails(

--- a/apps/aigateway/tests/unit/test_oauth_connection_api_key_routes.py
+++ b/apps/aigateway/tests/unit/test_oauth_connection_api_key_routes.py
@@ -11,6 +11,8 @@ and never echoed back.
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 from aigateway.core.oauth.store import credential_key_for
 from aigateway.plugins.anthropic_provider.auth import (
@@ -18,6 +20,17 @@ from aigateway.plugins.anthropic_provider.auth import (
 )
 
 _KEY = "sk-ant-api03-test-connection-key"
+
+
+@contextmanager
+def _server_errors_as_responses(client) -> Iterator[None]:
+    transport = getattr(client, "_transport")
+    previous = transport.raise_server_exceptions
+    transport.raise_server_exceptions = False
+    try:
+        yield
+    finally:
+        transport.raise_server_exceptions = previous
 
 
 def _create(client, *, provider="anthropic", label: str | None = "work", api_key=_KEY):
@@ -103,12 +116,96 @@ def test_replace_key_updates_blob(authenticated_client, credential_blobs) -> Non
     assert json.loads(credential_blobs.read(service, "default"))["api_key"] == new_key
 
 
+def test_replace_key_persist_failure_is_sanitized_and_keeps_old_blob(
+    authenticated_client, credential_blobs, monkeypatch
+) -> None:
+    created = _create(authenticated_client, label="rotate-fail").json()
+    service = anthropic_service_for(credential_key_for(created["account_id"], created["id"]))
+    before = credential_blobs.read(service, "default")
+    assert before is not None
+    new_key = "sk-ant-api03-new-key-that-must-not-leak"
+
+    async def _boom(*_a, **_k):
+        raise RuntimeError(f"credential store failed for {new_key}")
+
+    monkeypatch.setattr(authenticated_client.app.state.credential_store, "write", _boom)
+
+    with _server_errors_as_responses(authenticated_client):
+        resp = authenticated_client.put(
+            f"/v1/oauth/connections/{created['id']}/api-key",
+            json={"api_key": new_key},
+        )
+
+    assert resp.status_code == 503
+    assert resp.json()["detail"]["code"] == "credential_store_unavailable"
+    assert new_key not in resp.text
+    assert credential_blobs.read(service, "default") == before
+
+
+def test_delete_api_key_connection_removes_blob(authenticated_client, credential_blobs) -> None:
+    """API-key connections use the shared connection delete path; deleting the
+    connection must remove the same credential blob the chat path reads."""
+    created = _create(authenticated_client, label="delete-key").json()
+    service = anthropic_service_for(credential_key_for(created["account_id"], created["id"]))
+    assert credential_blobs.read(service, "default") is not None
+
+    resp = authenticated_client.delete(f"/v1/oauth/connections/{created['id']}")
+
+    assert resp.status_code == 204
+    assert credential_blobs.read(service, "default") is None
+
+
 def test_replace_key_on_missing_connection_404(authenticated_client) -> None:
     resp = authenticated_client.put(
         "/v1/oauth/connections/00000000-0000-0000-0000-000000000000/api-key",
         json={"api_key": _KEY},
     )
     assert resp.status_code == 404
+
+
+def test_replace_key_on_oauth_connection_has_actionable_message(authenticated_client) -> None:
+    from uuid import uuid4
+
+    from aigateway.core.oauth.store import OAuthConnectionStore
+
+    seed = _create(authenticated_client, label="seed-for-oauth-replace-test").json()
+
+    async def _create_oauth_connection() -> str:
+        store = OAuthConnectionStore()
+        conn = await store.create_pending(
+            account_id=seed["account_id"],
+            provider="anthropic",
+            label="oauth-only",
+            connection_id=uuid4(),
+        )
+        return str(conn.id)
+
+    connection_id = authenticated_client.portal.call(_create_oauth_connection)
+    resp = authenticated_client.put(
+        f"/v1/oauth/connections/{connection_id}/api-key",
+        json={"api_key": _KEY},
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == {
+        "code": "connection_not_api_key",
+        "message": "Connection does not use API-key authentication",
+    }
+
+
+def test_replace_key_unknown_provider_error_includes_provider(
+    authenticated_client, monkeypatch
+) -> None:
+    created = _create(authenticated_client, label="missing-provider").json()
+    monkeypatch.setattr(authenticated_client.app.state.providers, "get", lambda _provider: None)
+
+    resp = authenticated_client.put(
+        f"/v1/oauth/connections/{created['id']}/api-key",
+        json={"api_key": _KEY},
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == {"code": "unknown_provider", "provider": "anthropic"}
 
 
 def test_api_key_connection_token_endpoint_rejected(authenticated_client) -> None:
@@ -192,6 +289,27 @@ def test_create_api_key_atomic_on_persist_failure(authenticated_client, monkeypa
         pass  # TestClient re-raises server exceptions; the invariant is what matters
     listing = authenticated_client.get("/v1/oauth/connections").json()["connections"]
     assert all(c["label"] != "atomic" for c in listing)
+
+
+def test_create_api_key_persist_failure_returns_sanitized_5xx(
+    authenticated_client, monkeypatch
+) -> None:
+    """Credential-store failures should be structured and must not echo the key."""
+    leak_marker = "sk-ant-api03-create-key-that-must-not-leak"
+
+    async def _boom(*_a, **_k):
+        raise RuntimeError(f"credential store failed for {leak_marker}")
+
+    monkeypatch.setattr(authenticated_client.app.state.credential_store, "write", _boom)
+
+    with _server_errors_as_responses(authenticated_client):
+        resp = _create(authenticated_client, label="atomic-http", api_key=leak_marker)
+
+    assert resp.status_code == 503
+    assert resp.json()["detail"]["code"] == "credential_store_unavailable"
+    assert leak_marker not in resp.text
+    listing = authenticated_client.get("/v1/oauth/connections").json()["connections"]
+    assert all(c["label"] != "atomic-http" for c in listing)
 
 
 def test_create_api_key_deletes_blob_when_row_create_fails(

--- a/apps/aigateway/tests/unit/test_oauth_connection_api_key_routes.py
+++ b/apps/aigateway/tests/unit/test_oauth_connection_api_key_routes.py
@@ -1,0 +1,119 @@
+"""API-key connection endpoints (SF-291 / D-AIGW-018).
+
+POST /v1/oauth/connections/api-key       — create an api-key connection
+PUT  /v1/oauth/connections/{id}/api-key  — replace the key
+
+The key is written to the SAME credential-blob slot the chat path reads for a
+connection (credential_key_for(account_id, connection.id)), encrypted at rest,
+and never echoed back.
+"""
+
+from __future__ import annotations
+
+import json
+
+from aigateway.core.oauth.store import credential_key_for
+from aigateway.plugins.anthropic_provider.auth import (
+    credential_service_for as anthropic_service_for,
+)
+
+_KEY = "sk-ant-api03-test-connection-key"
+
+
+def _create(client, *, provider="anthropic", label: str | None = "work", api_key=_KEY):
+    body: dict[str, str] = {"provider": provider, "api_key": api_key}
+    if label is not None:
+        body["label"] = label
+    return client.post("/v1/oauth/connections/api-key", json=body)
+
+
+def test_create_api_key_connection_is_active_and_typed(authenticated_client) -> None:
+    resp = _create(authenticated_client)
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["status"] == "active"
+    assert data["auth_type"] == "api_key"
+    assert data["label"] == "work"
+    assert data["provider"] == "anthropic"
+    # The raw key must never be echoed back.
+    assert _KEY not in resp.text
+
+
+def test_create_writes_key_to_chat_read_slot_encrypted(
+    authenticated_client, credential_blobs
+) -> None:
+    resp = _create(authenticated_client)
+    data = resp.json()
+    service = anthropic_service_for(credential_key_for(data["account_id"], data["id"]))
+    # Decrypted blob is the api-key blob the chat path expects.
+    decrypted = credential_blobs.read(service, "default")
+    assert json.loads(decrypted) == {"auth_type": "api_key", "api_key": _KEY}
+    # At-rest ciphertext does not contain the plaintext key.
+    assert _KEY not in (credential_blobs.read_raw(service, "default") or "")
+
+
+def test_create_anthropic_requires_label(authenticated_client) -> None:
+    resp = _create(authenticated_client, label=None)
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["code"] == "label_required"
+
+
+def test_create_duplicate_label_conflicts(authenticated_client) -> None:
+    assert _create(authenticated_client, label="dup").status_code == 201
+    resp = _create(authenticated_client, label="dup")
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["code"] == "label_conflict"
+
+
+def test_create_codex_is_api_key_not_supported(authenticated_client) -> None:
+    resp = _create(authenticated_client, provider="codex", label="cdx")
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["code"] == "api_key_not_supported"
+
+
+def test_create_short_key_rejected(authenticated_client) -> None:
+    resp = _create(authenticated_client, api_key="short")
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["code"] == "invalid_api_key"
+
+
+def test_create_requires_auth(client) -> None:
+    resp = _create(client)
+    assert resp.status_code == 401
+
+
+def test_list_connections_exposes_auth_type(authenticated_client) -> None:
+    _create(authenticated_client, label="listed")
+    listing = authenticated_client.get("/v1/oauth/connections")
+    assert listing.status_code == 200
+    rows = listing.json()["connections"]
+    assert any(c["label"] == "listed" and c["auth_type"] == "api_key" for c in rows)
+
+
+def test_replace_key_updates_blob(authenticated_client, credential_blobs) -> None:
+    created = _create(authenticated_client, label="rotate").json()
+    new_key = "sk-ant-api03-rotated-key-value"
+    resp = authenticated_client.put(
+        f"/v1/oauth/connections/{created['id']}/api-key",
+        json={"api_key": new_key},
+    )
+    assert resp.status_code == 200, resp.text
+    assert new_key not in resp.text
+    service = anthropic_service_for(credential_key_for(created["account_id"], created["id"]))
+    assert json.loads(credential_blobs.read(service, "default"))["api_key"] == new_key
+
+
+def test_replace_key_on_missing_connection_404(authenticated_client) -> None:
+    resp = authenticated_client.put(
+        "/v1/oauth/connections/00000000-0000-0000-0000-000000000000/api-key",
+        json={"api_key": _KEY},
+    )
+    assert resp.status_code == 404
+
+
+def test_api_key_connection_token_endpoint_rejected(authenticated_client) -> None:
+    """An api-key connection has no OAuth token; /token must 400, not mint one."""
+    created = _create(authenticated_client, label="notoken").json()
+    resp = authenticated_client.get(f"/v1/oauth/connections/{created['id']}/token")
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["code"] == "connection_not_oauth"

--- a/apps/aigateway/tests/unit/test_oauth_connection_api_key_routes.py
+++ b/apps/aigateway/tests/unit/test_oauth_connection_api_key_routes.py
@@ -143,6 +143,38 @@ def test_create_missing_provider_does_not_echo_key(authenticated_client) -> None
         assert "input" not in err
 
 
+def test_errored_api_key_connection_recovers_via_replace_key(authenticated_client) -> None:
+    """An api-key connection that errored (e.g. a bad key) keeps its label and
+    is recoverable via Replace key, which re-activates it (review RF2-1)."""
+    from uuid import UUID
+
+    from aigateway.core.oauth.store import OAuthConnectionStore
+
+    created = _create(authenticated_client, label="recover").json()
+    cid = created["id"]
+    account_id = created["account_id"]
+
+    async def _force_error() -> None:
+        store = OAuthConnectionStore()
+        conn = await store.get(account_id, UUID(cid))
+        assert conn is not None
+        await store.mark_error(conn, "bad key")
+
+    authenticated_client.portal.call(_force_error)
+
+    errored = authenticated_client.get(f"/v1/oauth/connections/{cid}").json()
+    assert errored["status"] == "error"
+    assert errored["label"] == "recover"  # label preserved, NOT "error:<id>"
+
+    resp = authenticated_client.put(
+        f"/v1/oauth/connections/{cid}/api-key",
+        json={"api_key": "sk-ant-api03-fresh-good-key"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "active"
+    assert resp.json()["label"] == "recover"
+
+
 def test_create_api_key_atomic_on_persist_failure(authenticated_client, monkeypatch) -> None:
     """If the credential write fails, no active orphan connection row is left
     behind (review F4 — persist before activating the row)."""

--- a/apps/aigateway/tests/unit/test_oauth_connection_api_key_routes.py
+++ b/apps/aigateway/tests/unit/test_oauth_connection_api_key_routes.py
@@ -117,3 +117,44 @@ def test_api_key_connection_token_endpoint_rejected(authenticated_client) -> Non
     resp = authenticated_client.get(f"/v1/oauth/connections/{created['id']}/token")
     assert resp.status_code == 400
     assert resp.json()["detail"]["code"] == "connection_not_oauth"
+
+
+def test_refresh_on_api_key_connection_rejected_without_corrupting(authenticated_client) -> None:
+    """/refresh is OAuth-only: an api-key connection must be rejected (400
+    connection_not_oauth) and must NOT be flipped to error (review F2)."""
+    created = _create(authenticated_client, label="norefresh").json()
+    resp = authenticated_client.post(f"/v1/oauth/connections/{created['id']}/refresh")
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["code"] == "connection_not_oauth"
+    after = authenticated_client.get(f"/v1/oauth/connections/{created['id']}").json()
+    assert after["status"] == "active"
+    assert after["auth_type"] == "api_key"
+
+
+def test_create_missing_provider_does_not_echo_key(authenticated_client) -> None:
+    """A malformed body (missing provider) must 422 WITHOUT echoing the raw key
+    in the validation error input (review F1)."""
+    resp = authenticated_client.post(
+        "/v1/oauth/connections/api-key", json={"label": "w", "api_key": _KEY}
+    )
+    assert resp.status_code == 422
+    assert _KEY not in resp.text
+    for err in resp.json()["detail"]:
+        assert "input" not in err
+
+
+def test_create_api_key_atomic_on_persist_failure(authenticated_client, monkeypatch) -> None:
+    """If the credential write fails, no active orphan connection row is left
+    behind (review F4 — persist before activating the row)."""
+    store = authenticated_client.app.state.credential_store
+
+    async def _boom(*_a, **_k):
+        raise RuntimeError("credential store unavailable")
+
+    monkeypatch.setattr(store, "write", _boom)
+    try:
+        _create(authenticated_client, label="atomic")
+    except RuntimeError:
+        pass  # TestClient re-raises server exceptions; the invariant is what matters
+    listing = authenticated_client.get("/v1/oauth/connections").json()["connections"]
+    assert all(c["label"] != "atomic" for c in listing)

--- a/apps/aigateway/tests/unit/test_oauth_connection_api_key_routes.py
+++ b/apps/aigateway/tests/unit/test_oauth_connection_api_key_routes.py
@@ -165,6 +165,7 @@ def test_errored_api_key_connection_recovers_via_replace_key(authenticated_clien
     errored = authenticated_client.get(f"/v1/oauth/connections/{cid}").json()
     assert errored["status"] == "error"
     assert errored["label"] == "recover"  # label preserved, NOT "error:<id>"
+    assert errored["error_message"] == "bad key"
 
     resp = authenticated_client.put(
         f"/v1/oauth/connections/{cid}/api-key",
@@ -173,6 +174,7 @@ def test_errored_api_key_connection_recovers_via_replace_key(authenticated_clien
     assert resp.status_code == 200, resp.text
     assert resp.json()["status"] == "active"
     assert resp.json()["label"] == "recover"
+    assert resp.json()["error_message"] is None  # reactivate clears the error
 
 
 def test_create_api_key_atomic_on_persist_failure(authenticated_client, monkeypatch) -> None:
@@ -190,3 +192,31 @@ def test_create_api_key_atomic_on_persist_failure(authenticated_client, monkeypa
         pass  # TestClient re-raises server exceptions; the invariant is what matters
     listing = authenticated_client.get("/v1/oauth/connections").json()["connections"]
     assert all(c["label"] != "atomic" for c in listing)
+
+
+def test_create_api_key_deletes_blob_when_row_create_fails(
+    authenticated_client, credential_blobs, monkeypatch
+) -> None:
+    """If the key persists but the row create fails (e.g. label race -> Integrity
+    Error), the compensating cleanup deletes the orphan blob so no credential is
+    left without a connection (review F4 cleanup path)."""
+    from tortoise.exceptions import IntegrityError
+
+    from aigateway.core.oauth.store import OAuthConnectionStore
+
+    captured: dict = {}
+
+    async def _boom(self, **kwargs):  # noqa: ANN001
+        captured["account_id"] = kwargs["account_id"]
+        captured["connection_id"] = kwargs["connection_id"]
+        raise IntegrityError("label race")
+
+    monkeypatch.setattr(OAuthConnectionStore, "create_api_key", _boom)
+    resp = _create(authenticated_client, label="cleanup")
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["code"] == "label_conflict"
+    # The key was persisted before create; the except-branch must have removed it.
+    service = anthropic_service_for(
+        credential_key_for(captured["account_id"], captured["connection_id"])
+    )
+    assert credential_blobs.read(service, "default") is None

--- a/apps/aigateway/tests/unit/test_provider_supports_api_key.py
+++ b/apps/aigateway/tests/unit/test_provider_supports_api_key.py
@@ -1,0 +1,31 @@
+"""Per-provider API-key capability flag (SF-291).
+
+The desktop UI is capability-driven: it only offers the API-key option for
+providers whose gateway plugin reports ``supports_api_key()``. Anthropic and
+Gemini accept raw keys; Codex rides the ChatGPT subscription endpoint and does
+not.
+"""
+
+from __future__ import annotations
+
+from aigateway.plugins.anthropic_provider.plugin import PLUGIN as ANTHROPIC
+from aigateway.plugins.codex_provider.plugin import PLUGIN as CODEX
+from aigateway.plugins.gemini_provider.plugin import PLUGIN as GEMINI
+from aigateway.plugins.ollama_provider.plugin import PLUGIN as OLLAMA
+
+
+def test_anthropic_supports_api_key() -> None:
+    assert ANTHROPIC.supports_api_key() is True
+
+
+def test_gemini_supports_api_key() -> None:
+    assert GEMINI.supports_api_key() is True
+
+
+def test_codex_does_not_support_api_key() -> None:
+    assert CODEX.supports_api_key() is False
+
+
+def test_ollama_does_not_support_api_key() -> None:
+    # Ollama is local/no-auth; it does not take a provider API key.
+    assert OLLAMA.supports_api_key() is False

--- a/apps/desktop/src/main/ipc/__tests__/backend-status-ipc.test.ts
+++ b/apps/desktop/src/main/ipc/__tests__/backend-status-ipc.test.ts
@@ -312,6 +312,29 @@ describe('backend status IPC', () => {
       expect(result).toEqual({ ok: false, status: 400, message: 'api_key_not_supported' });
     });
 
+    it('surfaces the first error from an array-shaped 422 detail', async () => {
+      // FastAPI validation errors (incl. the redacted ones) return detail as an
+      // array; the message must be actionable, not a bare status (SF-291 R3-4).
+      const fetchMock = vi.fn(async () => ({
+        ok: false,
+        status: 422,
+        json: async () => ({
+          detail: [
+            {
+              type: 'string_pattern_mismatch',
+              loc: ['body', 'label'],
+              msg: 'String should match pattern',
+            },
+          ],
+        }),
+      }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const result = await getHandler()(event, 'claude', 'bad#label', 'sk-ant-api03-xyz-1234');
+
+      expect(result).toEqual({ ok: false, status: 422, message: 'String should match pattern' });
+    });
+
     it('rejects too-short keys without touching the network', async () => {
       const fetchMock = vi.fn();
       vi.stubGlobal('fetch', fetchMock);

--- a/apps/desktop/src/main/ipc/__tests__/backend-status-ipc.test.ts
+++ b/apps/desktop/src/main/ipc/__tests__/backend-status-ipc.test.ts
@@ -252,4 +252,121 @@ describe('backend status IPC', () => {
       expect(result).toEqual({ ok: false, status: 500, message: undefined });
     });
   });
+
+  describe('createConnectionApiKey', () => {
+    const event = { senderFrame: { url: 'file:///Applications/ScreamingFace.app/index.html' } };
+
+    const getHandler = () => {
+      registerBackendStatusHandlers();
+      const handler = mocks.ipcHandlers.get('backends:createConnectionApiKey');
+      if (!handler) throw new Error('createConnectionApiKey handler was not registered');
+      return handler;
+    };
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('POSTs label + key to the connections api-key proxy', async () => {
+      const fetchMock = vi.fn(async () => ({ ok: true, status: 201 }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const result = await getHandler()(event, 'claude', 'work', 'sk-ant-api03-xyz-1234');
+
+      expect(result).toEqual({ ok: true });
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://127.0.0.1:8001/claude/auth/connections/api-key',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'X-SF-Desktop-Secret': 'desktop-secret',
+            'Content-Type': 'application/json',
+          }),
+          body: JSON.stringify({ api_key: 'sk-ant-api03-xyz-1234', label: 'work' }),
+        }),
+      );
+    });
+
+    it('omits the label when none is provided', async () => {
+      const fetchMock = vi.fn(async () => ({ ok: true, status: 201 }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      await getHandler()(event, 'gemini', undefined, 'sk-gemini-xyz-1234');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://127.0.0.1:8001/gemini/auth/connections/api-key',
+        expect.objectContaining({ body: JSON.stringify({ api_key: 'sk-gemini-xyz-1234' }) }),
+      );
+    });
+
+    it('surfaces the gateway error code on failure', async () => {
+      const fetchMock = vi.fn(async () => ({
+        ok: false,
+        status: 400,
+        json: async () => ({ detail: { code: 'api_key_not_supported' } }),
+      }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const result = await getHandler()(event, 'codex', 'cdx', 'sk-proj-xyz-1234');
+
+      expect(result).toEqual({ ok: false, status: 400, message: 'api_key_not_supported' });
+    });
+
+    it('rejects too-short keys without touching the network', async () => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+
+      const result = await getHandler()(event, 'claude', 'work', 'abc');
+
+      expect(result).toEqual({
+        ok: false,
+        status: 400,
+        message: 'API key is missing or too short',
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setConnectionApiKey', () => {
+    const event = { senderFrame: { url: 'file:///Applications/ScreamingFace.app/index.html' } };
+    const cid = '11111111-1111-1111-1111-111111111111';
+
+    const getHandler = () => {
+      registerBackendStatusHandlers();
+      const handler = mocks.ipcHandlers.get('backends:setConnectionApiKey');
+      if (!handler) throw new Error('setConnectionApiKey handler was not registered');
+      return handler;
+    };
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('PUTs the new key to the connection api-key proxy', async () => {
+      const fetchMock = vi.fn(async () => ({ ok: true, status: 200 }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const result = await getHandler()(event, 'claude', cid, 'sk-ant-api03-rotated-key');
+
+      expect(result).toEqual({ ok: true });
+      expect(fetchMock).toHaveBeenCalledWith(
+        `http://127.0.0.1:8001/claude/auth/connections/${cid}/api-key`,
+        expect.objectContaining({
+          method: 'PUT',
+          body: JSON.stringify({ api_key: 'sk-ant-api03-rotated-key' }),
+        }),
+      );
+    });
+
+    it('rejects an unsafe connection id without touching the network', async () => {
+      mocks.isSafeOAuthConnectionId.mockReturnValue(false);
+      const fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+
+      const result = await getHandler()(event, 'claude', 'bad id', 'sk-ant-api03-rotated-key');
+
+      expect(result).toEqual({ ok: false, status: 400, message: 'invalid connection id' });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/desktop/src/main/ipc/backend-status.ipc.ts
+++ b/apps/desktop/src/main/ipc/backend-status.ipc.ts
@@ -503,8 +503,19 @@ function currentGatewayRedirectPorts(): string[] {
 
 async function responseMessage(resp: Response): Promise<string | undefined> {
   try {
-    const body = (await resp.json()) as { detail?: { code?: string; message?: string } };
-    return body.detail?.message ?? body.detail?.code;
+    const body = (await resp.json()) as {
+      detail?:
+        | { code?: string; message?: string }
+        | Array<{ msg?: string; code?: string; message?: string }>;
+    };
+    const detail = body.detail;
+    // FastAPI validation errors (incl. the redacted ones) return detail as an
+    // ARRAY of error objects; surface the first error's message so an invalid
+    // label/body shows an actionable reason, not a bare status (SF-291 R3-4).
+    if (Array.isArray(detail)) {
+      return detail[0]?.msg ?? detail[0]?.message ?? detail[0]?.code;
+    }
+    return detail?.message ?? detail?.code;
   } catch {
     return undefined;
   }

--- a/apps/desktop/src/main/ipc/backend-status.ipc.ts
+++ b/apps/desktop/src/main/ipc/backend-status.ipc.ts
@@ -338,6 +338,75 @@ export function registerBackendStatusHandlers(): void {
   );
 
   ipcMain.handle(
+    'backends:createConnectionApiKey',
+    async (event, backend: string, label: string | undefined, apiKey: string) => {
+      requireTrustedIpcSender(event);
+      if (!isSafeBackendName(backend)) {
+        return { ok: false, status: 400, message: 'invalid backend name' };
+      }
+      if (typeof apiKey !== 'string' || apiKey.trim().length < 8) {
+        return { ok: false, status: 400, message: 'API key is missing or too short' };
+      }
+
+      const sfBaseUrl = backendStatusService.getServerUrl();
+      if (!sfBaseUrl) {
+        return { ok: false, status: 0, message: 'SF server is not running' };
+      }
+      try {
+        // The key transits to the SF server, which proxies it to the gateway's
+        // credential store. Never log it.
+        const body: { label?: string; api_key: string } = { api_key: apiKey.trim() };
+        const trimmedLabel = label?.trim();
+        if (trimmedLabel) body.label = trimmedLabel;
+        const resp = await fetch(`${sfBaseUrl}/${backend}/auth/connections/api-key`, {
+          method: 'POST',
+          headers: { ...desktopSecretHeader(), 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        if (resp.ok) return { ok: true };
+        return { ok: false, status: resp.status, message: await responseMessage(resp) };
+      } catch {
+        return { ok: false, status: 0, message: 'gateway unreachable' };
+      }
+    },
+  );
+
+  ipcMain.handle(
+    'backends:setConnectionApiKey',
+    async (event, backend: string, connectionId: string, apiKey: string) => {
+      requireTrustedIpcSender(event);
+      if (!isSafeBackendName(backend)) {
+        return { ok: false, status: 400, message: 'invalid backend name' };
+      }
+      if (!isSafeOAuthConnectionId(connectionId)) {
+        return { ok: false, status: 400, message: 'invalid connection id' };
+      }
+      if (typeof apiKey !== 'string' || apiKey.trim().length < 8) {
+        return { ok: false, status: 400, message: 'API key is missing or too short' };
+      }
+
+      const sfBaseUrl = backendStatusService.getServerUrl();
+      if (!sfBaseUrl) {
+        return { ok: false, status: 0, message: 'SF server is not running' };
+      }
+      try {
+        const resp = await fetch(
+          `${sfBaseUrl}/${backend}/auth/connections/${encodeURIComponent(connectionId)}/api-key`,
+          {
+            method: 'PUT',
+            headers: { ...desktopSecretHeader(), 'Content-Type': 'application/json' },
+            body: JSON.stringify({ api_key: apiKey.trim() }),
+          },
+        );
+        if (resp.ok) return { ok: true };
+        return { ok: false, status: resp.status, message: await responseMessage(resp) };
+      } catch {
+        return { ok: false, status: 0, message: 'gateway unreachable' };
+      }
+    },
+  );
+
+  ipcMain.handle(
     'backends:deleteConnection',
     async (event, backend: string, connectionId: string) => {
       requireTrustedIpcSender(event);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -79,6 +79,10 @@ const api: ElectronAPI = {
     setProfileApiKey: (backend, profileName, apiKey) =>
       ipcRenderer.invoke('backends:setProfileApiKey', backend, profileName, apiKey),
     listConnections: (backend) => ipcRenderer.invoke('backends:listConnections', backend),
+    createConnectionApiKey: (backend, label, apiKey) =>
+      ipcRenderer.invoke('backends:createConnectionApiKey', backend, label, apiKey),
+    setConnectionApiKey: (backend, connectionId, apiKey) =>
+      ipcRenderer.invoke('backends:setConnectionApiKey', backend, connectionId, apiKey),
     deleteConnection: (backend, connectionId) =>
       ipcRenderer.invoke('backends:deleteConnection', backend, connectionId),
     refreshConnection: (backend, connectionId) =>

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -88,6 +88,9 @@ export interface ProviderAuthStatus {
   provider: string;
   profile: string;
   state: 'authenticated' | 'pending' | 'missing_profile' | 'error';
+  // Whether this provider accepts a raw API key (vs OAuth-only). The UI only
+  // offers the API-key option where true. Absent => false (backward compat).
+  supports_api_key?: boolean;
 }
 
 export interface BackendStatusV2 {
@@ -151,6 +154,7 @@ export interface OAuthConnection {
   provider: string;
   label: string;
   status: OAuthConnectionStatus;
+  auth_type?: BackendProfileAuthType;
   account?: OAuthConnectionAccount | null;
   created_at?: string;
   last_used_at?: string | null;
@@ -167,6 +171,12 @@ export interface ListConnectionsResult {
 export interface DeleteConnectionResult {
   ok: boolean;
   status?: number;
+}
+
+export interface SetConnectionApiKeyResult {
+  ok: boolean;
+  status?: number;
+  message?: string;
 }
 
 export interface RefreshConnectionResult {
@@ -316,6 +326,16 @@ export interface ElectronAPI {
       apiKey: string,
     ) => Promise<SetProfileApiKeyResult>;
     listConnections: (backend: string) => Promise<ListConnectionsResult>;
+    createConnectionApiKey: (
+      backend: string,
+      label: string | undefined,
+      apiKey: string,
+    ) => Promise<SetConnectionApiKeyResult>;
+    setConnectionApiKey: (
+      backend: string,
+      connectionId: string,
+      apiKey: string,
+    ) => Promise<SetConnectionApiKeyResult>;
     deleteConnection: (backend: string, connectionId: string) => Promise<DeleteConnectionResult>;
     refreshConnection: (backend: string, connectionId: string) => Promise<RefreshConnectionResult>;
     getPendingAuthState: (backend: string, profileName?: string) => Promise<string | null>;

--- a/apps/desktop/src/renderer/src/components/server/BackendStatusPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/server/BackendStatusPanel.tsx
@@ -724,28 +724,31 @@ function ConnectionRow({
           )}
         </div>
         <div className="flex items-center gap-2 shrink-0">
-          {connection.status === 'active' &&
-            (isApiKey ? (
-              <button
-                disabled={busy}
-                onClick={() => {
-                  setReplacingKey((v) => !v);
-                  setKeyInput('');
-                  setError(null);
-                }}
-                className="rounded bg-chart-1/20 px-2 py-0.5 text-xs font-medium text-chart-1 hover:bg-chart-1/30 transition-colors disabled:opacity-60"
-              >
-                {busy ? 'Working…' : replacingKey ? 'Cancel' : 'Replace key'}
-              </button>
-            ) : (
-              <button
-                disabled={busy}
-                onClick={onRefreshConnection}
-                className="rounded bg-chart-1/20 px-2 py-0.5 text-xs font-medium text-chart-1 hover:bg-chart-1/30 transition-colors disabled:opacity-60"
-              >
-                {busy ? 'Working…' : 'Refresh'}
-              </button>
-            ))}
+          {isApiKey
+            ? // An api-key connection is re-keyed in place, so Replace key is
+              // available while active AND after it errored (recovery, RF2-1).
+              (connection.status === 'active' || connection.status === 'error') && (
+                <button
+                  disabled={busy}
+                  onClick={() => {
+                    setReplacingKey((v) => !v);
+                    setKeyInput('');
+                    setError(null);
+                  }}
+                  className="rounded bg-chart-1/20 px-2 py-0.5 text-xs font-medium text-chart-1 hover:bg-chart-1/30 transition-colors disabled:opacity-60"
+                >
+                  {busy ? 'Working…' : replacingKey ? 'Cancel' : 'Replace key'}
+                </button>
+              )
+            : connection.status === 'active' && (
+                <button
+                  disabled={busy}
+                  onClick={onRefreshConnection}
+                  className="rounded bg-chart-1/20 px-2 py-0.5 text-xs font-medium text-chart-1 hover:bg-chart-1/30 transition-colors disabled:opacity-60"
+                >
+                  {busy ? 'Working…' : 'Refresh'}
+                </button>
+              )}
           <button
             disabled={busy}
             onClick={onDelete}

--- a/apps/desktop/src/renderer/src/components/server/BackendStatusPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/server/BackendStatusPanel.tsx
@@ -675,6 +675,10 @@ function ConnectionRow({
       } else {
         setError(result.message ?? `Replace failed${result.status ? ` (${result.status})` : ''}`);
       }
+    } catch (err) {
+      // Defensive: the IPC handler normally returns {ok:false} rather than
+      // rejecting, but never leave a rejection unsurfaced (SF-291 R3-3).
+      setError(`Replace failed — ${err instanceof Error ? err.message : String(err)}`);
     } finally {
       setBusy(false);
       onChanged();

--- a/apps/desktop/src/renderer/src/components/server/BackendStatusPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/server/BackendStatusPanel.tsx
@@ -818,6 +818,9 @@ function ConnectionsSubPanel({
   const [addError, setAddError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  // API-key saving is tracked separately from `submitting` (OAuth) so it never
+  // feeds oauthInFlight / the "Waiting for browser sign-in" UI (SF-291 F5).
+  const [savingKey, setSavingKey] = useState(false);
   const [pendingConnectionId, setPendingConnectionId] = useState<string | null>(null);
   const [pasteCode, setPasteCode] = useState('');
   const [pasteBusy, setPasteBusy] = useState(false);
@@ -945,7 +948,7 @@ function ConnectionsSubPanel({
         setAddError('Paste a valid API key');
         return;
       }
-      setSubmitting(true);
+      setSavingKey(true);
       setAddError(null);
       setNotice(null);
       void (async () => {
@@ -969,7 +972,7 @@ function ConnectionsSubPanel({
         } catch (err) {
           setAddError(`Saving key failed — ${err instanceof Error ? err.message : String(err)}`);
         } finally {
-          setSubmitting(false);
+          setSavingKey(false);
           void refresh();
         }
       })();
@@ -1043,7 +1046,7 @@ function ConnectionsSubPanel({
           {supportsApiKey && (
             <select
               value={authType}
-              disabled={submitting}
+              disabled={submitting || savingKey}
               onChange={(e) => {
                 setAuthType(e.target.value as 'oauth' | 'api_key');
                 setAddError(null);
@@ -1060,7 +1063,7 @@ function ConnectionsSubPanel({
               autoFocus
               type="text"
               value={label}
-              disabled={submitting}
+              disabled={submitting || savingKey}
               onChange={(e) => {
                 setLabel(e.target.value);
                 setAddError(null);
@@ -1084,7 +1087,7 @@ function ConnectionsSubPanel({
               type="password"
               value={apiKey}
               autoComplete="off"
-              disabled={submitting}
+              disabled={submitting || savingKey}
               onChange={(e) => {
                 setApiKey(e.target.value);
                 setAddError(null);
@@ -1102,15 +1105,15 @@ function ConnectionsSubPanel({
           )}
           <button
             type="submit"
-            disabled={submitting}
+            disabled={submitting || savingKey}
             className="rounded bg-chart-1/20 px-2 py-0.5 text-xs font-medium text-chart-1 hover:bg-chart-1/30 disabled:opacity-60"
           >
-            {authType === 'api_key' ? (submitting ? 'Saving…' : 'Confirm') : 'Start'}
+            {authType === 'api_key' ? (savingKey ? 'Saving…' : 'Confirm') : 'Start'}
           </button>
           <button
             type="button"
             onClick={onCancel}
-            disabled={submitting}
+            disabled={submitting || savingKey}
             className="text-xs text-muted-foreground hover:text-foreground disabled:opacity-60"
           >
             Cancel

--- a/apps/desktop/src/renderer/src/components/server/BackendStatusPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/server/BackendStatusPanel.tsx
@@ -627,11 +627,14 @@ function ConnectionRow({
 }) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [replacingKey, setReplacingKey] = useState(false);
+  const [keyInput, setKeyInput] = useState('');
   const cfg = connectionStateConfig[connection.status] ?? {
     dot: 'bg-muted',
     label: connection.status,
   };
   const isPending = connection.status === 'pending';
+  const isApiKey = connection.auth_type === 'api_key';
   const accountLabel = connectionAccountLabel(connection);
 
   const onRefreshConnection = async (): Promise<void> => {
@@ -644,6 +647,33 @@ function ConnectionRow({
       );
       if (!result.ok) {
         setError(result.message ?? `Refresh failed${result.status ? ` (${result.status})` : ''}`);
+      }
+    } finally {
+      setBusy(false);
+      onChanged();
+    }
+  };
+
+  const onReplaceKey = async (e?: React.FormEvent): Promise<void> => {
+    e?.preventDefault();
+    const key = keyInput.trim();
+    if (key.length < 8) {
+      setError('Paste a valid API key');
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await window.electronAPI.backends.setConnectionApiKey(
+        backendName,
+        connection.id,
+        key,
+      );
+      if (result.ok) {
+        setReplacingKey(false);
+        setKeyInput('');
+      } else {
+        setError(result.message ?? `Replace failed${result.status ? ` (${result.status})` : ''}`);
       }
     } finally {
       setBusy(false);
@@ -678,6 +708,11 @@ function ConnectionRow({
             <span className={cn('relative inline-flex h-2 w-2 rounded-none', cfg.dot)} />
           </span>
           <span className="text-xs font-medium text-foreground truncate">{connection.label}</span>
+          {isApiKey && (
+            <span className="shrink-0 rounded bg-chart-1/15 px-1.5 py-0.5 text-[10px] font-medium text-chart-1">
+              API key
+            </span>
+          )}
           {accountLabel && (
             <span className="text-xs text-muted-foreground truncate">{accountLabel}</span>
           )}
@@ -689,15 +724,28 @@ function ConnectionRow({
           )}
         </div>
         <div className="flex items-center gap-2 shrink-0">
-          {connection.status === 'active' && (
-            <button
-              disabled={busy}
-              onClick={onRefreshConnection}
-              className="rounded bg-chart-1/20 px-2 py-0.5 text-xs font-medium text-chart-1 hover:bg-chart-1/30 transition-colors disabled:opacity-60"
-            >
-              {busy ? 'Working…' : 'Refresh'}
-            </button>
-          )}
+          {connection.status === 'active' &&
+            (isApiKey ? (
+              <button
+                disabled={busy}
+                onClick={() => {
+                  setReplacingKey((v) => !v);
+                  setKeyInput('');
+                  setError(null);
+                }}
+                className="rounded bg-chart-1/20 px-2 py-0.5 text-xs font-medium text-chart-1 hover:bg-chart-1/30 transition-colors disabled:opacity-60"
+              >
+                {busy ? 'Working…' : replacingKey ? 'Cancel' : 'Replace key'}
+              </button>
+            ) : (
+              <button
+                disabled={busy}
+                onClick={onRefreshConnection}
+                className="rounded bg-chart-1/20 px-2 py-0.5 text-xs font-medium text-chart-1 hover:bg-chart-1/30 transition-colors disabled:opacity-60"
+              >
+                {busy ? 'Working…' : 'Refresh'}
+              </button>
+            ))}
           <button
             disabled={busy}
             onClick={onDelete}
@@ -708,6 +756,43 @@ function ConnectionRow({
           </button>
         </div>
       </div>
+      {replacingKey && (
+        <form
+          onSubmit={onReplaceKey}
+          className="flex items-center gap-2 mt-1 pl-4"
+          aria-label={`Replace API key for ${connection.label}`}
+        >
+          <input
+            autoFocus
+            type="password"
+            value={keyInput}
+            autoComplete="off"
+            disabled={busy}
+            onChange={(e) => {
+              setKeyInput(e.target.value);
+              setError(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                setReplacingKey(false);
+                setKeyInput('');
+                setError(null);
+              }
+            }}
+            placeholder="paste new API key"
+            aria-label="New API key"
+            className="flex-1 rounded border border-border bg-background px-2 py-0.5 text-xs font-mono"
+          />
+          <button
+            type="submit"
+            disabled={busy}
+            className="rounded bg-chart-1/20 px-2 py-0.5 text-xs font-medium text-chart-1 hover:bg-chart-1/30 disabled:opacity-60"
+          >
+            {busy ? 'Saving…' : 'Save'}
+          </button>
+        </form>
+      )}
       {error && <p className="mt-1 pl-4 text-xs text-destructive">{error}</p>}
     </div>
   );
@@ -716,16 +801,20 @@ function ConnectionRow({
 function ConnectionsSubPanel({
   name,
   requiresLabel,
+  supportsApiKey,
   onSummaryChange,
 }: {
   name: string;
   requiresLabel: boolean;
+  supportsApiKey: boolean;
   onSummaryChange?: (summary: ConnectionAuthSummary) => void;
 }) {
   const [connections, setConnections] = useState<OAuthConnection[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [adding, setAdding] = useState(false);
   const [label, setLabel] = useState('');
+  const [authType, setAuthType] = useState<'oauth' | 'api_key'>('oauth');
+  const [apiKey, setApiKey] = useState('');
   const [addError, setAddError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -847,6 +936,45 @@ function ConnectionsSubPanel({
       setAddError('Connection already exists');
       return;
     }
+    if (authType === 'api_key') {
+      // API-key connections need no browser round-trip: store the key and the
+      // gateway marks the connection active immediately. Keep the form open on
+      // failure so the user can correct the key.
+      const key = apiKey.trim();
+      if (key.length < 8) {
+        setAddError('Paste a valid API key');
+        return;
+      }
+      setSubmitting(true);
+      setAddError(null);
+      setNotice(null);
+      void (async () => {
+        try {
+          const result = await window.electronAPI.backends.createConnectionApiKey(
+            name,
+            trimmed || undefined,
+            key,
+          );
+          if (result.ok) {
+            setAdding(false);
+            setLabel('');
+            setApiKey('');
+            setAuthType('oauth');
+            setNotice('API key saved.');
+          } else {
+            setAddError(
+              `Saving key failed — ${result.message ?? result.status ?? 'unknown error'}`,
+            );
+          }
+        } catch (err) {
+          setAddError(`Saving key failed — ${err instanceof Error ? err.message : String(err)}`);
+        } finally {
+          setSubmitting(false);
+          void refresh();
+        }
+      })();
+      return;
+    }
     setSubmitting(true);
     setAdding(false);
     setLabel('');
@@ -889,13 +1017,15 @@ function ConnectionsSubPanel({
   const onCancel = (): void => {
     setAdding(false);
     setLabel('');
+    setApiKey('');
+    setAuthType('oauth');
     setAddError(null);
   };
 
   return (
     <div className="ml-6 mt-1 mb-2 border-t border-border pt-2">
       {loaded && connections.length === 0 && !oauthInFlight && (
-        <p className="text-xs text-muted-foreground py-1">No OAuth connections yet.</p>
+        <p className="text-xs text-muted-foreground py-1">No connections yet.</p>
       )}
       {connections.map((connection) => (
         <ConnectionRow
@@ -909,12 +1039,28 @@ function ConnectionsSubPanel({
         />
       ))}
       {adding && !oauthInFlight ? (
-        <form onSubmit={onAdd} className="flex items-center gap-2 py-1.5">
-          {requiresLabel ? (
+        <form onSubmit={onAdd} className="flex flex-wrap items-center gap-2 py-1.5">
+          {supportsApiKey && (
+            <select
+              value={authType}
+              disabled={submitting}
+              onChange={(e) => {
+                setAuthType(e.target.value as 'oauth' | 'api_key');
+                setAddError(null);
+              }}
+              aria-label="Authentication type"
+              className="rounded border border-border bg-background px-1.5 py-0.5 text-xs disabled:opacity-60"
+            >
+              <option value="oauth">OAuth</option>
+              <option value="api_key">API key</option>
+            </select>
+          )}
+          {requiresLabel || authType === 'api_key' ? (
             <input
               autoFocus
               type="text"
               value={label}
+              disabled={submitting}
               onChange={(e) => {
                 setLabel(e.target.value);
                 setAddError(null);
@@ -926,23 +1072,46 @@ function ConnectionsSubPanel({
                 }
               }}
               placeholder="connection label (e.g. work-anthropic)"
-              className="flex-1 rounded border border-border bg-background px-2 py-0.5 text-xs"
+              className="flex-1 rounded border border-border bg-background px-2 py-0.5 text-xs disabled:opacity-60"
             />
           ) : (
             <span className="flex-1 text-xs text-muted-foreground">
               The label will be filled from the signed-in account identity.
             </span>
           )}
+          {authType === 'api_key' && (
+            <input
+              type="password"
+              value={apiKey}
+              autoComplete="off"
+              disabled={submitting}
+              onChange={(e) => {
+                setApiKey(e.target.value);
+                setAddError(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') {
+                  e.preventDefault();
+                  onCancel();
+                }
+              }}
+              placeholder="paste API key"
+              aria-label="API key"
+              className="flex-1 rounded border border-border bg-background px-2 py-0.5 text-xs font-mono disabled:opacity-60"
+            />
+          )}
           <button
             type="submit"
-            className="rounded bg-chart-1/20 px-2 py-0.5 text-xs font-medium text-chart-1 hover:bg-chart-1/30"
+            disabled={submitting}
+            className="rounded bg-chart-1/20 px-2 py-0.5 text-xs font-medium text-chart-1 hover:bg-chart-1/30 disabled:opacity-60"
           >
-            Start
+            {authType === 'api_key' ? (submitting ? 'Saving…' : 'Confirm') : 'Start'}
           </button>
           <button
             type="button"
             onClick={onCancel}
-            className="text-xs text-muted-foreground hover:text-foreground"
+            disabled={submitting}
+            className="text-xs text-muted-foreground hover:text-foreground disabled:opacity-60"
           >
             Cancel
           </button>
@@ -1074,6 +1243,7 @@ function BackendRow({
           <ConnectionsSubPanel
             name={name}
             requiresLabel={connectionRequiresLabel}
+            supportsApiKey={providerAuth?.supports_api_key ?? false}
             onSummaryChange={setConnectionSummary}
           />
         ) : (

--- a/apps/desktop/src/renderer/src/components/server/BackendStatusPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/server/BackendStatusPanel.tsx
@@ -656,6 +656,7 @@ function ConnectionRow({
 
   const onReplaceKey = async (e?: React.FormEvent): Promise<void> => {
     e?.preventDefault();
+    if (busy) return;
     const key = keyInput.trim();
     if (key.length < 8) {
       setError('Paste a valid API key');

--- a/apps/desktop/src/renderer/src/components/server/__tests__/BackendStatusPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/components/server/__tests__/BackendStatusPanel.test.tsx
@@ -512,6 +512,34 @@ describe('BackendStatusPanel v2 gateway status', () => {
     expect(await screen.findByText('Connected')).toBeTruthy();
   });
 
+  it('counts active OAuth and API-key connections together as ambiguous', async () => {
+    getStatus.mockResolvedValue(v2WithApiKey(true));
+    listConnections.mockResolvedValue({
+      connections: [
+        {
+          id: '00000000-0000-0000-0000-000000000012',
+          provider: 'anthropic',
+          label: 'work-oauth',
+          status: 'active',
+        },
+        {
+          id: '00000000-0000-0000-0000-000000000013',
+          provider: 'anthropic',
+          label: 'work-key',
+          status: 'active',
+          auth_type: 'api_key',
+        },
+      ],
+    });
+
+    render(<BackendStatusPanel />);
+
+    expect(await screen.findByText('work-oauth')).toBeTruthy();
+    expect(await screen.findByText('work-key')).toBeTruthy();
+    expect(await screen.findByText('Needs Auth')).toBeTruthy();
+    expect(screen.queryByText('Connected')).toBeNull();
+  });
+
   it('does not show the OAuth browser-sign-in UI during an api-key save', async () => {
     getStatus.mockResolvedValue(v2WithApiKey(true));
     let resolveSave: (v: { ok: boolean }) => void = () => {};
@@ -584,6 +612,44 @@ describe('BackendStatusPanel v2 gateway status', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
     expect(await screen.findByText(/Replace failed/i)).toBeTruthy();
+  });
+
+  it('ignores duplicate Replace-key submits while a save is busy', async () => {
+    getStatus.mockResolvedValue(v2WithApiKey(true));
+    listConnections.mockResolvedValue({
+      connections: [
+        {
+          id: '00000000-0000-0000-0000-000000000014',
+          provider: 'anthropic',
+          label: 'work-key',
+          status: 'active',
+          auth_type: 'api_key',
+        },
+      ],
+    });
+    let resolveSave: (v: { ok: boolean }) => void = () => {};
+    setConnectionApiKey.mockImplementation(
+      () =>
+        new Promise<{ ok: boolean }>((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+
+    render(<BackendStatusPanel />);
+    await screen.findByText('work-key');
+    fireEvent.click(screen.getByRole('button', { name: 'Replace key' }));
+    fireEvent.change(screen.getByLabelText('New API key'), {
+      target: { value: 'sk-ant-api03-new-key-value' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(await screen.findByRole('button', { name: 'Saving…' })).toBeTruthy();
+
+    fireEvent.submit(screen.getByRole('form', { name: /Replace API key/i }));
+
+    expect(setConnectionApiKey).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      resolveSave({ ok: true });
+    });
   });
 
   it('keeps v2 provider rows needing auth when connections are not active', async () => {

--- a/apps/desktop/src/renderer/src/components/server/__tests__/BackendStatusPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/components/server/__tests__/BackendStatusPanel.test.tsx
@@ -21,6 +21,12 @@ const setProfileApiKey = vi.fn(
 const getPendingAuthState = vi.fn(async (): Promise<string | null> => null);
 const exchangeOAuthCode = vi.fn(async () => ({ ok: true }) as { ok: boolean; message?: string });
 const listConnections = vi.fn(async () => ({ connections: [] }));
+const createConnectionApiKey = vi.fn(
+  async () => ({ ok: true }) as { ok: boolean; status?: number; message?: string },
+);
+const setConnectionApiKey = vi.fn(
+  async () => ({ ok: true }) as { ok: boolean; status?: number; message?: string },
+);
 const deleteConnection = vi.fn(async () => ({ ok: true }));
 const refreshConnection = vi.fn(async () => ({ ok: true }));
 const getPendingConnectionAuthState = vi.fn(async (): Promise<string | null> => null);
@@ -47,6 +53,8 @@ const exchangeOAuthConnectionCode = vi.fn(
     getPendingAuthState,
     exchangeOAuthCode,
     listConnections,
+    createConnectionApiKey,
+    setConnectionApiKey,
     deleteConnection,
     refreshConnection,
     getPendingConnectionAuthState,
@@ -93,6 +101,10 @@ beforeEach(() => {
   exchangeOAuthCode.mockResolvedValue({ ok: true });
   listConnections.mockClear();
   listConnections.mockResolvedValue({ connections: [] });
+  createConnectionApiKey.mockClear();
+  createConnectionApiKey.mockResolvedValue({ ok: true });
+  setConnectionApiKey.mockClear();
+  setConnectionApiKey.mockResolvedValue({ ok: true });
   deleteConnection.mockClear();
   deleteConnection.mockResolvedValue({ ok: true });
   refreshConnection.mockClear();
@@ -407,6 +419,97 @@ describe('BackendStatusPanel v2 gateway status', () => {
     expect(screen.queryByText('Needs Auth')).toBeNull();
     expect(screen.queryByText(/OAuth profile is missing or expired/i)).toBeNull();
     expect(listProfiles).not.toHaveBeenCalled();
+  });
+
+  const v2WithApiKey = (supports: boolean) => ({
+    version: 2,
+    gateway: {
+      mode: 'external',
+      managed_by_runner: false,
+      reachable: true,
+      authenticated: true,
+      auth_required: true,
+      url: 'https://gateway.example.com',
+    },
+    action: 'healthy',
+    backends: {
+      claude: {
+        authenticated: false,
+        action: 'reauth',
+        auth_kind: 'browser',
+        model: 'anthropic/claude-sonnet-4-5',
+      },
+    },
+    provider_auth: {
+      providers: {
+        claude: {
+          provider: 'anthropic',
+          profile: 'default',
+          state: 'missing_profile',
+          supports_api_key: supports,
+        },
+      },
+    },
+  });
+
+  it('offers the API-key option when the provider supports it', async () => {
+    getStatus.mockResolvedValue(v2WithApiKey(true));
+    render(<BackendStatusPanel />);
+    fireEvent.click(await screen.findByRole('button', { name: '+ Add Connection' }));
+    expect(screen.getByLabelText('Authentication type')).toBeTruthy();
+  });
+
+  it('hides the API-key option when the provider does not support it', async () => {
+    getStatus.mockResolvedValue(v2WithApiKey(false));
+    render(<BackendStatusPanel />);
+    fireEvent.click(await screen.findByRole('button', { name: '+ Add Connection' }));
+    expect(screen.queryByLabelText('Authentication type')).toBeNull();
+  });
+
+  it('adding via API key calls createConnectionApiKey and not OAuth', async () => {
+    getStatus.mockResolvedValue(v2WithApiKey(true));
+    render(<BackendStatusPanel />);
+    fireEvent.click(await screen.findByRole('button', { name: '+ Add Connection' }));
+    fireEvent.change(screen.getByLabelText('Authentication type'), {
+      target: { value: 'api_key' },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/connection label/i), {
+      target: { value: 'work' },
+    });
+    fireEvent.change(screen.getByLabelText('API key'), {
+      target: { value: 'sk-ant-api03-secret-key' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    await waitFor(() =>
+      expect(createConnectionApiKey).toHaveBeenCalledWith(
+        'claude',
+        'work',
+        'sk-ant-api03-secret-key',
+      ),
+    );
+    expect(authenticateOAuthConnection).not.toHaveBeenCalled();
+  });
+
+  it('renders an api-key connection with a badge and Replace key, no Refresh', async () => {
+    getStatus.mockResolvedValue(v2WithApiKey(true));
+    listConnections.mockResolvedValue({
+      connections: [
+        {
+          id: '00000000-0000-0000-0000-000000000009',
+          provider: 'anthropic',
+          label: 'work-key',
+          status: 'active',
+          auth_type: 'api_key',
+        },
+      ],
+    });
+    render(<BackendStatusPanel />);
+    expect(await screen.findByText('work-key')).toBeTruthy();
+    expect(screen.getByText('API key')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Replace key' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Refresh' })).toBeNull();
+    // An active api-key connection counts toward the connected indicator.
+    expect(await screen.findByText('Connected')).toBeTruthy();
   });
 
   it('keeps v2 provider rows needing auth when connections are not active', async () => {

--- a/apps/desktop/src/renderer/src/components/server/__tests__/BackendStatusPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/components/server/__tests__/BackendStatusPanel.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen, fireEvent, waitFor, within, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within, cleanup, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const authenticate = vi.fn();
@@ -534,7 +534,32 @@ describe('BackendStatusPanel v2 gateway status', () => {
     // OAuth "Waiting for browser sign-in" message must NOT appear (F5).
     expect(await screen.findByRole('button', { name: 'Saving…' })).toBeTruthy();
     expect(screen.queryByText(/Waiting for browser sign-in/i)).toBeNull();
-    resolveSave({ ok: true });
+    // Resolve inside act and wait for the post-save state to flush so the test
+    // leaves no un-acted update behind (RF2-2).
+    await act(async () => {
+      resolveSave({ ok: true });
+    });
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Saving…' })).toBeNull());
+  });
+
+  it('shows Replace key for an errored api-key connection (recovery)', async () => {
+    getStatus.mockResolvedValue(v2WithApiKey(true));
+    listConnections.mockResolvedValue({
+      connections: [
+        {
+          id: '00000000-0000-0000-0000-000000000010',
+          provider: 'anthropic',
+          label: 'work-key',
+          status: 'error',
+          auth_type: 'api_key',
+          error_message: 'bad key',
+        },
+      ],
+    });
+    render(<BackendStatusPanel />);
+    expect(await screen.findByText('work-key')).toBeTruthy();
+    // Even errored, an api-key connection can be re-keyed in place (RF2-1).
+    expect(screen.getByRole('button', { name: 'Replace key' })).toBeTruthy();
   });
 
   it('keeps v2 provider rows needing auth when connections are not active', async () => {

--- a/apps/desktop/src/renderer/src/components/server/__tests__/BackendStatusPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/components/server/__tests__/BackendStatusPanel.test.tsx
@@ -562,6 +562,30 @@ describe('BackendStatusPanel v2 gateway status', () => {
     expect(screen.getByRole('button', { name: 'Replace key' })).toBeTruthy();
   });
 
+  it('shows an inline error if a Replace-key IPC call rejects (defensive, R3-3)', async () => {
+    getStatus.mockResolvedValue(v2WithApiKey(true));
+    listConnections.mockResolvedValue({
+      connections: [
+        {
+          id: '00000000-0000-0000-0000-000000000011',
+          provider: 'anthropic',
+          label: 'work-key',
+          status: 'active',
+          auth_type: 'api_key',
+        },
+      ],
+    });
+    setConnectionApiKey.mockRejectedValueOnce(new Error('ipc exploded'));
+    render(<BackendStatusPanel />);
+    await screen.findByText('work-key');
+    fireEvent.click(screen.getByRole('button', { name: 'Replace key' }));
+    fireEvent.change(screen.getByLabelText('New API key'), {
+      target: { value: 'sk-ant-api03-new-key-value' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(await screen.findByText(/Replace failed/i)).toBeTruthy();
+  });
+
   it('keeps v2 provider rows needing auth when connections are not active', async () => {
     getStatus.mockResolvedValue({
       version: 2,

--- a/apps/desktop/src/renderer/src/components/server/__tests__/BackendStatusPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/components/server/__tests__/BackendStatusPanel.test.tsx
@@ -512,6 +512,31 @@ describe('BackendStatusPanel v2 gateway status', () => {
     expect(await screen.findByText('Connected')).toBeTruthy();
   });
 
+  it('does not show the OAuth browser-sign-in UI during an api-key save', async () => {
+    getStatus.mockResolvedValue(v2WithApiKey(true));
+    let resolveSave: (v: { ok: boolean }) => void = () => {};
+    createConnectionApiKey.mockImplementation(
+      () => new Promise((r) => (resolveSave = r as (v: { ok: boolean }) => void)),
+    );
+    render(<BackendStatusPanel />);
+    fireEvent.click(await screen.findByRole('button', { name: '+ Add Connection' }));
+    fireEvent.change(screen.getByLabelText('Authentication type'), {
+      target: { value: 'api_key' },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/connection label/i), {
+      target: { value: 'work' },
+    });
+    fireEvent.change(screen.getByLabelText('API key'), {
+      target: { value: 'sk-ant-api03-secret-key' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    // While the save is in flight the form stays visible ("Saving…") and the
+    // OAuth "Waiting for browser sign-in" message must NOT appear (F5).
+    expect(await screen.findByRole('button', { name: 'Saving…' })).toBeTruthy();
+    expect(screen.queryByText(/Waiting for browser sign-in/i)).toBeNull();
+    resolveSave({ ok: true });
+  });
+
   it('keeps v2 provider rows needing auth when connections are not active', async () => {
     getStatus.mockResolvedValue({
       version: 2,

--- a/apps/server/src/screamingface/core/app.py
+++ b/apps/server/src/screamingface/core/app.py
@@ -10,6 +10,9 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request, Response
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
 
 from screamingface.core.admin_router import register_admin_routes
 from screamingface.core.classes import ClassRegistry
@@ -100,6 +103,18 @@ def _activate_plugins(
             logger.debug("cleanup_stale for %s failed (non-fatal)", name, exc_info=True)
 
 
+async def _redact_validation_errors(_request: Request, exc: Exception) -> JSONResponse:
+    """Strip the echoed request body (``input``) from 422 errors.
+
+    FastAPI's default validation handler returns the raw submitted body in each
+    error; for the api-key proxy routes that body carries the raw key, so
+    echoing it leaks the secret into error responses and logs (SF-291 review
+    F1). Preserve type/loc/msg, drop ``input``."""
+    errors = exc.errors() if isinstance(exc, RequestValidationError) else []
+    cleaned = [{k: v for k, v in err.items() if k != "input"} for err in errors]
+    return JSONResponse(status_code=422, content=jsonable_encoder({"detail": cleaned}))
+
+
 def create_app(config: AppConfig | None = None) -> FastAPI:
     """Create and configure the FastAPI application with all registries."""
     logging.basicConfig(level=logging.INFO, format="%(levelname)s:     %(name)s - %(message)s")
@@ -117,6 +132,7 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
         version=config.version,
         lifespan=_build_lifespan(hooks, config),
     )
+    app.add_exception_handler(RequestValidationError, _redact_validation_errors)
 
     routes = RouteRegistry(app)
     frontends = FrontendRegistry()

--- a/apps/server/src/screamingface/plugins/aigw_base/auth_proxy_router.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/auth_proxy_router.py
@@ -56,6 +56,15 @@ class _StartConnectionBody(BaseModel):
     label: str | None = None
 
 
+class _CreateConnectionApiKeyBody(BaseModel):
+    label: str | None = None
+    api_key: str
+
+
+class _SetConnectionApiKeyBody(BaseModel):
+    api_key: str
+
+
 class _AigwCallbackBridge(Protocol):
     async def prepare_redirect_uri(self, *, gateway_provider: str) -> str | None: ...
 
@@ -328,6 +337,53 @@ def build_aigw_auth_proxy_router(
             "POST",
             base,
             f"/v1/oauth/connections/{connection_id}/refresh",
+        )
+        return JSONResponse(content=resp.json(), status_code=resp.status_code)
+
+    @router.post(f"{path_prefix}/auth/connections/api-key", status_code=201)
+    async def create_connection_api_key(body: _CreateConnectionApiKeyBody) -> JSONResponse:
+        """Create an api-key connection on the gateway (no OAuth cycle).
+
+        The provider is injected server-side; the key passes through to the
+        gateway, which owns all credential state — it is never logged or
+        persisted on the SF server.
+        """
+        payload: dict[str, Any] = {"provider": gateway_provider, "api_key": body.api_key}
+        if body.label:
+            payload["label"] = body.label
+        resp = await _gateway_response(
+            app,
+            factory,
+            timeout_seconds,
+            "POST",
+            base,
+            "/v1/oauth/connections/api-key",
+            json=payload,
+        )
+        return JSONResponse(content=resp.json(), status_code=resp.status_code)
+
+    @router.put(f"{path_prefix}/auth/connections/{{connection_id}}/api-key")
+    async def set_connection_api_key(
+        connection_id: str, body: _SetConnectionApiKeyBody
+    ) -> JSONResponse:
+        """Replace the key on an api-key connection. Never logged."""
+        # Assert the connection belongs to this backend's provider before the PUT.
+        await _gateway_connection_json(
+            app,
+            factory,
+            timeout_seconds,
+            base,
+            connection_id,
+            gateway_provider,
+        )
+        resp = await _gateway_response(
+            app,
+            factory,
+            timeout_seconds,
+            "PUT",
+            base,
+            f"/v1/oauth/connections/{connection_id}/api-key",
+            json={"api_key": body.api_key},
         )
         return JSONResponse(content=resp.json(), status_code=resp.status_code)
 

--- a/apps/server/src/screamingface/plugins/aigw_base/auth_proxy_router.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/auth_proxy_router.py
@@ -390,6 +390,18 @@ def build_aigw_auth_proxy_router(
     return router
 
 
+def _strip_validation_input(detail: Any) -> Any:
+    """Drop the echoed request body (`input`) from FastAPI validation errors so
+    a raw API key in a malformed request never transits the proxy (SF-291 R3-1).
+    Non-validation detail (dict/str) passes through unchanged."""
+    if isinstance(detail, list):
+        return [
+            {k: v for k, v in err.items() if k != "input"} if isinstance(err, dict) else err
+            for err in detail
+        ]
+    return detail
+
+
 def _safe_json(resp: httpx.Response) -> Any:
     try:
         body = resp.json()
@@ -400,7 +412,13 @@ def _safe_json(resp: httpx.Response) -> Any:
         # {"detail": {...}}. Re-raising that verbatim would double-wrap
         # ({"detail": {"detail": ...}}) and hide the code/message from the
         # desktop's body.detail parsing (SF-244 audit F05).
-        return body["detail"]
+        #
+        # A FastAPI validation error's detail is a LIST of error dicts, each
+        # carrying the raw submitted body in `input`. The bundled gateway
+        # redacts that, but an EXTERNAL/older gateway may not — so strip `input`
+        # here too, or a malformed api-key request leaks the raw key through the
+        # proxy (SF-291 review R3-1).
+        return _strip_validation_input(body["detail"])
     return body
 
 

--- a/apps/server/src/screamingface/plugins/aigw_base/tests/test_auth_proxy.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/tests/test_auth_proxy.py
@@ -896,3 +896,92 @@ def test_set_api_key_gateway_unreachable_becomes_502() -> None:
     resp = client.put("/claude/auth/profiles/work/api-key", json={"api_key": "sk-ant-12345678"})
     assert resp.status_code == 502
     assert resp.json()["detail"]["code"] == "gateway_unreachable"
+
+
+_CONN = {
+    "id": "11111111-1111-1111-1111-111111111111",
+    "account_id": "22222222-2222-2222-2222-222222222222",
+    "provider": "anthropic",
+    "label": "work",
+    "status": "active",
+    "auth_type": "api_key",
+    "credential_locator": {},
+    "created_at": "2026-06-18T00:00:00Z",
+}
+
+
+def test_create_connection_api_key_injects_provider_and_forwards_key() -> None:
+    seen: dict = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen["method"] = req.method
+        seen["path"] = req.url.path
+        seen["body"] = json.loads(req.content)
+        return httpx.Response(201, json=_CONN)
+
+    client = _make_client(handler)
+    resp = client.post(
+        "/claude/auth/connections/api-key",
+        json={"label": "work", "api_key": "sk-ant-secret-key"},
+    )
+    assert resp.status_code == 201, resp.text
+    assert seen["method"] == "POST"
+    assert seen["path"] == "/v1/oauth/connections/api-key"
+    # Provider is injected server-side; label + key forwarded verbatim.
+    assert seen["body"] == {
+        "provider": "anthropic",
+        "label": "work",
+        "api_key": "sk-ant-secret-key",
+    }
+    assert resp.json()["auth_type"] == "api_key"
+
+
+def test_create_connection_api_key_gateway_4xx_single_wrapped() -> None:
+    def handler(_req: httpx.Request) -> httpx.Response:
+        # Gateway is FastAPI: error body is {"detail": {...}} (SF-244 F05).
+        return httpx.Response(
+            400, json={"detail": {"code": "api_key_not_supported", "provider": "codex"}}
+        )
+
+    client = _make_client(handler)
+    resp = client.post(
+        "/claude/auth/connections/api-key",
+        json={"label": "x", "api_key": "sk-ant-secret-key"},
+    )
+    assert resp.status_code == 400
+    # Single-wrapped so the desktop's body.detail.code parsing works.
+    assert resp.json()["detail"]["code"] == "api_key_not_supported"
+
+
+def test_set_connection_api_key_guards_provider_then_puts() -> None:
+    calls: list[tuple[str, str]] = []
+    cid = _CONN["id"]
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        calls.append((req.method, req.url.path))
+        return httpx.Response(200, json=_CONN)
+
+    client = _make_client(handler)
+    resp = client.put(
+        f"/claude/auth/connections/{cid}/api-key",
+        json={"api_key": "sk-ant-rotated-key"},
+    )
+    assert resp.status_code == 200, resp.text
+    # Ownership GET precedes the PUT.
+    assert ("GET", f"/v1/oauth/connections/{cid}") in calls
+    assert ("PUT", f"/v1/oauth/connections/{cid}/api-key") in calls
+
+
+def test_set_connection_api_key_wrong_provider_is_404() -> None:
+    cid = _CONN["id"]
+
+    def handler(_req: httpx.Request) -> httpx.Response:
+        # Ownership GET returns a connection owned by a different provider.
+        return httpx.Response(200, json={**_CONN, "provider": "gemini-cli"})
+
+    client = _make_client(handler)
+    resp = client.put(
+        f"/claude/auth/connections/{cid}/api-key",
+        json={"api_key": "sk-ant-rotated-key"},
+    )
+    assert resp.status_code == 404

--- a/apps/server/src/screamingface/plugins/aigw_base/tests/test_auth_proxy.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/tests/test_auth_proxy.py
@@ -985,3 +985,40 @@ def test_set_connection_api_key_wrong_provider_is_404() -> None:
         json={"api_key": "sk-ant-rotated-key"},
     )
     assert resp.status_code == 404
+
+
+def test_create_connection_api_key_strips_input_from_external_gateway_422() -> None:
+    """An EXTERNAL/older gateway may return a 422 whose validation errors still
+    carry the raw request body in `input` (incl. the api_key). The SF proxy must
+    not echo that key — _safe_json strips `input` from array-shaped detail
+    (SF-291 review R3-1)."""
+
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            422,
+            json={
+                "detail": [
+                    {
+                        "type": "missing",
+                        "loc": ["body", "provider"],
+                        "msg": "Field required",
+                        "input": {"api_key": "sk-ant-leak-12345678", "label": "x"},
+                    }
+                ]
+            },
+        )
+
+    client = _make_client(handler)
+    resp = client.post(
+        "/claude/auth/connections/api-key",
+        json={"label": "x", "api_key": "sk-ant-leak-12345678"},
+    )
+    assert resp.status_code == 422
+    # The raw key must NOT appear anywhere in the proxied error body.
+    assert "sk-ant-leak-12345678" not in resp.text
+    detail = resp.json()["detail"]
+    assert isinstance(detail, list)
+    for err in detail:
+        assert "input" not in err
+    # The actionable bits survive.
+    assert detail[0]["msg"] == "Field required"

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/plugin.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/plugin.py
@@ -71,6 +71,7 @@ class AigwClaudeBackendPlugin(AigwBackendApiPluginBase):
     backend_call_paths: list[str] = ["/claude"]
     conflicts: list[str] = ["claude-backend-api"]
     gateway_provider = "anthropic"
+    supports_api_key = True
     settings_class = AigwClaudeBackendSettings
     schema_link_base = "/claude/"
     create_router = staticmethod(create_router)

--- a/apps/server/src/screamingface/plugins/aigw_gemini_backend/plugin.py
+++ b/apps/server/src/screamingface/plugins/aigw_gemini_backend/plugin.py
@@ -42,6 +42,7 @@ class AigwGeminiBackendPlugin(AigwBackendApiPluginBase):
     backend_call_paths: list[str] = ["/gemini"]
     conflicts: list[str] = ["gemini-backend-api"]
     gateway_provider = "gemini-cli"
+    supports_api_key = True
     settings_class = AigwGeminiBackendSettings
     schema_link_base = "/gemini/"
     create_router = staticmethod(create_router)

--- a/apps/server/src/screamingface/plugins/llm_base/routes.py
+++ b/apps/server/src/screamingface/plugins/llm_base/routes.py
@@ -209,6 +209,10 @@ def _provider_auth_status(app: Any, backends: dict[str, Any]) -> dict[str, Any]:
             "provider": provider,
             "profile": profile,
             "state": _provider_state(backends.get(name, {})),
+            # Capability flag so the desktop only offers API-key auth where the
+            # backend's gateway provider supports it (anthropic/gemini today;
+            # codex is OAuth-only). Declared per backend plugin.
+            "supports_api_key": bool(getattr(plugin, "supports_api_key", False)),
         }
     return providers
 

--- a/apps/server/src/screamingface/plugins/llm_base/routes.py
+++ b/apps/server/src/screamingface/plugins/llm_base/routes.py
@@ -212,6 +212,13 @@ def _provider_auth_status(app: Any, backends: dict[str, Any]) -> dict[str, Any]:
             # Capability flag so the desktop only offers API-key auth where the
             # backend's gateway provider supports it (anthropic/gemini today;
             # codex is OAuth-only). Declared per backend plugin.
+            #
+            # KNOWN DEBT (SF-291 review R3-2): this is the SF backend's local
+            # declaration, not the gateway provider's actual supports_api_key()
+            # capability. They agree today, but an external/older/custom gateway
+            # could desync and show a dead-end api-key UI. The single-source fix
+            # is to source this from the gateway (e.g. a provider-capabilities
+            # endpoint) — deferred as a separate task; accepted tradeoff for now.
             "supports_api_key": bool(getattr(plugin, "supports_api_key", False)),
         }
     return providers

--- a/apps/server/src/screamingface/plugins/llm_base/tests/test_backends_status_v2.py
+++ b/apps/server/src/screamingface/plugins/llm_base/tests/test_backends_status_v2.py
@@ -72,3 +72,38 @@ async def test_external_auth_disabled_gateway_fails_closed(monkeypatch) -> None:
     assert payload["gateway"]["authenticated"] is False
     assert "provider_auth" not in payload
     assert "backends" not in payload
+
+
+def test_provider_auth_status_exposes_supports_api_key() -> None:
+    """The desktop reads supports_api_key per provider to gate the API-key UI."""
+
+    def _plugin(provider, path, *, supports=None):
+        ns = SimpleNamespace(
+            gateway_provider=provider,
+            backend_call_paths=[path],
+            settings=SimpleNamespace(auth_profile="default"),
+        )
+        if supports is not None:
+            ns.supports_api_key = supports
+        return ns
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            plugins=SimpleNamespace(
+                active_plugins={
+                    "claude": _plugin("anthropic", "/claude", supports=True),
+                    "gemini": _plugin("gemini-cli", "/gemini", supports=True),
+                    "codex": _plugin("codex", "/codex", supports=False),
+                    # A plugin that never declares the attr defaults to False.
+                    "ollama": _plugin("ollama", "/ollama"),
+                }
+            )
+        )
+    )
+
+    providers = status_routes._provider_auth_status(app, {})
+
+    assert providers["claude"]["supports_api_key"] is True
+    assert providers["gemini"]["supports_api_key"] is True
+    assert providers["codex"]["supports_api_key"] is False
+    assert providers["ollama"]["supports_api_key"] is False

--- a/apps/server/src/screamingface/plugins/llm_base/tests/test_backends_status_v2.py
+++ b/apps/server/src/screamingface/plugins/llm_base/tests/test_backends_status_v2.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 import pytest
 from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
 from fastapi.testclient import TestClient
 
 from screamingface.core.app import create_app
@@ -107,3 +109,32 @@ def test_provider_auth_status_exposes_supports_api_key() -> None:
     assert providers["gemini"]["supports_api_key"] is True
     assert providers["codex"]["supports_api_key"] is False
     assert providers["ollama"]["supports_api_key"] is False
+
+
+def test_create_app_registers_validation_redactor() -> None:
+    app = create_app(AppConfig(plugins=[]))
+    assert RequestValidationError in app.exception_handlers
+
+
+@pytest.mark.anyio
+async def test_validation_redactor_strips_input() -> None:
+    """A 422 must not echo the submitted body (e.g. a raw API key) — SF-291 F1."""
+    from pydantic import BaseModel, ValidationError
+
+    from screamingface.core.app import _redact_validation_errors
+
+    class _Body(BaseModel):
+        provider: str
+        api_key: str
+
+    try:
+        _Body.model_validate({"api_key": "sk-secret-XYZ"})
+        raise AssertionError("expected validation to fail")
+    except ValidationError as err:
+        exc = RequestValidationError(err.errors())
+
+    resp = await _redact_validation_errors(None, exc)  # type: ignore[arg-type]
+    body = bytes(resp.body)
+    assert b"sk-secret-XYZ" not in body
+    for entry in json.loads(body)["detail"]:
+        assert "input" not in entry


### PR DESCRIPTION
## Description

ScreamingFace AIGateway supports API-key authentication end-to-end, but the desktop app only exposed it on the legacy `ProfilesSubPanel`, which the live v2 app never renders. This PR lets a user **create, view, replace, and delete an API-key `OAuthConnection`** directly in the v2 connections panel the runtime actually shows — reusing the existing credential machinery rather than the dead legacy path.

**Motivation:** let a user add an API key from the screen they actually use, instead of falling back to OAuth or a panel the app never displays.

**What's included**

- **Gateway (`apps/aigateway`)**
  - `POST /v1/oauth/connections/api-key` and `PUT /v1/oauth/connections/{id}/api-key` create/replace an api-key connection directly in the active state.
  - The key is persisted (encrypted at rest) to the exact credential-blob slot the chat path reads (`credential_key_for(account_id, connection_id)`); it is never echoed in a response or written to logs.
  - `/token` and `/refresh` reject api-key connections (`connection_not_oauth`) without corrupting the row.
  - A per-provider `supports_api_key()` capability drives the experience: Anthropic + Gemini today; Codex stays OAuth-only and returns `api_key_not_supported`.
  - Request-validation error bodies are redacted so a raw key can never surface in a `422`.
  - Persist failures are converted to a sanitized `503` and logged by service + exception type only (never the key or the underlying message).

- **SF server (`apps/server`)**
  - Proxy routes forward api-key create/replace to the gateway; the proxy strips any `input` field from upstream validation errors so an external gateway can't echo a key.
  - `provider_auth.supports_api_key` is surfaced on `/backends/status` so the desktop can be capability-driven.

- **Desktop (`apps/desktop`)**
  - The v2 connections panel shows an auth-type selector + masked key input only for providers that support API keys, an "API key" badge, in-place **Replace key** (also the recovery path for an errored connection), and **Delete**. **Refresh** is hidden for api-key connections.

Scope is intentionally Anthropic + Gemini. No GitHub issue is linked (tracked internally as SF-291).

## Affected Dependencies

None. No new runtime or build dependencies — this reuses the existing credential-strategy abstraction and the ORM-backed, encrypted credential-blob store. No new database migration is required (the `auth_type` column already exists).

## How has this been tested?

Automated suites (all green):

- **Gateway** (`apps/aigateway`): `pytest -m "not live"` — 575 passed, 1 skipped; `ruff check` clean; `pyright` 0 errors; enterprise-import guard passes.
- **SF server** (`apps/server`): `aigw_base` + `llm_base` suites — 205 passed (proxy routes, capability flag, validation redaction).
- **Desktop** (`apps/desktop`): `vitest` for the connections UI + IPC handlers — 44 passed; `eslint` clean.

New tests cover: create writes the key to the chat-read slot (encrypted, read-after-write); missing/duplicate label; Codex → `api_key_not_supported`; short key rejected; `/token` and `/refresh` rejection without corrupting the row; errored → Replace-key recovery; atomic create with orphan-blob cleanup on failure; persist-failure → sanitized `503` without leaking the key; and DELETE removes the stored blob.

Manual reproduction:

1. Run the desktop app against a gateway with Anthropic/Gemini providers configured.
2. In the connections panel: **+ Add Connection** → choose **API key**, paste a key, save → it appears in the list with an **API key** badge.
3. Make a real chat call → it uses the stored key.
4. **Replace key** updates it in place; **Delete** removes the connection and its stored credential.
5. For Codex, the API-key option is hidden; a direct submit returns `api_key_not_supported`.

## Checklist

- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
