### PR TITLE
SF-289: fix Eval Studio runs list scroll (clipped by panel inline overflow)

### DIFF
--- a/apps/desktop/src/renderer/src/views/EvalStudioView.test.tsx
+++ b/apps/desktop/src/renderer/src/views/EvalStudioView.test.tsx
@@ -2,8 +2,9 @@
 import { render, screen, cleanup } from '@testing-library/react';
 import { it, expect, vi, afterEach } from 'vitest';
 
+const runsData = { data: [] as unknown[], loading: false, error: null, refresh: vi.fn() };
 vi.mock('@/hooks/use-eval-runs', () => ({
-  useEvalRunsList: () => ({ data: [], loading: false, error: null, refresh: vi.fn() }),
+  useEvalRunsList: () => runsData,
 }));
 vi.mock('@/hooks/use-eval-run-actions', () => ({
   useEvalRunActions: () => ({ toggleFavorite: vi.fn(), deleteRun: vi.fn() }),
@@ -27,10 +28,30 @@ afterEach(cleanup);
 
 import { EvalStudioView } from './EvalStudioView';
 
+afterEach(() => {
+  runsData.data = [];
+});
+
 it('renders header, empty state, and both pane toggles', () => {
   render(<EvalStudioView />);
   expect(screen.getByText('Eval Studio')).toBeTruthy();
   expect(screen.getByText('Select a run to see details')).toBeTruthy();
   expect(screen.getByRole('button', { name: /hide runs list/i })).toBeTruthy();
   expect(screen.getByRole('button', { name: /hide run details/i })).toBeTruthy();
+});
+
+// SF-289: the resizable Panel hard-codes inline overflow:hidden, so the runs
+// list must live inside its own bounded, scrollable container or it gets clipped.
+it('wraps the runs list in a bounded scroll container', () => {
+  runsData.data = Array.from({ length: 30 }, (_, i) => ({
+    id: `run-${i}`,
+    spec_name: `Spec ${i}`,
+    started_at: '2026-06-20T00:00:00Z',
+    status: 'done',
+    favorite: false,
+    url4_expression: 'x',
+  }));
+  render(<EvalStudioView />);
+  const firstRun = screen.getByText('Spec 0');
+  expect(firstRun.closest('.overflow-y-auto.h-full')).not.toBeNull();
 });

--- a/apps/desktop/src/renderer/src/views/EvalStudioView.tsx
+++ b/apps/desktop/src/renderer/src/views/EvalStudioView.tsx
@@ -170,13 +170,16 @@ export function EvalStudioView({ pendingRun, onPendingConsumed }: EvalStudioView
           defaultSize={50}
           onCollapse={() => setLeftCollapsed(true)}
           onExpand={() => setLeftCollapsed(false)}
-          className="overflow-auto"
+          className="overflow-hidden"
         >
-          <EvalRunsList
-            selectedId={selectedRunId}
-            onSelect={setSelectedRunId}
-            onRunLocally={runAndSelect}
-          />
+          {/* Panel forces inline overflow:hidden, so scroll must live on an inner h-full container. */}
+          <div className="h-full overflow-y-auto">
+            <EvalRunsList
+              selectedId={selectedRunId}
+              onSelect={setSelectedRunId}
+              onRunLocally={runAndSelect}
+            />
+          </div>
         </ResizablePanel>
 
         <ResizableHandle withHandle />


### PR DESCRIPTION
## What

Fixes the Eval Studio runs list not scrolling when it overflows the viewport — overflowing runs were unreachable.

## Root cause

`react-resizable-panels` (v2.1.9) applies an **inline** `overflow: "hidden"` to every `Panel` (to stop content from resizing the panel). Inline style beats the Tailwind `overflow-auto` class the left panel relied on, so that class was dead — the list was clipped and unscrollable.

## Fix

Keep the `Panel` as the bounded-height clip (`overflow-hidden`, its real behavior) and move scrolling to an inner `h-full overflow-y-auto` wrapper around `<EvalRunsList>` — the same pattern the detail pane already uses. Layout/scroll concern lives in the view; `EvalRunsList` stays a pure item renderer.

## Verification

- `tsc --noEmit` clean; ESLint clean (only pre-existing warnings).
- Full desktop suite: **212/212 pass**.
- Added a regression test (30 runs → asserts a bounded `.overflow-y-auto.h-full` scroll container). Confirmed it **fails on the old code, passes on the fix**.

## Acceptance

With many runs, the runs list scrolls within its panel; header stays put; no full-page or cut-off content.

Asana: https://app.asana.com/0/1213628819033917/1215806107759482