### PR TITLE
SF-295: Eval Studio bulk-delete runs (Clear all / Clear non-starred)

### DIFF
--- a/apps/desktop/src/renderer/src/components/eval/EvalRunsList.test.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/EvalRunsList.test.tsx
@@ -34,21 +34,23 @@ const rows: EvalRunSummary[] = [
   },
 ];
 
-const { refresh, toggleFavorite } = vi.hoisted(() => ({
+const { refresh, toggleFavorite, deleteRun } = vi.hoisted(() => ({
   refresh: vi.fn(),
   toggleFavorite: vi.fn().mockResolvedValue(true),
+  deleteRun: vi.fn().mockResolvedValue(true),
 }));
 
 vi.mock('@/hooks/use-eval-runs', () => ({
   useEvalRunsList: () => ({ data: rows, loading: false, error: null, refresh }),
 }));
 vi.mock('@/hooks/use-eval-run-actions', () => ({
-  useEvalRunActions: () => ({ toggleFavorite }),
+  useEvalRunActions: () => ({ toggleFavorite, deleteRun }),
 }));
 
 beforeEach(() => {
   refresh.mockClear();
   toggleFavorite.mockClear();
+  deleteRun.mockClear();
 });
 afterEach(cleanup);
 
@@ -97,7 +99,47 @@ it('toggles favorite on the un-favorited row', async () => {
   expect(refresh).toHaveBeenCalled();
 });
 
-it('has no delete control in the list (delete lives in the detail panel)', () => {
+it('has no per-row delete control in the list (single delete lives in the detail panel)', () => {
   render(<EvalRunsList selectedId={null} onSelect={vi.fn()} onRunLocally={vi.fn()} />);
   expect(screen.queryByRole('button', { name: /delete run/i })).toBeNull();
+});
+
+it('clears all runs after confirmation, deleting every run then refreshing', async () => {
+  const onBulkDeleted = vi.fn();
+  render(
+    <EvalRunsList
+      selectedId={null}
+      onSelect={vi.fn()}
+      onRunLocally={vi.fn()}
+      onBulkDeleted={onBulkDeleted}
+    />,
+  );
+  fireEvent.click(screen.getByRole('button', { name: /clear all/i }));
+  // Guard dialog appears; nothing deleted until confirmed.
+  expect(screen.getByRole('alertdialog')).toBeTruthy();
+  expect(deleteRun).not.toHaveBeenCalled();
+  fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+  await waitFor(() => expect(deleteRun).toHaveBeenCalledTimes(2));
+  expect(deleteRun).toHaveBeenCalledWith('r1');
+  expect(deleteRun).toHaveBeenCalledWith('r2');
+  expect(onBulkDeleted).toHaveBeenCalledWith(['r1', 'r2']);
+  expect(refresh).toHaveBeenCalled();
+});
+
+it('clears only non-starred runs, keeping favorites', async () => {
+  render(<EvalRunsList selectedId={null} onSelect={vi.fn()} onRunLocally={vi.fn()} />);
+  fireEvent.click(screen.getByRole('button', { name: /clear non-starred/i }));
+  fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+  await waitFor(() => expect(deleteRun).toHaveBeenCalledTimes(1));
+  // r1 is non-starred, r2 is favorite — only r1 is removed.
+  expect(deleteRun).toHaveBeenCalledWith('r1');
+  expect(deleteRun).not.toHaveBeenCalledWith('r2');
+});
+
+it('cancelling the confirm dialog deletes nothing', () => {
+  render(<EvalRunsList selectedId={null} onSelect={vi.fn()} onRunLocally={vi.fn()} />);
+  fireEvent.click(screen.getByRole('button', { name: /clear all/i }));
+  fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+  expect(deleteRun).not.toHaveBeenCalled();
+  expect(screen.queryByRole('alertdialog')).toBeNull();
 });

--- a/apps/desktop/src/renderer/src/components/eval/EvalRunsList.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/EvalRunsList.tsx
@@ -1,5 +1,8 @@
-import { Play, Star } from 'lucide-react';
+import { useState, type ReactNode } from 'react';
+import { Play, Star, Trash2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { useEvalRunsList } from '@/hooks/use-eval-runs';
 import { useEvalRunActions } from '@/hooks/use-eval-run-actions';
 import { EvalStatusBadge } from './EvalStatusBadge';
@@ -11,21 +14,33 @@ interface Props {
   selectedId: string | null;
   onSelect: (id: string) => void;
   onRunLocally?: (payload: RunPayload) => void;
+  /** Called after a bulk delete removes runs, so the parent can clear selection. */
+  onBulkDeleted?: (deletedIds: string[]) => void;
 }
 
-function formatTime(iso: string): string {
-  const d = new Date(iso);
-  return `${d.toLocaleDateString()} ${d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+// Which bulk action is pending confirmation. null = no dialog open.
+type BulkMode = 'all' | 'non-starred';
+
+interface RunsBodyProps {
+  data: EvalRunSummary[];
+  loading: boolean;
+  error: Error | null;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  onToggleFavorite: (run: EvalRunSummary) => void;
+  onRunLocally?: (payload: RunPayload) => void;
 }
 
-export function EvalRunsList({ selectedId, onSelect, onRunLocally }: Props) {
-  const { data, loading, error, refresh } = useEvalRunsList();
-  const { toggleFavorite } = useEvalRunActions();
-
-  const onToggleFavorite = async (run: EvalRunSummary): Promise<void> => {
-    if (await toggleFavorite(run.id, !run.favorite)) await refresh(true);
-  };
-
+// Loading / error / empty / list states for the runs panel body.
+function RunsBody({
+  data,
+  loading,
+  error,
+  selectedId,
+  onSelect,
+  onToggleFavorite,
+  onRunLocally,
+}: RunsBodyProps): ReactNode {
   if (loading && data.length === 0) {
     return <div className="p-6 text-sm text-muted-foreground">Loading runs…</div>;
   }
@@ -34,75 +49,188 @@ export function EvalRunsList({ selectedId, onSelect, onRunLocally }: Props) {
   }
   if (data.length === 0) {
     return (
-      <div className="flex h-full flex-col items-center justify-center p-8 text-center text-sm text-muted-foreground">
+      <div className="flex flex-col items-center justify-center p-8 text-center text-sm text-muted-foreground">
         <p className="mb-2 font-medium">No evaluation runs yet.</p>
         <p className="text-xs">Use "New run" above, or the play button on a leaderboard entry.</p>
       </div>
     );
   }
+  return (
+    <>
+      {data.map((run) => (
+        <RunRow
+          key={run.id}
+          run={run}
+          active={run.id === selectedId}
+          onSelect={onSelect}
+          onToggleFavorite={onToggleFavorite}
+          onRunLocally={onRunLocally}
+        />
+      ))}
+    </>
+  );
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  return `${d.toLocaleDateString()} ${d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+}
+
+interface RunRowProps {
+  run: EvalRunSummary;
+  active: boolean;
+  onSelect: (id: string) => void;
+  onToggleFavorite: (run: EvalRunSummary) => void;
+  onRunLocally?: (payload: RunPayload) => void;
+}
+
+function RunRow({ run, active, onSelect, onToggleFavorite, onRunLocally }: RunRowProps) {
+  return (
+    <div
+      onClick={() => onSelect(run.id)}
+      className={cn(
+        'cursor-pointer border-b border-border/50 px-6 py-3 transition-colors hover:bg-accent/40',
+        active && 'bg-accent/60',
+      )}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="truncate font-medium text-foreground">{run.spec_name}</div>
+          <div className="text-xs text-muted-foreground">{formatTime(run.started_at)}</div>
+        </div>
+        {/* Right indicators on one line, vertically centered: pct, status, star, run. */}
+        <div className="flex items-center gap-2 whitespace-nowrap">
+          <span
+            className="text-sm tabular-nums"
+            title={isUngradedDone(run) ? 'Not graded — 0 checked questions' : undefined}
+          >
+            {formatAccuracy(run)}
+          </span>
+          <EvalStatusBadge status={run.status} />
+          <button
+            type="button"
+            aria-label={run.favorite ? 'Unfavorite' : 'Favorite'}
+            aria-pressed={run.favorite}
+            title={run.favorite ? 'Unfavorite' : 'Favorite'}
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleFavorite(run);
+            }}
+            className={cn(
+              'rounded p-1 transition-colors hover:bg-accent',
+              run.favorite ? 'text-chart-5' : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            <Star className={cn('h-4 w-4', run.favorite && 'fill-current')} />
+          </button>
+          {onRunLocally && (
+            <button
+              type="button"
+              aria-label="Run locally"
+              title="Run locally"
+              onClick={(e) => {
+                e.stopPropagation();
+                onRunLocally({ spec: run.spec_name, expression: run.url4_expression });
+              }}
+              className="rounded p-1 text-primary transition-colors hover:bg-primary/10"
+            >
+              <Play className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function EvalRunsList({ selectedId, onSelect, onRunLocally, onBulkDeleted }: Props) {
+  const { data, loading, error, refresh } = useEvalRunsList();
+  const { toggleFavorite, deleteRun } = useEvalRunActions();
+  const [bulkMode, setBulkMode] = useState<BulkMode | null>(null);
+  const [bulkDeleting, setBulkDeleting] = useState(false);
+
+  const onToggleFavorite = async (run: EvalRunSummary): Promise<void> => {
+    if (await toggleFavorite(run.id, !run.favorite)) await refresh(true);
+  };
+
+  const nonStarred = data.filter((run) => run.favorite === false);
+  const hasRuns = data.length > 0;
+  const hasNonStarred = nonStarred.length > 0;
+
+  // Delete the targeted set sequentially (no bulk endpoint exists), then refresh
+  // the list once. Selection is cleared by the parent via onBulkDeleted.
+  const confirmBulkDelete = async (): Promise<void> => {
+    const targets = bulkMode === 'non-starred' ? nonStarred : data;
+    const ids = targets.map((run) => run.id);
+    setBulkDeleting(true);
+    const deleted: string[] = [];
+    for (const id of ids) {
+      if (await deleteRun(id)) deleted.push(id);
+    }
+    setBulkDeleting(false);
+    setBulkMode(null);
+    if (deleted.length > 0) {
+      onBulkDeleted?.(deleted);
+      await refresh(true);
+    }
+  };
+
+  // Header with the bulk-clear controls. Always shown so the actions stay
+  // discoverable; buttons disable when there's nothing to clear.
+  const header = (
+    <div className="flex items-center justify-end gap-2 border-b border-border px-6 py-2">
+      <Button
+        variant="ghost"
+        size="sm"
+        className="text-muted-foreground hover:text-destructive"
+        disabled={!hasNonStarred}
+        onClick={() => setBulkMode('non-starred')}
+      >
+        <Trash2 className="h-3.5 w-3.5" /> Clear non-starred
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="text-muted-foreground hover:text-destructive"
+        disabled={!hasRuns}
+        onClick={() => setBulkMode('all')}
+      >
+        <Trash2 className="h-3.5 w-3.5" /> Clear all
+      </Button>
+    </div>
+  );
+
+  const targetCount = bulkMode === 'non-starred' ? nonStarred.length : data.length;
+  const noun = `run${targetCount === 1 ? '' : 's'}`;
+  const confirmTitle = bulkMode === 'non-starred' ? 'Clear non-starred runs?' : 'Clear all runs?';
+  const confirmMessage =
+    bulkMode === 'non-starred'
+      ? `${targetCount} non-starred ${noun} and their question results will be permanently removed. Starred runs are kept. This can't be undone.`
+      : `All ${targetCount} ${noun} and their question results will be permanently removed. This can't be undone.`;
 
   return (
     <div className="flex flex-col">
-      {data.map((run: EvalRunSummary) => {
-        const active = run.id === selectedId;
-        return (
-          <div
-            key={run.id}
-            onClick={() => onSelect(run.id)}
-            className={cn(
-              'cursor-pointer border-b border-border/50 px-6 py-3 transition-colors hover:bg-accent/40',
-              active && 'bg-accent/60',
-            )}
-          >
-            <div className="flex items-center justify-between gap-3">
-              <div className="min-w-0 flex-1">
-                <div className="truncate font-medium text-foreground">{run.spec_name}</div>
-                <div className="text-xs text-muted-foreground">{formatTime(run.started_at)}</div>
-              </div>
-              {/* Right indicators on one line, vertically centered: pct, status, star, run. */}
-              <div className="flex items-center gap-2 whitespace-nowrap">
-                <span
-                  className="text-sm tabular-nums"
-                  title={isUngradedDone(run) ? 'Not graded — 0 checked questions' : undefined}
-                >
-                  {formatAccuracy(run)}
-                </span>
-                <EvalStatusBadge status={run.status} />
-                <button
-                  type="button"
-                  aria-label={run.favorite ? 'Unfavorite' : 'Favorite'}
-                  aria-pressed={run.favorite}
-                  title={run.favorite ? 'Unfavorite' : 'Favorite'}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    void onToggleFavorite(run);
-                  }}
-                  className={cn(
-                    'rounded p-1 transition-colors hover:bg-accent',
-                    run.favorite ? 'text-chart-5' : 'text-muted-foreground hover:text-foreground',
-                  )}
-                >
-                  <Star className={cn('h-4 w-4', run.favorite && 'fill-current')} />
-                </button>
-                {onRunLocally && (
-                  <button
-                    type="button"
-                    aria-label="Run locally"
-                    title="Run locally"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onRunLocally({ spec: run.spec_name, expression: run.url4_expression });
-                    }}
-                    className="rounded p-1 text-primary transition-colors hover:bg-primary/10"
-                  >
-                    <Play className="h-4 w-4" />
-                  </button>
-                )}
-              </div>
-            </div>
-          </div>
-        );
-      })}
+      {header}
+      <RunsBody
+        data={data}
+        loading={loading}
+        error={error}
+        selectedId={selectedId}
+        onSelect={onSelect}
+        onToggleFavorite={(r) => void onToggleFavorite(r)}
+        onRunLocally={onRunLocally}
+      />
+      {bulkMode && (
+        <ConfirmDialog
+          title={confirmTitle}
+          message={confirmMessage}
+          confirmLabel={bulkDeleting ? 'Deleting…' : 'Delete'}
+          destructive
+          busy={bulkDeleting}
+          onConfirm={() => void confirmBulkDelete()}
+          onCancel={() => setBulkMode(null)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/views/EvalStudioView.tsx
+++ b/apps/desktop/src/renderer/src/views/EvalStudioView.tsx
@@ -79,6 +79,11 @@ export function EvalStudioView({ pendingRun, onPendingConsumed }: EvalStudioView
     setSelectedRunId((current) => (current === id ? null : current));
   }, []);
 
+  // Clear the right panel if a bulk delete removed the selected run.
+  const handleBulkDeleted = useCallback((deletedIds: string[]): void => {
+    setSelectedRunId((current) => (current && deletedIds.includes(current) ? null : current));
+  }, []);
+
   // Consume a deep-linked pending run exactly once.
   const handledPendingRef = useRef<RunPayload | null>(null);
   useEffect(() => {
@@ -178,6 +183,7 @@ export function EvalStudioView({ pendingRun, onPendingConsumed }: EvalStudioView
               selectedId={selectedRunId}
               onSelect={setSelectedRunId}
               onRunLocally={runAndSelect}
+              onBulkDeleted={handleBulkDeleted}
             />
           </div>
         </ResizablePanel>


### PR DESCRIPTION
## What
Adds list-level bulk-delete actions to the Eval Studio runs panel:
- **Clear all** — deletes every run.
- **Clear non-starred** — deletes runs with `favorite === false`, keeping starred runs.

## Why
Individual run delete already existed (detail panel). SF-295 asks for list-level cleanup so users can prune run history quickly without deleting one at a time.

## How
- New header bar at the top of `EvalRunsList` with two ghost buttons (disabled when there are no runs / no non-starred runs).
- Guarded by the existing `ConfirmDialog` (same pattern as single-run delete) — no new confirm UI.
- No backend bulk endpoint exists, so deletes run sequentially via `deleteRun`, then the list refreshes once.
- `onBulkDeleted` clears the right-panel selection in `EvalStudioView` when the open run is removed.
- Refactored the row into `RunRow` and the loading/error/empty/list states into `RunsBody` for SRP and to keep cyclomatic complexity in check.

## Verification
- `npx tsc --noEmit` — clean
- `npx vitest run` — 231 passed (added 3 bulk-delete tests: clear-all, clear-non-starred-keeps-favorites, cancel-deletes-nothing)
- `npx eslint` on changed files — 0 errors

Part of the SF-295..300 stacked batch; base=main.

Asana: https://app.asana.com/0/1213628819033917/1215875206211367