### PR TITLE
SF-296: reorder left nav (URL4 Studio before Sessions)

### DIFF
--- a/apps/desktop/src/renderer/src/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/layout/Sidebar.tsx
@@ -34,9 +34,9 @@ interface NavItem {
 
 const coreItems: NavItem[] = [
   { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
+  { id: 'url4-studio', label: 'URL4 Studio', icon: Workflow },
   { id: 'sessions', label: 'Sessions', icon: Terminal },
   { id: 'eval-studio', label: 'Eval Studio', icon: FlaskConical },
-  { id: 'url4-studio', label: 'URL4 Studio', icon: Workflow },
   { id: 'code-studio', label: 'Code Studio', icon: FileCode2 },
   { id: 'private-data', label: 'Private Data', icon: FileText },
 ];

--- a/apps/desktop/src/renderer/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/layout/__tests__/Sidebar.test.tsx
@@ -40,6 +40,29 @@ beforeEach(() => {
   logoutAigwSession.mockClear();
 });
 
+describe('Sidebar nav order', () => {
+  it('renders core nav items in the expected order', () => {
+    const { container } = render(
+      <Sidebar currentView="dashboard" onNavigate={vi.fn()} plugins={[]} />,
+    );
+    const nav = container.querySelector('nav');
+    if (!nav) throw new Error('nav not rendered');
+
+    const labels = within(nav)
+      .getAllByRole('button')
+      .map((button) => button.textContent?.trim());
+
+    expect(labels).toEqual([
+      'Dashboard',
+      'URL4 Studio',
+      'Sessions',
+      'Eval Studio',
+      'Code Studio',
+      'Private Data',
+    ]);
+  });
+});
+
 describe('Sidebar gateway status', () => {
   it('shows external gateway login in the sidebar bottom area', async () => {
     getStatus.mockResolvedValue({


### PR DESCRIPTION
## What
Reorder the Eval Studio left navigation to exactly: Dashboard -> URL4 Studio -> Sessions -> Eval Studio -> Code Studio -> Private Data. Pure ordering change of the existing `coreItems` list in `Sidebar.tsx`.

## Why
Surface URL4 Studio higher in the nav per product ordering decision.

## Verification
- `npx tsc --noEmit` clean
- `npx vitest run` — 232 tests pass (added a test asserting core nav order in `Sidebar.test.tsx`)
- `npx eslint` on changed files — 0 new errors

Part of the SF-295..300 stacked batch; base=SF-295-eval-bulk-delete-runs.

Asana: https://app.asana.com/0/1213628819033917/1215875162423293