### PR TITLE
SF-297: Eval Studio — remove "Save"; rename "Rerun" → "Run"

### DIFF
--- a/apps/desktop/src/renderer/src/components/CodeEditorPopup.tsx
+++ b/apps/desktop/src/renderer/src/components/CodeEditorPopup.tsx
@@ -15,7 +15,8 @@ interface Props {
   title: string;
   language: string;
   value: string;
-  onSave: (value: string) => void;
+  /** Primary action. Omit to hide the primary button entirely (e.g. a run-only popup). */
+  onSave?: (value: string) => void;
   onClose: () => void;
   /** Inset from every app border (CSS length). Defaults to 5%. */
   inset?: string;
@@ -118,14 +119,16 @@ export default function CodeEditorPopup({
                 {secondaryIcon} {secondaryLabel}
               </Button>
             )}
-            <Button
-              onClick={() => {
-                onSave(draft);
-                onClose();
-              }}
-            >
-              {confirmIcon} {confirmLabel}
-            </Button>
+            {onSave && (
+              <Button
+                onClick={() => {
+                  onSave(draft);
+                  onClose();
+                }}
+              >
+                {confirmIcon} {confirmLabel}
+              </Button>
+            )}
           </div>
         </div>
       </div>

--- a/apps/desktop/src/renderer/src/components/eval/EvalRunDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/EvalRunDetail.tsx
@@ -1,6 +1,6 @@
 // apps/desktop/src/renderer/src/components/eval/EvalRunDetail.tsx
 import { useState, lazy, Suspense } from 'react';
-import { Upload, Play, Pencil, Trash2, Save } from 'lucide-react';
+import { Upload, Play, Pencil, Trash2 } from 'lucide-react';
 import type { OnMount } from '@monaco-editor/react';
 import { useServerStatus } from '@/hooks/use-server-status';
 import { useEvalRunDetail } from '@/hooks/use-eval-runs';
@@ -42,8 +42,8 @@ export function EvalRunDetail({
   onDeleted?: () => void;
 }) {
   const { info } = useServerStatus();
-  const { data, loading, error, refresh } = useEvalRunDetail(runId);
-  const { deleteRun, saveExpression } = useEvalRunActions();
+  const { data, loading, error } = useEvalRunDetail(runId);
+  const { deleteRun } = useEvalRunActions();
   const [publishing, setPublishing] = useState(false);
   const [editing, setEditing] = useState(false);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
@@ -61,15 +61,10 @@ export function EvalRunDetail({
   }
   if (!data) return null;
 
-  // Run (or re-run an edited expression) as a fresh run; the parent selects it.
+  // Run an edited (or unchanged) expression as a fresh run; the parent selects it.
   const triggerRun = (expression: string): void => {
     onRunLocally?.({ spec: data.spec_name, expression });
     setEditing(false);
-  };
-
-  // Persist an edited expression onto this run, then refetch so the panel updates.
-  const handleSaveExpression = async (expression: string): Promise<void> => {
-    if (await saveExpression(runId, expression)) await refresh();
   };
 
   const confirmDelete = async (): Promise<void> => {
@@ -179,13 +174,10 @@ export function EvalRunDetail({
             value={data.url4_expression}
             inset="10%"
             onEditorMount={mountUrl4Editor}
-            confirmLabel="Save"
-            confirmIcon={<Save className="h-4 w-4" />}
-            onSave={(expr) => void handleSaveExpression(expr)}
+            confirmLabel="Run"
+            confirmIcon={<Play className="h-4 w-4" />}
+            onSave={triggerRun}
             onFormat={(expr) => formatUrl4(serverUrl, expr)}
-            secondaryLabel="Re-run"
-            secondaryIcon={<Play className="h-4 w-4" />}
-            onSecondary={triggerRun}
             onClose={() => setEditing(false)}
           />
         </Suspense>

--- a/apps/desktop/src/renderer/src/components/eval/__tests__/EvalRunDetail.test.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/__tests__/EvalRunDetail.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { EvalRunDetail } from '../EvalRunDetail';
+import type { EvalRunDetail as EvalRunDetailData } from '../types';
+
+const runData: EvalRunDetailData = {
+  id: 'eval-run-1',
+  spec_name: 'hle:hle-ensemble-three',
+  url4_expression: 'url4://ensemble(claude,codex,gemini)/hle',
+  started_at: '2026-05-04T11:00:00Z',
+  finished_at: '2026-05-04T11:55:00Z',
+  status: 'done',
+  accuracy: 0.81,
+  total_questions: 1000,
+  correct_questions: 810,
+  error: null,
+  favorite: false,
+  questions: [],
+};
+
+const deleteRun = vi.fn();
+vi.mock('@/hooks/use-server-status', () => ({
+  useServerStatus: () => ({ info: { scheme: 'http', host: 'localhost', port: 8000 } }),
+}));
+vi.mock('@/hooks/use-eval-runs', () => ({
+  useEvalRunDetail: () => ({ data: runData, loading: false, error: null, refresh: vi.fn() }),
+}));
+vi.mock('@/hooks/use-eval-run-actions', () => ({
+  useEvalRunActions: () => ({ deleteRun }),
+}));
+vi.mock('@/components/Url4Field', () => ({
+  Url4Field: ({ value }: { value: string }) => <span data-testid="url4">{value}</span>,
+}));
+vi.mock('@/components/eval/EvalQuestionsTable', () => ({
+  EvalQuestionsTable: () => null,
+}));
+
+// Stand in for the lazy monaco popup; surfaces the action props EvalRunDetail wires.
+vi.mock('@/components/CodeEditorPopup', () => ({
+  default: ({
+    onSave,
+    confirmLabel,
+    secondaryLabel,
+    value,
+  }: {
+    onSave?: (v: string) => void;
+    confirmLabel?: string;
+    secondaryLabel?: string;
+    value: string;
+  }) => (
+    <div data-testid="code-popup">
+      {onSave && <button onClick={() => onSave(value)}>{confirmLabel ?? 'PRIMARY'}</button>}
+      {secondaryLabel && <span data-testid="secondary">{secondaryLabel}</span>}
+    </div>
+  ),
+}));
+
+describe('EvalRunDetail edit popup controls', () => {
+  beforeEach(() => {
+    deleteRun.mockReset();
+  });
+
+  it('labels the primary action "Run" with no "Save" or "Re-run" control', async () => {
+    const onRunLocally = vi.fn();
+    render(<EvalRunDetail runId="eval-run-1" onRunLocally={onRunLocally} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+    await screen.findByTestId('code-popup');
+
+    expect(screen.getByRole('button', { name: 'Run' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('secondary')).not.toBeInTheDocument();
+  });
+
+  it('Run starts a fresh run from the edited expression', async () => {
+    const onRunLocally = vi.fn();
+    render(<EvalRunDetail runId="eval-run-1" onRunLocally={onRunLocally} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+    await screen.findByTestId('code-popup');
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+
+    expect(onRunLocally).toHaveBeenCalledWith({
+      spec: runData.spec_name,
+      expression: runData.url4_expression,
+    });
+  });
+});


### PR DESCRIPTION
## What
In the Eval Studio run-detail edit popup:
- Drop the **Save** action (persist edited expression) entirely.
- Rename the run action from **Re-run** to **Run** and promote it to the primary CTA (Play icon).

## Why
Run always creates a NEW run record, so the rerun-vs-run distinction is gone. The save-onto-this-run behavior is no longer offered here; the only action is to launch a fresh run from the (possibly edited) expression.

## How
- `CodeEditorPopup`: made the primary `onSave` action optional so callers can omit the primary button without breaking the shared component (its other 8+ callers still pass `onSave`).
- `EvalRunDetail`: routed the run action through the primary slot as "Run", removed the Save wiring (`saveExpression`/`handleSaveExpression`/`refresh`) and the now-unused `Save` lucide import.

## Verification
- `npx tsc --noEmit` clean
- `npx vitest run` — 43 files / 234 tests pass (added `EvalRunDetail.test.tsx` asserting the "Run" label and absence of "Save"/"Re-run", plus that Run starts a fresh run)
- `npx eslint` on changed files — 0 errors

Part of the SF-295..300 stacked batch; base=SF-296-reorder-left-nav.

Asana: https://app.asana.com/0/1213628819033917/1215875206229556