### PR TITLE
SF-299: persist submitter name across publishes

### DIFF
--- a/apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
@@ -25,6 +25,27 @@ function formatPercent(accuracy: number | null): string {
   return `${(accuracy * 100).toFixed(1)}%`;
 }
 
+// Submitter name is remembered across publishes within a session so it doesn't
+// have to be re-typed each time. Matches the sessionStorage usage elsewhere in
+// the renderer (see federation/registry.ts for the localStorage analogue).
+const SUBMITTER_KEY = 'sf-leaderboard-submitter';
+
+function loadSubmitter(): string {
+  try {
+    return window.sessionStorage.getItem(SUBMITTER_KEY) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function saveSubmitter(name: string): void {
+  try {
+    window.sessionStorage.setItem(SUBMITTER_KEY, name);
+  } catch {
+    // sessionStorage unavailable — non-fatal, just skip persistence.
+  }
+}
+
 export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
   const { toast } = useToast();
   const { publish, status, error, result } = usePublishScore();
@@ -37,7 +58,7 @@ export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
   const [providersText, setProvidersText] = useState(
     deriveProviders(run.url4_expression).join(', '),
   );
-  const [submittedBy, setSubmittedBy] = useState('');
+  const [submittedBy, setSubmittedBy] = useState(loadSubmitter);
   // Redaction choices: only relevant when the expression references /data blobs.
   const [sanitize, setSanitize] = useState(hasDataRefs);
   const [ackExpose, setAckExpose] = useState(false);
@@ -65,6 +86,9 @@ export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
     !blockReason && benchmarkId.trim().length > 0 && specId.trim().length > 0 && redactionResolved;
 
   const handlePublish = async (): Promise<void> => {
+    // Remember the entered name for subsequent publishes this session, whether
+    // or not the round-trip ultimately succeeds.
+    saveSubmitter(submittedBy.trim());
     const out = await publish({
       run,
       benchmarkId: benchmarkId.trim(),

--- a/apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
@@ -50,6 +50,7 @@ beforeEach(() => {
   hookState.status = 'idle';
   hookState.error = null;
   hookState.result = null;
+  window.sessionStorage.clear();
   (window as unknown as { electronAPI: unknown }).electronAPI = {
     publish: { openExternal: vi.fn(async () => {}), getContext: vi.fn() },
   };
@@ -109,6 +110,21 @@ describe('PublishToLeaderboardDialog', () => {
     render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
     expect(screen.queryByText(/no graded questions/i)).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled();
+  });
+
+  it('persists the submitter name to sessionStorage on publish', () => {
+    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    fireEvent.change(screen.getByPlaceholderText('leave blank for anonymous'), {
+      target: { value: 'Ada Lovelace' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /publish/i }));
+    expect(window.sessionStorage.getItem('sf-leaderboard-submitter')).toBe('Ada Lovelace');
+  });
+
+  it('prefills the submitter name from sessionStorage on open', () => {
+    window.sessionStorage.setItem('sf-leaderboard-submitter', 'Grace Hopper');
+    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    expect(screen.getByPlaceholderText('leave blank for anonymous')).toHaveValue('Grace Hopper');
   });
 
   it('shows the success state and opens the leaderboard deep link', () => {


### PR DESCRIPTION
## What
Persist the leaderboard submitter name in `window.sessionStorage` and prefill it when the publish dialog reopens, so it is remembered across subsequent publishes within a session.

## Why
Users re-publishing multiple runs had to retype their submitter name each time. This removes that friction.

## How
- `PublishToLeaderboardDialog`: lazy-init the `submittedBy` state from `sessionStorage` (key `sf-leaderboard-submitter`), and save the trimmed name on every publish attempt (success or failure). Read/write wrapped in try/catch, matching the resilient storage pattern in `federation/registry.ts`.

## Verification
- `npx tsc --noEmit` clean
- `npx vitest run` — 241 tests pass (added 2: persists on publish, prefills on open)
- `npx eslint` on changed files — 0 errors (pre-existing warnings only)

Part of the SF-295..300 stacked batch; base=SF-298-eval-leaderboard-link.

Asana: https://app.asana.com/0/1213628819033917/1215874884794827