### PR TITLE
SF-300: Eval Studio publish — auto-derive benchmark identity (filename + ID + content signature)

### DIFF
--- a/apps/desktop/src/main/services/__tests__/publish-score.test.ts
+++ b/apps/desktop/src/main/services/__tests__/publish-score.test.ts
@@ -16,6 +16,7 @@ import { submitScore } from '../publish-score';
 
 const REQUEST: PublishScoreRequest = {
   benchmarkId: 'hle',
+  benchmarkSignature: 'a'.repeat(64),
   specId: 'hle-ensemble-three',
   url4Expression: 'url4://ensemble(claude,codex,gemini)/hle',
   providers: ['claude', 'codex', 'gemini'],
@@ -75,6 +76,8 @@ describe('submitScore (main process)', () => {
     expect(body.ran_with_providers).toEqual(['claude', 'codex', 'gemini']);
     expect(body.submitted_by).toBeNull();
     expect(body.ran_at_local).toBe('2026-05-04T11:55:00Z');
+    // SF-300: content signature carried as free-form metadata for server-side verification.
+    expect(body.metadata).toEqual({ benchmark_signature: 'a'.repeat(64), signature_alg: 'sha256' });
 
     expect(outcome).toEqual({
       ok: true,
@@ -86,6 +89,16 @@ describe('submitScore (main process)', () => {
           'https://screamingface.ai/portal/spec.html?benchmark=hle&spec=hle-ensemble-three',
       },
     });
+  });
+
+  it('sends metadata=null when there is no benchmark signature', async () => {
+    const fetchMock = vi.fn(async () => okResponse());
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await submitScore({ ...REQUEST, benchmarkSignature: '' });
+
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.metadata).toBeNull();
   });
 
   it('recomputes accuracy from totals (ignores any drift)', async () => {

--- a/apps/desktop/src/main/services/publish-score.ts
+++ b/apps/desktop/src/main/services/publish-score.ts
@@ -103,7 +103,16 @@ function buildBody(
     ran_with_providers: request.providers,
     ran_at_local: request.ranAtLocal,
     client: { name: client.name, version: client.version, platform: client.platform },
-    metadata: null,
+    // Carry the client-derived benchmark content signature (SF-300) so the
+    // scoreboard can pin benchmark_id to the exact eval content this run used.
+    // SERVER FOLLOW-UP: verify this signature against the source dataset bytes
+    // server-side (the client cannot — it holds only reconstructed rows, not the
+    // original jsonl). Until then it is recorded as metadata for auditing.
+    // `metadata` is a free-form object in the scoreboard contract; null when no
+    // signature is available so we never send an empty-string hash.
+    metadata: request.benchmarkSignature
+      ? { benchmark_signature: request.benchmarkSignature, signature_alg: 'sha256' }
+      : null,
   };
 }
 

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -231,6 +231,13 @@ export interface PublishContext {
 export interface PublishScoreRequest {
   benchmarkId: string;
   specId: string;
+  /**
+   * SHA-256 content signature of the eval content the run executed against,
+   * derived client-side alongside benchmarkId (SF-300). Pins the benchmark id
+   * to the exact dataset content so an id can't drift onto different content.
+   * Empty when the run had no graded content to sign.
+   */
+  benchmarkSignature: string;
   /** url4 expression to publish — already sanitized if the user chose to. */
   url4Expression: string;
   providers: string[];

--- a/apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
@@ -1,5 +1,5 @@
 // apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { X, Upload, ExternalLink, AlertTriangle, CheckCircle2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Url4Field } from '@/components/Url4Field';
@@ -12,6 +12,11 @@ import {
   sanitizeDataRefs,
 } from '@/lib/url4-redaction';
 import { publishBlockReason } from '@/lib/publish-guard';
+import {
+  deriveBenchmarkIdentity,
+  verifyIdentityConsistency,
+  type BenchmarkIdentity,
+} from '@/lib/benchmark-identity';
 import type { EvalRunDetail } from './types';
 
 interface Props {
@@ -53,7 +58,20 @@ export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
   const parsed = useMemo(() => parseSpecName(run.spec_name), [run.spec_name]);
   const hasDataRefs = useMemo(() => hasLocalDataRefs(run.url4_expression), [run.url4_expression]);
 
-  const [benchmarkId, setBenchmarkId] = useState(parsed.benchmark_id ?? '');
+  // SF-300: the benchmark identity (id + label + dataset filename + content
+  // signature) is AUTO-DERIVED from the run — never typed. We derive it async
+  // because the signature is a Web Crypto SHA-256 digest over the run's content.
+  const [identity, setIdentity] = useState<BenchmarkIdentity | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void deriveBenchmarkIdentity(run).then((next) => {
+      if (!cancelled) setIdentity(next);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [run]);
+
   const [specId, setSpecId] = useState(parsed.spec_id);
   const [providersText, setProvidersText] = useState(
     deriveProviders(run.url4_expression).join(', '),
@@ -79,19 +97,28 @@ export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
     () => publishBlockReason({ run, url4Expression: expressionToPublish }),
     [run, expressionToPublish],
   );
-  // Block publish until: run is publishable, benchmark known, and any /data refs
-  // are either sanitized or explicitly acknowledged as exposing local data.
+  // Verify the derived benchmark id <-> content signature are internally
+  // consistent (id derivable + content available to sign) before allowing a
+  // publish. Disagreement (e.g. a run with no graded content) blocks here.
+  const identityCheck = useMemo(
+    () => (identity ? verifyIdentityConsistency(identity) : { ok: false, reason: null }),
+    [identity],
+  );
+  // Block publish until: run is publishable, identity derived + consistent, and
+  // any /data refs are either sanitized or explicitly acknowledged.
   const redactionResolved = !hasDataRefs || sanitize || ackExpose;
   const canPublish =
-    !blockReason && benchmarkId.trim().length > 0 && specId.trim().length > 0 && redactionResolved;
+    !blockReason && !!identity && identityCheck.ok && specId.trim().length > 0 && redactionResolved;
 
   const handlePublish = async (): Promise<void> => {
+    if (!identity) return;
     // Remember the entered name for subsequent publishes this session, whether
     // or not the round-trip ultimately succeeds.
     saveSubmitter(submittedBy.trim());
     const out = await publish({
       run,
-      benchmarkId: benchmarkId.trim(),
+      benchmarkId: identity.id,
+      benchmarkSignature: identity.signature,
       specId: specId.trim(),
       url4Expression: expressionToPublish,
       providers,
@@ -200,19 +227,47 @@ export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
                 )}
               </div>
 
-              {/* benchmark / spec ids */}
+              {/* benchmark identity (auto-derived, read-only) + spec id */}
               <div className="grid grid-cols-2 gap-3">
-                <label className="block">
+                <div className="block">
                   <span className="mb-1 block text-xs font-medium text-muted-foreground">
-                    Benchmark ID <span className="text-destructive">*</span>
+                    Benchmark
                   </span>
-                  <input
-                    className="w-full rounded-none border border-border bg-background px-3 py-2 text-sm"
-                    value={benchmarkId}
-                    placeholder="e.g. hle"
-                    onChange={(e) => setBenchmarkId(e.target.value)}
-                  />
-                </label>
+                  {/* Derived from the dataset filename in the URL4 expression and
+                      pinned by a content signature — not editable (SF-300). */}
+                  <div
+                    data-testid="benchmark-identity"
+                    className="w-full rounded-none border border-border bg-muted/30 px-3 py-2 text-sm text-foreground"
+                    title={identity?.datasetFilename ?? undefined}
+                  >
+                    {identity ? (
+                      <>
+                        <span className="font-medium">{identity.label || identity.id || '—'}</span>
+                        {identity.id && (
+                          <span className="ml-1 text-xs text-muted-foreground">
+                            ({identity.id})
+                          </span>
+                        )}
+                      </>
+                    ) : (
+                      <span className="text-muted-foreground">Deriving…</span>
+                    )}
+                  </div>
+                  {identity && (
+                    <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
+                      {identity.datasetFilename
+                        ? `From ${identity.datasetFilename}`
+                        : 'Derived from the run’s spec (no dataset file in the expression).'}
+                      {identity.signature && (
+                        <>
+                          {' '}
+                          · signature{' '}
+                          <code className="font-mono">{identity.signature.slice(0, 12)}…</code>
+                        </>
+                      )}
+                    </p>
+                  )}
+                </div>
                 <label className="block">
                   <span className="mb-1 block text-xs font-medium text-muted-foreground">
                     Spec ID <span className="text-destructive">*</span>
@@ -224,6 +279,14 @@ export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
                   />
                 </label>
               </div>
+
+              {/* Identity consistency: id<->signature must agree before publish. */}
+              {identity && !identityCheck.ok && identityCheck.reason && (
+                <div className="flex items-start gap-1.5 rounded-none border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  <span>{identityCheck.reason}</span>
+                </div>
+              )}
 
               {/* providers (editable) */}
               <label className="block">

--- a/apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { PublishToLeaderboardDialog } from '../PublishToLeaderboardDialog';
 import type { EvalRunDetail } from '../types';
@@ -26,11 +26,25 @@ vi.mock('@/components/Url4Field', () => ({
   Url4Field: ({ value }: { value: string }) => <span data-testid="url4">{value}</span>,
 }));
 
+const QUESTIONS: EvalRunDetail['questions'] = [
+  {
+    id: 'q-0',
+    idx: 0,
+    question: '2+2?',
+    expected: '4',
+    predicted: '4',
+    correct: true,
+    raw_output: null,
+    error: null,
+  },
+];
+
 function makeRun(overrides: Partial<EvalRunDetail> = {}): EvalRunDetail {
   return {
     id: 'eval-run-1',
     spec_name: 'hle:hle-ensemble-three',
-    url4_expression: 'url4://ensemble(claude,codex,gemini)/hle',
+    url4_expression:
+      'https://screamingface.ai/honest-agi-live-week-3.eval.jsonl*(/claude($item.question))',
     started_at: '2026-05-04T11:00:00Z',
     finished_at: '2026-05-04T11:55:00Z',
     status: 'done',
@@ -39,7 +53,7 @@ function makeRun(overrides: Partial<EvalRunDetail> = {}): EvalRunDetail {
     correct_questions: 810,
     error: null,
     favorite: false,
-    questions: [],
+    questions: QUESTIONS,
     ...overrides,
   };
 }
@@ -57,46 +71,64 @@ beforeEach(() => {
 });
 
 describe('PublishToLeaderboardDialog', () => {
-  it('prefills benchmark/spec from a colon-delimited spec_name', () => {
+  it('auto-derives a read-only benchmark identity from the dataset filename and prefills spec', async () => {
     render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
-    expect(screen.getByPlaceholderText('e.g. hle')).toHaveValue('hle');
+    // Spec id still prefilled from the colon-delimited spec_name.
     expect(screen.getByDisplayValue('hle-ensemble-three')).toBeInTheDocument();
+    // Benchmark is derived + read-only — no free-text input, label shown instead.
+    expect(screen.queryByPlaceholderText('e.g. hle')).not.toBeInTheDocument();
+    const identity = await screen.findByTestId('benchmark-identity');
+    expect(identity).toHaveTextContent('Honest AGI Live week 3');
+    expect(identity).toHaveTextContent('honest-agi-live-week-3');
+    expect(screen.getByText(/From honest-agi-live-week-3\.eval\.jsonl/i)).toBeInTheDocument();
   });
 
-  it('requires a benchmark id when spec_name has no colon', () => {
+  it('publishes the derived benchmark id + content signature (no manual entry)', async () => {
+    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    await screen.findByTestId('benchmark-identity');
+    await waitFor(() => expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: /publish/i }));
+    await waitFor(() => expect(publishMock).toHaveBeenCalledTimes(1));
+    const sent = publishMock.mock.calls[0][0];
+    expect(sent.benchmarkId).toBe('honest-agi-live-week-3');
+    expect(sent.benchmarkSignature).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('blocks publish when the run has no graded content to sign the identity', async () => {
     render(
       <PublishToLeaderboardDialog
-        run={makeRun({ spec_name: 'hle-claude-single' })}
+        run={makeRun({ questions: [] })}
         serverUrl=""
         onClose={vi.fn()}
       />,
     );
-    const benchmark = screen.getByPlaceholderText('e.g. hle');
-    expect(benchmark).toHaveValue('');
+    await screen.findByTestId('benchmark-identity');
+    expect(await screen.findByText(/no graded content/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /publish/i })).toBeDisabled();
-    fireEvent.change(benchmark, { target: { value: 'hle' } });
-    expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled();
   });
 
-  it('warns about /data refs and publishes the sanitized expression by default', () => {
+  it('warns about /data refs and publishes the sanitized expression by default', async () => {
     const run = makeRun({ url4_expression: '(/data/abc123)!$prompt' });
     render(<PublishToLeaderboardDialog run={run} serverUrl="" onClose={vi.fn()} />);
     expect(screen.getByText(/references local/i)).toBeInTheDocument();
     // sanitize defaults on → the displayed/published expression is redacted.
     expect(screen.getByTestId('url4')).toHaveTextContent('/data/<redacted>');
+    await screen.findByTestId('benchmark-identity');
+    await waitFor(() => expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled());
     fireEvent.click(screen.getByRole('button', { name: /publish/i }));
     expect(publishMock).toHaveBeenCalledTimes(1);
     expect(publishMock.mock.calls[0][0].url4Expression).toContain('/data/<redacted>');
   });
 
-  it('blocks publish if /data refs are neither sanitized nor acknowledged', () => {
+  it('blocks publish if /data refs are neither sanitized nor acknowledged', async () => {
     const run = makeRun({ url4_expression: '(/data/abc123)!$prompt' });
     render(<PublishToLeaderboardDialog run={run} serverUrl="" onClose={vi.fn()} />);
+    await screen.findByTestId('benchmark-identity');
     const sanitize = screen.getByRole('checkbox', { name: /sanitize/i });
     fireEvent.click(sanitize); // uncheck
     expect(screen.getByRole('button', { name: /publish/i })).toBeDisabled();
     fireEvent.click(screen.getByRole('checkbox', { name: /exposes my local data/i }));
-    expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled();
+    await waitFor(() => expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled());
   });
 
   it('blocks a zero-question run with an explanation (preflight guard)', () => {
@@ -106,17 +138,20 @@ describe('PublishToLeaderboardDialog', () => {
     expect(screen.getByRole('button', { name: /publish/i })).toBeDisabled();
   });
 
-  it('does not block a normal completed run', () => {
+  it('does not block a normal completed run', async () => {
     render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
     expect(screen.queryByText(/no graded questions/i)).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled();
+    await screen.findByTestId('benchmark-identity');
+    await waitFor(() => expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled());
   });
 
-  it('persists the submitter name to sessionStorage on publish', () => {
+  it('persists the submitter name to sessionStorage on publish', async () => {
     render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    await screen.findByTestId('benchmark-identity');
     fireEvent.change(screen.getByPlaceholderText('leave blank for anonymous'), {
       target: { value: 'Ada Lovelace' },
     });
+    await waitFor(() => expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled());
     fireEvent.click(screen.getByRole('button', { name: /publish/i }));
     expect(window.sessionStorage.getItem('sf-leaderboard-submitter')).toBe('Ada Lovelace');
   });

--- a/apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
@@ -78,7 +78,9 @@ describe('PublishToLeaderboardDialog', () => {
     // Benchmark is derived + read-only — no free-text input, label shown instead.
     expect(screen.queryByPlaceholderText('e.g. hle')).not.toBeInTheDocument();
     const identity = await screen.findByTestId('benchmark-identity');
-    expect(identity).toHaveTextContent('Honest AGI Live week 3');
+    // Derivation is async (Web Crypto SHA-256 signature) — wait for the resolved
+    // label, not just the element, which first renders a "Deriving…" placeholder.
+    await waitFor(() => expect(identity).toHaveTextContent('Honest AGI Live week 3'));
     expect(identity).toHaveTextContent('honest-agi-live-week-3');
     expect(screen.getByText(/From honest-agi-live-week-3\.eval\.jsonl/i)).toBeInTheDocument();
   });

--- a/apps/desktop/src/renderer/src/hooks/__tests__/use-publish-score.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/__tests__/use-publish-score.test.ts
@@ -23,6 +23,7 @@ const RUN: EvalRunDetail = {
 const INPUTS: PublishInputs = {
   run: RUN,
   benchmarkId: 'hle',
+  benchmarkSignature: 'a'.repeat(64),
   specId: 'hle-ensemble-three',
   url4Expression: RUN.url4_expression,
   providers: ['claude', 'codex', 'gemini'],
@@ -63,6 +64,7 @@ describe('usePublishScore', () => {
     expect(submitScore).toHaveBeenCalledTimes(1);
     expect(submitScore).toHaveBeenCalledWith({
       benchmarkId: 'hle',
+      benchmarkSignature: 'a'.repeat(64),
       specId: 'hle-ensemble-three',
       url4Expression: 'url4://ensemble(claude,codex,gemini)/hle',
       providers: ['claude', 'codex', 'gemini'],

--- a/apps/desktop/src/renderer/src/hooks/use-publish-score.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-publish-score.ts
@@ -15,6 +15,8 @@ export type PublishStatus = 'idle' | 'submitting' | 'success' | 'error';
 export interface PublishInputs {
   run: EvalRunDetail;
   benchmarkId: string;
+  /** SHA-256 content signature derived from the run's eval content (SF-300). */
+  benchmarkSignature: string;
   specId: string;
   /** url4 expression to publish — already sanitized if the user chose to. */
   url4Expression: string;
@@ -30,6 +32,7 @@ function toRequest(inputs: PublishInputs): PublishScoreRequest {
   const { run } = inputs;
   return {
     benchmarkId: inputs.benchmarkId,
+    benchmarkSignature: inputs.benchmarkSignature,
     specId: inputs.specId,
     url4Expression: inputs.url4Expression,
     providers: inputs.providers,

--- a/apps/desktop/src/renderer/src/lib/__tests__/benchmark-identity.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/benchmark-identity.test.ts
@@ -1,0 +1,189 @@
+// apps/desktop/src/renderer/src/lib/__tests__/benchmark-identity.test.ts
+import { describe, it, expect } from 'vitest';
+import {
+  detectDatasetFilename,
+  deriveBenchmarkId,
+  deriveBenchmarkLabel,
+  normalizeEvalContent,
+  computeContentSignature,
+  deriveBenchmarkIdentity,
+  verifyIdentityConsistency,
+} from '../benchmark-identity';
+import type { EvalRunDetail, EvalQuestion } from '@/components/eval/types';
+
+function q(idx: number, question: string, expected: string): EvalQuestion {
+  return {
+    id: `q-${idx}`,
+    idx,
+    question,
+    expected,
+    predicted: null,
+    correct: null,
+    raw_output: null,
+    error: null,
+  };
+}
+
+function makeRun(overrides: Partial<EvalRunDetail> = {}): EvalRunDetail {
+  return {
+    id: 'eval-run-1',
+    spec_name: 'honest-agi-live-week-3',
+    url4_expression:
+      'https://screamingface.ai/honest-agi-live-week-3.eval.jsonl*(/claude($item.question))!reduce',
+    started_at: '2026-05-04T11:00:00Z',
+    finished_at: '2026-05-04T11:55:00Z',
+    status: 'done',
+    accuracy: 0.5,
+    total_questions: 2,
+    correct_questions: 1,
+    error: null,
+    favorite: false,
+    questions: [q(0, '2+2?', '4'), q(1, 'capital of France?', 'Paris')],
+    ...overrides,
+  };
+}
+
+describe('detectDatasetFilename', () => {
+  it('extracts the .eval.jsonl filename from a collection source URL', () => {
+    expect(
+      detectDatasetFilename(
+        'https://screamingface.ai/honest-agi-live-week-3.eval.jsonl*(/claude($item.question))',
+      ),
+    ).toBe('honest-agi-live-week-3.eval.jsonl');
+  });
+
+  it('extracts a plain .jsonl filename', () => {
+    expect(detectDatasetFilename('https://example.com/data.jsonl*(text)!intent')).toBe(
+      'data.jsonl',
+    );
+  });
+
+  it('prefers an .eval.jsonl over another dataset file in the same expression', () => {
+    const expr = 'https://x.test/hle.eval.jsonl*(/python(reduce.csv)!{$item})';
+    expect(detectDatasetFilename(expr)).toBe('hle.eval.jsonl');
+  });
+
+  it('returns null when there is no dataset filename', () => {
+    expect(detectDatasetFilename('(/data/abc123)!$prompt')).toBeNull();
+    expect(detectDatasetFilename('url4://ensemble(claude,codex)/hle')).toBeNull();
+    expect(detectDatasetFilename('')).toBeNull();
+  });
+});
+
+describe('deriveBenchmarkId', () => {
+  it('strips the eval extension and slugifies', () => {
+    expect(deriveBenchmarkId('honest-agi-live-week-3.eval.jsonl')).toBe('honest-agi-live-week-3');
+  });
+
+  it('slugifies spaces and underscores', () => {
+    expect(deriveBenchmarkId('Honest AGI_Live week 3.jsonl')).toBe('honest-agi-live-week-3');
+  });
+
+  it('handles plain .json and .csv', () => {
+    expect(deriveBenchmarkId('hle.json')).toBe('hle');
+    expect(deriveBenchmarkId('data.csv')).toBe('data');
+  });
+});
+
+describe('deriveBenchmarkLabel', () => {
+  it('renders the Honest AGI Live week family', () => {
+    expect(deriveBenchmarkLabel('honest-agi-live-week-3')).toBe('Honest AGI Live week 3');
+    expect(deriveBenchmarkLabel('honest-agi-live')).toBe('Honest AGI Live');
+  });
+
+  it('uppercases known acronyms and titleizes the rest', () => {
+    expect(deriveBenchmarkLabel('hle')).toBe('HLE');
+    expect(deriveBenchmarkLabel('my-custom-bench')).toBe('My Custom Bench');
+  });
+});
+
+describe('normalizeEvalContent', () => {
+  it('orders rows by idx and emits {question, expected} jsonl', () => {
+    const run = makeRun({
+      questions: [q(1, 'capital of France?', 'Paris'), q(0, '2+2?', '4')],
+    });
+    expect(normalizeEvalContent(run)).toBe(
+      '{"question":"2+2?","expected":"4"}\n{"question":"capital of France?","expected":"Paris"}',
+    );
+  });
+
+  it('is empty for a run with no questions', () => {
+    expect(normalizeEvalContent(makeRun({ questions: [] }))).toBe('');
+  });
+});
+
+describe('computeContentSignature', () => {
+  it('is a stable 64-char hex SHA-256 over the normalized content', async () => {
+    const sig = await computeContentSignature(makeRun());
+    expect(sig).toMatch(/^[0-9a-f]{64}$/);
+    // Stable: same content -> same hash regardless of input row order.
+    const reordered = await computeContentSignature(
+      makeRun({ questions: [q(1, 'capital of France?', 'Paris'), q(0, '2+2?', '4')] }),
+    );
+    expect(reordered).toBe(sig);
+  });
+
+  it('differs when the eval content differs', async () => {
+    const a = await computeContentSignature(makeRun());
+    const b = await computeContentSignature(makeRun({ questions: [q(0, '2+2?', '5')] }));
+    expect(b).not.toBe(a);
+  });
+
+  it('returns empty string for a run with no graded content', async () => {
+    expect(await computeContentSignature(makeRun({ questions: [] }))).toBe('');
+  });
+});
+
+describe('deriveBenchmarkIdentity', () => {
+  it('derives id, label, filename, and signature from a collection run', async () => {
+    const identity = await deriveBenchmarkIdentity(makeRun());
+    expect(identity.datasetFilename).toBe('honest-agi-live-week-3.eval.jsonl');
+    expect(identity.id).toBe('honest-agi-live-week-3');
+    expect(identity.label).toBe('Honest AGI Live week 3');
+    expect(identity.signature).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('falls back to spec_name when the expression has no dataset filename', async () => {
+    const identity = await deriveBenchmarkIdentity(
+      makeRun({ url4_expression: '(/data/abc)!$prompt', spec_name: 'hle' }),
+    );
+    expect(identity.datasetFilename).toBeNull();
+    expect(identity.id).toBe('hle');
+    expect(identity.label).toBe('HLE');
+  });
+});
+
+describe('verifyIdentityConsistency', () => {
+  it('passes a fully derived identity', () => {
+    expect(
+      verifyIdentityConsistency({
+        id: 'honest-agi-live-week-3',
+        label: 'Honest AGI Live week 3',
+        datasetFilename: 'honest-agi-live-week-3.eval.jsonl',
+        signature: 'a'.repeat(64),
+      }),
+    ).toEqual({ ok: true, reason: null });
+  });
+
+  it('blocks when the id could not be derived', () => {
+    const out = verifyIdentityConsistency({
+      id: '',
+      label: '',
+      datasetFilename: null,
+      signature: 'a'.repeat(64),
+    });
+    expect(out.ok).toBe(false);
+    expect(out.reason).toMatch(/could not derive a benchmark id/i);
+  });
+
+  it('blocks when the signature is missing (no content to pin the id to)', () => {
+    const out = verifyIdentityConsistency({
+      id: 'hle',
+      label: 'HLE',
+      datasetFilename: 'hle.eval.jsonl',
+      signature: '',
+    });
+    expect(out.ok).toBe(false);
+    expect(out.reason).toMatch(/no graded content/i);
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/benchmark-identity.ts
+++ b/apps/desktop/src/renderer/src/lib/benchmark-identity.ts
@@ -1,0 +1,174 @@
+// apps/desktop/src/renderer/src/lib/benchmark-identity.ts
+//
+// Auto-derives a benchmark *identity* for the "Publish to Leaderboard" flow
+// (SF-300), replacing the old free-text Benchmark-ID input. An identity has
+// three parts, all derived — never typed by the user:
+//
+//   1. datasetFilename — the `*.eval.jsonl` (or .jsonl/.json/.csv) file the run's
+//      url4 expression iterated over, pulled from the dataset/collection source URL.
+//   2. id             — a stable, slugified benchmark id derived from that filename
+//      (e.g. `honest-agi-live-week-3.eval.jsonl` -> `honest-agi-live-week-3`).
+//   3. signature      — a SHA-256 content hash that pins the id to the exact eval
+//      content the run executed against, so an id can't silently drift onto a
+//      different dataset.
+//
+// CLIENT-SIDE GAP (documented, intentional): the desktop app does NOT hold the
+// raw jsonl bytes the server fetched — an eval_run only persists the per-question
+// `question`/`expected` pairs (see eval/types.ts) and the url4 expression. So the
+// signature here is computed over a *normalized reconstruction* of those rows,
+// not the original file bytes. It is stable and collision-resistant for our
+// purposes (detecting "same id, different content"), but it is NOT byte-identical
+// to a hash the scoreboard would compute over the source file.
+//
+// SERVER FOLLOW-UP (out of scope for this client ticket — see PR body): the
+// authoritative fix is for the server to (a) embed a non-editable benchmark-ID
+// metadata field into each dataset row, and (b) record/verify a hash of the
+// fetched source bytes, so the scoreboard can verify id<->signature against the
+// real file rather than this client reconstruction.
+
+import type { EvalRunDetail } from '@/components/eval/types';
+
+/** Matches a dataset/collection source filename ending in a known eval extension. */
+const DATASET_FILE_RE = /([A-Za-z0-9._-]+\.(?:eval\.jsonl|jsonl|json|csv))(?=$|[)\s*!,;])/i;
+/** Strips the trailing dataset extension to leave the benchmark stem. */
+const EXT_STRIP_RE = /\.(?:eval\.jsonl|jsonl|json|csv)$/i;
+
+export interface BenchmarkIdentity {
+  /** Slugified, stable benchmark id derived from the dataset filename. */
+  id: string;
+  /** Human label (e.g. "Honest AGI Live week 3") when the filename matches a known pattern, else a titleized stem. */
+  label: string;
+  /** The dataset filename detected in the url4 expression, or null when none found. */
+  datasetFilename: string | null;
+  /** SHA-256 over the normalized reconstructed eval content (hex). Empty when no content. */
+  signature: string;
+}
+
+/**
+ * Pull the dataset filename out of a url4 expression. We look for the last path
+ * segment of a dataset/collection source URL ending in a known eval extension.
+ * Returns null when the expression has no recognizable dataset file (e.g. an
+ * inline `/data/<hash>` blob run, or a single-prompt run).
+ */
+export function detectDatasetFilename(expression: string): string | null {
+  if (!expression) return null;
+  // Scan all matches and take the last dataset-like filename: the collection
+  // source is typically the left operand of `*`, but reducers/checks may name
+  // other files — the dataset is the one carrying an eval extension. We prefer
+  // the first `.eval.jsonl` match, else the first match of any kind.
+  const all = expression.match(new RegExp(DATASET_FILE_RE, 'gi')) ?? [];
+  if (all.length === 0) return null;
+  const evalJsonl = all.find((f) => /\.eval\.jsonl$/i.test(f));
+  return evalJsonl ?? all[0];
+}
+
+/**
+ * Slugify a dataset filename into a stable benchmark id: strip the extension,
+ * lowercase, and collapse non-alphanumeric runs to single hyphens.
+ */
+export function deriveBenchmarkId(filename: string): string {
+  const stem = filename.replace(EXT_STRIP_RE, '');
+  return stem
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Human-readable label for a benchmark id. Recognizes the "honest-agi-live-week-N"
+ * family and renders it as "Honest AGI Live week N"; otherwise titleizes the slug.
+ */
+export function deriveBenchmarkLabel(id: string): string {
+  const week = id.match(/^honest-agi-live-week-(\d+)$/i);
+  if (week) return `Honest AGI Live week ${week[1]}`;
+  if (/^honest-agi-live$/i.test(id)) return 'Honest AGI Live';
+  if (!id) return '';
+  return id
+    .split('-')
+    .filter(Boolean)
+    .map((word) => {
+      // Keep all-caps acronyms (agi -> AGI, hle -> HLE) uppercased when short.
+      if (/^[a-z]{2,4}$/.test(word) && /^(agi|hle|gpqa|mmlu|swe)$/i.test(word)) {
+        return word.toUpperCase();
+      }
+      return word.charAt(0).toUpperCase() + word.slice(1);
+    })
+    .join(' ');
+}
+
+/**
+ * Normalize the run's graded questions into stable jsonl bytes for hashing:
+ * one `{question, expected}` object per row, ordered by `idx`, NFC-normalized,
+ * newline-joined. This is the reconstruction the signature is computed over (see
+ * the CLIENT-SIDE GAP note at the top of this file).
+ */
+export function normalizeEvalContent(run: EvalRunDetail): string {
+  const rows = [...run.questions]
+    .sort((a, b) => a.idx - b.idx)
+    .map((q) => JSON.stringify({ question: q.question, expected: q.expected }).normalize('NFC'));
+  return rows.join('\n');
+}
+
+function toHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/**
+ * SHA-256 (hex) over the normalized eval content. Returns '' for empty content
+ * so callers can treat "no content to sign" distinctly from a real digest.
+ */
+export async function computeContentSignature(run: EvalRunDetail): Promise<string> {
+  const content = normalizeEvalContent(run);
+  if (content.length === 0) return '';
+  const bytes = new TextEncoder().encode(content);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return toHex(digest);
+}
+
+/**
+ * Derive the full benchmark identity (id + label + filename + signature) for a
+ * run. Async because the signature is a Web Crypto digest.
+ */
+export async function deriveBenchmarkIdentity(run: EvalRunDetail): Promise<BenchmarkIdentity> {
+  const datasetFilename = detectDatasetFilename(run.url4_expression);
+  // Fall back to the run's spec_name stem when the expression has no dataset
+  // file (inline blob / single-prompt runs) so the id is never empty when a
+  // spec name exists. The signature still pins it to the executed content.
+  const baseName = datasetFilename ?? run.spec_name;
+  const id = deriveBenchmarkId(baseName);
+  const label = deriveBenchmarkLabel(id);
+  const signature = await computeContentSignature(run);
+  return { id, label, datasetFilename, signature };
+}
+
+export interface IdentityConsistency {
+  ok: boolean;
+  /** User-facing reason when not ok; null when consistent. */
+  reason: string | null;
+}
+
+/**
+ * Verify a derived id<->signature pair is internally consistent before publish.
+ * Blocks when the id is empty (nothing to attribute the score to) or the
+ * signature is missing (no graded content to pin the id to — i.e. the id can't
+ * be trusted to describe what actually ran).
+ */
+export function verifyIdentityConsistency(identity: BenchmarkIdentity): IdentityConsistency {
+  if (!identity.id) {
+    return {
+      ok: false,
+      reason:
+        'Could not derive a benchmark ID from this run (no dataset filename in the URL4 expression and no spec name). This run can’t be attributed to a leaderboard benchmark.',
+    };
+  }
+  if (!identity.signature) {
+    return {
+      ok: false,
+      reason:
+        'This run has no graded content to sign, so its benchmark ID can’t be verified against what it ran. Re-run the eval against the dataset before publishing.',
+    };
+  }
+  return { ok: true, reason: null };
+}


### PR DESCRIPTION
## What

Replaces the manual free-text **Benchmark ID** field in the desktop "Publish to Leaderboard" flow with an **auto-derived, read-only benchmark identity**:

- **Dataset filename** detected from the run's URL4 dataset/collection source URL (`*.eval.jsonl`, also `.jsonl`/`.json`/`.csv`), preferring `.eval.jsonl`.
- **Benchmark id** slugified from that filename (`honest-agi-live-week-3.eval.jsonl` → `honest-agi-live-week-3`); falls back to the run's `spec_name` when no dataset file is in the expression.
- **Human label** for known families (e.g. "Honest AGI Live week 3"), titleized otherwise (acronyms like HLE uppercased).
- **Content signature** — SHA-256 (Web Crypto) over the run's normalized, idx-ordered `{question, expected}` rows.

The dialog shows the identity read-only (no text input), records **both** the id and the signature in the publish payload (signature carried as score `metadata.benchmark_signature` + `signature_alg`), and **verifies id↔signature consistency before publish** — a run with no graded content (no signature) or no derivable id is blocked with an explanation.

## Why

Manual benchmark-ID entry let a submitter mistype or mis-attribute a run to the wrong leaderboard. Deriving the identity from what actually ran, and pinning it with a content hash, removes that failure mode and gives the scoreboard a signature to verify against.

## Documented client-side gap + server follow-up

The desktop app does **not** hold the raw jsonl bytes the server fetched — an `eval_run` only persists per-question `question`/`expected` and the URL4 expression. So the signature is computed over a **normalized reconstruction** of those rows, not the original file bytes: stable and collision-resistant for "same id, different content" detection, but **not byte-identical** to a hash over the source file. This is called out in a header comment in `benchmark-identity.ts`.

**Server follow-up (out of scope here):** (a) embed a non-editable benchmark-ID metadata field into each dataset row, and (b) record/verify a hash of the fetched source bytes server-side, so the scoreboard verifies id↔signature against the real file instead of the client reconstruction. The client already sends `metadata.benchmark_signature` for this.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — 262 passed (incl. new `benchmark-identity.test.ts`, updated dialog/hook/main-process publish tests)
- `npx eslint` on changed files — 0 errors (pre-existing sonarjs warnings only)

Part of the SF-295..300 stacked batch; base=SF-299-persist-submitter-name.

Asana: https://app.asana.com/0/1213628819033917/1215875162400820