### PR TITLE
SF-309: manual benchmark combobox + full-height URL4 field in publish dialog

### DIFF
--- a/apps/desktop/src/main/ipc/publish.ipc.ts
+++ b/apps/desktop/src/main/ipc/publish.ipc.ts
@@ -8,8 +8,9 @@
 import { BrowserWindow, ipcMain, shell } from 'electron';
 import { resolvePublishContext, type PublishContext } from '../services/publish-context';
 import { submitScore } from '../services/publish-score';
+import { listBenchmarks } from '../services/list-benchmarks';
 import { getPublishLog, onPublishLog } from '../services/publish-log';
-import type { PublishOutcome, PublishScoreRequest } from '../../preload/types';
+import type { KnownBenchmark, PublishOutcome, PublishScoreRequest } from '../../preload/types';
 import { requireTrustedIpcSender } from './sender-validation';
 
 function isHttpUrl(value: string): boolean {
@@ -38,6 +39,11 @@ export function registerPublishHandlers(): void {
   ipcMain.handle('publish:getLogs', (event): string[] => {
     requireTrustedIpcSender(event);
     return getPublishLog();
+  });
+
+  ipcMain.handle('publish:listBenchmarks', (event): Promise<KnownBenchmark[] | null> => {
+    requireTrustedIpcSender(event);
+    return listBenchmarks();
   });
 
   // Stream new publish/scoreboard diagnostic lines to every renderer window.

--- a/apps/desktop/src/main/services/__tests__/list-benchmarks.test.ts
+++ b/apps/desktop/src/main/services/__tests__/list-benchmarks.test.ts
@@ -1,0 +1,69 @@
+import { vi, describe, it, expect, afterEach } from 'vitest';
+
+// Mirror publish-score.test: stub context (URLs) + publish-log (pulls in electron).
+const CTX = {
+  scoreboardUrl: 'https://scoreboard.screamingface.ai',
+  portalUrl: 'https://screamingface.ai/portal/',
+  client: { name: 'screamingface-desktop', version: '0.4.2', platform: 'darwin' },
+};
+vi.mock('../publish-context', () => ({ resolvePublishContext: () => CTX }));
+vi.mock('../publish-log', () => ({ publishLog: () => {} }));
+
+import { listBenchmarks } from '../list-benchmarks';
+
+function okResponse(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('listBenchmarks (main process)', () => {
+  it('hits GET /v1/benchmarks on the configured scoreboard and maps the rows', async () => {
+    const fetchMock = vi.fn(async () =>
+      okResponse({
+        benchmarks: [
+          { id: 'honest-agi-live-week-3', display_name: 'Honest AGI Live week 3' },
+          { id: 'hle', display_name: 'HLE' },
+        ],
+      }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const out = await listBenchmarks();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toBe(
+      'https://scoreboard.screamingface.ai/v1/benchmarks',
+    );
+    expect(out).toEqual([
+      { id: 'honest-agi-live-week-3', displayName: 'Honest AGI Live week 3' },
+      { id: 'hle', displayName: 'HLE' },
+    ]);
+  });
+
+  it('falls back to id when display_name is missing, and drops rows without an id', async () => {
+    global.fetch = vi.fn(async () =>
+      okResponse({ benchmarks: [{ id: 'gpqa' }, { display_name: 'no id' }, { id: '' }] }),
+    ) as unknown as typeof fetch;
+
+    const out = await listBenchmarks();
+
+    expect(out).toEqual([{ id: 'gpqa', displayName: 'gpqa' }]);
+  });
+
+  it('returns null on a non-2xx response (so callers show no false "unknown")', async () => {
+    global.fetch = vi.fn(
+      async () => ({ ok: false, status: 503 }) as unknown as Response,
+    ) as unknown as typeof fetch;
+    expect(await listBenchmarks()).toBeNull();
+  });
+
+  it('returns null when the registry is unreachable', async () => {
+    global.fetch = vi.fn(async () => {
+      throw new Error('network down');
+    }) as unknown as typeof fetch;
+    expect(await listBenchmarks()).toBeNull();
+  });
+});

--- a/apps/desktop/src/main/services/__tests__/publish-score.test.ts
+++ b/apps/desktop/src/main/services/__tests__/publish-score.test.ts
@@ -16,6 +16,7 @@ import { submitScore } from '../publish-score';
 
 const REQUEST: PublishScoreRequest = {
   benchmarkId: 'hle',
+  benchmarkSignature: 'a'.repeat(64),
   specId: 'hle-ensemble-three',
   url4Expression: 'url4://ensemble(claude,codex,gemini)/hle',
   providers: ['claude', 'codex', 'gemini'],
@@ -75,6 +76,8 @@ describe('submitScore (main process)', () => {
     expect(body.ran_with_providers).toEqual(['claude', 'codex', 'gemini']);
     expect(body.submitted_by).toBeNull();
     expect(body.ran_at_local).toBe('2026-05-04T11:55:00Z');
+    // SF-300: content signature carried as free-form metadata for server-side verification.
+    expect(body.metadata).toEqual({ benchmark_signature: 'a'.repeat(64), signature_alg: 'sha256' });
 
     expect(outcome).toEqual({
       ok: true,
@@ -86,6 +89,16 @@ describe('submitScore (main process)', () => {
           'https://screamingface.ai/portal/spec.html?benchmark=hle&spec=hle-ensemble-three',
       },
     });
+  });
+
+  it('sends metadata=null when there is no benchmark signature', async () => {
+    const fetchMock = vi.fn(async () => okResponse());
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await submitScore({ ...REQUEST, benchmarkSignature: '' });
+
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.metadata).toBeNull();
   });
 
   it('recomputes accuracy from totals (ignores any drift)', async () => {

--- a/apps/desktop/src/main/services/list-benchmarks.ts
+++ b/apps/desktop/src/main/services/list-benchmarks.ts
@@ -1,0 +1,52 @@
+// apps/desktop/src/main/services/list-benchmarks.ts
+//
+// Fetches the canonical set of benchmarks registered on the public scoreboard
+// (GET /v1/benchmarks) from the MAIN process, so the request is exempt from
+// renderer CORS (same rationale as publish-score, SF-273). Used for pre-flight
+// validation of the SF-300 auto-derived benchmark id: the publish dialog warns
+// when the derived id isn't registered (publish itself hard-404s unknown ids).
+//
+// Returns null on ANY failure (unreachable, non-2xx, bad body) so the renderer
+// can treat "registry unavailable" distinctly from "benchmark not registered"
+// and never show a false "unknown benchmark" warning.
+
+import { resolvePublishContext } from './publish-context';
+import { publishLog } from './publish-log';
+import type { KnownBenchmark } from '../../preload/types';
+
+const TIMEOUT_MS = 8_000;
+
+interface BenchmarksResponseBody {
+  benchmarks?: Array<{ id?: unknown; display_name?: unknown }>;
+}
+
+export async function listBenchmarks(): Promise<KnownBenchmark[] | null> {
+  const ctx = resolvePublishContext();
+  const url = `${ctx.scoreboardUrl.replace(/\/$/, '')}/v1/benchmarks`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    if (!res.ok) {
+      publishLog(`benchmarks: GET ${url} -> HTTP ${res.status}`);
+      return null;
+    }
+    const data = (await res.json()) as BenchmarksResponseBody;
+    const rows = Array.isArray(data.benchmarks) ? data.benchmarks : [];
+    return rows
+      .filter(
+        (b): b is { id: string; display_name?: unknown } =>
+          typeof b?.id === 'string' && b.id.length > 0,
+      )
+      .map((b) => ({
+        id: b.id,
+        displayName:
+          typeof b.display_name === 'string' && b.display_name.length > 0 ? b.display_name : b.id,
+      }));
+  } catch (e) {
+    publishLog(`benchmarks: GET ${url} failed: ${(e as Error).message}`);
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/apps/desktop/src/main/services/publish-score.ts
+++ b/apps/desktop/src/main/services/publish-score.ts
@@ -103,7 +103,16 @@ function buildBody(
     ran_with_providers: request.providers,
     ran_at_local: request.ranAtLocal,
     client: { name: client.name, version: client.version, platform: client.platform },
-    metadata: null,
+    // Carry the client-derived benchmark content signature (SF-300) so the
+    // scoreboard can pin benchmark_id to the exact eval content this run used.
+    // SERVER FOLLOW-UP: verify this signature against the source dataset bytes
+    // server-side (the client cannot — it holds only reconstructed rows, not the
+    // original jsonl). Until then it is recorded as metadata for auditing.
+    // `metadata` is a free-form object in the scoreboard contract; null when no
+    // signature is available so we never send an empty-string hash.
+    metadata: request.benchmarkSignature
+      ? { benchmark_signature: request.benchmarkSignature, signature_alg: 'sha256' }
+      : null,
   };
 }
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -52,6 +52,7 @@ const api: ElectronAPI = {
     getLogs: () => ipcRenderer.invoke('publish:getLogs'),
     onLog: (cb) => onEvent('publish:log', cb),
     openExternal: (url) => ipcRenderer.invoke('publish:openExternal', url),
+    listBenchmarks: () => ipcRenderer.invoke('publish:listBenchmarks'),
   },
   backends: {
     getStatus: () => ipcRenderer.invoke('backends:getStatus'),

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -262,6 +262,12 @@ export interface PublishResult {
 /** Discriminated outcome of a publish attempt — never throws across IPC. */
 export type PublishOutcome = { ok: true; value: PublishResult } | { ok: false; error: string };
 
+/** A benchmark registered on the public scoreboard (from GET /v1/benchmarks). */
+export interface KnownBenchmark {
+  id: string;
+  displayName: string;
+}
+
 export interface ElectronAPI {
   popup: {
     open: (url: string, title?: string) => Promise<void>;
@@ -315,6 +321,12 @@ export interface ElectronAPI {
     /** Subscribe to live publish/scoreboard log lines; returns an unsubscribe fn. */
     onLog: (callback: (line: string) => void) => () => void;
     openExternal: (url: string) => Promise<void>;
+    /**
+     * Canonical benchmarks registered on the scoreboard (GET /v1/benchmarks),
+     * for pre-flight validation of the derived benchmark id. Resolves to null
+     * when the registry is unreachable, so callers never show a false "unknown".
+     */
+    listBenchmarks: () => Promise<KnownBenchmark[] | null>;
   };
   backends: {
     getStatus: () => Promise<BackendStatusResponse>;

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -231,6 +231,13 @@ export interface PublishContext {
 export interface PublishScoreRequest {
   benchmarkId: string;
   specId: string;
+  /**
+   * SHA-256 content signature of the eval content the run executed against,
+   * derived client-side alongside benchmarkId (SF-300). Pins the benchmark id
+   * to the exact dataset content so an id can't drift onto different content.
+   * Empty when the run had no graded content to sign.
+   */
+  benchmarkSignature: string;
   /** url4 expression to publish — already sanitized if the user chose to. */
   url4Expression: string;
   providers: string[];

--- a/apps/desktop/src/renderer/src/components/CodeEditorPopup.tsx
+++ b/apps/desktop/src/renderer/src/components/CodeEditorPopup.tsx
@@ -15,7 +15,8 @@ interface Props {
   title: string;
   language: string;
   value: string;
-  onSave: (value: string) => void;
+  /** Primary action. Omit to hide the primary button entirely (e.g. a run-only popup). */
+  onSave?: (value: string) => void;
   onClose: () => void;
   /** Inset from every app border (CSS length). Defaults to 5%. */
   inset?: string;
@@ -118,14 +119,16 @@ export default function CodeEditorPopup({
                 {secondaryIcon} {secondaryLabel}
               </Button>
             )}
-            <Button
-              onClick={() => {
-                onSave(draft);
-                onClose();
-              }}
-            >
-              {confirmIcon} {confirmLabel}
-            </Button>
+            {onSave && (
+              <Button
+                onClick={() => {
+                  onSave(draft);
+                  onClose();
+                }}
+              >
+                {confirmIcon} {confirmLabel}
+              </Button>
+            )}
           </div>
         </div>
       </div>

--- a/apps/desktop/src/renderer/src/components/Url4Field.tsx
+++ b/apps/desktop/src/renderer/src/components/Url4Field.tsx
@@ -15,6 +15,8 @@ interface Url4FieldProps {
   readOnly?: boolean;
   serverUrl: string;
   className?: string;
+  /** Upper bound for the editor's auto-grow height; null = grow to full content (no inner scrollbar). Defaults to 360. */
+  maxContentHeight?: number | null;
 }
 
 export function Url4Field(props: Url4FieldProps) {

--- a/apps/desktop/src/renderer/src/components/Url4MonacoEditor.tsx
+++ b/apps/desktop/src/renderer/src/components/Url4MonacoEditor.tsx
@@ -10,6 +10,7 @@ import Editor, { type OnMount } from '@monaco-editor/react';
 // Side-effect: bundle Monaco (no CDN) before it mounts.
 import '@/lib/monaco-setup';
 import { registerUrl4Language, setUrl4SpecNames } from '@/lib/url4-language';
+import { clampEditorHeight } from '@/lib/editor-height';
 
 interface Props {
   value: string;
@@ -17,6 +18,7 @@ interface Props {
   readOnly?: boolean;
   serverUrl: string;
   className?: string;
+  maxContentHeight?: number | null;
 }
 
 export default function Url4MonacoEditor({
@@ -25,6 +27,7 @@ export default function Url4MonacoEditor({
   readOnly,
   serverUrl,
   className,
+  maxContentHeight = 360,
 }: Props) {
   const ro = readOnly ?? onChange === undefined;
   const wrapRef = useRef<HTMLDivElement>(null);
@@ -36,7 +39,7 @@ export default function Url4MonacoEditor({
 
     // Auto-grow to fit content (capped) so it reads like a highlighted block.
     const applyHeight = (): void => {
-      const h = Math.min(Math.max(editor.getContentHeight(), 28), 360);
+      const h = clampEditorHeight(editor.getContentHeight(), maxContentHeight);
       if (wrapRef.current) wrapRef.current.style.height = `${h}px`;
       editor.layout();
     };
@@ -90,7 +93,11 @@ export default function Url4MonacoEditor({
           renderLineHighlight: 'none',
           overviewRulerLanes: 0,
           hideCursorInOverviewRuler: true,
-          scrollbar: { horizontalScrollbarSize: 0, verticalScrollbarSize: 8 },
+          scrollbar: {
+            horizontalScrollbarSize: 0,
+            verticalScrollbarSize: 8,
+            alwaysConsumeMouseWheel: false,
+          },
           automaticLayout: true,
           contextmenu: !ro,
           fixedOverflowWidgets: true,

--- a/apps/desktop/src/renderer/src/components/eval/EvalRunDetail.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/EvalRunDetail.tsx
@@ -1,6 +1,6 @@
 // apps/desktop/src/renderer/src/components/eval/EvalRunDetail.tsx
 import { useState, lazy, Suspense } from 'react';
-import { Upload, Play, Pencil, Trash2, Save } from 'lucide-react';
+import { Upload, Play, Pencil, Trash2 } from 'lucide-react';
 import type { OnMount } from '@monaco-editor/react';
 import { useServerStatus } from '@/hooks/use-server-status';
 import { useEvalRunDetail } from '@/hooks/use-eval-runs';
@@ -42,8 +42,8 @@ export function EvalRunDetail({
   onDeleted?: () => void;
 }) {
   const { info } = useServerStatus();
-  const { data, loading, error, refresh } = useEvalRunDetail(runId);
-  const { deleteRun, saveExpression } = useEvalRunActions();
+  const { data, loading, error } = useEvalRunDetail(runId);
+  const { deleteRun } = useEvalRunActions();
   const [publishing, setPublishing] = useState(false);
   const [editing, setEditing] = useState(false);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
@@ -61,15 +61,10 @@ export function EvalRunDetail({
   }
   if (!data) return null;
 
-  // Run (or re-run an edited expression) as a fresh run; the parent selects it.
+  // Run an edited (or unchanged) expression as a fresh run; the parent selects it.
   const triggerRun = (expression: string): void => {
     onRunLocally?.({ spec: data.spec_name, expression });
     setEditing(false);
-  };
-
-  // Persist an edited expression onto this run, then refetch so the panel updates.
-  const handleSaveExpression = async (expression: string): Promise<void> => {
-    if (await saveExpression(runId, expression)) await refresh();
   };
 
   const confirmDelete = async (): Promise<void> => {
@@ -179,13 +174,10 @@ export function EvalRunDetail({
             value={data.url4_expression}
             inset="10%"
             onEditorMount={mountUrl4Editor}
-            confirmLabel="Save"
-            confirmIcon={<Save className="h-4 w-4" />}
-            onSave={(expr) => void handleSaveExpression(expr)}
+            confirmLabel="Run"
+            confirmIcon={<Play className="h-4 w-4" />}
+            onSave={triggerRun}
             onFormat={(expr) => formatUrl4(serverUrl, expr)}
-            secondaryLabel="Re-run"
-            secondaryIcon={<Play className="h-4 w-4" />}
-            onSecondary={triggerRun}
             onClose={() => setEditing(false)}
           />
         </Suspense>

--- a/apps/desktop/src/renderer/src/components/eval/EvalRunsList.test.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/EvalRunsList.test.tsx
@@ -34,21 +34,23 @@ const rows: EvalRunSummary[] = [
   },
 ];
 
-const { refresh, toggleFavorite } = vi.hoisted(() => ({
+const { refresh, toggleFavorite, deleteRun } = vi.hoisted(() => ({
   refresh: vi.fn(),
   toggleFavorite: vi.fn().mockResolvedValue(true),
+  deleteRun: vi.fn().mockResolvedValue(true),
 }));
 
 vi.mock('@/hooks/use-eval-runs', () => ({
   useEvalRunsList: () => ({ data: rows, loading: false, error: null, refresh }),
 }));
 vi.mock('@/hooks/use-eval-run-actions', () => ({
-  useEvalRunActions: () => ({ toggleFavorite }),
+  useEvalRunActions: () => ({ toggleFavorite, deleteRun }),
 }));
 
 beforeEach(() => {
   refresh.mockClear();
   toggleFavorite.mockClear();
+  deleteRun.mockClear();
 });
 afterEach(cleanup);
 
@@ -97,7 +99,47 @@ it('toggles favorite on the un-favorited row', async () => {
   expect(refresh).toHaveBeenCalled();
 });
 
-it('has no delete control in the list (delete lives in the detail panel)', () => {
+it('has no per-row delete control in the list (single delete lives in the detail panel)', () => {
   render(<EvalRunsList selectedId={null} onSelect={vi.fn()} onRunLocally={vi.fn()} />);
   expect(screen.queryByRole('button', { name: /delete run/i })).toBeNull();
+});
+
+it('clears all runs after confirmation, deleting every run then refreshing', async () => {
+  const onBulkDeleted = vi.fn();
+  render(
+    <EvalRunsList
+      selectedId={null}
+      onSelect={vi.fn()}
+      onRunLocally={vi.fn()}
+      onBulkDeleted={onBulkDeleted}
+    />,
+  );
+  fireEvent.click(screen.getByRole('button', { name: /clear all/i }));
+  // Guard dialog appears; nothing deleted until confirmed.
+  expect(screen.getByRole('alertdialog')).toBeTruthy();
+  expect(deleteRun).not.toHaveBeenCalled();
+  fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+  await waitFor(() => expect(deleteRun).toHaveBeenCalledTimes(2));
+  expect(deleteRun).toHaveBeenCalledWith('r1');
+  expect(deleteRun).toHaveBeenCalledWith('r2');
+  expect(onBulkDeleted).toHaveBeenCalledWith(['r1', 'r2']);
+  expect(refresh).toHaveBeenCalled();
+});
+
+it('clears only non-starred runs, keeping favorites', async () => {
+  render(<EvalRunsList selectedId={null} onSelect={vi.fn()} onRunLocally={vi.fn()} />);
+  fireEvent.click(screen.getByRole('button', { name: /clear non-starred/i }));
+  fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+  await waitFor(() => expect(deleteRun).toHaveBeenCalledTimes(1));
+  // r1 is non-starred, r2 is favorite — only r1 is removed.
+  expect(deleteRun).toHaveBeenCalledWith('r1');
+  expect(deleteRun).not.toHaveBeenCalledWith('r2');
+});
+
+it('cancelling the confirm dialog deletes nothing', () => {
+  render(<EvalRunsList selectedId={null} onSelect={vi.fn()} onRunLocally={vi.fn()} />);
+  fireEvent.click(screen.getByRole('button', { name: /clear all/i }));
+  fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+  expect(deleteRun).not.toHaveBeenCalled();
+  expect(screen.queryByRole('alertdialog')).toBeNull();
 });

--- a/apps/desktop/src/renderer/src/components/eval/EvalRunsList.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/EvalRunsList.tsx
@@ -1,5 +1,8 @@
-import { Play, Star } from 'lucide-react';
+import { useState, type ReactNode } from 'react';
+import { Play, Star, Trash2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { useEvalRunsList } from '@/hooks/use-eval-runs';
 import { useEvalRunActions } from '@/hooks/use-eval-run-actions';
 import { EvalStatusBadge } from './EvalStatusBadge';
@@ -11,21 +14,33 @@ interface Props {
   selectedId: string | null;
   onSelect: (id: string) => void;
   onRunLocally?: (payload: RunPayload) => void;
+  /** Called after a bulk delete removes runs, so the parent can clear selection. */
+  onBulkDeleted?: (deletedIds: string[]) => void;
 }
 
-function formatTime(iso: string): string {
-  const d = new Date(iso);
-  return `${d.toLocaleDateString()} ${d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+// Which bulk action is pending confirmation. null = no dialog open.
+type BulkMode = 'all' | 'non-starred';
+
+interface RunsBodyProps {
+  data: EvalRunSummary[];
+  loading: boolean;
+  error: Error | null;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  onToggleFavorite: (run: EvalRunSummary) => void;
+  onRunLocally?: (payload: RunPayload) => void;
 }
 
-export function EvalRunsList({ selectedId, onSelect, onRunLocally }: Props) {
-  const { data, loading, error, refresh } = useEvalRunsList();
-  const { toggleFavorite } = useEvalRunActions();
-
-  const onToggleFavorite = async (run: EvalRunSummary): Promise<void> => {
-    if (await toggleFavorite(run.id, !run.favorite)) await refresh(true);
-  };
-
+// Loading / error / empty / list states for the runs panel body.
+function RunsBody({
+  data,
+  loading,
+  error,
+  selectedId,
+  onSelect,
+  onToggleFavorite,
+  onRunLocally,
+}: RunsBodyProps): ReactNode {
   if (loading && data.length === 0) {
     return <div className="p-6 text-sm text-muted-foreground">Loading runs…</div>;
   }
@@ -34,75 +49,188 @@ export function EvalRunsList({ selectedId, onSelect, onRunLocally }: Props) {
   }
   if (data.length === 0) {
     return (
-      <div className="flex h-full flex-col items-center justify-center p-8 text-center text-sm text-muted-foreground">
+      <div className="flex flex-col items-center justify-center p-8 text-center text-sm text-muted-foreground">
         <p className="mb-2 font-medium">No evaluation runs yet.</p>
         <p className="text-xs">Use "New run" above, or the play button on a leaderboard entry.</p>
       </div>
     );
   }
+  return (
+    <>
+      {data.map((run) => (
+        <RunRow
+          key={run.id}
+          run={run}
+          active={run.id === selectedId}
+          onSelect={onSelect}
+          onToggleFavorite={onToggleFavorite}
+          onRunLocally={onRunLocally}
+        />
+      ))}
+    </>
+  );
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  return `${d.toLocaleDateString()} ${d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+}
+
+interface RunRowProps {
+  run: EvalRunSummary;
+  active: boolean;
+  onSelect: (id: string) => void;
+  onToggleFavorite: (run: EvalRunSummary) => void;
+  onRunLocally?: (payload: RunPayload) => void;
+}
+
+function RunRow({ run, active, onSelect, onToggleFavorite, onRunLocally }: RunRowProps) {
+  return (
+    <div
+      onClick={() => onSelect(run.id)}
+      className={cn(
+        'cursor-pointer border-b border-border/50 px-6 py-3 transition-colors hover:bg-accent/40',
+        active && 'bg-accent/60',
+      )}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="truncate font-medium text-foreground">{run.spec_name}</div>
+          <div className="text-xs text-muted-foreground">{formatTime(run.started_at)}</div>
+        </div>
+        {/* Right indicators on one line, vertically centered: pct, status, star, run. */}
+        <div className="flex items-center gap-2 whitespace-nowrap">
+          <span
+            className="text-sm tabular-nums"
+            title={isUngradedDone(run) ? 'Not graded — 0 checked questions' : undefined}
+          >
+            {formatAccuracy(run)}
+          </span>
+          <EvalStatusBadge status={run.status} />
+          <button
+            type="button"
+            aria-label={run.favorite ? 'Unfavorite' : 'Favorite'}
+            aria-pressed={run.favorite}
+            title={run.favorite ? 'Unfavorite' : 'Favorite'}
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleFavorite(run);
+            }}
+            className={cn(
+              'rounded p-1 transition-colors hover:bg-accent',
+              run.favorite ? 'text-chart-5' : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            <Star className={cn('h-4 w-4', run.favorite && 'fill-current')} />
+          </button>
+          {onRunLocally && (
+            <button
+              type="button"
+              aria-label="Run locally"
+              title="Run locally"
+              onClick={(e) => {
+                e.stopPropagation();
+                onRunLocally({ spec: run.spec_name, expression: run.url4_expression });
+              }}
+              className="rounded p-1 text-primary transition-colors hover:bg-primary/10"
+            >
+              <Play className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function EvalRunsList({ selectedId, onSelect, onRunLocally, onBulkDeleted }: Props) {
+  const { data, loading, error, refresh } = useEvalRunsList();
+  const { toggleFavorite, deleteRun } = useEvalRunActions();
+  const [bulkMode, setBulkMode] = useState<BulkMode | null>(null);
+  const [bulkDeleting, setBulkDeleting] = useState(false);
+
+  const onToggleFavorite = async (run: EvalRunSummary): Promise<void> => {
+    if (await toggleFavorite(run.id, !run.favorite)) await refresh(true);
+  };
+
+  const nonStarred = data.filter((run) => run.favorite === false);
+  const hasRuns = data.length > 0;
+  const hasNonStarred = nonStarred.length > 0;
+
+  // Delete the targeted set sequentially (no bulk endpoint exists), then refresh
+  // the list once. Selection is cleared by the parent via onBulkDeleted.
+  const confirmBulkDelete = async (): Promise<void> => {
+    const targets = bulkMode === 'non-starred' ? nonStarred : data;
+    const ids = targets.map((run) => run.id);
+    setBulkDeleting(true);
+    const deleted: string[] = [];
+    for (const id of ids) {
+      if (await deleteRun(id)) deleted.push(id);
+    }
+    setBulkDeleting(false);
+    setBulkMode(null);
+    if (deleted.length > 0) {
+      onBulkDeleted?.(deleted);
+      await refresh(true);
+    }
+  };
+
+  // Header with the bulk-clear controls. Always shown so the actions stay
+  // discoverable; buttons disable when there's nothing to clear.
+  const header = (
+    <div className="flex items-center justify-end gap-2 border-b border-border px-6 py-2">
+      <Button
+        variant="ghost"
+        size="sm"
+        className="text-muted-foreground hover:text-destructive"
+        disabled={!hasNonStarred}
+        onClick={() => setBulkMode('non-starred')}
+      >
+        <Trash2 className="h-3.5 w-3.5" /> Clear non-starred
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="text-muted-foreground hover:text-destructive"
+        disabled={!hasRuns}
+        onClick={() => setBulkMode('all')}
+      >
+        <Trash2 className="h-3.5 w-3.5" /> Clear all
+      </Button>
+    </div>
+  );
+
+  const targetCount = bulkMode === 'non-starred' ? nonStarred.length : data.length;
+  const noun = `run${targetCount === 1 ? '' : 's'}`;
+  const confirmTitle = bulkMode === 'non-starred' ? 'Clear non-starred runs?' : 'Clear all runs?';
+  const confirmMessage =
+    bulkMode === 'non-starred'
+      ? `${targetCount} non-starred ${noun} and their question results will be permanently removed. Starred runs are kept. This can't be undone.`
+      : `All ${targetCount} ${noun} and their question results will be permanently removed. This can't be undone.`;
 
   return (
     <div className="flex flex-col">
-      {data.map((run: EvalRunSummary) => {
-        const active = run.id === selectedId;
-        return (
-          <div
-            key={run.id}
-            onClick={() => onSelect(run.id)}
-            className={cn(
-              'cursor-pointer border-b border-border/50 px-6 py-3 transition-colors hover:bg-accent/40',
-              active && 'bg-accent/60',
-            )}
-          >
-            <div className="flex items-center justify-between gap-3">
-              <div className="min-w-0 flex-1">
-                <div className="truncate font-medium text-foreground">{run.spec_name}</div>
-                <div className="text-xs text-muted-foreground">{formatTime(run.started_at)}</div>
-              </div>
-              {/* Right indicators on one line, vertically centered: pct, status, star, run. */}
-              <div className="flex items-center gap-2 whitespace-nowrap">
-                <span
-                  className="text-sm tabular-nums"
-                  title={isUngradedDone(run) ? 'Not graded — 0 checked questions' : undefined}
-                >
-                  {formatAccuracy(run)}
-                </span>
-                <EvalStatusBadge status={run.status} />
-                <button
-                  type="button"
-                  aria-label={run.favorite ? 'Unfavorite' : 'Favorite'}
-                  aria-pressed={run.favorite}
-                  title={run.favorite ? 'Unfavorite' : 'Favorite'}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    void onToggleFavorite(run);
-                  }}
-                  className={cn(
-                    'rounded p-1 transition-colors hover:bg-accent',
-                    run.favorite ? 'text-chart-5' : 'text-muted-foreground hover:text-foreground',
-                  )}
-                >
-                  <Star className={cn('h-4 w-4', run.favorite && 'fill-current')} />
-                </button>
-                {onRunLocally && (
-                  <button
-                    type="button"
-                    aria-label="Run locally"
-                    title="Run locally"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onRunLocally({ spec: run.spec_name, expression: run.url4_expression });
-                    }}
-                    className="rounded p-1 text-primary transition-colors hover:bg-primary/10"
-                  >
-                    <Play className="h-4 w-4" />
-                  </button>
-                )}
-              </div>
-            </div>
-          </div>
-        );
-      })}
+      {header}
+      <RunsBody
+        data={data}
+        loading={loading}
+        error={error}
+        selectedId={selectedId}
+        onSelect={onSelect}
+        onToggleFavorite={(r) => void onToggleFavorite(r)}
+        onRunLocally={onRunLocally}
+      />
+      {bulkMode && (
+        <ConfirmDialog
+          title={confirmTitle}
+          message={confirmMessage}
+          confirmLabel={bulkDeleting ? 'Deleting…' : 'Delete'}
+          destructive
+          busy={bulkDeleting}
+          onConfirm={() => void confirmBulkDelete()}
+          onCancel={() => setBulkMode(null)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/eval/EvalRunsList.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/EvalRunsList.tsx
@@ -6,6 +6,7 @@ import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { useEvalRunsList } from '@/hooks/use-eval-runs';
 import { useEvalRunActions } from '@/hooks/use-eval-run-actions';
 import { EvalStatusBadge } from './EvalStatusBadge';
+import { LeaderboardLink } from './LeaderboardLink';
 import { formatAccuracy, isUngradedDone } from './format';
 import type { EvalRunSummary } from './types';
 import type { RunPayload } from '@/components/run/types';
@@ -52,6 +53,7 @@ function RunsBody({
       <div className="flex flex-col items-center justify-center p-8 text-center text-sm text-muted-foreground">
         <p className="mb-2 font-medium">No evaluation runs yet.</p>
         <p className="text-xs">Use "New run" above, or the play button on a leaderboard entry.</p>
+        <LeaderboardLink className="mt-4" />
       </div>
     );
   }

--- a/apps/desktop/src/renderer/src/components/eval/LeaderboardLink.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/LeaderboardLink.tsx
@@ -1,0 +1,38 @@
+// apps/desktop/src/renderer/src/components/eval/LeaderboardLink.tsx
+//
+// Static "Check the latest leaderboard" affordance for Eval Studio (SF-298).
+// Points at the configured public scoreboard (reused via useScoreboardUrl) and
+// opens it in the system browser through the main-process shell.openExternal IPC
+// — never a raw window.open against the external CORS host. Minimal chrome: a
+// plain inline link, no card/banner background.
+
+import { ExternalLink } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useScoreboardUrl } from '@/hooks/use-scoreboard-url';
+
+interface Props {
+  className?: string;
+}
+
+export function LeaderboardLink({ className }: Props) {
+  const scoreboardUrl = useScoreboardUrl();
+
+  const open = (): void => {
+    if (scoreboardUrl) void window.electronAPI.publish.openExternal(scoreboardUrl);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={open}
+      disabled={!scoreboardUrl}
+      className={cn(
+        'inline-flex items-center gap-1.5 text-xs text-primary transition-colors hover:underline disabled:opacity-50',
+        className,
+      )}
+    >
+      Check the latest leaderboard
+      <ExternalLink className="h-3 w-3" />
+    </button>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
@@ -13,12 +13,8 @@ import {
   sanitizeDataRefs,
 } from '@/lib/url4-redaction';
 import { publishBlockReason } from '@/lib/publish-guard';
-import {
-  deriveBenchmarkIdentity,
-  verifyIdentityConsistency,
-  checkBenchmarkRegistration,
-  type BenchmarkIdentity,
-} from '@/lib/benchmark-identity';
+import { computeContentSignature, checkBenchmarkRegistration } from '@/lib/benchmark-identity';
+import { Combobox } from '@/components/ui/combobox';
 import type { EvalRunDetail } from './types';
 
 interface Props {
@@ -60,14 +56,15 @@ export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
   const parsed = useMemo(() => parseSpecName(run.spec_name), [run.spec_name]);
   const hasDataRefs = useMemo(() => hasLocalDataRefs(run.url4_expression), [run.url4_expression]);
 
-  // SF-300: the benchmark identity (id + label + dataset filename + content
-  // signature) is AUTO-DERIVED from the run — never typed. We derive it async
-  // because the signature is a Web Crypto SHA-256 digest over the run's content.
-  const [identity, setIdentity] = useState<BenchmarkIdentity | null>(null);
+  // Manual benchmark selection (SF-309): blank default, registered list + free text.
+  const [benchmarkId, setBenchmarkId] = useState('');
+  // The content signature still travels with the publish as metadata so the
+  // scoreboard can later verify what actually ran — computed, never displayed.
+  const [signature, setSignature] = useState('');
   useEffect(() => {
     let cancelled = false;
-    void deriveBenchmarkIdentity(run).then((next) => {
-      if (!cancelled) setIdentity(next);
+    void computeContentSignature(run).then((sig) => {
+      if (!cancelled) setSignature(sig);
     });
     return () => {
       cancelled = true;
@@ -99,42 +96,39 @@ export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
     () => publishBlockReason({ run, url4Expression: expressionToPublish }),
     [run, expressionToPublish],
   );
-  // Verify the derived benchmark id <-> content signature are internally
-  // consistent (id derivable + content available to sign) before allowing a
-  // publish. Disagreement (e.g. a run with no graded content) blocks here.
-  const identityCheck = useMemo(
-    () => (identity ? verifyIdentityConsistency(identity) : { ok: false, reason: null }),
-    [identity],
-  );
   // Pre-flight: is the derived benchmark id actually registered on the
   // scoreboard? Publish hard-404s unknown ids, so warn early. While the registry
   // is loading or unreachable we pass null → 'unavailable' → no warning (never a
   // false negative). This is advisory only — it does NOT gate canPublish, since a
   // brand-new benchmark is legitimately unknown until the scoreboard owner adds it.
   const { benchmarks: knownBenchmarks, loading: benchmarksLoading } = useKnownBenchmarks();
+  const benchmarkOptions = useMemo(
+    () => (knownBenchmarks ?? []).map((b) => ({ value: b.id, label: b.displayName })),
+    [knownBenchmarks],
+  );
+  // Advisory registry check on the CURRENT field value (not a derived id).
   const registryCheck = useMemo(
     () =>
       checkBenchmarkRegistration(
-        identity?.id ?? '',
+        benchmarkId.trim(),
         benchmarksLoading ? null : (knownBenchmarks?.map((b) => b.id) ?? null),
       ),
-    [identity, knownBenchmarks, benchmarksLoading],
+    [benchmarkId, knownBenchmarks, benchmarksLoading],
   );
   // Block publish until: run is publishable, identity derived + consistent, and
   // any /data refs are either sanitized or explicitly acknowledged.
   const redactionResolved = !hasDataRefs || sanitize || ackExpose;
   const canPublish =
-    !blockReason && !!identity && identityCheck.ok && specId.trim().length > 0 && redactionResolved;
+    !blockReason && benchmarkId.trim().length > 0 && specId.trim().length > 0 && redactionResolved;
 
   const handlePublish = async (): Promise<void> => {
-    if (!identity) return;
     // Remember the entered name for subsequent publishes this session, whether
     // or not the round-trip ultimately succeeds.
     saveSubmitter(submittedBy.trim());
     const out = await publish({
       run,
-      benchmarkId: identity.id,
-      benchmarkSignature: identity.signature,
+      benchmarkId: benchmarkId.trim(),
+      benchmarkSignature: signature,
       specId: specId.trim(),
       url4Expression: expressionToPublish,
       providers,
@@ -243,68 +237,37 @@ export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
                 )}
               </div>
 
-              {/* benchmark identity (auto-derived, read-only) + spec id */}
+              {/* benchmark (manual selection) + spec id */}
               <div className="grid grid-cols-2 gap-3">
                 <div className="block">
                   <span className="mb-1 block text-xs font-medium text-muted-foreground">
-                    Benchmark
+                    Benchmark <span className="text-destructive">*</span>
                   </span>
-                  {/* Derived from the dataset filename in the URL4 expression and
-                      pinned by a content signature — not editable (SF-300). */}
-                  <div
-                    data-testid="benchmark-identity"
-                    className="w-full rounded-none border border-border bg-muted/30 px-3 py-2 text-sm text-foreground"
-                    title={identity?.datasetFilename ?? undefined}
-                  >
-                    {identity ? (
-                      <>
-                        <span className="font-medium">{identity.label || identity.id || '—'}</span>
-                        {identity.id && (
-                          <span className="ml-1 text-xs text-muted-foreground">
-                            ({identity.id})
-                          </span>
-                        )}
-                      </>
-                    ) : (
-                      <span className="text-muted-foreground">Deriving…</span>
-                    )}
-                  </div>
-                  {identity && (
-                    <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
-                      {identity.datasetFilename
-                        ? `From ${identity.datasetFilename}`
-                        : 'Derived from the run’s spec (no dataset file in the expression).'}
-                      {identity.signature && (
-                        <>
-                          {' '}
-                          · signature{' '}
-                          <code className="font-mono">{identity.signature.slice(0, 12)}…</code>
-                        </>
-                      )}
-                    </p>
-                  )}
-                  {/* Registry pre-flight (SF-300 follow-up): advisory only — a
-                      registered ✓, or a non-blocking "not registered" warning
-                      with a closest-match suggestion. Silent while loading /
-                      unavailable so we never warn on a fetch failure. */}
-                  {identity && registryCheck.status === 'registered' && (
+                  <Combobox
+                    value={benchmarkId}
+                    onChange={setBenchmarkId}
+                    options={benchmarkOptions}
+                    placeholder="Select a benchmark"
+                    aria-label="Benchmark"
+                  />
+                  {registryCheck.status === 'registered' && (
                     <p className="mt-1 flex items-center gap-1 text-[11px] text-gain">
                       <CheckCircle2 className="h-3 w-3 shrink-0" />
                       Registered benchmark
                     </p>
                   )}
-                  {identity && registryCheck.status === 'unknown' && (
+                  {registryCheck.status === 'unknown' && (
                     <p className="mt-1 flex items-start gap-1 text-[11px] leading-relaxed text-destructive">
                       <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
                       <span>
                         Not a registered scoreboard benchmark — publishing will fail until the
-                        scoreboard owner registers <code className="font-mono">{identity.id}</code>.
+                        scoreboard owner registers{' '}
+                        <code className="font-mono">{benchmarkId.trim()}</code>.
                         {registryCheck.suggestion && (
                           <>
                             {' '}
                             Did you mean{' '}
-                            <code className="font-mono">{registryCheck.suggestion}</code>? Rename
-                            the dataset file to match.
+                            <code className="font-mono">{registryCheck.suggestion}</code>?
                           </>
                         )}
                       </span>
@@ -322,14 +285,6 @@ export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
                   />
                 </label>
               </div>
-
-              {/* Identity consistency: id<->signature must agree before publish. */}
-              {identity && !identityCheck.ok && identityCheck.reason && (
-                <div className="flex items-start gap-1.5 rounded-none border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
-                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                  <span>{identityCheck.reason}</span>
-                </div>
-              )}
 
               {/* providers (editable) */}
               <label className="block">

--- a/apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
@@ -1,5 +1,5 @@
 // apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { X, Upload, ExternalLink, AlertTriangle, CheckCircle2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Url4Field } from '@/components/Url4Field';
@@ -12,6 +12,11 @@ import {
   sanitizeDataRefs,
 } from '@/lib/url4-redaction';
 import { publishBlockReason } from '@/lib/publish-guard';
+import {
+  deriveBenchmarkIdentity,
+  verifyIdentityConsistency,
+  type BenchmarkIdentity,
+} from '@/lib/benchmark-identity';
 import type { EvalRunDetail } from './types';
 
 interface Props {
@@ -53,7 +58,20 @@ export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
   const parsed = useMemo(() => parseSpecName(run.spec_name), [run.spec_name]);
   const hasDataRefs = useMemo(() => hasLocalDataRefs(run.url4_expression), [run.url4_expression]);
 
-  const [benchmarkId, setBenchmarkId] = useState(parsed.benchmark_id ?? '');
+  // SF-300: the benchmark identity (id + label + dataset filename + content
+  // signature) is AUTO-DERIVED from the run — never typed. We derive it async
+  // because the signature is a Web Crypto SHA-256 digest over the run's content.
+  const [identity, setIdentity] = useState<BenchmarkIdentity | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void deriveBenchmarkIdentity(run).then((next) => {
+      if (!cancelled) setIdentity(next);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [run]);
+
   const [specId, setSpecId] = useState(parsed.spec_id);
   const [providersText, setProvidersText] = useState(
     deriveProviders(run.url4_expression).join(', '),
@@ -79,19 +97,28 @@ export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
     () => publishBlockReason({ run, url4Expression: expressionToPublish }),
     [run, expressionToPublish],
   );
-  // Block publish until: run is publishable, benchmark known, and any /data refs
-  // are either sanitized or explicitly acknowledged as exposing local data.
+  // Verify the derived benchmark id <-> content signature are internally
+  // consistent (id derivable + content available to sign) before allowing a
+  // publish. Disagreement (e.g. a run with no graded content) blocks here.
+  const identityCheck = useMemo(
+    () => (identity ? verifyIdentityConsistency(identity) : { ok: false, reason: null }),
+    [identity],
+  );
+  // Block publish until: run is publishable, identity derived + consistent, and
+  // any /data refs are either sanitized or explicitly acknowledged.
   const redactionResolved = !hasDataRefs || sanitize || ackExpose;
   const canPublish =
-    !blockReason && benchmarkId.trim().length > 0 && specId.trim().length > 0 && redactionResolved;
+    !blockReason && !!identity && identityCheck.ok && specId.trim().length > 0 && redactionResolved;
 
   const handlePublish = async (): Promise<void> => {
+    if (!identity) return;
     // Remember the entered name for subsequent publishes this session, whether
     // or not the round-trip ultimately succeeds.
     saveSubmitter(submittedBy.trim());
     const out = await publish({
       run,
-      benchmarkId: benchmarkId.trim(),
+      benchmarkId: identity.id,
+      benchmarkSignature: identity.signature,
       specId: specId.trim(),
       url4Expression: expressionToPublish,
       providers,
@@ -200,19 +227,47 @@ export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
                 )}
               </div>
 
-              {/* benchmark / spec ids */}
+              {/* benchmark identity (auto-derived, read-only) + spec id */}
               <div className="grid grid-cols-2 gap-3">
-                <label className="block">
+                <div className="block">
                   <span className="mb-1 block text-xs font-medium text-muted-foreground">
-                    Benchmark ID <span className="text-destructive">*</span>
+                    Benchmark
                   </span>
-                  <input
-                    className="w-full rounded-none border border-border bg-background px-3 py-2 text-sm"
-                    value={benchmarkId}
-                    placeholder="e.g. hle"
-                    onChange={(e) => setBenchmarkId(e.target.value)}
-                  />
-                </label>
+                  {/* Derived from the dataset filename in the URL4 expression and
+                      pinned by a content signature — not editable (SF-300). */}
+                  <div
+                    data-testid="benchmark-identity"
+                    className="w-full rounded-none border border-border bg-muted/30 px-3 py-2 text-sm text-foreground"
+                    title={identity?.datasetFilename ?? undefined}
+                  >
+                    {identity ? (
+                      <>
+                        <span className="font-medium">{identity.label || identity.id || '—'}</span>
+                        {identity.id && (
+                          <span className="ml-1 text-xs text-muted-foreground">
+                            ({identity.id})
+                          </span>
+                        )}
+                      </>
+                    ) : (
+                      <span className="text-muted-foreground">Deriving…</span>
+                    )}
+                  </div>
+                  {identity && (
+                    <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
+                      {identity.datasetFilename
+                        ? `From ${identity.datasetFilename}`
+                        : 'Derived from the run’s spec (no dataset file in the expression).'}
+                      {identity.signature && (
+                        <>
+                          {' '}
+                          · signature{' '}
+                          <code className="font-mono">{identity.signature.slice(0, 12)}…</code>
+                        </>
+                      )}
+                    </p>
+                  )}
+                </div>
                 <label className="block">
                   <span className="mb-1 block text-xs font-medium text-muted-foreground">
                     Spec ID <span className="text-destructive">*</span>
@@ -224,6 +279,14 @@ export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
                   />
                 </label>
               </div>
+
+              {/* Identity consistency: id<->signature must agree before publish. */}
+              {identity && !identityCheck.ok && identityCheck.reason && (
+                <div className="flex items-start gap-1.5 rounded-none border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  <span>{identityCheck.reason}</span>
+                </div>
+              )}
 
               {/* providers (editable) */}
               <label className="block">

--- a/apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
@@ -203,7 +203,12 @@ export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
                   URL4 expression {sanitize && hasDataRefs ? '(sanitized)' : ''}
                 </span>
                 <div className="rounded bg-muted/30 px-3 py-2">
-                  <Url4Field value={expressionToPublish} serverUrl={serverUrl} readOnly />
+                  <Url4Field
+                    value={expressionToPublish}
+                    serverUrl={serverUrl}
+                    readOnly
+                    maxContentHeight={null}
+                  />
                 </div>
                 {hasDataRefs && (
                   <div className="mt-2 rounded border border-chart-5/40 bg-chart-5/10 px-3 py-2 text-xs">

--- a/apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
@@ -115,11 +115,17 @@ export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
       ),
     [benchmarkId, knownBenchmarks, benchmarksLoading],
   );
-  // Block publish until: run is publishable, identity derived + consistent, and
-  // any /data refs are either sanitized or explicitly acknowledged.
+  // Block publish until: run is publishable, a benchmark is chosen, the content
+  // signature has been computed (so it always ships as metadata — never an empty
+  // hash; also blocks a run with no content to sign), and any /data refs are
+  // either sanitized or explicitly acknowledged.
   const redactionResolved = !hasDataRefs || sanitize || ackExpose;
   const canPublish =
-    !blockReason && benchmarkId.trim().length > 0 && specId.trim().length > 0 && redactionResolved;
+    !blockReason &&
+    benchmarkId.trim().length > 0 &&
+    signature.length > 0 &&
+    specId.trim().length > 0 &&
+    redactionResolved;
 
   const handlePublish = async (): Promise<void> => {
     // Remember the entered name for subsequent publishes this session, whether

--- a/apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Url4Field } from '@/components/Url4Field';
 import { useToast } from '@/hooks/use-toast';
 import { usePublishScore } from '@/hooks/use-publish-score';
+import { useKnownBenchmarks } from '@/hooks/use-known-benchmarks';
 import {
   parseSpecName,
   deriveProviders,
@@ -15,6 +16,7 @@ import { publishBlockReason } from '@/lib/publish-guard';
 import {
   deriveBenchmarkIdentity,
   verifyIdentityConsistency,
+  checkBenchmarkRegistration,
   type BenchmarkIdentity,
 } from '@/lib/benchmark-identity';
 import type { EvalRunDetail } from './types';
@@ -103,6 +105,20 @@ export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
   const identityCheck = useMemo(
     () => (identity ? verifyIdentityConsistency(identity) : { ok: false, reason: null }),
     [identity],
+  );
+  // Pre-flight: is the derived benchmark id actually registered on the
+  // scoreboard? Publish hard-404s unknown ids, so warn early. While the registry
+  // is loading or unreachable we pass null → 'unavailable' → no warning (never a
+  // false negative). This is advisory only — it does NOT gate canPublish, since a
+  // brand-new benchmark is legitimately unknown until the scoreboard owner adds it.
+  const { benchmarks: knownBenchmarks, loading: benchmarksLoading } = useKnownBenchmarks();
+  const registryCheck = useMemo(
+    () =>
+      checkBenchmarkRegistration(
+        identity?.id ?? '',
+        benchmarksLoading ? null : (knownBenchmarks?.map((b) => b.id) ?? null),
+      ),
+    [identity, knownBenchmarks, benchmarksLoading],
   );
   // Block publish until: run is publishable, identity derived + consistent, and
   // any /data refs are either sanitized or explicitly acknowledged.
@@ -265,6 +281,33 @@ export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
                           <code className="font-mono">{identity.signature.slice(0, 12)}…</code>
                         </>
                       )}
+                    </p>
+                  )}
+                  {/* Registry pre-flight (SF-300 follow-up): advisory only — a
+                      registered ✓, or a non-blocking "not registered" warning
+                      with a closest-match suggestion. Silent while loading /
+                      unavailable so we never warn on a fetch failure. */}
+                  {identity && registryCheck.status === 'registered' && (
+                    <p className="mt-1 flex items-center gap-1 text-[11px] text-gain">
+                      <CheckCircle2 className="h-3 w-3 shrink-0" />
+                      Registered benchmark
+                    </p>
+                  )}
+                  {identity && registryCheck.status === 'unknown' && (
+                    <p className="mt-1 flex items-start gap-1 text-[11px] leading-relaxed text-destructive">
+                      <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+                      <span>
+                        Not a registered scoreboard benchmark — publishing will fail until the
+                        scoreboard owner registers <code className="font-mono">{identity.id}</code>.
+                        {registryCheck.suggestion && (
+                          <>
+                            {' '}
+                            Did you mean{' '}
+                            <code className="font-mono">{registryCheck.suggestion}</code>? Rename
+                            the dataset file to match.
+                          </>
+                        )}
+                      </span>
                     </p>
                   )}
                 </div>

--- a/apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
@@ -25,6 +25,27 @@ function formatPercent(accuracy: number | null): string {
   return `${(accuracy * 100).toFixed(1)}%`;
 }
 
+// Submitter name is remembered across publishes within a session so it doesn't
+// have to be re-typed each time. Matches the sessionStorage usage elsewhere in
+// the renderer (see federation/registry.ts for the localStorage analogue).
+const SUBMITTER_KEY = 'sf-leaderboard-submitter';
+
+function loadSubmitter(): string {
+  try {
+    return window.sessionStorage.getItem(SUBMITTER_KEY) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function saveSubmitter(name: string): void {
+  try {
+    window.sessionStorage.setItem(SUBMITTER_KEY, name);
+  } catch {
+    // sessionStorage unavailable — non-fatal, just skip persistence.
+  }
+}
+
 export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
   const { toast } = useToast();
   const { publish, status, error, result } = usePublishScore();
@@ -37,7 +58,7 @@ export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
   const [providersText, setProvidersText] = useState(
     deriveProviders(run.url4_expression).join(', '),
   );
-  const [submittedBy, setSubmittedBy] = useState('');
+  const [submittedBy, setSubmittedBy] = useState(loadSubmitter);
   // Redaction choices: only relevant when the expression references /data blobs.
   const [sanitize, setSanitize] = useState(hasDataRefs);
   const [ackExpose, setAckExpose] = useState(false);
@@ -65,6 +86,9 @@ export function PublishToLeaderboardDialog({ run, serverUrl, onClose }: Props) {
     !blockReason && benchmarkId.trim().length > 0 && specId.trim().length > 0 && redactionResolved;
 
   const handlePublish = async (): Promise<void> => {
+    // Remember the entered name for subsequent publishes this session, whether
+    // or not the round-trip ultimately succeeds.
+    saveSubmitter(submittedBy.trim());
     const out = await publish({
       run,
       benchmarkId: benchmarkId.trim(),

--- a/apps/desktop/src/renderer/src/components/eval/__tests__/EvalRunDetail.test.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/__tests__/EvalRunDetail.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { EvalRunDetail } from '../EvalRunDetail';
+import type { EvalRunDetail as EvalRunDetailData } from '../types';
+
+const runData: EvalRunDetailData = {
+  id: 'eval-run-1',
+  spec_name: 'hle:hle-ensemble-three',
+  url4_expression: 'url4://ensemble(claude,codex,gemini)/hle',
+  started_at: '2026-05-04T11:00:00Z',
+  finished_at: '2026-05-04T11:55:00Z',
+  status: 'done',
+  accuracy: 0.81,
+  total_questions: 1000,
+  correct_questions: 810,
+  error: null,
+  favorite: false,
+  questions: [],
+};
+
+const deleteRun = vi.fn();
+vi.mock('@/hooks/use-server-status', () => ({
+  useServerStatus: () => ({ info: { scheme: 'http', host: 'localhost', port: 8000 } }),
+}));
+vi.mock('@/hooks/use-eval-runs', () => ({
+  useEvalRunDetail: () => ({ data: runData, loading: false, error: null, refresh: vi.fn() }),
+}));
+vi.mock('@/hooks/use-eval-run-actions', () => ({
+  useEvalRunActions: () => ({ deleteRun }),
+}));
+vi.mock('@/components/Url4Field', () => ({
+  Url4Field: ({ value }: { value: string }) => <span data-testid="url4">{value}</span>,
+}));
+vi.mock('@/components/eval/EvalQuestionsTable', () => ({
+  EvalQuestionsTable: () => null,
+}));
+
+// Stand in for the lazy monaco popup; surfaces the action props EvalRunDetail wires.
+vi.mock('@/components/CodeEditorPopup', () => ({
+  default: ({
+    onSave,
+    confirmLabel,
+    secondaryLabel,
+    value,
+  }: {
+    onSave?: (v: string) => void;
+    confirmLabel?: string;
+    secondaryLabel?: string;
+    value: string;
+  }) => (
+    <div data-testid="code-popup">
+      {onSave && <button onClick={() => onSave(value)}>{confirmLabel ?? 'PRIMARY'}</button>}
+      {secondaryLabel && <span data-testid="secondary">{secondaryLabel}</span>}
+    </div>
+  ),
+}));
+
+describe('EvalRunDetail edit popup controls', () => {
+  beforeEach(() => {
+    deleteRun.mockReset();
+  });
+
+  it('labels the primary action "Run" with no "Save" or "Re-run" control', async () => {
+    const onRunLocally = vi.fn();
+    render(<EvalRunDetail runId="eval-run-1" onRunLocally={onRunLocally} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+    await screen.findByTestId('code-popup');
+
+    expect(screen.getByRole('button', { name: 'Run' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('secondary')).not.toBeInTheDocument();
+  });
+
+  it('Run starts a fresh run from the edited expression', async () => {
+    const onRunLocally = vi.fn();
+    render(<EvalRunDetail runId="eval-run-1" onRunLocally={onRunLocally} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+    await screen.findByTestId('code-popup');
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+
+    expect(onRunLocally).toHaveBeenCalledWith({
+      spec: runData.spec_name,
+      expression: runData.url4_expression,
+    });
+  });
+});

--- a/apps/desktop/src/renderer/src/components/eval/__tests__/LeaderboardLink.test.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/__tests__/LeaderboardLink.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react';
+import { it, expect, vi, afterEach, beforeEach } from 'vitest';
+
+const { getContext, openExternal } = vi.hoisted(() => ({
+  getContext: vi.fn(),
+  openExternal: vi.fn(),
+}));
+
+beforeEach(() => {
+  getContext.mockReset().mockResolvedValue({
+    scoreboardUrl: 'https://scoreboard.screamingface.ai',
+    portalUrl: 'https://portal.test',
+    client: { name: 'test', version: '0.0.0', platform: 'test' },
+  });
+  openExternal.mockReset().mockResolvedValue(undefined);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (window as any).electronAPI = { publish: { getContext, openExternal } };
+});
+afterEach(cleanup);
+
+import { LeaderboardLink } from '../LeaderboardLink';
+
+it('renders the static leaderboard label', () => {
+  render(<LeaderboardLink />);
+  expect(screen.getByText(/check the latest leaderboard/i)).toBeTruthy();
+});
+
+it('resolves the scoreboard URL via the publish context (reused, not hardcoded)', async () => {
+  render(<LeaderboardLink />);
+  await waitFor(() => expect(getContext).toHaveBeenCalled());
+});
+
+it('opens the resolved scoreboard URL through the external IPC, not window.open', async () => {
+  render(<LeaderboardLink />);
+  const button = screen.getByRole('button', { name: /check the latest leaderboard/i });
+  await waitFor(() => expect(button).not.toBeDisabled());
+  fireEvent.click(button);
+  expect(openExternal).toHaveBeenCalledWith('https://scoreboard.screamingface.ai');
+});
+
+it('stays disabled (no-op) until the URL resolves', async () => {
+  let resolve!: (value: unknown) => void;
+  getContext.mockReturnValue(new Promise((r) => (resolve = r)));
+  render(<LeaderboardLink />);
+  const button = screen.getByRole('button', { name: /check the latest leaderboard/i });
+  expect(button).toBeDisabled();
+  fireEvent.click(button);
+  expect(openExternal).not.toHaveBeenCalled();
+  resolve({
+    scoreboardUrl: 'https://scoreboard.screamingface.ai',
+    portalUrl: 'https://portal.test',
+    client: { name: 'test', version: '0.0.0', platform: 'test' },
+  });
+  await waitFor(() => expect(button).not.toBeDisabled());
+});

--- a/apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { PublishToLeaderboardDialog } from '../PublishToLeaderboardDialog';
 import type { EvalRunDetail } from '../types';
 
@@ -59,6 +59,12 @@ function makeRun(overrides: Partial<EvalRunDetail> = {}): EvalRunDetail {
   };
 }
 
+function benchmarkInput(): HTMLInputElement {
+  return screen.getByRole('combobox', { name: 'Benchmark' }) as HTMLInputElement;
+}
+
+afterEach(cleanup);
+
 beforeEach(() => {
   publishMock.mockReset();
   toastMock.mockReset();
@@ -66,11 +72,10 @@ beforeEach(() => {
   hookState.error = null;
   hookState.result = null;
   window.sessionStorage.clear();
-  // Default: the derived benchmark (honest-agi-live-week-3) IS registered, so
-  // the registry note is "registered" and existing tests are unaffected.
-  listBenchmarksMock
-    .mockReset()
-    .mockResolvedValue([{ id: 'honest-agi-live-week-3', displayName: 'Honest AGI Live week 3' }]);
+  listBenchmarksMock.mockReset().mockResolvedValue([
+    { id: 'hle', displayName: 'News Hallucinations' },
+    { id: 'livetruth', displayName: 'News Livetruth' },
+  ]);
   (window as unknown as { electronAPI: unknown }).electronAPI = {
     publish: {
       openExternal: vi.fn(async () => {}),
@@ -80,68 +85,72 @@ beforeEach(() => {
   };
 });
 
-describe('PublishToLeaderboardDialog', () => {
-  it('auto-derives a read-only benchmark identity from the dataset filename and prefills spec', async () => {
+describe('PublishToLeaderboardDialog — benchmark combobox', () => {
+  it('opens with a blank benchmark and Publish disabled until one is chosen', async () => {
     render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
-    // Spec id still prefilled from the colon-delimited spec_name.
-    expect(screen.getByDisplayValue('hle-ensemble-three')).toBeInTheDocument();
-    // Benchmark is derived + read-only — no free-text input, label shown instead.
-    expect(screen.queryByPlaceholderText('e.g. hle')).not.toBeInTheDocument();
-    const identity = await screen.findByTestId('benchmark-identity');
-    // Derivation is async (Web Crypto SHA-256 signature) — wait for the resolved
-    // label, not just the element, which first renders a "Deriving…" placeholder.
-    await waitFor(() => expect(identity).toHaveTextContent('Honest AGI Live week 3'));
-    expect(identity).toHaveTextContent('honest-agi-live-week-3');
-    expect(screen.getByText(/From honest-agi-live-week-3\.eval\.jsonl/i)).toBeInTheDocument();
-  });
-
-  it('marks the derived benchmark as registered when it is in the scoreboard registry', async () => {
-    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
-    expect(await screen.findByText(/registered benchmark/i)).toBeInTheDocument();
-    expect(screen.queryByText(/not a registered scoreboard benchmark/i)).not.toBeInTheDocument();
-  });
-
-  it('warns (non-blocking) with a closest-match suggestion when the id is not registered', async () => {
-    listBenchmarksMock.mockResolvedValue([
-      { id: 'honest-agi-live-week-4', displayName: 'Honest AGI Live week 4' },
-    ]);
-    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
-    expect(await screen.findByText(/not a registered scoreboard benchmark/i)).toBeInTheDocument();
-    expect(screen.getByText('honest-agi-live-week-4')).toBeInTheDocument();
-    // Advisory only — publish stays enabled (the server is the hard gate).
+    expect(benchmarkInput().value).toBe('');
+    expect(screen.getByRole('button', { name: /publish/i })).toBeDisabled();
+    fireEvent.focus(benchmarkInput());
+    fireEvent.mouseDown(await screen.findByRole('option', { name: /livetruth/i }));
     await waitFor(() => expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled());
   });
 
-  it('stays silent about registration when the registry is unreachable', async () => {
+  it('filters registered benchmarks and allows free text', async () => {
+    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    fireEvent.change(benchmarkInput(), { target: { value: 'live' } });
+    // Options load async via useKnownBenchmarks — wait for the filtered option.
+    expect(await screen.findByRole('option', { name: /livetruth/i })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /^hle/i })).not.toBeInTheDocument();
+    fireEvent.change(benchmarkInput(), { target: { value: 'brand-new-2026' } });
+    expect(benchmarkInput().value).toBe('brand-new-2026');
+  });
+
+  it('shows ✓ registered for a registered value and ⚠ + suggestion for an unknown one', async () => {
+    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    fireEvent.change(benchmarkInput(), { target: { value: 'hle' } });
+    expect(await screen.findByText(/registered benchmark/i)).toBeInTheDocument();
+    fireEvent.change(benchmarkInput(), { target: { value: 'livetruh' } });
+    expect(await screen.findByText(/not a registered scoreboard benchmark/i)).toBeInTheDocument();
+    expect(screen.getByText('livetruth')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled();
+  });
+
+  it('stays silent about registration while the registry is unreachable', async () => {
     listBenchmarksMock.mockResolvedValue(null);
     render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
-    const identity = await screen.findByTestId('benchmark-identity');
-    await waitFor(() => expect(identity).toHaveTextContent('Honest AGI Live week 3'));
+    fireEvent.change(benchmarkInput(), { target: { value: 'whatever' } });
+    await Promise.resolve();
     expect(screen.queryByText(/registered benchmark/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/not a registered scoreboard benchmark/i)).not.toBeInTheDocument();
   });
 
-  it('publishes the derived benchmark id + content signature (no manual entry)', async () => {
+  it('publishes the chosen benchmark id plus the content signature', async () => {
     render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
-    await screen.findByTestId('benchmark-identity');
+    fireEvent.change(benchmarkInput(), { target: { value: 'livetruth' } });
     await waitFor(() => expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled());
     fireEvent.click(screen.getByRole('button', { name: /publish/i }));
     await waitFor(() => expect(publishMock).toHaveBeenCalledTimes(1));
     const sent = publishMock.mock.calls[0][0];
-    expect(sent.benchmarkId).toBe('honest-agi-live-week-3');
+    expect(sent.benchmarkId).toBe('livetruth');
     expect(sent.benchmarkSignature).toMatch(/^[0-9a-f]{64}$/);
   });
+});
 
-  it('blocks publish when the run has no graded content to sign the identity', async () => {
+describe('PublishToLeaderboardDialog — guards & misc', () => {
+  it('prefills spec id from the colon-delimited spec_name', () => {
+    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    expect(screen.getByDisplayValue('hle-ensemble-three')).toBeInTheDocument();
+  });
+
+  it('blocks a zero-question run with an explanation (preflight guard)', () => {
     render(
       <PublishToLeaderboardDialog
-        run={makeRun({ questions: [] })}
+        run={makeRun({ total_questions: 0, correct_questions: 0 })}
         serverUrl=""
         onClose={vi.fn()}
       />,
     );
-    await screen.findByTestId('benchmark-identity');
-    expect(await screen.findByText(/no graded content/i)).toBeInTheDocument();
+    expect(screen.getByText(/no graded questions/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /publish/i })).toBeDisabled();
   });
 
@@ -149,9 +158,8 @@ describe('PublishToLeaderboardDialog', () => {
     const run = makeRun({ url4_expression: '(/data/abc123)!$prompt' });
     render(<PublishToLeaderboardDialog run={run} serverUrl="" onClose={vi.fn()} />);
     expect(screen.getByText(/references local/i)).toBeInTheDocument();
-    // sanitize defaults on → the displayed/published expression is redacted.
     expect(screen.getByTestId('url4')).toHaveTextContent('/data/<redacted>');
-    await screen.findByTestId('benchmark-identity');
+    fireEvent.change(benchmarkInput(), { target: { value: 'livetruth' } });
     await waitFor(() => expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled());
     fireEvent.click(screen.getByRole('button', { name: /publish/i }));
     expect(publishMock).toHaveBeenCalledTimes(1);
@@ -161,31 +169,16 @@ describe('PublishToLeaderboardDialog', () => {
   it('blocks publish if /data refs are neither sanitized nor acknowledged', async () => {
     const run = makeRun({ url4_expression: '(/data/abc123)!$prompt' });
     render(<PublishToLeaderboardDialog run={run} serverUrl="" onClose={vi.fn()} />);
-    await screen.findByTestId('benchmark-identity');
-    const sanitize = screen.getByRole('checkbox', { name: /sanitize/i });
-    fireEvent.click(sanitize); // uncheck
+    fireEvent.change(benchmarkInput(), { target: { value: 'livetruth' } });
+    fireEvent.click(screen.getByRole('checkbox', { name: /sanitize/i })); // uncheck
     expect(screen.getByRole('button', { name: /publish/i })).toBeDisabled();
     fireEvent.click(screen.getByRole('checkbox', { name: /exposes my local data/i }));
     await waitFor(() => expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled());
   });
 
-  it('blocks a zero-question run with an explanation (preflight guard)', () => {
-    const run = makeRun({ total_questions: 0, correct_questions: 0 });
-    render(<PublishToLeaderboardDialog run={run} serverUrl="" onClose={vi.fn()} />);
-    expect(screen.getByText(/no graded questions/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /publish/i })).toBeDisabled();
-  });
-
-  it('does not block a normal completed run', async () => {
-    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
-    expect(screen.queryByText(/no graded questions/i)).not.toBeInTheDocument();
-    await screen.findByTestId('benchmark-identity');
-    await waitFor(() => expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled());
-  });
-
   it('persists the submitter name to sessionStorage on publish', async () => {
     render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
-    await screen.findByTestId('benchmark-identity');
+    fireEvent.change(benchmarkInput(), { target: { value: 'livetruth' } });
     fireEvent.change(screen.getByPlaceholderText('leave blank for anonymous'), {
       target: { value: 'Ada Lovelace' },
     });

--- a/apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { PublishToLeaderboardDialog } from '../PublishToLeaderboardDialog';
 import type { EvalRunDetail } from '../types';
@@ -26,11 +26,25 @@ vi.mock('@/components/Url4Field', () => ({
   Url4Field: ({ value }: { value: string }) => <span data-testid="url4">{value}</span>,
 }));
 
+const QUESTIONS: EvalRunDetail['questions'] = [
+  {
+    id: 'q-0',
+    idx: 0,
+    question: '2+2?',
+    expected: '4',
+    predicted: '4',
+    correct: true,
+    raw_output: null,
+    error: null,
+  },
+];
+
 function makeRun(overrides: Partial<EvalRunDetail> = {}): EvalRunDetail {
   return {
     id: 'eval-run-1',
     spec_name: 'hle:hle-ensemble-three',
-    url4_expression: 'url4://ensemble(claude,codex,gemini)/hle',
+    url4_expression:
+      'https://screamingface.ai/honest-agi-live-week-3.eval.jsonl*(/claude($item.question))',
     started_at: '2026-05-04T11:00:00Z',
     finished_at: '2026-05-04T11:55:00Z',
     status: 'done',
@@ -39,7 +53,7 @@ function makeRun(overrides: Partial<EvalRunDetail> = {}): EvalRunDetail {
     correct_questions: 810,
     error: null,
     favorite: false,
-    questions: [],
+    questions: QUESTIONS,
     ...overrides,
   };
 }
@@ -57,46 +71,64 @@ beforeEach(() => {
 });
 
 describe('PublishToLeaderboardDialog', () => {
-  it('prefills benchmark/spec from a colon-delimited spec_name', () => {
+  it('auto-derives a read-only benchmark identity from the dataset filename and prefills spec', async () => {
     render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
-    expect(screen.getByPlaceholderText('e.g. hle')).toHaveValue('hle');
+    // Spec id still prefilled from the colon-delimited spec_name.
     expect(screen.getByDisplayValue('hle-ensemble-three')).toBeInTheDocument();
+    // Benchmark is derived + read-only — no free-text input, label shown instead.
+    expect(screen.queryByPlaceholderText('e.g. hle')).not.toBeInTheDocument();
+    const identity = await screen.findByTestId('benchmark-identity');
+    expect(identity).toHaveTextContent('Honest AGI Live week 3');
+    expect(identity).toHaveTextContent('honest-agi-live-week-3');
+    expect(screen.getByText(/From honest-agi-live-week-3\.eval\.jsonl/i)).toBeInTheDocument();
   });
 
-  it('requires a benchmark id when spec_name has no colon', () => {
+  it('publishes the derived benchmark id + content signature (no manual entry)', async () => {
+    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    await screen.findByTestId('benchmark-identity');
+    await waitFor(() => expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: /publish/i }));
+    await waitFor(() => expect(publishMock).toHaveBeenCalledTimes(1));
+    const sent = publishMock.mock.calls[0][0];
+    expect(sent.benchmarkId).toBe('honest-agi-live-week-3');
+    expect(sent.benchmarkSignature).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('blocks publish when the run has no graded content to sign the identity', async () => {
     render(
       <PublishToLeaderboardDialog
-        run={makeRun({ spec_name: 'hle-claude-single' })}
+        run={makeRun({ questions: [] })}
         serverUrl=""
         onClose={vi.fn()}
       />,
     );
-    const benchmark = screen.getByPlaceholderText('e.g. hle');
-    expect(benchmark).toHaveValue('');
+    await screen.findByTestId('benchmark-identity');
+    expect(await screen.findByText(/no graded content/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /publish/i })).toBeDisabled();
-    fireEvent.change(benchmark, { target: { value: 'hle' } });
-    expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled();
   });
 
-  it('warns about /data refs and publishes the sanitized expression by default', () => {
+  it('warns about /data refs and publishes the sanitized expression by default', async () => {
     const run = makeRun({ url4_expression: '(/data/abc123)!$prompt' });
     render(<PublishToLeaderboardDialog run={run} serverUrl="" onClose={vi.fn()} />);
     expect(screen.getByText(/references local/i)).toBeInTheDocument();
     // sanitize defaults on → the displayed/published expression is redacted.
     expect(screen.getByTestId('url4')).toHaveTextContent('/data/<redacted>');
+    await screen.findByTestId('benchmark-identity');
+    await waitFor(() => expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled());
     fireEvent.click(screen.getByRole('button', { name: /publish/i }));
     expect(publishMock).toHaveBeenCalledTimes(1);
     expect(publishMock.mock.calls[0][0].url4Expression).toContain('/data/<redacted>');
   });
 
-  it('blocks publish if /data refs are neither sanitized nor acknowledged', () => {
+  it('blocks publish if /data refs are neither sanitized nor acknowledged', async () => {
     const run = makeRun({ url4_expression: '(/data/abc123)!$prompt' });
     render(<PublishToLeaderboardDialog run={run} serverUrl="" onClose={vi.fn()} />);
+    await screen.findByTestId('benchmark-identity');
     const sanitize = screen.getByRole('checkbox', { name: /sanitize/i });
     fireEvent.click(sanitize); // uncheck
     expect(screen.getByRole('button', { name: /publish/i })).toBeDisabled();
     fireEvent.click(screen.getByRole('checkbox', { name: /exposes my local data/i }));
-    expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled();
+    await waitFor(() => expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled());
   });
 
   it('blocks a zero-question run with an explanation (preflight guard)', () => {
@@ -106,17 +138,20 @@ describe('PublishToLeaderboardDialog', () => {
     expect(screen.getByRole('button', { name: /publish/i })).toBeDisabled();
   });
 
-  it('does not block a normal completed run', () => {
+  it('does not block a normal completed run', async () => {
     render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
     expect(screen.queryByText(/no graded questions/i)).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled();
+    await screen.findByTestId('benchmark-identity');
+    await waitFor(() => expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled());
   });
 
-  it('persists the submitter name to sessionStorage on publish', () => {
+  it('persists the submitter name to sessionStorage on publish', async () => {
     render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    await screen.findByTestId('benchmark-identity');
     fireEvent.change(screen.getByPlaceholderText('leave blank for anonymous'), {
       target: { value: 'Ada Lovelace' },
     });
+    await waitFor(() => expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled());
     fireEvent.click(screen.getByRole('button', { name: /publish/i }));
     expect(window.sessionStorage.getItem('sf-leaderboard-submitter')).toBe('Ada Lovelace');
   });

--- a/apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
@@ -50,6 +50,7 @@ beforeEach(() => {
   hookState.status = 'idle';
   hookState.error = null;
   hookState.result = null;
+  window.sessionStorage.clear();
   (window as unknown as { electronAPI: unknown }).electronAPI = {
     publish: { openExternal: vi.fn(async () => {}), getContext: vi.fn() },
   };
@@ -109,6 +110,21 @@ describe('PublishToLeaderboardDialog', () => {
     render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
     expect(screen.queryByText(/no graded questions/i)).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled();
+  });
+
+  it('persists the submitter name to sessionStorage on publish', () => {
+    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    fireEvent.change(screen.getByPlaceholderText('leave blank for anonymous'), {
+      target: { value: 'Ada Lovelace' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /publish/i }));
+    expect(window.sessionStorage.getItem('sf-leaderboard-submitter')).toBe('Ada Lovelace');
+  });
+
+  it('prefills the submitter name from sessionStorage on open', () => {
+    window.sessionStorage.setItem('sf-leaderboard-submitter', 'Grace Hopper');
+    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    expect(screen.getByPlaceholderText('leave blank for anonymous')).toHaveValue('Grace Hopper');
   });
 
   it('shows the success state and opens the leaderboard deep link', () => {

--- a/apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
@@ -7,6 +7,7 @@ import type { EvalRunDetail } from '../types';
 
 const publishMock = vi.fn();
 const toastMock = vi.fn();
+const listBenchmarksMock = vi.fn();
 const hookState: {
   status: 'idle' | 'submitting' | 'success' | 'error';
   error: string | null;
@@ -65,8 +66,17 @@ beforeEach(() => {
   hookState.error = null;
   hookState.result = null;
   window.sessionStorage.clear();
+  // Default: the derived benchmark (honest-agi-live-week-3) IS registered, so
+  // the registry note is "registered" and existing tests are unaffected.
+  listBenchmarksMock
+    .mockReset()
+    .mockResolvedValue([{ id: 'honest-agi-live-week-3', displayName: 'Honest AGI Live week 3' }]);
   (window as unknown as { electronAPI: unknown }).electronAPI = {
-    publish: { openExternal: vi.fn(async () => {}), getContext: vi.fn() },
+    publish: {
+      openExternal: vi.fn(async () => {}),
+      getContext: vi.fn(),
+      listBenchmarks: listBenchmarksMock,
+    },
   };
 });
 
@@ -83,6 +93,32 @@ describe('PublishToLeaderboardDialog', () => {
     await waitFor(() => expect(identity).toHaveTextContent('Honest AGI Live week 3'));
     expect(identity).toHaveTextContent('honest-agi-live-week-3');
     expect(screen.getByText(/From honest-agi-live-week-3\.eval\.jsonl/i)).toBeInTheDocument();
+  });
+
+  it('marks the derived benchmark as registered when it is in the scoreboard registry', async () => {
+    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    expect(await screen.findByText(/registered benchmark/i)).toBeInTheDocument();
+    expect(screen.queryByText(/not a registered scoreboard benchmark/i)).not.toBeInTheDocument();
+  });
+
+  it('warns (non-blocking) with a closest-match suggestion when the id is not registered', async () => {
+    listBenchmarksMock.mockResolvedValue([
+      { id: 'honest-agi-live-week-4', displayName: 'Honest AGI Live week 4' },
+    ]);
+    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    expect(await screen.findByText(/not a registered scoreboard benchmark/i)).toBeInTheDocument();
+    expect(screen.getByText('honest-agi-live-week-4')).toBeInTheDocument();
+    // Advisory only — publish stays enabled (the server is the hard gate).
+    await waitFor(() => expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled());
+  });
+
+  it('stays silent about registration when the registry is unreachable', async () => {
+    listBenchmarksMock.mockResolvedValue(null);
+    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    const identity = await screen.findByTestId('benchmark-identity');
+    await waitFor(() => expect(identity).toHaveTextContent('Honest AGI Live week 3'));
+    expect(screen.queryByText(/registered benchmark/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/not a registered scoreboard benchmark/i)).not.toBeInTheDocument();
   });
 
   it('publishes the derived benchmark id + content signature (no manual entry)', async () => {

--- a/apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
@@ -78,7 +78,9 @@ describe('PublishToLeaderboardDialog', () => {
     // Benchmark is derived + read-only — no free-text input, label shown instead.
     expect(screen.queryByPlaceholderText('e.g. hle')).not.toBeInTheDocument();
     const identity = await screen.findByTestId('benchmark-identity');
-    expect(identity).toHaveTextContent('Honest AGI Live week 3');
+    // Derivation is async (Web Crypto SHA-256 signature) — wait for the resolved
+    // label, not just the element, which first renders a "Deriving…" placeholder.
+    await waitFor(() => expect(identity).toHaveTextContent('Honest AGI Live week 3'));
     expect(identity).toHaveTextContent('honest-agi-live-week-3');
     expect(screen.getByText(/From honest-agi-live-week-3\.eval\.jsonl/i)).toBeInTheDocument();
   });

--- a/apps/desktop/src/renderer/src/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/layout/Sidebar.tsx
@@ -34,9 +34,9 @@ interface NavItem {
 
 const coreItems: NavItem[] = [
   { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
+  { id: 'url4-studio', label: 'URL4 Studio', icon: Workflow },
   { id: 'sessions', label: 'Sessions', icon: Terminal },
   { id: 'eval-studio', label: 'Eval Studio', icon: FlaskConical },
-  { id: 'url4-studio', label: 'URL4 Studio', icon: Workflow },
   { id: 'code-studio', label: 'Code Studio', icon: FileCode2 },
   { id: 'private-data', label: 'Private Data', icon: FileText },
 ];

--- a/apps/desktop/src/renderer/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/layout/__tests__/Sidebar.test.tsx
@@ -40,6 +40,29 @@ beforeEach(() => {
   logoutAigwSession.mockClear();
 });
 
+describe('Sidebar nav order', () => {
+  it('renders core nav items in the expected order', () => {
+    const { container } = render(
+      <Sidebar currentView="dashboard" onNavigate={vi.fn()} plugins={[]} />,
+    );
+    const nav = container.querySelector('nav');
+    if (!nav) throw new Error('nav not rendered');
+
+    const labels = within(nav)
+      .getAllByRole('button')
+      .map((button) => button.textContent?.trim());
+
+    expect(labels).toEqual([
+      'Dashboard',
+      'URL4 Studio',
+      'Sessions',
+      'Eval Studio',
+      'Code Studio',
+      'Private Data',
+    ]);
+  });
+});
+
 describe('Sidebar gateway status', () => {
   it('shows external gateway login in the sidebar bottom area', async () => {
     getStatus.mockResolvedValue({

--- a/apps/desktop/src/renderer/src/components/ui/__tests__/combobox.test.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/__tests__/combobox.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { useState } from 'react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { Combobox, type ComboboxOption } from '../combobox';
+
+const OPTIONS: ComboboxOption[] = [
+  { value: 'hle', label: 'News Hallucinations' },
+  { value: 'livetruth', label: 'News Livetruth' },
+];
+
+afterEach(cleanup);
+
+// Drives the pure-controlled Combobox with real state (so filtering updates as
+// the parent would in production) while still spying on every onChange call.
+function setup(initial = '') {
+  const onChange = vi.fn();
+  function Controlled() {
+    const [value, setValue] = useState(initial);
+    return (
+      <Combobox
+        value={value}
+        onChange={(v) => {
+          onChange(v);
+          setValue(v);
+        }}
+        options={OPTIONS}
+        placeholder="Select a benchmark"
+        aria-label="Benchmark"
+      />
+    );
+  }
+  render(<Controlled />);
+  const input = screen.getByRole('combobox', { name: 'Benchmark' }) as HTMLInputElement;
+  return { onChange, input };
+}
+
+describe('Combobox', () => {
+  it('shows all options on focus and filters by value or label', () => {
+    const { input } = setup();
+    fireEvent.focus(input);
+    expect(screen.getByRole('option', { name: /hle/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /livetruth/i })).toBeInTheDocument();
+    fireEvent.change(input, { target: { value: 'truth' } });
+    expect(screen.queryByRole('option', { name: /hle/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /livetruth/i })).toBeInTheDocument();
+  });
+
+  it('passes free text straight through onChange', () => {
+    const { input, onChange } = setup();
+    fireEvent.change(input, { target: { value: 'custom-id' } });
+    expect(onChange).toHaveBeenLastCalledWith('custom-id');
+  });
+
+  it('selecting an option emits its value and closes the list', () => {
+    const { input, onChange } = setup();
+    fireEvent.focus(input);
+    fireEvent.mouseDown(screen.getByRole('option', { name: /livetruth/i }));
+    expect(onChange).toHaveBeenLastCalledWith('livetruth');
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('keyboard: ArrowDown + Enter selects the highlighted option', () => {
+    const { input, onChange } = setup();
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onChange).toHaveBeenLastCalledWith('livetruth');
+  });
+
+  it('Escape closes the list without changing the value', () => {
+    const { input, onChange } = setup();
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('keeps Enter selection valid after filtering narrows the list', () => {
+    const { input, onChange } = setup();
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'ArrowDown' }); // highlight index 1 (livetruth)
+    fireEvent.change(input, { target: { value: 'hle' } }); // list narrows to [hle]; active clamps to 0
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onChange).toHaveBeenLastCalledWith('hle');
+  });
+});

--- a/apps/desktop/src/renderer/src/components/ui/combobox.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/combobox.tsx
@@ -1,0 +1,137 @@
+// apps/desktop/src/renderer/src/components/ui/combobox.tsx
+//
+// Minimal, dependency-free filterable combobox: a text input plus a filtered
+// listbox. Pure controlled — the `value` prop is the single source of truth and
+// also drives the filter; typing/selecting calls `onChange`. Free text is
+// allowed. Brand-styled (square, hairline, mono ids). Keyboard: ArrowUp/Down
+// move the highlight, Enter selects it, Escape closes.
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+
+export interface ComboboxOption {
+  value: string;
+  label: string;
+}
+
+interface ComboboxProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: ComboboxOption[];
+  placeholder?: string;
+  disabled?: boolean;
+  'aria-label'?: string;
+}
+
+export function Combobox({
+  value,
+  onChange,
+  options,
+  placeholder,
+  disabled,
+  'aria-label': ariaLabel,
+}: ComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState(0);
+  const listId = useId();
+  const blurTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const filtered = useMemo(() => {
+    const q = value.trim().toLowerCase();
+    if (q.length === 0) return options;
+    return options.filter(
+      (o) => o.value.toLowerCase().includes(q) || o.label.toLowerCase().includes(q),
+    );
+  }, [options, value]);
+
+  // Keep the highlight within the (possibly newly-filtered) list, so the visual
+  // highlight, aria-activedescendant, and Enter selection never go out of bounds.
+  useEffect(() => {
+    setActive((i) => (filtered.length === 0 ? 0 : Math.min(i, filtered.length - 1)));
+  }, [filtered]);
+
+  // Cancel a pending blur-close if we unmount within the timeout window.
+  useEffect(
+    () => () => {
+      if (blurTimer.current) clearTimeout(blurTimer.current);
+    },
+    [],
+  );
+
+  const commit = (v: string): void => {
+    onChange(v);
+    setOpen(false);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setOpen(true);
+      setActive((i) => Math.min(i + 1, filtered.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActive((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter') {
+      if (open && filtered[active]) {
+        e.preventDefault();
+        commit(filtered[active].value);
+      }
+    } else if (e.key === 'Escape') {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div className="relative">
+      <input
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={listId}
+        aria-autocomplete="list"
+        aria-activedescendant={open && filtered[active] ? `${listId}-${active}` : undefined}
+        aria-label={ariaLabel}
+        className="w-full rounded-none border border-border bg-background px-3 py-2 text-sm"
+        value={value}
+        placeholder={placeholder}
+        disabled={disabled}
+        onChange={(e) => {
+          onChange(e.target.value);
+          setOpen(true);
+          setActive(0);
+        }}
+        onFocus={() => setOpen(true)}
+        onBlur={() => {
+          blurTimer.current = setTimeout(() => setOpen(false), 120);
+        }}
+        onKeyDown={onKeyDown}
+      />
+      {open && filtered.length > 0 && (
+        <ul
+          id={listId}
+          role="listbox"
+          className="absolute z-20 mt-1 max-h-48 w-full overflow-auto rounded-none border border-border bg-popover text-sm"
+        >
+          {filtered.map((o, i) => (
+            <li
+              key={o.value}
+              id={`${listId}-${i}`}
+              role="option"
+              aria-selected={i === active}
+              className={`cursor-pointer px-3 py-1.5 ${
+                i === active ? 'bg-accent text-accent-foreground' : ''
+              }`}
+              onMouseEnter={() => setActive(i)}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                commit(o.value);
+              }}
+            >
+              <span className="font-mono">{o.value}</span>
+              {o.label && o.label !== o.value && (
+                <span className="ml-2 text-xs text-muted-foreground">{o.label}</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/hooks/__tests__/use-known-benchmarks.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/__tests__/use-known-benchmarks.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor, cleanup } from '@testing-library/react';
+import { it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { useKnownBenchmarks } from '../use-known-benchmarks';
+
+const listBenchmarks = vi.fn();
+
+beforeEach(() => {
+  listBenchmarks.mockReset();
+  (window as unknown as { electronAPI: unknown }).electronAPI = { publish: { listBenchmarks } };
+});
+afterEach(cleanup);
+
+it('starts loading, then resolves the registry list', async () => {
+  listBenchmarks.mockResolvedValue([{ id: 'hle', displayName: 'HLE' }]);
+  const { result } = renderHook(() => useKnownBenchmarks());
+  expect(result.current.loading).toBe(true);
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  expect(result.current.benchmarks).toEqual([{ id: 'hle', displayName: 'HLE' }]);
+});
+
+it('resolves to null (not loading) when the registry is unreachable', async () => {
+  listBenchmarks.mockResolvedValue(null);
+  const { result } = renderHook(() => useKnownBenchmarks());
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  expect(result.current.benchmarks).toBeNull();
+});
+
+it('treats a rejected IPC call as unavailable rather than throwing', async () => {
+  listBenchmarks.mockRejectedValue(new Error('ipc down'));
+  const { result } = renderHook(() => useKnownBenchmarks());
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  expect(result.current.benchmarks).toBeNull();
+});

--- a/apps/desktop/src/renderer/src/hooks/__tests__/use-publish-score.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/__tests__/use-publish-score.test.ts
@@ -23,6 +23,7 @@ const RUN: EvalRunDetail = {
 const INPUTS: PublishInputs = {
   run: RUN,
   benchmarkId: 'hle',
+  benchmarkSignature: 'a'.repeat(64),
   specId: 'hle-ensemble-three',
   url4Expression: RUN.url4_expression,
   providers: ['claude', 'codex', 'gemini'],
@@ -63,6 +64,7 @@ describe('usePublishScore', () => {
     expect(submitScore).toHaveBeenCalledTimes(1);
     expect(submitScore).toHaveBeenCalledWith({
       benchmarkId: 'hle',
+      benchmarkSignature: 'a'.repeat(64),
       specId: 'hle-ensemble-three',
       url4Expression: 'url4://ensemble(claude,codex,gemini)/hle',
       providers: ['claude', 'codex', 'gemini'],

--- a/apps/desktop/src/renderer/src/hooks/use-known-benchmarks.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-known-benchmarks.ts
@@ -1,0 +1,42 @@
+// apps/desktop/src/renderer/src/hooks/use-known-benchmarks.ts
+//
+// Loads the canonical benchmarks registered on the scoreboard (GET
+// /v1/benchmarks via the main process, exempt from renderer CORS) for pre-flight
+// validation of the derived benchmark id in the publish dialog (SF-300 follow-up).
+//
+// `benchmarks` is null while loading AND when the registry is unreachable —
+// callers must gate on `loading` so they don't treat "still fetching" or
+// "registry down" as "benchmark not registered".
+
+import { useEffect, useState } from 'react';
+import type { KnownBenchmark } from '../../../../preload/types';
+
+export interface KnownBenchmarksState {
+  benchmarks: KnownBenchmark[] | null;
+  loading: boolean;
+}
+
+export function useKnownBenchmarks(): KnownBenchmarksState {
+  const [benchmarks, setBenchmarks] = useState<KnownBenchmark[] | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    void window.electronAPI.publish
+      .listBenchmarks()
+      .then((list) => {
+        if (active) setBenchmarks(list);
+      })
+      .catch(() => {
+        if (active) setBenchmarks(null);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return { benchmarks, loading };
+}

--- a/apps/desktop/src/renderer/src/hooks/use-publish-score.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-publish-score.ts
@@ -15,6 +15,8 @@ export type PublishStatus = 'idle' | 'submitting' | 'success' | 'error';
 export interface PublishInputs {
   run: EvalRunDetail;
   benchmarkId: string;
+  /** SHA-256 content signature derived from the run's eval content (SF-300). */
+  benchmarkSignature: string;
   specId: string;
   /** url4 expression to publish — already sanitized if the user chose to. */
   url4Expression: string;
@@ -30,6 +32,7 @@ function toRequest(inputs: PublishInputs): PublishScoreRequest {
   const { run } = inputs;
   return {
     benchmarkId: inputs.benchmarkId,
+    benchmarkSignature: inputs.benchmarkSignature,
     specId: inputs.specId,
     url4Expression: inputs.url4Expression,
     providers: inputs.providers,

--- a/apps/desktop/src/renderer/src/hooks/use-scoreboard-url.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-scoreboard-url.ts
@@ -1,0 +1,24 @@
+// apps/desktop/src/renderer/src/hooks/use-scoreboard-url.ts
+//
+// Resolves the public scoreboard URL the same way publishing does (env →
+// sf.json → production default; SF-271 set the default in publish-context).
+// The renderer can't read env/config itself, so it asks the main process via
+// publish.getContext(). Returns null until resolved.
+
+import { useEffect, useState } from 'react';
+
+export function useScoreboardUrl(): string | null {
+  const [url, setUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    void window.electronAPI.publish.getContext().then((ctx) => {
+      if (active) setUrl(ctx.scoreboardUrl);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return url;
+}

--- a/apps/desktop/src/renderer/src/lib/__tests__/benchmark-identity.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/benchmark-identity.test.ts
@@ -1,0 +1,189 @@
+// apps/desktop/src/renderer/src/lib/__tests__/benchmark-identity.test.ts
+import { describe, it, expect } from 'vitest';
+import {
+  detectDatasetFilename,
+  deriveBenchmarkId,
+  deriveBenchmarkLabel,
+  normalizeEvalContent,
+  computeContentSignature,
+  deriveBenchmarkIdentity,
+  verifyIdentityConsistency,
+} from '../benchmark-identity';
+import type { EvalRunDetail, EvalQuestion } from '@/components/eval/types';
+
+function q(idx: number, question: string, expected: string): EvalQuestion {
+  return {
+    id: `q-${idx}`,
+    idx,
+    question,
+    expected,
+    predicted: null,
+    correct: null,
+    raw_output: null,
+    error: null,
+  };
+}
+
+function makeRun(overrides: Partial<EvalRunDetail> = {}): EvalRunDetail {
+  return {
+    id: 'eval-run-1',
+    spec_name: 'honest-agi-live-week-3',
+    url4_expression:
+      'https://screamingface.ai/honest-agi-live-week-3.eval.jsonl*(/claude($item.question))!reduce',
+    started_at: '2026-05-04T11:00:00Z',
+    finished_at: '2026-05-04T11:55:00Z',
+    status: 'done',
+    accuracy: 0.5,
+    total_questions: 2,
+    correct_questions: 1,
+    error: null,
+    favorite: false,
+    questions: [q(0, '2+2?', '4'), q(1, 'capital of France?', 'Paris')],
+    ...overrides,
+  };
+}
+
+describe('detectDatasetFilename', () => {
+  it('extracts the .eval.jsonl filename from a collection source URL', () => {
+    expect(
+      detectDatasetFilename(
+        'https://screamingface.ai/honest-agi-live-week-3.eval.jsonl*(/claude($item.question))',
+      ),
+    ).toBe('honest-agi-live-week-3.eval.jsonl');
+  });
+
+  it('extracts a plain .jsonl filename', () => {
+    expect(detectDatasetFilename('https://example.com/data.jsonl*(text)!intent')).toBe(
+      'data.jsonl',
+    );
+  });
+
+  it('prefers an .eval.jsonl over another dataset file in the same expression', () => {
+    const expr = 'https://x.test/hle.eval.jsonl*(/python(reduce.csv)!{$item})';
+    expect(detectDatasetFilename(expr)).toBe('hle.eval.jsonl');
+  });
+
+  it('returns null when there is no dataset filename', () => {
+    expect(detectDatasetFilename('(/data/abc123)!$prompt')).toBeNull();
+    expect(detectDatasetFilename('url4://ensemble(claude,codex)/hle')).toBeNull();
+    expect(detectDatasetFilename('')).toBeNull();
+  });
+});
+
+describe('deriveBenchmarkId', () => {
+  it('strips the eval extension and slugifies', () => {
+    expect(deriveBenchmarkId('honest-agi-live-week-3.eval.jsonl')).toBe('honest-agi-live-week-3');
+  });
+
+  it('slugifies spaces and underscores', () => {
+    expect(deriveBenchmarkId('Honest AGI_Live week 3.jsonl')).toBe('honest-agi-live-week-3');
+  });
+
+  it('handles plain .json and .csv', () => {
+    expect(deriveBenchmarkId('hle.json')).toBe('hle');
+    expect(deriveBenchmarkId('data.csv')).toBe('data');
+  });
+});
+
+describe('deriveBenchmarkLabel', () => {
+  it('renders the Honest AGI Live week family', () => {
+    expect(deriveBenchmarkLabel('honest-agi-live-week-3')).toBe('Honest AGI Live week 3');
+    expect(deriveBenchmarkLabel('honest-agi-live')).toBe('Honest AGI Live');
+  });
+
+  it('uppercases known acronyms and titleizes the rest', () => {
+    expect(deriveBenchmarkLabel('hle')).toBe('HLE');
+    expect(deriveBenchmarkLabel('my-custom-bench')).toBe('My Custom Bench');
+  });
+});
+
+describe('normalizeEvalContent', () => {
+  it('orders rows by idx and emits {question, expected} jsonl', () => {
+    const run = makeRun({
+      questions: [q(1, 'capital of France?', 'Paris'), q(0, '2+2?', '4')],
+    });
+    expect(normalizeEvalContent(run)).toBe(
+      '{"question":"2+2?","expected":"4"}\n{"question":"capital of France?","expected":"Paris"}',
+    );
+  });
+
+  it('is empty for a run with no questions', () => {
+    expect(normalizeEvalContent(makeRun({ questions: [] }))).toBe('');
+  });
+});
+
+describe('computeContentSignature', () => {
+  it('is a stable 64-char hex SHA-256 over the normalized content', async () => {
+    const sig = await computeContentSignature(makeRun());
+    expect(sig).toMatch(/^[0-9a-f]{64}$/);
+    // Stable: same content -> same hash regardless of input row order.
+    const reordered = await computeContentSignature(
+      makeRun({ questions: [q(1, 'capital of France?', 'Paris'), q(0, '2+2?', '4')] }),
+    );
+    expect(reordered).toBe(sig);
+  });
+
+  it('differs when the eval content differs', async () => {
+    const a = await computeContentSignature(makeRun());
+    const b = await computeContentSignature(makeRun({ questions: [q(0, '2+2?', '5')] }));
+    expect(b).not.toBe(a);
+  });
+
+  it('returns empty string for a run with no graded content', async () => {
+    expect(await computeContentSignature(makeRun({ questions: [] }))).toBe('');
+  });
+});
+
+describe('deriveBenchmarkIdentity', () => {
+  it('derives id, label, filename, and signature from a collection run', async () => {
+    const identity = await deriveBenchmarkIdentity(makeRun());
+    expect(identity.datasetFilename).toBe('honest-agi-live-week-3.eval.jsonl');
+    expect(identity.id).toBe('honest-agi-live-week-3');
+    expect(identity.label).toBe('Honest AGI Live week 3');
+    expect(identity.signature).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('falls back to spec_name when the expression has no dataset filename', async () => {
+    const identity = await deriveBenchmarkIdentity(
+      makeRun({ url4_expression: '(/data/abc)!$prompt', spec_name: 'hle' }),
+    );
+    expect(identity.datasetFilename).toBeNull();
+    expect(identity.id).toBe('hle');
+    expect(identity.label).toBe('HLE');
+  });
+});
+
+describe('verifyIdentityConsistency', () => {
+  it('passes a fully derived identity', () => {
+    expect(
+      verifyIdentityConsistency({
+        id: 'honest-agi-live-week-3',
+        label: 'Honest AGI Live week 3',
+        datasetFilename: 'honest-agi-live-week-3.eval.jsonl',
+        signature: 'a'.repeat(64),
+      }),
+    ).toEqual({ ok: true, reason: null });
+  });
+
+  it('blocks when the id could not be derived', () => {
+    const out = verifyIdentityConsistency({
+      id: '',
+      label: '',
+      datasetFilename: null,
+      signature: 'a'.repeat(64),
+    });
+    expect(out.ok).toBe(false);
+    expect(out.reason).toMatch(/could not derive a benchmark id/i);
+  });
+
+  it('blocks when the signature is missing (no content to pin the id to)', () => {
+    const out = verifyIdentityConsistency({
+      id: 'hle',
+      label: 'HLE',
+      datasetFilename: 'hle.eval.jsonl',
+      signature: '',
+    });
+    expect(out.ok).toBe(false);
+    expect(out.reason).toMatch(/no graded content/i);
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/__tests__/benchmark-identity.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/benchmark-identity.test.ts
@@ -8,6 +8,8 @@ import {
   computeContentSignature,
   deriveBenchmarkIdentity,
   verifyIdentityConsistency,
+  editDistance,
+  checkBenchmarkRegistration,
 } from '../benchmark-identity';
 import type { EvalRunDetail, EvalQuestion } from '@/components/eval/types';
 
@@ -185,5 +187,43 @@ describe('verifyIdentityConsistency', () => {
     });
     expect(out.ok).toBe(false);
     expect(out.reason).toMatch(/no graded content/i);
+  });
+});
+
+describe('editDistance', () => {
+  it('is 0 for equal strings and the length for empty comparisons', () => {
+    expect(editDistance('hle', 'hle')).toBe(0);
+    expect(editDistance('', 'abc')).toBe(3);
+    expect(editDistance('abc', '')).toBe(3);
+  });
+
+  it('counts single edits (substitution / format drift)', () => {
+    expect(editDistance('livetruth_latest', 'livetruth-latest')).toBe(1);
+    expect(editDistance('hle', 'hles')).toBe(1);
+  });
+});
+
+describe('checkBenchmarkRegistration', () => {
+  it("returns 'registered' when the derived id is in the registry", () => {
+    const out = checkBenchmarkRegistration('hle', ['hle', 'gpqa']);
+    expect(out.status).toBe('registered');
+    expect(out.suggestion).toBeNull();
+  });
+
+  it("returns 'unknown' with the closest match when the id drifts in format", () => {
+    const out = checkBenchmarkRegistration('livetruth_latest', ['livetruth-latest', 'hle']);
+    expect(out.status).toBe('unknown');
+    expect(out.suggestion).toBe('livetruth-latest');
+  });
+
+  it("returns 'unknown' with no suggestion when nothing is close", () => {
+    const out = checkBenchmarkRegistration('honest-agi-live-week-3', ['hle', 'gpqa']);
+    expect(out.status).toBe('unknown');
+    expect(out.suggestion).toBeNull();
+  });
+
+  it("returns 'unavailable' when the registry couldn't be fetched (null) or id is empty", () => {
+    expect(checkBenchmarkRegistration('hle', null).status).toBe('unavailable');
+    expect(checkBenchmarkRegistration('', ['hle']).status).toBe('unavailable');
   });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/editor-height.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/editor-height.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { clampEditorHeight } from '../editor-height';
+
+describe('clampEditorHeight', () => {
+  it('floors at 28px', () => {
+    expect(clampEditorHeight(10, 360)).toBe(28);
+  });
+  it('caps at the given maximum', () => {
+    expect(clampEditorHeight(500, 360)).toBe(360);
+  });
+  it('returns content height between the floor and the cap', () => {
+    expect(clampEditorHeight(120, 360)).toBe(120);
+  });
+  it('removes the cap when max is null (full content height)', () => {
+    expect(clampEditorHeight(5000, null)).toBe(5000);
+    expect(clampEditorHeight(10, null)).toBe(28);
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/benchmark-identity.ts
+++ b/apps/desktop/src/renderer/src/lib/benchmark-identity.ts
@@ -172,3 +172,62 @@ export function verifyIdentityConsistency(identity: BenchmarkIdentity): Identity
   }
   return { ok: true, reason: null };
 }
+
+/** Levenshtein edit distance between two short strings (benchmark ids). */
+export function editDistance(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  // Single-row DP; row[j] = distance between a[0..i] and b[0..j].
+  let prev = Array.from({ length: b.length + 1 }, (_, j) => j);
+  for (let i = 1; i <= a.length; i += 1) {
+    const curr = [i];
+    for (let j = 1; j <= b.length; j += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
+    }
+    prev = curr;
+  }
+  return prev[b.length];
+}
+
+export type BenchmarkRegistryStatus = 'registered' | 'unknown' | 'unavailable';
+
+export interface BenchmarkRegistryCheck {
+  status: BenchmarkRegistryStatus;
+  /** Closest registered id when the derived id is unknown but a near-match exists. */
+  suggestion: string | null;
+}
+
+/**
+ * Validate a derived benchmark id against the scoreboard's registered set —
+ * pre-flight, since publish hard-404s an unknown benchmark_id. `knownIds` is
+ * null when the registry couldn't be fetched: we return 'unavailable' (never a
+ * false 'unknown') so the dialog stays silent rather than warning wrongly.
+ * On 'unknown' we suggest the closest registered id within a small edit distance
+ * (catches format drift like `livetruth_latest` vs `livetruth-latest`).
+ */
+export function checkBenchmarkRegistration(
+  id: string,
+  knownIds: string[] | null,
+): BenchmarkRegistryCheck {
+  if (knownIds === null || !id) return { status: 'unavailable', suggestion: null };
+  if (knownIds.includes(id)) return { status: 'registered', suggestion: null };
+
+  let best: string | null = null;
+  let bestDistance = Infinity;
+  for (const known of knownIds) {
+    const distance = editDistance(id, known);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = known;
+    }
+  }
+  // Only suggest when it's plausibly the same benchmark mistyped/reformatted —
+  // scale the threshold with id length so long ids tolerate a bit more drift.
+  const threshold = Math.max(2, Math.floor(id.length / 4));
+  return {
+    status: 'unknown',
+    suggestion: best !== null && bestDistance <= threshold ? best : null,
+  };
+}

--- a/apps/desktop/src/renderer/src/lib/benchmark-identity.ts
+++ b/apps/desktop/src/renderer/src/lib/benchmark-identity.ts
@@ -1,0 +1,174 @@
+// apps/desktop/src/renderer/src/lib/benchmark-identity.ts
+//
+// Auto-derives a benchmark *identity* for the "Publish to Leaderboard" flow
+// (SF-300), replacing the old free-text Benchmark-ID input. An identity has
+// three parts, all derived — never typed by the user:
+//
+//   1. datasetFilename — the `*.eval.jsonl` (or .jsonl/.json/.csv) file the run's
+//      url4 expression iterated over, pulled from the dataset/collection source URL.
+//   2. id             — a stable, slugified benchmark id derived from that filename
+//      (e.g. `honest-agi-live-week-3.eval.jsonl` -> `honest-agi-live-week-3`).
+//   3. signature      — a SHA-256 content hash that pins the id to the exact eval
+//      content the run executed against, so an id can't silently drift onto a
+//      different dataset.
+//
+// CLIENT-SIDE GAP (documented, intentional): the desktop app does NOT hold the
+// raw jsonl bytes the server fetched — an eval_run only persists the per-question
+// `question`/`expected` pairs (see eval/types.ts) and the url4 expression. So the
+// signature here is computed over a *normalized reconstruction* of those rows,
+// not the original file bytes. It is stable and collision-resistant for our
+// purposes (detecting "same id, different content"), but it is NOT byte-identical
+// to a hash the scoreboard would compute over the source file.
+//
+// SERVER FOLLOW-UP (out of scope for this client ticket — see PR body): the
+// authoritative fix is for the server to (a) embed a non-editable benchmark-ID
+// metadata field into each dataset row, and (b) record/verify a hash of the
+// fetched source bytes, so the scoreboard can verify id<->signature against the
+// real file rather than this client reconstruction.
+
+import type { EvalRunDetail } from '@/components/eval/types';
+
+/** Matches a dataset/collection source filename ending in a known eval extension. */
+const DATASET_FILE_RE = /([A-Za-z0-9._-]+\.(?:eval\.jsonl|jsonl|json|csv))(?=$|[)\s*!,;])/i;
+/** Strips the trailing dataset extension to leave the benchmark stem. */
+const EXT_STRIP_RE = /\.(?:eval\.jsonl|jsonl|json|csv)$/i;
+
+export interface BenchmarkIdentity {
+  /** Slugified, stable benchmark id derived from the dataset filename. */
+  id: string;
+  /** Human label (e.g. "Honest AGI Live week 3") when the filename matches a known pattern, else a titleized stem. */
+  label: string;
+  /** The dataset filename detected in the url4 expression, or null when none found. */
+  datasetFilename: string | null;
+  /** SHA-256 over the normalized reconstructed eval content (hex). Empty when no content. */
+  signature: string;
+}
+
+/**
+ * Pull the dataset filename out of a url4 expression. We look for the last path
+ * segment of a dataset/collection source URL ending in a known eval extension.
+ * Returns null when the expression has no recognizable dataset file (e.g. an
+ * inline `/data/<hash>` blob run, or a single-prompt run).
+ */
+export function detectDatasetFilename(expression: string): string | null {
+  if (!expression) return null;
+  // Scan all matches and take the last dataset-like filename: the collection
+  // source is typically the left operand of `*`, but reducers/checks may name
+  // other files — the dataset is the one carrying an eval extension. We prefer
+  // the first `.eval.jsonl` match, else the first match of any kind.
+  const all = expression.match(new RegExp(DATASET_FILE_RE, 'gi')) ?? [];
+  if (all.length === 0) return null;
+  const evalJsonl = all.find((f) => /\.eval\.jsonl$/i.test(f));
+  return evalJsonl ?? all[0];
+}
+
+/**
+ * Slugify a dataset filename into a stable benchmark id: strip the extension,
+ * lowercase, and collapse non-alphanumeric runs to single hyphens.
+ */
+export function deriveBenchmarkId(filename: string): string {
+  const stem = filename.replace(EXT_STRIP_RE, '');
+  return stem
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Human-readable label for a benchmark id. Recognizes the "honest-agi-live-week-N"
+ * family and renders it as "Honest AGI Live week N"; otherwise titleizes the slug.
+ */
+export function deriveBenchmarkLabel(id: string): string {
+  const week = id.match(/^honest-agi-live-week-(\d+)$/i);
+  if (week) return `Honest AGI Live week ${week[1]}`;
+  if (/^honest-agi-live$/i.test(id)) return 'Honest AGI Live';
+  if (!id) return '';
+  return id
+    .split('-')
+    .filter(Boolean)
+    .map((word) => {
+      // Keep all-caps acronyms (agi -> AGI, hle -> HLE) uppercased when short.
+      if (/^[a-z]{2,4}$/.test(word) && /^(agi|hle|gpqa|mmlu|swe)$/i.test(word)) {
+        return word.toUpperCase();
+      }
+      return word.charAt(0).toUpperCase() + word.slice(1);
+    })
+    .join(' ');
+}
+
+/**
+ * Normalize the run's graded questions into stable jsonl bytes for hashing:
+ * one `{question, expected}` object per row, ordered by `idx`, NFC-normalized,
+ * newline-joined. This is the reconstruction the signature is computed over (see
+ * the CLIENT-SIDE GAP note at the top of this file).
+ */
+export function normalizeEvalContent(run: EvalRunDetail): string {
+  const rows = [...run.questions]
+    .sort((a, b) => a.idx - b.idx)
+    .map((q) => JSON.stringify({ question: q.question, expected: q.expected }).normalize('NFC'));
+  return rows.join('\n');
+}
+
+function toHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/**
+ * SHA-256 (hex) over the normalized eval content. Returns '' for empty content
+ * so callers can treat "no content to sign" distinctly from a real digest.
+ */
+export async function computeContentSignature(run: EvalRunDetail): Promise<string> {
+  const content = normalizeEvalContent(run);
+  if (content.length === 0) return '';
+  const bytes = new TextEncoder().encode(content);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return toHex(digest);
+}
+
+/**
+ * Derive the full benchmark identity (id + label + filename + signature) for a
+ * run. Async because the signature is a Web Crypto digest.
+ */
+export async function deriveBenchmarkIdentity(run: EvalRunDetail): Promise<BenchmarkIdentity> {
+  const datasetFilename = detectDatasetFilename(run.url4_expression);
+  // Fall back to the run's spec_name stem when the expression has no dataset
+  // file (inline blob / single-prompt runs) so the id is never empty when a
+  // spec name exists. The signature still pins it to the executed content.
+  const baseName = datasetFilename ?? run.spec_name;
+  const id = deriveBenchmarkId(baseName);
+  const label = deriveBenchmarkLabel(id);
+  const signature = await computeContentSignature(run);
+  return { id, label, datasetFilename, signature };
+}
+
+export interface IdentityConsistency {
+  ok: boolean;
+  /** User-facing reason when not ok; null when consistent. */
+  reason: string | null;
+}
+
+/**
+ * Verify a derived id<->signature pair is internally consistent before publish.
+ * Blocks when the id is empty (nothing to attribute the score to) or the
+ * signature is missing (no graded content to pin the id to — i.e. the id can't
+ * be trusted to describe what actually ran).
+ */
+export function verifyIdentityConsistency(identity: BenchmarkIdentity): IdentityConsistency {
+  if (!identity.id) {
+    return {
+      ok: false,
+      reason:
+        'Could not derive a benchmark ID from this run (no dataset filename in the URL4 expression and no spec name). This run can’t be attributed to a leaderboard benchmark.',
+    };
+  }
+  if (!identity.signature) {
+    return {
+      ok: false,
+      reason:
+        'This run has no graded content to sign, so its benchmark ID can’t be verified against what it ran. Re-run the eval against the dataset before publishing.',
+    };
+  }
+  return { ok: true, reason: null };
+}

--- a/apps/desktop/src/renderer/src/lib/editor-height.ts
+++ b/apps/desktop/src/renderer/src/lib/editor-height.ts
@@ -1,0 +1,13 @@
+// apps/desktop/src/renderer/src/lib/editor-height.ts
+//
+// Pure height-clamp for the url4 Monaco editor's auto-grow. Extracted so the cap
+// logic is unit-testable without mounting Monaco. `maxContentHeight === null`
+// means "no upper cap" — grow to the full content height (SF-309) so the editor
+// never shows its own scrollbar inside a scrolling dialog.
+
+const MIN_HEIGHT = 28;
+
+export function clampEditorHeight(contentHeight: number, maxContentHeight: number | null): number {
+  const lower = Math.max(contentHeight, MIN_HEIGHT);
+  return maxContentHeight == null ? lower : Math.min(lower, maxContentHeight);
+}

--- a/apps/desktop/src/renderer/src/views/EvalStudioView.test.tsx
+++ b/apps/desktop/src/renderer/src/views/EvalStudioView.test.tsx
@@ -40,6 +40,15 @@ it('renders header, empty state, and both pane toggles', () => {
   expect(screen.getByRole('button', { name: /hide run details/i })).toBeTruthy();
 });
 
+// SF-298: a static "Check the latest leaderboard" link is shown at the top and,
+// with no runs, also in the empty state (so two affordances appear).
+it('shows the leaderboard link at the top and in the empty runs state', () => {
+  render(<EvalStudioView />);
+  expect(
+    screen.getAllByRole('button', { name: /check the latest leaderboard/i }).length,
+  ).toBeGreaterThanOrEqual(2);
+});
+
 // SF-289: the resizable Panel hard-codes inline overflow:hidden, so the runs
 // list must live inside its own bounded, scrollable container or it gets clipped.
 it('wraps the runs list in a bounded scroll container', () => {

--- a/apps/desktop/src/renderer/src/views/EvalStudioView.tsx
+++ b/apps/desktop/src/renderer/src/views/EvalStudioView.tsx
@@ -79,6 +79,11 @@ export function EvalStudioView({ pendingRun, onPendingConsumed }: EvalStudioView
     setSelectedRunId((current) => (current === id ? null : current));
   }, []);
 
+  // Clear the right panel if a bulk delete removed the selected run.
+  const handleBulkDeleted = useCallback((deletedIds: string[]): void => {
+    setSelectedRunId((current) => (current && deletedIds.includes(current) ? null : current));
+  }, []);
+
   // Consume a deep-linked pending run exactly once.
   const handledPendingRef = useRef<RunPayload | null>(null);
   useEffect(() => {
@@ -178,6 +183,7 @@ export function EvalStudioView({ pendingRun, onPendingConsumed }: EvalStudioView
               selectedId={selectedRunId}
               onSelect={setSelectedRunId}
               onRunLocally={runAndSelect}
+              onBulkDeleted={handleBulkDeleted}
             />
           </div>
         </ResizablePanel>

--- a/apps/desktop/src/renderer/src/views/EvalStudioView.tsx
+++ b/apps/desktop/src/renderer/src/views/EvalStudioView.tsx
@@ -11,6 +11,7 @@ import {
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
 import { Button } from '@/components/ui/button';
 import { EvalRunsList } from '@/components/eval/EvalRunsList';
+import { LeaderboardLink } from '@/components/eval/LeaderboardLink';
 import { EvalRunDetail } from '@/components/eval/EvalRunDetail';
 import { AddEvalRunDialog } from '@/components/eval/AddEvalRunDialog';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
@@ -124,6 +125,7 @@ export function EvalStudioView({ pendingRun, onPendingConsumed }: EvalStudioView
           <p className="text-xs text-muted-foreground">
             History of evaluation runs across leaderboard entries
           </p>
+          <LeaderboardLink className="mt-1.5" />
         </div>
         <div className="flex items-center gap-1">
           <Button variant="outline" size="sm" className="mr-1" onClick={() => setAdding(true)}>

--- a/apps/desktop/src/test-setup.ts
+++ b/apps/desktop/src/test-setup.ts
@@ -15,3 +15,22 @@
     disconnect() {}
   };
 /* eslint-enable @typescript-eslint/no-explicit-any */
+
+// Minimal default `window.electronAPI` so renderer components that call into the
+// preload bridge during effects (e.g. LeaderboardLink → publish.getContext) don't
+// throw in jsdom tests. Individual tests can override specific methods as needed.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+if (typeof (globalThis as any).window !== 'undefined') {
+  const win = (globalThis as any).window;
+  win.electronAPI = win.electronAPI ?? {};
+  win.electronAPI.publish = win.electronAPI.publish ?? {
+    getContext: () =>
+      Promise.resolve({
+        scoreboardUrl: 'https://scoreboard.test',
+        portalUrl: 'https://portal.test',
+        client: { name: 'test', version: '0.0.0', platform: 'test' },
+      }),
+    openExternal: () => Promise.resolve(),
+  };
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/docs/superpowers/plans/2026-06-22-publish-dialog-benchmark-combobox.md
+++ b/docs/superpowers/plans/2026-06-22-publish-dialog-benchmark-combobox.md
@@ -1,0 +1,982 @@
+# Publish Dialog: Manual Benchmark Combobox + Full-Height URL4 Field — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the auto-derived read-only benchmark field in the Publish-to-Leaderboard dialog with a manual, filterable combobox (registered list + free text, blank default), and make the read-only URL4 field grow to full content height so the dialog has a single scrollbar.
+
+**Architecture:** Desktop-only (`apps/desktop`). A new reusable `Combobox` UI primitive (no new deps) feeds from the already-committed `useKnownBenchmarks()` registry layer. The dialog drops the SF-300 derived-id display + consistency gate but still computes the content signature (sent as payload metadata) and reuses `checkBenchmarkRegistration` for an advisory hint on the chosen value. A small pure `clampEditorHeight` helper plus a `maxContentHeight` prop lets `Url4MonacoEditor` opt out of its 360px cap.
+
+**Tech Stack:** React 19 + TypeScript + Vite + Tailwind v4 + Vitest/jsdom + Monaco (`@monaco-editor/react`).
+
+**Spec:** `docs/superpowers/specs/2026-06-22-publish-dialog-benchmark-combobox-and-url4-height-design.md`
+
+**Branch:** `SF-309-publish-benchmark-combobox` (already created, off the SF-300 registry-validation baseline).
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+| --- | --- | --- |
+| `apps/desktop/src/renderer/src/components/ui/combobox.tsx` | Reusable filterable combobox primitive (input + listbox, keyboard, a11y) | Create |
+| `apps/desktop/src/renderer/src/components/ui/__tests__/combobox.test.tsx` | Combobox unit tests | Create |
+| `apps/desktop/src/renderer/src/lib/editor-height.ts` | Pure `clampEditorHeight(contentHeight, maxContentHeight)` | Create |
+| `apps/desktop/src/renderer/src/lib/__tests__/editor-height.test.ts` | Height-clamp unit tests | Create |
+| `apps/desktop/src/renderer/src/components/Url4MonacoEditor.tsx` | Use `clampEditorHeight` + new `maxContentHeight` prop + release wheel capture | Modify |
+| `apps/desktop/src/renderer/src/components/Url4Field.tsx` | Thread `maxContentHeight` prop through | Modify |
+| `apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx` | Combobox replaces derived display; gating/payload; URL4 full height | Modify |
+| `apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx` | Rewrite benchmark-related tests for manual pick | Modify |
+
+**Reused as-is (no edits):** `hooks/use-known-benchmarks.ts`, `lib/benchmark-identity.ts` (`computeContentSignature`, `checkBenchmarkRegistration`), `main/services/list-benchmarks.ts`, `publish:listBenchmarks` IPC, `hooks/use-publish-score.ts` (`PublishInputs` already carries `benchmarkSignature`).
+
+---
+
+## Task 1: Reusable `Combobox` primitive
+
+**Files:**
+- Create: `apps/desktop/src/renderer/src/components/ui/combobox.tsx`
+- Test: `apps/desktop/src/renderer/src/components/ui/__tests__/combobox.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/desktop/src/renderer/src/components/ui/__tests__/combobox.test.tsx`:
+
+```tsx
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { Combobox, type ComboboxOption } from '../combobox';
+
+const OPTIONS: ComboboxOption[] = [
+  { value: 'hle', label: 'News Hallucinations' },
+  { value: 'livetruth', label: 'News Livetruth' },
+];
+
+afterEach(cleanup);
+
+function setup(value = '') {
+  const onChange = vi.fn();
+  render(
+    <Combobox value={value} onChange={onChange} options={OPTIONS} placeholder="Select a benchmark" aria-label="Benchmark" />,
+  );
+  const input = screen.getByRole('combobox', { name: 'Benchmark' }) as HTMLInputElement;
+  return { onChange, input };
+}
+
+describe('Combobox', () => {
+  it('shows all options on focus and filters by value or label', () => {
+    const { input } = setup();
+    fireEvent.focus(input);
+    expect(screen.getByRole('option', { name: /hle/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /livetruth/i })).toBeInTheDocument();
+    // Filter by label substring ("truth") — only livetruth remains.
+    fireEvent.change(input, { target: { value: 'truth' } });
+    expect(screen.queryByRole('option', { name: /hle/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /livetruth/i })).toBeInTheDocument();
+  });
+
+  it('passes free text straight through onChange', () => {
+    const { input, onChange } = setup();
+    fireEvent.change(input, { target: { value: 'custom-id' } });
+    expect(onChange).toHaveBeenLastCalledWith('custom-id');
+  });
+
+  it('selecting an option emits its value and closes the list', () => {
+    const { input, onChange } = setup();
+    fireEvent.focus(input);
+    fireEvent.mouseDown(screen.getByRole('option', { name: /livetruth/i }));
+    expect(onChange).toHaveBeenLastCalledWith('livetruth');
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('keyboard: ArrowDown + Enter selects the highlighted option', () => {
+    const { input, onChange } = setup();
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'ArrowDown' }); // highlight index 1 (livetruth)
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onChange).toHaveBeenLastCalledWith('livetruth');
+  });
+
+  it('Escape closes the list without changing the value', () => {
+    const { input, onChange } = setup();
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/desktop && npx vitest run src/renderer/src/components/ui/__tests__/combobox.test.tsx`
+Expected: FAIL — `Failed to resolve import "../combobox"`.
+
+- [ ] **Step 3: Implement the component**
+
+Create `apps/desktop/src/renderer/src/components/ui/combobox.tsx`:
+
+```tsx
+// apps/desktop/src/renderer/src/components/ui/combobox.tsx
+//
+// Minimal, dependency-free filterable combobox: a text input plus a filtered
+// listbox. Free text is allowed (the input value IS the value), and the list
+// offers known options. Brand-styled (square, hairline, mono ids). Keyboard:
+// ArrowUp/Down move the highlight, Enter selects it, Escape closes.
+import { useId, useMemo, useRef, useState } from 'react';
+
+export interface ComboboxOption {
+  value: string;
+  label: string;
+}
+
+interface ComboboxProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: ComboboxOption[];
+  placeholder?: string;
+  disabled?: boolean;
+  'aria-label'?: string;
+}
+
+export function Combobox({
+  value,
+  onChange,
+  options,
+  placeholder,
+  disabled,
+  'aria-label': ariaLabel,
+}: ComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState(0);
+  const listId = useId();
+  const blurTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const filtered = useMemo(() => {
+    const q = value.trim().toLowerCase();
+    if (q.length === 0) return options;
+    return options.filter(
+      (o) => o.value.toLowerCase().includes(q) || o.label.toLowerCase().includes(q),
+    );
+  }, [options, value]);
+
+  const commit = (v: string): void => {
+    onChange(v);
+    setOpen(false);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setOpen(true);
+      setActive((i) => Math.min(i + 1, filtered.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActive((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter') {
+      if (open && filtered[active]) {
+        e.preventDefault();
+        commit(filtered[active].value);
+      }
+    } else if (e.key === 'Escape') {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div className="relative">
+      <input
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={listId}
+        aria-autocomplete="list"
+        aria-activedescendant={open && filtered[active] ? `${listId}-${active}` : undefined}
+        aria-label={ariaLabel}
+        className="w-full rounded-none border border-border bg-background px-3 py-2 text-sm"
+        value={value}
+        placeholder={placeholder}
+        disabled={disabled}
+        onChange={(e) => {
+          onChange(e.target.value);
+          setOpen(true);
+          setActive(0);
+        }}
+        onFocus={() => setOpen(true)}
+        onBlur={() => {
+          // Delay close so a mouse selection on an option still registers.
+          blurTimer.current = setTimeout(() => setOpen(false), 120);
+        }}
+        onKeyDown={onKeyDown}
+      />
+      {open && filtered.length > 0 && (
+        <ul
+          id={listId}
+          role="listbox"
+          className="absolute z-20 mt-1 max-h-48 w-full overflow-auto rounded-none border border-border bg-popover text-sm"
+        >
+          {filtered.map((o, i) => (
+            <li
+              key={o.value}
+              id={`${listId}-${i}`}
+              role="option"
+              aria-selected={i === active}
+              className={`cursor-pointer px-3 py-1.5 ${
+                i === active ? 'bg-accent text-accent-foreground' : ''
+              }`}
+              onMouseEnter={() => setActive(i)}
+              onMouseDown={(e) => {
+                // mousedown fires before the input's blur, so the click isn't lost.
+                e.preventDefault();
+                commit(o.value);
+              }}
+            >
+              <span className="font-mono">{o.value}</span>
+              {o.label && o.label !== o.value && (
+                <span className="ml-2 text-xs text-muted-foreground">{o.label}</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/desktop && npx vitest run src/renderer/src/components/ui/__tests__/combobox.test.tsx`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src/renderer/src/components/ui/combobox.tsx \
+        apps/desktop/src/renderer/src/components/ui/__tests__/combobox.test.tsx
+git commit -m "SF-309: add reusable filterable Combobox primitive
+
+Brand-styled, dependency-free combobox (input + filtered listbox) with free-text
+entry and keyboard nav, for the publish dialog's manual benchmark picker.
+
+https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215924460243610"
+```
+
+---
+
+## Task 2: Wire the combobox into the publish dialog
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx`
+- Modify (rewrite benchmark tests): `apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx`
+
+### Behavior being implemented
+- Benchmark becomes a `Combobox` (blank default, registered options + free text).
+- Advisory hint (✓ registered / ⚠ not-registered + suggestion) computed on the **current combobox value**, silent while loading/unreachable.
+- The content **signature** is still computed (via `computeContentSignature`) and sent as `benchmarkSignature`.
+- `canPublish = !blockReason && benchmarkId.trim() && specId.trim() && redactionResolved`. The SF-300 `verifyIdentityConsistency` gate is removed.
+
+- [ ] **Step 1: Rewrite the benchmark-related dialog tests (failing)**
+
+Replace the whole file `apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx` with:
+
+```tsx
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { PublishToLeaderboardDialog } from '../PublishToLeaderboardDialog';
+import type { EvalRunDetail } from '../types';
+
+const publishMock = vi.fn();
+const toastMock = vi.fn();
+const listBenchmarksMock = vi.fn();
+const hookState: {
+  status: 'idle' | 'submitting' | 'success' | 'error';
+  error: string | null;
+  result: { id: string; benchmarkId: string; specId: string; portalLink: string } | null;
+} = { status: 'idle', error: null, result: null };
+
+vi.mock('@/hooks/use-publish-score', () => ({
+  usePublishScore: () => ({
+    publish: publishMock,
+    status: hookState.status,
+    error: hookState.error,
+    result: hookState.result,
+  }),
+}));
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: toastMock }) }));
+vi.mock('@/components/Url4Field', () => ({
+  Url4Field: ({ value }: { value: string }) => <span data-testid="url4">{value}</span>,
+}));
+
+const QUESTIONS: EvalRunDetail['questions'] = [
+  {
+    id: 'q-0',
+    idx: 0,
+    question: '2+2?',
+    expected: '4',
+    predicted: '4',
+    correct: true,
+    raw_output: null,
+    error: null,
+  },
+];
+
+function makeRun(overrides: Partial<EvalRunDetail> = {}): EvalRunDetail {
+  return {
+    id: 'eval-run-1',
+    spec_name: 'hle:hle-ensemble-three',
+    url4_expression:
+      'https://screamingface.ai/honest-agi-live-week-3.eval.jsonl*(/claude($item.question))',
+    started_at: '2026-05-04T11:00:00Z',
+    finished_at: '2026-05-04T11:55:00Z',
+    status: 'done',
+    accuracy: 0.81,
+    total_questions: 1000,
+    correct_questions: 810,
+    error: null,
+    favorite: false,
+    questions: QUESTIONS,
+    ...overrides,
+  };
+}
+
+function benchmarkInput(): HTMLInputElement {
+  return screen.getByRole('combobox', { name: 'Benchmark' }) as HTMLInputElement;
+}
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  publishMock.mockReset();
+  toastMock.mockReset();
+  hookState.status = 'idle';
+  hookState.error = null;
+  hookState.result = null;
+  window.sessionStorage.clear();
+  listBenchmarksMock
+    .mockReset()
+    .mockResolvedValue([
+      { id: 'hle', displayName: 'News Hallucinations' },
+      { id: 'livetruth', displayName: 'News Livetruth' },
+    ]);
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    publish: {
+      openExternal: vi.fn(async () => {}),
+      getContext: vi.fn(),
+      listBenchmarks: listBenchmarksMock,
+    },
+  };
+});
+
+describe('PublishToLeaderboardDialog — benchmark combobox', () => {
+  it('opens with a blank benchmark and Publish disabled until one is chosen', async () => {
+    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    expect(benchmarkInput().value).toBe('');
+    expect(screen.getByRole('button', { name: /publish/i })).toBeDisabled();
+    // Choosing a registered benchmark enables publish.
+    fireEvent.focus(benchmarkInput());
+    fireEvent.mouseDown(await screen.findByRole('option', { name: /livetruth/i }));
+    await waitFor(() => expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled());
+  });
+
+  it('filters registered benchmarks and allows free text', () => {
+    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    fireEvent.change(benchmarkInput(), { target: { value: 'live' } });
+    expect(screen.getByRole('option', { name: /livetruth/i })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /^hle/i })).not.toBeInTheDocument();
+    // Free text that matches nothing keeps the typed value.
+    fireEvent.change(benchmarkInput(), { target: { value: 'brand-new-2026' } });
+    expect(benchmarkInput().value).toBe('brand-new-2026');
+  });
+
+  it('shows ✓ registered for a registered value and ⚠ + suggestion for an unknown one', async () => {
+    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    fireEvent.change(benchmarkInput(), { target: { value: 'hle' } });
+    expect(await screen.findByText(/registered benchmark/i)).toBeInTheDocument();
+    // A near-miss of a registered id → not-registered warning with did-you-mean.
+    fireEvent.change(benchmarkInput(), { target: { value: 'livetruh' } });
+    expect(await screen.findByText(/not a registered scoreboard benchmark/i)).toBeInTheDocument();
+    expect(screen.getByText('livetruth')).toBeInTheDocument();
+    // Advisory only — publish stays enabled.
+    expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled();
+  });
+
+  it('stays silent about registration while the registry is unreachable', async () => {
+    listBenchmarksMock.mockResolvedValue(null);
+    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    fireEvent.change(benchmarkInput(), { target: { value: 'whatever' } });
+    await Promise.resolve();
+    expect(screen.queryByText(/registered benchmark/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/not a registered scoreboard benchmark/i)).not.toBeInTheDocument();
+  });
+
+  it('publishes the chosen benchmark id plus the content signature', async () => {
+    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    fireEvent.change(benchmarkInput(), { target: { value: 'livetruth' } });
+    await waitFor(() => expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: /publish/i }));
+    await waitFor(() => expect(publishMock).toHaveBeenCalledTimes(1));
+    const sent = publishMock.mock.calls[0][0];
+    expect(sent.benchmarkId).toBe('livetruth');
+    expect(sent.benchmarkSignature).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe('PublishToLeaderboardDialog — guards & misc', () => {
+  it('prefills spec id from the colon-delimited spec_name', () => {
+    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    expect(screen.getByDisplayValue('hle-ensemble-three')).toBeInTheDocument();
+  });
+
+  it('blocks a zero-question run with an explanation (preflight guard)', () => {
+    render(
+      <PublishToLeaderboardDialog
+        run={makeRun({ total_questions: 0, correct_questions: 0 })}
+        serverUrl=""
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/no graded questions/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /publish/i })).toBeDisabled();
+  });
+
+  it('warns about /data refs and publishes the sanitized expression by default', async () => {
+    const run = makeRun({ url4_expression: '(/data/abc123)!$prompt' });
+    render(<PublishToLeaderboardDialog run={run} serverUrl="" onClose={vi.fn()} />);
+    expect(screen.getByText(/references local/i)).toBeInTheDocument();
+    expect(screen.getByTestId('url4')).toHaveTextContent('/data/<redacted>');
+    fireEvent.change(benchmarkInput(), { target: { value: 'livetruth' } });
+    await waitFor(() => expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: /publish/i }));
+    expect(publishMock).toHaveBeenCalledTimes(1);
+    expect(publishMock.mock.calls[0][0].url4Expression).toContain('/data/<redacted>');
+  });
+
+  it('blocks publish if /data refs are neither sanitized nor acknowledged', async () => {
+    const run = makeRun({ url4_expression: '(/data/abc123)!$prompt' });
+    render(<PublishToLeaderboardDialog run={run} serverUrl="" onClose={vi.fn()} />);
+    fireEvent.change(benchmarkInput(), { target: { value: 'livetruth' } });
+    fireEvent.click(screen.getByRole('checkbox', { name: /sanitize/i })); // uncheck
+    expect(screen.getByRole('button', { name: /publish/i })).toBeDisabled();
+    fireEvent.click(screen.getByRole('checkbox', { name: /exposes my local data/i }));
+    await waitFor(() => expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled());
+  });
+
+  it('persists the submitter name to sessionStorage on publish', async () => {
+    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    fireEvent.change(benchmarkInput(), { target: { value: 'livetruth' } });
+    fireEvent.change(screen.getByPlaceholderText('leave blank for anonymous'), {
+      target: { value: 'Ada Lovelace' },
+    });
+    await waitFor(() => expect(screen.getByRole('button', { name: /publish/i })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: /publish/i }));
+    expect(window.sessionStorage.getItem('sf-leaderboard-submitter')).toBe('Ada Lovelace');
+  });
+
+  it('prefills the submitter name from sessionStorage on open', () => {
+    window.sessionStorage.setItem('sf-leaderboard-submitter', 'Grace Hopper');
+    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    expect(screen.getByPlaceholderText('leave blank for anonymous')).toHaveValue('Grace Hopper');
+  });
+
+  it('shows the success state and opens the leaderboard deep link', () => {
+    hookState.status = 'success';
+    hookState.result = {
+      id: 'score-1',
+      benchmarkId: 'hle',
+      specId: 'hle-ensemble-three',
+      portalLink: 'http://localhost:8080/spec.html?benchmark=hle&spec=hle-ensemble-three',
+    };
+    render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /view on leaderboard/i }));
+    expect(
+      (
+        window as unknown as {
+          electronAPI: { publish: { openExternal: ReturnType<typeof vi.fn> } };
+        }
+      ).electronAPI.publish.openExternal,
+    ).toHaveBeenCalledWith('http://localhost:8080/spec.html?benchmark=hle&spec=hle-ensemble-three');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/desktop && npx vitest run src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx`
+Expected: FAIL — no `combobox` role (the dialog still renders the read-only `benchmark-identity` div).
+
+- [ ] **Step 3: Edit the dialog — imports**
+
+In `apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx`, replace the benchmark-identity import block:
+
+```tsx
+import {
+  deriveBenchmarkIdentity,
+  verifyIdentityConsistency,
+  checkBenchmarkRegistration,
+  type BenchmarkIdentity,
+} from '@/lib/benchmark-identity';
+```
+
+with:
+
+```tsx
+import { computeContentSignature, checkBenchmarkRegistration } from '@/lib/benchmark-identity';
+import { Combobox } from '@/components/ui/combobox';
+```
+
+- [ ] **Step 4: Edit the dialog — state, signature, gating**
+
+Replace the identity state/effect block:
+
+```tsx
+  const [identity, setIdentity] = useState<BenchmarkIdentity | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void deriveBenchmarkIdentity(run).then((next) => {
+      if (!cancelled) setIdentity(next);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [run]);
+
+  const [specId, setSpecId] = useState(parsed.spec_id);
+```
+
+with:
+
+```tsx
+  // Manual benchmark selection (SF-309): blank default, registered list + free text.
+  const [benchmarkId, setBenchmarkId] = useState('');
+  // The content signature still travels with the publish as metadata so the
+  // scoreboard can later verify what actually ran — computed, never displayed.
+  const [signature, setSignature] = useState('');
+  useEffect(() => {
+    let cancelled = false;
+    void computeContentSignature(run).then((sig) => {
+      if (!cancelled) setSignature(sig);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [run]);
+
+  const [specId, setSpecId] = useState(parsed.spec_id);
+```
+
+Replace the `identityCheck` + `registryCheck` block:
+
+```tsx
+  const identityCheck = useMemo(
+    () => (identity ? verifyIdentityConsistency(identity) : { ok: false, reason: null }),
+    [identity],
+  );
+  const { benchmarks: knownBenchmarks, loading: benchmarksLoading } = useKnownBenchmarks();
+  const registryCheck = useMemo(
+    () =>
+      checkBenchmarkRegistration(
+        identity?.id ?? '',
+        benchmarksLoading ? null : (knownBenchmarks?.map((b) => b.id) ?? null),
+      ),
+    [identity, knownBenchmarks, benchmarksLoading],
+  );
+```
+
+with:
+
+```tsx
+  const { benchmarks: knownBenchmarks, loading: benchmarksLoading } = useKnownBenchmarks();
+  const benchmarkOptions = useMemo(
+    () => (knownBenchmarks ?? []).map((b) => ({ value: b.id, label: b.displayName })),
+    [knownBenchmarks],
+  );
+  // Advisory registry check on the CURRENT field value (not a derived id).
+  const registryCheck = useMemo(
+    () =>
+      checkBenchmarkRegistration(
+        benchmarkId.trim(),
+        benchmarksLoading ? null : (knownBenchmarks?.map((b) => b.id) ?? null),
+      ),
+    [benchmarkId, knownBenchmarks, benchmarksLoading],
+  );
+```
+
+Replace the `canPublish` definition:
+
+```tsx
+  const canPublish =
+    !blockReason && !!identity && identityCheck.ok && specId.trim().length > 0 && redactionResolved;
+```
+
+with:
+
+```tsx
+  const canPublish =
+    !blockReason &&
+    benchmarkId.trim().length > 0 &&
+    specId.trim().length > 0 &&
+    redactionResolved;
+```
+
+- [ ] **Step 5: Edit the dialog — handlePublish payload**
+
+Replace the body of `handlePublish`:
+
+```tsx
+  const handlePublish = async (): Promise<void> => {
+    if (!identity) return;
+    saveSubmitter(submittedBy.trim());
+    const out = await publish({
+      run,
+      benchmarkId: identity.id,
+      benchmarkSignature: identity.signature,
+      specId: specId.trim(),
+      url4Expression: expressionToPublish,
+      providers,
+      submittedBy: submittedBy.trim() || null,
+    });
+```
+
+with:
+
+```tsx
+  const handlePublish = async (): Promise<void> => {
+    saveSubmitter(submittedBy.trim());
+    const out = await publish({
+      run,
+      benchmarkId: benchmarkId.trim(),
+      benchmarkSignature: signature,
+      specId: specId.trim(),
+      url4Expression: expressionToPublish,
+      providers,
+      submittedBy: submittedBy.trim() || null,
+    });
+```
+
+- [ ] **Step 6: Edit the dialog — replace the benchmark JSX**
+
+Replace the entire benchmark-identity `<div className="block">…</div>` (the first column inside `{/* benchmark identity (auto-derived, read-only) + spec id */}`, from `<div className="block">` through its closing `</div>` just before the Spec ID `<label>`) with:
+
+```tsx
+                <div className="block">
+                  <span className="mb-1 block text-xs font-medium text-muted-foreground">
+                    Benchmark <span className="text-destructive">*</span>
+                  </span>
+                  <Combobox
+                    value={benchmarkId}
+                    onChange={setBenchmarkId}
+                    options={benchmarkOptions}
+                    placeholder="Select a benchmark"
+                    aria-label="Benchmark"
+                  />
+                  {registryCheck.status === 'registered' && (
+                    <p className="mt-1 flex items-center gap-1 text-[11px] text-gain">
+                      <CheckCircle2 className="h-3 w-3 shrink-0" />
+                      Registered benchmark
+                    </p>
+                  )}
+                  {registryCheck.status === 'unknown' && (
+                    <p className="mt-1 flex items-start gap-1 text-[11px] leading-relaxed text-destructive">
+                      <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+                      <span>
+                        Not a registered scoreboard benchmark — publishing will fail until the
+                        scoreboard owner registers{' '}
+                        <code className="font-mono">{benchmarkId.trim()}</code>.
+                        {registryCheck.suggestion && (
+                          <>
+                            {' '}
+                            Did you mean{' '}
+                            <code className="font-mono">{registryCheck.suggestion}</code>?
+                          </>
+                        )}
+                      </span>
+                    </p>
+                  )}
+                </div>
+```
+
+Then delete the now-orphaned identity-consistency block:
+
+```tsx
+              {/* Identity consistency: id<->signature must agree before publish. */}
+              {identity && !identityCheck.ok && identityCheck.reason && (
+                <div className="flex items-start gap-1.5 rounded-none border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  <span>{identityCheck.reason}</span>
+                </div>
+              )}
+```
+
+- [ ] **Step 7: Run the dialog tests to verify they pass**
+
+Run: `cd apps/desktop && npx vitest run src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx`
+Expected: PASS (all describe blocks).
+
+If a test referencing `useMemo`/`useEffect`/`useState` errors on an unused import, remove any now-unused import (e.g. `BenchmarkIdentity`, `verifyIdentityConsistency`, `deriveBenchmarkIdentity`) — they were replaced in Step 3.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx \
+        apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
+git commit -m "SF-309: manual benchmark combobox in publish dialog
+
+Replace the SF-300 auto-derived read-only benchmark with a filterable combobox
+(registered list + free text, blank default). Keep computing the content
+signature as payload metadata; advisory registered/not-registered hint now runs
+on the chosen value; drop the id<->signature consistency gate.
+
+https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215924460243610"
+```
+
+---
+
+## Task 3: Full-height URL4 field (single scrollbar)
+
+**Files:**
+- Create: `apps/desktop/src/renderer/src/lib/editor-height.ts`
+- Test: `apps/desktop/src/renderer/src/lib/__tests__/editor-height.test.ts`
+- Modify: `apps/desktop/src/renderer/src/components/Url4MonacoEditor.tsx`
+- Modify: `apps/desktop/src/renderer/src/components/Url4Field.tsx`
+- Modify: `apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx`
+
+- [ ] **Step 1: Write the failing height-helper test**
+
+Create `apps/desktop/src/renderer/src/lib/__tests__/editor-height.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { clampEditorHeight } from '../editor-height';
+
+describe('clampEditorHeight', () => {
+  it('floors at 28px', () => {
+    expect(clampEditorHeight(10, 360)).toBe(28);
+  });
+  it('caps at the given maximum', () => {
+    expect(clampEditorHeight(500, 360)).toBe(360);
+  });
+  it('returns content height between the floor and the cap', () => {
+    expect(clampEditorHeight(120, 360)).toBe(120);
+  });
+  it('removes the cap when max is null (full content height)', () => {
+    expect(clampEditorHeight(5000, null)).toBe(5000);
+    expect(clampEditorHeight(10, null)).toBe(28);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd apps/desktop && npx vitest run src/renderer/src/lib/__tests__/editor-height.test.ts`
+Expected: FAIL — `Failed to resolve import "../editor-height"`.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `apps/desktop/src/renderer/src/lib/editor-height.ts`:
+
+```ts
+// apps/desktop/src/renderer/src/lib/editor-height.ts
+//
+// Pure height-clamp for the url4 Monaco editor's auto-grow. Extracted so the cap
+// logic is unit-testable without mounting Monaco. `maxContentHeight === null`
+// means "no upper cap" — grow to the full content height (SF-309) so the editor
+// never shows its own scrollbar inside a scrolling dialog.
+
+const MIN_HEIGHT = 28;
+
+export function clampEditorHeight(contentHeight: number, maxContentHeight: number | null): number {
+  const lower = Math.max(contentHeight, MIN_HEIGHT);
+  return maxContentHeight == null ? lower : Math.min(lower, maxContentHeight);
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `cd apps/desktop && npx vitest run src/renderer/src/lib/__tests__/editor-height.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Thread the prop through `Url4Field`**
+
+In `apps/desktop/src/renderer/src/components/Url4Field.tsx`, add `maxContentHeight` to the props interface (props already spread to the editor via `{...props}`, so no other change needed):
+
+```tsx
+interface Url4FieldProps {
+  value: string;
+  onChange?: (value: string) => void;
+  readOnly?: boolean;
+  serverUrl: string;
+  className?: string;
+  /** Upper bound for the editor's auto-grow height; null = grow to full content (no inner scrollbar). Defaults to 360. */
+  maxContentHeight?: number | null;
+}
+```
+
+- [ ] **Step 6: Use the helper + new prop in `Url4MonacoEditor`**
+
+In `apps/desktop/src/renderer/src/components/Url4MonacoEditor.tsx`:
+
+Add the import near the top:
+
+```tsx
+import { clampEditorHeight } from '@/lib/editor-height';
+```
+
+Add `maxContentHeight` to the `Props` interface and destructure it (default 360):
+
+```tsx
+interface Props {
+  value: string;
+  onChange?: (value: string) => void;
+  readOnly?: boolean;
+  serverUrl: string;
+  className?: string;
+  maxContentHeight?: number | null;
+}
+
+export default function Url4MonacoEditor({
+  value,
+  onChange,
+  readOnly,
+  serverUrl,
+  className,
+  maxContentHeight = 360,
+}: Props) {
+```
+
+Replace the `applyHeight` body:
+
+```tsx
+    const applyHeight = (): void => {
+      const h = Math.min(Math.max(editor.getContentHeight(), 28), 360);
+      if (wrapRef.current) wrapRef.current.style.height = `${h}px`;
+      editor.layout();
+    };
+```
+
+with:
+
+```tsx
+    const applyHeight = (): void => {
+      const h = clampEditorHeight(editor.getContentHeight(), maxContentHeight);
+      if (wrapRef.current) wrapRef.current.style.height = `${h}px`;
+      editor.layout();
+    };
+```
+
+In the editor `options`, change the `scrollbar` line so wheel events bubble to the surrounding scroll container when the editor is at full height:
+
+```tsx
+          scrollbar: { horizontalScrollbarSize: 0, verticalScrollbarSize: 8 },
+```
+
+to:
+
+```tsx
+          scrollbar: {
+            horizontalScrollbarSize: 0,
+            verticalScrollbarSize: 8,
+            alwaysConsumeMouseWheel: false,
+          },
+```
+
+- [ ] **Step 7: Pass `maxContentHeight={null}` from the dialog**
+
+In `apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx`, update the read-only `Url4Field` usage:
+
+```tsx
+                  <Url4Field value={expressionToPublish} serverUrl={serverUrl} readOnly />
+```
+
+to:
+
+```tsx
+                  <Url4Field
+                    value={expressionToPublish}
+                    serverUrl={serverUrl}
+                    readOnly
+                    maxContentHeight={null}
+                  />
+```
+
+- [ ] **Step 8: Run the editor-height + dialog tests**
+
+Run: `cd apps/desktop && npx vitest run src/renderer/src/lib/__tests__/editor-height.test.ts src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx`
+Expected: PASS (the dialog mocks `Url4Field`, so the new prop is inert in tests; the height logic is covered by the helper test).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/desktop/src/renderer/src/lib/editor-height.ts \
+        apps/desktop/src/renderer/src/lib/__tests__/editor-height.test.ts \
+        apps/desktop/src/renderer/src/components/Url4MonacoEditor.tsx \
+        apps/desktop/src/renderer/src/components/Url4Field.tsx \
+        apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx
+git commit -m "SF-309: full-height URL4 field in publish dialog (single scrollbar)
+
+Extract a pure clampEditorHeight helper and add a maxContentHeight prop to
+Url4Field/Url4MonacoEditor; pass null from the publish dialog so the read-only
+expression grows to full content height (and release Monaco's wheel capture), so
+the dialog has a single scrollbar instead of a nested one.
+
+https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215924460243610"
+```
+
+---
+
+## Task 4: Full verification & PR
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full desktop test suite**
+
+Run: `cd apps/desktop && npx vitest run`
+Expected: PASS — all files (the prior 278 baseline plus the new `combobox`, `editor-height`, and rewritten dialog tests).
+
+- [ ] **Step 2: Build (typechecks main + preload + renderer)**
+
+Run: `cd apps/desktop && npm run build`
+Expected: `✓ built` with no TypeScript errors.
+
+- [ ] **Step 3: Manual verification in the app**
+
+Per the project rule, close any running dev app first, then run a single instance:
+
+```bash
+cd apps/desktop && npm run dev
+```
+
+Open Eval Studio → a completed run → **Publish to Leaderboard** and confirm:
+1. Benchmark field is **blank** with a "Select a benchmark" placeholder; Publish is disabled.
+2. Focus/typing shows a filterable list of registered benchmarks (`id — display name`); arrow keys + Enter select; typing a custom id is allowed.
+3. A registered value shows ✓ "Registered benchmark"; an unknown value shows ⚠ + "Did you mean …"; Publish stays enabled either way.
+4. The **URL4 expression** block shows the full expression with **no inner scrollbar**, and scrolling over it scrolls the whole dialog (single scrollbar).
+
+- [ ] **Step 4: Push and open the PR**
+
+```bash
+git push -u origin SF-309-publish-benchmark-combobox
+gh pr create --title "SF-309: manual benchmark combobox + full-height URL4 field in publish dialog" --body "$(cat <<'BODY'
+Implements docs/superpowers/specs/2026-06-22-publish-dialog-benchmark-combobox-and-url4-height-design.md.
+
+- Reusable `Combobox` primitive (no new deps).
+- Publish dialog benchmark = manual combobox (registered list + free text, blank default); content signature still sent as metadata; advisory registered/not-registered hint on the chosen value; consistency gate dropped.
+- Read-only URL4 field grows to full content height (single scrollbar) via a `maxContentHeight` prop + `clampEditorHeight` helper + released Monaco wheel capture.
+- Builds on the SF-300 registry-validation commit on this branch.
+
+Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215924460243610
+BODY
+)"
+```
+
+Note: this branch also carries the SF-300 registry-validation commit (`6817e2e`) that the combobox builds on; it lands with this PR unless the team prefers to split it.
+
+---
+
+## Notes / decisions baked in (from the approved spec)
+
+- **Free-text 404 is accepted** — a typed unregistered id still 404s on publish, surfaced verbatim by the existing error handling; the ⚠ hint warns first.
+- **Trust trade-off acknowledged** — manual pick reverses SF-300's lock (a score can be published under a benchmark the run didn't execute against). The signature still records the true content; server-side verification remains a future follow-up.
+- **`computeContentSignature` empty signature** (e.g. a run with no question rows) is sent as an empty string — best-effort metadata, not a publish gate; the zero-question case is still blocked by `publish-guard` on the totals.

--- a/docs/superpowers/specs/2026-06-22-publish-dialog-benchmark-combobox-and-url4-height-design.md
+++ b/docs/superpowers/specs/2026-06-22-publish-dialog-benchmark-combobox-and-url4-height-design.md
@@ -1,0 +1,209 @@
+# Design Spec — Publish dialog: manual benchmark combobox + full-height URL4 field
+
+- **Date:** 2026-06-22
+- **Status:** Design (decisions locked with the user) → implementation plan next
+- **Scope:** `apps/desktop` only. No scoreboard / IPC / server changes.
+
+## Context
+
+Two independent UX changes to the "Publish to Leaderboard" dialog
+(`apps/desktop/src/renderer/src/components/eval/PublishToLeaderboardDialog.tsx`),
+raised together because they touch the same dialog:
+
+**A. Manual, filterable benchmark picker.** SF-300 made the benchmark
+**auto-derived and read-only** — `deriveBenchmarkIdentity(run)` slugifies an `id`
+from the run's dataset filename and pins it with a SHA-256 content signature; the
+field cannot be edited. The user wants to **replace auto-derive with a manual,
+filterable combobox** so they choose the benchmark themselves (decision locked).
+The benchmark-list data layer already exists: `useKnownBenchmarks()` →
+`publish:listBenchmarks` IPC → `list-benchmarks.ts` fetches `GET /v1/benchmarks`
+(main-process, CORS-exempt). It is currently used only for an advisory
+"registered ✓ / not registered ⚠ did-you-mean" hint.
+
+**B. Full-height URL4 field (single scrollbar).** The read-only URL4 expression in
+the dialog renders through `Url4Field` → `Url4MonacoEditor`, which auto-grows to
+content height **but caps at 360px** (`Math.min(Math.max(getContentHeight(),28),360)`
+in `Url4MonacoEditor.tsx:39`). Above the cap Monaco shows its own vertical
+scrollbar, so a long expression produces a nested scrollbar inside the dialog's
+scroll area. The user wants the URL4 field to **grow to full content height** in
+this dialog so Monaco never scrolls internally and the popup has a single
+scrollbar (the dialog body).
+
+## Decisions (locked with the user)
+
+- Replace auto-derive with a **manual benchmark combobox** (not browse-only, not override-only).
+- **Combobox = registered list + free text:** filterable dropdown of registered
+  benchmarks, but the user may also type a custom id. Re-allows a 404 on an
+  unregistered id — accepted; mitigated by the advisory hint (below) and by
+  SF-274 surfacing the real scoreboard error.
+- **Default value: blank** (`Select a benchmark` placeholder). No inherited
+  derivation pre-filled — fully manual each time.
+- The content **signature is still computed and sent** as `metadata.benchmark_signature`
+  (honest record of what ran; forward-compatible with the pending server-side
+  verification). The user picking the id does not change what the signature attests.
+
+## Key facts (from code research)
+
+- **No combobox primitive exists** in `components/ui/` (no command/combobox/select/
+  popover). A small one must be built; the repo hand-rolls its `ui/` primitives.
+- `useKnownBenchmarks(): { benchmarks: KnownBenchmark[] | null; loading }` —
+  `benchmarks` is null while loading **and** when the registry is unreachable;
+  callers must gate on `loading`. `KnownBenchmark` is `{ id: string; displayName: string }`.
+- `checkBenchmarkRegistration(id, knownIds | null)` (in `lib/benchmark-identity.ts`)
+  already returns `registered | unknown | unavailable` plus a closest-match
+  `suggestion` (edit-distance). Reused as-is for the advisory hint on the current
+  combobox value.
+- Publish payload: `benchmark_id` is a plain string; `benchmarkSignature` rides in
+  **`metadata`** only (`publish-score.ts:113`) and the scoreboard's `ScoreSubmission`
+  schema does **not** validate it. The only server-side benchmark check is
+  `Benchmark.exists(id=...)` → 404. So manual-pick is desktop-only.
+- `Url4MonacoEditor` already auto-grows via `editor.onDidContentSizeChange` →
+  `applyHeight`; the only thing forcing the inner scrollbar is the hardcoded
+  `360` cap and Monaco's default wheel-capture.
+
+## Design
+
+### Part A — Manual benchmark combobox
+
+**A1. New reusable primitive `components/ui/combobox.tsx`.**
+A controlled, keyboard-accessible filterable input + listbox, no new deps,
+brand-styled (square corners, hairline border, IBM Plex Mono for ids).
+
+```
+interface ComboboxOption { value: string; label: string }
+interface ComboboxProps {
+  value: string;
+  onChange: (value: string) => void;       // fires on both typing and selecting
+  options: ComboboxOption[];
+  placeholder?: string;
+  disabled?: boolean;
+  'aria-label'?: string;
+}
+```
+
+- Free text: the input value IS `value`; typing calls `onChange` directly (custom
+  ids allowed).
+- Filtering: case-insensitive substring over `option.value` **and** `option.label`.
+- Open the listbox on focus/typing; close on blur, Esc, or selection.
+- Keyboard: ↑/↓ move the highlighted option, Enter selects it, Esc closes.
+- Selecting a row sets `value = option.value` (the id).
+- Empty filtered list → no dropdown (free text still works).
+
+**A2. Dialog wiring (`PublishToLeaderboardDialog.tsx`).**
+- New state `const [benchmarkId, setBenchmarkId] = useState('')` (blank default).
+- Replace the read-only identity `<div>` (lines ~247–313) with:
+  ```
+  <Combobox
+    value={benchmarkId}
+    onChange={setBenchmarkId}
+    options={(knownBenchmarks ?? []).map(b => ({ value: b.id, label: b.displayName }))}
+    placeholder="Select a benchmark"
+    aria-label="Benchmark"
+  />
+  ```
+- Advisory hint under the combobox, driven by the existing `registryCheck` but
+  computed against `benchmarkId` (the current field value) instead of the derived
+  id: ✓ "Registered benchmark" when `status==='registered'`; ⚠ "Not a registered
+  scoreboard benchmark — publishing will 404 until the owner registers `<id>`.
+  Did you mean `<suggestion>`?" when `'unknown'`; render nothing when
+  `'unavailable'` (loading / registry down).
+- Keep computing the content signature: still call `deriveBenchmarkIdentity(run)`
+  (or just `computeContentSignature(run)`) so `benchmarkSignature` is available for
+  the payload metadata. The derived **id is no longer surfaced** and is not a default.
+- `handlePublish` sends `benchmarkId: benchmarkId.trim()` and
+  `benchmarkSignature: signature` (unchanged payload shape).
+
+**A3. Publish gating.**
+```
+canPublish = !blockReason                       // publish-guard (zero-question etc.)
+          && benchmarkId.trim().length > 0
+          && specId.trim().length > 0
+          && redactionResolved
+```
+Drop the SF-300 `verifyIdentityConsistency` gate (the user now owns the id; a
+zero-content run is already blocked by `publish-guard`). The signature becomes
+best-effort metadata, not a gate.
+
+**A4. Removed / kept.**
+- Removed: read-only benchmark identity display, the `identityCheck` consistency
+  gate, and the "Deriving…" state.
+- Kept: `lib/benchmark-identity.ts` (still computes the signature, and
+  `checkBenchmarkRegistration` is reused), `useKnownBenchmarks`,
+  `list-benchmarks.ts`, the IPC — all unchanged.
+
+### Part B — Full-height URL4 field
+
+**B1. Opt-out of the height cap.** Add an optional prop to `Url4Field` and
+`Url4MonacoEditor` controlling the upper bound of the auto-grow:
+
+```
+maxContentHeight?: number | null   // default 360 (current behavior); null = no cap (full content height)
+```
+
+In `Url4MonacoEditor.applyHeight`:
+```
+const lower = Math.max(editor.getContentHeight(), 28);
+const h = maxContentHeight == null ? lower : Math.min(lower, maxContentHeight);
+```
+
+**B2. Let wheel events bubble.** Add `scrollbar.alwaysConsumeMouseWheel: false` to
+the Monaco options so that, when the editor is at full content height (nothing to
+scroll internally), the wheel scrolls the dialog body instead of being captured.
+At full height with `scrollBeyondLastLine:false` the vertical scrollbar does not
+render, so the inner scrollbar disappears.
+
+**B3. Dialog usage.** The publish dialog passes `maxContentHeight={null}` to its
+`Url4Field`. The wrapping `<div className="rounded bg-muted/30 px-3 py-2">` keeps
+the field visually bounded; the single scrollbar is the dialog body's existing
+`overflow-y-auto` (`PublishToLeaderboardDialog.tsx:169`). All other `Url4Field`
+usages keep the default 360 cap (unchanged).
+
+## Data flow
+
+1. Dialog opens → `useKnownBenchmarks()` fetches registered benchmarks (existing).
+2. User types/selects in the combobox → `benchmarkId` updates → advisory hint
+   recomputes via `checkBenchmarkRegistration(benchmarkId, knownIds|null)`.
+3. Publish → `benchmark_id = benchmarkId.trim()`, `metadata.benchmark_signature =`
+   the computed content signature → existing `publish:submitScore` path.
+4. URL4 field renders at full content height; dialog body owns the only scrollbar.
+
+## Testing
+
+- **`combobox.test.tsx`** (new): filters by value and label; selecting a row sets
+  the value; free text passes through `onChange`; keyboard ↑/↓/Enter/Esc; empty
+  filter shows no dropdown but keeps the typed value.
+- **`PublishToLeaderboardDialog.test.tsx`** (extend existing): blank default →
+  Publish disabled until a benchmark is chosen; typing/selecting enables it and is
+  sent as `benchmark_id`; ✓ hint for a registered id, ⚠ + suggestion for an
+  unknown id, nothing while the registry is loading; existing zero-question guard
+  + redaction tests still pass.
+- **URL4 height**: a focused `Url4MonacoEditor`/`Url4Field` test asserting
+  `maxContentHeight={null}` removes the cap is hard to do under jsdom (Monaco
+  doesn't lay out); cover the cap logic by extracting a tiny pure helper
+  `clampEditorHeight(contentHeight, maxContentHeight)` and unit-testing it, and
+  verify the visual result manually in the running app.
+- Full `vitest` suite + `npm run build` green.
+
+## Risks / open questions
+
+- **Free-text 404 (accepted):** a typed unregistered id still 404s on publish.
+  Mitigated by the advisory ⚠ hint and SF-274's verbatim error surfacing. Not
+  blocked, per the user's "registered + free text" choice.
+- **Monaco wheel bubbling:** `alwaysConsumeMouseWheel:false` is the documented way
+  to release wheel capture; verify in-app that scrolling over the URL4 field
+  scrolls the dialog.
+- **Combobox a11y:** keep it minimal but correct (`role="combobox"`/`listbox`/
+  `option`, `aria-expanded`, `aria-activedescendant`) so it's usable and testable.
+- **Trust trade-off (acknowledged):** manual pick re-opens publishing a score under
+  a benchmark the run didn't execute against — the signature still records the true
+  content, but the server does not yet verify it. This reverses SF-300's lock by
+  explicit user choice.
+
+## Summary
+
+Replace the SF-300 auto-derived, read-only benchmark field with a manual,
+filterable **combobox** (registered list + free text, blank default), keeping the
+content signature as payload metadata and reusing the existing registry advisory
+hint. Separately, let the dialog's read-only **URL4 field grow to full content
+height** (opt-out of the 360px cap + release Monaco's wheel capture) so the popup
+has a single scrollbar. Desktop-only; no scoreboard or IPC changes.


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-06-22-publish-dialog-benchmark-combobox-and-url4-height-design.md` (brainstormed + planned + subagent-executed with per-task spec/quality review).

## What changed
**Benchmark picker (SF-309)** — replaces the SF-300 auto-derived read-only benchmark with a manual, filterable **combobox**:
- New reusable `components/ui/combobox.tsx` (no new deps): input + filtered listbox, free-text, keyboard nav (↑/↓/Enter/Esc), a11y roles.
- Dialog: blank default, options from the registered set (`useKnownBenchmarks`), free text allowed; advisory ✓ "Registered benchmark" / ⚠ "Not registered — did you mean …?" hint on the chosen value; the SF-300 read-only display + consistency gate are removed.
- The content **signature** is still computed and sent as `metadata.benchmark_signature`; publish is gated on the signature being present so it's never empty.

**Full-height URL4 field (SF-309)** — the read-only expression grows to full content height (single scrollbar): new pure `clampEditorHeight` helper + `maxContentHeight` prop through `Url4Field`→`Url4MonacoEditor`, plus `alwaysConsumeMouseWheel:false` so the dialog body scrolls.

**Foundation (SF-300):** this branch also carries the previously-uncommitted **benchmark registry-validation** commit (`list-benchmarks` IPC, `useKnownBenchmarks`, `checkBenchmarkRegistration`) that the combobox reuses.

## Trade-off (deliberate)
Manual pick reverses SF-300's lock — a score can be published under a benchmark the run didn't execute against. The signature still records the true content; server-side verification remains a follow-up.

## Test plan
- [x] `combobox` unit tests (filter / select / free-text / keyboard / clamp): 6
- [x] dialog tests rewritten for manual pick (blank default, ✓/⚠ hint, payload, guards): 12
- [x] `clampEditorHeight` unit tests: 4
- [x] Full desktop suite **287 passed / 49 files**; `npm run build` green
- [ ] Manual in-app check of single-scrollbar URL4 + dropdown (couldn't run the Electron dev window here)

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215924460243610

🤖 Generated with [Claude Code](https://claude.com/claude-code)