### PR TITLE
SF-310: combobox clear button + click-to-open showing all options

### DIFF
--- a/apps/desktop/src/renderer/src/components/ui/__tests__/combobox.test.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/__tests__/combobox.test.tsx
@@ -85,4 +85,33 @@ describe('Combobox', () => {
     fireEvent.keyDown(input, { key: 'Enter' });
     expect(onChange).toHaveBeenLastCalledWith('hle');
   });
+
+  it('hides the clear button when empty and shows it when a value is set', () => {
+    setup('');
+    expect(screen.queryByRole('button', { name: /clear/i })).not.toBeInTheDocument();
+    cleanup();
+    setup('livetruth');
+    expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument();
+  });
+
+  it('clears the value via the clear button and reopens showing all options', () => {
+    const { onChange } = setup('livetruth');
+    fireEvent.mouseDown(screen.getByRole('button', { name: /clear/i }));
+    expect(onChange).toHaveBeenLastCalledWith('');
+    // After clearing, the list is open and shows every option.
+    expect(screen.getByRole('option', { name: /hle/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /livetruth/i })).toBeInTheDocument();
+  });
+
+  it('chevron opens the full list even when a value is set (browse, not filter)', () => {
+    setup('livetruth');
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    fireEvent.mouseDown(screen.getByRole('button', { name: /toggle options/i }));
+    // All options shown — not just the one matching the current value.
+    expect(screen.getByRole('option', { name: /hle/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /livetruth/i })).toBeInTheDocument();
+    // Clicking the chevron again closes it.
+    fireEvent.mouseDown(screen.getByRole('button', { name: /toggle options/i }));
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
 });

--- a/apps/desktop/src/renderer/src/components/ui/combobox.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/combobox.tsx
@@ -1,11 +1,14 @@
 // apps/desktop/src/renderer/src/components/ui/combobox.tsx
 //
 // Minimal, dependency-free filterable combobox: a text input plus a filtered
-// listbox. Pure controlled — the `value` prop is the single source of truth and
-// also drives the filter; typing/selecting calls `onChange`. Free text is
-// allowed. Brand-styled (square, hairline, mono ids). Keyboard: ArrowUp/Down
-// move the highlight, Enter selects it, Escape closes.
+// listbox, with a clear (✕) button and a chevron toggle. Pure controlled — the
+// `value` prop is the single source of truth; typing/selecting/clearing calls
+// `onChange`. Free text is allowed. While typing, the list filters by the value;
+// when reopened by focus/click/chevron it shows ALL options so alternatives stay
+// visible even with a value set. Brand-styled (square, hairline, mono ids).
+// Keyboard: ArrowUp/Down move the highlight, Enter selects it, Escape closes.
 import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { ChevronDown, X } from 'lucide-react';
 
 export interface ComboboxOption {
   value: string;
@@ -31,16 +34,20 @@ export function Combobox({
 }: ComboboxProps) {
   const [open, setOpen] = useState(false);
   const [active, setActive] = useState(0);
+  // Distinguishes "typing" (filter by value) from "browsing" (show all options).
+  const [typing, setTyping] = useState(false);
   const listId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
   const blurTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const filtered = useMemo(() => {
     const q = value.trim().toLowerCase();
-    if (q.length === 0) return options;
+    // Only filter while actively typing — browsing shows the full list.
+    if (!typing || q.length === 0) return options;
     return options.filter(
       (o) => o.value.toLowerCase().includes(q) || o.label.toLowerCase().includes(q),
     );
-  }, [options, value]);
+  }, [options, value, typing]);
 
   // Keep the highlight within the (possibly newly-filtered) list, so the visual
   // highlight, aria-activedescendant, and Enter selection never go out of bounds.
@@ -58,7 +65,21 @@ export function Combobox({
 
   const commit = (v: string): void => {
     onChange(v);
+    setTyping(false);
     setOpen(false);
+  };
+
+  // Open the list in "browse" mode (all options), as opposed to typing/filtering.
+  const openBrowsing = (): void => {
+    setTyping(false);
+    setActive(0);
+    setOpen(true);
+  };
+
+  const clearValue = (): void => {
+    onChange('');
+    openBrowsing();
+    inputRef.current?.focus();
   };
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
@@ -82,27 +103,64 @@ export function Combobox({
   return (
     <div className="relative">
       <input
+        ref={inputRef}
         role="combobox"
         aria-expanded={open}
         aria-controls={listId}
         aria-autocomplete="list"
         aria-activedescendant={open && filtered[active] ? `${listId}-${active}` : undefined}
         aria-label={ariaLabel}
-        className="w-full rounded-none border border-border bg-background px-3 py-2 text-sm"
+        className="w-full rounded-none border border-border bg-background py-2 pl-3 pr-14 text-sm"
         value={value}
         placeholder={placeholder}
         disabled={disabled}
         onChange={(e) => {
           onChange(e.target.value);
+          setTyping(true);
           setOpen(true);
           setActive(0);
         }}
-        onFocus={() => setOpen(true)}
+        onFocus={openBrowsing}
         onBlur={() => {
           blurTimer.current = setTimeout(() => setOpen(false), 120);
         }}
         onKeyDown={onKeyDown}
       />
+      {/* Trailing controls: clear (when a value is set) + chevron toggle. Both use
+          onMouseDown+preventDefault so the input doesn't blur-close before the click,
+          and tabIndex=-1 since the input is the single focusable control. */}
+      <div className="absolute inset-y-0 right-0 flex items-center gap-0.5 pr-1.5">
+        {value.length > 0 && !disabled && (
+          <button
+            type="button"
+            aria-label="Clear"
+            tabIndex={-1}
+            className="text-muted-foreground transition-colors hover:text-foreground"
+            onMouseDown={(e) => {
+              e.preventDefault();
+              clearValue();
+            }}
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        )}
+        <button
+          type="button"
+          aria-label="Toggle options"
+          aria-expanded={open}
+          tabIndex={-1}
+          disabled={disabled}
+          className="text-muted-foreground transition-colors hover:text-foreground"
+          onMouseDown={(e) => {
+            e.preventDefault();
+            if (open) setOpen(false);
+            else openBrowsing();
+            inputRef.current?.focus();
+          }}
+        >
+          <ChevronDown className="h-3.5 w-3.5" />
+        </button>
+      </div>
       {open && filtered.length > 0 && (
         <ul
           id={listId}


### PR DESCRIPTION
## What
Enhances the reusable `components/ui/combobox.tsx` (used by the publish benchmark picker and any future optional-text dropdown):

- **Clear (✕) button** on the right, shown when the field has a value — clears it, refocuses the input, and reopens the list.
- **Chevron toggle** — clicking the field or the ▾ opens the dropdown.
- **Browse vs filter:** opening via focus/click/chevron shows **all** options (so you can see and pick alternatives even with a value set); typing filters. Stays pure-controlled.

Both trailing buttons use `onMouseDown`+`preventDefault` (so the input doesn't blur-close before the click) and `tabIndex={-1}` (the input is the single focusable control). Brand-styled (square, hairline, muted icons).

## Test plan
- [x] New combobox tests: clear hides/shows + clears + reopens-all; chevron opens full list with a value set + toggles closed. Existing 6 still pass (9 total).
- [x] Publish dialog tests unaffected (12).
- [x] Full desktop suite **290 passed / 49 files**; `npm run build` green.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215930089623604

🤖 Generated with [Claude Code](https://claude.com/claude-code)