### PR TITLE
SF-311: make Check-the-latest-leaderboard a visible amber CTA button

### DIFF
--- a/apps/desktop/src/renderer/src/components/eval/LeaderboardLink.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/LeaderboardLink.tsx
@@ -1,13 +1,14 @@
 // apps/desktop/src/renderer/src/components/eval/LeaderboardLink.tsx
 //
-// Static "Check the latest leaderboard" affordance for Eval Studio (SF-298).
-// Points at the configured public scoreboard (reused via useScoreboardUrl) and
-// opens it in the system browser through the main-process shell.openExternal IPC
-// — never a raw window.open against the external CORS host. Minimal chrome: a
-// plain inline link, no card/banner background.
+// "Check the latest leaderboard" CTA for Eval Studio (SF-298 / SF-311). Points at
+// the configured public scoreboard (reused via useScoreboardUrl) and opens it in
+// the system browser through the main-process shell.openExternal IPC — never a
+// raw window.open against the external CORS host. Styled as the primary amber CTA
+// (square, hairline, no shadow): the leaderboard is the thing to look at, so it
+// earns the one --mark spark instead of a faint inline link.
 
 import { ExternalLink } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
 import { useScoreboardUrl } from '@/hooks/use-scoreboard-url';
 
 interface Props {
@@ -22,17 +23,16 @@ export function LeaderboardLink({ className }: Props) {
   };
 
   return (
-    <button
+    <Button
       type="button"
+      variant="default"
+      size="sm"
       onClick={open}
       disabled={!scoreboardUrl}
-      className={cn(
-        'inline-flex items-center gap-1.5 text-xs text-primary transition-colors hover:underline disabled:opacity-50',
-        className,
-      )}
+      className={className}
     >
+      <ExternalLink className="h-3.5 w-3.5" />
       Check the latest leaderboard
-      <ExternalLink className="h-3 w-3" />
-    </button>
+    </Button>
   );
 }


### PR DESCRIPTION
## What
The Eval Studio "Check the latest leaderboard" affordance (`LeaderboardLink.tsx`, SF-298) was a faint inline amber **text link** (`text-xs text-primary`, no background) — easy to miss. It's now the primary **amber CTA button** (shared `Button variant="default"` → `bg-primary` fill, square, hairline, no shadow), so the leaderboard earns the one `--mark` accent spark per the brand.

Behavior is unchanged: opens the resolved scoreboard URL (`https://scoreboard.screamingface.ai`) via `shell.openExternal` IPC; disabled until the URL resolves.

## Design
Consulted `screamingface-design`: amber (`--mark`/`--primary`) is the legitimate UI spark for "the one thing the reader should understand," and the button keeps square corners + hairline + no shadow. Matches the app's existing default buttons.

## Test plan
- [x] `LeaderboardLink.test.tsx` (role/label/click/disabled) + `EvalStudioView.test.tsx` pass — 7.
- [x] Full desktop suite **290 passed / 49 files**; `npm run build` green.
- [ ] Visual confirm in the running app (it renders amber now; harness screenshotting of `../src` component classes is unreliable, so left for the real app).

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215969223745970

🤖 Generated with [Claude Code](https://claude.com/claude-code)