### PR TITLE
SF-312: post-publish View-on-leaderboard → scoreboard benchmark page

### DIFF
--- a/apps/desktop/src/main/services/__tests__/publish-score.test.ts
+++ b/apps/desktop/src/main/services/__tests__/publish-score.test.ts
@@ -85,8 +85,7 @@ describe('submitScore (main process)', () => {
         id: 'score-1',
         benchmarkId: 'hle',
         specId: 'hle-ensemble-three',
-        portalLink:
-          'https://screamingface.ai/portal/spec.html?benchmark=hle&spec=hle-ensemble-three',
+        portalLink: 'https://scoreboard.screamingface.ai/benchmark.html?id=hle',
       },
     });
   });

--- a/apps/desktop/src/main/services/publish-score.ts
+++ b/apps/desktop/src/main/services/publish-score.ts
@@ -171,7 +171,9 @@ export async function submitScore(request: PublishScoreRequest): Promise<Publish
     if (res.ok) {
       const data = (await res.json()) as ScoreResponse;
       publishLog(`publish: ${label} -> HTTP ${res.status} ok, score=${data.id}`);
-      const portalLink = `${ctx.portalUrl.replace(/\/$/, '')}/spec.html?benchmark=${encodeURIComponent(data.benchmark_id)}&spec=${encodeURIComponent(data.spec_id)}`;
+      // Deep link to the benchmark's page on the public scoreboard portal
+      // (SF-312): https://scoreboard.screamingface.ai/benchmark.html?id=<benchmark>.
+      const portalLink = `${ctx.scoreboardUrl.replace(/\/$/, '')}/benchmark.html?id=${encodeURIComponent(data.benchmark_id)}`;
       const value: PublishResult = {
         id: data.id,
         benchmarkId: data.benchmark_id,

--- a/apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/__tests__/PublishToLeaderboardDialog.test.tsx
@@ -199,7 +199,7 @@ describe('PublishToLeaderboardDialog — guards & misc', () => {
       id: 'score-1',
       benchmarkId: 'hle',
       specId: 'hle-ensemble-three',
-      portalLink: 'http://localhost:8080/spec.html?benchmark=hle&spec=hle-ensemble-three',
+      portalLink: 'https://scoreboard.screamingface.ai/benchmark.html?id=hle',
     };
     render(<PublishToLeaderboardDialog run={makeRun()} serverUrl="" onClose={vi.fn()} />);
     fireEvent.click(screen.getByRole('button', { name: /view on leaderboard/i }));
@@ -209,6 +209,6 @@ describe('PublishToLeaderboardDialog — guards & misc', () => {
           electronAPI: { publish: { openExternal: ReturnType<typeof vi.fn> } };
         }
       ).electronAPI.publish.openExternal,
-    ).toHaveBeenCalledWith('http://localhost:8080/spec.html?benchmark=hle&spec=hle-ensemble-three');
+    ).toHaveBeenCalledWith('https://scoreboard.screamingface.ai/benchmark.html?id=hle');
   });
 });

--- a/apps/desktop/src/renderer/src/hooks/__tests__/use-publish-score.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/__tests__/use-publish-score.test.ts
@@ -36,7 +36,7 @@ const SUCCESS: PublishOutcome = {
     id: 'score-1',
     benchmarkId: 'hle',
     specId: 'hle-ensemble-three',
-    portalLink: 'https://screamingface.ai/portal/spec.html?benchmark=hle&spec=hle-ensemble-three',
+    portalLink: 'https://scoreboard.screamingface.ai/benchmark.html?id=hle',
   },
 };
 


### PR DESCRIPTION
## What
The post-publish **"View on leaderboard"** button opened `{portalUrl}/spec.html?benchmark=X&spec=Y`. The leaderboard now lives on the deployed scoreboard portal, so it must point to the new domain/page:

`https://scoreboard.screamingface.ai/benchmark.html?id=<benchmark>` (e.g. `…?id=hle`, verified **200**).

Changed the `portalLink` construction in `publish-score.ts` to `{scoreboardUrl}/benchmark.html?id=<benchmark_id>` and updated the construction test + success-state fixtures.

## Note
`ctx.portalUrl` was only consumed by this link, so it's now unused (still resolved in `publish-context`). Left in place to keep this focused; can be removed in a follow-up.

## Test plan
- [x] `publish-score.test.ts` asserts the new URL; dialog + hook fixtures updated.
- [x] Full desktop suite **290 passed / 49 files**; `npm run build` green.
- [x] Target URL `https://scoreboard.screamingface.ai/benchmark.html?id=hle` → 200.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215969668752088

🤖 Generated with [Claude Code](https://claude.com/claude-code)