### PR TITLE
SF-313: url4 fails loudly on unknown $item.<field>

### DIFF
--- a/apps/server/src/screamingface/plugins/url4_executor/ensemble_helpers.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/ensemble_helpers.py
@@ -215,34 +215,56 @@ def split_collection_iteration(source_expr: str) -> tuple[str | None, str | None
     return None, None
 
 
+class Url4ItemFieldError(ValueError):
+    """A url4 spec references ``$item.<field>`` that isn't present in a structured
+    dataset row — almost always a spec/dataset field-name mismatch. Surfacing it
+    (instead of leaving the literal token) prevents a silent mis-grade / 0% run.
+    """
+
+
 def substitute_item(template: str, item_json: str) -> str:
     """Replace ``$item`` / ``$item.field`` in ``template`` with values from ``item_json``.
 
     - ``$item`` alone → the full item string.
-    - ``$item.field`` → the field value from a parsed JSON object. If
-      the item isn't a JSON object or the field doesn't exist, the
-      ``$item.field`` token is left as-is.
+    - ``$item.field`` → the field value from a parsed JSON object.
+      - If the item IS a JSON object but lacks ``field``, raise
+        ``Url4ItemFieldError`` (SF-313): a structured row missing a referenced
+        field is a spec/dataset mismatch and must fail loudly, not silently
+        leave the literal ``$item.field`` and mis-grade.
+      - If the item isn't a JSON object, ``$item.field`` is left as-is.
     """
     field_pattern = re.compile(r"\$item\.([a-zA-Z_][a-zA-Z0-9_]*)")
-    parsed_item: dict | None = None
     blob_spans = _json_blob_spans(template)
+    # Parse lazily on the first ``$item.field`` hit. After ``parse_done``,
+    # ``parsed`` is the dict when the item is a JSON object, else ``None``
+    # (so ``$item.field`` on a non-object item is left as-is).
+    parsed: dict | None = None
+    parse_done = False
 
     def _field_replacer(match: re.Match) -> str:
-        nonlocal parsed_item
-        if parsed_item is None:
+        nonlocal parsed, parse_done
+        if not parse_done:
+            parse_done = True
             try:
-                parsed_item = json.loads(item_json)
+                obj = json.loads(item_json)
             except (json.JSONDecodeError, TypeError):
-                parsed_item = {}
+                obj = None
+            parsed = obj if isinstance(obj, dict) else None
         field = match.group(1)
-        if isinstance(parsed_item, dict) and field in parsed_item:
-            val = parsed_item[field]
-            if isinstance(val, str):
-                if _in_json_blob(match.start(), blob_spans):
-                    return _escape_for_json_string(val)
-                return val
-            return json.dumps(val)
-        return match.group(0)  # unknown field — leave as-is
+        if parsed is not None:
+            if field in parsed:
+                val = parsed[field]
+                if isinstance(val, str):
+                    if _in_json_blob(match.start(), blob_spans):
+                        return _escape_for_json_string(val)
+                    return val
+                return json.dumps(val)
+            available = ", ".join(sorted(parsed.keys())) or "(none)"
+            raise Url4ItemFieldError(
+                f"url4 spec references unknown item field '$item.{field}'. "
+                f"Available fields in the dataset row: {available}."
+            )
+        return match.group(0)  # item is not a JSON object — leave as-is
 
     result = field_pattern.sub(_field_replacer, template)
 
@@ -295,6 +317,7 @@ _substitute_item = substitute_item
 
 __all__ = [
     "FanoutResponse",
+    "Url4ItemFieldError",
     "_ResponseEntry",
     "_build_reducer_input",
     "_split_collection_iteration",

--- a/apps/server/src/screamingface/plugins/url4_executor/tests/test_ensemble.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/tests/test_ensemble.py
@@ -16,6 +16,7 @@ from screamingface.plugins.url4_executor.ensemble import (
     _substitute_item,
     _substitute_response_vars,
 )
+from screamingface.plugins.url4_executor.ensemble_helpers import Url4ItemFieldError
 from screamingface.plugins.url4_executor.url4 import (
     Url4BackendCall,
     Url4List,
@@ -491,11 +492,18 @@ class TestSubstituteItem:
         result = _substitute_item("$item.question", '{"question":"What is 2+2?"}')
         assert result == "What is 2+2?"
 
-    def test_item_field_not_found(self):
-        result = _substitute_item("$item.missing", '{"question":"hi"}')
-        assert result == "$item.missing"
+    def test_item_field_not_found_raises(self):
+        # A structured row that lacks the referenced field is almost always a
+        # spec/dataset field-name mismatch — fail loudly (SF-313) instead of
+        # leaving the literal '$item.missing' and silently mis-grading.
+        with pytest.raises(Url4ItemFieldError) as exc:
+            _substitute_item("$item.missing", '{"question":"hi"}')
+        msg = str(exc.value)
+        assert "missing" in msg  # names the bad field
+        assert "question" in msg  # lists the available fields
 
     def test_non_json_item_field_left_as_is(self):
+        # Item isn't a JSON object → '$item.field' is left as-is (unchanged).
         result = _substitute_item("$item.field", "plain text")
         assert result == "$item.field"
 


### PR DESCRIPTION
## Problem
`substitute_item` silently left an unresolved `$item.<field>` as the **literal token** when the field was absent from a structured dataset row. A spec/dataset field-name mismatch then produced a confident-looking **0% "done"** run with no error.

Concretely: a ScoredLiveTruth spec references `$item.expected_answer`, but the `livetruth-latest.jsonl` rows store ground truth in **`answer`** — so the grader compared every prediction against the literal string `"$item.expected_answer"` → 0%. (`$item.question` worked only because `question` exists.)

## Fix
When the item **is** a JSON object but lacks the referenced field, raise `Url4ItemFieldError` naming the missing field + available fields:

> `url4 spec references unknown item field '$item.expected_answer'. Available fields in the dataset row: answer, context, id, question, ...`

So a mismatch now fails loudly (the run goes degraded/failed via the collection error path) instead of silently mis-grading. Non-JSON-object items keep the prior leave-as-is behavior (lower risk).

## Tests
- `test_item_field_not_found` → now asserts it **raises** (with the field name + available fields); `test_non_json_item_field_left_as_is` unchanged.
- url4_executor suite: **289 passed**; full server suite: **1454 passed / 41 skipped**.

## Note
This makes the failure obvious; to actually score the affected run, the spec must use `$item.answer` (the dataset's ground-truth field).

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215970272770713

🤖 Generated with [Claude Code](https://claude.com/claude-code)