### PR TITLE
SF-314: make the leaderboard CTA pop (shiny/animated/rounded, scoped override)

### DIFF
--- a/apps/desktop/src/renderer/src/components/eval/LeaderboardLink.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/LeaderboardLink.tsx
@@ -1,14 +1,18 @@
 // apps/desktop/src/renderer/src/components/eval/LeaderboardLink.tsx
 //
-// "Check the latest leaderboard" CTA for Eval Studio (SF-298 / SF-311). Points at
-// the configured public scoreboard (reused via useScoreboardUrl) and opens it in
-// the system browser through the main-process shell.openExternal IPC — never a
-// raw window.open against the external CORS host. Styled as the primary amber CTA
-// (square, hairline, no shadow): the leaderboard is the thing to look at, so it
-// earns the one --mark spark instead of a faint inline link.
+// "Check the latest leaderboard" CTA for Eval Studio (SF-298 / SF-311 / SF-314).
+// Points at the configured public scoreboard (reused via useScoreboardUrl) and
+// opens it in the system browser through the main-process shell.openExternal IPC
+// — never a raw window.open against the external CORS host.
+//
+// NOTE: this button is a DELIBERATE, user-approved brand override (SF-314): a
+// glossy, rounded, animated amber pill so the leaderboard "pops". It intentionally
+// breaks the square/flat/no-motion design rules — but ONLY here; the rest of the
+// app keeps the brand. The sheen/glow keyframes live in globals.css (sf-cta-*) and
+// respect prefers-reduced-motion.
 
 import { ExternalLink } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 import { useScoreboardUrl } from '@/hooks/use-scoreboard-url';
 
 interface Props {
@@ -23,16 +27,32 @@ export function LeaderboardLink({ className }: Props) {
   };
 
   return (
-    <Button
+    <button
       type="button"
-      variant="default"
-      size="sm"
       onClick={open}
       disabled={!scoreboardUrl}
-      className={className}
+      className={cn(
+        'sf-cta-glow group relative inline-flex items-center gap-1.5 overflow-hidden rounded-full',
+        'bg-gradient-to-b from-[#f4c264] via-[#e0a23c] to-[#c9821f]',
+        'px-4 py-1.5 text-sm font-semibold text-[#241803]',
+        'transition-transform duration-200 ease-out [animation:sf-cta-glow_3s_ease-in-out_infinite]',
+        'hover:scale-[1.04] hover:brightness-110 active:scale-100',
+        'disabled:cursor-default disabled:opacity-50 disabled:[animation:none] disabled:hover:scale-100',
+        className,
+      )}
     >
-      <ExternalLink className="h-3.5 w-3.5" />
-      Check the latest leaderboard
-    </Button>
+      {/* Top gloss highlight */}
+      <span
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 h-1/2 bg-gradient-to-b from-white/35 to-transparent"
+      />
+      {/* Animated sheen sweep */}
+      <span
+        aria-hidden
+        className="sf-cta-sheen pointer-events-none absolute inset-y-0 left-0 w-1/4 bg-white/45 blur-[2px] [animation:sf-cta-sheen_3s_ease-in-out_infinite] group-disabled:[animation:none]"
+      />
+      <ExternalLink className="relative h-4 w-4" />
+      <span className="relative">Check the latest leaderboard</span>
+    </button>
   );
 }

--- a/apps/desktop/src/renderer/src/globals.css
+++ b/apps/desktop/src/renderer/src/globals.css
@@ -154,3 +154,35 @@
     font-family: var(--font-mono), monospace;
   }
 }
+
+/* SF-314 — deliberate brand override, scoped to the "Check the latest leaderboard"
+   CTA only (LeaderboardLink). A glossy amber pill: a sheen that sweeps across and
+   a soft pulsing glow. Not used anywhere else; the rest of the app stays flat. */
+@keyframes sf-cta-sheen {
+  0% {
+    transform: translateX(-160%) skewX(-20deg);
+  }
+  60%,
+  100% {
+    transform: translateX(320%) skewX(-20deg);
+  }
+}
+@keyframes sf-cta-glow {
+  0%,
+  100% {
+    box-shadow:
+      0 0 0 1px rgba(224, 162, 60, 0.5),
+      0 2px 10px rgba(224, 162, 60, 0.35);
+  }
+  50% {
+    box-shadow:
+      0 0 0 1px rgba(224, 162, 60, 0.7),
+      0 4px 22px rgba(224, 162, 60, 0.6);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .sf-cta-glow,
+  .sf-cta-sheen {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## What
User-requested "make it pop" for the Eval Studio **"Check the latest leaderboard"** button. A **deliberate, approved brand override scoped to this one button**: a glossy amber pill — rounded, a vertical gradient with a top gloss highlight, an **animated sheen sweep** + a **soft pulsing glow**, and a hover lift/brighten.

- Scoped to `LeaderboardLink.tsx` + two prefixed keyframes (`sf-cta-sheen`, `sf-cta-glow`) in `globals.css`. **No shared design tokens changed**; every other button keeps the square/flat brand.
- Respects `prefers-reduced-motion` (animations off).
- Behavior unchanged: opens the resolved scoreboard URL via `openExternal`; disabled until resolved.

## Note
This intentionally breaks the square/flat/no-motion design rules — but only here, by request.

## Test plan
- [x] `LeaderboardLink.test.tsx` + `EvalStudioView.test.tsx` pass (behavior unchanged) — 7.
- [x] Full desktop suite **290 passed / 49 files**; `npm run build` green.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215971224084530

🤖 Generated with [Claude Code](https://claude.com/claude-code)