### PR TITLE
SF-316: leaderboard CTA — shrink, center, shorten to 'Check Leaderboard', no wrap

### DIFF
--- a/apps/desktop/src/renderer/src/components/eval/LeaderboardLink.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/LeaderboardLink.tsx
@@ -32,9 +32,9 @@ export function LeaderboardLink({ className }: Props) {
       onClick={open}
       disabled={!scoreboardUrl}
       className={cn(
-        'sf-cta-glow group relative inline-flex items-center gap-1.5 overflow-hidden rounded-full',
+        'sf-cta-glow group relative inline-flex items-center gap-1 overflow-hidden rounded-full',
         'bg-gradient-to-b from-[#f4c264] via-[#e0a23c] to-[#c9821f]',
-        'px-4 py-1.5 text-sm font-semibold text-[#241803]',
+        'px-3 py-1 text-xs font-semibold text-[#241803]',
         'transition-transform duration-200 ease-out [animation:sf-cta-glow_3s_ease-in-out_infinite]',
         'hover:scale-[1.04] hover:brightness-110 active:scale-100',
         'disabled:cursor-default disabled:opacity-50 disabled:[animation:none] disabled:hover:scale-100',
@@ -51,7 +51,7 @@ export function LeaderboardLink({ className }: Props) {
         aria-hidden
         className="sf-cta-sheen pointer-events-none absolute inset-y-0 left-0 w-1/4 bg-white/45 blur-[2px] [animation:sf-cta-sheen_3s_ease-in-out_infinite] group-disabled:[animation:none]"
       />
-      <ExternalLink className="relative h-4 w-4" />
+      <ExternalLink className="relative h-3 w-3" />
       <span className="relative">Check the latest leaderboard</span>
     </button>
   );

--- a/apps/desktop/src/renderer/src/components/eval/LeaderboardLink.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/LeaderboardLink.tsx
@@ -32,7 +32,7 @@ export function LeaderboardLink({ className }: Props) {
       onClick={open}
       disabled={!scoreboardUrl}
       className={cn(
-        'sf-cta-glow group relative inline-flex items-center gap-1 overflow-hidden rounded-full',
+        'sf-cta-glow group relative inline-flex items-center gap-1 overflow-hidden whitespace-nowrap rounded-full',
         'bg-gradient-to-b from-[#f4c264] via-[#e0a23c] to-[#c9821f]',
         'px-3 py-1 text-xs font-semibold text-[#241803]',
         'transition-transform duration-200 ease-out [animation:sf-cta-glow_3s_ease-in-out_infinite]',
@@ -52,7 +52,7 @@ export function LeaderboardLink({ className }: Props) {
         className="sf-cta-sheen pointer-events-none absolute inset-y-0 left-0 w-1/4 bg-white/45 blur-[2px] [animation:sf-cta-sheen_3s_ease-in-out_infinite] group-disabled:[animation:none]"
       />
       <ExternalLink className="relative h-3 w-3" />
-      <span className="relative">Check the latest leaderboard</span>
+      <span className="relative">Check Leaderboard</span>
     </button>
   );
 }

--- a/apps/desktop/src/renderer/src/components/eval/__tests__/LeaderboardLink.test.tsx
+++ b/apps/desktop/src/renderer/src/components/eval/__tests__/LeaderboardLink.test.tsx
@@ -24,7 +24,7 @@ import { LeaderboardLink } from '../LeaderboardLink';
 
 it('renders the static leaderboard label', () => {
   render(<LeaderboardLink />);
-  expect(screen.getByText(/check the latest leaderboard/i)).toBeTruthy();
+  expect(screen.getByText(/check leaderboard/i)).toBeTruthy();
 });
 
 it('resolves the scoreboard URL via the publish context (reused, not hardcoded)', async () => {
@@ -34,7 +34,7 @@ it('resolves the scoreboard URL via the publish context (reused, not hardcoded)'
 
 it('opens the resolved scoreboard URL through the external IPC, not window.open', async () => {
   render(<LeaderboardLink />);
-  const button = screen.getByRole('button', { name: /check the latest leaderboard/i });
+  const button = screen.getByRole('button', { name: /check leaderboard/i });
   await waitFor(() => expect(button).not.toBeDisabled());
   fireEvent.click(button);
   expect(openExternal).toHaveBeenCalledWith('https://scoreboard.screamingface.ai');
@@ -44,7 +44,7 @@ it('stays disabled (no-op) until the URL resolves', async () => {
   let resolve!: (value: unknown) => void;
   getContext.mockReturnValue(new Promise((r) => (resolve = r)));
   render(<LeaderboardLink />);
-  const button = screen.getByRole('button', { name: /check the latest leaderboard/i });
+  const button = screen.getByRole('button', { name: /check leaderboard/i });
   expect(button).toBeDisabled();
   fireEvent.click(button);
   expect(openExternal).not.toHaveBeenCalled();

--- a/apps/desktop/src/renderer/src/views/EvalStudioView.test.tsx
+++ b/apps/desktop/src/renderer/src/views/EvalStudioView.test.tsx
@@ -45,7 +45,7 @@ it('renders header, empty state, and both pane toggles', () => {
 it('shows the leaderboard link at the top and in the empty runs state', () => {
   render(<EvalStudioView />);
   expect(
-    screen.getAllByRole('button', { name: /check the latest leaderboard/i }).length,
+    screen.getAllByRole('button', { name: /check leaderboard/i }).length,
   ).toBeGreaterThanOrEqual(2);
 });
 

--- a/apps/desktop/src/renderer/src/views/EvalStudioView.tsx
+++ b/apps/desktop/src/renderer/src/views/EvalStudioView.tsx
@@ -119,13 +119,16 @@ export function EvalStudioView({ pendingRun, onPendingConsumed }: EvalStudioView
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex items-start justify-between border-b border-border px-6 py-4">
+      <div className="flex items-center justify-between gap-4 border-b border-border px-6 py-4">
         <div>
           <h1 className="text-[1.6875rem] font-semibold text-foreground">Eval Studio</h1>
           <p className="text-xs text-muted-foreground">
             History of evaluation runs across leaderboard entries
           </p>
-          <LeaderboardLink className="mt-1.5" />
+        </div>
+        {/* Centered between the title and the New Run button */}
+        <div className="flex flex-1 justify-center">
+          <LeaderboardLink />
         </div>
         <div className="flex items-center gap-1">
           <Button variant="outline" size="sm" className="mr-1" onClick={() => setAdding(true)}>


### PR DESCRIPTION
## What
- **Centered** the "Check the latest leaderboard" pill horizontally between the "Eval Studio" title (left) and the New Run button (right) — moved out of the left title block into a `flex-1 justify-center` middle slot; header switched to `items-center`.
- **~25% smaller**: `px-4 py-1.5 text-sm` → `px-3 py-1 text-xs`, icon `h-4 w-4` → `h-3 w-3`, gap `1.5` → `1`.

## Test plan
- [x] `LeaderboardLink` + `EvalStudioView` tests pass (7); full desktop suite **290 / 49 files**; `npm run build` green.
- [x] Visual confirmed in a harness (smaller pill, centered between title and New Run).

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1215972148507426

🤖 Generated with [Claude Code](https://claude.com/claude-code)