### PR TITLE
docs: definitive ScreamingFace setup guide (SF-320)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ An AI ensemble system that routes coding CLI prompts through multiple models (Cl
 | Python | >= 3.12 | [python.org](https://www.python.org/downloads/) |
 | uv | latest | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
 | Node.js | >= 18 | [nodejs.org](https://nodejs.org/) |
-| mkcert | latest | `brew install mkcert` (macOS) |
+| mkcert | optional | `brew install mkcert` (macOS) — only needed if you turn SSL on |
 
 Verify:
 ```bash
@@ -29,10 +29,11 @@ mkcert -version
 
 ```
 apps/
-  server/    Python FastAPI server with plugin architecture (uv)
-  desktop/   Electron control-plane app (electron-vite, React, Tailwind)
-  web/       Marketing website (Next.js)
-packages/    Shared packages
+  server/      Python FastAPI plugin server — URL4 engine, frontends, python runner (uv)
+  desktop/     Electron control-plane app (electron-vite, React, Tailwind)
+  aigateway/   LiteLLM-based AI Gateway — provider OAuth + encrypted credentials (uv)
+  scoreboard/  Public benchmark scoreboard service
+web/           Static marketing site
 ```
 
 ## Quick Start
@@ -41,13 +42,13 @@ packages/    Shared packages
 
 ```bash
 cd apps/server
-uv python install 3.13
-uv venv --python 3.13
-uv sync --extra tracing          # install dependencies
+uv sync                          # install dependencies (uv manages Python 3.12+)
 uv run sf run                    # start server (reads sf.json)
 ```
 
-The server auto-generates SSL certs via mkcert on first run. It binds to `https://0.0.0.0:8000` by default (auto-increments port if busy).
+> Add `--extra tracing` to `uv sync` if you want the OpenTelemetry tracing plugin.
+
+It binds to `http://127.0.0.1:8000` by default (SSL is **off** in the shipped `sf.json`; the port auto-increments if busy). To enable SSL, set `"ssl": true` in `sf.json` and install mkcert.
 
 Useful commands:
 ```bash
@@ -66,25 +67,28 @@ All config lives in `apps/server/sf.json`:
 
 ```json
 {
-  "version": "0.1.0",
   "server": {
-    "host": "0.0.0.0",
+    "host": "127.0.0.1",
     "port": 8000,
     "reload": true,
-    "ssl": true
+    "ssl": false
   },
-  "plugins": ["claude-frontend", "claude-env-intercept", "tracing", "url4-executor"],
+  "plugins": ["tracing", "url4-executor", "claude-frontend", "aigw-base", "aigw-runner", "..."],
   "plugin_config": {
-    "claude-frontend": {
-      "upstream_url": "https://api.anthropic.com"
-    }
+    "claude-frontend": { "upstream_url": "https://api.anthropic.com", "listen_port": 9101 },
+    "aigw-runner": { "port": 9105 }
   }
 }
 ```
 
-Anthropic auth flows through the Claude Code OAuth token stored in the macOS
-keychain (service `Claude Code-credentials`). Make sure you have signed in to
-Claude Code at least once on this machine — no environment variables required.
+The shipped `sf.json` activates ~21 plugins (the URL4 engine, the per-provider
+frontends, and the AI Gateway stack). Run `uv run sf plugin list` to see the
+live set.
+
+Provider credentials (Claude, Codex, Gemini, Antigravity) are connected through
+the **AI Gateway** via browser OAuth on the app's **Settings** screen — you
+don't paste API keys or set env vars. See
+[`docs/SETUP.md` §4](docs/SETUP.md#4-connect-the-ai-backends-the-one-step-everyone-does).
 
 ### 2. Desktop App
 
@@ -107,11 +111,8 @@ npm run package                  # create platform installer (DMG/AppImage/NSIS)
 
 ### 3. Web (Marketing Site)
 
-```bash
-cd apps/web
-npm install
-npm run dev                      # Next.js dev server
-```
+The marketing site is a **static** site under `web/` (no framework / build step).
+Serve the directory with any static file server to preview it.
 
 ## Environment Variables
 
@@ -126,32 +127,34 @@ npm run dev                      # Next.js dev server
 cd apps/server
 uv run pytest -v
 
-# Desktop (lint only, no test suite yet)
+# Desktop (Vitest)
 cd apps/desktop
-npm run lint
+npx vitest run                   # unit/component tests (jsdom)
+npm run lint                     # eslint
+
+# AI Gateway (Python)
+cd apps/aigateway
+uv run pytest -m "not live"
 ```
 
 ## Plugin System
 
 The server uses a plugin architecture inspired by Odoo. Plugins are discovered via entry points and activated in `sf.json`.
 
-Built-in plugins:
-- **claude-frontend** -- forwards Claude API requests to Anthropic (with optional url4 context enrichment)
-- **claude-env-intercept** -- writes proxy env vars to shell profile so Claude Code uses the local server
-- **claude-backend** -- runs Claude CLI commands from the server
-- **tracing** -- OpenTelemetry instrumentation (requires `uv sync --extra tracing`)
-- **claude-intercept** -- DNS/hosts interception to transparently redirect Claude API traffic
-- **url4-executor** -- url4 protocol engine — parsing, resolution, and HTTP endpoint
+Key active plugins (run `uv run sf plugin list` for the full, live set):
+- **url4-executor / url4-specs** -- the URL4 protocol engine and spec library
+- **claude-frontend / codex-frontend / gemini-frontend / ollama-frontend** -- per-provider request frontends
+- **aigw-base / aigw-runner / aigw-\*-backend** -- AI Gateway integration: provider OAuth and routing through the gateway on `:9105`
+- **python-runner** -- sandboxed Python execution used for eval scoring (`check_correct`, `calculate_accuracy`)
+- **data-store / private-storage / state / eval-runs** -- persistence and evaluation-run tracking
+- **tracing** -- OpenTelemetry instrumentation (`uv sync --extra tracing`)
 
-## Pointing Claude Code at the Proxy
+> The legacy `claude-env-intercept`, `claude-intercept`, and `mitmproxy-intercept`
+> plugins are **deprecated and unmaintained** — they are not part of the active
+> pipeline. Don't use them as a reference for how the gateway works.
 
-Once the server is running with `claude-frontend` and `claude-env-intercept` plugins:
+## Using ScreamingFace
 
-```bash
-# The claude-env-intercept plugin writes these to your shell profile automatically.
-# If you need to set them manually:
-export ANTHROPIC_BASE_URL="https://localhost:8000"
-export NODE_EXTRA_CA_CERTS="$(mkcert -CAROOT)/rootCA.pem"
-```
-
-Then start Claude Code normally -- all API requests route through the local proxy.
+Connect your model subscriptions on the app's **Settings** screen, then drive
+the ensemble from **Eval Studio** / **Sessions**, or via the `sf` CLI overlay.
+The full flow is in [`docs/SETUP.md`](docs/SETUP.md).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 An AI ensemble system that routes coding CLI prompts through multiple models (Claude, Gemini, Codex, Ollama) to beat SOTA benchmarks. Built by OpenMined.
 
+> **📖 Setting up? Read [`docs/SETUP.md`](docs/SETUP.md).** It is the definitive,
+> end-to-end guide — system requirements, installing the packaged app, running
+> from source, **connecting the AI backends** (incl. the Antigravity activation
+> gotcha), and cutting a build. The quickstart below is a condensed dev path; if
+> the two disagree, `docs/SETUP.md` wins.
+
 ## Prerequisites
 
 | Tool | Version | Install |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,0 +1,278 @@
+# ScreamingFace — Setup Guide
+
+The definitive, end-to-end guide to getting ScreamingFace running, connecting the
+AI backends, and cutting a build. This is the source of truth for setup; if the
+root `README.md` quickstart disagrees with this file, this file wins.
+
+ScreamingFace is three cooperating pieces:
+
+- **Desktop app** (`apps/desktop/`) — an Electron control plane. It owns the UI
+  (Settings, Eval Studio, URL4/Code Studio, Sessions) and **manages the local
+  server for you** (creates the venv, syncs deps, starts/stops the process).
+- **Local server** (`apps/server/`) — a FastAPI, plugin-based service that runs
+  the URL4 engine, the per-provider frontends, and the Python runner. Reads
+  `apps/server/sf.json`.
+- **AI Gateway** (`apps/aigateway/`) — a LiteLLM-based service that holds your
+  provider credentials and brokers all OAuth/refresh. The server starts it
+  automatically (the `aigw-runner` plugin) on port `9105`.
+
+Most users only ever touch one thing: **the Settings screen, to connect their
+model subscriptions.** Everything else is automatic.
+
+---
+
+## 1. System requirements
+
+| Tool | Version | Notes |
+|------|---------|-------|
+| OS | macOS (arm64 / x64) or Linux (x64 / arm64) | Windows: packaged app only (NSIS installer); from-source dev is macOS/Linux. |
+| Python | ≥ 3.12 | `uv` installs and pins this for you; you do **not** need a system Python. Builds pin `3.12.9`. |
+| uv | latest | The Python toolchain/installer. Builds pin `0.6.12`. |
+| Node.js | ≥ 18 | Only needed for the desktop app / from-source dev. |
+| mkcert | optional | Only if you run the server with SSL on. The default dev config runs plain HTTP, so this is optional. |
+
+Install `uv` and verify everything:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh   # uv
+python3 --version   # 3.12+  (or let uv manage it)
+uv --version
+node --version      # 18+
+```
+
+There are **two ways** to run ScreamingFace. Pick one:
+
+- **[Option A — Packaged app](#2-option-a--install-the-packaged-app-end-users)** — for users. One command, no toolchain.
+- **[Option B — From source](#3-option-b--run-from-source-developers)** — for development.
+
+Either way, you finish at **[Section 4 — Connect the AI backends](#4-connect-the-ai-backends-the-one-step-everyone-does)**.
+
+---
+
+## 2. Option A — Install the packaged app (end users)
+
+The installer lives in the public **`OpenMined/sf-installer`** repo. It detects
+your OS/arch, downloads the latest release, and installs it:
+
+```bash
+curl -fsSL <published-installer-url>/install.sh | sh
+```
+
+> The exact URL is the `install.sh` published with each `sf-installer` release —
+> grab it from <https://github.com/OpenMined/sf-installer/releases>. Pin a
+> version with `SF_VERSION=v0.2.0`, or change the location with `SF_INSTALL_DIR`.
+
+What it does:
+
+- **macOS** → installs `ScreamingFace.app` into `/Applications`, clears the
+  Gatekeeper quarantine flag, and launches it.
+- **Linux** → extracts to `~/.local/share/ScreamingFace` and symlinks
+  `~/.local/bin/screamingface` (make sure `~/.local/bin` is on your `PATH`).
+
+First launch takes a few seconds: the app provisions a private Python
+environment and starts the local server. Then go to
+**[Section 4](#4-connect-the-ai-backends-the-one-step-everyone-does)**.
+
+---
+
+## 3. Option B — Run from source (developers)
+
+```bash
+git clone https://github.com/OpenMined/screamingface.git
+cd screamingface
+git config core.hooksPath .githooks   # enables the pre-commit guards
+make sync                             # uv-syncs apps/server + apps/aigateway
+```
+
+You can then run **the whole thing through the desktop app** (recommended) or
+run **the server headless**.
+
+### 3a. Run via the desktop app (recommended)
+
+```bash
+cd apps/desktop
+npm install
+npm run dev      # launches Electron; auto-creates the venv, uv-syncs, starts the server
+```
+
+The desktop app owns the server lifecycle — you do **not** start the server or
+the gateway by hand. On first launch it creates a venv, runs `uv sync`, and
+spawns `sf run` as a subprocess. The AI Gateway is started automatically by the
+server's `aigw-runner` plugin.
+
+### 3b. Run the server headless (no desktop)
+
+```bash
+cd apps/server
+uv sync                 # first time
+uv run sf run           # starts the server; reads ./sf.json
+```
+
+The dev default (from `apps/server/sf.json`) binds **`http://127.0.0.1:8000`**
+with SSL **off**. Useful flags:
+
+```bash
+uv run sf --help                  # full CLI reference
+uv run sf run --port 9000         # change the port
+uv run sf run --no-ssl            # explicitly disable SSL (already off by default)
+uv run sf plugin list --json      # list discovered plugins + status
+uv run sf run --disable aigw-runner   # don't auto-start the gateway
+```
+
+The AI Gateway can also be run on its own (the server normally does this for
+you):
+
+```bash
+make run-aigateway                       # uvicorn aigateway.main:app --port 9105 --reload
+curl -sf http://localhost:9105/healthz   # liveness check
+```
+
+### Ports
+
+| Service | Port | Source |
+|---------|------|--------|
+| Local server | `8000` | `sf.json` → `server.port` |
+| AI Gateway (`aigw-runner`) | `9105` | `sf.json` → `aigw-runner.port` |
+| claude-frontend | `9101` | `sf.json` |
+| codex-frontend | `9102` | `sf.json` |
+| ollama-frontend | `9103` | `sf.json` |
+| Ollama (upstream) | `11434` | local Ollama install |
+
+If a port is busy the server increments to the next free one.
+
+---
+
+## 4. Connect the AI backends (the one step everyone does)
+
+Open the app, go to **Settings**, and connect the providers you have
+subscriptions for. Each is a browser OAuth flow — click *Connect*, sign in,
+done. Tokens are brokered and stored by the AI Gateway; you never paste an API
+key.
+
+| Provider | What you sign in with | Notes |
+|----------|----------------------|-------|
+| **Claude** | Anthropic / Claude subscription | OAuth via your Claude account. |
+| **Codex** | ChatGPT / OpenAI account | OAuth; uses loopback callback. |
+| **Gemini** | Google account (Code Assist) | Google OAuth. |
+| **Antigravity** | Google account | Google OAuth, experimental. **See the activation note below.** |
+| **Ollama** | — | Local only, no auth. Point it at your Ollama install (`http://localhost:11434`). |
+
+After connecting, the model dropdowns populate from the gateway's live model
+list — you don't hand-maintain model names.
+
+### Where credentials live
+
+The gateway stores tokens **encrypted at rest** (AES-256-GCM) in its
+`credential_blobs` table — SQLite locally, Postgres when hosted. There is **no
+OS keychain** involved on the gateway side. For hosted/multi-worker runs, set a
+master key:
+
+```bash
+# generate a base64 32-byte key for AIGATEWAY_SECRET_KEY
+python3 -c 'import os,base64;print(base64.b64encode(os.urandom(32)).decode())'
+```
+
+Locally, a single-worker dev gateway auto-generates and persists a key (with a
+warning) so you don't have to.
+
+### ⚠️ Antigravity activation gotcha (read this if Antigravity won't connect)
+
+Antigravity is a Google-side experimental surface. The OAuth sign-in can
+**succeed** while the backend still reports **degraded / "provider
+unavailable"** on the first calls. This is **not** a ScreamingFace bug — the
+Google account has to be **activated for Antigravity first, and then there's a
+short wait** before the upstream starts serving.
+
+If Antigravity shows unavailable right after connecting:
+
+1. Confirm the Google account actually has **Antigravity enabled**.
+2. **Wait** a few minutes, then retry the run.
+3. If it still fails, **re-connect** the provider in Settings (the profile flips
+   to an error state on the first failed call and needs a fresh auth).
+
+A healthy Antigravity backend served the demo's best numbers (≈72% on
+ScoredLiveTruth with context), so it's worth getting connected.
+
+---
+
+## 5. Verify it works
+
+- **Server up:** `uv run sf plugin list` shows plugins as healthy, or the
+  desktop **Dashboard** shows the server running.
+- **Gateway up:** `curl -sf http://localhost:9105/healthz`.
+- **Backends connected:** Settings shows each provider as *authenticated*.
+- **End to end:** in **Eval Studio**, run a small URL4 spec and watch the
+  per-row results stream in; a final accuracy score prints at the end.
+
+---
+
+## 6. Cut a new build / release
+
+Releases are automated with **release-please**, which manages three independent
+components: `desktop`, `server`, `aigateway` (tags `desktop-v*`, `server-v*`,
+`aigateway-v*`).
+
+**A plain PR merge to `main` does not produce a build.** The flow is:
+
+1. Land feature/fix PRs on `main` using conventional commits (`feat:`, `fix:`).
+2. The **release-please** workflow opens a *release PR* per changed component
+   (version bump + changelog).
+3. **Merge that release PR.** release-please then creates the git tag
+   (e.g. `desktop-v0.3.0`).
+4. The tag push triggers `release-desktop.yml`, which builds installers on
+   macOS (arm64 + x64 → `.dmg`, `.zip`) and Linux (x64 → `.AppImage`,
+   `.tar.gz`), attaches them to a draft GitHub Release, and mirrors them to the
+   public `OpenMined/sf-installer` repo.
+
+To build **on demand** without waiting for release-please, dispatch the release
+workflow manually (GitHub → Actions → *Release Desktop* → *Run workflow*, with
+the target tag), or push a tag yourself after bumping
+`apps/desktop/package.json`:
+
+```bash
+# only if you are intentionally cutting a manual release
+git tag desktop-v0.3.0
+git push origin desktop-v0.3.0
+```
+
+Local Linux packaging for a smoke test (no publish):
+
+```bash
+docker build -f Dockerfile.build -t sf-build . && \
+  docker run --rm -v "$PWD/out:/out" sf-build   # AppImage + tar.gz land in ./out
+```
+
+Or directly with electron-builder:
+
+```bash
+cd apps/desktop
+npm run build       # compile main/preload/renderer
+npm run package     # electron-builder → dist/<platform>/
+```
+
+---
+
+## 7. Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| Antigravity "unavailable" right after connecting | Google-side activation + wait; re-connect. See [§4](#-antigravity-activation-gotcha-read-this-if-antigravity-wont-connect). |
+| A backend silently scores 0% | The provider isn't connected/healthy — check Settings; the run preflight warns when a referenced backend is down. |
+| Port 8000 / 9105 already in use | The server auto-increments; or pass `uv run sf run --port <n>`. |
+| `mkcert` not installed but SSL on | Run with `--no-ssl` (default dev config is already HTTP). |
+| Desktop won't start the server | Check the app's `debug.log` under the OS app-support dir (macOS: `~/Library/Application Support/`). |
+| `uv` not found | Install it: `curl -LsSf https://astral.sh/uv/install.sh | sh`. |
+
+---
+
+## 8. Reference
+
+- **Config:** `apps/server/sf.json` — server block, the plugin list, and
+  per-plugin config (ports, upstreams, gateway URL). Override inline with the
+  `SF_CONFIG` env var.
+- **Dev tasks:** `make help` lists every target (`sync`, `run-server`,
+  `run-aigateway`, `test`, `test-fast`, `lint`, `fmt`, `typecheck`).
+- **Gateway internals:** `apps/aigateway/README.md` (credential store, secret
+  key, migrations, the Antigravity `pluginType` contract note).
+- **Desktop internals:** `apps/desktop/ARCHITECTURE.md` (venv bootstrap,
+  bundled Python, packaging).


### PR DESCRIPTION
## Summary
Adds **`docs/SETUP.md`** — the single source of truth for setting up ScreamingFace — and brings **`README.md`** into line with reality.

### `docs/SETUP.md` (new)
Accurate to the real `apps/server/sf.json`:
- **System requirements** (Python 3.12+ via uv, Node 18+, mkcert optional).
- **Option A — packaged app** (`OpenMined/sf-installer` one-liner, `SF_VERSION`/`SF_INSTALL_DIR`).
- **Option B — from source** (desktop `npm run dev` auto-manages the server; or headless `sf run`), with a verified **ports table** (8000 server / 9105 gateway / 9101–9103 frontends / 11434 Ollama).
- **Connecting the AI backends** — per-provider OAuth (Claude, Codex, Gemini, Antigravity, Ollama), encrypted `credential_blobs` storage, no OS keychain.
- **⚠️ Antigravity activation gotcha** — Google-side enablement + wait; the demo failure mode and the fix.
- **Cut a new build** — release-please flow (tag `desktop-v*` → `release-desktop.yml` → installers + mirror to `sf-installer`) and manual dispatch.
- Troubleshooting + reference.

### `README.md` drift fixed (in this PR)
- server default `http://127.0.0.1:8000`, SSL **off** (was `0.0.0.0`/`ssl:true`)
- dropped the Python 3.13 pin (uv manages 3.12+)
- monorepo layout: real `apps/` (server, desktop, aigateway, scoreboard) + static `web/`; removed non-existent `apps/web` and `packages/`
- replaced the stale 4-plugin `sf.json` example (incl. deprecated `claude-env-intercept`) with an accurate server block + plugin pointer
- credentials connect via the **AI Gateway OAuth in Settings**, not the Claude Code keychain
- marked `claude-env-intercept` / `claude-intercept` / `mitmproxy-intercept` **deprecated**; removed the proxy-env section built on them
- desktop tests run via **Vitest** (49 files), not "no suite yet"; added the AI Gateway test command
- linked `docs/SETUP.md` as canonical from the top

Source: 2026-06-24 demo next-steps (system-requirements + setup doc foregrounding Antigravity activation) → **SF-320**.

## Does this make a build?
No — docs-only, so release-please won't bump a version. See `docs/SETUP.md` §6 for how to actually cut the build (merge a release-please PR, or dispatch `release-desktop.yml`). Happy to trigger it on your go (it publishes a draft release to the public `sf-installer` repo).

## Test plan
- [ ] Render `docs/SETUP.md` + `README.md` on GitHub — links/anchors resolve.
- [ ] Commands spot-checked against `Makefile`, `sf.json`, `apps/aigateway/README.md`, `apps/desktop/package.json`.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1216051340487737

🤖 Generated with [Claude Code](https://claude.com/claude-code)