### PR TITLE
fix: installer version parse for component-prefixed tags (SF-321)

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -55,12 +55,12 @@ The installer lives in the public **`OpenMined/sf-installer`** repo. It detects
 your OS/arch, downloads the latest release, and installs it:
 
 ```bash
-curl -fsSL <published-installer-url>/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/OpenMined/sf-installer/main/install.sh | sh
 ```
 
-> The exact URL is the `install.sh` published with each `sf-installer` release —
-> grab it from <https://github.com/OpenMined/sf-installer/releases>. Pin a
-> version with `SF_VERSION=v0.2.0`, or change the location with `SF_INSTALL_DIR`.
+> The installer lives at the root of the `sf-installer` repo. It installs the
+> newest release by default. Pin a version with the **full release tag**
+> (`SF_VERSION=desktop-v0.3.0`), or change the location with `SF_INSTALL_DIR`.
 
 What it does:
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -73,7 +73,12 @@ main() {
     info "Latest version: ${TAG}"
   fi
 
-  VERSION="${TAG#v}"
+  # Release tags are component-prefixed (e.g. "desktop-v0.3.0"); the artifact
+  # name uses the bare version ("0.3.0"). Strip the "<component>-v" prefix, and
+  # tolerate a bare "v0.3.0" tag too. The full TAG is still used for the
+  # download path below.
+  VERSION="${TAG#*-v}"
+  VERSION="${VERSION#v}"
 
   # Determine artifact name and install dir
   case "$OS" in


### PR DESCRIPTION
## Problem

A fresh `curl -fsSL .../install.sh | sh` **404s** for the `desktop-v0.3.0` release. Caught smoke-testing the 0.3.0 build into a scratch dir.

`scripts/install.sh` derived the artifact version with `VERSION="${TAG#v}"`, which only strips a leading `v`. Our tags are component-prefixed (`desktop-v0.3.0`), so `VERSION` stayed `desktop-v0.3.0` and the script requested:

```
ScreamingFace-desktop-v0.3.0-mac-arm64.zip   # 404
```

while the real asset is `ScreamingFace-0.3.0-mac-arm64.zip`.

## Fix

```sh
VERSION="${TAG#*-v}"     # desktop-v0.3.0 -> 0.3.0
VERSION="${VERSION#v}"   # tolerate a bare "v0.3.0" tag too
```

The full `TAG` is still used for the `releases/download/${TAG}/...` path (already correct). Verified across tag forms and that the resulting URL returns **200** for `desktop-v0.3.0`.

Also fixes `docs/SETUP.md`: canonical raw `install.sh` URL + correct full-tag `SF_VERSION=desktop-v0.3.0` example (was `v0.2.0`).

## Note — second repo

`scripts/install.sh` is **byte-identical** to the live `OpenMined/sf-installer/install.sh`, and CI's mirror step only pushes *artifacts*, not the script. The same fix is being applied to `OpenMined/sf-installer` directly so the published installer works.

## Test plan
- [x] Parse validated: `desktop-v0.3.0 → 0.3.0`, `v0.3.0 → 0.3.0`, `desktop-v0.3.0-alpha.1 → 0.3.0-alpha.1`
- [x] Fixed URL HEAD → `200`
- [x] Corrected install into scratch dir produced a valid `ScreamingFace.app` (CFBundleShortVersionString 0.3.0, arm64)

https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1216051564604520