### PR TITLE
SF-326: Fix server container startup command

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -34,4 +34,4 @@ USER app
 EXPOSE 8000
 
 ENTRYPOINT ["sf"]
-CMD ["serve"]
+CMD ["run"]

--- a/apps/server/tests/core/test_dockerfile.py
+++ b/apps/server/tests/core/test_dockerfile.py
@@ -1,0 +1,33 @@
+"""Tests for the server container contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from screamingface.cli.main import app
+
+
+def _json_instruction(name: str) -> list[str]:
+    dockerfile = Path(__file__).resolve().parents[2] / "Dockerfile"
+    prefix = f"{name} "
+    for line in dockerfile.read_text().splitlines():
+        if line.startswith(prefix):
+            value = json.loads(line.removeprefix(prefix))
+            assert isinstance(value, list)
+            assert all(isinstance(item, str) for item in value)
+            return value
+    raise AssertionError(f"Dockerfile is missing {name}")
+
+
+def test_runtime_command_invokes_registered_sf_command() -> None:
+    entrypoint = _json_instruction("ENTRYPOINT")
+    command = _json_instruction("CMD")
+
+    assert entrypoint == ["sf"]
+
+    result = CliRunner().invoke(app, [*command, "--help"])
+
+    assert result.exit_code == 0, result.output

--- a/apps/server/uv.lock
+++ b/apps/server/uv.lock
@@ -2754,7 +2754,7 @@ wheels = [
 
 [[package]]
 name = "screamingface"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },


### PR DESCRIPTION
Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1216051625040868

## Description
The server Docker image now starts the registered `sf run` command instead of the non-existent `sf serve` command.

This fixes the default container startup path: the CLI exposes `run`, so the previous image command exited immediately with `No such command serve`. The PR also adds a regression test that parses the Dockerfile `ENTRYPOINT` and `CMD`, then verifies the configured command is a registered `sf` CLI command.

The server lockfile package metadata is also synced from `0.2.0` to `0.2.1` to match `apps/server/pyproject.toml`; no dependency set changes are introduced.

## Affected Dependencies
None.

## How has this been tested?
- `uv run pytest tests/core/test_dockerfile.py -q`
- `uv run sf run --help`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest -m "not e2e and not e2e_live"`
- `uv run pyright`
- `docker build -f apps/server/Dockerfile -t screamingface-server:sf-326 .`
- `docker image inspect screamingface-server:sf-326 --format "{{json .Config.Entrypoint}} {{json .Config.Cmd}}"`
- `docker run --rm screamingface-server:sf-326 run --help`

Test configuration: commands were run from `apps/server` unless the command references the repo-root Docker build context. Pyright completed with 0 errors and one existing missing-source warning for `mitmproxy_rs.local`.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests