### PR TITLE
docs: add root CONTRIBUTING.md run-from-source guide (SF-344)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,167 @@
+# Contributing to ScreamingFace
+
+This guide is for **running ScreamingFace from source and developing it**. If you
+just want to *install and use* the packaged app, or connect your model
+subscriptions, read [`docs/SETUP.md`](docs/SETUP.md) instead — that's the
+end-user setup guide.
+
+ScreamingFace is three cooperating pieces, all in this monorepo:
+
+- **Desktop app** (`apps/desktop/`) — Electron control plane (React + Vite +
+  Tailwind). Owns the UI and **manages the local server for you** (creates the
+  venv, syncs deps, starts/stops the process).
+- **Local server** (`apps/server/`) — FastAPI, plugin-based. Runs the URL4
+  engine, the per-provider frontends, and the Python runner. Reads
+  `apps/server/sf.json`.
+- **AI Gateway** (`apps/aigateway/`) — LiteLLM-based service that holds provider
+  credentials and brokers OAuth/refresh. The server starts it automatically
+  (the `aigw-runner` plugin) on port `9105`.
+
+There is also a static marketing site under `web/` and a public scoreboard
+service under `apps/scoreboard/`.
+
+## Prerequisites
+
+| Tool | Version | Notes |
+|------|---------|-------|
+| Python | ≥ 3.12 | `uv` installs and pins this for you; no system Python needed. |
+| uv | latest | Python toolchain/installer. `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
+| Node.js | ≥ 18 | Only for the desktop app. |
+| mkcert | optional | Only if you run the server with SSL on (default dev config is plain HTTP). |
+
+## Get the code
+
+```bash
+git clone https://github.com/OpenMined/screamingface.git
+cd screamingface
+git config core.hooksPath .githooks   # enables the pre-commit guards (see Git workflow)
+make sync                             # uv-syncs apps/server + apps/aigateway
+```
+
+## Run from source
+
+There are two ways. Pick one.
+
+### Option A — via the desktop app (recommended)
+
+```bash
+cd apps/desktop
+npm install
+npm run dev      # launches Electron; auto-creates the venv, uv-syncs, starts the server
+```
+
+The desktop app owns the server lifecycle — you do **not** start the server or
+the gateway by hand. On first launch it creates a venv in `apps/server/.venv`,
+runs `uv sync`, and spawns `sf run` as a subprocess. The AI Gateway is started
+automatically by the server's `aigw-runner` plugin.
+
+Build/package the app locally:
+
+```bash
+npm run build      # compile main/preload/renderer
+npm run package    # electron-builder → dist/<platform>/
+```
+
+### Option B — headless server (no desktop)
+
+```bash
+make run-server                  # = uv run sf run in apps/server (reads ./sf.json)
+# or, equivalently:
+cd apps/server && uv run sf run
+```
+
+The dev default (from `apps/server/sf.json`) binds **`http://127.0.0.1:8000`**
+with SSL **off**. Useful flags:
+
+```bash
+uv run sf --help                  # full CLI reference
+uv run sf run --port 9000         # change the port
+uv run sf run --no-ssl            # explicitly disable SSL (already off by default)
+uv run sf plugin list --json      # list discovered plugins + status
+uv run sf run --disable aigw-runner   # don't auto-start the gateway
+```
+
+Run the gateway on its own (the server normally does this for you):
+
+```bash
+make run-aigateway                       # uvicorn aigateway.main:app --port 9105 --reload
+curl -sf http://localhost:9105/healthz   # liveness check
+```
+
+### Ports
+
+| Service | Port | Source |
+|---------|------|--------|
+| Local server | `8000` | `sf.json` → `server.port` |
+| AI Gateway (`aigw-runner`) | `9105` | `sf.json` → `aigw-runner.port` |
+| claude-frontend | `9101` | `sf.json` |
+| codex-frontend | `9102` | `sf.json` |
+| ollama-frontend | `9103` | `sf.json` |
+| Ollama (upstream) | `11434` | local Ollama install |
+
+If a port is busy the server increments to the next free one.
+
+## Connect AI backends
+
+Connecting model subscriptions (Claude, Codex, Gemini, Antigravity, Ollama) is
+the same from source as for the packaged app — browser OAuth on the **Settings**
+screen, brokered and stored by the AI Gateway (encrypted `credential_blobs`, no
+OS keychain). See
+[`docs/SETUP.md` §4](docs/SETUP.md#4-connect-the-ai-backends-the-one-step-everyone-does),
+including the Antigravity activation gotcha.
+
+## Tests, lint, typecheck
+
+All targets are in the `Makefile` (`make help` lists them). The Python suites run
+through `uv`; the desktop suite runs through Vitest.
+
+```bash
+# Python (server + aigateway)
+make test            # full unit suite (no live)
+make test-fast       # skip the slow e2e marker
+make test-server     # apps/server only
+make test-aigateway  # apps/aigateway only (skips live)
+make test-e2e        # apps/server parallel CLI e2e (claude/codex/gemini/multi)
+make lint            # ruff lint every subproject
+make fmt             # ruff format
+make typecheck       # pyright
+
+# Desktop (Vitest — note: no `test` npm script, call vitest directly)
+cd apps/desktop
+npx vitest run       # unit/component tests (jsdom)
+npm run lint         # eslint
+```
+
+`make test-aigateway-live` exercises real provider OAuth and is skipped in CI;
+run it locally (with backends actually connected) before asking to merge changes
+that touch the gateway request/refresh path.
+
+## Git workflow
+
+- **Branch naming:** `SF-{n}-{description}` (e.g. `SF-344-contributing-guide`),
+  where `{n}` is the ticket's `SF` number.
+- **Never commit directly to `main`.** The `.githooks/pre-commit` hook (enabled
+  by `git config core.hooksPath .githooks` above) blocks it.
+- **Conventional commits.** Use `feat:`, `fix:`, `docs:`, `chore:` etc. —
+  release-please derives version bumps and changelogs from them (`feat:` → minor,
+  `fix:` → patch; `docs:`/`chore:` don't bump). See "Cut a build" below.
+- **Architecture is enforced.** Core must not import from plugins/adapters;
+  plugins implement core's ports. DRY/SOLID/hexagonal are mandatory — see the
+  "Architecture Principles" section of [`CLAUDE.md`](CLAUDE.md) before adding a
+  backend or transport.
+
+## Cut a build / release
+
+Releases are automated with release-please and produce the installable app. The
+full flow (release PR → tag → installer build → publish/mirror) is documented in
+[`docs/SETUP.md` §6](docs/SETUP.md#6-cut-a-new-build--release).
+
+## Reference
+
+- **Make targets:** `make help`
+- **Server config & plugins:** `apps/server/sf.json`, `apps/server/README.md`
+- **Gateway internals:** `apps/aigateway/README.md` (credential store, secret key,
+  migrations)
+- **Desktop internals:** `apps/desktop/ARCHITECTURE.md` (venv bootstrap, bundled
+  Python, packaging)
+- **Glossary:** `docs/GLOSSARY.md` (url4, Enclave, Ensemble, SOTA, …)

--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 An AI ensemble system that routes coding CLI prompts through multiple models (Claude, Gemini, Codex, Ollama) to beat SOTA benchmarks. Built by OpenMined.
 
-> **📖 Setting up? Read [`docs/SETUP.md`](docs/SETUP.md).** It is the definitive,
-> end-to-end guide — system requirements, installing the packaged app, running
-> from source, **connecting the AI backends** (incl. the Antigravity activation
-> gotcha), and cutting a build. The quickstart below is a condensed dev path; if
-> the two disagree, `docs/SETUP.md` wins.
+> **📖 Setting up?**
+> - **Installing / using the app** → [`docs/SETUP.md`](docs/SETUP.md): the
+>   definitive end-to-end guide (system requirements, packaged-app install,
+>   **connecting the AI backends** incl. the Antigravity gotcha, cutting a build).
+> - **Developing / running from source** → [`CONTRIBUTING.md`](CONTRIBUTING.md):
+>   the canonical dev guide (clone, run, ports, tests, git workflow).
+>
+> The quickstart below is a condensed dev path; if it disagrees with those, they win.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -39,83 +39,29 @@ apps/
 web/           Static marketing site
 ```
 
-## Quick Start
+## Running it
 
-### 1. Server
+Full instructions live in the two canonical guides — this avoids a third copy
+drifting out of sync:
 
-```bash
-cd apps/server
-uv sync                          # install dependencies (uv manages Python 3.12+)
-uv run sf run                    # start server (reads sf.json)
-```
+- **Run from source / develop** → [`CONTRIBUTING.md`](CONTRIBUTING.md): clone,
+  run via the desktop app or the headless server, ports, `sf.json` config,
+  tests, and the git workflow.
+- **Install the packaged app + connect the AI backends** →
+  [`docs/SETUP.md`](docs/SETUP.md).
 
-> Add `--extra tracing` to `uv sync` if you want the OpenTelemetry tracing plugin.
-
-It binds to `http://127.0.0.1:8000` by default (SSL is **off** in the shipped `sf.json`; the port auto-increments if busy). To enable SSL, set `"ssl": true` in `sf.json` and install mkcert.
-
-Useful commands:
-```bash
-uv run sf --help                 # CLI reference
-uv run sf run --no-ssl           # skip SSL if mkcert not installed
-uv run sf run --port 9000        # custom port
-uv run sf run --enable claude-frontend  # run only specific plugins
-uv run sf plugin list --json     # list discovered plugins
-uv run pytest                    # run tests
-uv run ruff check src tests      # lint
-```
-
-#### Server Configuration
-
-All config lives in `apps/server/sf.json`:
-
-```json
-{
-  "server": {
-    "host": "127.0.0.1",
-    "port": 8000,
-    "reload": true,
-    "ssl": false
-  },
-  "plugins": ["tracing", "url4-executor", "claude-frontend", "aigw-base", "aigw-runner", "..."],
-  "plugin_config": {
-    "claude-frontend": { "upstream_url": "https://api.anthropic.com", "listen_port": 9101 },
-    "aigw-runner": { "port": 9105 }
-  }
-}
-```
-
-The shipped `sf.json` activates ~21 plugins (the URL4 engine, the per-provider
-frontends, and the AI Gateway stack). Run `uv run sf plugin list` to see the
-live set.
-
-Provider credentials (Claude, Codex, Gemini, Antigravity) are connected through
-the **AI Gateway** via browser OAuth on the app's **Settings** screen — you
-don't paste API keys or set env vars. See
-[`docs/SETUP.md` §4](docs/SETUP.md#4-connect-the-ai-backends-the-one-step-everyone-does).
-
-### 2. Desktop App
+Thirty-second from-source path:
 
 ```bash
-cd apps/desktop
-npm install                      # install dependencies
-npm run dev                      # launch Electron in dev mode
+git clone https://github.com/OpenMined/screamingface.git
+cd screamingface
+git config core.hooksPath .githooks      # pre-commit guards
+make sync                                # uv-sync server + aigateway
+cd apps/desktop && npm install && npm run dev   # desktop app auto-starts the server
 ```
 
-The desktop app manages the Python server lifecycle automatically (venv creation, dependency sync, start/stop). On first launch it will:
-1. Detect or create a Python venv in `apps/server/.venv`
-2. Sync dependencies via `uv sync`
-3. Start the server as a subprocess
-
-Build for distribution:
-```bash
-npm run build                    # compile main/preload/renderer
-npm run package                  # create platform installer (DMG/AppImage/NSIS)
-```
-
-### 3. Web (Marketing Site)
-
-The marketing site is a **static** site under `web/` (no framework / build step).
-Serve the directory with any static file server to preview it.
+The marketing site under `web/` is static (no build step) — serve the directory
+with any static file server to preview it.
 
 ## Environment Variables
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -77,68 +77,24 @@ environment and starts the local server. Then go to
 
 ## 3. Option B — Run from source (developers)
 
+Running from source is the developer path. The full guide —
+clone + git hooks, running via the desktop app or the headless server,
+the ports table, tests/lint/typecheck, and the git workflow — lives in the
+root **[`CONTRIBUTING.md`](../CONTRIBUTING.md)**.
+
+The short version:
+
 ```bash
 git clone https://github.com/OpenMined/screamingface.git
 cd screamingface
 git config core.hooksPath .githooks   # enables the pre-commit guards
 make sync                             # uv-syncs apps/server + apps/aigateway
+
+# then either run the desktop app (auto-manages the server)…
+cd apps/desktop && npm install && npm run dev
+# …or run the server headless:
+make run-server                       # http://127.0.0.1:8000, SSL off
 ```
-
-You can then run **the whole thing through the desktop app** (recommended) or
-run **the server headless**.
-
-### 3a. Run via the desktop app (recommended)
-
-```bash
-cd apps/desktop
-npm install
-npm run dev      # launches Electron; auto-creates the venv, uv-syncs, starts the server
-```
-
-The desktop app owns the server lifecycle — you do **not** start the server or
-the gateway by hand. On first launch it creates a venv, runs `uv sync`, and
-spawns `sf run` as a subprocess. The AI Gateway is started automatically by the
-server's `aigw-runner` plugin.
-
-### 3b. Run the server headless (no desktop)
-
-```bash
-cd apps/server
-uv sync                 # first time
-uv run sf run           # starts the server; reads ./sf.json
-```
-
-The dev default (from `apps/server/sf.json`) binds **`http://127.0.0.1:8000`**
-with SSL **off**. Useful flags:
-
-```bash
-uv run sf --help                  # full CLI reference
-uv run sf run --port 9000         # change the port
-uv run sf run --no-ssl            # explicitly disable SSL (already off by default)
-uv run sf plugin list --json      # list discovered plugins + status
-uv run sf run --disable aigw-runner   # don't auto-start the gateway
-```
-
-The AI Gateway can also be run on its own (the server normally does this for
-you):
-
-```bash
-make run-aigateway                       # uvicorn aigateway.main:app --port 9105 --reload
-curl -sf http://localhost:9105/healthz   # liveness check
-```
-
-### Ports
-
-| Service | Port | Source |
-|---------|------|--------|
-| Local server | `8000` | `sf.json` → `server.port` |
-| AI Gateway (`aigw-runner`) | `9105` | `sf.json` → `aigw-runner.port` |
-| claude-frontend | `9101` | `sf.json` |
-| codex-frontend | `9102` | `sf.json` |
-| ollama-frontend | `9103` | `sf.json` |
-| Ollama (upstream) | `11434` | local Ollama install |
-
-If a port is busy the server increments to the next free one.
 
 ---
 


### PR DESCRIPTION
## What

Adds a canonical **`CONTRIBUTING.md`** at the repo root — the run-from-source / developer guide:

- Prerequisites (Python ≥3.12 via uv, Node ≥18, mkcert optional)
- Clone + `git config core.hooksPath .githooks` + `make sync`
- Run from source: **Option A** desktop app (`npm run dev`, auto-manages server) / **Option B** headless (`make run-server`, `make run-aigateway`)
- Ports table
- Tests / lint / typecheck via the `Makefile` targets, plus desktop `npx vitest run`
- Git workflow: `SF-{n}` branches, conventional commits (drives release-please), no direct commits to `main`, architecture rules

## DRY

Single source of truth for from-source:
- `docs/SETUP.md §3` trimmed from the full walkthrough to a short pointer at `CONTRIBUTING.md`.
- CONTRIBUTING points to `docs/SETUP.md §4` (connect backends) and `§6` (cut a build) instead of duplicating them.
- README banner now routes **install → SETUP.md**, **develop → CONTRIBUTING.md**.

All content verified against the repo (Makefile `make help`, ports in `sf.json`, desktop scripts, cross-referenced files all exist).

https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1216073298381035