### PR TITLE
SF-335: resolve AIGateway auth cleanup

### DIFF
--- a/apps/aigateway/src/aigateway/core/oauth_base.py
+++ b/apps/aigateway/src/aigateway/core/oauth_base.py
@@ -1,9 +1,28 @@
 """Template-method base for OAuth-backed credential strategies.
 
-Owns the shared flow: in-memory cache, double-checked locking with an
-asyncio.Lock, proactive refresh inside the lock, 401-driven invalidation.
-Provider plugins implement four hooks: read, is_expired, refresh,
-build_headers (plus an optional header_override for hybrid api-key paths).
+Owns the shared *credential* flow only: in-memory cache, double-checked
+locking with an asyncio.Lock, and proactive refresh inside the lock. Provider
+plugins implement four hooks: read, is_expired, refresh, build_headers (plus
+an optional header_override for hybrid api-key paths).
+
+This base does NOT detect auth failures. Upstream HTTP auth failures are a
+transport concern handled in the chat route (`routes/chat.py`):
+`_dispatch_failure_response` consults the provider plugin's
+`should_mark_profile_error_on_dispatch_status` (`core/plugin_base.py`; anthropic
+401, gemini/antigravity 401+403, base default never) and evicts the SHARED
+strategy instance from the process-wide `CredentialStrategyCache`
+(`core/credential_strategy_cache.py`) via its `evict()`. Credential read/refresh
+errors raised before dispatch are also handled in the chat route's
+`_inject_credentials` path. Eviction lives there, not here, because the cache
+holds the one instance shared across a fan-out; `invalidate()` on this object
+clears only its own `_cached`, not the shared entry the next request would reuse.
+
+CONTRACT MIRROR (SF-335): this OAuth base mirrors the OAuth base in the SF
+server (plugins/llm_base/oauth_base.py) *by contract, not by code*: NO shared
+module, NO cross-app import. Keep in sync: refresh_window_seconds == 60;
+refresh fires when (expiry - now) <= refresh_window_seconds; double-checked
+asyncio.Lock single-flight; drop the cached strategy on an upstream auth
+failure. If you change refresh_window_seconds here, change it in the other app.
 """
 
 from __future__ import annotations

--- a/apps/aigateway/src/aigateway/core/request_cache/store.py
+++ b/apps/aigateway/src/aigateway/core/request_cache/store.py
@@ -108,6 +108,13 @@ class TortoiseRequestCacheStore:
         if row is None:
             try:
                 await RequestCacheEntry.create(key_hash=entry.key_hash, **values)
+                # SF-335: per-write opportunistic purge is INTENTIONAL, not a
+                # correctness mechanism. get() refuses expired rows on read
+                # (store.py:67-69), so a stale row is never served even if this
+                # never runs; it only reclaims space, and the delete is
+                # index-assisted (expires_at indexed). If this write path is ever
+                # measured as hot, switch to probabilistic GC (SF-335 follow-up);
+                # do not add a background task.
                 await self.delete_expired()
                 return
             except IntegrityError:
@@ -117,7 +124,10 @@ class TortoiseRequestCacheStore:
         for field, value in values.items():
             setattr(row, field, value)
         await row.save(update_fields=list(values.keys()))
-        await self.delete_expired()
+        await self.delete_expired()  # SF-335: intentional opportunistic purge (see note above)
 
     async def delete_expired(self) -> int:
+        # SF-335: index-assisted (expires_at index, request_cache_entry.py:27),
+        # NOT a full-table scan. Called opportunistically from set(); see the
+        # note there on why this per-write purge is intentional.
         return await RequestCacheEntry.filter(expires_at__lte=datetime.now(UTC)).delete()

--- a/apps/aigateway/src/aigateway/routes/auth.py
+++ b/apps/aigateway/src/aigateway/routes/auth.py
@@ -1032,8 +1032,10 @@ async def set_profile_api_key(
 
     No OAuth round-trip: the profile is AUTHENTICATED as soon as the key is
     stored. The key is persisted to the profile's credential blob slot (so a
-    later OAuth completion overwrites it, and delete removes it) and is never
-    echoed back in responses or logs.
+    later OAuth completion overwrites it, and delete removes it). The RAW key is
+    never returned in responses or logs; the profile carries only a masked
+    display label of the last 4 characters (``account_label = "API key ····WXYZ"``),
+    the same last-4 convention used by Stripe/AWS/GitHub.
     """
     plugin = _registry(request).get(provider)
     if plugin is None:

--- a/apps/aigateway/src/aigateway/routes/auth_session.py
+++ b/apps/aigateway/src/aigateway/routes/auth_session.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, HTTPException, Request
@@ -10,6 +11,8 @@ from ..core.auth.models import Account
 from ..core.auth.passwords import verify_password_or_dummy
 from ..core.auth.schemas import AccountOut, LoginRequest, LoginResponse
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
 
 _INVALID_CREDENTIALS = {"code": "invalid_credentials", "message": "Invalid username or password"}
@@ -19,8 +22,8 @@ _INVALID_CREDENTIALS = {"code": "invalid_credentials", "message": "Invalid usern
 async def login(body: LoginRequest, request: Request) -> LoginResponse:
     """Authenticate an account and return a stateless JWT session.
 
-    Inactive accounts return 423. This leaks that a username exists, but v1 is
-    single-tenant/admin-provisioned and the distinction is operationally useful.
+    Inactive accounts receive the same generic 401 as bad credentials (no
+    account-status disclosure, per OWASP); the refusal is logged server-side.
     """
     account = await Account.get_or_none(username=body.username)
     password_hash = account.password_hash if account is not None else None
@@ -28,7 +31,11 @@ async def login(body: LoginRequest, request: Request) -> LoginResponse:
     if account is None or not password_ok:
         raise HTTPException(status_code=401, detail=_INVALID_CREDENTIALS)
     if not account.is_active:
-        raise HTTPException(status_code=423, detail={"code": "account_locked"})
+        # SF-335: do NOT disclose account status to the client (OWASP: respond
+        # generically). Still refuse to issue a session; a server-side log keeps
+        # ops visibility without the 423 enumeration oracle.
+        logger.info("login refused for inactive account username=%s", account.username)
+        raise HTTPException(status_code=401, detail=_INVALID_CREDENTIALS)
 
     account.last_login_at = datetime.now(UTC)
     await account.save(update_fields=["last_login_at"])

--- a/apps/aigateway/tests/unit/auth/test_login.py
+++ b/apps/aigateway/tests/unit/auth/test_login.py
@@ -41,7 +41,7 @@ def test_login_rejects_overlong_password(client) -> None:
     assert response.status_code == 422
 
 
-def test_inactive_account_returns_locked(client) -> None:
+def test_inactive_account_returns_generic_401(client) -> None:
     async def _deactivate() -> None:
         admin = await Account.get(username="admin")
         admin.is_active = False
@@ -52,7 +52,17 @@ def test_inactive_account_returns_locked(client) -> None:
         "/v1/auth/login",
         json={"username": "admin", "password": "test-admin-password"},
     )
-    assert response.status_code == 423
+    # SF-335: an inactive account (with the CORRECT password) must be
+    # INDISTINGUISHABLE from bad credentials: same status AND identical body,
+    # so no account-status enumeration oracle remains. Compare against a
+    # wrong-password attempt on the same (still-deactivated) user.
+    wrong = client.post(
+        "/v1/auth/login",
+        json={"username": "admin", "password": "definitely-wrong-password"},
+    )
+    assert response.status_code == 401
+    assert response.json()["detail"]["code"] == "invalid_credentials"
+    assert (response.status_code, response.content) == (wrong.status_code, wrong.content)
 
 
 @pytest.mark.asyncio

--- a/apps/aigateway/tests/unit/test_credential_strategy_cache.py
+++ b/apps/aigateway/tests/unit/test_credential_strategy_cache.py
@@ -13,6 +13,19 @@ import asyncio
 import pytest
 
 from aigateway.core.credential_strategy_cache import CredentialStrategyCache
+from aigateway.core.oauth_base import BaseOAuthStrategy
+
+# SF-335 / C12 cross-app contract: this window value is mirrored BY CONTRACT
+# (not by shared code) with the SF-server OAuth base
+# (apps/server/src/screamingface/plugins/llm_base/oauth_base.py).
+EXPECTED_REFRESH_WINDOW_SECONDS = 60
+
+
+def test_refresh_window_matches_cross_app_contract() -> None:
+    # The one genuinely-shared-yet-unpinned cross-app invariant (SF-335 / C12):
+    # if this drifts from the SF-server base, fan-out refresh decisions disagree
+    # across the HTTP boundary (SF-282 class). Mirror any change in BOTH apps.
+    assert BaseOAuthStrategy.refresh_window_seconds == EXPECTED_REFRESH_WINDOW_SECONDS
 
 
 def test_get_or_create_caches_per_key() -> None:

--- a/apps/server/src/screamingface/plugins/llm_base/oauth_base.py
+++ b/apps/server/src/screamingface/plugins/llm_base/oauth_base.py
@@ -25,6 +25,18 @@ to ~100.
 Hybrid strategies (e.g. Gemini supports API-key OR OAuth) override
 :meth:`_header_override` to short-circuit the OAuth path when an
 API-key env var is present.
+
+CONTRACT MIRROR (SF-335): this OAuth base mirrors the OAuth base in the
+AIGateway app (aigateway/core/oauth_base.py) *by contract, not by code* —
+there is NO shared module and NO cross-app import (forbidden by the
+dependency rules). Keep these invariants in sync across both apps:
+
+    * refresh_window_seconds == 60
+    * refresh fires when (expiry - now) <= refresh_window_seconds
+    * double-checked locking with an asyncio.Lock (single-flight refresh)
+    * drop the cached strategy on an upstream auth failure
+
+If you change refresh_window_seconds here, change it in the other app too.
 """
 
 from __future__ import annotations

--- a/apps/server/src/screamingface/plugins/llm_base/tests/test_oauth_base_aigw.py
+++ b/apps/server/src/screamingface/plugins/llm_base/tests/test_oauth_base_aigw.py
@@ -10,6 +10,16 @@ import pytest
 from screamingface.plugins.llm_base.aigw_token_source import AigwTokenSource
 from screamingface.plugins.llm_base.oauth_base import OAuthStrategy
 
+# SF-335 / C12 cross-app contract: mirrored BY CONTRACT (not shared code) with
+# the AIGateway OAuth base (apps/aigateway/src/aigateway/core/oauth_base.py).
+EXPECTED_REFRESH_WINDOW_SECONDS = 60
+
+
+def test_refresh_window_matches_cross_app_contract() -> None:
+    # The one genuinely-shared-yet-unpinned cross-app invariant (SF-335 / C12);
+    # mirror any change in BOTH apps or fan-out refresh decisions drift (SF-282).
+    assert OAuthStrategy.refresh_window_seconds == EXPECTED_REFRESH_WINDOW_SECONDS
+
 
 class _FakeStrategy(OAuthStrategy):
     """Concrete strategy that uses the snake_case shape (like Codex/Gemini)."""

--- a/apps/server/uv.lock
+++ b/apps/server/uv.lock
@@ -2754,7 +2754,7 @@ wheels = [
 
 [[package]]
 name = "screamingface"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },


### PR DESCRIPTION
Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1216051659906347

## Description
This PR resolves the reviewed D-AIGW-020/SF-335 low-risk cleanup items across AIGateway auth, OAuth refresh contracts, and request-cache maintenance.

It aligns the API-key profile docstring with the existing masked-last-4 display behavior, collapses inactive-account login responses to the same generic 401 used for invalid credentials, documents where OAuth auth-failure eviction actually lives, pins the cross-app OAuth refresh window contract with tests in both apps, and records the request-cache per-write expiry purge as intentional opportunistic GC.

The change keeps the existing app boundary intact: no shared module, no cross-app import, no migrations, no dependency additions, and no request-cache behavior change.

## Affected Dependencies
None.

## How has this been tested?
- `cd apps/aigateway && uv run pytest -m "not live" -q`
- `cd apps/aigateway && uv run ruff check .`
- `cd apps/aigateway && uv run ruff format --check .`
- `cd apps/aigateway && uv run pyright`
- `cd apps/aigateway && uv run python scripts/check_no_enterprise.py`
- `cd apps/server && uv run pytest src/screamingface/plugins/llm_base/tests/test_oauth_base_aigw.py -q`
- `cd apps/server && uv run ruff check .`
- `cd apps/server && uv run ruff format --check .`
- `cd apps/server && uv run pyright`

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests