### PR TITLE
SF-318: harden Antigravity activation errors

### DIFF
--- a/apps/aigateway/src/aigateway/plugins/antigravity_provider/chat_handler.py
+++ b/apps/aigateway/src/aigateway/plugins/antigravity_provider/chat_handler.py
@@ -63,6 +63,35 @@ CLIENT_AUTH_HEADER_NAMES = frozenset(
         "cookie",
     }
 )
+ANTIGRAVITY_ACTIVATION_REQUIRED_MESSAGE = (
+    "Activate Google Antigravity for this Google account, then retry. "
+    "If Antigravity is not available for this account, use a different activated account."
+)
+ANTIGRAVITY_ACTIVATION_REQUIRED_CODE = "account_activation_required"
+
+# Best-effort until we have a captured unactivated-account response: prefer
+# structured Google ErrorInfo reasons and keep prose markers narrowly scoped.
+_ACTIVATION_REQUIRED_REASONS = frozenset(
+    {
+        "SERVICE_DISABLED",
+        "ACCOUNT_NOT_ELIGIBLE",
+        "ANTIGRAVITY_ACCOUNT_NOT_ELIGIBLE",
+        "ANTIGRAVITY_NOT_ACTIVATED",
+        "ANTIGRAVITY_NOT_ENABLED",
+    }
+)
+_ACTIVATION_REQUIRED_PHRASES = frozenset(
+    {
+        "not eligible for antigravity",
+        "account is not eligible",
+        "ineligible to use antigravity",
+        "unexpected issue setting up your account",
+        "not activated",
+        "activation required",
+        "activate google antigravity",
+        "activated antigravity",
+    }
+)
 
 _HANDLER: AntigravityCustomLLM | None = None
 
@@ -106,8 +135,74 @@ def _profile_header_value(headers: dict[str, Any]) -> str:
     return "default"
 
 
+def _response_error_payload(response: httpx.Response) -> dict[str, Any] | None:
+    try:
+        data = response.json()
+    except ValueError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    error = data.get("error")
+    return error if isinstance(error, dict) else None
+
+
+def _response_error_text(response: httpx.Response) -> str:
+    error = _response_error_payload(response)
+    if error is None:
+        return response.text
+
+    parts: list[str] = []
+    for key in ("status", "message"):
+        value = error.get(key)
+        if isinstance(value, str) and value:
+            parts.append(value)
+    for item in _iter_google_error_detail_items(error):
+        for key in ("reason", "message", "domain", "@type"):
+            value = item.get(key)
+            if isinstance(value, str) and value:
+                parts.append(value)
+    return " ".join(parts) if parts else response.text
+
+
+def _iter_google_error_detail_items(error: dict[str, Any]) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for key in ("details", "errors"):
+        raw = error.get(key)
+        if isinstance(raw, list):
+            items.extend(item for item in raw if isinstance(item, dict))
+    return items
+
+
+def _google_error_reasons(error: dict[str, Any]) -> set[str]:
+    reasons: set[str] = set()
+    for item in _iter_google_error_detail_items(error):
+        reason = item.get("reason")
+        if isinstance(reason, str) and reason:
+            reasons.add(reason.upper())
+    return reasons
+
+
+def _activation_required_error(status_code: int) -> CustomLLMError:
+    error = CustomLLMError(
+        status_code=status_code,
+        message=ANTIGRAVITY_ACTIVATION_REQUIRED_MESSAGE,
+    )
+    error.detail_code = ANTIGRAVITY_ACTIVATION_REQUIRED_CODE  # type: ignore[attr-defined]
+    return error
+
+
+def _looks_like_activation_required(response: httpx.Response) -> bool:
+    error = _response_error_payload(response)
+    if error is not None and _google_error_reasons(error) & _ACTIVATION_REQUIRED_REASONS:
+        return True
+    text = _response_error_text(response).lower()
+    return any(marker in text for marker in _ACTIVATION_REQUIRED_PHRASES)
+
+
 def _error_from_response(response: httpx.Response) -> CustomLLMError:
     status = response.status_code
+    if status == 403 and _looks_like_activation_required(response):
+        return _activation_required_error(status)
     if status in (401, 403):
         return CustomLLMError(status_code=status, message="Antigravity rejected credentials")
     if status == 429:

--- a/apps/aigateway/src/aigateway/plugins/antigravity_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/antigravity_provider/plugin.py
@@ -30,6 +30,7 @@ from aigateway.core.plugin_base import (
 
 from .auth import AntigravityOAuth, exchange_authorization_code
 from .chat_handler import (
+    ANTIGRAVITY_ACTIVATION_REQUIRED_CODE,
     CLIENT_AUTH_HEADER_NAMES,
     AntigravityCustomLLM,
     ensure_litellm_antigravity_provider_registered,
@@ -52,7 +53,9 @@ def _retry_after_header(exc: CustomLLMError) -> dict[str, str]:
 def _detail_for_error(exc: CustomLLMError) -> dict[str, str]:
     status_code = int(exc.status_code or 502)
     code = "provider_error"
-    if status_code in (401, 403):
+    if getattr(exc, "detail_code", None) == ANTIGRAVITY_ACTIVATION_REQUIRED_CODE:
+        code = ANTIGRAVITY_ACTIVATION_REQUIRED_CODE
+    elif status_code in (401, 403):
         code = "auth_required"
     elif status_code == 429:
         code = "rate_limited"

--- a/apps/aigateway/tests/unit/antigravity/test_antigravity_chat_handler.py
+++ b/apps/aigateway/tests/unit/antigravity/test_antigravity_chat_handler.py
@@ -386,6 +386,111 @@ async def test_pre_stream_error_mapping(status: int, expected: int) -> None:
 
 
 @pytest.mark.asyncio
+async def test_ineligible_account_points_to_antigravity_activation() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url).endswith(f"{_API_VERSION}:loadCodeAssist"):
+            return httpx.Response(
+                403,
+                json={
+                    "error": {
+                        "status": "PERMISSION_DENIED",
+                        "message": "Your current account is not eligible for Antigravity.",
+                    }
+                },
+            )
+        return httpx.Response(200, json={"response": _antigravity_response("x")})
+
+    custom = AntigravityCustomLLM(
+        settings=_SETTINGS, http_client_factory=_http_factory(httpx.MockTransport(handler))
+    )
+    with pytest.raises(CustomLLMError) as exc_info:
+        await _complete(custom, headers={ANTIGRAVITY_PROFILE_HEADER: "p1"})
+
+    assert exc_info.value.status_code == 403
+    assert "Activate Google Antigravity" in exc_info.value.message
+    assert "rejected credentials" not in exc_info.value.message
+
+
+@pytest.mark.asyncio
+async def test_structured_service_disabled_reason_points_to_activation() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url).endswith(f"{_API_VERSION}:loadCodeAssist"):
+            return httpx.Response(
+                403,
+                json={
+                    "error": {
+                        "code": 403,
+                        "status": "PERMISSION_DENIED",
+                        "message": "The caller does not have permission.",
+                        "details": [
+                            {
+                                "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+                                "reason": "SERVICE_DISABLED",
+                                "domain": "cloudcode-pa.googleapis.com",
+                            }
+                        ],
+                    }
+                },
+            )
+        return httpx.Response(200, json={"response": _antigravity_response("x")})
+
+    custom = AntigravityCustomLLM(
+        settings=_SETTINGS, http_client_factory=_http_factory(httpx.MockTransport(handler))
+    )
+    with pytest.raises(CustomLLMError) as exc_info:
+        await _complete(custom, headers={ANTIGRAVITY_PROFILE_HEADER: "p1"})
+
+    assert exc_info.value.status_code == 403
+    assert "Activate Google Antigravity" in exc_info.value.message
+
+
+@pytest.mark.asyncio
+async def test_plain_permission_denied_stays_credentials_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url).endswith(f"{_API_VERSION}:loadCodeAssist"):
+            return httpx.Response(
+                403,
+                json={
+                    "error": {
+                        "status": "PERMISSION_DENIED",
+                        "message": "The caller does not have permission.",
+                    }
+                },
+            )
+        return httpx.Response(200, json={"response": _antigravity_response("x")})
+
+    custom = AntigravityCustomLLM(
+        settings=_SETTINGS, http_client_factory=_http_factory(httpx.MockTransport(handler))
+    )
+    with pytest.raises(CustomLLMError) as exc_info:
+        await _complete(custom, headers={ANTIGRAVITY_PROFILE_HEADER: "p1"})
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.message == "Antigravity rejected credentials"
+
+
+@pytest.mark.asyncio
+async def test_non_utf8_permission_denied_stays_credentials_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url).endswith(f"{_API_VERSION}:loadCodeAssist"):
+            return httpx.Response(
+                403,
+                content=b"\xa9",
+                headers={"content-type": "application/json"},
+            )
+        return httpx.Response(200, json={"response": _antigravity_response("x")})
+
+    custom = AntigravityCustomLLM(
+        settings=_SETTINGS, http_client_factory=_http_factory(httpx.MockTransport(handler))
+    )
+    with pytest.raises(CustomLLMError) as exc_info:
+        await _complete(custom, headers={ANTIGRAVITY_PROFILE_HEADER: "p1"})
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.message == "Antigravity rejected credentials"
+
+
+@pytest.mark.asyncio
 async def test_429_carries_retry_after() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         if str(request.url).endswith(f"{_API_VERSION}:loadCodeAssist"):

--- a/apps/aigateway/tests/unit/antigravity/test_antigravity_provider.py
+++ b/apps/aigateway/tests/unit/antigravity/test_antigravity_provider.py
@@ -13,6 +13,7 @@ import inspect
 
 import litellm
 import pytest
+from litellm.llms.custom_llm import CustomLLMError
 
 from aigateway.core.loader import load_plugins
 from aigateway.core.registry import ProviderRegistry
@@ -259,3 +260,23 @@ async def test_extract_identity_maps_to_core_account_identity() -> None:
 def test_account_label_from_credentials_delegates_to_core() -> None:
     label = _plugin().account_label_from_credentials({"account_label": "u@example.com"})
     assert label == "u@example.com"
+
+
+def test_activation_error_uses_specific_detail_code() -> None:
+    from aigateway.plugins.antigravity_provider.chat_handler import (
+        ANTIGRAVITY_ACTIVATION_REQUIRED_CODE,
+        ANTIGRAVITY_ACTIVATION_REQUIRED_MESSAGE,
+    )
+    from aigateway.plugins.antigravity_provider.plugin import _detail_for_error
+
+    error = CustomLLMError(
+        status_code=403,
+        message=ANTIGRAVITY_ACTIVATION_REQUIRED_MESSAGE,
+    )
+    error.detail_code = ANTIGRAVITY_ACTIVATION_REQUIRED_CODE  # type: ignore[attr-defined]
+    detail = _detail_for_error(error)
+
+    assert detail == {
+        "code": ANTIGRAVITY_ACTIVATION_REQUIRED_CODE,
+        "message": ANTIGRAVITY_ACTIVATION_REQUIRED_MESSAGE,
+    }

--- a/apps/server/src/screamingface/plugins/aigw_base/backend.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/backend.py
@@ -29,6 +29,8 @@ from .config import resolve_aigw_runtime_config
 
 logger = logging.getLogger(__name__)
 
+AIGW_ACCOUNT_ACTIVATION_REQUIRED_CODE = "account_activation_required"
+
 
 class AigwGatewayError(BackendError):
     """Raised for unexpected gateway responses (gateway 500, malformed JSON)."""
@@ -204,6 +206,7 @@ class AigwBackend(Backend):
         # Map gateway error codes onto SF's error hierarchy.
         detail = _detail_or_text(resp)
         code = (detail or {}).get("code") if isinstance(detail, dict) else None
+        retry_after = _parse_retry_after(resp.headers.get("retry-after"))
 
         if resp.status_code == 404 and code == "profile_not_found":
             raise CredentialNotFoundError(
@@ -215,20 +218,38 @@ class AigwBackend(Backend):
                 f"Gateway profile {self._profile_name!r} is awaiting OAuth callback. "
                 f"Complete the flow in Electron."
             )
-        if resp.status_code == 401 and code == "auth_required":
-            msg = (
-                detail.get("message", "auth required")
-                if isinstance(detail, dict)
-                else "auth required"
-            )
+        if resp.status_code in (401, 403) and code in {
+            "auth_required",
+            AIGW_ACCOUNT_ACTIVATION_REQUIRED_CODE,
+        }:
+            msg = _detail_message(detail, "auth required")
             raise AuthError(f"Gateway: {msg}")
         if resp.status_code in (400, 422):
             raise BackendError(
                 f"Gateway rejected request ({resp.status_code}): {detail}",
                 status=resp.status_code,
             )
+        if code == "provider_unavailable":
+            raise BackendError(
+                f"Gateway provider unavailable: {_detail_message(detail, 'provider unavailable')}",
+                status=resp.status_code,
+                retry_after=retry_after,
+            )
+        if code == "provider_error":
+            # A bare gateway provider_error with HTTP 403 remains provider-level
+            # until gateway emitters explicitly classify generic 403s as auth.
+            raise BackendError(
+                f"Gateway provider error: {_detail_message(detail, 'provider error')}",
+                status=resp.status_code,
+                retry_after=retry_after,
+            )
+        if resp.status_code == 429 and code == "rate_limited":
+            raise BackendError(
+                f"Gateway rate limited: {_detail_message(detail, 'rate limited')}",
+                status=resp.status_code,
+                retry_after=retry_after,
+            )
         # Anything else → unexpected gateway error
-        retry_after = _parse_retry_after(resp.headers.get("retry-after"))
         raise AigwGatewayError(
             f"Gateway returned status {resp.status_code}: {resp.text[:500]}",
             status=resp.status_code,
@@ -355,6 +376,13 @@ def _detail_or_text(resp: httpx.Response):
     except (ValueError, httpx.DecodingError):
         return resp.text
     return body.get("detail", body) if isinstance(body, dict) else body
+
+
+def _detail_message(detail, fallback: str) -> str:
+    if isinstance(detail, dict):
+        message = detail.get("message")
+        return message if isinstance(message, str) and message else fallback
+    return str(detail or fallback)
 
 
 def _parse_retry_after(value: str | None) -> float | None:

--- a/apps/server/src/screamingface/plugins/aigw_base/tests/test_aigw_backend.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/tests/test_aigw_backend.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 import httpx
 import pytest
 
 from screamingface.plugins.aigw_base.backend import (
+    AIGW_ACCOUNT_ACTIVATION_REQUIRED_CODE,
     AigwBackend,
     AigwGatewayError,
 )
@@ -143,6 +145,124 @@ async def test_401_auth_required_maps_to_auth_error() -> None:
             [CoreMessage(role="user", content="hi")],
             model="anthropic/claude-haiku-4-5",
         )
+
+
+@pytest.mark.anyio
+async def test_403_account_activation_required_maps_to_auth_error() -> None:
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            403,
+            json={
+                "detail": {
+                    "code": "account_activation_required",
+                    "message": "Activate Google Antigravity for this Google account, then retry.",
+                }
+            },
+        )
+
+    backend = _backend(http_client_factory=_factory(httpx.MockTransport(handler)))
+    with pytest.raises(AuthError, match="Activate Google Antigravity"):
+        await backend.run(
+            [CoreMessage(role="user", content="hi")],
+            model="antigravity/gemini-3-flash",
+        )
+
+
+@pytest.mark.anyio
+async def test_provider_unavailable_detail_maps_to_backend_error() -> None:
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            502,
+            json={
+                "detail": {
+                    "code": "provider_unavailable",
+                    "message": "Antigravity backend unavailable. Try again later.",
+                }
+            },
+        )
+
+    backend = _backend(http_client_factory=_factory(httpx.MockTransport(handler)))
+    with pytest.raises(BackendError) as exc_info:
+        await backend.run(
+            [CoreMessage(role="user", content="hi")],
+            model="antigravity/gemini-3-flash",
+        )
+
+    assert type(exc_info.value) is BackendError
+    assert exc_info.value.status == 502
+    assert (
+        str(exc_info.value)
+        == "Gateway provider unavailable: Antigravity backend unavailable. Try again later."
+    )
+
+
+@pytest.mark.anyio
+async def test_rate_limited_detail_preserves_retry_after() -> None:
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            429,
+            json={"detail": {"code": "rate_limited", "message": "quota reset later"}},
+            headers={"retry-after": "30"},
+        )
+
+    backend = _backend(http_client_factory=_factory(httpx.MockTransport(handler)))
+    with pytest.raises(BackendError) as exc_info:
+        await backend.run(
+            [CoreMessage(role="user", content="hi")],
+            model="antigravity/gemini-3-flash",
+        )
+
+    assert exc_info.value.status == 429
+    assert exc_info.value.retry_after == 30.0
+    assert str(exc_info.value) == "Gateway rate limited: quota reset later"
+
+
+@pytest.mark.anyio
+async def test_gateway_error_fallthrough_preserves_retry_after() -> None:
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="boom", headers={"retry-after": "5"})
+
+    backend = _backend(http_client_factory=_factory(httpx.MockTransport(handler)))
+    with pytest.raises(AigwGatewayError) as exc_info:
+        await backend.run(
+            [CoreMessage(role="user", content="hi")],
+            model="antigravity/gemini-3-flash",
+        )
+
+    assert exc_info.value.status == 503
+    assert exc_info.value.retry_after == 5.0
+
+
+@pytest.mark.anyio
+async def test_provider_error_403_remains_backend_error_until_gateway_semantics_change() -> None:
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            403,
+            json={"detail": {"code": "provider_error", "message": "raw provider forbidden"}},
+        )
+
+    backend = _backend(http_client_factory=_factory(httpx.MockTransport(handler)))
+    with pytest.raises(BackendError) as exc_info:
+        await backend.run(
+            [CoreMessage(role="user", content="hi")],
+            model="antigravity/gemini-3-flash",
+        )
+
+    assert type(exc_info.value) is BackendError
+    assert exc_info.value.status == 403
+    assert str(exc_info.value) == "Gateway provider error: raw provider forbidden"
+
+
+def test_account_activation_code_contract_matches_gateway_literal() -> None:
+    repo_root = Path(__file__).resolve().parents[7]
+    source = (
+        repo_root / "apps/aigateway/src/aigateway/plugins/antigravity_provider/chat_handler.py"
+    ).read_text()
+
+    assert (
+        f'ANTIGRAVITY_ACTIVATION_REQUIRED_CODE = "{AIGW_ACCOUNT_ACTIVATION_REQUIRED_CODE}"'
+        in source
+    )
 
 
 @pytest.mark.anyio

--- a/apps/server/uv.lock
+++ b/apps/server/uv.lock
@@ -2754,7 +2754,7 @@ wheels = [
 
 [[package]]
 name = "screamingface"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },


### PR DESCRIPTION
## Description
Hardens Antigravity activation and gateway error handling for SF-318.

- Detects Antigravity account activation or eligibility failures from structured Google error reasons and narrowly scoped activation-related messages.
- Emits the explicit `account_activation_required` detail code from AIGateway so the SF server can surface an actionable auth error.
- Keeps generic `PERMISSION_DENIED` responses as credential failures instead of treating every provider `403` as account activation.
- Maps gateway provider availability, provider error, and rate-limit responses to `BackendError` with `retry_after` preserved where present.
- Adds regression and contract tests for the activation-code mapping and gateway error semantics.
- Syncs the server lock metadata version with the current server package version.

The URL4 double-slash follow-up remains separate on SF-290 and is not included in this PR.

## Implementation Notes / Follow-ups
- Health/status/profile state: this PR intentionally does not change `ProfileState` or backend health semantics. Antigravity activation failures are request-level `AuthError` responses with `account_activation_required`; health/status continues to describe backend/service availability rather than whether a specific user account has activated Antigravity. A persistent UI CTA for activation can be handled separately if needed.
- Real unactivated-account response: detection is best-effort based on known Google error shapes and public error patterns. This does not block the PR; a future follow-up can add a sanitized fixture/test if we capture a real unactivated Antigravity account `403` body that differs from the covered shapes.
- Generic provider `403`: this PR intentionally keeps bare gateway `provider_error` + HTTP `403` mapped to `BackendError` unless the gateway explicitly emits `auth_required` or `account_activation_required`. Treating every `403` as auth would risk false positives for quota, policy, regional restrictions, disabled APIs, and permission-scope failures; provider-specific classification happens at the gateway boundary via `detail.code`.

## Affected Dependencies
None. No dependency additions or removals.

## How has this been tested?
- `cd apps/aigateway && uv run pytest tests/unit/antigravity -q`
- `cd apps/server && uv run pytest src/screamingface/plugins/aigw_base/tests -q`
- `cd apps/server && uv run pytest src/screamingface/plugins/url4_executor/tests/test_backend_context_fetch.py -q`
- `cd apps/aigateway && uv run pytest -m "not live" -q`
- `cd apps/server && uv run pytest -m "not e2e and not e2e_live" -q`
- `cd apps/aigateway && uv run ruff check .`
- `cd apps/aigateway && uv run ruff format --check .`
- `cd apps/aigateway && uv run pyright`
- `cd apps/aigateway && uv run python scripts/check_no_enterprise.py`
- `cd apps/server && uv run ruff check .`
- `cd apps/server && uv run ruff format --check .`
- `cd apps/server && uv run pyright`

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
