### PR TITLE
SF-290: normalize repeated slashes in URL4 fetches

### DIFF
--- a/apps/server/src/screamingface/plugins/url4_executor/tests/test_backend_context_fetch.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/tests/test_backend_context_fetch.py
@@ -199,6 +199,30 @@ async def test_e2e_offline_llm_backend_fetches_private_context_path(app_url4) ->
 
 
 @pytest.mark.asyncio
+async def test_e2e_offline_llm_backend_normalizes_repeated_leading_slashes(
+    app_url4,
+) -> None:
+    async def private_doc(pid: str) -> PlainTextResponse:
+        return PlainTextResponse(f"PRIVATE-DOC[{pid}]")
+
+    async def wrong_doc() -> PlainTextResponse:
+        return PlainTextResponse("WRONG-DOC")
+
+    app_url4.add_api_route("/private/{pid}", private_doc, methods=["GET"])
+    app_url4.add_api_route("/abc123", wrong_doc, methods=["GET"])
+    llm = _EchoLlmPlugin()
+    _inject(app_url4, llm)
+
+    resp = await _ensemble(app_url4, "/claude(Who, what, //private/abc123)!answer")
+
+    assert resp.status_code == 200, resp.text
+    assert llm.last_sources is not None
+    assert "PRIVATE-DOC[abc123]" in llm.last_sources
+    assert "WRONG-DOC" not in llm.last_sources
+    assert "//private/abc123" not in llm.last_sources
+
+
+@pytest.mark.asyncio
 async def test_e2e_offline_python_backend_keeps_raw_locator(app_url4) -> None:
     """Offline e2e: a /python backend (no opt-in) still receives the raw
     locator path — the dispatcher must NOT pre-fetch it."""

--- a/apps/server/src/screamingface/plugins/url4_executor/url4_resolve.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/url4_resolve.py
@@ -294,6 +294,8 @@ async def _fetch_relative(app: Any, path: str) -> str:
 
     if not app:
         raise ValueError(f"Cannot resolve relative URL {path!r} without app context")
+    if path.startswith("//"):
+        path = "/" + path.lstrip("/")
     with traced("url4.fetch_relative", kind="client"):
         set_span_attrs({"http.method": "GET", "url4.path": path})
         transport = httpx.ASGITransport(app=app)

--- a/apps/server/uv.lock
+++ b/apps/server/uv.lock
@@ -2754,7 +2754,7 @@ wheels = [
 
 [[package]]
 name = "screamingface"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },


### PR DESCRIPTION
## Description
Fixes the remaining SF-290 URL4 backend-context edge case where a context ref with repeated leading slashes could be misresolved before reaching the in-process ASGI route.

Previously, a backend call such as `/claude(..., //private/abc123)!answer` could be passed to the local HTTP client as `//private/abc123`. With `base_url="http://localhost"`, that path was interpreted as `/abc123`, dropping the `private` segment and allowing the wrong route to be fetched.

This PR normalizes repeated leading slashes for relative URL4 fetches before they reach the ASGI transport, so `//private/abc123` resolves as `/private/abc123`. It also adds a regression test with a poison `/abc123` route to prove the private route is fetched and the wrong route is not.

## Affected Dependencies
None. No dependency additions or removals.

## How has this been tested?
- `cd apps/server && uv run pytest src/screamingface/plugins/url4_executor/tests/test_backend_context_fetch.py -q`
- `cd apps/server && uv run pytest src/screamingface/plugins/url4_executor/tests -q`
- `cd apps/server && uv run ruff check .`
- `cd apps/server && uv run ruff format --check .`
- `cd apps/server && uv run pyright`
- `cd apps/server && uv run pytest -m "not e2e and not e2e_live" -q`

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
