### PR TITLE
SF-334: stabilize OAuth launch and token cache

### DIFF
--- a/apps/desktop/src/main/services/__tests__/oauth-launcher.test.ts
+++ b/apps/desktop/src/main/services/__tests__/oauth-launcher.test.ts
@@ -293,6 +293,86 @@ describe('runOAuthLauncher', () => {
     expect(getPendingAuthState(BROWSER_BACKEND, 'personal')).toBe('state-personal');
   });
 
+  it('rejects duplicate profile OAuth launch without overwriting manual auth state', async () => {
+    await runOAuthLauncher({
+      sfBaseUrl: 'http://127.0.0.1:1234',
+      backendName: BROWSER_BACKEND,
+      profileName: 'work',
+      timeoutMs: 0,
+      fetchImpl: makeFetch([
+        () =>
+          new Response(JSON.stringify({ authorize_url: AUTHORIZE_URL, state: 'state-original' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+      ]) as unknown as typeof fetch,
+    });
+    const duplicateFetch = makeFetch([
+      () =>
+        new Response(JSON.stringify({ authorize_url: AUTHORIZE_URL, state: 'state-duplicate' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    ]);
+
+    const duplicate = await runOAuthLauncher({
+      sfBaseUrl: 'http://127.0.0.1:1234',
+      backendName: BROWSER_BACKEND,
+      profileName: 'work',
+      timeoutMs: 0,
+      fetchImpl: duplicateFetch as unknown as typeof fetch,
+    });
+
+    expect(duplicate.kind).toBe('failed');
+    if (duplicate.kind === 'failed') {
+      expect(duplicate.reason).toBe('gateway_error');
+      expect(duplicate.message).toContain('already pending');
+    }
+    expect(duplicateFetch).not.toHaveBeenCalled();
+    expect(getPendingAuthState(BROWSER_BACKEND, 'work')).toBe('state-original');
+  });
+
+  it('rejects duplicate profile OAuth launch while a start request is in flight', async () => {
+    let resolveStart: (response: Response) => void = () => undefined;
+    const startResponse = new Promise<Response>((resolve) => {
+      resolveStart = resolve;
+    });
+    const firstFetch = vi.fn(async () => startResponse);
+    const firstLaunch = runOAuthLauncher({
+      sfBaseUrl: 'http://127.0.0.1:1234',
+      backendName: BROWSER_BACKEND,
+      profileName: 'work',
+      timeoutMs: 0,
+      fetchImpl: firstFetch as unknown as typeof fetch,
+    });
+    await Promise.resolve();
+    const duplicateFetch = vi.fn();
+
+    const duplicate = await runOAuthLauncher({
+      sfBaseUrl: 'http://127.0.0.1:1234',
+      backendName: BROWSER_BACKEND,
+      profileName: 'work',
+      timeoutMs: 0,
+      fetchImpl: duplicateFetch as unknown as typeof fetch,
+    });
+
+    expect(duplicate.kind).toBe('failed');
+    if (duplicate.kind === 'failed') {
+      expect(duplicate.reason).toBe('gateway_error');
+      expect(duplicate.message).toContain('already pending');
+    }
+    expect(duplicateFetch).not.toHaveBeenCalled();
+
+    resolveStart(
+      new Response(JSON.stringify({ authorize_url: AUTHORIZE_URL, state: 'state-original' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    await firstLaunch;
+    expect(getPendingAuthState(BROWSER_BACKEND, 'work')).toBe('state-original');
+  });
+
   it('returns gateway_error when /auth/start returns 502', async () => {
     const fetchMock = makeFetch([
       () =>

--- a/apps/desktop/src/main/services/oauth-launcher.ts
+++ b/apps/desktop/src/main/services/oauth-launcher.ts
@@ -28,6 +28,7 @@ import {
  */
 const pendingStateByBackendProfile = new Map<string, string>();
 const pendingStateByBackendConnection = new Map<string, string>();
+const activeLaunchesByBackendProfile = new Set<string>();
 
 function pendingAuthKey(backendName: string, profileName?: string): string {
   return `${backendName}\0${profileName ?? ''}`;
@@ -35,6 +36,10 @@ function pendingAuthKey(backendName: string, profileName?: string): string {
 
 function pendingConnectionAuthKey(backendName: string, connectionId: string): string {
   return `${backendName}\0connection\0${connectionId}`;
+}
+
+function hasPendingProfileLaunch(authKey: string): boolean {
+  return activeLaunchesByBackendProfile.has(authKey) || pendingStateByBackendProfile.has(authKey);
 }
 
 export function getPendingAuthState(backendName: string, profileName?: string): string | null {
@@ -105,9 +110,21 @@ export interface ConnectionLauncherOptions {
   abortSignal?: AbortSignal;
 }
 
+interface ProfileStatusPollOptions {
+  backendName: string;
+  profileName?: string;
+  statusUrl: string;
+  fetchImpl: typeof fetch;
+  headers?: Record<string, string>;
+  pollIntervalMs: number;
+  timeoutMs: number;
+  abortSignal?: AbortSignal;
+}
+
 export function clearPendingOAuthStates(): void {
   pendingStateByBackendProfile.clear();
   pendingStateByBackendConnection.clear();
+  activeLaunchesByBackendProfile.clear();
 }
 
 export async function runOAuthLauncher(opts: LauncherOptions): Promise<LauncherResult> {
@@ -126,64 +143,87 @@ export async function runOAuthLauncher(opts: LauncherOptions): Promise<LauncherR
   const startUrl = `${opts.sfBaseUrl}/${opts.backendName}/auth/start${query}`;
   const statusUrl = `${opts.sfBaseUrl}/${opts.backendName}/auth/status${query}`;
   if (opts.abortSignal?.aborted) return cancelledResult();
+  const authKey = pendingAuthKey(opts.backendName, opts.profileName);
+  if (hasPendingProfileLaunch(authKey)) {
+    return {
+      kind: 'failed',
+      reason: 'gateway_error',
+      message: 'OAuth launch already pending for this backend/profile',
+    };
+  }
+  activeLaunchesByBackendProfile.add(authKey);
 
-  console.log(`[oauth-launcher] POST ${startUrl}`);
-  let startResp: Response;
   try {
-    startResp = await fetchImpl(startUrl, {
-      method: 'POST',
-      headers: opts.headers,
-      ...abortFetchInit(opts.abortSignal),
-    });
-  } catch (e) {
-    if (isAbortError(e, opts.abortSignal)) return cancelledResult();
-    console.log(`[oauth-launcher] start fetch threw:`, e);
-    return { kind: 'failed', reason: 'network_error', message: String(e) };
-  }
-  console.log(`[oauth-launcher] start status=${startResp.status}`);
-  if (!startResp.ok) {
-    let body = '';
+    console.log(`[oauth-launcher] POST ${startUrl}`);
+    let startResp: Response;
     try {
-      body = await startResp.text();
-    } catch {
-      /* ignore */
+      startResp = await fetchImpl(startUrl, {
+        method: 'POST',
+        headers: opts.headers,
+        ...abortFetchInit(opts.abortSignal),
+      });
+    } catch (e) {
+      if (isAbortError(e, opts.abortSignal)) return cancelledResult();
+      console.log(`[oauth-launcher] start fetch threw:`, e);
+      return { kind: 'failed', reason: 'network_error', message: String(e) };
     }
-    console.log(`[oauth-launcher] start body=${body.slice(0, 500)}`);
-    return {
-      kind: 'failed',
-      reason: 'gateway_error',
-      message: `start returned ${startResp.status}: ${body.slice(0, 200)}`,
-    };
-  }
-  const startBody = (await startResp.json()) as { authorize_url?: string; state?: string };
-  if (
-    !startBody.authorize_url ||
-    !isAllowedOAuthAuthorizeUrl(startBody.authorize_url, {
-      allowedRedirectPorts: opts.allowedOAuthRedirectPorts,
-    })
-  ) {
-    return {
-      kind: 'failed',
-      reason: 'gateway_error',
-      message: 'blocked unexpected OAuth authorize URL',
-    };
-  }
-  if (startBody.state) {
-    pendingStateByBackendProfile.set(
-      pendingAuthKey(opts.backendName, opts.profileName),
-      startBody.state,
-    );
-  }
-  if (opts.abortSignal?.aborted) return cancelledResult();
-  console.log(`[oauth-launcher] opening browser for ${opts.backendName}`);
-  await shell.openExternal(startBody.authorize_url);
+    console.log(`[oauth-launcher] start status=${startResp.status}`);
+    if (!startResp.ok) {
+      let body = '';
+      try {
+        body = await startResp.text();
+      } catch {
+        /* ignore */
+      }
+      console.log(`[oauth-launcher] start body=${body.slice(0, 500)}`);
+      return {
+        kind: 'failed',
+        reason: 'gateway_error',
+        message: `start returned ${startResp.status}: ${body.slice(0, 200)}`,
+      };
+    }
+    const startBody = (await startResp.json()) as { authorize_url?: string; state?: string };
+    if (
+      !startBody.authorize_url ||
+      !isAllowedOAuthAuthorizeUrl(startBody.authorize_url, {
+        allowedRedirectPorts: opts.allowedOAuthRedirectPorts,
+      })
+    ) {
+      return {
+        kind: 'failed',
+        reason: 'gateway_error',
+        message: 'blocked unexpected OAuth authorize URL',
+      };
+    }
+    if (startBody.state) {
+      pendingStateByBackendProfile.set(authKey, startBody.state);
+    }
+    if (opts.abortSignal?.aborted) return cancelledResult();
+    console.log(`[oauth-launcher] opening browser for ${opts.backendName}`);
+    await shell.openExternal(startBody.authorize_url);
 
-  const deadline = Date.now() + timeoutMs;
+    return await pollProfileOAuthStatus({
+      backendName: opts.backendName,
+      profileName: opts.profileName,
+      headers: opts.headers,
+      abortSignal: opts.abortSignal,
+      statusUrl,
+      fetchImpl,
+      pollIntervalMs,
+      timeoutMs,
+    });
+  } finally {
+    activeLaunchesByBackendProfile.delete(authKey);
+  }
+}
+
+async function pollProfileOAuthStatus(opts: ProfileStatusPollOptions): Promise<LauncherResult> {
+  const deadline = Date.now() + opts.timeoutMs;
   let networkBlips = 0;
   while (Date.now() < deadline) {
     let statusResp: Response;
     try {
-      statusResp = await fetchImpl(statusUrl, {
+      statusResp = await opts.fetchImpl(opts.statusUrl, {
         headers: opts.headers,
         ...abortFetchInit(opts.abortSignal),
       });
@@ -193,7 +233,9 @@ export async function runOAuthLauncher(opts: LauncherOptions): Promise<LauncherR
       if (networkBlips >= 5) {
         return { kind: 'failed', reason: 'network_error' };
       }
-      if ((await sleep(pollIntervalMs, opts.abortSignal)) === 'aborted') return cancelledResult();
+      if ((await sleep(opts.pollIntervalMs, opts.abortSignal)) === 'aborted') {
+        return cancelledResult();
+      }
       continue;
     }
     networkBlips = 0;
@@ -215,7 +257,8 @@ export async function runOAuthLauncher(opts: LauncherOptions): Promise<LauncherR
     if (body.state === 'error') {
       return { kind: 'failed', reason: 'provider_error', message: body.error };
     }
-    if ((await sleep(pollIntervalMs, opts.abortSignal)) === 'aborted') return cancelledResult();
+    if ((await sleep(opts.pollIntervalMs, opts.abortSignal)) === 'aborted')
+      return cancelledResult();
   }
   return { kind: 'failed', reason: 'timeout' };
 }

--- a/apps/server/src/screamingface/plugins/llm_base/aigw_token_source.py
+++ b/apps/server/src/screamingface/plugins/llm_base/aigw_token_source.py
@@ -84,6 +84,10 @@ class AigwTokenSource:
         self._cache = None
 
     @property
+    def cached_expires_at(self) -> datetime | None:
+        return self._cache.expires_at if self._cache is not None else None
+
+    @property
     def connection_id(self) -> str:
         return self._connection_id
 

--- a/apps/server/src/screamingface/plugins/llm_base/oauth_base.py
+++ b/apps/server/src/screamingface/plugins/llm_base/oauth_base.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import asyncio
 from abc import abstractmethod
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from screamingface.plugins.llm_base.aigw_token_source import AigwTokenSource
 from screamingface.plugins.llm_base.auth_base import AuthStrategy
@@ -50,6 +50,7 @@ class OAuthStrategy(AuthStrategy):
 
     def __init__(self, *, aigw_source: AigwTokenSource | None = None) -> None:
         self._cached: dict | None = None
+        self._cached_aigw_expires_at: datetime | None = None
         self._lock = asyncio.Lock()
         self._aigw_source = aigw_source
 
@@ -63,7 +64,11 @@ class OAuthStrategy(AuthStrategy):
             return override
 
         if self._aigw_source is not None:
-            self._cached = await self._fetch_via_aigw()
+            if self._cached is not None and self._is_aigw_cache_fresh():
+                return self._build_headers(self._cached)
+            async with self._lock:
+                if self._cached is None or not self._is_aigw_cache_fresh():
+                    self._cached = await self._fetch_via_aigw()
             return self._build_headers(self._cached)
 
         # Fast path: cache hit, still fresh.
@@ -98,6 +103,7 @@ class OAuthStrategy(AuthStrategy):
     def invalidate_cache(self) -> None:
         """Drop in-memory state. The next header build re-reads the store."""
         self._cached = None
+        self._cached_aigw_expires_at = None
         if self._aigw_source is not None and hasattr(self._aigw_source, "invalidate_cache"):
             self._aigw_source.invalidate_cache()
 
@@ -118,8 +124,25 @@ class OAuthStrategy(AuthStrategy):
     async def _fetch_via_aigw(self) -> dict:
         assert self._aigw_source is not None
         token = await self._aigw_source.fetch_token()
-        placeholder_expiry = datetime.now(UTC).replace(microsecond=0)
-        return self._aigw_creds_shape(token, placeholder_expiry)
+        expires_at = self._aigw_source_expires_at()
+        self._cached_aigw_expires_at = expires_at
+        return self._aigw_creds_shape(token, expires_at or datetime.now(UTC).replace(microsecond=0))
+
+    def _aigw_source_expires_at(self) -> datetime | None:
+        assert self._aigw_source is not None
+        expires_at = getattr(self._aigw_source, "cached_expires_at", None)
+        if not isinstance(expires_at, datetime):
+            return None
+        if expires_at.tzinfo is None:
+            return expires_at.replace(tzinfo=UTC)
+        return expires_at
+
+    def _is_aigw_cache_fresh(self) -> bool:
+        if self._cached_aigw_expires_at is None:
+            return False
+        return self._cached_aigw_expires_at - datetime.now(UTC) > timedelta(
+            seconds=self.refresh_window_seconds
+        )
 
     def _aigw_creds_shape(self, access_token: str, expires_at: datetime) -> dict:
         """Translate aigw token response → provider-shaped creds dict.

--- a/apps/server/src/screamingface/plugins/llm_base/tests/test_oauth_base_aigw.py
+++ b/apps/server/src/screamingface/plugins/llm_base/tests/test_oauth_base_aigw.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock
 
 import pytest
@@ -53,6 +53,32 @@ async def test_aigw_source_remains_authoritative_for_each_header_request():
     assert first == {"Authorization": "Bearer aigw-token-1"}
     assert second == {"Authorization": "Bearer aigw-token-2"}
     assert fake_source.fetch_token.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_aigw_source_expiry_restores_strategy_fast_path():
+    class _ExpiringSource(AigwTokenSource):
+        def __init__(self) -> None:
+            self.calls = 0
+            self.expires_at = datetime.now(UTC) + timedelta(hours=1)
+
+        async def fetch_token(self) -> str:
+            self.calls += 1
+            return f"aigw-token-{self.calls}"
+
+        @property
+        def cached_expires_at(self) -> datetime | None:
+            return self.expires_at
+
+    source = _ExpiringSource()
+    strat = _FakeStrategy(aigw_source=source)
+
+    first = await strat.get_authorization_header()
+    second = await strat.get_authorization_header()
+
+    assert first == {"Authorization": "Bearer aigw-token-1"}
+    assert second == {"Authorization": "Bearer aigw-token-1"}
+    assert source.calls == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description
Stabilizes OAuth launch concurrency and AIGW token caching for SF-334.

- Rejects duplicate desktop OAuth launches for the same backend/profile before a second `/auth/start` can overwrite pending manual-auth state.
- Preserves the original pending state so the paste-code flow remains predictable after duplicate-launch attempts.
- Exposes the cached AIGW token expiry to the server-side OAuth strategy.
- Restores a fresh-token fast path for AIGW-backed server strategies, avoiding repeated token-source lock entry while the gateway token is still fresh.
- Adds regression coverage for duplicate launch behavior and AIGW expiry propagation.

## Affected Dependencies
None. No dependency additions or removals.

## How has this been tested?
- `cd apps/desktop && npx vitest run src/main/ipc/__tests__/backend-status-ipc.test.ts src/main/services/__tests__/oauth-launcher.test.ts`
- `cd apps/desktop && npx prettier --check src/main/services/oauth-launcher.ts src/main/services/__tests__/oauth-launcher.test.ts`
- `cd apps/desktop && npx eslint src/main/services/oauth-launcher.ts src/main/services/__tests__/oauth-launcher.test.ts src/main/ipc/__tests__/backend-status-ipc.test.ts`
- `cd apps/desktop && npm run build`
- `cd apps/server && uv run pytest src/screamingface/plugins/llm_base/tests src/screamingface/plugins/claude_backend_api/tests/test_auth.py src/screamingface/plugins/codex_backend_api/tests/test_auth.py src/screamingface/plugins/gemini_backend_api/tests/test_auth.py -q`
- `cd apps/server && uv run ruff check .`
- `cd apps/server && uv run ruff format --check .`
- `cd apps/server && uv run pyright`
- `cd apps/server && uv run pytest -m "not e2e and not e2e_live" -q`

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
