### PR TITLE
feat(aigateway): add Hugging Face provider (SF-345)

### DIFF
--- a/apps/aigateway/src/aigateway/plugins/huggingface_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/huggingface_provider/plugin.py
@@ -1,0 +1,105 @@
+"""Hugging Face provider plugin for the AI Gateway (SF-345).
+
+An API-key-only provider (no OAuth). Chat routes through LiteLLM's built-in
+``huggingface`` provider against the unified OpenAI-compatible router
+(``https://router.huggingface.co/v1``); the request-local HF token is injected by
+the gateway as ``body["api_key"]`` and never read from the process environment.
+
+Key design points (validated against litellm 1.87.0):
+- ``register_models`` emits ``huggingface/<org>/<model>:<provider>`` entries with the
+  router pinned as ``api_base``. Pinning ``api_base`` short-circuits litellm's
+  per-request provider-mapping fetch to ``huggingface.co`` (which would be
+  ``HUGGINGFACE_API_KEY``-env-keyed and ignore the request token).
+- ``prepare_chat_body`` injects that same ``api_base`` on dispatch (the default
+  ``chat_completion`` calls ``litellm.acompletion(**body)``, which does not read
+  ``register_models`` params) and strips any caller-supplied auth so only the
+  gateway-owned credential reaches upstream.
+- Only 401 marks the stored credential unusable; 403 is ambiguous (model-access vs
+  token permission) and must not nuke a valid key.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from aigateway.core.api_key_strategy import ApiKeyStrategy
+from aigateway.core.plugin_base import (
+    CredentialStrategy,
+    ModelEntry,
+    ProviderPluginBase,
+)
+
+from .settings import HuggingFacePluginSettings
+
+if TYPE_CHECKING:
+    from aigateway.core.credential_blob.store import CredentialBlobStore
+
+# Caller-supplied copies of these are stripped before the gateway injects its own
+# credential, so a client can never smuggle auth material to the upstream router.
+_CLIENT_AUTH_HEADER_NAMES = {"authorization", "x-api-key", "proxy-authorization"}
+
+
+def _credential_service_for(profile_name: str) -> str:
+    """Namespace the stored credential slot by provider + profile/connection."""
+    return f"aigateway:huggingface:{profile_name}"
+
+
+class HuggingFaceProviderPlugin(ProviderPluginBase[HuggingFacePluginSettings]):
+    custom_llm_provider = "huggingface"
+    settings_cls = HuggingFacePluginSettings
+
+    def register_models(self) -> list[ModelEntry]:
+        api_base = self.settings.router_api_base
+        return [
+            ModelEntry(model_name=slug, litellm_params={"model": slug, "api_base": api_base})
+            for slug in self.settings.default_models
+        ]
+
+    def supports_api_key(self) -> bool:
+        return True
+
+    def api_key_strategy_for(
+        self,
+        profile_name: str,
+        *,
+        credential_store: CredentialBlobStore | None = None,
+    ) -> CredentialStrategy:
+        return ApiKeyStrategy(
+            profile_name,
+            service=_credential_service_for(profile_name),
+            account="default",
+            header_builder=lambda api_key: {"Authorization": f"Bearer {api_key}"},
+            credential_store=credential_store,
+        )
+
+    def should_mark_profile_error_on_dispatch_status(self, status_code: int) -> bool:
+        # 401 => bad/missing token (invalidate). 403 is ambiguous (model-access vs
+        # token permission) and must not invalidate a valid stored credential.
+        return status_code == 401
+
+    def prepare_chat_body(self, body: dict[str, Any]) -> dict[str, Any]:
+        out = dict(body)
+        # The gateway owns the key; a caller copy would be overwritten by injection
+        # anyway, but drop it explicitly for defense in depth.
+        out.pop("api_key", None)
+        extra_headers = out.get("extra_headers")
+        if isinstance(extra_headers, dict):
+            sanitized = {
+                key: value
+                for key, value in extra_headers.items()
+                if str(key).lower() not in _CLIENT_AUTH_HEADER_NAMES
+            }
+            if sanitized:
+                out["extra_headers"] = sanitized
+            else:
+                out.pop("extra_headers", None)
+        elif "extra_headers" in out:
+            # A non-dict extra_headers would crash the downstream handler; drop it.
+            out.pop("extra_headers", None)
+        # Gateway-owned router base. routes/chat.py strips the caller's api_base
+        # first, then we set our own; this keeps litellm on the request-local path.
+        out["api_base"] = self.settings.router_api_base
+        return out
+
+
+PLUGIN = HuggingFaceProviderPlugin()

--- a/apps/aigateway/src/aigateway/plugins/huggingface_provider/settings.py
+++ b/apps/aigateway/src/aigateway/plugins/huggingface_provider/settings.py
@@ -1,0 +1,82 @@
+"""Configurable settings for the Hugging Face provider plugin (SF-345).
+
+Model seeds are ``list[str]`` (not ``list[ModelEntry]``) so the whole list is
+env-overridable as a JSON array via ``AIGW_HUGGINGFACE_DEFAULT_MODELS`` —
+pydantic-settings cannot deserialize a frozen ``ModelEntry`` dataclass from an
+env var. ``register_models`` turns each slug into a ``ModelEntry``.
+
+Every slug is validated to the router-suffix form ``huggingface/<org>/<model>``
+(optionally ``:<provider|policy>``). This rejects the unsafe provider-as-path-segment
+form ``huggingface/<provider>/<org>/<model>``, which sends a malformed id to the
+unified router and — without the pinned ``api_base`` — triggers an env-keyed
+``huggingface.co`` mapping lookup that ignores the per-request token.
+"""
+
+from __future__ import annotations
+
+from pydantic import Field, field_validator
+from pydantic_settings import SettingsConfigDict
+
+from aigateway.core.plugin_base import PluginSettings
+
+# Unified OpenAI-compatible router. Pinning this as api_base short-circuits
+# litellm's per-request provider-mapping fetch to huggingface.co.
+_ROUTER_API_BASE = "https://router.huggingface.co/v1"
+
+
+def _default_model_slugs() -> list[str]:
+    """Seed models in ``huggingface/<org>/<model>:<provider>`` router form.
+
+    Single source of truth for the SF model dropdown via ``GET /v1/models``
+    (SF-284), so it must NOT be copied SF-side. Verify live provider mappings
+    before relying on any seed (opt-in ``AIGW_LIVE`` test).
+    """
+    return [
+        "huggingface/openai/gpt-oss-120b:cerebras",
+        "huggingface/Qwen/Qwen3-Coder-480B-A35B-Instruct:novita",
+        "huggingface/deepseek-ai/DeepSeek-R1:novita",
+        "huggingface/google/gemma-2-2b-it:featherless-ai",
+        "huggingface/meta-llama/Llama-3.1-8B-Instruct:nscale",
+    ]
+
+
+def _validate_model_slug(slug: str) -> str:
+    """Enforce the safe router shape ``huggingface/<org>/<model>[:<provider|policy>]``.
+
+    The repo part (before any ``:``) must be exactly ``<org>/<model>`` — one ``/``.
+    Rejects the forbidden ``huggingface/<provider>/<org>/<model>`` path-segment form.
+    """
+    if not slug.startswith("huggingface/"):
+        raise ValueError(f"HF model must start with 'huggingface/': {slug!r}")
+    body = slug[len("huggingface/") :]
+    repo, sep, suffix = body.partition(":")
+    org, slash, model = repo.partition("/")
+    if not slash or not org or not model or "/" in model:
+        raise ValueError(
+            f"unsafe/malformed HF model {slug!r}: expected "
+            "'huggingface/<org>/<model>[:<provider>]'. The provider-as-path-segment "
+            "form 'huggingface/<provider>/<org>/<model>' is forbidden."
+        )
+    if sep and (not suffix or ":" in suffix or "/" in suffix):
+        raise ValueError(
+            f"malformed HF model {slug!r}: the ':<provider|policy>' suffix must be a "
+            "single non-empty token (e.g. ':novita')."
+        )
+    return slug
+
+
+class HuggingFacePluginSettings(PluginSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="AIGW_HUGGINGFACE_",
+        extra="ignore",
+        populate_by_name=True,
+    )
+
+    default_models: list[str] = Field(default_factory=_default_model_slugs)
+    router_api_base: str = _ROUTER_API_BASE
+
+    @field_validator("default_models")
+    @classmethod
+    def _validate_models(cls, value: list[str]) -> list[str]:
+        # Rejects unsafe/malformed entries (defaults AND env overrides) at construction.
+        return [_validate_model_slug(slug) for slug in value]

--- a/apps/aigateway/tests/unit/huggingface/test_huggingface_dispatch.py
+++ b/apps/aigateway/tests/unit/huggingface/test_huggingface_dispatch.py
@@ -1,0 +1,127 @@
+"""Dispatch-path hardening for the Hugging Face provider (SF-345).
+
+These lock the request-local invariants against litellm upgrades:
+- the pinned ``api_base`` short-circuits litellm's env-keyed provider-mapping fetch
+  (spying the call-site symbol, not ``common_utils``, because
+  ``chat/transformation.py`` imports the name into its own module namespace);
+- the injected per-request key wins over litellm's ``OPENAI_API_KEY`` /
+  ``litellm.api_key`` / ``litellm.openai_key`` fallbacks, and the gateway never
+  reaches those fallbacks (HF is not chatless);
+- the prepared body (api_base + gateway key) is what actually reaches
+  ``litellm.acompletion`` on both the sync and streaming paths.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import litellm
+import litellm.llms.huggingface.chat.transformation as hf_transformation
+import pytest
+from litellm.llms.huggingface.chat.transformation import HuggingFaceChatConfig
+
+from aigateway.plugins.huggingface_provider.plugin import PLUGIN
+
+_ROUTER = "https://router.huggingface.co/v1"
+_MODEL = "huggingface/deepseek-ai/DeepSeek-R1:novita"
+
+
+def test_pinned_api_base_short_circuits_provider_mapping() -> None:
+    # Spy the CALL-SITE binding: transformation.py does
+    # `from ..common_utils import _fetch_inference_provider_mapping`, so patching
+    # common_utils alone would not be observed by transform_request. (getattr keeps
+    # the dynamic access to litellm's private helper off pyright's private-import radar.)
+    getattr(hf_transformation, "_fetch_inference_provider_mapping").cache_clear()
+    cfg = HuggingFaceChatConfig()
+    with mock.patch.object(hf_transformation, "_fetch_inference_provider_mapping") as spy:
+        out = cfg.transform_request(
+            model="deepseek-ai/DeepSeek-R1:novita",  # post-'huggingface/'-strip form
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params={},
+            litellm_params={"api_base": _ROUTER},
+            headers={},
+        )
+    spy.assert_not_called()
+    # Model is passed through verbatim (no env-keyed remap to a providerId).
+    assert out["model"] == "deepseek-ai/DeepSeek-R1:novita"
+
+
+def test_complete_url_is_unified_router() -> None:
+    url = HuggingFaceChatConfig().get_complete_url(
+        api_base=_ROUTER,
+        api_key="hf_x",
+        model="deepseek-ai/DeepSeek-R1:novita",
+        optional_params={},
+        litellm_params={},
+    )
+    assert url == "https://router.huggingface.co/v1/chat/completions"
+
+
+def test_injected_key_wins_over_openai_env_poison(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-POISON")
+    monkeypatch.setattr(litellm, "api_key", None, raising=False)
+    monkeypatch.setattr(litellm, "openai_key", None, raising=False)
+    # The gateway passes the stored HF key as the per-request api_key; it must win.
+    assert HuggingFaceChatConfig.get_api_key("hf_stored") == "hf_stored"
+
+
+def test_get_api_key_falls_back_to_openai_env_when_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Documents the dangerous fallback: with NO per-request key, litellm would use
+    # OPENAI_API_KEY as the HF bearer. The gateway never hits this — it always
+    # injects the stored key, and HF is not chatless (see test below).
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-POISON")
+    monkeypatch.setattr(litellm, "api_key", None, raising=False)
+    monkeypatch.setattr(litellm, "openai_key", None, raising=False)
+    assert HuggingFaceChatConfig.get_api_key(None) == "sk-POISON"
+
+
+def test_plugin_disallows_keyless_dispatch() -> None:
+    # No stored profile/connection => the chat route 404s before dispatch, so the
+    # env-key fallback above is never reachable through the gateway.
+    assert PLUGIN.allows_chatless_profile() is False
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_forwards_prepared_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+
+    async def fake_acompletion(**kwargs):
+        captured.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+    # Mirror the route: prepare the body (injects api_base + strips caller auth),
+    # then inject the stored key exactly as routes/chat.py _inject_credentials does.
+    body = PLUGIN.prepare_chat_body(
+        {"model": _MODEL, "messages": [{"role": "user", "content": "hi"}]}
+    )
+    body["api_key"] = "hf_stored"
+
+    result = await PLUGIN.chat_completion(body)
+
+    assert result == {"ok": True}
+    assert captured["model"] == _MODEL
+    assert captured["api_base"] == _ROUTER
+    assert captured["api_key"] == "hf_stored"
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_stream_yields_chunks(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_stream():
+        yield "chunk-1"
+        yield "chunk-2"
+
+    async def fake_acompletion(**kwargs):
+        assert kwargs["api_base"] == _ROUTER
+        assert kwargs["api_key"] == "hf_stored"
+        return fake_stream()
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+    body = PLUGIN.prepare_chat_body({"model": _MODEL, "messages": [], "stream": True})
+    body["api_key"] = "hf_stored"
+
+    chunks = [chunk async for chunk in PLUGIN.chat_completion_stream(body)]
+
+    assert chunks == ["chunk-1", "chunk-2"]

--- a/apps/aigateway/tests/unit/huggingface/test_huggingface_gateway_acceptance.py
+++ b/apps/aigateway/tests/unit/huggingface/test_huggingface_gateway_acceptance.py
@@ -1,0 +1,68 @@
+"""End-to-end gateway acceptance for Hugging Face (SF-345).
+
+Proves the shared, provider-generic surfaces work for the new provider with NO
+per-provider route/table code:
+- ``GET /v1/models`` lists HF ids with ``owned_by == "huggingface"``;
+- ``POST /v1/oauth/connections/api-key`` creates an HF api-key connection and
+  writes the key to the same encrypted credential-blob slot the chat path reads,
+  never echoing it back.
+"""
+
+from __future__ import annotations
+
+import json
+
+from aigateway.core.oauth.store import credential_key_for
+from aigateway.plugins.huggingface_provider.plugin import _credential_service_for
+
+_HF_KEY = "hf_test_connection_key_1234567890"
+
+
+def test_models_lists_huggingface_owner(authenticated_client) -> None:
+    resp = authenticated_client.get("/v1/models")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()["data"]
+    owners = {entry["owned_by"] for entry in data}
+    assert "huggingface" in owners
+    hf_ids = [e["id"] for e in data if e["owned_by"] == "huggingface"]
+    assert hf_ids, "no huggingface models surfaced"
+    assert all(mid.startswith("huggingface/") for mid in hf_ids)
+    assert "huggingface/deepseek-ai/DeepSeek-R1:novita" in hf_ids
+
+
+def test_create_api_key_connection_for_huggingface(authenticated_client) -> None:
+    resp = authenticated_client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "huggingface", "api_key": _HF_KEY, "label": "my-hf-key"},
+    )
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["status"] == "active"
+    assert data["auth_type"] == "api_key"
+    assert data["provider"] == "huggingface"
+    assert data["label"] == "my-hf-key"
+    # The raw token must never be echoed back.
+    assert _HF_KEY not in resp.text
+
+
+def test_api_key_connection_without_label_succeeds(authenticated_client) -> None:
+    # HF does not require an up-front label (requires_oauth_connection_label() is False).
+    resp = authenticated_client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "huggingface", "api_key": _HF_KEY},
+    )
+    assert resp.status_code == 201, resp.text
+
+
+def test_key_written_to_chat_read_slot_encrypted(authenticated_client, credential_blobs) -> None:
+    resp = authenticated_client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "huggingface", "api_key": _HF_KEY, "label": "my-hf-key"},
+    )
+    data = resp.json()
+    # Same slot the chat path rebuilds: service = aigateway:huggingface:<account>:<conn>.
+    service = _credential_service_for(credential_key_for(data["account_id"], data["id"]))
+    decrypted = credential_blobs.read(service, "default")
+    assert json.loads(decrypted) == {"auth_type": "api_key", "api_key": _HF_KEY}
+    # At-rest ciphertext must not contain the plaintext token.
+    assert _HF_KEY not in (credential_blobs.read_raw(service, "default") or "")

--- a/apps/aigateway/tests/unit/huggingface/test_huggingface_provider.py
+++ b/apps/aigateway/tests/unit/huggingface/test_huggingface_provider.py
@@ -1,0 +1,147 @@
+"""Hugging Face provider plugin unit behavior (SF-345).
+
+Covers the contract a new api-key-only provider must satisfy: model registration
+in router-suffix form, the API-key credential strategy (Bearer header + stable
+credential slot), the no-OAuth shape, 401-only credential invalidation, and the
+``prepare_chat_body`` guarantees (caller-auth stripping + gateway-owned api_base).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from aigateway.core.api_key_strategy import ApiKeyStrategy
+from aigateway.plugins.huggingface_provider.plugin import (
+    PLUGIN,
+    HuggingFaceProviderPlugin,
+)
+
+_ROUTER = "https://router.huggingface.co/v1"
+
+
+class _FakeStore:
+    """Dict-backed CredentialBlobStore (Protocol) stand-in — no DB."""
+
+    def __init__(self, api_key: str) -> None:
+        self._blob = json.dumps({"auth_type": "api_key", "api_key": api_key})
+
+    async def read(self, service: str, account: str) -> str | None:
+        return self._blob
+
+    async def write(self, service: str, account: str, value: str) -> None: ...
+
+    async def delete(self, service: str, account: str) -> None: ...
+
+
+def test_plugin_identity() -> None:
+    assert isinstance(PLUGIN, HuggingFaceProviderPlugin)
+    assert PLUGIN.custom_llm_provider == "huggingface"
+    # credential namespace defaults to the provider id (name already matches)
+    assert PLUGIN.credential_service_provider() == "huggingface"
+
+
+def test_register_models_are_router_entries() -> None:
+    entries = PLUGIN.register_models()
+    assert entries, "must contribute at least one model"
+    for entry in entries:
+        assert entry.model_name.startswith("huggingface/")
+        # model_name and the litellm dispatch string are identical (:suffix slug)
+        assert entry.litellm_params["model"] == entry.model_name
+        # api_base pinned to the unified router -> keeps litellm request-local
+        assert entry.litellm_params["api_base"] == _ROUTER
+
+
+def test_supports_api_key() -> None:
+    assert PLUGIN.supports_api_key() is True
+
+
+def test_no_oauth_surface() -> None:
+    # Novel shape: api-key-only with NO OAuth. Core routes api_key without oauth_config.
+    assert PLUGIN.oauth_config() is None
+    assert PLUGIN.oauth_strategy_for("acct:conn") is None
+
+
+def test_streaming_enabled_by_default() -> None:
+    # Decision (SF-345): keep streaming on via the built-in litellm router path.
+    assert PLUGIN.supports_chat_streaming() is True
+
+
+@pytest.mark.parametrize(
+    ("status", "marks"),
+    [(401, True), (403, False), (429, False), (500, False), (200, False)],
+)
+def test_marks_credential_error_on_401_only(status: int, marks: bool) -> None:
+    # 401 => bad/missing token (invalidate). 403 is ambiguous (model access vs token),
+    # so it must NOT nuke the stored credential.
+    assert PLUGIN.should_mark_profile_error_on_dispatch_status(status) is marks
+
+
+def test_api_key_strategy_shape() -> None:
+    strategy = PLUGIN.api_key_strategy_for("acct:conn", credential_store=_FakeStore("hf_x"))
+    assert isinstance(strategy, ApiKeyStrategy)
+    assert strategy.credential_service() == "aigateway:huggingface:acct:conn"
+    assert strategy.credential_account() == "default"
+
+
+@pytest.mark.asyncio
+async def test_api_key_strategy_builds_bearer_header() -> None:
+    strategy = PLUGIN.api_key_strategy_for(
+        "acct:conn", credential_store=_FakeStore("hf_secrettoken")
+    )
+    headers = await strategy.get_authorization_header()
+    assert headers == {"Authorization": "Bearer hf_secrettoken"}
+
+
+def test_prepare_chat_body_injects_router_api_base() -> None:
+    out = PLUGIN.prepare_chat_body(
+        {"model": "huggingface/deepseek-ai/DeepSeek-R1:novita", "messages": []}
+    )
+    assert out["api_base"] == _ROUTER
+    # model keeps the 'huggingface/' prefix (litellm needs it to resolve the provider)
+    assert out["model"] == "huggingface/deepseek-ai/DeepSeek-R1:novita"
+
+
+def test_prepare_chat_body_overrides_caller_api_base() -> None:
+    out = PLUGIN.prepare_chat_body(
+        {"model": "huggingface/x/y:novita", "messages": [], "api_base": "http://evil.example"}
+    )
+    assert out["api_base"] == _ROUTER
+
+
+def test_prepare_chat_body_strips_caller_credentials() -> None:
+    out = PLUGIN.prepare_chat_body(
+        {
+            "model": "huggingface/x/y:novita",
+            "messages": [],
+            "api_key": "caller-key",
+            "extra_headers": {
+                "Authorization": "Bearer attacker",
+                "X-Api-Key": "attacker",
+                "proxy-authorization": "attacker",
+                "X-Trace": "keep-me",
+            },
+        }
+    )
+    assert "api_key" not in out
+    # only the non-auth header survives (case-insensitive strip of auth names)
+    assert out["extra_headers"] == {"X-Trace": "keep-me"}
+
+
+def test_prepare_chat_body_drops_all_auth_headers_leaves_none() -> None:
+    out = PLUGIN.prepare_chat_body(
+        {
+            "model": "huggingface/x/y:novita",
+            "messages": [],
+            "extra_headers": {"authorization": "Bearer x"},
+        }
+    )
+    assert "extra_headers" not in out
+
+
+def test_prepare_chat_body_drops_non_dict_extra_headers() -> None:
+    out = PLUGIN.prepare_chat_body(
+        {"model": "huggingface/x/y:novita", "messages": [], "extra_headers": "bogus"}
+    )
+    assert "extra_headers" not in out

--- a/apps/aigateway/tests/unit/huggingface/test_huggingface_settings.py
+++ b/apps/aigateway/tests/unit/huggingface/test_huggingface_settings.py
@@ -1,0 +1,82 @@
+"""Hugging Face provider settings: seed list + model-slug safety validator (SF-345).
+
+The validator is the guard that keeps env overrides on the request-local routing
+path. The unsafe provider-as-path-segment form
+``huggingface/<provider>/<org>/<model>`` sends a malformed id to the unified router
+(and, without the pinned ``api_base``, triggers an env-keyed huggingface.co mapping
+lookup that ignores the per-request token), so it must be rejected up front.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from aigateway.plugins.huggingface_provider.settings import (
+    HuggingFacePluginSettings,
+    _validate_model_slug,
+)
+
+
+def test_defaults_use_router_suffix_form() -> None:
+    settings = HuggingFacePluginSettings()
+    assert settings.default_models, "seed list must not be empty"
+    for slug in settings.default_models:
+        assert slug.startswith("huggingface/")
+        # provider is encoded as a ":suffix", never as a path segment
+        repo = slug[len("huggingface/") :].split(":", 1)[0]
+        assert repo.count("/") == 1, f"seed {slug!r} is not '<org>/<model>'"
+
+
+def test_router_api_base_default() -> None:
+    assert HuggingFacePluginSettings().router_api_base == "https://router.huggingface.co/v1"
+
+
+def test_validator_accepts_suffix_and_bare_forms() -> None:
+    assert (
+        _validate_model_slug("huggingface/deepseek-ai/DeepSeek-R1:novita")
+        == "huggingface/deepseek-ai/DeepSeek-R1:novita"
+    )
+    # bare '<org>/<model>' (router default provider) is also valid
+    assert _validate_model_slug("huggingface/openai/gpt-oss-120b")
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "huggingface/novita/deepseek-ai/DeepSeek-R1",  # provider-as-path-segment (forbidden)
+        "huggingface/org/model/extra",  # too many path segments
+        "huggingface/justmodel",  # missing '<org>/<model>' split
+        "openai/gpt-oss-120b",  # missing 'huggingface/' prefix
+        "huggingface/deepseek-ai/:novita",  # empty model
+        "huggingface/org/model:",  # empty provider/policy suffix
+        "huggingface/org/model::novita",  # malformed double-colon suffix
+    ],
+)
+def test_validator_rejects_unsafe_or_malformed(bad: str) -> None:
+    with pytest.raises(ValueError):
+        _validate_model_slug(bad)
+
+
+def test_env_override_accepts_valid_json_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "AIGW_HUGGINGFACE_DEFAULT_MODELS",
+        '["huggingface/deepseek-ai/DeepSeek-R1:novita", "huggingface/openai/gpt-oss-120b"]',
+    )
+    settings = HuggingFacePluginSettings()
+    assert settings.default_models == [
+        "huggingface/deepseek-ai/DeepSeek-R1:novita",
+        "huggingface/openai/gpt-oss-120b",
+    ]
+
+
+def test_env_override_rejects_unsafe_path_segment_form(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # An operator must not be able to silently reintroduce the unsafe routing form.
+    monkeypatch.setenv(
+        "AIGW_HUGGINGFACE_DEFAULT_MODELS",
+        '["huggingface/novita/deepseek-ai/DeepSeek-R1"]',
+    )
+    with pytest.raises(ValidationError):
+        HuggingFacePluginSettings()

--- a/apps/aigateway/tests/unit/test_plugin_loader.py
+++ b/apps/aigateway/tests/unit/test_plugin_loader.py
@@ -44,3 +44,17 @@ def test_loader_discovers_antigravity_provider() -> None:
     assert "antigravity/gemini-3-flash" in names
     for m in models:
         assert m.litellm_params["model"].startswith("antigravity/")
+
+
+def test_loader_discovers_huggingface_provider() -> None:
+    reg = ProviderRegistry()
+    load_plugins(reg)
+    plugin = reg.get("huggingface")
+    assert plugin is not None
+    assert plugin.custom_llm_provider == "huggingface"
+    models = plugin.register_models()
+    names = {m.model_name for m in models}
+    assert "huggingface/deepseek-ai/DeepSeek-R1:novita" in names
+    for m in models:
+        assert m.litellm_params["model"].startswith("huggingface/")
+        assert m.litellm_params["api_base"] == "https://router.huggingface.co/v1"

--- a/apps/aigateway/tests/unit/test_provider_supports_api_key.py
+++ b/apps/aigateway/tests/unit/test_provider_supports_api_key.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from aigateway.plugins.anthropic_provider.plugin import PLUGIN as ANTHROPIC
 from aigateway.plugins.codex_provider.plugin import PLUGIN as CODEX
 from aigateway.plugins.gemini_provider.plugin import PLUGIN as GEMINI
+from aigateway.plugins.huggingface_provider.plugin import PLUGIN as HUGGINGFACE
 from aigateway.plugins.ollama_provider.plugin import PLUGIN as OLLAMA
 
 
@@ -29,3 +30,8 @@ def test_codex_does_not_support_api_key() -> None:
 def test_ollama_does_not_support_api_key() -> None:
     # Ollama is local/no-auth; it does not take a provider API key.
     assert OLLAMA.supports_api_key() is False
+
+
+def test_huggingface_supports_api_key() -> None:
+    # Hugging Face is api-key-only (PAT); no OAuth in v1.
+    assert HUGGINGFACE.supports_api_key() is True

--- a/apps/desktop/src/main/services/backend-status.ts
+++ b/apps/desktop/src/main/services/backend-status.ts
@@ -59,6 +59,11 @@ export interface ProviderAuthStatus {
   provider: string;
   profile: string;
   state: 'authenticated' | 'pending' | 'missing_profile' | 'error';
+  // Capability flags mirrored from the server status (kept aligned with
+  // preload/types.ts). Passed through to the renderer, which gates the
+  // connection auth UI on them. Absent => api-key false / oauth true.
+  supports_api_key?: boolean;
+  supports_oauth?: boolean;
 }
 
 export interface BackendStatusV2 {

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -91,6 +91,10 @@ export interface ProviderAuthStatus {
   // Whether this provider accepts a raw API key (vs OAuth-only). The UI only
   // offers the API-key option where true. Absent => false (backward compat).
   supports_api_key?: boolean;
+  // Whether this provider offers browser OAuth. Absent => true (backward compat;
+  // every gateway backend except Hugging Face is OAuth-capable). When false, the
+  // connection UI defaults to and only offers the API-key flow.
+  supports_oauth?: boolean;
 }
 
 export interface BackendStatusV2 {

--- a/apps/desktop/src/renderer/src/components/server/BackendStatusPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/server/BackendStatusPanel.tsx
@@ -47,6 +47,7 @@ const backendLabels: Record<string, string> = {
   claude: 'Claude',
   codex: 'Codex',
   gemini: 'Gemini',
+  huggingface: 'Hugging Face',
 };
 
 function statusBackends(status: BackendStatusResponse): BackendStatusMap {
@@ -810,18 +811,31 @@ function ConnectionsSubPanel({
   name,
   requiresLabel,
   supportsApiKey,
+  supportsOauth,
   onSummaryChange,
 }: {
   name: string;
   requiresLabel: boolean;
   supportsApiKey: boolean;
+  supportsOauth: boolean;
   onSummaryChange?: (summary: ConnectionAuthSummary) => void;
 }) {
   const [connections, setConnections] = useState<OAuthConnection[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [adding, setAdding] = useState(false);
   const [label, setLabel] = useState('');
-  const [authType, setAuthType] = useState<'oauth' | 'api_key'>('oauth');
+  // HF-style api-key-only providers (supports_oauth=false) default to — and only
+  // offer — the API-key flow; OAuth-capable providers keep OAuth as the default.
+  const defaultAuthType: 'oauth' | 'api_key' = supportsOauth ? 'oauth' : 'api_key';
+  const [authType, setAuthType] = useState<'oauth' | 'api_key'>(defaultAuthType);
+  // Capabilities can resolve after mount (e.g. supports_oauth: false arrives on a
+  // later poll). Correct an auth type that is no longer offered so the hidden
+  // selector can't leave the submit path stuck on OAuth. Only fires when the
+  // current choice becomes invalid, so it never overrides a valid user selection.
+  useEffect(() => {
+    if (!supportsOauth && authType === 'oauth') setAuthType('api_key');
+    else if (!supportsApiKey && authType === 'api_key') setAuthType('oauth');
+  }, [supportsOauth, supportsApiKey, authType]);
   const [apiKey, setApiKey] = useState('');
   const [addError, setAddError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -970,7 +984,7 @@ function ConnectionsSubPanel({
             setAdding(false);
             setLabel('');
             setApiKey('');
-            setAuthType('oauth');
+            setAuthType(defaultAuthType);
             setNotice('API key saved.');
           } else {
             setAddError(
@@ -1029,7 +1043,7 @@ function ConnectionsSubPanel({
     setAdding(false);
     setLabel('');
     setApiKey('');
-    setAuthType('oauth');
+    setAuthType(defaultAuthType);
     setAddError(null);
   };
 
@@ -1051,7 +1065,7 @@ function ConnectionsSubPanel({
       ))}
       {adding && !oauthInFlight ? (
         <form onSubmit={onAdd} className="flex flex-wrap items-center gap-2 py-1.5">
-          {supportsApiKey && (
+          {supportsApiKey && supportsOauth && (
             <select
               value={authType}
               disabled={submitting || savingKey}
@@ -1255,6 +1269,7 @@ function BackendRow({
             name={name}
             requiresLabel={connectionRequiresLabel}
             supportsApiKey={providerAuth?.supports_api_key ?? false}
+            supportsOauth={providerAuth?.supports_oauth ?? true}
             onSummaryChange={setConnectionSummary}
           />
         ) : (

--- a/apps/desktop/src/renderer/src/components/server/__tests__/BackendStatusPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/components/server/__tests__/BackendStatusPanel.test.tsx
@@ -951,3 +951,73 @@ describe('BackendStatusPanel auth_kind=cli (regression)', () => {
     expect(listProfiles).not.toHaveBeenCalled();
   });
 });
+
+describe('BackendStatusPanel huggingface (api-key-only, SF-345)', () => {
+  const v2Huggingface = () => ({
+    version: 2,
+    gateway: {
+      mode: 'external',
+      managed_by_runner: false,
+      reachable: true,
+      authenticated: true,
+      auth_required: true,
+      url: 'https://gateway.example.com',
+    },
+    action: 'healthy',
+    backends: {
+      huggingface: {
+        authenticated: false,
+        action: 'reauth',
+        auth_kind: 'browser',
+        model: 'huggingface/deepseek-ai/DeepSeek-R1:novita',
+      },
+    },
+    provider_auth: {
+      providers: {
+        huggingface: {
+          provider: 'huggingface',
+          profile: 'default',
+          state: 'missing_profile',
+          supports_api_key: true,
+          supports_oauth: false,
+        },
+      },
+    },
+  });
+
+  it('renders the friendly "Hugging Face" display label', async () => {
+    getStatus.mockResolvedValue(v2Huggingface());
+    render(<BackendStatusPanel />);
+    expect(await screen.findByText('Hugging Face')).toBeTruthy();
+  });
+
+  it('defaults to API key and hides the OAuth option (no dead-end OAuth start)', async () => {
+    getStatus.mockResolvedValue(v2Huggingface());
+    render(<BackendStatusPanel />);
+    fireEvent.click(await screen.findByRole('button', { name: '+ Add Connection' }));
+    // api-key-only: no auth-type dropdown; the API key field is shown directly.
+    expect(screen.queryByLabelText('Authentication type')).toBeNull();
+    expect(screen.getByLabelText('API key')).toBeTruthy();
+  });
+
+  it('creates an api-key connection and never starts OAuth', async () => {
+    getStatus.mockResolvedValue(v2Huggingface());
+    render(<BackendStatusPanel />);
+    fireEvent.click(await screen.findByRole('button', { name: '+ Add Connection' }));
+    fireEvent.change(screen.getByPlaceholderText(/connection label/i), {
+      target: { value: 'work' },
+    });
+    fireEvent.change(screen.getByLabelText('API key'), {
+      target: { value: 'hf_secret_token_123456' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    await waitFor(() =>
+      expect(createConnectionApiKey).toHaveBeenCalledWith(
+        'huggingface',
+        'work',
+        'hf_secret_token_123456',
+      ),
+    );
+    expect(authenticateOAuthConnection).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/__tests__/referenced-backends.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/referenced-backends.test.ts
@@ -12,6 +12,9 @@ describe('referencedBackends', () => {
   it('finds antigravity backend references', () => {
     expect(referencedBackends('/antigravity($q)!answer')).toEqual(['antigravity']);
   });
+  it('finds huggingface backend references', () => {
+    expect(referencedBackends('/huggingface($q)!answer')).toEqual(['huggingface']);
+  });
   it('excludes /python and /data (non-auth, not model backends)', () => {
     expect(referencedBackends('/python(/data/code/check_correct.py)!{}')).toEqual([]);
   });

--- a/apps/desktop/src/renderer/src/lib/__tests__/url4-language.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/url4-language.test.ts
@@ -44,6 +44,7 @@ describe('registerUrl4Language', () => {
       .provideCompletionItems(model, position)
       .suggestions.map((s) => s.label);
     expect(labels).toContain('/antigravity');
+    expect(labels).toContain('/huggingface');
     expect(labels).toContain('/claude');
     expect(labels).toContain('/python');
     expect(labels).toContain('$prompt');

--- a/apps/desktop/src/renderer/src/lib/__tests__/url4-redaction.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/url4-redaction.test.ts
@@ -101,4 +101,8 @@ describe('deriveProviders', () => {
   it('detects antigravity', () => {
     expect(deriveProviders('/antigravity($prompt)!answer')).toEqual(['antigravity']);
   });
+
+  it('detects huggingface', () => {
+    expect(deriveProviders('/huggingface($prompt)!answer')).toEqual(['huggingface']);
+  });
 });

--- a/apps/desktop/src/renderer/src/lib/referenced-backends.ts
+++ b/apps/desktop/src/renderer/src/lib/referenced-backends.ts
@@ -1,8 +1,16 @@
 // Which auth-requiring model backends a url4 expression dispatches to, by
-// scanning for their call-paths (/claude, /codex, /gemini, /antigravity, /ollama). /python,
+// scanning for their call-paths (/claude, /codex, /gemini, /antigravity,
+// /huggingface, /ollama). /python,
 // /data and /private are intentionally excluded — no credentials / not models.
 // Mirrors the server's backend keying (backend_call_paths[0].lstrip('/')).
-const AUTH_BACKENDS = ['claude', 'codex', 'gemini', 'antigravity', 'ollama'] as const;
+const AUTH_BACKENDS = [
+  'claude',
+  'codex',
+  'gemini',
+  'antigravity',
+  'huggingface',
+  'ollama',
+] as const;
 export type BackendName = (typeof AUTH_BACKENDS)[number];
 
 export function referencedBackends(expression: string): BackendName[] {

--- a/apps/desktop/src/renderer/src/lib/url4-language.ts
+++ b/apps/desktop/src/renderer/src/lib/url4-language.ts
@@ -9,7 +9,15 @@ import type { Monaco } from '@monaco-editor/react';
 const LANGUAGE_ID = 'url4';
 
 // Backend dispatch paths and well-known variables/modifiers for autocomplete.
-const BACKENDS = ['/claude', '/codex', '/gemini', '/antigravity', '/python', '/ollama'];
+const BACKENDS = [
+  '/claude',
+  '/codex',
+  '/gemini',
+  '/antigravity',
+  '/huggingface',
+  '/python',
+  '/ollama',
+];
 const VARIABLES = ['$prompt', '$consensus', '$item.', '$var.'];
 const MODIFIERS = ['foreach.concurrency=', 'foreach.on_error=collect'];
 

--- a/apps/desktop/src/renderer/src/lib/url4-redaction.ts
+++ b/apps/desktop/src/renderer/src/lib/url4-redaction.ts
@@ -15,7 +15,14 @@
 
 const DATA_REF_RE = /\/data\/[A-Za-z0-9_./-]+/g;
 const REDACTED_REF = '/data/<redacted>';
-const KNOWN_PROVIDERS = ['claude', 'codex', 'gemini', 'antigravity', 'ollama'] as const;
+const KNOWN_PROVIDERS = [
+  'claude',
+  'codex',
+  'gemini',
+  'antigravity',
+  'huggingface',
+  'ollama',
+] as const;
 
 /** Every `/data/<ref>` segment in the expression (empty array if none). */
 export function findLocalDataRefs(expression: string): string[] {

--- a/apps/server/sf.json
+++ b/apps/server/sf.json
@@ -27,6 +27,7 @@
     "ollama-frontend",
     "aigw-base",
     "aigw-claude-backend",
+    "aigw-huggingface-backend",
     "aigw-runner",
     "state",
     "eval-runs"
@@ -87,6 +88,38 @@
       "auth_profile": "default",
       "default_model": "gemini-cli/gemini-2.5-flash-lite",
       "default_effort": "medium",
+      "interpreter_system_prompt": "You are a helpful assistant. Answer the user's question based only on the provided context. Be concise and factual.",
+      "timeout_seconds": 600,
+      "max_budget_usd": null,
+      "permission_mode": null,
+      "dangerously_skip_permissions": false,
+      "profiles": {
+        "default": {
+          "context": null,
+          "system_prompt": null,
+          "append_system_prompt": null,
+          "model": null,
+          "output_format": null,
+          "max_budget_usd": null,
+          "effort": null,
+          "tools": null,
+          "allowed_tools": null,
+          "disallowed_tools": null,
+          "mcp_config": null,
+          "permission_mode": null,
+          "add_dirs": null,
+          "fallback_model": null,
+          "dangerously_skip_permissions": false,
+          "no_session_persistence": true,
+          "timeout_seconds": null
+        }
+      },
+      "default_profile": "default"
+    },
+    "aigw-huggingface-backend": {
+      "gateway_url": "http://127.0.0.1:9105",
+      "auth_profile": "default",
+      "default_model": "huggingface/deepseek-ai/DeepSeek-R1:novita",
       "interpreter_system_prompt": "You are a helpful assistant. Answer the user's question based only on the provided context. Be concise and factual.",
       "timeout_seconds": 600,
       "max_budget_usd": null,

--- a/apps/server/src/screamingface/plugins/aigw_base/auth_proxy_router.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/auth_proxy_router.py
@@ -89,6 +89,7 @@ def build_aigw_auth_proxy_router(
     http_client_factory: HttpClientFactory | None = None,
     timeout_seconds: float = 10.0,
     defaults: dict[str, Any] | None = None,
+    include_oauth_routes: bool = True,
 ) -> APIRouter:
     """Build the SF-side proxy routes that drive the gateway OAuth flow.
 
@@ -386,6 +387,30 @@ def build_aigw_auth_proxy_router(
             json={"api_key": body.api_key},
         )
         return JSONResponse(content=resp.json(), status_code=resp.status_code)
+
+    if not include_oauth_routes:
+        # Providers with no gateway OAuth surface (e.g. Hugging Face, api-key only)
+        # would dead-end on every OAuth route. Keep only the api-key connection CRUD
+        # (list/get/delete/create-key/replace-key). Drop all profile/OAuth-start
+        # routes (they forward to /v1/auth/{provider}/*, for which HF has no router)
+        # AND the two connection routes that target OAuth-only gateway endpoints:
+        # POST /connections starts an OAuth cycle (rejected: provider_does_not_use_oauth)
+        # and /connections/{id}/refresh only refreshes OAuth tokens (rejected for api-key).
+        # (Rebuilding router.routes is the same mechanism the RouteRegistry uses to deactivate.)
+        connection_prefix = f"{path_prefix}/auth/connections"
+        oauth_only = {
+            ("POST", connection_prefix),
+            ("POST", f"{connection_prefix}/{{connection_id}}/refresh"),
+        }
+
+        def _is_api_key_route(route: Any) -> bool:
+            path = getattr(route, "path", "")
+            if not path.startswith(connection_prefix):
+                return False
+            methods = getattr(route, "methods", None) or set()
+            return all((method, path) not in oauth_only for method in methods)
+
+        router.routes = [route for route in router.routes if _is_api_key_route(route)]
 
     return router
 

--- a/apps/server/src/screamingface/plugins/aigw_base/backend.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/backend.py
@@ -145,13 +145,13 @@ class AigwBackend(Backend):
             return HealthStatus(
                 authenticated=False,
                 error=(
-                    "Multiple active OAuth connections exist; select one with the "
+                    "Multiple active connections exist; select one with the "
                     "backend auth_profile setting"
                 ),
             )
         return HealthStatus(
             authenticated=False,
-            error=f"No active OAuth connection named {self._profile_name!r}",
+            error=f"No active connection named {self._profile_name!r}",
         )
 
     async def run(

--- a/apps/server/src/screamingface/plugins/aigw_huggingface_backend/__init__.py
+++ b/apps/server/src/screamingface/plugins/aigw_huggingface_backend/__init__.py
@@ -1,0 +1,5 @@
+"""aigw-huggingface-backend: routes /huggingface through the AI Gateway."""
+
+from .plugin import AigwHuggingfaceBackendPlugin, AigwHuggingfaceBackendSettings
+
+__all__ = ["AigwHuggingfaceBackendPlugin", "AigwHuggingfaceBackendSettings"]

--- a/apps/server/src/screamingface/plugins/aigw_huggingface_backend/plugin.py
+++ b/apps/server/src/screamingface/plugins/aigw_huggingface_backend/plugin.py
@@ -1,0 +1,53 @@
+"""aigw-huggingface-backend plugin — Hugging Face served via the local AI Gateway."""
+
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import SettingsConfigDict
+
+from screamingface.plugins.aigw_base import (
+    AigwBackendApiPluginBase,
+    AigwBackendApiSettingsBase,
+)
+from screamingface.plugins.aigw_huggingface_backend.routes import create_router
+
+
+class AigwHuggingfaceBackendSettings(AigwBackendApiSettingsBase):
+    model_config = SettingsConfigDict(
+        env_prefix="SF_AIGW_HUGGINGFACE_BACKEND__",
+        env_nested_delimiter="__",
+    )
+
+    # `default_model` suggestions are derived live from the gateway's /v1/models
+    # registry by AigwBackendApiPluginBase.customize_schema (SF-284) — not copied
+    # here. Source of truth: apps/aigateway/.../huggingface_provider/settings.py.
+    default_model: str | None = Field(
+        default="huggingface/deepseek-ai/DeepSeek-R1:novita",
+        description=(
+            "Default Hugging Face model. The gateway routes by the 'huggingface/' "
+            "prefix; use the unified-router form 'huggingface/<org>/<model>:<provider>'. "
+            "Pick from the dropdown or type a custom slug the gateway already supports."
+        ),
+    )
+
+
+class AigwHuggingfaceBackendPlugin(AigwBackendApiPluginBase):
+    name = "aigw-huggingface-backend"
+    description = (
+        "Hugging Face served at /huggingface via the local AI Gateway. Auth "
+        "(API key/PAT), profile storage, and provider adaptation live in the "
+        "gateway; this plugin exposes the standard SF backend routes and the "
+        "browser-driven API-key connection proxy."
+    )
+    tags: list[str] = ["product:huggingface"]
+    backend_call_paths: list[str] = ["/huggingface"]
+    conflicts: list[str] = []
+    gateway_provider = "huggingface"
+    supports_api_key = True
+    # Hugging Face is API-key/PAT only — no browser OAuth. This drives the desktop
+    # connection UI to default to (and only offer) the API-key flow; without it the
+    # form would default to an OAuth 'Start' the gateway rejects for HF.
+    supports_oauth = False
+    settings_class = AigwHuggingfaceBackendSettings
+    schema_link_base = "/huggingface/"
+    create_router = staticmethod(create_router)

--- a/apps/server/src/screamingface/plugins/aigw_huggingface_backend/routes.py
+++ b/apps/server/src/screamingface/plugins/aigw_huggingface_backend/routes.py
@@ -1,0 +1,85 @@
+"""Routes for aigw-huggingface-backend."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from fastapi import APIRouter
+
+from screamingface.plugins.aigw_base import (
+    AigwBackend,
+    AigwInterpreter,
+    build_aigw_auth_proxy_router,
+    build_profile_defaults_from_settings,
+)
+from screamingface.plugins.aigw_base.config import resolve_aigw_runtime_config
+from screamingface.plugins.llm_base.routes_shared import (
+    BackendApiConfig,
+    build_backend_api_router,
+)
+
+if TYPE_CHECKING:
+    from screamingface.plugins.aigw_huggingface_backend.plugin import (
+        AigwHuggingfaceBackendSettings,
+    )
+
+_GATEWAY_PROVIDER = "huggingface"
+_PATH_PREFIX = "/huggingface"
+_DEFAULT_MODEL = "huggingface/deepseek-ai/DeepSeek-R1:novita"
+
+
+def create_router(
+    settings: AigwHuggingfaceBackendSettings,
+    app: Any = None,
+    *,
+    backend: AigwBackend | None = None,
+) -> APIRouter:
+    gateway_url = _gateway_url(app, settings.gateway_url)
+    backend = backend or AigwBackend(
+        gateway_url=gateway_url,
+        profile_name=settings.auth_profile,
+        gateway_provider=_GATEWAY_PROVIDER,
+        app=app,
+    )
+
+    def build_interpreter() -> Any:
+        return AigwInterpreter(
+            app=app,
+            settings=settings,
+            backend=backend,
+            gateway_provider=_GATEWAY_PROVIDER,
+        )
+
+    router = build_backend_api_router(
+        BackendApiConfig(
+            name="aigw-huggingface-backend",
+            path_prefix=_PATH_PREFIX,
+            default_model=_DEFAULT_MODEL,
+            backend=backend,
+            settings=settings,
+            app=app,
+            build_interpreter=build_interpreter,
+            span_prefix="aigw_huggingface",
+        )
+    )
+    profile_defaults = build_profile_defaults_from_settings(settings)
+    router.include_router(
+        build_aigw_auth_proxy_router(
+            path_prefix=_PATH_PREFIX,
+            gateway_url=gateway_url,
+            gateway_provider=_GATEWAY_PROVIDER,
+            profile_name=settings.auth_profile,
+            app=app,
+            defaults=profile_defaults or None,
+            # HF is api-key only: the gateway exposes no OAuth/profile auth router,
+            # so mount only the (working) api-key connection routes.
+            include_oauth_routes=False,
+        )
+    )
+    return router
+
+
+def _gateway_url(app: Any, fallback: str) -> str:
+    if app is None:
+        return fallback
+    return resolve_aigw_runtime_config(app).gateway_url

--- a/apps/server/src/screamingface/plugins/aigw_huggingface_backend/tests/test_auth_proxy_mount.py
+++ b/apps/server/src/screamingface/plugins/aigw_huggingface_backend/tests/test_auth_proxy_mount.py
@@ -1,0 +1,124 @@
+"""HF is API-key-only: the connection api-key proxy is the flow it actually uses.
+
+The gateway mounts a provider OAuth router only when ``plugin.auth_router()`` is set,
+and the HF provider has none — so ``/v1/auth/huggingface/*`` does not exist and the
+OAuth-start proxy path is a dead end for HF. The real path is the provider-generic
+api-key connection endpoint, which this asserts end to end (through the SF proxy).
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.routing import Route
+
+from screamingface.plugins.aigw_base import auth_proxy_router as apr
+from screamingface.plugins.aigw_huggingface_backend.plugin import (
+    AigwHuggingfaceBackendPlugin,
+    AigwHuggingfaceBackendSettings,
+)
+
+_HF_KEY = "hf_secret_token_1234567890"
+
+
+def test_mounts_api_key_connection_routes() -> None:
+    app = FastAPI()
+    settings = AigwHuggingfaceBackendSettings()
+    router = AigwHuggingfaceBackendPlugin.create_router(settings, app=app)
+    app.include_router(router)
+
+    routes = {
+        (method, r.path)
+        for r in app.routes
+        if isinstance(r, Route)
+        for method in (r.methods or set())
+    }
+    assert ("POST", "/huggingface/auth/connections/api-key") in routes
+    assert ("GET", "/huggingface/auth/connections") in routes
+
+
+def test_does_not_mount_dead_oauth_routes() -> None:
+    # HF has no gateway OAuth surface (the provider exposes no auth_router), so all
+    # OAuth routes would dead-end. Only the api-key connection CRUD is exposed —
+    # which also drops the two OAuth-only connection routes the gateway rejects for
+    # api-key providers (POST /connections starts an OAuth cycle; /refresh needs OAuth).
+    app = FastAPI()
+    settings = AigwHuggingfaceBackendSettings()
+    router = AigwHuggingfaceBackendPlugin.create_router(settings, app=app)
+    app.include_router(router)
+
+    routes = {
+        (method, r.path)
+        for r in app.routes
+        if isinstance(r, Route)
+        for method in (r.methods or set())
+    }
+    paths = {path for _, path in routes}
+
+    # Profile/OAuth-start proxy routes: not mounted.
+    assert "/huggingface/auth/start" not in paths
+    assert "/huggingface/auth/status" not in paths
+    assert "/huggingface/auth/profiles" not in paths
+    assert "/huggingface/auth/profiles/{name}" not in paths
+
+    # OAuth-only connection routes: not mounted (gateway rejects them for HF).
+    assert ("POST", "/huggingface/auth/connections") not in routes
+    assert ("POST", "/huggingface/auth/connections/{connection_id}/refresh") not in routes
+
+    # api-key connection CRUD: mounted.
+    assert ("GET", "/huggingface/auth/connections") in routes
+    assert ("GET", "/huggingface/auth/connections/{connection_id}") in routes
+    assert ("DELETE", "/huggingface/auth/connections/{connection_id}") in routes
+    assert ("POST", "/huggingface/auth/connections/api-key") in routes
+    assert ("PUT", "/huggingface/auth/connections/{connection_id}/api-key") in routes
+
+
+def test_create_api_key_connection_forwards_to_generic_gateway_endpoint() -> None:
+    settings = AigwHuggingfaceBackendSettings()
+    captured: dict = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/oauth/connections/api-key":
+            captured["url"] = str(req.url)
+            captured["body"] = json.loads(req.read().decode())
+            return httpx.Response(
+                201,
+                json={
+                    "id": "conn-1",
+                    "provider": "huggingface",
+                    "status": "active",
+                    "auth_type": "api_key",
+                },
+            )
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+
+    def http_factory(timeout: float) -> httpx.AsyncClient:
+        return httpx.AsyncClient(transport=transport, timeout=timeout)
+
+    original = apr._default_http_factory
+    apr._default_http_factory = http_factory  # type: ignore[assignment]
+    try:
+        app = FastAPI()
+        router = AigwHuggingfaceBackendPlugin.create_router(settings, app=app)
+        app.include_router(router)
+        response = TestClient(app).post(
+            "/huggingface/auth/connections/api-key",
+            json={"api_key": _HF_KEY, "label": "work"},
+        )
+        assert response.status_code == 201, response.text
+    finally:
+        apr._default_http_factory = original  # type: ignore[assignment]
+
+    # Provider is injected server-side and forwarded to the generic gateway endpoint
+    # (NOT /v1/auth/huggingface/*, which does not exist).
+    assert captured["url"].endswith("/v1/oauth/connections/api-key")
+    assert captured["body"]["provider"] == "huggingface"
+    assert captured["body"]["api_key"] == _HF_KEY
+    assert captured["body"]["label"] == "work"
+    # The raw key is never echoed back in the SF response.
+    assert _HF_KEY not in response.text

--- a/apps/server/src/screamingface/plugins/aigw_huggingface_backend/tests/test_plugin_metadata.py
+++ b/apps/server/src/screamingface/plugins/aigw_huggingface_backend/tests/test_plugin_metadata.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from screamingface.plugins.aigw_huggingface_backend.plugin import (
+    AigwHuggingfaceBackendPlugin,
+    AigwHuggingfaceBackendSettings,
+)
+
+
+def test_plugin_name_is_canonical() -> None:
+    assert AigwHuggingfaceBackendPlugin.name == "aigw-huggingface-backend"
+
+
+def test_plugin_grouped_under_huggingface_product_tag() -> None:
+    assert "product:huggingface" in AigwHuggingfaceBackendPlugin.tags
+    assert "product:aigw" not in AigwHuggingfaceBackendPlugin.tags
+
+
+def test_plugin_dependency_chain() -> None:
+    assert "aigw-base" in AigwHuggingfaceBackendPlugin.depends
+    assert "llm-base" in AigwHuggingfaceBackendPlugin.depends
+    assert "backend-api-base" in AigwHuggingfaceBackendPlugin.depends
+
+
+def test_plugin_has_no_legacy_conflict() -> None:
+    # No legacy direct huggingface-backend-api plugin exists.
+    assert AigwHuggingfaceBackendPlugin.conflicts == []
+
+
+def test_backend_call_paths_owns_canonical_huggingface_path() -> None:
+    assert AigwHuggingfaceBackendPlugin.backend_call_paths == ["/huggingface"]
+
+
+def test_plugin_declares_gateway_provider() -> None:
+    assert AigwHuggingfaceBackendPlugin.gateway_provider == "huggingface"
+
+
+def test_plugin_declares_api_key_capability() -> None:
+    # Drives the capability-driven desktop UI (api-key auth option).
+    assert AigwHuggingfaceBackendPlugin.supports_api_key is True
+
+
+def test_plugin_declares_no_oauth() -> None:
+    # HF is api-key-only; the desktop must default to the API-key flow, not OAuth.
+    assert AigwHuggingfaceBackendPlugin.supports_oauth is False
+
+
+def test_default_settings() -> None:
+    settings = AigwHuggingfaceBackendSettings()
+    assert settings.default_model == "huggingface/deepseek-ai/DeepSeek-R1:novita"
+    assert settings.gateway_url == "http://127.0.0.1:9105"
+    assert settings.auth_profile == "default"
+    assert settings.timeout_seconds == 300.0
+
+
+def test_settings_env_prefix(monkeypatch) -> None:
+    monkeypatch.setenv("SF_AIGW_HUGGINGFACE_BACKEND__AUTH_PROFILE", "work")
+    settings = AigwHuggingfaceBackendSettings()
+    assert settings.auth_profile == "work"

--- a/apps/server/src/screamingface/plugins/llm_base/routes.py
+++ b/apps/server/src/screamingface/plugins/llm_base/routes.py
@@ -220,6 +220,12 @@ def _provider_auth_status(app: Any, backends: dict[str, Any]) -> dict[str, Any]:
             # is to source this from the gateway (e.g. a provider-capabilities
             # endpoint) — deferred as a separate task; accepted tradeoff for now.
             "supports_api_key": bool(getattr(plugin, "supports_api_key", False)),
+            # Whether the provider offers browser OAuth. Defaults True (every
+            # gateway-backed backend today except Hugging Face is OAuth-capable);
+            # an api-key-only backend declares False so the desktop defaults to —
+            # and only offers — the API-key flow instead of dead-ending on an
+            # OAuth 'Start' the gateway rejects (no oauth_config).
+            "supports_oauth": bool(getattr(plugin, "supports_oauth", True)),
         }
     return providers
 
@@ -369,7 +375,9 @@ def _help_text(plugin: Any, health: dict[str, Any]) -> str | None:
         return "Backend rate limit reached. Capacity will reset automatically."
     if action == "reauth":
         if getattr(plugin, "gateway_provider", None):
-            return "OAuth profile is missing or expired. Click Authenticate to open a browser."
+            if getattr(plugin, "supports_oauth", True):
+                return "OAuth profile is missing or expired. Click Authenticate to open a browser."
+            return "API key is missing or invalid. Add a connection with your API key."
         command = getattr(plugin, "cli_auth_command", None)
         if isinstance(command, str):
             return f"Credential is missing or expired. Click Re-authenticate to run '{command}'."

--- a/apps/server/src/screamingface/plugins/llm_base/tests/test_backends_status_v2.py
+++ b/apps/server/src/screamingface/plugins/llm_base/tests/test_backends_status_v2.py
@@ -111,6 +111,54 @@ def test_provider_auth_status_exposes_supports_api_key() -> None:
     assert providers["ollama"]["supports_api_key"] is False
 
 
+def test_provider_auth_status_exposes_supports_oauth() -> None:
+    """The desktop reads supports_oauth to default/gate the OAuth option. An
+    api-key-only provider (huggingface) must report False so the connection UI does
+    not dead-end on an OAuth 'Start' the gateway rejects."""
+
+    def _plugin(provider, path, *, supports_oauth=None):
+        ns = SimpleNamespace(
+            gateway_provider=provider,
+            backend_call_paths=[path],
+            settings=SimpleNamespace(auth_profile="default"),
+        )
+        if supports_oauth is not None:
+            ns.supports_oauth = supports_oauth
+        return ns
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            plugins=SimpleNamespace(
+                active_plugins={
+                    "huggingface": _plugin("huggingface", "/huggingface", supports_oauth=False),
+                    # A plugin that never declares the attr defaults to True (OAuth-capable).
+                    "gemini": _plugin("gemini-cli", "/gemini"),
+                }
+            )
+        )
+    )
+
+    providers = status_routes._provider_auth_status(app, {})
+
+    assert providers["huggingface"]["supports_oauth"] is False
+    assert providers["gemini"]["supports_oauth"] is True
+
+
+def test_help_text_is_api_key_specific_for_oauthless_provider() -> None:
+    """An api-key-only provider (supports_oauth=False) must not tell users to
+    complete OAuth on reauth — the help must point at the API key instead."""
+    reauth = {"action": "reauth"}
+    oauth_plugin = SimpleNamespace(gateway_provider="anthropic")  # supports_oauth defaults True
+    apikey_plugin = SimpleNamespace(gateway_provider="huggingface", supports_oauth=False)
+
+    oauth_text = status_routes._help_text(oauth_plugin, reauth)
+    apikey_text = status_routes._help_text(apikey_plugin, reauth)
+
+    assert oauth_text is not None and "OAuth" in oauth_text
+    assert apikey_text is not None and "API key" in apikey_text
+    assert "OAuth" not in apikey_text
+
+
 def test_create_app_registers_validation_redactor() -> None:
     app = create_app(AppConfig(plugins=[]))
     assert RequestValidationError in app.exception_handlers


### PR DESCRIPTION
## Description
Adds Hugging Face as an API-key-only AIGateway provider and exposes it through the SF backend/Desktop connection flow.

- Registers Hugging Face router models with safe `huggingface/<org>/<model>:<provider>` slugs and a pinned router base.
- Stores Hugging Face PATs through the existing encrypted gateway API-key connection flow.
- Adds the SF `aigw-huggingface-backend` wrapper and exposes only working API-key connection routes.
- Updates Desktop provider capability handling so Hugging Face offers API-key auth without OAuth dead ends.

Task: SF-345

## Affected Dependencies
No new dependencies.

## How has this been tested?
- `cd apps/aigateway && uv run pytest -m "not live" -q`
- `cd apps/aigateway && uv run ruff check .`
- `cd apps/aigateway && uv run pyright`
- `cd apps/aigateway && uv run ruff format --check . && uv run python scripts/check_no_enterprise.py`
- `cd apps/server && uv run pytest -m "not e2e and not e2e_live" -q`
- `cd apps/server && uv run ruff check . && uv run ruff format --check .`
- `cd apps/desktop && npx vitest run`
- `cd apps/desktop && npm run build`
- `cd apps/desktop && npx eslint .`

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests