### PR TITLE
SF-347: working-in-this-repo skill, CODEOWNERS/PR enforcement, doc consolidation

### DIFF
--- a/.claude/skills/project-knowledge/SKILL.md
+++ b/.claude/skills/project-knowledge/SKILL.md
@@ -1,3 +1,8 @@
+---
+description: ScreamingFace product & domain knowledge — what the product is, the team, and the key concepts (url4, Enclave, Ensemble, SOTA, Gates). Use for product/domain context. For repo structure, CI, ownership, and the PR/merge process, use the working-in-this-repo skill instead.
+user_invocable: true
+---
+
 # ScreamingFace — Project Knowledge
 
 ## Product

--- a/.claude/skills/working-in-this-repo/SKILL.md
+++ b/.claude/skills/working-in-this-repo/SKILL.md
@@ -1,0 +1,80 @@
+---
+description: How to work in the ScreamingFace polyglot monorepo with many concurrent developers — which app/component a change belongs to, the per-stack toolchain (Python/Go/JS/TS), how to add a new app or shared package, which CI runs, who reviews, and the branch/commit/PR/merge/release rules. Use when starting any change here, when unsure where code goes, which tests or CI apply, who reviews, or how to open and merge a PR.
+user_invocable: true
+---
+
+# Working in this repo
+
+ScreamingFace is a **polyglot monorepo** worked on by 10+ developers concurrently. This skill is the **routing map**: given a change, it tells you which component you're in, the toolchain, the CI that will gate it, who reviews, and the branch/PR/release lane.
+
+> **This skill routes; it does not restate policy.** Process rules live in **`docs/team-development.md`** (the canonical process doc). Setup lives in **`CONTRIBUTING.md`**. Per-app guardrails live in each app's `CLAUDE.md`. When this skill and a canonical doc disagree, the canonical doc wins — fix the drift.
+
+## 1. Component taxonomy
+
+- **`apps/<name>`** — an independently deployable service or app. Has its own toolchain, lockfile, CI workflow, and release lane.
+- **`packages/<name>`** — a shared library consumed by **≥2** components; **not** independently deployed. (None exist yet — the convention is reserved. Put shared code here instead of importing one app's internals from another.)
+- **`web/`** — static site (`web/public/` → GitHub Pages; `web/portal/` leaderboard). No build toolchain.
+
+**Rule:** apps never import another app's internals. Cross-app sharing goes through `packages/` (or a stable HTTP contract). This keeps each app independently testable and releasable.
+
+## 2. Current apps — the routing table
+
+| Component | Stack | Run / test / lint / typecheck | Gating CI | Release lane | Key guardrails |
+|---|---|---|---|---|---|
+| `apps/server` | Python · uv · FastAPI (plugins, CLI `sf`) | `make run-server` · `make test-server` (`-fast` skips e2e) · `make test-e2e` · `make lint` · `make typecheck` | `server-tests.yml` + `pre-commit.yml` (pyright gate) | release-please → `server-v*` → `release-server.yml` (GHCR image + sf-installer mirror) | **Core must not import plugins.** New behavior = a plugin. Deprecated intercept plugins are off-limits (see root `CLAUDE.md`). |
+| `apps/aigateway` | Python · uv · FastAPI (LiteLLM) | `make run-aigateway` · `make test-aigateway` (`-fast`, `-live`) · `make check-no-enterprise` · `make lint` · `make typecheck` | `aigateway-tests.yml` (matrix 3.12/3.13) | release-please → `aigateway-v*` → `release-aigateway.yml` (GHCR image + Helm chart + mirror) | **Never import `litellm-enterprise`** (guarded). Credentials via ORMStore/Tortoise `credential_blobs`, **no OS keychain**; secrets AES-256-GCM; master key `AIGATEWAY_SECRET_KEY` never stored/logged. See `apps/aigateway/CLAUDE.md`. |
+| `apps/scoreboard` | Python · uv · FastAPI | `cd apps/scoreboard && uv run pytest` · `uv run ruff check .` · `uv run pyright` (not in the root Makefile) | `scoreboard-tests.yml` (also fires on `web/portal/**`) | **Manual** tag `scoreboard-v*` → `release-scoreboard.yml` (GHCR image + Helm; **not** in release-please) | Portal artifacts under `web/portal/` are covered by this workflow. |
+| `apps/desktop` | TS · npm · Electron + Vite | `cd apps/desktop && npm run dev` · `npx vitest run` · `npm run lint` · `npm run build` (no `test` npm script) | `desktop-tests.yml` | release-please → `desktop-v*` → `release-desktop.yml` (electron-builder artifacts + mirror) | Bundles `apps/server` + `apps/aigateway` **source** at build time. External HTTP (scoreboard/portal) must run in the Electron **main** process, not the renderer (CORS). |
+| `web/public` | Static HTML/CSS/JS | edit files directly | — | `deploy-website.yml` on push to `main` touching `web/public/**` (unversioned) | — |
+
+**Owner / reviewer per path:** see `.github/CODEOWNERS` (once added) or the **Cross-Service Collaboration** section of `docs/team-development.md`. This skill deliberately does not hardcode owners — read them from one place.
+
+## 3. Which CI runs on my PR?
+
+CI is **path-filtered**: a PR only triggers the workflow(s) for the paths it touches. A desktop-only PR runs `desktop-tests.yml`, not the Python suites. A PR touching two apps runs both. Each `<component>-tests.yml` also self-triggers when its own YAML changes.
+
+## 4. Adding a new component (any stack: Python / Go / JS / TS)
+
+Bring whatever stack fits; satisfy this **invariant contract** so the coordination machinery sees it:
+
+| Stack | Pkg manager | Layout | Lint | Typecheck | Test | CI: copy from | Release |
+|---|---|---|---|---|---|---|---|
+| Python | uv + hatchling | `src/<pkg>/` | ruff | pyright | pytest (+ markers) | `aigateway-tests.yml` | release-please `python`, or manual tag |
+| JS / TS | npm | `src/` | eslint | `tsc --noEmit` | vitest | `desktop-tests.yml` | release-please `node`, or manual tag |
+| Go | go modules | `cmd/` + `internal/` / `pkg/` | golangci-lint | `go vet` / build | `go test ./...` | new `go-<comp>-tests.yml` | release-please `go`, or manual tag |
+
+**7-step checklist for a new component:**
+1. Pick `apps/` (deployable) or `packages/` (shared lib).
+2. Self-contained toolchain + lockfile; no dependency on another app's internals.
+3. Add a path-filtered `.github/workflows/<component>-tests.yml` running that stack's lint + typecheck + test.
+4. Register a release lane — add to `release-please-config.json` **or** document a manual tag (or mark "not released").
+5. Add a `.github/CODEOWNERS` entry.
+6. Add the matching `dependabot.yml` ecosystem (`uv` / `npm` / `gomod`).
+7. Wire it into the root `Makefile` dispatcher.
+
+## 5. Where does my change belong? (core vs plugin)
+
+- **`apps/server`:** almost everything is a **plugin** under `src/screamingface/plugins/<name>/`. Core defines ports (registries); plugins implement them. **Core must not import plugins.** New CLI/route/hook/base-lib → a plugin (use the `create-plugin` skill). Never route new behavior through the deprecated `claude_intercept` / `mitmproxy_intercept` / `claude_env_intercept` shims.
+- **`apps/aigateway`:** new providers/secrets backends implement the port and register in the factory — never edit ORMStore. See `apps/aigateway/CLAUDE.md`.
+- **Shared logic used by ≥2 apps:** it belongs in `packages/`, not copied.
+
+## 6. Branch / commit / PR / merge — the 5-second version
+
+Full rules: **`docs/team-development.md`**. Quick reference:
+
+- **Branch:** `SF-{n}-{description}`, `n` = the Asana `SF` field (auto-assigned; don't invent one). Never commit to `main`.
+- **Commit:** `SF-N: summary` or `feat(SF-N): …`; put the Asana permalink in the body; **no `Co-Authored-By`** lines.
+- **Keep current:** rebase on `origin/main` (don't merge `main` into your branch); force-push only your own branch.
+- **Merge:** squash-merge; the author merges after review approval + green required checks.
+- **Checks are path-dependent.** Live tests (`AIGW_LIVE=1`, `e2e_live`) are opt-in diagnostics, **not** merge gates.
+- **WIP limit:** 2 tickets per dev (one coding, one in review).
+- **PR body:** Asana link · summary · test plan · screenshots for UI. If a PR spans two owners' areas, state the cross-service contract in the body.
+
+## 7. Pointers (single source of truth)
+
+- **Process policy:** `docs/team-development.md`
+- **Setup / run-from-source:** `CONTRIBUTING.md`
+- **Per-app guardrails:** `apps/*/CLAUDE.md`, `apps/server/CONTRIBUTING.md`
+- **Glossary / architecture:** `docs/GLOSSARY.md`, `docs/architecture/`
+- **Scaffold a server plugin:** the `create-plugin` skill
+- **Brand / UI law:** the `screamingface-design` skill

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,23 @@
+# CODEOWNERS — auto-requests reviewers by path.
+#
+# GitHub uses the LAST matching pattern, so broad defaults come first and specific
+# paths override them. Handles verified from repo contributors (2026-07). Keep in
+# sync with the "Cross-Service Collaboration" section of docs/team-development.md.
+
+# Default: shared areas (docs, root config, release glue) → both leads
+*                                @sergio-bershadsky @HupBaHa
+
+# Deployable apps
+/apps/server/                    @sergio-bershadsky
+/apps/desktop/                   @sergio-bershadsky
+/apps/aigateway/                 @HupBaHa
+/apps/scoreboard/                @HupBaHa
+
+# Web
+/web/portal/                     @bennettfarkas
+/web/public/                     @KyleNumann
+
+# CI / release configuration → both leads (flag changes in the PR body)
+/.github/                        @sergio-bershadsky @HupBaHa
+/release-please-config.json      @sergio-bershadsky @HupBaHa
+/.release-please-manifest.json   @sergio-bershadsky @HupBaHa

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,15 @@ updates:
       aigateway-python:
         patterns: ["*"]
 
+  - package-ecosystem: "uv"
+    directory: "/apps/scoreboard"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      scoreboard-python:
+        patterns: ["*"]
+
   - package-ecosystem: "npm"
     directory: "/apps/desktop"
     schedule:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- What changed and why (1–3 sentences). -->
+
+**Asana:** <!-- paste the SF-N task permalink -->
+
+## Components touched
+
+<!-- e.g. apps/server, apps/desktop, web/portal — this drives which CI runs and who reviews. -->
+
+## Test plan
+
+<!-- Checks are path-dependent; see docs/team-development.md. List what you actually ran. -->
+
+- [ ] Ran the relevant `make` / app checks for the touched component(s)
+- [ ] Gateway request/refresh change → ran `make test-aigateway-live` locally
+- [ ] Screenshots / recording attached (UI changes)
+
+## Cross-service notes
+
+<!-- If this spans another owner's area, state the contract and @-mention them. -->

--- a/.github/workflows/aigateway-tests.yml
+++ b/.github/workflows/aigateway-tests.yml
@@ -10,6 +10,11 @@ on:
       - "apps/aigateway/**"
       - ".github/workflows/aigateway-tests.yml"
   workflow_dispatch:
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/desktop-tests.yml
+++ b/.github/workflows/desktop-tests.yml
@@ -10,6 +10,11 @@ on:
       - "apps/desktop/**"
       - ".github/workflows/desktop-tests.yml"
   workflow_dispatch:
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/scoreboard-tests.yml
+++ b/.github/workflows/scoreboard-tests.yml
@@ -18,6 +18,11 @@ on:
       - "output_artifacts/eval_results/livetruth-masking.dataset.jsonl"
       - ".github/workflows/scoreboard-tests.yml"
   workflow_dispatch:
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -10,6 +10,11 @@ on:
       - "apps/server/**"
       - ".github/workflows/server-tests.yml"
   workflow_dispatch:
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,6 @@
 {
   "apps/desktop": "0.3.0",
   "apps/server": "0.2.1",
-  "apps/aigateway": "0.2.0"
+  "apps/aigateway": "0.2.0",
+  "apps/scoreboard": "0.1.0"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,20 @@
 An AI ensemble system combining Claude Code, Gemini CLI, Codex, and Ollama to beat SOTA benchmarks. Users install it locally, it routes coding CLI prompts through the best available models, and they can share AI credits with friends. Built by OpenMined.
 
 ## Monorepo Structure
-- `web/` — static marketing website (leaderboard chart, install flow)
-- `app/` — local Electron desktop app
-- `cloud/` — cloud webapp (Gates/token sharing UI, leaderboards)
-- `personas/` — audience personas, research cohorts, and weighting guide
-- `brand/` — brand research (competitive landscape, design, SEO)
-- `docs/` — development plan, design guidance, internal docs
-  - **`docs/😱 Development Plan.docx`** — the original product development plan. Key reference for scope, phasing, and product decisions. A plain-text version is at `docs/devplan.txt`.
+
+Polyglot monorepo: each component is self-contained (own toolchain, lockfile, CI lane, release lane) and may be any stack (Python / Go / JS / TS).
+
+- `apps/` — independently deployable services & apps:
+  - `apps/server` — FastAPI localhost server + plugin system (Python, uv). CLI: `sf`.
+  - `apps/aigateway` — LiteLLM-based unified AI gateway (Python, uv).
+  - `apps/scoreboard` — benchmark scoreboard service (Python, uv).
+  - `apps/desktop` — Electron desktop app / control plane (TypeScript, npm).
+- `packages/` — shared libraries consumed by ≥2 components, **not** independently deployed (any stack; none exist yet — convention reserved to avoid cross-app coupling).
+- `web/` — static marketing site (`web/public/` → GitHub Pages) + leaderboard portal (`web/portal/`); no build toolchain.
+- `docs/` — architecture, setup, glossary, process docs, and superpowers plans/specs.
+- `infra/` — k3s / Kubernetes manifests. `scripts/`, `eval_scripts/` — repo-level tooling. `personas/` — audience & design personas.
+
+**Working across components** — which app to touch, which CI runs, who reviews, the branch/PR/release lane, and how to add a new component in any stack: see the **`working-in-this-repo`** skill (`.claude/skills/working-in-this-repo/`) and the canonical process doc `docs/team-development.md`.
 
 ## The Four App Screens
 - **Settings** — configure which AI models are in the ensemble
@@ -88,11 +95,10 @@ If a task involves copy, design, or positioning and you're unsure which audience
 ### Commit Rules
 
 - **Before every commit**, ask the user for the associated Asana ticket.
-- If no ticket exists, create one via the `/asana` command (default project `1213628819033917`), and set its `SF` custom field (GID `1213702745960748`) to the next sequential number.
-  - To find the next SF number: query project tasks with `opt_fields=custom_fields.display_value`, find the highest existing `SF-N` value, and use `N+1`.
+- If no ticket exists, create one via the `/asana` command (default project `1213628819033917`). The `SF` custom field (GID `1213703035415126`) is **auto-assigned** by an Asana rule — do **not** set it manually. Read the assigned `SF-N` back from the created task (poll its `custom_fields`) and use it for the branch name.
 - **Branch naming:** `SF-{n}-{description}` (e.g. `SF-22-fix-auth-bug`). Derive from the ticket's SF field value.
 - If on the wrong branch, ask to create/switch to the correct one before committing.
-- **Never commit directly to `main`** — the `.githooks/pre-commit` hook enforces this.
+- **Never commit directly to `main`** — enforced by branch protection (authoritative) plus a local pre-commit guard (`.githooks/pre-commit`, or the husky hook once desktop deps are installed).
 - Include the Asana task permalink in the commit message body.
 
 ## Planning Tickets
@@ -114,4 +120,4 @@ After cloning, activate the shared git hooks:
 git config core.hooksPath .githooks
 ```
 
-This enables the pre-commit hook that blocks direct commits to `main`.
+This enables the pre-commit hook that blocks direct commits to `main`. Note: if you develop the desktop app, `npm install` in `apps/desktop` makes husky take over `core.hooksPath` for the whole repo — the husky hook carries the same `main` guard plus the lint/format/type gates.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,8 +140,11 @@ that touch the gateway request/refresh path.
 
 - **Branch naming:** `SF-{n}-{description}` (e.g. `SF-344-contributing-guide`),
   where `{n}` is the ticket's `SF` number.
-- **Never commit directly to `main`.** The `.githooks/pre-commit` hook (enabled
-  by `git config core.hooksPath .githooks` above) blocks it.
+- **Never commit directly to `main`.** A local pre-commit guard blocks it —
+  `.githooks/pre-commit` (enabled by `git config core.hooksPath .githooks` above),
+  or the husky hook once you `npm install` in `apps/desktop` (husky then takes over
+  `core.hooksPath` for the whole repo). Branch protection on `main` is the
+  authoritative server-side gate.
 - **Conventional commits.** Use `feat:`, `fix:`, `docs:`, `chore:` etc. —
   release-please derives version bumps and changelogs from them (`feat:` → minor,
   `fix:` → patch; `docs:`/`chore:` don't bump). See "Cut a build" below.

--- a/apps/desktop/.husky/pre-commit
+++ b/apps/desktop/.husky/pre-commit
@@ -1,6 +1,16 @@
 # Husky owns core.hooksPath for the whole repo, so this script dispatches
 # every language's gates from one entrypoint.
 
+# Block direct commits to main. Because husky overrides core.hooksPath, the
+# standalone .githooks/pre-commit guard is inactive once desktop deps are
+# installed — so the guard must live here too. (Branch protection on main is the
+# authoritative server-side gate; this is just a fast local backstop.)
+branch="$(git symbolic-ref --short HEAD 2>/dev/null)"
+if [ "$branch" = "main" ]; then
+    echo "ERROR: Direct commits to 'main' are not allowed. Use an SF-{n} feature branch."
+    exit 1
+fi
+
 # JS/TS gates — lint-staged + eslint + prettier (only fires on staged JS/TS).
 ( cd apps/desktop && npx lint-staged ) || exit 1
 

--- a/docs/superpowers/plans/SF-347-repo-coordination-skill.md
+++ b/docs/superpowers/plans/SF-347-repo-coordination-skill.md
@@ -1,0 +1,172 @@
+# Plan: Multi-developer coordination — repo skill + enforcement + doc consolidation
+
+## Context
+
+ScreamingFace now has 10+ developers landing changes concurrently. The stated ask was to "define a way to
+separate our output" and encode it in a **Claude skill attached to the repo**, covering (1) the monorepo /
+app-package model, (2) how GitHub Actions are separated & identified, and (3) PR/merge policy.
+
+**Exploration finding that reframes the task:** ~70% of this already exists — it is *fragmented and
+unenforced*, not absent.
+
+- **PR/merge policy** already lives in `docs/team-development.md` (branching, PR lifecycle, per-path required
+  checks, cross-service ownership, WIP-limit-2, squash-merge, rebase-not-merge, quality gates).
+- **Actions are already separated** by path-filtered `<component>-tests.yml` + tag-triggered
+  `release-<component>.yml` + `release-please` per-component tags (`desktop-v*`, `server-v*`, `aigateway-v*`).
+- **Run-from-source / branch / commit conventions** live in root `CONTRIBUTING.md`.
+
+The problem at 10 devs is therefore **fragmentation + contradiction + no machine enforcement**:
+- Root `CLAUDE.md` monorepo section is **stale** (lists `app/`, `cloud/`, `brand/`; references a non-existent
+  `docs/devplan.txt`). Real layout is `apps/{server,desktop,aigateway,scoreboard}` + `web/`.
+- Git-hooks path is documented two incompatible ways (`.githooks` vs husky `apps/desktop/.husky/_`); the active
+  path is husky, which does **not** carry the "no direct commits to `main`" guard — so that guard is effectively
+  off.
+- Team roster differs between `CLAUDE.md` and the `project-knowledge` skill.
+- **No `CODEOWNERS`, no PR template, no merge queue, no concurrency groups** on test workflows.
+- `apps/scoreboard` is excluded from both `release-please` and `dependabot`.
+- `project-knowledge/SKILL.md` has **no frontmatter**, so Claude can't auto-discover it.
+
+**Intended outcome:** one discoverable guidance skill that *routes* (not duplicates), a thin machine-enforcement
+layer that actually protects `main`, and a single canonical process doc that the skill + all `CLAUDE.md` files
+point to.
+
+## Assumptions (defaults chosen — veto any before we start)
+
+The three scope questions went unanswered; proceeding on these defaults:
+
+1. **Scope = Skill + Enforcement + Consolidation** (the full three layers below).
+2. **Packages = polyglot component model (python/go/js/ts).** Per user directive, the monorepo model is
+   documented as a **stack-agnostic component contract**, not a hardcoded list of today's apps. Define both
+   `apps/<name>` (deployables) and `packages/<name>` (shared libs) as first-class, each of which may be
+   Python, Go, JS, or TS. This change **defines the convention** (directory taxonomy + per-stack toolchain/CI/
+   release contract) in the skill and canonical doc; it does **not** scaffold real shared libraries or migrate
+   the duplicated Python pins yet (that's a follow-up ticket). Note the DRY smell (`tortoise-orm[asyncpg]==1.1.7`
+   pinned independently across the Python apps) as the first candidate for a future `packages/py-*`.
+3. **Branch protection = ownership unknown → verify first.** The plan configures what we can and *documents the
+   desired branch-protection/merge-queue config as a request* if we don't hold admin.
+
+## Guiding principle
+
+**Single source of truth. The skill and every `CLAUDE.md` are pointers, never copies.** Any policy statement
+lives in exactly one file. This is the whole point — a sixth document that restates the other five is a
+regression.
+
+---
+
+## Layer 1 — Guidance skill (Claude-facing router)
+
+**Create `.claude/skills/working-in-this-repo/SKILL.md`** with proper triggering frontmatter
+(`name`, `description`, `user_invocable: true`). Description must fire on: "which app / where does this go /
+what CI runs / who reviews / how do I branch/commit/PR/release here."
+
+Content is a **router**, not a manual:
+- **Component taxonomy (stack-agnostic):**
+  - `apps/<name>` — an independently deployable service/app (has a release lane + image/installer).
+  - `packages/<name>` — a shared library consumed by ≥2 components, **not** independently deployed. (None exist
+    today; the convention is defined so a future shared lib in any stack lands cleanly.)
+  - `web/` — static site (no build toolchain).
+- **Current-apps router table** — one row per `apps/{server,desktop,aigateway,scoreboard}` + `web/`: path ·
+  stack · run/test/lint/typecheck (the `make` target) · gating CI workflow · owner/reviewer · release lane
+  (release-please component vs manual `scoreboard-v*` tag) · gotchas (aigateway no-Enterprise guard, credential
+  storage).
+- **Polyglot per-stack contract** — the invariant every new component must satisfy, one row per stack:
+
+  | Stack | Pkg manager | Layout | Lint | Typecheck | Test | CI pattern | Release lane |
+  |-------|-------------|--------|------|-----------|------|-----------|--------------|
+  | Python | uv + hatchling | `src/<pkg>/` | ruff | pyright | pytest (+ markers) | copy `aigateway-tests.yml` | release-please `python`, or manual tag |
+  | JS/TS | npm | `src/` | eslint | `tsc --noEmit` | vitest | copy `desktop-tests.yml` | release-please `node`, or manual tag |
+  | Go | go modules | `cmd/` + `internal/`/`pkg/` | golangci-lint | `go vet` / build | `go test ./...` | new `go-<comp>-tests.yml` | release-please `go`, or manual tag |
+
+- **"Adding a new component (any stack)" checklist** — the 7 things that make it visible to the coordination
+  machinery: (1) pick `apps/` vs `packages/`; (2) self-contained toolchain + lockfile, no dep on another app's
+  internals (depend only via `packages/`); (3) add a path-filtered `<component>-tests.yml`; (4) register a
+  release lane (or mark "not released"); (5) add a CODEOWNERS entry; (6) add the matching dependabot ecosystem
+  (uv/npm/gomod); (7) wire into the root `Makefile`.
+- **"Which layer does my change belong to?"** — core vs plugin decision per the hexagonal rules already in
+  `CLAUDE.md` (core must not import plugins); route new gateway behavior to active frontend plugins, never the
+  deprecated intercept shims.
+- **5-second branch/commit/PR/merge rules** inline, each linking to the canonical doc for the full version.
+- Explicit links to `docs/team-development.md`, `CONTRIBUTING.md`, per-app `CLAUDE.md`.
+
+Decide `project-knowledge/SKILL.md`'s fate: **merge it into this skill** (preferred) or give it frontmatter so
+it's discoverable. Do not leave two overlapping knowledge skills.
+
+## Layer 2 — Machine enforcement
+
+- **`.github/CODEOWNERS`** — encode the informal ownership from `docs/team-development.md`:
+  `apps/server/**` + `apps/desktop/**` → Sergey; `apps/aigateway/**` + `apps/scoreboard/**` + `web/portal/**` →
+  Dmitry; root/`docs/**`/`.github/**` → both. Enables auto review-request routing.
+- **`.github/pull_request_template.md`** — Asana permalink, summary, **which app(s) touched**, test plan,
+  screenshots, and a path-aware checklist (ran the relevant `make` checks; ran `make test-aigateway-live` if
+  gateway request/refresh changed).
+- **Concurrency groups** added to each `<component>-tests.yml`:
+  `concurrency: { group: ${{ github.workflow }}-${{ github.ref }}, cancel-in-progress: true }` — kills wasted CI
+  on rapid re-pushes (10 devs = many rapid pushes). Do **not** add to release workflows.
+- **Hooks fix** — the active hooksPath is husky. Fold the `.githooks/pre-commit` "no commits to `main`" guard
+  into `apps/desktop/.husky/pre-commit`, and correct `CONTRIBUTING.md` (stop instructing `git config
+  core.hooksPath .githooks`, which silently disables the husky suite). Note in the skill that hooks are
+  local-only; server-side protection is branch protection.
+- **Branch protection & merge queue** — verify admin access first. If we control it: require the per-path check
+  names, require branch up-to-date, enable **merge queue**. If org-owned: write the desired config as a request
+  in `docs/team-development.md`.
+
+> **⚠ Gotcha to design around (this bites hard at 10 devs):** GitHub branch-protection **required checks +
+> path-filtered workflows deadlock**. A required check whose workflow is skipped (paths didn't match) never
+> reports success, so the PR can never merge. Two viable fixes — pick one in implementation:
+> (a) a tiny always-runs "changes-detected" dispatcher job per component that reports the required status, or
+> (b) rely on **merge queue**, which treats a skipped required check as passing. This choice is load-bearing;
+> flag it explicitly when we implement.
+
+## Layer 3 — Consolidation (delete & point)
+
+- Designate **`docs/team-development.md` as the single canonical process doc.**
+- **Fix root `CLAUDE.md`** — replace the stale monorepo section with the real `apps/*` + `web/` layout; drop the
+  `docs/devplan.txt` / `app/` / `cloud/` / `brand/` references; add one-line pointers to the canonical doc and
+  the new skill.
+- **Reconcile team rosters** across `CLAUDE.md` and `project-knowledge` (include Dmitry, Kyle consistently).
+- **Close the scoreboard drift** — add `apps/scoreboard` to `release-please-config.json` +
+  `.github/dependabot.yml`, **or** add a one-line "intentionally manual" note explaining the exclusion.
+- **Typecheck consistency** — either add `pyright` to `server-tests.yml`, or document that `pre-commit.yml` is
+  the authoritative server typecheck gate (today it's implicit).
+- **Resolve the stray `.claude/wf-sf295-300.js`** (untracked stacked-PR orchestration script) — move to a
+  `.claude/workflows/` dir or `scripts/`, or delete. Decide whether stacked PRs are a sanctioned pattern and, if
+  so, add one line to the canonical doc.
+
+## Files to create / modify (representative)
+
+**Create:** `.claude/skills/working-in-this-repo/SKILL.md`, `.github/CODEOWNERS`,
+`.github/pull_request_template.md`.
+
+**Modify:** root `CLAUDE.md` (destale), `docs/team-development.md` (canonical + branch-protection config),
+`CONTRIBUTING.md` (hooks correction), `.github/workflows/{server,aigateway,desktop,scoreboard}-tests.yml`
+(concurrency), `apps/desktop/.husky/pre-commit` (main-guard), `release-please-config.json` +
+`.github/dependabot.yml` (scoreboard), `.claude/skills/project-knowledge/SKILL.md` (merge or add frontmatter).
+
+## Out of scope (this change)
+
+- Introducing a shared `packages/` layer or a JS workspace (turbo/nx/pnpm) — assessment only, no code.
+- Rewriting per-app `CLAUDE.md` guardrails (aigateway secrets, server plugin contract) — the skill routes to
+  them unchanged.
+- Any change to the deprecated intercept plugins.
+
+## Verification
+
+- **Skill fires & routes:** in a fresh Claude Code session ask "where do I add an aigateway route / which CI
+  runs for a desktop-only PR / who reviews `apps/server` changes / how do I cut a scoreboard release" — confirm
+  the skill triggers and each answer matches the canonical doc.
+- **CODEOWNERS:** open a draft PR touching `apps/server/**`; confirm the correct owner is auto-requested.
+- **Required checks ≠ deadlock:** open a docs-only PR (no app paths) and confirm it can still merge under the
+  chosen dispatcher/merge-queue approach.
+- **Concurrency:** push twice quickly to a branch; confirm the first component-test run is cancelled.
+- **Hooks:** attempt `git commit` on `main`; confirm it's blocked under the active (husky) path.
+- **De-stale:** `grep -rn "devplan.txt\|^app/\|cloud/" CLAUDE.md` returns nothing; roster matches across files.
+
+## Sequencing
+
+1. Create SF-{n} ticket + branch (per repo rule; ask for/create Asana ticket before first commit).
+2. Mirror this plan to `docs/superpowers/plans/` per the repo planning convention (plan-mode currently restricts
+   edits to this plan file).
+3. Layer 3 consolidation first (removes contradictions before we point at anything).
+4. Layer 1 skill (points at the now-clean canonical doc).
+5. Layer 2 enforcement (CODEOWNERS, PR template, concurrency, hooks, branch protection).
+6. Verify per above; run relevant `make` checks; open PR.

--- a/docs/team-development.md
+++ b/docs/team-development.md
@@ -21,9 +21,10 @@ the source of truth when it is stricter than this document.
    the branch. Resolve conflicts locally, then push the rebased branch.
 6. Force-push is allowed only on your own PR branch after a rebase or cleanup.
    Do not force-push someone else's branch. Never force-push `main`.
-7. Direct commits to `main` are forbidden. Run `git config core.hooksPath .githooks`
-   once per checkout; `.githooks/pre-commit` blocks commits while the current
-   branch is `main`.
+7. Direct commits to `main` are forbidden, enforced in layers: branch protection
+   on `main` (authoritative), plus a local pre-commit guard — `.githooks/pre-commit`
+   (`git config core.hooksPath .githooks`), or the husky hook once you `npm install`
+   in `apps/desktop` (husky then owns `core.hooksPath` and carries the same guard).
 
 ## PR Lifecycle
 
@@ -49,10 +50,35 @@ the source of truth when it is stricter than this document.
    Asana moved to the right terminal state, and follow-up tickets filed for
    intentionally deferred work.
 8. PR descriptions must include the Asana link, a short summary, test plan, and
-   screenshots or recordings for UI changes. A template file is intentionally not
-   added yet; add one only if PR descriptions become inconsistent.
+   screenshots or recordings for UI changes. The template at
+   `.github/pull_request_template.md` prefills these fields.
 9. WIP limit is two tickets per developer: one actively coding and one waiting
    for review. Exceptions are allowed for urgent unblockers.
+
+## Branch Protection & Merge Queue
+
+Two-tier CI, so path-filtered checks never deadlock a merge:
+
+1. **On the PR** — the path-filtered `<component>-tests.yml` workflows run for
+   fast, relevant feedback. A workflow skipped by its `paths:` filter cannot report
+   a required status, so these are advisory, not the hard gate.
+2. **In the merge queue** — the same workflows also trigger on `merge_group` (no
+   path filter), so the full suite runs against the queued, rebased commit and must
+   pass before it lands. This is the authoritative gate, and the queue serializes
+   merges so `main` never breaks from stale-base races. Trade-off: every queued
+   merge runs all components' suites; add a `dorny/paths-filter` gate later if that
+   cost matters.
+
+Admin setup for `main` (one-time; needs repo admin — GitHub → Settings →
+Rules/Branches):
+
+- Require a PR before merging; require Code Owner approval.
+- Require status checks to pass and branches to be up to date.
+- Enable the merge queue for `main`.
+- Required checks = the `merge_group`-triggered test jobs (job `test` in each
+  `<component>-tests.yml`, matrix-expanded for aigateway: `test (3.12)`,
+  `test (3.13)`). Pick the exact contexts from a PR's checks list after the first
+  merge-queue run so the names match.
 
 ## Cross-Service Collaboration
 
@@ -60,11 +86,12 @@ the source of truth when it is stricter than this document.
    intermediate state. Split changes when they can land independently.
 2. Bias toward smaller PRs. If a change touches both Sergey-owned and
    Dmitry-owned areas, state the cross-service contract in the PR body.
-3. Informal ownership for now: Sergey owns `apps/server` and `apps/desktop`;
-   Dmitry owns `apps/aigateway` and future scoreboard/portal work; both own
-   `docs`, root files, workflows, and release glue.
-4. Do not add `.github/CODEOWNERS` yet. Add it after ownership stabilizes and
-   GitHub review routing would save more time than it costs.
+3. Ownership (routed by `.github/CODEOWNERS`): Sergey owns `apps/server` and
+   `apps/desktop`; Dmitry owns `apps/aigateway` and `apps/scoreboard`; Bennett owns
+   `web/portal`; Kyle owns `web/public` (marketing site); both leads own `docs`,
+   root files, workflows, and release glue.
+4. `.github/CODEOWNERS` now auto-routes review requests (added once the team grew
+   past ~10 developers). Keep it in sync with item 3.
 5. If two PRs touch the same file, the PR opened first has right-of-way. The
    second author rebases, unless the first author agrees to rebase instead.
 6. Before changing shared config, root docs, or workflow files, leave a short

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -40,6 +40,15 @@
       "tag-separator": "-",
       "include-component-in-tag": true,
       "version-file": "apps/aigateway/pyproject.toml"
+    },
+    "apps/scoreboard": {
+      "release-type": "python",
+      "package-name": "scoreboard",
+      "component": "scoreboard",
+      "tag-separator": "-",
+      "include-component-in-tag": true,
+      "version-file": "apps/scoreboard/pyproject.toml",
+      "bootstrap-sha": "8a10b5d013b2719c140408683deeec13530b3700"
     }
   }
 }


### PR DESCRIPTION
## Summary

Scales multi-developer coordination from the informal 2-person model to 10+ devs. ~70% of the policy already existed but was **fragmented, contradictory, and unenforced** — this consolidates it, makes it Claude-discoverable, and adds machine enforcement.

**Guidance**
- New `working-in-this-repo` skill — routing map: component taxonomy (`apps/` vs `packages/` vs `web/`), per-app table (stack · run/test/lint · gating CI · release lane · guardrails), **polyglot per-stack contract (Python/Go/JS/TS)** + 7-step "add a component" checklist, core-vs-plugin guide, 5-second PR/merge rules. Points to canonical docs, doesn't duplicate.
- `project-knowledge` skill given frontmatter so it's actually discoverable.

**Enforcement**
- `.github/CODEOWNERS` (real handles) + `.github/pull_request_template.md`.
- Merge queue: `merge_group:` trigger + PR-only concurrency on the 4 test workflows. Solves the path-filtered-required-check **deadlock** and serializes merges (no stale-base breakage).
- Restored the no-commit-to-`main` guard in the active **husky** hook (it was inactive because husky owns `core.hooksPath`).

**Consolidation**
- Destaled `CLAUDE.md` (real polyglot structure; fixed wrong `SF`-field GID + auto-assign footgun).
- `docs/team-development.md`: flipped the CODEOWNERS/PR-template "not yet" calls, updated ownership (Bennett→portal, Kyle→public), added a **Branch Protection & Merge Queue** section.
- `CONTRIBUTING.md` hook docs corrected; scoreboard added to release-please + dependabot.

## Follow-ups (not in this PR)
- **Enable branch protection + merge queue** on `main` (repo admin; exact config documented in `team-development.md`).
- release-please will open a **scoreboard release PR** on its next `main` run; dependabot will start scanning `apps/scoreboard`.

## Test plan
- All JSON/YAML parse; husky hook `sh -n` clean; both skills register in Claude Code; stale-ref sweep clean. No application code changed.

**Asana:** https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1216233706791237

🤖 Generated with [Claude Code](https://claude.com/claude-code)
