### PR TITLE
SF-346: Add URL4 model/profile aliases

### DIFF
--- a/apps/aigateway/src/aigateway/plugins/huggingface_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/huggingface_provider/plugin.py
@@ -35,8 +35,13 @@ if TYPE_CHECKING:
     from aigateway.core.credential_blob.store import CredentialBlobStore
 
 # Caller-supplied copies of these are stripped before the gateway injects its own
-# credential, so a client can never smuggle auth material to the upstream router.
-_CLIENT_AUTH_HEADER_NAMES = {"authorization", "x-api-key", "proxy-authorization"}
+# provider-owned values, so a client can never smuggle auth/billing material upstream.
+_CLIENT_OWNED_HEADER_NAMES = {
+    "authorization",
+    "proxy-authorization",
+    "x-api-key",
+    "x-hf-bill-to",
+}
 
 
 def _credential_service_for(profile_name: str) -> str:
@@ -87,7 +92,7 @@ class HuggingFaceProviderPlugin(ProviderPluginBase[HuggingFacePluginSettings]):
             sanitized = {
                 key: value
                 for key, value in extra_headers.items()
-                if str(key).lower() not in _CLIENT_AUTH_HEADER_NAMES
+                if str(key).lower() not in _CLIENT_OWNED_HEADER_NAMES
             }
             if sanitized:
                 out["extra_headers"] = sanitized
@@ -99,6 +104,14 @@ class HuggingFaceProviderPlugin(ProviderPluginBase[HuggingFacePluginSettings]):
         # Gateway-owned router base. routes/chat.py strips the caller's api_base
         # first, then we set our own; this keeps litellm on the request-local path.
         out["api_base"] = self.settings.router_api_base
+        # HF provider caps differ by backend; omitting max_tokens lets the router choose
+        # a provider-safe default instead of rejecting SF's generic 16k default.
+        out.pop("max_tokens", None)
+        bill_to = (self.settings.bill_to or "").strip()
+        if bill_to:
+            headers = dict(out.get("extra_headers") or {})
+            headers["X-HF-Bill-To"] = bill_to
+            out["extra_headers"] = headers
         return out
 
 

--- a/apps/aigateway/src/aigateway/plugins/huggingface_provider/settings.py
+++ b/apps/aigateway/src/aigateway/plugins/huggingface_provider/settings.py
@@ -74,6 +74,13 @@ class HuggingFacePluginSettings(PluginSettings):
 
     default_models: list[str] = Field(default_factory=_default_model_slugs)
     router_api_base: str = _ROUTER_API_BASE
+    bill_to: str | None = Field(
+        default=None,
+        description=(
+            "Optional Hugging Face organization name for Inference Providers billing. "
+            "When set, gateway injects X-HF-Bill-To on router requests."
+        ),
+    )
 
     @field_validator("default_models")
     @classmethod

--- a/apps/aigateway/tests/unit/huggingface/test_huggingface_provider.py
+++ b/apps/aigateway/tests/unit/huggingface/test_huggingface_provider.py
@@ -17,6 +17,7 @@ from aigateway.plugins.huggingface_provider.plugin import (
     PLUGIN,
     HuggingFaceProviderPlugin,
 )
+from aigateway.plugins.huggingface_provider.settings import HuggingFacePluginSettings
 
 _ROUTER = "https://router.huggingface.co/v1"
 
@@ -120,13 +121,55 @@ def test_prepare_chat_body_strips_caller_credentials() -> None:
                 "Authorization": "Bearer attacker",
                 "X-Api-Key": "attacker",
                 "proxy-authorization": "attacker",
+                "X-HF-Bill-To": "attacker-org",
                 "X-Trace": "keep-me",
             },
         }
     )
     assert "api_key" not in out
-    # only the non-auth header survives (case-insensitive strip of auth names)
+    # only the non-sensitive header survives (case-insensitive strip)
     assert out["extra_headers"] == {"X-Trace": "keep-me"}
+
+
+def test_prepare_chat_body_injects_configured_bill_to() -> None:
+    plugin = HuggingFaceProviderPlugin(HuggingFacePluginSettings(bill_to="OpenMinedFoundation"))
+
+    out = plugin.prepare_chat_body(
+        {
+            "model": "huggingface/x/y:novita",
+            "messages": [],
+            "extra_headers": {"X-HF-Bill-To": "attacker-org", "X-Trace": "keep-me"},
+        }
+    )
+
+    assert out["extra_headers"] == {
+        "X-HF-Bill-To": "OpenMinedFoundation",
+        "X-Trace": "keep-me",
+    }
+
+
+def test_prepare_chat_body_omits_large_max_tokens() -> None:
+    out = PLUGIN.prepare_chat_body(
+        {
+            "model": "huggingface/google/gemma-2-2b-it:featherless-ai",
+            "messages": [],
+            "max_tokens": 16_000,
+        }
+    )
+
+    assert "max_tokens" not in out
+
+
+def test_prepare_chat_body_omits_safe_max_tokens() -> None:
+    out = PLUGIN.prepare_chat_body(
+        {
+            "model": "huggingface/google/gemma-2-2b-it:featherless-ai",
+            "messages": [],
+            "max_tokens": 256,
+        }
+    )
+
+    assert "max_tokens" not in out
 
 
 def test_prepare_chat_body_drops_all_auth_headers_leaves_none() -> None:

--- a/apps/aigateway/tests/unit/huggingface/test_huggingface_settings.py
+++ b/apps/aigateway/tests/unit/huggingface/test_huggingface_settings.py
@@ -32,6 +32,11 @@ def test_router_api_base_default() -> None:
     assert HuggingFacePluginSettings().router_api_base == "https://router.huggingface.co/v1"
 
 
+def test_bill_to_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AIGW_HUGGINGFACE_BILL_TO", "OpenMinedFoundation")
+    assert HuggingFacePluginSettings().bill_to == "OpenMinedFoundation"
+
+
 def test_validator_accepts_suffix_and_bare_forms() -> None:
     assert (
         _validate_model_slug("huggingface/deepseek-ai/DeepSeek-R1:novita")

--- a/apps/desktop/src/main/services/__tests__/external-url-policy.test.ts
+++ b/apps/desktop/src/main/services/__tests__/external-url-policy.test.ts
@@ -317,6 +317,9 @@ describe('external URL policy', () => {
     ).toBe(true);
     expect(isAllowedServerFetchUrl('https://127.0.0.1:8000/plugins', serverInfo, 'GET')).toBe(true);
     expect(
+      isAllowedServerFetchUrl('https://127.0.0.1:8000/plugins/backend-aliases', serverInfo, 'GET'),
+    ).toBe(true);
+    expect(
       isAllowedServerFetchUrl(
         'https://127.0.0.1:8000/plugins/url4-specs/settings',
         serverInfo,
@@ -388,6 +391,23 @@ describe('external URL policy', () => {
     ).toBe(false);
     expect(
       isAllowedServerFetchUrl('https://127.0.0.1:8000/plugins/Bad/settings', serverInfo, 'GET'),
+    ).toBe(false);
+    expect(
+      isAllowedServerFetchUrl(
+        'https://127.0.0.1:8000/plugins/backend-aliases?debug=1',
+        serverInfo,
+        'GET',
+      ),
+    ).toBe(false);
+    expect(
+      isAllowedServerFetchUrl(
+        'https://127.0.0.1:8000/plugins/backend-aliases/extra',
+        serverInfo,
+        'GET',
+      ),
+    ).toBe(false);
+    expect(
+      isAllowedServerFetchUrl('https://127.0.0.1:8000/plugins/backend-aliases', serverInfo, 'POST'),
     ).toBe(false);
     expect(isAllowedServerFetchUrl('https://127.0.0.1:8000/private', serverInfo, 'PUT')).toBe(
       false,

--- a/apps/desktop/src/main/services/external-url-policy.ts
+++ b/apps/desktop/src/main/services/external-url-policy.ts
@@ -239,6 +239,9 @@ function isAllowedServerFetchPathAndMethod(url: URL, method: string): boolean {
   if (url.pathname === '/plugins' && hasNoQuery(url)) {
     return normalizedMethod === 'GET';
   }
+  if (url.pathname === '/plugins/backend-aliases' && hasNoQuery(url)) {
+    return normalizedMethod === 'GET';
+  }
   if (/^\/plugins\/[a-z0-9-]+\/schema$/.test(url.pathname) && hasNoQuery(url)) {
     return normalizedMethod === 'GET';
   }

--- a/apps/desktop/src/renderer/src/components/Url4MonacoEditor.tsx
+++ b/apps/desktop/src/renderer/src/components/Url4MonacoEditor.tsx
@@ -9,7 +9,7 @@ import { useRef } from 'react';
 import Editor, { type OnMount } from '@monaco-editor/react';
 // Side-effect: bundle Monaco (no CDN) before it mounts.
 import '@/lib/monaco-setup';
-import { registerUrl4Language, setUrl4SpecNames } from '@/lib/url4-language';
+import { refreshBackendAliases, registerUrl4Language, setUrl4SpecNames } from '@/lib/url4-language';
 import { clampEditorHeight } from '@/lib/editor-height';
 
 interface Props {
@@ -60,6 +60,12 @@ export default function Url4MonacoEditor({
         /* offline — skip */
       }
     })();
+
+    // SF-346: refresh configured backend profile aliases for autocomplete
+    // (best-effort, fail-closed). Always overwrites — including clearing — so
+    // aliases from a prior server/config don't linger in the shared cache.
+    // Sourced from SF-server backend plugin settings, not the AIGateway inventory.
+    void refreshBackendAliases((url) => window.electronAPI.server.fetch(url), serverUrl);
 
     // NOTE: no server-side validation markers. /ensemble/highlight parses with
     // the base url4 grammar, which rejects the ensemble fan-out shape

--- a/apps/desktop/src/renderer/src/lib/__tests__/referenced-backends.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/referenced-backends.test.ts
@@ -28,4 +28,8 @@ describe('referencedBackends', () => {
     const e = '(a:/huggingface/oss20b($q)!x, b:/gemini/flash($q)!y)!reduce';
     expect(referencedBackends(e).sort()).toEqual(['gemini', 'huggingface']);
   });
+  it('does not detect provider names inside alias segments', () => {
+    expect(referencedBackends('/huggingface/claude-alt($q)!answer')).toEqual(['huggingface']);
+    expect(referencedBackends('/ollama/codex-clone($q)!answer')).toEqual(['ollama']);
+  });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/referenced-backends.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/referenced-backends.test.ts
@@ -19,8 +19,8 @@ describe('referencedBackends', () => {
     expect(referencedBackends('/python(/data/code/check_correct.py)!{}')).toEqual([]);
   });
   // SF-346: profile-alias form `/backend/<alias>` must still resolve to the
-  // backend. The `/name\b` word boundary already matches (existing behavior;
-  // locked here so a future regex change can't silently break alias detection).
+  // backend. Locked here so a future shared regex change can't silently break
+  // alias detection.
   it('detects the backend from an alias-form path (/huggingface/oss20b)', () => {
     expect(referencedBackends('/huggingface/oss20b($q)!answer')).toEqual(['huggingface']);
   });

--- a/apps/desktop/src/renderer/src/lib/__tests__/referenced-backends.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/referenced-backends.test.ts
@@ -18,4 +18,14 @@ describe('referencedBackends', () => {
   it('excludes /python and /data (non-auth, not model backends)', () => {
     expect(referencedBackends('/python(/data/code/check_correct.py)!{}')).toEqual([]);
   });
+  // SF-346: profile-alias form `/backend/<alias>` must still resolve to the
+  // backend. The `/name\b` word boundary already matches (existing behavior;
+  // locked here so a future regex change can't silently break alias detection).
+  it('detects the backend from an alias-form path (/huggingface/oss20b)', () => {
+    expect(referencedBackends('/huggingface/oss20b($q)!answer')).toEqual(['huggingface']);
+  });
+  it('detects each backend in an alias-form ensemble', () => {
+    const e = '(a:/huggingface/oss20b($q)!x, b:/gemini/flash($q)!y)!reduce';
+    expect(referencedBackends(e).sort()).toEqual(['gemini', 'huggingface']);
+  });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/url4-language.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/url4-language.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { registerUrl4Language, setUrl4SpecNames } from '../url4-language';
+import { loadBackendAliases, registerUrl4Language, setUrl4SpecNames } from '../url4-language';
 
 type Provider = {
   provideCompletionItems: (
@@ -56,5 +56,98 @@ describe('registerUrl4Language', () => {
     const { monaco } = makeMonaco();
     registerUrl4Language(monaco as never); // module-level flag already set above
     expect(monaco.languages.register).not.toHaveBeenCalled();
+  });
+
+  // registerUrl4Language is idempotent via module state, so only one provider is
+  // ever captured per module instance. These tests reset modules to get a fresh
+  // registration (and thus a fresh provider) without disturbing the tests above.
+  async function freshProvider(): Promise<{
+    mod: typeof import('../url4-language');
+    provider: Provider;
+  }> {
+    vi.resetModules();
+    const mod = await import('../url4-language');
+    const { monaco, getProvider } = makeMonaco();
+    mod.registerUrl4Language(monaco as never);
+    return { mod, provider: getProvider()! };
+  }
+
+  it('suggests dynamically-configured backend profile aliases (SF-346)', async () => {
+    const { mod, provider } = await freshProvider();
+
+    mod.setUrl4BackendAliases(['/huggingface/oss20b', '/gemini/flash']);
+    const labels = provider.provideCompletionItems(model, position).suggestions.map((s) => s.label);
+
+    expect(labels).toContain('/huggingface/oss20b');
+    expect(labels).toContain('/gemini/flash');
+    // static backend paths remain (aliases augment, not replace)
+    expect(labels).toContain('/huggingface');
+  });
+
+  it('keeps static suggestions when no aliases are configured', async () => {
+    const { mod, provider } = await freshProvider();
+
+    mod.setUrl4BackendAliases([]);
+    const labels = provider.provideCompletionItems(model, position).suggestions.map((s) => s.label);
+
+    expect(labels).toContain('/claude');
+    expect(labels).toContain('$prompt');
+  });
+
+  it('refreshBackendAliases clears stale aliases when a later load returns none (SF-346)', async () => {
+    const { mod, provider } = await freshProvider();
+    const labels = (): string[] =>
+      provider.provideCompletionItems(model, position).suggestions.map((s) => s.label);
+
+    // Server/config A has a profile → alias appears.
+    const withProfile = async (url: string): Promise<{ ok: boolean; body: string }> =>
+      url.endsWith('/plugins/aigw-huggingface-backend/settings')
+        ? { ok: true, body: JSON.stringify({ profiles: { oss20b: {} } }) }
+        : { ok: false, body: '' };
+    await mod.refreshBackendAliases(withProfile, 'http://x');
+    expect(labels()).toContain('/huggingface/oss20b');
+
+    // Config B (or offline) yields no aliases → the stale one MUST be cleared,
+    // not left in the shared module cache (regresses if the setter is guarded by
+    // `if (aliases.length)`).
+    const noProfiles = async (): Promise<{ ok: boolean; body: string }> => ({
+      ok: false,
+      body: '',
+    });
+    await mod.refreshBackendAliases(noProfiles, 'http://x');
+    expect(labels()).not.toContain('/huggingface/oss20b');
+    expect(labels()).toContain('/huggingface'); // static backends remain
+  });
+});
+
+describe('loadBackendAliases (SF-346)', () => {
+  it('derives /path/alias from each profile-capable backend plugin settings', async () => {
+    const fetchFn = async (url: string): Promise<{ ok: boolean; body: string }> => {
+      if (url.endsWith('/plugins/aigw-huggingface-backend/settings')) {
+        return { ok: true, body: JSON.stringify({ profiles: { oss20b: {}, llama8b: {} } }) };
+      }
+      return { ok: false, body: '' };
+    };
+
+    const aliases = await loadBackendAliases(fetchFn, 'http://localhost:8000');
+
+    expect(aliases).toContain('/huggingface/oss20b');
+    expect(aliases).toContain('/huggingface/llama8b');
+  });
+
+  it('does not hardcode models — an empty profiles map yields no aliases', async () => {
+    const fetchFn = async (url: string): Promise<{ ok: boolean; body: string }> => {
+      if (url.endsWith('/plugins/aigw-huggingface-backend/settings')) {
+        return { ok: true, body: JSON.stringify({ profiles: {} }) };
+      }
+      return { ok: false, body: '' };
+    };
+
+    expect(await loadBackendAliases(fetchFn, 'http://localhost:8000')).toEqual([]);
+  });
+
+  it('ignores inactive/404 plugins and never throws (fail closed)', async () => {
+    const fetchFn = async (): Promise<{ ok: boolean; body: string }> => ({ ok: false, body: '' });
+    expect(await loadBackendAliases(fetchFn, 'http://localhost:8000')).toEqual([]);
   });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/url4-language.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/url4-language.test.ts
@@ -101,8 +101,8 @@ describe('registerUrl4Language', () => {
 
     // Server/config A has a profile → alias appears.
     const withProfile = async (url: string): Promise<{ ok: boolean; body: string }> =>
-      url.endsWith('/plugins/aigw-huggingface-backend/settings')
-        ? { ok: true, body: JSON.stringify({ profiles: { oss20b: {} } }) }
+      url.endsWith('/plugins/backend-aliases')
+        ? { ok: true, body: JSON.stringify({ aliases: ['/huggingface/oss20b'] }) }
         : { ok: false, body: '' };
     await mod.refreshBackendAliases(withProfile, 'http://x');
     expect(labels()).toContain('/huggingface/oss20b');
@@ -121,24 +121,26 @@ describe('registerUrl4Language', () => {
 });
 
 describe('loadBackendAliases (SF-346)', () => {
-  it('derives /path/alias from each profile-capable backend plugin settings', async () => {
-    const fetchFn = async (url: string): Promise<{ ok: boolean; body: string }> => {
-      if (url.endsWith('/plugins/aigw-huggingface-backend/settings')) {
-        return { ok: true, body: JSON.stringify({ profiles: { oss20b: {}, llama8b: {} } }) };
-      }
-      return { ok: false, body: '' };
-    };
+  it('loads aliases from the server-owned backend alias endpoint', async () => {
+    const fetchFn = vi.fn(async (url: string): Promise<{ ok: boolean; body: string }> => {
+      expect(url).toBe('http://localhost:8000/plugins/backend-aliases');
+      return {
+        ok: true,
+        body: JSON.stringify({ aliases: ['/huggingface/oss20b', '/huggingface/llama8b'] }),
+      };
+    });
 
     const aliases = await loadBackendAliases(fetchFn, 'http://localhost:8000');
 
+    expect(fetchFn).toHaveBeenCalledTimes(1);
     expect(aliases).toContain('/huggingface/oss20b');
     expect(aliases).toContain('/huggingface/llama8b');
   });
 
-  it('does not hardcode models — an empty profiles map yields no aliases', async () => {
+  it('does not hardcode models — an empty server alias list yields no aliases', async () => {
     const fetchFn = async (url: string): Promise<{ ok: boolean; body: string }> => {
-      if (url.endsWith('/plugins/aigw-huggingface-backend/settings')) {
-        return { ok: true, body: JSON.stringify({ profiles: {} }) };
+      if (url.endsWith('/plugins/backend-aliases')) {
+        return { ok: true, body: JSON.stringify({ aliases: [] }) };
       }
       return { ok: false, body: '' };
     };

--- a/apps/desktop/src/renderer/src/lib/__tests__/url4-language.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/url4-language.test.ts
@@ -94,7 +94,7 @@ describe('registerUrl4Language', () => {
     expect(labels).toContain('$prompt');
   });
 
-  it('refreshBackendAliases clears stale aliases when a later load returns none (SF-346)', async () => {
+  it('refreshBackendAliases clears stale aliases when a later successful load returns none (SF-346)', async () => {
     const { mod, provider } = await freshProvider();
     const labels = (): string[] =>
       provider.provideCompletionItems(model, position).suggestions.map((s) => s.label);
@@ -107,16 +107,34 @@ describe('registerUrl4Language', () => {
     await mod.refreshBackendAliases(withProfile, 'http://x');
     expect(labels()).toContain('/huggingface/oss20b');
 
-    // Config B (or offline) yields no aliases → the stale one MUST be cleared,
+    // Config B yields no aliases → the stale one MUST be cleared,
     // not left in the shared module cache (regresses if the setter is guarded by
     // `if (aliases.length)`).
     const noProfiles = async (): Promise<{ ok: boolean; body: string }> => ({
-      ok: false,
-      body: '',
+      ok: true,
+      body: JSON.stringify({ aliases: [] }),
     });
     await mod.refreshBackendAliases(noProfiles, 'http://x');
     expect(labels()).not.toContain('/huggingface/oss20b');
     expect(labels()).toContain('/huggingface'); // static backends remain
+  });
+
+  it('refreshBackendAliases keeps cached aliases when a later load fails', async () => {
+    const { mod, provider } = await freshProvider();
+    const labels = (): string[] =>
+      provider.provideCompletionItems(model, position).suggestions.map((s) => s.label);
+
+    const withProfile = async (): Promise<{ ok: boolean; body: string }> => ({
+      ok: true,
+      body: JSON.stringify({ aliases: ['/huggingface/oss20b'] }),
+    });
+    await mod.refreshBackendAliases(withProfile, 'http://x');
+    expect(labels()).toContain('/huggingface/oss20b');
+
+    const failed = async (): Promise<{ ok: boolean; body: string }> => ({ ok: false, body: '' });
+    await mod.refreshBackendAliases(failed, 'http://x');
+
+    expect(labels()).toContain('/huggingface/oss20b');
   });
 });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/url4-redaction.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/url4-redaction.test.ts
@@ -111,4 +111,11 @@ describe('deriveProviders', () => {
   it('detects the provider from an alias-form path (/huggingface/oss20b)', () => {
     expect(deriveProviders('/huggingface/oss20b($prompt)!answer')).toEqual(['huggingface']);
   });
+
+  it('does not detect provider names inside alias segments or intent text', () => {
+    expect(deriveProviders('/huggingface/mygemini($prompt)!answer')).toEqual(['huggingface']);
+    expect(deriveProviders('/huggingface/geminipro($prompt)!answer')).toEqual(['huggingface']);
+    expect(deriveProviders('/huggingface/claude-alt($prompt)!answer')).toEqual(['huggingface']);
+    expect(deriveProviders('/claude($prompt)!compare against gemini output')).toEqual(['claude']);
+  });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/url4-redaction.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/url4-redaction.test.ts
@@ -105,4 +105,10 @@ describe('deriveProviders', () => {
   it('detects huggingface', () => {
     expect(deriveProviders('/huggingface($prompt)!answer')).toEqual(['huggingface']);
   });
+
+  // SF-346: alias-form paths carry the provider substring, so the publish
+  // dialog still derives the right provider without knowing the alias/model.
+  it('detects the provider from an alias-form path (/huggingface/oss20b)', () => {
+    expect(deriveProviders('/huggingface/oss20b($prompt)!answer')).toEqual(['huggingface']);
+  });
 });

--- a/apps/desktop/src/renderer/src/lib/backend-call-path.ts
+++ b/apps/desktop/src/renderer/src/lib/backend-call-path.ts
@@ -1,0 +1,3 @@
+export function backendCallPathRe(name: string): RegExp {
+  return new RegExp(`(^|[^A-Za-z0-9_./-])/${name}(?:/[a-z0-9][a-z0-9_-]*)?\\s*\\(`);
+}

--- a/apps/desktop/src/renderer/src/lib/referenced-backends.ts
+++ b/apps/desktop/src/renderer/src/lib/referenced-backends.ts
@@ -13,10 +13,14 @@ const AUTH_BACKENDS = [
 ] as const;
 export type BackendName = (typeof AUTH_BACKENDS)[number];
 
+function backendCallPathRe(name: BackendName): RegExp {
+  return new RegExp(`(^|[^A-Za-z0-9_./-])/${name}(?:/[a-z0-9][a-z0-9_-]*)?\\s*\\(`);
+}
+
 export function referencedBackends(expression: string): BackendName[] {
   const found: BackendName[] = [];
   for (const name of AUTH_BACKENDS) {
-    if (new RegExp(`/${name}\\b`).test(expression)) found.push(name);
+    if (backendCallPathRe(name).test(expression)) found.push(name);
   }
   return found;
 }

--- a/apps/desktop/src/renderer/src/lib/referenced-backends.ts
+++ b/apps/desktop/src/renderer/src/lib/referenced-backends.ts
@@ -3,6 +3,8 @@
 // /huggingface, /ollama). /python,
 // /data and /private are intentionally excluded — no credentials / not models.
 // Mirrors the server's backend keying (backend_call_paths[0].lstrip('/')).
+import { backendCallPathRe } from './backend-call-path';
+
 const AUTH_BACKENDS = [
   'claude',
   'codex',
@@ -12,10 +14,6 @@ const AUTH_BACKENDS = [
   'ollama',
 ] as const;
 export type BackendName = (typeof AUTH_BACKENDS)[number];
-
-function backendCallPathRe(name: BackendName): RegExp {
-  return new RegExp(`(^|[^A-Za-z0-9_./-])/${name}(?:/[a-z0-9][a-z0-9_-]*)?\\s*\\(`);
-}
 
 export function referencedBackends(expression: string): BackendName[] {
   const found: BackendName[] = [];

--- a/apps/desktop/src/renderer/src/lib/url4-language.ts
+++ b/apps/desktop/src/renderer/src/lib/url4-language.ts
@@ -37,45 +37,24 @@ export function setUrl4BackendAliases(aliases: string[]): void {
   backendAliases = aliases;
 }
 
-// Profile-capable backends and the SF plugin(s) that may serve each URL4 path. Only the
-// plugin NAMES are fixed (a small known set, like BACKENDS above); the aliases come
-// dynamically from each plugin's `profiles` config — individual models are never hardcoded.
-const PROFILE_CAPABLE_BACKENDS: Array<{ path: string; plugins: string[] }> = [
-  { path: '/claude', plugins: ['aigw-claude-backend', 'claude-backend-api'] },
-  { path: '/codex', plugins: ['aigw-codex-backend', 'codex-backend-api'] },
-  { path: '/gemini', plugins: ['aigw-gemini-backend', 'gemini-backend-api'] },
-  { path: '/antigravity', plugins: ['aigw-antigravity-backend'] },
-  { path: '/huggingface', plugins: ['aigw-huggingface-backend'] },
-  { path: '/ollama', plugins: ['aigw-ollama-backend', 'ollama-backend-api'] },
-];
-
 /**
- * Fetch each profile-capable backend plugin's settings and derive `/path/<alias>`
- * suggestions from its configured `profiles`. Best-effort and fail-closed: inactive or
- * conflicting plugins 404 and are skipped, and any error yields no aliases rather than
- * throwing. `fetchFn` matches window.electronAPI.server.fetch's shape.
+ * Fetch configured backend profile alias suggestions from the SF server-owned inventory.
+ * Best-effort and fail-closed: any error yields no aliases rather than throwing.
+ * `fetchFn` matches window.electronAPI.server.fetch's shape.
  */
 export async function loadBackendAliases(
   fetchFn: (url: string) => Promise<{ ok: boolean; body: string }>,
   serverUrl: string,
 ): Promise<string[]> {
-  const out: string[] = [];
-  for (const { path, plugins } of PROFILE_CAPABLE_BACKENDS) {
-    for (const name of plugins) {
-      try {
-        const res = await fetchFn(`${serverUrl}/plugins/${name}/settings`);
-        if (!res.ok) continue;
-        const data = JSON.parse(res.body) as { profiles?: Record<string, unknown> };
-        if (data.profiles) {
-          for (const alias of Object.keys(data.profiles)) out.push(`${path}/${alias}`);
-          break; // one active plugin per path (conflicts guarantee a single owner)
-        }
-      } catch {
-        /* inactive plugin / offline / malformed body — skip */
-      }
-    }
+  try {
+    const res = await fetchFn(`${serverUrl}/plugins/backend-aliases`);
+    if (!res.ok) return [];
+    const data = JSON.parse(res.body) as { aliases?: unknown };
+    if (!Array.isArray(data.aliases)) return [];
+    return data.aliases.filter((alias): alias is string => typeof alias === 'string');
+  } catch {
+    return [];
   }
-  return out;
 }
 
 /**

--- a/apps/desktop/src/renderer/src/lib/url4-language.ts
+++ b/apps/desktop/src/renderer/src/lib/url4-language.ts
@@ -37,6 +37,24 @@ export function setUrl4BackendAliases(aliases: string[]): void {
   backendAliases = aliases;
 }
 
+async function loadBackendAliasResult(
+  fetchFn: (url: string) => Promise<{ ok: boolean; body: string }>,
+  serverUrl: string,
+): Promise<{ ok: boolean; aliases: string[] }> {
+  try {
+    const res = await fetchFn(`${serverUrl}/plugins/backend-aliases`);
+    if (!res.ok) return { ok: false, aliases: [] };
+    const data = JSON.parse(res.body) as { aliases?: unknown };
+    if (!Array.isArray(data.aliases)) return { ok: false, aliases: [] };
+    return {
+      ok: true,
+      aliases: data.aliases.filter((alias): alias is string => typeof alias === 'string'),
+    };
+  } catch {
+    return { ok: false, aliases: [] };
+  }
+}
+
 /**
  * Fetch configured backend profile alias suggestions from the SF server-owned inventory.
  * Best-effort and fail-closed: any error yields no aliases rather than throwing.
@@ -46,29 +64,21 @@ export async function loadBackendAliases(
   fetchFn: (url: string) => Promise<{ ok: boolean; body: string }>,
   serverUrl: string,
 ): Promise<string[]> {
-  try {
-    const res = await fetchFn(`${serverUrl}/plugins/backend-aliases`);
-    if (!res.ok) return [];
-    const data = JSON.parse(res.body) as { aliases?: unknown };
-    if (!Array.isArray(data.aliases)) return [];
-    return data.aliases.filter((alias): alias is string => typeof alias === 'string');
-  } catch {
-    return [];
-  }
+  return (await loadBackendAliasResult(fetchFn, serverUrl)).aliases;
 }
 
 /**
- * Load configured backend aliases and publish them to the completion cache.
- * ALWAYS overwrites the cache — including with an empty list — so aliases from a
- * previously-selected server/config are cleared rather than left stale in the
- * module-level cache. (`loadBackendAliases` is fail-closed, returning [] on
- * offline or when no plugin has profiles.) Best-effort: never throws.
+ * Load configured backend aliases and publish them to the completion cache. A
+ * successful empty result clears stale aliases from the previous server/config;
+ * a failed fetch keeps the last known-good cache because autocomplete is
+ * best-effort and offline should not erase already-loaded local suggestions.
  */
 export async function refreshBackendAliases(
   fetchFn: (url: string) => Promise<{ ok: boolean; body: string }>,
   serverUrl: string,
 ): Promise<void> {
-  setUrl4BackendAliases(await loadBackendAliases(fetchFn, serverUrl));
+  const result = await loadBackendAliasResult(fetchFn, serverUrl);
+  if (result.ok) setUrl4BackendAliases(result.aliases);
 }
 
 let registered = false;

--- a/apps/desktop/src/renderer/src/lib/url4-language.ts
+++ b/apps/desktop/src/renderer/src/lib/url4-language.ts
@@ -29,6 +29,69 @@ export function setUrl4SpecNames(names: string[]): void {
   specNames = names;
 }
 
+// SF-346: dynamically-configured backend profile aliases (e.g. '/huggingface/oss20b').
+// Populated best-effort from server plugin settings via loadBackendAliases(); read by
+// the shared completion provider. Module-level so the single provider sees the latest.
+let backendAliases: string[] = [];
+export function setUrl4BackendAliases(aliases: string[]): void {
+  backendAliases = aliases;
+}
+
+// Profile-capable backends and the SF plugin(s) that may serve each URL4 path. Only the
+// plugin NAMES are fixed (a small known set, like BACKENDS above); the aliases come
+// dynamically from each plugin's `profiles` config — individual models are never hardcoded.
+const PROFILE_CAPABLE_BACKENDS: Array<{ path: string; plugins: string[] }> = [
+  { path: '/claude', plugins: ['aigw-claude-backend', 'claude-backend-api'] },
+  { path: '/codex', plugins: ['aigw-codex-backend', 'codex-backend-api'] },
+  { path: '/gemini', plugins: ['aigw-gemini-backend', 'gemini-backend-api'] },
+  { path: '/antigravity', plugins: ['aigw-antigravity-backend'] },
+  { path: '/huggingface', plugins: ['aigw-huggingface-backend'] },
+  { path: '/ollama', plugins: ['aigw-ollama-backend', 'ollama-backend-api'] },
+];
+
+/**
+ * Fetch each profile-capable backend plugin's settings and derive `/path/<alias>`
+ * suggestions from its configured `profiles`. Best-effort and fail-closed: inactive or
+ * conflicting plugins 404 and are skipped, and any error yields no aliases rather than
+ * throwing. `fetchFn` matches window.electronAPI.server.fetch's shape.
+ */
+export async function loadBackendAliases(
+  fetchFn: (url: string) => Promise<{ ok: boolean; body: string }>,
+  serverUrl: string,
+): Promise<string[]> {
+  const out: string[] = [];
+  for (const { path, plugins } of PROFILE_CAPABLE_BACKENDS) {
+    for (const name of plugins) {
+      try {
+        const res = await fetchFn(`${serverUrl}/plugins/${name}/settings`);
+        if (!res.ok) continue;
+        const data = JSON.parse(res.body) as { profiles?: Record<string, unknown> };
+        if (data.profiles) {
+          for (const alias of Object.keys(data.profiles)) out.push(`${path}/${alias}`);
+          break; // one active plugin per path (conflicts guarantee a single owner)
+        }
+      } catch {
+        /* inactive plugin / offline / malformed body — skip */
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Load configured backend aliases and publish them to the completion cache.
+ * ALWAYS overwrites the cache — including with an empty list — so aliases from a
+ * previously-selected server/config are cleared rather than left stale in the
+ * module-level cache. (`loadBackendAliases` is fail-closed, returning [] on
+ * offline or when no plugin has profiles.) Best-effort: never throws.
+ */
+export async function refreshBackendAliases(
+  fetchFn: (url: string) => Promise<{ ok: boolean; body: string }>,
+  serverUrl: string,
+): Promise<void> {
+  setUrl4BackendAliases(await loadBackendAliases(fetchFn, serverUrl));
+}
+
 let registered = false;
 
 export function registerUrl4Language(monaco: Monaco): void {
@@ -85,6 +148,13 @@ export function registerUrl4Language(monaco: Monaco): void {
           label,
           kind: CompletionItemKind.Function,
           insertText: label,
+          range,
+        })),
+        ...backendAliases.map((label) => ({
+          label,
+          kind: CompletionItemKind.Function,
+          insertText: label,
+          detail: 'url4 profile alias',
           range,
         })),
         ...VARIABLES.map((label) => ({

--- a/apps/desktop/src/renderer/src/lib/url4-redaction.ts
+++ b/apps/desktop/src/renderer/src/lib/url4-redaction.ts
@@ -12,6 +12,7 @@
 //
 // Also parses spec_name into benchmark/spec ids and derives the providers a run
 // used from the expression. All functions are pure and dependency-free.
+import { backendCallPathRe } from './backend-call-path';
 
 const DATA_REF_RE = /\/data\/[A-Za-z0-9_./-]+/g;
 const REDACTED_REF = '/data/<redacted>';
@@ -25,10 +26,6 @@ const KNOWN_PROVIDERS = [
 ] as const;
 
 type KnownProvider = (typeof KNOWN_PROVIDERS)[number];
-
-function providerCallPathRe(provider: KnownProvider): RegExp {
-  return new RegExp(`(^|[^A-Za-z0-9_./-])/${provider}(?:/[a-z0-9][a-z0-9_-]*)?\\s*\\(`);
-}
 
 function bareProviderTokenRe(provider: KnownProvider): RegExp {
   return new RegExp(`(^|[(,:\\s])${provider}(?=\\s*(?:[,):]|$))`);
@@ -84,6 +81,6 @@ export function deriveProviders(expression: string): string[] {
   const lower = expression.toLowerCase();
   return KNOWN_PROVIDERS.filter(
     (provider) =>
-      providerCallPathRe(provider).test(lower) || bareProviderTokenRe(provider).test(lower),
+      backendCallPathRe(provider).test(lower) || bareProviderTokenRe(provider).test(lower),
   );
 }

--- a/apps/desktop/src/renderer/src/lib/url4-redaction.ts
+++ b/apps/desktop/src/renderer/src/lib/url4-redaction.ts
@@ -24,6 +24,16 @@ const KNOWN_PROVIDERS = [
   'ollama',
 ] as const;
 
+type KnownProvider = (typeof KNOWN_PROVIDERS)[number];
+
+function providerCallPathRe(provider: KnownProvider): RegExp {
+  return new RegExp(`(^|[^A-Za-z0-9_./-])/${provider}(?:/[a-z0-9][a-z0-9_-]*)?\\s*\\(`);
+}
+
+function bareProviderTokenRe(provider: KnownProvider): RegExp {
+  return new RegExp(`(^|[(,:\\s])${provider}(?=\\s*(?:[,):]|$))`);
+}
+
 /** Every `/data/<ref>` segment in the expression (empty array if none). */
 export function findLocalDataRefs(expression: string): string[] {
   if (!expression) return [];
@@ -72,5 +82,8 @@ export function parseSpecName(specName: string): ParsedSpecName {
 export function deriveProviders(expression: string): string[] {
   if (!expression) return [];
   const lower = expression.toLowerCase();
-  return KNOWN_PROVIDERS.filter((provider) => lower.includes(provider));
+  return KNOWN_PROVIDERS.filter(
+    (provider) =>
+      providerCallPathRe(provider).test(lower) || bareProviderTokenRe(provider).test(lower),
+  );
 }

--- a/apps/server/sf.json
+++ b/apps/server/sf.json
@@ -44,7 +44,8 @@
       "enabled": true,
       "aigw_env": {
         "AIGW_PROVIDER_MAX_CONCURRENCY": "4",
-        "AIGW_PROVIDER_MAX_CONCURRENCY_OVERRIDES": "{\"gemini-cli\":1,\"anthropic\":1}"
+        "AIGW_PROVIDER_MAX_CONCURRENCY_OVERRIDES": "{\"gemini-cli\":1,\"anthropic\":1}",
+        "AIGW_HUGGINGFACE_BILL_TO": "OpenMinedFoundation"
       }
     },
     "aigw-base": {

--- a/apps/server/src/screamingface/core/admin_router.py
+++ b/apps/server/src/screamingface/core/admin_router.py
@@ -145,7 +145,11 @@ def _backend_alias_inventory(active_plugins: dict[str, Plugin]) -> dict:
             if (normalized := normalize_backend_call_path(path)) is not None
         ]
         settings = getattr(plugin, "settings", None)
-        profiles = getattr(settings, "profiles", {}) or {}
+        alias_profiles_fn = getattr(plugin, "backend_alias_profiles", None)
+        if callable(alias_profiles_fn):
+            profiles = alias_profiles_fn()
+        else:
+            profiles = getattr(settings, "profiles", {}) or {}
         if not paths or not isinstance(profiles, dict):
             continue
         default_profile = getattr(settings, "default_profile", None)

--- a/apps/server/src/screamingface/core/admin_router.py
+++ b/apps/server/src/screamingface/core/admin_router.py
@@ -130,6 +130,33 @@ def _inject_examples(schema: dict, field_name: str, examples: list[str]) -> None
     _walk(schema)
 
 
+def _backend_alias_inventory(active_plugins: dict[str, Plugin]) -> dict:
+    aliases: list[str] = []
+    backends: list[dict[str, object]] = []
+
+    for plugin in active_plugins.values():
+        if not getattr(plugin, "supports_profile_aliases", False):
+            continue
+        paths = [
+            path.rstrip("/")
+            for path in getattr(plugin, "backend_call_paths", [])
+            if isinstance(path, str) and path.startswith("/") and path.rstrip("/")
+        ]
+        settings = getattr(plugin, "settings", None)
+        profiles = getattr(settings, "profiles", {}) or {}
+        if not paths or not isinstance(profiles, dict):
+            continue
+        profile_names = [name for name in profiles if isinstance(name, str) and name]
+        if not profile_names:
+            continue
+
+        backends.append({"plugin": plugin.name, "paths": paths, "profiles": profile_names})
+        for path in paths:
+            aliases.extend(f"{path}/{profile}" for profile in profile_names)
+
+    return {"aliases": aliases, "backends": backends}
+
+
 def register_admin_routes(app: FastAPI) -> None:
     """Attach the built-in admin/diagnostic endpoints to ``app``.
 
@@ -159,6 +186,10 @@ def register_admin_routes(app: FastAPI) -> None:
             }
             for name, p in app.state.plugins.active_plugins.items()
         }
+
+    @app.get("/plugins/backend-aliases")
+    async def list_backend_aliases() -> dict:
+        return _backend_alias_inventory(app.state.plugins.active_plugins)
 
     @app.get("/plugins/{name}/schema")
     async def plugin_schema(name: str) -> dict:

--- a/apps/server/src/screamingface/core/admin_router.py
+++ b/apps/server/src/screamingface/core/admin_router.py
@@ -20,6 +20,7 @@ import subprocess
 
 from fastapi import FastAPI, HTTPException, Request
 
+from screamingface.core.backend_paths import normalize_backend_call_path
 from screamingface.plugin import Plugin
 
 logger = logging.getLogger(__name__)
@@ -133,26 +134,34 @@ def _inject_examples(schema: dict, field_name: str, examples: list[str]) -> None
 def _backend_alias_inventory(active_plugins: dict[str, Plugin]) -> dict:
     aliases: list[str] = []
     backends: list[dict[str, object]] = []
+    seen_aliases: set[str] = set()
 
     for plugin in active_plugins.values():
         if not getattr(plugin, "supports_profile_aliases", False):
             continue
         paths = [
-            path.rstrip("/")
+            normalized
             for path in getattr(plugin, "backend_call_paths", [])
-            if isinstance(path, str) and path.startswith("/") and path.rstrip("/")
+            if (normalized := normalize_backend_call_path(path)) is not None
         ]
         settings = getattr(plugin, "settings", None)
         profiles = getattr(settings, "profiles", {}) or {}
         if not paths or not isinstance(profiles, dict):
             continue
-        profile_names = [name for name in profiles if isinstance(name, str) and name]
+        default_profile = getattr(settings, "default_profile", None)
+        profile_names = [
+            name for name in profiles if isinstance(name, str) and name and name != default_profile
+        ]
         if not profile_names:
             continue
 
         backends.append({"plugin": plugin.name, "paths": paths, "profiles": profile_names})
         for path in paths:
-            aliases.extend(f"{path}/{profile}" for profile in profile_names)
+            for profile in profile_names:
+                alias = f"{path}/{profile}"
+                if alias not in seen_aliases:
+                    seen_aliases.add(alias)
+                    aliases.append(alias)
 
     return {"aliases": aliases, "backends": backends}
 

--- a/apps/server/src/screamingface/core/admin_router.py
+++ b/apps/server/src/screamingface/core/admin_router.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 import logging
 import subprocess
+from collections.abc import Awaitable, Callable
+from typing import Any, cast
 
 from fastapi import FastAPI, HTTPException, Request
 
@@ -150,24 +152,64 @@ def _backend_alias_inventory(active_plugins: dict[str, Plugin]) -> dict:
             profiles = alias_profiles_fn()
         else:
             profiles = getattr(settings, "profiles", {}) or {}
-        if not paths or not isinstance(profiles, dict):
-            continue
-        default_profile = getattr(settings, "default_profile", None)
-        profile_names = [
-            name for name in profiles if isinstance(name, str) and name and name != default_profile
-        ]
-        if not profile_names:
-            continue
-
-        backends.append({"plugin": plugin.name, "paths": paths, "profiles": profile_names})
-        for path in paths:
-            for profile in profile_names:
-                alias = f"{path}/{profile}"
-                if alias not in seen_aliases:
-                    seen_aliases.add(alias)
-                    aliases.append(alias)
+        _add_backend_alias_inventory(plugin, paths, profiles, aliases, backends, seen_aliases)
 
     return {"aliases": aliases, "backends": backends}
+
+
+async def _backend_alias_inventory_async(active_plugins: dict[str, Plugin]) -> dict:
+    aliases: list[str] = []
+    backends: list[dict[str, object]] = []
+    seen_aliases: set[str] = set()
+
+    for plugin in active_plugins.values():
+        if not getattr(plugin, "supports_profile_aliases", False):
+            continue
+        paths = [
+            normalized
+            for path in getattr(plugin, "backend_call_paths", [])
+            if (normalized := normalize_backend_call_path(path)) is not None
+        ]
+        settings = getattr(plugin, "settings", None)
+        alias_profiles_async_fn = getattr(plugin, "backend_alias_profiles_async", None)
+        if callable(alias_profiles_async_fn):
+            profiles = await cast(
+                Callable[[], Awaitable[dict[str, Any]]], alias_profiles_async_fn
+            )()
+        elif callable(alias_profiles_fn := getattr(plugin, "backend_alias_profiles", None)):
+            profiles = alias_profiles_fn()
+        else:
+            profiles = getattr(settings, "profiles", {}) or {}
+        _add_backend_alias_inventory(plugin, paths, profiles, aliases, backends, seen_aliases)
+
+    return {"aliases": aliases, "backends": backends}
+
+
+def _add_backend_alias_inventory(
+    plugin: Plugin,
+    paths: list[str],
+    profiles: object,
+    aliases: list[str],
+    backends: list[dict[str, object]],
+    seen_aliases: set[str],
+) -> None:
+    if not paths or not isinstance(profiles, dict):
+        return
+    settings = getattr(plugin, "settings", None)
+    default_profile = getattr(settings, "default_profile", None)
+    profile_names = [
+        name for name in profiles if isinstance(name, str) and name and name != default_profile
+    ]
+    if not profile_names:
+        return
+
+    backends.append({"plugin": plugin.name, "paths": paths, "profiles": profile_names})
+    for path in paths:
+        for profile in profile_names:
+            alias = f"{path}/{profile}"
+            if alias not in seen_aliases:
+                seen_aliases.add(alias)
+                aliases.append(alias)
 
 
 def register_admin_routes(app: FastAPI) -> None:
@@ -202,7 +244,7 @@ def register_admin_routes(app: FastAPI) -> None:
 
     @app.get("/plugins/backend-aliases")
     async def list_backend_aliases() -> dict:
-        return _backend_alias_inventory(app.state.plugins.active_plugins)
+        return await _backend_alias_inventory_async(app.state.plugins.active_plugins)
 
     @app.get("/plugins/{name}/schema")
     async def plugin_schema(name: str) -> dict:

--- a/apps/server/src/screamingface/core/backend_paths.py
+++ b/apps/server/src/screamingface/core/backend_paths.py
@@ -1,0 +1,20 @@
+"""Shared helpers for URL4 backend-call paths and profile aliases."""
+
+from __future__ import annotations
+
+import re
+
+PROFILE_ALIAS_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
+
+def is_valid_profile_alias(alias: str) -> bool:
+    return PROFILE_ALIAS_RE.match(alias) is not None
+
+
+def normalize_backend_call_path(path: object) -> str | None:
+    if not isinstance(path, str):
+        return None
+    normalized = path.rstrip("/")
+    if not normalized or not normalized.startswith("/"):
+        return None
+    return normalized

--- a/apps/server/src/screamingface/core/backend_paths.py
+++ b/apps/server/src/screamingface/core/backend_paths.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import hashlib
+import logging
 import re
+
+_log = logging.getLogger(__name__)
 
 PROFILE_ALIAS_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 _UNSAFE_ALIAS_CHARS_RE = re.compile(r"[^a-z0-9_-]+")
@@ -30,22 +34,41 @@ def catalog_aliases_from_model_ids(model_ids: list[str]) -> dict[str, str]:
     """
 
     candidates: list[tuple[str, str | None, str | None, str]] = []
+    seen_model_ids: set[str] = set()
     for model_id in model_ids:
+        if model_id in seen_model_ids:
+            continue
         parts = _model_alias_parts(model_id)
         if parts is not None:
             candidates.append((*parts, model_id))
+            seen_model_ids.add(model_id)
+    candidates.sort(key=lambda item: item[3])
 
     base_counts: dict[str, int] = {}
     for base, _suffix, _owner, _model_id in candidates:
         base_counts[base] = base_counts.get(base, 0) + 1
 
-    aliases: dict[str, str] = {}
+    alias_groups: dict[str, list[str]] = {}
     for base, suffix, owner, model_id in candidates:
         alias = base
         if base_counts[base] > 1:
             alias = _join_alias_parts(base, suffix or owner)
-        alias = _unique_alias(alias, aliases)
-        aliases[alias] = model_id
+        alias_groups.setdefault(alias, []).append(model_id)
+
+    aliases: dict[str, str] = {}
+    for alias, ids in sorted(alias_groups.items()):
+        if len(ids) == 1:
+            aliases[alias] = ids[0]
+            continue
+        for model_id in ids:
+            hashed_alias = _hashed_alias(alias, model_id, aliases)
+            _log.warning(
+                "catalog model alias collision for %r; using %r for model %r",
+                alias,
+                hashed_alias,
+                model_id,
+            )
+            aliases[hashed_alias] = model_id
     return aliases
 
 
@@ -86,3 +109,8 @@ def _unique_alias(alias: str, aliases: dict[str, str]) -> str:
     while f"{alias}-{i}" in aliases:
         i += 1
     return f"{alias}-{i}"
+
+
+def _hashed_alias(alias: str, model_id: str, aliases: dict[str, str]) -> str:
+    digest = hashlib.sha1(model_id.encode("utf-8")).hexdigest()[:8]
+    return _unique_alias(f"{alias}-{digest}", aliases)

--- a/apps/server/src/screamingface/core/backend_paths.py
+++ b/apps/server/src/screamingface/core/backend_paths.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 
 PROFILE_ALIAS_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+_UNSAFE_ALIAS_CHARS_RE = re.compile(r"[^a-z0-9_-]+")
 
 
 def is_valid_profile_alias(alias: str) -> bool:
@@ -18,3 +19,70 @@ def normalize_backend_call_path(path: object) -> str | None:
     if not normalized or not normalized.startswith("/"):
         return None
     return normalized
+
+
+def catalog_aliases_from_model_ids(model_ids: list[str]) -> dict[str, str]:
+    """Derive deterministic URL4-safe aliases from gateway model ids.
+
+    The gateway's ``/v1/models`` ids are already the model registry source of
+    truth. URL4 aliases should be short enough to type, but collision-safe enough
+    that autocomplete never advertises two aliases for different models.
+    """
+
+    candidates: list[tuple[str, str | None, str | None, str]] = []
+    for model_id in model_ids:
+        parts = _model_alias_parts(model_id)
+        if parts is not None:
+            candidates.append((*parts, model_id))
+
+    base_counts: dict[str, int] = {}
+    for base, _suffix, _owner, _model_id in candidates:
+        base_counts[base] = base_counts.get(base, 0) + 1
+
+    aliases: dict[str, str] = {}
+    for base, suffix, owner, model_id in candidates:
+        alias = base
+        if base_counts[base] > 1:
+            alias = _join_alias_parts(base, suffix or owner)
+        alias = _unique_alias(alias, aliases)
+        aliases[alias] = model_id
+    return aliases
+
+
+def _model_alias_parts(model_id: str) -> tuple[str, str | None, str | None] | None:
+    if not isinstance(model_id, str) or not model_id:
+        return None
+    path_parts = [part for part in model_id.split("/") if part]
+    if not path_parts:
+        return None
+
+    last = path_parts[-1]
+    model_part, _sep, provider_suffix = last.partition(":")
+    base = _slugify_alias(model_part)
+    if base is None:
+        return None
+    suffix = _slugify_alias(provider_suffix) if provider_suffix else None
+    owner = _slugify_alias(path_parts[-2]) if len(path_parts) > 2 else None
+    return base, suffix, owner
+
+
+def _slugify_alias(value: str) -> str | None:
+    slug = _UNSAFE_ALIAS_CHARS_RE.sub("-", value.lower()).strip("-_")
+    if not slug or not slug[0].isalnum():
+        return None
+    return slug if is_valid_profile_alias(slug) else None
+
+
+def _join_alias_parts(base: str, suffix: str | None) -> str:
+    if not suffix:
+        return base
+    return f"{base}-{suffix}"
+
+
+def _unique_alias(alias: str, aliases: dict[str, str]) -> str:
+    if alias not in aliases:
+        return alias
+    i = 2
+    while f"{alias}-{i}" in aliases:
+        i += 1
+    return f"{alias}-{i}"

--- a/apps/server/src/screamingface/plugins/aigw_antigravity_backend/plugin.py
+++ b/apps/server/src/screamingface/plugins/aigw_antigravity_backend/plugin.py
@@ -7,7 +7,7 @@ from typing import ClassVar
 from pydantic import Field
 from pydantic_settings import SettingsConfigDict
 
-from screamingface.plugins.aigw_antigravity_backend.routes import create_router
+from screamingface.plugins.aigw_antigravity_backend.routes import create_route_bundle, create_router
 from screamingface.plugins.aigw_base import (
     AigwBackendApiPluginBase,
     AigwBackendApiSettingsBase,
@@ -64,4 +64,5 @@ class AigwAntigravityBackendPlugin(AigwBackendApiPluginBase):
     supports_api_key = False
     settings_class = AigwAntigravityBackendSettings
     schema_link_base = "/antigravity/"
+    create_route_bundle = staticmethod(create_route_bundle)
     create_router = staticmethod(create_router)

--- a/apps/server/src/screamingface/plugins/aigw_antigravity_backend/routes.py
+++ b/apps/server/src/screamingface/plugins/aigw_antigravity_backend/routes.py
@@ -15,7 +15,8 @@ from screamingface.plugins.aigw_base import (
 from screamingface.plugins.aigw_base.config import resolve_aigw_runtime_config
 from screamingface.plugins.llm_base.routes_shared import (
     BackendApiConfig,
-    build_backend_api_router,
+    BackendApiRouteBundle,
+    build_backend_api_route_bundle,
 )
 
 if TYPE_CHECKING:
@@ -28,12 +29,12 @@ _PATH_PREFIX = "/antigravity"
 _DEFAULT_MODEL = "antigravity/gemini-3-flash"
 
 
-def create_router(
+def create_route_bundle(
     settings: AigwAntigravityBackendSettings,
     app: Any = None,
     *,
     backend: AigwBackend | None = None,
-) -> APIRouter:
+) -> BackendApiRouteBundle:
     gateway_url = _gateway_url(app, settings.gateway_url)
     backend = backend or AigwBackend(
         gateway_url=gateway_url,
@@ -50,7 +51,7 @@ def create_router(
             gateway_provider=_GATEWAY_PROVIDER,
         )
 
-    router = build_backend_api_router(
+    bundle = build_backend_api_route_bundle(
         BackendApiConfig(
             name="aigw-antigravity-backend",
             path_prefix=_PATH_PREFIX,
@@ -62,6 +63,7 @@ def create_router(
             span_prefix="aigw_antigravity",
         )
     )
+    router = bundle.router
     profile_defaults = build_profile_defaults_from_settings(settings)
     router.include_router(
         build_aigw_auth_proxy_router(
@@ -73,7 +75,16 @@ def create_router(
             defaults=profile_defaults or None,
         )
     )
-    return router
+    return bundle
+
+
+def create_router(
+    settings: AigwAntigravityBackendSettings,
+    app: Any = None,
+    *,
+    backend: AigwBackend | None = None,
+) -> APIRouter:
+    return create_route_bundle(settings, app, backend=backend).router
 
 
 def _gateway_url(app: Any, fallback: str) -> str:

--- a/apps/server/src/screamingface/plugins/aigw_base/plugin_base.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/plugin_base.py
@@ -80,6 +80,9 @@ class AigwBackendApiPluginBase(BackendApiPluginBase):
         self._assert_loopback_server_bind(app)
         router = type(self).create_router(self.settings, app, backend=self._backend(app))
         routes.add_router(self.name, router, prefix="")
+        # SF-346: same profile-alias wiring capture as BackendApiPluginBase.setup
+        # (this override does not call super().setup()).
+        self._api_config = getattr(router, "sf_api_config", None)
 
     def _assert_loopback_server_bind(self, app: FastAPI) -> None:
         assert_loopback_server_bind(

--- a/apps/server/src/screamingface/plugins/aigw_base/plugin_base.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/plugin_base.py
@@ -13,7 +13,13 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import httpx
 
+from screamingface.core.backend_paths import (
+    PROFILE_ALIAS_RE,
+    catalog_aliases_from_model_ids,
+    is_valid_profile_alias,
+)
 from screamingface.core.local_only import assert_loopback_server_bind
+from screamingface.plugins.backend_api_base.models import BackendProfile
 from screamingface.plugins.backend_api_base.plugin_base import BackendApiPluginBase
 
 from .backend import AigwBackend
@@ -88,6 +94,37 @@ class AigwBackendApiPluginBase(BackendApiPluginBase):
         super()._refresh_api_config_for_alias(app)
         if self._api_config is not None:
             self._api_config.backend = self._backend(app)
+
+    def backend_alias_profiles(self) -> dict[str, BackendProfile]:
+        profiles = dict(super().backend_alias_profiles())
+        for alias, model in self._catalog_alias_model_map().items():
+            profiles.setdefault(alias, BackendProfile(model=model))
+        return profiles
+
+    def resolve_backend_alias_profile(
+        self, alias: str, *, base_path: str | None = None, app: FastAPI | None = None
+    ) -> BackendProfile:
+        base = base_path or (self.backend_call_paths[0] if self.backend_call_paths else "")
+        if not is_valid_profile_alias(alias):
+            raise ValueError(
+                f"Invalid profile alias {alias!r} for backend {base}. "
+                f"Aliases must match {PROFILE_ALIAS_RE.pattern}."
+            )
+
+        profiles = getattr(self.settings, "profiles", {}) or {}
+        if isinstance(profiles, dict) and alias in profiles:
+            return profiles[alias]
+
+        model = self._catalog_alias_model_map().get(alias)
+        if model is not None:
+            return BackendProfile(model=model)
+        raise ValueError(f"No profile alias {alias!r} is configured for backend {base}.")
+
+    def _catalog_alias_model_map(self) -> dict[str, str]:
+        models = self._fetch_gateway_model_ids()
+        if not models:
+            return {}
+        return catalog_aliases_from_model_ids(models)
 
     def _assert_loopback_server_bind(self, app: FastAPI) -> None:
         assert_loopback_server_bind(

--- a/apps/server/src/screamingface/plugins/aigw_base/plugin_base.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/plugin_base.py
@@ -2,7 +2,7 @@
 
 Subclasses mirror direct backend plugin style: declare class-level metadata
 (`name`, `backend_call_paths`, `schema_link_base`, `settings_class`,
-`create_router`) and inherit `_make_interpreter` here.
+`create_route_bundle`/`create_router`) and inherit `_make_interpreter` here.
 """
 
 from __future__ import annotations
@@ -78,11 +78,11 @@ class AigwBackendApiPluginBase(BackendApiPluginBase):
     def setup(self, app: FastAPI, hooks, classes, routes) -> None:
         self._app = app
         self._assert_loopback_server_bind(app)
-        router = type(self).create_router(self.settings, app, backend=self._backend(app))
-        routes.add_router(self.name, router, prefix="")
-        # SF-346: same profile-alias wiring capture as BackendApiPluginBase.setup
-        # (this override does not call super().setup()).
-        self._api_config = getattr(router, "sf_api_config", None)
+        bundle = type(self).create_route_bundle(self.settings, app, backend=self._backend(app))
+        routes.add_router(self.name, bundle.router, prefix="")
+        # SF-346: same explicit profile-alias wiring capture as
+        # BackendApiPluginBase.setup (this override does not call super().setup()).
+        self._api_config = bundle.config
 
     def _assert_loopback_server_bind(self, app: FastAPI) -> None:
         assert_loopback_server_bind(

--- a/apps/server/src/screamingface/plugins/aigw_base/plugin_base.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/plugin_base.py
@@ -84,6 +84,11 @@ class AigwBackendApiPluginBase(BackendApiPluginBase):
         # BackendApiPluginBase.setup (this override does not call super().setup()).
         self._api_config = bundle.config
 
+    def _refresh_api_config_for_alias(self, app: FastAPI) -> None:
+        super()._refresh_api_config_for_alias(app)
+        if self._api_config is not None:
+            self._api_config.backend = self._backend(app)
+
     def _assert_loopback_server_bind(self, app: FastAPI) -> None:
         assert_loopback_server_bind(
             app,

--- a/apps/server/src/screamingface/plugins/aigw_base/plugin_base.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/plugin_base.py
@@ -7,16 +7,16 @@ Subclasses mirror direct backend plugin style: declare class-level metadata
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import httpx
 
 from screamingface.core.backend_paths import (
-    PROFILE_ALIAS_RE,
     catalog_aliases_from_model_ids,
-    is_valid_profile_alias,
 )
 from screamingface.core.local_only import assert_loopback_server_bind
 from screamingface.plugins.backend_api_base.models import BackendProfile
@@ -36,6 +36,21 @@ _log = logging.getLogger(__name__)
 # Hard cap on the gateway profile-list fetch performed during schema
 # emission. The /plugins/{name}/schema endpoint must never hang the UI.
 _SCHEMA_FETCH_TIMEOUT_S = 2.0
+_CATALOG_ALIAS_CACHE_TTL_S = 30.0
+
+
+class AigwCatalogUnavailable(RuntimeError):
+    """Raised when a live gateway catalog is required but unavailable."""
+
+    retryable = True
+
+    def __init__(self, provider: str, cause: BaseException) -> None:
+        self.provider = provider
+        self.cause = cause
+        super().__init__(
+            f"gateway model catalog unavailable for provider {provider!r}; "
+            f"cannot resolve dynamic URL4 aliases ({type(cause).__name__}: {cause})"
+        )
 
 
 class AigwBackendApiPluginBase(BackendApiPluginBase):
@@ -97,34 +112,102 @@ class AigwBackendApiPluginBase(BackendApiPluginBase):
 
     def backend_alias_profiles(self) -> dict[str, BackendProfile]:
         profiles = dict(super().backend_alias_profiles())
-        for alias, model in self._catalog_alias_model_map().items():
+        for alias, model in self._catalog_alias_model_map_or_empty().items():
             profiles.setdefault(alias, BackendProfile(model=model))
         return profiles
 
-    def resolve_backend_alias_profile(
-        self, alias: str, *, base_path: str | None = None, app: FastAPI | None = None
-    ) -> BackendProfile:
-        base = base_path or (self.backend_call_paths[0] if self.backend_call_paths else "")
-        if not is_valid_profile_alias(alias):
-            raise ValueError(
-                f"Invalid profile alias {alias!r} for backend {base}. "
-                f"Aliases must match {PROFILE_ALIAS_RE.pattern}."
+    async def backend_alias_profiles_async(self) -> dict[str, BackendProfile]:
+        profiles = dict(super().backend_alias_profiles())
+        try:
+            catalog_profiles = await self._catalog_alias_model_map_async(
+                app=getattr(self, "_app", None)
             )
+        except AigwCatalogUnavailable as exc:
+            _log.debug("aigw alias inventory: gateway model-list fetch failed (%s)", exc)
+            catalog_profiles = {}
+        for alias, model in catalog_profiles.items():
+            profiles.setdefault(alias, BackendProfile(model=model))
+        return profiles
 
-        profiles = getattr(self.settings, "profiles", {}) or {}
-        if isinstance(profiles, dict) and alias in profiles:
-            return profiles[alias]
-
-        model = self._catalog_alias_model_map().get(alias)
+    def _resolve_alias_fallback(
+        self, alias: str, *, base_path: str, app: FastAPI | None = None
+    ) -> BackendProfile | None:
+        del base_path
+        model = self._catalog_alias_model_map(app=app).get(alias)
         if model is not None:
             return BackendProfile(model=model)
-        raise ValueError(f"No profile alias {alias!r} is configured for backend {base}.")
 
-    def _catalog_alias_model_map(self) -> dict[str, str]:
-        models = self._fetch_gateway_model_ids()
-        if not models:
+        return None
+
+    async def _resolve_alias_fallback_async(
+        self, alias: str, *, base_path: str, app: FastAPI | None = None
+    ) -> BackendProfile | None:
+        del base_path
+        model = (await self._catalog_alias_model_map_async(app=app)).get(alias)
+        if model is not None:
+            return BackendProfile(model=model)
+        return None
+
+    def _catalog_alias_model_map_or_empty(self) -> dict[str, str]:
+        try:
+            return self._catalog_alias_model_map(app=getattr(self, "_app", None))
+        except AigwCatalogUnavailable as exc:
+            _log.debug("aigw alias inventory: gateway model-list fetch failed (%s)", exc)
             return {}
-        return catalog_aliases_from_model_ids(models)
+
+    def _catalog_alias_model_map(self, *, app: FastAPI | None = None) -> dict[str, str]:
+        key = self._catalog_alias_cache_key(app)
+        cached = self._catalog_alias_cache_get(key)
+        if cached is not None:
+            return cached
+        models = self._fetch_gateway_model_ids_strict()
+        aliases = catalog_aliases_from_model_ids(models)
+        self._catalog_alias_cache_set(key, aliases)
+        return aliases
+
+    async def _catalog_alias_model_map_async(self, *, app: FastAPI | None = None) -> dict[str, str]:
+        key = self._catalog_alias_cache_key(app)
+        cached = self._catalog_alias_cache_get(key)
+        if cached is not None:
+            return cached
+        models = await asyncio.to_thread(self._fetch_gateway_model_ids_strict)
+        aliases = catalog_aliases_from_model_ids(models)
+        self._catalog_alias_cache_set(key, aliases)
+        return aliases
+
+    def _catalog_alias_cache_key(self, app: FastAPI | None) -> tuple[str, str] | None:
+        if not self.gateway_provider or self.settings is None:
+            return None
+        settings = cast(AigwBackendApiSettingsBase, self.settings)
+        if app is not None:
+            gateway_url = resolve_aigw_runtime_config(app).gateway_url
+        else:
+            gateway_url = getattr(settings, "gateway_url", "")
+        return str(gateway_url).rstrip("/"), self.gateway_provider
+
+    def _catalog_alias_cache_get(self, key: tuple[str, str] | None) -> dict[str, str] | None:
+        if key is None:
+            return None
+        cache = getattr(self, "_catalog_alias_cache", {})
+        entry = cache.get(key)
+        if entry is None:
+            return None
+        expires_at, aliases = entry
+        if expires_at <= time.monotonic():
+            cache.pop(key, None)
+            return None
+        return dict(aliases)
+
+    def _catalog_alias_cache_set(
+        self, key: tuple[str, str] | None, aliases: dict[str, str]
+    ) -> None:
+        if key is None:
+            return
+        cache = getattr(self, "_catalog_alias_cache", None)
+        if not isinstance(cache, dict):
+            cache = {}
+            self._catalog_alias_cache = cache
+        cache[key] = (time.monotonic() + _CATALOG_ALIAS_CACHE_TTL_S, dict(aliases))
 
     def _assert_loopback_server_bind(self, app: FastAPI) -> None:
         assert_loopback_server_bind(
@@ -222,21 +305,42 @@ class AigwBackendApiPluginBase(BackendApiPluginBase):
         aggregates every loaded provider, so results are filtered to this
         backend's `gateway_provider` (which equals the gateway's ``owned_by``).
         """
-        if not self.gateway_provider:
-            return None
-        if self.settings is None:
-            return None
-        client = self._schema_gateway_client()
         try:
-            payload = _gateway_json(client, "/v1/models")
-        except (AigwGatewayClientError, httpx.HTTPError, ValueError) as exc:
+            return self._fetch_gateway_model_ids_strict()
+        except AigwCatalogUnavailable as exc:
             _log.debug(
                 "aigw schema: gateway model-list fetch failed (%s); "
                 "falling back to configured model values",
                 exc,
             )
             return None
-        return _model_ids_from_payload(payload, self.gateway_provider)
+
+    def _fetch_gateway_model_ids_strict(self) -> list[str]:
+        if not self.gateway_provider:
+            return []
+        if self.settings is None:
+            return []
+        instance_override = self.__dict__.get("_fetch_gateway_model_ids")
+        if callable(instance_override):
+            models = cast(Callable[[], list[str] | None], instance_override)()
+            if models is None:
+                raise AigwCatalogUnavailable(
+                    self.gateway_provider,
+                    ValueError("gateway model catalog override returned no models"),
+                )
+            return list(models)
+        client = self._schema_gateway_client()
+        try:
+            payload = _gateway_json(client, "/v1/models")
+        except (AigwGatewayClientError, httpx.HTTPError, ValueError) as exc:
+            raise AigwCatalogUnavailable(self.gateway_provider, exc) from exc
+        models = _model_ids_from_payload(payload, self.gateway_provider)
+        if models is None:
+            raise AigwCatalogUnavailable(
+                self.gateway_provider,
+                ValueError("unexpected /v1/models payload shape"),
+            )
+        return models
 
     def _inject_auth_profile_enum(self, auth_profile_field: dict[str, Any]) -> None:
         settings = cast(AigwBackendApiSettingsBase, self.settings)

--- a/apps/server/src/screamingface/plugins/aigw_base/tests/test_interpreter.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/tests/test_interpreter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any, cast
 
 import httpx
@@ -64,15 +65,19 @@ async def test_process_returns_empty_when_no_input() -> None:
 def test_plugin_setup_and_interpreter_share_backend(monkeypatch) -> None:
     captured: dict[str, Any] = {}
 
-    def create_router(settings, app=None, *, backend=None):  # noqa: ANN001
+    def create_route_bundle(settings, app=None, *, backend=None):  # noqa: ANN001, ARG001
         captured["backend"] = backend
-        return APIRouter()
+        return SimpleNamespace(router=APIRouter(), config=SimpleNamespace())
 
     class _Routes:
         def add_router(self, name, router, prefix=""):  # noqa: ANN001, ARG002
             return None
 
-    monkeypatch.setattr(AigwClaudeBackendPlugin, "create_router", staticmethod(create_router))
+    monkeypatch.setattr(
+        AigwClaudeBackendPlugin,
+        "create_route_bundle",
+        staticmethod(create_route_bundle),
+    )
     plugin = AigwClaudeBackendPlugin()
     plugin.settings = AigwClaudeBackendSettings()
     app = FastAPI()

--- a/apps/server/src/screamingface/plugins/aigw_base/tests/test_interpreter.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/tests/test_interpreter.py
@@ -9,6 +9,7 @@ import httpx
 import pytest
 from fastapi import APIRouter, FastAPI
 
+from screamingface.core.backend_paths import catalog_aliases_from_model_ids
 from screamingface.plugins.aigw_base.backend import AigwBackend
 from screamingface.plugins.aigw_base.interpreter import AigwInterpreter
 from screamingface.plugins.aigw_claude_backend.plugin import (
@@ -93,3 +94,21 @@ def test_plugin_setup_and_interpreter_share_backend(monkeypatch) -> None:
 
     assert captured["backend"] is interpreter._backend
     assert plugin._api_config is captured["config"]
+
+
+def test_catalog_aliases_from_model_ids_are_short_and_collision_safe() -> None:
+    aliases = catalog_aliases_from_model_ids(
+        [
+            "huggingface/openai/gpt-oss-120b:cerebras",
+            "huggingface/openai/gpt-oss-120b:novita",
+            "huggingface/meta-llama/Llama-3.1-8B-Instruct:nscale",
+            "gemini/gemini-2.5-pro",
+        ]
+    )
+
+    assert aliases == {
+        "gpt-oss-120b-cerebras": "huggingface/openai/gpt-oss-120b:cerebras",
+        "gpt-oss-120b-novita": "huggingface/openai/gpt-oss-120b:novita",
+        "llama-3-1-8b-instruct": "huggingface/meta-llama/Llama-3.1-8B-Instruct:nscale",
+        "gemini-2-5-pro": "gemini/gemini-2.5-pro",
+    }

--- a/apps/server/src/screamingface/plugins/aigw_base/tests/test_interpreter.py
+++ b/apps/server/src/screamingface/plugins/aigw_base/tests/test_interpreter.py
@@ -67,7 +67,8 @@ def test_plugin_setup_and_interpreter_share_backend(monkeypatch) -> None:
 
     def create_route_bundle(settings, app=None, *, backend=None):  # noqa: ANN001, ARG001
         captured["backend"] = backend
-        return SimpleNamespace(router=APIRouter(), config=SimpleNamespace())
+        captured["config"] = SimpleNamespace()
+        return SimpleNamespace(router=APIRouter(), config=captured["config"])
 
     class _Routes:
         def add_router(self, name, router, prefix=""):  # noqa: ANN001, ARG002
@@ -91,3 +92,4 @@ def test_plugin_setup_and_interpreter_share_backend(monkeypatch) -> None:
     interpreter = plugin._make_interpreter(app)
 
     assert captured["backend"] is interpreter._backend
+    assert plugin._api_config is captured["config"]

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/plugin.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/plugin.py
@@ -17,7 +17,7 @@ from screamingface.plugins.aigw_base import (
     AigwBackendApiPluginBase,
     AigwBackendApiSettingsBase,
 )
-from screamingface.plugins.aigw_claude_backend.routes import create_router
+from screamingface.plugins.aigw_claude_backend.routes import create_route_bundle, create_router
 
 if TYPE_CHECKING:
     pass
@@ -74,4 +74,5 @@ class AigwClaudeBackendPlugin(AigwBackendApiPluginBase):
     supports_api_key = True
     settings_class = AigwClaudeBackendSettings
     schema_link_base = "/claude/"
+    create_route_bundle = staticmethod(create_route_bundle)
     create_router = staticmethod(create_router)

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/routes.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/routes.py
@@ -22,7 +22,8 @@ from screamingface.plugins.aigw_claude_backend._defaults import (
 )
 from screamingface.plugins.llm_base.routes_shared import (
     BackendApiConfig,
-    build_backend_api_router,
+    BackendApiRouteBundle,
+    build_backend_api_route_bundle,
 )
 
 if TYPE_CHECKING:
@@ -33,12 +34,12 @@ _DEFAULT_MODEL = "anthropic/claude-sonnet-4-5"
 _GATEWAY_PROVIDER = "anthropic"
 
 
-def create_router(
+def create_route_bundle(
     settings: AigwClaudeBackendSettings,
     app: Any = None,
     *,
     backend: AigwBackend | None = None,
-) -> APIRouter:
+) -> BackendApiRouteBundle:
     gateway_url = _gateway_url(app, settings.gateway_url)
     backend = backend or AigwBackend(
         gateway_url=gateway_url,
@@ -55,7 +56,7 @@ def create_router(
             gateway_provider=_GATEWAY_PROVIDER,
         )
 
-    router = build_backend_api_router(
+    bundle = build_backend_api_route_bundle(
         BackendApiConfig(
             name="aigw-claude-backend",
             path_prefix="/claude",
@@ -67,6 +68,7 @@ def create_router(
             span_prefix="aigw_claude",
         )
     )
+    router = bundle.router
     profile_defaults = _build_profile_defaults_from_settings(settings)
     router.include_router(
         build_aigw_auth_proxy_router(
@@ -78,7 +80,16 @@ def create_router(
             defaults=profile_defaults or None,
         )
     )
-    return router
+    return bundle
+
+
+def create_router(
+    settings: AigwClaudeBackendSettings,
+    app: Any = None,
+    *,
+    backend: AigwBackend | None = None,
+) -> APIRouter:
+    return create_route_bundle(settings, app, backend=backend).router
 
 
 def _gateway_url(app: Any, fallback: str) -> str:

--- a/apps/server/src/screamingface/plugins/aigw_claude_backend/tests/test_url4_dispatch.py
+++ b/apps/server/src/screamingface/plugins/aigw_claude_backend/tests/test_url4_dispatch.py
@@ -14,6 +14,7 @@ from screamingface.plugins.aigw_claude_backend.plugin import (
     AigwClaudeBackendPlugin,
     AigwClaudeBackendSettings,
 )
+from screamingface.plugins.backend_api_base.models import BackendProfile
 
 
 def _factory_returning(text: str, captured: dict | None = None):
@@ -143,3 +144,35 @@ async def test_interpreter_retries_fallback_model_on_429() -> None:
         "anthropic/claude-sonnet-4-5",
         "anthropic/claude-haiku-4-5",
     ]
+
+
+@pytest.mark.anyio
+async def test_bare_path_uses_default_model_not_default_profile() -> None:
+    """SF-346 plan negative assertion: a bare exact /claude(...) URL4 call runs
+    settings.default_model through the interpreter and must NOT switch to a
+    configured profile's model just because a default_profile is set. Alias
+    dispatch is the only path that reads profiles; the bare path is unchanged."""
+    captured: dict = {}
+    factory = _factory_returning("pong", captured)
+    settings = AigwClaudeBackendSettings(
+        default_model="anthropic/claude-haiku-4-5",
+        profiles={"other": BackendProfile(model="anthropic/claude-opus-4-1")},
+        default_profile="other",
+    )
+    backend = AigwBackend(
+        gateway_url=settings.gateway_url,
+        profile_name=settings.auth_profile,
+        gateway_provider="anthropic",
+        http_client_factory=factory,
+    )
+    interpreter = AigwInterpreter(
+        app=None,
+        settings=settings,
+        backend=backend,
+        gateway_provider="anthropic",
+    )
+
+    await interpreter.process(sources="", intent="hi")
+
+    assert captured["body"]["model"] == "anthropic/claude-haiku-4-5"  # settings.default_model
+    assert captured["body"]["model"] != "anthropic/claude-opus-4-1"  # NOT default_profile's model

--- a/apps/server/src/screamingface/plugins/aigw_codex_backend/plugin.py
+++ b/apps/server/src/screamingface/plugins/aigw_codex_backend/plugin.py
@@ -9,7 +9,7 @@ from screamingface.plugins.aigw_base import (
     AigwBackendApiPluginBase,
     AigwBackendApiSettingsBase,
 )
-from screamingface.plugins.aigw_codex_backend.routes import create_router
+from screamingface.plugins.aigw_codex_backend.routes import create_route_bundle, create_router
 
 
 class AigwCodexBackendSettings(AigwBackendApiSettingsBase):
@@ -44,4 +44,5 @@ class AigwCodexBackendPlugin(AigwBackendApiPluginBase):
     gateway_provider = "codex"
     settings_class = AigwCodexBackendSettings
     schema_link_base = "/codex/"
+    create_route_bundle = staticmethod(create_route_bundle)
     create_router = staticmethod(create_router)

--- a/apps/server/src/screamingface/plugins/aigw_codex_backend/routes.py
+++ b/apps/server/src/screamingface/plugins/aigw_codex_backend/routes.py
@@ -15,7 +15,8 @@ from screamingface.plugins.aigw_base import (
 from screamingface.plugins.aigw_base.config import resolve_aigw_runtime_config
 from screamingface.plugins.llm_base.routes_shared import (
     BackendApiConfig,
-    build_backend_api_router,
+    BackendApiRouteBundle,
+    build_backend_api_route_bundle,
 )
 
 if TYPE_CHECKING:
@@ -26,12 +27,12 @@ _PATH_PREFIX = "/codex"
 _DEFAULT_MODEL = "codex/gpt-5.4-mini"
 
 
-def create_router(
+def create_route_bundle(
     settings: AigwCodexBackendSettings,
     app: Any = None,
     *,
     backend: AigwBackend | None = None,
-) -> APIRouter:
+) -> BackendApiRouteBundle:
     gateway_url = _gateway_url(app, settings.gateway_url)
     backend = backend or AigwBackend(
         gateway_url=gateway_url,
@@ -48,7 +49,7 @@ def create_router(
             gateway_provider=_GATEWAY_PROVIDER,
         )
 
-    router = build_backend_api_router(
+    bundle = build_backend_api_route_bundle(
         BackendApiConfig(
             name="aigw-codex-backend",
             path_prefix=_PATH_PREFIX,
@@ -60,6 +61,7 @@ def create_router(
             span_prefix="aigw_codex",
         )
     )
+    router = bundle.router
     profile_defaults = build_profile_defaults_from_settings(settings)
     router.include_router(
         build_aigw_auth_proxy_router(
@@ -71,7 +73,16 @@ def create_router(
             defaults=profile_defaults or None,
         )
     )
-    return router
+    return bundle
+
+
+def create_router(
+    settings: AigwCodexBackendSettings,
+    app: Any = None,
+    *,
+    backend: AigwBackend | None = None,
+) -> APIRouter:
+    return create_route_bundle(settings, app, backend=backend).router
 
 
 def _gateway_url(app: Any, fallback: str) -> str:

--- a/apps/server/src/screamingface/plugins/aigw_gemini_backend/plugin.py
+++ b/apps/server/src/screamingface/plugins/aigw_gemini_backend/plugin.py
@@ -9,7 +9,7 @@ from screamingface.plugins.aigw_base import (
     AigwBackendApiPluginBase,
     AigwBackendApiSettingsBase,
 )
-from screamingface.plugins.aigw_gemini_backend.routes import create_router
+from screamingface.plugins.aigw_gemini_backend.routes import create_route_bundle, create_router
 
 
 class AigwGeminiBackendSettings(AigwBackendApiSettingsBase):
@@ -45,4 +45,5 @@ class AigwGeminiBackendPlugin(AigwBackendApiPluginBase):
     supports_api_key = True
     settings_class = AigwGeminiBackendSettings
     schema_link_base = "/gemini/"
+    create_route_bundle = staticmethod(create_route_bundle)
     create_router = staticmethod(create_router)

--- a/apps/server/src/screamingface/plugins/aigw_gemini_backend/routes.py
+++ b/apps/server/src/screamingface/plugins/aigw_gemini_backend/routes.py
@@ -15,7 +15,8 @@ from screamingface.plugins.aigw_base import (
 from screamingface.plugins.aigw_base.config import resolve_aigw_runtime_config
 from screamingface.plugins.llm_base.routes_shared import (
     BackendApiConfig,
-    build_backend_api_router,
+    BackendApiRouteBundle,
+    build_backend_api_route_bundle,
 )
 
 if TYPE_CHECKING:
@@ -26,12 +27,12 @@ _PATH_PREFIX = "/gemini"
 _DEFAULT_MODEL = "gemini-cli/gemini-2.5-flash"
 
 
-def create_router(
+def create_route_bundle(
     settings: AigwGeminiBackendSettings,
     app: Any = None,
     *,
     backend: AigwBackend | None = None,
-) -> APIRouter:
+) -> BackendApiRouteBundle:
     gateway_url = _gateway_url(app, settings.gateway_url)
     backend = backend or AigwBackend(
         gateway_url=gateway_url,
@@ -48,7 +49,7 @@ def create_router(
             gateway_provider=_GATEWAY_PROVIDER,
         )
 
-    router = build_backend_api_router(
+    bundle = build_backend_api_route_bundle(
         BackendApiConfig(
             name="aigw-gemini-backend",
             path_prefix=_PATH_PREFIX,
@@ -60,6 +61,7 @@ def create_router(
             span_prefix="aigw_gemini",
         )
     )
+    router = bundle.router
     profile_defaults = build_profile_defaults_from_settings(settings)
     router.include_router(
         build_aigw_auth_proxy_router(
@@ -71,7 +73,16 @@ def create_router(
             defaults=profile_defaults or None,
         )
     )
-    return router
+    return bundle
+
+
+def create_router(
+    settings: AigwGeminiBackendSettings,
+    app: Any = None,
+    *,
+    backend: AigwBackend | None = None,
+) -> APIRouter:
+    return create_route_bundle(settings, app, backend=backend).router
 
 
 def _gateway_url(app: Any, fallback: str) -> str:

--- a/apps/server/src/screamingface/plugins/aigw_huggingface_backend/plugin.py
+++ b/apps/server/src/screamingface/plugins/aigw_huggingface_backend/plugin.py
@@ -9,7 +9,7 @@ from screamingface.plugins.aigw_base import (
     AigwBackendApiPluginBase,
     AigwBackendApiSettingsBase,
 )
-from screamingface.plugins.aigw_huggingface_backend.routes import create_router
+from screamingface.plugins.aigw_huggingface_backend.routes import create_route_bundle, create_router
 
 
 class AigwHuggingfaceBackendSettings(AigwBackendApiSettingsBase):
@@ -50,4 +50,5 @@ class AigwHuggingfaceBackendPlugin(AigwBackendApiPluginBase):
     supports_oauth = False
     settings_class = AigwHuggingfaceBackendSettings
     schema_link_base = "/huggingface/"
+    create_route_bundle = staticmethod(create_route_bundle)
     create_router = staticmethod(create_router)

--- a/apps/server/src/screamingface/plugins/aigw_huggingface_backend/routes.py
+++ b/apps/server/src/screamingface/plugins/aigw_huggingface_backend/routes.py
@@ -15,7 +15,8 @@ from screamingface.plugins.aigw_base import (
 from screamingface.plugins.aigw_base.config import resolve_aigw_runtime_config
 from screamingface.plugins.llm_base.routes_shared import (
     BackendApiConfig,
-    build_backend_api_router,
+    BackendApiRouteBundle,
+    build_backend_api_route_bundle,
 )
 
 if TYPE_CHECKING:
@@ -28,12 +29,12 @@ _PATH_PREFIX = "/huggingface"
 _DEFAULT_MODEL = "huggingface/deepseek-ai/DeepSeek-R1:novita"
 
 
-def create_router(
+def create_route_bundle(
     settings: AigwHuggingfaceBackendSettings,
     app: Any = None,
     *,
     backend: AigwBackend | None = None,
-) -> APIRouter:
+) -> BackendApiRouteBundle:
     gateway_url = _gateway_url(app, settings.gateway_url)
     backend = backend or AigwBackend(
         gateway_url=gateway_url,
@@ -50,7 +51,7 @@ def create_router(
             gateway_provider=_GATEWAY_PROVIDER,
         )
 
-    router = build_backend_api_router(
+    bundle = build_backend_api_route_bundle(
         BackendApiConfig(
             name="aigw-huggingface-backend",
             path_prefix=_PATH_PREFIX,
@@ -62,6 +63,7 @@ def create_router(
             span_prefix="aigw_huggingface",
         )
     )
+    router = bundle.router
     profile_defaults = build_profile_defaults_from_settings(settings)
     router.include_router(
         build_aigw_auth_proxy_router(
@@ -76,7 +78,16 @@ def create_router(
             include_oauth_routes=False,
         )
     )
-    return router
+    return bundle
+
+
+def create_router(
+    settings: AigwHuggingfaceBackendSettings,
+    app: Any = None,
+    *,
+    backend: AigwBackend | None = None,
+) -> APIRouter:
+    return create_route_bundle(settings, app, backend=backend).router
 
 
 def _gateway_url(app: Any, fallback: str) -> str:

--- a/apps/server/src/screamingface/plugins/backend_api_base/plugin_base.py
+++ b/apps/server/src/screamingface/plugins/backend_api_base/plugin_base.py
@@ -139,14 +139,17 @@ class BackendApiPluginBase(Plugin):
       ``settings_class``).
     - ``schema_link_base``: URL prefix shown to RJSF as the "x-link-base"
       hint on the ``profiles`` field, e.g. ``"/claude/"``.
-    - ``create_router``: a callable returning the provider's APIRouter.
-      Signature ``(settings, app)`` matches the existing factories.
+    - ``create_route_bundle``: a callable returning the provider's generated
+      APIRouter plus the BackendApiConfig that powers shared profile helpers.
+    - ``create_router``: compatibility callable returning only the provider's
+      APIRouter. Signature ``(settings, app)`` matches the existing factories.
     - ``_make_interpreter(app)``: lazy interpreter construction. Each
       subclass imports its provider-specific Interpreter class inside
       this method to keep module-load free of circular imports.
     """
 
     schema_link_base: ClassVar[str] = "/"
+    create_route_bundle: ClassVar[Callable[..., Any]]
     create_router: ClassVar[Callable[..., Any]]
     # SF-290: LLM backends pack context into a prompt, so the url4 dispatcher
     # pre-fetches any ``/...`` / ``http(s)://`` ref in a backend call's context
@@ -159,8 +162,8 @@ class BackendApiPluginBase(Plugin):
     # MUST NOT import this class, so python-runner and other non-profile plugins
     # simply never opt in and ``/python/foo`` stays an unknown backend call.
     supports_profile_aliases: ClassVar[bool] = True
-    # Shared execution wiring captured from the router at setup() so alias
-    # dispatch runs profiles through the same helpers as the HTTP profile route.
+    # Shared execution wiring captured explicitly at setup() so alias dispatch
+    # runs profiles through the same helpers as the HTTP profile route.
     _api_config: BackendApiConfig | None = None
 
     def customize_schema(self, schema: dict) -> dict:
@@ -181,12 +184,12 @@ class BackendApiPluginBase(Plugin):
         routes: RouteRegistry,
     ) -> None:
         self._assert_loopback_server_bind(app)
-        router = type(self).create_router(self.settings, app)
-        routes.add_router(self.name, router, prefix="")
-        # SF-346: capture the shared BackendApiConfig the router factory stashed,
-        # so handle_backend_alias can execute profiles through the same helpers
-        # the HTTP profile route uses (no divergent second execution path).
-        self._api_config = getattr(router, "sf_api_config", None)
+        bundle = type(self).create_route_bundle(self.settings, app)
+        routes.add_router(self.name, bundle.router, prefix="")
+        # SF-346: capture the shared BackendApiConfig explicitly, so
+        # handle_backend_alias can execute profiles through the same helpers the
+        # HTTP profile route uses (no divergent second execution path).
+        self._api_config = bundle.config
 
     def _assert_loopback_server_bind(self, app: FastAPI) -> None:
         assert_loopback_server_bind(

--- a/apps/server/src/screamingface/plugins/backend_api_base/plugin_base.py
+++ b/apps/server/src/screamingface/plugins/backend_api_base/plugin_base.py
@@ -14,12 +14,12 @@ This base concentrates the shared behavior. Each subclass shrinks to
 
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import SettingsConfigDict
 
+from screamingface.core.backend_paths import PROFILE_ALIAS_RE, is_valid_profile_alias
 from screamingface.core.local_only import assert_loopback_server_bind
 from screamingface.plugin import Plugin, PluginSettings
 from screamingface.plugins.backend_api_base.models import BackendProfile
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from screamingface.plugins.llm_base.routes_shared import BackendApiConfig
     from screamingface.plugins.url4_executor.scope import Env
 
-_PROFILE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+_PROFILE_NAME_RE = PROFILE_ALIAS_RE
 
 
 class BackendApiSettingsBase(PluginSettings):
@@ -100,9 +100,9 @@ class BackendApiSettingsBase(PluginSettings):
         default_factory=dict,
         description="Named pre-configured execution profiles.",
     )
-    default_profile: str = Field(
-        default="default",
-        description="Profile to use when none is specified. Must exist in profiles.",
+    default_profile: str | None = Field(
+        default=None,
+        description="Profile to use when none is specified. Must exist in profiles when set.",
     )
 
     @field_validator("profiles")
@@ -236,20 +236,13 @@ class BackendApiPluginBase(Plugin):
         message on an invalid or unknown alias.
         """
         del env
-        base = self.backend_call_paths[0] if self.backend_call_paths else ""
-        if not _PROFILE_NAME_RE.match(alias):
-            raise ValueError(
-                f"Invalid profile alias {alias!r} for backend {base}. "
-                f"Aliases must match {_PROFILE_NAME_RE.pattern}."
-            )
-        profiles = getattr(self.settings, "profiles", {}) or {}
-        if alias not in profiles:
-            raise ValueError(f"No profile alias {alias!r} is configured for backend {base}.")
+        self.validate_backend_alias(alias)
         if self._api_config is None:
             raise RuntimeError(
                 f"{self.name!r} cannot dispatch profile alias {alias!r}: backend-api "
                 "config was not captured during setup()."
             )
+        self._refresh_api_config_for_alias(app)
         # Local import — llm_base imports backend_api_base.models, so a module-load
         # import here would cycle. Mirrors the lazy-import pattern in routes_shared.
         from screamingface.plugins.llm_base.routes_shared import execute_profile_text
@@ -257,6 +250,24 @@ class BackendApiPluginBase(Plugin):
         return await execute_profile_text(
             self._api_config, alias, packed_context=sources, intent=intent
         )
+
+    def validate_backend_alias(self, alias: str, *, base_path: str | None = None) -> None:
+        """Validate alias syntax/existence before any context fetch or backend run."""
+
+        base = base_path or (self.backend_call_paths[0] if self.backend_call_paths else "")
+        if not is_valid_profile_alias(alias):
+            raise ValueError(
+                f"Invalid profile alias {alias!r} for backend {base}. "
+                f"Aliases must match {_PROFILE_NAME_RE.pattern}."
+            )
+        profiles = getattr(self.settings, "profiles", {}) or {}
+        if alias not in profiles:
+            raise ValueError(f"No profile alias {alias!r} is configured for backend {base}.")
+
+    def _refresh_api_config_for_alias(self, app: FastAPI) -> None:
+        del app
+        if self._api_config is not None:
+            self._api_config.settings = self.settings
 
     def _make_interpreter(self, app: FastAPI) -> Any:
         """Subclass hook: build a fresh provider-specific interpreter.

--- a/apps/server/src/screamingface/plugins/backend_api_base/plugin_base.py
+++ b/apps/server/src/screamingface/plugins/backend_api_base/plugin_base.py
@@ -236,10 +236,29 @@ class BackendApiPluginBase(Plugin):
         message on an invalid or unknown alias.
         """
         del env
-        profile = self.resolve_backend_alias_profile(alias)
+        profile = self.resolve_backend_alias_profile(alias, app=app)
+        return await self.handle_resolved_backend_alias(
+            profile,
+            sources=sources,
+            intent=intent,
+            app=app,
+        )
+
+    async def handle_resolved_backend_alias(
+        self,
+        profile: BackendProfile,
+        *,
+        sources: str = "",
+        intent: str = "",
+        app: FastAPI,
+        env: Env | None = None,
+    ) -> str:
+        """Execute a URL4 profile alias after the dispatcher resolved it once."""
+
+        del env
         if self._api_config is None:
             raise RuntimeError(
-                f"{self.name!r} cannot dispatch profile alias {alias!r}: backend-api "
+                f"{self.name!r} cannot dispatch resolved profile alias: backend-api "
                 "config was not captured during setup()."
             )
         self._refresh_api_config_for_alias(app)
@@ -274,18 +293,58 @@ class BackendApiPluginBase(Plugin):
     ) -> BackendProfile:
         """Return the profile object backing a URL4 alias, or raise clearly."""
 
-        del app
-        base = base_path or (self.backend_call_paths[0] if self.backend_call_paths else "")
+        base = self._alias_base_path(base_path)
+        self._validate_profile_alias(alias, base)
+        profile = self._configured_alias_profile(alias)
+        if profile is None:
+            profile = self._resolve_alias_fallback(alias, base_path=base, app=app)
+        if profile is None:
+            raise self._unknown_profile_alias(alias, base)
+        return profile
+
+    async def resolve_backend_alias_profile_async(
+        self, alias: str, *, base_path: str | None = None, app: FastAPI | None = None
+    ) -> BackendProfile:
+        """Async resolver hook for plugins whose alias fallback does I/O."""
+
+        base = self._alias_base_path(base_path)
+        self._validate_profile_alias(alias, base)
+        profile = self._configured_alias_profile(alias)
+        if profile is None:
+            profile = await self._resolve_alias_fallback_async(alias, base_path=base, app=app)
+        if profile is None:
+            raise self._unknown_profile_alias(alias, base)
+        return profile
+
+    def _alias_base_path(self, base_path: str | None) -> str:
+        return base_path or (self.backend_call_paths[0] if self.backend_call_paths else "")
+
+    def _validate_profile_alias(self, alias: str, base: str) -> None:
         if not is_valid_profile_alias(alias):
             raise ValueError(
                 f"Invalid profile alias {alias!r} for backend {base}. "
                 f"Aliases must match {_PROFILE_NAME_RE.pattern}."
             )
+
+    def _configured_alias_profile(self, alias: str) -> BackendProfile | None:
         profiles = getattr(self.settings, "profiles", {}) or {}
-        profile = profiles.get(alias) if isinstance(profiles, dict) else None
-        if profile is None:
-            raise ValueError(f"No profile alias {alias!r} is configured for backend {base}.")
-        return profile
+        return profiles.get(alias) if isinstance(profiles, dict) else None
+
+    def _resolve_alias_fallback(
+        self, alias: str, *, base_path: str, app: FastAPI | None = None
+    ) -> BackendProfile | None:
+        """Subclass hook for non-configured aliases."""
+
+        del alias, base_path, app
+        return None
+
+    async def _resolve_alias_fallback_async(
+        self, alias: str, *, base_path: str, app: FastAPI | None = None
+    ) -> BackendProfile | None:
+        return self._resolve_alias_fallback(alias, base_path=base_path, app=app)
+
+    def _unknown_profile_alias(self, alias: str, base: str) -> ValueError:
+        return ValueError(f"No profile alias {alias!r} is configured for backend {base}.")
 
     def _refresh_api_config_for_alias(self, app: FastAPI) -> None:
         del app

--- a/apps/server/src/screamingface/plugins/backend_api_base/plugin_base.py
+++ b/apps/server/src/screamingface/plugins/backend_api_base/plugin_base.py
@@ -231,12 +231,12 @@ class BackendApiPluginBase(Plugin):
         :attr:`supports_profile_aliases`. Validates the alias with the same
         ``_PROFILE_NAME_RE`` that guards profile-config keys — one regex, so the
         alias gate and the config-key rule can never drift — then runs the
-        matching profile through the shared :func:`execute_profile_text` helper so
-        the profile's model reaches the backend. Raises with a clear URL4-facing
+        matching profile through the shared backend-profile helper so the
+        profile's model reaches the backend. Raises with a clear URL4-facing
         message on an invalid or unknown alias.
         """
         del env
-        self.validate_backend_alias(alias)
+        profile = self.resolve_backend_alias_profile(alias)
         if self._api_config is None:
             raise RuntimeError(
                 f"{self.name!r} cannot dispatch profile alias {alias!r}: backend-api "
@@ -245,15 +245,36 @@ class BackendApiPluginBase(Plugin):
         self._refresh_api_config_for_alias(app)
         # Local import — llm_base imports backend_api_base.models, so a module-load
         # import here would cycle. Mirrors the lazy-import pattern in routes_shared.
-        from screamingface.plugins.llm_base.routes_shared import execute_profile_text
+        from screamingface.plugins.llm_base.routes_shared import execute_backend_profile_text
 
-        return await execute_profile_text(
-            self._api_config, alias, packed_context=sources, intent=intent
+        return await execute_backend_profile_text(
+            self._api_config, profile, packed_context=sources, intent=intent
         )
+
+    def backend_alias_profiles(self) -> dict[str, BackendProfile]:
+        """Profiles to advertise as URL4 aliases in `/plugins/backend-aliases`."""
+
+        profiles = getattr(self.settings, "profiles", {}) or {}
+        if not isinstance(profiles, dict):
+            return {}
+        default_profile = getattr(self.settings, "default_profile", None)
+        return {
+            name: profile
+            for name, profile in profiles.items()
+            if isinstance(name, str) and name and name != default_profile
+        }
 
     def validate_backend_alias(self, alias: str, *, base_path: str | None = None) -> None:
         """Validate alias syntax/existence before any context fetch or backend run."""
 
+        self.resolve_backend_alias_profile(alias, base_path=base_path)
+
+    def resolve_backend_alias_profile(
+        self, alias: str, *, base_path: str | None = None, app: FastAPI | None = None
+    ) -> BackendProfile:
+        """Return the profile object backing a URL4 alias, or raise clearly."""
+
+        del app
         base = base_path or (self.backend_call_paths[0] if self.backend_call_paths else "")
         if not is_valid_profile_alias(alias):
             raise ValueError(
@@ -261,8 +282,10 @@ class BackendApiPluginBase(Plugin):
                 f"Aliases must match {_PROFILE_NAME_RE.pattern}."
             )
         profiles = getattr(self.settings, "profiles", {}) or {}
-        if alias not in profiles:
+        profile = profiles.get(alias) if isinstance(profiles, dict) else None
+        if profile is None:
             raise ValueError(f"No profile alias {alias!r} is configured for backend {base}.")
+        return profile
 
     def _refresh_api_config_for_alias(self, app: FastAPI) -> None:
         del app

--- a/apps/server/src/screamingface/plugins/backend_api_base/plugin_base.py
+++ b/apps/server/src/screamingface/plugins/backend_api_base/plugin_base.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from screamingface.core.classes import ClassRegistry
     from screamingface.core.hooks import HookRegistry
     from screamingface.core.routes import RouteRegistry
+    from screamingface.plugins.llm_base.routes_shared import BackendApiConfig
     from screamingface.plugins.url4_executor.scope import Env
 
 _PROFILE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
@@ -152,6 +153,15 @@ class BackendApiPluginBase(Plugin):
     # before handing it over. Backends that consume a raw locator instead
     # (e.g. python_runner, which fetches its own script) leave this False.
     resolves_context_sources: ClassVar[bool] = True
+    # SF-346: this plugin can resolve a URL4 backend-call suffix
+    # (``/<path>/<alias>``) to one of its configured ``settings.profiles`` and
+    # execute it. The URL4 dispatcher reads this flag by duck-typing (getattr) and
+    # MUST NOT import this class, so python-runner and other non-profile plugins
+    # simply never opt in and ``/python/foo`` stays an unknown backend call.
+    supports_profile_aliases: ClassVar[bool] = True
+    # Shared execution wiring captured from the router at setup() so alias
+    # dispatch runs profiles through the same helpers as the HTTP profile route.
+    _api_config: BackendApiConfig | None = None
 
     def customize_schema(self, schema: dict) -> dict:
         settings: BackendApiSettingsBase = self.settings  # type: ignore[assignment]
@@ -173,6 +183,10 @@ class BackendApiPluginBase(Plugin):
         self._assert_loopback_server_bind(app)
         router = type(self).create_router(self.settings, app)
         routes.add_router(self.name, router, prefix="")
+        # SF-346: capture the shared BackendApiConfig the router factory stashed,
+        # so handle_backend_alias can execute profiles through the same helpers
+        # the HTTP profile route uses (no divergent second execution path).
+        self._api_config = getattr(router, "sf_api_config", None)
 
     def _assert_loopback_server_bind(self, app: FastAPI) -> None:
         assert_loopback_server_bind(
@@ -198,6 +212,48 @@ class BackendApiPluginBase(Plugin):
         del env
         interpreter = self._make_interpreter(app)
         return await interpreter.process(sources=sources, intent=intent)
+
+    async def handle_backend_alias(
+        self,
+        alias: str,
+        *,
+        sources: str = "",
+        intent: str = "",
+        app: FastAPI,  # noqa: ARG002 — signature parity with handle_backend_call
+        env: Env | None = None,
+    ) -> str:
+        """Execute a URL4 profile alias (``/<backend>/<alias>(ctx)!intent``).
+
+        Called by the URL4 dispatcher only for plugins that advertise
+        :attr:`supports_profile_aliases`. Validates the alias with the same
+        ``_PROFILE_NAME_RE`` that guards profile-config keys — one regex, so the
+        alias gate and the config-key rule can never drift — then runs the
+        matching profile through the shared :func:`execute_profile_text` helper so
+        the profile's model reaches the backend. Raises with a clear URL4-facing
+        message on an invalid or unknown alias.
+        """
+        del env
+        base = self.backend_call_paths[0] if self.backend_call_paths else ""
+        if not _PROFILE_NAME_RE.match(alias):
+            raise ValueError(
+                f"Invalid profile alias {alias!r} for backend {base}. "
+                f"Aliases must match {_PROFILE_NAME_RE.pattern}."
+            )
+        profiles = getattr(self.settings, "profiles", {}) or {}
+        if alias not in profiles:
+            raise ValueError(f"No profile alias {alias!r} is configured for backend {base}.")
+        if self._api_config is None:
+            raise RuntimeError(
+                f"{self.name!r} cannot dispatch profile alias {alias!r}: backend-api "
+                "config was not captured during setup()."
+            )
+        # Local import — llm_base imports backend_api_base.models, so a module-load
+        # import here would cycle. Mirrors the lazy-import pattern in routes_shared.
+        from screamingface.plugins.llm_base.routes_shared import execute_profile_text
+
+        return await execute_profile_text(
+            self._api_config, alias, packed_context=sources, intent=intent
+        )
 
     def _make_interpreter(self, app: FastAPI) -> Any:
         """Subclass hook: build a fresh provider-specific interpreter.

--- a/apps/server/src/screamingface/plugins/backend_api_base/tests/test_profile_alias.py
+++ b/apps/server/src/screamingface/plugins/backend_api_base/tests/test_profile_alias.py
@@ -19,7 +19,10 @@ from screamingface.core.config import AppConfig, ServerConfig
 from screamingface.core.hooks import HookRegistry
 from screamingface.core.routes import RouteRegistry
 from screamingface.plugins.backend_api_base.models import BackendProfile
-from screamingface.plugins.backend_api_base.plugin_base import BackendApiPluginBase
+from screamingface.plugins.backend_api_base.plugin_base import (
+    BackendApiPluginBase,
+    BackendApiSettingsBase,
+)
 from screamingface.plugins.llm_base.backend_base import Backend, HealthStatus
 from screamingface.plugins.llm_base.messages import CoreMessage, ToolDefinition, extract_text
 from screamingface.plugins.llm_base.routes_shared import (
@@ -87,6 +90,13 @@ def test_backend_api_base_supports_profile_aliases_by_default() -> None:
     assert BackendApiPluginBase.supports_profile_aliases is True
 
 
+def test_profile_aliases_do_not_require_a_default_profile_entry() -> None:
+    settings = BackendApiSettingsBase(profiles={"oss20b": BackendProfile(model="m/x")})
+
+    assert "oss20b" in settings.profiles
+    assert settings.default_profile is None
+
+
 @pytest.mark.asyncio
 async def test_handle_backend_alias_runs_the_profile_model() -> None:
     backend = _RecordingBackend()
@@ -97,6 +107,22 @@ async def test_handle_backend_alias_runs_the_profile_model() -> None:
 
     assert backend.calls[0]["model"] == "huggingface/openai/gpt-oss-20b:cheapest"
     assert "gpt-oss-20b" in out
+
+
+@pytest.mark.asyncio
+async def test_handle_backend_alias_uses_current_settings_after_rebind() -> None:
+    backend = _RecordingBackend()
+    plugin = _make_plugin(backend, {"old": BackendProfile(model="m/old")})
+    plugin.settings = SimpleNamespace(  # type: ignore[assignment]
+        default_model=None,
+        timeout_seconds=300.0,
+        profiles={"new": BackendProfile(model="m/new")},
+    )
+
+    out = await plugin.handle_backend_alias("new", sources="", intent="answer", app=_APP)
+
+    assert backend.calls[0]["model"] == "m/new"
+    assert "m/new" in out
 
 
 @pytest.mark.asyncio

--- a/apps/server/src/screamingface/plugins/backend_api_base/tests/test_profile_alias.py
+++ b/apps/server/src/screamingface/plugins/backend_api_base/tests/test_profile_alias.py
@@ -22,7 +22,10 @@ from screamingface.plugins.backend_api_base.models import BackendProfile
 from screamingface.plugins.backend_api_base.plugin_base import BackendApiPluginBase
 from screamingface.plugins.llm_base.backend_base import Backend, HealthStatus
 from screamingface.plugins.llm_base.messages import CoreMessage, ToolDefinition, extract_text
-from screamingface.plugins.llm_base.routes_shared import BackendApiConfig, build_backend_api_router
+from screamingface.plugins.llm_base.routes_shared import (
+    BackendApiConfig,
+    build_backend_api_route_bundle,
+)
 
 # handle_backend_alias ignores its ``app`` argument (it delegates through the
 # captured config), so a bare app satisfies the type without any wiring.
@@ -120,15 +123,17 @@ async def test_handle_backend_alias_unknown_alias_names_the_backend() -> None:
     assert backend.calls == []
 
 
-def test_setup_captures_api_config_from_router() -> None:
+def test_setup_captures_api_config_from_explicit_route_bundle() -> None:
     backend = _RecordingBackend()
     profiles = {"oss20b": BackendProfile(model="m/x")}
     cfg = _cfg(backend, profiles)
+    bundle = build_backend_api_route_bundle(cfg)
 
     class _P(BackendApiPluginBase):
         name = "alias-test-backend-api"
         backend_call_paths = ["/aliastest"]
-        create_router = staticmethod(lambda settings, app=None: build_backend_api_router(cfg))
+        create_route_bundle = staticmethod(lambda settings, app=None: bundle)
+        create_router = staticmethod(lambda settings, app=None: bundle.router)
 
     plugin = _P()
     plugin.settings = cfg.settings  # type: ignore[assignment]
@@ -138,3 +143,4 @@ def test_setup_captures_api_config_from_router() -> None:
     plugin.setup(app=app, hooks=HookRegistry(), classes=ClassRegistry(), routes=RouteRegistry(app))
 
     assert plugin._api_config is cfg
+    assert not hasattr(bundle.router, "sf_api_config")

--- a/apps/server/src/screamingface/plugins/backend_api_base/tests/test_profile_alias.py
+++ b/apps/server/src/screamingface/plugins/backend_api_base/tests/test_profile_alias.py
@@ -1,0 +1,140 @@
+"""Tests for URL4 profile-alias dispatch on ``BackendApiPluginBase`` (SF-346).
+
+``handle_backend_alias`` is the profile-capable seam the URL4 dispatcher calls
+for ``/<backend>/<alias>(...)`` expressions. It validates the alias (reusing the
+same ``_PROFILE_NAME_RE`` that guards profile-config keys), then executes the
+profile through the shared ``execute_profile_text`` helper — so the alias runs
+the profile's model, never the backend default.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+
+from screamingface.core.classes import ClassRegistry
+from screamingface.core.config import AppConfig, ServerConfig
+from screamingface.core.hooks import HookRegistry
+from screamingface.core.routes import RouteRegistry
+from screamingface.plugins.backend_api_base.models import BackendProfile
+from screamingface.plugins.backend_api_base.plugin_base import BackendApiPluginBase
+from screamingface.plugins.llm_base.backend_base import Backend, HealthStatus
+from screamingface.plugins.llm_base.messages import CoreMessage, ToolDefinition, extract_text
+from screamingface.plugins.llm_base.routes_shared import BackendApiConfig, build_backend_api_router
+
+# handle_backend_alias ignores its ``app`` argument (it delegates through the
+# captured config), so a bare app satisfies the type without any wiring.
+_APP = FastAPI()
+
+
+class _RecordingBackend(Backend):
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def health(self, model: str | None = None) -> HealthStatus:  # noqa: ARG002
+        return HealthStatus(authenticated=True)
+
+    async def run(
+        self,
+        messages: list[CoreMessage],
+        *,
+        model: str,
+        system: str | None = None,  # noqa: ARG002
+        tools: list[ToolDefinition] | None = None,  # noqa: ARG002
+        max_tokens: int = 16000,  # noqa: ARG002
+        temperature: float | None = None,  # noqa: ARG002
+        timeout_seconds: float = 300.0,  # noqa: ARG002
+    ) -> CoreMessage:
+        self.calls.append({"model": model, "prompt": extract_text(messages[0]) if messages else ""})
+        return CoreMessage(role="assistant", content=f"ran {model}")
+
+
+class _AliasPlugin(BackendApiPluginBase):
+    name = "alias-test-backend-api"
+    backend_call_paths = ["/aliastest"]
+    schema_link_base = "/aliastest/"
+
+
+def _cfg(backend: Backend, profiles: dict[str, BackendProfile]) -> BackendApiConfig:
+    settings = SimpleNamespace(default_model=None, timeout_seconds=300.0, profiles=profiles)
+    return BackendApiConfig(
+        name="alias-test-backend-api",
+        path_prefix="/aliastest",
+        default_model="provider/hardcoded-default",
+        backend=backend,
+        settings=settings,
+        app=None,
+        build_interpreter=lambda: None,
+        span_prefix="aliastest",
+    )
+
+
+def _make_plugin(backend: Backend, profiles: dict[str, BackendProfile]) -> _AliasPlugin:
+    plugin = _AliasPlugin()
+    plugin.settings = SimpleNamespace(  # type: ignore[assignment]
+        default_model=None, timeout_seconds=300.0, profiles=profiles
+    )
+    plugin._api_config = _cfg(backend, profiles)
+    return plugin
+
+
+def test_backend_api_base_supports_profile_aliases_by_default() -> None:
+    assert BackendApiPluginBase.supports_profile_aliases is True
+
+
+@pytest.mark.asyncio
+async def test_handle_backend_alias_runs_the_profile_model() -> None:
+    backend = _RecordingBackend()
+    profiles = {"oss20b": BackendProfile(model="huggingface/openai/gpt-oss-20b:cheapest")}
+    plugin = _make_plugin(backend, profiles)
+
+    out = await plugin.handle_backend_alias("oss20b", sources="", intent="answer", app=_APP)
+
+    assert backend.calls[0]["model"] == "huggingface/openai/gpt-oss-20b:cheapest"
+    assert "gpt-oss-20b" in out
+
+
+@pytest.mark.asyncio
+async def test_handle_backend_alias_rejects_invalid_syntax() -> None:
+    backend = _RecordingBackend()
+    profiles = {"oss20b": BackendProfile(model="m/x")}
+    plugin = _make_plugin(backend, profiles)
+
+    with pytest.raises(Exception, match="Invalid profile alias 'OSS20b'"):
+        await plugin.handle_backend_alias("OSS20b", sources="", intent="q", app=_APP)
+    assert backend.calls == []
+
+
+@pytest.mark.asyncio
+async def test_handle_backend_alias_unknown_alias_names_the_backend() -> None:
+    backend = _RecordingBackend()
+    profiles = {"oss20b": BackendProfile(model="m/x")}
+    plugin = _make_plugin(backend, profiles)
+
+    with pytest.raises(
+        Exception, match="No profile alias 'nope' is configured for backend /aliastest"
+    ):
+        await plugin.handle_backend_alias("nope", sources="", intent="q", app=_APP)
+    assert backend.calls == []
+
+
+def test_setup_captures_api_config_from_router() -> None:
+    backend = _RecordingBackend()
+    profiles = {"oss20b": BackendProfile(model="m/x")}
+    cfg = _cfg(backend, profiles)
+
+    class _P(BackendApiPluginBase):
+        name = "alias-test-backend-api"
+        backend_call_paths = ["/aliastest"]
+        create_router = staticmethod(lambda settings, app=None: build_backend_api_router(cfg))
+
+    plugin = _P()
+    plugin.settings = cfg.settings  # type: ignore[assignment]
+
+    app = FastAPI()
+    app.state.config = AppConfig(server=ServerConfig(host="127.0.0.1"))
+    plugin.setup(app=app, hooks=HookRegistry(), classes=ClassRegistry(), routes=RouteRegistry(app))
+
+    assert plugin._api_config is cfg

--- a/apps/server/src/screamingface/plugins/claude_backend_api/plugin.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/plugin.py
@@ -20,7 +20,7 @@ from screamingface.plugins.backend_api_base import (
     BackendApiPluginBase,
     BackendApiSettingsBase,
 )
-from screamingface.plugins.claude_backend_api.routes import create_router
+from screamingface.plugins.claude_backend_api.routes import create_route_bundle, create_router
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
@@ -91,6 +91,7 @@ class ClaudeBackendApiPlugin(BackendApiPluginBase):
     settings_class = ClaudeBackendApiSettings
 
     schema_link_base = "/claude/"
+    create_route_bundle = staticmethod(create_route_bundle)
     create_router = staticmethod(create_router)
 
     def customize_schema(self, schema: dict) -> dict:

--- a/apps/server/src/screamingface/plugins/claude_backend_api/routes.py
+++ b/apps/server/src/screamingface/plugins/claude_backend_api/routes.py
@@ -22,7 +22,8 @@ from fastapi import APIRouter
 from screamingface.plugins.claude_backend_api.backend import AnthropicBackend
 from screamingface.plugins.llm_base.routes_shared import (
     BackendApiConfig,
-    build_backend_api_router,
+    BackendApiRouteBundle,
+    build_backend_api_route_bundle,
 )
 
 if TYPE_CHECKING:
@@ -32,7 +33,9 @@ if TYPE_CHECKING:
 _DEFAULT_MODEL = "claude-sonnet-4-6"
 
 
-def create_router(settings: ClaudeBackendApiSettings, app: Any = None) -> APIRouter:
+def create_route_bundle(
+    settings: ClaudeBackendApiSettings, app: Any = None
+) -> BackendApiRouteBundle:
     from screamingface.plugins.claude_backend_api.plugin import _maybe_aigw_source
 
     backend = AnthropicBackend(aigw_source=_maybe_aigw_source(settings, app))
@@ -45,7 +48,7 @@ def create_router(settings: ClaudeBackendApiSettings, app: Any = None) -> APIRou
 
         return ClaudeBackendApiInterpreter(app=app, settings=settings, backend=backend)
 
-    return build_backend_api_router(
+    return build_backend_api_route_bundle(
         BackendApiConfig(
             name="claude-backend-api",
             path_prefix="/claude",
@@ -57,3 +60,7 @@ def create_router(settings: ClaudeBackendApiSettings, app: Any = None) -> APIRou
             span_prefix="claude",
         )
     )
+
+
+def create_router(settings: ClaudeBackendApiSettings, app: Any = None) -> APIRouter:
+    return create_route_bundle(settings, app).router

--- a/apps/server/src/screamingface/plugins/codex_backend_api/plugin.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/plugin.py
@@ -15,7 +15,7 @@ from screamingface.plugins.backend_api_base import (
     BackendApiPluginBase,
     BackendApiSettingsBase,
 )
-from screamingface.plugins.codex_backend_api.routes import create_router
+from screamingface.plugins.codex_backend_api.routes import create_route_bundle, create_router
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
@@ -83,6 +83,7 @@ class CodexBackendApiPlugin(BackendApiPluginBase):
     settings_class = CodexBackendApiSettings
 
     schema_link_base = "/codex/"
+    create_route_bundle = staticmethod(create_route_bundle)
     create_router = staticmethod(create_router)
 
     def customize_schema(self, schema: dict) -> dict:

--- a/apps/server/src/screamingface/plugins/codex_backend_api/routes.py
+++ b/apps/server/src/screamingface/plugins/codex_backend_api/routes.py
@@ -9,7 +9,8 @@ from fastapi import APIRouter
 from screamingface.plugins.codex_backend_api.backend import OpenAIBackend
 from screamingface.plugins.llm_base.routes_shared import (
     BackendApiConfig,
-    build_backend_api_router,
+    BackendApiRouteBundle,
+    build_backend_api_route_bundle,
 )
 
 if TYPE_CHECKING:
@@ -19,7 +20,9 @@ if TYPE_CHECKING:
 _DEFAULT_MODEL = "o4-mini"
 
 
-def create_router(settings: CodexBackendApiSettings, app: Any = None) -> APIRouter:
+def create_route_bundle(
+    settings: CodexBackendApiSettings, app: Any = None
+) -> BackendApiRouteBundle:
     from screamingface.plugins.codex_backend_api.plugin import _maybe_aigw_source
 
     backend = OpenAIBackend(aigw_source=_maybe_aigw_source(settings, app))
@@ -31,7 +34,7 @@ def create_router(settings: CodexBackendApiSettings, app: Any = None) -> APIRout
 
         return CodexBackendApiInterpreter(app=app, settings=settings, backend=backend)
 
-    return build_backend_api_router(
+    return build_backend_api_route_bundle(
         BackendApiConfig(
             name="codex-backend-api",
             path_prefix="/codex",
@@ -43,3 +46,7 @@ def create_router(settings: CodexBackendApiSettings, app: Any = None) -> APIRout
             span_prefix="codex",
         )
     )
+
+
+def create_router(settings: CodexBackendApiSettings, app: Any = None) -> APIRouter:
+    return create_route_bundle(settings, app).router

--- a/apps/server/src/screamingface/plugins/gemini_backend_api/plugin.py
+++ b/apps/server/src/screamingface/plugins/gemini_backend_api/plugin.py
@@ -16,7 +16,7 @@ from screamingface.plugins.backend_api_base import (
     BackendApiPluginBase,
     BackendApiSettingsBase,
 )
-from screamingface.plugins.gemini_backend_api.routes import create_router
+from screamingface.plugins.gemini_backend_api.routes import create_route_bundle, create_router
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
@@ -102,6 +102,7 @@ class GeminiBackendApiPlugin(BackendApiPluginBase):
     settings_class = GeminiBackendApiSettings
 
     schema_link_base = "/gemini/"
+    create_route_bundle = staticmethod(create_route_bundle)
     create_router = staticmethod(create_router)
 
     def customize_schema(self, schema: dict) -> dict:

--- a/apps/server/src/screamingface/plugins/gemini_backend_api/routes.py
+++ b/apps/server/src/screamingface/plugins/gemini_backend_api/routes.py
@@ -9,7 +9,8 @@ from fastapi import APIRouter
 from screamingface.plugins.gemini_backend_api.backend import GeminiBackend
 from screamingface.plugins.llm_base.routes_shared import (
     BackendApiConfig,
-    build_backend_api_router,
+    BackendApiRouteBundle,
+    build_backend_api_route_bundle,
 )
 
 if TYPE_CHECKING:
@@ -19,7 +20,9 @@ if TYPE_CHECKING:
 _DEFAULT_MODEL = "gemini-2.5-flash"
 
 
-def create_router(settings: GeminiBackendApiSettings, app: Any = None) -> APIRouter:
+def create_route_bundle(
+    settings: GeminiBackendApiSettings, app: Any = None
+) -> BackendApiRouteBundle:
     from screamingface.plugins.gemini_backend_api.plugin import _maybe_aigw_source
 
     backend = GeminiBackend(
@@ -35,7 +38,7 @@ def create_router(settings: GeminiBackendApiSettings, app: Any = None) -> APIRou
 
         return GeminiBackendApiInterpreter(app=app, settings=settings, backend=backend)
 
-    return build_backend_api_router(
+    return build_backend_api_route_bundle(
         BackendApiConfig(
             name="gemini-backend-api",
             path_prefix="/gemini",
@@ -47,3 +50,7 @@ def create_router(settings: GeminiBackendApiSettings, app: Any = None) -> APIRou
             span_prefix="gemini",
         )
     )
+
+
+def create_router(settings: GeminiBackendApiSettings, app: Any = None) -> APIRouter:
+    return create_route_bundle(settings, app).router

--- a/apps/server/src/screamingface/plugins/llm_base/routes_shared.py
+++ b/apps/server/src/screamingface/plugins/llm_base/routes_shared.py
@@ -29,7 +29,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 
-from screamingface.plugins.backend_api_base.models import RunRequest, RunResponse
+from screamingface.plugins.backend_api_base.models import BackendProfile, RunRequest, RunResponse
 from screamingface.plugins.llm_base._route_telemetry import (
     record_ignored_fields,
     record_span_success,
@@ -51,7 +51,7 @@ from screamingface.plugins.llm_base.messages import CoreMessage, TextPart, extra
 logger = logging.getLogger(__name__)
 
 
-__all__ = ["BackendApiConfig", "build_backend_api_router"]
+__all__ = ["BackendApiConfig", "build_backend_api_router", "execute_profile_text"]
 
 
 @dataclass
@@ -152,44 +152,9 @@ def build_backend_api_router(cfg: BackendApiConfig) -> APIRouter:
 
         record_ignored_fields(request, cfg.name)
 
-        timeout = request.timeout_seconds or settings.timeout_seconds
-        model = request.model or settings.default_model or cfg.default_model
-
-        system_parts: list[str] = []
-        if request.system_prompt:
-            system_parts.append(request.system_prompt)
-        if request.append_system_prompt:
-            system_parts.append(request.append_system_prompt)
-        system = "\n\n".join(system_parts) if system_parts else None
-
-        messages = [CoreMessage(role="user", content=[TextPart(text=request.prompt)])]
-
-        async def run_backend(model_to_use: str) -> CoreMessage:
-            return await backend.run(
-                messages,
-                model=model_to_use,
-                system=system,
-                max_tokens=DEFAULT_MAX_TOKENS,
-                temperature=None,
-                timeout_seconds=timeout,
-            )
-
         start = time.monotonic()
         try:
-            fallback_model = request.fallback_model or getattr(settings, "fallback_model", None)
-            try:
-                result = await run_backend(model)
-            except BackendError as exc:
-                if not _should_try_fallback(exc, model, fallback_model):
-                    raise
-                assert isinstance(fallback_model, str)
-                logger.warning(
-                    "%s primary model %s rate limited; retrying fallback model %s",
-                    cfg.name,
-                    model,
-                    fallback_model,
-                )
-                result = await run_backend(fallback_model)
+            result = await _run_backend_with_fallback(cfg, request)
             duration = time.monotonic() - start
             stdout = extract_text(result)
             parsed: dict | list | str | None = None
@@ -326,26 +291,7 @@ def build_backend_api_router(cfg: BackendApiConfig) -> APIRouter:
 
         full_prompt = f"{resolved_context}\n\n{prompt}" if resolved_context else prompt
 
-        run_request = RunRequest(
-            prompt=full_prompt,
-            model=prof.model,
-            system_prompt=prof.system_prompt,
-            append_system_prompt=prof.append_system_prompt,
-            output_format=prof.output_format,
-            json_schema=prof.json_schema,
-            max_budget_usd=prof.max_budget_usd,
-            effort=prof.effort,
-            tools=prof.tools,
-            allowed_tools=prof.allowed_tools,
-            disallowed_tools=prof.disallowed_tools,
-            mcp_config=prof.mcp_config,
-            permission_mode=prof.permission_mode,
-            add_dirs=prof.add_dirs,
-            fallback_model=prof.fallback_model,
-            dangerously_skip_permissions=prof.dangerously_skip_permissions,
-            no_session_persistence=prof.no_session_persistence,
-            timeout_seconds=prof.timeout_seconds,
-        )
+        run_request = _build_run_request_from_profile(prof, full_prompt)
         result = await _execute(run_request)
 
         if is_url4 and isinstance(result, JSONResponse):
@@ -382,6 +328,10 @@ def build_backend_api_router(cfg: BackendApiConfig) -> APIRouter:
     ) -> JSONResponse | StreamingResponse | PlainTextResponse:
         return await _handle_profile(profile_name, prompt, context, raw_context)
 
+    # Expose the wiring so BackendApiPluginBase can execute profile aliases
+    # (URL4 ``/backend/<alias>(...)``) through the same shared helpers the
+    # HTTP profile route uses — no divergent second execution path.
+    router.sf_api_config = cfg  # type: ignore[attr-defined]
     return router
 
 
@@ -396,6 +346,118 @@ def _should_try_fallback(
         and bool(fallback_model)
         and fallback_model != model
     )
+
+
+def _build_run_request_from_profile(prof: BackendProfile, prompt: str) -> RunRequest:
+    """Map a configured :class:`BackendProfile` onto a :class:`RunRequest`.
+
+    Single source of truth shared by the HTTP profile route
+    (``GET/POST /<backend>/<profile>``) and URL4 alias dispatch
+    (:func:`execute_profile_text`), so the two paths can never diverge on which
+    profile fields reach the backend.
+    """
+    return RunRequest(
+        prompt=prompt,
+        model=prof.model,
+        system_prompt=prof.system_prompt,
+        append_system_prompt=prof.append_system_prompt,
+        output_format=prof.output_format,
+        json_schema=prof.json_schema,
+        max_budget_usd=prof.max_budget_usd,
+        effort=prof.effort,
+        tools=prof.tools,
+        allowed_tools=prof.allowed_tools,
+        disallowed_tools=prof.disallowed_tools,
+        mcp_config=prof.mcp_config,
+        permission_mode=prof.permission_mode,
+        add_dirs=prof.add_dirs,
+        fallback_model=prof.fallback_model,
+        dangerously_skip_permissions=prof.dangerously_skip_permissions,
+        no_session_persistence=prof.no_session_persistence,
+        timeout_seconds=prof.timeout_seconds,
+    )
+
+
+async def _run_backend_with_fallback(cfg: BackendApiConfig, request: RunRequest) -> CoreMessage:
+    """Resolve model/system/timeout from ``request`` + settings and run the backend.
+
+    Retries the configured fallback model exactly once on a 429 (the SF-wide
+    rate-limit fallback contract). Raises :class:`BackendError` /
+    :class:`AuthError` / :class:`CredentialNotFoundError` to the caller: the HTTP
+    ``/run`` route wraps them into responses, while the URL4 alias path lets them
+    propagate to the dispatcher. This is the single execution core both callers
+    share, so ``model = request.model or settings.default_model or cfg.default_model``
+    resolves identically everywhere.
+    """
+    settings = cfg.settings
+    timeout = request.timeout_seconds or settings.timeout_seconds
+    model = request.model or settings.default_model or cfg.default_model
+
+    system_parts: list[str] = []
+    if request.system_prompt:
+        system_parts.append(request.system_prompt)
+    if request.append_system_prompt:
+        system_parts.append(request.append_system_prompt)
+    system = "\n\n".join(system_parts) if system_parts else None
+
+    messages = [CoreMessage(role="user", content=[TextPart(text=request.prompt)])]
+
+    async def run_backend(model_to_use: str) -> CoreMessage:
+        return await cfg.backend.run(
+            messages,
+            model=model_to_use,
+            system=system,
+            max_tokens=DEFAULT_MAX_TOKENS,
+            temperature=None,
+            timeout_seconds=timeout,
+        )
+
+    fallback_model = request.fallback_model or getattr(settings, "fallback_model", None)
+    try:
+        return await run_backend(model)
+    except BackendError as exc:
+        if not _should_try_fallback(exc, model, fallback_model):
+            raise
+        assert isinstance(fallback_model, str)
+        logger.warning(
+            "%s primary model %s rate limited; retrying fallback model %s",
+            cfg.name,
+            model,
+            fallback_model,
+        )
+        return await run_backend(fallback_model)
+
+
+async def execute_profile_text(
+    cfg: BackendApiConfig, profile_name: str, *, packed_context: str, intent: str
+) -> str:
+    """Execute a configured backend profile as a URL4 backend-call alias, as text.
+
+    Prompt assembly matches :class:`Url4Interpreter` semantics — intent first,
+    then sources — so ``/backend/<alias>(ctx)!q`` behaves exactly like
+    ``/backend(ctx)!q`` and only the profile's model / system prompt / timeout
+    differ. Context precedence mirrors the HTTP profile route: the URL4 paren
+    context (already resolved by the dispatcher) wins; the profile's own
+    ``context`` applies only when the parens are empty and is resolved as a URL4
+    expression. Raises ``ValueError`` for an unknown profile and propagates
+    backend errors so the URL4 dispatcher surfaces them.
+    """
+    prof = cfg.settings.profiles.get(profile_name)
+    if prof is None:
+        raise ValueError(f"Unknown profile alias {profile_name!r}")
+
+    context = packed_context
+    if not context.strip() and prof.context:
+        # Local import: llm_base must not depend on url4_executor at module load
+        # (url4_executor imports backend plugins during its own setup).
+        from screamingface.plugins.url4_executor.url4 import resolve_str
+
+        context = await resolve_str(prof.context, cfg.app)
+
+    prompt = f"{intent}\n\n{context}" if intent and context else (intent or context or "")
+    request = _build_run_request_from_profile(prof, prompt)
+    result = await _run_backend_with_fallback(cfg, request)
+    return extract_text(result)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/server/src/screamingface/plugins/llm_base/routes_shared.py
+++ b/apps/server/src/screamingface/plugins/llm_base/routes_shared.py
@@ -51,7 +51,13 @@ from screamingface.plugins.llm_base.messages import CoreMessage, TextPart, extra
 logger = logging.getLogger(__name__)
 
 
-__all__ = ["BackendApiConfig", "build_backend_api_router", "execute_profile_text"]
+__all__ = [
+    "BackendApiConfig",
+    "BackendApiRouteBundle",
+    "build_backend_api_route_bundle",
+    "build_backend_api_router",
+    "execute_profile_text",
+]
 
 
 @dataclass
@@ -94,8 +100,16 @@ class BackendApiConfig:
             self.operation_id_prefix = self.name.replace("-backend-api", "").replace("-", "_")
 
 
-def build_backend_api_router(cfg: BackendApiConfig) -> APIRouter:
-    """Produce a FastAPI router with the four canonical backend-API endpoints.
+@dataclass(frozen=True)
+class BackendApiRouteBundle:
+    """The generated backend router plus the config that drives its shared helpers."""
+
+    router: APIRouter
+    config: BackendApiConfig
+
+
+def build_backend_api_route_bundle(cfg: BackendApiConfig) -> BackendApiRouteBundle:
+    """Produce a FastAPI router bundle with the canonical backend-API endpoints.
 
     Endpoints:
 
@@ -328,11 +342,13 @@ def build_backend_api_router(cfg: BackendApiConfig) -> APIRouter:
     ) -> JSONResponse | StreamingResponse | PlainTextResponse:
         return await _handle_profile(profile_name, prompt, context, raw_context)
 
-    # Expose the wiring so BackendApiPluginBase can execute profile aliases
-    # (URL4 ``/backend/<alias>(...)``) through the same shared helpers the
-    # HTTP profile route uses — no divergent second execution path.
-    router.sf_api_config = cfg  # type: ignore[attr-defined]
-    return router
+    return BackendApiRouteBundle(router=router, config=cfg)
+
+
+def build_backend_api_router(cfg: BackendApiConfig) -> APIRouter:
+    """Compatibility wrapper returning only the generated backend APIRouter."""
+
+    return build_backend_api_route_bundle(cfg).router
 
 
 def _should_try_fallback(

--- a/apps/server/src/screamingface/plugins/llm_base/routes_shared.py
+++ b/apps/server/src/screamingface/plugins/llm_base/routes_shared.py
@@ -462,6 +462,20 @@ async def execute_profile_text(
     if prof is None:
         raise ValueError(f"Unknown profile alias {profile_name!r}")
 
+    return await execute_backend_profile_text(
+        cfg, prof, packed_context=packed_context, intent=intent
+    )
+
+
+async def execute_backend_profile_text(
+    cfg: BackendApiConfig, prof: BackendProfile, *, packed_context: str, intent: str
+) -> str:
+    """Execute a concrete profile object as URL4 backend-call text.
+
+    This powers both configured SF profiles and gateway-catalog model aliases,
+    keeping prompt assembly and backend execution identical for both paths.
+    """
+
     context = packed_context
     if not context.strip() and prof.context:
         # Local import: llm_base must not depend on url4_executor at module load

--- a/apps/server/src/screamingface/plugins/llm_base/tests/test_routes_shared.py
+++ b/apps/server/src/screamingface/plugins/llm_base/tests/test_routes_shared.py
@@ -12,18 +12,19 @@ import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
-from screamingface.plugins.backend_api_base.models import RunRequest
+from screamingface.plugins.backend_api_base.models import BackendProfile, RunRequest
 from screamingface.plugins.llm_base.backend_base import Backend, HealthStatus
 from screamingface.plugins.llm_base.constants import (
     CLI_ONLY_FIELD_DEFAULTS,
     CLI_ONLY_FIELDS,
 )
 from screamingface.plugins.llm_base.errors import BackendError
-from screamingface.plugins.llm_base.messages import CoreMessage, ToolDefinition
+from screamingface.plugins.llm_base.messages import CoreMessage, ToolDefinition, extract_text
 from screamingface.plugins.llm_base.routes_shared import (
     BackendApiConfig,
     _reject_cli_only_fields,
     build_backend_api_router,
+    execute_profile_text,
 )
 
 
@@ -188,3 +189,210 @@ def test_run_retries_configured_fallback_model_on_429() -> None:
     assert resp.status_code == 200
     assert resp.json()["so"] == "fallback ok"
     assert backend.models == ["primary/model", "fallback/model"]
+
+
+# ---------------------------------------------------------------------------
+# SF-346: shared profile execution helper (execute_profile_text)
+#
+# URL4 model/profile aliases dispatch through this helper. The invariant that
+# matters most: the profile's own `model` must reach ``backend.run()`` — a naive
+# implementation can false-pass by dispatching to the right backend while still
+# running ``default_model``. Every test here asserts the *recorded* model/prompt.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingBackend(Backend):
+    """Backend that records what it was asked to run."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def health(self, model: str | None = None) -> HealthStatus:  # noqa: ARG002
+        return HealthStatus(authenticated=True)
+
+    async def run(
+        self,
+        messages: list[CoreMessage],
+        *,
+        model: str,
+        system: str | None = None,
+        tools: list[ToolDefinition] | None = None,  # noqa: ARG002
+        max_tokens: int = 16000,  # noqa: ARG002
+        temperature: float | None = None,  # noqa: ARG002
+        timeout_seconds: float = 300.0,
+    ) -> CoreMessage:
+        self.calls.append(
+            {
+                "model": model,
+                "system": system,
+                "timeout_seconds": timeout_seconds,
+                "prompt": extract_text(messages[0]) if messages else "",
+            }
+        )
+        return CoreMessage(role="assistant", content=f"ran {model}")
+
+
+def _profile_cfg(
+    backend: Backend,
+    profiles: dict[str, BackendProfile],
+    *,
+    default_model: str = "provider/hardcoded-default",
+    settings_default_model: str | None = None,
+) -> BackendApiConfig:
+    settings = SimpleNamespace(
+        default_model=settings_default_model,
+        timeout_seconds=300.0,
+        profiles=profiles,
+    )
+    return BackendApiConfig(
+        name="test-backend-api",
+        path_prefix="/test",
+        default_model=default_model,
+        backend=backend,
+        settings=settings,
+        app=None,
+        build_interpreter=lambda: None,
+        span_prefix="test",
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_profile_text_sends_profile_model_to_backend() -> None:
+    """MANDATORY anti-false-pass: the profile's model — not default_model — runs."""
+    backend = _RecordingBackend()
+    cfg = _profile_cfg(
+        backend,
+        {"oss20b": BackendProfile(model="huggingface/openai/gpt-oss-20b:cheapest")},
+        default_model="provider/hardcoded-default",
+        settings_default_model="huggingface/settings-default",
+    )
+
+    result = await execute_profile_text(cfg, "oss20b", packed_context="", intent="answer this")
+
+    assert backend.calls[0]["model"] == "huggingface/openai/gpt-oss-20b:cheapest"
+    assert backend.calls[0]["model"] != "huggingface/settings-default"
+    assert backend.calls[0]["model"] != "provider/hardcoded-default"
+    assert "gpt-oss-20b" in result  # _RecordingBackend echoes the model it ran
+
+
+@pytest.mark.asyncio
+async def test_execute_profile_text_intent_first_ordering() -> None:
+    """URL4 parity: prompt is ``intent\\n\\nsources`` (matches Url4Interpreter),
+    NOT the route's context-first ordering."""
+    backend = _RecordingBackend()
+    cfg = _profile_cfg(backend, {"oss20b": BackendProfile(model="m/x")})
+
+    await execute_profile_text(cfg, "oss20b", packed_context="CONTEXT", intent="QUESTION")
+
+    assert backend.calls[0]["prompt"] == "QUESTION\n\nCONTEXT"
+
+
+@pytest.mark.asyncio
+async def test_execute_profile_text_paren_context_wins_over_profile_context() -> None:
+    backend = _RecordingBackend()
+    cfg = _profile_cfg(backend, {"oss20b": BackendProfile(model="m/x", context="PROFILE_CONTEXT")})
+
+    await execute_profile_text(cfg, "oss20b", packed_context="PAREN_CONTEXT", intent="Q")
+
+    assert backend.calls[0]["prompt"] == "Q\n\nPAREN_CONTEXT"
+    assert "PROFILE_CONTEXT" not in backend.calls[0]["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_execute_profile_text_profile_context_used_when_parens_empty() -> None:
+    backend = _RecordingBackend()
+    cfg = _profile_cfg(backend, {"oss20b": BackendProfile(model="m/x", context="PROFILE_CONTEXT")})
+
+    await execute_profile_text(cfg, "oss20b", packed_context="", intent="Q")
+
+    assert backend.calls[0]["prompt"] == "Q\n\nPROFILE_CONTEXT"
+
+
+@pytest.mark.asyncio
+async def test_execute_profile_text_carries_system_prompt_and_timeout() -> None:
+    backend = _RecordingBackend()
+    cfg = _profile_cfg(
+        backend,
+        {
+            "oss20b": BackendProfile(
+                model="m/x",
+                system_prompt="SYS",
+                append_system_prompt="MORE",
+                timeout_seconds=42.0,
+            )
+        },
+    )
+
+    await execute_profile_text(cfg, "oss20b", packed_context="", intent="Q")
+
+    assert backend.calls[0]["system"] == "SYS\n\nMORE"
+    assert backend.calls[0]["timeout_seconds"] == 42.0
+
+
+@pytest.mark.asyncio
+async def test_execute_profile_text_none_model_uses_settings_default() -> None:
+    """A profile with no model uses settings.default_model (not the hardcoded cfg default)."""
+    backend = _RecordingBackend()
+    cfg = _profile_cfg(
+        backend,
+        {"bare": BackendProfile(model=None)},
+        default_model="provider/hardcoded-default",
+        settings_default_model="settings/chosen",
+    )
+
+    await execute_profile_text(cfg, "bare", packed_context="", intent="Q")
+
+    assert backend.calls[0]["model"] == "settings/chosen"
+
+
+@pytest.mark.asyncio
+async def test_execute_profile_text_unknown_profile_raises() -> None:
+    backend = _RecordingBackend()
+    cfg = _profile_cfg(backend, {"oss20b": BackendProfile(model="m/x")})
+
+    with pytest.raises(Exception, match="nope"):
+        await execute_profile_text(cfg, "nope", packed_context="", intent="Q")
+    assert backend.calls == []
+
+
+@pytest.mark.asyncio
+async def test_execute_profile_text_retries_profile_fallback_model_on_429() -> None:
+    """The profile's own fallback_model is carried into the RunRequest and used
+    on a 429 — locks BackendProfile.fallback_model -> RunRequest.fallback_model
+    -> _run_backend_with_fallback for the URL4 alias path (a rate-limit contract
+    that would otherwise regress silently)."""
+    backend = _FallbackBackend()
+    cfg = _profile_cfg(
+        backend,
+        {"p": BackendProfile(model="primary/model", fallback_model="fallback/model")},
+    )
+
+    result = await execute_profile_text(cfg, "p", packed_context="", intent="Q")
+
+    assert backend.models == ["primary/model", "fallback/model"]
+    assert "fallback ok" in result
+
+
+@pytest.mark.asyncio
+async def test_execute_profile_text_does_not_reresolve_nonempty_paren_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Anti-double-resolution: when the URL4 parens already carry (dispatcher-
+    resolved) context, execute_profile_text uses it verbatim and must NOT run it
+    back through resolve_str — otherwise already-fetched context would be
+    re-fetched or re-interpreted as a URL4 expression."""
+    calls: list[str] = []
+
+    async def _spy_resolve_str(expr: str, app: object = None, env: object = None) -> str:
+        calls.append(expr)
+        return f"RERESOLVED:{expr}"
+
+    monkeypatch.setattr("screamingface.plugins.url4_executor.url4.resolve_str", _spy_resolve_str)
+    backend = _RecordingBackend()
+    cfg = _profile_cfg(backend, {"p": BackendProfile(model="m/x", context="PROFILE_CTX")})
+
+    await execute_profile_text(cfg, "p", packed_context="ALREADY_RESOLVED", intent="Q")
+
+    assert calls == []  # non-empty parens → resolve_str never invoked
+    assert backend.calls[0]["prompt"] == "Q\n\nALREADY_RESOLVED"
+    assert "RERESOLVED" not in backend.calls[0]["prompt"]

--- a/apps/server/src/screamingface/plugins/ollama_backend_api/plugin.py
+++ b/apps/server/src/screamingface/plugins/ollama_backend_api/plugin.py
@@ -16,7 +16,7 @@ from screamingface.plugins.backend_api_base import (
     BackendApiPluginBase,
     BackendApiSettingsBase,
 )
-from screamingface.plugins.ollama_backend_api.routes import create_router
+from screamingface.plugins.ollama_backend_api.routes import create_route_bundle, create_router
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
@@ -60,6 +60,7 @@ class OllamaBackendApiPlugin(BackendApiPluginBase):
     settings_class = OllamaBackendApiSettings
 
     schema_link_base = "/ollama/"
+    create_route_bundle = staticmethod(create_route_bundle)
     create_router = staticmethod(create_router)
 
     def _make_interpreter(self, app: FastAPI):

--- a/apps/server/src/screamingface/plugins/ollama_backend_api/routes.py
+++ b/apps/server/src/screamingface/plugins/ollama_backend_api/routes.py
@@ -8,7 +8,8 @@ from fastapi import APIRouter
 
 from screamingface.plugins.llm_base.routes_shared import (
     BackendApiConfig,
-    build_backend_api_router,
+    BackendApiRouteBundle,
+    build_backend_api_route_bundle,
 )
 from screamingface.plugins.ollama_backend_api.auth import OllamaAuth
 from screamingface.plugins.ollama_backend_api.backend import OllamaBackend
@@ -20,7 +21,9 @@ if TYPE_CHECKING:
 _DEFAULT_MODEL = "llama3.2"
 
 
-def create_router(settings: OllamaBackendApiSettings, app: Any = None) -> APIRouter:
+def create_route_bundle(
+    settings: OllamaBackendApiSettings, app: Any = None
+) -> BackendApiRouteBundle:
     backend = OllamaBackend(
         base_url=settings.base_url,
         auth=OllamaAuth(api_key=settings.api_key),
@@ -33,7 +36,7 @@ def create_router(settings: OllamaBackendApiSettings, app: Any = None) -> APIRou
 
         return OllamaBackendApiInterpreter(app=app, settings=settings, backend=backend)
 
-    return build_backend_api_router(
+    return build_backend_api_route_bundle(
         BackendApiConfig(
             name="ollama-backend-api",
             path_prefix="/ollama",
@@ -45,3 +48,7 @@ def create_router(settings: OllamaBackendApiSettings, app: Any = None) -> APIRou
             span_prefix="ollama",
         )
     )
+
+
+def create_router(settings: OllamaBackendApiSettings, app: Any = None) -> APIRouter:
+    return create_route_bundle(settings, app).router

--- a/apps/server/src/screamingface/plugins/url4_executor/tests/test_url4.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/tests/test_url4.py
@@ -325,6 +325,26 @@ def test_parse_backend_call_different_paths() -> None:
         assert node.path == path
 
 
+def test_parse_backend_call_alias_path() -> None:
+    """SF-346: a two-segment ``/backend/<alias>`` path parses to a single
+    Url4BackendCall whose ``path`` retains both segments. The dispatcher's
+    alias branch derives the alias from ``node.path`` after the exact-match
+    miss, so this grammar contract must fail loudly if the backend_path rule
+    ever stops accepting an interior '/' (otherwise alias specs silently
+    reparse as a relative-URL fetch and never dispatch)."""
+    node = parse("/huggingface/oss20b($prompt)!answer")
+    assert isinstance(node, Url4BackendCall)
+    assert node.path == "/huggingface/oss20b"
+    assert node.packed_context == "$prompt"
+    assert isinstance(node.intent, Url4Text)
+    assert node.intent.value == "answer"
+
+    for path in ("/huggingface/oss20b", "/gemini/flash"):
+        aliased = parse(f"{path}()!test")
+        assert isinstance(aliased, Url4BackendCall)
+        assert aliased.path == path
+
+
 def test_parse_list_of_backend_calls_fanout_shape() -> None:
     """The target spec's fan-out shape: a parenthesized list where every
     element is a backend call to a different backend with the same intent."""

--- a/apps/server/src/screamingface/plugins/url4_executor/tests/test_url4_alias_dispatch.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/tests/test_url4_alias_dispatch.py
@@ -1,0 +1,239 @@
+"""URL4 profile-alias dispatch in ``_dispatch_backend_call`` (SF-346).
+
+``/backend/<alias>(ctx)!intent`` resolves — only after an exact-path miss — to a
+configured profile on a profile-capable plugin, executed via the model-aware
+shared path. These tests pin: exact-match precedence, alias routing, single-
+segment enforcement, the ``/python`` (non-profile) guard, unchanged unknown-
+backend behavior, the ensemble/collection reducer path, and — most importantly —
+that the profile's *model* actually reaches ``backend.run()``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+
+from screamingface.plugin import Plugin
+from screamingface.plugins.backend_api_base.models import BackendProfile
+from screamingface.plugins.backend_api_base.plugin_base import BackendApiPluginBase
+from screamingface.plugins.llm_base.backend_base import Backend, HealthStatus
+from screamingface.plugins.llm_base.messages import CoreMessage, ToolDefinition, extract_text
+from screamingface.plugins.llm_base.routes_shared import BackendApiConfig
+from screamingface.plugins.url4_executor.scope import Env
+from screamingface.plugins.url4_executor.url4 import Url4BackendCall, Url4Text
+from screamingface.plugins.url4_executor.url4_resolve import (
+    _dispatch_backend_call,
+    _dispatch_backend_call_with_intent,
+)
+
+
+class _Registry:
+    def __init__(self, plugins: dict) -> None:
+        self.active_plugins = plugins
+
+
+def _app(plugins: dict) -> FastAPI:
+    app = FastAPI()
+    app.state.plugins = _Registry(plugins)
+    return app
+
+
+class _SpyBackendPlugin(Plugin):
+    """Records which dispatch method fired without doing real work."""
+
+    name = "spy"
+    backend_call_paths = ["/spy"]
+    supports_profile_aliases = True
+
+    def __init__(self) -> None:
+        self.exact_called = False
+        self.alias_called: str | None = None
+
+    async def handle_backend_call(self, intent, *, sources="", app, env=None):  # noqa: ANN001, ARG002
+        self.exact_called = True
+        return "EXACT"
+
+    async def handle_backend_alias(self, alias, *, sources="", intent="", app, env=None):  # noqa: ANN001, ARG002
+        self.alias_called = alias
+        return f"ALIAS:{alias}"
+
+
+class _NonProfilePlugin(Plugin):
+    """Mirrors python-runner: a dispatch target that is NOT profile-capable."""
+
+    name = "python-runner"
+    backend_call_paths = ["/python"]
+    # supports_profile_aliases intentionally absent (getattr default False).
+
+    async def handle_backend_call(self, intent, *, sources="", app, env=None):  # noqa: ANN001, ARG002
+        return "PYTHON"
+
+
+class _RecordingBackend(Backend):
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def health(self, model: str | None = None) -> HealthStatus:  # noqa: ARG002
+        return HealthStatus(authenticated=True)
+
+    async def run(
+        self,
+        messages: list[CoreMessage],
+        *,
+        model: str,
+        system: str | None = None,  # noqa: ARG002
+        tools: list[ToolDefinition] | None = None,  # noqa: ARG002
+        max_tokens: int = 16000,  # noqa: ARG002
+        temperature: float | None = None,  # noqa: ARG002
+        timeout_seconds: float = 300.0,  # noqa: ARG002
+    ) -> CoreMessage:
+        self.calls.append({"model": model, "prompt": extract_text(messages[0]) if messages else ""})
+        return CoreMessage(role="assistant", content=f"ran {model}")
+
+
+class _RealAliasPlugin(BackendApiPluginBase):
+    """A real profile-capable plugin wired to a recording backend — exercises the
+    genuine handle_backend_alias -> execute_profile_text -> backend.run path."""
+
+    name = "faketest-backend-api"
+    backend_call_paths = ["/faketest"]
+
+    def __init__(self, backend: Backend, profiles: dict[str, BackendProfile]) -> None:
+        self.settings = SimpleNamespace(  # type: ignore[assignment]
+            default_model=None, timeout_seconds=300.0, profiles=profiles
+        )
+        self._api_config = BackendApiConfig(
+            name="faketest-backend-api",
+            path_prefix="/faketest",
+            default_model="provider/hardcoded-default",
+            backend=backend,
+            settings=self.settings,
+            app=None,
+            build_interpreter=lambda: None,
+            span_prefix="faketest",
+        )
+
+
+@pytest.mark.asyncio
+async def test_exact_path_takes_precedence_over_alias() -> None:
+    spy = _SpyBackendPlugin()
+    app = _app({"spy": spy})
+    node = Url4BackendCall(path="/spy", intent=Url4Text(value="q"))
+
+    result = await _dispatch_backend_call(node, app, Env.root())
+
+    assert result == "EXACT"
+    assert spy.exact_called is True
+    assert spy.alias_called is None
+
+
+@pytest.mark.asyncio
+async def test_alias_path_routes_to_handle_backend_alias() -> None:
+    spy = _SpyBackendPlugin()
+    app = _app({"spy": spy})
+    node = Url4BackendCall(path="/spy/oss20b", intent=Url4Text(value="q"))
+
+    result = await _dispatch_backend_call(node, app, Env.root())
+
+    assert result == "ALIAS:oss20b"
+    assert spy.alias_called == "oss20b"
+    assert spy.exact_called is False
+
+
+@pytest.mark.asyncio
+async def test_multi_segment_suffix_is_rejected() -> None:
+    spy = _SpyBackendPlugin()
+    app = _app({"spy": spy})
+    node = Url4BackendCall(path="/spy/org/model", intent=Url4Text(value="q"))
+
+    with pytest.raises(RuntimeError, match="single segment"):
+        await _dispatch_backend_call(node, app, Env.root())
+    assert spy.alias_called is None
+
+
+@pytest.mark.asyncio
+async def test_non_profile_plugin_does_not_get_alias_dispatch() -> None:
+    """`/python/foo` must stay an unknown backend call, never a profile alias."""
+    app = _app({"python-runner": _NonProfilePlugin()})
+    node = Url4BackendCall(path="/python/foo", intent=Url4Text(value="q"))
+
+    with pytest.raises(
+        RuntimeError, match=r"No active plugin handles the backend call /python/foo"
+    ):
+        await _dispatch_backend_call(node, app, Env.root())
+
+
+@pytest.mark.asyncio
+async def test_unknown_backend_error_unchanged() -> None:
+    app = _app({"spy": _SpyBackendPlugin()})
+    node = Url4BackendCall(path="/nope", intent=Url4Text(value="q"))
+
+    with pytest.raises(RuntimeError, match=r"No active plugin handles the backend call /nope"):
+        await _dispatch_backend_call(node, app, Env.root())
+
+
+@pytest.mark.asyncio
+async def test_reducer_path_supports_alias() -> None:
+    """The ensemble/collection reducer re-enters via _dispatch_backend_call_with_intent,
+    so alias support there comes for free from the dispatcher-level fix."""
+    spy = _SpyBackendPlugin()
+    app = _app({"spy": spy})
+    node = Url4BackendCall(path="/spy/oss20b", intent=Url4Text(value="original"))
+
+    result = await _dispatch_backend_call_with_intent(node, '["a","b"]', app, Env.root())
+
+    assert result == "ALIAS:oss20b"
+    assert spy.alias_called == "oss20b"
+
+
+@pytest.mark.asyncio
+async def test_alias_sends_profile_model_to_backend_end_to_end() -> None:
+    """MANDATORY anti-false-pass: dispatching `/faketest/oss20b` must reach
+    backend.run() with the *profile* model, not default_model. Exercises the real
+    handle_backend_alias -> execute_profile_text -> backend.run chain."""
+    backend = _RecordingBackend()
+    plugin = _RealAliasPlugin(
+        backend, {"oss20b": BackendProfile(model="huggingface/openai/gpt-oss-20b:cheapest")}
+    )
+    app = _app({"faketest-backend-api": plugin})
+    node = Url4BackendCall(path="/faketest/oss20b", intent=Url4Text(value="answer this"))
+
+    result = await _dispatch_backend_call(node, app, Env.root())
+
+    assert backend.calls[0]["model"] == "huggingface/openai/gpt-oss-20b:cheapest"
+    assert backend.calls[0]["prompt"] == "answer this"
+    assert "gpt-oss-20b" in result
+
+
+@pytest.mark.asyncio
+async def test_unknown_alias_on_known_backend_reports_clearly() -> None:
+    backend = _RecordingBackend()
+    plugin = _RealAliasPlugin(backend, {"oss20b": BackendProfile(model="m/x")})
+    app = _app({"faketest-backend-api": plugin})
+    node = Url4BackendCall(path="/faketest/nope", intent=Url4Text(value="q"))
+
+    with pytest.raises(
+        Exception, match="No profile alias 'nope' is configured for backend /faketest"
+    ):
+        await _dispatch_backend_call(node, app, Env.root())
+    assert backend.calls == []
+
+
+@pytest.mark.asyncio
+async def test_reducer_alias_sends_profile_model_to_backend() -> None:
+    """Plan line 246: the reducer entry point (_dispatch_backend_call_with_intent,
+    used by the collection/ensemble reducers) must also run the alias profile's
+    model on backend.run — not merely dispatch to the right plugin."""
+    backend = _RecordingBackend()
+    plugin = _RealAliasPlugin(
+        backend, {"oss20b": BackendProfile(model="huggingface/openai/gpt-oss-20b:cheapest")}
+    )
+    app = _app({"faketest-backend-api": plugin})
+    node = Url4BackendCall(path="/faketest/oss20b", intent=Url4Text(value="original"))
+
+    result = await _dispatch_backend_call_with_intent(node, '["a","b"]', app, Env.root())
+
+    assert backend.calls[0]["model"] == "huggingface/openai/gpt-oss-20b:cheapest"
+    assert "gpt-oss-20b" in result

--- a/apps/server/src/screamingface/plugins/url4_executor/tests/test_url4_alias_dispatch.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/tests/test_url4_alias_dispatch.py
@@ -10,13 +10,19 @@ that the profile's *model* actually reaches ``backend.run()``.
 
 from __future__ import annotations
 
+import asyncio
+import time
 from types import SimpleNamespace
 
+import httpx
 import pytest
 from fastapi import FastAPI
 
 from screamingface.plugin import Plugin
-from screamingface.plugins.aigw_base.plugin_base import AigwBackendApiPluginBase
+from screamingface.plugins.aigw_base.plugin_base import (
+    AigwBackendApiPluginBase,
+    AigwCatalogUnavailable,
+)
 from screamingface.plugins.backend_api_base.models import BackendProfile
 from screamingface.plugins.backend_api_base.plugin_base import BackendApiPluginBase
 from screamingface.plugins.llm_base.backend_base import Backend, HealthStatus
@@ -129,6 +135,7 @@ class _CatalogAliasPlugin(AigwBackendApiPluginBase):
         profiles: dict[str, BackendProfile] | None = None,
     ) -> None:
         self._models = models
+        self.fetch_count = 0
         self.settings = SimpleNamespace(  # type: ignore[assignment]
             default_model=None,
             timeout_seconds=300.0,
@@ -150,7 +157,42 @@ class _CatalogAliasPlugin(AigwBackendApiPluginBase):
         return self._api_config.backend
 
     def _fetch_gateway_model_ids(self) -> list[str] | None:
+        self.fetch_count += 1
         return list(self._models)
+
+    def _fetch_gateway_model_ids_strict(self) -> list[str]:
+        self.fetch_count += 1
+        return list(self._models)
+
+
+class _GatewayCatalogAliasPlugin(AigwBackendApiPluginBase):
+    name = "gatewaycatalog-backend-api"
+    backend_call_paths = ["/gatewaycatalog"]
+    gateway_provider = "gatewaycatalog"
+
+    def __init__(self, backend: Backend, transport: httpx.MockTransport) -> None:
+        self._http_transport = transport
+        self.settings = SimpleNamespace(  # type: ignore[assignment]
+            default_model=None,
+            timeout_seconds=300.0,
+            profiles={},
+            gateway_url="http://127.0.0.1:9105",
+            auth_profile="default",
+        )
+        self._api_config = BackendApiConfig(
+            name="gatewaycatalog-backend-api",
+            path_prefix="/gatewaycatalog",
+            default_model="provider/hardcoded-default",
+            backend=backend,
+            settings=self.settings,
+            app=None,
+            build_interpreter=lambda: None,
+            span_prefix="gatewaycatalog",
+        )
+
+    def _backend(self, app=None):  # noqa: ANN001
+        assert self._api_config is not None
+        return self._api_config.backend
 
 
 @pytest.mark.asyncio
@@ -366,6 +408,103 @@ async def test_aigw_catalog_alias_sends_catalog_model_to_backend() -> None:
     assert backend.calls[0]["model"] == "huggingface/openai/gpt-oss-120b:cerebras"
     assert backend.calls[0]["prompt"] == "answer this"
     assert "gpt-oss-120b" in result
+    assert plugin.fetch_count == 1
+
+
+@pytest.mark.asyncio
+async def test_aigw_catalog_alias_dispatch_uses_cached_real_gateway_client() -> None:
+    backend = _RecordingBackend()
+    requests: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request.url.path)
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [
+                    {
+                        "id": "gatewaycatalog/openai/gpt-oss-120b:cerebras",
+                        "object": "model",
+                        "owned_by": "gatewaycatalog",
+                    }
+                ],
+            },
+        )
+
+    plugin = _GatewayCatalogAliasPlugin(backend, httpx.MockTransport(handler))
+    app = _app({"gatewaycatalog-backend-api": plugin})
+    plugin._app = app
+    node = Url4BackendCall(path="/gatewaycatalog/gpt-oss-120b", intent=Url4Text(value="q"))
+
+    await _dispatch_backend_call(node, app, Env.root())
+    await _dispatch_backend_call(node, app, Env.root())
+
+    assert requests == ["/v1/models"]
+    assert [call["model"] for call in backend.calls] == [
+        "gatewaycatalog/openai/gpt-oss-120b:cerebras",
+        "gatewaycatalog/openai/gpt-oss-120b:cerebras",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_aigw_catalog_alias_dispatch_does_not_block_event_loop() -> None:
+    backend = _RecordingBackend()
+    tick_times: list[float] = []
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        time.sleep(0.08)
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [
+                    {
+                        "id": "gatewaycatalog/openai/gpt-oss-120b:cerebras",
+                        "object": "model",
+                        "owned_by": "gatewaycatalog",
+                    }
+                ],
+            },
+        )
+
+    async def heartbeat() -> None:
+        await asyncio.sleep(0.01)
+        tick_times.append(time.perf_counter())
+
+    plugin = _GatewayCatalogAliasPlugin(backend, httpx.MockTransport(handler))
+    app = _app({"gatewaycatalog-backend-api": plugin})
+    plugin._app = app
+    node = Url4BackendCall(path="/gatewaycatalog/gpt-oss-120b", intent=Url4Text(value="q"))
+
+    heartbeat_task = asyncio.create_task(heartbeat())
+    await _dispatch_backend_call(node, app, Env.root())
+    dispatch_finished_at = time.perf_counter()
+    await heartbeat_task
+
+    assert tick_times and tick_times[0] < dispatch_finished_at
+
+
+def test_gateway_model_fetch_failure_is_distinct_from_unknown_alias() -> None:
+    backend = _RecordingBackend()
+    down = _GatewayCatalogAliasPlugin(
+        backend,
+        httpx.MockTransport(lambda _request: httpx.Response(503, json={"error": "down"})),
+    )
+
+    with pytest.raises(AigwCatalogUnavailable, match="gateway model catalog unavailable"):
+        down.resolve_backend_alias_profile("missing", base_path="/gatewaycatalog")
+
+    empty = _GatewayCatalogAliasPlugin(
+        backend,
+        httpx.MockTransport(
+            lambda _request: httpx.Response(200, json={"object": "list", "data": []})
+        ),
+    )
+    with pytest.raises(
+        ValueError, match="No profile alias 'missing' is configured for backend /gatewaycatalog"
+    ):
+        empty.resolve_backend_alias_profile("missing", base_path="/gatewaycatalog")
 
 
 @pytest.mark.asyncio
@@ -415,3 +554,4 @@ async def test_explicit_profile_alias_wins_over_catalog_alias() -> None:
 
     assert backend.calls[0]["model"] == "huggingface/curated/pinned"
     assert "curated/pinned" in result
+    assert plugin.fetch_count == 0

--- a/apps/server/src/screamingface/plugins/url4_executor/tests/test_url4_alias_dispatch.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/tests/test_url4_alias_dispatch.py
@@ -16,6 +16,7 @@ import pytest
 from fastapi import FastAPI
 
 from screamingface.plugin import Plugin
+from screamingface.plugins.aigw_base.plugin_base import AigwBackendApiPluginBase
 from screamingface.plugins.backend_api_base.models import BackendProfile
 from screamingface.plugins.backend_api_base.plugin_base import BackendApiPluginBase
 from screamingface.plugins.llm_base.backend_base import Backend, HealthStatus
@@ -114,6 +115,42 @@ class _RealAliasPlugin(BackendApiPluginBase):
             build_interpreter=lambda: None,
             span_prefix="faketest",
         )
+
+
+class _CatalogAliasPlugin(AigwBackendApiPluginBase):
+    name = "catalogtest-backend-api"
+    backend_call_paths = ["/catalogtest"]
+    gateway_provider = "catalogtest"
+
+    def __init__(
+        self,
+        backend: Backend,
+        models: list[str],
+        profiles: dict[str, BackendProfile] | None = None,
+    ) -> None:
+        self._models = models
+        self.settings = SimpleNamespace(  # type: ignore[assignment]
+            default_model=None,
+            timeout_seconds=300.0,
+            profiles=profiles or {},
+        )
+        self._api_config = BackendApiConfig(
+            name="catalogtest-backend-api",
+            path_prefix="/catalogtest",
+            default_model="provider/hardcoded-default",
+            backend=backend,
+            settings=self.settings,
+            app=None,
+            build_interpreter=lambda: None,
+            span_prefix="catalogtest",
+        )
+
+    def _backend(self, app=None):  # noqa: ANN001
+        assert self._api_config is not None
+        return self._api_config.backend
+
+    def _fetch_gateway_model_ids(self) -> list[str] | None:
+        return list(self._models)
 
 
 @pytest.mark.asyncio
@@ -312,3 +349,69 @@ async def test_resolve_ensemble_processor_alias_sends_profile_model_to_backend()
     assert backend.calls[0]["model"] == "huggingface/openai/gpt-oss-20b:cheapest"
     assert "[Response 1]" in backend.calls[0]["prompt"]
     assert "gpt-oss-20b" in result
+
+
+@pytest.mark.asyncio
+async def test_aigw_catalog_alias_sends_catalog_model_to_backend() -> None:
+    backend = _RecordingBackend()
+    plugin = _CatalogAliasPlugin(
+        backend,
+        ["huggingface/openai/gpt-oss-120b:cerebras"],
+    )
+    app = _app({"catalogtest-backend-api": plugin})
+    node = Url4BackendCall(path="/catalogtest/gpt-oss-120b", intent=Url4Text(value="answer this"))
+
+    result = await _dispatch_backend_call(node, app, Env.root())
+
+    assert backend.calls[0]["model"] == "huggingface/openai/gpt-oss-120b:cerebras"
+    assert backend.calls[0]["prompt"] == "answer this"
+    assert "gpt-oss-120b" in result
+
+
+@pytest.mark.asyncio
+async def test_catalog_alias_rejects_accidental_backend_prefix_segment() -> None:
+    backend = _RecordingBackend()
+    plugin = _CatalogAliasPlugin(
+        backend,
+        ["catalogtest/gpt-oss-120b"],
+    )
+    app = _app({"catalogtest-backend-api": plugin})
+    node = Url4BackendCall(
+        path="/catalogtest/catalogtest/gpt-oss-120b",
+        intent=Url4Text(value="answer this"),
+    )
+
+    with pytest.raises(RuntimeError, match="single segment"):
+        await _dispatch_backend_call(node, app, Env.root())
+    assert backend.calls == []
+
+
+@pytest.mark.asyncio
+async def test_catalog_alias_still_rejects_raw_slug_after_backend_prefix() -> None:
+    backend = _RecordingBackend()
+    plugin = _CatalogAliasPlugin(backend, ["catalogtest/gpt-oss-120b"])
+    app = _app({"catalogtest-backend-api": plugin})
+    node = Url4BackendCall(
+        path="/catalogtest/catalogtest/org/model",
+        intent=Url4Text(value="answer this"),
+    )
+
+    with pytest.raises(RuntimeError, match="single segment"):
+        await _dispatch_backend_call(node, app, Env.root())
+
+
+@pytest.mark.asyncio
+async def test_explicit_profile_alias_wins_over_catalog_alias() -> None:
+    backend = _RecordingBackend()
+    plugin = _CatalogAliasPlugin(
+        backend,
+        ["huggingface/openai/gpt-oss-120b:cerebras"],
+        profiles={"gpt-oss-120b": BackendProfile(model="huggingface/curated/pinned")},
+    )
+    app = _app({"catalogtest-backend-api": plugin})
+    node = Url4BackendCall(path="/catalogtest/gpt-oss-120b", intent=Url4Text(value="answer this"))
+
+    result = await _dispatch_backend_call(node, app, Env.root())
+
+    assert backend.calls[0]["model"] == "huggingface/curated/pinned"
+    assert "curated/pinned" in result

--- a/apps/server/src/screamingface/plugins/url4_executor/tests/test_url4_alias_dispatch.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/tests/test_url4_alias_dispatch.py
@@ -143,6 +143,19 @@ async def test_alias_path_routes_to_handle_backend_alias() -> None:
 
 
 @pytest.mark.asyncio
+async def test_alias_path_matches_backend_paths_with_trailing_slashes() -> None:
+    spy = _SpyBackendPlugin()
+    spy.backend_call_paths = ["/spy/"]
+    app = _app({"spy": spy})
+    node = Url4BackendCall(path="/spy/oss20b", intent=Url4Text(value="q"))
+
+    result = await _dispatch_backend_call(node, app, Env.root())
+
+    assert result == "ALIAS:oss20b"
+    assert spy.alias_called == "oss20b"
+
+
+@pytest.mark.asyncio
 async def test_multi_segment_suffix_is_rejected() -> None:
     spy = _SpyBackendPlugin()
     app = _app({"spy": spy})
@@ -151,6 +164,45 @@ async def test_multi_segment_suffix_is_rejected() -> None:
     with pytest.raises(RuntimeError, match="single segment"):
         await _dispatch_backend_call(node, app, Env.root())
     assert spy.alias_called is None
+
+
+@pytest.mark.asyncio
+async def test_invalid_alias_rejected_before_context_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    backend = _RecordingBackend()
+    plugin = _RealAliasPlugin(backend, {"oss20b": BackendProfile(model="m/x")})
+    app = _app({"faketest-backend-api": plugin})
+    node = Url4BackendCall(
+        path="/faketest/OSS20b",
+        packed_context="/private/00000000-0000-0000-0000-000000000001",
+        intent=Url4Text(value="q"),
+    )
+    calls: list[str] = []
+
+    async def _spy_resolve_context(sources, app, env):  # noqa: ANN001
+        calls.append(sources)
+        return "FETCHED"
+
+    monkeypatch.setattr(
+        "screamingface.plugins.url4_executor.url4_resolve._resolve_context_sources",
+        _spy_resolve_context,
+    )
+
+    with pytest.raises(ValueError, match="Invalid profile alias 'OSS20b'"):
+        await _dispatch_backend_call(node, app, Env.root())
+    assert calls == []
+    assert backend.calls == []
+
+
+@pytest.mark.asyncio
+async def test_invalid_alias_reports_matched_backend_path_for_multi_path_plugin() -> None:
+    backend = _RecordingBackend()
+    plugin = _RealAliasPlugin(backend, {"oss20b": BackendProfile(model="m/x")})
+    plugin.backend_call_paths = ["/primary", "/secondary/"]
+    app = _app({"faketest-backend-api": plugin})
+    node = Url4BackendCall(path="/secondary/OSS20b", intent=Url4Text(value="q"))
+
+    with pytest.raises(ValueError, match="backend /secondary"):
+        await _dispatch_backend_call(node, app, Env.root())
 
 
 @pytest.mark.asyncio
@@ -236,4 +288,27 @@ async def test_reducer_alias_sends_profile_model_to_backend() -> None:
     result = await _dispatch_backend_call_with_intent(node, '["a","b"]', app, Env.root())
 
     assert backend.calls[0]["model"] == "huggingface/openai/gpt-oss-20b:cheapest"
+    assert "gpt-oss-20b" in result
+
+
+@pytest.mark.asyncio
+async def test_resolve_ensemble_processor_alias_sends_profile_model_to_backend() -> None:
+    from screamingface.plugins.url4_executor.ensemble_helpers import resolve_ensemble
+
+    backend = _RecordingBackend()
+    plugin = _RealAliasPlugin(
+        backend, {"synthesizer": BackendProfile(model="huggingface/openai/gpt-oss-20b:cheapest")}
+    )
+    app = _app({"faketest-backend-api": plugin})
+
+    result = await resolve_ensemble(
+        [Url4Text(value="A"), Url4Text(value="B")],
+        "merge these",
+        processor="/faketest/synthesizer",
+        app=app,
+        env=Env.root(),
+    )
+
+    assert backend.calls[0]["model"] == "huggingface/openai/gpt-oss-20b:cheapest"
+    assert "[Response 1]" in backend.calls[0]["prompt"]
     assert "gpt-oss-20b" in result

--- a/apps/server/src/screamingface/plugins/url4_executor/url4_resolve.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/url4_resolve.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
+from collections.abc import Awaitable, Callable
+from typing import Any, cast
 from urllib.parse import quote, urlparse, urlunparse
 
 import httpx
@@ -234,9 +235,16 @@ async def _dispatch_backend_call(node: Url4BackendCall, app: Any, env: Env | Non
                         f"Profile alias paths must be a single segment: {node.path}. "
                         "Raw provider model slugs are not valid URL4 paths."
                     )
-                alias_resolver = getattr(plugin, "resolve_backend_alias_profile", None)
-                if callable(alias_resolver):
-                    alias_resolver(suffix, base_path=base_path, app=app)
+                alias_profile = None
+                alias_resolver_async = getattr(plugin, "resolve_backend_alias_profile_async", None)
+                if callable(alias_resolver_async):
+                    alias_profile = await cast(Callable[..., Awaitable[Any]], alias_resolver_async)(
+                        suffix, base_path=base_path, app=app
+                    )
+                elif callable(
+                    alias_resolver := getattr(plugin, "resolve_backend_alias_profile", None)
+                ):
+                    alias_profile = alias_resolver(suffix, base_path=base_path, app=app)
                 else:
                     alias_validator = getattr(plugin, "validate_backend_alias", None)
                     if callable(alias_validator):
@@ -244,15 +252,24 @@ async def _dispatch_backend_call(node: Url4BackendCall, app: Any, env: Env | Non
                 call_sources = sources_text
                 if getattr(plugin, "resolves_context_sources", False):
                     call_sources = await _resolve_context_sources(sources_text, app, env)
-                # `handle_backend_alias` lives on BackendApiPluginBase, not the base
-                # Plugin; fetch it by name so url4_executor stays free of a
-                # backend_api_base import (same duck-typing as the capability flag).
-                alias_handler = getattr(plugin, "handle_backend_alias", None)
-                if alias_handler is None:
-                    continue
-                result = await alias_handler(
-                    suffix, sources=call_sources, intent=intent_text, app=app, env=env
-                )
+                # Keep url4_executor dependency-neutral: resolved-profile handlers
+                # and legacy alias handlers are both duck-typed plugin hooks.
+                resolved_alias_handler = getattr(plugin, "handle_resolved_backend_alias", None)
+                if alias_profile is not None and callable(resolved_alias_handler):
+                    result = await cast(Callable[..., Awaitable[str]], resolved_alias_handler)(
+                        alias_profile,
+                        sources=call_sources,
+                        intent=intent_text,
+                        app=app,
+                        env=env,
+                    )
+                else:
+                    alias_handler = getattr(plugin, "handle_backend_alias", None)
+                    if alias_handler is None:
+                        continue
+                    result = await alias_handler(
+                        suffix, sources=call_sources, intent=intent_text, app=app, env=env
+                    )
                 set_span_attrs(
                     {"sf.backend_plugin": plugin.name, "url4.result_length": len(result)}
                 )

--- a/apps/server/src/screamingface/plugins/url4_executor/url4_resolve.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/url4_resolve.py
@@ -176,15 +176,21 @@ async def _dispatch_backend_call(node: Url4BackendCall, app: Any, env: Env | Non
         # provider request/response).
         set_openinference("CHAIN", input_value=_format_prompt_context(sources_text, intent_text))
 
+        from screamingface.core.backend_paths import normalize_backend_call_path
         from screamingface.core.helpers import get_plugins_registry
 
         plugins_registry = get_plugins_registry(app)
+        node_path = normalize_backend_call_path(node.path) or node.path
 
         known_paths: list[str] = []
         for plugin in plugins_registry.active_plugins.values():
-            paths = getattr(plugin, "backend_call_paths", [])
+            paths = [
+                path
+                for raw_path in getattr(plugin, "backend_call_paths", [])
+                if (path := normalize_backend_call_path(raw_path)) is not None
+            ]
             known_paths.extend(paths)
-            if node.path in paths:
+            if node_path in paths:
                 # SF-290: for backends that pack context into a prompt (LLM
                 # backends), fetch any ``/...`` or ``http(s)://`` ref in the
                 # context first. ``/python`` opts out — it receives the raw
@@ -212,11 +218,14 @@ async def _dispatch_backend_call(node: Url4BackendCall, app: Any, env: Env | Non
         for plugin in plugins_registry.active_plugins.values():
             if not getattr(plugin, "supports_profile_aliases", False):
                 continue
-            for base_path in getattr(plugin, "backend_call_paths", []):
-                prefix = f"{base_path}/"
-                if not node.path.startswith(prefix):
+            for raw_base_path in getattr(plugin, "backend_call_paths", []):
+                base_path = normalize_backend_call_path(raw_base_path)
+                if base_path is None:
                     continue
-                suffix = node.path[len(prefix) :]
+                prefix = f"{base_path}/"
+                if not node_path.startswith(prefix):
+                    continue
+                suffix = node_path[len(prefix) :]
                 if "/" in suffix:
                     # Reject raw provider model slugs (``/huggingface/org/model``);
                     # aliases are one safe segment, validated by the plugin.
@@ -224,6 +233,9 @@ async def _dispatch_backend_call(node: Url4BackendCall, app: Any, env: Env | Non
                         f"Profile alias paths must be a single segment: {node.path}. "
                         "Raw provider model slugs are not valid URL4 paths."
                     )
+                alias_validator = getattr(plugin, "validate_backend_alias", None)
+                if callable(alias_validator):
+                    alias_validator(suffix, base_path=base_path)
                 call_sources = sources_text
                 if getattr(plugin, "resolves_context_sources", False):
                     call_sources = await _resolve_context_sources(sources_text, app, env)

--- a/apps/server/src/screamingface/plugins/url4_executor/url4_resolve.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/url4_resolve.py
@@ -201,6 +201,47 @@ async def _dispatch_backend_call(node: Url4BackendCall, app: Any, env: Env | Non
                 set_openinference("CHAIN", output_value=result[:16000])
                 return result
 
+        # SF-346: no exact match — try profile-alias fallback. ``/backend/<alias>``
+        # resolves to a configured profile on a profile-capable plugin (one that
+        # advertises ``supports_profile_aliases`` — read by duck-typing so this
+        # module never imports the backend plugin classes). Exact matches above
+        # always win, so declaring an exact ``/backend/healthcheck`` path would
+        # shadow an alias of the same name. All three dispatch entry points (this
+        # function, the collection reducer, and the ensemble reducer) funnel here,
+        # so they inherit alias support.
+        for plugin in plugins_registry.active_plugins.values():
+            if not getattr(plugin, "supports_profile_aliases", False):
+                continue
+            for base_path in getattr(plugin, "backend_call_paths", []):
+                prefix = f"{base_path}/"
+                if not node.path.startswith(prefix):
+                    continue
+                suffix = node.path[len(prefix) :]
+                if "/" in suffix:
+                    # Reject raw provider model slugs (``/huggingface/org/model``);
+                    # aliases are one safe segment, validated by the plugin.
+                    raise RuntimeError(
+                        f"Profile alias paths must be a single segment: {node.path}. "
+                        "Raw provider model slugs are not valid URL4 paths."
+                    )
+                call_sources = sources_text
+                if getattr(plugin, "resolves_context_sources", False):
+                    call_sources = await _resolve_context_sources(sources_text, app, env)
+                # `handle_backend_alias` lives on BackendApiPluginBase, not the base
+                # Plugin; fetch it by name so url4_executor stays free of a
+                # backend_api_base import (same duck-typing as the capability flag).
+                alias_handler = getattr(plugin, "handle_backend_alias", None)
+                if alias_handler is None:
+                    continue
+                result = await alias_handler(
+                    suffix, sources=call_sources, intent=intent_text, app=app, env=env
+                )
+                set_span_attrs(
+                    {"sf.backend_plugin": plugin.name, "url4.result_length": len(result)}
+                )
+                set_openinference("CHAIN", output_value=result[:16000])
+                return result
+
         raise RuntimeError(
             f"No active plugin handles the backend call {node.path}(). "
             f"Known backend_call_paths across active plugins: {known_paths!r}. "

--- a/apps/server/src/screamingface/plugins/url4_executor/url4_resolve.py
+++ b/apps/server/src/screamingface/plugins/url4_executor/url4_resolve.py
@@ -227,15 +227,20 @@ async def _dispatch_backend_call(node: Url4BackendCall, app: Any, env: Env | Non
                     continue
                 suffix = node_path[len(prefix) :]
                 if "/" in suffix:
-                    # Reject raw provider model slugs (``/huggingface/org/model``);
-                    # aliases are one safe segment, validated by the plugin.
+                    # Reject raw provider model slugs (``/huggingface/org/model``)
+                    # and double-prefixed aliases (``/claude/claude/foo``). URL4
+                    # aliases are exactly one safe path segment.
                     raise RuntimeError(
                         f"Profile alias paths must be a single segment: {node.path}. "
                         "Raw provider model slugs are not valid URL4 paths."
                     )
-                alias_validator = getattr(plugin, "validate_backend_alias", None)
-                if callable(alias_validator):
-                    alias_validator(suffix, base_path=base_path)
+                alias_resolver = getattr(plugin, "resolve_backend_alias_profile", None)
+                if callable(alias_resolver):
+                    alias_resolver(suffix, base_path=base_path, app=app)
+                else:
+                    alias_validator = getattr(plugin, "validate_backend_alias", None)
+                    if callable(alias_validator):
+                        alias_validator(suffix, base_path=base_path)
                 call_sources = sources_text
                 if getattr(plugin, "resolves_context_sources", False):
                     call_sources = await _resolve_context_sources(sources_text, app, env)

--- a/apps/server/tests/core/test_backend_paths.py
+++ b/apps/server/tests/core/test_backend_paths.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import logging
+
+from screamingface.core.backend_paths import catalog_aliases_from_model_ids
+
+
+def test_catalog_aliases_are_independent_of_model_order_for_numeric_collisions() -> None:
+    ids = ["codex/gpt-5.4-mini", "codex/gpt-5-4-mini"]
+
+    assert catalog_aliases_from_model_ids(ids) == catalog_aliases_from_model_ids(
+        list(reversed(ids))
+    )
+
+
+def test_catalog_aliases_hash_true_slug_collisions_and_warn(caplog) -> None:
+    ids = ["codex/gpt-5.4-mini", "codex/gpt-5-4-mini"]
+
+    with caplog.at_level(logging.WARNING, logger="screamingface.core.backend_paths"):
+        aliases = catalog_aliases_from_model_ids(ids)
+
+    assert "gpt-5-4-mini" not in aliases
+    assert "gpt-5-4-mini-2" not in aliases
+    assert sorted(aliases.values()) == sorted(ids)
+    assert all(alias.startswith("gpt-5-4-mini-") for alias in aliases)
+    assert "catalog model alias collision" in caplog.text
+
+
+def test_catalog_aliases_disambiguate_owner_only_collisions_stably() -> None:
+    ids = ["huggingface/openai/model", "huggingface/meta/model"]
+
+    aliases = catalog_aliases_from_model_ids(list(reversed(ids)))
+
+    assert aliases == {
+        "model-meta": "huggingface/meta/model",
+        "model-openai": "huggingface/openai/model",
+    }
+
+
+def test_catalog_aliases_drop_empty_inputs_and_empty_slugs() -> None:
+    assert catalog_aliases_from_model_ids([]) == {}
+    assert catalog_aliases_from_model_ids(["", "/", "huggingface/!!!"]) == {}
+
+
+def test_catalog_aliases_dedupe_identical_model_ids() -> None:
+    assert catalog_aliases_from_model_ids(["codex/gpt-5.4", "codex/gpt-5.4"]) == {
+        "gpt-5-4": "codex/gpt-5.4"
+    }

--- a/apps/server/tests/core/test_plugin_settings.py
+++ b/apps/server/tests/core/test_plugin_settings.py
@@ -182,7 +182,9 @@ def test_backend_aliases_endpoint_uses_active_profile_capable_plugins() -> None:
     }
 
 
-def test_backend_aliases_endpoint_excludes_default_and_empty_profiles() -> None:
+def test_backend_aliases_endpoint_excludes_default_and_empty_profiles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     class EmptySettings(PluginSettings):
         profiles: dict[str, str] = {}
         default_profile: str | None = None
@@ -200,6 +202,7 @@ def test_backend_aliases_endpoint_excludes_default_and_empty_profiles() -> None:
             "oss20b": BackendProfile(model="huggingface/openai/gpt-oss-20b:cheapest"),
         },
     )
+    monkeypatch.setattr(hf, "_fetch_gateway_model_ids", lambda: None)
     empty = EmptyProfileBackend()
     empty.settings = EmptySettings()
     missing_settings = EmptyProfileBackend()
@@ -230,6 +233,70 @@ def test_backend_aliases_endpoint_excludes_default_and_empty_profiles() -> None:
             }
         ],
     }
+
+
+def test_backend_aliases_endpoint_includes_aigw_catalog_aliases_without_profiles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hf = AigwHuggingfaceBackendPlugin()
+    hf.settings = AigwHuggingfaceBackendSettings()
+    monkeypatch.setattr(
+        hf,
+        "_fetch_gateway_model_ids",
+        lambda: [
+            "huggingface/openai/gpt-oss-120b:cerebras",
+            "huggingface/meta-llama/Llama-3.1-8B-Instruct:nscale",
+        ],
+    )
+
+    app = FastAPI()
+    app.state.plugins = SimpleNamespace(active_plugins={hf.name: hf})
+    register_admin_routes(app)
+
+    resp = TestClient(app).get("/plugins/backend-aliases")
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "aliases": [
+            "/huggingface/gpt-oss-120b",
+            "/huggingface/llama-3-1-8b-instruct",
+        ],
+        "backends": [
+            {
+                "plugin": "aigw-huggingface-backend",
+                "paths": ["/huggingface"],
+                "profiles": ["gpt-oss-120b", "llama-3-1-8b-instruct"],
+            }
+        ],
+    }
+
+
+def test_backend_aliases_endpoint_uses_single_segment_claude_catalog_aliases(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    claude = AigwClaudeBackendPlugin()
+    claude.settings = AigwClaudeBackendSettings()
+    monkeypatch.setattr(
+        claude,
+        "_fetch_gateway_model_ids",
+        lambda: [
+            "anthropic/claude-haiku-4-5",
+            "anthropic/claude-sonnet-4-5",
+        ],
+    )
+
+    app = FastAPI()
+    app.state.plugins = SimpleNamespace(active_plugins={claude.name: claude})
+    register_admin_routes(app)
+
+    resp = TestClient(app).get("/plugins/backend-aliases")
+
+    assert resp.status_code == 200
+    assert resp.json()["aliases"] == [
+        "/claude/claude-haiku-4-5",
+        "/claude/claude-sonnet-4-5",
+    ]
+    assert "/claude/claude/claude-haiku-4-5" not in resp.json()["aliases"]
 
 
 def test_plugin_schema_endpoint(settings_client: TestClient) -> None:

--- a/apps/server/tests/core/test_plugin_settings.py
+++ b/apps/server/tests/core/test_plugin_settings.py
@@ -20,6 +20,11 @@ from screamingface.plugins.aigw_claude_backend.plugin import (
     AigwClaudeBackendPlugin,
     AigwClaudeBackendSettings,
 )
+from screamingface.plugins.aigw_huggingface_backend.plugin import (
+    AigwHuggingfaceBackendPlugin,
+    AigwHuggingfaceBackendSettings,
+)
+from screamingface.plugins.backend_api_base.models import BackendProfile
 from screamingface.plugins.claude_frontend.plugin import ClaudeFrontendSettings
 
 # --- Settings resolution ---
@@ -172,6 +177,56 @@ def test_backend_aliases_endpoint_uses_active_profile_capable_plugins() -> None:
                 "plugin": "profile-backend",
                 "paths": ["/hf", "/huggingface"],
                 "profiles": ["oss20b", "fast"],
+            }
+        ],
+    }
+
+
+def test_backend_aliases_endpoint_excludes_default_and_empty_profiles() -> None:
+    class EmptySettings(PluginSettings):
+        profiles: dict[str, str] = {}
+        default_profile: str | None = None
+
+    class EmptyProfileBackend(Plugin):
+        name = "empty-profile-backend"
+        backend_call_paths = ["/empty"]
+        supports_profile_aliases = True
+
+    hf = AigwHuggingfaceBackendPlugin()
+    hf.settings = AigwHuggingfaceBackendSettings(
+        default_profile="default",
+        profiles={
+            "default": BackendProfile(model=None),
+            "oss20b": BackendProfile(model="huggingface/openai/gpt-oss-20b:cheapest"),
+        },
+    )
+    empty = EmptyProfileBackend()
+    empty.settings = EmptySettings()
+    missing_settings = EmptyProfileBackend()
+    missing_settings.name = "missing-settings-backend"
+    missing_settings.backend_call_paths = ["/missing"]
+    missing_settings.settings = None
+
+    app = FastAPI()
+    app.state.plugins = SimpleNamespace(
+        active_plugins={
+            hf.name: hf,
+            empty.name: empty,
+            missing_settings.name: missing_settings,
+        }
+    )
+    register_admin_routes(app)
+
+    resp = TestClient(app).get("/plugins/backend-aliases")
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "aliases": ["/huggingface/oss20b"],
+        "backends": [
+            {
+                "plugin": "aigw-huggingface-backend",
+                "paths": ["/huggingface"],
+                "profiles": ["oss20b"],
             }
         ],
     }

--- a/apps/server/tests/core/test_plugin_settings.py
+++ b/apps/server/tests/core/test_plugin_settings.py
@@ -135,6 +135,48 @@ def test_plugins_list_endpoint(settings_client: TestClient) -> None:
     assert data["claude-frontend"]["has_settings"] is True
 
 
+def test_backend_aliases_endpoint_uses_active_profile_capable_plugins() -> None:
+    class AliasSettings(PluginSettings):
+        profiles: dict[str, str]
+
+    class ProfileBackend(Plugin):
+        name = "profile-backend"
+        backend_call_paths = ["/hf", "/huggingface"]
+        supports_profile_aliases = True
+
+    class PlainBackend(Plugin):
+        name = "plain-backend"
+        backend_call_paths = ["/plain"]
+
+    profile_backend = ProfileBackend()
+    profile_backend.settings = AliasSettings(profiles={"oss20b": "", "fast": ""})
+    plain_backend = PlainBackend()
+    plain_backend.settings = AliasSettings(profiles={"hidden": ""})
+
+    app = FastAPI()
+    app.state.plugins = SimpleNamespace(
+        active_plugins={
+            profile_backend.name: profile_backend,
+            plain_backend.name: plain_backend,
+        }
+    )
+    register_admin_routes(app)
+
+    resp = TestClient(app).get("/plugins/backend-aliases")
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "aliases": ["/hf/oss20b", "/hf/fast", "/huggingface/oss20b", "/huggingface/fast"],
+        "backends": [
+            {
+                "plugin": "profile-backend",
+                "paths": ["/hf", "/huggingface"],
+                "profiles": ["oss20b", "fast"],
+            }
+        ],
+    }
+
+
 def test_plugin_schema_endpoint(settings_client: TestClient) -> None:
     resp = settings_client.get("/plugins/claude-frontend/schema")
     assert resp.status_code == 200


### PR DESCRIPTION
## Description
Adds generic URL4 model/profile aliases so backend calls can target configured backend profiles with `/backend/<alias>(...)` while preserving the existing bare `/backend(...)` behavior.

This PR:
- routes `/backend/<alias>` through the existing model-aware backend profile execution path
- keeps strict one-segment alias handling so raw provider model slugs and double-prefixed paths are rejected
- adds server-owned backend alias inventory for Desktop autocomplete
- derives AIGW dynamic aliases from the gateway model catalog with deterministic collision handling, typed catalog failures, short-TTL caching, and async/offloaded lookup
- updates Desktop autocomplete, provider/reference detection, and server fetch policy for alias-style URL4 expressions

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1216206619715343

## Affected Dependencies
None.

## How has this been tested?
- `uv run pytest -m "not e2e and not e2e_live" -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest tests/core/test_backend_paths.py src/screamingface/plugins/url4_executor/tests/test_url4_alias_dispatch.py src/screamingface/plugins/backend_api_base/tests/test_profile_alias.py -q`
- `npx vitest run src/renderer/src/lib/__tests__/referenced-backends.test.ts src/renderer/src/lib/__tests__/url4-redaction.test.ts src/renderer/src/lib/__tests__/url4-language.test.ts src/main/services/__tests__/external-url-policy.test.ts`
- `npx tsc --noEmit`
- `git diff --check`

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
