### PR TITLE
SF-323: single-flight OAuth connection refresh

### DIFF
--- a/apps/aigateway/src/aigateway/core/oauth/token_service.py
+++ b/apps/aigateway/src/aigateway/core/oauth/token_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import asyncio
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Protocol, cast
 from uuid import UUID
@@ -28,6 +28,17 @@ class TokenWithExpiryStrategy(Protocol):
     async def get_token_with_expiry(self) -> tuple[str, int, bool]: ...
 
 
+class StrategyCacheLike(Protocol):
+    def get_or_create(
+        self,
+        *,
+        provider: str,
+        auth_type: str,
+        credential_name: str,
+        build: Callable[[], Any],
+    ) -> Any: ...
+
+
 @dataclass(frozen=True)
 class OAuthConnectionToken:
     connection: OAuthConnection
@@ -44,9 +55,14 @@ class OAuthConnectionTokenError(Exception):
 
 
 class OAuthConnectionTokenService:
-    def __init__(self) -> None:
-        self._locks: dict[str, asyncio.Lock] = {}
-        self._locks_guard = asyncio.Lock()
+    """Mint a fresh access token for an OAuth connection.
+
+    Stateless use-case orchestrator: it resolves the connection, then defers to
+    the SHARED ``CredentialStrategyCache`` strategy whose ``asyncio.Lock``
+    single-flights the OAuth refresh across the token endpoint, chat dispatch,
+    and manual refresh (SF-323). It holds no lock of its own — the strategy is
+    the one and only refresh single-flight point (SF-282).
+    """
 
     async def get_token(
         self,
@@ -57,27 +73,7 @@ class OAuthConnectionTokenService:
         providers: ProviderRegistryLike,
         credential_store: Any,
         http_client_factory_for,
-    ) -> OAuthConnectionToken:
-        lock = await self._lock_for(account_id, connection_id)
-        async with lock:
-            return await self._get_token_locked(
-                account_id=account_id,
-                connection_id=connection_id,
-                store=store,
-                providers=providers,
-                credential_store=credential_store,
-                http_client_factory_for=http_client_factory_for,
-            )
-
-    async def _get_token_locked(
-        self,
-        *,
-        account_id: str | UUID,
-        connection_id: UUID,
-        store: OAuthConnectionStoreLike,
-        providers: ProviderRegistryLike,
-        credential_store: Any,
-        http_client_factory_for,
+        strategy_cache: StrategyCacheLike,
     ) -> OAuthConnectionToken:
         connection = await store.get(account_id, connection_id)
         if connection is None:
@@ -93,10 +89,20 @@ class OAuthConnectionTokenService:
         plugin = providers.get(connection.provider)
         if plugin is None:
             raise OAuthConnectionTokenError(404, {"code": "unknown_provider"})
-        strategy = plugin.oauth_strategy_for(
-            credential_key_for(account_id, connection.id),
-            credential_store=credential_store,
-            http_client_factory=http_client_factory_for(connection.provider),
+        # Resolve the SHARED strategy (keyed identically to routes/chat.py) so its
+        # asyncio.Lock single-flights the refresh across the token endpoint, chat
+        # dispatch, and manual refresh (SF-323). Building is only a constructor
+        # call; the cache is evicted on every credential mutation.
+        credential_name = credential_key_for(account_id, connection.id)
+        strategy = strategy_cache.get_or_create(
+            provider=connection.provider,
+            auth_type="oauth",
+            credential_name=credential_name,
+            build=lambda: plugin.oauth_strategy_for(
+                credential_name,
+                credential_store=credential_store,
+                http_client_factory=http_client_factory_for(connection.provider),
+            ),
         )
         if strategy is None:
             raise OAuthConnectionTokenError(400, {"code": "provider_does_not_use_oauth"})
@@ -128,15 +134,6 @@ class OAuthConnectionTokenService:
             expires_at_ms=expires_at_ms,
             refreshed=refreshed,
         )
-
-    async def _lock_for(self, account_id: str | UUID, connection_id: UUID) -> asyncio.Lock:
-        key = f"{account_id}:{connection_id}"
-        async with self._locks_guard:
-            lock = self._locks.get(key)
-            if lock is None:
-                lock = asyncio.Lock()
-                self._locks[key] = lock
-            return lock
 
 
 def oauth_connection_token_service(app: Any) -> OAuthConnectionTokenService:

--- a/apps/aigateway/src/aigateway/routes/oauth_connections.py
+++ b/apps/aigateway/src/aigateway/routes/oauth_connections.py
@@ -343,6 +343,7 @@ async def get_connection_token(
             http_client_factory_for=lambda provider: getattr(
                 request.app.state, f"{provider}_http_factory", None
             ),
+            strategy_cache=credential_strategy_cache(request.app),
         )
     except OAuthConnectionTokenError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
@@ -374,10 +375,21 @@ async def refresh_connection(
     plugin = request.app.state.providers.get(connection.provider)
     if plugin is None:
         raise HTTPException(status_code=404, detail={"code": "unknown_provider"})
-    strategy = plugin.oauth_strategy_for(
-        credential_key_for(current.id, connection.id),
-        credential_store=request.app.state.credential_store,
-        http_client_factory=getattr(request.app.state, f"{connection.provider}_http_factory", None),
+    # Resolve the SHARED strategy (same cache key as chat/token dispatch) so its
+    # asyncio.Lock single-flights the refresh across paths instead of a private
+    # fresh strategy with its own lock (SF-323). The post-refresh eviction below
+    # still forces later dispatch to rebuild from the persisted credentials.
+    provider = connection.provider
+    credential_name = credential_key_for(str(current.id), connection.id)
+    strategy = credential_strategy_cache(request.app).get_or_create(
+        provider=provider,
+        auth_type="oauth",
+        credential_name=credential_name,
+        build=lambda: plugin.oauth_strategy_for(
+            credential_name,
+            credential_store=request.app.state.credential_store,
+            http_client_factory=getattr(request.app.state, f"{provider}_http_factory", None),
+        ),
     )
     if strategy is None:
         raise HTTPException(status_code=400, detail={"code": "provider_does_not_use_oauth"})
@@ -385,15 +397,13 @@ async def refresh_connection(
         await strategy.refresh_credentials()
     except (CredentialNotFoundError, AuthError) as exc:
         await store.mark_error(connection, str(exc))
-        credential_strategy_cache(request.app).evict(
-            credential_key_for(str(current.id), connection.id)
-        )
+        credential_strategy_cache(request.app).evict(credential_name)
         raise HTTPException(
             status_code=401, detail={"code": "auth_required", "message": str(exc)}
         ) from exc
     # Manual refresh wrote new tokens to the store; drop the cached instance so the
     # chat path rebuilds and reads them (SF-282).
-    credential_strategy_cache(request.app).evict(credential_key_for(str(current.id), connection.id))
+    credential_strategy_cache(request.app).evict(credential_name)
     connection = await store.complete(
         connection,
         label=connection.label,

--- a/apps/aigateway/tests/unit/test_oauth_connection_token_service.py
+++ b/apps/aigateway/tests/unit/test_oauth_connection_token_service.py
@@ -1,3 +1,21 @@
+"""SF-323: the connection token endpoint single-flights OAuth refresh through the
+same app-scoped ``CredentialStrategyCache`` as chat dispatch.
+
+Before SF-323 the token service built a *fresh* ``BaseOAuthStrategy`` per call,
+guarded by its own per-``(account, connection)`` lock. That lock serialized
+token↔token only; it could not serialize token↔chat, so a ``GET .../token`` and
+a ``POST /v1/chat/completions`` for the same connection each held a *different*
+lock and both refreshed the same rotating OAuth token (Anthropic then rejects the
+racer with ``429 refresh_token_conflict`` — the exact class SF-282 fixed for
+chat↔chat).
+
+The fix routes the token service through the shared cache keyed identically to
+chat ``(provider, "oauth", credential_key_for(account_id, connection.id))`` so
+both paths resolve ONE strategy instance and contend on its single
+``asyncio.Lock``. These tests prove the *cache*, not a singleton test double, is
+what shares the instance, and that refresh is single-flighted across BOTH paths.
+"""
+
 from __future__ import annotations
 
 import asyncio
@@ -7,7 +25,18 @@ from uuid import uuid4
 
 import pytest
 
-from aigateway.core.oauth.token_service import OAuthConnectionTokenService
+from aigateway.core.credential_strategy_cache import CredentialStrategyCache
+from aigateway.core.errors import AuthError, ReauthRequiredError
+from aigateway.core.oauth.store import credential_key_for
+from aigateway.core.oauth.token_service import (
+    OAuthConnectionTokenError,
+    OAuthConnectionTokenService,
+)
+
+_CONNECTION_ID = uuid4()
+_CREDENTIAL_STORE = object()
+_ACCOUNT_ID = "acct-1"
+_FAR_FUTURE_MS = int((time.time() + 3600) * 1000)
 
 
 class _FakeStore:
@@ -15,13 +44,15 @@ class _FakeStore:
         self.connection = connection
         self.last_refreshed_touches = 0
         self.last_used_touches = 0
+        self.error_marks = 0
 
     async def get(self, account_id, connection_id):  # noqa: ANN001
-        assert account_id == "acct-1"
+        assert account_id == _ACCOUNT_ID
         assert connection_id == self.connection.id
         return self.connection
 
     async def mark_error(self, connection, message: str):  # noqa: ANN001
+        self.error_marks += 1
         connection.status = "error"
         connection.error_message = message
         return connection
@@ -35,73 +66,246 @@ class _FakeStore:
         return connection
 
 
-class _FakeStrategy:
-    active_calls = 0
-    max_active_calls = 0
-    total_calls = 0
+class _SharedRefreshStrategy:
+    """Lock-bearing fake mirroring ``BaseOAuthStrategy``'s locked, once-only
+    refresh across BOTH the token path (``get_token_with_expiry``) and the chat
+    path (``get_authorization_header``) — see ``core/oauth_base.py:56-89``.
+
+    It starts COLD (``_cached is None``) on purpose: the real
+    ``get_authorization_header`` has a lock-free fast path
+    (``core/oauth_base.py:80``) that returns an *already-valid* token without
+    taking the lock. A warm start would let the chat path short-circuit and the
+    test could prove cache identity without ever proving token↔chat refresh
+    contention (a false positive). Cold start forces every first refresh through
+    the shared lock. Both methods refresh via ``_refresh_locked`` so
+    ``max_concurrent_refresh`` is the true cross-path concurrency of the refresh.
+    """
+
+    def __init__(self, *, refresh_error: Exception | None = None) -> None:
+        self._lock = asyncio.Lock()
+        self._cached: dict | None = None
+        self._refresh_error = refresh_error
+        self.refreshes = 0
+        self._active = 0
+        self.max_concurrent_refresh = 0
+
+    async def _refresh_locked(self) -> None:
+        # Invariant under test: this only ever runs while holding self._lock.
+        self._active += 1
+        self.max_concurrent_refresh = max(self.max_concurrent_refresh, self._active)
+        try:
+            await asyncio.sleep(0.02)  # widen the window so a real race would overlap
+            if self._refresh_error is not None:
+                raise self._refresh_error
+            self.refreshes += 1
+            self._cached = {
+                "access_token": f"tok-{self.refreshes}",
+                "expires_at_ms": _FAR_FUTURE_MS,
+            }
+        finally:
+            self._active -= 1
 
     async def get_token_with_expiry(self) -> tuple[str, int, bool]:
-        type(self).active_calls += 1
-        type(self).total_calls += 1
-        type(self).max_active_calls = max(type(self).max_active_calls, type(self).active_calls)
-        try:
-            await asyncio.sleep(0.02)
-            return (
-                f"token-{type(self).total_calls}",
-                int((time.time() + 3600) * 1000),
-                True,
-            )
-        finally:
-            type(self).active_calls -= 1
+        refreshed = False
+        async with self._lock:
+            if self._cached is None:
+                await self._refresh_locked()
+                refreshed = True
+        assert self._cached is not None  # a successful _refresh_locked always populates it
+        return self._cached["access_token"], int(self._cached["expires_at_ms"]), refreshed
+
+    async def get_authorization_header(self) -> dict[str, str]:
+        async with self._lock:
+            if self._cached is None:
+                await self._refresh_locked()
+        assert self._cached is not None  # a successful _refresh_locked always populates it
+        return {"Authorization": f"Bearer {self._cached['access_token']}"}
 
 
 class _FakePlugin:
+    """Builds a NEW lock-bearing strategy on every call and counts builds, so a
+    test can prove the *cache* (not this plugin) is what shares the instance."""
+
+    def __init__(self, *, refresh_error: Exception | None = None) -> None:
+        self.builds = 0
+        self.built: list[_SharedRefreshStrategy] = []
+        self._refresh_error = refresh_error
+
     def oauth_strategy_for(self, profile_name: str, **kwargs):  # noqa: ANN003
         assert profile_name.endswith(str(_CONNECTION_ID))
         assert kwargs["credential_store"] is _CREDENTIAL_STORE
-        return _FakeStrategy()
+        self.builds += 1
+        strategy = _SharedRefreshStrategy(refresh_error=self._refresh_error)
+        self.built.append(strategy)
+        return strategy
 
 
 class _FakeProviders:
+    def __init__(self, plugin: _FakePlugin) -> None:
+        self._plugin = plugin
+
     def get(self, provider: str):
         assert provider == "anthropic"
-        return _FakePlugin()
+        return self._plugin
 
 
-_CONNECTION_ID = uuid4()
-_CREDENTIAL_STORE = object()
+def _active_connection() -> SimpleNamespace:
+    # No auth_type attr -> getattr(..., "oauth") -> treated as an OAuth connection.
+    return SimpleNamespace(id=_CONNECTION_ID, provider="anthropic", status="active")
+
+
+def _token_call(service, cache, plugin, store):  # noqa: ANN001
+    return service.get_token(
+        account_id=_ACCOUNT_ID,
+        connection_id=_CONNECTION_ID,
+        store=store,
+        providers=_FakeProviders(plugin),
+        credential_store=_CREDENTIAL_STORE,
+        http_client_factory_for=lambda _provider: None,
+        strategy_cache=cache,
+    )
+
+
+def _chat_build(plugin: _FakePlugin):
+    return plugin.oauth_strategy_for(
+        credential_key_for(_ACCOUNT_ID, _CONNECTION_ID),
+        credential_store=_CREDENTIAL_STORE,
+        http_client_factory=None,
+    )
+
+
+async def _chat_call(cache: CredentialStrategyCache, plugin: _FakePlugin) -> None:
+    # Mirrors routes/chat.py:_strategy_for_credential_target — the *identical*
+    # cache key the token service now uses, then the chat-dispatch entry point.
+    strategy = cache.get_or_create(
+        provider="anthropic",
+        auth_type="oauth",
+        credential_name=credential_key_for(_ACCOUNT_ID, _CONNECTION_ID),
+        build=lambda: _chat_build(plugin),
+    )
+    await strategy.get_authorization_header()
 
 
 @pytest.mark.asyncio
 async def test_token_service_serializes_refresh_for_same_connection() -> None:
-    _FakeStrategy.active_calls = 0
-    _FakeStrategy.max_active_calls = 0
-    _FakeStrategy.total_calls = 0
-    connection = SimpleNamespace(id=_CONNECTION_ID, provider="anthropic", status="active")
-    store = _FakeStore(connection)
+    # Two concurrent token requests share ONE cached strategy, so exactly one
+    # refresh happens (single-flight). The cache — not a shared test double — is
+    # what makes them share: the plugin builds a fresh strategy per call.
+    cache = CredentialStrategyCache()
+    plugin = _FakePlugin()
+    store = _FakeStore(_active_connection())
     service = OAuthConnectionTokenService()
 
     first, second = await asyncio.gather(
-        service.get_token(
-            account_id="acct-1",
-            connection_id=_CONNECTION_ID,
-            store=store,
-            providers=_FakeProviders(),
-            credential_store=_CREDENTIAL_STORE,
-            http_client_factory_for=lambda _provider: None,
-        ),
-        service.get_token(
-            account_id="acct-1",
-            connection_id=_CONNECTION_ID,
-            store=store,
-            providers=_FakeProviders(),
-            credential_store=_CREDENTIAL_STORE,
-            http_client_factory_for=lambda _provider: None,
-        ),
+        _token_call(service, cache, plugin, store),
+        _token_call(service, cache, plugin, store),
     )
 
-    assert {first.access_token, second.access_token} == {"token-1", "token-2"}
-    assert _FakeStrategy.total_calls == 2
-    assert _FakeStrategy.max_active_calls == 1
-    assert store.last_refreshed_touches == 2
+    assert plugin.builds == 1, "the shared cache must build the strategy exactly once"
+    assert len(plugin.built) == 1
+    shared = plugin.built[0]
+    assert shared.refreshes == 1, "exactly one refresh across both token calls (single-flight)"
+    assert shared.max_concurrent_refresh == 1, "no concurrent refresh"
+    # Both callers observe the same freshly-refreshed token.
+    assert first.access_token == second.access_token == "tok-1"
+    assert first.refreshed != second.refreshed, "exactly one caller performed the refresh"
+    # Only the refreshing caller touches last_refreshed; both touch last_used.
+    assert store.last_refreshed_touches == 1
     assert store.last_used_touches == 2
+
+
+@pytest.mark.asyncio
+async def test_token_and_chat_paths_single_flight_through_shared_cache() -> None:
+    # AC2 / AC3 deliverable: the token endpoint (get_token_with_expiry) and chat
+    # dispatch (get_authorization_header) for the same connection must resolve ONE
+    # strategy instance and refresh it exactly once, even when interleaved.
+    cache = CredentialStrategyCache()
+    plugin = _FakePlugin()
+    store = _FakeStore(_active_connection())
+    service = OAuthConnectionTokenService()
+
+    await asyncio.gather(
+        _token_call(service, cache, plugin, store),
+        _chat_call(cache, plugin),
+        _token_call(service, cache, plugin, store),
+        _chat_call(cache, plugin),
+    )
+
+    assert plugin.builds == 1, "token and chat must land on one cached instance, not two"
+    assert len(plugin.built) == 1
+    shared = plugin.built[0]
+    assert shared.refreshes == 1, "single-flight across BOTH the token and chat paths"
+    assert shared.max_concurrent_refresh == 1, "token↔chat refresh never overlaps"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_failing_refresh_never_overlaps() -> None:
+    # Removing the token-service outer lock means two already-in-flight callers
+    # can each surface an error and each mark the connection errored — that is the
+    # documented, accepted trade-off (SF-323 plan §3). The invariant that still
+    # MUST hold is that the doomed refreshes never run concurrently against the
+    # provider (no 429 refresh_token_conflict).
+    cache = CredentialStrategyCache()
+    plugin = _FakePlugin(refresh_error=ReauthRequiredError("refresh token revoked"))
+    store = _FakeStore(_active_connection())
+    service = OAuthConnectionTokenService()
+
+    results = await asyncio.gather(
+        _token_call(service, cache, plugin, store),
+        _token_call(service, cache, plugin, store),
+        return_exceptions=True,
+    )
+
+    assert plugin.builds == 1
+    shared = plugin.built[0]
+    assert shared.refreshes == 0, "a failing refresh never records a success"
+    assert shared.max_concurrent_refresh == 1, "refresh attempts are serialized, never concurrent"
+    # Narrow inside one comprehension so the type checker sees status_code, and
+    # so each result is asserted to be BOTH the error type AND a 401 together.
+    assert all(isinstance(r, OAuthConnectionTokenError) and r.status_code == 401 for r in results)
+    # Both in-flight callers reached mark_error before the first status flip was
+    # visible; the store must tolerate the duplicate marking.
+    assert store.error_marks == 2
+
+
+@pytest.mark.asyncio
+async def test_transient_refresh_failure_maps_to_503_without_marking_error() -> None:
+    # AuthError (transient upstream 5xx) leaves the connection active so callers
+    # back off and retry; it must NOT mark the connection errored.
+    cache = CredentialStrategyCache()
+    plugin = _FakePlugin(refresh_error=AuthError("provider 503"))
+    store = _FakeStore(_active_connection())
+    service = OAuthConnectionTokenService()
+
+    with pytest.raises(OAuthConnectionTokenError) as excinfo:
+        await _token_call(service, cache, plugin, store)
+
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.detail["code"] == "upstream_refresh_failed"
+    assert store.error_marks == 0
+
+
+@pytest.mark.asyncio
+async def test_without_shared_cache_each_path_refreshes_independently() -> None:
+    # Contrast / regression guard: the OLD token-path behavior (a fresh strategy
+    # per call, NOT shared with chat) refreshes the rotating token twice — the
+    # SF-323 bug. Mirrors test_credential_strategy_cache.py::
+    # test_without_cache_each_request_refreshes_independently.
+    plugin = _FakePlugin()
+
+    async def token_like() -> None:
+        await plugin.oauth_strategy_for(
+            credential_key_for(_ACCOUNT_ID, _CONNECTION_ID),
+            credential_store=_CREDENTIAL_STORE,
+        ).get_token_with_expiry()
+
+    async def chat_like() -> None:
+        await plugin.oauth_strategy_for(
+            credential_key_for(_ACCOUNT_ID, _CONNECTION_ID),
+            credential_store=_CREDENTIAL_STORE,
+        ).get_authorization_header()
+
+    await asyncio.gather(token_like(), chat_like())
+
+    assert plugin.builds == 2
+    assert sum(s.refreshes for s in plugin.built) == 2, "unshared strategies each refresh (the bug)"

--- a/apps/aigateway/tests/unit/test_oauth_connections_routes.py
+++ b/apps/aigateway/tests/unit/test_oauth_connections_routes.py
@@ -9,6 +9,8 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 import pytest
 
+from aigateway.core.credential_strategy_cache import credential_strategy_cache
+from aigateway.core.oauth.store import credential_key_for
 from aigateway.core.plugin_base import OAuthConfig
 from aigateway.plugins.codex_provider.oauth_config import (
     CODEX_AUTHORIZE_EXTRA_PARAMS,
@@ -431,6 +433,46 @@ def test_refresh_error_releases_label_for_reauth(authenticated_client, credentia
         ).status_code
         == 200
     )
+
+
+def test_refresh_connection_refreshes_the_shared_cached_strategy(
+    authenticated_client, credential_blobs
+) -> None:
+    # SF-323: manual refresh must resolve its strategy from the SAME app-scoped
+    # cache as chat/token dispatch, so a concurrent chat/token single-flights on
+    # ONE lock instead of building a private fresh strategy with its own lock.
+    # Pre-seed a sentinel under the connection's cache key: the route must refresh
+    # THAT instance, then evict it so later dispatch rebuilds from persisted creds.
+    connection_id = _connect_anthropic(authenticated_client, "refresh-shared-cache")
+    account_id = _account_id(authenticated_client)
+    _ = credential_blobs
+
+    class _SentinelStrategy:
+        def __init__(self) -> None:
+            self.refresh_calls = 0
+
+        async def refresh_credentials(self) -> None:
+            self.refresh_calls += 1
+
+    cache = credential_strategy_cache(authenticated_client.app)
+    key = credential_key_for(account_id, connection_id)
+    sentinel = _SentinelStrategy()
+    cache.get_or_create(
+        provider="anthropic", auth_type="oauth", credential_name=key, build=lambda: sentinel
+    )
+
+    resp = authenticated_client.post(f"/v1/oauth/connections/{connection_id}/refresh")
+    assert resp.status_code == 200
+    # Refreshed the shared cached instance (the fix), not a fresh build (the bug).
+    assert sentinel.refresh_calls == 1
+    # ...and evicted afterwards, so a subsequent chat/token rebuilds from the store.
+    rebuilt = cache.get_or_create(
+        provider="anthropic",
+        auth_type="oauth",
+        credential_name=key,
+        build=lambda: _SentinelStrategy(),
+    )
+    assert rebuilt is not sentinel
 
 
 def test_patch_connection_label_conflict_returns_409(authenticated_client) -> None:


### PR DESCRIPTION
## Description
Fixes SF-323: the OAuth connection token endpoint and manual connection refresh route now resolve OAuth strategies through the same app-scoped `CredentialStrategyCache` used by chat dispatch.

Previously, `GET /v1/oauth/connections/{id}/token` and `POST /v1/oauth/connections/{id}/refresh` each built a fresh `BaseOAuthStrategy` with its own `asyncio.Lock`. A token or manual-refresh request could therefore race a chat request for the same rotating credential, causing duplicate refresh attempts and provider-side `refresh_token_conflict` responses.

This change makes token, chat, and manual refresh paths share one strategy instance for the same OAuth connection key, so refresh work is single-flighted by the strategy lock. Manual refresh still evicts the cached strategy afterward so future dispatch rebuilds from persisted credentials.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1216051623424913

## Affected Dependencies
None.

## How has this been tested?
- `cd apps/aigateway && uv run pytest tests/unit/test_oauth_connection_token_service.py tests/unit/test_oauth_connections_routes.py -q` -> `38 passed`
- `cd apps/aigateway && uv run pytest -m "not live and not needs_postgres" -q` -> `702 passed, 28 deselected`
- `cd apps/aigateway && uv run ruff check .` -> passed
- `cd apps/aigateway && uv run ruff format --check .` -> passed
- `cd apps/aigateway && uv run pyright` -> `0 errors`
- `cd apps/aigateway && uv run python scripts/check_no_enterprise.py` -> passed

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
