### PR TITLE
feat(desktop): add main-process leaderboard-fetch service

### DIFF
--- a/apps/desktop/src/main/services/__tests__/fetch-leaderboard.test.ts
+++ b/apps/desktop/src/main/services/__tests__/fetch-leaderboard.test.ts
@@ -1,0 +1,148 @@
+import { vi, describe, it, expect, afterEach } from 'vitest';
+
+// Mirror list-benchmarks.test: stub context (URLs) + publish-log (pulls in electron).
+const CTX = {
+  scoreboardUrl: 'https://scoreboard.screamingface.ai',
+  portalUrl: 'https://screamingface.ai/portal/',
+  client: { name: 'screamingface-desktop', version: '0.4.2', platform: 'darwin' },
+};
+vi.mock('../publish-context', () => ({ resolvePublishContext: () => CTX }));
+vi.mock('../publish-log', () => ({ publishLog: () => {} }));
+
+import { listLeaderboard } from '../fetch-leaderboard';
+
+const BENCHMARK = {
+  id: 'livetruth',
+  display_name: 'LiveTruth',
+  description: 'Sample benchmark for local dev',
+  dataset_url: null,
+};
+
+const ENTRY = {
+  rank: 1,
+  spec_id: 'local-smoke',
+  accuracy: 0.5,
+  total_questions: 2,
+  ran_with_providers: ['smoke'],
+  submitted_at: '2026-07-07T15:30:05.108456Z',
+  submitted_by: 'filip-local',
+  verified_by_openmined: false,
+  url4_expression: 'url4://smoke',
+};
+
+function okResponse(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('listLeaderboard (main process)', () => {
+  it('hits GET /v1/leaderboard/{id} on the configured scoreboard and maps benchmark + entries', async () => {
+    const fetchMock = vi.fn(async () => okResponse({ benchmark: BENCHMARK, entries: [ENTRY] }));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const out = await listLeaderboard('livetruth');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toBe(
+      'https://scoreboard.screamingface.ai/v1/leaderboard/livetruth',
+    );
+    expect(out).toEqual({
+      benchmark: {
+        id: 'livetruth',
+        displayName: 'LiveTruth',
+        description: 'Sample benchmark for local dev',
+        datasetUrl: null,
+      },
+      entries: [
+        {
+          rank: 1,
+          specId: 'local-smoke',
+          accuracy: 0.5,
+          totalQuestions: 2,
+          ranWithProviders: ['smoke'],
+          submittedAt: '2026-07-07T15:30:05.108456Z',
+          submittedBy: 'filip-local',
+          verifiedByOpenmined: false,
+          url4Expression: 'url4://smoke',
+        },
+      ],
+    });
+  });
+
+  it('appends ?top= when provided', async () => {
+    const fetchMock = vi.fn(async () => okResponse({ benchmark: BENCHMARK, entries: [] }));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await listLeaderboard('livetruth', 10);
+
+    expect(String(fetchMock.mock.calls[0][0])).toBe(
+      'https://scoreboard.screamingface.ai/v1/leaderboard/livetruth?top=10',
+    );
+  });
+
+  it('drops a malformed entry rather than throwing, keeping the well-formed ones', async () => {
+    global.fetch = vi.fn(async () =>
+      okResponse({
+        benchmark: BENCHMARK,
+        entries: [ENTRY, { ...ENTRY, rank: 2, accuracy: 'not-a-number' }],
+      }),
+    ) as unknown as typeof fetch;
+
+    const out = await listLeaderboard('livetruth');
+
+    expect(out?.entries).toHaveLength(1);
+    expect(out?.entries[0].rank).toBe(1);
+  });
+
+  it('returns null when the benchmark field is missing/malformed', async () => {
+    global.fetch = vi.fn(async () => okResponse({ entries: [ENTRY] })) as unknown as typeof fetch;
+    expect(await listLeaderboard('livetruth')).toBeNull();
+  });
+
+  it('returns null on a non-2xx response (e.g. unknown benchmark 404)', async () => {
+    global.fetch = vi.fn(
+      async () => ({ ok: false, status: 404 }) as unknown as Response,
+    ) as unknown as typeof fetch;
+    expect(await listLeaderboard('unknown-benchmark')).toBeNull();
+  });
+
+  it('returns null when the scoreboard is unreachable', async () => {
+    global.fetch = vi.fn(async () => {
+      throw new Error('network down');
+    }) as unknown as typeof fetch;
+    expect(await listLeaderboard('livetruth')).toBeNull();
+  });
+
+  it('aborts and returns null after the 8s timeout', async () => {
+    vi.useFakeTimers();
+    global.fetch = vi.fn(
+      (_url, opts?: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          opts?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+        }),
+    ) as unknown as typeof fetch;
+
+    const promise = listLeaderboard('livetruth');
+    await vi.advanceTimersByTimeAsync(8_000);
+    const out = await promise;
+
+    expect(out).toBeNull();
+  });
+
+  it('builds the URL from resolvePublishContext, not a hardcoded host', async () => {
+    CTX.scoreboardUrl = 'http://localhost:9106';
+    const fetchMock = vi.fn(async () => okResponse({ benchmark: BENCHMARK, entries: [] }));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await listLeaderboard('livetruth');
+
+    expect(String(fetchMock.mock.calls[0][0])).toBe(
+      'http://localhost:9106/v1/leaderboard/livetruth',
+    );
+    CTX.scoreboardUrl = 'https://scoreboard.screamingface.ai';
+  });
+});

--- a/apps/desktop/src/main/services/fetch-leaderboard.ts
+++ b/apps/desktop/src/main/services/fetch-leaderboard.ts
@@ -1,0 +1,144 @@
+// apps/desktop/src/main/services/fetch-leaderboard.ts
+//
+// Fetches the ranked leaderboard for one benchmark from the public scoreboard
+// (GET /v1/leaderboard/{benchmark_id}) from the MAIN process, so the request is
+// exempt from renderer CORS (same rationale as list-benchmarks/publish-score,
+// SF-273).
+//
+// Returns null on ANY failure (unreachable, non-2xx incl. unknown-benchmark 404,
+// bad body) — this milestone has no consumer yet, so there is no need for
+// status-specific error surfacing; a later milestone's renderer hook can treat
+// "couldn't load" as a single state.
+//
+// OME-321, milestone 1: this function is intentionally unwired — no IPC channel,
+// no preload exposure, no UI. It only proves the fetch/mapping/error-handling
+// logic in isolation ahead of later milestones that make it reachable.
+
+import { resolvePublishContext } from './publish-context';
+import { publishLog } from './publish-log';
+
+const TIMEOUT_MS = 8_000;
+
+export interface LeaderboardBenchmark {
+  id: string;
+  displayName: string;
+  description: string | null;
+  datasetUrl: string | null;
+}
+
+export interface LeaderboardEntry {
+  rank: number;
+  specId: string;
+  accuracy: number;
+  totalQuestions: number;
+  ranWithProviders: string[];
+  submittedAt: string;
+  submittedBy: string | null;
+  verifiedByOpenmined: boolean;
+  url4Expression: string;
+}
+
+export interface LeaderboardData {
+  benchmark: LeaderboardBenchmark;
+  entries: LeaderboardEntry[];
+}
+
+interface BenchmarkResponseBody {
+  id?: unknown;
+  display_name?: unknown;
+  description?: unknown;
+  dataset_url?: unknown;
+}
+
+interface LeaderboardEntryResponseBody {
+  rank?: unknown;
+  spec_id?: unknown;
+  accuracy?: unknown;
+  total_questions?: unknown;
+  ran_with_providers?: unknown;
+  submitted_at?: unknown;
+  submitted_by?: unknown;
+  verified_by_openmined?: unknown;
+  url4_expression?: unknown;
+}
+
+interface LeaderboardResponseBody {
+  benchmark?: BenchmarkResponseBody;
+  entries?: unknown[];
+}
+
+function mapBenchmark(b: BenchmarkResponseBody | undefined): LeaderboardBenchmark | null {
+  if (typeof b?.id !== 'string' || b.id.length === 0) return null;
+  return {
+    id: b.id,
+    displayName:
+      typeof b.display_name === 'string' && b.display_name.length > 0 ? b.display_name : b.id,
+    description: typeof b.description === 'string' ? b.description : null,
+    datasetUrl: typeof b.dataset_url === 'string' ? b.dataset_url : null,
+  };
+}
+
+function mapEntry(e: unknown): LeaderboardEntry | null {
+  const row = e as LeaderboardEntryResponseBody;
+  if (
+    typeof row?.rank !== 'number' ||
+    typeof row.spec_id !== 'string' ||
+    row.spec_id.length === 0 ||
+    typeof row.accuracy !== 'number' ||
+    typeof row.total_questions !== 'number' ||
+    !Array.isArray(row.ran_with_providers) ||
+    typeof row.submitted_at !== 'string' ||
+    typeof row.verified_by_openmined !== 'boolean' ||
+    typeof row.url4_expression !== 'string'
+  ) {
+    return null;
+  }
+  return {
+    rank: row.rank,
+    specId: row.spec_id,
+    accuracy: row.accuracy,
+    totalQuestions: row.total_questions,
+    ranWithProviders: row.ran_with_providers.filter((p): p is string => typeof p === 'string'),
+    submittedAt: row.submitted_at,
+    submittedBy: typeof row.submitted_by === 'string' ? row.submitted_by : null,
+    verifiedByOpenmined: row.verified_by_openmined,
+    url4Expression: row.url4_expression,
+  };
+}
+
+/**
+ * Fetch the ranked leaderboard for a benchmark. Returns null if the benchmark
+ * is unknown (404), the scoreboard is unreachable, or the response is malformed.
+ */
+export async function listLeaderboard(
+  benchmarkId: string,
+  top?: number,
+): Promise<LeaderboardData | null> {
+  const ctx = resolvePublishContext();
+  const base = `${ctx.scoreboardUrl.replace(/\/$/, '')}/v1/leaderboard/${encodeURIComponent(benchmarkId)}`;
+  const url = typeof top === 'number' ? `${base}?top=${top}` : base;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    if (!res.ok) {
+      publishLog(`leaderboard: GET ${url} -> HTTP ${res.status}`);
+      return null;
+    }
+    const data = (await res.json()) as LeaderboardResponseBody;
+    const benchmark = mapBenchmark(data.benchmark);
+    if (benchmark === null) {
+      publishLog(`leaderboard: GET ${url} -> malformed benchmark in response body`);
+      return null;
+    }
+    const entries = Array.isArray(data.entries)
+      ? data.entries.map(mapEntry).filter((e): e is LeaderboardEntry => e !== null)
+      : [];
+    return { benchmark, entries };
+  } catch (e) {
+    publishLog(`leaderboard: GET ${url} failed: ${(e as Error).message}`);
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `listLeaderboard()`, a main-process function that fetches one benchmark's ranked leaderboard from the public scoreboard (`GET /v1/leaderboard/{id}`), modeled on the existing `list-benchmarks.ts`: main-process fetch (exempt from renderer CORS), 8s timeout, defensive row mapping, `null` on any failure.
- Deliberately unwired — no IPC channel, no preload exposure, no UI. This is milestone 1 of 6 in a stacked sequence for OME-321; each subsequent PR builds on this one.

## Stack
1. **→ this PR** — main-process fetch service
2. `ome-321-leaderboard-ipc-preload` — IPC channel + preload exposure
3. `ome-321-leaderboard-hook` — renderer hook
4. `ome-321-leaderboard-table` — presentational table component
5. `ome-321-leaderboard-view` — the view wiring it together
6. `ome-321-leaderboard-nav` — sidebar/nav wiring + docs

## Test plan
- [x] `npx vitest run` — 8 new unit tests, all passing (happy path, `?top=` param, malformed-entry dropping, malformed benchmark, 404, network failure, 8s timeout, config-driven URL)
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — succeeds
- [x] Manually verified `listLeaderboard()` against a real local `apps/scoreboard` instance (seeded `livetruth` benchmark) — output matched `curl`'s response exactly; confirmed `null` (not throw) on a real 404 and on an unreachable host

Linear: [OME-321](https://linear.app/openmined/issue/OME-321/sf-27-leaderboard-pull-the-public-board-into-desktop-sdk)