### PR TITLE
feat(desktop): expose leaderboard reads over IPC + preload

### DIFF
--- a/apps/desktop/src/main/ipc/__tests__/leaderboard.ipc.test.ts
+++ b/apps/desktop/src/main/ipc/__tests__/leaderboard.ipc.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  ipcHandlers: new Map<string, (...args: unknown[]) => unknown>(),
+  listLeaderboard: vi.fn(),
+  requireTrustedIpcSender: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: (...args: unknown[]) => unknown) => {
+      mocks.ipcHandlers.set(channel, handler);
+    },
+  },
+}));
+vi.mock('../../services/fetch-leaderboard', () => ({
+  listLeaderboard: mocks.listLeaderboard,
+}));
+vi.mock('../sender-validation', () => ({
+  requireTrustedIpcSender: mocks.requireTrustedIpcSender,
+}));
+
+import { registerLeaderboardHandlers } from '../leaderboard.ipc';
+
+const EVENT = { senderFrame: { url: 'file:///Applications/ScreamingFace.app/index.html' } };
+
+describe('leaderboard IPC', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.ipcHandlers.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('registers leaderboard:getLeaderboard', () => {
+    registerLeaderboardHandlers();
+    expect(mocks.ipcHandlers.has('leaderboard:getLeaderboard')).toBe(true);
+  });
+
+  it('validates the sender before delegating to listLeaderboard', async () => {
+    mocks.listLeaderboard.mockResolvedValue({ benchmark: { id: 'livetruth' }, entries: [] });
+    registerLeaderboardHandlers();
+
+    const handler = mocks.ipcHandlers.get('leaderboard:getLeaderboard');
+    if (!handler) throw new Error('leaderboard:getLeaderboard was not registered');
+
+    const out = await handler(EVENT, 'livetruth', 10);
+
+    expect(mocks.requireTrustedIpcSender).toHaveBeenCalledWith(EVENT);
+    expect(mocks.listLeaderboard).toHaveBeenCalledWith('livetruth', 10);
+    expect(out).toEqual({ benchmark: { id: 'livetruth' }, entries: [] });
+  });
+
+  it('propagates a null result (unknown benchmark / unreachable scoreboard) without throwing', async () => {
+    mocks.listLeaderboard.mockResolvedValue(null);
+    registerLeaderboardHandlers();
+
+    const handler = mocks.ipcHandlers.get('leaderboard:getLeaderboard');
+    if (!handler) throw new Error('leaderboard:getLeaderboard was not registered');
+
+    expect(await handler(EVENT, 'unknown-benchmark')).toBeNull();
+  });
+});

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -6,6 +6,7 @@ import { registerSessionHandlers } from './session.ipc';
 import { registerBackendStatusHandlers } from './backend-status.ipc';
 import { registerAigwSessionHandlers } from './aigw-session.ipc';
 import { registerPublishHandlers } from './publish.ipc';
+import { registerLeaderboardHandlers } from './leaderboard.ipc';
 
 export function registerAllHandlers(): void {
   registerConfigHandlers();
@@ -16,4 +17,5 @@ export function registerAllHandlers(): void {
   registerAigwSessionHandlers();
   registerBackendStatusHandlers();
   registerPublishHandlers();
+  registerLeaderboardHandlers();
 }

--- a/apps/desktop/src/main/ipc/leaderboard.ipc.ts
+++ b/apps/desktop/src/main/ipc/leaderboard.ipc.ts
@@ -1,0 +1,24 @@
+// apps/desktop/src/main/ipc/leaderboard.ipc.ts
+//
+// IPC for reading the public leaderboard (OME-321):
+//   - leaderboard:getLeaderboard — ranked leaderboard for a benchmark, fetched
+//     from main (exempt from renderer CORS, same rationale as publish.ipc.ts).
+//
+// Deliberately its own file, not folded into publish.ipc.ts: that file's scope
+// is the write/publish flow (SF-181/D-SCORE-006); this is an unrelated read
+// surface, so it gets its own bounded IPC namespace.
+
+import { ipcMain } from 'electron';
+import { listLeaderboard } from '../services/fetch-leaderboard';
+import type { LeaderboardData } from '../../preload/types';
+import { requireTrustedIpcSender } from './sender-validation';
+
+export function registerLeaderboardHandlers(): void {
+  ipcMain.handle(
+    'leaderboard:getLeaderboard',
+    (event, benchmarkId: string, top?: number): Promise<LeaderboardData | null> => {
+      requireTrustedIpcSender(event);
+      return listLeaderboard(benchmarkId, top);
+    },
+  );
+}

--- a/apps/desktop/src/main/services/fetch-leaderboard.ts
+++ b/apps/desktop/src/main/services/fetch-leaderboard.ts
@@ -6,42 +6,18 @@
 // SF-273).
 //
 // Returns null on ANY failure (unreachable, non-2xx incl. unknown-benchmark 404,
-// bad body) — this milestone has no consumer yet, so there is no need for
-// status-specific error surfacing; a later milestone's renderer hook can treat
-// "couldn't load" as a single state.
+// bad body) — there is no status-specific error surfacing; the renderer hook
+// treats "couldn't load" as a single state.
 //
-// OME-321, milestone 1: this function is intentionally unwired — no IPC channel,
-// no preload exposure, no UI. It only proves the fetch/mapping/error-handling
-// logic in isolation ahead of later milestones that make it reachable.
+// Types live in preload/types.ts (not here), matching KnownBenchmark's
+// convention, since leaderboard.ipc.ts's handler return type and the renderer
+// hook both need them across the IPC boundary.
 
 import { resolvePublishContext } from './publish-context';
 import { publishLog } from './publish-log';
+import type { LeaderboardBenchmark, LeaderboardEntry, LeaderboardData } from '../../preload/types';
 
 const TIMEOUT_MS = 8_000;
-
-export interface LeaderboardBenchmark {
-  id: string;
-  displayName: string;
-  description: string | null;
-  datasetUrl: string | null;
-}
-
-export interface LeaderboardEntry {
-  rank: number;
-  specId: string;
-  accuracy: number;
-  totalQuestions: number;
-  ranWithProviders: string[];
-  submittedAt: string;
-  submittedBy: string | null;
-  verifiedByOpenmined: boolean;
-  url4Expression: string;
-}
-
-export interface LeaderboardData {
-  benchmark: LeaderboardBenchmark;
-  entries: LeaderboardEntry[];
-}
 
 interface BenchmarkResponseBody {
   id?: unknown;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -54,6 +54,10 @@ const api: ElectronAPI = {
     openExternal: (url) => ipcRenderer.invoke('publish:openExternal', url),
     listBenchmarks: () => ipcRenderer.invoke('publish:listBenchmarks'),
   },
+  leaderboard: {
+    getLeaderboard: (benchmarkId, top?) =>
+      ipcRenderer.invoke('leaderboard:getLeaderboard', benchmarkId, top),
+  },
   backends: {
     getStatus: () => ipcRenderer.invoke('backends:getStatus'),
     getPollingError: () => ipcRenderer.invoke('backends:getPollingError'),

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -272,6 +272,33 @@ export interface KnownBenchmark {
   displayName: string;
 }
 
+/** A benchmark's descriptive fields as returned alongside a leaderboard (GET /v1/leaderboard/{id}). */
+export interface LeaderboardBenchmark {
+  id: string;
+  displayName: string;
+  description: string | null;
+  datasetUrl: string | null;
+}
+
+/** One ranked leaderboard row (GET /v1/leaderboard/{id}). */
+export interface LeaderboardEntry {
+  rank: number;
+  specId: string;
+  accuracy: number;
+  totalQuestions: number;
+  ranWithProviders: string[];
+  submittedAt: string;
+  submittedBy: string | null;
+  verifiedByOpenmined: boolean;
+  url4Expression: string;
+}
+
+/** The ranked leaderboard for one benchmark (GET /v1/leaderboard/{id}). */
+export interface LeaderboardData {
+  benchmark: LeaderboardBenchmark;
+  entries: LeaderboardEntry[];
+}
+
 export interface ElectronAPI {
   popup: {
     open: (url: string, title?: string) => Promise<void>;
@@ -331,6 +358,15 @@ export interface ElectronAPI {
      * when the registry is unreachable, so callers never show a false "unknown".
      */
     listBenchmarks: () => Promise<KnownBenchmark[] | null>;
+  };
+  leaderboard: {
+    /**
+     * Ranked leaderboard for a benchmark (GET /v1/leaderboard/{id}), fetched
+     * from the main process (exempt from renderer CORS, SF-273). Resolves to
+     * null when the benchmark is unknown (404), the scoreboard is
+     * unreachable, or the response is malformed.
+     */
+    getLeaderboard: (benchmarkId: string, top?: number) => Promise<LeaderboardData | null>;
   };
   backends: {
     getStatus: () => Promise<BackendStatusResponse>;


### PR DESCRIPTION
## Summary
- Promotes `LeaderboardBenchmark`/`LeaderboardEntry`/`LeaderboardData` into `preload/types.ts` (matching `KnownBenchmark`'s convention, since they now cross the IPC boundary).
- Adds a `leaderboard:getLeaderboard` IPC channel in its own file (`leaderboard.ipc.ts`), not folded into `publish.ipc.ts` (that file is scoped to the write/publish flow), guarded by `requireTrustedIpcSender`.
- Exposes it on `window.electronAPI.leaderboard.getLeaderboard`.
- `listLeaderboard()` itself is behaviorally unchanged from the previous PR; still no renderer hook or UI consuming this yet.

Stacked on #363 (milestone 1 of 6 for OME-321) — review that one first.

## Test plan
- [x] New: `leaderboard.ipc.test.ts` — registration, sender validation, delegation to `listLeaderboard`, null-propagation
- [x] `npx vitest run` — 51 files / 318 tests, all passing
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — succeeds
- [x] Verified this branch in isolation (stashed all later-milestone work, reran full gates) before stacking milestone 3 on top

Linear: [OME-321](https://linear.app/openmined/issue/OME-321/sf-27-leaderboard-pull-the-public-board-into-desktop-sdk)