### PR TITLE
feat(desktop): add useLeaderboard renderer hook

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/__tests__/use-leaderboard.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/__tests__/use-leaderboard.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor, cleanup, act } from '@testing-library/react';
+import { it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { useLeaderboard } from '../use-leaderboard';
+
+const getLeaderboard = vi.fn();
+const DATA = {
+  benchmark: { id: 'livetruth', displayName: 'LiveTruth', description: null, datasetUrl: null },
+  entries: [],
+};
+
+beforeEach(() => {
+  getLeaderboard.mockReset();
+  (window as unknown as { electronAPI: unknown }).electronAPI = { leaderboard: { getLeaderboard } };
+});
+afterEach(cleanup);
+
+it('does nothing while benchmarkId is null', () => {
+  const { result } = renderHook(() => useLeaderboard(null));
+  expect(result.current.loading).toBe(false);
+  expect(result.current.data).toBeNull();
+  expect(getLeaderboard).not.toHaveBeenCalled();
+});
+
+it('loads, then resolves data for the given benchmark', async () => {
+  getLeaderboard.mockResolvedValue(DATA);
+  const { result } = renderHook(() => useLeaderboard('livetruth'));
+  expect(result.current.loading).toBe(true);
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  expect(result.current.data).toEqual(DATA);
+  expect(result.current.error).toBe(false);
+  expect(getLeaderboard).toHaveBeenCalledWith('livetruth');
+});
+
+it('treats a null result as an error, distinct from an empty entries list', async () => {
+  getLeaderboard.mockResolvedValue(null);
+  const { result } = renderHook(() => useLeaderboard('livetruth'));
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  expect(result.current.data).toBeNull();
+  expect(result.current.error).toBe(true);
+});
+
+it('treats a rejected IPC call as an error rather than throwing', async () => {
+  getLeaderboard.mockRejectedValue(new Error('ipc down'));
+  const { result } = renderHook(() => useLeaderboard('livetruth'));
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  expect(result.current.error).toBe(true);
+});
+
+it('re-fetches when benchmarkId changes', async () => {
+  getLeaderboard.mockResolvedValue(DATA);
+  const { result, rerender } = renderHook(({ id }) => useLeaderboard(id), {
+    initialProps: { id: 'livetruth' as string | null },
+  });
+  await waitFor(() => expect(result.current.loading).toBe(false));
+
+  rerender({ id: 'hle' });
+  await waitFor(() => expect(getLeaderboard).toHaveBeenCalledWith('hle'));
+  expect(getLeaderboard).toHaveBeenCalledTimes(2);
+});
+
+it('refresh() re-fetches the current benchmark on demand', async () => {
+  getLeaderboard.mockResolvedValue(DATA);
+  const { result } = renderHook(() => useLeaderboard('livetruth'));
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  expect(getLeaderboard).toHaveBeenCalledTimes(1);
+
+  act(() => result.current.refresh());
+  await waitFor(() => expect(getLeaderboard).toHaveBeenCalledTimes(2));
+});

--- a/apps/desktop/src/renderer/src/hooks/use-leaderboard.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-leaderboard.ts
@@ -1,0 +1,62 @@
+// apps/desktop/src/renderer/src/hooks/use-leaderboard.ts
+//
+// Loads the ranked leaderboard for one benchmark (GET /v1/leaderboard/{id} via
+// the main process, exempt from renderer CORS). Re-fetches whenever
+// `benchmarkId` changes; `refresh()` re-fetches the current benchmark on
+// demand (manual retry — see fetch-leaderboard.ts for why reads don't retry
+// automatically the way publish does).
+//
+// `error` is distinct from "no entries": a benchmark with zero submissions is
+// a successful, non-null response with an empty `entries` array.
+
+import { useCallback, useEffect, useState } from 'react';
+import type { LeaderboardData } from '../../../../preload/types';
+
+export interface LeaderboardState {
+  data: LeaderboardData | null;
+  loading: boolean;
+  error: boolean;
+  refresh: () => void;
+}
+
+export function useLeaderboard(benchmarkId: string | null): LeaderboardState {
+  const [data, setData] = useState<LeaderboardData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+  const [version, setVersion] = useState(0);
+
+  useEffect(() => {
+    if (benchmarkId === null) {
+      setData(null);
+      setLoading(false);
+      setError(false);
+      return;
+    }
+    let active = true;
+    setLoading(true);
+    setError(false);
+    void window.electronAPI.leaderboard
+      .getLeaderboard(benchmarkId)
+      .then((result) => {
+        if (!active) return;
+        setData(result);
+        setError(result === null);
+      })
+      .catch(() => {
+        if (active) {
+          setData(null);
+          setError(true);
+        }
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [benchmarkId, version]);
+
+  const refresh = useCallback(() => setVersion((v) => v + 1), []);
+
+  return { data, loading, error, refresh };
+}


### PR DESCRIPTION
## Summary
- Adds `useLeaderboard(benchmarkId)`, loading the ranked leaderboard via `window.electronAPI.leaderboard.getLeaderboard`, modeled on `use-known-benchmarks.ts`'s `{data, loading}` shape.
- Adds `error: boolean`, distinct from a benchmark with zero submissions (a successful response with an empty `entries` array — not an error).
- Adds `refresh()` for manual retry — reads don't auto-retry with backoff the way publish does (see rationale in `fetch-leaderboard.ts`: a read has no idempotency-safety reason to retry silently).
- Still no UI consumer.

Stacked on #364 (milestone 2 of 6 for OME-321).

## Test plan
- [x] New: `use-leaderboard.test.ts` — null-benchmarkId no-op, load/resolve, null-result-as-error (distinct from empty entries), rejected-IPC-as-error, re-fetch on benchmarkId change, refresh() on demand
- [x] `npx vitest run` — 52 files / 324 tests, all passing
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — succeeds
- [x] Verified this branch in isolation before stacking milestone 4 on top

Linear: [OME-321](https://linear.app/openmined/issue/OME-321/sf-27-leaderboard-pull-the-public-board-into-desktop-sdk)