### PR TITLE
feat(desktop): add LeaderboardTable presentational component

### DIFF
--- a/apps/desktop/src/renderer/src/components/leaderboard/LeaderboardTable.tsx
+++ b/apps/desktop/src/renderer/src/components/leaderboard/LeaderboardTable.tsx
@@ -1,0 +1,74 @@
+// apps/desktop/src/renderer/src/components/leaderboard/LeaderboardTable.tsx
+//
+// Pure presentational table for one benchmark's ranked entries. Modeled on
+// EvalQuestionsTable.tsx's markup (plain <table> + Tailwind — this app has no
+// shared Table primitive). `verified_by_openmined` is rendered as plain text
+// for this first pass; a designed badge treatment is deferred.
+
+import type { LeaderboardEntry } from '../../../../preload/types';
+
+const TRUNC = 80;
+
+function truncate(s: string): string {
+  return s.length > TRUNC ? s.slice(0, TRUNC) + '…' : s;
+}
+
+function formatAccuracy(accuracy: number): string {
+  return `${(accuracy * 100).toFixed(1)}%`;
+}
+
+function formatSubmittedAt(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return `${d.toLocaleDateString()} ${d.toLocaleTimeString()}`;
+}
+
+export function LeaderboardTable({ entries }: { entries: LeaderboardEntry[] }) {
+  if (entries.length === 0) {
+    return (
+      <div className="p-6 text-sm text-muted-foreground">
+        No submissions yet for this benchmark.
+      </div>
+    );
+  }
+  return (
+    <table className="w-full text-sm">
+      <thead className="bg-muted/30 text-xs text-muted-foreground">
+        <tr className="border-b border-border">
+          <th className="w-10 px-3 py-2 text-right font-medium">#</th>
+          <th className="px-3 py-2 text-left font-medium">Spec</th>
+          <th className="px-3 py-2 text-right font-medium">Accuracy</th>
+          <th className="px-3 py-2 text-right font-medium">Questions</th>
+          <th className="px-3 py-2 text-left font-medium">Providers</th>
+          <th className="px-3 py-2 text-left font-medium">Submitted</th>
+          <th className="px-3 py-2 text-left font-medium">Submitted by</th>
+          <th className="px-3 py-2 text-left font-medium">Verified</th>
+          <th className="px-3 py-2 text-left font-medium">url4</th>
+        </tr>
+      </thead>
+      <tbody>
+        {entries.map((entry) => (
+          <tr key={entry.specId} className="border-b border-border/50">
+            <td className="px-3 py-2 text-right tabular-nums text-xs text-muted-foreground">
+              {entry.rank}
+            </td>
+            <td className="px-3 py-2 font-mono text-xs">{entry.specId}</td>
+            <td className="px-3 py-2 text-right tabular-nums">{formatAccuracy(entry.accuracy)}</td>
+            <td className="px-3 py-2 text-right tabular-nums">{entry.totalQuestions}</td>
+            <td className="px-3 py-2">{entry.ranWithProviders.join(', ')}</td>
+            <td className="px-3 py-2 text-xs text-muted-foreground">
+              {formatSubmittedAt(entry.submittedAt)}
+            </td>
+            <td className="px-3 py-2">
+              {entry.submittedBy ?? <span className="text-muted-foreground">—</span>}
+            </td>
+            <td className="px-3 py-2 text-xs">{entry.verifiedByOpenmined ? '✓ verified' : ''}</td>
+            <td className="px-3 py-2 font-mono text-xs" title={entry.url4Expression}>
+              {truncate(entry.url4Expression)}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/leaderboard/__tests__/LeaderboardTable.test.tsx
+++ b/apps/desktop/src/renderer/src/components/leaderboard/__tests__/LeaderboardTable.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { LeaderboardTable } from '../LeaderboardTable';
+import type { LeaderboardEntry } from '../../../../../preload/types';
+
+const ENTRY: LeaderboardEntry = {
+  rank: 1,
+  specId: 'local-smoke',
+  accuracy: 0.5,
+  totalQuestions: 2,
+  ranWithProviders: ['smoke'],
+  submittedAt: '2026-07-07T15:30:05.108456Z',
+  submittedBy: 'filip-local',
+  verifiedByOpenmined: false,
+  url4Expression: 'url4://smoke',
+};
+
+afterEach(cleanup);
+
+describe('LeaderboardTable', () => {
+  it('renders one row per entry with the expected columns', () => {
+    render(<LeaderboardTable entries={[ENTRY]} />);
+    expect(screen.getByText('local-smoke')).toBeInTheDocument();
+    expect(screen.getByText('50.0%')).toBeInTheDocument();
+    expect(screen.getByText('smoke')).toBeInTheDocument();
+    expect(screen.getByText('filip-local')).toBeInTheDocument();
+    expect(screen.getByText('url4://smoke')).toBeInTheDocument();
+  });
+
+  it('renders "—" for an anonymous (null submittedBy) entry', () => {
+    render(<LeaderboardTable entries={[{ ...ENTRY, submittedBy: null }]} />);
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('marks a verified entry, and leaves an unverified one blank', () => {
+    render(<LeaderboardTable entries={[{ ...ENTRY, verifiedByOpenmined: true }]} />);
+    expect(screen.getByText('✓ verified')).toBeInTheDocument();
+  });
+
+  it('truncates a long url4 expression and keeps the full text in the title', () => {
+    const long = 'url4://' + 'x'.repeat(100);
+    render(<LeaderboardTable entries={[{ ...ENTRY, url4Expression: long }]} />);
+    const cell = screen.getByTitle(long);
+    expect(cell.textContent?.endsWith('…')).toBe(true);
+    expect(cell.textContent?.length).toBeLessThan(long.length);
+  });
+
+  it('shows an empty-state message when there are no entries', () => {
+    render(<LeaderboardTable entries={[]} />);
+    expect(screen.getByText(/no submissions yet/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a pure `LeaderboardTable` for one benchmark's ranked entries — rank, spec, accuracy, questions, providers, submitted at/by, verified, url4 (truncated, full text in `title`).
- Modeled on `EvalQuestionsTable.tsx`'s markup (plain `<table>` + Tailwind — this app has no shared `Table` primitive).
- `verified_by_openmined` renders as plain text for this first pass; a designed badge treatment is explicitly deferred (design work, not data plumbing).
- No hook/view wiring yet — takes `entries` as a prop.

Stacked on #365 (milestone 3 of 6 for OME-321).

## Test plan
- [x] New: `LeaderboardTable.test.tsx` — column rendering, anonymous (`—`) submittedBy, verified marker, url4 truncation, empty-state message
- [x] `npx vitest run` — 53 files / 329 tests, all passing
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — succeeds
- [x] Verified this branch in isolation before stacking milestone 5 on top

Linear: [OME-321](https://linear.app/openmined/issue/OME-321/sf-27-leaderboard-pull-the-public-board-into-desktop-sdk)