### PR TITLE
feat(desktop): add LeaderboardView

### DIFF
--- a/apps/desktop/src/renderer/src/views/LeaderboardView.test.tsx
+++ b/apps/desktop/src/renderer/src/views/LeaderboardView.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { it, expect, vi, afterEach, beforeEach } from 'vitest';
+
+const knownBenchmarksState: {
+  benchmarks: Array<{ id: string; displayName: string }> | null;
+  loading: boolean;
+} = { benchmarks: null, loading: true };
+
+const leaderboardState: {
+  data: { benchmark: unknown; entries: unknown[] } | null;
+  loading: boolean;
+  error: boolean;
+  refresh: () => void;
+} = { data: null, loading: false, error: false, refresh: vi.fn() };
+
+vi.mock('@/hooks/use-known-benchmarks', () => ({
+  useKnownBenchmarks: () => knownBenchmarksState,
+}));
+vi.mock('@/hooks/use-leaderboard', () => ({
+  useLeaderboard: () => leaderboardState,
+}));
+vi.mock('@/components/leaderboard/LeaderboardTable', () => ({
+  LeaderboardTable: ({ entries }: { entries: unknown[] }) => (
+    <div data-testid="leaderboard-table">{entries.length} entries</div>
+  ),
+}));
+
+afterEach(cleanup);
+
+import { LeaderboardView } from './LeaderboardView';
+
+beforeEach(() => {
+  knownBenchmarksState.benchmarks = null;
+  knownBenchmarksState.loading = true;
+  leaderboardState.data = null;
+  leaderboardState.loading = false;
+  leaderboardState.error = false;
+});
+
+it('shows a loading state while benchmarks are loading', () => {
+  render(<LeaderboardView />);
+  expect(screen.getByText(/loading benchmarks/i)).toBeTruthy();
+});
+
+it('shows a distinct empty state when no benchmarks are registered', () => {
+  knownBenchmarksState.benchmarks = [];
+  knownBenchmarksState.loading = false;
+  render(<LeaderboardView />);
+  expect(screen.getByText(/no benchmarks are registered/i)).toBeTruthy();
+});
+
+it('renders the benchmark selector and table once benchmarks and leaderboard data load', () => {
+  knownBenchmarksState.benchmarks = [{ id: 'livetruth', displayName: 'LiveTruth' }];
+  knownBenchmarksState.loading = false;
+  leaderboardState.data = { benchmark: { id: 'livetruth' }, entries: [1, 2] };
+  render(<LeaderboardView />);
+  expect(screen.getByLabelText('Benchmark')).toBeTruthy();
+  expect(screen.getByTestId('leaderboard-table')).toHaveTextContent('2 entries');
+});
+
+it('shows the leaderboard loading state distinct from the benchmarks loading state', () => {
+  knownBenchmarksState.benchmarks = [{ id: 'livetruth', displayName: 'LiveTruth' }];
+  knownBenchmarksState.loading = false;
+  leaderboardState.loading = true;
+  render(<LeaderboardView />);
+  expect(screen.getByText(/loading leaderboard/i)).toBeTruthy();
+});
+
+it('shows a retry button on error, distinct from the empty-entries state', () => {
+  knownBenchmarksState.benchmarks = [{ id: 'livetruth', displayName: 'LiveTruth' }];
+  knownBenchmarksState.loading = false;
+  leaderboardState.error = true;
+  render(<LeaderboardView />);
+  expect(screen.getByText(/couldn't load the leaderboard/i)).toBeTruthy();
+  expect(screen.getByRole('button', { name: /retry/i })).toBeTruthy();
+});

--- a/apps/desktop/src/renderer/src/views/LeaderboardView.tsx
+++ b/apps/desktop/src/renderer/src/views/LeaderboardView.tsx
@@ -1,0 +1,84 @@
+// apps/desktop/src/renderer/src/views/LeaderboardView.tsx
+//
+// In-app read-only view of the public scoreboard (OME-321). Net-new screen —
+// there was no prior mock-data leaderboard view to replace; the existing
+// "Check Leaderboard" button (LeaderboardLink.tsx) still opens the full public
+// portal externally and is unaffected by this view.
+//
+// Deferred (not in this pass): verified-badge visual treatment, client-side
+// filtering/sorting beyond the API's accuracy-desc order, spec-history
+// drill-in, and comparing a local run against the board (that's OME-318).
+
+import { useEffect, useMemo, useState } from 'react';
+import { Combobox } from '@/components/ui/combobox';
+import { useKnownBenchmarks } from '@/hooks/use-known-benchmarks';
+import { useLeaderboard } from '@/hooks/use-leaderboard';
+import { LeaderboardTable } from '@/components/leaderboard/LeaderboardTable';
+
+export function LeaderboardView() {
+  const { benchmarks, loading: benchmarksLoading } = useKnownBenchmarks();
+  const [benchmarkId, setBenchmarkId] = useState<string | null>(null);
+
+  // Default to the first registered benchmark once the registry loads, so the
+  // common single-benchmark case doesn't require an extra click.
+  useEffect(() => {
+    if (benchmarkId === null && benchmarks && benchmarks.length > 0) {
+      setBenchmarkId(benchmarks[0].id);
+    }
+  }, [benchmarkId, benchmarks]);
+
+  const options = useMemo(
+    () => (benchmarks ?? []).map((b) => ({ value: b.id, label: b.displayName })),
+    [benchmarks],
+  );
+
+  const { data, loading, error, refresh } = useLeaderboard(benchmarkId);
+
+  return (
+    <div className="flex h-full flex-col overflow-y-auto p-6">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <h1 className="text-lg font-semibold">Leaderboard</h1>
+        {benchmarks && benchmarks.length > 0 && benchmarkId !== null && (
+          <div className="w-64">
+            <Combobox
+              value={benchmarkId}
+              onChange={setBenchmarkId}
+              options={options}
+              placeholder="Select a benchmark"
+              aria-label="Benchmark"
+            />
+          </div>
+        )}
+      </div>
+
+      {benchmarksLoading && (
+        <div className="p-6 text-sm text-muted-foreground">Loading benchmarks…</div>
+      )}
+
+      {!benchmarksLoading && (!benchmarks || benchmarks.length === 0) && (
+        <div className="p-6 text-sm text-muted-foreground">
+          No benchmarks are registered on the scoreboard yet.
+        </div>
+      )}
+
+      {!benchmarksLoading && benchmarks && benchmarks.length > 0 && (
+        <div className="rounded-md border border-border">
+          {loading && <div className="p-6 text-sm text-muted-foreground">Loading leaderboard…</div>}
+          {!loading && error && (
+            <div className="flex items-center justify-between gap-3 p-6 text-sm text-destructive">
+              <span>Couldn&apos;t load the leaderboard. Check your connection and try again.</span>
+              <button
+                type="button"
+                onClick={refresh}
+                className="shrink-0 rounded border border-border px-2 py-1 text-xs text-foreground hover:bg-muted/50"
+              >
+                Retry
+              </button>
+            </div>
+          )}
+          {!loading && !error && data && <LeaderboardTable entries={data.entries} />}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Wires the benchmark selector (`Combobox` + `useKnownBenchmarks`, reused verbatim from the publish dialog) to `useLeaderboard` + `LeaderboardTable`, with distinct loading / error / empty-entries / no-benchmarks-registered states and a manual retry button on error.
- Net-new screen — there was no prior mock-data leaderboard view to replace. The existing "Check Leaderboard" button (`LeaderboardLink.tsx`) still opens the full public portal externally and is unaffected.
- **Not yet reachable from the sidebar** — nav wiring is the next PR in the stack, so placement can get a final look from Irina against her Figma leaderboard wireframe before it's live.

Stacked on #366 (milestone 4 of 6 for OME-321).

## Test plan
- [x] New: `LeaderboardView.test.tsx` — benchmarks-loading state, no-benchmarks-registered state, selector+table render together, leaderboard-loading state (distinct from benchmarks-loading), error state with retry button
- [x] `npx vitest run` — 54 files / 334 tests, all passing
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — succeeds
- [x] **End-to-end verified against the real running app**: launched desktop with `SF_SCOREBOARD_URL` pointed at a local `apps/scoreboard` instance seeded with real data, drove the renderer via Chrome DevTools Protocol, confirmed the view renders the actual seeded leaderboard entry correctly and produces zero console errors (screenshot captured during development, not included in this PR's diff)

Linear: [OME-321](https://linear.app/openmined/issue/OME-321/sf-27-leaderboard-pull-the-public-board-into-desktop-sdk)