### PR TITLE
feat(desktop): wire Leaderboard into the sidebar nav

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -4,6 +4,7 @@ import type { View } from '@/components/layout/Sidebar';
 import { DashboardView } from '@/views/DashboardView';
 import { SessionsView } from '@/views/SessionsView';
 import { EvalStudioView } from '@/views/EvalStudioView';
+import { LeaderboardView } from '@/views/LeaderboardView';
 import { Url4StudioView } from '@/views/Url4StudioView';
 import { CodeStudioView } from '@/views/CodeStudioView';
 import { PrivateDataView } from '@/views/PrivateDataView';
@@ -79,6 +80,7 @@ export function App() {
         <EvalStudioView pendingRun={pendingRun} onPendingConsumed={() => setPendingRun(null)} />
       );
     }
+    if (currentView === 'leaderboard') return <LeaderboardView />;
     if (currentView === 'url4-studio') return <Url4StudioView />;
     if (currentView === 'code-studio') return <CodeStudioView />;
     if (currentView === 'private-data') return <PrivateDataView />;

--- a/apps/desktop/src/renderer/src/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/layout/Sidebar.tsx
@@ -4,6 +4,7 @@ import {
   Settings,
   Puzzle,
   Terminal,
+  Trophy,
   Workflow,
   FileCode2,
   FileText,
@@ -20,6 +21,7 @@ export type View =
   | 'dashboard'
   | 'sessions'
   | 'eval-studio'
+  | 'leaderboard'
   | 'url4-studio'
   | 'code-studio'
   | 'private-data'
@@ -37,6 +39,7 @@ const coreItems: NavItem[] = [
   { id: 'url4-studio', label: 'URL4 Studio', icon: Workflow },
   { id: 'sessions', label: 'Sessions', icon: Terminal },
   { id: 'eval-studio', label: 'Eval Studio', icon: FlaskConical },
+  { id: 'leaderboard', label: 'Leaderboard', icon: Trophy },
   { id: 'code-studio', label: 'Code Studio', icon: FileCode2 },
   { id: 'private-data', label: 'Private Data', icon: FileText },
 ];

--- a/apps/desktop/src/renderer/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/layout/__tests__/Sidebar.test.tsx
@@ -57,6 +57,7 @@ describe('Sidebar nav order', () => {
       'URL4 Studio',
       'Sessions',
       'Eval Studio',
+      'Leaderboard',
       'Code Studio',
       'Private Data',
     ]);

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -7,8 +7,9 @@ root `README.md` quickstart disagrees with this file, this file wins.
 ScreamingFace is three cooperating pieces:
 
 - **Desktop app** (`apps/desktop/`) — an Electron control plane. It owns the UI
-  (Settings, Eval Studio, URL4/Code Studio, Sessions) and **manages the local
-  server for you** (creates the venv, syncs deps, starts/stops the process).
+  (Settings, Eval Studio, Leaderboard, URL4/Code Studio, Sessions) and
+  **manages the local server for you** (creates the venv, syncs deps,
+  starts/stops the process).
 - **Local server** (`apps/server/`) — a FastAPI, plugin-based service that runs
   the URL4 engine, the per-provider frontends, and the Python runner. Reads
   `apps/server/sf.json`.


### PR DESCRIPTION
## Summary
- Adds `'leaderboard'` to the `Sidebar` `View` union and `coreItems` (Trophy icon, placed after Eval Studio — a related but distinct surface, consistent with `url4-studio`/`code-studio`/`private-data` already being separate top-level items rather than tabs), plus the corresponding render branch in `App.tsx`.
- Updates `docs/SETUP.md`'s desktop-screens list to mention Leaderboard alongside the others it already names.
- This is the PR that makes the whole stack (#363–#367) actually reachable/visible in the running app.

**Nav placement is a judgment call pending a final look from Irina against her Figma leaderboard wireframe.** Nothing in the data-plumbing layers below this PR depends on where it mounts, so this commit is trivial to move or revert on its own if she calls for a different spot — please weigh in on placement specifically in review.

Stacked on #367 (milestone 5 of 6, and final PR, for OME-321).

## Test plan
- [x] Updated the existing `Sidebar.test.tsx` nav-order snapshot test to include the new item
- [x] `npx vitest run` — 54 files / 334 tests, all passing
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — succeeds
- [x] **End-to-end verified twice** against the real running app (once before this PR's commit existed, once after, to catch anything the lint/prettier auto-fix hooks might have altered): clicked the actual "Leaderboard" sidebar button via CDP, confirmed it renders the real seeded scoreboard data with zero console errors and no layout issues
- [x] Style pass: new files' lint output cross-checked against their template files (`list-benchmarks.ts`, `use-known-benchmarks.ts`, `EvalQuestionsTable.tsx`, `EvalStudioView.tsx`) — identical warning categories (pre-existing sonarjs baseline noise across the whole repo), nothing specific to this change
- [x] Docs check: `docs/ARCHITECTURE.md` and `docs/GLOSSARY.md` also list desktop's screens but are already broadly stale (missing Dashboard/URL4 Studio/Code Studio/Private Data too, predating this change) — did not touch those to avoid unrelated scope creep in this stack; flagging as a separate follow-up worth doing on its own. `docs/SETUP.md` is the actively-maintained canonical setup guide, so it got the one-line update.

Linear: [OME-321](https://linear.app/openmined/issue/OME-321/sf-27-leaderboard-pull-the-public-board-into-desktop-sdk)