### PR TITLE
fix: restore web/public + GitHub Pages deploy (screamingface.ai)

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,42 @@
+name: Deploy website to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "web/public/**"
+      - ".github/workflows/deploy-website.yml"
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare Pages artifact
+        run: |
+          rm -rf /tmp/sf-pages
+          mkdir -p /tmp/sf-pages
+          cp -R web/public/. /tmp/sf-pages/
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: /tmp/sf-pages
+
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,41 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# env files (can opt-in for committing if needed)
+.env*
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/web/public/CNAME
+++ b/web/public/CNAME
@@ -1,0 +1,1 @@
+screamingface.ai

--- a/web/public/ch4/v1/index.html
+++ b/web/public/ch4/v1/index.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>screamingface — SOTA on your laptop</title>
+  <meta name="description" content="An AI ensemble that combines Claude Code, Gemini CLI, Codex, and Ollama to beat state-of-the-art benchmarks. One command to install.">
+  <meta name="robots" content="noindex, nofollow">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>😱</text></svg>">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body { font-family: "Times New Roman", Times, serif; font-size: 16px; color: #000; background: #fff; }
+    code, pre, kbd { font-family: monospace; }
+    a { color: #0000EE; text-decoration: underline; }
+    a:visited { color: #551A8B; }
+
+    #gate {
+      min-height: 100vh; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; gap: 32px; padding: 0 24px;
+    }
+    #gate .emoji { font-size: 64px; user-select: none; }
+    #gate .title { font-size: 20px; font-weight: 500; }
+    #gate form { display: flex; flex-direction: column; align-items: center; gap: 12px; width: 100%; max-width: 280px; }
+    #gate input[type="password"] {
+      width: 100%; border: 1px solid #ccc; border-radius: 6px;
+      padding: 10px 14px; font-size: 14px; outline: none; font-family: inherit;
+    }
+    #gate input.error { border-color: #dc2626; }
+    #gate .error-msg { font-size: 12px; color: #dc2626; display: none; }
+    #gate button {
+      width: 100%; background: #1a1a1a; color: #fff; padding: 10px 0;
+      border-radius: 6px; font-size: 14px; font-weight: 500; border: none; cursor: pointer;
+    }
+    #content { display: none; }
+  </style>
+</head>
+<body>
+
+  <div id="gate">
+    <div class="emoji">😱</div>
+    <p class="title">screamingface</p>
+    <form id="gate-form">
+      <input type="password" id="gate-input" placeholder="Password" autocomplete="current-password">
+      <p class="error-msg" id="gate-error">Incorrect password.</p>
+      <button type="submit">Enter</button>
+    </form>
+  </div>
+
+  <div id="content">
+    <div style="max-width:600px; margin:0 auto; padding:40px 20px;">
+      <div style="text-align:center; margin-bottom:40px;">
+        <div style="font-size:64px; margin-bottom:16px;">😱</div>
+        <h1 style="font-size:36px; font-weight:bold; margin-bottom:12px;">SOTA on your laptop.</h1>
+        <p>An ensemble of the CLI models you already run. Combines their outputs, picks the best answer. Open source. No new accounts.</p>
+      </div>
+
+      <div style="margin-bottom:40px;">
+        <h2 style="font-size:24px; font-weight:bold; margin-bottom:8px;">One command</h2>
+        <p style="margin-bottom:16px;">Detects models on your machine. Configures itself. Nothing sent to a server.</p>
+        <pre style="background:#f0f0f0; border:1px solid #000; padding:12px 16px; overflow-x:auto; margin-bottom:32px;"><code>$ curl -fsSL https://screamingface.ai/install | sh</code></pre>
+        <p style="margin-bottom:8px;"><strong>01 — Install.</strong> One command. Configures locally. Nothing uploaded.</p>
+        <p style="margin-bottom:8px;"><strong>02 — Auto-detect.</strong> Finds Claude Code, Gemini CLI, Codex, and Ollama on your PATH.</p>
+        <p style="margin-bottom:8px;"><strong>03 — Route.</strong> Each prompt goes to whichever model scores best on the task.</p>
+      </div>
+
+      <p style="margin-bottom:40px;">
+        <a href="https://github.com/OpenMined/screamingface" target="_blank" rel="noopener noreferrer">github.com/OpenMined/screamingface</a>
+      </p>
+
+      <hr style="border:none; border-top:1px solid #000; margin-bottom:16px;">
+
+      <footer style="font-size:14px;">
+        😱 screamingface, built by <a href="https://openmined.org" target="_blank" rel="noopener noreferrer">OpenMined</a> — <a href="https://github.com/OpenMined/screamingface" target="_blank" rel="noopener noreferrer">GitHub</a>
+      </footer>
+    </div>
+  </div>
+
+  <script>
+    (function() {
+      var PASSWORD = "letmein";
+      var KEY = "sf_auth";
+      if (sessionStorage.getItem(KEY) === "1") {
+        document.getElementById("gate").style.display = "none";
+        document.getElementById("content").style.display = "block";
+        return;
+      }
+      document.getElementById("gate-input").focus();
+      document.getElementById("gate-form").addEventListener("submit", function(e) {
+        e.preventDefault();
+        var input = document.getElementById("gate-input");
+        if (input.value === PASSWORD) {
+          sessionStorage.setItem(KEY, "1");
+          document.getElementById("gate").style.display = "none";
+          document.getElementById("content").style.display = "block";
+        } else {
+          input.value = "";
+          input.classList.add("error");
+          document.getElementById("gate-error").style.display = "block";
+          setTimeout(function() {
+            input.classList.remove("error");
+            document.getElementById("gate-error").style.display = "none";
+          }, 1200);
+        }
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/web/public/ch4/v2/index.html
+++ b/web/public/ch4/v2/index.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>screamingface — SOTA on your laptop</title>
+  <meta name="description" content="An AI ensemble that combines Claude Code, Gemini CLI, Codex, and Ollama to beat state-of-the-art benchmarks. One command to install.">
+  <meta name="robots" content="noindex, nofollow">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>😱</text></svg>">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: "Times New Roman", Times, Georgia, serif; font-size: 16px; line-height: 1.6; color: #000; background: #fff; }
+    a { color: #0000EE; text-decoration: underline; }
+    a:visited { color: #551A8B; }
+    a:hover { color: #FF0000; }
+    code, pre, kbd { font-family: "Courier New", Courier, monospace; }
+
+    #gate {
+      min-height: 100vh; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; gap: 32px; padding: 0 24px;
+    }
+    #gate .emoji { font-size: 64px; user-select: none; }
+    #gate .title { font-size: 20px; font-weight: 500; }
+    #gate form { display: flex; flex-direction: column; align-items: center; gap: 12px; width: 100%; max-width: 280px; }
+    #gate input[type="password"] {
+      width: 100%; border: 1px solid #ccc; border-radius: 6px;
+      padding: 10px 14px; font-size: 14px; outline: none; font-family: inherit;
+    }
+    #gate input.error { border-color: #dc2626; }
+    #gate .error-msg { font-size: 12px; color: #dc2626; display: none; }
+    #gate button {
+      width: 100%; background: #1a1a1a; color: #fff; padding: 10px 0;
+      border-radius: 6px; font-size: 14px; font-weight: 500; border: none; cursor: pointer;
+    }
+    #content { display: none; }
+  </style>
+</head>
+<body>
+
+  <div id="gate">
+    <div class="emoji">😱</div>
+    <p class="title">screamingface</p>
+    <form id="gate-form">
+      <input type="password" id="gate-input" placeholder="Password" autocomplete="current-password">
+      <p class="error-msg" id="gate-error">Incorrect password.</p>
+      <button type="submit">Enter</button>
+    </form>
+  </div>
+
+  <div id="content">
+    <div style="max-width:700px; margin:0 auto; padding:40px 20px 20px;">
+
+      <div style="text-align:center; margin-bottom:10px;">
+        <div style="font-size:64px; margin-bottom:8px;">😱</div>
+        <h1 style="font-size:36px; font-weight:bold; margin-bottom:8px; font-family:'Times New Roman', Times, serif;">screamingface</h1>
+      </div>
+
+      <marquee scrollamount="4" style="font-size:18px; font-weight:bold; padding:8px 0; margin-bottom:10px; letter-spacing:1px;">*** SOTA ON YOUR LAPTOP *** SOTA ON YOUR LAPTOP *** SOTA ON YOUR LAPTOP ***</marquee>
+
+      <p style="text-align:center; margin-bottom:24px;">
+        An ensemble of the CLI models you already run.<br>
+        Combines their outputs, picks the best answer.<br>
+        Open source. No new accounts.
+      </p>
+
+      <div style="text-align:center; margin:16px 0; letter-spacing:2px; color:#999;">════════════════════════════════════</div>
+
+      <h2 style="font-size:24px; font-weight:bold; text-align:center; margin-bottom:8px;">Install</h2>
+      <p style="text-align:center; margin-bottom:16px;">
+        One command. Detects models on your machine. Configures itself.<br>
+        Nothing sent to a server.
+      </p>
+
+      <div style="border:2px dotted #000; padding:12px 16px; margin-bottom:24px; background:#f5f5f5; font-family:'Courier New', Courier, monospace; font-size:14px; overflow-x:auto; white-space:nowrap;">
+        <span style="user-select:none;">$ </span>curl -fsSL https://screamingface.ai/install | sh
+      </div>
+
+      <h3 style="font-size:20px; font-weight:bold; margin-bottom:12px; text-align:center;">How it works:</h3>
+
+      <ol style="margin-bottom:24px; padding-left:24px; line-height:2;">
+        <li><b>Install</b> &mdash; One command. Configures locally. Nothing uploaded.</li>
+        <li><b>Auto-detect</b> &mdash; Finds Claude Code, Gemini CLI, Codex, and Ollama on your PATH.</li>
+        <li><b>Route</b> &mdash; Each prompt goes to whichever model scores best on the task.</li>
+      </ol>
+
+      <div style="text-align:center; margin:16px 0; letter-spacing:2px; color:#999;">════════════════════════════════════</div>
+
+      <p style="text-align:center; margin-bottom:24px; font-size:18px;">
+        <a href="https://github.com/OpenMined/screamingface" target="_blank" rel="noopener noreferrer">github.com/OpenMined/screamingface</a>
+      </p>
+
+      <footer style="text-align:center; padding-top:16px; padding-bottom:8px; font-size:14px; border-top:1px solid #ccc;">
+        <p style="margin-bottom:12px;">
+          😱 screamingface, built by <a href="https://openmined.org" target="_blank" rel="noopener noreferrer">OpenMined</a>
+        </p>
+        <div style="display:inline-block; width:88px; height:31px; border:1px solid #000; font-size:9px; line-height:31px; font-family:'Courier New', Courier, monospace; font-weight:bold; background:#000; color:#0f0; letter-spacing:0.5px; text-align:center; margin-bottom:12px;">😱 ENSEMBLE</div>
+        <p style="color:#888; font-size:12px;">Last updated: March 2026</p>
+      </footer>
+    </div>
+  </div>
+
+  <script>
+    (function() {
+      var PASSWORD = "letmein";
+      var KEY = "sf_auth";
+      if (sessionStorage.getItem(KEY) === "1") {
+        document.getElementById("gate").style.display = "none";
+        document.getElementById("content").style.display = "block";
+        return;
+      }
+      document.getElementById("gate-input").focus();
+      document.getElementById("gate-form").addEventListener("submit", function(e) {
+        e.preventDefault();
+        var input = document.getElementById("gate-input");
+        if (input.value === PASSWORD) {
+          sessionStorage.setItem(KEY, "1");
+          document.getElementById("gate").style.display = "none";
+          document.getElementById("content").style.display = "block";
+        } else {
+          input.value = "";
+          input.classList.add("error");
+          document.getElementById("gate-error").style.display = "block";
+          setTimeout(function() {
+            input.classList.remove("error");
+            document.getElementById("gate-error").style.display = "none";
+          }, 1200);
+        }
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/web/public/ch4/v3/index.html
+++ b/web/public/ch4/v3/index.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>screamingface — SOTA on your laptop</title>
+  <meta name="description" content="An AI ensemble that combines Claude Code, Gemini CLI, Codex, and Ollama to beat state-of-the-art benchmarks. One command to install.">
+  <meta name="robots" content="noindex, nofollow">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>😱</text></svg>">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body {
+      font-family: "SF Mono", "Menlo", "Monaco", "Cascadia Mono", "Courier New", monospace;
+      font-size: 14px; line-height: 1.6; color: #1a1a1a; background: #fff;
+    }
+    a { color: #1a1a1a; text-decoration: underline; }
+    a:hover { color: #555; }
+
+    #gate {
+      min-height: 100vh; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; gap: 32px; padding: 0 24px;
+    }
+    #gate .emoji { font-size: 64px; user-select: none; }
+    #gate .title { font-size: 20px; font-weight: 500; }
+    #gate form { display: flex; flex-direction: column; align-items: center; gap: 12px; width: 100%; max-width: 280px; }
+    #gate input[type="password"] {
+      width: 100%; border: 1px solid #ccc; border-radius: 6px;
+      padding: 10px 14px; font-size: 14px; outline: none; font-family: inherit;
+    }
+    #gate input.error { border-color: #dc2626; }
+    #gate .error-msg { font-size: 12px; color: #dc2626; display: none; }
+    #gate button {
+      width: 100%; background: #1a1a1a; color: #fff; padding: 10px 0;
+      border-radius: 6px; font-size: 14px; font-weight: 500; border: none; cursor: pointer;
+    }
+    #content { display: none; }
+  </style>
+</head>
+<body>
+
+  <div id="gate">
+    <div class="emoji">😱</div>
+    <p class="title">screamingface</p>
+    <form id="gate-form">
+      <input type="password" id="gate-input" placeholder="Password" autocomplete="current-password">
+      <p class="error-msg" id="gate-error">Incorrect password.</p>
+      <button type="submit">Enter</button>
+    </form>
+  </div>
+
+  <div id="content">
+    <div style="max-width:540px; margin:0 auto; padding:48px 20px;">
+
+      <header style="margin-bottom:40px;">
+        <h1 style="font-size:20px; font-weight:normal; margin-bottom:4px;">screamingface</h1>
+        <p style="color:#666;">AI model ensemble for your terminal</p>
+      </header>
+
+      <section style="margin-bottom:32px;">
+        <p style="margin-bottom:12px;">Routes prompts across Claude Code, Gemini CLI, Codex, and Ollama. Picks the best response. Runs locally.</p>
+        <p>No accounts. No API keys you don't already have. Open source.</p>
+      </section>
+
+      <section style="margin-bottom:32px;">
+        <div style="margin-bottom:8px;">Install:</div>
+        <pre style="background:#f6f6f6; border:1px solid #ddd; padding:10px 14px; overflow-x:auto;"><code>$ curl -fsSL https://screamingface.ai/install | sh</code></pre>
+      </section>
+
+      <section style="margin-bottom:32px;">
+        <div style="margin-bottom:8px;">How it works:</div>
+        <ol style="padding-left:20px; list-style-type:decimal;">
+          <li style="margin-bottom:4px;">Detects models on your PATH</li>
+          <li style="margin-bottom:4px;">Sends each prompt to the best-scoring model for that task type</li>
+          <li style="margin-bottom:4px;">Ensemble mode: runs multiple models, picks the best output</li>
+          <li>Everything stays on your machine</li>
+        </ol>
+      </section>
+
+      <section style="margin-bottom:32px;">
+        <div style="margin-bottom:8px;">Why:</div>
+        <p>No single model wins every benchmark. Ensembles beat individual models on SWE-bench, HumanEval, and MMLU — but deploying them is a pain. This makes it one command.</p>
+      </section>
+
+      <section style="margin-bottom:40px;">
+        <div style="display:flex; gap:20px;">
+          <a href="https://github.com/OpenMined/screamingface" target="_blank" rel="noopener noreferrer">github</a>
+          <a href="https://github.com/OpenMined/screamingface/issues" target="_blank" rel="noopener noreferrer">issues</a>
+          <a href="https://openmined.org" target="_blank" rel="noopener noreferrer">openmined</a>
+        </div>
+      </section>
+
+      <footer style="border-top:1px solid #ddd; padding-top:16px; color:#999; font-size:12px;">
+        built by OpenMined · open source · alpha
+      </footer>
+    </div>
+  </div>
+
+  <script>
+    (function() {
+      var PASSWORD = "letmein";
+      var KEY = "sf_auth";
+      if (sessionStorage.getItem(KEY) === "1") {
+        document.getElementById("gate").style.display = "none";
+        document.getElementById("content").style.display = "block";
+        return;
+      }
+      document.getElementById("gate-input").focus();
+      document.getElementById("gate-form").addEventListener("submit", function(e) {
+        e.preventDefault();
+        var input = document.getElementById("gate-input");
+        if (input.value === PASSWORD) {
+          sessionStorage.setItem(KEY, "1");
+          document.getElementById("gate").style.display = "none";
+          document.getElementById("content").style.display = "block";
+        } else {
+          input.value = "";
+          input.classList.add("error");
+          document.getElementById("gate-error").style.display = "block";
+          setTimeout(function() {
+            input.classList.remove("error");
+            document.getElementById("gate-error").style.display = "none";
+          }, 1200);
+        }
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>screamingface — SOTA on your laptop</title>
+  <meta name="description" content="An AI ensemble that combines Claude Code, Gemini CLI, Codex, and Ollama to beat state-of-the-art benchmarks. One command to install.">
+  <meta name="robots" content="noindex, nofollow">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>😱</text></svg>">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    :root {
+      --bg: #faf9fb;
+      --fg: #14121a;
+      --card: #f0eef5;
+      --border: #d4d0e4;
+      --muted: #14121a;
+      --primary: #c8842a;
+      --secondary-bg: rgba(228,225,239,0.6);
+      --font-sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+    }
+    html, body { font-family: var(--font-sans); font-size: 16px; color: var(--fg); background: var(--bg); -webkit-font-smoothing: antialiased; }
+    a { color: var(--primary); text-decoration: underline; text-underline-offset: 2px; }
+    a:hover { opacity: 0.8; }
+    code, pre, kbd { font-family: var(--font-mono); }
+    h1, h2, h3 { text-wrap: balance; }
+    p { text-wrap: pretty; }
+
+    /* Gate */
+    #gate {
+      min-height: 100vh; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; gap: 32px; padding: 0 24px;
+    }
+    #gate .emoji { font-size: 60px; user-select: none; }
+    #gate .title { font-size: 20px; font-weight: 500; letter-spacing: -0.02em; }
+    #gate form { display: flex; flex-direction: column; align-items: center; gap: 12px; width: 100%; max-width: 320px; }
+    #gate input[type="password"] {
+      width: 100%; background: var(--card); border: 1px solid var(--border); border-radius: 8px;
+      padding: 12px 16px; font-size: 14px; color: var(--fg); outline: none; font-family: var(--font-sans);
+      transition: border-color 0.15s;
+    }
+    #gate input:focus { border-color: var(--primary); box-shadow: 0 0 0 1px var(--primary); }
+    #gate input.error { border-color: #b84e5e; }
+    #gate input.error:focus { box-shadow: 0 0 0 1px #b84e5e; }
+    #gate .error-msg { font-size: 12px; color: #b84e5e; display: none; }
+    #gate button {
+      width: 100%; background: var(--fg); color: var(--bg); padding: 12px 0;
+      border-radius: 8px; font-size: 14px; font-weight: 500; border: none; cursor: pointer;
+      transition: opacity 0.15s;
+    }
+    #gate button:hover { opacity: 0.9; }
+    #content { display: none; }
+
+    /* Layout */
+    .page { min-height: 100vh; display: flex; flex-direction: column; }
+    .main { flex: 1; }
+    .hero { padding: 48px 20px 40px; max-width: 896px; margin: 0 auto; text-align: center; }
+    .hero .emoji { font-size: 72px; margin-bottom: 24px; user-select: none; }
+    .hero h1 { font-size: 48px; font-weight: 600; letter-spacing: -0.02em; line-height: 1.1; margin-bottom: 20px; }
+    .hero p { max-width: 560px; margin: 0 auto; line-height: 1.6; }
+
+    /* Install */
+    .install { padding: 48px 20px; }
+    .install-inner { max-width: 768px; margin: 0 auto; }
+    .install-header { text-align: center; margin-bottom: 32px; }
+    .install-header h2 { font-size: 30px; font-weight: 600; margin-bottom: 8px; }
+
+    /* Terminal block */
+    .terminal { background: var(--card); border: 1px solid var(--border); border-radius: 15px; overflow: hidden; margin-bottom: 32px; }
+    .terminal-bar { display: flex; align-items: center; gap: 8px; padding: 10px 16px; border-bottom: 1px solid var(--border); background: var(--secondary-bg); }
+    .dot { width: 12px; height: 12px; border-radius: 50%; }
+    .dot-red { background: #ff5f57; }
+    .dot-yellow { background: #febc2e; }
+    .dot-green { background: #28c840; }
+    .terminal-bar .label { margin-left: auto; font-size: 12px; font-family: var(--font-mono); }
+    .terminal-cmd { padding: 16px 20px; display: flex; align-items: center; gap: 12px; font-family: var(--font-mono); }
+    .terminal-cmd .prompt { user-select: none; flex-shrink: 0; }
+    .terminal-cmd .cmd { min-width: 0; overflow-x: auto; white-space: nowrap; }
+
+    /* Steps */
+    .steps { display: grid; grid-template-columns: 1fr; gap: 24px; }
+    @media (min-width: 768px) { .steps { grid-template-columns: repeat(3, 1fr); } }
+    .step-num { font-size: 12px; font-family: var(--font-mono); margin-bottom: 8px; }
+    .step-title { font-weight: 500; margin-bottom: 8px; }
+    .step-desc { line-height: 1.6; }
+
+    /* GitHub link */
+    .gh-link { padding: 32px 20px; text-align: center; }
+
+    /* Footer */
+    .footer {
+      padding: 24px 20px; display: flex; flex-wrap: wrap;
+      align-items: center; justify-content: space-between; gap: 12px; color: var(--fg);
+    }
+    @media (max-width: 639px) { .footer { flex-direction: column; text-align: center; } }
+  </style>
+</head>
+<body>
+
+  <div id="gate">
+    <div class="emoji">😱</div>
+    <p class="title">screamingface</p>
+    <form id="gate-form">
+      <input type="password" id="gate-input" placeholder="Password" autocomplete="current-password">
+      <p class="error-msg" id="gate-error">Incorrect password.</p>
+      <button type="submit">Enter</button>
+    </form>
+  </div>
+
+  <div id="content">
+    <div class="page">
+      <main class="main">
+
+        <section class="hero">
+          <div class="emoji">😱</div>
+          <h1>SOTA on your laptop.</h1>
+          <p>An ensemble of the CLI models you already run. Combines their outputs, picks the best answer. Open source. No new accounts.</p>
+        </section>
+
+        <section class="install">
+          <div class="install-inner">
+            <div class="install-header">
+              <h2>One command</h2>
+              <p>Detects models on your machine. Configures itself. Nothing sent to a server.</p>
+            </div>
+
+            <div class="terminal">
+              <div class="terminal-bar">
+                <span class="dot dot-red"></span>
+                <span class="dot dot-yellow"></span>
+                <span class="dot dot-green"></span>
+                <span class="label">bash</span>
+              </div>
+              <div class="terminal-cmd">
+                <span class="prompt">$</span>
+                <span class="cmd">curl -fsSL https://screamingface.ai/install | sh</span>
+              </div>
+            </div>
+
+            <div class="steps">
+              <div>
+                <div class="step-num">01</div>
+                <h3 class="step-title">Install</h3>
+                <p class="step-desc">One command. Configures locally. Nothing uploaded.</p>
+              </div>
+              <div>
+                <div class="step-num">02</div>
+                <h3 class="step-title">Auto-detect</h3>
+                <p class="step-desc">Finds Claude Code, Gemini CLI, Codex, and Ollama on your PATH.</p>
+              </div>
+              <div>
+                <div class="step-num">03</div>
+                <h3 class="step-title">Route</h3>
+                <p class="step-desc">Each prompt goes to whichever model scores best on the task.</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div class="gh-link">
+          <a href="https://github.com/OpenMined/screamingface" target="_blank" rel="noopener noreferrer">github.com/OpenMined/screamingface</a>
+        </div>
+
+      </main>
+
+      <footer class="footer">
+        <span>😱 screamingface, built by <a href="https://openmined.org" target="_blank" rel="noopener noreferrer">OpenMined</a></span>
+        <a href="https://github.com/OpenMined/screamingface" target="_blank" rel="noopener noreferrer">GitHub</a>
+      </footer>
+    </div>
+  </div>
+
+  <script>
+    (function() {
+      var PASSWORD = "letmein";
+      var KEY = "sf_auth";
+      if (sessionStorage.getItem(KEY) === "1") {
+        document.getElementById("gate").style.display = "none";
+        document.getElementById("content").style.display = "block";
+        return;
+      }
+      document.getElementById("gate-input").focus();
+      document.getElementById("gate-form").addEventListener("submit", function(e) {
+        e.preventDefault();
+        var input = document.getElementById("gate-input");
+        if (input.value === PASSWORD) {
+          sessionStorage.setItem(KEY, "1");
+          document.getElementById("gate").style.display = "none";
+          document.getElementById("content").style.display = "block";
+        } else {
+          input.value = "";
+          input.classList.add("error");
+          document.getElementById("gate-error").style.display = "block";
+          setTimeout(function() {
+            input.classList.remove("error");
+            document.getElementById("gate-error").style.display = "none";
+          }, 1200);
+        }
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
## Summary

SF-348 (#371) removed `web/` and `deploy-website.yml`. The live site **screamingface.ai** (GitHub Pages, workflow-built) kept serving its last deploy but became unmaintainable — no source, no deploy lane. This restores exactly what publishes to the internet, verbatim from tag `legacy-monorepo-2026-07-08`:

- `web/public/**` — the static site incl. `CNAME` (screamingface.ai), robots.txt, ch4 previews
- `.github/workflows/deploy-website.yml` — the Pages deploy lane (push to main touching `web/public/**`)
- `web/.gitignore`

**Not restored:** `web/portal` — the scoreboard app owns its vendored copy (`apps/scoreboard/portal`) since SF-348; no duplication reintroduced.

## Test plan

- Pages config verified: build_type=workflow, cname=screamingface.ai, status=built (frozen)
- Merging this PR touches `web/public/**` on main → `deploy-website.yml` fires → site re-deploys from restored source
- No app CI lanes triggered (web-only paths)

## Cross-service notes

Restores @KyleNumann's ability to update the site. Follow-up (separate): re-add `/web/public/` CODEOWNERS entry + README mention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtTBgAyrFNpDuDbZnvfJ61