### PR TITLE
feat(OME-358): adopt Linear AI SDLC — skills, cards, agents, scripts, CI

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,95 @@
+# Claude in this repo — the guide
+
+Everything Claude-related in `OpenMined/screamingface`: skills, agents, cards, scripts,
+process, and the context that used to bloat `CLAUDE.md`. `CLAUDE.md` stays minimal and
+mandatory; this file is the map.
+
+## TL;DR — how a unit of work flows
+
+```
+Linear work item (OME-N, 😱 ScreamingFace V1)          ← task-management skill
+  └─ mirror docs/tasks/YYYY-MM-DD-<name>.md
+branch OME-N-<desc>
+  └─ ledger docs/work/YYYY-MM-DD-OME-N-<desc>.md       ← created BEFORE any code (D8)
+sdlc loop: FRAME → DESIGN → RED → GREEN → REFACTOR      ← sdlc-python / sdlc-electron
+  → gates: uv run .claude/scripts/run_gates.py <stack>
+commit "feat: …" + body "Refs: OME-N" → PR → review → squash-merge
+close: Linear comment (close template) + state Done + mirror closed
+```
+
+## Skills (`.claude/skills/`)
+
+| Skill | Invoke when | What it does |
+|---|---|---|
+| `task-management` | ANY ticket work — session start, before starting/filing/closing a work item | The Linear lifecycle: card resolution, label taxonomy, D9 cross-cutting rule, STOP labels, close discipline, MCP command crib, the Linear rich-text dialect |
+| `sdlc-python` | EVERY Python change (apps/aigateway, apps/scoreboard, future pkg) | Rigid TDD loop: ledger-first → RED → GREEN → gates → wisdom → commit. Tortoise ORM work → `tortoise-dev` companion (mandatory) |
+| `sdlc-electron` | EVERY Electron change (upcoming desktop app) | Same loop; Electron idiom: main/preload/renderer, both-side IPC contracts (S2), official security checklist encoded, a11y gate (S1) |
+| `asana-product` | Reading product/marketing context from Asana | READ-ONLY. Never creates/updates in Asana; dev items link back via `asana_url` |
+| `working-in-this-repo` | Starting any change; unsure where code goes / which CI / how to PR | The routing map: components, toolchains, CI lanes, release lanes, branch/PR rules |
+| `screamingface-design` | Any UI/UX/visual/copy decision | The brand law (overrides shadcn/Tailwind defaults) |
+
+Loop parity: the `SHARED-LOOP` regions of `sdlc-python` and `sdlc-electron` are
+byte-identical — edit them TOGETHER, `repo-checks.yml` CI enforces it.
+
+## Agents (`.claude/agents/`)
+
+| Agent | Use |
+|---|---|
+| `sdlc-unit-executor` | Execute ONE `OME-N` work item end-to-end through the SDLC loop, autonomously. STOPs compile to `blocked ⛔`/`needs-owner` labels + comment. Batch: one executor per independent item; serialize same-stack items |
+| `ticket-filer` | File an already-approved list of work items into Linear — mechanical only, all-or-nothing validation against the card (actor label mandatory) |
+
+## Cards (committed repo config — the registries)
+
+- **`.claude/task-board.local.md`** — Linear registry: team (Engineering/OME), project
+  (😱 ScreamingFace V1), state IDs, every label ID, priority map, close template, ticket
+  rules. **Card missing → HARD STOP** (restore from git).
+- **`.claude/sdlc.local.md`** — stacks (aigateway, scoreboard → `sdlc-python`), their
+  gates, `test_globs`, invariants, companion skills, `commit_refs`, `ledger_dir`.
+
+## Scripts & CI (`.claude/scripts/`, `.github/workflows/repo-checks.yml`)
+
+- `run_gates.py <stack>` — deterministic gate runner (append-only test check + the card's
+  gates, first-red stops). Run from repo root: `uv run .claude/scripts/run_gates.py aigateway`.
+- `check_loop_parity.py` — verifies the sdlc skills' SHARED-LOOP regions are identical.
+- `repo-checks.yml` — runs parity on any `.claude/skills/sdlc-**` / `.claude/scripts/**` change.
+
+## Linear — the work-item system (MCP ONLY)
+
+- Transport: **the Linear MCP plugin only** (`/mcp` to activate). API tokens/GraphQL are
+  forbidden; what MCP can't do (label/team/state admin) is an owner action in the Linear UI.
+- IDs: `OME-N` (Engineering team, one sequence). Every item attaches to
+  **😱 ScreamingFace V1** and carries: workstream (`Epic` group: url4 Engine, AI Gateway,
+  Desktop App, Python SDK, Leaderboard, …) when applicable · landing (`app/aigateway`,
+  `app/scoreboard`, `pkg/url4-python-sdk`, or `repo`) · one `who-acts`
+  (design-session/autonomous/deferred) · **one `actor` (agentic|human — mandatory)**.
+- Cross-cutting (≥2 app/pkg labels) → epic + one sub-issue per affected app/package.
+- STOPs are labels (`blocked ⛔`, `needs-owner`) + a comment — never new states.
+- Sprints = the project's milestones (S0–S5), owned by the project lead.
+
+## docs/ — the artifact trail
+
+`docs/spec/` (design before planning) → `docs/plan/` (plan before code) → `docs/tasks/`
+(work-item mirrors) → `docs/work/` (ledgers, created at work START) → `docs/diagrams/`
+(SVG + PNG). Local scratch: gitignored `.docs/`. See `docs/README.md`.
+
+## Product context
+
+- **ScreamingFace**: an open-source AI ensemble toolkit — combine models (Claude, Gemini,
+  Codex, Ollama) to beat single-model SOTA, running locally on subscriptions users already
+  pay for, scores tracked on a public leaderboard (screamingface.ai). Built by OpenMined.
+- **Key concepts**: `url4` — DAG-based protocol encoding AI task chains as readable URLs ·
+  **Enclave** — secure cloud runner + cache · **Ensemble** — multi-model > any single
+  model · **SOTA** — the benchmark scores to beat.
+- **App screens** (desktop): Settings (model connections) · Spend (usage/cost) ·
+  Eval Studio (run benchmarks) · Cache/Log (query cache browser).
+- **Team**: TBD — being reshuffled, to be settled in the next couple of days
+  (2026-07-08). Linear project lead: Irina.
+
+## History
+
+- **Re-foundation (July 2026, SF-348/PR #371):** legacy `apps/desktop` + `apps/server`
+  (and old docs/web/infra/personas) removed; full tree preserved read-only at tag
+  **`legacy-monorepo-2026-07-08`** — never resurrect from it into the live tree. New
+  desktop + CLI packages arrive as separate components once naming locks.
+- **AI SDLC adoption (OME-358/PR #376):** everything this guide describes; decisions
+  D1–D13 in `docs/spec/2026-07-08-ai-sdlc-adoption-spec.md`.

--- a/.claude/agents/sdlc-unit-executor.md
+++ b/.claude/agents/sdlc-unit-executor.md
@@ -1,0 +1,72 @@
+---
+name: sdlc-unit-executor
+description: |
+  Use to execute ONE Linear work item end-to-end through the rigid SDLC loop (ledger → RED →
+  GREEN → gates → wisdom → commit → close) in this repo. Designed for batch mode — one
+  executor per independent work item, sequential when items share a stack.
+
+  <example>
+  Context: three independent approved work items are queued in Linear.
+  user: "Run OME-372, OME-374 and OME-375"
+  assistant: "I'll dispatch one sdlc-unit-executor per item — OME-372 and OME-374 touch the same stack, so those run sequentially."
+  <commentary>Independent SDLC-unit-sized items → one executor each; same-stack items serialize.</commentary>
+  </example>
+---
+
+You execute exactly ONE Linear work item through the full SDLC loop, autonomously, and
+return a structured result. You never expand scope beyond the work item.
+
+## Inputs
+
+- The Linear identifier (`OME-N`, required) and, optionally, a stack hint.
+
+## Procedure
+
+1. Read `.claude/task-board.local.md` and `.claude/sdlc.local.md`. Either missing → return
+   `blocked` immediately with "card missing — restore from git" as the question (do NOT
+   touch Linear).
+2. Read the issue (title, description, labels) via the **Linear MCP** (`get_issue`).
+   **MCP is the ONLY Linear transport — API tokens/GraphQL are forbidden.** Resolve the
+   stack: the issue's `app/*`/`pkg/*` landing labels / affected paths → the sdlc card entry
+   whose `skill:` governs them (`sdlc-python` / `sdlc-electron`).
+3. Invoke that stack's skill and the `task-management` skill, and follow them EXACTLY:
+   ledger first (issue → In Progress via `save_issue`), companion skills per the card,
+   RED → GREEN → REFACTOR → COVERAGE, gates via `uv run .claude/scripts/run_gates.py
+   <stack>`, wisdom review, ledger outcome, commit (Conventional message; body carries
+   `Refs: OME-N`; never `Co-Authored-By`), close with the card's `close_template` filled
+   (`save_comment` then `save_issue` state Done; close the `docs/tasks/` mirror).
+
+## STOP compilation — you cannot ask the owner mid-run
+
+Every STOP the skills define compiles to a Linear label + comment + return (D12: the issue
+STAYS In Progress; labels via read-union-resend — `save_issue.labels` replaces the set).
+NEVER push through a STOP condition, and NEVER ask interactive questions:
+
+| STOP condition | Linear move | Comment carries |
+|---|---|---|
+| 95% Confidence Gate (ambiguity, design fork, prior-test change, new dependency, security-sensitive) | add label **`blocked ⛔`** | the exact question, the options you see, your recommendation |
+| Append-only test conflict | add label **`blocked ⛔`** | which prior test blocks, why, what change it would need |
+| 10-retry HARD STOP | add label **`blocked ⛔`** | the loop diagnosis (recurring failure, what changed each round, suspected root cause) |
+| Pure decision / visual verification is the ONLY thing pending | add label **`needs-owner`** | what to decide/verify, with your proposal |
+
+## Return value (your final message — raw data, no prose)
+
+```json
+{
+  "ticket": "<OME-N>",
+  "status": "done" | "blocked",
+  "commits": ["<sha> <message>", …],
+  "gates": "<run_gates.py summary line>",
+  "deviations": ["…"],
+  "question": "<present only when blocked — the exact question posted to Linear>"
+}
+```
+
+## Prohibitions
+
+- No work outside the work item (file a new item per `task-management` for discoveries —
+  30 seconds — then continue).
+- Never weaken a gate, edit a prior test, or lower coverage to pass.
+- Never close an issue without the full close comment.
+- Never invent card values; missing/ambiguous card data is a `blocked` return.
+- Never use Linear API tokens or raw GraphQL — MCP only.

--- a/.claude/agents/ticket-filer.md
+++ b/.claude/agents/ticket-filer.md
@@ -1,0 +1,56 @@
+---
+name: ticket-filer
+description: |
+  Use to file an ALREADY-APPROVED list of work items into Linear (Engineering team,
+  😱 ScreamingFace V1 project) — mechanical execution only (create issue → labels →
+  priority → parent). Decomposition judgment stays with the caller; this agent keeps the
+  filing calls out of the main context.
+
+  <example>
+  Context: a plan was decomposed into six work items and the owner approved the list.
+  user: "File these six items"
+  assistant: "I'll dispatch the ticket-filer with the approved list; it returns the identifier↔title table."
+  <commentary>Approved list → mechanical filing is delegated; the decomposition already happened in the main conversation.</commentary>
+  </example>
+tools: Read, ToolSearch
+---
+
+You file work items into Linear. You do not decide what the items should be.
+**Transport: the Linear MCP tools ONLY** (load via ToolSearch: `save_issue`, `get_issue`,
+`list_issue_labels`). API tokens and raw GraphQL are FORBIDDEN.
+
+## Input
+
+An approved work-item list; each entry: `title`, `body` (Linear markdown — real newlines,
+IDs in backticks unless a relation is wanted), `labels` (workstream from the `Epic` group
+when applicable + `app/*`/`pkg/*` or `repo` landing + one who-acts + **one actor —
+agentic|human, MANDATORY**), `priority` (P1/P2/P3), `parent?` (`OME-N`), `milestone?`
+(only with the project lead's agreement).
+
+## Procedure
+
+1. Read `.claude/task-board.local.md`. Missing → return an error ("card missing — restore
+   from git"); file nothing.
+2. Validate EVERY entry against the card first: every label exists in the card's `labels:`
+   registry; exactly one who-acts; **exactly one actor label — a missing actor is a
+   validation failure (D13)**; landing present (`app/*`/`pkg/*` or `repo`); ≥2 landing
+   labels only on an epic with per-app sub-issues in the same batch (D9). Any violation →
+   return the exact discrepancy WITHOUT filing anything (all-or-nothing).
+3. Per item: `save_issue {team: "Engineering", project: "<card project slug>", title,
+   description, labels, priority: <card map>, parentId?}`. Collect identifier, title, URL,
+   state.
+4. If a call fails mid-batch, stop, report what WAS filed (identifiers) and what remains —
+   never retry blindly past one failure.
+
+## Return value (your final message — raw data, no prose)
+
+A markdown table: `identifier | title | URL | state`, followed by `FILED n/m`
+(or the validation/failure report per steps 2/4).
+
+## Prohibitions
+
+- Never invent, merge, split, reword, or re-prioritize items — any gap in the list is a
+  question back to the caller, not a judgment call.
+- Never mint a label the card doesn't register.
+- Never close or edit existing issues.
+- Never use Linear API tokens or raw GraphQL — MCP only.

--- a/.claude/scripts/check_loop_parity.py
+++ b/.claude/scripts/check_loop_parity.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""LOOP PARITY gate.
+
+The `SHARED-LOOP`-marked regions of the sdlc-* skills must be verbatim-identical.
+Exit 0 on parity, 1 on drift (with a unified diff), 2 on structural errors
+(missing file/markers or unbalanced marker pairs).
+"""
+import difflib
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent  # .claude/
+SKILLS = ["sdlc-python", "sdlc-electron"]
+MARKER = re.compile(r"<!-- SHARED-LOOP:BEGIN -->\n(.*?)<!-- SHARED-LOOP:END -->", re.S)
+
+
+def shared_regions(name: str) -> str:
+    path = ROOT / "skills" / name / "SKILL.md"
+    if not path.exists():
+        print(f"ERROR: {path} missing")
+        sys.exit(2)
+    text = path.read_text()
+    if text.count("SHARED-LOOP:BEGIN") != text.count("SHARED-LOOP:END"):
+        print(f"ERROR: unbalanced SHARED-LOOP markers in {name}")
+        sys.exit(2)
+    regions = MARKER.findall(text)
+    if not regions:
+        print(f"ERROR: no SHARED-LOOP regions in {name}")
+        sys.exit(2)
+    return "\n<<<REGION>>>\n".join(regions)
+
+
+def main() -> int:
+    baseline_name, *rest = SKILLS
+    baseline = shared_regions(baseline_name)
+    drift = False
+    for name in rest:
+        other = shared_regions(name)
+        if other != baseline:
+            drift = True
+            print(f"DRIFT: {name} shared regions differ from {baseline_name}:")
+            sys.stdout.writelines(
+                difflib.unified_diff(
+                    baseline.splitlines(keepends=True),
+                    other.splitlines(keepends=True),
+                    fromfile=baseline_name,
+                    tofile=name,
+                )
+            )
+    if drift:
+        return 1
+    print(f"LOOP PARITY OK: {', '.join(SKILLS)} share identical SHARED-LOOP regions.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/scripts/run_gates.py
+++ b/.claude/scripts/run_gates.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml"]
+# ///
+"""Deterministic quality-gate runner for the sdlc plugin.
+
+Reads the project's stack card (.claude/sdlc.local.md), runs the named stack's
+gates in order (cwd = stack root), preceded by the append-only test check.
+Stops at the first red gate and prints its output verbatim — the caller needs
+the raw failing signal, not a summary.
+
+Usage:
+    uv run run_gates.py <stack-name> [--card PATH] [--base REF] [--skip-append-only]
+
+Exit codes: 0 all green · 1 a gate or the append-only check failed · 2 config error.
+"""
+import argparse
+import fnmatch
+import pathlib
+import subprocess
+import sys
+from typing import NoReturn
+
+try:
+    import yaml
+except ImportError:  # bare python3 without PyYAML
+    print(
+        "ERROR: PyYAML is required. Run via `uv run run_gates.py …` (PEP 723 resolves it) "
+        "or install it: pip install pyyaml"
+    )
+    sys.exit(2)
+
+GREEN, RED = "✓", "✗"
+
+
+def fail_config(msg: str) -> NoReturn:
+    print(f"CONFIG ERROR: {msg}")
+    print("If the card is missing: copy templates/sdlc.local.md from the sdlc plugin "
+          "into .claude/, fill it, and re-run.")
+    sys.exit(2)
+
+
+def load_card(path: pathlib.Path) -> dict:
+    if not path.exists():
+        fail_config(f"stack card not found: {path}")
+    lines = path.read_text().splitlines()
+    if not lines or lines[0].strip() != "---":
+        fail_config(f"{path} has no YAML frontmatter (must start with ---)")
+    try:
+        end = next(i for i, line in enumerate(lines[1:], start=1) if line.strip() == "---")
+    except StopIteration:
+        fail_config(f"{path} frontmatter is not closed with ---")
+    try:
+        data = yaml.safe_load("\n".join(lines[1:end])) or {}
+    except yaml.YAMLError as exc:
+        fail_config(f"{path} frontmatter is not valid YAML: {exc}")
+    if not isinstance(data.get("stacks"), list):
+        fail_config(f"{path} frontmatter must define a `stacks:` list")
+    return data
+
+
+def append_only_check(root: pathlib.Path, base: str, globs: list[str]) -> bool:
+    """True when no previously committed test file was modified/deleted/renamed."""
+    proc = subprocess.run(
+        ["git", "diff", "--relative", "--name-status", base],
+        cwd=root, capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        fail_config(f"git diff failed in {root}: {proc.stderr.strip()}")
+    offenders = []
+    for line in proc.stdout.splitlines():
+        parts = line.split("\t")
+        status, paths = parts[0], parts[1:]
+        if status[:1] not in "MDR":  # A(dded)/C(opied) etc. are fine — adding tests is always fine
+            continue
+        for p in paths:
+            if any(fnmatch.fnmatch(p, g) for g in globs):
+                offenders.append(f"  {status}\t{p}")
+                break
+    if offenders:
+        print(f"{RED} append-only test check — prior tests were modified/deleted (vs {base}):")
+        print("\n".join(offenders))
+        print("Tests are append-only across cycles (sdlc rule 5). Changing a prior test is a "
+              "Confidence-Gate decision — STOP and ask.")
+        return False
+    print(f"{GREEN} append-only test check (vs {base})")
+    return True
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("stack", help="stack name from the card's stacks[].name")
+    ap.add_argument("--card", default=".claude/sdlc.local.md", type=pathlib.Path)
+    ap.add_argument("--base", default="HEAD", help="git ref for the append-only check")
+    ap.add_argument("--skip-append-only", action="store_true")
+    args = ap.parse_args()
+
+    card = load_card(args.card)
+    stack = next((s for s in card["stacks"] if s.get("name") == args.stack), None)
+    if stack is None:
+        names = ", ".join(s.get("name", "?") for s in card["stacks"])
+        fail_config(f"stack '{args.stack}' not in {args.card} (has: {names})")
+
+    root = pathlib.Path(stack.get("root", ".")).resolve()
+    if not root.is_dir():
+        fail_config(f"stack root does not exist: {root}")
+    gates = stack.get("gates") or []
+    if not gates:
+        fail_config(f"stack '{args.stack}' defines no gates")
+
+    ok = True
+    if args.skip_append_only:
+        print("- append-only test check skipped (--skip-append-only)")
+    else:
+        ok = append_only_check(root, args.base, stack.get("test_globs") or [])
+
+    if ok:
+        for gate in gates:
+            proc = subprocess.run(gate, shell=True, cwd=root, capture_output=True, text=True)
+            if proc.returncode == 0:
+                print(f"{GREEN} {gate}")
+            else:
+                ok = False
+                print(f"{RED} {gate}  (exit {proc.returncode})")
+                # verbatim failing signal — the fix loop needs it raw
+                if proc.stdout:
+                    print(proc.stdout, end="")
+                if proc.stderr:
+                    print(proc.stderr, end="", file=sys.stderr)
+                break  # fix-and-rerun works one failing signal at a time
+
+    print("ALL GATES GREEN" if ok else "GATE FAILED — fix the code, never the gate")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/sdlc.local.md
+++ b/.claude/sdlc.local.md
@@ -22,8 +22,8 @@ stacks:
 commit_refs: "Refs: OME-N"
 extra_anchors: []
 companion_skills:
-  - skill: tortoise-dev
-    when: "models/ or migrations/ touched in a python stack"
+  - skill: tortoise-dev  # https://github.com/sergio-bershadsky/ai/tree/main/plugins/tortoise-dev — propose install if absent
+    when: "any Tortoise ORM work in a python stack — models, querysets, migrations, transactions, signals, lifespan wiring"
     mandatory: true
 ledger_dir: docs/work/
 ---

--- a/.claude/sdlc.local.md
+++ b/.claude/sdlc.local.md
@@ -1,0 +1,51 @@
+---
+stacks:
+  - name: aigateway
+    root: apps/aigateway
+    skill: sdlc-python
+    test_globs: ["tests/**"]
+    gates:
+      - uv run ruff check
+      - uv run ruff format --check
+      - uv run pyright
+      - uv run python scripts/check_no_enterprise.py
+      - uv run pytest --cov=aigateway --cov-fail-under=80 -q
+  - name: scoreboard
+    root: apps/scoreboard
+    skill: sdlc-python
+    test_globs: ["tests/**"]
+    gates:
+      - uv run ruff check
+      - uv run ruff format --check
+      - uv run pyright
+      - uv run pytest --cov=scoreboard --cov-fail-under=80 -q
+commit_refs: "Refs: OME-N"
+extra_anchors: []
+companion_skills:
+  - skill: tortoise-dev
+    when: "models/ or migrations/ touched in a python stack"
+    mandatory: true
+ledger_dir: docs/work/
+---
+
+# Stack conventions
+
+## aigateway (python)
+
+- INVARIANTS: credentials only via ORMStore/`credential_blobs` (AES-256-GCM through
+  SecretStoreMixin); no OS keychain; `AIGATEWAY_SECRET_KEY` never stored/logged; never
+  import litellm-enterprise (gate-guarded by `scripts/check_no_enterprise.py`).
+- Providers/secrets backends implement the port + register in the factory; never edit
+  ORMStore or its call sites.
+
+## scoreboard (python)
+
+- INVARIANTS: public artifact allowlist in `src/scoreboard/portal.py` (PUBLIC_ARTIFACTS /
+  FORBIDDEN_ARTIFACTS — forbidden routes must stay 404); portal + artifacts stay app-local
+  (`portal/`, `artifacts/`).
+
+## ledger naming (D8)
+
+`docs/work/YYYY-MM-DD-<ticket-id>-<short-description>.md` — created at work START
+(date = start), frontmatter `status: planned|in_progress|done|blocked` + `finished:` filled
+at close. Template: copy `docs/work/TEMPLATE.md`.

--- a/.claude/skills/asana-product/SKILL.md
+++ b/.claude/skills/asana-product/SKILL.md
@@ -1,0 +1,82 @@
+---
+description: Read-only view of product/marketing top-level tasks in Asana. Use to list, read, or search product context (projects, tasks, briefs) or when the user references an Asana task URL/GID. NEVER creates, updates, completes, or moves anything in Asana — technical work items live in Linear (task-management skill).
+user_invocable: true
+---
+
+# Asana — read-only product/marketing source
+
+**Announce at start:** "Using the asana-product skill — read-only Asana access."
+
+## Hard rules
+
+- **READ-ONLY. GET requests only.** Any request to create, update, complete, move, or
+  section an Asana task → refuse and point to the `task-management` skill (Linear).
+- Asana holds product/marketing top-level tasks defined by product/marketing tooling —
+  it is a SOURCE of context, never a destination for technical work.
+- A dev work item descending from an Asana task records the Asana permalink in its Linear
+  description and in the `docs/tasks/` mirror frontmatter (`asana_url`).
+
+## Defaults (OpenMined workspace)
+
+- **Workspace:** `1185126988600652` (OpenMined)
+- **Default project:** `1213628819033917`
+- **User task list:** `1213642528476271` (Sergey Bershadsky)
+
+## API Access
+
+Always use Bash with `curl`. Do NOT use WebFetch — it doesn't support custom auth headers.
+
+Locate `ASANA_PAT` from the first available source (check in this order):
+
+1. Already exported in env: `printenv ASANA_PAT`
+2. `$CLAUDE_PROJECT_DIR/.env` (if set and file exists)
+3. `./.env` in the current working directory
+4. `~/.config/asana/.env`
+5. `~/.asana.env`
+
+```bash
+for f in "$CLAUDE_PROJECT_DIR/.env" "./.env" "$HOME/.config/asana/.env" "$HOME/.asana.env"; do
+  [ -f "$f" ] && export $(grep -E '^ASANA_PAT=' "$f" | xargs) && break
+done
+[ -z "$ASANA_PAT" ] && echo "ASANA_PAT not found. Add ASANA_PAT=<token> to ~/.config/asana/.env" && exit 1
+
+curl -s -H "Authorization: Bearer $ASANA_PAT" \
+  "https://app.asana.com/api/1.0/<endpoint>" | python3 -m json.tool
+```
+
+If the PAT is missing, tell the user where to put it and stop.
+
+## Parsing Asana URLs
+
+`https://app.asana.com/1/<workspace>/project/<project_gid>/task/<task_gid>` → extract the
+trailing `task/<task_gid>` segment and run the `task <gid>` operation.
+
+## Operations (all GET)
+
+### "my tasks" / "what's on my plate"
+`GET /user_task_lists/1213642528476271/tasks?completed_since=now&opt_fields=name,due_on,assignee_section.name,permalink_url`
+
+### "workspaces"
+`GET /workspaces?opt_fields=name,gid`
+
+### "projects" or "projects <workspace_gid>"
+`GET /workspaces/{workspace_gid}/projects?opt_fields=name,gid,archived&limit=100` (filter archived)
+
+### "tasks <project_gid>"
+`GET /projects/{project_gid}/tasks?opt_fields=name,completed,due_on,assignee.name,assignee_section.name&limit=100`
+
+### "task <task_gid>" (or pasted URL)
+`GET /tasks/{task_gid}?opt_fields=name,notes,due_on,completed,assignee.name,projects.name,tags.name,permalink_url,custom_fields.name,custom_fields.display_value,memberships.section.name`
+
+### "search <query>"
+`GET /workspaces/1185126988600652/tasks/search?text={query}&opt_fields=name,completed,due_on,assignee.name,permalink_url&is_subtask=false&limit=20`
+(URL-encode: `python3 -c 'import urllib.parse,sys;print(urllib.parse.quote(sys.argv[1]))' "<text>"`)
+
+### "sections <project_gid>"
+`GET /projects/{project_gid}/sections?opt_fields=name,gid`
+
+## Output format
+
+- Clean markdown tables/lists; always include GIDs and permalink URLs.
+- When the user wants to act on what was found (implement, fix, follow up): file the Linear
+  work item via the `task-management` skill and carry the Asana permalink over.

--- a/.claude/skills/sdlc-electron/SKILL.md
+++ b/.claude/skills/sdlc-electron/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: sdlc-electron
+description: >-
+  Use for EVERY development iteration on Electron desktop code — any change (feature, bug
+  fix, refactor, follow-up) across main / preload / renderer in a project whose
+  `.claude/sdlc.local.md` maps a stack to this skill. Rigid SDLC loop: work-ledger first →
+  frame → a11y-first design → TDD (RED first, Testing-Library; IPC contracts tested on both
+  sides) → append-only wise coverage → quality gates via run_gates.py (incl. a11y) → wisdom +
+  95%-confidence review → commit. Invoke BEFORE writing or modifying any Electron code;
+  re-enter per unit of work. Toolchain commands and project conventions come from the card;
+  Python uses `sdlc-python`.
+---
+
+# SDLC Iteration — Electron
+
+**Announce at start:** "Using the sdlc-electron skill — the rigid TDD loop for the Electron stack."
+
+This is a **RIGID** process skill. Every Electron change in a card-carrying project goes through
+this loop. No shortcuts, no "this one is too small." One iteration = one focused, tested,
+reviewed, committed unit of work — then re-enter the loop. The loop, ledger, and gates are
+shared verbatim with the sibling skill (Python uses `sdlc-python`) under LOOP PARITY — the
+`SHARED-LOOP` regions below are changed in both skills together, never in one
+(`.claude/scripts/check_loop_parity.py` enforces it).
+
+<!-- SHARED-LOOP:BEGIN -->
+## Card resolution — before anything
+
+Read `.claude/sdlc.local.md` in the project root. **Missing → HARD STOP:** tell the user the
+card is missing (it is committed repo config — restore it from git) and stop; never guess
+gates, paths, or conventions. Resolve the active stack entry: match the planned/changed paths
+against `stacks[].root` for entries whose `skill:` names this skill; ambiguous or cross-stack
+→ ask. Then read the card BODY section for the active stack — those project conventions bind
+every cycle.
+
+## Non-negotiable rules
+
+1. **Work-ledger first.** Before any code or test, create the ledger in `ledger_dir` from the
+   card (this repo: `docs/work/`, named `YYYY-MM-DD-<ticket-id>-<desc>.md` per D8; copy
+   `docs/work/TEMPLATE.md`) with Intent + Planned changes + Test plan + Acceptance. Fill the
+   Outcome at the end. **No code before its ledger.**
+2. **One iteration = one focused unit.** Never batch unrelated changes.
+3. **Companion skills are binding.** Invoke every card `companion_skills` entry whose `when`
+   condition matches this unit of work; skipping one marked `mandatory: true` is a process
+   violation — STOP and run it.
+4. **TDD always.** Write the failing test FIRST, then minimal code to pass. No production
+   code without a test that demanded it. Test idioms: see the Stack idiom section.
+5. **Tests are append-only across cycles.** NEVER delete/rewrite/weaken/skip a prior test to
+   make new code pass. A prior test that genuinely must change is a Confidence-Gate decision
+   → STOP and ask. Adding tests is always fine.
+6. **Wise & thorough coverage — not just lines.** Happy path, boundaries, error paths, and
+   the invariant the code protects (the card body names the project's invariants).
+   Assertions verify *behavior*, never "it ran".
+7. **Quality gates are absolute.** Run the repo's gate runner —
+   `uv run .claude/scripts/run_gates.py <stack>` (from the repo root) — all card gates
+   green before commit; never weaken a gate — fix the code. Also verify the card's `gates:`
+   cover this skill's gate categories (Stack idiom section); a missing category is a card
+   defect — surface it.
+8. **The 95% Confidence Gate.** For ANY decision < 95% confident it is both correct AND
+   wanted, STOP and ask first: ambiguous requirements, a design fork, changing a prior test
+   or a public contract, a new dependency, or anything security-sensitive. The gate is
+   call-and-return: pause → ask → resume the step you were on.
+9. **"Is this wise?" is a required step**, not optional.
+10. **Project conventions hold every cycle** — the card body's rules for the active stack.
+11. **Bounded retries — HARD STOP at 10.** A unit gets at most 10 fix-and-rerun attempts
+    against the same failing signal. On the 10th still-failing, HARD STOP and escalate with
+    a **loop diagnosis** (the recurring failure, what changed each round, the suspected
+    root cause). Never loop past 10.
+12. **Semantic comment layer — write for the NEXT AI iteration.** Comment generously with
+    ONLY this fixed, greppable anchor vocabulary (syntax per the Stack idiom section) plus
+    the card's `extra_anchors` — an open set defeats greppability, so invent no others:
+    - `WHY:` — the rationale/decision the type or test cannot encode.
+    - `INVARIANT:` — a property that must always hold (the contract this code protects).
+    - `AIDEV-NOTE:` — guidance/warning for the next agent touching this code.
+    - `FEATURE:` — the product feature this code serves (name it).
+    - `STORY:` — the user story / scenario it satisfies ("as a <persona>, I …").
+    Anchor WHY/INVARIANT next to the code (and in tests for contracts). Do NOT add a
+    comment that merely restates the code.
+<!-- SHARED-LOOP:END -->
+
+## Stack idiom — Electron (TS: main / preload / renderer)
+
+- **Anchor syntax:** `//` (TS/TSX; e.g. `// WHY:`, `// INVARIANT:`).
+- **Process model:** every unit names which process(es) it touches — **main** (Node
+  services, IPC handlers, external I/O), **preload** (the `contextBridge` API surface),
+  **renderer** (React UI). Cross-process work is still ONE unit when it implements one
+  IPC contract end-to-end.
+- **Testing idiom:** renderer — React Testing Library: assert **behavior and accessible
+  roles**, never implementation details; cover the render states (loading / empty / error /
+  success), user interactions, and boundary inputs. Main — unit-test services with Electron
+  APIs mocked at the boundary. **IPC contracts are tested on BOTH sides** (main handler +
+  typed preload bridge) with typed payloads.
+- **Strict TypeScript:** no `any` at boundaries — especially IPC payloads and the preload
+  API surface.
+- **Security posture is non-negotiable:** `contextIsolation: true`,
+  `nodeIntegration: false`, no `remote`. **All external HTTP runs in the main process** —
+  the renderer reaches the network only via typed IPC (CORS + credential hygiene).
+- **Gate categories the card's `gates:` must cover:** typecheck (tsc) · lint · format · test
+  (full suite) · **a11y** (jest-axe / Testing-Library a11y assertions) · coverage. a11y is a
+  GATE, not a nicety.
+- **Stack rule S1 — a11y-first DESIGN.** Accessibility (roles, labels, focus, keyboard nav,
+  contrast) is designed in at the DESIGN step, and a11y assertions land WITH the component in
+  the SAME iteration. Declare it in the ledger's Planned changes; confirm it in the Outcome.
+- **Stack rule S2 — IPC contracts ship whole.** Any new or changed IPC channel lands WITH
+  its typed contract and both-side tests (main handler + preload surface) in the SAME
+  iteration. Declare it in the ledger's Planned changes; confirm it in the Outcome.
+
+<!-- SHARED-LOOP:BEGIN -->
+## The loop
+
+```
+WRITE LEDGER (PLANNED) → FRAME ──intent<95%?──▶ ASK (pause→resume) → DESIGN (is this wise?)
+  ──companion `when` matches?──▶ INVOKE companion skill(s) ──approach<95%?──▶ ASK
+  → RED (failing test; never touch prior tests) → GREEN (minimal code; run NEW + ALL prior tests)
+  → REFACTOR (stay green, ≤450-line files) → COVERAGE PASS
+  → QUALITY GATE (run_gates.py <stack>) ──red & attempt<10?──▶ fix & rerun
+                                        ──red on 10th──▶ HARD STOP + loop diagnosis
+  ──green──▶ WISDOM + CONFIDENCE REVIEW ──any change<95% or altered a prior test?──▶ ASK
+  ──ok──▶ UPDATE LEDGER OUTCOME (actual files, commits, gates, deviations) → COMMIT → NEXT
+```
+
+The **95% gate is call-and-return**: pause → ask → resume the step you were on. The
+QUALITY-GATE red path loops to GREEN only while `attempt < 10`.
+
+## Checklist (one todo item per step, in order)
+
+1. **LEDGER (PLANNED)** — Intent + Planned files + Test plan + Acceptance. Flip to
+   IN_PROGRESS when coding. **Ticket first:** the unit's issue exists (file it per
+   `task-management` if missing) and moves to **In Progress**; the ledger names the issue.
+2. **FRAME** — restate task + acceptance; list exact files. *Intent <95%? ask.*
+3. **DESIGN** — interfaces, file placement, test approach; simplest wise design (DRY, SOLID,
+   YAGNI); apply the card body's conventions. **Invoke every companion skill whose `when`
+   matches — now.** *Approach <95%? ask.*
+4. **RED** — write failing test(s) (happy + boundaries + errors); run; confirm they fail for
+   the right reason. Do not touch prior tests.
+5. **GREEN** — minimal code; run the full test suite (new + all prior).
+6. **REFACTOR** — clean while green; keep files focused (≤450 lines).
+7. **COVERAGE PASS** — assert the meaningful branches/edges/errors per rule 6.
+8. **QUALITY GATE** — `run_gates.py <stack>` all green. Bounded to 10 attempts (rule 11).
+9. **WISDOM + CONFIDENCE REVIEW** — answer the wisdom prompts; altered a prior test? any
+   decision <95%? → ask.
+10. **LEDGER OUTCOME** — actual vs planned files, commit sha/message, gate results,
+    **Deviations**. Status DONE | BLOCKED.
+11. **COMMIT** — only when gates green and confidence ≥95% (or confirmed). Conventional
+    message; never append `Co-Authored-By`. Body carries the card's `commit_refs` with the
+    ticket number.
+12. **NEXT** — re-enter the loop. All prior tests remain and keep passing. Close the ticket
+    per `task-management` (commits + gates + ledger comment; state → Done).
+
+## Test-preservation — the hard rule
+
+Prior cycles' tests are the contract you must not break. New code earns its place by passing
+**new** tests while **all old tests stay green and unmodified**. A wrong/obsolete old test is
+a finding to surface, not a thing to quietly edit.
+
+## Wisdom prompts (answer before commit — plus the Stack prompts below and any in the card body)
+
+- Simpler design? Speculative generality (YAGNI)? Duplicated logic?
+- Do tests assert real behavior and the invariants the card body names, or just "it ran"?
+- Blast radius — did I touch a public contract, a shared interface, or a schema?
+- Security — any secret logged/exposed? any fail-open path introduced?
+- Card conventions honored for the active stack?
+
+## Red flags — STOP immediately (plus the Stack red flags below and any in the card body)
+
+| Thought | Action |
+|---|---|
+| "I'll update this old test to match the new code." | STOP. Confidence Gate — ask. |
+| "Tests pass, ship it." (skipping wisdom review) | STOP. Run the review. |
+| "~85% sure this is what they want." | STOP. Ask. |
+| Weakening a gate / lowering coverage to move on. | STOP. Fix the code, or ask. |
+| Production code with no failing test driving it. | STOP. Test first. |
+| Code/tests before the ledger exists. | STOP. Create the ledger first. |
+| Skipping a `mandatory: true` companion skill. | STOP (rule 3). Invoke it now. |
+| Same gate/test red on the 10th retry. | HARD STOP (rule 11). Escalate with a loop diagnosis. |
+| Non-obvious code with no `WHY:`/`INVARIANT:` and no `FEATURE:`/`STORY:` link — or a comment that just restates the code. | STOP (rule 12). Add a real semantic anchor; delete noise. |
+<!-- SHARED-LOOP:END -->
+
+## Stack wisdom prompts — Electron
+
+- Do tests assert behavior + accessible roles, or brittle implementation details?
+- All render states (loading/empty/error/success) covered? a11y assertions present (S1)?
+- Any `any` at a boundary — IPC payload, preload surface, external API response?
+- New/changed IPC channel → typed contract + both-side tests in this same iteration (S2)?
+- Any external HTTP or Node API creeping into the renderer?
+
+## Stack red flags — Electron
+
+| Thought | Action |
+|---|---|
+| `any` at a boundary / `eslint-disable` to move on. | STOP. Fix the types/code, or ask. |
+| Asserting on implementation details. | STOP. Test behavior and roles. |
+| Disabling or skipping an a11y check. | STOP (S1). a11y is a gate. |
+| `nodeIntegration: true` / `contextIsolation: false` "to make it work". | HARD STOP. Security posture is non-negotiable — ask. |
+| External HTTP (or Node APIs) in the renderer. | STOP. Route via the main process over typed IPC. |
+| New IPC channel without its contract + both-side tests. | STOP (S2). Land them in the same iteration. |

--- a/.claude/skills/sdlc-electron/SKILL.md
+++ b/.claude/skills/sdlc-electron/SKILL.md
@@ -91,9 +91,21 @@ every cycle.
   typed preload bridge) with typed payloads.
 - **Strict TypeScript:** no `any` at boundaries — especially IPC payloads and the preload
   API surface.
-- **Security posture is non-negotiable:** `contextIsolation: true`,
-  `nodeIntegration: false`, no `remote`. **All external HTTP runs in the main process** —
-  the renderer reaches the network only via typed IPC (CORS + credential hygiene).
+- **Security posture is non-negotiable** — the official Electron security checklist
+  (electronjs.org/docs/latest/tutorial/security) is encoded here:
+  - `contextIsolation: true` · `nodeIntegration: false` · `sandbox: true` · never disable
+    `webSecurity` · never enable `allowRunningInsecureContent` or experimental features ·
+    no `<webview>` without `will-attach-webview` verification.
+  - **Validate the sender of every IPC message** in main-process handlers
+    (`event.senderFrame` against a URL allowlist) — an unvalidated handler is a
+    privileged-action hole.
+  - `session.setPermissionRequestHandler` set, deny-by-default; a **CSP** is defined
+    (headers via `onHeadersReceived` or meta tag).
+  - Navigation restricted (`will-navigate`) and window creation controlled
+    (`setWindowOpenHandler`); never pass untrusted input to `shell.openExternal`.
+  - Remote content only over `https:`/`wss:`; Electron stays on a current version.
+  - **All external HTTP runs in the main process** — the renderer reaches the network only
+    via typed IPC (CORS + credential hygiene).
 - **Gate categories the card's `gates:` must cover:** typecheck (tsc) · lint · format · test
   (full suite) · **a11y** (jest-axe / Testing-Library a11y assertions) · coverage. a11y is a
   GATE, not a nicety.
@@ -181,6 +193,8 @@ a finding to surface, not a thing to quietly edit.
 - All render states (loading/empty/error/success) covered? a11y assertions present (S1)?
 - Any `any` at a boundary — IPC payload, preload surface, external API response?
 - New/changed IPC channel → typed contract + both-side tests in this same iteration (S2)?
+- New IPC handler → is the sender validated (`senderFrame` allowlist)?
+- New window / navigation / external-link path → restricted per the checklist?
 - Any external HTTP or Node API creeping into the renderer?
 
 ## Stack red flags — Electron
@@ -190,6 +204,8 @@ a finding to surface, not a thing to quietly edit.
 | `any` at a boundary / `eslint-disable` to move on. | STOP. Fix the types/code, or ask. |
 | Asserting on implementation details. | STOP. Test behavior and roles. |
 | Disabling or skipping an a11y check. | STOP (S1). a11y is a gate. |
-| `nodeIntegration: true` / `contextIsolation: false` "to make it work". | HARD STOP. Security posture is non-negotiable — ask. |
+| `nodeIntegration: true` / `contextIsolation: false` / `sandbox: false` / `webSecurity: false` "to make it work". | HARD STOP. Security posture is non-negotiable — ask. |
 | External HTTP (or Node APIs) in the renderer. | STOP. Route via the main process over typed IPC. |
 | New IPC channel without its contract + both-side tests. | STOP (S2). Land them in the same iteration. |
+| `ipcMain` handler without sender validation (`senderFrame`). | STOP. Validate against the allowlist first. |
+| Untrusted input to `shell.openExternal` / unrestricted `will-navigate` / `setWindowOpenHandler`. | STOP. Restrict per the security checklist. |

--- a/.claude/skills/sdlc-python/SKILL.md
+++ b/.claude/skills/sdlc-python/SKILL.md
@@ -78,6 +78,14 @@ every cycle.
 ## Stack idiom — Python
 
 - **Anchor syntax:** `#` (e.g. `# WHY:`, `# INVARIANT:`).
+- **Tortoise ORM work — STRONGLY RECOMMENDED companion:** this repo's Python services
+  (`apps/aigateway`, `apps/scoreboard`) use Tortoise ORM. For ANY Tortoise-touching unit
+  (models, querysets, migrations, transactions, signals, FastAPI lifespan wiring), invoke
+  the **`tortoise-dev`** skill — it carries the house patterns (model-per-file, abstract
+  Base interfaces, strict member ordering, built-in Tortoise migrations — never Aerich,
+  Pydantic v2). It is `mandatory: true` in the card's `companion_skills` (rule 3). If the
+  plugin is not installed, STOP and propose installing it:
+  https://github.com/sergio-bershadsky/ai/tree/main/plugins/tortoise-dev
 - **Testing idiom:** unit-test service/business logic against abstract interfaces — no DB, no
   network. Integration-test persistence on an ephemeral database (in-memory engine or
   testcontainers). Parametrize table-style where it clarifies.

--- a/.claude/skills/sdlc-python/SKILL.md
+++ b/.claude/skills/sdlc-python/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: sdlc-python
+description: >-
+  Use for EVERY development iteration on Python code — any change (feature, bug fix,
+  refactor, follow-up) in a project whose `.claude/sdlc.local.md` maps a stack to this skill.
+  Rigid SDLC loop: work-ledger first → frame → design → TDD (RED first) → append-only wise
+  coverage → quality gates via run_gates.py → wisdom + 95%-confidence review → commit. Invoke
+  BEFORE writing or modifying any Python code; re-enter per unit of work. Toolchain commands
+  and project conventions come from the card; Electron desktop code uses `sdlc-electron`.
+---
+
+# SDLC Iteration — Python
+
+**Announce at start:** "Using the sdlc-python skill — the rigid TDD loop for the Python stack."
+
+This is a **RIGID** process skill. Every Python change in a card-carrying project goes through
+this loop. No shortcuts, no "this one is too small." One iteration = one focused, tested,
+reviewed, committed unit of work — then re-enter the loop. The loop, ledger, and gates are
+shared verbatim with the sibling skill (Electron uses `sdlc-electron`) under LOOP PARITY — the
+`SHARED-LOOP` regions below are changed in both skills together, never in one
+(`.claude/scripts/check_loop_parity.py` enforces it).
+
+<!-- SHARED-LOOP:BEGIN -->
+## Card resolution — before anything
+
+Read `.claude/sdlc.local.md` in the project root. **Missing → HARD STOP:** tell the user the
+card is missing (it is committed repo config — restore it from git) and stop; never guess
+gates, paths, or conventions. Resolve the active stack entry: match the planned/changed paths
+against `stacks[].root` for entries whose `skill:` names this skill; ambiguous or cross-stack
+→ ask. Then read the card BODY section for the active stack — those project conventions bind
+every cycle.
+
+## Non-negotiable rules
+
+1. **Work-ledger first.** Before any code or test, create the ledger in `ledger_dir` from the
+   card (this repo: `docs/work/`, named `YYYY-MM-DD-<ticket-id>-<desc>.md` per D8; copy
+   `docs/work/TEMPLATE.md`) with Intent + Planned changes + Test plan + Acceptance. Fill the
+   Outcome at the end. **No code before its ledger.**
+2. **One iteration = one focused unit.** Never batch unrelated changes.
+3. **Companion skills are binding.** Invoke every card `companion_skills` entry whose `when`
+   condition matches this unit of work; skipping one marked `mandatory: true` is a process
+   violation — STOP and run it.
+4. **TDD always.** Write the failing test FIRST, then minimal code to pass. No production
+   code without a test that demanded it. Test idioms: see the Stack idiom section.
+5. **Tests are append-only across cycles.** NEVER delete/rewrite/weaken/skip a prior test to
+   make new code pass. A prior test that genuinely must change is a Confidence-Gate decision
+   → STOP and ask. Adding tests is always fine.
+6. **Wise & thorough coverage — not just lines.** Happy path, boundaries, error paths, and
+   the invariant the code protects (the card body names the project's invariants).
+   Assertions verify *behavior*, never "it ran".
+7. **Quality gates are absolute.** Run the repo's gate runner —
+   `uv run .claude/scripts/run_gates.py <stack>` (from the repo root) — all card gates
+   green before commit; never weaken a gate — fix the code. Also verify the card's `gates:`
+   cover this skill's gate categories (Stack idiom section); a missing category is a card
+   defect — surface it.
+8. **The 95% Confidence Gate.** For ANY decision < 95% confident it is both correct AND
+   wanted, STOP and ask first: ambiguous requirements, a design fork, changing a prior test
+   or a public contract, a new dependency, or anything security-sensitive. The gate is
+   call-and-return: pause → ask → resume the step you were on.
+9. **"Is this wise?" is a required step**, not optional.
+10. **Project conventions hold every cycle** — the card body's rules for the active stack.
+11. **Bounded retries — HARD STOP at 10.** A unit gets at most 10 fix-and-rerun attempts
+    against the same failing signal. On the 10th still-failing, HARD STOP and escalate with
+    a **loop diagnosis** (the recurring failure, what changed each round, the suspected
+    root cause). Never loop past 10.
+12. **Semantic comment layer — write for the NEXT AI iteration.** Comment generously with
+    ONLY this fixed, greppable anchor vocabulary (syntax per the Stack idiom section) plus
+    the card's `extra_anchors` — an open set defeats greppability, so invent no others:
+    - `WHY:` — the rationale/decision the type or test cannot encode.
+    - `INVARIANT:` — a property that must always hold (the contract this code protects).
+    - `AIDEV-NOTE:` — guidance/warning for the next agent touching this code.
+    - `FEATURE:` — the product feature this code serves (name it).
+    - `STORY:` — the user story / scenario it satisfies ("as a <persona>, I …").
+    Anchor WHY/INVARIANT next to the code (and in tests for contracts). Do NOT add a
+    comment that merely restates the code.
+<!-- SHARED-LOOP:END -->
+
+## Stack idiom — Python
+
+- **Anchor syntax:** `#` (e.g. `# WHY:`, `# INVARIANT:`).
+- **Testing idiom:** unit-test service/business logic against abstract interfaces — no DB, no
+  network. Integration-test persistence on an ephemeral database (in-memory engine or
+  testcontainers). Parametrize table-style where it clarifies.
+- **Exceptions:** catch specific exceptions; never bare `except`.
+- **Gate categories the card's `gates:` must cover:** format · lint · typecheck · test (full
+  suite) · coverage.
+- **Stack rule S1 — migrations ship with the schema.** Any schema/model change is authored
+  AND its migration is created + committed in the SAME iteration (ORM-specific mechanics come
+  from the card's `companion_skills`). Declare it in the ledger's Planned changes; confirm it
+  in the Outcome. A schema change without its migration is an incomplete iteration — treat it
+  like a red gate.
+
+<!-- SHARED-LOOP:BEGIN -->
+## The loop
+
+```
+WRITE LEDGER (PLANNED) → FRAME ──intent<95%?──▶ ASK (pause→resume) → DESIGN (is this wise?)
+  ──companion `when` matches?──▶ INVOKE companion skill(s) ──approach<95%?──▶ ASK
+  → RED (failing test; never touch prior tests) → GREEN (minimal code; run NEW + ALL prior tests)
+  → REFACTOR (stay green, ≤450-line files) → COVERAGE PASS
+  → QUALITY GATE (run_gates.py <stack>) ──red & attempt<10?──▶ fix & rerun
+                                        ──red on 10th──▶ HARD STOP + loop diagnosis
+  ──green──▶ WISDOM + CONFIDENCE REVIEW ──any change<95% or altered a prior test?──▶ ASK
+  ──ok──▶ UPDATE LEDGER OUTCOME (actual files, commits, gates, deviations) → COMMIT → NEXT
+```
+
+The **95% gate is call-and-return**: pause → ask → resume the step you were on. The
+QUALITY-GATE red path loops to GREEN only while `attempt < 10`.
+
+## Checklist (one todo item per step, in order)
+
+1. **LEDGER (PLANNED)** — Intent + Planned files + Test plan + Acceptance. Flip to
+   IN_PROGRESS when coding. **Ticket first:** the unit's issue exists (file it per
+   `task-management` if missing) and moves to **In Progress**; the ledger names the issue.
+2. **FRAME** — restate task + acceptance; list exact files. *Intent <95%? ask.*
+3. **DESIGN** — interfaces, file placement, test approach; simplest wise design (DRY, SOLID,
+   YAGNI); apply the card body's conventions. **Invoke every companion skill whose `when`
+   matches — now.** *Approach <95%? ask.*
+4. **RED** — write failing test(s) (happy + boundaries + errors); run; confirm they fail for
+   the right reason. Do not touch prior tests.
+5. **GREEN** — minimal code; run the full test suite (new + all prior).
+6. **REFACTOR** — clean while green; keep files focused (≤450 lines).
+7. **COVERAGE PASS** — assert the meaningful branches/edges/errors per rule 6.
+8. **QUALITY GATE** — `run_gates.py <stack>` all green. Bounded to 10 attempts (rule 11).
+9. **WISDOM + CONFIDENCE REVIEW** — answer the wisdom prompts; altered a prior test? any
+   decision <95%? → ask.
+10. **LEDGER OUTCOME** — actual vs planned files, commit sha/message, gate results,
+    **Deviations**. Status DONE | BLOCKED.
+11. **COMMIT** — only when gates green and confidence ≥95% (or confirmed). Conventional
+    message; never append `Co-Authored-By`. Body carries the card's `commit_refs` with the
+    ticket number.
+12. **NEXT** — re-enter the loop. All prior tests remain and keep passing. Close the ticket
+    per `task-management` (commits + gates + ledger comment; state → Done).
+
+## Test-preservation — the hard rule
+
+Prior cycles' tests are the contract you must not break. New code earns its place by passing
+**new** tests while **all old tests stay green and unmodified**. A wrong/obsolete old test is
+a finding to surface, not a thing to quietly edit.
+
+## Wisdom prompts (answer before commit — plus the Stack prompts below and any in the card body)
+
+- Simpler design? Speculative generality (YAGNI)? Duplicated logic?
+- Do tests assert real behavior and the invariants the card body names, or just "it ran"?
+- Blast radius — did I touch a public contract, a shared interface, or a schema?
+- Security — any secret logged/exposed? any fail-open path introduced?
+- Card conventions honored for the active stack?
+
+## Red flags — STOP immediately (plus the Stack red flags below and any in the card body)
+
+| Thought | Action |
+|---|---|
+| "I'll update this old test to match the new code." | STOP. Confidence Gate — ask. |
+| "Tests pass, ship it." (skipping wisdom review) | STOP. Run the review. |
+| "~85% sure this is what they want." | STOP. Ask. |
+| Weakening a gate / lowering coverage to move on. | STOP. Fix the code, or ask. |
+| Production code with no failing test driving it. | STOP. Test first. |
+| Code/tests before the ledger exists. | STOP. Create the ledger first. |
+| Skipping a `mandatory: true` companion skill. | STOP (rule 3). Invoke it now. |
+| Same gate/test red on the 10th retry. | HARD STOP (rule 11). Escalate with a loop diagnosis. |
+| Non-obvious code with no `WHY:`/`INVARIANT:` and no `FEATURE:`/`STORY:` link — or a comment that just restates the code. | STOP (rule 12). Add a real semantic anchor; delete noise. |
+<!-- SHARED-LOOP:END -->
+
+## Stack wisdom prompts — Python
+
+- Schema/model touched → is the migration present in this same iteration (S1)?
+- Any bare `except`, or a swallowed exception that should surface?
+- Typecheck clean without `# type: ignore` escapes?
+
+## Stack red flags — Python
+
+| Thought | Action |
+|---|---|
+| `# type: ignore` to move on. | STOP. Fix the types, or ask. |
+| A bare `except:` / silently swallowed exception. | STOP. Catch the specific exception; surface failures. |
+| Schema/model change with no migration this cycle. | STOP (S1). Create + commit the migration now. |

--- a/.claude/skills/task-management/SKILL.md
+++ b/.claude/skills/task-management/SKILL.md
@@ -1,0 +1,140 @@
+---
+description: Use for ANY task/ticket work — creating, triaging, planning, implementing, or closing work items — in this repo. All units of work live as Linear issues (OME-N) in the Engineering team under the 😱 ScreamingFace V1 project, per the .claude/task-board.local.md card. Defines the lifecycle (plan → tickets → owner review → per-ticket SDLC → close), the label taxonomy (workstream Epic group, app/pkg landing, who-acts, mandatory actor), STOP labels, close discipline, docs/tasks mirrors, the Linear MCP command crib, and the Linear rich-text dialect. Invoke at session start, before starting any unit of work, and before filing or closing an issue.
+user_invocable: true
+---
+
+# Task Management — Linear work items
+
+**Announce at start:** "Using the task-management skill — the Linear work-item lifecycle."
+
+## Card resolution — before anything
+
+Read `.claude/task-board.local.md` in the project root. **Missing → HARD STOP:** tell the
+user the card is gone and stop — never guess the team, project, states, or label IDs. Every
+`{{…}}` placeholder below resolves from that card. Read the card BODY too — its ticket
+rules bind alongside this skill.
+
+**Transport: the Linear MCP plugin ONLY** (`mcp__plugin_linear_linear__*` tools; activate
+via `/mcp`). **API tokens and raw GraphQL are FORBIDDEN.** Operations the MCP cannot
+perform (label/team/state management, issue deletion) are OWNER actions in the Linear UI —
+hand them over with precise steps.
+
+The single task holder is the card's team + project. No parallel boards: session-local todo
+tools are fine for intra-session step tracking, but any unit of work that outlives the
+session MUST be a Linear issue. The work-ledger (`docs/work/`) stays the how/audit record;
+the issue is the what/status record — they cross-reference, they don't duplicate. Every
+issue additionally gets a repo mirror `docs/tasks/YYYY-MM-DD-<name>.md` (frontmatter: id,
+linear_url, asana_url?, status, type, priority, labels, created, closed) — written at
+create, closed at finish; **Linear is the status authority**.
+
+## The label taxonomy (locked — D10/D13)
+
+- **Workstream** — the existing `Epic` label group (ONE per issue, Linear-enforced):
+  url4 Engine · AI Gateway · Eval Runner & Datasets · Results & Runs · Leaderboard ·
+  Auth & Subsidized Compute · Desktop App · Python SDK · Multi-turn Ensembles · SOTA Hunt ·
+  Compute Budgeting. Apply whenever the work belongs to one. Workstreams are PRODUCT
+  concepts — never mint one for an internal module; additions are coordinated with the
+  project lead and registered in the card in the same change.
+- **Landing (WHERE)** — plain multi-value labels: `app/aigateway`, `app/scoreboard`,
+  `pkg/url4-python-sdk` (more at name lock), or `repo` for repo/process work (no app/pkg).
+- **`who-acts` group** (ONE per issue): `design-session` — a direction fork; agents may
+  PREPARE, never decide · `autonomous` — agent-runnable end-to-end · `deferred` — recorded,
+  gated on a named precondition (state the gate in the body).
+- **`actor` group (ONE per issue, MANDATORY — D13):** `agentic` or `human` — who executes
+  the work. Set at filing; flip if ownership changes.
+- **STOP labels (D12):** existing `blocked ⛔` (hard question pending) and `needs-owner`
+  (only a decision/visual check pending). A STOP = apply the label + comment the exact
+  question; the issue STAYS In Progress; remove the label when resolved. Never add
+  workflow states to the shared team.
+- Optional type tagging via existing plain labels `Bug` / `Feature` / `Improvement`.
+- **Priority** (Linear ints): P1→2 (High, work next) · P2→3 (Medium, queued) · P3→4 (Low,
+  parked); 1 (Urgent) is reserved for incidents. The agent proposes; the owner's setting wins.
+
+**Cross-cutting rule (D9):** work touching **≥2** `app/*`/`pkg/*` landings → file an
+**epic** (parent issue) carrying its workstream label + ALL affected landing labels, with
+one sub-issue per affected app/package (one SDLC unit each; each sub-issue carries its own
+landing label + the same workstream label). Never a single-app filing, never one mega-ticket.
+
+## The lifecycle
+
+```
+PLAN (docs/plan artifact) ──▶ TICKETS (one issue per SDLC-unit-sized deliverable;
+  multi-unit arcs get a parent epic with sub-issues)
+──▶ OWNER TICKET REVIEW (scope/priority/labels; design-session forks resolved or scheduled)
+──▶ PLAN ONE TICKET ──▶ IMPLEMENT IT (the stack's sdlc-* loop: ledger → RED → GREEN →
+  gates → commit; the ledger names the issue; commit bodies carry `Refs: OME-N`)
+──▶ CLOSE (see close discipline) ──▶ NEXT TICKET
+```
+
+- **Status mapping:** Todo → **In Progress** when the ticket's ledger is created → **Done**
+  when the issue closes. `In Review` while the PR awaits review. STOPs are labels (D12),
+  not states. Move status at those moments, not retroactively.
+- **Batching:** several INDEPENDENT tickets may run in one batch (one sdlc-unit-executor
+  per ticket; sequential when they share a stack). Declare the batch up front — each ticket
+  still gets its own ledger, commits, and close comment.
+- **Mid-session discoveries:** new work found while implementing → file the ticket first
+  (30 seconds), then decide: in-scope for the current unit, or leave it. Never let work
+  exist only in a chat transcript.
+- **Milestones** belong to the product project (sprints S0–S5, owned by the project lead).
+  Product work slots into the current sprint milestone with the lead's agreement;
+  repo/process items take no milestone.
+
+## Close discipline
+
+An issue closes ONLY with a comment carrying the card's `close_template` filled: commit
+shas + messages, the gates that ran (test counts/baselines), the ledger path(s), deviations,
+and anything the owner must verify visually. Wrap long gate output in a `+++ Gates` …
+`+++` collapsible. Then set state Done and close the `docs/tasks/` mirror (status + closed
+date). Closing without this comment is a process violation.
+
+## Command crib (Linear MCP tools; names resolve via the card)
+
+- **Create:** `save_issue {team: "Engineering", project: "{{project.slug}}", title, description,
+  labels: ["repo"|"app/…", "<workstream>", "autonomous"|…, "agentic"|"human"], priority, parentId?}`
+  → returns the native `OME-N` identifier + URL. NO id parameter on create.
+- **Move state:** `save_issue {id: "OME-N", state: "In Progress" | "In Review" | "Done"}`
+- **STOP / un-STOP:** read current labels (`get_issue`), then `save_issue {id, labels: [<union
+  ± stop label>]}` + `save_comment {issueId: "OME-N", body: "<exact question>"}`
+- **Close comment:** `save_comment {issueId: "OME-N", body: <close_template filled>}`
+- **List/find:** `list_issues {project, label?, state?, query?, parentId?}` · `get_issue {id}`
+- **New label** (only when the card registers it in the same change): `create_issue_label
+  {name, color, description, parent?/isGroup?}`
+
+**MCP quirks (encode these in your calls):**
+- `save_issue.labels` **REPLACES the full label set** — always read current labels first
+  and resend the union. Relations (`blockedBy`, `relatedTo`, `links`) are append-only.
+- Send **raw markdown with literal newlines** — never `\n` escape sequences.
+- `assignee` accepts `"me"`, a name, or an email.
+
+## Linear rich text — the markdown dialect for descriptions & comments
+
+- **Headings:** `#`–`####` (H1–H4). Deeper levels don't exist.
+- **Text:** `**bold**`, `_italic_`, `~~strike~~`, `` `inline code` ``. Underline has NO
+  markdown syntax (editor-only) — don't try.
+- **Lists:** `-`/`*`/`+` bullets, `1.` numbered, `- [ ]` checklists (render as interactive
+  checkboxes — good for acceptance lists); all nestable.
+- **Blockquote:** `>` · **Collapsible section:** `+++ Title` on its own line, content,
+  closing `+++` (nestable) — use for long logs/gate output.
+- **Code:** fenced ``` blocks with a language tag; ` ```mermaid ` renders a Mermaid diagram.
+- **Divider:** `---` · **Tables:** GFM pipe tables (keep simple — no spans).
+- **Emoji:** `:name:` · **No HTML** — it is not rendered.
+- **Mentions — SIDE-EFFECTS:** `@displayName` notifies + subscribes that user. Issue
+  references auto-link aggressively: `@OME-123`, pasted issue URLs, AND bare `OME-123`
+  identifiers in plain prose all become issue embeds (verified live) and can create
+  "related to" relations. Wrap IDs in backticks when no link/relation is wanted.
+- **Embeds:** bare YouTube/Loom/Figma/Google-Docs URLs auto-embed; wrap in `[text](url)`
+  to keep a plain link.
+
+## Anti-patterns — STOP immediately
+
+| Thought | Reality |
+|---|---|
+| "I'll track this in the session todo only." | Outlives the session? It's a Linear issue. File it. |
+| "One big issue for the whole plan." | Decompose: epic parent + SDLC-unit sub-issues. |
+| "It touches two apps but I'll label just one." | D9 STOP: epic + one sub-issue per affected app/package. |
+| "I'll skip the actor label." | D13: `agentic` or `human` is MANDATORY on every item. |
+| "Close it, the code's merged." | No close without the commits+gates+ledger comment. |
+| "It's a design-session ticket but the answer is obvious." | Prepare a proposal; the owner decides. |
+| "I'll mint a label the card doesn't register." | The card is the registry. Register first, same change. |
+| "The MCP can't do it — I'll use the API key." | FORBIDDEN. MCP-uncovered ops are owner UI actions. |
+| "I'll set labels without reading current ones." | `labels` REPLACES the set — read, union, resend. |

--- a/.claude/skills/working-in-this-repo/SKILL.md
+++ b/.claude/skills/working-in-this-repo/SKILL.md
@@ -19,10 +19,10 @@ ScreamingFace is a **polyglot monorepo** worked on by multiple developers concur
 
 ## 2. Current apps — the routing table
 
-| Component | Stack | Run / test / lint / typecheck | Gating CI | Release lane | Key guardrails |
-|---|---|---|---|---|---|
-| `apps/aigateway` | Python · uv · FastAPI (LiteLLM) | `uv run uvicorn aigateway.main:app --port 9105` · `uv run pytest` (live tests opt-in) · `uv run ruff check` · `uv run pyright` | `aigateway-tests.yml` (matrix 3.12/3.13) | release-please → `aigateway-v*` → `release-aigateway.yml` (GHCR image + Helm chart) | **Never import `litellm-enterprise`** (guarded by `scripts/check_no_enterprise.py`). Credentials via ORMStore/Tortoise `credential_blobs`, **no OS keychain**; secrets AES-256-GCM; master key `AIGATEWAY_SECRET_KEY` never stored/logged. See `apps/aigateway/CLAUDE.md`. |
-| `apps/scoreboard` | Python · uv · FastAPI | `uv run scoreboard` · `uv run pytest` · `uv run ruff check` · `uv run pyright` | `scoreboard-tests.yml` | **Manual** tag `scoreboard-v*` → `release-scoreboard.yml` (GHCR image + Helm; **not** in release-please) | Portal assets and public eval artifacts are app-local (`portal/`, `artifacts/`) — they ship inside the image. |
+| Component | Landing label | Stack | Run / test / lint / typecheck | Gating CI | Release lane | Key guardrails |
+|---|---|---|---|---|---|---|
+| `apps/aigateway` | `app/aigateway` | Python · uv · FastAPI (LiteLLM) | `uv run uvicorn aigateway.main:app --port 9105` · `uv run pytest` (live tests opt-in) · `uv run ruff check` · `uv run pyright` | `aigateway-tests.yml` (matrix 3.12/3.13) | release-please → `aigateway-v*` → `release-aigateway.yml` (GHCR image + Helm chart) | **Never import `litellm-enterprise`** (guarded by `scripts/check_no_enterprise.py`). Credentials via ORMStore/Tortoise `credential_blobs`, **no OS keychain**; secrets AES-256-GCM; master key `AIGATEWAY_SECRET_KEY` never stored/logged. See `apps/aigateway/CLAUDE.md`. |
+| `apps/scoreboard` | `app/scoreboard` | Python · uv · FastAPI | `uv run scoreboard` · `uv run pytest` · `uv run ruff check` · `uv run pyright` | `scoreboard-tests.yml` | **Manual** tag `scoreboard-v*` → `release-scoreboard.yml` (GHCR image + Helm; **not** in release-please) | Portal assets and public eval artifacts are app-local (`portal/`, `artifacts/`) — they ship inside the image. |
 
 **Owner / reviewer per path:** see `.github/CODEOWNERS`. This skill deliberately does not hardcode owners — read them from one place.
 
@@ -56,8 +56,8 @@ Bring whatever stack fits; satisfy this **invariant contract** so the coordinati
 
 ## 6. Branch / commit / PR / merge
 
-- **Branch:** `SF-{n}-{description}`, `n` = the Asana `SF` field (auto-assigned; don't invent one). Never commit to `main`.
-- **Commit:** `SF-N: summary` or `feat(SF-N): …`; put the Asana permalink in the body; **no `Co-Authored-By`** lines.
+- **Branch:** `OME-N-<description>`, `N` = the Linear work-item number (file the item per the `task-management` skill; registry `.claude/task-board.local.md`). Never commit to `main`.
+- **Commit:** conventional (`feat: …`, `fix: …`); body carries `Refs: OME-N`; **no `Co-Authored-By`** lines.
 - **Keep current:** rebase on `origin/main` (don't merge `main` into your branch); force-push only your own branch.
 - **Merge:** squash-merge; the author merges after review approval + green required checks.
 - **Checks are path-dependent.** Live tests (`AIGW_LIVE=1`) are opt-in diagnostics, **not** merge gates.
@@ -68,6 +68,8 @@ Bring whatever stack fits; satisfy this **invariant contract** so the coordinati
 
 - **Setup / run-from-source:** `CONTRIBUTING.md`
 - **Per-app guardrails:** `apps/*/CLAUDE.md`
-- **Decision records / plans / specs:** `docs/`
+- **Work items / ticket lifecycle:** the `task-management` skill + `.claude/task-board.local.md`
+- **Per-stack dev loop:** the `sdlc-python` / `sdlc-electron` skills + `.claude/sdlc.local.md`
+- **Decision records & SDLC artifacts:** `docs/` (see `docs/README.md`)
 - **Brand / UI law:** the `screamingface-design` skill
 - **Legacy reference (desktop, server, url4 engine, web, infra):** tag `legacy-monorepo-2026-07-08`

--- a/.claude/task-board.local.md
+++ b/.claude/task-board.local.md
@@ -1,0 +1,77 @@
+---
+system: linear
+workspace: openmined
+transport: "Linear MCP plugin (plugin:linear) — the ONLY transport; PRECONDITION: activate via /mcp. API tokens/GraphQL FORBIDDEN; MCP-uncovered ops (label/team/state management) are owner actions in the Linear UI"
+team: { key: OME, name: Engineering, id: "5f4d721f-4452-4ed1-990a-7cdbcd923508" }
+project: { name: "😱 ScreamingFace V1", slug: screamingface-v1-27666092fc7f, id: "7cbe5759-cc07-476d-b81e-da05b6b2d4d7" }
+states:
+  todo: "88de5fec-8ce3-4172-b462-6c418837accf"
+  in_progress: "03621515-86a4-4669-aad7-5467a23505f1"
+  in_review: "62b4c1a3-752f-456b-bdf6-7ce484959e5d"
+  done: "699b96ac-cd89-42db-a717-4f8b291a7388"
+  triage: "a6fc6a19-f6fd-4fda-baf6-2d26cc54adae"
+labels:
+  epic_group:  # existing workstream axis (Linear group "Epic", one per issue) — adopted as-is (D10)
+    "url4 Engine": "4cf80371-0eab-48e3-b396-efbf5b4837a7"
+    "AI Gateway": "554a9f5f-0535-4165-be15-60c5385f2c2a"
+    "Eval Runner & Datasets": "f4d5724b-34ab-47f0-b7bd-cfa3d420c0fb"
+    "Results & Runs": "0aff5dce-0a3e-4797-96e8-60b2098ef657"
+    "Leaderboard": "7f2af383-b322-45a6-8d37-cd45a8dcd3e5"
+    "Auth & Subsidized Compute": "016ca5be-1d4b-475f-b19d-cd3a6d43db6b"
+    "Desktop App": "481804a4-453c-4ceb-8a47-6e3745ee440a"
+    "Python SDK": "dced9623-7411-41a3-83f3-3ce817b02cf6"
+    "Multi-turn Ensembles": "2e1ab59e-2806-4d99-96d0-074bbfd1adb4"
+    "SOTA Hunt": "2f3ff3a5-8147-4aad-856c-84dea081fde3"
+    "Compute Budgeting": "81708f79-1d29-4103-b61c-8d23a221ffd7"
+  landing:  # WHERE the work lands — multi-value plain labels; app/desktop + app/cli at name lock
+    "app/aigateway": "70c87650-e737-49e5-8e5e-09d4c9649fab"
+    "app/scoreboard": "035ce6ac-dc2b-4560-86ae-fe93807702b0"
+    "pkg/url4-python-sdk": "65e0b370-12c8-45e4-9b9d-0fb5fe72bac8"
+    "repo": "89353e43-30b4-4e4b-b0a6-d781f9dcfebc"
+  stop:  # D12: STOPs are labels + comment (issue stays In Progress), never new states
+    "blocked ⛔": "f97992bc-7374-44fb-abca-2faf289f915f"
+    "needs-owner": "b2542eee-1aa6-4af3-8b9d-41baa3618fd8"
+  who_acts:  # Linear group — one per issue
+    group: "a5829dd1-ee74-4212-9641-1b3c198778ac"
+    "design-session": "b23148b7-7779-415d-b1c8-5480fa967067"
+    "autonomous": "6c277f7f-e4b3-41c6-b1ba-406781bb84ed"
+    "deferred": "24c84d24-251d-42d0-ba0f-d0c174a68809"
+  actor:  # Linear group — MANDATORY, one per issue (D13)
+    group: "4060acd7-9bee-41dc-9e45-da9b432d6f89"
+    "agentic": "836136d4-994f-457a-9e5e-7f14cf15b4f1"
+    "human": "6bb84ba1-b63e-43d6-a061-b80db8565ecf"
+  type_ish:  # existing plain labels, optional tagging
+    "Bug": "834f8e74-7b87-4af7-a8a7-2462451c4b42"
+    "Feature": "67b0111f-30e1-4aa1-bc7f-8ca8f3880890"
+    "Improvement": "923adfec-c4eb-4108-ad1b-aefb3e3bd72a"
+priority: { P1: 2, P2: 3, P3: 4 }  # Linear ints; 1 (Urgent) reserved for incidents
+close_template: |
+  Commits: <sha> <message>[, …]
+  Gates: <run_gates.py summary / test counts>
+  Ledger: docs/work/<file>.md
+  Deviations: <none | list>
+  Owner-verify: <none | what to check visually>
+---
+
+# Ticket rules (bind alongside the task-management skill)
+
+- Every work item: team Engineering + project 😱 ScreamingFace V1 (D11) + a landing label
+  (`app/*`/`pkg/*`, or `repo` for process work) + one `who-acts` label + one `actor` label
+  (agentic|human — D13, MANDATORY). Add the workstream (`Epic` group) label whenever the
+  work belongs to one; workstream additions are coordinated with the project lead.
+- D9: ≥2 `app/*`/`pkg/*` labels → cross-cutting: epic carrying the workstream label + all
+  affected landing labels, with one sub-issue per affected app/package (one SDLC unit
+  each). Never a single-app filing, never one mega-ticket.
+- D12 STOPs: apply `blocked ⛔` or `needs-owner` + a comment stating the exact question;
+  the issue stays In Progress; remove the label when resolved. Never add workflow states
+  to the shared team.
+- MCP quirks: `save_issue.labels` REPLACES the whole set — read current labels and resend
+  the union. Relations (blockedBy/relatedTo) are append-only. Send raw markdown with real
+  newlines. Bare `OME-N` identifiers auto-link and may create relations — wrap in
+  backticks when no link is wanted.
+- New app/package/workstream ⇒ its label created AND registered here in the same change.
+- Every work item gets a mirror `docs/tasks/YYYY-MM-DD-<name>.md` at create; status closed
+  in BOTH Linear and the mirror at finish. Linear is the status authority.
+- A dev item descending from a product/marketing Asana task carries the Asana URL in its
+  description (`asana_url` in the mirror frontmatter). Technical work NEVER goes to Asana
+  (`asana-product` skill is read-only).

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -1,0 +1,22 @@
+name: Repo Checks
+on:
+  push:
+    paths:
+      - ".claude/skills/sdlc-**"
+      - ".claude/scripts/**"
+      - ".github/workflows/repo-checks.yml"
+  pull_request:
+    paths:
+      - ".claude/skills/sdlc-**"
+      - ".claude/scripts/**"
+      - ".github/workflows/repo-checks.yml"
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  loop-parity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: SHARED-LOOP parity
+        run: python3 .claude/scripts/check_loop_parity.py

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ __pycache__/
 *.pyc
 .venv/
 venv/
+.coverage
+coverage.xml
 
 # Local databases
 *.sqlite3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,107 +1,57 @@
-# Project Context
+# CLAUDE.md — mandatory minimum
 
-## The Project
-An AI ensemble system combining Claude Code, Gemini CLI, Codex, and Ollama to beat SOTA benchmarks. Users install it locally, it routes coding CLI prompts through the best available models, and they can share AI credits with friends. Built by OpenMined.
+ScreamingFace: an open-source AI ensemble toolkit (Claude/Gemini/Codex/Ollama) that beats
+single-model SOTA, runs locally, publishes to a public leaderboard. By OpenMined.
 
-## Repo Re-foundation (July 2026)
+**The full guide — skills, agents, cards, process, product context, history:
+`.claude/README.md`.** Repo routing: the `working-in-this-repo` skill.
 
-The legacy `apps/desktop` (Electron control plane) and `apps/server` (FastAPI plugin server, `sf` CLI) were **deprecated and removed**. The full pre-teardown tree — including the url4 engine, marketing site, infra manifests, and personas — is preserved at the git tag **`legacy-monorepo-2026-07-08`**. Do not resurrect code from those trees into the live repo; treat the tag as read-only reference.
+## Monorepo
 
-Being built next, as **separate packages with separate lifecycles and CI lanes** (names pending team lock-down, prefix `screamingface-*` or `sf-*`):
-
-- **Desktop app** — pure Electron (no bundled Python); detects and launches the server CLI if installed; brew-distributed, signed macOS/Windows/Linux builds.
-- **Server CLI** — Python (Typer), installable from PyPI.
-- **`packages/url4-python-sdk`** — url4 SDK, published as `url4` on PyPI (extraction source: the url4 executor under the legacy tag).
-
-## Monorepo Structure
-
-Polyglot monorepo: each component is self-contained (own toolchain, lockfile, CI lane, release lane).
-
-- `apps/aigateway` — LiteLLM-based unified AI gateway (Python, uv). Provider OAuth, encrypted credential store.
-- `apps/scoreboard` — benchmark scoreboard service + demo portal (Python, uv). Portal assets and public eval artifacts live inside the app (`portal/`, `artifacts/`).
-- `packages/` — shared libraries consumed by ≥2 components, **not** independently deployed (none exist yet; `url4-python-sdk` lands here first).
-- `docs/` — AI-agentic decision records: plans, specs, and future decision docs (being extended). Local scratch drafts go to gitignored `.docs/`.
-
-**Working across components** — which app to touch, which CI runs, who reviews, the branch/PR/release lane, and how to add a new component in any stack: see the **`working-in-this-repo`** skill (`.claude/skills/working-in-this-repo/`).
-
-## The Four App Screens
-- **Settings** — configure which AI models are in the ensemble
-- **Spend** — view/manage token usage and cost across all models
-- **Eval Studio** — run benchmark evals against available models, view results
-- **Cache/Log** — browse, search, filter cached AI queries; delete entries; view stats
-
-## Team
-- **Bennett** — design lead
-- **Sergey** — Electron packaging, local microservices (localhost backends)
-- **Kevin** — app backend, url4 protocol
-- **Trask** — product owner
-
-## Key Concepts
-- **url4** — custom protocol; encodes AI task chains as human-readable URLs (DAG-based)
-- **Enclave** — secure cloud server running model runners and cache
-- **Ensemble** — combining multiple AI models for better results than any single model
-- **SOTA** — State of the Art benchmark accuracy scores we're trying to beat
-
-## Architecture Principles
-
-These are **mandatory** for all code in this repo. PRs that violate them must be fixed before merge.
-
-- **DRY** — Don't Repeat Yourself. Extract shared logic; never copy-paste implementations across modules.
-- **SOLID** — all five principles apply, but most load-bearing here:
-  - **S**ingle Responsibility — one reason to change per module/class.
-  - **O**pen/Closed — extend via new plugins, not by editing core.
-  - **L**iskov Substitution — plugin implementations must be interchangeable behind their interface.
-  - **I**nterface Segregation — many small interfaces beat one fat one.
-  - **D**ependency Inversion — high-level (core) depends on abstractions; low-level (plugins) implement them.
-- **Dependency direction (Clean Architecture / Hexagonal / Ports & Adapters):**
-  - **Core MUST NOT import from plugins/adapters.** Plugins import from core, never the reverse.
-  - Core defines interfaces ("ports"); plugins/adapters implement them.
-  - Discovery/wiring of plugins happens via a registry, not via direct imports in core.
-- **AIGateway credential storage:** `apps/aigateway` uses ORMStore through Tortoise (`credential_blobs`): SQLite locally, Postgres in hosted/prod. No OS keychain/libsecret/Credential Manager usage in AIGateway.
+- `apps/aigateway` — LiteLLM-based AI gateway (Python, uv)
+- `apps/scoreboard` — benchmark scoreboard + portal (Python, uv)
+- `packages/` — shared libs (reserved; `url4-python-sdk` first)
+- `web/public` — static site → GitHub Pages (screamingface.ai)
+- `docs/` — SDLC artifacts: `spec/ plan/ tasks/ work/ diagrams/` (see `docs/README.md`)
+- Legacy (desktop, server, url4 engine): tag `legacy-monorepo-2026-07-08` — read-only,
+  never resurrect from it.
 
 ## AI SDLC — MANDATORY
 
-Full process: `task-management` skill (work items) + `sdlc-*` skills (per-stack loop) +
-cards `.claude/task-board.local.md` / `.claude/sdlc.local.md`. These rules always hold:
+Process: `task-management` skill + `sdlc-*` skills + cards `.claude/task-board.local.md` /
+`.claude/sdlc.local.md`. Always:
 
-0. **95% confidence gate — TOP RULE.** Never write, assert, or implement anything you are
-   not ≥95% confident is both correct AND wanted. Below 95% → STOP and ask first. Applies
-   to every rule below and every artifact: code, work items, docs, diagrams.
-1. **Work item first.** All work starts as a Linear issue (`OME-N`) in the Engineering
-   team, attached to the **😱 ScreamingFace V1** project, carrying its labels (workstream
-   from the `Epic` group when it belongs to one; `app/*`/`pkg/*` or `repo` for landing;
-   one `who-acts`; one `actor` — agentic|human, mandatory) plus a mirror
-   `docs/tasks/YYYY-MM-DD-<name>.md`. At finish, close status in BOTH Linear and the mirror.
-2. **Work ledger.** Every finished unit has `docs/work/YYYY-MM-DD-<ticket-id>-<desc>.md`
-   (created at work start from `docs/work/TEMPLATE.md`, outcome filled at finish — see the
-   sdlc skills).
-3. **Spec before plan, plan before code.** A `docs/spec/` artifact is required before
-   planning; a `docs/plan/` artifact before implementation. Produce them via
-   `superpowers:brainstorming` → `superpowers:writing-plans` (or equivalent); local scratch
-   drafts go to gitignored `.docs/`. Reach ≥95% confidence before proposing a plan/spec,
-   and never start implementation until the user explicitly approves it in plain words.
-4. **Diagrams.** Propose the diagramming plugin
-   (https://github.com/sergio-bershadsky/ai/tree/main/plugins/diagramming) when it's
-   absent; assets live in `docs/diagrams/` (SVG source + PNG).
-5. **Branches/commits.** Branch `OME-N-<desc>` (e.g. `OME-12-fix-refresh`). Conventional
-   commits; body carries `Refs: OME-N`; never `Co-Authored-By`; never commit directly to
-   `main` — enforced by branch protection plus the local pre-commit guard
-   (`.githooks/pre-commit`).
-6. **Asana boundary.** Asana is READ-ONLY product/marketing input (`asana-product` skill).
-   Technical work items never go to Asana.
-7. **Cross-cutting work.** Touching ≥2 apps/packages → epic with its workstream (`Epic`
-   group) label + all affected `app/*`/`pkg/*` labels, one sub-issue per affected
-   app/package. Never a single-app filing, never one mega-ticket.
-8. **Linear via MCP only.** All Linear operations go through the Linear MCP plugin
-   (activate via `/mcp`). API tokens and raw GraphQL are forbidden; operations the MCP
-   cannot perform are owner actions in the Linear UI.
+0. **95% confidence gate — TOP RULE.** Below 95% confident it's correct AND wanted →
+   STOP and ask. Applies to everything: code, work items, docs, diagrams.
+1. **Work item first.** Every unit of work is a Linear issue (`OME-N`, Engineering team,
+   😱 ScreamingFace V1 project) with its labels (workstream when applicable;
+   `app/*`/`pkg/*` or `repo`; one `who-acts`; one `actor` — agentic|human, mandatory) +
+   a mirror in `docs/tasks/`. Close status in BOTH at finish.
+2. **Work ledger.** Every unit has `docs/work/YYYY-MM-DD-<ticket-id>-<desc>.md` — created
+   at work START from `docs/work/TEMPLATE.md`, outcome filled at finish.
+3. **Spec before plan, plan before code.** `docs/spec/` then `docs/plan/` artifacts are
+   hard prerequisites (superpowers brainstorming → writing-plans; scratch in gitignored
+   `.docs/`). Implementation starts only on explicit approval in plain words.
+4. **Diagrams** → `docs/diagrams/` (SVG + PNG); propose the diagramming plugin
+   (https://github.com/sergio-bershadsky/ai/tree/main/plugins/diagramming) if absent.
+5. **Branches/commits.** `OME-N-<desc>`; conventional commits; body `Refs: OME-N`;
+   never `Co-Authored-By`; never commit to `main` (`.githooks/pre-commit` + protection).
+6. **Asana is READ-ONLY** product/marketing input (`asana-product` skill). Technical work
+   never goes to Asana.
+7. **Cross-cutting** (≥2 apps/packages) → epic + one sub-issue per affected app/package.
+   Never one mega-ticket.
+8. **Linear via MCP only** (`/mcp` to activate). API tokens / raw GraphQL are forbidden;
+   MCP-uncovered operations are owner actions in the Linear UI.
 
-### Setup (one-time)
+## Architecture — MANDATORY
 
-After cloning, activate the shared git hooks:
+- DRY · SOLID · hexagonal: core defines ports; plugins/adapters implement them; **core
+  never imports plugins**; wiring via registry, not direct imports.
+- AIGateway credentials: ORMStore/Tortoise `credential_blobs` only (AES-256-GCM via
+  SecretStoreMixin); no OS keychain; `AIGATEWAY_SECRET_KEY` never stored or logged.
+
+## Setup (one-time)
 
 ```sh
 git config core.hooksPath .githooks
 ```
-
-This enables the pre-commit hook that blocks direct commits to `main`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,28 +59,42 @@ These are **mandatory** for all code in this repo. PRs that violate them must be
   - Discovery/wiring of plugins happens via a registry, not via direct imports in core.
 - **AIGateway credential storage:** `apps/aigateway` uses ORMStore through Tortoise (`credential_blobs`): SQLite locally, Postgres in hosted/prod. No OS keychain/libsecret/Credential Manager usage in AIGateway.
 
-## Git Workflow
+## AI SDLC — MANDATORY
 
-### Commit Rules
+Full process: `task-management` skill (work items) + `sdlc-*` skills (per-stack loop) +
+cards `.claude/task-board.local.md` / `.claude/sdlc.local.md`. These rules always hold:
 
-- **Before every commit**, ask the user for the associated Asana ticket.
-- If no ticket exists, create one via the `/asana` command (default project `1213628819033917`). The `SF` custom field (GID `1213703035415126`) is **auto-assigned** by an Asana rule — do **not** set it manually. Read the assigned `SF-N` back from the created task (poll its `custom_fields`) and use it for the branch name.
-- **Branch naming:** `SF-{n}-{description}` (e.g. `SF-22-fix-auth-bug`). Derive from the ticket's SF field value.
-- If on the wrong branch, ask to create/switch to the correct one before committing.
-- **Never commit directly to `main`** — enforced by branch protection (authoritative) plus the local pre-commit guard (`.githooks/pre-commit`).
-- Include the Asana task permalink in the commit message body.
-
-## Planning Tickets
-
-When the user asks to **plan a ticket** (or any non-trivial task):
-
-- **Always use the agentic superpowers team for planning.** Use `superpowers:brainstorming` first, then `superpowers:writing-plans` (or the equivalent `write-plan` / `brainstorm` skills). Dispatch parallel agents (`superpowers:dispatching-parallel-agents`) for independent research as needed.
-- **Write output to disk** in this project:
-  - **Plans** → `docs/plan/`
-  - **Specs** → `docs/spec/`
-  - Local scratch drafts (not for commit) → `.docs/` (gitignored)
-- **Reach ≥95% confidence before proposing the plan/spec for review.** Iterate — re-read source files, dispatch more research agents, ask the user targeted questions — until you can honestly claim ≥95% confidence in the plan's correctness, completeness, and feasibility. State the confidence level explicitly when presenting.
-- **Never switch to implementation until the user explicitly approves the plan.** Writing the plan to disk and presenting it is the end of the planning phase. Do not start editing code, creating branches, or executing the plan until the user says so in plain words. Implicit cues ("looks good", "thanks") are not approval — wait for an explicit go-ahead.
+0. **95% confidence gate — TOP RULE.** Never write, assert, or implement anything you are
+   not ≥95% confident is both correct AND wanted. Below 95% → STOP and ask first. Applies
+   to every rule below and every artifact: code, work items, docs, diagrams.
+1. **Work item first.** All work starts as a Linear issue (`OME-N`) in the Engineering
+   team, attached to the **😱 ScreamingFace V1** project, carrying its labels (workstream
+   from the `Epic` group when it belongs to one; `app/*`/`pkg/*` or `repo` for landing;
+   one `who-acts`; one `actor` — agentic|human, mandatory) plus a mirror
+   `docs/tasks/YYYY-MM-DD-<name>.md`. At finish, close status in BOTH Linear and the mirror.
+2. **Work ledger.** Every finished unit has `docs/work/YYYY-MM-DD-<ticket-id>-<desc>.md`
+   (created at work start from `docs/work/TEMPLATE.md`, outcome filled at finish — see the
+   sdlc skills).
+3. **Spec before plan, plan before code.** A `docs/spec/` artifact is required before
+   planning; a `docs/plan/` artifact before implementation. Produce them via
+   `superpowers:brainstorming` → `superpowers:writing-plans` (or equivalent); local scratch
+   drafts go to gitignored `.docs/`. Reach ≥95% confidence before proposing a plan/spec,
+   and never start implementation until the user explicitly approves it in plain words.
+4. **Diagrams.** Propose the diagramming plugin
+   (https://github.com/sergio-bershadsky/ai/tree/main/plugins/diagramming) when it's
+   absent; assets live in `docs/diagrams/` (SVG source + PNG).
+5. **Branches/commits.** Branch `OME-N-<desc>` (e.g. `OME-12-fix-refresh`). Conventional
+   commits; body carries `Refs: OME-N`; never `Co-Authored-By`; never commit directly to
+   `main` — enforced by branch protection plus the local pre-commit guard
+   (`.githooks/pre-commit`).
+6. **Asana boundary.** Asana is READ-ONLY product/marketing input (`asana-product` skill).
+   Technical work items never go to Asana.
+7. **Cross-cutting work.** Touching ≥2 apps/packages → epic with its workstream (`Epic`
+   group) label + all affected `app/*`/`pkg/*` labels, one sub-issue per affected
+   app/package. Never a single-app filing, never one mega-ticket.
+8. **Linear via MCP only.** All Linear operations go through the Linear MCP plugin
+   (activate via `/mcp`). API tokens and raw GraphQL are forbidden; operations the MCP
+   cannot perform are owner actions in the Linear UI.
 
 ### Setup (one-time)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,15 +61,18 @@ Gateway-specific:
 
 ## Git workflow
 
-- **Branch naming:** `SF-{n}-{description}` (e.g. `SF-344-contributing-guide`),
-  where `{n}` is the Asana ticket's `SF` number.
+- **Work item first.** Every unit of work is a Linear issue (`OME-N`) — see the
+  `task-management` skill and the "AI SDLC" section of [`CLAUDE.md`](CLAUDE.md).
+- **Branch naming:** `OME-N-<description>` (e.g. `OME-12-fix-refresh`), where
+  `N` is the Linear work-item number.
 - **Never commit directly to `main`.** The `.githooks/pre-commit` hook (enabled
   above) blocks it; branch protection enforces it remotely.
 - **Conventional commits.** Use `feat:`, `fix:`, `docs:`, `chore:` etc. —
   release-please derives version bumps and changelogs from them (`feat:` →
-  minor, `fix:` → patch; `docs:`/`chore:` don't bump).
+  minor, `fix:` → patch; `docs:`/`chore:` don't bump). The body carries
+  `Refs: OME-N`.
 - **PRs:** squash-merge after review approval + green required checks. Include
-  the Asana permalink, a summary, and a test plan in the body.
+  the Linear work-item link, a summary, and a test plan in the body.
 - **Architecture is enforced.** DRY/SOLID/hexagonal are mandatory — see the
   "Architecture Principles" section of [`CLAUDE.md`](CLAUDE.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,10 +6,10 @@ by/with AI agents:
 - `docs/spec/`     — designs/specs (required before planning)
 - `docs/plan/`     — implementation plans (required before implementation)
 - `docs/diagrams/` — diagram assets (SVG source + PNG)
-- `docs/tasks/`    — work-item mirrors (arrive with the AI SDLC implementation)
-- `docs/work/`     — work ledgers (arrive with the AI SDLC implementation)
+- `docs/tasks/`    — work-item mirrors (`YYYY-MM-DD-<name>.md`, frontmatter; Linear is authority)
+- `docs/work/`     — work ledgers (`YYYY-MM-DD-<ticket-id>-<desc>.md`, created at work start; copy `TEMPLATE.md`)
 
-Process: `docs/spec/2026-07-08-ai-sdlc-adoption-spec.md` + its plan in `docs/plan/`.
+Process: the `task-management` + `sdlc-*` skills, the cards in `.claude/`, and CLAUDE.md "AI SDLC".
 Local scratch drafts that shouldn't be committed go to `.docs/` (gitignored).
 
 The previous `docs/` tree (architecture, setup, glossary, superpowers plans)

--- a/docs/plan/2026-07-08-ai-sdlc-adoption.md
+++ b/docs/plan/2026-07-08-ai-sdlc-adoption.md
@@ -244,7 +244,7 @@ Linear converts Markdown to its rich-text editor model. When writing via API/MCP
 
 ---
 
-### Task 8: `sdlc-python` + `sdlc-react` skills
+### Task 8: `sdlc-python` + `sdlc-electron` skills
 
 **Files:** Create both from `$SRC/skills/<name>/SKILL.md`
 
@@ -253,7 +253,7 @@ Linear converts Markdown to its rich-text editor model. When writing via API/MCP
   2. Rule 1 ledger → `(copy docs/work/TEMPLATE.md; this repo: docs/work/, named YYYY-MM-DD-<ticket-id>-<desc>.md per D8)`.
   3. Sibling references: name only the adopted pair; drop `sdlc-go` mentions.
 - [ ] **Step 8.2:** Stack sections stay verbatim.
-- [ ] **Step 8.3:** Parity check green (Task 10 script). Commit: `git add .claude/skills/sdlc-* && git commit -m "feat(OME-E): sdlc-python + sdlc-react rigid-loop skills" -m "Refs: OME-E"`
+- [ ] **Step 8.3:** Parity check green (Task 10 script). Commit: `git add .claude/skills/sdlc-* && git commit -m "feat(OME-E): sdlc-python + sdlc-electron rigid-loop skills" -m "Refs: OME-E"`
 
 ---
 
@@ -270,7 +270,7 @@ Linear converts Markdown to its rich-text editor model. When writing via API/MCP
 ### Task 10: Scripts
 
 - [ ] **Step 10.1:** `cp $SRC/scripts/run_gates.py .claude/scripts/run_gates.py` (verbatim); smoke-test: `uv run .claude/scripts/run_gates.py aigateway` and `… scoreboard` → ALL GATES GREEN.
-- [ ] **Step 10.2:** Write `.claude/scripts/check_loop_parity.py` — the plugin's parity script with `ROOT = pathlib.Path(__file__).resolve().parent.parent`, `SKILLS = ["sdlc-python","sdlc-react"]`, `path = ROOT / "skills" / name / "SKILL.md"`; rest byte-identical.
+- [ ] **Step 10.2:** Write `.claude/scripts/check_loop_parity.py` — the plugin's parity script with `ROOT = pathlib.Path(__file__).resolve().parent.parent`, `SKILLS = ["sdlc-python","sdlc-electron"]`, `path = ROOT / "skills" / name / "SKILL.md"`; rest byte-identical.
 - [ ] **Step 10.3:** `python3 .claude/scripts/check_loop_parity.py` → `LOOP PARITY OK …`.
 - [ ] **Step 10.4:** Commit: `git add .claude/scripts && git commit -m "feat(OME-E): run_gates + loop-parity scripts" -m "Refs: OME-E"`
 

--- a/docs/plan/2026-07-08-ai-sdlc-adoption.md
+++ b/docs/plan/2026-07-08-ai-sdlc-adoption.md
@@ -2,121 +2,44 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Adopt the Linear-based AI SDLC per `docs/spec/2026-07-08-ai-sdlc-adoption-spec.md` — one Linear team (`OM-N` IDs) with an `app/*`/`pkg/*`/`com/*` label matrix as system of record, repo-local skills/cards/agents/scripts, mandatory docs artifacts.
+**Goal:** Adopt the Linear-based AI SDLC per `docs/spec/2026-07-08-ai-sdlc-adoption-spec.md` — work items as `OME-N` in the existing Engineering team under the 😱 ScreamingFace V1 project, an `app/*`/`pkg/*`/`com/*` label matrix, repo-local skills/cards/agents/scripts, mandatory docs artifacts.
 
-**Architecture:** Single Linear team `OM` = one ID sequence; labels place the work (D10 taxonomy); two committed cards (`.claude/task-board.local.md`, `.claude/sdlc.local.md`) parameterize four skills (`asana-product`, `task-management`, `sdlc-python`, `sdlc-react`), two agents, and two scripts adapted from the installed sdlc plugin.
+**Architecture:** One ID sequence (`OME-N`, existing team — D2); labels place the work (D10) with the mandatory `actor` group agentic|human (D13); STOPs are labels, not states (D12); every item attaches to the ScreamingFace V1 project (D11). Two committed cards parameterize four skills, two agents, and two scripts adapted from the installed sdlc plugin.
 
-**Tech Stack:** Linear GraphQL API (curl), markdown skills/cards, Python (uv, PEP-723) scripts, GitHub Actions.
+**Tech Stack:** Linear MCP plugin (the ONLY Linear transport — D4; API tokens/GraphQL forbidden), markdown skills/cards, Python (uv, PEP-723) scripts, GitHub Actions.
 
 **Source plugin (copy-from):** `SRC=/Users/sergey/.claude/plugins/cache/socket0-claude/sdlc/0.1.0`
-**Spec:** `docs/spec/2026-07-08-ai-sdlc-adoption-spec.md` (decisions D1–D10)
+**Spec:** `docs/spec/2026-07-08-ai-sdlc-adoption-spec.md` (decisions D1–D13)
 
-**Terminology (binding for all authored text):** ONE team, one sequence — every work item is
-`OM-N`. `app/[name]`, `pkg/[name]`, `com/[name]` are plain multi-value labels; `type` and
-`who-acts` are Linear label groups. "Team" appears only where it names the Linear API object
-(`teamId`, `teamCreate`).
+**Terminology (binding for all authored text):** ONE team; every work item is `OME-N`.
+Labels place the work. "Team" appears only where it names the Linear object.
 
 ---
 
-### Task 0: Preconditions
+### Task 0: Preconditions — DONE 2026-07-08
 
-- [ ] **Step 0.1: Verify Linear API key**
+- [x] **Linear MCP activated in Claude** — `/mcp` → `plugin:linear:linear` authenticated. This is THE precondition: ALL Linear operations go through MCP tools (`save_issue`, `save_comment`, `create_issue_label`, `list_*`). **API tokens / raw GraphQL are FORBIDDEN**; operations the MCP cannot perform (label delete, team create, workflow states) are OWNER actions in the Linear UI.
+- [x] Source plugin present at `$SRC`.
+- [x] Workspace facts confirmed: team **Engineering** key `OME` id `5f4d721f-4452-4ed1-990a-7cdbcd923508`; project **😱 ScreamingFace V1** id `7cbe5759-cc07-476d-b81e-da05b6b2d4d7` (slug `screamingface-v1-27666092fc7f`); states Todo `88de5fec…` / In Progress `03621515…` / In Review `62b4c1a3…` / Done `699b96ac…` / Triage `a6fc6a19…` (full map in `.docs/linear-bootstrap-ids.md`).
 
-```bash
-export $(grep LINEAR_API_KEY ~/.config/linear/.env | xargs)
-curl -s -H "Authorization: $LINEAR_API_KEY" -H "Content-Type: application/json" \
-  -d '{"query":"{ viewer { id name email } }"}' https://api.linear.app/graphql
-```
-Expected: JSON with viewer name/email. 401 → mint a key at linear.app → Settings → API, store as `LINEAR_API_KEY=lin_api_…` in `~/.config/linear/.env` (`chmod 600`).
+### Task 1: Linear bootstrap — labels — **DONE 2026-07-08 (taxonomy LOCKED: align + extend)**
 
-- [ ] **Step 0.2: Verify source plugin present**
+- [x] Taxonomy locked (D10): existing `Epic` group children = workstream axis; existing `blocked ⛔` reused; plain `Bug`/`Feature`/`Improvement` reused for type-ish tagging.
+- [x] Labels in place (survivors of the earlier trial, now canonical): `actor` group (agentic/human — D13), `who-acts` group (design-session/autonomous/deferred), `app/aigateway`, `app/scoreboard`, `pkg/url4-python-sdk`, `repo`, `needs-owner`. (`app/desktop`, `app/cli` wait for name lock — spec §7.)
+- [x] IDs recorded in `.docs/linear-bootstrap-ids.md` (source for Task 3's card).
+- [ ] **Owner UI cleanup:** delete obsolete trial labels — `com/url4`, `com/evalstudio`, `com/ensemble`, `com/credentials`, the `type` group (children task/decision), plain `blocked`.
 
-```bash
-ls $SRC/skills/sdlc-python/SKILL.md $SRC/agents/sdlc-unit-executor.md $SRC/scripts/run_gates.py $SRC/templates/task-board.local.md
-```
-Expected: all four paths listed.
+### Task 2: Adoption epic + sub-issues — FILED 2026-07-08
 
----
-
-### Task 1: Linear bootstrap — team `OM`, states, labels
-
-**Files:** Create: `.docs/linear-bootstrap-ids.md` (scratch, gitignored — IDs for Task 3)
-
-- [ ] **Step 1.1: Create (or confirm) the team**
-
-```bash
-curl -s -H "Authorization: $LINEAR_API_KEY" -H "Content-Type: application/json" -d '{
-  "query": "mutation{ teamCreate(input:{name:\"OpenMined\",key:\"OM\"}){ team { id key name } } }"
-}' https://api.linear.app/graphql
-```
-Expected: `team.id` UUID. Key already exists → `{"query":"{ teams { nodes { id key } } }"}` and reuse. Record the ID.
-
-- [ ] **Step 1.2: Add `Blocked` and `Needs Owner` workflow states**
-
-```bash
-curl -s -H "Authorization: $LINEAR_API_KEY" -H "Content-Type: application/json" -d '{
-  "query": "mutation($t:String!,$n:String!,$c:String!){ workflowStateCreate(input:{teamId:$t,name:$n,type:\"started\",color:$c}){ workflowState { id name } } }",
-  "variables": {"t":"<TEAM_ID>","n":"Blocked","c":"#eb5757"}
-}' https://api.linear.app/graphql
-```
-Repeat with `"n":"Needs Owner","c":"#f2994a"`. Then dump the full state map and record Todo / In Progress / Blocked / Needs Owner / Done IDs:
-
-```bash
-curl -s -H "Authorization: $LINEAR_API_KEY" -H "Content-Type: application/json" \
-  -d '{"query":"{ teams { nodes { key states { nodes { id name type } } } } }"}' https://api.linear.app/graphql
-```
-
-- [ ] **Step 1.3: Create plain labels** — `app/aigateway`, `app/scoreboard`, `pkg/url4-python-sdk`, `com/url4`, `com/evalstudio`, `com/ensemble`, `com/credentials`, `repo`:
-
-```bash
-curl -s -H "Authorization: $LINEAR_API_KEY" -H "Content-Type: application/json" -d '{
-  "query": "mutation($n:String!){ issueLabelCreate(input:{name:$n}){ issueLabel { id name } } }",
-  "variables": {"n":"app/aigateway"}
-}' https://api.linear.app/graphql
-```
-(`app/desktop`, `app/cli` are NOT created — they wait for name lock, spec §7.)
-
-- [ ] **Step 1.4: Create label GROUPS `type` and `who-acts`** — create the parent, then children with `parentId`:
-
-```bash
-# parent (group)
-… issueLabelCreate(input:{name:"type"}) …                                   # → <TYPE_GROUP_ID>
-# children
-… issueLabelCreate(input:{name:"epic",parentId:"<TYPE_GROUP_ID>"}) …        # repeat: feature, bug, task, decision
-… issueLabelCreate(input:{name:"who-acts"}) …                               # → <WHO_GROUP_ID>
-… issueLabelCreate(input:{name:"design-session",parentId:"<WHO_GROUP_ID>"}) …  # repeat: autonomous, deferred
-```
-Verify grouping in the Linear UI: children render as `type → epic` and the group enforces one-per-issue. Record all label IDs in `.docs/linear-bootstrap-ids.md`.
-
----
-
-### Task 2: File the adoption epic; create the branch
-
-- [ ] **Step 2.1: Create the epic**
-
-```bash
-curl -s -H "Authorization: $LINEAR_API_KEY" -H "Content-Type: application/json" -d '{
-  "query": "mutation($i:IssueCreateInput!){ issueCreate(input:$i){ issue { id identifier url } } }",
-  "variables": {"i": {"teamId":"<TEAM_ID>","title":"AI SDLC adoption — Linear work items, repo skills, docs artifacts","labelIds":["<repo>","<type/epic>","<who-acts/autonomous>"],"priority":2,"description":"Spec: docs/spec/2026-07-08-ai-sdlc-adoption-spec.md — implement per docs/plan/2026-07-08-ai-sdlc-adoption.md"}}
-}' https://api.linear.app/graphql
-```
-Expected: identifier `OM-<n>` (call it `OM-E` below; likely `OM-1`). Create sub-issues (same mutation + `"parentId":"<epic id>"`, labels `repo` + `type/task` + `autonomous`) titled: `Cards + CLAUDE.md`, `Skills`, `Agents + scripts + CI`, `Backfill work items`.
-
+- [x] **Epic `OME-358`** + sub-issues `OME-359` (cards+docs+CLAUDE.md), `OME-360` (skills), `OME-361` (agents+scripts+CI), `OME-362` (backfill, deferred) — team Engineering, project 😱 ScreamingFace V1, labels `repo`+`agentic`+`autonomous`, priority High. Everywhere below, `OME-E` = **OME-358**.
 - [ ] **Step 2.2: Branch**
 
 ```bash
-git checkout main && git pull --ff-only && git checkout -b OM-E-ai-sdlc-adoption
+git checkout main && git pull --ff-only && git checkout -b OME-E-ai-sdlc-adoption
 ```
-(Substitute the real number, e.g. `OM-1-ai-sdlc-adoption`.) NOTE: this PR bootstraps the convention it documents — the branch uses the NEW format while CLAUDE.md still says SF-N until Task 5 lands. Deliberate one-time exception; state it in the PR body.
+(Substitute the epic's real number.) NOTE: this PR bootstraps the convention it documents — deliberate one-time exception; state it in the PR body.
 
-- [ ] **Step 2.3: Epic → In Progress**
-
-```bash
-curl -s -H "Authorization: $LINEAR_API_KEY" -H "Content-Type: application/json" -d '{
-  "query": "mutation($id:String!,$s:String!){ issueUpdate(id:$id,input:{stateId:$s}){ issue { identifier state { name } } } }",
-  "variables": {"id":"<EPIC_ID>","s":"<In Progress state id>"}
-}' https://api.linear.app/graphql
-```
+- [ ] **Step 2.3:** Epic → In Progress via MCP: `save_issue {id: "OME-E", state: "In Progress"}`.
 
 ---
 
@@ -129,19 +52,22 @@ curl -s -H "Authorization: $LINEAR_API_KEY" -H "Content-Type: application/json" 
 ```markdown
 ---
 system: linear
-workspace: <workspace-slug>
-key_source: ~/.config/linear/.env   # LINEAR_API_KEY
-endpoint: https://api.linear.app/graphql
-team: { key: OM, id: "<uuid>" }
-states: { todo: "<id>", in_progress: "<id>", blocked: "<id>", needs_owner: "<id>", done: "<id>" }
+workspace: openmined
+transport: "Linear MCP plugin (plugin:linear) — the ONLY transport; PRECONDITION: activate via /mcp. API tokens/GraphQL FORBIDDEN; MCP-uncovered ops are owner UI actions"
+team: { key: OME, name: Engineering, id: "5f4d721f-4452-4ed1-990a-7cdbcd923508" }
+project: { name: "😱 ScreamingFace V1", slug: screamingface-v1-27666092fc7f, id: "7cbe5759-cc07-476d-b81e-da05b6b2d4d7" }
+states: { todo: "<id>", in_progress: "<id>", in_review: "<id>", done: "<id>", triage: "<id>" }
 labels:
-  apps: { aigateway: "<id>", scoreboard: "<id>" }   # app/desktop, app/cli at name lock
-  pkgs: { url4-python-sdk: "<id>" }
-  coms: { url4: "<id>", evalstudio: "<id>", ensemble: "<id>", credentials: "<id>" }
-  repo: "<id>"
-  types: { group: "<id>", epic: "<id>", feature: "<id>", bug: "<id>", task: "<id>", decision: "<id>" }
+  epic_group:   # existing workstream axis (one per issue) — adopted as-is (D10)
+    url4-engine: "<id>", ai-gateway: "<id>", eval-runner-datasets: "<id>", results-runs: "<id>",
+    leaderboard: "<id>", auth-subsidized-compute: "<id>", desktop-app: "<id>", python-sdk: "<id>",
+    multi-turn-ensembles: "<id>", sota-hunt: "<id>", compute-budgeting: "<id>"
+  landing: { app/aigateway: "<id>", app/scoreboard: "<id>", pkg/url4-python-sdk: "<id>", repo: "<id>" }  # app/desktop, app/cli at name lock
+  stop: { blocked: "<blocked ⛔ id>", needs-owner: "<id>" }   # D12: labels + comment, not states
   who_acts: { group: "<id>", design-session: "<id>", autonomous: "<id>", deferred: "<id>" }
-priority: { P1: 2, P2: 3, P3: 4 }   # Linear ints: 1 urgent (incidents only), 2 high, 3 medium, 4 low
+  actor: { group: "<id>", agentic: "<id>", human: "<id>" }    # D13: MANDATORY, one per item
+  type_ish: { bug: "<Bug id>", feature: "<Feature id>", improvement: "<Improvement id>" }  # existing plain labels, optional
+priority: { P1: 2, P2: 3, P3: 4 }   # Linear ints: 1 urgent (incidents only)
 close_template: |
   Commits: <sha> <message>[, …]
   Gates: <run_gates.py summary / test counts>
@@ -152,11 +78,16 @@ close_template: |
 
 # Ticket rules (bind alongside the task-management skill)
 
+- Every work item: team Engineering + project 😱 ScreamingFace V1 (D11) + exactly one
+  `type` label + one `who-acts` label + one `actor` label (agentic|human — D13, mandatory).
 - Labels place the work: `app/*`/`pkg/*` = WHERE (multi-value), `com/*` = product component
   (open set — PRODUCT concepts, never internal modules), `repo` = process work (no app/pkg).
-  One `type/*` + one who-acts label per issue (Linear groups enforce it).
 - D9: ≥2 app/pkg labels → cross-component epic (`com/X` + all affected labels) with one
   sub-issue per affected app/package. Never a single-app filing, never one mega-ticket.
+- D12 STOPs: apply `blocked` or `needs-owner` label + comment stating the exact question;
+  issue stays In Progress; remove the label when resolved. Never add states to the shared team.
+- MCP quirk: `save_issue.labels` REPLACES the whole set — read current labels, resend the
+  union. Relations (blockedBy/relatedTo) are append-only.
 - New app/package/component ⇒ its label created AND registered here in the same change.
 - Every work item gets a mirror `docs/tasks/YYYY-MM-DD-<name>.md` at create; status closed
   in BOTH Linear and the mirror at finish. Linear is the status authority.
@@ -164,7 +95,7 @@ close_template: |
   description (`asana_url` in the mirror frontmatter). Technical work NEVER goes to Asana.
 ```
 
-- [ ] **Step 3.2: Write `.claude/sdlc.local.md`**:
+- [ ] **Step 3.2: Write `.claude/sdlc.local.md`** — unchanged from spec §3.2:
 
 ```markdown
 ---
@@ -188,7 +119,7 @@ stacks:
       - uv run ruff format --check
       - uv run pyright
       - uv run pytest --cov=scoreboard --cov-fail-under=80 -q
-commit_refs: "Refs: OM-N"
+commit_refs: "Refs: OME-N"
 extra_anchors: []
 companion_skills:
   - skill: tortoise-dev
@@ -219,55 +150,38 @@ Template: copy docs/work/TEMPLATE.md.
 
 ```bash
 git add .claude/task-board.local.md .claude/sdlc.local.md
-git commit -m "feat(OM-E): add task-board + sdlc cards (Linear registry, stack gates)" -m "Refs: OM-E"
+git commit -m "feat(OME-E): add task-board + sdlc cards (Linear registry, stack gates)" -m "Refs: OME-E"
 ```
 
 ---
 
-### Task 4: docs tree + artifact placement (+ dogfood mirror/ledger)
+### Task 4: docs tree + dogfood mirror/ledger
 
 **Files:**
-- Create: `docs/tasks/`, `docs/work/` (`docs/spec/`, `docs/plan/`, `docs/diagrams/` landed with SF-348)
-- Create: `docs/work/TEMPLATE.md` (copy `$SRC/templates/work-ledger/TEMPLATE.md`)
-- Modify: `docs/README.md`
-- Create: `docs/tasks/2026-07-08-ai-sdlc-adoption.md`, `docs/work/2026-07-08-OM-E-ai-sdlc-adoption.md`
+- Create: `docs/tasks/`, `docs/work/`; `docs/work/TEMPLATE.md` (copy `$SRC/templates/work-ledger/TEMPLATE.md`)
+- Modify: `docs/README.md` (mark tasks/work as live)
+- Create: `docs/tasks/2026-07-08-ai-sdlc-adoption.md`, `docs/work/2026-07-08-OME-E-ai-sdlc-adoption.md`
 
-- [ ] **Step 4.1:** `mkdir -p docs/{tasks,work}`; `cp $SRC/templates/work-ledger/TEMPLATE.md docs/work/TEMPLATE.md`. (Diagram already at `docs/diagrams/work-item-topology.{svg,png}`.)
-- [ ] **Step 4.2:** Rewrite `docs/README.md`:
+- [ ] **Step 4.1:** `mkdir -p docs/{tasks,work}`; `cp $SRC/templates/work-ledger/TEMPLATE.md docs/work/TEMPLATE.md`.
+- [ ] **Step 4.2:** In `docs/README.md` drop the "(arrive with the AI SDLC implementation)" qualifiers.
+- [ ] **Step 4.3:** Mirror `docs/tasks/2026-07-08-ai-sdlc-adoption.md`:
 
-```markdown
-# docs/ — AI-agentic decision records & SDLC artifacts
-
-- `docs/tasks/`    — work-item mirrors (`YYYY-MM-DD-<name>.md`, frontmatter; Linear is authority)
-- `docs/work/`     — work ledgers (`YYYY-MM-DD-<ticket-id>-<desc>.md`, created at start — D8)
-- `docs/spec/`     — designs/specs (required before planning)
-- `docs/plan/`     — implementation plans (required before implementation)
-- `docs/diagrams/` — diagram assets (SVG source + PNG)
-
-Process: see the `task-management` + `sdlc-*` skills and CLAUDE.md "AI SDLC".
-Local scratch drafts go to gitignored `.docs/`.
-Pre-July-2026 docs live at tag `legacy-monorepo-2026-07-08`.
-```
-
-- [ ] **Step 4.3:** Create this work's own mirror + ledger (dogfooding):
-
-`docs/tasks/2026-07-08-ai-sdlc-adoption.md`:
 ```markdown
 ---
-id: OM-E
+id: OME-E
 linear_url: <epic url>
 status: in_progress
 type: epic
 priority: P1
-labels: [repo]
+labels: [repo, agentic, autonomous]
 created: 2026-07-08
 closed:
 ---
 Adopt the Linear AI SDLC per docs/spec/2026-07-08-ai-sdlc-adoption-spec.md.
 ```
-`docs/work/2026-07-08-OM-E-ai-sdlc-adoption.md`: from TEMPLATE, Intent/Planned/Test plan/Acceptance from this plan; Outcome at close.
+Ledger `docs/work/2026-07-08-OME-E-ai-sdlc-adoption.md`: from TEMPLATE, Intent/Planned/Test plan/Acceptance from this plan; Outcome at close.
 
-- [ ] **Step 4.4: Commit** — `git add docs && git commit -m "feat(OM-E): docs SDLC tree + spec, plan, topology diagram" -m "Refs: OM-E"`
+- [ ] **Step 4.4: Commit** — `git add docs && git commit -m "feat(OME-E): docs tasks/work tree + dogfood mirror and ledger" -m "Refs: OME-E"`
 
 ---
 
@@ -275,41 +189,8 @@ Adopt the Linear AI SDLC per docs/spec/2026-07-08-ai-sdlc-adoption-spec.md.
 
 **Files:** Modify: `CLAUDE.md`
 
-- [ ] **Step 5.1:** DELETE sections `## Git Workflow` (incl. `### Commit Rules`, `### Setup (one-time)`) and `## Planning Tickets`. INSERT:
-
-```markdown
-## AI SDLC — MANDATORY
-
-Full process: `task-management` skill (work items) + `sdlc-*` skills (per-stack loop) +
-cards `.claude/task-board.local.md` / `.claude/sdlc.local.md`. These rules always hold:
-
-0. **95% confidence gate — TOP RULE.** Never write, assert, or implement anything you are
-   not ≥95% confident is both correct AND wanted. Below 95% → STOP and ask first. Applies
-   to every rule below and every artifact: code, work items, docs, diagrams.
-1. **Work item first.** All work starts as a Linear issue (`OM-N`) carrying its labels —
-   `app/*`/`pkg/*` (where it lands) or `repo` (process work); `com/*` when a product
-   component is affected; exactly one `type/*` and one who-acts label — plus a mirror
-   `docs/tasks/YYYY-MM-DD-<name>.md` (frontmatter: id, linear_url, asana_url?, status,
-   type, priority, labels, created, closed). At finish, close status in BOTH.
-2. **Work ledger.** Every finished unit has `docs/work/YYYY-MM-DD-<ticket-id>-<desc>.md`
-   (created at work start, outcome filled at finish — see the sdlc skills).
-3. **Spec before plan, plan before code.** `docs/spec/` artifact required before planning;
-   `docs/plan/` artifact required before implementation. Prefer `/superpowers`
-   (brainstorming → writing-plans) or similar. Never plan or implement without them.
-4. **Diagrams.** Propose the diagramming plugin
-   (https://github.com/sergio-bershadsky/ai/tree/main/plugins/diagramming) when it's absent;
-   assets live in `docs/diagrams/` (SVG source + PNG).
-5. **Branches/commits.** Branch `OM-N-<desc>` (e.g. `OM-12-fix-refresh`). Conventional
-   commits; body carries `Refs: OM-N`; never `Co-Authored-By`; never commit to `main`
-   (branch protection + `.githooks/pre-commit`; one-time: `git config core.hooksPath .githooks`).
-6. **Asana boundary.** Asana is READ-ONLY product/marketing input (`asana-product` skill).
-   Technical work items never go to Asana.
-7. **Cross-cutting work (D9).** Touching ≥2 apps/packages → epic with `com/<component>` +
-   all affected `app/*`/`pkg/*` labels, one sub-issue per affected app/package. Never a
-   single-app filing, never one mega-ticket.
-```
-
-- [ ] **Step 5.2:** Commit: `git add CLAUDE.md && git commit -m "feat(OM-E): replace Asana git workflow with AI SDLC rules" -m "Refs: OM-E"`
+- [ ] **Step 5.1:** DELETE sections `## Git Workflow` (incl. subsections) and `## Planning Tickets`. INSERT the spec §4 rules VERBATIM (rules 0–7: 95% gate top rule; work item first — Engineering team + ScreamingFace V1 project + labels incl. one `actor` agentic|human; work ledger; spec-before-plan-before-code; diagramming plugin + docs/diagrams; branches `OME-N-<desc>` + `Refs: OME-N`, no Co-Authored-By, never commit to main; Asana read-only boundary; D9 cross-cutting rule).
+- [ ] **Step 5.2:** Commit: `git add CLAUDE.md && git commit -m "feat(OME-E): replace Asana git workflow with AI SDLC rules" -m "Refs: OME-E"`
 
 ---
 
@@ -317,46 +198,49 @@ cards `.claude/task-board.local.md` / `.claude/sdlc.local.md`. These rules alway
 
 **Files:** Create: `.claude/skills/asana-product/SKILL.md`
 
-- [ ] **Step 6.1:** Author from `~/.claude/skills/asana/SKILL.md`, keeping the API-access block (PAT discovery order, curl pattern, URL parsing) VERBATIM and the read operations (`my tasks`, `workspaces`, `projects`, `tasks <gid>`, `task <gid>`, `search`, `sections`). DELETE: `create`, `update`, `complete`, `move`. Frontmatter description: "Read-only view of product/marketing top-level tasks in Asana. Use to list/read/search product context. NEVER creates or updates anything in Asana." Add:
-
-```markdown
-## Hard rules
-
-- READ-ONLY. GET requests only. Any request to create, update, complete, or move an Asana
-  task → refuse and point to the `task-management` skill (Linear).
-- Asana holds product/marketing top-level tasks defined by product/marketing tooling —
-  a SOURCE of context, never a destination for technical work.
-- A dev work item descending from an Asana task records the Asana permalink in its Linear
-  description and mirror frontmatter (`asana_url`).
-```
-
-- [ ] **Step 6.2:** Commit: `git add .claude/skills/asana-product && git commit -m "feat(OM-E): asana-product read-only skill" -m "Refs: OM-E"`
+- [ ] **Step 6.1:** Author from `~/.claude/skills/asana/SKILL.md`: keep the API-access block (PAT discovery, curl pattern, URL parsing) VERBATIM and the read operations (`my tasks`, `workspaces`, `projects`, `tasks <gid>`, `task <gid>`, `search`, `sections`). DELETE `create`, `update`, `complete`, `move`. Frontmatter description: "Read-only view of product/marketing top-level tasks in Asana. NEVER creates or updates anything in Asana." Add the Hard rules block (read-only; Asana = source, never destination; `asana_url` linkage — spec §2.1).
+- [ ] **Step 6.2:** Commit: `git add .claude/skills/asana-product && git commit -m "feat(OME-E): asana-product read-only skill" -m "Refs: OME-E"`
 
 ---
 
-### Task 7: `task-management` skill — Linear rewrite
+### Task 7: `task-management` skill — Linear rewrite (MCP-first)
 
 **Files:** Create: `.claude/skills/task-management/SKILL.md`
 
-- [ ] **Step 7.1:** Author using `$SRC/skills/task-management/SKILL.md` as the structural source. Keep verbatim-in-spirit: announce line ("Using the task-management skill — the Linear work-item lifecycle."), card-resolution HARD STOP, single-task-holder rule, lifecycle (PLAN → TICKETS → OWNER REVIEW → PLAN ONE → IMPLEMENT → CLOSE → NEXT), batching, mid-session-discovery (file first, 30s), status-mapping moments, milestones→Linear projects (one per plan doc with 3+ items), close discipline, anti-pattern table. Replace: the affect matrix section → D10 label taxonomy (app/pkg/com plain multi-value; type/who-acts groups; `repo`); ticket-ID/code-registry section → "one team, `OM-N` native; the card's label registry is THE single label source"; D9 section per spec §1; source-board anti-pattern rows → label-discipline rows ("cross-cutting work with a single app label" → D9 STOP; "minting an unregistered label" → register in card first, same commit). Command crib:
+- [ ] **Step 7.1:** Author using `$SRC/skills/task-management/SKILL.md` as the structural source, per spec §2.2: announce line "Using the task-management skill — the Linear work-item lifecycle."; card-resolution HARD STOP; lifecycle; batching; mid-session-discovery; close discipline; anti-pattern table with label-discipline rows. Transport section: **MCP tools first** (`save_issue`, `save_comment`, `list_issues`, `list_issue_labels`, `create_issue_label`; team/project/labels/state by NAME, priority ints), with these encoded quirks: `labels` REPLACES the set (read-modify-write); relations append-only; every create sets `team: Engineering` + `project: 😱 ScreamingFace V1` + one type + one who-acts + one actor label. No token/GraphQL usage anywhere — MCP only; uncovered ops go to the owner (D4). D12 STOP mechanics (label + comment). 
+
+- [ ] **Step 7.2: Include this "Linear rich text" reference section VERBATIM in the skill** (research 2026-07-08 — sources: [Editor docs](https://linear.app/docs/editor), [collapsible changelog](https://linear.app/changelog/2025-03-19-collapsible-sections), MCP tool contracts):
 
 ````markdown
-## Command crib (auth: `export $(grep LINEAR_API_KEY ~/.config/linear/.env | xargs)`; POST {{endpoint}})
+## Linear rich text — the markdown dialect for descriptions & comments
 
-# create work item (returns native OM-N)
-curl -s -H "Authorization: $LINEAR_API_KEY" -H "Content-Type: application/json" -d '{
- "query":"mutation($i:IssueCreateInput!){issueCreate(input:$i){issue{id identifier url}}}",
- "variables":{"i":{"teamId":"{{team.id}}","title":"…","description":"…",
-   "labelIds":["{{labels…}}"],"priority":{{priority.P2}},"parentId":null}}}' {{endpoint}}
-# move state (Todo→In Progress at ledger creation; →Blocked/Needs Owner on STOP; →Done at close)
-… issueUpdate(id:$id,input:{stateId:"{{states.in_progress}}"}) …
-# close comment (MANDATORY before Done — card close_template filled)
-… commentCreate(input:{issueId:$id,body:$body}) …
-# list open items by label
-{"query":"{ issues(filter:{labels:{name:{eq:\"app/aigateway\"}},state:{type:{neq:\"completed\"}}}){nodes{identifier title state{name}}}}"}
+Linear converts Markdown to its rich-text editor model. When writing via API/MCP:
+
+- **Send raw markdown with literal newlines — NEVER escape sequences** (`\n` arrives as
+  two characters). The MCP tools state this contract explicitly.
+- **Headings:** `#`–`####` (H1–H4). Deeper levels don't exist.
+- **Text:** `**bold**`, `_italic_`, `~~strike~~`, `` `inline code` ``. Underline has NO
+  markdown syntax (editor-only Cmd/Ctrl U) — don't try.
+- **Lists:** `-`/`*`/`+` bullets, `1.` numbered, `- [ ]` / `[]` checklists; all nestable.
+  Checklists in a description render as interactive checkboxes — good for acceptance lists.
+- **Blockquote:** `>` … · **Collapsible section:** `+++ Title` on its own line, content,
+  closing `+++` (nestable) — use for long logs/gate output in close comments.
+- **Code:** fenced ``` blocks with language tag; ` ```mermaid ` renders a Mermaid diagram.
+- **Divider:** `---` on its own line. **Tables:** GFM pipe tables render as Linear tables —
+  keep them simple (no spans).
+- **Emoji:** `:name:` (`:warning:` etc.).
+- **Mentions — SIDE-EFFECTS:** `@displayName` mentions a user → notifies + subscribes them
+  (MCP contract). Issue references auto-link aggressively: `@OME-123`, pasted issue URLs,
+  AND **bare `OME-123` identifiers in plain prose** all get converted to issue embeds
+  (verified live 2026-07-08) and can create "related to" relations. When no link/relation
+  is wanted, wrap the ID in backticks — code spans are left alone.
+- **Embeds:** bare YouTube/Loom/Figma/Google-Docs URLs auto-embed. To keep a plain link,
+  wrap it in standard `[text](url)` markdown.
+- **No HTML.** Raw HTML is not rendered — write markdown only.
+- Copy an issue back out as markdown via the in-app command `copy issue in markdown`.
 ````
 
-- [ ] **Step 7.2:** Commit: `git add .claude/skills/task-management && git commit -m "feat(OM-E): task-management skill — Linear work-item lifecycle" -m "Refs: OM-E"`
+- [ ] **Step 7.3:** Commit: `git add .claude/skills/task-management && git commit -m "feat(OME-E): task-management skill — Linear MCP lifecycle + rich-text reference" -m "Refs: OME-E"`
 
 ---
 
@@ -364,12 +248,12 @@ curl -s -H "Authorization: $LINEAR_API_KEY" -H "Content-Type: application/json" 
 
 **Files:** Create both from `$SRC/skills/<name>/SKILL.md`
 
-- [ ] **Step 8.1:** `cp` both files, then apply IDENTICAL edits inside the SHARED-LOOP regions of BOTH:
-  1. Rule 7 runner: `uv run ${CLAUDE_PLUGIN_ROOT}/scripts/run_gates.py <stack>` (+ the "plugin root = two levels up…" parenthetical) → `uv run .claude/scripts/run_gates.py <stack>` (run from repo root).
-  2. Rule 1 ledger: `(copy TEMPLATE.md; ledger_dir from the card, default docs/work-ledger/)` → `(copy docs/work/TEMPLATE.md; ledger_dir from the card — this repo: docs/work/, named YYYY-MM-DD-<ticket-id>-<desc>.md per D8)`.
-  3. Sibling references: name only the adopted pair (python ↔ react); drop `sdlc-go` mentions from description + LOOP PARITY sentence.
-- [ ] **Step 8.2:** Stack sections (outside SHARED-LOOP) stay verbatim.
-- [ ] **Step 8.3:** Run parity (Task 10 script) → `LOOP PARITY OK`. Commit: `git add .claude/skills/sdlc-* && git commit -m "feat(OM-E): sdlc-python + sdlc-react rigid-loop skills" -m "Refs: OM-E"`
+- [ ] **Step 8.1:** `cp` both, then IDENTICAL edits in the SHARED-LOOP regions of BOTH:
+  1. Rule 7 runner path → `uv run .claude/scripts/run_gates.py <stack>` (drop the plugin-root parenthetical).
+  2. Rule 1 ledger → `(copy docs/work/TEMPLATE.md; this repo: docs/work/, named YYYY-MM-DD-<ticket-id>-<desc>.md per D8)`.
+  3. Sibling references: name only the adopted pair; drop `sdlc-go` mentions.
+- [ ] **Step 8.2:** Stack sections stay verbatim.
+- [ ] **Step 8.3:** Parity check green (Task 10 script). Commit: `git add .claude/skills/sdlc-* && git commit -m "feat(OME-E): sdlc-python + sdlc-react rigid-loop skills" -m "Refs: OME-E"`
 
 ---
 
@@ -377,45 +261,24 @@ curl -s -H "Authorization: $LINEAR_API_KEY" -H "Content-Type: application/json" 
 
 **Files:** Create both from `$SRC/agents/<name>.md`
 
-- [ ] **Step 9.1:** `sdlc-unit-executor.md` edits: "GitHub issue number" → "Linear identifier (`OM-N`)"; issue read "from the board card's `repo`" → "via the Linear API per the card"; stack resolution "affected paths / `app/*` labels" stays (labels now Linear); STOP table's board moves → Linear state changes (issueUpdate to `blocked`/`needs_owner` + commentCreate); drop `sdlc-go` from the skills list. JSON contract: `"ticket": "<OM-N>"` (string).
-- [ ] **Step 9.2:** `ticket-filer.md` edits: entry fields `title, body, labels (from the card registry), priority, type, parent?`; validation against the card's `labels:`/`priority:` maps (unknown value → all-or-nothing reject); procedure → issueCreate crib (labelIds resolved from the card; parentId for sub-issues; NO retitle step); return table `identifier | title | URL | state`.
-- [ ] **Step 9.3:** Commit: `git add .claude/agents && git commit -m "feat(OM-E): sdlc-unit-executor + ticket-filer agents (Linear)" -m "Refs: OM-E"`
+- [ ] **Step 9.1:** `sdlc-unit-executor.md` edits: input = "Linear identifier (`OME-N`)"; reads via Linear MCP per the card; STOP table's "Board move" column → "apply `blocked` (or `needs-owner`) label + comment via MCP `save_issue`/`save_comment`" (D12 — issue stays In Progress); drop `sdlc-go`; JSON contract `"ticket": "<OME-N>"`.
+- [ ] **Step 9.2:** `ticket-filer.md` edits: entries `title, body, labels, priority, type, actor, parent?`; validate against the card registry incl. **actor mandatory (D13)** — missing actor label → all-or-nothing reject; files via MCP `save_issue` (team + project from card); returns `identifier | title | URL | state`.
+- [ ] **Step 9.3:** Commit: `git add .claude/agents && git commit -m "feat(OME-E): sdlc-unit-executor + ticket-filer agents (Linear MCP)" -m "Refs: OME-E"`
 
 ---
 
 ### Task 10: Scripts
 
-**Files:**
-- Create: `.claude/scripts/run_gates.py` — `cp $SRC/scripts/run_gates.py` VERBATIM
-- Create: `.claude/scripts/check_loop_parity.py`
-
-- [ ] **Step 10.1:** Copy `run_gates.py`; smoke-test:
-
-```bash
-uv run .claude/scripts/run_gates.py aigateway    # expected: ALL GATES GREEN (exit 0)
-uv run .claude/scripts/run_gates.py scoreboard   # expected: ALL GATES GREEN (exit 0)
-```
-
-- [ ] **Step 10.2:** Write `check_loop_parity.py` — the plugin's parity script with:
-
-```python
-ROOT = pathlib.Path(__file__).resolve().parent.parent   # .claude/
-SKILLS = ["sdlc-python", "sdlc-react"]
-# shared_regions() path:
-path = ROOT / "skills" / name / "SKILL.md"
-```
-(rest byte-identical: MARKER regex, drift diff, exit codes 0/1/2)
-
-- [ ] **Step 10.3:** `python3 .claude/scripts/check_loop_parity.py` → `LOOP PARITY OK: sdlc-python, sdlc-react …`. Drift → fix Task 8 edits in BOTH files and re-run.
-- [ ] **Step 10.4:** Commit: `git add .claude/scripts && git commit -m "feat(OM-E): run_gates + loop-parity scripts" -m "Refs: OM-E"`
+- [ ] **Step 10.1:** `cp $SRC/scripts/run_gates.py .claude/scripts/run_gates.py` (verbatim); smoke-test: `uv run .claude/scripts/run_gates.py aigateway` and `… scoreboard` → ALL GATES GREEN.
+- [ ] **Step 10.2:** Write `.claude/scripts/check_loop_parity.py` — the plugin's parity script with `ROOT = pathlib.Path(__file__).resolve().parent.parent`, `SKILLS = ["sdlc-python","sdlc-react"]`, `path = ROOT / "skills" / name / "SKILL.md"`; rest byte-identical.
+- [ ] **Step 10.3:** `python3 .claude/scripts/check_loop_parity.py` → `LOOP PARITY OK …`.
+- [ ] **Step 10.4:** Commit: `git add .claude/scripts && git commit -m "feat(OME-E): run_gates + loop-parity scripts" -m "Refs: OME-E"`
 
 ---
 
 ### Task 11: CI — `repo-checks.yml`
 
-**Files:** Create: `.github/workflows/repo-checks.yml`
-
-- [ ] **Step 11.1:**
+- [ ] **Step 11.1:** Create `.github/workflows/repo-checks.yml`:
 
 ```yaml
 name: Repo Checks
@@ -435,42 +298,40 @@ jobs:
         run: python3 .claude/scripts/check_loop_parity.py
 ```
 
-- [ ] **Step 11.2:** Commit: `git add .github/workflows/repo-checks.yml && git commit -m "ci(OM-E): loop-parity check on sdlc skill changes" -m "Refs: OM-E"`
+- [ ] **Step 11.2:** Commit: `git add .github/workflows/repo-checks.yml && git commit -m "ci(OME-E): loop-parity check on sdlc skill changes" -m "Refs: OME-E"`
 
 ---
 
 ### Task 12: `working-in-this-repo` skill update
 
-**Files:** Modify: `.claude/skills/working-in-this-repo/SKILL.md`
-
-- [ ] **Step 12.1:** §6: branch `SF-{n}-{description}` + Asana `SF` field → `OM-N-<desc>` ("`N` = the Linear number; labels per `.claude/task-board.local.md`"); commit bullet → body carries `Refs: OM-N`. Routing table: add `Label` column (`app/aigateway`, `app/scoreboard`). §7 pointers: add `task-management`, `sdlc-python`/`sdlc-react`, both cards; `docs/` pointer → "decision records & SDLC artifacts (docs/README.md)".
-- [ ] **Step 12.2:** Commit: `git add .claude/skills/working-in-this-repo && git commit -m "docs(OM-E): route working-in-this-repo to Linear SDLC" -m "Refs: OM-E"`
+- [ ] **Step 12.1:** §6: `SF-{n}` branch rule → `OME-N-<desc>` ("N = the Linear number; registry `.claude/task-board.local.md`"); commit body `Refs: OME-N`. Routing table: add `Label` column (`app/aigateway`, `app/scoreboard`). §7 pointers: add `task-management`, `sdlc-*` skills, both cards.
+- [ ] **Step 12.2:** Commit: `git add .claude/skills/working-in-this-repo && git commit -m "docs(OME-E): route working-in-this-repo to Linear SDLC" -m "Refs: OME-E"`
 
 ---
 
 ### Task 13: Verification sweep
 
-- [ ] **Step 13.1:** `python3 .claude/scripts/check_loop_parity.py` → OK; both `run_gates.py` stacks → ALL GATES GREEN.
-- [ ] **Step 13.2:** Stale-reference grep (tracked files):
+- [ ] **Step 13.1:** Parity OK; both `run_gates.py` stacks GREEN.
+- [ ] **Step 13.2:** Stale-reference grep:
 
 ```bash
-git grep -nE 'SF-\{n\}|Asana ticket|asana permalink|docs/plans/|docs/specs/|AAGW-|PUPS-|C-team|C-prefix|1213703035415126' -- . ':!docs/plan' ':!docs/spec' ':!.docs'
+git grep -nE 'SF-\{n\}|Asana ticket|asana permalink|docs/plans/|docs/specs/|AAGW-|C-team|C-prefix|OM-N|1213703035415126' -- . ':!docs/plan' ':!docs/spec' ':!.docs'
 ```
-Expected: zero hits (spec/plan may reference the old flow narratively; they're excluded).
-- [ ] **Step 13.3:** End-to-end crib dry-run: create a throwaway issue (labels `repo` + `type/task` + `autonomous`), move Todo→In Progress→Done with a close comment, verify the `type` group rejected a second type label, then `issueDelete` it.
+Expected: zero hits (spec/plan narrate history; they're excluded).
+- [ ] **Step 13.3:** MCP dry-run: create a throwaway issue (team Engineering, project ScreamingFace V1, labels `repo`+`task`+`autonomous`+`agentic`), verify the `type`/`actor` groups reject a second label from the same group, move Todo→In Progress→Done with a close comment, then delete it in the Linear UI (MCP has no delete tool).
 
 ---
 
 ### Task 14: Ledger outcome, PR, close discipline
 
-- [ ] **Step 14.1:** Fill Outcome in `docs/work/2026-07-08-OM-E-ai-sdlc-adoption.md`; set mirror + ledger `status: done` / `closed:` date.
-- [ ] **Step 14.2:** Push, open PR `feat(OM-E): adopt Linear AI SDLC (skills, cards, agents, scripts, CI)`; body: summary, epic URL, test plan (parity + gates + dry-run), the bootstrap-exception note (Step 2.2), "supersedes SF-N/Asana workflow".
-- [ ] **Step 14.3:** After CI green + review + squash-merge: close sub-issues then the epic with the card's `close_template` filled; file backfill items — `repo`: "Lock package names + reserve (pypi/npm/brew)", "GitHub Pages: keep frozen vs disable"; `app/scoreboard`: "Portal vendoring stopgap — revisit with web story"; `pkg/url4-python-sdk` + `com/url4`: "Extract url4 SDK from legacy tag" (epic).
+- [ ] **Step 14.1:** Fill ledger Outcome; mirror + ledger `status: done` / `closed:` date.
+- [ ] **Step 14.2:** Push, open PR `feat(OME-E): adopt Linear AI SDLC (skills, cards, agents, scripts, CI)`; body: summary, epic URL, test plan, bootstrap-exception note, "supersedes SF-N/Asana workflow".
+- [ ] **Step 14.3:** After CI green + review + squash-merge: close sub-issues then the epic with the card's `close_template` filled (use a `+++ Gates +++` collapsible for gate output); file backfill items (all with `actor` labels): `repo`+`human`: "Lock package names + reserve (pypi/npm/brew)" (design-session), "GitHub Pages: keep frozen vs disable" (design-session); `app/scoreboard`+`agentic`: "Portal vendoring stopgap — revisit with web story" (deferred); `pkg/url4-python-sdk`+`com/url4`+`agentic`: "Extract url4 SDK from legacy tag" (epic).
 
 ---
 
 ## Self-review
 
-- Spec coverage: D1/D2/D10 → Tasks 1–3, 7; D3 → Task 6; D5 → Tasks 8/10; D6/D8 → Task 4; D7/D9 → card rules + CLAUDE.md rules 1/7 (Task 5, incl. rule 0 the 95% gate); §5 → Tasks 9–11; §2.4 → Task 12; §6 phase 5 → Task 14.3. `app/desktop`/`app/cli`/`sdlc-go` deliberately absent (spec §7).
-- No placeholders beyond `<uuid>/<id>/OM-E` slots that Tasks 1–2 explicitly produce (inputs, not TBDs).
-- Naming consistent: `task-management`, `asana-product`, card paths, `docs/work/TEMPLATE.md`, `Refs: OM-N`, label namespaces `app/ pkg/ com/`.
+- Spec coverage: D1/D2 → Tasks 0–2 (done) + 3; D3 → 6; D4 → Task 0 + Task 7 transport; D5 → 8/10; D6/D8 → 4; D7/D9 → cards + CLAUDE.md (5); D10/D13 → Task 1 (done) + card + filer validation (9.2); D11 → card + every save_issue; D12 → card + executor STOP table (9.1); §5 → 9–11; §2.4 → 12; §6 phase 5 → 14.3. Rich-text research → Task 7.2 verbatim block.
+- No placeholders beyond `<id>/OME-E` slots produced by Tasks 0–2 (recorded in `.docs/linear-bootstrap-ids.md`).
+- Naming consistent: `Refs: OME-N`, label namespaces `app/ pkg/ com/`, groups `type`/`who-acts`/`actor`.

--- a/docs/spec/2026-07-08-ai-sdlc-adoption-spec.md
+++ b/docs/spec/2026-07-08-ai-sdlc-adoption-spec.md
@@ -130,8 +130,10 @@ Changes:
   name only the adopted pair; card-missing wording → restore from git.
 - `sdlc-electron` extends the source sdlc-react stack sections: main/preload/renderer
   process model, both-side IPC contract testing (rule S2), strict-TS at IPC boundaries,
-  security posture (contextIsolation on, nodeIntegration off, external HTTP in main only),
-  a11y gate retained (rule S1).
+  the **official Electron security checklist encoded** (contextIsolation/sandbox on,
+  nodeIntegration/webSecurity-off forbidden, IPC sender validation, permission handler +
+  CSP, navigation/window-open restriction, shell.openExternal hygiene, https-only,
+  current Electron; external HTTP in main only), a11y gate retained (rule S1).
 
 ### 2.4 `working-in-this-repo` (update, same change)
 §6 branch/PR rules → Linear flow (branch `OME-N-<desc>`, `Refs: OME-N` in commit body);

--- a/docs/spec/2026-07-08-ai-sdlc-adoption-spec.md
+++ b/docs/spec/2026-07-08-ai-sdlc-adoption-spec.md
@@ -31,7 +31,7 @@ copied verbatim.
 | D2 | Ticket IDs *(revised twice same day)* | **The existing `openmined` workspace Engineering team, key `OME`** — one global sequence `OME-N` for every work item (the Asana SF-N model). No new team is created in the shared org workspace. Per-component team keys (`AAGW-321` style) and a dedicated `OM` team were evaluated and dropped. No zero-padding (Linear cannot render it — verified; sources below). |
 | D3 | Asana role | **Strictly read-only** source of product/marketing top-level tasks (list/read/search). Never create or update. Technical work items NEVER go to Asana. |
 | D4 | Linear access *(revised twice)* | **The Linear MCP plugin, activated/authenticated in Claude, is the ONLY transport and a hard PRECONDITION** (`/mcp` → plugin:linear connected). **API tokens / raw GraphQL are FORBIDDEN.** Operations the MCP cannot perform (label deletion, team creation, workflow states) are OWNER actions in the Linear UI. |
-| D5 | Stack skills now | `sdlc-python` + `sdlc-react`. **`sdlc-go` deferred** until a Go component exists (YAGNI). |
+| D5 | Stack skills now *(revised)* | `sdlc-python` + **`sdlc-electron`** (transformed from the source plugin's sdlc-react for the upcoming desktop app: main/preload/renderer idiom, both-side IPC contract rule S2, security posture — contextIsolation on, external HTTP in main only). **`sdlc-go` deferred** until a Go component exists (YAGNI). |
 | D6 | Docs dirs | `docs/tasks/`, `docs/work/`, `docs/spec/`, `docs/plan/`, `docs/diagrams/` (spec/plan singular — user decision). |
 | D7 | Repo/process work | Plain **`repo`** label, no `app/*`/`pkg/*` label. |
 | D8 | Ledger timing | Ledger file created at work **start** (`docs/work/YYYY-MM-DD-<ticket-id>-<desc>.md`, date = start), frontmatter `status: planned|in_progress|done` + `finished:` date at close. Reconciles "ledger-first" (sdlc rule 1) with "write ledger when finished" (user rule 2). |
@@ -121,14 +121,17 @@ Changes:
 - Every work item gets a `docs/tasks/` mirror (see §4) — a repo-side record, not a second
   board: Linear stays the status authority; the mirror updates at create/close only.
 
-### 2.3 `sdlc-python` and `sdlc-react` (adopted; `sdlc-go` deferred — D5)
+### 2.3 `sdlc-python` and `sdlc-electron` (adopted; `sdlc-go` deferred — D5)
 - SHARED-LOOP regions kept **verbatim-identical** across the two adopted skills (loop parity
   enforced by script, §5).
-- Adaptations (identical in both files): gate runner path
+- Shared adaptations (identical in both files): gate runner path
   `uv run .claude/scripts/run_gates.py <stack>`; `ledger_dir` → `docs/work/` with D8 naming;
   ticket refs are `OME-N` (`Refs: OME-N` as the card's `commit_refs`); sibling references
-  name only the adopted pair; project names/examples → this repo's.
-- Stack idiom sections unchanged.
+  name only the adopted pair; card-missing wording → restore from git.
+- `sdlc-electron` extends the source sdlc-react stack sections: main/preload/renderer
+  process model, both-side IPC contract testing (rule S2), strict-TS at IPC boundaries,
+  security posture (contextIsolation on, nodeIntegration off, external HTTP in main only),
+  a11y gate retained (rule S1).
 
 ### 2.4 `working-in-this-repo` (update, same change)
 §6 branch/PR rules → Linear flow (branch `OME-N-<desc>`, `Refs: OME-N` in commit body);
@@ -188,7 +191,7 @@ per-stack invariants (aigateway credential rules; scoreboard artifact allowlist)
   registry, then files via the Linear MCP (`save_issue` with team + project + labels);
   all-or-nothing; returns `identifier | title | URL | state` table.
 - `.claude/scripts/run_gates.py` — adopted near-verbatim (card-driven, PEP-723 uv script).
-- `.claude/scripts/check_loop_parity.py` — `SKILLS = ["sdlc-python","sdlc-react"]`, paths
+- `.claude/scripts/check_loop_parity.py` — `SKILLS = ["sdlc-python","sdlc-electron"]`, paths
   under `.claude/skills/`; extended per stack added.
 - `.github/workflows/repo-checks.yml` — path-filtered to `.claude/skills/sdlc-*/**` +
   `.claude/scripts/**`; runs loop-parity.
@@ -203,7 +206,7 @@ per-stack invariants (aigateway credential rules; scoreboard artifact allowlist)
 2. **Cards + docs tree + CLAUDE.md** — both cards; docs/tasks + docs/work (+TEMPLATE);
    CLAUDE.md §4 rules; dogfood mirror/ledger for the epic.
 3. **Skills** — `asana-product`, `task-management` (Linear+MCP, incl. the rich-text
-   reference), `sdlc-python`, `sdlc-react`, `working-in-this-repo` update.
+   reference), `sdlc-python`, `sdlc-electron`, `working-in-this-repo` update.
 4. **Agents + scripts + CI** — §5 items; parity green.
 5. **Backfill work items** — `repo`: name lock-down/reservation, GH Pages decision;
    `app/scoreboard`: portal stopgap revisit; `pkg/url4-python-sdk` + `com/url4`: url4 SDK

--- a/docs/spec/2026-07-08-ai-sdlc-adoption-spec.md
+++ b/docs/spec/2026-07-08-ai-sdlc-adoption-spec.md
@@ -7,6 +7,7 @@ supersedes: Asana-based git workflow in CLAUDE.md (SF-N tickets)
 related:
   - .docs/teardown-plan.md (SF-348, PR #371)
   - docs/diagrams/work-item-topology.png (+ .svg source)
+  - https://linear.app/openmined/project/screamingface-v1-27666092fc7f (default Linear project)
   - https://github.com/sergio-bershadsky/ai/tree/main/plugins (source of sdlc/task-management artifacts)
 ---
 
@@ -27,57 +28,64 @@ copied verbatim.
 | # | Decision | Choice |
 |---|---|---|
 | D1 | System of record | **Linear** is the single system of record for dev work items; the task-management skill runs on it. |
-| D2 | Ticket IDs *(revised same day)* | **Single Linear team, key `OM`** — one global sequence `OM-N` for every work item (the Asana SF-N model). Per-component team keys (`AAGW-321` style) were evaluated and dropped: too heavy for ad-hoc work. No zero-padding (Linear cannot render it — verified; sources below). |
+| D2 | Ticket IDs *(revised twice same day)* | **The existing `openmined` workspace Engineering team, key `OME`** — one global sequence `OME-N` for every work item (the Asana SF-N model). No new team is created in the shared org workspace. Per-component team keys (`AAGW-321` style) and a dedicated `OM` team were evaluated and dropped. No zero-padding (Linear cannot render it — verified; sources below). |
 | D3 | Asana role | **Strictly read-only** source of product/marketing top-level tasks (list/read/search). Never create or update. Technical work items NEVER go to Asana. |
-| D4 | Linear access | Workspace + API key exist. Key stored at `~/.config/linear/.env` as `LINEAR_API_KEY`. |
+| D4 | Linear access *(revised twice)* | **The Linear MCP plugin, activated/authenticated in Claude, is the ONLY transport and a hard PRECONDITION** (`/mcp` → plugin:linear connected). **API tokens / raw GraphQL are FORBIDDEN.** Operations the MCP cannot perform (label deletion, team creation, workflow states) are OWNER actions in the Linear UI. |
 | D5 | Stack skills now | `sdlc-python` + `sdlc-react`. **`sdlc-go` deferred** until a Go component exists (YAGNI). |
-| D6 | Docs dirs | `docs/tasks/`, `docs/work/`, `docs/spec/`, `docs/plan/`, `docs/diagrams/` (spec/plan singular — user decision, overriding the plural SF-348 landed; CLAUDE.md + docs/README.md updated at implementation). |
-| D7 | Repo/process work *(revised)* | Plain **`repo`** label, no `app/*`/`pkg/*` label. (The earlier REPO catch-all team is obsolete under single-team D2.) |
+| D6 | Docs dirs | `docs/tasks/`, `docs/work/`, `docs/spec/`, `docs/plan/`, `docs/diagrams/` (spec/plan singular — user decision). |
+| D7 | Repo/process work | Plain **`repo`** label, no `app/*`/`pkg/*` label. |
 | D8 | Ledger timing | Ledger file created at work **start** (`docs/work/YYYY-MM-DD-<ticket-id>-<desc>.md`, date = start), frontmatter `status: planned|in_progress|done` + `finished:` date at close. Reconciles "ledger-first" (sdlc rule 1) with "write ledger when finished" (user rule 2). |
-| D9 | Cross-cutting work *(revised)* | Work spanning ≥2 apps/packages is **signed as a cross-app product component via labels**: `com/<component>` + every affected `app/*`/`pkg/*` label, filed as an **epic with one sub-issue per affected app/package**. (The interim C-prefix-team scheme is superseded by single-team D2.) |
-| D10 | Label taxonomy | Namespaced full-name labels: `app/[name]`, `pkg/[name]`, `com/[name]` as **plain multi-value labels** (Linear label groups enforce one-per-issue and would break cross-cutting); `type` and `who-acts` as **Linear label groups** (one-per-issue enforcement wanted there). |
+| D9 | Cross-cutting work | Work spanning ≥2 apps/packages is **signed as a cross-app product component via labels**: `com/<component>` + every affected `app/*`/`pkg/*` label, filed as an **epic with one sub-issue per affected app/package**. |
+| D10 | Label taxonomy — **LOCKED (align + extend)** | The existing Engineering **`Epic` label group children remain the workstream/component axis** (one per issue: url4 Engine, AI Gateway, Eval Runner & Datasets, Results & Runs, Leaderboard, Auth & Subsidized Compute, Desktop App, Python SDK, Multi-turn Ensembles, SOTA Hunt, Compute Budgeting). **Added:** `actor` group (D13), `who-acts` group (design-session/autonomous/deferred), plain landing labels `app/aigateway`, `app/scoreboard`, `pkg/url4-python-sdk`, `repo`, and `needs-owner`. **Reused:** existing `blocked ⛔`. **No `com/*` axis, no `type` group** (plain `Bug`/`Feature`/`Improvement` reused where useful; epics are parent issues). Obsolete trial labels (`com/*`, `type` group, plain `blocked`) → owner deletes in UI. |
+| D13 | Actor label — **MANDATORY, LOCKED** | Every work item carries exactly one **`actor` group label: `agentic` or `human`** — who executes it. Set at filing; flipped if ownership changes. |
+| D11 | Default project | Every work item for this repo attaches to the Linear project **😱 ScreamingFace V1** (`screamingface-v1-27666092fc7f`). |
+| D12 | STOP signals | The Engineering team's workflow is SHARED — we do not add states to it. `Blocked` / `Needs Owner` are **workspace labels** (`blocked`, `needs-owner`): a STOP = apply the label + a comment stating the exact question; the issue stays In Progress. Clearing the STOP removes the label. |
 
-Linear ID research sources: [Linear conceptual model](https://linear.app/docs/conceptual-model),
+Linear research sources: [conceptual model](https://linear.app/docs/conceptual-model),
 [Teams](https://linear.app/docs/teams), [Creating issues](https://linear.app/docs/creating-issues),
-[Labels](https://linear.app/docs/labels).
+[Editor](https://linear.app/docs/editor), [Collapsible sections changelog](https://linear.app/changelog/2025-03-19-collapsible-sections).
 
 ## 1. Work-item topology
 
-**We are ONE team.** One Linear team (key **`OM`**) → every work item is `OM-N`, one global
-sequence. WHERE the work lands and WHAT it affects live in **labels**, not in the ID:
+**We are ONE team.** Work items live in the existing **Engineering** team (key **`OME`**,
+id `5f4d721f-4452-4ed1-990a-7cdbcd923508`) → every work item is `OME-N`, one global
+sequence — attached to the **😱 ScreamingFace V1** project (D11). WHERE the work lands and
+WHAT it affects live in **labels**, not in the ID:
 
-| Namespace | Axis | Values (initial) |
+| Axis | Labels | Notes |
 |---|---|---|
-| `app/[name]` | application the work lands in | `app/aigateway`, `app/scoreboard`; `app/desktop`, `app/cli` created at name lock |
-| `pkg/[name]` | package the work lands in | `pkg/url4-python-sdk` |
-| `com/[name]` | product component affected (open set) | `com/url4`, `com/evalstudio`, `com/ensemble`, `com/credentials` |
-| `repo` | repo/process work (no app/pkg label) | — |
-| `type` group | deliverable kind — ONE per issue | `type/epic`, `type/feature`, `type/bug`, `type/task`, `type/decision` |
-| `who-acts` group | who moves it — ONE per issue | `design-session`, `autonomous`, `deferred` |
+| Workstream/component — ONE per issue | existing **`Epic` group** children: url4 Engine, AI Gateway, Eval Runner & Datasets, Results & Runs, Leaderboard, Auth & Subsidized Compute, Desktop App, Python SDK, Multi-turn Ensembles, SOTA Hunt, Compute Budgeting | pre-existing team layout, adopted as-is (D10) |
+| Repo landing (WHERE) — multi-value | plain `app/aigateway`, `app/scoreboard`, `pkg/url4-python-sdk`; `app/desktop`, `app/cli` at name lock | added by us |
+| Repo/process work | plain `repo` (no app/pkg label) | added by us (D7) |
+| `who-acts` group — ONE per issue | `design-session`, `autonomous`, `deferred` | added by us |
+| `actor` group — ONE per issue, MANDATORY (D13) | `agentic`, `human` | added by us |
+| STOP labels (D12) | existing `blocked ⛔` + added `needs-owner` | label + comment, not states |
 
 Mechanics:
-- `app/*`, `pkg/*`, `com/*` are **plain namespaced labels** — an issue may carry several
-  (required for cross-cutting epics). `type` and `who-acts` are **Linear label groups**, so
-  Linear itself enforces one-per-issue.
-- `com/*` names are PRODUCT concepts, never internal modules. New app/package/component ⇒
-  its label registered in the card **in the same change** that introduces it.
+- `app/*`/`pkg/*` are **plain labels** — an issue may carry several (required for
+  cross-cutting epics). `who-acts` and `actor` are **Linear label groups**, so Linear
+  itself enforces one-per-issue. The workstream axis is the existing `Epic` group.
+- New app/package/workstream ⇒ its label registered in the card **in the same change**
+  that introduces it (workstream additions coordinated with the project lead).
 - Priority: Linear's native field (card maps P1→High(2), P2→Medium(3), P3→Low(4); Urgent(1)
   reserved for incidents).
-- Workflow states (one set, one team): `Todo → In Progress → Blocked → Needs Owner → Done`
-  (+ built-ins Backlog/Canceled). `Blocked`/`Needs Owner` are the unit-executor STOP targets.
-- Epics = Linear parent issues with sub-issues; milestones = Linear projects (one per plan
-  doc that decomposes into 3+ work items).
+- Workflow states: the Engineering team's EXISTING set (`Todo → In Progress → In Review →
+  Done`, plus its backlog/triage states). We add none (D12); STOPs are labels + comment.
+- Epics = Linear parent issues with sub-issues; milestones = milestones of the
+  ScreamingFace V1 project.
 
-**Cross-cutting rule (D9):** ≥2 `app/*`/`pkg/*` labels ⇒ the work is cross-component: file an
-**epic** carrying `com/<component>` + all affected `app/*`/`pkg/*` labels, with **one
-sub-issue per affected app/package** (one SDLC unit each; each sub-issue carries its own
-`app/*`/`pkg/*` label + the same `com/*` label). Never one mega-ticket, never filed as if it
-were single-app work.
+**Cross-cutting rule (D9):** ≥2 `app/*`/`pkg/*` labels ⇒ the work is cross-cutting: file an
+**epic** carrying its workstream (`Epic` group) label + all affected `app/*`/`pkg/*` labels,
+with **one sub-issue per affected app/package** (one SDLC unit each; each sub-issue carries
+its own `app/*`/`pkg/*` label + the same workstream label). Never one mega-ticket, never
+filed as if it were single-app work.
 
 **Registry card:** `.claude/task-board.local.md` — **committed** (repo config, not personal).
-Contains: workspace slug, team key+ID, state name→ID map, label registry (all namespaces +
-group IDs), priority map, close-comment template, key source path. Card missing → HARD STOP
-(same rule as the source skill).
+Contains: workspace slug, team key+ID, default project (name/slug/ID), state name→ID map
+(existing states), label registry (all namespaces + group IDs + STOP labels), priority map,
+close-comment template, transport note (MCP ONLY — tokens/GraphQL forbidden). Label
+registry sections: `epic_group:` (workstream children), `landing:` (app/pkg/repo),
+`who_acts:`, `actor:`, `stop:`. Card missing → HARD STOP (same rule as the source skill).
 
 ## 2. Skills (repo-local, `.claude/skills/`)
 
@@ -94,14 +102,22 @@ Keeps verbatim-in-spirit: announce line, card-resolution HARD STOP, single-task-
 lifecycle (PLAN → TICKETS → owner ticket review → plan one ticket → implement via stack SDLC
 → close → next), batching, mid-session-discovery rule (file first, 30 seconds), close
 discipline (commits + gates + ledger paths + deviations in a comment before Done),
-anti-pattern table (GitHub-specific rows replaced with label-discipline rows, e.g. "filing
-cross-cutting work with a single app label" → D9 STOP).
+anti-pattern table (label-discipline rows: cross-cutting with a single app label → D9 STOP;
+minting unregistered labels → register in card first).
 Changes:
-- Command crib: Linear GraphQL via `curl` (`Authorization: <LINEAR_API_KEY>`), templated
-  from the card: issueCreate, issueUpdate (state), commentCreate, issue search/filter by label.
-- No retitle/code bookkeeping — Linear assigns `OM-N` natively.
-- Affect matrix: **entirely labels** — `app/*`/`pkg/*` = WHERE (multi-value), `com/*` = WHAT;
-  D9 epic/sub-issue discipline whenever WHERE has ≥2 values.
+- **Transport: the Linear MCP tools ONLY** (`save_issue`, `save_comment`, `list_issues`,
+  `create_issue_label`, …) — activated in Claude as a precondition (D4). Tokens/GraphQL
+  are forbidden; MCP-uncovered operations go to the owner (Linear UI).
+- Every work item sets `project: 😱 ScreamingFace V1` (D11) and `team: Engineering`.
+- No retitle/code bookkeeping — Linear assigns `OME-N` natively.
+- Affect matrix: **entirely labels** — `app/*`/`pkg/*` = WHERE (multi-value), the `Epic`
+  group workstream = WHAT; D9 epic/sub-issue discipline whenever WHERE has ≥2 values.
+- STOPs per D12: `blocked`/`needs-owner` label + comment; label removed when resolved.
+- MCP quirk encoded in the skill: `save_issue.labels` REPLACES the full label set — always
+  read current labels first and resend the union; relations (`blockedBy`, `relatedTo`) are
+  append-only by contrast.
+- **Embeds the "Linear rich text" reference** (research 2026-07-08) — the markdown dialect
+  for descriptions/comments (full content in the plan, Task 7).
 - Every work item gets a `docs/tasks/` mirror (see §4) — a repo-side record, not a second
   board: Linear stays the status authority; the mirror updates at create/close only.
 
@@ -109,72 +125,68 @@ Changes:
 - SHARED-LOOP regions kept **verbatim-identical** across the two adopted skills (loop parity
   enforced by script, §5).
 - Adaptations (identical in both files): gate runner path
-  `uv run .claude/scripts/run_gates.py <stack>` (no `${CLAUDE_PLUGIN_ROOT}` repo-locally);
-  `ledger_dir` → `docs/work/` with D8 naming; ticket refs are `OM-N` (`Refs: OM-N` as the
-  card's `commit_refs`); sibling references name only the adopted pair; project
-  names/examples → this repo's.
-- Stack idiom sections unchanged (python: migrations-with-schema S1, no bare except, no
-  type:ignore; react: a11y gate S1, RTL behavior/roles, no `any` at boundaries).
+  `uv run .claude/scripts/run_gates.py <stack>`; `ledger_dir` → `docs/work/` with D8 naming;
+  ticket refs are `OME-N` (`Refs: OME-N` as the card's `commit_refs`); sibling references
+  name only the adopted pair; project names/examples → this repo's.
+- Stack idiom sections unchanged.
 
 ### 2.4 `working-in-this-repo` (update, same change)
-§6 branch/PR rules → Linear flow (branch `OM-N-<desc>`, `Refs: OM-N` in commit body);
+§6 branch/PR rules → Linear flow (branch `OME-N-<desc>`, `Refs: OME-N` in commit body);
 pointers add task-management + sdlc-* skills and the two cards; routing table gains the
 `app/*` label per app.
 
 ## 3. Cards
 
 ### 3.1 `.claude/task-board.local.md` (committed)
-Frontmatter: `system: linear`, workspace, `team: {key: OM, id}`, states map (todo /
-in_progress / blocked / needs_owner / done), label registry (`apps:`, `pkgs:`, `coms:`,
-`repo:`, `types:` group, `who_acts:` group — name→ID), priority map,
-`key_source: ~/.config/linear/.env`, `close_template`. Body: ticket rules (D9 label
-discipline, Asana-URL rule, mirror-file rule, com-labels-are-product-concepts).
+Frontmatter: `system: linear`, workspace `openmined`, `team: {key: OME, id}`,
+`project: {name, slug, id}`, states map (existing: todo / in_progress / in_review / done /
+triage / backlog), label registry (`apps:`, `pkgs:`, `coms:`, `repo:`, `stop:` (blocked /
+needs-owner), `types:` group, `who_acts:` group — name→ID), priority map, transport
+(`mcp: plugin:linear`, `fallback_key_source: ~/.config/linear/.env`), `close_template`.
+Body: ticket rules (D9 label discipline, D11 project rule, D12 STOP rule, Asana-URL rule,
+mirror-file rule, com-labels-are-product-concepts, labels-REPLACE quirk).
 
 ### 3.2 `.claude/sdlc.local.md` (committed)
-Frontmatter `stacks:`:
-- `aigateway` — root `apps/aigateway`, skill `sdlc-python`, gates: `uv run ruff check`,
-  `uv run ruff format --check`, `uv run pyright`, enterprise-import guard,
-  `uv run pytest --cov=aigateway --cov-fail-under=80`; `test_globs: ["tests/**"]`.
-- `scoreboard` — root `apps/scoreboard`, skill `sdlc-python`, same pattern (`--cov=scoreboard`).
-- (react/desktop stack entry added when the app lands.)
-Body per stack: invariants (aigateway: credential encryption path, no OS keychain, no
-litellm-enterprise; scoreboard: artifact allowlist/forbidden routes), `commit_refs: "Refs: OM-N"`,
-`extra_anchors: []`, companion_skills (e.g. `tortoise-dev` for schema/migrations — mandatory).
+As previously specified: stacks `aigateway` + `scoreboard` (python; ruff/format/pyright/
+pytest-cov gates; aigateway adds the enterprise-import guard), `commit_refs: "Refs: OME-N"`,
+`ledger_dir: docs/work/`, companion_skills (tortoise-dev mandatory for schema/migrations),
+per-stack invariants (aigateway credential rules; scoreboard artifact allowlist).
 
 ## 4. Mandatory CLAUDE.md "AI SDLC" section (replaces "Git Workflow" Asana rules)
 
 0. **95% confidence gate — TOP RULE.** Never write, assert, or implement anything you are
    not ≥95% confident is both correct AND wanted. Below 95% → STOP and ask first. Applies
    to every rule below and every artifact: code, work items, docs, diagrams.
-1. **Work item first.** All work starts as a Linear issue (`OM-N`) carrying its labels
-   (`app/*`/`pkg/*` or `repo`; `com/*` when a product component is affected; one `type/*`;
-   one who-acts) plus a mirror `docs/tasks/YYYY-MM-DD-<name>.md` (frontmatter: id,
-   linear_url, asana_url?, status, type, priority, labels, created, closed). At finish,
-   close status in BOTH.
+1. **Work item first.** All work starts as a Linear issue (`OME-N`) in the Engineering team,
+   attached to the **😱 ScreamingFace V1** project, carrying its labels (workstream from the
+   `Epic` group; `app/*`/`pkg/*` or `repo` for landing; one who-acts; one `actor` —
+   agentic|human) plus a mirror `docs/tasks/YYYY-MM-DD-<name>.md`. At finish, close status
+   in BOTH.
 2. **Work ledger.** Every finished unit has `docs/work/YYYY-MM-DD-<ticket-id>-<desc>.md`
    (created at work start, outcome filled at finish — see the sdlc skills).
 3. **Spec before plan, plan before code.** `docs/spec/` artifact required before planning;
-   `docs/plan/` artifact required before implementation. Prefer/propose `/superpowers`
+   `docs/plan/` artifact required before implementation. Prefer `/superpowers`
    (brainstorming → writing-plans) or similar. Never plan or implement without them.
 4. **Diagrams.** Propose the diagramming plugin
    (https://github.com/sergio-bershadsky/ai/tree/main/plugins/diagramming) when it's absent;
    assets live in `docs/diagrams/` (SVG source + PNG).
-5. **Branches/commits.** Branch `OM-N-<desc>` (e.g. `OM-12-fix-refresh`). Conventional
-   commits; body carries `Refs: OM-N`; never `Co-Authored-By`; never commit to `main`.
+5. **Branches/commits.** Branch `OME-N-<desc>` (e.g. `OME-12-fix-refresh`). Conventional
+   commits; body carries `Refs: OME-N`; never `Co-Authored-By`; never commit to `main`.
 6. **Asana boundary.** Asana is READ-ONLY product/marketing input (`asana-product` skill).
    Technical work items never go to Asana.
-7. **Cross-cutting work (D9).** Touching ≥2 apps/packages → epic with `com/<component>` +
-   all affected `app/*`/`pkg/*` labels, one sub-issue per affected app/package. Never a
-   single-app filing, never one mega-ticket.
+7. **Cross-cutting work (D9).** Touching ≥2 apps/packages → epic with its workstream
+   (`Epic` group) label + all affected `app/*`/`pkg/*` labels, one sub-issue per affected
+   app/package. Never a single-app filing, never one mega-ticket.
 
 ## 5. Agents & scripts
 
-- `.claude/agents/sdlc-unit-executor.md` — executes ONE `OM-N` work item through the stack's
-  SDLC loop; STOP conditions compile to Linear state moves (`Blocked` / `Needs Owner`) +
-  comment; same JSON return contract and prohibitions as the source agent.
+- `.claude/agents/sdlc-unit-executor.md` — executes ONE `OME-N` work item through the
+  stack's SDLC loop; STOP conditions compile to the D12 labels (`blocked` / `needs-owner`)
+  + a comment via the Linear MCP; same JSON return contract and prohibitions as the source
+  agent.
 - `.claude/agents/ticket-filer.md` — validates every entry against the card's label/priority
-  registry, then files via Linear GraphQL; all-or-nothing; returns
-  `identifier | title | URL | state` table.
+  registry, then files via the Linear MCP (`save_issue` with team + project + labels);
+  all-or-nothing; returns `identifier | title | URL | state` table.
 - `.claude/scripts/run_gates.py` — adopted near-verbatim (card-driven, PEP-723 uv script).
 - `.claude/scripts/check_loop_parity.py` — `SKILLS = ["sdlc-python","sdlc-react"]`, paths
   under `.claude/skills/`; extended per stack added.
@@ -183,29 +195,28 @@ litellm-enterprise; scoreboard: artifact allowlist/forbidden routes), `commit_re
 
 ## 6. Implementation phases
 
-1. **Bootstrap Linear** — create/confirm team `OM`; add `Blocked` + `Needs Owner` states;
-   create labels (plain: `app/*`, `pkg/*`, `com/*`, `repo`; groups: `type`, `who-acts`);
-   record IDs; verify key at `~/.config/linear/.env`. File the adoption epic (`type/epic`,
-   `repo`, `autonomous`) with phase sub-issues.
-2. **Cards + CLAUDE.md** — write both cards; replace CLAUDE.md Git-Workflow section with §4;
-   update `working-in-this-repo`.
-3. **Skills** — `asana-product`, `task-management` (Linear), `sdlc-python`, `sdlc-react`.
+1. **Bootstrap Linear** *(DONE 2026-07-08)* — Linear MCP activated (D4); taxonomy locked
+   (D10 align + extend) and labels in place; adoption epic **OME-358** filed with phase
+   sub-issues OME-359/360/361/362 under 😱 ScreamingFace V1. IDs in
+   `.docs/linear-bootstrap-ids.md`. Owner cleanup pending: delete obsolete trial labels
+   (`com/*`, `type` group, plain `blocked`) in the Linear UI.
+2. **Cards + docs tree + CLAUDE.md** — both cards; docs/tasks + docs/work (+TEMPLATE);
+   CLAUDE.md §4 rules; dogfood mirror/ledger for the epic.
+3. **Skills** — `asana-product`, `task-management` (Linear+MCP, incl. the rich-text
+   reference), `sdlc-python`, `sdlc-react`, `working-in-this-repo` update.
 4. **Agents + scripts + CI** — §5 items; parity green.
 5. **Backfill work items** — `repo`: name lock-down/reservation, GH Pages decision;
-   `app/scoreboard`: portal stopgap revisit; `pkg/url4-python-sdk`: url4 SDK extraction epic
-   (`app/desktop` / `app/cli` epics wait for name lock).
+   `app/scoreboard`: portal stopgap revisit; `pkg/url4-python-sdk` + `com/url4`: url4 SDK
+   extraction epic (`app/desktop` / `app/cli` epics wait for name lock).
 
 ## 7. Out of scope / deferred
 
 - `sdlc-go` (until a Go component exists — D5).
 - `app/desktop` / `app/cli` labels and epics (until package names locked).
 - Migration of historical Asana SF-N tickets into Linear (not requested).
-- Linear MCP integration (curl/GraphQL chosen; MCP can replace transport later without
-  changing the process).
 
 ## Open questions (none blocking)
 
-- Exact Linear team/state/label IDs — resolved during phase 1 bootstrap.
 - Whether `repo-checks.yml` also runs actionlint — nice-to-have, decide in implementation.
 
-Confidence: ≥95% on design correctness/completeness given locked decisions D1–D10.
+Confidence: ≥95% on design correctness/completeness given locked decisions D1–D12.

--- a/docs/tasks/2026-07-08-ai-sdlc-adoption.md
+++ b/docs/tasks/2026-07-08-ai-sdlc-adoption.md
@@ -1,0 +1,16 @@
+---
+id: OME-358
+linear_url: https://linear.app/openmined/issue/OME-358/ai-sdlc-adoption-linear-work-items-repo-skills-docs-artifacts
+status: in_progress
+type: epic
+priority: P1
+labels: [repo, agentic, autonomous]
+created: 2026-07-08
+closed:
+---
+
+Adopt the Linear AI SDLC per `docs/spec/2026-07-08-ai-sdlc-adoption-spec.md`, implemented
+per `docs/plan/2026-07-08-ai-sdlc-adoption.md`.
+
+Sub-issues: OME-359 (cards + docs tree + CLAUDE.md), OME-360 (skills), OME-361
+(agents + scripts + CI), OME-362 (backfill, deferred until the adoption PR merges).

--- a/docs/tasks/2026-07-08-team-roster-codeowners.md
+++ b/docs/tasks/2026-07-08-team-roster-codeowners.md
@@ -1,0 +1,20 @@
+---
+id: OME-363
+linear_url: https://linear.app/openmined/issue/OME-363/team-roster-codeowners-provide-accurate-post-reshuffle-information
+status: todo
+type: task
+priority: P1
+labels: [repo, human, design-session]
+assignee: Kevin McDonough (+ Irina Bejan subscribed)
+created: 2026-07-08
+closed:
+---
+
+Provide accurate post-reshuffle team information in two places:
+
+1. `.claude/README.md` → "Product context → Team" (currently TBD placeholder).
+2. `.github/CODEOWNERS` → confirmed owners per path with correct GitHub handles,
+   including an owner for the restored `/web/public/` (currently unowned).
+
+Human task (design-session): Kevin/Irina either edit directly on a branch or post the
+facts in the Linear issue for application.

--- a/docs/work/2026-07-08-OME-358-ai-sdlc-adoption.md
+++ b/docs/work/2026-07-08-OME-358-ai-sdlc-adoption.md
@@ -22,7 +22,7 @@ loop.
 - `docs/tasks/`, `docs/work/` (+ `TEMPLATE.md`), this mirror + ledger; `docs/README.md`
 - `CLAUDE.md` — AI SDLC rules 0–7 replace the Asana git workflow
 - `.claude/skills/asana-product/`, `.claude/skills/task-management/`,
-  `.claude/skills/sdlc-python/`, `.claude/skills/sdlc-react/`
+  `.claude/skills/sdlc-python/`, `.claude/skills/sdlc-electron/`
 - `.claude/agents/sdlc-unit-executor.md`, `.claude/agents/ticket-filer.md`
 - `.claude/scripts/run_gates.py`, `.claude/scripts/check_loop_parity.py`
 - `.github/workflows/repo-checks.yml`
@@ -30,9 +30,9 @@ loop.
 
 ## Test plan
 
-- `check_loop_parity.py` → LOOP PARITY OK (sdlc-python ↔ sdlc-react SHARED-LOOP regions)
+- `check_loop_parity.py` → LOOP PARITY OK (sdlc-python ↔ sdlc-electron SHARED-LOOP regions)
 - `run_gates.py aigateway` and `run_gates.py scoreboard` → ALL GATES GREEN
-- Stale-reference grep (SF-{n}/Asana workflow/old paths) → zero hits outside spec/plan
+- Stale-reference grep (legacy Asana-workflow strings, old paths) → zero hits outside spec/plan
 - Linear round-trip already exercised live: labels, epic OME-358 + sub-issues, state moves
 
 ## Acceptance
@@ -43,8 +43,17 @@ loop.
 
 ## Outcome (fill at the end — required before COMMIT)
 
-- **Actual files:**
-- **Commits:**
-- **Gates:**
+- **Actual files:** as planned, plus: CONTRIBUTING.md git-workflow section (Linear flow —
+  found by the sweep), docs/README.md, docs/spec + docs/plan updates (taxonomy lock,
+  sdlc-electron rename, MCP-only transport).
+- **Commits:** 75f5254 (taxonomy lock), 51c62af (cards), faf315e (docs tree),
+  2313367 (CLAUDE.md rules), 6ccbd19 (skill set), 132f79c (agents/scripts/CI/routing),
+  + this verification commit.
+- **Gates:** run_gates.py aigateway → ALL GATES GREEN (ruff, format, pyright,
+  no-enterprise guard, pytest-cov≥80); run_gates.py scoreboard → ALL GATES GREEN;
+  check_loop_parity.py → LOOP PARITY OK.
 - **Deviations:** work-ledger TEMPLATE adapted from the sdlc plugin (Linear ticket field +
-  D8 frontmatter instead of repo#N).
+  D8 frontmatter instead of repo#N); sdlc-react transformed to sdlc-electron (owner
+  decision mid-implementation); STOPs use existing `blocked ⛔` label instead of a new
+  `blocked` label; taxonomy aligned with the pre-existing Epic-group workstreams instead
+  of a `com/*` axis.

--- a/docs/work/2026-07-08-OME-358-ai-sdlc-adoption.md
+++ b/docs/work/2026-07-08-OME-358-ai-sdlc-adoption.md
@@ -1,0 +1,50 @@
+---
+ticket: OME-358
+stack: repo
+status: in_progress
+started: 2026-07-08
+finished:
+---
+
+# OME-358 — Adopt the Linear AI SDLC (skills, cards, agents, scripts, CI)
+
+## Intent
+
+Replace the Asana/SF-N workflow with the Linear-based AI SDLC: Linear (MCP-only) as the
+system of record for work items under the 😱 ScreamingFace V1 project, mandatory repo
+artifacts (tasks mirrors, work ledgers, spec/plan gates, diagrams), rigid per-stack SDLC
+skills, and supporting agents/scripts/CI — so agentic and human work runs one disciplined
+loop.
+
+## Planned changes
+
+- `.claude/task-board.local.md`, `.claude/sdlc.local.md` (cards)
+- `docs/tasks/`, `docs/work/` (+ `TEMPLATE.md`), this mirror + ledger; `docs/README.md`
+- `CLAUDE.md` — AI SDLC rules 0–7 replace the Asana git workflow
+- `.claude/skills/asana-product/`, `.claude/skills/task-management/`,
+  `.claude/skills/sdlc-python/`, `.claude/skills/sdlc-react/`
+- `.claude/agents/sdlc-unit-executor.md`, `.claude/agents/ticket-filer.md`
+- `.claude/scripts/run_gates.py`, `.claude/scripts/check_loop_parity.py`
+- `.github/workflows/repo-checks.yml`
+- `.claude/skills/working-in-this-repo/SKILL.md` (Linear routing)
+
+## Test plan
+
+- `check_loop_parity.py` → LOOP PARITY OK (sdlc-python ↔ sdlc-react SHARED-LOOP regions)
+- `run_gates.py aigateway` and `run_gates.py scoreboard` → ALL GATES GREEN
+- Stale-reference grep (SF-{n}/Asana workflow/old paths) → zero hits outside spec/plan
+- Linear round-trip already exercised live: labels, epic OME-358 + sub-issues, state moves
+
+## Acceptance
+
+- All planned files exist and are internally consistent (cards ↔ skills ↔ CLAUDE.md)
+- Gates + parity green; PR open referencing OME-358; sub-issues closable with the card's
+  close template
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+- **Commits:**
+- **Gates:**
+- **Deviations:** work-ledger TEMPLATE adapted from the sdlc plugin (Linear ticket field +
+  D8 frontmatter instead of repo#N).

--- a/docs/work/TEMPLATE.md
+++ b/docs/work/TEMPLATE.md
@@ -1,0 +1,32 @@
+---
+ticket: OME-<N>
+stack: <stacks[].name from .claude/sdlc.local.md | repo>
+status: planned   # planned | in_progress | done | blocked
+started: <YYYY-MM-DD>
+finished:
+---
+
+# OME-<N> — <one-line unit title>
+
+## Intent
+
+<What this unit changes and why — one paragraph, product-linked.>
+
+## Planned changes
+
+- <exact files to create/modify>
+
+## Test plan
+
+- <the failing tests to write first: happy path, boundaries, error paths, the invariant protected>
+
+## Acceptance
+
+- <observable criteria that close the unit>
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** <vs planned>
+- **Commits:** <sha — message>
+- **Gates:** <run_gates.py result line / counts>
+- **Deviations:** <anything that differed from the plan, or "none">


### PR DESCRIPTION
## Summary

Implements the AI SDLC per `docs/spec/2026-07-08-ai-sdlc-adoption-spec.md` (D1–D13) and `docs/plan/2026-07-08-ai-sdlc-adoption.md`. Linear (MCP-only) is the system of record: work items are `OME-N` in the Engineering team under 😱 ScreamingFace V1, with the locked label taxonomy (existing Epic-group workstreams + actor/who-acts groups + app/pkg/repo landing labels + STOP labels).

**Linear:** epic [OME-358](https://linear.app/openmined/issue/OME-358/ai-sdlc-adoption-linear-work-items-repo-skills-docs-artifacts) · sub-issues OME-359/360/361/362

## What's in

- **Cards:** `.claude/task-board.local.md` (Linear registry: team/project/states/label IDs, close template, ticket rules), `.claude/sdlc.local.md` (aigateway + scoreboard stacks, gates, invariants)
- **Skills:** `asana-product` (read-only Asana), `task-management` (Linear MCP lifecycle + rich-text dialect reference), `sdlc-python`, `sdlc-electron` (transformed from sdlc-react: main/preload/renderer idiom, both-side IPC rule, security posture); `working-in-this-repo` routed to the Linear flow
- **Agents:** `sdlc-unit-executor`, `ticket-filer` (Linear MCP; STOPs = `blocked ⛔`/`needs-owner` labels + comment; actor label mandatory)
- **Scripts + CI:** `.claude/scripts/run_gates.py` (adopted verbatim), `check_loop_parity.py`; `repo-checks.yml` runs parity on skill changes
- **CLAUDE.md:** AI SDLC rules 0–8 replace the Asana git workflow (95% confidence gate is rule 0; Linear-via-MCP-only is rule 8); CONTRIBUTING.md git workflow updated
- **docs/:** `tasks/` + `work/` trees with the dogfooded OME-358 mirror + ledger

## Test plan

- [x] `check_loop_parity.py` → **LOOP PARITY OK** (sdlc-python ↔ sdlc-electron)
- [x] `run_gates.py aigateway` → **ALL GATES GREEN** (ruff, format, pyright, no-enterprise guard, pytest-cov ≥80)
- [x] `run_gates.py scoreboard` → **ALL GATES GREEN**
- [x] Stale-reference sweep → zero legacy Asana-workflow strings outside spec/plan narrative
- [x] Linear round-trip exercised live via MCP: label creation, epic + sub-issues, state moves

## Notes

- Bootstrap exception: this branch uses the `OME-N` convention it introduces (CLAUDE.md switches mid-PR by design).
- Owner cleanup (Linear UI): delete obsolete trial labels `com/*` ×4, `type` group, plain `blocked`.
- CI lanes on this PR: repo-checks (new) + WIP only — no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtTBgAyrFNpDuDbZnvfJ61