### PR TITLE
docs(OME-358): close-out — mirrors, ledger outcome, backfill mirrors

### DIFF
--- a/docs/tasks/2026-07-08-ai-sdlc-adoption.md
+++ b/docs/tasks/2026-07-08-ai-sdlc-adoption.md
@@ -1,12 +1,12 @@
 ---
 id: OME-358
 linear_url: https://linear.app/openmined/issue/OME-358/ai-sdlc-adoption-linear-work-items-repo-skills-docs-artifacts
-status: in_progress
+status: done
 type: epic
 priority: P1
 labels: [repo, agentic, autonomous]
 created: 2026-07-08
-closed:
+closed: 2026-07-08
 ---
 
 Adopt the Linear AI SDLC per `docs/spec/2026-07-08-ai-sdlc-adoption-spec.md`, implemented

--- a/docs/tasks/2026-07-08-ai-sdlc-agents-scripts-ci.md
+++ b/docs/tasks/2026-07-08-ai-sdlc-agents-scripts-ci.md
@@ -1,0 +1,15 @@
+---
+id: OME-361
+linear_url: https://linear.app/openmined/issue/OME-361/ai-sdlc-agents-scripts-repo-checks-ci
+status: done
+type: task
+priority: P1
+labels: [repo, agentic, autonomous]
+parent: OME-358
+created: 2026-07-08
+closed: 2026-07-08
+---
+
+Agents (`sdlc-unit-executor`, `ticket-filer`), scripts (`run_gates.py`,
+`check_loop_parity.py`), `repo-checks.yml` CI lane, `working-in-this-repo` Linear routing.
+Merged in PR #376 (`21da64a`).

--- a/docs/tasks/2026-07-08-ai-sdlc-backfill.md
+++ b/docs/tasks/2026-07-08-ai-sdlc-backfill.md
@@ -1,0 +1,16 @@
+---
+id: OME-362
+linear_url: https://linear.app/openmined/issue/OME-362/ai-sdlc-backfill-work-items-name-lock-gh-pages-portal-stopgap-url4-sdk
+status: done
+type: task
+priority: P2
+labels: [repo, agentic, deferred]
+parent: OME-358
+created: 2026-07-08
+closed: 2026-07-08
+---
+
+Backfill filed at close: OME-364 (package-name lock + reservation), OME-365 (README/
+CONTRIBUTING refresh + human-vs-agent artifact-scope decision), OME-366 (scoreboard portal
+stopgap revisit), OME-367 (url4 SDK extraction). GH Pages item resolved differently —
+web restored via PR #374; remainder folded into OME-363 + OME-365.

--- a/docs/tasks/2026-07-08-ai-sdlc-cards-docs-claudemd.md
+++ b/docs/tasks/2026-07-08-ai-sdlc-cards-docs-claudemd.md
@@ -1,0 +1,15 @@
+---
+id: OME-359
+linear_url: https://linear.app/openmined/issue/OME-359/ai-sdlc-cards-docs-tree-claudemd-rules
+status: done
+type: task
+priority: P1
+labels: [repo, agentic, autonomous]
+parent: OME-358
+created: 2026-07-08
+closed: 2026-07-08
+---
+
+Cards (`.claude/task-board.local.md`, `.claude/sdlc.local.md`), docs tasks/work tree +
+ledger TEMPLATE + dogfood mirror/ledger, CLAUDE.md AI SDLC rules 0–8. Merged in PR #376
+(`21da64a`).

--- a/docs/tasks/2026-07-08-ai-sdlc-skills.md
+++ b/docs/tasks/2026-07-08-ai-sdlc-skills.md
@@ -1,0 +1,15 @@
+---
+id: OME-360
+linear_url: https://linear.app/openmined/issue/OME-360/ai-sdlc-skills-asana-product-task-management-sdlc-python-sdlc-electron
+status: done
+type: task
+priority: P1
+labels: [repo, agentic, autonomous]
+parent: OME-358
+created: 2026-07-08
+closed: 2026-07-08
+---
+
+Skills: `asana-product` (read-only), `task-management` (Linear MCP + rich-text reference),
+`sdlc-python` (incl. tortoise-dev mandate), `sdlc-electron` (transformed from sdlc-react;
+official Electron security checklist). Merged in PR #376 (`21da64a`).

--- a/docs/tasks/2026-07-08-docs-refresh-readme-contributing.md
+++ b/docs/tasks/2026-07-08-docs-refresh-readme-contributing.md
@@ -1,0 +1,15 @@
+---
+id: OME-365
+linear_url: https://linear.app/openmined/issue/OME-365/docs-refresh-readme-contributing-accuracy-after-web-restore-sdlc
+status: todo
+type: task
+priority: P1
+labels: [repo, agentic, design-session]
+created: 2026-07-08
+closed:
+---
+
+README + CONTRIBUTING accuracy fixes from the 2026-07-08 critical review (web/ in layout,
+gate-runner as canonical command, product-pitch-first README, web/public contribution
+path). Gated on the design decision: do mirrors/ledgers/spec-plan artifacts bind human
+contributors or stay agentic-only.

--- a/docs/tasks/2026-07-08-package-name-lock.md
+++ b/docs/tasks/2026-07-08-package-name-lock.md
@@ -1,0 +1,14 @@
+---
+id: OME-364
+linear_url: https://linear.app/openmined/issue/OME-364/lock-package-names-reserve-everywhere-pypi-npm-brew-gh-repos
+status: todo
+type: task
+priority: P1
+labels: [repo, human, design-session]
+created: 2026-07-08
+closed:
+---
+
+Lock the package-name prefix (`screamingface` vs `sf`) for the new desktop/CLI packages,
+then reserve everywhere: PyPI (0.0.1 stub), npm `openmined` org scope (`@openmined/url4`),
+brew tap/cask, GH repo names. Unlocks `app/desktop` + `app/cli` labels.

--- a/docs/tasks/2026-07-08-scoreboard-portal-stopgap.md
+++ b/docs/tasks/2026-07-08-scoreboard-portal-stopgap.md
@@ -1,0 +1,13 @@
+---
+id: OME-366
+linear_url: https://linear.app/openmined/issue/OME-366/scoreboard-portal-vendoring-stopgap-revisit-with-the-web-story
+status: todo
+type: task
+priority: P3
+labels: [app/scoreboard, Leaderboard, agentic, deferred]
+created: 2026-07-08
+closed:
+---
+
+Revisit the SF-348 portal/artifacts vendoring into apps/scoreboard once the new
+web/leaderboard direction is decided.

--- a/docs/tasks/2026-07-08-url4-sdk-extraction.md
+++ b/docs/tasks/2026-07-08-url4-sdk-extraction.md
@@ -1,0 +1,14 @@
+---
+id: OME-367
+linear_url: https://linear.app/openmined/issue/OME-367/extract-url4-sdk-from-the-legacy-tag-packagesurl4-python-sdk
+status: todo
+type: task
+priority: P2
+labels: [pkg/url4-python-sdk, Python SDK, agentic, deferred]
+created: 2026-07-08
+closed:
+---
+
+Stand up `packages/url4-python-sdk` (publishes as `url4` on PyPI) by extracting the url4
+executor (grammar/AST/resolver) from `apps/server/.../url4_executor/` at tag
+`legacy-monorepo-2026-07-08`. Gate: url4 grammar ownership confirmed post-reshuffle (OME-363).

--- a/docs/work/2026-07-08-OME-358-ai-sdlc-adoption.md
+++ b/docs/work/2026-07-08-OME-358-ai-sdlc-adoption.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-358
 stack: repo
-status: in_progress
+status: done
 started: 2026-07-08
-finished:
+finished: 2026-07-08
 ---
 
 # OME-358 — Adopt the Linear AI SDLC (skills, cards, agents, scripts, CI)
@@ -46,9 +46,12 @@ loop.
 - **Actual files:** as planned, plus: CONTRIBUTING.md git-workflow section (Linear flow —
   found by the sweep), docs/README.md, docs/spec + docs/plan updates (taxonomy lock,
   sdlc-electron rename, MCP-only transport).
-- **Commits:** 75f5254 (taxonomy lock), 51c62af (cards), faf315e (docs tree),
-  2313367 (CLAUDE.md rules), 6ccbd19 (skill set), 132f79c (agents/scripts/CI/routing),
-  + this verification commit.
+- **Commits:** squash-merged as `21da64a` (#376). Branch constituents: 75f5254 (taxonomy
+  lock), 51c62af (cards), faf315e (docs tree), 2313367 (CLAUDE.md rules), 6ccbd19 (skill
+  set), a4eb053 (Electron security checklist), f601896 (tortoise-dev mandate),
+  132f79c (agents/scripts/CI/routing), d55e0e8 (CONTRIBUTING/ledger), 0f8a563 (guide +
+  distilled CLAUDE.md), 7e328b7 (OME-363 mirror), d78804d (gitignore). Sub-issue mirrors
+  landed post-merge via the close-out PR (raced the squash).
 - **Gates:** run_gates.py aigateway → ALL GATES GREEN (ruff, format, pyright,
   no-enterprise guard, pytest-cov≥80); run_gates.py scoreboard → ALL GATES GREEN;
   check_loop_parity.py → LOOP PARITY OK.


### PR DESCRIPTION
## Summary

Bookkeeping close-out for the merged AI SDLC adoption (#376 / [OME-358](https://linear.app/openmined/issue/OME-358/ai-sdlc-adoption-linear-work-items-repo-skills-docs-artifacts)):

- Lands the four sub-issue mirrors (OME-359..362) whose commit raced the squash-merge
- Sets epic + sub-issue mirrors and the work ledger to `done` / `closed: 2026-07-08` — matching Linear, where all five issues are now Done with close-template comments
- Adds mirrors for the backfill items filed at close: OME-364 (name lock), OME-365 (docs refresh), OME-366 (portal stopgap), OME-367 (url4 SDK)

Docs-only; no CI lanes beyond WIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtTBgAyrFNpDuDbZnvfJ61