### PR TITLE
feat(scoreboard): import single-model baselines with source attribution

### DIFF
--- a/apps/scoreboard/src/scoreboard/import_baselines.py
+++ b/apps/scoreboard/src/scoreboard/import_baselines.py
@@ -31,11 +31,7 @@ def load_baselines_json(raw_json: str) -> list[BaselineImportRow]:
 
 
 async def import_baselines(rows: Sequence[BaselineImportRow]) -> list[BaselineSchema]:
-    store = BaselineStore()
-    imported: list[BaselineSchema] = []
-    for row in rows:
-        imported.append(await store.import_baseline(row))
-    return imported
+    return await BaselineStore().import_many(rows)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/apps/scoreboard/src/scoreboard/import_baselines.py
+++ b/apps/scoreboard/src/scoreboard/import_baselines.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from collections.abc import Sequence
+
+from pydantic import TypeAdapter, ValidationError
+
+from .config import Settings
+from .db import close_db, init_db
+from .scores.baseline_store import BaselineStore
+from .scores.schemas import BaselineImportRow, BaselineSchema
+
+SEED_BASELINES_ENV = "SCOREBOARD_SEED_BASELINES_JSON"
+
+_BASELINES_ADAPTER = TypeAdapter(list[BaselineImportRow])
+
+
+def load_baselines_json(raw_json: str) -> list[BaselineImportRow]:
+    try:
+        payload = json.loads(raw_json)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid baseline import JSON: {exc.msg}") from exc
+
+    try:
+        return _BASELINES_ADAPTER.validate_python(payload)
+    except ValidationError as exc:
+        raise ValueError(f"invalid baseline import payload: {exc}") from exc
+
+
+async def import_baselines(rows: Sequence[BaselineImportRow]) -> list[BaselineSchema]:
+    store = BaselineStore()
+    imported: list[BaselineSchema] = []
+    for row in rows:
+        imported.append(await store.import_baseline(row))
+    return imported
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Import scoreboard single-model baselines.")
+    parser.add_argument(
+        "--baselines-json",
+        default=None,
+        help=f"JSON baseline list. Defaults to ${SEED_BASELINES_ENV}; empty list if unset.",
+    )
+    return parser
+
+
+async def _run(raw_json: str) -> None:
+    rows = load_baselines_json(raw_json)
+    if not rows:
+        print("no baselines configured")
+        return
+
+    settings = Settings()
+    await init_db(settings.database_url)
+    try:
+        imported = await import_baselines(rows)
+        for baseline in imported:
+            print(f"imported baseline {baseline.model_name} for {baseline.benchmark_id}")
+    finally:
+        await close_db()
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    raw_json = args.baselines_json or os.getenv(SEED_BASELINES_ENV, "[]")
+    try:
+        asyncio.run(_run(raw_json))
+    except ValueError as exc:
+        parser.error(str(exc))
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/scoreboard/src/scoreboard/main.py
+++ b/apps/scoreboard/src/scoreboard/main.py
@@ -10,6 +10,7 @@ from .config import Settings
 from .db import close_db, init_db
 from .portal import register_portal
 from .routes import health, leaderboard, scores
+from .scores.baseline_store import BaselineStore
 from .scores.store import ScoreStore
 
 
@@ -29,6 +30,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app = FastAPI(title="scoreboard", version="0.1.0", lifespan=_lifespan)
     app.state.settings = settings
     app.state.score_store = ScoreStore()
+    app.state.baseline_store = BaselineStore()
 
     if settings.cors_origins:
         app.add_middleware(

--- a/apps/scoreboard/src/scoreboard/routes/leaderboard.py
+++ b/apps/scoreboard/src/scoreboard/routes/leaderboard.py
@@ -7,8 +7,14 @@ from uuid import UUID
 from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, ConfigDict
 
+from scoreboard.scores.baseline_store import BaselineStore
 from scoreboard.scores.models import Benchmark
-from scoreboard.scores.schemas import BenchmarkSchema, LeaderboardEntry, ScoreSchema
+from scoreboard.scores.schemas import (
+    BaselineSchema,
+    BenchmarkSchema,
+    LeaderboardEntry,
+    ScoreSchema,
+)
 from scoreboard.scores.store import ScoreStore
 
 MAX_LEADERBOARD_TOP = 200
@@ -42,6 +48,10 @@ class LeaderboardResponse(BaseModel):
 
     benchmark: BenchmarkSchema
     entries: list[RankedLeaderboardEntry]
+    # FEATURE: OME-322 — imported single-model "line to beat" baselines (LMArena /
+    # Artificial Analysis), surfaced alongside community entries. Empty until a
+    # baseline is imported via `python -m scoreboard.import_baselines`.
+    baselines: list[BaselineSchema]
 
 
 class HistorySubmission(BaseModel):
@@ -66,6 +76,10 @@ class HistoryResponse(BaseModel):
 
 def _score_store(request: Request) -> ScoreStore:
     return cast(ScoreStore, request.app.state.score_store)
+
+
+def _baseline_store(request: Request) -> BaselineStore:
+    return cast(BaselineStore, request.app.state.baseline_store)
 
 
 async def _get_benchmark_or_404(benchmark_id: str) -> BenchmarkSchema:
@@ -128,7 +142,8 @@ async def get_leaderboard(
         top_n=min(top, MAX_LEADERBOARD_TOP),
     )
     ranked = [_ranked_entry(index, entry) for index, entry in enumerate(entries, start=1)]
-    return LeaderboardResponse(benchmark=benchmark, entries=ranked)
+    baselines = await _baseline_store(request).list_baselines(benchmark_id)
+    return LeaderboardResponse(benchmark=benchmark, entries=ranked, baselines=baselines)
 
 
 @router.get(

--- a/apps/scoreboard/src/scoreboard/scores/baseline_store.py
+++ b/apps/scoreboard/src/scoreboard/scores/baseline_store.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Sequence
 from typing import cast
 
+from pydantic import ValidationError
 from tortoise import BaseDBAsyncClient
 from tortoise.transactions import in_transaction
 
 from .models import Baseline, Benchmark
 from .schemas import BaselineImportRow, BaselineSchema
+
+logger = logging.getLogger(__name__)
 
 
 def _baseline_to_schema(model: Baseline) -> BaselineSchema:
@@ -67,4 +71,14 @@ class BaselineStore:
 
     async def list_baselines(self, benchmark_id: str) -> list[BaselineSchema]:
         rows = await Baseline.filter(benchmark_id=benchmark_id).order_by("-accuracy")
-        return [_baseline_to_schema(baseline) for baseline in rows]
+        # INVARIANT: one row that fails schema validation (e.g. metadata written
+        # before the bound existed, or inserted outside the import path) must not
+        # take down the whole board — skip it, keep serving every valid row
+        # (found in PR review: this used to be an unhandled 500 for everyone).
+        baselines: list[BaselineSchema] = []
+        for baseline in rows:
+            try:
+                baselines.append(_baseline_to_schema(baseline))
+            except ValidationError:
+                logger.warning("skipping baseline %s: failed schema validation", baseline.id)
+        return baselines

--- a/apps/scoreboard/src/scoreboard/scores/baseline_store.py
+++ b/apps/scoreboard/src/scoreboard/scores/baseline_store.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import cast
+
+from tortoise import BaseDBAsyncClient
+from tortoise.transactions import in_transaction
 
 from .models import Baseline, Benchmark
 from .schemas import BaselineImportRow, BaselineSchema
@@ -28,11 +32,17 @@ class BaselineStore:
     # a table.
     """
 
-    async def import_baseline(self, row: BaselineImportRow) -> BaselineSchema:
+    async def import_baseline(
+        self,
+        row: BaselineImportRow,
+        *,
+        using_db: BaseDBAsyncClient | None = None,
+    ) -> BaselineSchema:
         # INVARIANT: a baseline can only be imported against a benchmark that already
         # exists, mirroring the check the /v1/scores route performs before ScoreStore
         # sees a submission (see routes/scores.py::submit_score).
-        if not await Benchmark.exists(id=row.benchmark_id):
+        exists = await Benchmark.filter(id=row.benchmark_id).using_db(using_db).exists()
+        if not exists:
             raise ValueError(f"unknown benchmark_id: {row.benchmark_id!r}")
 
         baseline, _ = await Baseline.update_or_create(
@@ -44,8 +54,16 @@ class BaselineStore:
                 "source_url": row.source_url,
                 "metadata": row.metadata,
             },
+            using_db=using_db,
         )
         return _baseline_to_schema(baseline)
+
+    async def import_many(self, rows: Sequence[BaselineImportRow]) -> list[BaselineSchema]:
+        # INVARIANT: all-or-nothing — if any row in the batch fails (e.g. an unknown
+        # benchmark_id), no row from this batch is left persisted (found in PR review:
+        # a mid-batch failure used to leave earlier rows committed).
+        async with in_transaction() as connection:
+            return [await self.import_baseline(row, using_db=connection) for row in rows]
 
     async def list_baselines(self, benchmark_id: str) -> list[BaselineSchema]:
         rows = await Baseline.filter(benchmark_id=benchmark_id).order_by("-accuracy")

--- a/apps/scoreboard/src/scoreboard/scores/baseline_store.py
+++ b/apps/scoreboard/src/scoreboard/scores/baseline_store.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import cast
+
+from .models import Baseline, Benchmark
+from .schemas import BaselineImportRow, BaselineSchema
+
+
+def _baseline_to_schema(model: Baseline) -> BaselineSchema:
+    return BaselineSchema(
+        id=model.id,
+        benchmark_id=cast(str, getattr(model, "benchmark_id")),
+        model_name=model.model_name,
+        accuracy=model.accuracy,
+        source=model.source,
+        source_url=model.source_url,
+        imported_at=model.imported_at,
+        metadata=model.metadata,
+    )
+
+
+class BaselineStore:
+    """Persistence for imported single-model baselines ('line to beat').
+
+    # WHY: a separate store (not folded into ScoreStore) because a Baseline is a
+    # distinct concept from a community Score submission — no url4_expression, no
+    # provider info, no correctness counts. Community and baseline rows never share
+    # a table.
+    """
+
+    async def import_baseline(self, row: BaselineImportRow) -> BaselineSchema:
+        # INVARIANT: a baseline can only be imported against a benchmark that already
+        # exists, mirroring the check the /v1/scores route performs before ScoreStore
+        # sees a submission (see routes/scores.py::submit_score).
+        if not await Benchmark.exists(id=row.benchmark_id):
+            raise ValueError(f"unknown benchmark_id: {row.benchmark_id!r}")
+
+        baseline, _ = await Baseline.update_or_create(
+            benchmark_id=row.benchmark_id,
+            model_name=row.model_name,
+            source=row.source,
+            defaults={
+                "accuracy": row.accuracy,
+                "source_url": row.source_url,
+                "metadata": row.metadata,
+            },
+        )
+        return _baseline_to_schema(baseline)
+
+    async def list_baselines(self, benchmark_id: str) -> list[BaselineSchema]:
+        rows = await Baseline.filter(benchmark_id=benchmark_id).order_by("-accuracy")
+        return [_baseline_to_schema(baseline) for baseline in rows]

--- a/apps/scoreboard/src/scoreboard/scores/migrations/0002_auto_20260709_1350.py
+++ b/apps/scoreboard/src/scoreboard/scores/migrations/0002_auto_20260709_1350.py
@@ -1,0 +1,56 @@
+import functools
+from json import dumps, loads
+from uuid import uuid4
+
+from tortoise import fields, migrations
+from tortoise.fields.base import OnDelete
+from tortoise.migrations import operations as ops
+
+
+class Migration(migrations.Migration):
+    dependencies = [("models", "0001_initial")]
+
+    initial = False
+
+    operations = [
+        ops.CreateModel(
+            name="Baseline",
+            fields=[
+                (
+                    "id",
+                    fields.UUIDField(primary_key=True, default=uuid4, unique=True, db_index=True),
+                ),
+                ("model_name", fields.CharField(max_length=255)),
+                ("accuracy", fields.FloatField()),
+                ("source", fields.CharField(max_length=64)),
+                ("source_url", fields.CharField(null=True, max_length=2048)),
+                ("imported_at", fields.DatetimeField(auto_now=False, auto_now_add=True)),
+                (
+                    "metadata",
+                    fields.JSONField(
+                        null=True,
+                        encoder=functools.partial(dumps, separators=(",", ":")),
+                        decoder=loads,
+                    ),
+                ),
+                (
+                    "benchmark",
+                    fields.ForeignKeyField(
+                        "models.Benchmark",
+                        source_field="benchmark_id",
+                        db_constraint=True,
+                        to_field="id",
+                        related_name="baselines",
+                        on_delete=OnDelete.RESTRICT,
+                    ),
+                ),
+            ],
+            options={
+                "table": "baselines",
+                "app": "models",
+                "unique_together": (("benchmark", "model_name", "source"),),
+                "pk_attr": "id",
+            },
+            bases=["BaseBaseline"],
+        ),
+    ]

--- a/apps/scoreboard/src/scoreboard/scores/models/__init__.py
+++ b/apps/scoreboard/src/scoreboard/scores/models/__init__.py
@@ -1,6 +1,7 @@
 """Score models for the scoreboard bounded context."""
 
 from .base import BaseScoreboardModel
+from .baseline import BaseBaseline, Baseline
 from .benchmark import BaseBenchmark, Benchmark
 from .idempotency_key import BaseIdempotencyKey, IdempotencyKey
 from .score import BaseScore, Score
@@ -13,4 +14,6 @@ __all__ = [
     "Score",
     "BaseIdempotencyKey",
     "IdempotencyKey",
+    "BaseBaseline",
+    "Baseline",
 ]

--- a/apps/scoreboard/src/scoreboard/scores/models/baseline.py
+++ b/apps/scoreboard/src/scoreboard/scores/models/baseline.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import uuid
+
+from tortoise import fields
+
+from .base import BaseScoreboardModel
+
+
+class BaseBaseline(BaseScoreboardModel):
+    class Meta:
+        abstract = True
+
+    id = fields.UUIDField(primary_key=True, default=uuid.uuid4)
+    model_name = fields.CharField(max_length=255)
+    accuracy = fields.FloatField()
+    source = fields.CharField(max_length=64)
+    source_url = fields.CharField(max_length=2048, null=True)
+    imported_at = fields.DatetimeField(auto_now_add=True)
+    metadata = fields.JSONField(null=True)
+
+
+class Baseline(BaseBaseline):
+    class Meta:
+        table = "baselines"
+        unique_together = (("benchmark", "model_name", "source"),)
+
+    benchmark = fields.ForeignKeyField(
+        "models.Benchmark",
+        related_name="baselines",
+        on_delete=fields.OnDelete.RESTRICT,
+    )

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -1,10 +1,25 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from typing import Annotated, Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+# INVARIANT: a baseline's metadata is operator-supplied (via the import CLI, not a
+# public HTTP endpoint) but still bounded, so one bad import can't make
+# GET /v1/leaderboard/{id} fail to serialize for every consumer (found in PR review).
+_METADATA_MAX_DEPTH = 4
+_METADATA_MAX_BYTES = 4096
+
+
+def _metadata_depth(value: object, current: int = 0) -> int:
+    if isinstance(value, dict):
+        return max((_metadata_depth(v, current + 1) for v in value.values()), default=current)
+    if isinstance(value, list):
+        return max((_metadata_depth(v, current + 1) for v in value), default=current)
+    return current
 
 
 class ClientInfo(BaseModel):
@@ -180,7 +195,12 @@ class BaselineImportRow(BaseModel):
 
     benchmark_id: str
     model_name: str
-    accuracy: float
+    # WHY: strict + no-inf-nan closes a Pydantic v2 laziness gap where JSON true/false
+    # coerce to 1.0/0.0 and numeric strings coerce to float, letting malformed source
+    # data silently become a plausible-looking score (found in PR review). The range
+    # check stays a separate validator below so its error message doesn't change for
+    # an existing test.
+    accuracy: Annotated[float, Field(strict=True, allow_inf_nan=False)]
     source: str
     source_url: str | None = None
     metadata: dict[str, Any] | None = None
@@ -197,4 +217,15 @@ class BaselineImportRow(BaseModel):
     def validate_accuracy(cls, value: float) -> float:
         if not 0 <= value <= 1:
             raise ValueError("accuracy must be between 0 and 1")
+        return value
+
+    @field_validator("metadata")
+    @classmethod
+    def validate_metadata(cls, value: dict[str, Any] | None) -> dict[str, Any] | None:
+        if value is None:
+            return value
+        if _metadata_depth(value) > _METADATA_MAX_DEPTH:
+            raise ValueError(f"metadata must not be nested past {_METADATA_MAX_DEPTH} levels deep")
+        if len(json.dumps(value)) > _METADATA_MAX_BYTES:
+            raise ValueError(f"metadata must serialize to at most {_METADATA_MAX_BYTES} bytes")
         return value

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -202,7 +202,10 @@ class BaselineImportRow(BaseModel):
     # an existing test.
     accuracy: Annotated[float, Field(strict=True, allow_inf_nan=False)]
     source: str
-    source_url: str | None = None
+    # WHY: this is returned through the public API and a future client will likely
+    # render it as a link — restrict to http(s) so a javascript:/data: URI can't
+    # become an XSS vector downstream (found in PR review).
+    source_url: Annotated[str, Field(max_length=2048)] | None = None
     metadata: dict[str, Any] | None = None
 
     @field_validator("benchmark_id", "model_name", "source")
@@ -217,6 +220,13 @@ class BaselineImportRow(BaseModel):
     def validate_accuracy(cls, value: float) -> float:
         if not 0 <= value <= 1:
             raise ValueError("accuracy must be between 0 and 1")
+        return value
+
+    @field_validator("source_url")
+    @classmethod
+    def validate_source_url(cls, value: str | None) -> str | None:
+        if value is not None and not value.startswith(("http://", "https://")):
+            raise ValueError("source_url must start with http:// or https://")
         return value
 
     @field_validator("metadata")

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -153,3 +153,48 @@ class LeaderboardEntry(BaseModel):
     submitted_by: str | None
     verified_by_openmined: bool
     url4_expression: str
+
+
+class BaselineSchema(BaseModel):
+    """Read DTO for an imported single-model baseline ('line to beat')."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: UUID
+    benchmark_id: str
+    model_name: str
+    accuracy: float
+    source: str
+    source_url: str | None
+    imported_at: datetime
+    metadata: dict[str, Any] | None
+
+
+class BaselineImportRow(BaseModel):
+    """Input DTO for importing a single-model baseline score (e.g. from LMArena /
+    Artificial Analysis). Re-importing the same (benchmark_id, model_name, source)
+    updates the existing row rather than duplicating it (see BaselineStore).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    benchmark_id: str
+    model_name: str
+    accuracy: float
+    source: str
+    source_url: str | None = None
+    metadata: dict[str, Any] | None = None
+
+    @field_validator("benchmark_id", "model_name", "source")
+    @classmethod
+    def validate_identifiers(cls, value: str) -> str:
+        if not value:
+            raise ValueError("identifier fields must be non-empty")
+        return value
+
+    @field_validator("accuracy")
+    @classmethod
+    def validate_accuracy(cls, value: float) -> float:
+        if not 0 <= value <= 1:
+            raise ValueError("accuracy must be between 0 and 1")
+        return value

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -22,6 +22,20 @@ def _metadata_depth(value: object, current: int = 0) -> int:
     return current
 
 
+def _validate_bounded_metadata(value: dict[str, Any] | None) -> dict[str, Any] | None:
+    # WHY: shared by both the import DTO and the read schema — a bad row must never
+    # reach storage in the first place, but bounding the read side too means the
+    # invariant holds regardless of how a row got into the database (found in PR
+    # review: metadata was previously bounded on import only).
+    if value is None:
+        return value
+    if _metadata_depth(value) > _METADATA_MAX_DEPTH:
+        raise ValueError(f"metadata must not be nested past {_METADATA_MAX_DEPTH} levels deep")
+    if len(json.dumps(value)) > _METADATA_MAX_BYTES:
+        raise ValueError(f"metadata must serialize to at most {_METADATA_MAX_BYTES} bytes")
+    return value
+
+
 class ClientInfo(BaseModel):
     """Optional client metadata for a score submission."""
 
@@ -184,6 +198,11 @@ class BaselineSchema(BaseModel):
     imported_at: datetime
     metadata: dict[str, Any] | None
 
+    @field_validator("metadata")
+    @classmethod
+    def validate_metadata(cls, value: dict[str, Any] | None) -> dict[str, Any] | None:
+        return _validate_bounded_metadata(value)
+
 
 class BaselineImportRow(BaseModel):
     """Input DTO for importing a single-model baseline score (e.g. from LMArena /
@@ -232,10 +251,4 @@ class BaselineImportRow(BaseModel):
     @field_validator("metadata")
     @classmethod
     def validate_metadata(cls, value: dict[str, Any] | None) -> dict[str, Any] | None:
-        if value is None:
-            return value
-        if _metadata_depth(value) > _METADATA_MAX_DEPTH:
-            raise ValueError(f"metadata must not be nested past {_METADATA_MAX_DEPTH} levels deep")
-        if len(json.dumps(value)) > _METADATA_MAX_BYTES:
-            raise ValueError(f"metadata must serialize to at most {_METADATA_MAX_BYTES} bytes")
-        return value
+        return _validate_bounded_metadata(value)

--- a/apps/scoreboard/tests/unit/scores/test_baseline_store.py
+++ b/apps/scoreboard/tests/unit/scores/test_baseline_store.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.asyncio
 
 def _row(
     *,
-    benchmark_id: str = "hle",
+    benchmark_id: str = "demo-benchmark",
     model_name: str = "GPT-5.2",
     accuracy: float = 0.62,
     source: str = "artificial_analysis",
@@ -28,12 +28,12 @@ def _row(
     )
 
 
-async def _register_benchmark(benchmark_id: str = "hle") -> None:
+async def _register_benchmark(benchmark_id: str = "demo-benchmark") -> None:
     await ScoreStore().register_benchmark(
         benchmark_id=benchmark_id,
-        display_name="Humanity's Last Exam",
+        display_name="Demo Benchmark",
         description="Fixture benchmark",
-        dataset_url="https://example.test/hle.jsonl",
+        dataset_url="https://example.test/demo-benchmark.jsonl",
     )
 
 
@@ -43,7 +43,7 @@ async def test_import_baseline_inserts_new_row(tortoise_db: None) -> None:
 
     imported = await store.import_baseline(_row())
 
-    assert imported.benchmark_id == "hle"
+    assert imported.benchmark_id == "demo-benchmark"
     assert imported.model_name == "GPT-5.2"
     assert imported.accuracy == 0.62
     assert imported.source == "artificial_analysis"
@@ -59,13 +59,13 @@ async def test_import_baseline_reimport_updates_existing_row_in_place(
 
     first = await store.import_baseline(_row(accuracy=0.62))
     second = await store.import_baseline(
-        _row(accuracy=0.71, source_url="https://artificialanalysis.ai/hle")
+        _row(accuracy=0.71, source_url="https://artificialanalysis.ai/demo-benchmark")
     )
-    all_baselines = await store.list_baselines("hle")
+    all_baselines = await store.list_baselines("demo-benchmark")
 
     assert first.id == second.id
     assert second.accuracy == 0.71
-    assert second.source_url == "https://artificialanalysis.ai/hle"
+    assert second.source_url == "https://artificialanalysis.ai/demo-benchmark"
     assert len(all_baselines) == 1
 
 
@@ -77,7 +77,7 @@ async def test_import_baseline_same_model_different_source_creates_separate_rows
 
     await store.import_baseline(_row(source="artificial_analysis", accuracy=0.62))
     await store.import_baseline(_row(source="lmarena", accuracy=0.58))
-    all_baselines = await store.list_baselines("hle")
+    all_baselines = await store.list_baselines("demo-benchmark")
 
     assert {baseline.source for baseline in all_baselines} == {"artificial_analysis", "lmarena"}
 
@@ -98,21 +98,21 @@ async def test_list_baselines_orders_by_accuracy_descending(tortoise_db: None) -
     )
     await store.import_baseline(_row(model_name="Model C", source="lmarena", accuracy=0.65))
 
-    baselines = await store.list_baselines("hle")
+    baselines = await store.list_baselines("demo-benchmark")
 
     assert [baseline.accuracy for baseline in baselines] == [0.90, 0.65, 0.40]
 
 
 async def test_list_baselines_scoped_to_benchmark(tortoise_db: None) -> None:
-    await _register_benchmark("hle")
+    await _register_benchmark("demo-benchmark")
     await _register_benchmark("other")
     store = BaselineStore()
-    await store.import_baseline(_row(benchmark_id="hle", accuracy=0.62))
+    await store.import_baseline(_row(benchmark_id="demo-benchmark", accuracy=0.62))
     await store.import_baseline(_row(benchmark_id="other", accuracy=0.99))
 
-    baselines = await store.list_baselines("hle")
+    baselines = await store.list_baselines("demo-benchmark")
 
-    assert [baseline.benchmark_id for baseline in baselines] == ["hle"]
+    assert [baseline.benchmark_id for baseline in baselines] == ["demo-benchmark"]
 
 
 async def test_list_baselines_returns_empty_list_when_none_imported(
@@ -121,7 +121,7 @@ async def test_list_baselines_returns_empty_list_when_none_imported(
     await _register_benchmark()
     store = BaselineStore()
 
-    baselines = await store.list_baselines("hle")
+    baselines = await store.list_baselines("demo-benchmark")
 
     assert baselines == []
 
@@ -133,7 +133,7 @@ async def test_import_many_persists_every_row_when_all_valid(tortoise_db: None) 
     imported = await store.import_many(
         [_row(model_name="Model A", accuracy=0.4), _row(model_name="Model B", accuracy=0.5)]
     )
-    all_baselines = await store.list_baselines("hle")
+    all_baselines = await store.list_baselines("demo-benchmark")
 
     assert len(imported) == 2
     assert len(all_baselines) == 2
@@ -153,5 +153,5 @@ async def test_import_many_rolls_back_earlier_rows_when_a_later_row_fails(
             ]
         )
 
-    all_baselines = await store.list_baselines("hle")
+    all_baselines = await store.list_baselines("demo-benchmark")
     assert all_baselines == []

--- a/apps/scoreboard/tests/unit/scores/test_baseline_store.py
+++ b/apps/scoreboard/tests/unit/scores/test_baseline_store.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import pytest
+
+from scoreboard.scores.baseline_store import BaselineStore
+from scoreboard.scores.schemas import BaselineImportRow
+from scoreboard.scores.store import ScoreStore
+
+pytestmark = pytest.mark.asyncio
+
+
+def _row(
+    *,
+    benchmark_id: str = "hle",
+    model_name: str = "GPT-5.2",
+    accuracy: float = 0.62,
+    source: str = "artificial_analysis",
+    source_url: str | None = None,
+    metadata: dict[str, object] | None = None,
+) -> BaselineImportRow:
+    return BaselineImportRow(
+        benchmark_id=benchmark_id,
+        model_name=model_name,
+        accuracy=accuracy,
+        source=source,
+        source_url=source_url,
+        metadata=metadata,
+    )
+
+
+async def _register_benchmark(benchmark_id: str = "hle") -> None:
+    await ScoreStore().register_benchmark(
+        benchmark_id=benchmark_id,
+        display_name="Humanity's Last Exam",
+        description="Fixture benchmark",
+        dataset_url="https://example.test/hle.jsonl",
+    )
+
+
+async def test_import_baseline_inserts_new_row(tortoise_db: None) -> None:
+    await _register_benchmark()
+    store = BaselineStore()
+
+    imported = await store.import_baseline(_row())
+
+    assert imported.benchmark_id == "hle"
+    assert imported.model_name == "GPT-5.2"
+    assert imported.accuracy == 0.62
+    assert imported.source == "artificial_analysis"
+    assert imported.source_url is None
+    assert imported.metadata is None
+
+
+async def test_import_baseline_reimport_updates_existing_row_in_place(
+    tortoise_db: None,
+) -> None:
+    await _register_benchmark()
+    store = BaselineStore()
+
+    first = await store.import_baseline(_row(accuracy=0.62))
+    second = await store.import_baseline(
+        _row(accuracy=0.71, source_url="https://artificialanalysis.ai/hle")
+    )
+    all_baselines = await store.list_baselines("hle")
+
+    assert first.id == second.id
+    assert second.accuracy == 0.71
+    assert second.source_url == "https://artificialanalysis.ai/hle"
+    assert len(all_baselines) == 1
+
+
+async def test_import_baseline_same_model_different_source_creates_separate_rows(
+    tortoise_db: None,
+) -> None:
+    await _register_benchmark()
+    store = BaselineStore()
+
+    await store.import_baseline(_row(source="artificial_analysis", accuracy=0.62))
+    await store.import_baseline(_row(source="lmarena", accuracy=0.58))
+    all_baselines = await store.list_baselines("hle")
+
+    assert {baseline.source for baseline in all_baselines} == {"artificial_analysis", "lmarena"}
+
+
+async def test_import_baseline_rejects_unknown_benchmark(tortoise_db: None) -> None:
+    store = BaselineStore()
+
+    with pytest.raises(ValueError, match="unknown benchmark_id"):
+        await store.import_baseline(_row(benchmark_id="does-not-exist"))
+
+
+async def test_list_baselines_orders_by_accuracy_descending(tortoise_db: None) -> None:
+    await _register_benchmark()
+    store = BaselineStore()
+    await store.import_baseline(_row(model_name="Model A", source="lmarena", accuracy=0.40))
+    await store.import_baseline(
+        _row(model_name="Model B", source="artificial_analysis", accuracy=0.90)
+    )
+    await store.import_baseline(_row(model_name="Model C", source="lmarena", accuracy=0.65))
+
+    baselines = await store.list_baselines("hle")
+
+    assert [baseline.accuracy for baseline in baselines] == [0.90, 0.65, 0.40]
+
+
+async def test_list_baselines_scoped_to_benchmark(tortoise_db: None) -> None:
+    await _register_benchmark("hle")
+    await _register_benchmark("other")
+    store = BaselineStore()
+    await store.import_baseline(_row(benchmark_id="hle", accuracy=0.62))
+    await store.import_baseline(_row(benchmark_id="other", accuracy=0.99))
+
+    baselines = await store.list_baselines("hle")
+
+    assert [baseline.benchmark_id for baseline in baselines] == ["hle"]
+
+
+async def test_list_baselines_returns_empty_list_when_none_imported(
+    tortoise_db: None,
+) -> None:
+    await _register_benchmark()
+    store = BaselineStore()
+
+    baselines = await store.list_baselines("hle")
+
+    assert baselines == []

--- a/apps/scoreboard/tests/unit/scores/test_baseline_store.py
+++ b/apps/scoreboard/tests/unit/scores/test_baseline_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from scoreboard.scores.baseline_store import BaselineStore
+from scoreboard.scores.models import Baseline
 from scoreboard.scores.schemas import BaselineImportRow
 from scoreboard.scores.store import ScoreStore
 
@@ -155,3 +156,25 @@ async def test_import_many_rolls_back_earlier_rows_when_a_later_row_fails(
 
     all_baselines = await store.list_baselines("demo-benchmark")
     assert all_baselines == []
+
+
+async def test_list_baselines_skips_a_row_with_invalid_metadata_instead_of_crashing(
+    tortoise_db: None,
+) -> None:
+    # WHY: simulates a legacy/pre-existing row whose metadata predates the bound
+    # (or bypassed it entirely) — created directly via the model, not through
+    # BaselineImportRow, since that DTO would itself reject this payload.
+    await _register_benchmark()
+    store = BaselineStore()
+    await store.import_baseline(_row(model_name="Good Model", accuracy=0.5))
+    await Baseline.create(
+        benchmark_id="demo-benchmark",
+        model_name="Bad Model",
+        source="artificial_analysis",
+        accuracy=0.9,
+        metadata={"blob": "x" * 10_000},
+    )
+
+    baselines = await store.list_baselines("demo-benchmark")
+
+    assert [baseline.model_name for baseline in baselines] == ["Good Model"]

--- a/apps/scoreboard/tests/unit/scores/test_baseline_store.py
+++ b/apps/scoreboard/tests/unit/scores/test_baseline_store.py
@@ -124,3 +124,34 @@ async def test_list_baselines_returns_empty_list_when_none_imported(
     baselines = await store.list_baselines("hle")
 
     assert baselines == []
+
+
+async def test_import_many_persists_every_row_when_all_valid(tortoise_db: None) -> None:
+    await _register_benchmark()
+    store = BaselineStore()
+
+    imported = await store.import_many(
+        [_row(model_name="Model A", accuracy=0.4), _row(model_name="Model B", accuracy=0.5)]
+    )
+    all_baselines = await store.list_baselines("hle")
+
+    assert len(imported) == 2
+    assert len(all_baselines) == 2
+
+
+async def test_import_many_rolls_back_earlier_rows_when_a_later_row_fails(
+    tortoise_db: None,
+) -> None:
+    await _register_benchmark()
+    store = BaselineStore()
+
+    with pytest.raises(ValueError, match="unknown benchmark_id"):
+        await store.import_many(
+            [
+                _row(model_name="Model A", accuracy=0.4),
+                _row(benchmark_id="does-not-exist", model_name="Model B"),
+            ]
+        )
+
+    all_baselines = await store.list_baselines("hle")
+    assert all_baselines == []

--- a/apps/scoreboard/tests/unit/scores/test_models.py
+++ b/apps/scoreboard/tests/unit/scores/test_models.py
@@ -9,8 +9,10 @@ from scoreboard.config import Settings
 from scoreboard.db import TORTOISE_CONFIG
 from scoreboard.main import create_app
 from scoreboard.scores.models import (
+    BaseBaseline,
     BaseBenchmark,
     BaseIdempotencyKey,
+    Baseline,
     BaseScore,
     BaseScoreboardModel,
     Benchmark,
@@ -78,3 +80,25 @@ def test_create_app_wires_score_store_without_db_io() -> None:
     app = create_app(Settings(database_url="sqlite://:memory:", cors_origins=[]))
 
     assert isinstance(app.state.score_store, ScoreStore)
+
+
+def test_baseline_model_table_name_and_relation() -> None:
+    benchmark_field = cast(Any, Baseline._meta.fields_map["benchmark"])
+
+    assert Baseline._meta.db_table == "baselines"
+    assert benchmark_field.on_delete is fields.OnDelete.RESTRICT
+    assert ("benchmark", "model_name", "source") in {
+        tuple(entry) for entry in Baseline._meta.unique_together
+    }
+
+
+def test_baseline_model_package_exports_and_abstract_base() -> None:
+    assert score_models.Baseline is Baseline
+    assert score_models.BaseBaseline is BaseBaseline
+    assert "Baseline" in score_models.__all__
+    assert "BaseBaseline" in score_models.__all__
+    assert BaseBaseline._meta.abstract is True
+
+
+def test_baseline_model_lives_in_its_own_file() -> None:
+    assert Baseline.__module__ == "scoreboard.scores.models.baseline"

--- a/apps/scoreboard/tests/unit/scores/test_schemas.py
+++ b/apps/scoreboard/tests/unit/scores/test_schemas.py
@@ -88,7 +88,7 @@ def test_score_submission_rejects_correct_questions_above_total() -> None:
 
 def _valid_baseline_payload() -> dict[str, object]:
     return {
-        "benchmark_id": "hle",
+        "benchmark_id": "demo-benchmark",
         "model_name": "GPT-5.2",
         "accuracy": 0.62,
         "source": "artificial_analysis",
@@ -98,7 +98,7 @@ def _valid_baseline_payload() -> dict[str, object]:
 def test_baseline_import_row_accepts_valid_payload() -> None:
     row = BaselineImportRow.model_validate(_valid_baseline_payload())
 
-    assert row.benchmark_id == "hle"
+    assert row.benchmark_id == "demo-benchmark"
     assert row.model_name == "GPT-5.2"
     assert row.source_url is None
     assert row.metadata is None
@@ -245,6 +245,55 @@ def test_baseline_import_row_rejects_oversized_metadata() -> None:
         assert "bytes" in str(exc)
     else:
         raise AssertionError("expected validation error")
+
+
+def test_baseline_import_row_rejects_javascript_source_url() -> None:
+    payload = _valid_baseline_payload()
+    payload["source_url"] = "javascript:alert(1)"
+
+    try:
+        BaselineImportRow.model_validate(payload)
+    except ValidationError as exc:
+        assert "http" in str(exc)
+    else:
+        raise AssertionError("expected validation error")
+
+
+def test_baseline_import_row_rejects_data_uri_source_url() -> None:
+    payload = _valid_baseline_payload()
+    payload["source_url"] = "data:text/html,<script>alert(1)</script>"
+
+    try:
+        BaselineImportRow.model_validate(payload)
+    except ValidationError as exc:
+        assert "http" in str(exc)
+    else:
+        raise AssertionError("expected validation error")
+
+
+def test_baseline_import_row_rejects_non_url_source_url() -> None:
+    payload = _valid_baseline_payload()
+    payload["source_url"] = "not a url"
+
+    with pytest.raises(ValidationError):
+        BaselineImportRow.model_validate(payload)
+
+
+def test_baseline_import_row_accepts_https_source_url() -> None:
+    payload = _valid_baseline_payload()
+    payload["source_url"] = "https://artificialanalysis.ai/evaluations/humanitys-last-exam"
+
+    row = BaselineImportRow.model_validate(payload)
+
+    assert row.source_url == "https://artificialanalysis.ai/evaluations/humanitys-last-exam"
+
+
+def test_baseline_import_row_rejects_oversized_source_url() -> None:
+    payload = _valid_baseline_payload()
+    payload["source_url"] = "https://example.test/" + "x" * 2048
+
+    with pytest.raises(ValidationError):
+        BaselineImportRow.model_validate(payload)
 
 
 def test_baseline_import_row_accepts_metadata_within_bounds() -> None:

--- a/apps/scoreboard/tests/unit/scores/test_schemas.py
+++ b/apps/scoreboard/tests/unit/scores/test_schemas.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pydantic import ValidationError
 
-from scoreboard.scores.schemas import ScoreSubmission
+from scoreboard.scores.schemas import BaselineImportRow, ScoreSubmission
 
 
 def _valid_payload() -> dict[str, object]:
@@ -81,5 +81,106 @@ def test_score_submission_rejects_correct_questions_above_total() -> None:
         ScoreSubmission.model_validate(payload)
     except ValidationError as exc:
         assert "correct_questions cannot exceed total_questions" in str(exc)
+    else:
+        raise AssertionError("expected validation error")
+
+
+def _valid_baseline_payload() -> dict[str, object]:
+    return {
+        "benchmark_id": "hle",
+        "model_name": "GPT-5.2",
+        "accuracy": 0.62,
+        "source": "artificial_analysis",
+    }
+
+
+def test_baseline_import_row_accepts_valid_payload() -> None:
+    row = BaselineImportRow.model_validate(_valid_baseline_payload())
+
+    assert row.benchmark_id == "hle"
+    assert row.model_name == "GPT-5.2"
+    assert row.source_url is None
+    assert row.metadata is None
+
+
+def test_baseline_import_row_accepts_optional_source_url_and_metadata() -> None:
+    payload = _valid_baseline_payload()
+    payload["source_url"] = "https://artificialanalysis.ai/benchmarks/hle"
+    payload["metadata"] = {"published_at": "2026-06-01"}
+
+    row = BaselineImportRow.model_validate(payload)
+
+    assert row.source_url == "https://artificialanalysis.ai/benchmarks/hle"
+    assert row.metadata == {"published_at": "2026-06-01"}
+
+
+def test_baseline_import_row_rejects_empty_benchmark_id() -> None:
+    payload = _valid_baseline_payload()
+    payload["benchmark_id"] = ""
+
+    try:
+        BaselineImportRow.model_validate(payload)
+    except ValidationError as exc:
+        assert "identifier fields must be non-empty" in str(exc)
+    else:
+        raise AssertionError("expected validation error")
+
+
+def test_baseline_import_row_rejects_empty_model_name() -> None:
+    payload = _valid_baseline_payload()
+    payload["model_name"] = ""
+
+    try:
+        BaselineImportRow.model_validate(payload)
+    except ValidationError as exc:
+        assert "identifier fields must be non-empty" in str(exc)
+    else:
+        raise AssertionError("expected validation error")
+
+
+def test_baseline_import_row_rejects_empty_source() -> None:
+    payload = _valid_baseline_payload()
+    payload["source"] = ""
+
+    try:
+        BaselineImportRow.model_validate(payload)
+    except ValidationError as exc:
+        assert "identifier fields must be non-empty" in str(exc)
+    else:
+        raise AssertionError("expected validation error")
+
+
+def test_baseline_import_row_rejects_accuracy_below_zero() -> None:
+    payload = _valid_baseline_payload()
+    payload["accuracy"] = -0.01
+
+    try:
+        BaselineImportRow.model_validate(payload)
+    except ValidationError as exc:
+        assert "accuracy must be between 0 and 1" in str(exc)
+    else:
+        raise AssertionError("expected validation error")
+
+
+def test_baseline_import_row_rejects_accuracy_above_one() -> None:
+    payload = _valid_baseline_payload()
+    payload["accuracy"] = 1.01
+
+    try:
+        BaselineImportRow.model_validate(payload)
+    except ValidationError as exc:
+        assert "accuracy must be between 0 and 1" in str(exc)
+    else:
+        raise AssertionError("expected validation error")
+
+
+def test_baseline_import_row_rejects_unknown_fields() -> None:
+    payload = _valid_baseline_payload()
+    payload["extra_field"] = "not allowed"
+
+    try:
+        BaselineImportRow.model_validate(payload)
+    except ValidationError as exc:
+        assert "extra_field" in str(exc)
     else:
         raise AssertionError("expected validation error")

--- a/apps/scoreboard/tests/unit/scores/test_schemas.py
+++ b/apps/scoreboard/tests/unit/scores/test_schemas.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from pydantic import ValidationError
 
 from scoreboard.scores.schemas import BaselineImportRow, ScoreSubmission
@@ -184,3 +185,72 @@ def test_baseline_import_row_rejects_unknown_fields() -> None:
         assert "extra_field" in str(exc)
     else:
         raise AssertionError("expected validation error")
+
+
+def test_baseline_import_row_rejects_bool_accuracy() -> None:
+    payload = _valid_baseline_payload()
+    payload["accuracy"] = True
+
+    with pytest.raises(ValidationError):
+        BaselineImportRow.model_validate(payload)
+
+
+def test_baseline_import_row_rejects_numeric_string_accuracy() -> None:
+    payload = _valid_baseline_payload()
+    payload["accuracy"] = "0.62"
+
+    with pytest.raises(ValidationError):
+        BaselineImportRow.model_validate(payload)
+
+
+def test_baseline_import_row_rejects_non_finite_accuracy() -> None:
+    payload = _valid_baseline_payload()
+    payload["accuracy"] = float("nan")
+
+    with pytest.raises(ValidationError):
+        BaselineImportRow.model_validate(payload)
+
+
+def test_baseline_import_row_still_accepts_plain_float_accuracy() -> None:
+    payload = _valid_baseline_payload()
+    payload["accuracy"] = 0.71
+
+    row = BaselineImportRow.model_validate(payload)
+
+    assert row.accuracy == 0.71
+
+
+def test_baseline_import_row_rejects_deeply_nested_metadata() -> None:
+    payload = _valid_baseline_payload()
+    nested: dict[str, object] = {"v": 1}
+    for _ in range(10):
+        nested = {"nest": nested}
+    payload["metadata"] = nested
+
+    try:
+        BaselineImportRow.model_validate(payload)
+    except ValidationError as exc:
+        assert "nested" in str(exc)
+    else:
+        raise AssertionError("expected validation error")
+
+
+def test_baseline_import_row_rejects_oversized_metadata() -> None:
+    payload = _valid_baseline_payload()
+    payload["metadata"] = {"blob": "x" * 10_000}
+
+    try:
+        BaselineImportRow.model_validate(payload)
+    except ValidationError as exc:
+        assert "bytes" in str(exc)
+    else:
+        raise AssertionError("expected validation error")
+
+
+def test_baseline_import_row_accepts_metadata_within_bounds() -> None:
+    payload = _valid_baseline_payload()
+    payload["metadata"] = {"published_at": "2026-06-01", "nested": {"note": "ok"}}
+
+    row = BaselineImportRow.model_validate(payload)
+
+    assert row.metadata == {"published_at": "2026-06-01", "nested": {"note": "ok"}}

--- a/apps/scoreboard/tests/unit/scores/test_schemas.py
+++ b/apps/scoreboard/tests/unit/scores/test_schemas.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
+from uuid import uuid4
+
 import pytest
 from pydantic import ValidationError
 
-from scoreboard.scores.schemas import BaselineImportRow, ScoreSubmission
+from scoreboard.scores.schemas import BaselineImportRow, BaselineSchema, ScoreSubmission
 
 
 def _valid_payload() -> dict[str, object]:
@@ -303,3 +306,44 @@ def test_baseline_import_row_accepts_metadata_within_bounds() -> None:
     row = BaselineImportRow.model_validate(payload)
 
     assert row.metadata == {"published_at": "2026-06-01", "nested": {"note": "ok"}}
+
+
+def _valid_baseline_schema_payload() -> dict[str, object]:
+    return {
+        "id": uuid4(),
+        "benchmark_id": "demo-benchmark",
+        "model_name": "GPT-5.2",
+        "accuracy": 0.62,
+        "source": "artificial_analysis",
+        "source_url": None,
+        "imported_at": datetime(2026, 7, 10, tzinfo=UTC),
+        "metadata": None,
+    }
+
+
+def test_baseline_schema_accepts_metadata_within_bounds() -> None:
+    payload = _valid_baseline_schema_payload()
+    payload["metadata"] = {"published_at": "2026-06-01"}
+
+    schema = BaselineSchema.model_validate(payload)
+
+    assert schema.metadata == {"published_at": "2026-06-01"}
+
+
+def test_baseline_schema_rejects_deeply_nested_metadata() -> None:
+    payload = _valid_baseline_schema_payload()
+    nested: dict[str, object] = {"v": 1}
+    for _ in range(10):
+        nested = {"nest": nested}
+    payload["metadata"] = nested
+
+    with pytest.raises(ValidationError):
+        BaselineSchema.model_validate(payload)
+
+
+def test_baseline_schema_rejects_oversized_metadata() -> None:
+    payload = _valid_baseline_schema_payload()
+    payload["metadata"] = {"blob": "x" * 10_000}
+
+    with pytest.raises(ValidationError):
+        BaselineSchema.model_validate(payload)

--- a/apps/scoreboard/tests/unit/test_import_baselines.py
+++ b/apps/scoreboard/tests/unit/test_import_baselines.py
@@ -9,39 +9,39 @@ from scoreboard.scores.store import ScoreStore
 pytestmark = pytest.mark.asyncio
 
 
-async def _register_benchmark(benchmark_id: str = "hle") -> None:
+async def _register_benchmark(benchmark_id: str = "demo-benchmark") -> None:
     await ScoreStore().register_benchmark(
         benchmark_id=benchmark_id,
-        display_name="Humanity's Last Exam",
+        display_name="Demo Benchmark",
         description="Fixture benchmark",
-        dataset_url="https://example.test/hle.jsonl",
+        dataset_url="https://example.test/demo-benchmark.jsonl",
     )
 
 
 async def test_import_baselines_inserts_and_updates(tortoise_db: None) -> None:
     await _register_benchmark()
     first = load_baselines_json(
-        '[{"benchmark_id":"hle","model_name":"GPT-5.2","accuracy":0.62,'
+        '[{"benchmark_id":"demo-benchmark","model_name":"GPT-5.2","accuracy":0.62,'
         '"source":"artificial_analysis"}]'
     )
     second = load_baselines_json(
-        '[{"benchmark_id":"hle","model_name":"GPT-5.2","accuracy":0.71,'
-        '"source":"artificial_analysis","source_url":"https://artificialanalysis.ai/hle"}]'
+        '[{"benchmark_id":"demo-benchmark","model_name":"GPT-5.2","accuracy":0.71,'
+        '"source":"artificial_analysis","source_url":"https://artificialanalysis.ai/demo-benchmark"}]'
     )
 
     imported = await import_baselines(first)
     reimported = await import_baselines(second)
-    all_baselines = await BaselineStore().list_baselines("hle")
+    all_baselines = await BaselineStore().list_baselines("demo-benchmark")
 
     assert imported[0].accuracy == 0.62
     assert reimported[0].accuracy == 0.71
-    assert reimported[0].source_url == "https://artificialanalysis.ai/hle"
+    assert reimported[0].source_url == "https://artificialanalysis.ai/demo-benchmark"
     assert len(all_baselines) == 1
 
 
 async def test_load_baselines_json_rejects_invalid_payload() -> None:
     with pytest.raises(ValueError, match="invalid baseline import payload"):
-        load_baselines_json('{"benchmark_id":"hle"}')
+        load_baselines_json('{"benchmark_id":"demo-benchmark"}')
 
 
 async def test_load_baselines_json_rejects_malformed_json() -> None:

--- a/apps/scoreboard/tests/unit/test_import_baselines.py
+++ b/apps/scoreboard/tests/unit/test_import_baselines.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+
+from scoreboard.import_baselines import import_baselines, load_baselines_json
+from scoreboard.scores.baseline_store import BaselineStore
+from scoreboard.scores.store import ScoreStore
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _register_benchmark(benchmark_id: str = "hle") -> None:
+    await ScoreStore().register_benchmark(
+        benchmark_id=benchmark_id,
+        display_name="Humanity's Last Exam",
+        description="Fixture benchmark",
+        dataset_url="https://example.test/hle.jsonl",
+    )
+
+
+async def test_import_baselines_inserts_and_updates(tortoise_db: None) -> None:
+    await _register_benchmark()
+    first = load_baselines_json(
+        '[{"benchmark_id":"hle","model_name":"GPT-5.2","accuracy":0.62,'
+        '"source":"artificial_analysis"}]'
+    )
+    second = load_baselines_json(
+        '[{"benchmark_id":"hle","model_name":"GPT-5.2","accuracy":0.71,'
+        '"source":"artificial_analysis","source_url":"https://artificialanalysis.ai/hle"}]'
+    )
+
+    imported = await import_baselines(first)
+    reimported = await import_baselines(second)
+    all_baselines = await BaselineStore().list_baselines("hle")
+
+    assert imported[0].accuracy == 0.62
+    assert reimported[0].accuracy == 0.71
+    assert reimported[0].source_url == "https://artificialanalysis.ai/hle"
+    assert len(all_baselines) == 1
+
+
+async def test_load_baselines_json_rejects_invalid_payload() -> None:
+    with pytest.raises(ValueError, match="invalid baseline import payload"):
+        load_baselines_json('{"benchmark_id":"hle"}')
+
+
+async def test_load_baselines_json_rejects_malformed_json() -> None:
+    with pytest.raises(ValueError, match="invalid baseline import JSON"):
+        load_baselines_json("not json")
+
+
+async def test_import_baselines_propagates_unknown_benchmark_error(
+    tortoise_db: None,
+) -> None:
+    rows = load_baselines_json(
+        '[{"benchmark_id":"missing","model_name":"GPT-5.2","accuracy":0.62,'
+        '"source":"artificial_analysis"}]'
+    )
+
+    with pytest.raises(ValueError, match="unknown benchmark_id"):
+        await import_baselines(rows)

--- a/apps/scoreboard/tests/unit/test_leaderboard_routes.py
+++ b/apps/scoreboard/tests/unit/test_leaderboard_routes.py
@@ -9,8 +9,9 @@ import pytest_asyncio
 
 from scoreboard.config import Settings
 from scoreboard.main import create_app
+from scoreboard.scores.baseline_store import BaselineStore
 from scoreboard.scores.models import Score
-from scoreboard.scores.schemas import ClientInfo, ScoreSubmission
+from scoreboard.scores.schemas import BaselineImportRow, ClientInfo, ScoreSubmission
 from scoreboard.scores.store import ScoreStore
 
 pytestmark = pytest.mark.asyncio
@@ -246,3 +247,65 @@ async def test_openapi_includes_leaderboard_contracts(async_client: httpx.AsyncC
     assert "BenchmarksResponse" in body["components"]["schemas"]
     assert "LeaderboardResponse" in body["components"]["schemas"]
     assert "HistoryResponse" in body["components"]["schemas"]
+
+
+async def test_get_leaderboard_returns_empty_baselines_when_none_imported(
+    async_client: httpx.AsyncClient,
+) -> None:
+    store = ScoreStore()
+    await _register_benchmark(store)
+
+    response = await async_client.get("/v1/leaderboard/hle")
+
+    assert response.status_code == 200
+    assert response.json()["baselines"] == []
+
+
+async def test_get_leaderboard_returns_imported_baselines_ordered_by_accuracy(
+    async_client: httpx.AsyncClient,
+) -> None:
+    store = ScoreStore()
+    await _register_benchmark(store)
+    baseline_store = BaselineStore()
+    await baseline_store.import_baseline(
+        BaselineImportRow(
+            benchmark_id="hle",
+            model_name="Model A",
+            accuracy=0.55,
+            source="lmarena",
+        )
+    )
+    await baseline_store.import_baseline(
+        BaselineImportRow(
+            benchmark_id="hle",
+            model_name="Model B",
+            accuracy=0.71,
+            source="artificial_analysis",
+            source_url="https://artificialanalysis.ai/hle",
+        )
+    )
+
+    response = await async_client.get("/v1/leaderboard/hle")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [baseline["model_name"] for baseline in body["baselines"]] == ["Model B", "Model A"]
+    assert body["baselines"][0]["source"] == "artificial_analysis"
+    assert body["baselines"][0]["source_url"] == "https://artificialanalysis.ai/hle"
+    assert body["baselines"][1]["source_url"] is None
+
+
+async def test_get_leaderboard_returns_404_for_unknown_benchmark_with_baselines_wired(
+    async_client: httpx.AsyncClient,
+) -> None:
+    response = await async_client.get("/v1/leaderboard/missing")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Benchmark not found"}
+
+
+async def test_openapi_includes_baseline_schema(async_client: httpx.AsyncClient) -> None:
+    response = await async_client.get("/openapi.json")
+
+    assert response.status_code == 200
+    assert "BaselineSchema" in response.json()["components"]["schemas"]

--- a/apps/scoreboard/tests/unit/test_leaderboard_routes.py
+++ b/apps/scoreboard/tests/unit/test_leaderboard_routes.py
@@ -253,9 +253,9 @@ async def test_get_leaderboard_returns_empty_baselines_when_none_imported(
     async_client: httpx.AsyncClient,
 ) -> None:
     store = ScoreStore()
-    await _register_benchmark(store)
+    await _register_benchmark(store, benchmark_id="demo-benchmark", display_name="Demo Benchmark")
 
-    response = await async_client.get("/v1/leaderboard/hle")
+    response = await async_client.get("/v1/leaderboard/demo-benchmark")
 
     assert response.status_code == 200
     assert response.json()["baselines"] == []
@@ -265,11 +265,11 @@ async def test_get_leaderboard_returns_imported_baselines_ordered_by_accuracy(
     async_client: httpx.AsyncClient,
 ) -> None:
     store = ScoreStore()
-    await _register_benchmark(store)
+    await _register_benchmark(store, benchmark_id="demo-benchmark", display_name="Demo Benchmark")
     baseline_store = BaselineStore()
     await baseline_store.import_baseline(
         BaselineImportRow(
-            benchmark_id="hle",
+            benchmark_id="demo-benchmark",
             model_name="Model A",
             accuracy=0.55,
             source="lmarena",
@@ -277,21 +277,21 @@ async def test_get_leaderboard_returns_imported_baselines_ordered_by_accuracy(
     )
     await baseline_store.import_baseline(
         BaselineImportRow(
-            benchmark_id="hle",
+            benchmark_id="demo-benchmark",
             model_name="Model B",
             accuracy=0.71,
             source="artificial_analysis",
-            source_url="https://artificialanalysis.ai/hle",
+            source_url="https://artificialanalysis.ai/demo-benchmark",
         )
     )
 
-    response = await async_client.get("/v1/leaderboard/hle")
+    response = await async_client.get("/v1/leaderboard/demo-benchmark")
 
     assert response.status_code == 200
     body = response.json()
     assert [baseline["model_name"] for baseline in body["baselines"]] == ["Model B", "Model A"]
     assert body["baselines"][0]["source"] == "artificial_analysis"
-    assert body["baselines"][0]["source_url"] == "https://artificialanalysis.ai/hle"
+    assert body["baselines"][0]["source_url"] == "https://artificialanalysis.ai/demo-benchmark"
     assert body["baselines"][1]["source_url"] is None
 
 

--- a/docs/tasks/2026-07-09-import-lmarena-baselines.md
+++ b/docs/tasks/2026-07-09-import-lmarena-baselines.md
@@ -1,0 +1,31 @@
+---
+id: OME-322
+linear_url: https://linear.app/openmined/issue/OME-322/sf-28-leaderboard-import-single-model-baselines-from-lmarena
+status: in_progress
+type: task
+priority: P2
+labels: [Leaderboard, app/scoreboard, autonomous, agentic]
+created: 2026-07-09
+closed:
+---
+
+Seed each benchmark's "line to beat" from external single-model baselines.
+
+**Scope**
+
+* Import single-model scores (LMArena / Artificial Analysis) as baseline entries with
+  source attribution, surfaced via the existing `GET /v1/leaderboard/{benchmark_id}`
+  read path.
+* Later: scheduled auto-sync (out of scope here).
+
+**Done when** each board shows real imported single-model baselines as the target
+line.
+
+**Scoping decisions (agreed with owner 2026-07-09):**
+- Build the import mechanism only — no real baseline numbers seeded this pass
+  (`livetruth`/`livetruth-latest` are OpenMined-proprietary; only `hle` has real
+  external single-model data to import, and that's left for a follow-up once sourced).
+- Backend/API only — the portal "target line" rendering is an explicit follow-up, not
+  covered by this ticket.
+
+Plan: `/Users/filip/.claude/plans/resume-fluttering-moon.md` (approved in plain words).

--- a/docs/tasks/2026-07-09-import-lmarena-baselines.md
+++ b/docs/tasks/2026-07-09-import-lmarena-baselines.md
@@ -1,7 +1,7 @@
 ---
 id: OME-322
 linear_url: https://linear.app/openmined/issue/OME-322/sf-28-leaderboard-import-single-model-baselines-from-lmarena
-status: in_progress
+status: in_review
 type: task
 priority: P2
 labels: [Leaderboard, app/scoreboard, autonomous, agentic]

--- a/docs/work/2026-07-09-OME-322-import-lmarena-baselines.md
+++ b/docs/work/2026-07-09-OME-322-import-lmarena-baselines.md
@@ -1,0 +1,99 @@
+---
+ticket: OME-322
+stack: scoreboard
+status: done
+started: 2026-07-09
+finished: 2026-07-09
+---
+
+# OME-322 — Import single-model baselines (mechanism only, backend/API)
+
+## Intent
+
+The public scoreboard only shows community-submitted `Score` rows (URL4 ensemble
+runs) — there's no "line to beat" showing what a single frontier model already
+scores, so users can't tell whether an ensemble is actually beating a strong
+baseline. Add a mechanism to import single-model baseline scores (from LMArena /
+Artificial Analysis) with source attribution, surfaced through the existing
+leaderboard read path.
+
+Scoping decisions agreed with the owner (2026-07-09): build the import mechanism
+only — no real baseline numbers seeded this pass (`livetruth`/`livetruth-latest` are
+OpenMined-proprietary; only `hle` has real external single-model data, left for a
+follow-up once sourced) — and backend/API only, no portal "target line" rendering
+(explicit follow-up).
+
+## Planned changes
+
+- `apps/scoreboard/src/scoreboard/scores/models/baseline.py` (new `Baseline` model)
+- `apps/scoreboard/src/scoreboard/scores/models/__init__.py` (export, if models are
+  re-exported there — confirm during DESIGN)
+- `apps/scoreboard/src/scoreboard/scores/migrations/` (new migration for `baselines` table)
+- `apps/scoreboard/src/scoreboard/scores/schemas.py` (`BaselineSchema`, `BaselineImportRow`)
+- `apps/scoreboard/src/scoreboard/scores/baseline_store.py` (new `BaselineStore`)
+- `apps/scoreboard/src/scoreboard/routes/leaderboard.py` (`LeaderboardResponse.baselines`)
+- `apps/scoreboard/src/scoreboard/import_baselines.py` (new CLI, mirrors `seed.py`)
+- Tests: `tests/unit/scores/test_models.py`, `tests/unit/scores/test_schemas.py`,
+  `tests/unit/scores/test_baseline_store.py` (new),
+  `tests/unit/test_leaderboard_routes.py`, `tests/unit/test_import_baselines.py` (new)
+
+## Test plan
+
+- Model: table name, FK to `Benchmark` (`on_delete=RESTRICT`), `unique_together`
+  (benchmark, model_name, source) enforced.
+- Schema: `BaselineSchema`/`BaselineImportRow` validation (accuracy bounds 0-1,
+  required fields, `extra="forbid"`).
+- Store: `import_baseline` insert + upsert-on-conflict (re-import same
+  model_name+source updates in place, doesn't duplicate); `list_baselines` ordering
+  (accuracy desc); unknown `benchmark_id` → clear error, no orphan row.
+- Route: `GET /v1/leaderboard/{benchmark_id}` returns `baselines: []` when none exist,
+  and populated `BaselineSchema` entries when present — existing `entries` behavior
+  unchanged (regression check on prior tests).
+- Import CLI: JSON-string-in → store-state-out, mirroring `test_seed.py`'s pattern;
+  invalid rows handled the same way `seed.py` handles invalid benchmark rows.
+
+## Acceptance
+
+- `GET /v1/leaderboard/{id}` exposes a `baselines` field consumers can read.
+- `python -m scoreboard.import_baselines` can idempotently load baseline rows from a
+  JSON payload.
+- All existing scoreboard tests remain green; new tests cover the above.
+- `run_gates.py scoreboard` all green (ruff, format, pyright, pytest --cov-fail-under=80).
+- Migration applies cleanly and a second run is a no-op.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned —
+  `src/scoreboard/scores/models/baseline.py` (new), `models/__init__.py` (edit),
+  `scores/migrations/0002_auto_20260709_1350.py` (new, generated via
+  `uv run tortoise makemigrations`), `scores/schemas.py` (edit: `BaselineSchema`,
+  `BaselineImportRow`), `scores/baseline_store.py` (new), `main.py` (edit: wire
+  `app.state.baseline_store`), `routes/leaderboard.py` (edit: `baselines` field +
+  `_baseline_store` helper), `import_baselines.py` (new CLI, mirrors `seed.py`);
+  tests: `test_models.py`, `test_schemas.py`, `test_leaderboard_routes.py` (extended),
+  `test_baseline_store.py`, `test_import_baselines.py` (new).
+- **Commits:** <fill after commit below>
+- **Gates:** `run_gates.py scoreboard --skip-append-only` → ALL GATES GREEN (ruff
+  check, ruff format --check, pyright 0 errors, pytest 95 passed/1 skipped,
+  coverage 87.57% ≥ 80%). Migration applied + re-applied → second run "No migrations
+  to apply" (idempotent, per README's verification convention).
+- **Deviations:**
+  1. `tortoise-dev` companion skill (mandatory per `.claude/sdlc.local.md`
+     `companion_skills`) was installed mid-session
+     (`tortoise-dev@bershadsky-claude-tools`) but never loaded into this active
+     session — plugin loads require a session restart, which wasn't done. Followed
+     the same house patterns by reading `models/benchmark.py`/`models/score.py`
+     directly (model-per-file, abstract base, native Tortoise migrations, Pydantic
+     v2) instead of invoking the skill.
+  2. `run_gates.py`'s append-only check (`--base HEAD`) false-positived on
+     `test_models.py`/`test_schemas.py`/`test_leaderboard_routes.py` — it flags any
+     git-modified test file regardless of content, and can't distinguish a pure
+     addition from a rewrite. Verified via `git diff` that all three files only have
+     `+` hunks (new imports, new test functions) — zero existing test lines
+     altered/removed. Ran with `--skip-append-only` for this cycle. Filed **OME-369**
+     to fix the check's heuristic (diff added/removed lines within changed test
+     files, not file-level git status).
+  3. Scope, per owner decision at ticket start: mechanism only, no real baseline
+     data seeded (`hle` is the only benchmark with real external single-model data;
+     `livetruth`/`livetruth-latest` are OpenMined-proprietary); portal "target line"
+     rendering is an explicit follow-up, not part of this unit.

--- a/docs/work/2026-07-09-OME-322-import-lmarena-baselines.md
+++ b/docs/work/2026-07-09-OME-322-import-lmarena-baselines.md
@@ -72,7 +72,7 @@ follow-up once sourced) — and backend/API only, no portal "target line" render
   `_baseline_store` helper), `import_baselines.py` (new CLI, mirrors `seed.py`);
   tests: `test_models.py`, `test_schemas.py`, `test_leaderboard_routes.py` (extended),
   `test_baseline_store.py`, `test_import_baselines.py` (new).
-- **Commits:** <fill after commit below>
+- **Commits:** 0582ce6 — feat(scoreboard): import single-model baselines with source attribution
 - **Gates:** `run_gates.py scoreboard --skip-append-only` → ALL GATES GREEN (ruff
   check, ruff format --check, pyright 0 errors, pytest 95 passed/1 skipped,
   coverage 87.57% ≥ 80%). Migration applied + re-applied → second run "No migrations

--- a/docs/work/2026-07-10-OME-322-address-review-feedback.md
+++ b/docs/work/2026-07-10-OME-322-address-review-feedback.md
@@ -1,0 +1,73 @@
+---
+ticket: OME-322
+stack: scoreboard
+status: done
+started: 2026-07-10
+finished: 2026-07-10
+---
+
+# OME-322 — address Dmitry's PR #379 review feedback (round 1)
+
+## Intent
+
+Dmitry left 4 substantive review comments on PR #379. Address the 3 that are clean,
+well-scoped code fixes; the 4th (benchmark-identity mismatch: production's `hle` is
+OpenMined's internal "News Hallucinations", not the real Humanity's Last Exam) spans
+the benchmark registry/import contract/docs per his own note and is a design/data
+decision, not a code fix — asked him directly on the PR thread instead of guessing.
+
+## Planned changes
+
+- `apps/scoreboard/src/scoreboard/scores/schemas.py`:
+  - `BaselineImportRow.accuracy` — add `strict=True, allow_inf_nan=False` (keep the
+    existing custom range validator/message as-is, don't replace it with `Field(ge=,
+    le=)`, to avoid changing the error text a prior test already asserts on).
+  - `BaselineImportRow.metadata` — add a depth+size bound validator so a deeply
+    nested/oversized payload is rejected at import time, before it can ever reach
+    storage or response serialization.
+- `apps/scoreboard/src/scoreboard/scores/baseline_store.py`:
+  - `import_baseline` — accept an optional `using_db` for transactional use.
+  - new `import_many` — wraps a batch in one `in_transaction()`, all-or-nothing.
+- `apps/scoreboard/src/scoreboard/import_baselines.py`:
+  - `import_baselines()` delegates to `BaselineStore.import_many` instead of looping
+    row-by-row itself.
+- Tests: extend `test_schemas.py` (strict accuracy, metadata bounds),
+  `test_baseline_store.py` (batch atomicity), `test_import_baselines.py` (same, via
+  the CLI-facing function).
+
+## Test plan
+
+- Reject `accuracy: true`/`false` (bool coercion), a numeric string, and `NaN`/`Infinity`.
+- Accept a plain float/int in range (regression — must keep passing).
+- Reject metadata nested past a bound; reject metadata serializing past a byte bound;
+  accept metadata within bounds (regression).
+- Batch import: row 1 valid + row 2 unknown benchmark → raises, AND row 1 is NOT
+  persisted (list_baselines returns empty for that benchmark afterward).
+
+## Acceptance
+
+- All 3 fixes land with tests proving the specific failure mode each one closes.
+- All prior tests remain green and unmodified.
+- `run_gates.py scoreboard` all green (same `--skip-append-only` situation as before,
+  OME-369 fixes this but isn't merged yet).
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned — `schemas.py`, `baseline_store.py`,
+  `import_baselines.py`, `test_schemas.py`, `test_baseline_store.py`.
+- **Commits:** <fill after commit below>
+- **Gates:** `run_gates.py scoreboard --skip-append-only` → ALL GATES GREEN (ruff,
+  format, pyright 0 errors, pytest 104 passed/1 skipped, coverage 87.81% ≥ 80%).
+- **Deviations:**
+  1. Benchmark-identity mismatch (Dmitry's 4th comment) deliberately not addressed
+     this cycle — replied on the PR thread asking him to pick a direction first, per
+     owner decision.
+  2. Kept the existing custom range validator for `accuracy` instead of moving the
+     0-1 bound into `Field(ge=, le=)` as Dmitry's suggestion literally showed, so the
+     error message a prior test asserts on doesn't change (rule 5). Added
+     `strict=True, allow_inf_nan=False` via `Field` for the actual coercion/inf-nan
+     fix; the range check stays a separate validator, same message as before.
+  3. Bounded the `metadata` field only on the import DTO (the only writer today), not
+     also on the response schema — the import bound already prevents the reported
+     crash since nothing unbounded can reach storage. Noted as a deliberately minimal
+     scope, not a missed spot.

--- a/docs/work/2026-07-10-OME-322-address-review-feedback.md
+++ b/docs/work/2026-07-10-OME-322-address-review-feedback.md
@@ -55,7 +55,7 @@ decision, not a code fix — asked him directly on the PR thread instead of gues
 
 - **Actual files:** as planned — `schemas.py`, `baseline_store.py`,
   `import_baselines.py`, `test_schemas.py`, `test_baseline_store.py`.
-- **Commits:** <fill after commit below>
+- **Commits:** be2d082 — fix(scoreboard): harden baseline import per review (metadata, accuracy, batch)
 - **Gates:** `run_gates.py scoreboard --skip-append-only` → ALL GATES GREEN (ruff,
   format, pyright 0 errors, pytest 104 passed/1 skipped, coverage 87.81% ≥ 80%).
 - **Deviations:**

--- a/docs/work/2026-07-10-OME-322-bound-response-metadata.md
+++ b/docs/work/2026-07-10-OME-322-bound-response-metadata.md
@@ -1,0 +1,63 @@
+---
+ticket: OME-322
+stack: scoreboard
+status: done
+started: 2026-07-10
+finished: 2026-07-10
+---
+
+# OME-322 — bound BaselineSchema.metadata + make list_baselines resilient to a bad row
+
+## Intent
+
+Dmitry's 3rd round follow-up (non-blocking, PR already approved): a deeply
+nested/oversized `metadata` value that somehow reaches the DB still crashes
+`GET /v1/leaderboard/{id}` with a 500 on SQLite (PostgreSQL rejects it at insertion
+instead) — so today, one bad row can make the whole board unavailable, and the
+failure mode is database-dependent. `BaselineImportRow` already bounds `metadata` at
+import time (round 2), but `BaselineSchema` (the read side) has no such bound, and
+`list_baselines()` has no defense if a row still fails to convert.
+
+Chose option C (discussed with owner): bound `BaselineSchema.metadata` too (shared
+validator, consistency), AND make `list_baselines()` skip a row that fails to convert
+instead of raising — that's the part that actually keeps the board available when one
+row is bad, not just moving where the same crash happens.
+
+## Planned changes
+
+- `apps/scoreboard/src/scoreboard/scores/schemas.py`: extract the existing
+  depth/size check out of `BaselineImportRow.validate_metadata` into a shared
+  `_validate_bounded_metadata` function; add the same `@field_validator("metadata")`
+  to `BaselineSchema` calling it.
+- `apps/scoreboard/src/scoreboard/scores/baseline_store.py`: `list_baselines()` —
+  catch a conversion failure per row, skip that row (log via `print` to stderr; no
+  logging convention exists yet in this app), keep returning the rest.
+
+## Test plan
+
+- `BaselineSchema` construction: valid metadata passes (regression); oversized/deep
+  metadata raises.
+- `list_baselines()`: seed one good row + one row whose metadata bypasses the import
+  guard (inserted directly via the model, not through `BaselineImportRow`) with
+  oversized metadata → the good row is still returned, the bad one is silently
+  dropped, not a crash.
+
+## Acceptance
+
+- A single bad row never prevents `GET /v1/leaderboard/{id}` from returning the good
+  rows.
+- All prior tests remain green and unmodified.
+- `run_gates.py scoreboard --skip-append-only` all green.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned — `schemas.py` (shared `_validate_bounded_metadata` +
+  `BaselineSchema` validator), `baseline_store.py` (`list_baselines` skip-on-error),
+  `test_schemas.py`, `test_baseline_store.py`.
+- **Commits:** <fill after commit below>
+- **Gates:** `run_gates.py scoreboard --skip-append-only` → ALL GATES GREEN (ruff,
+  format, pyright 0 errors, pytest 113 passed/1 skipped, coverage 88.16% ≥ 80%).
+- **Deviations:** none — matches the plan (option C, agreed with owner). Confirmed via
+  test that the validator alone (without the store-side fix) still raised at
+  construction time — proving the skip-on-error logic in `list_baselines` is the part
+  that actually keeps the board available, not just the added validator.

--- a/docs/work/2026-07-10-OME-322-bound-response-metadata.md
+++ b/docs/work/2026-07-10-OME-322-bound-response-metadata.md
@@ -54,7 +54,7 @@ row is bad, not just moving where the same crash happens.
 - **Actual files:** as planned — `schemas.py` (shared `_validate_bounded_metadata` +
   `BaselineSchema` validator), `baseline_store.py` (`list_baselines` skip-on-error),
   `test_schemas.py`, `test_baseline_store.py`.
-- **Commits:** <fill after commit below>
+- **Commits:** ade85fa — fix(scoreboard): bound response metadata + skip a bad baseline row
 - **Gates:** `run_gates.py scoreboard --skip-append-only` → ALL GATES GREEN (ruff,
   format, pyright 0 errors, pytest 113 passed/1 skipped, coverage 88.16% ≥ 80%).
 - **Deviations:** none — matches the plan (option C, agreed with owner). Confirmed via

--- a/docs/work/2026-07-10-OME-322-source-url-scheme-and-fixture-rename.md
+++ b/docs/work/2026-07-10-OME-322-source-url-scheme-and-fixture-rename.md
@@ -1,0 +1,63 @@
+---
+ticket: OME-322
+stack: scoreboard
+status: done
+started: 2026-07-10
+finished: 2026-07-10
+---
+
+# OME-322 — restrict source_url scheme + rename demo test fixtures away from hle
+
+## Intent
+
+Second round of Dmitry's PR #379 review. Two items:
+1. `BaselineImportRow.source_url` accepts any string, including `javascript:`/`data:`
+   URIs, which the public API returns and a future client could render as a link.
+2. Non-blocking cleanup he suggested: rename the `hle` benchmark id used in this
+   ticket's test fixtures to a neutral placeholder, since production's real `hle` is
+   an unrelated demo dataset (tracked separately as OME-396) — avoids reinforcing an
+   ambiguity these tests never meant to claim.
+
+Filed OME-396 for the actual registry/canonical-id decision; that's out of scope here.
+
+## Planned changes
+
+- `apps/scoreboard/src/scoreboard/scores/schemas.py`: `BaselineImportRow.source_url` —
+  add a field_validator requiring an `http://`/`https://` prefix (consistent style
+  with the other custom validators in this file, not a raw `Field(pattern=...)`), plus
+  `Field(max_length=2048)` to match the DB column limit.
+- Rename `benchmark_id="hle"` to a neutral placeholder (`demo-benchmark`) across this
+  ticket's OWN test fixtures in `test_baseline_store.py`, `test_import_baselines.py`,
+  and the leaderboard-route baseline tests. This touches prior-cycle test bodies —
+  explicitly authorized by the owner (not a silent rule-5 violation) — full test suite
+  run required after to confirm nothing regresses.
+
+## Test plan
+
+- Reject `javascript:alert(1)`, `data:text/html,...`, and a plain non-URL string for
+  `source_url`.
+- Accept a valid `https://` URL (regression).
+- Reject a `source_url` over 2048 chars.
+- After the fixture rename: full suite green, same pass count as before (rename only,
+  no behavior change).
+
+## Acceptance
+
+- New validator tests pass; all prior tests pass under their new fixture names.
+- `run_gates.py scoreboard --skip-append-only` all green.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned — `schemas.py`, plus renamed fixtures in
+  `test_schemas.py`, `test_baseline_store.py`, `test_import_baselines.py`, and (only
+  the 2 baseline-specific tests, via explicit override, not the shared helper default)
+  `test_leaderboard_routes.py`. Also filed OME-396 (Linear, not a repo file).
+- **Commits:** <fill after commit below>
+- **Gates:** `run_gates.py scoreboard --skip-append-only` → ALL GATES GREEN (ruff,
+  format, pyright 0 errors, pytest 109 passed/1 skipped, coverage 87.91% ≥ 80%).
+- **Deviations:** none — matches the plan. Fixture rename in
+  `test_leaderboard_routes.py` was scoped to only the 2 baseline-specific tests
+  (explicit `benchmark_id`/`display_name` override), not the shared `_register_benchmark`
+  default or any of the pre-existing, unrelated score/leaderboard tests that also use
+  "hle" — renaming those would have been out of scope and touched tests this ticket
+  doesn't own.

--- a/docs/work/2026-07-10-OME-322-source-url-scheme-and-fixture-rename.md
+++ b/docs/work/2026-07-10-OME-322-source-url-scheme-and-fixture-rename.md
@@ -52,7 +52,7 @@ Filed OME-396 for the actual registry/canonical-id decision; that's out of scope
   `test_schemas.py`, `test_baseline_store.py`, `test_import_baselines.py`, and (only
   the 2 baseline-specific tests, via explicit override, not the shared helper default)
   `test_leaderboard_routes.py`. Also filed OME-396 (Linear, not a repo file).
-- **Commits:** <fill after commit below>
+- **Commits:** 420d081 — fix(scoreboard): restrict baseline source_url to http(s), rename demo fixtures
 - **Gates:** `run_gates.py scoreboard --skip-append-only` → ALL GATES GREEN (ruff,
   format, pyright 0 errors, pytest 109 passed/1 skipped, coverage 87.91% ≥ 80%).
 - **Deviations:** none — matches the plan. Fixture rename in


### PR DESCRIPTION
## Summary

- Adds a `Baseline` model (`apps/scoreboard/src/scoreboard/scores/models/baseline.py`), FK to `Benchmark`, unique on `(benchmark, model_name, source)` so re-imports upsert in place instead of duplicating.
- Adds `BaselineStore` (`import_baseline`, `list_baselines`) — separate from `ScoreStore` since a baseline is a distinct concept from a community submission (no url4_expression/provider/correctness fields).
- Adds `import_baselines.py`, a CLI mirroring the existing `seed.py` pattern (`python -m scoreboard.import_baselines`, `SCOREBOARD_SEED_BASELINES_JSON` env var).
- Surfaces baselines via a new `baselines` field on `GET /v1/leaderboard/{benchmark_id}` — additive, no breaking change to the existing response shape.
- New migration `0002_auto_20260709_1350.py`, applied + re-applied to confirm idempotency.

**Scoped deliberately to mechanism only** (agreed with the ticket owner at kickoff):
- No real baseline data seeded this pass — `livetruth`/`livetruth-latest` are OpenMined-proprietary benchmarks with no external LMArena/Artificial Analysis coverage; only `hle` has real data to import, left for a follow-up once sourced.
- No portal UI rendering of a "target line" — the portal has no reference-line concept today; that's an explicit follow-up, not part of this PR.

## Test plan

- [x] `uv run ruff check` / `ruff format --check` / `pyright` — all clean
- [x] `uv run pytest --cov=scoreboard --cov-fail-under=80` — 95 passed, 1 skipped, 87.57% coverage
- [x] Migration applied twice — second run reports no pending migrations
- [x] New tests: model (table/FK/unique_together), schema validation, store (insert/upsert/unknown-benchmark/ordering), route (`baselines` field empty + populated), CLI (JSON-in/store-state-out)
- [x] All prior tests remain green and unmodified (verified via `git diff` — pure additions only)

Refs: OME-322

🤖 Generated with [Claude Code](https://claude.com/claude-code)