### PR TITLE
fix(repo): append-only gate checks line-level diffs, not file status

### DIFF
--- a/.claude/scripts/run_gates.py
+++ b/.claude/scripts/run_gates.py
@@ -18,9 +18,9 @@ Exit codes: 0 all green · 1 a gate or the append-only check failed · 2 config 
 
 import argparse
 import ast
+import difflib
 import fnmatch
 import pathlib
-import re
 import subprocess
 import sys
 from typing import NoReturn
@@ -65,9 +65,6 @@ def load_card(path: pathlib.Path) -> dict:
     if not isinstance(data.get("stacks"), list):
         fail_config(f"{path} frontmatter must define a `stacks:` list")
     return data
-
-
-_HUNK_HEADER = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+\d+(?:,\d+)? @@")
 
 
 # WHY: an ALLOWLIST of data-holding node types, not a denylist of "everything
@@ -141,94 +138,64 @@ def _old_protected_ranges(root: pathlib.Path, base: str, path: str) -> list[tupl
 
 
 def _diff_positions(root: pathlib.Path, base: str, path: str) -> tuple[set[int], set[int]]:
-    """Old-file positions the diff for `path` vs `base` touches, in two forms:
+    """Old-file positions where `path`'s content differs between `base` and the
+    working tree, in two forms:
 
-    - `removed`: an old line number itself changed/removed (a `-` line) — checked
-      against a protected range INCLUSIVE on both ends (`lo <= ln <= hi`).
+    - `removed`: an old line number itself changed/removed — checked against a
+      protected range INCLUSIVE on both ends (`lo <= ln <= hi`).
     - `inserted_after`: an old line number that NEW content was inserted directly
       after, with no old line consumed for it — checked EXCLUSIVE at the upper end
       (`lo <= n < hi`).
     """
+    # WHY: diff actual line CONTENT (old file via `git show`, new file read
+    # straight off disk) with difflib.SequenceMatcher, rather than hand-parsing
+    # `git diff`'s unified-diff TEXT. Three separate rounds of bugs (a removed
+    # line starting with `--` false-matching a text-based header check; a
+    # replace pair's insertion anchor landing one line later than it should;
+    # an EOF-newline-only change rendering as a remove+add of unchanged text,
+    # in a way that couldn't be fixed correctly for multi-line hunks without
+    # LCS-style pairing) all stemmed from the same root cause: unified-diff TEXT
+    # has representational quirks (headers, no-newline markers, replace-pair
+    # ambiguity) that have nothing to do with whether a line's CONTENT actually
+    # changed. SequenceMatcher's opcodes are computed directly from line
+    # sequences, so a line byte-identical between old and new is always
+    # "equal" — none of those text-format artifacts can arise by construction.
+    #
     # AIDEV-NOTE: the exclusive bound on `inserted_after` is load-bearing. A pure
     # insertion (e.g. a whole new test function typed directly after an existing
     # one, zero blank lines between them) anchors at `n == hi` of the PRECEDING
     # function — that must stay unflagged, or this reopens the exact false-positive
     # OME-369 exists to fix (pure additions rejected as violations). Inserting as a
     # new first/middle statement anchors at `lo <= n < hi` and must be caught: a
-    # pure `+`-only diff can still silently neuter a prior test's assertions (e.g.
-    # forcing a variable's value right before the check) with zero `-` lines, which
-    # `removed` alone can never see.
-    #
-    # AIDEV-NOTE: file-level header lines (`diff --git`, `index`, `--- a/...`,
-    # `+++ b/...`) only ever appear BEFORE the first `@@` hunk line — track that
-    # boundary structurally (`in_hunk`) instead of prefix-matching `---`/`+++`
-    # against line content. A *removed* line whose actual content starts with `--`
-    # at column 0 (e.g. a bare `---` separator) renders as `----` in the diff,
-    # which would false-match a content-based header check and silently vanish
-    # from `removed` while desyncing `old_line` for every later line in the hunk.
-    #
-    # WHY: also track whether the most recent "-" line was immediately followed
-    # by "\ No newline at end of file" and, if so, whether the very next "+"
-    # line is byte-identical to it. git represents "content was appended after a
-    # file that didn't end in a newline" as a remove+add of that unchanged last
-    # line (its EOF status changed, not its text) — without this check, that
-    # renders as a false "removed/changed" hit on a protected range's last line
-    # for the ordinary, non-adversarial act of appending new content to a file
-    # that happened not to end in `\n`.
-    proc = subprocess.run(
-        ["git", "diff", "--relative", "--unified=0", base, "--", path],
-        cwd=root, capture_output=True, text=True,
+    # pure insertion can still silently neuter a prior test's assertions (e.g.
+    # forcing a variable's value right before the check) with zero removed lines,
+    # which `removed` alone can never see.
+    old_proc = subprocess.run(
+        ["git", "show", f"{base}:./{path}"], cwd=root, capture_output=True, text=True,
     )
-    if proc.returncode != 0:
-        fail_config(f"git diff failed in {root}: {proc.stderr.strip()}")
+    if old_proc.returncode != 0:
+        return set(), set()  # file didn't exist at base — nothing to protect
+    # AIDEV-NOTE: `append_only_check` only ever calls this for status "M" files,
+    # which are guaranteed to exist in the working tree — reading directly off
+    # disk is the correct equivalent of `git diff base -- path`'s implicit
+    # "against the working tree" comparison (no second ref given).
+    new_content = (root / path).read_text()
+    old_lines = old_proc.stdout.splitlines()
+    new_lines = new_content.splitlines()
+    matcher = difflib.SequenceMatcher(a=old_lines, b=new_lines, autojunk=False)
     removed: set[int] = set()
     inserted_after: set[int] = set()
-    old_line = 0
-    in_hunk = False
-    pure_insert_hunk = False
-    last_removed: tuple[int, str, bool] | None = None  # (old_line, content, no_newline)
-    for line in proc.stdout.splitlines():
-        if line.startswith("@@"):
-            m = _HUNK_HEADER.match(line)
-            if m:
-                old_line = int(m.group(1))
-                old_count = int(m.group(2)) if m.group(2) is not None else 1
-                # WHY: a hunk whose header declares old-count 0 is UNAMBIGUOUSLY a
-                # pure insertion straight from the header. Inferring "pure insert"
-                # by pairing "-"/"+" lines line-by-line instead would mis-anchor a
-                # replace pair (a "-" immediately followed by a "+") one line later
-                # than the line it actually replaces — which can land exactly on
-                # the start of the NEXT protected range and false-positive an edit
-                # that never touched it (e.g. replacing the blank separator line
-                # between two functions falsely flags the second function).
-                pure_insert_hunk = old_count == 0
-            in_hunk = True
-            last_removed = None
-        elif not in_hunk:
-            continue  # pre-hunk file header (diff --git / index / --- a/ / +++ b/)
-        elif line.startswith("\\"):
-            # "\ No newline at end of file" describes the line just emitted —
-            # never consumes a line number, but mark it on a pending removal so
-            # a byte-identical "+" right after can be recognized as an EOF-status
-            # artifact, not a real edit.
-            if last_removed is not None:
-                last_removed = (last_removed[0], last_removed[1], True)
-        elif line.startswith("-"):
-            removed.add(old_line)
-            last_removed = (old_line, line[1:], False)
-            old_line += 1
-        elif line.startswith("+"):
-            if last_removed is not None and last_removed[2] and last_removed[1] == line[1:]:
-                removed.discard(last_removed[0])
-            elif pure_insert_hunk:
-                inserted_after.add(old_line)  # anchored right after the current old_line
-            # else: part of a replace pair with a preceding "-" in THIS hunk —
-            # already captured via `removed`; anchoring it too would double-count
-            # and can mis-fire per the WHY note above.
-            last_removed = None
-        else:
-            last_removed = None
-            old_line += 1  # context line (present only if a non-zero unified context is used)
+    for tag, i1, i2, _j1, _j2 in matcher.get_opcodes():
+        if tag == "equal":
+            continue
+        if tag in ("delete", "replace"):
+            removed.update(range(i1 + 1, i2 + 1))  # old_lines is 0-indexed, ranges are 1-indexed
+        if tag == "insert":
+            inserted_after.add(i1)  # anchored right after old 1-indexed line i1
+        # "replace" deliberately does NOT also populate inserted_after — the
+        # removed lines already comprehensively signal the violation if inside
+        # a range, and anchoring the replacement's added lines too would
+        # double-count without adding coverage.
     return removed, inserted_after
 
 

--- a/.claude/scripts/run_gates.py
+++ b/.claude/scripts/run_gates.py
@@ -17,8 +17,10 @@ Exit codes: 0 all green · 1 a gate or the append-only check failed · 2 config 
 """
 
 import argparse
+import ast
 import fnmatch
 import pathlib
+import re
 import subprocess
 import sys
 from typing import NoReturn
@@ -65,8 +67,61 @@ def load_card(path: pathlib.Path) -> dict:
     return data
 
 
+_HUNK_HEADER = re.compile(r"^@@ -(\d+)(?:,\d+)? \+\d+(?:,\d+)? @@")
+
+
+def _old_test_ranges(root: pathlib.Path, base: str, path: str) -> list[tuple[int, int]]:
+    """Line ranges (1-indexed, inclusive) of every test function body in `path` at `base`."""
+    proc = subprocess.run(
+        ["git", "show", f"{base}:{path}"], cwd=root, capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        return []  # file didn't exist at base — nothing to protect
+    try:
+        tree = ast.parse(proc.stdout)
+    except SyntaxError:
+        return []  # can't parse — fall through to the safe (permissive) side
+    ranges = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test_"):
+            ranges.append((node.lineno, getattr(node, "end_lineno", node.lineno)))
+    return ranges
+
+
+def _removed_old_lines(root: pathlib.Path, base: str, path: str) -> set[int]:
+    """Old-file line numbers that a removal/change touches, per the diff for `path` vs `base`."""
+    proc = subprocess.run(
+        ["git", "diff", "--relative", "--unified=0", base, "--", path],
+        cwd=root, capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        fail_config(f"git diff failed in {root}: {proc.stderr.strip()}")
+    removed: set[int] = set()
+    old_line = 0
+    for line in proc.stdout.splitlines():
+        if line.startswith("@@"):
+            m = _HUNK_HEADER.match(line)
+            old_line = int(m.group(1)) if m else old_line
+        elif line.startswith(("---", "+++", "\\")):
+            continue
+        elif line.startswith("-"):
+            removed.add(old_line)
+            old_line += 1
+        elif line.startswith("+"):
+            continue  # inserted line — doesn't consume an old line number
+        else:
+            old_line += 1  # context line (present only if a non-zero unified context is used)
+    return removed
+
+
 def append_only_check(root: pathlib.Path, base: str, globs: list[str]) -> bool:
-    """True when no previously committed test file was modified/deleted/renamed."""
+    """True when no previously committed *test* was modified/deleted (rule 5).
+
+    Pure additions to a test file (new test functions, new imports for them) are
+    always fine — only a removed/changed line that falls INSIDE a test function body
+    that already existed at `base` counts as a violation. Deleting or renaming a
+    whole test file is always a violation regardless of content.
+    """
     proc = subprocess.run(
         ["git", "diff", "--relative", "--name-status", base],
         cwd=root,
@@ -83,10 +138,20 @@ def append_only_check(root: pathlib.Path, base: str, globs: list[str]) -> bool:
             status[:1] not in "MDR"
         ):  # A(dded)/C(opied) etc. are fine — adding tests is always fine
             continue
-        for p in paths:
-            if any(fnmatch.fnmatch(p, g) for g in globs):
-                offenders.append(f"  {status}\t{p}")
-                break
+        matched = [p for p in paths if any(fnmatch.fnmatch(p, g) for g in globs)]
+        if not matched:
+            continue
+        p = matched[-1]  # for R(ename), name-status gives "old\tnew" — the new path is what's on disk
+        if status[:1] != "M":
+            offenders.append(f"  {status}\t{p}")
+            continue
+        test_ranges = _old_test_ranges(root, base, p)
+        bad_lines = sorted(
+            ln for ln in _removed_old_lines(root, base, p)
+            if any(lo <= ln <= hi for lo, hi in test_ranges)
+        )
+        if bad_lines:
+            offenders.append(f"  M\t{p}  (removed/changed inside an existing test, old line(s) {bad_lines})")
     if offenders:
         print(
             f"{RED} append-only test check — prior tests were modified/deleted (vs {base}):"

--- a/.claude/scripts/run_gates.py
+++ b/.claude/scripts/run_gates.py
@@ -88,14 +88,17 @@ def _old_protected_ranges(root: pathlib.Path, base: str, path: str) -> list[tupl
     # returns `[]` (falls into the "didn't exist" branch) for every stack whose
     # root isn't the repo root, i.e. every real stack in `.claude/sdlc.local.md`.
     proc = subprocess.run(
-        ["git", "show", f"{base}:./{path}"], cwd=root, capture_output=True, text=True,
+        ["git", "show", f"{base}:./{path}"], cwd=root, capture_output=True,
     )
     if proc.returncode != 0:
         return []  # file didn't exist at base — nothing to protect
     try:
-        tree = ast.parse(proc.stdout)
-    except SyntaxError:
-        return []  # can't parse — fall through to the safe (permissive) side
+        # WHY: bytes + errors="replace", not text=True — a committed undecodable
+        # file must fall through to the permissive SyntaxError branch below, not
+        # crash the subprocess decode with UnicodeDecodeError.
+        tree = ast.parse(proc.stdout.decode("utf-8", errors="replace"))
+    except (SyntaxError, ValueError):
+        return []  # can't parse (incl. null bytes) — fall through to the safe (permissive) side
     ranges = []
     # INVARIANT: covers EVERY function, not just `test_*`-named ones — a
     # `conftest.py` fixture or a plain helper a test depends on is just as
@@ -170,8 +173,13 @@ def _diff_positions(root: pathlib.Path, base: str, path: str) -> tuple[set[int],
     # pure insertion can still silently neuter a prior test's assertions (e.g.
     # forcing a variable's value right before the check) with zero removed lines,
     # which `removed` alone can never see.
+    # WHY: compare BYTES on both sides, never decoded text — a working-tree file
+    # rewritten with undecodable/binary content would make a text-mode read raise
+    # UnicodeDecodeError and crash the gate with a traceback instead of a verdict.
+    # Byte lines diff identically for ordinary text, and binary junk replacing a
+    # protected test simply differs line-wise → flagged (fail-closed), no crash.
     old_proc = subprocess.run(
-        ["git", "show", f"{base}:./{path}"], cwd=root, capture_output=True, text=True,
+        ["git", "show", f"{base}:./{path}"], cwd=root, capture_output=True,
     )
     if old_proc.returncode != 0:
         return set(), set()  # file didn't exist at base — nothing to protect
@@ -179,9 +187,8 @@ def _diff_positions(root: pathlib.Path, base: str, path: str) -> tuple[set[int],
     # which are guaranteed to exist in the working tree — reading directly off
     # disk is the correct equivalent of `git diff base -- path`'s implicit
     # "against the working tree" comparison (no second ref given).
-    new_content = (root / path).read_text()
     old_lines = old_proc.stdout.splitlines()
-    new_lines = new_content.splitlines()
+    new_lines = (root / path).read_bytes().splitlines()
     matcher = difflib.SequenceMatcher(a=old_lines, b=new_lines, autojunk=False)
     removed: set[int] = set()
     inserted_after: set[int] = set()

--- a/.claude/scripts/run_gates.py
+++ b/.claude/scripts/run_gates.py
@@ -20,6 +20,8 @@ import argparse
 import ast
 import difflib
 import fnmatch
+import io
+import os
 import pathlib
 import subprocess
 import sys
@@ -72,39 +74,65 @@ def load_card(path: pathlib.Path) -> dict:
 # (a docstring, an `if __name__ == "__main__":` block, an import nested inside
 # a version-guard) silently becomes a false positive the next time someone
 # edits one. Assign/AnnAssign/AugAssign hold the kind of shared test data (e.g.
-# a `_BASE_KW = {...}` dict, or a `_CASES += [...]` accumulator) rule 5 needs
-# to protect.
-_MODULE_LEVEL_DATA = (ast.Assign, ast.AnnAssign, ast.AugAssign)
+# a `_BASE_KW = {...}` dict, a `_CASES += [...]` accumulator, or a direct
+# collection-time assertion) rule 5 needs to protect.
+_MODULE_LEVEL_DATA = (ast.Assign, ast.AnnAssign, ast.AugAssign, ast.Assert)
 
 
-def _old_protected_ranges(root: pathlib.Path, base: str, path: str) -> list[tuple[int, int, int]]:
+def _class_header_end(tokens: list, node: ast.ClassDef) -> int:
+    """Last source line in a class header, excluding the class body."""
+    started = False
+    depth = 0
+    for token in tokens:
+        if not started:
+            started = token.string == "class" and token.start == (
+                node.lineno,
+                node.col_offset,
+            )
+            continue
+        if token.string in "([{":
+            depth += 1
+        elif token.string in ")]}" and depth:
+            depth -= 1
+        elif token.string == ":" and depth == 0:
+            return token.end[0]
+    return node.lineno
+
+
+def _old_protected_ranges(
+    root: pathlib.Path, base: str, path: str
+) -> list[tuple[int, int, int | None]] | None:
     """(start_line, end_line, def_column) triples — lines 1-indexed inclusive — for
     every protected node in `path` at `base`: every function body, plus every direct
     module-level Assign/AnnAssign/AugAssign statement. `def_column` is the node's
     own column offset, used to tell "new sibling appended after this body" apart
     from "new line appended INTO this body" (see append_only_check).
     """
+    import tokenize
+
     # AIDEV-NOTE: `path` is cwd-relative (it comes from `git diff --relative`), but
     # `git show rev:path` resolves a bare path relative to the REPO ROOT, not cwd —
     # the `./` prefix is what makes it cwd-relative. Without it, this silently
     # returns `[]` (falls into the "didn't exist" branch) for every stack whose
     # root isn't the repo root, i.e. every real stack in `.claude/sdlc.local.md`.
+    # Non-Python files still appear in active stack globs (for example the
+    # aigateway-ui TypeScript tests). Until a language-aware range parser exists,
+    # modifications to an existing unsupported artifact keep the old fail-closed
+    # behavior; A/C statuses remain legitimate additions in append_only_check.
+    if pathlib.PurePosixPath(path).suffix != ".py":
+        return None
+
     proc = subprocess.run(
         ["git", "show", f"{base}:./{path}"], cwd=root, capture_output=True,
     )
     if proc.returncode != 0:
-        return []  # file didn't exist at base — nothing to protect
+        return None
     try:
-        # WHY: bytes + errors="replace", not text=True — a committed undecodable
-        # file must fall through to the permissive SyntaxError branch below, not
-        # crash the subprocess decode with UnicodeDecodeError. The BOM strip is
-        # load-bearing too: CPython's tokenizer skips a UTF-8 BOM when reading
-        # source BYTES, but ast.parse of a STR starting with U+FEFF raises
-        # SyntaxError — without the strip, a BOM'd (perfectly valid, runnable)
-        # test file would fall into the permissive branch and lose ALL protection.
-        tree = ast.parse(proc.stdout.decode("utf-8", errors="replace").lstrip("\ufeff"))
-    except (SyntaxError, ValueError):
-        return []  # can't parse (incl. null bytes) — fall through to the safe (permissive) side
+        # Passing bytes lets Python honor UTF-8 BOM and PEP-263 source encodings.
+        tree = ast.parse(proc.stdout)
+        tokens = list(tokenize.tokenize(io.BytesIO(proc.stdout).readline))
+    except (IndentationError, SyntaxError, UnicodeDecodeError, ValueError, tokenize.TokenError):
+        return None
     ranges = []
     # INVARIANT: covers EVERY function, not just `test_*`-named ones — a
     # `conftest.py` fixture or a plain helper a test depends on is just as
@@ -117,6 +145,14 @@ def _old_protected_ranges(root: pathlib.Path, base: str, path: str) -> list[tupl
             # outermost decorator onto an old function is NOT caught — see gap (5).
             start = node.decorator_list[0].lineno if node.decorator_list else node.lineno
             ranges.append((start, getattr(node, "end_lineno", node.lineno), node.col_offset))
+        elif isinstance(node, ast.ClassDef):
+            # Protect only existing decorators and the class header/bases, not the
+            # whole body: adding a new sibling method must remain a pure addition.
+            start = node.decorator_list[0].lineno if node.decorator_list else node.lineno
+            # `None` disables the function-only end-of-body indentation rule:
+            # content after a class header is its body, where a first new method is
+            # a legitimate addition rather than an extension of old test logic.
+            ranges.append((start, _class_header_end(tokens, node), None))
     # INVARIANT: module-level test data is just as protected as a fixture — a
     # `-` line there is invisible to the function-only pass above.
     for node in tree.body:  # direct top-level children only — see AIDEV-NOTE below
@@ -154,7 +190,52 @@ def _old_protected_ranges(root: pathlib.Path, base: str, path: str) -> list[tupl
     return ranges
 
 
-def _diff_positions(root: pathlib.Path, base: str, path: str) -> tuple[set[int], dict[int, int]]:
+def _added_span_indent(
+    tokens: list | None,
+    new_lines: list[bytes],
+    start: int,
+    end: int,
+) -> int:
+    """Indent of the first code token in new_lines[start:end], else first text."""
+    import tokenize
+
+    ignored = {
+        tokenize.COMMENT,
+        tokenize.DEDENT,
+        tokenize.ENCODING,
+        tokenize.ENDMARKER,
+        tokenize.INDENT,
+        tokenize.NEWLINE,
+        tokenize.NL,
+    }
+    if tokens is not None:
+        for token in tokens:
+            if start + 1 <= token.start[0] <= end and token.type not in ignored:
+                line = new_lines[token.start[0] - 1]
+                prefix = line[: token.start[1]]
+                return len(prefix.rsplit(b"\f", 1)[-1])
+    else:
+        # Invalid current source will fail later gates, but must not fail open here.
+        return max(
+            (
+                len(
+                    line[: len(line) - len(line.lstrip(b" \t\f"))].rsplit(b"\f", 1)[-1]
+                )
+                for line in new_lines[start:end]
+                if line.strip()
+            ),
+            default=0,
+        )
+    for line in new_lines[start:end]:
+        if line.strip():
+            prefix = line[: len(line) - len(line.lstrip(b" \t\f"))]
+            return len(prefix.rsplit(b"\f", 1)[-1])
+    return 0
+
+
+def _diff_positions(
+    root: pathlib.Path, base: str, path: str
+) -> tuple[set[int], dict[int, int], bool]:
     """Old-file positions where `path`'s content differs between `base` and the
     working tree, in two forms:
 
@@ -167,6 +248,8 @@ def _diff_positions(root: pathlib.Path, base: str, path: str) -> tuple[set[int],
       end (`n == hi`) whose indent is deeper than the range's own definition
       column extends that body and is a violation too (see append_only_check).
     """
+    import tokenize
+
     # WHY: diff actual line CONTENT (old file via `git show`, new file read
     # straight off disk) with difflib.SequenceMatcher, rather than hand-parsing
     # `git diff`'s unified-diff TEXT. Three separate rounds of bugs (a removed
@@ -199,13 +282,26 @@ def _diff_positions(root: pathlib.Path, base: str, path: str) -> tuple[set[int],
         ["git", "show", f"{base}:./{path}"], cwd=root, capture_output=True,
     )
     if old_proc.returncode != 0:
-        return set(), set()  # file didn't exist at base — nothing to protect
+        return set(), {}, True  # file didn't exist at base — nothing to protect
     # AIDEV-NOTE: `append_only_check` only ever calls this for status "M" files,
     # which are guaranteed to exist in the working tree — reading directly off
     # disk is the correct equivalent of `git diff base -- path`'s implicit
     # "against the working tree" comparison (no second ref given).
     old_lines = old_proc.stdout.splitlines()
-    new_lines = (root / path).read_bytes().splitlines()
+    new_source = (root / path).read_bytes()
+    new_lines = new_source.splitlines()
+    try:
+        compile(new_source, path, "exec")
+        new_tokens = list(tokenize.tokenize(io.BytesIO(new_source).readline))
+    except (
+        IndentationError,
+        SyntaxError,
+        UnicodeDecodeError,
+        ValueError,
+        tokenize.TokenError,
+    ):
+        new_tokens = None
+    current_parseable = new_tokens is not None
     matcher = difflib.SequenceMatcher(a=old_lines, b=new_lines, autojunk=False)
     removed: set[int] = set()
     inserted_after: dict[int, int] = {}
@@ -214,20 +310,40 @@ def _diff_positions(root: pathlib.Path, base: str, path: str) -> tuple[set[int],
             continue
         if tag in ("delete", "replace"):
             removed.update(range(i1 + 1, i2 + 1))  # old_lines is 0-indexed, ranges are 1-indexed
-        if tag == "insert":
-            # Indent of the first non-blank inserted line; 0 when all blank
-            # (blank lines can never extend a body's logic).
-            indent = 0
-            for line in new_lines[j1:j2]:
-                if line.strip():
-                    indent = len(line) - len(line.lstrip(b" \t"))
-                    break
-            inserted_after[i1] = indent  # anchored right after old 1-indexed line i1
-        # "replace" deliberately does NOT also populate inserted_after — the
-        # removed lines already comprehensively signal the violation if inside
-        # a range, and anchoring the replacement's added lines too would
-        # double-count without adding coverage.
-    return removed, inserted_after
+        if tag in ("insert", "replace") and j1 < j2:
+            # A replace can remove an unprotected separator while adding code that
+            # extends the preceding protected body. Comments are not indentation
+            # tokens, so use the first real Python token when one exists.
+            indent = _added_span_indent(new_tokens, new_lines, j1, j2)
+            inserted_after[i1] = max(inserted_after.get(i1, 0), indent)
+    return removed, inserted_after, current_parseable
+
+
+def _matches_glob(path: str, pattern: str) -> bool:
+    """Match slash-delimited globs; only a complete `**` spans directories."""
+    path_parts = path.split("/")
+    pattern_parts = pattern.split("/")
+    memo: dict[tuple[int, int], bool] = {}
+
+    def matches(path_index: int, pattern_index: int) -> bool:
+        key = (path_index, pattern_index)
+        if key in memo:
+            return memo[key]
+        if pattern_index == len(pattern_parts):
+            result = path_index == len(path_parts)
+        elif pattern_parts[pattern_index] == "**":
+            result = matches(path_index, pattern_index + 1) or (
+                path_index < len(path_parts)
+                and matches(path_index + 1, pattern_index)
+            )
+        else:
+            result = path_index < len(path_parts) and fnmatch.fnmatchcase(
+                path_parts[path_index], pattern_parts[pattern_index]
+            ) and matches(path_index + 1, pattern_index + 1)
+        memo[key] = result
+        return result
+
+    return matches(0, 0)
 
 
 def append_only_check(root: pathlib.Path, base: str, globs: list[str]) -> bool:
@@ -243,26 +359,36 @@ def append_only_check(root: pathlib.Path, base: str, globs: list[str]) -> bool:
     Deleting, renaming, or type-changing (e.g. replacing with a symlink) a whole
     test file is always a violation regardless of content.
     """
-    # WHY: core.quotepath=off — with the default quoting, a non-ASCII filename
-    # (e.g. test_ä.py) is emitted as an octal-escaped C-string in double quotes,
-    # which never matches any glob → deletions AND rewrites of such files were
-    # silently skipped (fail-open). Off = raw UTF-8 paths that match normally.
+    # NUL delimiters preserve tabs, newlines, quotes, and backslashes in paths;
+    # core.quotepath=off additionally keeps non-ASCII names unescaped.
     proc = subprocess.run(
-        ["git", "-c", "core.quotepath=off", "diff", "--relative", "--name-status", base],
-        cwd=root, capture_output=True, text=True,
+        [
+            "git", "-c", "core.quotepath=off", "diff", "--relative",
+            "--name-status", "-z", base,
+        ],
+        cwd=root, capture_output=True,
     )
     if proc.returncode != 0:
-        fail_config(f"git diff failed in {root}: {proc.stderr.strip()}")
+        fail_config(f"git diff failed in {root}: {os.fsdecode(proc.stderr).strip()}")
     offenders = []
-    for line in proc.stdout.splitlines():
-        parts = line.split("\t")
-        status, paths = parts[0], parts[1:]
+    fields = proc.stdout.split(b"\0")
+    if fields[-1:] == [b""]:
+        fields.pop()
+    field_index = 0
+    while field_index < len(fields):
+        status = os.fsdecode(fields[field_index])
+        field_index += 1
+        path_count = 2 if status[:1] in "RC" else 1
+        if field_index + path_count > len(fields):
+            fail_config(f"malformed git diff --name-status output in {root}")
+        paths = [os.fsdecode(p) for p in fields[field_index:field_index + path_count]]
+        field_index += path_count
         # WHY: T(ypechange) is in the offender set — replacing a committed test
         # file with a symlink wholesale swaps its effective content, exactly like
         # a delete+recreate. A(dded)/C(opied) stay fine: adding tests is always fine.
         if status[:1] not in "MDRT":
             continue
-        matched = [p for p in paths if any(fnmatch.fnmatch(p, g) for g in globs)]
+        matched = [p for p in paths if any(_matches_glob(p, g) for g in globs)]
         if not matched:
             continue
         p = matched[-1]  # for R(ename), name-status gives "old\tnew" — the new path is what's on disk
@@ -270,7 +396,13 @@ def append_only_check(root: pathlib.Path, base: str, globs: list[str]) -> bool:
             offenders.append(f"  {status}\t{p}")
             continue
         ranges = _old_protected_ranges(root, base, p)
-        removed, inserted_after = _diff_positions(root, base, p)
+        if ranges is None:
+            offenders.append(f"  M\t{p}  (existing test artifact is unsupported or unparseable)")
+            continue
+        removed, inserted_after, current_parseable = _diff_positions(root, base, p)
+        if not current_parseable:
+            offenders.append(f"  M\t{p}  (current Python test file is unparseable)")
+            continue
         bad_removed = sorted(ln for ln in removed if any(lo <= ln <= hi for lo, hi, _ in ranges))
         # INVARIANT: two distinct insertion violations — (a) anchored strictly
         # inside a range (`lo <= n < hi`), and (b) anchored exactly at a range's
@@ -281,7 +413,10 @@ def append_only_check(root: pathlib.Path, base: str, globs: list[str]) -> bool:
         # same anchor starts at the same-or-shallower column and stays legitimate.
         bad_inserted = sorted(
             n for n, indent in inserted_after.items()
-            if any(lo <= n < hi or (n == hi and indent > col) for lo, hi, col in ranges)
+            if any(
+                lo <= n < hi or (n == hi and col is not None and indent > col)
+                for lo, hi, col in ranges
+            )
         )
         if bad_removed or bad_inserted:
             detail = []

--- a/.claude/scripts/run_gates.py
+++ b/.claude/scripts/run_gates.py
@@ -77,10 +77,12 @@ def load_card(path: pathlib.Path) -> dict:
 _MODULE_LEVEL_DATA = (ast.Assign, ast.AnnAssign, ast.AugAssign)
 
 
-def _old_protected_ranges(root: pathlib.Path, base: str, path: str) -> list[tuple[int, int]]:
-    """Line ranges (1-indexed, inclusive) of every protected node in `path` at `base`:
-    every function body, plus every direct module-level Assign/AnnAssign/AugAssign
-    statement.
+def _old_protected_ranges(root: pathlib.Path, base: str, path: str) -> list[tuple[int, int, int]]:
+    """(start_line, end_line, def_column) triples — lines 1-indexed inclusive — for
+    every protected node in `path` at `base`: every function body, plus every direct
+    module-level Assign/AnnAssign/AugAssign statement. `def_column` is the node's
+    own column offset, used to tell "new sibling appended after this body" apart
+    from "new line appended INTO this body" (see append_only_check).
     """
     # AIDEV-NOTE: `path` is cwd-relative (it comes from `git diff --relative`), but
     # `git show rev:path` resolves a bare path relative to the REPO ROOT, not cwd —
@@ -95,8 +97,12 @@ def _old_protected_ranges(root: pathlib.Path, base: str, path: str) -> list[tupl
     try:
         # WHY: bytes + errors="replace", not text=True — a committed undecodable
         # file must fall through to the permissive SyntaxError branch below, not
-        # crash the subprocess decode with UnicodeDecodeError.
-        tree = ast.parse(proc.stdout.decode("utf-8", errors="replace"))
+        # crash the subprocess decode with UnicodeDecodeError. The BOM strip is
+        # load-bearing too: CPython's tokenizer skips a UTF-8 BOM when reading
+        # source BYTES, but ast.parse of a STR starting with U+FEFF raises
+        # SyntaxError — without the strip, a BOM'd (perfectly valid, runnable)
+        # test file would fall into the permissive branch and lose ALL protection.
+        tree = ast.parse(proc.stdout.decode("utf-8", errors="replace").lstrip("\ufeff"))
     except (SyntaxError, ValueError):
         return []  # can't parse (incl. null bytes) — fall through to the safe (permissive) side
     ranges = []
@@ -105,17 +111,19 @@ def _old_protected_ranges(root: pathlib.Path, base: str, path: str) -> list[tupl
     # protected as the test itself.
     for node in ast.walk(tree):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            # INVARIANT: a decorator (e.g. @pytest.mark.parametrize(...), @pytest.fixture)
-            # is part of the protected body — node.lineno points at `def`, not the
-            # decorator line(s) above it.
+            # INVARIANT: an EXISTING decorator (e.g. @pytest.mark.parametrize(...),
+            # @pytest.fixture) is part of the protected body — node.lineno points
+            # at `def`, not the decorator line(s) above it. Stacking a brand-NEW
+            # outermost decorator onto an old function is NOT caught — see gap (5).
             start = node.decorator_list[0].lineno if node.decorator_list else node.lineno
-            ranges.append((start, getattr(node, "end_lineno", node.lineno)))
+            ranges.append((start, getattr(node, "end_lineno", node.lineno), node.col_offset))
     # INVARIANT: module-level test data is just as protected as a fixture — a
     # `-` line there is invisible to the function-only pass above.
     for node in tree.body:  # direct top-level children only — see AIDEV-NOTE below
         if isinstance(node, _MODULE_LEVEL_DATA):
-            ranges.append((node.lineno, getattr(node, "end_lineno", node.lineno)))
-    # AIDEV-NOTE: known, deliberate gaps — tracked as follow-ups, not chased here:
+            ranges.append((node.lineno, getattr(node, "end_lineno", node.lineno), node.col_offset))
+    # AIDEV-NOTE: known, deliberate gaps — deferred follow-ups (ticket filing
+    # queued behind the PR re-review, per owner instruction), not chased here:
     # (1) class-level attributes (e.g. a shared constant on a unittest.TestCase
     #     subclass) aren't covered — would need the same per-statement treatment
     #     inside class bodies, not a whole-class-span shortcut (that would
@@ -137,18 +145,27 @@ def _old_protected_ranges(root: pathlib.Path, base: str, path: str) -> list[tupl
     #     structural name-shadowing/monkeypatching limitation tracked as its own
     #     follow-up (line-diffing can't see what a statement's *effect* is, only
     #     its position), not a gap this allowlist could ever close by growing.
+    # (5) stacking a brand-NEW outermost decorator (e.g. @pytest.mark.skip) onto
+    #     a previously-existing function isn't caught — it anchors at the same
+    #     diff position as legitimately inserting a new function directly above,
+    #     which line positions can't distinguish. Needs old-vs-new AST identity
+    #     matching (compare each function's decorator list across versions) —
+    #     a separate deferred follow-up, same status as (4).
     return ranges
 
 
-def _diff_positions(root: pathlib.Path, base: str, path: str) -> tuple[set[int], set[int]]:
+def _diff_positions(root: pathlib.Path, base: str, path: str) -> tuple[set[int], dict[int, int]]:
     """Old-file positions where `path`'s content differs between `base` and the
     working tree, in two forms:
 
     - `removed`: an old line number itself changed/removed — checked against a
       protected range INCLUSIVE on both ends (`lo <= ln <= hi`).
-    - `inserted_after`: an old line number that NEW content was inserted directly
-      after, with no old line consumed for it — checked EXCLUSIVE at the upper end
-      (`lo <= n < hi`).
+    - `inserted_after`: maps each old line number that NEW content was inserted
+      directly after (no old line consumed) to the INDENT (leading spaces/tabs)
+      of the first non-blank inserted line — checked EXCLUSIVE at the upper end
+      (`lo <= n < hi`), except that an insertion anchored exactly at a range's
+      end (`n == hi`) whose indent is deeper than the range's own definition
+      column extends that body and is a violation too (see append_only_check).
     """
     # WHY: diff actual line CONTENT (old file via `git show`, new file read
     # straight off disk) with difflib.SequenceMatcher, rather than hand-parsing
@@ -191,14 +208,21 @@ def _diff_positions(root: pathlib.Path, base: str, path: str) -> tuple[set[int],
     new_lines = (root / path).read_bytes().splitlines()
     matcher = difflib.SequenceMatcher(a=old_lines, b=new_lines, autojunk=False)
     removed: set[int] = set()
-    inserted_after: set[int] = set()
-    for tag, i1, i2, _j1, _j2 in matcher.get_opcodes():
+    inserted_after: dict[int, int] = {}
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
         if tag == "equal":
             continue
         if tag in ("delete", "replace"):
             removed.update(range(i1 + 1, i2 + 1))  # old_lines is 0-indexed, ranges are 1-indexed
         if tag == "insert":
-            inserted_after.add(i1)  # anchored right after old 1-indexed line i1
+            # Indent of the first non-blank inserted line; 0 when all blank
+            # (blank lines can never extend a body's logic).
+            indent = 0
+            for line in new_lines[j1:j2]:
+                if line.strip():
+                    indent = len(line) - len(line.lstrip(b" \t"))
+                    break
+            inserted_after[i1] = indent  # anchored right after old 1-indexed line i1
         # "replace" deliberately does NOT also populate inserted_after — the
         # removed lines already comprehensively signal the violation if inside
         # a range, and anchoring the replacement's added lines too would
@@ -214,15 +238,18 @@ def append_only_check(root: pathlib.Path, base: str, globs: list[str]) -> bool:
     data, new imports for them, even a whole new function typed directly next to
     an existing one) are always fine — a violation is either a removed/changed
     line, OR new content inserted, that falls INSIDE a protected range (a
-    function body — test, fixture, or helper — or a module-level Assign/AnnAssign
-    statement) that already existed at `base`. Deleting or renaming a whole test
-    file is always a violation regardless of content.
+    function body — test, fixture, or helper — or a module-level
+    Assign/AnnAssign/AugAssign statement) that already existed at `base`.
+    Deleting, renaming, or type-changing (e.g. replacing with a symlink) a whole
+    test file is always a violation regardless of content.
     """
+    # WHY: core.quotepath=off — with the default quoting, a non-ASCII filename
+    # (e.g. test_ä.py) is emitted as an octal-escaped C-string in double quotes,
+    # which never matches any glob → deletions AND rewrites of such files were
+    # silently skipped (fail-open). Off = raw UTF-8 paths that match normally.
     proc = subprocess.run(
-        ["git", "diff", "--relative", "--name-status", base],
-        cwd=root,
-        capture_output=True,
-        text=True,
+        ["git", "-c", "core.quotepath=off", "diff", "--relative", "--name-status", base],
+        cwd=root, capture_output=True, text=True,
     )
     if proc.returncode != 0:
         fail_config(f"git diff failed in {root}: {proc.stderr.strip()}")
@@ -230,9 +257,10 @@ def append_only_check(root: pathlib.Path, base: str, globs: list[str]) -> bool:
     for line in proc.stdout.splitlines():
         parts = line.split("\t")
         status, paths = parts[0], parts[1:]
-        if (
-            status[:1] not in "MDR"
-        ):  # A(dded)/C(opied) etc. are fine — adding tests is always fine
+        # WHY: T(ypechange) is in the offender set — replacing a committed test
+        # file with a symlink wholesale swaps its effective content, exactly like
+        # a delete+recreate. A(dded)/C(opied) stay fine: adding tests is always fine.
+        if status[:1] not in "MDRT":
             continue
         matched = [p for p in paths if any(fnmatch.fnmatch(p, g) for g in globs)]
         if not matched:
@@ -243,8 +271,18 @@ def append_only_check(root: pathlib.Path, base: str, globs: list[str]) -> bool:
             continue
         ranges = _old_protected_ranges(root, base, p)
         removed, inserted_after = _diff_positions(root, base, p)
-        bad_removed = sorted(ln for ln in removed if any(lo <= ln <= hi for lo, hi in ranges))
-        bad_inserted = sorted(n for n in inserted_after if any(lo <= n < hi for lo, hi in ranges))
+        bad_removed = sorted(ln for ln in removed if any(lo <= ln <= hi for lo, hi, _ in ranges))
+        # INVARIANT: two distinct insertion violations — (a) anchored strictly
+        # inside a range (`lo <= n < hi`), and (b) anchored exactly at a range's
+        # end (`n == hi`) with the first non-blank inserted line indented DEEPER
+        # than the range's own definition column: that extends the old body
+        # (e.g. appending `break` inside a final test's loop flips it green with
+        # zero old lines touched), whereas a new sibling def/decorator at the
+        # same anchor starts at the same-or-shallower column and stays legitimate.
+        bad_inserted = sorted(
+            n for n, indent in inserted_after.items()
+            if any(lo <= n < hi or (n == hi and indent > col) for lo, hi, col in ranges)
+        )
         if bad_removed or bad_inserted:
             detail = []
             if bad_removed:

--- a/.claude/scripts/run_gates.py
+++ b/.claude/scripts/run_gates.py
@@ -67,43 +67,27 @@ def load_card(path: pathlib.Path) -> dict:
     return data
 
 
-_HUNK_HEADER = re.compile(r"^@@ -(\d+)(?:,\d+)? \+\d+(?:,\d+)? @@")
+_HUNK_HEADER = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+\d+(?:,\d+)? @@")
 
 
-_EXEMPT_TOP_LEVEL = (ast.Import, ast.ImportFrom, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+# WHY: an ALLOWLIST of data-holding node types, not a denylist of "everything
+# except X". A denylist means every statement type nobody thought to exclude
+# (a docstring, an `if __name__ == "__main__":` block, an import nested inside
+# a version-guard) silently becomes a false positive the next time someone
+# edits one. Only Assign/AnnAssign hold the kind of shared test data (e.g. a
+# `_BASE_KW = {...}` dict several tests build on) rule 5 needs to protect.
+_MODULE_LEVEL_DATA = (ast.Assign, ast.AnnAssign)
 
 
 def _old_protected_ranges(root: pathlib.Path, base: str, path: str) -> list[tuple[int, int]]:
     """Line ranges (1-indexed, inclusive) of every protected node in `path` at `base`:
-    every function body, plus every module-level statement except imports.
-
-    AIDEV-NOTE: `path` is cwd-relative (it comes from `git diff --relative`), but
-    `git show rev:path` resolves a bare path relative to the REPO ROOT, not cwd —
-    the `./` prefix is what makes it cwd-relative. Without it, this silently returns
-    `[]` (falls into the "didn't exist" branch) for every stack whose root isn't the
-    repo root, i.e. every real stack in `.claude/sdlc.local.md`.
-
-    INVARIANT: covers EVERY function, not just `test_*`-named ones — a `conftest.py`
-    fixture or a plain helper a test depends on is just as protected as the test
-    itself. Rule 5 doesn't only mean "don't rewrite a `def test_...`" — it means
-    don't silently change what a previously-committed test actually exercises.
-
-    INVARIANT: also covers module-level test data (e.g. a shared `_BASE_KW = {...}`
-    dict several tests build on) — a `-` line there is invisible to the
-    function-only pass, exactly like an unprotected fixture. Imports are the one
-    deliberate exemption: round 1 decided "an existing import line changed to
-    support a new test" must stay legitimate, so `Import`/`ImportFrom` never get a
-    protected range even when edited.
-
-    AIDEV-NOTE: class-level attributes (e.g. a shared constant on a
-    `unittest.TestCase` subclass) are NOT covered by this pass — same shape of gap
-    as module-level data, deliberately deferred rather than silently left unnoted.
-    A naive "protect the whole class body as one range" would itself reintroduce
-    OME-369's original false positive (inserting a new method between two existing
-    ones in the same class would anchor inside the class's overall span even
-    though it's outside any individual method's), so it needs the same
-    per-statement treatment as this function does for module scope, not a shortcut.
+    every function body, plus every direct module-level Assign/AnnAssign statement.
     """
+    # AIDEV-NOTE: `path` is cwd-relative (it comes from `git diff --relative`), but
+    # `git show rev:path` resolves a bare path relative to the REPO ROOT, not cwd —
+    # the `./` prefix is what makes it cwd-relative. Without it, this silently
+    # returns `[]` (falls into the "didn't exist" branch) for every stack whose
+    # root isn't the repo root, i.e. every real stack in `.claude/sdlc.local.md`.
     proc = subprocess.run(
         ["git", "show", f"{base}:./{path}"], cwd=root, capture_output=True, text=True,
     )
@@ -114,6 +98,9 @@ def _old_protected_ranges(root: pathlib.Path, base: str, path: str) -> list[tupl
     except SyntaxError:
         return []  # can't parse — fall through to the safe (permissive) side
     ranges = []
+    # INVARIANT: covers EVERY function, not just `test_*`-named ones — a
+    # `conftest.py` fixture or a plain helper a test depends on is just as
+    # protected as the test itself.
     for node in ast.walk(tree):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             # INVARIANT: a decorator (e.g. @pytest.mark.parametrize(...), @pytest.fixture)
@@ -121,10 +108,20 @@ def _old_protected_ranges(root: pathlib.Path, base: str, path: str) -> list[tupl
             # decorator line(s) above it.
             start = node.decorator_list[0].lineno if node.decorator_list else node.lineno
             ranges.append((start, getattr(node, "end_lineno", node.lineno)))
-    for node in tree.body:  # module-level (non-recursive) — data, not imports/defs
-        if isinstance(node, _EXEMPT_TOP_LEVEL):
-            continue
-        ranges.append((node.lineno, getattr(node, "end_lineno", node.lineno)))
+    # INVARIANT: module-level test data is just as protected as a fixture — a
+    # `-` line there is invisible to the function-only pass above.
+    for node in tree.body:  # direct top-level children only — see AIDEV-NOTE below
+        if isinstance(node, _MODULE_LEVEL_DATA):
+            ranges.append((node.lineno, getattr(node, "end_lineno", node.lineno)))
+    # AIDEV-NOTE: known, deliberate gaps — tracked as follow-ups, not chased here:
+    # (1) class-level attributes (e.g. a shared constant on a unittest.TestCase
+    #     subclass) aren't covered — would need the same per-statement treatment
+    #     inside class bodies, not a whole-class-span shortcut (that would
+    #     reopen "insert a new method between two existing ones" as a false
+    #     positive, the same way OME-369's original bug worked).
+    # (2) an Assign/AnnAssign nested inside a module-level If/Try/With (e.g. a
+    #     version-guarded conditional constant) isn't covered either, since
+    #     this loop only walks direct `tree.body` children, not recursively.
     return ranges
 
 
@@ -135,24 +132,25 @@ def _diff_positions(root: pathlib.Path, base: str, path: str) -> tuple[set[int],
       against a protected range INCLUSIVE on both ends (`lo <= ln <= hi`).
     - `inserted_after`: an old line number that NEW content was inserted directly
       after, with no old line consumed for it — checked EXCLUSIVE at the upper end
-      (`lo <= n < hi`). AIDEV-NOTE: the exclusive bound is load-bearing. A pure
-      insertion (e.g. a whole new test function typed directly after an existing
-      one, zero blank lines between them) anchors at `n == hi` of the PRECEDING
-      function — that must stay unflagged, or this reopens the exact false-positive
-      OME-369 exists to fix (pure additions rejected as violations). Inserting as a
-      new first/middle statement anchors at `lo <= n < hi` and must be caught: a
-      pure `+`-only diff can still silently neuter a prior test's assertions (e.g.
-      forcing a variable's value right before the check) with zero `-` lines, which
-      `removed` alone can never see.
-
-    AIDEV-NOTE: file-level header lines (`diff --git`, `index`, `--- a/...`,
-    `+++ b/...`) only ever appear BEFORE the first `@@` hunk line — track that
-    boundary structurally (`in_hunk`) instead of prefix-matching `---`/`+++` against
-    line content. A *removed* line whose actual content starts with `--` at column 0
-    (e.g. a bare `---` separator) renders as `----` in the diff, which would
-    false-match a content-based header check and silently vanish from `removed`
-    while desyncing `old_line` for every later line in the same hunk.
+      (`lo <= n < hi`).
     """
+    # AIDEV-NOTE: the exclusive bound on `inserted_after` is load-bearing. A pure
+    # insertion (e.g. a whole new test function typed directly after an existing
+    # one, zero blank lines between them) anchors at `n == hi` of the PRECEDING
+    # function — that must stay unflagged, or this reopens the exact false-positive
+    # OME-369 exists to fix (pure additions rejected as violations). Inserting as a
+    # new first/middle statement anchors at `lo <= n < hi` and must be caught: a
+    # pure `+`-only diff can still silently neuter a prior test's assertions (e.g.
+    # forcing a variable's value right before the check) with zero `-` lines, which
+    # `removed` alone can never see.
+    #
+    # AIDEV-NOTE: file-level header lines (`diff --git`, `index`, `--- a/...`,
+    # `+++ b/...`) only ever appear BEFORE the first `@@` hunk line — track that
+    # boundary structurally (`in_hunk`) instead of prefix-matching `---`/`+++`
+    # against line content. A *removed* line whose actual content starts with `--`
+    # at column 0 (e.g. a bare `---` separator) renders as `----` in the diff,
+    # which would false-match a content-based header check and silently vanish
+    # from `removed` while desyncing `old_line` for every later line in the hunk.
     proc = subprocess.run(
         ["git", "diff", "--relative", "--unified=0", base, "--", path],
         cwd=root, capture_output=True, text=True,
@@ -163,10 +161,22 @@ def _diff_positions(root: pathlib.Path, base: str, path: str) -> tuple[set[int],
     inserted_after: set[int] = set()
     old_line = 0
     in_hunk = False
+    pure_insert_hunk = False
     for line in proc.stdout.splitlines():
         if line.startswith("@@"):
             m = _HUNK_HEADER.match(line)
-            old_line = int(m.group(1)) if m else old_line
+            if m:
+                old_line = int(m.group(1))
+                old_count = int(m.group(2)) if m.group(2) is not None else 1
+                # WHY: a hunk whose header declares old-count 0 is UNAMBIGUOUSLY a
+                # pure insertion straight from the header. Inferring "pure insert"
+                # by pairing "-"/"+" lines line-by-line instead would mis-anchor a
+                # replace pair (a "-" immediately followed by a "+") one line later
+                # than the line it actually replaces — which can land exactly on
+                # the start of the NEXT protected range and false-positive an edit
+                # that never touched it (e.g. replacing the blank separator line
+                # between two functions falsely flags the second function).
+                pure_insert_hunk = old_count == 0
             in_hunk = True
         elif not in_hunk:
             continue  # pre-hunk file header (diff --git / index / --- a/ / +++ b/)
@@ -176,21 +186,27 @@ def _diff_positions(root: pathlib.Path, base: str, path: str) -> tuple[set[int],
             removed.add(old_line)
             old_line += 1
         elif line.startswith("+"):
-            inserted_after.add(old_line)  # anchored right after the current old_line
+            if pure_insert_hunk:
+                inserted_after.add(old_line)  # anchored right after the current old_line
+            # else: part of a replace pair with a preceding "-" in THIS hunk —
+            # already captured via `removed`; anchoring it too would double-count
+            # and can mis-fire per the WHY note above.
         else:
             old_line += 1  # context line (present only if a non-zero unified context is used)
     return removed, inserted_after
 
 
 def append_only_check(root: pathlib.Path, base: str, globs: list[str]) -> bool:
-    """True when no previously committed test/fixture was modified/deleted (rule 5).
+    """True when no previously committed test/fixture/data was modified/deleted
+    (rule 5).
 
-    Pure additions (new test functions, new fixtures/helpers, new imports for them,
-    even a whole new function typed directly next to an existing one) are always
-    fine — a violation is either a removed/changed line, OR new content inserted,
-    that falls INSIDE a function body (test, fixture, or helper) that already
-    existed at `base`. Deleting or renaming a whole test file is always a violation
-    regardless of content.
+    Pure additions (new test functions, new fixtures/helpers, new module-level
+    data, new imports for them, even a whole new function typed directly next to
+    an existing one) are always fine — a violation is either a removed/changed
+    line, OR new content inserted, that falls INSIDE a protected range (a
+    function body — test, fixture, or helper — or a module-level Assign/AnnAssign
+    statement) that already existed at `base`. Deleting or renaming a whole test
+    file is always a violation regardless of content.
     """
     proc = subprocess.run(
         ["git", "diff", "--relative", "--name-status", base],

--- a/.claude/scripts/run_gates.py
+++ b/.claude/scripts/run_gates.py
@@ -70,10 +70,22 @@ def load_card(path: pathlib.Path) -> dict:
 _HUNK_HEADER = re.compile(r"^@@ -(\d+)(?:,\d+)? \+\d+(?:,\d+)? @@")
 
 
-def _old_test_ranges(root: pathlib.Path, base: str, path: str) -> list[tuple[int, int]]:
-    """Line ranges (1-indexed, inclusive) of every test function body in `path` at `base`."""
+def _old_protected_ranges(root: pathlib.Path, base: str, path: str) -> list[tuple[int, int]]:
+    """Line ranges (1-indexed, inclusive) of every function body in `path` at `base`.
+
+    AIDEV-NOTE: `path` is cwd-relative (it comes from `git diff --relative`), but
+    `git show rev:path` resolves a bare path relative to the REPO ROOT, not cwd —
+    the `./` prefix is what makes it cwd-relative. Without it, this silently returns
+    `[]` (falls into the "didn't exist" branch) for every stack whose root isn't the
+    repo root, i.e. every real stack in `.claude/sdlc.local.md`.
+
+    INVARIANT: covers EVERY function, not just `test_*`-named ones — a `conftest.py`
+    fixture or a plain helper a test depends on is just as protected as the test
+    itself. Rule 5 doesn't only mean "don't rewrite a `def test_...`" — it means
+    don't silently change what a previously-committed test actually exercises.
+    """
     proc = subprocess.run(
-        ["git", "show", f"{base}:{path}"], cwd=root, capture_output=True, text=True,
+        ["git", "show", f"{base}:./{path}"], cwd=root, capture_output=True, text=True,
     )
     if proc.returncode != 0:
         return []  # file didn't exist at base — nothing to protect
@@ -83,13 +95,40 @@ def _old_test_ranges(root: pathlib.Path, base: str, path: str) -> list[tuple[int
         return []  # can't parse — fall through to the safe (permissive) side
     ranges = []
     for node in ast.walk(tree):
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test_"):
-            ranges.append((node.lineno, getattr(node, "end_lineno", node.lineno)))
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            # INVARIANT: a decorator (e.g. @pytest.mark.parametrize(...), @pytest.fixture)
+            # is part of the protected body — node.lineno points at `def`, not the
+            # decorator line(s) above it.
+            start = node.decorator_list[0].lineno if node.decorator_list else node.lineno
+            ranges.append((start, getattr(node, "end_lineno", node.lineno)))
     return ranges
 
 
-def _removed_old_lines(root: pathlib.Path, base: str, path: str) -> set[int]:
-    """Old-file line numbers that a removal/change touches, per the diff for `path` vs `base`."""
+def _diff_positions(root: pathlib.Path, base: str, path: str) -> tuple[set[int], set[int]]:
+    """Old-file positions the diff for `path` vs `base` touches, in two forms:
+
+    - `removed`: an old line number itself changed/removed (a `-` line) — checked
+      against a protected range INCLUSIVE on both ends (`lo <= ln <= hi`).
+    - `inserted_after`: an old line number that NEW content was inserted directly
+      after, with no old line consumed for it — checked EXCLUSIVE at the upper end
+      (`lo <= n < hi`). AIDEV-NOTE: the exclusive bound is load-bearing. A pure
+      insertion (e.g. a whole new test function typed directly after an existing
+      one, zero blank lines between them) anchors at `n == hi` of the PRECEDING
+      function — that must stay unflagged, or this reopens the exact false-positive
+      OME-369 exists to fix (pure additions rejected as violations). Inserting as a
+      new first/middle statement anchors at `lo <= n < hi` and must be caught: a
+      pure `+`-only diff can still silently neuter a prior test's assertions (e.g.
+      forcing a variable's value right before the check) with zero `-` lines, which
+      `removed` alone can never see.
+
+    AIDEV-NOTE: file-level header lines (`diff --git`, `index`, `--- a/...`,
+    `+++ b/...`) only ever appear BEFORE the first `@@` hunk line — track that
+    boundary structurally (`in_hunk`) instead of prefix-matching `---`/`+++` against
+    line content. A *removed* line whose actual content starts with `--` at column 0
+    (e.g. a bare `---` separator) renders as `----` in the diff, which would
+    false-match a content-based header check and silently vanish from `removed`
+    while desyncing `old_line` for every later line in the same hunk.
+    """
     proc = subprocess.run(
         ["git", "diff", "--relative", "--unified=0", base, "--", path],
         cwd=root, capture_output=True, text=True,
@@ -97,30 +136,37 @@ def _removed_old_lines(root: pathlib.Path, base: str, path: str) -> set[int]:
     if proc.returncode != 0:
         fail_config(f"git diff failed in {root}: {proc.stderr.strip()}")
     removed: set[int] = set()
+    inserted_after: set[int] = set()
     old_line = 0
+    in_hunk = False
     for line in proc.stdout.splitlines():
         if line.startswith("@@"):
             m = _HUNK_HEADER.match(line)
             old_line = int(m.group(1)) if m else old_line
-        elif line.startswith(("---", "+++", "\\")):
-            continue
+            in_hunk = True
+        elif not in_hunk:
+            continue  # pre-hunk file header (diff --git / index / --- a/ / +++ b/)
+        elif line.startswith("\\"):
+            continue  # "\ No newline at end of file" — never consumes a line number
         elif line.startswith("-"):
             removed.add(old_line)
             old_line += 1
         elif line.startswith("+"):
-            continue  # inserted line — doesn't consume an old line number
+            inserted_after.add(old_line)  # anchored right after the current old_line
         else:
             old_line += 1  # context line (present only if a non-zero unified context is used)
-    return removed
+    return removed, inserted_after
 
 
 def append_only_check(root: pathlib.Path, base: str, globs: list[str]) -> bool:
-    """True when no previously committed *test* was modified/deleted (rule 5).
+    """True when no previously committed test/fixture was modified/deleted (rule 5).
 
-    Pure additions to a test file (new test functions, new imports for them) are
-    always fine — only a removed/changed line that falls INSIDE a test function body
-    that already existed at `base` counts as a violation. Deleting or renaming a
-    whole test file is always a violation regardless of content.
+    Pure additions (new test functions, new fixtures/helpers, new imports for them,
+    even a whole new function typed directly next to an existing one) are always
+    fine — a violation is either a removed/changed line, OR new content inserted,
+    that falls INSIDE a function body (test, fixture, or helper) that already
+    existed at `base`. Deleting or renaming a whole test file is always a violation
+    regardless of content.
     """
     proc = subprocess.run(
         ["git", "diff", "--relative", "--name-status", base],
@@ -145,13 +191,17 @@ def append_only_check(root: pathlib.Path, base: str, globs: list[str]) -> bool:
         if status[:1] != "M":
             offenders.append(f"  {status}\t{p}")
             continue
-        test_ranges = _old_test_ranges(root, base, p)
-        bad_lines = sorted(
-            ln for ln in _removed_old_lines(root, base, p)
-            if any(lo <= ln <= hi for lo, hi in test_ranges)
-        )
-        if bad_lines:
-            offenders.append(f"  M\t{p}  (removed/changed inside an existing test, old line(s) {bad_lines})")
+        ranges = _old_protected_ranges(root, base, p)
+        removed, inserted_after = _diff_positions(root, base, p)
+        bad_removed = sorted(ln for ln in removed if any(lo <= ln <= hi for lo, hi in ranges))
+        bad_inserted = sorted(n for n in inserted_after if any(lo <= n < hi for lo, hi in ranges))
+        if bad_removed or bad_inserted:
+            detail = []
+            if bad_removed:
+                detail.append(f"removed/changed old line(s) {bad_removed}")
+            if bad_inserted:
+                detail.append(f"new content inserted after old line(s) {bad_inserted}")
+            offenders.append(f"  M\t{p}  ({'; '.join(detail)} — inside an existing test/fixture)")
     if offenders:
         print(
             f"{RED} append-only test check — prior tests were modified/deleted (vs {base}):"

--- a/.claude/scripts/run_gates.py
+++ b/.claude/scripts/run_gates.py
@@ -70,8 +70,12 @@ def load_card(path: pathlib.Path) -> dict:
 _HUNK_HEADER = re.compile(r"^@@ -(\d+)(?:,\d+)? \+\d+(?:,\d+)? @@")
 
 
+_EXEMPT_TOP_LEVEL = (ast.Import, ast.ImportFrom, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+
+
 def _old_protected_ranges(root: pathlib.Path, base: str, path: str) -> list[tuple[int, int]]:
-    """Line ranges (1-indexed, inclusive) of every function body in `path` at `base`.
+    """Line ranges (1-indexed, inclusive) of every protected node in `path` at `base`:
+    every function body, plus every module-level statement except imports.
 
     AIDEV-NOTE: `path` is cwd-relative (it comes from `git diff --relative`), but
     `git show rev:path` resolves a bare path relative to the REPO ROOT, not cwd —
@@ -83,6 +87,22 @@ def _old_protected_ranges(root: pathlib.Path, base: str, path: str) -> list[tupl
     fixture or a plain helper a test depends on is just as protected as the test
     itself. Rule 5 doesn't only mean "don't rewrite a `def test_...`" — it means
     don't silently change what a previously-committed test actually exercises.
+
+    INVARIANT: also covers module-level test data (e.g. a shared `_BASE_KW = {...}`
+    dict several tests build on) — a `-` line there is invisible to the
+    function-only pass, exactly like an unprotected fixture. Imports are the one
+    deliberate exemption: round 1 decided "an existing import line changed to
+    support a new test" must stay legitimate, so `Import`/`ImportFrom` never get a
+    protected range even when edited.
+
+    AIDEV-NOTE: class-level attributes (e.g. a shared constant on a
+    `unittest.TestCase` subclass) are NOT covered by this pass — same shape of gap
+    as module-level data, deliberately deferred rather than silently left unnoted.
+    A naive "protect the whole class body as one range" would itself reintroduce
+    OME-369's original false positive (inserting a new method between two existing
+    ones in the same class would anchor inside the class's overall span even
+    though it's outside any individual method's), so it needs the same
+    per-statement treatment as this function does for module scope, not a shortcut.
     """
     proc = subprocess.run(
         ["git", "show", f"{base}:./{path}"], cwd=root, capture_output=True, text=True,
@@ -101,6 +121,10 @@ def _old_protected_ranges(root: pathlib.Path, base: str, path: str) -> list[tupl
             # decorator line(s) above it.
             start = node.decorator_list[0].lineno if node.decorator_list else node.lineno
             ranges.append((start, getattr(node, "end_lineno", node.lineno)))
+    for node in tree.body:  # module-level (non-recursive) — data, not imports/defs
+        if isinstance(node, _EXEMPT_TOP_LEVEL):
+            continue
+        ranges.append((node.lineno, getattr(node, "end_lineno", node.lineno)))
     return ranges
 
 

--- a/.claude/scripts/run_gates.py
+++ b/.claude/scripts/run_gates.py
@@ -127,6 +127,16 @@ def _old_protected_ranges(root: pathlib.Path, base: str, path: str) -> list[tupl
     # (3) a bare module-level walrus statement (`(_TOTAL := 10)`, parsed as an
     #     ast.Expr wrapping an ast.NamedExpr) isn't covered — an exotic enough
     #     pattern in real test code that it isn't worth a special-case check.
+    #     NOTE: unlike (4), adding `ast.NamedExpr` to `_MODULE_LEVEL_DATA` would
+    #     NOT fix this — `tree.body`'s direct child here is the outer `ast.Expr`
+    #     wrapper, never the inner `NamedExpr` itself, so that "just add the
+    #     type" pattern (used for AugAssign) silently does nothing for this case.
+    # (4) mutating a protected object in place (`_CASES.append(...)`,
+    #     `del _CASES[1]`, `_BASE_KW["x"] = 999`) rather than rebinding its name
+    #     isn't covered by ANY allowlist entry, by design — this is the same
+    #     structural name-shadowing/monkeypatching limitation tracked as its own
+    #     follow-up (line-diffing can't see what a statement's *effect* is, only
+    #     its position), not a gap this allowlist could ever close by growing.
     return ranges
 
 
@@ -156,6 +166,15 @@ def _diff_positions(root: pathlib.Path, base: str, path: str) -> tuple[set[int],
     # at column 0 (e.g. a bare `---` separator) renders as `----` in the diff,
     # which would false-match a content-based header check and silently vanish
     # from `removed` while desyncing `old_line` for every later line in the hunk.
+    #
+    # WHY: also track whether the most recent "-" line was immediately followed
+    # by "\ No newline at end of file" and, if so, whether the very next "+"
+    # line is byte-identical to it. git represents "content was appended after a
+    # file that didn't end in a newline" as a remove+add of that unchanged last
+    # line (its EOF status changed, not its text) — without this check, that
+    # renders as a false "removed/changed" hit on a protected range's last line
+    # for the ordinary, non-adversarial act of appending new content to a file
+    # that happened not to end in `\n`.
     proc = subprocess.run(
         ["git", "diff", "--relative", "--unified=0", base, "--", path],
         cwd=root, capture_output=True, text=True,
@@ -167,6 +186,7 @@ def _diff_positions(root: pathlib.Path, base: str, path: str) -> tuple[set[int],
     old_line = 0
     in_hunk = False
     pure_insert_hunk = False
+    last_removed: tuple[int, str, bool] | None = None  # (old_line, content, no_newline)
     for line in proc.stdout.splitlines():
         if line.startswith("@@"):
             m = _HUNK_HEADER.match(line)
@@ -183,20 +203,31 @@ def _diff_positions(root: pathlib.Path, base: str, path: str) -> tuple[set[int],
                 # between two functions falsely flags the second function).
                 pure_insert_hunk = old_count == 0
             in_hunk = True
+            last_removed = None
         elif not in_hunk:
             continue  # pre-hunk file header (diff --git / index / --- a/ / +++ b/)
         elif line.startswith("\\"):
-            continue  # "\ No newline at end of file" — never consumes a line number
+            # "\ No newline at end of file" describes the line just emitted —
+            # never consumes a line number, but mark it on a pending removal so
+            # a byte-identical "+" right after can be recognized as an EOF-status
+            # artifact, not a real edit.
+            if last_removed is not None:
+                last_removed = (last_removed[0], last_removed[1], True)
         elif line.startswith("-"):
             removed.add(old_line)
+            last_removed = (old_line, line[1:], False)
             old_line += 1
         elif line.startswith("+"):
-            if pure_insert_hunk:
+            if last_removed is not None and last_removed[2] and last_removed[1] == line[1:]:
+                removed.discard(last_removed[0])
+            elif pure_insert_hunk:
                 inserted_after.add(old_line)  # anchored right after the current old_line
             # else: part of a replace pair with a preceding "-" in THIS hunk —
             # already captured via `removed`; anchoring it too would double-count
             # and can mis-fire per the WHY note above.
+            last_removed = None
         else:
+            last_removed = None
             old_line += 1  # context line (present only if a non-zero unified context is used)
     return removed, inserted_after
 

--- a/.claude/scripts/run_gates.py
+++ b/.claude/scripts/run_gates.py
@@ -74,14 +74,16 @@ _HUNK_HEADER = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+\d+(?:,\d+)? @@")
 # except X". A denylist means every statement type nobody thought to exclude
 # (a docstring, an `if __name__ == "__main__":` block, an import nested inside
 # a version-guard) silently becomes a false positive the next time someone
-# edits one. Only Assign/AnnAssign hold the kind of shared test data (e.g. a
-# `_BASE_KW = {...}` dict several tests build on) rule 5 needs to protect.
-_MODULE_LEVEL_DATA = (ast.Assign, ast.AnnAssign)
+# edits one. Assign/AnnAssign/AugAssign hold the kind of shared test data (e.g.
+# a `_BASE_KW = {...}` dict, or a `_CASES += [...]` accumulator) rule 5 needs
+# to protect.
+_MODULE_LEVEL_DATA = (ast.Assign, ast.AnnAssign, ast.AugAssign)
 
 
 def _old_protected_ranges(root: pathlib.Path, base: str, path: str) -> list[tuple[int, int]]:
     """Line ranges (1-indexed, inclusive) of every protected node in `path` at `base`:
-    every function body, plus every direct module-level Assign/AnnAssign statement.
+    every function body, plus every direct module-level Assign/AnnAssign/AugAssign
+    statement.
     """
     # AIDEV-NOTE: `path` is cwd-relative (it comes from `git diff --relative`), but
     # `git show rev:path` resolves a bare path relative to the REPO ROOT, not cwd —
@@ -119,9 +121,12 @@ def _old_protected_ranges(root: pathlib.Path, base: str, path: str) -> list[tupl
     #     inside class bodies, not a whole-class-span shortcut (that would
     #     reopen "insert a new method between two existing ones" as a false
     #     positive, the same way OME-369's original bug worked).
-    # (2) an Assign/AnnAssign nested inside a module-level If/Try/With (e.g. a
-    #     version-guarded conditional constant) isn't covered either, since
-    #     this loop only walks direct `tree.body` children, not recursively.
+    # (2) an Assign/AnnAssign/AugAssign nested inside a module-level If/Try/With
+    #     (e.g. a version-guarded conditional constant) isn't covered either,
+    #     since this loop only walks direct `tree.body` children, not recursively.
+    # (3) a bare module-level walrus statement (`(_TOTAL := 10)`, parsed as an
+    #     ast.Expr wrapping an ast.NamedExpr) isn't covered — an exotic enough
+    #     pattern in real test code that it isn't worth a special-case check.
     return ranges
 
 

--- a/.claude/scripts/tests/test_run_gates.py
+++ b/.claude/scripts/tests/test_run_gates.py
@@ -495,6 +495,92 @@ class AppendOnlyCheckTests(unittest.TestCase):
             _write(root / "test_a.py", base_src.replace("assert 2 == 2", "assert 2 == 999"))
             self.assertFalse(self._check(root, base))
 
+    def test_bom_file_rewrite_detected(self):
+        """Regression test (code-review finding, false-negative direction): a
+        UTF-8 BOM at base must not strip protection. CPython's tokenizer skips
+        a BOM when reading source BYTES, but ast.parse of a STR starting with
+        U+FEFF raises SyntaxError — without stripping it, a BOM'd (valid,
+        runnable) test file fell into the permissive branch and lost ALL
+        protection."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            (root / "test_a.py").write_bytes(
+                b"\xef\xbb\xbfdef test_one():\n    assert 1 == 1\n"
+            )
+            base = _commit_all(root, "base")
+            (root / "test_a.py").write_bytes(
+                b"\xef\xbb\xbfdef test_one():\n    assert 1 == 2\n"
+            )
+            self.assertFalse(self._check(root, base))
+
+    def test_typechange_to_symlink_flagged(self):
+        """Regression test (code-review finding, false-negative direction):
+        replacing a committed test file with a symlink is git status T
+        (typechange), not M/D — it must be flagged like a delete, not silently
+        skipped as 'not in MDR'."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(root / "test_a.py", "def test_one():\n    assert 1 == 1\n")
+            _write(root / "junk.txt", "not a test\n")
+            base = _commit_all(root, "base")
+            (root / "test_a.py").unlink()
+            (root / "test_a.py").symlink_to("junk.txt")
+            self.assertFalse(self._check(root, base))
+
+    def test_non_ascii_filename_rewrite_detected(self):
+        """Regression test (code-review finding, false-negative direction): with
+        git's default core.quotepath, a non-ASCII filename is emitted as an
+        octal-escaped quoted C-string that matches no glob — rewrites (and
+        deletions) of such files were silently skipped."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(root / "test_ä.py", "def test_one():\n    assert 1 == 1\n")
+            base = _commit_all(root, "base")
+            _write(root / "test_ä.py", "def test_one():\n    assert 1 == 2\n")
+            self.assertFalse(self._check(root, base))
+
+    def test_indented_append_extending_final_test_body_detected(self):
+        """Regression test (code-review finding, false-negative direction): an
+        INDENTED line appended directly after the file's final test extends
+        that test's body — e.g. appending `break` inside its loop flips a
+        failing test green with zero old lines touched. An insertion anchored
+        at a range's end whose first non-blank line is indented deeper than the
+        range's own definition column is a violation."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            base_src = (
+                "CASES = [1, 2, 3]\n\n\ndef test_all_cases():\n"
+                "    for c in CASES:\n        assert c < 3\n"
+            )
+            _write(root / "test_a.py", base_src)
+            base = _commit_all(root, "base")
+            _write(root / "test_a.py", base_src + "        break\n")
+            self.assertFalse(self._check(root, base))
+
+    def test_new_method_after_existing_method_in_class_passes(self):
+        """Boundary guard for the indented-append rule: a new test METHOD typed
+        directly after an existing method inside a class shares the anchor
+        `n == hi` and IS indented — but at the same column as the existing
+        method's `def`, not deeper, so it must stay legitimate."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(
+                root / "test_a.py",
+                "class TestThings:\n    def test_one(self):\n        assert 1 == 1\n",
+            )
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                "class TestThings:\n    def test_one(self):\n        assert 1 == 1\n\n"
+                "    def test_two(self):\n        assert 2 == 2\n",
+            )
+            self.assertTrue(self._check(root, base))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/scripts/tests/test_run_gates.py
+++ b/.claude/scripts/tests/test_run_gates.py
@@ -401,6 +401,46 @@ class AppendOnlyCheckTests(unittest.TestCase):
             )
             self.assertTrue(self._check(root, base))
 
+    def test_losing_trailing_newline_with_no_other_change_passes(self):
+        """Regression test (code-review finding, mirror image of the previous
+        test): a protected range's last line LOSING its trailing newline, with
+        zero other change, must also stay legitimate — the SequenceMatcher
+        rewrite handles this by construction (splitlines() ignores trailing-
+        newline presence on either side), unlike the old text-parsing approach
+        which only recognized the "gained a newline" direction."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(root / "test_a.py", "def test_one():\n    assert 1 == 1\n")
+            base = _commit_all(root, "base")
+            with open(root / "test_a.py", "w", newline="\n") as f:
+                f.write("def test_one():\n    assert 1 == 1")  # lost trailing newline
+            self.assertTrue(self._check(root, base))
+
+    def test_real_edit_adjacent_to_eof_artifact_still_detected(self):
+        """Coverage guard: a real rewrite of one protected assertion, sharing a
+        hunk with an unrelated EOF-newline-only change to an adjacent protected
+        line, must still be caught. SequenceMatcher's LCS-based opcodes handle
+        multi-line hunks correctly by construction (each line is matched by
+        content, not by naive "first added line after last removed line"
+        position-pairing) — this guards that property, not any specific old
+        bug (a clean discriminating repro for the old pairing bug turns out to
+        require the shadowing technique, which is a separate, already-deferred
+        limitation, not something this fix does or should close)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            with open(root / "test_a.py", "w", newline="\n") as f:
+                f.write(
+                    "def test_one():\n    assert 1 == 1\ndef test_two():\n    assert 2 == 2"
+                )  # no trailing newline
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                "def test_one():\n    assert 1 == 999\ndef test_two():\n    assert 2 == 2\n",
+            )
+            self.assertFalse(self._check(root, base))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/scripts/tests/test_run_gates.py
+++ b/.claude/scripts/tests/test_run_gates.py
@@ -231,6 +231,67 @@ class AppendOnlyCheckTests(unittest.TestCase):
             )
             self.assertTrue(self._check(root, base))
 
+    def test_module_level_test_data_edit_detected(self):
+        """Regression test (review concern): shared module-level test data (e.g.
+        `_BASE_KW = {...}`, the real pattern in
+        apps/aigateway/tests/unit/test_request_cache_keys.py) is invisible to a
+        function-only pass — a `-` line there must still be caught."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(
+                root / "test_a.py",
+                '_BASE_KW = {\n    "x": 1,\n}\n\n\ndef test_uses_base_kw():\n    assert _BASE_KW["x"] == 1\n',
+            )
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                '_BASE_KW = {\n    "x": 999,\n}\n\n\ndef test_uses_base_kw():\n    assert _BASE_KW["x"] == 1\n',
+            )
+            self.assertFalse(self._check(root, base))
+
+    def test_existing_import_line_changed_still_passes_with_data_protection(self):
+        """Regression guard: protecting module-level data must not reverse round 1's
+        explicit decision that editing an existing import line is legitimate."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(
+                root / "test_a.py",
+                'import os\n\n_BASE_KW = {\n    "x": 1,\n}\n\n\ndef test_one():\n    assert _BASE_KW["x"] == 1\n',
+            )
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                'import os, sys\n\n_BASE_KW = {\n    "x": 1,\n}\n\n\ndef test_one():\n    assert _BASE_KW["x"] == 1\n',
+            )
+            self.assertTrue(self._check(root, base))
+
+    def test_new_module_level_constant_addition_passes(self):
+        """Pure addition of a brand new module-level constant must stay legitimate."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(root / "test_a.py", "def test_one():\n    assert 1 == 1\n")
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                '_NEW_CONST = 5\n\n\ndef test_one():\n    assert 1 == 1\n',
+            )
+            self.assertTrue(self._check(root, base))
+
+    def test_append_new_constant_immediately_after_existing_passes(self):
+        """Boundary case at module-data scope, mirroring the function-scope one:
+        a new constant typed directly after an existing one, zero blank lines,
+        must stay unflagged."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(root / "test_a.py", "_A = 1\ndef test_one():\n    assert _A == 1\n")
+            base = _commit_all(root, "base")
+            _write(root / "test_a.py", "_A = 1\n_B = 2\ndef test_one():\n    assert _A == 1\n")
+            self.assertTrue(self._check(root, base))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/scripts/tests/test_run_gates.py
+++ b/.claude/scripts/tests/test_run_gates.py
@@ -441,6 +441,40 @@ class AppendOnlyCheckTests(unittest.TestCase):
             )
             self.assertFalse(self._check(root, base))
 
+    def test_binary_content_flags_without_crashing(self):
+        """Regression test (code-review finding): a test file rewritten with
+        undecodable binary content must produce a verdict (flagged, since the
+        protected lines differ), not crash the gate with UnicodeDecodeError."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(root / "test_a.py", "def test_one():\n    assert 1 == 1\n")
+            base = _commit_all(root, "base")
+            (root / "test_a.py").write_bytes(b"def test_one():\n\x00\xff\xfe binary junk")
+            self.assertFalse(self._check(root, base))
+
+    def test_verbatim_test_swap_is_flagged(self):
+        """Behavior pin (deliberate, conservative): swapping two tests' order
+        verbatim — zero text changes, pure relocation — IS flagged. Reordering
+        previously-committed tests is a structural change to prior tests, and
+        rule 5 says a prior-test change is a Confidence-Gate decision (STOP and
+        ask), so the conservative outcome is intended, not a false positive to
+        fix. This test pins that choice so a future change flipping it is a
+        conscious decision, not an accident."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(
+                root / "test_a.py",
+                "def test_one():\n    assert 1 == 1\n\n\ndef test_two():\n    assert 2 == 2\n",
+            )
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                "def test_two():\n    assert 2 == 2\n\n\ndef test_one():\n    assert 1 == 1\n",
+            )
+            self.assertFalse(self._check(root, base))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/scripts/tests/test_run_gates.py
+++ b/.claude/scripts/tests/test_run_gates.py
@@ -384,6 +384,23 @@ class AppendOnlyCheckTests(unittest.TestCase):
             )
             self.assertFalse(self._check(root, base))
 
+    def test_append_after_file_without_trailing_newline_passes(self):
+        """Regression test (code-review finding): appending new content after a
+        protected range's last line, when that file didn't end in a newline at
+        base, must stay legitimate — git represents the unchanged last line as
+        a remove+add pair purely because its EOF status changed, not its text."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            with open(root / "test_a.py", "w", newline="\n") as f:
+                f.write("def test_one():\n    assert 1 == 1")  # no trailing newline
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                "def test_one():\n    assert 1 == 1\n\n\ndef test_two():\n    assert 2 == 2\n",
+            )
+            self.assertTrue(self._check(root, base))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/scripts/tests/test_run_gates.py
+++ b/.claude/scripts/tests/test_run_gates.py
@@ -542,6 +542,18 @@ class AppendOnlyCheckTests(unittest.TestCase):
             _write(root / "test_ä.py", "def test_one():\n    assert 1 == 2\n")
             self.assertFalse(self._check(root, base))
 
+    def test_git_quoted_filename_rewrite_detected(self):
+        """NUL-delimited git output must preserve path characters that trigger
+        C-style quoting or collide with line/tab-delimited status parsing."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            path = root / 'test_\t\n\\"case.py'
+            _write(path, "def test_one():\n    assert 1 == 1\n")
+            base = _commit_all(root, "base")
+            _write(path, "def test_one():\n    assert 1 == 2\n")
+            self.assertFalse(self._check(root, base))
+
     def test_indented_append_extending_final_test_body_detected(self):
         """Regression test (code-review finding, false-negative direction): an
         INDENTED line appended directly after the file's final test extends
@@ -580,6 +592,251 @@ class AppendOnlyCheckTests(unittest.TestCase):
                 "    def test_two(self):\n        assert 2 == 2\n",
             )
             self.assertTrue(self._check(root, base))
+
+    def test_existing_typescript_assertion_rewrite_fails_closed(self):
+        """A configured non-Python test file must not lose all protection merely
+        because Python's AST cannot parse it. Until a language-aware range parser
+        exists, modifications to an existing unsupported test artifact fail closed."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(
+                root / "src" / "nested" / "auth.test.ts",
+                'test("auth", () => {\n  expect(authorize()).toBe(false);\n});\n',
+            )
+            base = _commit_all(root, "base")
+            _write(
+                root / "src" / "nested" / "auth.test.ts",
+                'test("auth", () => {\n  expect(true).toBe(true);\n});\n',
+            )
+            self.assertFalse(self._check(root, base, ["src/**/*.test.ts"]))
+
+    def test_replacing_separator_with_indented_code_fails(self):
+        """The added side of a SequenceMatcher replace matters: replacing the
+        old blank immediately after a loop test with `break` extends that test."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            base_src = (
+                "CASES = [1, 2, 3]\n\n\ndef test_all_cases():\n"
+                "    for case in CASES:\n        assert case < 3\n\n\n"
+                "def test_other():\n    assert True\n"
+            )
+            _write(root / "test_a.py", base_src)
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                base_src.replace(
+                    "        assert case < 3\n\n",
+                    "        assert case < 3\n        break\n",
+                    1,
+                ),
+            )
+            self.assertFalse(self._check(root, base))
+
+    def test_comment_before_indented_append_does_not_hide_code(self):
+        """Comments do not emit Python indentation tokens. A column-zero comment
+        before an indented `break` must not make the body extension look dedented."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            base_src = (
+                "CASES = [1, 2, 3]\n\n\ndef test_all_cases():\n"
+                "    for case in CASES:\n        assert case < 3\n"
+            )
+            _write(root / "test_a.py", base_src)
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                base_src + "# explanation\n        break\n",
+            )
+            self.assertFalse(self._check(root, base))
+
+    def test_existing_test_class_decorator_edit_fails(self):
+        """Existing test-class metadata is prior test behavior too. This is not
+        OME-475's deferred case of stacking a new outer function decorator."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            base_src = (
+                "import pytest\n\n"
+                '@pytest.mark.skipif(False, reason="enabled")\n'
+                "class TestThings:\n"
+                "    def test_one(self):\n        assert False\n"
+            )
+            _write(root / "test_a.py", base_src)
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                base_src.replace("skipif(False", "skipif(True"),
+            )
+            self.assertFalse(self._check(root, base))
+
+    def test_module_level_assert_edit_fails(self):
+        """A direct module assertion executes during collection and is test logic,
+        not documentation or an exempt runner block."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(
+                root / "test_a.py",
+                "def behavior():\n    return False\n\nassert behavior()\n",
+            )
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                "def behavior():\n    return False\n\nassert True\n",
+            )
+            self.assertFalse(self._check(root, base))
+
+    def test_direct_child_typescript_test_matches_recursive_glob(self):
+        """`**/` includes zero directories in stack-card intent; direct children
+        must not escape merely because fnmatch treats the slash literally."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(
+                root / "src" / "auth.test.ts",
+                'test("auth", () => expect(authorize()).toBe(false));\n',
+            )
+            base = _commit_all(root, "base")
+            _write(
+                root / "src" / "auth.test.ts",
+                'test("auth", () => expect(true).toBe(true));\n',
+            )
+            self.assertFalse(self._check(root, base, ["src/**/*.test.ts"]))
+
+    def test_first_method_added_to_existing_class_passes(self):
+        """Protect class metadata without treating its header endpoint like a
+        function body endpoint: the first new method is a legitimate addition."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(root / "test_a.py", "class TestThings:\n    pass\n")
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                "class TestThings:\n    def test_one(self):\n        assert True\n    pass\n",
+            )
+            self.assertTrue(self._check(root, base))
+
+    def test_invalid_current_source_fails_closed_on_deep_added_code(self):
+        """If tokenization fails, a leading comment must not hide deeper added
+        code at a protected endpoint. Invalid current source should fail closed."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            base_src = (
+                "CASES = [1, 2, 3]\n\n\ndef test_all_cases():\n"
+                "    for case in CASES:\n        assert case < 3\n"
+            )
+            _write(root / "test_a.py", base_src)
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                base_src + "# explanation\n        break\n(\n",
+            )
+            self.assertFalse(self._check(root, base))
+
+    def test_each_recursive_glob_segment_can_match_zero_directories(self):
+        """Multiple `**/` segments vary independently; removing only a prefix
+        chain leaves valid direct-child combinations unmatched."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            path = root / "x" / "foo" / "bar.test.ts"
+            _write(path, 'test("x", () => expect(false).toBe(true));\n')
+            base = _commit_all(root, "base")
+            _write(path, 'test("x", () => expect(true).toBe(true));\n')
+            self.assertFalse(
+                self._check(root, base, ["**/foo/**/bar.test.ts"])
+            )
+
+    def test_invalid_source_form_feed_indentation_fails_closed(self):
+        """Python accepts form feed in leading indentation. The invalid-source
+        fallback must not treat a deeply indented line as column zero."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            base_src = (
+                "CASES = [1, 2, 3]\n\n\ndef test_all_cases():\n"
+                "    for case in CASES:\n        assert case < 3\n"
+            )
+            _write(root / "test_a.py", base_src)
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                base_src + "# explanation\n\f        break\n(\n",
+            )
+            self.assertFalse(self._check(root, base))
+
+    def test_form_feed_prefixed_sibling_function_passes(self):
+        """At the start of indentation, form feed resets Python's indentation
+        column; it must not make a module-level sibling look nested."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(root / "test_a.py", "def test_one():\n    assert True\n")
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                "def test_one():\n    assert True\n\fdef test_two():\n    assert True\n",
+            )
+            self.assertTrue(self._check(root, base))
+
+    def test_current_tab_error_fails_closed(self):
+        """Tokenization alone does not validate indentation. A current file that
+        ast.parse rejects with TabError must not pass append-only checking."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            base_src = (
+                "class TestThings:\n    def test_all(self):\n"
+                "        for case in [1, 2, 3]:\n            assert case < 3\n"
+            )
+            _write(root / "test_a.py", base_src)
+            base = _commit_all(root, "base")
+            _write(root / "test_a.py", base_src + "\t\tbreak\n")
+            self.assertFalse(self._check(root, base))
+
+    def test_current_compile_time_syntax_error_fails_closed(self):
+        """AST construction accepts some contextually invalid statements, so
+        current Python source must pass full compilation before it can pass."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            base_src = "def test_one():\n    assert True\n"
+            _write(root / "test_a.py", base_src)
+            base = _commit_all(root, "base")
+            _write(root / "test_a.py", base_src + "break\n")
+            self.assertFalse(self._check(root, base))
+
+    def test_globstar_inside_component_is_not_recursive(self):
+        """Only a standalone `**` path component has zero-directory semantics;
+        textual `**/` inside a larger component must retain fnmatch behavior."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            path = root / "src" / "testauth.test.ts"
+            _write(path, 'test("x", () => expect(false).toBe(true));\n')
+            base = _commit_all(root, "base")
+            _write(path, 'test("x", () => expect(true).toBe(true));\n')
+            self.assertTrue(
+                self._check(root, base, ["src/test**/auth.test.ts"])
+            )
+
+    def test_non_globstar_wildcard_does_not_cross_directories(self):
+        """Wildcards within a component must not consume path separators."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            path = root / "src" / "test" / "deep" / "auth.test.ts"
+            _write(path, 'test("x", () => expect(false).toBe(true));\n')
+            base = _commit_all(root, "base")
+            _write(path, 'test("x", () => expect(true).toBe(true));\n')
+            self.assertTrue(
+                self._check(root, base, ["src/test**/auth.test.ts"])
+            )
 
 
 if __name__ == "__main__":

--- a/.claude/scripts/tests/test_run_gates.py
+++ b/.claude/scripts/tests/test_run_gates.py
@@ -292,6 +292,80 @@ class AppendOnlyCheckTests(unittest.TestCase):
             _write(root / "test_a.py", "_A = 1\n_B = 2\ndef test_one():\n    assert _A == 1\n")
             self.assertTrue(self._check(root, base))
 
+    def test_module_docstring_edit_passes(self):
+        """Regression test (code-review finding): a bare module docstring is an
+        ast.Expr, not Assign/AnnAssign — editing it must stay legitimate, with
+        zero test logic touched."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(root / "test_a.py", '"""Old docstring."""\n\n\ndef test_one():\n    assert 1 == 1\n')
+            base = _commit_all(root, "base")
+            _write(root / "test_a.py", '"""New docstring."""\n\n\ndef test_one():\n    assert 1 == 1\n')
+            self.assertTrue(self._check(root, base))
+
+    def test_if_main_block_edit_passes(self):
+        """Regression test (code-review finding): the near-universal
+        `if __name__ == "__main__":` runner block is an ast.If, not
+        Assign/AnnAssign — editing it (e.g. switching runners) must stay
+        legitimate."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(
+                root / "test_a.py",
+                'def test_one():\n    assert 1 == 1\n\n\nif __name__ == "__main__":\n    pass\n',
+            )
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                'def test_one():\n    assert 1 == 1\n\n\nif __name__ == "__main__":\n'
+                "    import unittest\n\n    unittest.main()\n",
+            )
+            self.assertTrue(self._check(root, base))
+
+    def test_import_nested_in_conditional_edit_passes(self):
+        """Regression test (code-review finding): an import nested inside a
+        module-level version-guard (if/else) must stay legitimate to edit — the
+        whole `if` block is an ast.If, not Assign/AnnAssign, so it isn't swept
+        into a protected range that would incorrectly cover the nested import."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(
+                root / "test_a.py",
+                "import sys\n\nif sys.version_info >= (3, 10):\n    from typing import ParamSpec\n"
+                "else:\n    from typing_extensions import ParamSpec\n\n\n"
+                "def test_one():\n    assert ParamSpec\n",
+            )
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                "import sys\n\nif sys.version_info >= (3, 10):\n    from typing import ParamSpec\n"
+                "else:\n    from typing_extensions import ParamSpec as ParamSpec\n\n\n"
+                "def test_one():\n    assert ParamSpec\n",
+            )
+            self.assertTrue(self._check(root, base))
+
+    def test_replace_blank_separator_line_passes(self):
+        """Regression test (code-review finding): replacing the blank separator
+        line between two functions with a comment must stay legitimate — the
+        replacement's insertion anchor must not be mis-computed as landing on
+        the START of the second function's protected range."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(
+                root / "test_a.py",
+                "def test_one():\n    assert 1 == 1\n\ndef test_two():\n    assert 2 == 2\n",
+            )
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                "def test_one():\n    assert 1 == 1\n# note\ndef test_two():\n    assert 2 == 2\n",
+            )
+            self.assertTrue(self._check(root, base))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/scripts/tests/test_run_gates.py
+++ b/.claude/scripts/tests/test_run_gates.py
@@ -475,6 +475,26 @@ class AppendOnlyCheckTests(unittest.TestCase):
             )
             self.assertFalse(self._check(root, base))
 
+    def test_rewrite_after_exotic_linebreak_chars_detected(self):
+        """Regression test (code-review finding, false-NEGATIVE direction): a
+        string containing \\f or \\u2028 earlier in the file must not desync
+        diff line numbering from ast's. str.splitlines() splits on those
+        characters (+2 lines here) while Python's tokenizer does not, so the
+        old str-based comparison shifted every later position out of its
+        protected range — a rewrite of a later test went silently undetected.
+        bytes.splitlines() splits only on \\r/\\n, matching the tokenizer."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            base_src = (
+                'def test_one():\n    s = "a\fb c"\n    assert s\n\n\n'
+                "def test_two():\n    assert 2 == 2\n"
+            )
+            _write(root / "test_a.py", base_src)
+            base = _commit_all(root, "base")
+            _write(root / "test_a.py", base_src.replace("assert 2 == 2", "assert 2 == 999"))
+            self.assertFalse(self._check(root, base))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/scripts/tests/test_run_gates.py
+++ b/.claude/scripts/tests/test_run_gates.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml"]
+# ///
+"""Permanent temp-repo matrix for run_gates.py's append-only check (OME-369).
+
+Replaces the round-1 manual scratch-repo verification with a runnable suite, per
+PR #383 review feedback. Each test builds a throwaway git repo, commits a "base"
+state, mutates it, then calls the check functions directly against that repo.
+
+Usage: uv run .claude/scripts/tests/test_run_gates.py
+"""
+import importlib.util
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+_SCRIPT_PATH = pathlib.Path(__file__).resolve().parent.parent / "run_gates.py"
+_spec = importlib.util.spec_from_file_location("run_gates", _SCRIPT_PATH)
+run_gates = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(run_gates)
+
+
+def _git(root: pathlib.Path, *args: str) -> subprocess.CompletedProcess:
+    proc = subprocess.run(
+        ["git", *args], cwd=root, capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(f"git {' '.join(args)} failed: {proc.stderr}")
+    return proc
+
+
+def _init_repo(root: pathlib.Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    _git(root, "init", "-q")
+    # INVARIANT: repo-local only — never touches the real user's global git config.
+    _git(root, "config", "user.email", "test@example.com")
+    _git(root, "config", "user.name", "Test")
+    _git(root, "config", "commit.gpgsign", "false")
+
+
+def _commit_all(root: pathlib.Path, message: str) -> str:
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", message)
+    return _git(root, "rev-parse", "HEAD").stdout.strip()
+
+
+def _write(path: pathlib.Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+class AppendOnlyCheckTests(unittest.TestCase):
+    def _check(self, root: pathlib.Path, base: str, globs: list[str] | None = None) -> bool:
+        import io
+        import contextlib
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            return run_gates.append_only_check(root, base, globs or ["test_*.py"])
+
+    def test_pure_addition_passes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(root / "test_a.py", "def test_one():\n    assert 1 == 1\n")
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                "def test_one():\n    assert 1 == 1\n\n\ndef test_two():\n    assert 2 == 2\n",
+            )
+            self.assertTrue(self._check(root, base))
+
+    def test_real_rewrite_inside_existing_test_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(root / "test_a.py", "def test_one():\n    assert 1 == 1\n")
+            base = _commit_all(root, "base")
+            _write(root / "test_a.py", "def test_one():\n    assert 1 == 2\n")
+            self.assertFalse(self._check(root, base))
+
+    def test_new_import_insertion_passes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(root / "test_a.py", "def test_one():\n    assert 1 == 1\n")
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                "import os\n\n\ndef test_one():\n    assert 1 == 1\n",
+            )
+            self.assertTrue(self._check(root, base))
+
+    def test_existing_import_line_changed_no_test_touched_passes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(root / "test_a.py", "import os\n\n\ndef test_one():\n    assert 1 == 1\n")
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                "import os, sys\n\n\ndef test_one():\n    assert 1 == 1\n",
+            )
+            self.assertTrue(self._check(root, base))
+
+    def test_whole_test_file_delete_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(root / "test_a.py", "def test_one():\n    assert 1 == 1\n")
+            base = _commit_all(root, "base")
+            (root / "test_a.py").unlink()
+            self.assertFalse(self._check(root, base))
+
+    def test_nested_stack_root_detects_rewrite(self):
+        """Regression test for the review-flagged bug: a stack root below the repo
+        root (e.g. apps/scoreboard) must still detect a rewrite inside an existing
+        test body — `git show` needs the `./` cwd-relative prefix to find the file."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = pathlib.Path(tmp)
+            _init_repo(repo_root)
+            stack_root = repo_root / "apps" / "scoreboard"
+            _write(stack_root / "tests" / "test_a.py", "def test_one():\n    assert 1 == 1\n")
+            base = _commit_all(repo_root, "base")
+            _write(stack_root / "tests" / "test_a.py", "def test_one():\n    assert 1 == 2\n")
+            self.assertFalse(self._check(stack_root, base, ["tests/*.py"]))
+
+    def test_decorator_edit_detected(self):
+        """Regression test: editing a decorator above an existing test (e.g. its
+        parametrize list) must count as touching that test's body, even though
+        ast.FunctionDef.lineno points at `def`, not the decorator line."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(
+                root / "test_a.py",
+                'import pytest\n\n\n@pytest.mark.parametrize("x", [1])\ndef test_param(x):\n    assert x == 1\n',
+            )
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                'import pytest\n\n\n@pytest.mark.parametrize("x", [2])\ndef test_param(x):\n    assert x == 1\n',
+            )
+            self.assertFalse(self._check(root, base))
+
+    def test_dash_prefixed_content_detected(self):
+        """Regression test: a removed line whose content starts at column 0 with
+        `--` (diff form `----`) must not false-match the file-header skip."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(root / "test_a.py", 'def test_sep():\n    doc = """\n---\nsection\n"""\n    assert doc\n')
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                'def test_sep():\n    doc = """\nCHANGED\nsection\n"""\n    assert doc\n',
+            )
+            self.assertFalse(self._check(root, base))
+
+    def test_insertion_neuters_existing_test_fails(self):
+        """Regression test (review concern): a pure insertion — zero removed lines
+        — can still neuter a prior test's real check (e.g. forcing a variable's
+        value right before the assertion). `removed`-only detection is blind to
+        this; `inserted_after` must catch it."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(
+                root / "test_a.py",
+                "def compute():\n    return 41\n\n\ndef test_foo():\n    result = compute()\n"
+                "    assert result == 42\n",
+            )
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                "def compute():\n    return 41\n\n\ndef test_foo():\n    result = compute()\n"
+                "    result = 42  # neuters the assertion, nothing removed\n"
+                "    assert result == 42\n",
+            )
+            self.assertFalse(self._check(root, base))
+
+    def test_fixture_edit_detected(self):
+        """Regression test (review concern): a `@pytest.fixture` (not `test_*`-named)
+        that an existing test depends on must be protected too — editing it changes
+        what the dependent test actually exercises."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(
+                root / "test_a.py",
+                'import pytest\n\n\n@pytest.fixture\ndef db():\n    return {"ready": True}\n\n\n'
+                'def test_uses_fixture(db):\n    assert db["ready"]\n',
+            )
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                'import pytest\n\n\n@pytest.fixture\ndef db():\n    return {"ready": False}\n\n\n'
+                'def test_uses_fixture(db):\n    assert db["ready"]\n',
+            )
+            self.assertFalse(self._check(root, base))
+
+    def test_append_new_function_immediately_after_existing_passes(self):
+        """Boundary case: a whole new test typed directly after an existing one,
+        ZERO blank lines between them, must stay unflagged — its insertion anchors
+        at exactly the old function's last line (`n == hi`), which must be excluded
+        or this reopens OME-369's original false positive."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(root / "test_a.py", "def test_one():\n    assert 1 == 1\n")
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                "def test_one():\n    assert 1 == 1\ndef test_two():\n    assert 2 == 2\n",
+            )
+            self.assertTrue(self._check(root, base))
+
+    def test_insert_new_function_immediately_before_existing_passes(self):
+        """Symmetric boundary case: a whole new test typed directly before an
+        existing one, zero blank lines, must also stay unflagged."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(root / "test_a.py", "def test_two():\n    assert 2 == 2\n")
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                "def test_one():\n    assert 1 == 1\ndef test_two():\n    assert 2 == 2\n",
+            )
+            self.assertTrue(self._check(root, base))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/scripts/tests/test_run_gates.py
+++ b/.claude/scripts/tests/test_run_gates.py
@@ -366,6 +366,24 @@ class AppendOnlyCheckTests(unittest.TestCase):
             )
             self.assertTrue(self._check(root, base))
 
+    def test_module_level_augassign_edit_detected(self):
+        """Regression test (code-review finding): a module-level accumulator
+        statement (e.g. `_CASES += [...]`) is an ast.AugAssign, not covered by
+        Assign/AnnAssign alone — editing it must still be caught."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _init_repo(root)
+            _write(
+                root / "test_a.py",
+                "_CASES = [1, 2, 3]\n_CASES += [4, 5]\n\n\ndef test_uses_cases():\n    assert len(_CASES) == 5\n",
+            )
+            base = _commit_all(root, "base")
+            _write(
+                root / "test_a.py",
+                "_CASES = [1, 2, 3]\n_CASES += [4, 5, 999]\n\n\ndef test_uses_cases():\n    assert len(_CASES) == 5\n",
+            )
+            self.assertFalse(self._check(root, base))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/tasks/2026-07-09-append-only-line-diff.md
+++ b/docs/tasks/2026-07-09-append-only-line-diff.md
@@ -44,3 +44,14 @@ tickets instead: decorator-stacking (concern A) and name-shadowing/monkeypatchin
 (a structural line-diffing limitation). A third, non-code finding (no CI/hook
 independently enforces this check at all) filed as its own distinct ticket. See
 the ledger's Round 4 section for full detail and ticket links.
+
+**Round 5 (2026-07-17):** a structured multi-angle code-review pass on the
+pushed PR found round 4's own fix was too broad (a denylist, not an allowlist)
+— editing a module docstring, an `if __name__ == "__main__":` block, or an
+import nested in a version-guard all got falsely flagged, reopening OME-369's
+original false-positive problem. Also found a separate anchor-computation bug:
+replacing the blank line between two functions falsely flagged the second one.
+Fixed both at the root (switched to an `_MODULE_LEVEL_DATA` allowlist; anchor
+tracking now keyed off the diff hunk's declared old-line count) plus an
+anchor-syntax convention fix. 20/20 tests pass. See the ledger's Round 5
+section.

--- a/docs/tasks/2026-07-09-append-only-line-diff.md
+++ b/docs/tasks/2026-07-09-append-only-line-diff.md
@@ -71,3 +71,14 @@ examples (`_CASES.append(...)`, `del _CASES[1]`) turned out to be the same
 already-deferred shadowing/monkeypatching class, not new gaps — folded into
 existing documentation instead of new code. 22/22 tests pass. See the
 ledger's Round 7 section.
+
+**Round 8 (2026-07-17):** fourth structured review pass found round 7's fix
+itself only handled the EOF-newline artifact in one direction, and its
+pairing logic couldn't be correctly extended to multi-line hunks by more
+special-casing (tried and failed by hand first). Rewrote `_diff_positions` to
+diff actual line content via `difflib.SequenceMatcher` instead of hand-parsing
+git's diff text — this is the same root cause behind three separate bugs
+across rounds 2, 5, and 7, all eliminated at once by construction rather than
+patched one variant at a time. 24/24 tests pass. See the ledger's Round 8
+section (including a correction: one review finding turned out to be the
+already-deferred shadowing limitation, not a distinct bug).

--- a/docs/tasks/2026-07-09-append-only-line-diff.md
+++ b/docs/tasks/2026-07-09-append-only-line-diff.md
@@ -117,3 +117,9 @@ items (outdated PR body rewritten; in-code gap list gained decorator-stacking;
 AugAssign docstring omission; follow-up tickets accurately described as
 drafted-not-yet-filed pending owner go-ahead; stale line-count figures).
 32/32 tests pass. See the ledger's Round 11 section.
+
+**Round 12 (2026-07-18):** eighth review pass returned CLEAN — zero findings
+across the consistency sweep and nine adversarial execution probes of the
+round-11 changes. Review loop closed per owner instruction; PR #383 awaits
+re-review. Next: file the three drafted follow-up tickets one by one on
+owner go-ahead.

--- a/docs/tasks/2026-07-09-append-only-line-diff.md
+++ b/docs/tasks/2026-07-09-append-only-line-diff.md
@@ -36,3 +36,11 @@ assertion undetected, and fixtures/helpers (e.g. `conftest.py`, real in both
 (not just tests) and adding insertion-position detection with an exclusive upper
 bound (so appending a new function directly after an existing one stays legitimate).
 12/12 tests pass. See the ledger's Round 3 section.
+
+**Round 4 (2026-07-17):** fixed the reviewer's last P2 (module-level test data,
+e.g. `_BASE_KW`, wasn't protected). 16/16 tests pass. Two further findings from
+deeper probing deliberately NOT fixed here, tracked as separate follow-up
+tickets instead: decorator-stacking (concern A) and name-shadowing/monkeypatching
+(a structural line-diffing limitation). A third, non-code finding (no CI/hook
+independently enforces this check at all) filed as its own distinct ticket. See
+the ledger's Round 4 section for full detail and ticket links.

--- a/docs/tasks/2026-07-09-append-only-line-diff.md
+++ b/docs/tasks/2026-07-09-append-only-line-diff.md
@@ -90,3 +90,12 @@ made the gate raise UnicodeDecodeError instead of producing a verdict — now
 compares bytes on both sides (flags binary junk fail-closed, no crash). Also
 pinned the verbatim-swap-is-flagged behavior as deliberate. 26/26 tests pass.
 See the ledger's Round 9 section.
+
+**Round 10 (2026-07-17):** sixth review pass. Discovered the round-9 bytes
+change had also fixed a latent FALSE NEGATIVE: `str.splitlines()` splits on
+`\f`/` ` (which Python's tokenizer doesn't), desyncing diff numbering
+from ast ranges — a rewrite of a test after such a character went silently
+undetected on round-8 code. Proven and pinned with a discriminating test
+(27/27 pass). Also surfaced: the test file is now 480 lines (over the
+≤450 guideline) — splitting it means relocating prior tests, itself a rule-5
+STOP-and-ask decision, left to the owner. See the ledger's Round 10 section.

--- a/docs/tasks/2026-07-09-append-only-line-diff.md
+++ b/docs/tasks/2026-07-09-append-only-line-diff.md
@@ -18,3 +18,21 @@ status — only fail if a `-` line falls inside a previously-existing test funct
 
 No dedicated stack/tests exist for `.claude/scripts/`; verified with a manual
 synthetic-scenario check per owner decision, no new permanent test infra added.
+
+**Round 2 (2026-07-17):** `HupBaHa`'s PR review requested changes — the fix still
+let prior tests be modified undetected in nested stack roots (`apps/scoreboard`
+etc.), plus asked for a permanent test matrix. Confirmed and fixed three bugs
+(nested-root `git show` path resolution, decorator lines outside the recorded test
+range, dash-prefixed removed-line content false-matching the header skip); added
+`.claude/scripts/tests/test_run_gates.py` (8 permanent tests, stdlib `unittest`)
+replacing the manual-only verification. See the ledger's Round 2 section for full
+detail. Status stays `in_review` pending re-review.
+
+**Round 3 (2026-07-17):** two more concerns from the same review, both confirmed:
+pure insertions inside an existing test (zero removed lines) could neuter an
+assertion undetected, and fixtures/helpers (e.g. `conftest.py`, real in both
+`apps/scoreboard` and `apps/aigateway`) weren't protected at all since only
+`test_*`-named functions were tracked. Fixed by protecting every function's range
+(not just tests) and adding insertion-position detection with an exclusive upper
+bound (so appending a new function directly after an existing one stays legitimate).
+12/12 tests pass. See the ledger's Round 3 section.

--- a/docs/tasks/2026-07-09-append-only-line-diff.md
+++ b/docs/tasks/2026-07-09-append-only-line-diff.md
@@ -1,0 +1,20 @@
+---
+id: OME-369
+linear_url: https://linear.app/openmined/issue/OME-369/run-gatespy-append-only-check-flags-pure-test-additions-as-violations
+status: in_progress
+type: task
+priority: P2
+labels: [repo, autonomous, agentic, "Repo & Dev Process"]
+created: 2026-07-09
+closed:
+---
+
+`append_only_check()` in `.claude/scripts/run_gates.py` flags any git-modified test
+file regardless of content, so pure additions to an existing test file false-positive
+as a rule-5 violation. Found while working OME-322.
+
+Fix: diff added/removed lines within each changed test file rather than file-level git
+status — only fail if a `-` line falls inside a previously-existing test function body.
+
+No dedicated stack/tests exist for `.claude/scripts/`; verified with a manual
+synthetic-scenario check per owner decision, no new permanent test infra added.

--- a/docs/tasks/2026-07-09-append-only-line-diff.md
+++ b/docs/tasks/2026-07-09-append-only-line-diff.md
@@ -82,3 +82,11 @@ across rounds 2, 5, and 7, all eliminated at once by construction rather than
 patched one variant at a time. 24/24 tests pass. See the ledger's Round 8
 section (including a correction: one review finding turned out to be the
 already-deferred shadowing limitation, not a distinct bug).
+
+**Round 9 (2026-07-17):** fifth review pass on the rewrite (agents partially
+cut short by a session limit; remaining questions verified directly). Found
+and fixed one real crash: undecodable/binary content in a test-matched file
+made the gate raise UnicodeDecodeError instead of producing a verdict — now
+compares bytes on both sides (flags binary junk fail-closed, no crash). Also
+pinned the verbatim-swap-is-flagged behavior as deliberate. 26/26 tests pass.
+See the ledger's Round 9 section.

--- a/docs/tasks/2026-07-09-append-only-line-diff.md
+++ b/docs/tasks/2026-07-09-append-only-line-diff.md
@@ -1,7 +1,7 @@
 ---
 id: OME-369
 linear_url: https://linear.app/openmined/issue/OME-369/run-gatespy-append-only-check-flags-pure-test-additions-as-violations
-status: in_progress
+status: in_review
 type: task
 priority: P2
 labels: [repo, autonomous, agentic, "Repo & Dev Process"]

--- a/docs/tasks/2026-07-09-append-only-line-diff.md
+++ b/docs/tasks/2026-07-09-append-only-line-diff.md
@@ -55,3 +55,10 @@ Fixed both at the root (switched to an `_MODULE_LEVEL_DATA` allowlist; anchor
 tracking now keyed off the diff hunk's declared old-line count) plus an
 anchor-syntax convention fix. 20/20 tests pass. See the ledger's Round 5
 section.
+
+**Round 6 (2026-07-17):** second structured review pass — 5 of 8 angles clean.
+Fixed one more real gap (`ast.AugAssign` module-level accumulators were
+unprotected) and one docs-process gap (Round 1's ledger placeholder never
+filled). A walrus-statement edge case documented as a known limitation rather
+than fixed (too exotic to warrant a special case). 21/21 tests pass. See the
+ledger's Round 6 section.

--- a/docs/tasks/2026-07-09-append-only-line-diff.md
+++ b/docs/tasks/2026-07-09-append-only-line-diff.md
@@ -62,3 +62,12 @@ unprotected) and one docs-process gap (Round 1's ledger placeholder never
 filled). A walrus-statement edge case documented as a known limitation rather
 than fixed (too exotic to warrant a special case). 21/21 tests pass. See the
 ledger's Round 6 section.
+
+**Round 7 (2026-07-17):** third structured review pass — 5 of 8 angles clean.
+Fixed a real, plausible false positive: appending content after a file that
+lacked a trailing newline produced a git-diff artifact (remove+add of an
+unchanged line) that falsely triggered the gate. Two more mutation-in-place
+examples (`_CASES.append(...)`, `del _CASES[1]`) turned out to be the same
+already-deferred shadowing/monkeypatching class, not new gaps — folded into
+existing documentation instead of new code. 22/22 tests pass. See the
+ledger's Round 7 section.

--- a/docs/tasks/2026-07-09-append-only-line-diff.md
+++ b/docs/tasks/2026-07-09-append-only-line-diff.md
@@ -39,11 +39,13 @@ bound (so appending a new function directly after an existing one stays legitima
 
 **Round 4 (2026-07-17):** fixed the reviewer's last P2 (module-level test data,
 e.g. `_BASE_KW`, wasn't protected). 16/16 tests pass. Two further findings from
-deeper probing deliberately NOT fixed here, tracked as separate follow-up
-tickets instead: decorator-stacking (concern A) and name-shadowing/monkeypatching
-(a structural line-diffing limitation). A third, non-code finding (no CI/hook
-independently enforces this check at all) filed as its own distinct ticket. See
-the ledger's Round 4 section for full detail and ticket links.
+deeper probing deliberately NOT fixed here, deferred as follow-ups instead:
+decorator-stacking (concern A) and name-shadowing/monkeypatching (a structural
+line-diffing limitation). A third, non-code finding (no CI/hook independently
+enforces this check at all) also deferred as its own distinct unit. Ticket
+drafts are prepared but NOT yet filed — filing is queued behind the PR
+re-review per explicit owner instruction; IDs will be recorded in the ledger
+when filed. See the ledger's Round 4 section.
 
 **Round 5 (2026-07-17):** a structured multi-angle code-review pass on the
 pushed PR found round 4's own fix was too broad (a denylist, not an allowlist)
@@ -96,6 +98,22 @@ change had also fixed a latent FALSE NEGATIVE: `str.splitlines()` splits on
 `\f`/` ` (which Python's tokenizer doesn't), desyncing diff numbering
 from ast ranges — a rewrite of a test after such a character went silently
 undetected on round-8 code. Proven and pinned with a discriminating test
-(27/27 pass). Also surfaced: the test file is now 480 lines (over the
-≤450 guideline) — splitting it means relocating prior tests, itself a rule-5
-STOP-and-ask decision, left to the owner. See the ledger's Round 10 section.
+(27/27 pass). Also surfaced: the test file is over the ≤450-line guideline
+(480 at measurement, 586 after rounds 10-11's own tests) — splitting it means
+relocating prior tests, itself a rule-5 STOP-and-ask decision, left to the
+owner. See the ledger's Round 10 section.
+
+**Round 11 (2026-07-17/18):** seventh review pass found and fixed four more
+execution-verified fail-open bugs: a UTF-8 BOM at base stripped ALL protection
+from a file (ast.parse of a str BOM raises SyntaxError → permissive branch);
+typechange status `T` (test file replaced by a symlink) was silently skipped;
+non-ASCII filenames escaped glob matching under git's default path quoting;
+and an indented line appended after the file's final test extended its body
+undetected (e.g. appending `break` inside its loop flips a failing test
+green) — fixed by carrying each protected range's definition column and each
+insertion anchor's first-non-blank indent, flagging `n == hi` insertions
+indented deeper than the definition. Also corrected 5 documentation-drift
+items (outdated PR body rewritten; in-code gap list gained decorator-stacking;
+AugAssign docstring omission; follow-up tickets accurately described as
+drafted-not-yet-filed pending owner go-ahead; stale line-count figures).
+32/32 tests pass. See the ledger's Round 11 section.

--- a/docs/tasks/2026-07-18-append-only-gate-ci-enforcement.md
+++ b/docs/tasks/2026-07-18-append-only-gate-ci-enforcement.md
@@ -1,0 +1,22 @@
+---
+id: OME-477
+linear_url: https://linear.app/openmined/issue/OME-477/enforce-the-append-only-test-gate-in-ci-against-the-real-merge-base
+status: backlog
+type: task
+priority: P2
+labels: [repo, design-session, agentic]
+created: 2026-07-18
+closed:
+---
+
+Rule 5 (append-only tests) has zero independent enforcement: no CI workflow
+or hook runs `run_gates.py`, and every documented invocation defaults to
+`--base HEAD` (uncommitted delta only — a test weakened in an earlier commit
+of the same branch is invisible to later local runs). The gate is voluntary
+and local; nothing server-side re-verifies before merge, which caps the value
+of all the diff-logic hardening done in OME-369. Design-session fork: where
+it runs (per-component workflows vs. repo-wide vs. pre-push hook), the base
+ref (PR merge-base for CI), and enforcement level (required check vs.
+advisory, plus a deliberate override path for Confidence-Gate-approved prior
+test changes). Found during PR #383's review; distinct infra unit from
+OME-369's code fixes.

--- a/docs/tasks/2026-07-18-append-only-gate-decorator-stacking.md
+++ b/docs/tasks/2026-07-18-append-only-gate-decorator-stacking.md
@@ -1,0 +1,20 @@
+---
+id: OME-475
+linear_url: https://linear.app/openmined/issue/OME-475/append-only-gate-detect-a-new-outer-decorator-skipxfail-stacked-on-an
+status: backlog
+type: task
+priority: P3
+labels: [repo, deferred, agentic]
+created: 2026-07-18
+closed:
+---
+
+Append-only gate follow-up (from PR #383 / OME-369): stacking a new outermost
+decorator (`@pytest.mark.skip`/`xfail`) onto an existing test anchors at the
+same diff position as legitimately inserting a new function above it, so the
+gate can't see it — a direct way to silently disable a prior test. Deferred
+because a correct fix needs old-vs-new AST identity matching (compare each
+function's decorator list across versions), a different and larger mechanism
+than the gate's line-position diffing; gated on a design pass for that
+matching (renames, same-name functions, decorator-source comparison).
+Documented as gap (5) in `run_gates.py`'s AIDEV-NOTE.

--- a/docs/tasks/2026-07-18-append-only-gate-shadowing-limitation.md
+++ b/docs/tasks/2026-07-18-append-only-gate-shadowing-limitation.md
@@ -1,0 +1,21 @@
+---
+id: OME-476
+linear_url: https://linear.app/openmined/issue/OME-476/append-only-gate-name-shadowingmonkeypatching-bypass-decide-accept-vs
+status: backlog
+type: task
+priority: P3
+labels: [repo, design-session, agentic]
+created: 2026-07-18
+closed:
+---
+
+Append-only gate follow-up (from PR #383 / OME-369): name-shadowing /
+monkeypatching / mutation-in-place appends (same-name redefinition,
+`test_foo = lambda: None`, `del test_foo`, `compute = lambda: 42` at EOF,
+`_CASES.append(...)`) change prior tests' behavior without touching their
+lines — indistinguishable from legitimate additions at the diff level, so no
+line-diff fix exists and the mechanism list is open-ended. Design-session
+fork for the owner: (1) accept permanently as a documented limitation,
+(2) invest in semantic/data-flow analysis of appended statements, or
+(3) behavioral verification (run prior tests old-vs-new and diff outcomes).
+Documented as gap (4) in `run_gates.py`'s AIDEV-NOTE.

--- a/docs/work/2026-07-09-OME-369-append-only-line-diff.md
+++ b/docs/work/2026-07-09-OME-369-append-only-line-diff.md
@@ -685,7 +685,8 @@ verified directly with a consolidated script instead of re-spawning agents:
     `_diff_positions`; hardened decode in `_old_protected_ranges`.
   - `.claude/scripts/tests/test_run_gates.py` — 2 new tests
     (binary-content no-crash+flag, verbatim-swap behavior pin), 26 total.
-- **Commits:** <fill after commit>
+- **Commits:** `914640d` — fix(repo): compare bytes so binary content yields a
+  verdict, not a crash (Refs: OME-369).
 - **Gates:** `uv run .claude/scripts/tests/test_run_gates.py -v` → 26/26 pass.
   Binary test confirmed to ERROR (UnicodeDecodeError) on round-8 code, pass on
   round-9 code. `python3 -m py_compile` and `uvx ruff check` clean.

--- a/docs/work/2026-07-09-OME-369-append-only-line-diff.md
+++ b/docs/work/2026-07-09-OME-369-append-only-line-diff.md
@@ -313,8 +313,12 @@ simply not being run (also tracked separately, as a distinct infra unit).
   `test_module_level_test_data_edit_detected` confirmed to fail on round-3 code,
   pass on round-4 code. `python3 -m py_compile` and `uvx ruff check` clean.
 - **Deviations:** none from the round-4 plan.
-- **Follow-ups filed:** pending (concern A, shadowing/monkeypatching, and the
-  CI-enforcement-gap — filed as separate tickets right after this commit).
+- **Follow-ups filed:** NOT yet filed — drafts prepared, but filing is
+  deliberately queued behind the PR re-review, per explicit owner instruction
+  (2026-07-17: tickets one by one, only after the review loop finishes). The
+  three pending drafts: concern A (decorator-stacking), the
+  shadowing/monkeypatching structural limitation, and the CI-enforcement gap.
+  Record the OME-N identifiers here when filed.
 
 ## Round 5 (2026-07-17) — structured code-review pass on the already-pushed PR
 
@@ -709,11 +713,13 @@ rounds. Two findings:
   bytes comparison (`bytes.splitlines()` splits only on `\r`/`\n`, matching
   the tokenizer) it is correctly flagged. Pinned with
   `test_rewrite_after_exotic_linebreak_chars_detected` (27 tests total).
-- **`test_run_gates.py` is now 480 lines**, over the sdlc-python skill's
-  ≤450-line REFACTOR guideline. Deliberately NOT split here: relocating prior
-  tests to a new file is itself a rule-5 prior-test change (a STOP-and-ask
-  decision — the gate would flag its own test-file split), so this is
-  surfaced to the owner as a decision, not acted on unilaterally.
+- **`test_run_gates.py` is now over the sdlc-python skill's ≤450-line
+  REFACTOR guideline** (480 lines when measured this round, before this
+  round's own pin test and round 11's additions — 586 as of round 11).
+  Deliberately NOT split: relocating prior tests to a new file is itself a
+  rule-5 prior-test change (a STOP-and-ask decision — the gate would flag its
+  own test-file split), so this is surfaced to the owner as a decision, not
+  acted on unilaterally.
 
 ## Outcome (round 10)
 
@@ -724,4 +730,66 @@ rounds. Two findings:
   fix (Refs: OME-369).
 - **Gates:** 27/27 pass; new test confirmed to return the false-negative
   (True) on round-8 code and pass on current code. `py_compile`/`ruff` clean.
+- **Deviations:** none.
+
+## Round 11 (2026-07-17/18) — seventh review pass: plumbing fail-opens + docs drift
+
+Two agents on the final state (fresh-eyes correctness with execution-verified
+findings; docs-consistency), plus direct checks (self-check against the
+branch's own history → True; 27/27; CI green). The correctness agent found
+FOUR verified fail-open bugs — three in the M/D/R + decode + glob plumbing,
+one genuinely new positional bypass:
+
+1. **UTF-8 BOM stripped ALL protection** (false negative): the bytes decode
+   fine, but `ast.parse` of a str starting with U+FEFF raises SyntaxError, so
+   a BOM'd (perfectly valid, runnable) test file fell into the permissive
+   branch — a rewrite inside it went undetected. Fixed: `lstrip("\ufeff")`
+   after decode.
+2. **Typechange status `T` silently skipped** (false negative): replacing a
+   committed test file with a symlink is `T`, not M/D/R — it fell into the
+   "A/C are fine" bucket. Fixed: `T` joins the offender statuses (fail-closed,
+   like D/R).
+3. **Non-ASCII filenames escaped glob matching** (false negative, both M and
+   D): git's default `core.quotepath` emits e.g. `test_ä.py` as an
+   octal-escaped quoted C-string, which matches no glob — rewrites AND
+   deletions of such files were skipped entirely. Fixed:
+   `-c core.quotepath=off` on the name-status call.
+4. **Indented append extends a final test's body** (false negative, and a NEW
+   positional class distinct from every deferred gap): appending
+   `        break` after the file's last test line lands at anchor `n == hi`
+   (the exclusive bound's legitimate-append exemption) yet lives INSIDE the
+   old function — e.g. flips a failing loop-based test green with zero old
+   lines touched. Fixed at the mechanism level: protected ranges now carry
+   the node's column offset, insertion anchors now carry the first non-blank
+   inserted line's indent, and an insertion at `n == hi` with indent deeper
+   than the range's definition column is a violation. The critical boundary
+   stays correct: a new sibling def (col 0) or a new method after an existing
+   method in a class (same column as the def, not deeper) still passes —
+   pinned with a dedicated boundary-guard test.
+
+The docs-consistency agent found 5 drift items, all fixed: PR body still
+described the round-1 implementation (rewritten via `gh pr edit`); the
+in-code gap list omitted decorator-stacking (added as gap (5), and the
+decorator INVARIANT comment clarified to say EXISTING decorators);
+`append_only_check`'s docstring said Assign/AnnAssign omitting AugAssign
+(fixed, typechange also added); the ledger/mirror/code all overclaimed
+follow-up tickets as "filed/tracked" when they are drafts queued behind
+re-review per owner instruction (wording corrected in all three places);
+round 10's 480-line figure was measured before its own pin test (corrected
+with measurement context; 586 as of this round).
+
+## Outcome (round 11)
+
+- **Actual files:**
+  - `.claude/scripts/run_gates.py` — BOM strip; `T` status; quotepath=off;
+    ranges as (lo, hi, col) triples; `inserted_after` as anchor→indent dict;
+    the `n == hi and indent > col` body-extension rule; docstring/gap-list
+    corrections.
+  - `.claude/scripts/tests/test_run_gates.py` — 5 new tests (4 discriminating
+    + 1 boundary guard), 32 total.
+  - Ledger + mirror drift corrections; PR body rewritten.
+- **Commits:** <fill after commit>
+- **Gates:** 32/32 pass. All 4 discriminating tests confirmed to fail on
+  round-10 code and pass on round-11 code; the boundary guard passes on both.
+  `py_compile`/`ruff` clean.
 - **Deviations:** none.

--- a/docs/work/2026-07-09-OME-369-append-only-line-diff.md
+++ b/docs/work/2026-07-09-OME-369-append-only-line-diff.md
@@ -225,3 +225,91 @@ empirically (not just reasoned about) before touching code:
     once round-3 changes are restored.
   - `python3 -m py_compile` and `uvx ruff check` clean on both files.
 - **Deviations:** none from the round-3 plan.
+
+## Round 4 (2026-07-17) — the reviewer's last P2 concern, plus a deeper sweep
+
+Same review thread's second remaining P2: module-level test data (e.g. `_BASE_KW`
+in `apps/aigateway/tests/unit/test_request_cache_keys.py`, real and confirmed, not
+hypothetical) is invisible to a function-only pass. Confirmed empirically, fixed.
+
+At the user's request I then probed further, beyond what the reviewer asked, and
+found two more things — both deliberately **not fixed here**, tracked as separate
+follow-ups instead (see below) to avoid scope drift on this PR:
+
+1. **Decorator-stacking** ("concern A", the reviewer's OTHER remaining P2):
+   confirmed valid and reproducible, but needs old-vs-new AST identity matching —
+   a different, larger mechanism than this PR's line-position diffing. Deferred.
+2. **Name-shadowing / monkeypatching** (found via my own probing, not a reviewer
+   comment): redefining, reassigning, `del`-ing, or mutating shared state anywhere
+   later in a file — even far from what it affects — silently neuters prior
+   tests/fixtures/data while looking like an ordinary append. Proved with 4
+   variants (class redefinition, plain reassignment, `del`, monkeypatch appended
+   at file end unrelated to either test it affects). This is a structural
+   limitation of any pure line-diff gate, not a finite list of bugs — closing it
+   for real needs semantic/data-flow analysis or execution-based verification.
+3. Also found (not a code bug, a process/infra gap): **no independent
+   enforcement** of this check exists anywhere — no CI workflow references
+   `run_gates.py`, no pre-push hook, and every documented invocation omits
+   `--base` (defaults to `HEAD`, i.e. only the uncommitted delta vs the last local
+   commit, never the cumulative diff vs `origin/main`). Tracked as its own ticket,
+   separate from OME-369, since it's a different kind of unit of work entirely.
+
+## Planned changes (round 4)
+
+- `.claude/scripts/run_gates.py`: `_old_protected_ranges` also walks `tree.body`
+  (module-level, non-recursive) for every statement except
+  `Import`/`ImportFrom`/`FunctionDef`/`AsyncFunctionDef`/`ClassDef` — imports stay
+  exempt (preserves round 1's explicit decision); functions already covered by the
+  separate `ast.walk` pass; class-level attributes noted as a related, deliberately
+  out-of-scope gap (same shape of problem, would need per-statement treatment
+  inside class bodies too, not a whole-class-span shortcut — that would reopen the
+  "insert a new method between two existing ones" false positive).
+- `.claude/scripts/tests/test_run_gates.py`: 4 new tests —
+  `test_module_level_test_data_edit_detected` (the confirmed-bug regression),
+  `test_existing_import_line_changed_still_passes_with_data_protection` (guards
+  round 1's decision isn't reversed), `test_new_module_level_constant_addition_passes`
+  and `test_append_new_constant_immediately_after_existing_passes` (boundary cases
+  at data scope, mirroring the function-scope ones from round 3).
+
+## Test plan (round 4)
+
+- Same discipline as rounds 2-3: `test_module_level_test_data_edit_detected`
+  confirmed to **fail** against a snapshot of round-3-only code, pass on round-4
+  code. The three "must still pass" tests confirmed passing on both (expected,
+  since round 3 never inspected module-level statements at all — the meaningful
+  check is that they still pass under the NEW data-protection logic).
+- Sanity check against the real repo: parsed
+  `apps/aigateway/tests/unit/test_request_cache_keys.py` directly —
+  `_old_protected_ranges` finds 22 protected ranges including `_BASE_KW`'s own
+  span, no crash.
+
+## Acceptance (round 4)
+
+- Confirmed bug fixed; full matrix (16 tests: 12 from rounds 1-3 + 4 new) passes.
+- No regression: round 1's "existing import line changed" decision still holds
+  under the broadened protection.
+
+## Known limitations (documented, not fixed — see follow-up tickets)
+
+This gate catches accidental/naive test-weakening well after rounds 1-4 (line
+rewrites, insertions, decorator edits on existing decorators, fixtures, module
+data). It does **not**, and structurally cannot via line-diffing alone, catch
+determined bypass via name-shadowing/monkeypatching (tracked as a follow-up
+ticket, see Outcome below), or a new outermost decorator stacked onto a
+previously-undecorated (or already-decorated) test (concern A, tracked
+separately). It also has no independent enforcement — nothing stops it from
+simply not being run (also tracked separately, as a distinct infra unit).
+
+## Outcome (round 4, fill at the end — required before COMMIT)
+
+- **Actual files:**
+  - `.claude/scripts/run_gates.py` — `_EXEMPT_TOP_LEVEL` tuple + `_old_protected_ranges`'s
+    second pass over `tree.body`.
+  - `.claude/scripts/tests/test_run_gates.py` — 4 new tests, 16 total.
+- **Commits:** <fill after commit>
+- **Gates:** `uv run .claude/scripts/tests/test_run_gates.py -v` → 16/16 pass.
+  `test_module_level_test_data_edit_detected` confirmed to fail on round-3 code,
+  pass on round-4 code. `python3 -m py_compile` and `uvx ruff check` clean.
+- **Deviations:** none from the round-4 plan.
+- **Follow-ups filed:** <fill with Linear ticket IDs for concern A,
+  shadowing/monkeypatching, and the CI-enforcement-gap>.

--- a/docs/work/2026-07-09-OME-369-append-only-line-diff.md
+++ b/docs/work/2026-07-09-OME-369-append-only-line-diff.md
@@ -464,7 +464,8 @@ real, low-severity items:
   - `.claude/scripts/tests/test_run_gates.py` — 1 new test, 21 total.
   - `docs/work/2026-07-09-OME-369-append-only-line-diff.md` — Round 1's
     Commits placeholder filled.
-- **Commits:** <fill after commit>
+- **Commits:** `249e462` — fix(repo): protect module-level augmented-assignment
+  test data (Refs: OME-369).
 - **Gates:** `uv run .claude/scripts/tests/test_run_gates.py -v` → 21/21 pass.
   New test confirmed to fail on round-5 code, pass on round-6 code.
   `python3 -m py_compile` and `uvx ruff check` clean.

--- a/docs/work/2026-07-09-OME-369-append-only-line-diff.md
+++ b/docs/work/2026-07-09-OME-369-append-only-line-diff.md
@@ -788,7 +788,8 @@ with measurement context; 586 as of this round).
   - `.claude/scripts/tests/test_run_gates.py` — 5 new tests (4 discriminating
     + 1 boundary guard), 32 total.
   - Ledger + mirror drift corrections; PR body rewritten.
-- **Commits:** <fill after commit>
+- **Commits:** `ea5d1f6` — fix(repo): close four fail-open plumbing gaps in
+  the append-only gate (Refs: OME-369).
 - **Gates:** 32/32 pass. All 4 discriminating tests confirmed to fail on
   round-10 code and pass on round-11 code; the boundary guard passes on both.
   `py_compile`/`ruff` clean.

--- a/docs/work/2026-07-09-OME-369-append-only-line-diff.md
+++ b/docs/work/2026-07-09-OME-369-append-only-line-diff.md
@@ -3,7 +3,7 @@ ticket: OME-369
 stack: repo
 status: done
 started: 2026-07-09
-finished: 2026-07-17
+finished: 2026-07-18
 ---
 
 # OME-369 — Fix append-only check false positive on pure test additions

--- a/docs/work/2026-07-09-OME-369-append-only-line-diff.md
+++ b/docs/work/2026-07-09-OME-369-append-only-line-diff.md
@@ -44,7 +44,8 @@ quick manual check instead of adding permanent test infra:
 
 - **Actual files:** as planned — `.claude/scripts/run_gates.py` only (`append_only_check`
   rewritten; new `_old_test_ranges`/`_removed_old_lines` helpers; `ast`/`re` imports added).
-- **Commits:** <fill after commit below>
+- **Commits:** `ee8addd` — fix(repo): append-only gate checks line-level diffs,
+  not file status (Refs: OME-369).
 - **Gates:** no dedicated stack/tests for `.claude/scripts/` (confirmed with owner).
   Verified manually with 4 scratch-repo scenarios instead:
   1. Pure addition (new test function) → pass.
@@ -406,3 +407,65 @@ separately, not new scope).
   All 4 new tests confirmed to fail on round-4 code, pass on round-5 code.
   `python3 -m py_compile` and `uvx ruff check` clean.
 - **Deviations:** none from the round-5 plan.
+
+## Round 6 (2026-07-17) — second structured code-review pass
+
+Ran the same 8-angle `code-review` pass again on the now-pushed round-5 state,
+per the user's request for another round before filing follow-up tickets.
+5 of 8 angles came back clean (line-by-line, removed-behavior, cross-file,
+efficiency — all re-verified the fixes hold and found nothing new). 3 found
+real, low-severity items:
+
+- **Altitude** (verified by execution): `_MODULE_LEVEL_DATA = (Assign,
+  AnnAssign)` missed `ast.AugAssign` — a module-level accumulator statement
+  like `_CASES += [4, 5]` was unprotected. Fixed: added `ast.AugAssign` to the
+  allowlist (trivial, safe — same shape as the existing types). Also found a
+  bare module-level walrus statement (`(_TOTAL := 10)`) is unprotected too, but
+  judged too exotic a pattern in real test code to special-case — documented
+  as a third known limitation alongside the class-attribute and
+  nested-conditional-Assign gaps already in the code's AIDEV-NOTE.
+- **Conventions**: Round 1's ledger Outcome section still had the literal
+  placeholder `<fill after commit below>`, never filled in across all 5 prior
+  rounds. Fixed — filled with the real sha (`ee8addd`).
+- **Reuse** and **Simplification** each found one low-severity polish item
+  (a duplicated git-error-handling block between `_diff_positions` and
+  `append_only_check`; collapsing `old_count` into a direct string comparison).
+  Deliberately NOT acted on — pure style, no correctness impact, and the
+  Reuse finding itself warns that naively unifying the git-helper would risk
+  breaking `_old_protected_ranges`'s deliberately-different permissive-on-404
+  behavior.
+
+## Planned changes (round 6)
+
+- `.claude/scripts/run_gates.py`: `_MODULE_LEVEL_DATA` gains `ast.AugAssign`;
+  AIDEV-NOTE gains a third known-gap entry (walrus statements).
+- `.claude/scripts/tests/test_run_gates.py`: 1 new test —
+  `test_module_level_augassign_edit_detected`.
+- `docs/work/2026-07-09-OME-369-append-only-line-diff.md`: Round 1's Outcome
+  Commits field filled in (`ee8addd`).
+
+## Test plan (round 6)
+
+- Same discipline as every prior round: the new test confirmed to fail against
+  a snapshot of round-5 code, pass on round-6 code.
+- Full 21-test matrix (20 from rounds 1-5 + 1 new) passes.
+
+## Acceptance (round 6)
+
+- `AugAssign` gap fixed; 21/21 tests pass.
+- No regression: all 20 prior tests still pass unmodified.
+- Ledger placeholder gap fixed.
+
+## Outcome (round 6, fill at the end — required before COMMIT)
+
+- **Actual files:**
+  - `.claude/scripts/run_gates.py` — `_MODULE_LEVEL_DATA` gains `ast.AugAssign`;
+    AIDEV-NOTE gains the walrus-statement known-gap entry.
+  - `.claude/scripts/tests/test_run_gates.py` — 1 new test, 21 total.
+  - `docs/work/2026-07-09-OME-369-append-only-line-diff.md` — Round 1's
+    Commits placeholder filled.
+- **Commits:** <fill after commit>
+- **Gates:** `uv run .claude/scripts/tests/test_run_gates.py -v` → 21/21 pass.
+  New test confirmed to fail on round-5 code, pass on round-6 code.
+  `python3 -m py_compile` and `uvx ruff check` clean.
+- **Deviations:** none from the round-6 plan.

--- a/docs/work/2026-07-09-OME-369-append-only-line-diff.md
+++ b/docs/work/2026-07-09-OME-369-append-only-line-diff.md
@@ -691,3 +691,36 @@ verified directly with a consolidated script instead of re-spawning agents:
   Binary test confirmed to ERROR (UnicodeDecodeError) on round-8 code, pass on
   round-9 code. `python3 -m py_compile` and `uvx ruff check` clean.
 - **Deviations:** none.
+
+## Round 10 (2026-07-17) — sixth review pass; bonus false-negative discovered fixed
+
+Mechanical conventions checks re-run directly: anchors all `#`-prefixed, no
+bare excepts, test history 480 added / 0 deleted across every commit of all
+rounds. Two findings:
+
+- **The round-9 bytes change fixed a latent FALSE NEGATIVE nobody had spotted.**
+  `str.splitlines()` (the round-8 code) splits on `\f`, `\x85`, ` ` etc.,
+  which Python's tokenizer does NOT count as line boundaries — so a test file
+  containing e.g. a form feed inside any string literal had `_diff_positions`'
+  numbering desynced (+N) from `_old_protected_ranges`' ast-based ranges for
+  everything after it. Proven with a discriminating repro: on round-8 code, a
+  rewrite of `test_two`'s assertion positioned after a `\f`/` ` string
+  returned `True` (silently missed — the dangerous direction); on round-9's
+  bytes comparison (`bytes.splitlines()` splits only on `\r`/`\n`, matching
+  the tokenizer) it is correctly flagged. Pinned with
+  `test_rewrite_after_exotic_linebreak_chars_detected` (27 tests total).
+- **`test_run_gates.py` is now 480 lines**, over the sdlc-python skill's
+  ≤450-line REFACTOR guideline. Deliberately NOT split here: relocating prior
+  tests to a new file is itself a rule-5 prior-test change (a STOP-and-ask
+  decision — the gate would flag its own test-file split), so this is
+  surfaced to the owner as a decision, not acted on unilaterally.
+
+## Outcome (round 10)
+
+- **Actual files:** `.claude/scripts/tests/test_run_gates.py` — 1 new pin
+  test, 27 total. No production-code change (the fix itself shipped in
+  round 9's commit; this round proved and pinned its bonus effect).
+- **Commits:** <fill after commit>
+- **Gates:** 27/27 pass; new test confirmed to return the false-negative
+  (True) on round-8 code and pass on current code. `py_compile`/`ruff` clean.
+- **Deviations:** none.

--- a/docs/work/2026-07-09-OME-369-append-only-line-diff.md
+++ b/docs/work/2026-07-09-OME-369-append-only-line-diff.md
@@ -642,3 +642,51 @@ so none of those text-format artifacts can arise by construction. Net result:
   line-by-line agent was investigated and found to be entangled with the
   already-deferred shadowing limitation, not a distinct bug — documented in
   the narrative above rather than silently dropped.
+
+## Round 9 (2026-07-17) — fifth review pass on the SequenceMatcher rewrite
+
+The 8-agent review pass on round 8's fresh code was cut short by a session
+limit (2 of 8 completed: reuse — only the minor duplicate `git show` call
+between `_old_protected_ranges`/`_diff_positions`, judged not worth
+restructuring; removed-behavior — confirmed all 22 pre-rewrite tests pass
+unmodified against the new implementation). The remaining open questions were
+verified directly with a consolidated script instead of re-spawning agents:
+
+- **autojunk=False**: confirmed correct opcodes on repetitive test files (and
+  harmless either way for the constructed case — kept as the safe choice).
+- **replace-opcode math**: 3-old-lines→1-new-line correctly yields all three
+  old lines in `removed`, no spurious `inserted_after`.
+- **empty files**: empty-at-base + tests added → passes; truncated-to-empty →
+  flagged. Both correct.
+- **CRLF rewrite** (same logical content): not flagged — `splitlines()` on
+  both sides absorbs line-ending differences.
+- **performance**: SequenceMatcher on a 5000-line file = ~3ms; the
+  full-content-vs-diff-only concern is moot.
+- **nested stack root**: `(root / path).read_text()` resolution verified 2
+  levels deep.
+- **verbatim relocation** (two tests swapped, zero text changes): FLAGGED —
+  the conservative outcome. Judged intended (reordering prior tests is a
+  structural change to them; rule 5 says ask) and pinned with a dedicated
+  behavior-pin test so any future flip is a conscious decision.
+- **binary content — REAL CRASH FOUND**: a test-matched file rewritten with
+  undecodable bytes made `read_text()` raise UnicodeDecodeError — the gate
+  crashed with a traceback instead of producing a verdict. Fixed by comparing
+  BYTES on both sides (`git show` without text mode + `read_bytes()`;
+  SequenceMatcher diffs byte-lines identically for ordinary text, and binary
+  junk replacing a protected test differs line-wise → flagged, fail-closed).
+  `_old_protected_ranges`' own fetch hardened the same way (bytes +
+  `decode(errors="replace")` feeding the existing permissive SyntaxError
+  fallback, with ValueError also caught for null-byte source).
+
+## Outcome (round 9)
+
+- **Actual files:**
+  - `.claude/scripts/run_gates.py` — bytes-based comparison in
+    `_diff_positions`; hardened decode in `_old_protected_ranges`.
+  - `.claude/scripts/tests/test_run_gates.py` — 2 new tests
+    (binary-content no-crash+flag, verbatim-swap behavior pin), 26 total.
+- **Commits:** <fill after commit>
+- **Gates:** `uv run .claude/scripts/tests/test_run_gates.py -v` → 26/26 pass.
+  Binary test confirmed to ERROR (UnicodeDecodeError) on round-8 code, pass on
+  round-9 code. `python3 -m py_compile` and `uvx ruff check` clean.
+- **Deviations:** none.

--- a/docs/work/2026-07-09-OME-369-append-only-line-diff.md
+++ b/docs/work/2026-07-09-OME-369-append-only-line-diff.md
@@ -720,7 +720,8 @@ rounds. Two findings:
 - **Actual files:** `.claude/scripts/tests/test_run_gates.py` — 1 new pin
   test, 27 total. No production-code change (the fix itself shipped in
   round 9's commit; this round proved and pinned its bonus effect).
-- **Commits:** <fill after commit>
+- **Commits:** `da1cb6c` — test(repo): pin the exotic-linebreak false-negative
+  fix (Refs: OME-369).
 - **Gates:** 27/27 pass; new test confirmed to return the false-negative
   (True) on round-8 code and pass on current code. `py_compile`/`ruff` clean.
 - **Deviations:** none.

--- a/docs/work/2026-07-09-OME-369-append-only-line-diff.md
+++ b/docs/work/2026-07-09-OME-369-append-only-line-diff.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-369
 stack: repo
-status: done
+status: in_progress
 started: 2026-07-09
-finished: 2026-07-09
+finished:
 ---
 
 # OME-369 — Fix append-only check false positive on pure test additions
@@ -55,3 +55,171 @@ quick manual check instead of adding permanent test infra:
   Also ran the fixed check against our actual current branch vs `origin/main` as a
   real-world sanity check → passes cleanly (no test files touched by this ticket).
 - **Deviations:** none — matches the plan.
+
+## Round 2 (2026-07-17) — PR #383 review feedback
+
+`HupBaHa` requested changes on the PR: verified with temp git repos that adding a
+separate test passes and a root-level rewrite is rejected, but the check still lets
+prior tests be changed undetected in the *configured nested stacks*, and asked for a
+permanent temp-repo test matrix (nested roots, additive-inside-old-test, decorators/
+fixtures, dash-prefixed hunk content) instead of relying on manual scratch-repo
+verification.
+
+Dug in and confirmed three distinct, real bugs (verified each empirically with a
+throwaway repo before touching the fix):
+
+1. **Nested stack roots (the reviewer's main point).** `_old_test_ranges()` calls
+   `git show f"{base}:{path}"` with `cwd=root` (the stack root, e.g.
+   `apps/scoreboard`). `path` comes from `git diff --relative` and is already
+   relative to `cwd` — but `git show rev:path` resolves `path` relative to the
+   **repo root**, not `cwd`, unless prefixed with `./`. For any stack whose root
+   isn't `.` (i.e. every real stack in `.claude/sdlc.local.md` — `aigateway`,
+   `scoreboard`, `url4`), the `git show` call fails to find the file, hits the
+   `proc.returncode != 0` branch, and returns `[]` — meaning the check currently
+   protects **zero** test ranges for any real stack. Confirmed with a scratch repo:
+   `git show base:tests/x.py` from inside a nested cwd fails; `git show
+   base:./tests/x.py` succeeds.
+2. **Decorators/fixtures.** `ast.FunctionDef.lineno` points to the `def` line, not
+   the decorator above it (confirmed via `ast.parse` — decorator at line 3, function
+   range recorded starts at line 4). Editing a decorator/`parametrize(...)` list
+   above an existing test body isn't "inside" the recorded range, so it escapes
+   detection.
+3. **Dash-prefixed hunk content.** A removed line whose content starts at column 0
+   with `--` (e.g. a bare `---` separator) produces a diff line `----`, which
+   false-matches the `line.startswith(("---", "+++", "\\"))` header-skip check.
+   That both drops the line from `removed` *and* desyncs `old_line` for every
+   subsequent line in the same hunk (confirmed with a scratch repo: `git diff
+   --unified=0` on a `---` → `CHANGED` edit produces literal `----`/`+CHANGED`).
+
+## Planned changes (round 2)
+
+- `.claude/scripts/run_gates.py`:
+  - `_old_test_ranges`: prefix the `git show` path with `./` so it resolves
+    relative to `cwd` regardless of stack root depth.
+  - `_old_test_ranges`: extend a test's protected range to start at its first
+    decorator's line when it has decorators, not just `node.lineno`.
+  - `_removed_old_lines`: replace the `startswith(("---", "+++", "\\"))`
+    content-based header skip with hunk-boundary tracking (`in_hunk` flag flipped by
+    the first `@@` line) — file-level header lines only ever appear before the
+    first hunk, so this can't collide with real content regardless of what
+    characters that content starts with.
+- New `.claude/scripts/tests/test_run_gates.py` — the permanent temp-repo matrix the
+  reviewer asked for (stdlib `unittest`, no new toolchain/dependency), replacing the
+  round-1 manual-only verification. Covers: pure addition, real rewrite, new import,
+  existing-import-line-changed (the original 4 manual scenarios), plus the 3
+  confirmed bugs above (nested stack root, decorator edit, dash-prefixed content),
+  plus whole-file delete.
+
+## Test plan (round 2)
+
+- Every scenario above as its own `unittest` test building a throwaway git repo
+  under a `tempfile.TemporaryDirectory()`, calling `append_only_check`/
+  `_old_test_ranges`/`_removed_old_lines` directly (imported via
+  `importlib.util.spec_from_file_location`, since the script isn't an installed
+  package) — asserting the boolean/return value, not just "it ran".
+- Each of the 3 new tests must fail on the pre-fix code and pass on the post-fix
+  code (verified manually by running against git stash of the old version before
+  finalizing).
+
+## Acceptance (round 2)
+
+- All three confirmed bugs fixed; the new permanent test file covers all 8
+  scenarios and passes.
+- No regression on the round-1 scenarios (still covered, now as permanent tests
+  instead of manual scratch-repo checks).
+
+## Outcome (round 2, fill at the end — required before COMMIT)
+
+- **Actual files:**
+  - `.claude/scripts/run_gates.py` — `_old_test_ranges`: `./`-prefixed `git show`
+    path (nested-root fix) + decorator-inclusive range start. `_removed_old_lines`:
+    `in_hunk`-boundary header skip replacing the content-prefix check.
+  - `.claude/scripts/tests/test_run_gates.py` — new, 8 tests (the 4 round-1 manual
+    scenarios made permanent + 4 more: nested stack root, decorator edit,
+    dash-prefixed content, whole-file delete).
+- **Commits:** pending — not yet committed, holding for the user's go-ahead before
+  pushing to the open PR (#383).
+- **Gates:** no dedicated stack/tests wired for `.claude/scripts/` in
+  `.claude/sdlc.local.md` (unchanged from round 1). Verified instead:
+  - `uv run .claude/scripts/tests/test_run_gates.py -v` → 8/8 pass on the fixed code.
+  - Confirmed each of the 3 new regression tests (`test_nested_stack_root_...`,
+    `test_decorator_edit_...`, `test_dash_prefixed_content_...`) **fails** against
+    the pre-fix code via `git stash` of `run_gates.py` alone, then passes again
+    once restored — proves they're real regressions, not tautological assertions.
+  - `python3 -m py_compile` on both files clean; `uvx ruff check` on both files
+    clean (not a wired gate for this directory, done as hygiene).
+- **Deviations:** none from the round-2 plan.
+
+## Round 3 (2026-07-17) — two more review concerns, both confirmed valid
+
+Same review thread raised two further P2 concerns after round 2. Both verified
+empirically (not just reasoned about) before touching code:
+
+1. **Insertions inside existing tests bypass the gate.** `_removed_old_lines` only
+   ever populates from `-` lines — a pure insertion (zero removed lines) that
+   neuters a prior assertion (e.g. forcing a variable's value directly above the
+   check) produces a diff of only `+` lines and is invisible to it. Proved with a
+   throwaway repo: inserted `result = 42` directly above `assert result == 42`
+   (`compute()` actually returns 41) — `append_only_check` returned `True` (green)
+   against the round-2 code.
+2. **Fixtures/helpers aren't protected.** `_old_test_ranges` only walked
+   `test_*`-named functions. Confirmed this isn't hypothetical in this repo:
+   `apps/scoreboard/tests/conftest.py` and `apps/aigateway/tests/conftest.py` both
+   have real `@pytest.fixture` functions matched by the `tests/**` glob — editing
+   one today passes the append-only gate silently, where the pre-OME-369 blanket
+   file-status check would have caught it.
+
+## Planned changes (round 3)
+
+- `.claude/scripts/run_gates.py`:
+  - `_old_test_ranges` → renamed `_old_protected_ranges`, drops the `test_*` name
+    filter — protects every function (tests, fixtures, helpers alike).
+  - `_removed_old_lines` → renamed `_diff_positions`, now returns
+    `(removed, inserted_after)`. `inserted_after` records, for each contiguous run
+    of `+` lines, the old-file line number immediately preceding the insertion.
+  - `append_only_check`: violation is now `removed` INCLUSIVE-both-ends
+    (`lo <= ln <= hi`, unchanged) OR `inserted_after` EXCLUSIVE-at-`hi`
+    (`lo <= n < hi`). The exclusive upper bound is the crux of this round: it's
+    what keeps "append a new test directly after an existing one, zero blank
+    lines" (anchored at `n == hi` of the preceding function) legitimate, while
+    still catching "insert as the new first/middle statement of an existing
+    function" (`lo <= n < hi`).
+- `.claude/scripts/tests/test_run_gates.py`: 4 new tests —
+  `test_insertion_neuters_existing_test_fails`, `test_fixture_edit_detected`
+  (the two confirmed-bug regressions), plus
+  `test_append_new_function_immediately_after_existing_passes` and
+  `test_insert_new_function_immediately_before_existing_passes` (the boundary
+  cases that prove the exclusive bound doesn't reopen OME-369's original
+  false-positive).
+
+## Test plan (round 3)
+
+- Same discipline as round 2: each new "must fail" test proven to fail against the
+  round-2-only code (via a temp backup of `run_gates.py`, not git stash this time
+  since nothing is committed yet) and pass against round-3 code.
+- The two boundary "must still pass" tests are the regression guard for THIS
+  round's own change (round-2 code never inspected `+` lines at all, so they'd
+  trivially pass there too — the meaningful check is that they pass under the new
+  `inserted_after` logic, confirmed).
+
+## Acceptance (round 3)
+
+- Both confirmed bugs fixed; full matrix (12 tests: 8 from rounds 1–2 + 4 new) passes.
+- No regression: the two adjacent-append boundary cases still pass under the new
+  insertion-detection logic.
+
+## Outcome (round 3, fill at the end — required before COMMIT)
+
+- **Actual files:**
+  - `.claude/scripts/run_gates.py` — `_old_protected_ranges` (renamed, filter
+    dropped), `_diff_positions` (renamed, now returns removed + inserted_after),
+    `append_only_check` updated to check both with their respective bounds.
+  - `.claude/scripts/tests/test_run_gates.py` — 4 new tests, 12 total.
+- **Commits:** pending — holding for the user's go-ahead before pushing to PR #383.
+- **Gates:** same as round 2 (no wired stack for this directory). Verified:
+  - `uv run .claude/scripts/tests/test_run_gates.py -v` → 12/12 pass on round-3 code.
+  - `test_insertion_neuters_existing_test_fails` and `test_fixture_edit_detected`
+    confirmed to **fail** against a snapshot of the round-2-only code, then pass
+    once round-3 changes are restored.
+  - `python3 -m py_compile` and `uvx ruff check` clean on both files.
+- **Deviations:** none from the round-3 plan.

--- a/docs/work/2026-07-09-OME-369-append-only-line-diff.md
+++ b/docs/work/2026-07-09-OME-369-append-only-line-diff.md
@@ -306,10 +306,102 @@ simply not being run (also tracked separately, as a distinct infra unit).
   - `.claude/scripts/run_gates.py` — `_EXEMPT_TOP_LEVEL` tuple + `_old_protected_ranges`'s
     second pass over `tree.body`.
   - `.claude/scripts/tests/test_run_gates.py` — 4 new tests, 16 total.
-- **Commits:** <fill after commit>
+- **Commits:** `ad9394e` — fix(repo): protect module-level test data in
+  append-only gate (Refs: OME-369).
 - **Gates:** `uv run .claude/scripts/tests/test_run_gates.py -v` → 16/16 pass.
   `test_module_level_test_data_edit_detected` confirmed to fail on round-3 code,
   pass on round-4 code. `python3 -m py_compile` and `uvx ruff check` clean.
 - **Deviations:** none from the round-4 plan.
-- **Follow-ups filed:** <fill with Linear ticket IDs for concern A,
-  shadowing/monkeypatching, and the CI-enforcement-gap>.
+- **Follow-ups filed:** pending (concern A, shadowing/monkeypatching, and the
+  CI-enforcement-gap — filed as separate tickets right after this commit).
+
+## Round 5 (2026-07-17) — structured code-review pass on the already-pushed PR
+
+Per the user's request, ran a multi-angle `code-review` pass (8 finder agents:
+3 correctness, 3 cleanup, altitude, conventions) against the full pushed diff
+before requesting re-review. Correctness findings were verified by direct
+execution against the actual code (not just read), same standard as every prior
+round. Two findings meant round 4's fix, as pushed, had its own bugs:
+
+1. **Round 4's `_EXEMPT_TOP_LEVEL` was a denylist — the wrong shape.** Proved
+   two concrete false positives it produces: editing a bare module docstring
+   (an `ast.Expr`, not in the denylist) and editing the near-universal
+   `if __name__ == "__main__":` runner block (an `ast.If`, also not in the
+   denylist) both got flagged as rule-5 violations with ZERO test logic
+   touched — reopening the exact class of false-positive OME-369 exists to
+   eliminate. A third case, an import nested inside a module-level version-guard
+   (`if sys.version_info >= (3, 10): ... else: ...`), was also swept into the
+   `If` block's coarse protected range, contradicting round 1's own "editing an
+   import stays legitimate" invariant.
+2. **A separate bug in `_diff_positions`'s insertion-anchor tracking.**
+   Replacing the blank separator line between two functions with a comment
+   (touching neither function's body) got flagged, because the paired `+`
+   line's anchor was computed AFTER `old_line` advanced past the removed line,
+   landing exactly on the next function's range start. Verified: `removed={3}`
+   (correctly outside any range), but `inserted_after={4}` (the next function's
+   `lo`) — a false positive from anchor drift on replace pairs specifically.
+
+Fixed both at the root rather than patching each symptom:
+
+- Inverted `_EXEMPT_TOP_LEVEL` (denylist) to `_MODULE_LEVEL_DATA = (ast.Assign,
+  ast.AnnAssign)` (allowlist) — only the node types that actually hold shared
+  test data get a protected range. This single change resolves all three
+  denylist-shaped false positives (docstring, `if __main__`, nested import) at
+  once, since none of those node types are `Assign`/`AnnAssign`.
+- Changed `inserted_after` tracking to key off the diff hunk header's declared
+  OLD-LINE-COUNT (`old_count == 0` ⇒ unambiguously a pure-insertion hunk),
+  instead of inferring "pure insert" from `-`/`+` line pairing. Removes the
+  ambiguity entirely rather than trying to special-case replace-pair adjacency.
+- Also fixed, from the same review pass's conventions angle: several
+  `AIDEV-NOTE`/`INVARIANT` anchors were written as bare docstring prose instead
+  of `#`-prefixed comments (`.claude/skills/sdlc-python/SKILL.md`'s "Anchor
+  syntax: `#`" rule) — moved all of them to proper inline `#` comments.
+
+Deliberately NOT acted on from the same review pass (reported, not fixed, to
+avoid re-drifting): Reuse's test-boilerplate-duplication and
+FunctionDef-tuple-naming suggestions, Simplification's docstring-length and
+duplicate-comprehension suggestions, Efficiency's git-subprocess-batching
+suggestions, and Altitude's "this is a reactive patch stack" observations (all
+of which restate concern A / the class-attribute gap already tracked
+separately, not new scope).
+
+## Planned changes (round 5)
+
+- `.claude/scripts/run_gates.py`: `_EXEMPT_TOP_LEVEL` → `_MODULE_LEVEL_DATA`
+  allowlist; `_HUNK_HEADER` regex now captures the old-line count;
+  `_diff_positions` computes `pure_insert_hunk` from that count per-hunk;
+  anchor comments moved from docstring prose to `#`-prefixed inline comments.
+- `.claude/scripts/tests/test_run_gates.py`: 4 new tests —
+  `test_module_docstring_edit_passes`, `test_if_main_block_edit_passes`,
+  `test_import_nested_in_conditional_edit_passes`,
+  `test_replace_blank_separator_line_passes`.
+
+## Test plan (round 5)
+
+- Same discipline as every prior round: all 4 new tests confirmed to **fail**
+  against a snapshot of the round-4 (already-pushed) code, then pass once the
+  round-5 fix is restored.
+- Full 20-test matrix (16 from rounds 1-4 + 4 new) passes on the fixed code.
+- Real-file sanity check unchanged: `_old_protected_ranges` against
+  `apps/aigateway/tests/unit/test_request_cache_keys.py` still finds 22
+  protected ranges including `_BASE_KW`'s own span.
+
+## Acceptance (round 5)
+
+- Both code-review-discovered bugs fixed; 20/20 tests pass.
+- No regression: all 16 prior tests (rounds 1-4) still pass unmodified.
+- Anchor-syntax convention violation fixed (all `WHY:`/`INVARIANT:`/`AIDEV-NOTE:`
+  now `#`-prefixed).
+
+## Outcome (round 5, fill at the end — required before COMMIT)
+
+- **Actual files:**
+  - `.claude/scripts/run_gates.py` — `_MODULE_LEVEL_DATA` allowlist (replaces
+    `_EXEMPT_TOP_LEVEL`), `_HUNK_HEADER`/`_diff_positions` old-count-based
+    `pure_insert_hunk` fix, anchor comments moved to `#`-prefixed form.
+  - `.claude/scripts/tests/test_run_gates.py` — 4 new tests, 20 total.
+- **Commits:** <fill after commit>
+- **Gates:** `uv run .claude/scripts/tests/test_run_gates.py -v` → 20/20 pass.
+  All 4 new tests confirmed to fail on round-4 code, pass on round-5 code.
+  `python3 -m py_compile` and `uvx ruff check` clean.
+- **Deviations:** none from the round-5 plan.

--- a/docs/work/2026-07-09-OME-369-append-only-line-diff.md
+++ b/docs/work/2026-07-09-OME-369-append-only-line-diff.md
@@ -844,3 +844,74 @@ stack tamper; a bare `return` inserted as a new first line; shrinking a
 fixed by rounds 2, 3, 3, and 8 respectively. Nothing new to fix. The PR is
 genuinely just waiting on a re-review that hasn't happened in 3+ weeks, not
 on any further code change.
+
+## Round 14 (2026-08-06) — applied HupBaHa's validated review suggestions
+
+HupBaHa left a real, substantive review on the round-13 head (2026-08-06):
+his original 2026-07-17 nested-stack concern, plus several more gaps he found
+independently, delivered as validated GitHub suggestion blocks — "Applied
+together on an exact-head disposable copy, these pass all 48 tests on Python
+3.10 and 3.12; byte-compilation and whitespace checks pass, and Ruff remains
+baseline-identical. Two adversarial reviews found no blocking issues."
+
+Applied his suggestions verbatim (reconstructed from the review's GitHub
+suggestion blocks, cross-checked against the file's current structure since
+the review API returned no line anchors for these comments):
+
+- **Class-body protection.** `_old_protected_ranges` now also walks
+  `ast.ClassDef` nodes, protecting existing decorators + the class header
+  (via a new `_class_header_end` token-scanner) but not the body — so tamper
+  inside an existing test *class* is caught while a first new sibling method
+  stays a legitimate addition. This directly closes his original nested-stack
+  finding.
+- **Module-level `ast.Assert` protection.** `_MODULE_LEVEL_DATA` now also
+  covers a direct module-level assertion statement (executes at collection
+  time — real test logic, not documentation).
+- **Fail-closed on unsupported/unparseable files.** `_old_protected_ranges`
+  now returns `None` (not `[]`) for a non-`.py` file or one that fails to
+  parse — the caller now flags any modification to such a file as an
+  offender, rather than silently treating "can't protect it" as "nothing to
+  protect." Closes a real fail-open gap for configured non-Python globs
+  (e.g. `aigateway-ui`'s `*.test.ts`).
+- **Diff detection reworked onto real tokens.** `_diff_positions` now tracks
+  whether the *current* file tokenizes at all (`current_parseable`, also
+  fail-closed on `False`) and computes insertion indent via a new
+  `_added_span_indent` helper that reads real Python tokens (falling back to
+  leading-whitespace scanning only when tokenization fails) — more accurate
+  than the old raw-byte-prefix indent guess, and correctly ignores comments
+  as indentation signals.
+- **Glob matching rewritten.** New `_matches_glob` replaces `fnmatch.fnmatch`
+  directly on the whole path with a component-aware recursive matcher, so a
+  bare `**` component correctly spans zero-or-more path segments while a
+  `**` embedded inside a larger component (e.g. `test**`) does not.
+- **NUL-delimited git status parsing.** `append_only_check` now runs
+  `git diff --name-status -z` and splits on `\0` instead of `\t`/`\n`, so a
+  path containing a tab, newline, quote, or backslash can't desync the
+  status-line parser and slip through unchecked. Handles rename/copy's
+  two-path records explicitly.
+- **Test suite:** added his 16 new tests (1 quoted-filename-parsing
+  regression + 15 covering class/module-assert protection, fail-closed
+  non-Python/unparseable-source handling, and the new glob matcher's edge
+  cases) verbatim, landing at exactly the 48 he validated against.
+
+**Deviation, disclosed:** the review API returned every one of these
+suggestion comments with `line`/`start_line`/`original_line` all `null` (an
+anomaly in how this review was posted — worth flagging to HupBaHa, not
+something introduced by applying it), so the suggestions couldn't be
+mechanically applied via GitHub's own "commit suggestion" affordance. Mapped
+each suggestion onto the current file by matching function signatures/names
+instead, and one suggestion comment (the 15-new-tests block) was truncated
+mid-statement in the stored comment body itself (11506 characters, cut off
+inside the final test's closing parens) — completed the closing
+`assertTrue(...)` call and the file's trailing `if __name__ == "__main__":`
+block by mirroring the identical pattern already used one test earlier in
+the same block (`test_globstar_inside_component_is_not_recursive`, same exact
+glob string). Confirmed no tests were missing: 32 original + 1 + 15 = 48,
+exactly matching his stated count.
+
+**Gates:** `uv run .claude/scripts/tests/test_run_gates.py -v` → 48/48 passed.
+`python3 -m py_compile` on both files → OK. `ruff check`/`ruff format --check`
+(bare `uvx ruff`, no project config covers this path) → identical 8
+findings / 2-files-reformatted count on both the pre- and post-change file,
+confirming "Ruff remains baseline-identical" as claimed — pre-existing
+default-ruleset noise unrelated to this change, not a regression.

--- a/docs/work/2026-07-09-OME-369-append-only-line-diff.md
+++ b/docs/work/2026-07-09-OME-369-append-only-line-diff.md
@@ -400,7 +400,8 @@ separately, not new scope).
     `_EXEMPT_TOP_LEVEL`), `_HUNK_HEADER`/`_diff_positions` old-count-based
     `pure_insert_hunk` fix, anchor comments moved to `#`-prefixed form.
   - `.claude/scripts/tests/test_run_gates.py` — 4 new tests, 20 total.
-- **Commits:** <fill after commit>
+- **Commits:** `eee239e` — fix(repo): replace denylist with allowlist for
+  module-data protection (Refs: OME-369).
 - **Gates:** `uv run .claude/scripts/tests/test_run_gates.py -v` → 20/20 pass.
   All 4 new tests confirmed to fail on round-4 code, pass on round-5 code.
   `python3 -m py_compile` and `uvx ruff check` clean.

--- a/docs/work/2026-07-09-OME-369-append-only-line-diff.md
+++ b/docs/work/2026-07-09-OME-369-append-only-line-diff.md
@@ -1,0 +1,57 @@
+---
+ticket: OME-369
+stack: repo
+status: done
+started: 2026-07-09
+finished: 2026-07-09
+---
+
+# OME-369 — Fix append-only check false positive on pure test additions
+
+## Intent
+
+`append_only_check()` in `.claude/scripts/run_gates.py` currently flags any test file
+with git status `M` (modified) as a rule-5 violation, even when the change is a pure
+addition (new test functions appended, nothing existing touched). This blocked all
+downstream gates during OME-322 despite the changes being verifiably additive-only.
+Fix it to check line-level diffs instead of file-level git status.
+
+## Planned changes
+
+- `.claude/scripts/run_gates.py` — `append_only_check()`: for each modified test file,
+  parse `git diff <base> -- <file>` hunks and fail only if a hunk removes/changes a
+  line that was inside a previously-existing `def test_...`/`async def test_...` body
+  (i.e. a real `-` line inside old test code), not just because the file shows `M`.
+
+## Test plan
+
+No dedicated test suite exists for `.claude/scripts/` (confirmed — no stack in
+`.claude/sdlc.local.md` covers it, no pytest wiring). Per owner decision, verify with a
+quick manual check instead of adding permanent test infra:
+
+- Scenario A (pure addition): a synthetic git history where a test file only gains new
+  test functions → script must pass.
+- Scenario B (real rewrite): a synthetic git history where a test file's existing test
+  body is altered/removed → script must still fail.
+
+## Acceptance
+
+- Scenario A passes, Scenario B still correctly fails.
+- No regression: running the real OME-322 diff (already merged into this fix's base)
+  as a sanity check would have falsely failed before, passes after.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned — `.claude/scripts/run_gates.py` only (`append_only_check`
+  rewritten; new `_old_test_ranges`/`_removed_old_lines` helpers; `ast`/`re` imports added).
+- **Commits:** <fill after commit below>
+- **Gates:** no dedicated stack/tests for `.claude/scripts/` (confirmed with owner).
+  Verified manually with 4 scratch-repo scenarios instead:
+  1. Pure addition (new test function) → pass.
+  2. Real rewrite inside an existing test body → correctly fails.
+  3. New import inserted above existing code → pass.
+  4. An *existing* import line literally changed (the exact real OME-322 pattern) to
+     support a new test, no test body touched → pass.
+  Also ran the fixed check against our actual current branch vs `origin/main` as a
+  real-world sanity check → passes cleanly (no test files touched by this ticket).
+- **Deviations:** none — matches the plan.

--- a/docs/work/2026-07-09-OME-369-append-only-line-diff.md
+++ b/docs/work/2026-07-09-OME-369-append-only-line-diff.md
@@ -794,3 +794,18 @@ with measurement context; 586 as of this round).
   round-10 code and pass on round-11 code; the boundary guard passes on both.
   `py_compile`/`ruff` clean.
 - **Deviations:** none.
+
+## Round 12 (2026-07-18) — CLEAN round; review loop closed
+
+Eighth review pass on HEAD after round 11: the consistency sweep (anchors,
+BOM-escape source hygiene, shas, line counts, test-history purity, PR-body
+accuracy) returned zero findings, and all nine adversarial execution probes
+of the round-11 changes passed — tab-indented body extension flagged /
+tab-indented sibling method legitimate; indented junk after a protected dict
+flagged; BOM intact + append passes / + rewrite flagged; nested ranges
+sharing an end line handled on both sides of the boundary; NFD-normalized
+unicode filenames (macOS) flagged correctly. One recorded non-finding: an
+editor stripping a file's BOM with zero other changes is conservatively
+flagged (same deliberate fail-closed category as the verbatim-swap pin).
+Per the owner's instruction to loop until a round returns all-good: this is
+that round. 32/32 tests, CI green, PR #383 awaiting re-review.

--- a/docs/work/2026-07-09-OME-369-append-only-line-diff.md
+++ b/docs/work/2026-07-09-OME-369-append-only-line-diff.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-369
 stack: repo
-status: in_progress
+status: done
 started: 2026-07-09
-finished:
+finished: 2026-07-17
 ---
 
 # OME-369 — Fix append-only check false positive on pure test additions
@@ -137,8 +137,9 @@ throwaway repo before touching the fix):
   - `.claude/scripts/tests/test_run_gates.py` — new, 8 tests (the 4 round-1 manual
     scenarios made permanent + 4 more: nested stack root, decorator edit,
     dash-prefixed content, whole-file delete).
-- **Commits:** pending — not yet committed, holding for the user's go-ahead before
-  pushing to the open PR (#383).
+- **Commits:** `39f1483` — fix(repo): protect nested stacks, decorators, and
+  fixtures in append-only gate (Refs: OME-369) — combined rounds 2+3 in one commit,
+  not pushed yet per user instruction.
 - **Gates:** no dedicated stack/tests wired for `.claude/scripts/` in
   `.claude/sdlc.local.md` (unchanged from round 1). Verified instead:
   - `uv run .claude/scripts/tests/test_run_gates.py -v` → 8/8 pass on the fixed code.
@@ -215,7 +216,8 @@ empirically (not just reasoned about) before touching code:
     dropped), `_diff_positions` (renamed, now returns removed + inserted_after),
     `append_only_check` updated to check both with their respective bounds.
   - `.claude/scripts/tests/test_run_gates.py` — 4 new tests, 12 total.
-- **Commits:** pending — holding for the user's go-ahead before pushing to PR #383.
+- **Commits:** `39f1483` (same commit as round 2 — both rounds landed together
+  before the first push of this fix cycle). Not pushed yet per user instruction.
 - **Gates:** same as round 2 (no wired stack for this directory). Verified:
   - `uv run .claude/scripts/tests/test_run_gates.py -v` → 12/12 pass on round-3 code.
   - `test_insertion_neuters_existing_test_fails` and `test_fixture_edit_detected`

--- a/docs/work/2026-07-09-OME-369-append-only-line-diff.md
+++ b/docs/work/2026-07-09-OME-369-append-only-line-diff.md
@@ -819,3 +819,28 @@ that round. 32/32 tests, CI green, PR #383 awaiting re-review.
   (decorator-stacking), `OME-476` (shadowing/monkeypatching design fork),
   `OME-477` (CI enforcement of rule 5). Linear issue OME-369 updated with the
   full round summary; reviewer re-ping posted on PR #383.
+
+## Round 13 (2026-08-04) — rebase + empirical re-verification of HupBaHa's original review
+
+Rebased the branch onto current `origin/main` (111 commits behind; one real
+conflict in `run_gates.py` itself, since `main` never received any of this
+PR's rounds — resolved in favor of this branch's content, confirmed
+byte-identical to the pre-rebase tree modulo pre-commit-hook reformatting).
+32/32 tests still pass post-rebase.
+
+Separately: `gh pr view 383`'s `reviewDecision` still reads `CHANGES_REQUESTED`
+(GitHub doesn't auto-clear this without a new review event), which read at a
+glance like a fresh review had just landed. Checked directly — there has only
+ever been the one HupBaHa review, submitted **2026-07-17**, the same one that
+drove rounds 2-12. No new review exists.
+
+Rather than trust the ledger's own account, re-verified HupBaHa's four
+original inline comments **empirically**, against the current code, with a
+fresh temp-repo reproduction of each exact scenario he described (nested
+stack tamper; a bare `return` inserted as a new first line; shrinking a
+`@pytest.mark.parametrize` list; tampering a fixture a test depends on; a
+`---`-prefixed line removed from inside a multiline string). All four:
+**caught** (`append_only_check` returns `False` in every case) — already
+fixed by rounds 2, 3, 3, and 8 respectively. Nothing new to fix. The PR is
+genuinely just waiting on a re-review that hasn't happened in 3+ weeks, not
+on any further code change.

--- a/docs/work/2026-07-09-OME-369-append-only-line-diff.md
+++ b/docs/work/2026-07-09-OME-369-append-only-line-diff.md
@@ -313,12 +313,11 @@ simply not being run (also tracked separately, as a distinct infra unit).
   `test_module_level_test_data_edit_detected` confirmed to fail on round-3 code,
   pass on round-4 code. `python3 -m py_compile` and `uvx ruff check` clean.
 - **Deviations:** none from the round-4 plan.
-- **Follow-ups filed:** NOT yet filed — drafts prepared, but filing is
-  deliberately queued behind the PR re-review, per explicit owner instruction
-  (2026-07-17: tickets one by one, only after the review loop finishes). The
-  three pending drafts: concern A (decorator-stacking), the
-  shadowing/monkeypatching structural limitation, and the CI-enforcement gap.
-  Record the OME-N identifiers here when filed.
+- **Follow-ups filed (2026-07-18, after the review loop closed, per owner
+  go-ahead):** `OME-475` (decorator-stacking, deferred), `OME-476`
+  (shadowing/monkeypatching limitation, design-session), `OME-477`
+  (CI enforcement of rule 5 against the real merge-base, design-session).
+  Mirrors in `docs/tasks/2026-07-18-append-only-gate-*.md`.
 
 ## Round 5 (2026-07-17) — structured code-review pass on the already-pushed PR
 
@@ -809,3 +808,14 @@ editor stripping a file's BOM with zero other changes is conservatively
 flagged (same deliberate fail-closed category as the verbatim-swap pin).
 Per the owner's instruction to loop until a round returns all-good: this is
 that round. 32/32 tests, CI green, PR #383 awaiting re-review.
+
+## Post-loop wrap-up (2026-07-18)
+
+- **Owner decision — test-file length:** keep `test_run_gates.py` as is (586
+  lines, over the ≤450 guideline). No split; relocating prior tests would
+  itself be a rule-5 prior-test change, and the owner explicitly chose to
+  leave the file intact.
+- **Follow-up tickets filed** (one by one, per owner go-ahead): `OME-475`
+  (decorator-stacking), `OME-476` (shadowing/monkeypatching design fork),
+  `OME-477` (CI enforcement of rule 5). Linear issue OME-369 updated with the
+  full round summary; reviewer re-ping posted on PR #383.

--- a/docs/work/2026-07-09-OME-369-append-only-line-diff.md
+++ b/docs/work/2026-07-09-OME-369-append-only-line-diff.md
@@ -549,3 +549,95 @@ speed polish, zero correctness impact).
   New test confirmed to fail on round-6 code, pass on round-7 code.
   `python3 -m py_compile` and `uvx ruff check` clean.
 - **Deviations:** none from the round-7 plan.
+
+## Round 8 (2026-07-17) — architectural rewrite: SequenceMatcher over diff-text parsing
+
+Fourth structured code-review pass, on round 7's own fix. Two agents (reuse,
+line-by-line) independently found round 7's `last_removed` state machine only
+correctly pairs a hunk's LAST removed line with its FIRST added line — wrong
+whenever a hunk has more than one removed line. Concretely proved:
+
+1. **Mirror-image false positive** (clean, discriminating repro): an existing
+   protected line LOSING its trailing newline, with zero other change, still
+   got falsely flagged — round 7 only recognized the "gained a newline"
+   direction. Confirmed: fails on round-7 code, passes after the fix.
+2. **A "false negative" claim that turned out to be the shadowing gap, not a
+   distinct bug.** I attempted to build a clean repro of "a real assertion
+   rewrite gets masked by coincidental adjacent-line pairing," independent of
+   name-shadowing. Every construction either (a) still got caught anyway via
+   the OTHER removed line in the same hunk independently intersecting a
+   protected range, or (b) required the exact shadowing technique (redefining
+   a test with the same name right after the "moved" original) to work at
+   all — and running that exact repro against BOTH round-7 and the new
+   SequenceMatcher code returns the same result (`True`, pass) in both, proving
+   it's the already-accepted, already-deferred shadowing/monkeypatching
+   limitation wearing an EOF-newline costume, not a new independent gap this
+   fix does or should close. Corrected the test's docstring accordingly rather
+   than ship an inaccurate "this proves a security fix" claim.
+
+Rather than patch a third variant into the same state machine (attempted by
+hand first — the "which `+` line pairs with which `-` line" problem for
+multi-line hunks is genuinely not solvable by more special-casing, since it's
+exactly the LCS-alignment problem `difflib` exists to solve), rewrote
+`_diff_positions` to diff actual line CONTENT (old via `git show`, new read
+directly off the working-tree file) with `difflib.SequenceMatcher`, instead of
+hand-parsing `git diff`'s unified-diff TEXT. This is the same root cause behind
+THREE separate bugs across rounds 2, 5, and 7 (dash-prefixed content
+false-matching a text header check; the replace-pair insertion-anchor
+off-by-one; the EOF-newline artifact) — all are quirks of unified-diff's TEXT
+REPRESENTATION that have nothing to do with whether a line's content actually
+changed. SequenceMatcher's opcodes are computed directly from line sequences,
+so none of those text-format artifacts can arise by construction. Net result:
+~40 lines of state-tracking replaced by ~15 lines using a stdlib algorithm;
+`_HUNK_HEADER` and the `re` import are now dead code, removed.
+
+## Planned changes (round 8)
+
+- `.claude/scripts/run_gates.py`: `_diff_positions` fully rewritten to use
+  `difflib.SequenceMatcher(a=old_lines, b=new_lines)` and its `get_opcodes()`
+  — `delete`/`replace` opcodes populate `removed` (1-indexed old line range),
+  `insert` opcodes populate `inserted_after` (anchored at the old line
+  immediately preceding the insertion point). `_HUNK_HEADER` regex and
+  `import re` removed (dead code after the rewrite); `import difflib` added.
+- `.claude/scripts/tests/test_run_gates.py`: 2 new tests —
+  `test_losing_trailing_newline_with_no_other_change_passes` (the clean,
+  discriminating mirror-image repro) and
+  `test_real_edit_adjacent_to_eof_artifact_still_detected` (a coverage guard
+  for multi-line-hunk correctness in general, not a specific-bug regression).
+
+## Test plan (round 8)
+
+- All 22 prior tests re-run against the rewrite with ZERO changes to their
+  code — confirms the new mechanism preserves every previously-fixed behavior
+  (dash-content, insertion boundaries, decorator/fixture/module-data
+  protection, the round-7 EOF fix's original direction) despite being a
+  completely different implementation.
+- The new mirror-image test confirmed to fail on round-7 code, pass on
+  round-8 code — a real, clean discriminator.
+- The multi-line-hunk coverage test passes on both round-7 and round-8 code
+  (by design — it's a general correctness guard, not a discriminator; see the
+  round-8 narrative above for why a clean discriminator for the pairing bug
+  specifically wasn't constructible without invoking shadowing).
+
+## Acceptance (round 8)
+
+- 24/24 tests pass (22 prior + 2 new).
+- The mirror-image EOF false positive is fixed and proven.
+- `_HUNK_HEADER`/`import re` dead code removed; `import difflib` added.
+- No regression: every prior round's fix still holds under the new mechanism.
+
+## Outcome (round 8, fill at the end — required before COMMIT)
+
+- **Actual files:**
+  - `.claude/scripts/run_gates.py` — `_diff_positions` rewritten around
+    `difflib.SequenceMatcher`; `_HUNK_HEADER`/`import re` removed;
+    `import difflib` added.
+  - `.claude/scripts/tests/test_run_gates.py` — 2 new tests, 24 total.
+- **Commits:** <fill after commit>
+- **Gates:** `uv run .claude/scripts/tests/test_run_gates.py -v` → 24/24 pass.
+  Mirror-image test confirmed to fail on round-7 code, pass on round-8 code.
+  `python3 -m py_compile` and `uvx ruff check` clean.
+- **Deviations:** the "severe false negative" finding from review round 4's
+  line-by-line agent was investigated and found to be entangled with the
+  already-deferred shadowing limitation, not a distinct bug — documented in
+  the narrative above rather than silently dropped.

--- a/docs/work/2026-07-09-OME-369-append-only-line-diff.md
+++ b/docs/work/2026-07-09-OME-369-append-only-line-diff.md
@@ -633,7 +633,8 @@ so none of those text-format artifacts can arise by construction. Net result:
     `difflib.SequenceMatcher`; `_HUNK_HEADER`/`import re` removed;
     `import difflib` added.
   - `.claude/scripts/tests/test_run_gates.py` — 2 new tests, 24 total.
-- **Commits:** <fill after commit>
+- **Commits:** `b3e0d77` — refactor(repo): diff line content via
+  SequenceMatcher, not diff text (Refs: OME-369).
 - **Gates:** `uv run .claude/scripts/tests/test_run_gates.py -v` → 24/24 pass.
   Mirror-image test confirmed to fail on round-7 code, pass on round-8 code.
   `python3 -m py_compile` and `uvx ruff check` clean.

--- a/docs/work/2026-07-09-OME-369-append-only-line-diff.md
+++ b/docs/work/2026-07-09-OME-369-append-only-line-diff.md
@@ -470,3 +470,81 @@ real, low-severity items:
   New test confirmed to fail on round-5 code, pass on round-6 code.
   `python3 -m py_compile` and `uvx ruff check` clean.
 - **Deviations:** none from the round-6 plan.
+
+## Round 7 (2026-07-17) — third structured code-review pass
+
+Per the user's request to loop review rounds until one comes back clean. 5 of
+8 angles clean this round (cross-file, reuse, removed-behavior auditor,
+efficiency clean-except-one-polish-nit, simplification clean-except-one-doc-nit).
+Two angles found real things:
+
+- **Line-by-line** (verified by execution): a protected range's LAST line, if
+  it lacked a trailing newline at `base`, produces a git-diff artifact when new
+  content is appended after it — git represents the unchanged line as a
+  remove+add pair purely because its EOF status changed (a newline character
+  had to be added to make room for what follows), not because its text
+  changed. `_diff_positions` tracked only line *numbers*, so this false-matched
+  as a real edit — a plausible, non-adversarial trigger (any file lacking a
+  trailing newline, then having a normal new test appended), unlike the
+  already-deferred shadowing class. Fixed: track whether a removed line was
+  marked `\ No newline at end of file` and, if the immediately-following `+`
+  line is byte-identical, treat it as a no-op rather than a real change.
+- **Altitude** (verified by execution): found two more concrete instances of
+  mutating a protected object in place rather than rebinding its name —
+  `_CASES.append(...)` (an `ast.Expr` wrapping a `Call`) and `del _CASES[1]`
+  (`ast.Delete`) both bypass the gate. On reflection these are NOT new
+  independent allowlist gaps — they're the SAME structural
+  name-shadowing/monkeypatching limitation already identified and deferred
+  (mutating shared state in place instead of rebinding a name; adding
+  `Expr`/`Delete` to the allowlist wouldn't close this class either, and
+  broadly allowlisting `ast.Expr` would reopen the round-5 docstring false
+  positive). Folded into the existing "known gaps" AIDEV-NOTE as bullet (4)
+  with these two concrete examples, rather than treated as new code to write.
+
+Also applied, from **simplification**: a doc-only addition warning that the
+"just add the type to `_MODULE_LEVEL_DATA`" fix pattern (used for `AugAssign`)
+would NOT work for the walrus-statement gap, since `tree.body`'s direct child
+there is the outer `ast.Expr`, never the inner `NamedExpr` — prevents a future
+contributor from shipping a no-op "fix."
+
+Deliberately NOT acted on: efficiency's suggestion to fold 3 `git config`
+subprocess calls into `-c` flags on the commit call in the test suite (pure
+speed polish, zero correctness impact).
+
+## Planned changes (round 7)
+
+- `.claude/scripts/run_gates.py`: `_diff_positions` tracks `last_removed`
+  (old_line, content, no_newline_flag) so a `-`/no-newline-marker/byte-identical
+  `+` sequence is recognized as an EOF-status artifact and excluded from
+  `removed`. "Known gaps" AIDEV-NOTE gains bullet (4) (mutation-in-place
+  examples) and a warning note on bullet (3) (walrus fix-pattern doesn't work).
+- `.claude/scripts/tests/test_run_gates.py`: 1 new test —
+  `test_append_after_file_without_trailing_newline_passes`.
+
+## Test plan (round 7)
+
+- Same discipline as every prior round: the new test confirmed to fail against
+  a snapshot of round-6 code (reproduced the exact real `git diff` shape:
+  `-content` / `\ No newline at end of file` / `+content` / more `+` lines),
+  pass on round-7 code.
+- Full 22-test matrix (21 from rounds 1-6 + 1 new) passes.
+
+## Acceptance (round 7)
+
+- EOF-newline-artifact false positive fixed; 22/22 tests pass.
+- No regression: all 21 prior tests still pass unmodified.
+- Documentation gaps (walrus fix-pattern warning, mutation-in-place examples)
+  added without any corresponding code change, since both are correctly
+  out-of-scope for this allowlist mechanism.
+
+## Outcome (round 7, fill at the end — required before COMMIT)
+
+- **Actual files:**
+  - `.claude/scripts/run_gates.py` — `_diff_positions`'s `last_removed`
+    tracking for the EOF-newline-artifact fix; AIDEV-NOTE additions.
+  - `.claude/scripts/tests/test_run_gates.py` — 1 new test, 22 total.
+- **Commits:** <fill after commit>
+- **Gates:** `uv run .claude/scripts/tests/test_run_gates.py -v` → 22/22 pass.
+  New test confirmed to fail on round-6 code, pass on round-7 code.
+  `python3 -m py_compile` and `uvx ruff check` clean.
+- **Deviations:** none from the round-7 plan.

--- a/docs/work/2026-07-09-OME-369-append-only-line-diff.md
+++ b/docs/work/2026-07-09-OME-369-append-only-line-diff.md
@@ -543,7 +543,8 @@ speed polish, zero correctness impact).
   - `.claude/scripts/run_gates.py` — `_diff_positions`'s `last_removed`
     tracking for the EOF-newline-artifact fix; AIDEV-NOTE additions.
   - `.claude/scripts/tests/test_run_gates.py` — 1 new test, 22 total.
-- **Commits:** <fill after commit>
+- **Commits:** `ddf8371` — fix(repo): recognize EOF-newline artifacts as
+  non-edits (Refs: OME-369).
 - **Gates:** `uv run .claude/scripts/tests/test_run_gates.py -v` → 22/22 pass.
   New test confirmed to fail on round-6 code, pass on round-7 code.
   `python3 -m py_compile` and `uvx ruff check` clean.


### PR DESCRIPTION
## Summary

Fixes OME-369: `append_only_check()` in `.claude/scripts/run_gates.py` used to flag any git-modified test file as a rule-5 violation, even for pure additions. This PR replaces the file-status check with real content-level analysis — and, through 11 rounds of review-driven hardening, fixes a series of false positives AND false negatives in the mechanism itself.

**Final design:**
- **Protected ranges** (`_old_protected_ranges`): every function body (tests, fixtures, helpers alike — not just `test_*`-named), decorator lines included, plus every direct module-level `Assign`/`AnnAssign`/`AugAssign` statement (shared test data like `_BASE_KW = {...}`). Each range carries its definition column. BOM'd files stay protected; undecodable committed files fall to the permissive side.
- **Change detection** (`_diff_positions`): diffs actual line content — old bytes via `git show`, new bytes off the working tree — with `difflib.SequenceMatcher`, NOT by parsing `git diff` text (three separate bug classes came from text-format quirks: header false-matching, replace-pair anchor drift, EOF-newline artifacts; all impossible by construction now). Binary content yields a fail-closed verdict, not a crash.
- **Violation rule**: a removed/changed line inside a protected range (`lo <= ln <= hi`), an insertion strictly inside one (`lo <= n < hi`), or an insertion at a range's end indented deeper than its definition column (extends the old body, e.g. appending `break` inside a final test's loop). Appending a new sibling function/method at the same anchor stays legitimate.
- **File-level statuses**: `D`(elete), `R`(ename), and `T`(ypechange — e.g. replaced by a symlink) are always violations; `A`/`C` always fine. Non-ASCII filenames handled via `core.quotepath=off`.

**Documented, deliberately-deferred gaps** (in the code's AIDEV-NOTE + the work ledger; follow-up tickets drafted, filing queued behind this re-review): stacking a new outermost decorator on an existing test (needs old-vs-new AST identity matching), name-shadowing/monkeypatching incl. mutation-in-place (structural limit of any line-diff approach), class-level attributes, conditionally-nested data statements, bare walrus statements. Separately: nothing in CI independently enforces this check at all — its own infra ticket draft.

## Test plan

Permanent 32-test suite at `.claude/scripts/tests/test_run_gates.py` (stdlib `unittest`, throwaway git repo per test): `uv run .claude/scripts/tests/test_run_gates.py`. Every fix landed with a discriminating regression test proven to fail on the pre-fix code first; boundary guards pin the legitimate-append cases (new sibling def, new class method, module constants, import edits, docstring/`__main__` edits). Full history of all 11 rounds, each with fail-before/pass-after evidence: `docs/work/2026-07-09-OME-369-append-only-line-diff.md`.

Refs: OME-369

🤖 Generated with [Claude Code](https://claude.com/claude-code)