### PR TITLE
SF-328: harden AIGateway profile OAuth writes

### DIFF
--- a/apps/aigateway/src/aigateway/core/credential_blob/store.py
+++ b/apps/aigateway/src/aigateway/core/credential_blob/store.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import asyncio
+import random
+from collections.abc import Callable
+from datetime import UTC, datetime
 from typing import Protocol
 
 from tortoise.exceptions import DoesNotExist, IntegrityError
@@ -8,6 +12,15 @@ from ..secrets.factory import get_active_secret_store
 from ..secrets.mixin import SecretStoreMixin
 from .model import CredentialBlob
 
+_MUTATE_MAX_ATTEMPTS = 8
+_MUTATE_BACKOFF_BASE_SECONDS = 0.001
+_MUTATE_BACKOFF_MAX_SECONDS = 0.02
+_MUTATE_JITTER_SECONDS = 0.002
+
+
+class CredentialBlobMutationConflict(RuntimeError):
+    """Raised when optimistic credential-blob mutation exhausts its retry budget."""
+
 
 class CredentialBlobStore(Protocol):
     async def read(self, service: str, account: str) -> str | None: ...
@@ -15,6 +28,13 @@ class CredentialBlobStore(Protocol):
     async def write(self, service: str, account: str, value: str) -> None: ...
 
     async def delete(self, service: str, account: str) -> None: ...
+
+    async def mutate(
+        self,
+        service: str,
+        account: str,
+        mutator: Callable[[str | None], str | None],
+    ) -> None: ...
 
 
 class ORMStore:
@@ -62,3 +82,77 @@ class ORMStore:
 
     async def delete(self, service: str, account: str) -> None:
         await CredentialBlob.filter(service=service, account=account).delete()
+
+    async def mutate(
+        self,
+        service: str,
+        account: str,
+        mutator: Callable[[str | None], str | None],
+    ) -> None:
+        store = self._secrets()
+        for attempt in range(_MUTATE_MAX_ATTEMPTS):
+            blob = await CredentialBlob.filter(service=service, account=account).first()
+            current_ciphertext = blob.value if blob is not None else None
+            current_value = None if blob is None else await store.decrypt(blob.value)
+            next_value = mutator(current_value)
+
+            if blob is None:
+                if next_value is None:
+                    return
+                next_ciphertext = await store.encrypt(next_value)
+                try:
+                    await CredentialBlob.create(
+                        service=service,
+                        account=account,
+                        value=next_ciphertext,
+                        ciphertext_version=store.version,
+                    )
+                    return
+                except IntegrityError:
+                    if attempt + 1 < _MUTATE_MAX_ATTEMPTS:
+                        await _sleep_before_mutation_retry(attempt)
+                    continue
+
+            # INVARIANT: compare against the ciphertext read above. Encryption uses a
+            # fresh nonce, so comparing newly encrypted plaintext would always miss.
+            if next_value is None:
+                deleted = await CredentialBlob.filter(
+                    id=blob.id,
+                    service=service,
+                    account=account,
+                    value=current_ciphertext,
+                ).delete()
+                if deleted == 1:
+                    return
+                if attempt + 1 < _MUTATE_MAX_ATTEMPTS:
+                    await _sleep_before_mutation_retry(attempt)
+                continue
+
+            next_ciphertext = await store.encrypt(next_value)
+            updated = await CredentialBlob.filter(
+                id=blob.id,
+                service=service,
+                account=account,
+                value=current_ciphertext,
+            ).update(
+                value=next_ciphertext,
+                ciphertext_version=store.version,
+                updated_at=datetime.now(UTC),
+            )
+            if updated == 1:
+                return
+            if attempt + 1 < _MUTATE_MAX_ATTEMPTS:
+                await _sleep_before_mutation_retry(attempt)
+
+        raise CredentialBlobMutationConflict(
+            f"Credential blob mutation conflicted after {_MUTATE_MAX_ATTEMPTS} attempts"
+        )
+
+
+async def _sleep_before_mutation_retry(attempt: int) -> None:
+    delay = min(
+        _MUTATE_BACKOFF_BASE_SECONDS * 2**attempt,
+        _MUTATE_BACKOFF_MAX_SECONDS,
+    )
+    delay += random.uniform(0.0, _MUTATE_JITTER_SECONDS)
+    await asyncio.sleep(delay)

--- a/apps/aigateway/src/aigateway/core/profile_index.py
+++ b/apps/aigateway/src/aigateway/core/profile_index.py
@@ -9,38 +9,83 @@ from .profile_models import Profile, ProfileIndex
 logger = logging.getLogger(__name__)
 
 INDEX_CREDENTIAL_SERVICE = "aigateway:index"
-_INDEX_ACCOUNT = "default"  # one credential blob holds account-scoped profile metadata
+_LEGACY_INDEX_ACCOUNT = "default"
+_INDEX_ACCOUNT_PREFIX = "account:"
+
+
+def _index_account_for(account_id: str) -> str:
+    return f"{_INDEX_ACCOUNT_PREFIX}{account_id}"
+
+
+def _account_id_from_profile_id(profile_id: str) -> str:
+    account_id, separator, _rest = profile_id.partition(":")
+    if not separator or not account_id:
+        raise ValueError("profile_id must include account_id")
+    return account_id
 
 
 class ProfileIndexStore:
-    """Read/write the `aigateway:index` credential blob under an asyncio.Lock."""
+    """Read/write account-scoped `aigateway:index` credential blobs."""
 
     def __init__(self, credential_store: CredentialBlobStore | None = None) -> None:
         self._store = credential_store or ORMStore()
         self._lock = asyncio.Lock()
 
-    async def read(self) -> ProfileIndex:
-        raw = await self._store.read(INDEX_CREDENTIAL_SERVICE, _INDEX_ACCOUNT)
+    async def read(self, account_id: str | None = None) -> ProfileIndex:
+        account = _LEGACY_INDEX_ACCOUNT if account_id is None else _index_account_for(account_id)
+        raw = await self._store.read(INDEX_CREDENTIAL_SERVICE, account)
         if raw is None:
+            if account_id is not None:
+                return await self._read_legacy_account_index(account_id)
             return ProfileIndex()
         return ProfileIndex.model_validate_json(raw)
+
+    async def _read_legacy_account_index(self, account_id: str) -> ProfileIndex:
+        raw = await self._store.read(INDEX_CREDENTIAL_SERVICE, _LEGACY_INDEX_ACCOUNT)
+        if raw is None:
+            return ProfileIndex()
+        legacy = ProfileIndex.model_validate_json(raw)
+        return ProfileIndex(profiles=[p for p in legacy.profiles if p.account_id == account_id])
 
     async def upsert(self, profile: Profile) -> None:
         if not profile.account_id:
             raise ValueError("profile.account_id is required")
+
         async with self._lock:
-            idx = await self.read()
-            idx.profiles = [p for p in idx.profiles if p.id != profile.id] + [profile]
-            await self._store.write(INDEX_CREDENTIAL_SERVICE, _INDEX_ACCOUNT, idx.model_dump_json())
+            legacy_seed = await self._read_legacy_account_index(profile.account_id)
+
+            def mutate(raw: str | None) -> str:
+                # WHY: legacy installs used one global row; seed the account row lazily
+                # so existing profiles survive the storage-shape split.
+                idx = legacy_seed if raw is None else ProfileIndex.model_validate_json(raw)
+                idx.profiles = [p for p in idx.profiles if p.id != profile.id] + [profile]
+                return idx.model_dump_json()
+
+            await self._store.mutate(
+                INDEX_CREDENTIAL_SERVICE,
+                _index_account_for(profile.account_id),
+                mutate,
+            )
 
     async def remove(self, profile_id: str) -> None:
+        account_id = _account_id_from_profile_id(profile_id)
+
         async with self._lock:
-            idx = await self.read()
-            idx.profiles = [p for p in idx.profiles if p.id != profile_id]
-            await self._store.write(INDEX_CREDENTIAL_SERVICE, _INDEX_ACCOUNT, idx.model_dump_json())
+            legacy_seed = await self._read_legacy_account_index(account_id)
+
+            def mutate(raw: str | None) -> str:
+                idx = legacy_seed if raw is None else ProfileIndex.model_validate_json(raw)
+                idx.profiles = [p for p in idx.profiles if p.id != profile_id]
+                return idx.model_dump_json()
+
+            await self._store.mutate(
+                INDEX_CREDENTIAL_SERVICE,
+                _index_account_for(account_id),
+                mutate,
+            )
 
     async def list(self, account_id: str, provider: str | None = None) -> list[Profile]:
-        idx = await self.read()
+        idx = await self.read(account_id)
         return [
             p
             for p in idx.profiles
@@ -48,7 +93,7 @@ class ProfileIndexStore:
         ]
 
     async def get(self, account_id: str, provider: str, name: str) -> Profile | None:
-        idx = await self.read()
+        idx = await self.read(account_id)
         for p in idx.profiles:
             if p.account_id == account_id and p.provider == provider and p.name == name:
                 return p

--- a/apps/aigateway/src/aigateway/main.py
+++ b/apps/aigateway/src/aigateway/main.py
@@ -21,7 +21,7 @@ from .core.auth.log_filter import (
     install_provisioning_token_redaction,
 )
 from .core.auth.middleware import ANONYMOUS_ACCOUNT_ID
-from .core.credential_blob.store import ORMStore
+from .core.credential_blob.store import CredentialBlobMutationConflict, ORMStore
 from .core.loader import load_plugins
 from .core.pending_auth import PendingAuthTable
 from .core.profile_index import ProfileIndexStore
@@ -191,12 +191,25 @@ async def _redact_validation_errors(_request: Request, exc: Exception) -> JSONRe
     return JSONResponse(status_code=422, content=jsonable_encoder({"detail": cleaned}))
 
 
+async def _profile_index_conflict(_request: Request, _exc: Exception) -> JSONResponse:
+    return JSONResponse(
+        status_code=503,
+        content={
+            "detail": {
+                "code": "profile_index_conflict",
+                "message": "Profile metadata update conflicted. Try again.",
+            }
+        },
+    )
+
+
 def create_app(settings: Settings | None = None) -> FastAPI:
     if settings is None:
         settings = Settings()
     _attach_log_filter()
     app = FastAPI(title="aigateway", version="0.1.0", lifespan=_lifespan)
     app.add_exception_handler(RequestValidationError, _redact_validation_errors)
+    app.add_exception_handler(CredentialBlobMutationConflict, _profile_index_conflict)
     app.state.settings = settings
     if not settings.auth_enabled:
         app.add_middleware(AuthDisabledLocalOnlyMiddleware)

--- a/apps/aigateway/src/aigateway/routes/auth.py
+++ b/apps/aigateway/src/aigateway/routes/auth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -17,6 +18,7 @@ from pydantic import BaseModel
 from tortoise.exceptions import IntegrityError
 
 from ..core.auth.middleware import CurrentAccount
+from ..core.credential_blob.store import CredentialBlobMutationConflict
 from ..core.credential_strategy_cache import credential_strategy_cache
 from ..core.errors import AuthError, CredentialNotFoundError
 from ..core.oauth.store import (
@@ -40,7 +42,13 @@ from ..core.profile_models import (
     credential_name_for,
     profile_id_for,
 )
+from .credential_persistence import (
+    SupportsCredentialPersistence,
+    SupportsCredentialSlot,
+    persist_credentials_or_503,
+)
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
@@ -382,13 +390,15 @@ async def _handle_loopback_callback(
         body = _CALLBACK_HTML
     except Exception as exc:
         status = 500
-        body = (
-            "<!doctype html><html><body>"
-            "<h2>Authentication failed</h2>"
-            f"<p>Provider: {escape(provider)}</p>"
-            f"<pre style='white-space:pre-wrap'>{escape(type(exc).__name__)}: "
-            f"{escape(str(exc))}</pre>"
-            "</body></html>"
+        logger.error(
+            "Loopback OAuth callback failed for provider %s: %s",
+            provider,
+            type(exc).__name__,
+        )
+        body = _callback_failure_html(
+            provider,
+            type(exc).__name__,
+            "OAuth callback failed. Try again.",
         )
     finally:
         writer.write(_http_response(status, body))
@@ -569,6 +579,16 @@ _CALLBACK_HTML = """<!doctype html>
 """
 
 
+def _callback_failure_html(provider: str, code: str, message: str) -> str:
+    return (
+        "<!doctype html><html><body>"
+        "<h2>Authentication failed</h2>"
+        f"<p>Provider: {escape(provider)}</p>"
+        f"<pre style='white-space:pre-wrap'>{escape(code)}: {escape(message)}</pre>"
+        "</body></html>"
+    )
+
+
 @router.get("/callback")
 async def oauth_callback(code: str, state: str, request: Request):
     """Provider-agnostic OAuth callback.
@@ -591,17 +611,28 @@ async def oauth_callback(code: str, state: str, request: Request):
     provider = pending_entry.provider
     try:
         return await _generic_callback(provider, code, state, request)
-    except Exception as exc:
-        # Surface a readable error in the browser tab so the user sees what
-        # went wrong (instead of a generic 500). Most failures here are
-        # token-endpoint mismatches; the message is helpful for debugging.
+    except CredentialBlobMutationConflict:
         return HTMLResponse(
-            f"<!doctype html><html><body>"
-            f"<h2>Authentication failed</h2>"
-            f"<p>Provider: {escape(provider)}</p>"
-            f"<pre style='white-space:pre-wrap'>{escape(type(exc).__name__)}: "
-            f"{escape(str(exc))}</pre>"
-            f"</body></html>",
+            _callback_failure_html(
+                provider,
+                "profile_index_conflict",
+                "Profile metadata update conflicted. Try again.",
+            ),
+            status_code=503,
+        )
+    except HTTPException as exc:
+        return HTMLResponse(
+            _callback_failure_html(provider, type(exc).__name__, str(exc.detail)),
+            status_code=exc.status_code,
+        )
+    except Exception as exc:
+        logger.error("OAuth callback failed for provider %s: %s", provider, type(exc).__name__)
+        return HTMLResponse(
+            _callback_failure_html(
+                provider,
+                type(exc).__name__,
+                "OAuth callback failed. Try again.",
+            ),
             status_code=500,
         )
 
@@ -675,11 +706,54 @@ async def _complete_oauth_for_app(
     except Exception:
         await _mark_oauth_completion_error(app, pending, "OAuth code exchange failed", state)
         raise
+    profile_credential_slot: tuple[object, str, str, str | None, str | None] | None = None
     if pending.connection_id is None:
-        await strategy.persist_credentials(creds)
+        # WHY: the credential slot and profile index are separate stores, so OAuth
+        # profile completion must snapshot and compensate around the index write.
+        credential_store = _credential_store_for_app(app)
+        slot = cast(SupportsCredentialSlot, strategy)
+        credential_service = slot.credential_service()
+        credential_account = slot.credential_account()
+        previous_credential = await credential_store.read(credential_service, credential_account)
+        try:
+            await persist_credentials_or_503(
+                slot,
+                creds,
+                description="OAuth profile credentials",
+            )
+        except HTTPException:
+            await _mark_oauth_completion_error(app, pending, "credential_store_unavailable", state)
+            raise
+        written_credential = await credential_store.read(credential_service, credential_account)
+        profile_credential_slot = (
+            credential_store,
+            credential_service,
+            credential_account,
+            previous_credential,
+            written_credential,
+        )
         _invalidate_profile_session(app, plugin, pending.account_id, pending.profile_name)
 
-    await _mark_profile_authenticated(app, pending, plugin, creds)
+    try:
+        await _mark_profile_authenticated(app, pending, plugin, creds)
+    except Exception:
+        if profile_credential_slot is not None:
+            (
+                credential_store,
+                credential_service,
+                credential_account,
+                previous_credential,
+                written_credential,
+            ) = profile_credential_slot
+            await _restore_credential_slot_after_failure(
+                credential_store,
+                credential_service,
+                credential_account,
+                expected_credential=written_credential,
+                previous_credential=previous_credential,
+                description="OAuth profile",
+            )
+        raise
     await _record_oauth_connection_completion(app, pending, plugin, creds)
     await _close_loopback_callback(app, state)
 
@@ -785,8 +859,67 @@ async def _persist_connection_credentials(
         credential_key_for(account_id, connection_id),
     )
     if strategy is not None:
-        await strategy.persist_credentials(creds)
+        await persist_credentials_or_503(
+            cast(SupportsCredentialPersistence, strategy),
+            creds,
+            description="OAuth connection credentials",
+        )
     credential_strategy_cache(app).evict(credential_key_for(account_id, connection_id))
+
+
+async def _delete_connection_strategy_credentials(
+    app,
+    plugin,
+    provider: str,
+    account_id: str,
+    connection_id: str,
+) -> None:
+    strategy = _credential_strategy_for_credential_name(
+        app,
+        plugin,
+        provider,
+        credential_key_for(account_id, connection_id),
+    )
+    if strategy is None:
+        return
+    strategy_for_log = cast(SupportsCredentialPersistence, strategy)
+    try:
+        await strategy.delete_credentials()
+    except Exception as exc:
+        # Best-effort compensation: never mask the activation-conflict response.
+        logger.error(
+            "Failed to delete OAuth connection credentials for service %s during compensation: %s",
+            strategy_for_log.credential_service(),
+            type(exc).__name__,
+        )
+
+
+async def _restore_credential_slot_after_failure(
+    credential_store,
+    credential_service: str,
+    credential_account: str,
+    *,
+    expected_credential: str | None,
+    previous_credential: str | None,
+    description: str,
+) -> None:
+    def restore_if_unchanged(current: str | None) -> str | None:
+        # INVARIANT: compensate only our own credential write; a concurrent writer wins.
+        if current != expected_credential:
+            return current
+        return previous_credential
+
+    try:
+        await credential_store.mutate(credential_service, credential_account, restore_if_unchanged)
+    except Exception as compensation_exc:
+        # Double-fault signal: the original error still propagates to the caller.
+        logger.error(
+            "Failed to compensate %s credential slot %s/%s after profile-index failure: %s",
+            description,
+            credential_service,
+            credential_account,
+            type(compensation_exc).__name__,
+        )
 
 
 async def _record_oauth_connection_completion(
@@ -813,21 +946,49 @@ async def _record_oauth_connection_completion(
 
     connection = await _connection_for_pending(store, pending, plugin, label)
     try:
+        await _persist_connection_credentials(
+            app,
+            plugin,
+            pending.provider,
+            pending.account_id,
+            str(connection.id),
+            creds,
+        )
         await store.complete(connection, label=label, identity=identity)
     except IntegrityError as exc:
+        await _delete_connection_strategy_credentials(
+            app,
+            plugin,
+            pending.provider,
+            pending.account_id,
+            str(connection.id),
+        )
         await store.mark_revoked(connection, "connection_conflict")
         raise HTTPException(
             status_code=409,
             detail={"code": "connection_conflict", "provider": pending.provider, "label": label},
         ) from exc
-    await _persist_connection_credentials(
-        app,
-        plugin,
-        pending.provider,
-        pending.account_id,
-        str(connection.id),
-        creds,
-    )
+    except HTTPException as exc:
+        if exc.status_code == 503:
+            await store.mark_error(connection, "credential_store_unavailable")
+        raise
+    except Exception as exc:
+        await _delete_connection_strategy_credentials(
+            app,
+            plugin,
+            pending.provider,
+            pending.account_id,
+            str(connection.id),
+        )
+        await store.mark_error(connection, "connection_activation_failed")
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": "connection_activation_failed",
+                "provider": pending.provider,
+                "message": "Could not activate OAuth connection. Try again.",
+            },
+        ) from exc
 
 
 def _plugin_extracts_identity(plugin) -> bool:
@@ -1081,8 +1242,29 @@ async def set_profile_api_key(
     profile.account_label = f"API key ····{api_key[-4:]}"
     profile.scopes = []  # OAuth scopes are meaningless for API-key auth (F24)
 
-    await strategy.persist_credentials({"auth_type": "api_key", "api_key": api_key})
-    await idx.upsert(profile)
+    credential_store = _credential_store_for_app(request.app)
+    strategy_for_slot = cast(SupportsCredentialSlot, strategy)
+    credential_service = strategy_for_slot.credential_service()
+    credential_account = strategy_for_slot.credential_account()
+    previous_credential = await credential_store.read(credential_service, credential_account)
+    await persist_credentials_or_503(
+        strategy_for_slot,
+        {"auth_type": "api_key", "api_key": api_key},
+        description="API-key credentials",
+    )
+    written_credential = await credential_store.read(credential_service, credential_account)
+    try:
+        await idx.upsert(profile)
+    except Exception:
+        await _restore_credential_slot_after_failure(
+            credential_store,
+            credential_service,
+            credential_account,
+            expected_credential=written_credential,
+            previous_credential=previous_credential,
+            description="API-key",
+        )
+        raise
     _invalidate_profile_session(request.app, plugin, account_id, name)
     return profile.model_dump(mode="json")
 

--- a/apps/aigateway/src/aigateway/routes/credential_persistence.py
+++ b/apps/aigateway/src/aigateway/routes/credential_persistence.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Protocol
+
+from fastapi import HTTPException
+
+logger = logging.getLogger(__name__)
+
+
+class SupportsCredentialPersistence(Protocol):
+    async def persist_credentials(self, credentials: dict[str, Any]) -> None: ...
+
+    def credential_service(self) -> str: ...
+
+
+class SupportsCredentialSlot(SupportsCredentialPersistence, Protocol):
+    def credential_account(self) -> str: ...
+
+
+async def persist_credentials_or_503(
+    strategy: SupportsCredentialPersistence,
+    credentials: dict[str, Any],
+    *,
+    description: str,
+) -> None:
+    try:
+        await strategy.persist_credentials(credentials)
+    except Exception as exc:
+        # Store adapters may echo credentials in exception text; log only type + service.
+        logger.error(
+            "Failed to persist %s for service %s: %s",
+            description,
+            strategy.credential_service(),
+            type(exc).__name__,
+        )
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": "credential_store_unavailable",
+                "message": f"Could not store {description}. Try again.",
+            },
+        ) from exc

--- a/apps/aigateway/src/aigateway/routes/oauth_connections.py
+++ b/apps/aigateway/src/aigateway/routes/oauth_connections.py
@@ -34,6 +34,7 @@ from aigateway.core.pending_auth import PendingAuthEntry
 from aigateway.core.plugin_base import credential_service_provider_for, credential_strategy_from
 
 from .auth import _redirect_uri_for
+from .credential_persistence import persist_credentials_or_503
 
 logger = logging.getLogger(__name__)
 
@@ -450,25 +451,11 @@ def _validate_api_key(raw_key: str) -> str:
 
 
 async def _persist_api_key_credentials(strategy, api_key: str) -> None:
-    try:
-        await strategy.persist_credentials({"auth_type": "api_key", "api_key": api_key})
-    except Exception as exc:
-        # A caught store failure is otherwise a silent 503 — log which service
-        # failed and the exception TYPE so ops can diagnose. Deliberately NOT
-        # str(exc)/the traceback: a store implementation could echo its write
-        # argument (the key) in the message, and this path must never log a key.
-        logger.error(
-            "Failed to persist API-key credentials for service %s: %s",
-            strategy.credential_service(),
-            type(exc).__name__,
-        )
-        raise HTTPException(
-            status_code=503,
-            detail={
-                "code": "credential_store_unavailable",
-                "message": "Could not store API-key credentials. Try again.",
-            },
-        ) from exc
+    await persist_credentials_or_503(
+        strategy,
+        {"auth_type": "api_key", "api_key": api_key},
+        description="API-key credentials",
+    )
 
 
 def _duplicate_id(message: str | None) -> UUID | None:

--- a/apps/aigateway/tests/conftest.py
+++ b/apps/aigateway/tests/conftest.py
@@ -59,6 +59,18 @@ class _AsyncCredentialBlobProbe:
     async def delete(self, service: str, account: str) -> None:
         self._probe.delete(service, account)
 
+    async def mutate(
+        self,
+        service: str,
+        account: str,
+        mutator: Callable[[str | None], str | None],
+    ) -> None:
+        next_value = mutator(self._probe.read(service, account))
+        if next_value is None:
+            self._probe.delete(service, account)
+        else:
+            self._probe.write(service, account, next_value)
+
 
 class CredentialBlobProbe:
     def __init__(self, db_path: Path) -> None:

--- a/apps/aigateway/tests/unit/anthropic/test_anthropic_auth.py
+++ b/apps/aigateway/tests/unit/anthropic/test_anthropic_auth.py
@@ -31,6 +31,13 @@ class _FakeStore:
     async def delete(self, service: str, account: str) -> None:
         self.payload = None
 
+    async def mutate(self, service: str, account: str, mutator) -> None:
+        next_value = mutator(await self.read(service, account))
+        if next_value is None:
+            await self.delete(service, account)
+        else:
+            await self.write(service, account, next_value)
+
 
 def _wrap(creds: dict) -> str:
     """Token payload as stored in aigateway:anthropic:<name>."""

--- a/apps/aigateway/tests/unit/anthropic/test_bootstrap.py
+++ b/apps/aigateway/tests/unit/anthropic/test_bootstrap.py
@@ -71,9 +71,10 @@ async def test_bootstrap_imports_cc_default_when_index_empty(credential_blobs) -
     assert converted["refresh_token"] == "cc-rt"
     assert "expires_at_ms" in converted
 
-    idx_raw = credential_blobs.read(INDEX_CREDENTIAL_SERVICE, "default")
+    idx_raw = credential_blobs.read(INDEX_CREDENTIAL_SERVICE, f"account:{ACCOUNT_ID}")
     assert idx_raw is not None
     assert profile_id_for(ACCOUNT_ID, "anthropic", "default") in idx_raw
+    assert credential_blobs.read(INDEX_CREDENTIAL_SERVICE, "default") is None
 
     # CC entry untouched
     assert credential_blobs.read(settings.claude_code_keychain_service, "alice") == cc_payload

--- a/apps/aigateway/tests/unit/antigravity/test_antigravity_auth.py
+++ b/apps/aigateway/tests/unit/antigravity/test_antigravity_auth.py
@@ -55,6 +55,13 @@ class _FakeStore:
     async def delete(self, service: str, account: str) -> None:
         self.payload = None
 
+    async def mutate(self, service: str, account: str, mutator) -> None:
+        next_value = mutator(await self.read(service, account))
+        if next_value is None:
+            await self.delete(service, account)
+        else:
+            await self.write(service, account, next_value)
+
 
 def _jwt(payload: dict[str, Any]) -> str:
     def encode(value: dict[str, Any] | bytes) -> str:

--- a/apps/aigateway/tests/unit/codex/test_codex_auth.py
+++ b/apps/aigateway/tests/unit/codex/test_codex_auth.py
@@ -34,6 +34,13 @@ class _FakeStore:
     async def delete(self, service: str, account: str) -> None:
         self.payload = None
 
+    async def mutate(self, service: str, account: str, mutator) -> None:
+        next_value = mutator(await self.read(service, account))
+        if next_value is None:
+            await self.delete(service, account)
+        else:
+            await self.write(service, account, next_value)
+
 
 def _jwt(payload: dict[str, Any]) -> str:
     def encode(value: dict[str, Any] | bytes) -> str:

--- a/apps/aigateway/tests/unit/gemini/test_gemini_auth.py
+++ b/apps/aigateway/tests/unit/gemini/test_gemini_auth.py
@@ -39,6 +39,13 @@ class _FakeStore:
     async def delete(self, service: str, account: str) -> None:
         self.payload = None
 
+    async def mutate(self, service: str, account: str, mutator) -> None:
+        next_value = mutator(await self.read(service, account))
+        if next_value is None:
+            await self.delete(service, account)
+        else:
+            await self.write(service, account, next_value)
+
 
 def _creds(**extra: Any) -> dict[str, Any]:
     data: dict[str, Any] = {

--- a/apps/aigateway/tests/unit/huggingface/test_huggingface_provider.py
+++ b/apps/aigateway/tests/unit/huggingface/test_huggingface_provider.py
@@ -34,6 +34,9 @@ class _FakeStore:
 
     async def delete(self, service: str, account: str) -> None: ...
 
+    async def mutate(self, service: str, account: str, mutator) -> None:
+        self._blob = mutator(self._blob)
+
 
 def test_plugin_identity() -> None:
     assert isinstance(PLUGIN, HuggingFaceProviderPlugin)

--- a/apps/aigateway/tests/unit/test_api_key_routes.py
+++ b/apps/aigateway/tests/unit/test_api_key_routes.py
@@ -7,10 +7,14 @@ probe (which decrypts through the same master key as the app's ORMStore).
 from __future__ import annotations
 
 import json
+import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 import httpx
 import pytest
 
+from aigateway.core.credential_blob.store import CredentialBlobMutationConflict
 from aigateway.core.profile_index import ProfileIndexStore
 from aigateway.core.profile_models import (
     Profile,
@@ -24,6 +28,17 @@ from aigateway.plugins.gemini_provider.auth import (
 )
 
 ANTHROPIC_KEY = "sk-ant-api03-test-key-1234"
+
+
+@contextmanager
+def _server_errors_as_responses(client) -> Iterator[None]:
+    transport = getattr(client, "_transport")
+    previous = transport.raise_server_exceptions
+    transport.raise_server_exceptions = False
+    try:
+        yield
+    finally:
+        transport.raise_server_exceptions = previous
 
 
 def _oauth_token_factory():
@@ -90,6 +105,182 @@ def test_set_api_key_replaces_existing_key(authenticated_client, credential_blob
     assert json.loads(credential_blobs.read(service, "default"))["api_key"] == (
         "sk-ant-api03-rotated-9999"
     )
+
+
+def test_set_api_key_deletes_new_blob_when_profile_index_update_fails(
+    authenticated_client, credential_blobs, monkeypatch
+) -> None:
+    account_id = _account_id(authenticated_client)
+    service = credential_service_for(credential_name_for(account_id, "keyed"))
+
+    async def _boom(_profile) -> None:
+        raise RuntimeError("profile index unavailable")
+
+    monkeypatch.setattr(authenticated_client.app.state.profile_index, "upsert", _boom)
+
+    with _server_errors_as_responses(authenticated_client):
+        resp = _put_api_key(authenticated_client, "anthropic", "keyed", ANTHROPIC_KEY)
+
+    assert resp.status_code == 500
+    assert credential_blobs.read(service, "default") is None
+    assert authenticated_client.get("/v1/auth/anthropic/profiles/keyed").status_code == 404
+
+
+def test_set_api_key_profile_index_conflict_returns_retryable_503(
+    authenticated_client, credential_blobs, monkeypatch
+) -> None:
+    account_id = _account_id(authenticated_client)
+    service = credential_service_for(credential_name_for(account_id, "keyed"))
+
+    async def _boom(_profile) -> None:
+        raise CredentialBlobMutationConflict("forced contention")
+
+    monkeypatch.setattr(authenticated_client.app.state.profile_index, "upsert", _boom)
+
+    with _server_errors_as_responses(authenticated_client):
+        resp = _put_api_key(authenticated_client, "anthropic", "keyed", ANTHROPIC_KEY)
+
+    assert resp.status_code == 503
+    assert resp.json()["detail"]["code"] == "profile_index_conflict"
+    assert "forced contention" not in resp.text
+    assert credential_blobs.read(service, "default") is None
+
+
+def test_set_api_key_delete_compensation_failure_is_sanitized(
+    authenticated_client, monkeypatch, caplog
+) -> None:
+    leak_marker = "sk-ant-api03-compensation-secret-that-must-not-leak"
+
+    async def _boom(_profile) -> None:
+        raise RuntimeError("profile index unavailable")
+
+    async def _mutate_failure(_service: str, _account: str, _mutator) -> None:
+        raise RuntimeError(f"delete failed for {leak_marker}")
+
+    monkeypatch.setattr(authenticated_client.app.state.profile_index, "upsert", _boom)
+    monkeypatch.setattr(authenticated_client.app.state.credential_store, "mutate", _mutate_failure)
+    caplog.set_level(logging.ERROR, logger="aigateway.routes.auth")
+
+    with _server_errors_as_responses(authenticated_client):
+        resp = _put_api_key(authenticated_client, "anthropic", "keyed", ANTHROPIC_KEY)
+
+    assert resp.status_code == 500
+    assert "Failed to compensate API-key credential slot" in caplog.text
+    assert "RuntimeError" in caplog.text
+    assert ANTHROPIC_KEY not in caplog.text
+    assert leak_marker not in caplog.text
+
+
+def test_set_api_key_compensation_preserves_concurrent_slot_write(
+    authenticated_client, credential_blobs, monkeypatch
+) -> None:
+    account_id = _account_id(authenticated_client)
+    service = credential_service_for(credential_name_for(account_id, "keyed"))
+    concurrent = json.dumps({"auth_type": "api_key", "api_key": "sk-ant-api03-other-5678"})
+
+    async def _boom(_profile) -> None:
+        credential_blobs.write(service, "default", concurrent)
+        raise RuntimeError("profile index unavailable")
+
+    monkeypatch.setattr(authenticated_client.app.state.profile_index, "upsert", _boom)
+
+    with _server_errors_as_responses(authenticated_client):
+        resp = _put_api_key(authenticated_client, "anthropic", "keyed", ANTHROPIC_KEY)
+
+    assert resp.status_code == 500
+    assert credential_blobs.read(service, "default") == concurrent
+
+
+@pytest.mark.asyncio
+async def test_set_api_key_restores_oauth_blob_when_profile_index_update_fails(
+    authenticated_client, credential_blobs, monkeypatch
+) -> None:
+    account_id = _account_id(authenticated_client)
+    idx = ProfileIndexStore(credential_store=credential_blobs.store)
+    await idx.upsert(
+        Profile(
+            id=profile_id_for(account_id, "anthropic", "default"),
+            account_id=account_id,
+            provider="anthropic",
+            name="default",
+            state=ProfileState.AUTHENTICATED,
+            auth_type="oauth",
+            account_label="user@example.com",
+            scopes=["user:inference"],
+        )
+    )
+    service = credential_service_for(credential_name_for(account_id, "default"))
+    previous = json.dumps(
+        {
+            "access_token": "oauth-tok",
+            "refresh_token": "oauth-rt",
+            "expires_at_ms": 1,
+            "token_type": "Bearer",
+        }
+    )
+    credential_blobs.write(service, "default", previous)
+
+    async def _boom(_profile) -> None:
+        raise RuntimeError("profile index unavailable")
+
+    monkeypatch.setattr(authenticated_client.app.state.profile_index, "upsert", _boom)
+
+    with _server_errors_as_responses(authenticated_client):
+        resp = _put_api_key(authenticated_client, "anthropic", "default", ANTHROPIC_KEY)
+
+    assert resp.status_code == 500
+    assert credential_blobs.read(service, "default") == previous
+    profile = await idx.get(account_id, "anthropic", "default")
+    assert profile is not None
+    assert profile.auth_type == "oauth"
+
+
+@pytest.mark.asyncio
+async def test_set_api_key_restore_compensation_failure_is_sanitized(
+    authenticated_client, credential_blobs, monkeypatch, caplog
+) -> None:
+    account_id = _account_id(authenticated_client)
+    idx = ProfileIndexStore(credential_store=credential_blobs.store)
+    await idx.upsert(
+        Profile(
+            id=profile_id_for(account_id, "anthropic", "default"),
+            account_id=account_id,
+            provider="anthropic",
+            name="default",
+            state=ProfileState.AUTHENTICATED,
+            auth_type="oauth",
+        )
+    )
+    service = credential_service_for(credential_name_for(account_id, "default"))
+    previous = json.dumps(
+        {
+            "access_token": "oauth-tok",
+            "refresh_token": "oauth-rt",
+            "expires_at_ms": 1,
+            "token_type": "Bearer",
+        }
+    )
+    credential_blobs.write(service, "default", previous)
+    leak_marker = "sk-ant-api03-restore-secret-that-must-not-leak"
+
+    async def _boom(_profile) -> None:
+        raise RuntimeError("profile index unavailable")
+
+    async def _mutate_failure(_service: str, _account: str, _mutator) -> None:
+        raise RuntimeError(f"restore failed for {leak_marker}")
+
+    monkeypatch.setattr(authenticated_client.app.state.profile_index, "upsert", _boom)
+    monkeypatch.setattr(authenticated_client.app.state.credential_store, "mutate", _mutate_failure)
+    caplog.set_level(logging.ERROR, logger="aigateway.routes.auth")
+
+    with _server_errors_as_responses(authenticated_client):
+        resp = _put_api_key(authenticated_client, "anthropic", "default", ANTHROPIC_KEY)
+
+    assert resp.status_code == 500
+    assert "Failed to compensate API-key credential slot" in caplog.text
+    assert "RuntimeError" in caplog.text
+    assert ANTHROPIC_KEY not in caplog.text
+    assert leak_marker not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/apps/aigateway/tests/unit/test_api_key_strategy.py
+++ b/apps/aigateway/tests/unit/test_api_key_strategy.py
@@ -25,6 +25,13 @@ class FakeStore:
     async def delete(self, service: str, account: str) -> None:
         self.data.pop((service, account), None)
 
+    async def mutate(self, service: str, account: str, mutator) -> None:
+        next_value = mutator(await self.read(service, account))
+        if next_value is None:
+            self.data.pop((service, account), None)
+        else:
+            self.data[(service, account)] = next_value
+
 
 def _strategy(store: FakeStore | None = None) -> tuple[ApiKeyStrategy, FakeStore]:
     store = store or FakeStore()

--- a/apps/aigateway/tests/unit/test_auth_routes.py
+++ b/apps/aigateway/tests/unit/test_auth_routes.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import logging
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import cast
 from urllib.parse import parse_qs, urlparse
 
@@ -11,8 +14,9 @@ import httpx
 import pytest
 from fastapi import HTTPException
 from tortoise import Tortoise
-from tortoise.exceptions import IntegrityError
+from tortoise.exceptions import IntegrityError, OperationalError
 
+from aigateway.core.credential_blob.store import CredentialBlobMutationConflict
 from aigateway.core.pending_auth import PendingAuthEntry
 from aigateway.core.plugin_base import OAuthCodeExchangeRequest, OAuthConfig
 from aigateway.core.profile_index import ProfileIndexStore
@@ -40,6 +44,17 @@ from aigateway.routes.auth import (
 @pytest.fixture
 def client_with_index(authenticated_client, credential_blobs):
     return authenticated_client, credential_blobs
+
+
+@contextmanager
+def _server_errors_as_responses(client) -> Iterator[None]:
+    transport = getattr(client, "_transport")
+    previous = transport.raise_server_exceptions
+    transport.raise_server_exceptions = False
+    try:
+        yield
+    finally:
+        transport.raise_server_exceptions = previous
 
 
 def _account_id(client) -> str:
@@ -389,6 +404,12 @@ class _RecordingStrategy:
 
     async def refresh_credentials(self) -> None:
         self.refreshed = True
+
+    def credential_service(self) -> str:
+        return "aigateway:generic:test"
+
+    def credential_account(self) -> str:
+        return "default"
 
 
 class _GenericOAuthPlugin:
@@ -772,7 +793,7 @@ async def test_handle_loopback_callback_keeps_listener_for_stray_requests(
 
 
 @pytest.mark.asyncio
-async def test_handle_loopback_callback_escapes_completion_errors(client_with_index) -> None:
+async def test_handle_loopback_callback_sanitizes_completion_errors(client_with_index) -> None:
     client, credential_blobs = client_with_index
     account_id = _account_id(client)
     await _move_tortoise_to_pytest_loop(client, credential_blobs)
@@ -793,8 +814,9 @@ async def test_handle_loopback_callback_escapes_completion_errors(client_with_in
     )
 
     assert b"HTTP/1.1 500 Internal Server Error" in writer.response
-    assert b"&lt;script&gt;bad&lt;/script&gt;" in writer.response
+    assert b"&lt;script&gt;bad&lt;/script&gt;" not in writer.response
     assert b"<script>bad</script>" not in writer.response
+    assert b"OAuth callback failed. Try again." in writer.response
     assert server.closed is True
     assert server.waited is True
     profile = await client.app.state.profile_index.get(account_id, "generic", "loopback-error")
@@ -889,7 +911,7 @@ def test_connection_exchange_uses_redirect_uri_override(client_with_index) -> No
     assert plugin.exchange_request.redirect_uri == redirect_uri
 
 
-def test_connection_completion_persists_credentials_after_store_complete(
+def test_connection_completion_deletes_credentials_when_activation_conflicts(
     client_with_index, monkeypatch
 ) -> None:
     client, _ = client_with_index
@@ -917,7 +939,184 @@ def test_connection_completion_persists_credentials_after_store_complete(
 
     assert resp.status_code == 409
     assert resp.json()["detail"]["code"] == "connection_conflict"
-    assert plugin.strategy.creds is None
+    assert plugin.strategy.creds is not None
+    assert plugin.strategy.deleted is True
+
+
+def test_connection_completion_non_integrity_failure_deletes_credentials_and_marks_error(
+    client_with_index, monkeypatch
+) -> None:
+    client, _ = client_with_index
+    plugin = _GenericOAuthPlugin()
+    client.app.state.providers._plugins["generic"] = plugin
+    leak_marker = "sk-ant-api03-activation-secret-that-must-not-leak"
+
+    async def complete_failure(*_args, **_kwargs) -> None:
+        raise OperationalError(f"database locked while handling {leak_marker}")
+
+    monkeypatch.setattr(
+        "aigateway.routes.auth.OAuthConnectionStore.complete",
+        complete_failure,
+    )
+
+    start = client.post(
+        "/v1/oauth/connections",
+        json={"provider": "generic", "label": "operational-failure"},
+    )
+    assert start.status_code == 201
+    connection_id = start.json()["connection_id"]
+
+    with _server_errors_as_responses(client):
+        resp = client.post(
+            "/v1/auth/generic/exchange-code",
+            json={"code": "generic-code", "state": start.json()["state"]},
+        )
+
+    assert resp.status_code == 503
+    assert resp.json()["detail"]["code"] == "connection_activation_failed"
+    assert leak_marker not in resp.text
+    assert plugin.strategy.creds is not None
+    assert plugin.strategy.deleted is True
+    connection = client.get(f"/v1/oauth/connections/{connection_id}").json()
+    assert connection["status"] == "error"
+    assert leak_marker not in json.dumps(connection)
+
+
+def test_connection_completion_delete_compensation_failure_is_sanitized(
+    client_with_index, monkeypatch, caplog
+) -> None:
+    client, _ = client_with_index
+    plugin = _GenericOAuthPlugin()
+    client.app.state.providers._plugins["generic"] = plugin
+    leak_marker = "sk-ant-api03-delete-secret-that-must-not-leak"
+
+    async def complete_conflict(*_args, **_kwargs) -> None:
+        raise IntegrityError("simulated connection race")
+
+    async def delete_failure() -> None:
+        raise RuntimeError(f"delete failed for {leak_marker}")
+
+    monkeypatch.setattr(
+        "aigateway.routes.auth.OAuthConnectionStore.complete",
+        complete_conflict,
+    )
+    monkeypatch.setattr(plugin.strategy, "delete_credentials", delete_failure)
+    caplog.set_level(logging.ERROR, logger="aigateway.routes.auth")
+
+    start = client.post(
+        "/v1/oauth/connections",
+        json={"provider": "generic", "label": "delete-failure"},
+    )
+    assert start.status_code == 201
+
+    resp = client.post(
+        "/v1/auth/generic/exchange-code",
+        json={"code": "generic-code", "state": start.json()["state"]},
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["code"] == "connection_conflict"
+    assert "Failed to delete OAuth connection credentials" in caplog.text
+    assert "RuntimeError" in caplog.text
+    assert leak_marker not in caplog.text
+
+
+def test_connection_completion_persist_failure_is_sanitized_and_non_active(
+    client_with_index, monkeypatch
+) -> None:
+    client, _ = client_with_index
+    plugin = _GenericOAuthPlugin()
+    client.app.state.providers._plugins["generic"] = plugin
+    leak_marker = "sk-ant-api03-loopback-secret-that-must-not-leak"
+
+    async def persist_failure(_creds: dict) -> None:
+        raise RuntimeError(f"credential store exploded with {leak_marker}")
+
+    monkeypatch.setattr(plugin.strategy, "persist_credentials", persist_failure)
+    start = client.post(
+        "/v1/oauth/connections",
+        json={"provider": "generic", "label": "persist-failure"},
+    )
+    assert start.status_code == 201
+    connection_id = start.json()["connection_id"]
+
+    auth_header = client.headers.pop("Authorization")
+    try:
+        with _server_errors_as_responses(client):
+            cb = client.get(
+                "/callback",
+                params={"code": "generic-code", "state": start.json()["state"]},
+                follow_redirects=False,
+            )
+    finally:
+        client.headers["Authorization"] = auth_header
+
+    assert cb.status_code == 503
+    assert leak_marker not in cb.text
+    connection = client.get(f"/v1/oauth/connections/{connection_id}").json()
+    assert connection["status"] == "error"
+    assert leak_marker not in json.dumps(connection)
+
+
+def test_profile_oauth_persist_failure_is_sanitized_and_marks_error(
+    client_with_index, monkeypatch
+) -> None:
+    client, _ = client_with_index
+    plugin = _GenericOAuthPlugin()
+    client.app.state.providers._plugins["generic"] = plugin
+    leak_marker = "sk-ant-api03-profile-secret-that-must-not-leak"
+
+    async def persist_failure(_creds: dict) -> None:
+        raise RuntimeError(f"credential store exploded with {leak_marker}")
+
+    monkeypatch.setattr(plugin.strategy, "persist_credentials", persist_failure)
+    start = client.post("/v1/auth/generic/profiles", json={"name": "persist-failure"})
+    assert start.status_code == 201
+
+    auth_header = client.headers.pop("Authorization")
+    try:
+        with _server_errors_as_responses(client):
+            cb = client.get(
+                "/callback",
+                params={"code": "generic-code", "state": start.json()["state"]},
+                follow_redirects=False,
+            )
+    finally:
+        client.headers["Authorization"] = auth_header
+
+    assert cb.status_code == 503
+    assert leak_marker not in cb.text
+    profile = client.get("/v1/auth/generic/profiles/persist-failure").json()
+    assert profile["state"] == "error"
+
+
+def test_profile_oauth_profile_index_conflict_returns_sanitized_503_html(
+    client_with_index, monkeypatch
+) -> None:
+    client, _ = client_with_index
+    plugin = _GenericOAuthPlugin()
+    client.app.state.providers._plugins["generic"] = plugin
+    start = client.post("/v1/auth/generic/profiles", json={"name": "index-conflict"})
+    assert start.status_code == 201
+
+    async def upsert_conflict(_profile) -> None:
+        raise CredentialBlobMutationConflict("forced contention")
+
+    monkeypatch.setattr(client.app.state.profile_index, "upsert", upsert_conflict)
+    auth_header = client.headers.pop("Authorization")
+    try:
+        with _server_errors_as_responses(client):
+            cb = client.get(
+                "/callback",
+                params={"code": "generic-code", "state": start.json()["state"]},
+                follow_redirects=False,
+            )
+    finally:
+        client.headers["Authorization"] = auth_header
+
+    assert cb.status_code == 503
+    assert "profile_index_conflict" in cb.text
+    assert "forced contention" not in cb.text
 
 
 def test_start_oauth_creates_pending_profile(client_with_index) -> None:
@@ -1106,6 +1305,51 @@ def test_callback_completes_auth(client_with_index) -> None:
     assert "new-tok" in blob
 
 
+def test_callback_restores_api_key_blob_when_profile_index_update_fails(
+    client_with_index, monkeypatch
+) -> None:
+    client, credential_blobs = client_with_index
+    account_id = _account_id(client)
+    client.app.state.anthropic_http_factory = _mock_token_factory()
+    api_key = "sk-ant-api03-existing-1234"
+    api_key_resp = client.put(
+        "/v1/auth/anthropic/profiles/default/api-key",
+        json={"api_key": api_key},
+    )
+    assert api_key_resp.status_code == 200
+
+    from aigateway.plugins.anthropic_provider.auth import credential_service_for
+
+    service = credential_service_for(credential_name_for(account_id, "default"))
+    previous = credential_blobs.read(service, "default")
+    assert previous is not None
+    assert api_key in previous
+
+    start = client.post("/v1/auth/anthropic/profiles", json={"name": "default"})
+    state = start.json()["state"]
+
+    async def _boom(_profile) -> None:
+        raise RuntimeError("profile index unavailable")
+
+    monkeypatch.setattr(client.app.state.profile_index, "upsert", _boom)
+    auth_header = client.headers.pop("Authorization")
+    try:
+        with _server_errors_as_responses(client):
+            cb = client.get(
+                "/callback",
+                params={"code": "auth-code-1", "state": state},
+                follow_redirects=False,
+            )
+    finally:
+        client.headers["Authorization"] = auth_header
+
+    assert cb.status_code == 500
+    assert "new-tok" not in cb.text
+    assert credential_blobs.read(service, "default") == previous
+    profile = client.get("/v1/auth/anthropic/profiles/default").json()
+    assert profile["auth_type"] == "api_key"
+
+
 def test_codex_nested_callback_completes_auth_with_provider_hook(client_with_index) -> None:
     client, credential_blobs = client_with_index
     account_id = _account_id(client)
@@ -1223,7 +1467,7 @@ async def test_complete_oauth_invalidates_provider_profile_session(client_with_i
     await Tortoise.close_connections()
 
 
-def test_callback_error_html_escapes_provider_response(client_with_index) -> None:
+def test_callback_error_html_sanitizes_provider_response(client_with_index) -> None:
     client, _ = client_with_index
     client.app.state.anthropic_http_factory = _html_failing_token_factory()
     start = client.post("/v1/auth/anthropic/profiles", json={"name": "htmlfail"})
@@ -1241,7 +1485,8 @@ def test_callback_error_html_escapes_provider_response(client_with_index) -> Non
 
     assert resp.status_code == 500
     assert "<script>" not in resp.text
-    assert "&lt;script&gt;alert(&#x27;x&#x27;)&lt;/script&gt;" in resp.text
+    assert "&lt;script&gt;alert(&#x27;x&#x27;)&lt;/script&gt;" not in resp.text
+    assert "OAuth callback failed. Try again." in resp.text
 
 
 def test_callback_with_unknown_state_400(client_with_index) -> None:

--- a/apps/aigateway/tests/unit/test_credential_blob_store.py
+++ b/apps/aigateway/tests/unit/test_credential_blob_store.py
@@ -69,3 +69,20 @@ async def test_orm_store_reads_legacy_plaintext(credential_blobs, orm_store) -> 
 async def test_orm_store_delete_is_idempotent(credential_blobs, orm_store) -> None:
     await orm_store.delete("missing", "account")
     assert credential_blobs.read("missing", "account") is None
+
+
+@pytest.mark.asyncio
+async def test_orm_store_mutate_can_delete_existing_blob(credential_blobs, orm_store) -> None:
+    await orm_store.write("service", "account", "secret")
+
+    await orm_store.mutate("service", "account", lambda current: None)
+
+    assert await orm_store.read("service", "account") is None
+    assert credential_blobs.read_raw("service", "account") is None
+
+
+@pytest.mark.asyncio
+async def test_orm_store_mutate_delete_missing_blob_is_noop(credential_blobs, orm_store) -> None:
+    await orm_store.mutate("service", "account", lambda current: None)
+
+    assert await orm_store.read("service", "account") is None

--- a/apps/aigateway/tests/unit/test_profile_index.py
+++ b/apps/aigateway/tests/unit/test_profile_index.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
-import pytest
+import asyncio
 
+import pytest
+import pytest_asyncio
+from tortoise import Tortoise
+
+import aigateway.core.credential_blob.store as credential_blob_store
+from aigateway.core.credential_blob.model import CredentialBlob
+from aigateway.core.credential_blob.store import CredentialBlobMutationConflict, ORMStore
 from aigateway.core.profile_index import INDEX_CREDENTIAL_SERVICE, ProfileIndexStore
 from aigateway.core.profile_models import (
     Profile,
@@ -10,9 +17,76 @@ from aigateway.core.profile_models import (
     ProfileState,
     profile_id_for,
 )
+from aigateway.core.secrets.local import LocalSecretStore
+from aigateway.core.secrets.mixin import SecretStoreMixin
+from aigateway.db import build_tortoise_config
 
 ACCOUNT_ID = "account-1"
 OTHER_ACCOUNT_ID = "account-2"
+_TEST_KEY = bytes(range(32))
+
+
+def _index_account(account_id: str) -> str:
+    return f"account:{account_id}"
+
+
+class _BarrierSecretStore(SecretStoreMixin):
+    """Hold concurrent writes until both read the old profile index."""
+
+    def __init__(self, release_after_encrypts: int) -> None:
+        self._inner = LocalSecretStore(_TEST_KEY)
+        self._release_after_encrypts = release_after_encrypts
+        self._release = asyncio.Event()
+        self.encrypt_calls = 0
+
+    @property
+    def version(self) -> str:
+        return self._inner.version
+
+    async def encrypt(self, value: str) -> str:
+        self.encrypt_calls += 1
+        if self.encrypt_calls >= self._release_after_encrypts:
+            self._release.set()
+        await self._release.wait()
+        return await self._inner.encrypt(value)
+
+    async def decrypt(self, value: str) -> str:
+        return await self._inner.decrypt(value)
+
+
+@pytest_asyncio.fixture
+async def orm_profile_stores(credential_blobs):
+    await Tortoise.close_connections()
+    await Tortoise.init(
+        config=build_tortoise_config(f"sqlite://{credential_blobs.db_path}"),
+        _enable_global_fallback=True,
+    )
+    secret_store = _BarrierSecretStore(release_after_encrypts=2)
+    try:
+        yield (
+            ProfileIndexStore(credential_store=ORMStore(secret_store=secret_store)),
+            ProfileIndexStore(credential_store=ORMStore(secret_store=secret_store)),
+            secret_store,
+        )
+    finally:
+        await Tortoise.close_connections()
+
+
+@pytest_asyncio.fixture
+async def plain_orm_profile_stores(credential_blobs):
+    await Tortoise.close_connections()
+    await Tortoise.init(
+        config=build_tortoise_config(f"sqlite://{credential_blobs.db_path}"),
+        _enable_global_fallback=True,
+    )
+    secret_store = LocalSecretStore(_TEST_KEY)
+    try:
+        yield (
+            ProfileIndexStore(credential_store=ORMStore(secret_store=secret_store)),
+            ProfileIndexStore(credential_store=ORMStore(secret_store=secret_store)),
+        )
+    finally:
+        await Tortoise.close_connections()
 
 
 def test_profile_round_trips_through_json() -> None:
@@ -41,7 +115,7 @@ def test_profile_index_serializes_with_version() -> None:
 @pytest.mark.asyncio
 async def test_index_store_returns_empty_index_when_store_empty(credential_blobs) -> None:
     store = ProfileIndexStore(credential_store=credential_blobs.store)
-    idx = await store.read()
+    idx = await store.read(ACCOUNT_ID)
     assert idx.version == 1
     assert idx.profiles == []
 
@@ -57,12 +131,13 @@ async def test_index_store_round_trip(credential_blobs) -> None:
         defaults=ProfileDefaults(model="anthropic/claude-sonnet-4-5"),
     )
     await store.upsert(p)
-    idx = await store.read()
+    idx = await store.read(ACCOUNT_ID)
     assert len(idx.profiles) == 1
     assert idx.profiles[0].id == profile_id_for(ACCOUNT_ID, "anthropic", "default")
     assert idx.profiles[0].account_id == ACCOUNT_ID
-    raw = credential_blobs.read(INDEX_CREDENTIAL_SERVICE, "default")
+    raw = credential_blobs.read(INDEX_CREDENTIAL_SERVICE, _index_account(ACCOUNT_ID))
     assert profile_id_for(ACCOUNT_ID, "anthropic", "default") in raw
+    assert credential_blobs.read(INDEX_CREDENTIAL_SERVICE, "default") is None
 
 
 @pytest.mark.asyncio
@@ -85,7 +160,7 @@ async def test_index_store_upsert_replaces_by_id(credential_blobs) -> None:
             account_label="updated@example.com",
         )
     )
-    idx = await store.read()
+    idx = await store.read(ACCOUNT_ID)
     assert len(idx.profiles) == 1
     assert idx.profiles[0].account_label == "updated@example.com"
 
@@ -102,8 +177,103 @@ async def test_index_store_remove(credential_blobs) -> None:
         )
     )
     await store.remove(profile_id_for(ACCOUNT_ID, "anthropic", "default"))
-    idx = await store.read()
+    idx = await store.read(ACCOUNT_ID)
     assert idx.profiles == []
+
+
+@pytest.mark.asyncio
+async def test_index_store_lazy_reads_legacy_default_row(credential_blobs) -> None:
+    store = ProfileIndexStore(credential_store=credential_blobs.store)
+    legacy = ProfileIndex(
+        profiles=[
+            Profile(
+                id=profile_id_for(ACCOUNT_ID, "anthropic", "default"),
+                account_id=ACCOUNT_ID,
+                provider="anthropic",
+                name="default",
+            ),
+            Profile(
+                id=profile_id_for(OTHER_ACCOUNT_ID, "gemini", "work"),
+                account_id=OTHER_ACCOUNT_ID,
+                provider="gemini",
+                name="work",
+            ),
+        ]
+    )
+    credential_blobs.write(INDEX_CREDENTIAL_SERVICE, "default", legacy.model_dump_json())
+
+    profiles = await store.list(ACCOUNT_ID)
+
+    assert [p.name for p in profiles] == ["default"]
+    assert await store.get(OTHER_ACCOUNT_ID, "gemini", "work") is not None
+
+
+@pytest.mark.asyncio
+async def test_index_store_seeds_account_row_from_legacy_default_row(credential_blobs) -> None:
+    store = ProfileIndexStore(credential_store=credential_blobs.store)
+    legacy_profile = Profile(
+        id=profile_id_for(ACCOUNT_ID, "anthropic", "legacy"),
+        account_id=ACCOUNT_ID,
+        provider="anthropic",
+        name="legacy",
+    )
+    other_account_profile = Profile(
+        id=profile_id_for(OTHER_ACCOUNT_ID, "anthropic", "other"),
+        account_id=OTHER_ACCOUNT_ID,
+        provider="anthropic",
+        name="other",
+    )
+    credential_blobs.write(
+        INDEX_CREDENTIAL_SERVICE,
+        "default",
+        ProfileIndex(profiles=[legacy_profile, other_account_profile]).model_dump_json(),
+    )
+
+    await store.upsert(
+        Profile(
+            id=profile_id_for(ACCOUNT_ID, "anthropic", "new"),
+            account_id=ACCOUNT_ID,
+            provider="anthropic",
+            name="new",
+        )
+    )
+
+    profiles = await store.list(ACCOUNT_ID)
+    assert {p.name for p in profiles} == {"legacy", "new"}
+    raw = credential_blobs.read(INDEX_CREDENTIAL_SERVICE, _index_account(ACCOUNT_ID))
+    assert raw is not None
+    assert profile_id_for(ACCOUNT_ID, "anthropic", "legacy") in raw
+    assert profile_id_for(ACCOUNT_ID, "anthropic", "new") in raw
+    assert profile_id_for(OTHER_ACCOUNT_ID, "anthropic", "other") not in raw
+
+
+@pytest.mark.asyncio
+async def test_index_store_remove_seeds_account_row_from_legacy_default_row(
+    credential_blobs,
+) -> None:
+    store = ProfileIndexStore(credential_store=credential_blobs.store)
+    remove_profile = Profile(
+        id=profile_id_for(ACCOUNT_ID, "anthropic", "remove"),
+        account_id=ACCOUNT_ID,
+        provider="anthropic",
+        name="remove",
+    )
+    keep_profile = Profile(
+        id=profile_id_for(ACCOUNT_ID, "anthropic", "keep"),
+        account_id=ACCOUNT_ID,
+        provider="anthropic",
+        name="keep",
+    )
+    credential_blobs.write(
+        INDEX_CREDENTIAL_SERVICE,
+        "default",
+        ProfileIndex(profiles=[remove_profile, keep_profile]).model_dump_json(),
+    )
+
+    await store.remove(remove_profile.id)
+
+    profiles = await store.list(ACCOUNT_ID)
+    assert [p.name for p in profiles] == ["keep"]
 
 
 @pytest.mark.asyncio
@@ -155,6 +325,14 @@ async def test_concurrent_upserts_preserve_both_profiles() -> None:
         async def delete(self, service: str, account: str) -> None:
             self.data.pop((service, account), None)
 
+        async def mutate(self, service: str, account: str, mutator) -> None:
+            await asyncio.sleep(0)
+            next_value = mutator(self.data.get((service, account)))
+            if next_value is None:
+                self.data.pop((service, account), None)
+            else:
+                self.data[(service, account)] = next_value
+
     store = ProfileIndexStore(credential_store=_YieldingStore())
     first = Profile(
         id=profile_id_for(ACCOUNT_ID, "anthropic", "one"),
@@ -175,3 +353,226 @@ async def test_concurrent_upserts_preserve_both_profiles() -> None:
     profiles = await store.list(ACCOUNT_ID)
     assert {p.name for p in profiles} == {"one", "two"}
     assert {p.auth_type for p in profiles} == {"oauth", "api_key"}
+
+
+@pytest.mark.asyncio
+async def test_isolated_orm_stores_retry_empty_index_create_race(orm_profile_stores) -> None:
+    """Separate gateway workers must not lose the first concurrent profile writes."""
+    first_store, second_store, secret_store = orm_profile_stores
+    first = Profile(
+        id=profile_id_for(ACCOUNT_ID, "anthropic", "one"),
+        account_id=ACCOUNT_ID,
+        provider="anthropic",
+        name="one",
+    )
+    second = Profile(
+        id=profile_id_for(ACCOUNT_ID, "anthropic", "two"),
+        account_id=ACCOUNT_ID,
+        provider="anthropic",
+        name="two",
+        auth_type="api_key",
+    )
+
+    await asyncio.gather(first_store.upsert(first), second_store.upsert(second))
+
+    profiles = await first_store.list(ACCOUNT_ID)
+    assert {p.name for p in profiles} == {"one", "two"}
+    assert secret_store.encrypt_calls >= 3  # two initial attempts plus the CAS retry
+
+
+@pytest.mark.asyncio
+async def test_isolated_orm_stores_do_not_contend_across_accounts(
+    plain_orm_profile_stores,
+    credential_blobs,
+) -> None:
+    first_store, second_store = plain_orm_profile_stores
+    first = Profile(
+        id=profile_id_for(ACCOUNT_ID, "anthropic", "one"),
+        account_id=ACCOUNT_ID,
+        provider="anthropic",
+        name="one",
+    )
+    second = Profile(
+        id=profile_id_for(OTHER_ACCOUNT_ID, "anthropic", "two"),
+        account_id=OTHER_ACCOUNT_ID,
+        provider="anthropic",
+        name="two",
+    )
+
+    await asyncio.gather(first_store.upsert(first), second_store.upsert(second))
+
+    assert await first_store.get(ACCOUNT_ID, "anthropic", "one") is not None
+    assert await first_store.get(OTHER_ACCOUNT_ID, "anthropic", "two") is not None
+    assert (
+        credential_blobs.read_raw(INDEX_CREDENTIAL_SERVICE, _index_account(ACCOUNT_ID)) is not None
+    )
+    assert (
+        credential_blobs.read_raw(INDEX_CREDENTIAL_SERVICE, _index_account(OTHER_ACCOUNT_ID))
+        is not None
+    )
+    assert credential_blobs.read_raw(INDEX_CREDENTIAL_SERVICE, "default") is None
+
+
+@pytest.mark.asyncio
+async def test_profile_index_mutation_conflict_exhaustion_is_loud(
+    credential_blobs, monkeypatch
+) -> None:
+    class _ConflictOnceSecretStore(SecretStoreMixin):
+        def __init__(self) -> None:
+            self._inner = LocalSecretStore(_TEST_KEY)
+            self.conflicted = False
+
+        @property
+        def version(self) -> str:
+            return self._inner.version
+
+        async def encrypt(self, value: str) -> str:
+            return await self._inner.encrypt(value)
+
+        async def decrypt(self, value: str) -> str:
+            plaintext = await self._inner.decrypt(value)
+            if not self.conflicted:
+                self.conflicted = True
+                replacement = await self._inner.encrypt(ProfileIndex().model_dump_json())
+                await CredentialBlob.filter(
+                    service=INDEX_CREDENTIAL_SERVICE,
+                    account=_index_account(ACCOUNT_ID),
+                ).update(value=replacement, ciphertext_version=self.version)
+            return plaintext
+
+    await Tortoise.close_connections()
+    await Tortoise.init(
+        config=build_tortoise_config(f"sqlite://{credential_blobs.db_path}"),
+        _enable_global_fallback=True,
+    )
+    monkeypatch.setattr(credential_blob_store, "_MUTATE_MAX_ATTEMPTS", 1)
+    try:
+        seed_store = ProfileIndexStore(
+            credential_store=ORMStore(secret_store=LocalSecretStore(_TEST_KEY))
+        )
+        await seed_store.upsert(
+            Profile(
+                id=profile_id_for(ACCOUNT_ID, "anthropic", "seed"),
+                account_id=ACCOUNT_ID,
+                provider="anthropic",
+                name="seed",
+            )
+        )
+        conflict_store = ProfileIndexStore(
+            credential_store=ORMStore(secret_store=_ConflictOnceSecretStore())
+        )
+
+        with pytest.raises(CredentialBlobMutationConflict):
+            await conflict_store.upsert(
+                Profile(
+                    id=profile_id_for(ACCOUNT_ID, "anthropic", "new"),
+                    account_id=ACCOUNT_ID,
+                    provider="anthropic",
+                    name="new",
+                )
+            )
+    finally:
+        await Tortoise.close_connections()
+
+
+@pytest.mark.asyncio
+async def test_profile_index_mutation_exhaustion_does_not_sleep_after_final_attempt(
+    credential_blobs, monkeypatch
+) -> None:
+    class _AlwaysConflictSecretStore(SecretStoreMixin):
+        def __init__(self) -> None:
+            self._inner = LocalSecretStore(_TEST_KEY)
+
+        @property
+        def version(self) -> str:
+            return self._inner.version
+
+        async def encrypt(self, value: str) -> str:
+            return await self._inner.encrypt(value)
+
+        async def decrypt(self, value: str) -> str:
+            replacement = await self._inner.encrypt(ProfileIndex().model_dump_json())
+            await CredentialBlob.filter(
+                service=INDEX_CREDENTIAL_SERVICE,
+                account=_index_account(ACCOUNT_ID),
+            ).update(value=replacement, ciphertext_version=self.version)
+            return await self._inner.decrypt(value)
+
+    sleep_attempts: list[int] = []
+
+    async def _record_sleep(attempt: int) -> None:
+        sleep_attempts.append(attempt)
+
+    await Tortoise.close_connections()
+    await Tortoise.init(
+        config=build_tortoise_config(f"sqlite://{credential_blobs.db_path}"),
+        _enable_global_fallback=True,
+    )
+    monkeypatch.setattr(credential_blob_store, "_MUTATE_MAX_ATTEMPTS", 1)
+    monkeypatch.setattr(credential_blob_store, "_sleep_before_mutation_retry", _record_sleep)
+    try:
+        seed_store = ProfileIndexStore(
+            credential_store=ORMStore(secret_store=LocalSecretStore(_TEST_KEY))
+        )
+        await seed_store.upsert(
+            Profile(
+                id=profile_id_for(ACCOUNT_ID, "anthropic", "seed"),
+                account_id=ACCOUNT_ID,
+                provider="anthropic",
+                name="seed",
+            )
+        )
+        conflict_store = ProfileIndexStore(
+            credential_store=ORMStore(secret_store=_AlwaysConflictSecretStore())
+        )
+
+        with pytest.raises(CredentialBlobMutationConflict):
+            await conflict_store.upsert(
+                Profile(
+                    id=profile_id_for(ACCOUNT_ID, "anthropic", "new"),
+                    account_id=ACCOUNT_ID,
+                    provider="anthropic",
+                    name="new",
+                )
+            )
+
+        assert sleep_attempts == []
+    finally:
+        await Tortoise.close_connections()
+
+
+@pytest.mark.asyncio
+async def test_isolated_orm_stores_preserve_concurrent_remove_and_upsert(
+    plain_orm_profile_stores,
+) -> None:
+    seed_store, _ = plain_orm_profile_stores
+    keep = Profile(
+        id=profile_id_for(ACCOUNT_ID, "anthropic", "keep"),
+        account_id=ACCOUNT_ID,
+        provider="anthropic",
+        name="keep",
+    )
+    remove = Profile(
+        id=profile_id_for(ACCOUNT_ID, "anthropic", "remove"),
+        account_id=ACCOUNT_ID,
+        provider="anthropic",
+        name="remove",
+    )
+    await seed_store.upsert(keep)
+    await seed_store.upsert(remove)
+
+    barrier = _BarrierSecretStore(release_after_encrypts=2)
+    first_store = ProfileIndexStore(credential_store=ORMStore(secret_store=barrier))
+    second_store = ProfileIndexStore(credential_store=ORMStore(secret_store=barrier))
+    add = Profile(
+        id=profile_id_for(ACCOUNT_ID, "anthropic", "add"),
+        account_id=ACCOUNT_ID,
+        provider="anthropic",
+        name="add",
+    )
+
+    await asyncio.gather(first_store.remove(remove.id), second_store.upsert(add))
+
+    profiles = await seed_store.list(ACCOUNT_ID)
+    assert {p.name for p in profiles} == {"keep", "add"}
+    assert barrier.encrypt_calls >= 3

--- a/docs/work/aigw/2026-07-08-SF-328-aigw-atomic-profile-oauth-writes.md
+++ b/docs/work/aigw/2026-07-08-SF-328-aigw-atomic-profile-oauth-writes.md
@@ -1,0 +1,73 @@
+---
+ticket: SF-328
+stack: aigateway
+status: completed
+started: 2026-07-08
+finished: 2026-07-09
+---
+
+# SF-328 — AIGateway Atomic Profile/OAuth Credential Writes
+
+## Intent
+
+Make profile metadata and OAuth/API-key credential state transitions atomic where possible and explicitly compensating where cross-store atomicity is not available. This closes the C6/A2/A6 failure modes where concurrent profile-index writes could lose updates, OAuth connection completion could become active before credentials were durably persisted, and API-key profile writes could leave orphan credential blobs after profile-index failure.
+
+## Planned changes
+
+- `apps/aigateway/src/aigateway/core/credential_blob/store.py`: add a credential-blob mutation primitive with optimistic retry/conflict signaling.
+- `apps/aigateway/src/aigateway/core/profile_index.py`: route profile-index `upsert` and `remove` through the mutation primitive instead of read/modify/write.
+- `apps/aigateway/src/aigateway/main.py`: map profile-index mutation conflicts to a retryable sanitized response.
+- `apps/aigateway/src/aigateway/routes/auth.py`: persist OAuth connection credentials before activation, add activation-conflict cleanup, and add API-key profile-index failure compensation.
+- `apps/aigateway/src/aigateway/routes/oauth_connections.py`: share sanitized credential persistence behavior for API-key connection writes.
+- `apps/aigateway/src/aigateway/routes/credential_persistence.py`: centralize sanitized credential-persistence failure handling.
+- `apps/aigateway/tests/**`: add concurrency, retry-exhaustion, and injected-failure coverage for the protected state transitions.
+
+## Test plan
+
+- Cover concurrent profile-index updates across isolated store instances and assert no lost profile metadata.
+- Cover empty-index create races, retry behavior, retry exhaustion, and concurrent remove/upsert behavior.
+- Inject OAuth connection credential persistence failure and assert the connection does not become active without credentials.
+- Inject OAuth connection activation conflict after credential persistence and assert connection-scoped credentials are deleted as compensation.
+- Inject profile API-key index failure for new and existing profiles and assert the new blob is deleted or the prior blob is restored.
+- Assert retryable profile-index conflicts return sanitized `503` responses instead of raw internal errors.
+
+## Acceptance
+
+- Profile metadata writes are protected by a database-backed optimistic mutation path suitable for multi-worker deployments using the existing JSON index.
+- OAuth connection completion cannot leave an active connection without usable credentials.
+- Profile API-key writes include tested cleanup/restore compensation when profile-index persistence fails.
+- Tests cover concurrent isolated-store updates and injected write failures.
+- No schema or model change is part of this unit; no migration is required.
+
+## Test-Contract Exception
+
+- Rule-5 Confidence-Gate approval granted by the requester on 2026-07-09 for the single prior-test behavior rewrite in `apps/aigateway/tests/unit/test_auth_routes.py`.
+- The rewritten test is `test_connection_completion_persists_credentials_after_store_complete` renamed to `test_connection_completion_deletes_credentials_when_activation_conflicts`.
+- The old assertion encoded the prior buggy ordering. The new assertion is stricter and verifies the fixed A2 behavior: credentials are persisted before activation, and activation conflict triggers credential deletion compensation.
+- The remaining modified test files add coverage or update test doubles to satisfy the expanded credential-store port; they do not weaken prior assertions.
+- Additional approval granted on 2026-07-09 for tightening browser/loopback OAuth callback error-page assertions. The prior contract required provider exception text to be HTML-escaped; the new contract is stricter and requires provider exception text not to be rendered at all, even escaped.
+
+## Architecture Notes
+
+- The mutation behavior is exposed on the credential-blob port and consumed unconditionally by `ProfileIndexStore`, preserving the repository boundary and avoiding implementation-type checks.
+- The mutation behavior now supports `None` as a CAS delete/no-op result, so compensation can restore or delete a credential only when the slot still contains this request's write.
+- Profile metadata is stored in account-scoped index rows (`account:<account_id>`) instead of one gateway-global row; legacy `default` row data is read lazily so existing profiles remain visible.
+- The credential blob model shape is unchanged, and model files were not modified.
+- Cross-store profile/OAuth operations use explicit compensation rather than pretending profile metadata and credential writes are a single database transaction.
+
+## Hardening Follow-Up
+
+- OAuth connection activation failures after credential persistence now delete connection-scoped credentials, mark the connection `error`, and return a sanitized retryable response for non-`IntegrityError` failures.
+- OAuth browser and loopback callback generic failures now render a static sanitized message instead of provider exception text.
+- Added tests for OAuth activation non-integrity failure cleanup, OAuth delete-compensation double-fault logging, API-key compensation double-fault logging, and sanitized browser/loopback callback error pages.
+- Re-OAuth over an existing API-key profile now restores the prior API-key blob when profile-index completion fails.
+- API-key compensation now preserves a concurrent slot write instead of blindly restoring/deleting over it.
+- Added tests for nullable credential mutation delete/no-op behavior, API-key CAS compensation, API-key restore double-fault logging, and final-attempt retry exhaustion without extra backoff.
+- Added tests for account-scoped profile-index writes, cross-account non-contention, and lazy legacy `default` row preservation.
+
+## Outcome
+
+- **Actual files:** planned AIGateway source and test files plus this work ledger.
+- **Commits:** committed locally for SF-328.
+- **Gates:** affected unit set passed (`224 passed`); canonical AIGateway gate passed with the approved append-only exception applied: `ALL GATES GREEN`.
+- **Deviations:** no schema/model migration was added; the fix stays within the existing credential/profile storage shape.


### PR DESCRIPTION
## Description
Harden AIGateway profile metadata and OAuth/API-key credential writes for SF-328.

- Adds an optimistic credential-blob mutation path and uses it for profile-index updates.
- Stores profile metadata in account-scoped index rows while lazily preserving legacy `default` row reads.
- Persists OAuth connection credentials before activation and compensates on activation failures.
- Adds API-key cleanup/restore compensation for profile-index failures, including CAS-safe preservation of concurrent slot writes.
- Sanitizes retryable profile-index/OAuth failure responses and callback error pages.

Asana: https://app.asana.com/1/1185126988600652/project/1213628819033917/task/1216051639605302

## Affected Dependencies
None.

## How has this been tested?
- `uv run pytest tests/unit/test_profile_index.py -q`
- `uv run pytest tests/unit/anthropic/test_bootstrap.py -q`
- Affected AIGateway unit set: `224 passed`
- AIGateway quality gate with the documented append-only exception path: `ALL GATES GREEN`

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
