### PR TITLE
chore(OME-378): SDLC-gate UserPromptSubmit hook — enforce work-item-first

### DIFF
--- a/.claude/hooks/sdlc-gate.py
+++ b/.claude/hooks/sdlc-gate.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""UserPromptSubmit hook — re-inject the ScreamingFace SDLC work-item gate on every prompt.
+
+Advisory rules in CLAUDE.md don't self-enforce (they lose to the immediate task framing).
+This hook re-states the non-negotiable gate each turn so "file the work item first" stays
+salient. Non-blocking: it only injects context, never denies. Refs: OME-378.
+"""
+import json
+
+GATE = (
+    "[SDLC GATE — screamingface] If this turn starts a UNIT OF WORK: "
+    "(1) file the Linear issue (OME-N, Engineering / 😱 ScreamingFace V1) AND create a "
+    "docs/work ledger BEFORE writing any tracked path (docs/ .claude/ apps/ packages/ web/) "
+    "— never defer with \"want me to file?\"; "
+    "(2) invoke working-in-this-repo + task-management (+ the stack's sdlc-* skill for code); "
+    "(3) order is spec → plan → code; (4) never commit to main. "
+    "The scratchpad and the plan file are the ONLY exempt writes. "
+    "Pure question / read-only turn? Ignore this line."
+)
+
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "UserPromptSubmit",
+        "additionalContext": GATE,
+    }
+}))

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,5 +14,19 @@
       "mcp__plugin_playwright_playwright__*"
     ],
     "defaultMode": "plan"
+  },
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/sdlc-gate.py\"",
+            "timeout": 10,
+            "statusMessage": "SDLC gate"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/docs/tasks/2026-07-10-sdlc-gate-hook.md
+++ b/docs/tasks/2026-07-10-sdlc-gate-hook.md
@@ -1,0 +1,18 @@
+---
+id: OME-378
+linear_url: https://linear.app/openmined/issue/OME-378/chorerepo-sdlc-gate-userpromptsubmit-hook-enforce-work-item-first
+status: in_progress
+type: task
+priority: P2
+labels: [repo, autonomous, agentic]
+created: 2026-07-10
+closed:
+---
+
+Repo-wide, checked-in `UserPromptSubmit` hook that re-injects a compact SDLC gate every
+prompt, so work-item-first stops depending on long-context recall. Change:
+`.claude/settings.json` (add `hooks.UserPromptSubmit`, merged with existing `permissions`)
++ `.claude/hooks/sdlc-gate.py` (prints the gate as `additionalContext`; non-blocking).
+Motivated by the OME-377 process gap (artifacts produced before a work item existed).
+Scope/strength owner-approved: repo-wide + reminder-only (a PreToolUse write-guard was
+deferred). Ledger: `docs/work/2026-07-10-OME-378-sdlc-gate-hook.md`.

--- a/docs/work/2026-07-10-OME-378-sdlc-gate-hook.md
+++ b/docs/work/2026-07-10-OME-378-sdlc-gate-hook.md
@@ -1,0 +1,49 @@
+---
+ticket: OME-378
+stack: repo
+status: in_progress   # planned | in_progress | done | blocked
+started: 2026-07-10
+finished:
+---
+
+# OME-378 — SDLC-gate UserPromptSubmit hook (enforce work-item-first)
+
+## Intent
+
+CLAUDE.md already mandates work-item-first, but as long-context advisory text it lost to the
+immediate task framing on OME-377 (artifacts produced before a work item existed). Advisory
+rules don't self-enforce; the harness runs hooks. Add a repo-wide `UserPromptSubmit` hook
+that re-injects a compact SDLC gate every prompt so the rule stays salient.
+
+## Planned changes
+
+- `.claude/hooks/sdlc-gate.py` — prints the gate as JSON `hookSpecificOutput.additionalContext`
+  (non-blocking): file OME-N + docs/work ledger BEFORE writing tracked paths
+  (`docs/`, `.claude/`, `apps/`, `packages/`, `web/`); invoke working-in-this-repo +
+  task-management (+ sdlc-* for code); order spec→plan→code; never commit to main; scratchpad
+  + plan file exempt.
+- `.claude/settings.json` — add `hooks.UserPromptSubmit` → runs that script (merged with the
+  existing `permissions` block, not replacing it).
+
+## Test plan (config unit — verification, not TDD)
+
+- `echo '{}' | python3 .claude/hooks/sdlc-gate.py | jq -e .hookSpecificOutput.additionalContext` → valid JSON. ✅
+- `jq -e . .claude/settings.json` → parses. ✅
+- `jq -e '.hooks.UserPromptSubmit[].hooks[] | select(.type=="command") | .command'` → wired. ✅
+- `.permissions.allow` still 11 entries (merge, not overwrite). ✅
+- Live-fire: UserPromptSubmit fires outside this turn — confirm on the next prompt; `/hooks`
+  reload if the settings watcher didn't pick up the new hook.
+
+## Acceptance
+
+- Hook fires on prompt submit; gate text appears; nothing blocks.
+- `permissions` preserved.
+- Committed with `Refs: OME-378`.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** `.claude/hooks/sdlc-gate.py`, `.claude/settings.json` (+ this ledger +
+  docs/tasks mirror). Static checks 1–4 passed; live-fire pending next prompt.
+- **Commits:** _pending — not yet committed._
+- **Gates:** config unit — no run_gates; jq/pipe-test validation passed.
+- **Deviations:** PreToolUse write-guard considered and deferred (reminder-only, per owner).


### PR DESCRIPTION
## What

A repo-wide, checked-in `UserPromptSubmit` hook that re-injects a compact SDLC gate on **every** prompt, so the work-item-first rule stops depending on long-context recall.

- `.claude/hooks/sdlc-gate.py` — prints the gate as JSON `hookSpecificOutput.additionalContext` (non-blocking): file the `OME-N` issue + `docs/work` ledger **before** writing tracked paths (`docs/ .claude/ apps/ packages/ web/`); invoke `task-management` / `working-in-this-repo` / `sdlc-*`; order spec→plan→code; never commit to `main`; scratchpad + plan file exempt.
- `.claude/settings.json` — adds `hooks.UserPromptSubmit` → runs that script, **merged** with the existing `permissions` block (not replaced).

## Why

On OME-377 a full session produced repo artifacts (diagrams, a skill, a README edit) **before** any work item existed. CLAUDE.md rules 1–2 were in context but lost to the task framing — advisory rules don't self-enforce; the harness runs hooks. Scope/strength owner-approved: **repo-wide + reminder-only** (a `PreToolUse` write-guard was considered and deferred).

## Verification

- `echo '{}' | python3 .claude/hooks/sdlc-gate.py | jq -e .hookSpecificOutput.additionalContext` → valid JSON ✅
- `jq -e . .claude/settings.json` parses ✅ · hook wired under `UserPromptSubmit` ✅ · `permissions.allow` still 11 entries (merge, not overwrite) ✅
- Live-fire confirmed: the gate injected on the "push and PR" prompt that produced this PR.

Refs: OME-378 · https://linear.app/openmined/issue/OME-378

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EooGdwRWNBBcDrtFDcRkaD
