### PR TITLE
docs(OME-322): close-out — mirror status to done

### DIFF
--- a/docs/tasks/2026-07-09-import-lmarena-baselines.md
+++ b/docs/tasks/2026-07-09-import-lmarena-baselines.md
@@ -1,12 +1,12 @@
 ---
 id: OME-322
 linear_url: https://linear.app/openmined/issue/OME-322/sf-28-leaderboard-import-single-model-baselines-from-lmarena
-status: in_review
+status: done
 type: task
 priority: P2
 labels: [Leaderboard, app/scoreboard, autonomous, agentic]
 created: 2026-07-09
-closed:
+closed: 2026-07-10
 ---
 
 Seed each benchmark's "line to beat" from external single-model baselines.


### PR DESCRIPTION
## Summary
- Docs-only: syncs the docs/tasks mirror status to `done` now that OME-322 is merged (#379) and closed in Linear.

Refs: OME-322

🤖 Generated with [Claude Code](https://claude.com/claude-code)