### PR TITLE
fix(scoreboard): server-enforce submission dedup by content hash

### DIFF
--- a/apps/scoreboard/src/scoreboard/routes/scores.py
+++ b/apps/scoreboard/src/scoreboard/routes/scores.py
@@ -146,6 +146,11 @@ async def submit_score(
                 response.status_code = status.HTTP_200_OK
                 return existing
 
+        existing_by_recipe = await store.get_by_content_hash(submission)
+        if existing_by_recipe is not None:
+            response.status_code = status.HTTP_200_OK
+            return existing_by_recipe
+
         return await store.submit(submission, idempotency_key=idempotency_key)
     except OperationalError as exc:
         raise HTTPException(

--- a/apps/scoreboard/src/scoreboard/routes/scores.py
+++ b/apps/scoreboard/src/scoreboard/routes/scores.py
@@ -140,16 +140,10 @@ async def submit_score(
             )
 
         store = cast(ScoreStore, request.app.state.score_store)
-        if idempotency_key is not None:
-            existing = await store.get_by_idempotency_key(idempotency_key)
-            if existing is not None:
-                response.status_code = status.HTTP_200_OK
-                return existing
-
-        existing_by_recipe = await store.get_by_content_hash(submission)
-        if existing_by_recipe is not None:
+        existing = await store.find_existing(submission, idempotency_key=idempotency_key)
+        if existing is not None:
             response.status_code = status.HTTP_200_OK
-            return existing_by_recipe
+            return existing
 
         return await store.submit(submission, idempotency_key=idempotency_key)
     except OperationalError as exc:

--- a/apps/scoreboard/src/scoreboard/routes/scores.py
+++ b/apps/scoreboard/src/scoreboard/routes/scores.py
@@ -140,12 +140,14 @@ async def submit_score(
             )
 
         store = cast(ScoreStore, request.app.state.score_store)
-        existing = await store.find_existing(submission, idempotency_key=idempotency_key)
-        if existing is not None:
+        outcome = await store.submit(submission, idempotency_key=idempotency_key)
+        if not outcome.created:
+            # WHY: a single atomic submit() call — not a separate pre-check plus a
+            # second call — so the reported status code always matches what actually
+            # happened, including under a concurrent-duplicate race (found in PR
+            # review, OME-391 / C28).
             response.status_code = status.HTTP_200_OK
-            return existing
-
-        return await store.submit(submission, idempotency_key=idempotency_key)
+        return outcome.score
     except OperationalError as exc:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/apps/scoreboard/src/scoreboard/scores/migrations/0003_auto_20260713_1505.py
+++ b/apps/scoreboard/src/scoreboard/scores/migrations/0003_auto_20260713_1505.py
@@ -1,0 +1,16 @@
+from tortoise import fields, migrations
+from tortoise.migrations import operations as ops
+
+
+class Migration(migrations.Migration):
+    dependencies = [("models", "0002_auto_20260709_1350")]
+
+    initial = False
+
+    operations = [
+        ops.AddField(
+            model_name="Score",
+            name="content_hash",
+            field=fields.CharField(null=True, unique=True, max_length=64),
+        ),
+    ]

--- a/apps/scoreboard/src/scoreboard/scores/models/score.py
+++ b/apps/scoreboard/src/scoreboard/scores/models/score.py
@@ -27,6 +27,14 @@ class BaseScore(BaseScoreboardModel):
     client_platform = fields.CharField(max_length=32, null=True)
     verified_by_openmined = fields.BooleanField(default=False)
     metadata = fields.JSONField(null=True)
+    # INVARIANT: sha256 hex over the submission's recipe identity (benchmark, spec,
+    # url4 expression, result numbers, provider order) — NOT submitted_by or client
+    # metadata. Unique so the DB itself rejects a duplicate recipe, independent of
+    # any client-supplied Idempotency-Key (OME-391 / C28). Nullable so this column
+    # can be added to a table with pre-existing rows without a backfill migration —
+    # multiple NULLs don't violate a unique constraint, and every row created from
+    # here on always gets one (the store always computes it on submit).
+    content_hash = fields.CharField(max_length=64, unique=True, null=True)
 
 
 class Score(BaseScore):

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import json
 from datetime import UTC, datetime, timedelta
 from typing import cast
 from uuid import UUID
@@ -66,7 +68,26 @@ def _submission_to_kwargs(submission: ScoreSubmission) -> dict[str, object]:
         "client_version": submission.client.version if submission.client else None,
         "client_platform": submission.client.platform if submission.client else None,
         "metadata": submission.metadata,
+        "content_hash": _content_hash(submission),
     }
+
+
+def _content_hash(submission: ScoreSubmission) -> str:
+    # WHY: identity is the recipe (what was run + its result), not who ran it or
+    # when — submitted_by/client_*/ran_at_local/metadata are deliberately excluded.
+    # Provider order is kept as submitted (not sorted) since it's part of what
+    # actually happened, not incidental serialization (OME-391 / C28).
+    identity = {
+        "benchmark_id": submission.benchmark_id,
+        "spec_id": submission.spec_id,
+        "url4_expression": submission.url4_expression,
+        "accuracy": submission.accuracy,
+        "total_questions": submission.total_questions,
+        "correct_questions": submission.correct_questions,
+        "ran_with_providers": submission.ran_with_providers,
+    }
+    encoded = json.dumps(identity, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
 
 def _build_leaderboard_query(benchmark_id: str, top_n: int) -> QueryBuilder:
@@ -134,19 +155,35 @@ class ScoreStore:
         rows = await Benchmark.all().order_by("id")
         return [_benchmark_to_schema(benchmark) for benchmark in rows]
 
+    async def _resolve_existing(
+        self,
+        idempotency_key: str | None,
+        content_hash: str,
+    ) -> Score | None:
+        # Shared by the pre-insert check and the post-IntegrityError race handler —
+        # idempotency_key (a fast path keyed to one client's retry) takes priority
+        # when present; content_hash is the unconditional backstop (OME-391 / C28).
+        if idempotency_key is not None:
+            linked = await IdempotencyKey.get_or_none(
+                key=idempotency_key,
+                expires_at__gt=datetime.now(UTC),
+            ).prefetch_related("score")
+            if linked is not None:
+                return linked.score
+
+        return await Score.get_or_none(content_hash=content_hash)
+
     async def submit(
         self,
         submission: ScoreSubmission,
         idempotency_key: str | None = None,
     ) -> ScoreSchema:
         now_ts = datetime.now(UTC)
-        if idempotency_key is not None:
-            existing = await IdempotencyKey.get_or_none(
-                key=idempotency_key,
-                expires_at__gt=now_ts,
-            ).prefetch_related("score")
-            if existing is not None:
-                return _score_to_schema(existing.score)
+        content_hash = _content_hash(submission)
+
+        existing = await self._resolve_existing(idempotency_key, content_hash)
+        if existing is not None:
+            return _score_to_schema(existing)
 
         expires_at = now_ts + IDEMPOTENCY_TTL
         try:
@@ -176,17 +213,18 @@ class ScoreStore:
 
             return _score_to_schema(score)
         except IntegrityError:
-            if idempotency_key is None:
-                raise
-
-            live = await IdempotencyKey.get_or_none(
-                key=idempotency_key,
-                expires_at__gt=datetime.now(UTC),
-            ).prefetch_related("score")
-            if live is not None:
-                return _score_to_schema(live.score)
-
+            # A concurrent request may have won the race on either constraint.
+            existing = await self._resolve_existing(idempotency_key, content_hash)
+            if existing is not None:
+                return _score_to_schema(existing)
             raise
+
+    async def get_by_content_hash(self, submission: ScoreSubmission) -> ScoreSchema | None:
+        # Mirrors get_by_idempotency_key's shape — the route pre-checks this to know
+        # whether to answer 200 (existing) vs 201 (new), same as the idempotency-key
+        # path already does (OME-391 / C28).
+        existing = await Score.get_or_none(content_hash=_content_hash(submission))
+        return _score_to_schema(existing) if existing is not None else None
 
     async def get_by_idempotency_key(self, key: str) -> ScoreSchema | None:
         now_ts = datetime.now(UTC)

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -231,7 +231,9 @@ class ScoreStore:
         # whether a submission would dedupe, e.g. to answer 200 vs 201 — reuses the
         # exact same idempotency-key-then-content-hash priority as submit()'s own
         # pre-check, via one hash computation, instead of two separate lookups
-        # (OME-391 / C28).
+        # (OME-391 / C28). NOTE: submit() re-runs this same resolution internally on
+        # a miss — that's intentional (submit() must stand alone for callers that skip
+        # this pre-check), not a bug to "optimize away".
         existing = await self._resolve_existing(idempotency_key, _content_hash(submission))
         return _score_to_schema(existing) if existing is not None else None
 

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 from datetime import UTC, datetime, timedelta
-from typing import cast
+from typing import NamedTuple, cast
 from uuid import UUID
 
 from pypika_tortoise.analytics import RowNumber
@@ -80,17 +80,27 @@ def _content_hash(submission: ScoreSubmission) -> str:
     # also excluded — currently a no-op since ScoreSubmission.version is pinned to
     # Literal[1], but revisit this if a future schema version is ever accepted, since
     # two payloads differing only in version would otherwise dedupe together.
+    # accuracy is recomputed from correct_questions/total_questions rather than the
+    # client's raw reported value: the route accepts any reported accuracy within
+    # 0.01 of that ratio, so the same result (e.g. 2/3 correct) could otherwise be
+    # reported as 0.67 or 0.6666666667 and hash differently, defeating dedup for the
+    # exact near-duplicate case this hash exists to catch (found in PR review).
     identity = {
         "benchmark_id": submission.benchmark_id,
         "spec_id": submission.spec_id,
         "url4_expression": submission.url4_expression,
-        "accuracy": submission.accuracy,
+        "accuracy": submission.correct_questions / submission.total_questions,
         "total_questions": submission.total_questions,
         "correct_questions": submission.correct_questions,
         "ran_with_providers": submission.ran_with_providers,
     }
     encoded = json.dumps(identity, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+class SubmitOutcome(NamedTuple):
+    score: ScoreSchema
+    created: bool
 
 
 def _build_leaderboard_query(benchmark_id: str, top_n: int) -> QueryBuilder:
@@ -166,27 +176,62 @@ class ScoreStore:
         # Shared by the pre-insert check and the post-IntegrityError race handler —
         # idempotency_key (a fast path keyed to one client's retry) takes priority
         # when present; content_hash is the unconditional backstop (OME-391 / C28).
+        now_ts = datetime.now(UTC)
         if idempotency_key is not None:
             linked = await IdempotencyKey.get_or_none(
                 key=idempotency_key,
-                expires_at__gt=datetime.now(UTC),
+                expires_at__gt=now_ts,
             ).prefetch_related("score")
             if linked is not None:
                 return linked.score
 
-        return await Score.get_or_none(content_hash=content_hash)
+        existing = await Score.get_or_none(content_hash=content_hash)
+        if existing is not None and idempotency_key is not None:
+            # INVARIANT: a content-hash hit with an idempotency_key attached must
+            # bind that key to the found score NOW. Without this, the key stays
+            # unbound and a later, unrelated submission reusing it would silently
+            # rebind it to different content — breaking "the same key always
+            # replays the same original result" (found in PR review, OME-391 / C28).
+            await self._bind_idempotency_key(idempotency_key, existing, now_ts)
+        return existing
+
+    async def _bind_idempotency_key(
+        self,
+        idempotency_key: str,
+        score: Score,
+        now_ts: datetime,
+    ) -> None:
+        # Any stale (expired) row for this key is cleared first so it can be rebound
+        # cleanly. IntegrityError on create means a concurrent request already won
+        # this exact bind — the desired end state (key bound to this score) holds
+        # either way, so it's safe to ignore.
+        try:
+            async with in_transaction() as connection:
+                await (
+                    IdempotencyKey.filter(key=idempotency_key, expires_at__lte=now_ts)
+                    .using_db(connection)
+                    .delete()
+                )
+                await IdempotencyKey.create(
+                    using_db=connection,
+                    key=idempotency_key,
+                    score=score,
+                    expires_at=now_ts + IDEMPOTENCY_TTL,
+                )
+        except IntegrityError:
+            pass
 
     async def submit(
         self,
         submission: ScoreSubmission,
         idempotency_key: str | None = None,
-    ) -> ScoreSchema:
+    ) -> SubmitOutcome:
         now_ts = datetime.now(UTC)
         content_hash = _content_hash(submission)
 
         existing = await self._resolve_existing(idempotency_key, content_hash)
         if existing is not None:
-            return _score_to_schema(existing)
+            return SubmitOutcome(score=_score_to_schema(existing), created=False)
 
         expires_at = now_ts + IDEMPOTENCY_TTL
         try:
@@ -214,28 +259,13 @@ class ScoreStore:
                         expires_at=expires_at,
                     )
 
-            return _score_to_schema(score)
+            return SubmitOutcome(score=_score_to_schema(score), created=True)
         except IntegrityError:
             # A concurrent request may have won the race on either constraint.
             existing = await self._resolve_existing(idempotency_key, content_hash)
             if existing is not None:
-                return _score_to_schema(existing)
+                return SubmitOutcome(score=_score_to_schema(existing), created=False)
             raise
-
-    async def find_existing(
-        self,
-        submission: ScoreSubmission,
-        idempotency_key: str | None = None,
-    ) -> ScoreSchema | None:
-        # Public entry point for a caller (the route) that needs to know up front
-        # whether a submission would dedupe, e.g. to answer 200 vs 201 — reuses the
-        # exact same idempotency-key-then-content-hash priority as submit()'s own
-        # pre-check, via one hash computation, instead of two separate lookups
-        # (OME-391 / C28). NOTE: submit() re-runs this same resolution internally on
-        # a miss — that's intentional (submit() must stand alone for callers that skip
-        # this pre-check), not a bug to "optimize away".
-        existing = await self._resolve_existing(idempotency_key, _content_hash(submission))
-        return _score_to_schema(existing) if existing is not None else None
 
     async def get_by_idempotency_key(self, key: str) -> ScoreSchema | None:
         now_ts = datetime.now(UTC)

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -52,7 +52,7 @@ def _score_to_schema(model: Score) -> ScoreSchema:
     )
 
 
-def _submission_to_kwargs(submission: ScoreSubmission) -> dict[str, object]:
+def _submission_to_kwargs(submission: ScoreSubmission, content_hash: str) -> dict[str, object]:
     return {
         "benchmark_id": submission.benchmark_id,
         "version": submission.version,
@@ -68,7 +68,7 @@ def _submission_to_kwargs(submission: ScoreSubmission) -> dict[str, object]:
         "client_version": submission.client.version if submission.client else None,
         "client_platform": submission.client.platform if submission.client else None,
         "metadata": submission.metadata,
-        "content_hash": _content_hash(submission),
+        "content_hash": content_hash,
     }
 
 
@@ -76,7 +76,10 @@ def _content_hash(submission: ScoreSubmission) -> str:
     # WHY: identity is the recipe (what was run + its result), not who ran it or
     # when — submitted_by/client_*/ran_at_local/metadata are deliberately excluded.
     # Provider order is kept as submitted (not sorted) since it's part of what
-    # actually happened, not incidental serialization (OME-391 / C28).
+    # actually happened, not incidental serialization (OME-391 / C28). `version` is
+    # also excluded — currently a no-op since ScoreSubmission.version is pinned to
+    # Literal[1], but revisit this if a future schema version is ever accepted, since
+    # two payloads differing only in version would otherwise dedupe together.
     identity = {
         "benchmark_id": submission.benchmark_id,
         "spec_id": submission.spec_id,
@@ -200,7 +203,7 @@ class ScoreStore:
 
                 score = await Score.create(
                     using_db=connection,
-                    **_submission_to_kwargs(submission),
+                    **_submission_to_kwargs(submission, content_hash),
                 )
 
                 if idempotency_key is not None:
@@ -219,11 +222,17 @@ class ScoreStore:
                 return _score_to_schema(existing)
             raise
 
-    async def get_by_content_hash(self, submission: ScoreSubmission) -> ScoreSchema | None:
-        # Mirrors get_by_idempotency_key's shape — the route pre-checks this to know
-        # whether to answer 200 (existing) vs 201 (new), same as the idempotency-key
-        # path already does (OME-391 / C28).
-        existing = await Score.get_or_none(content_hash=_content_hash(submission))
+    async def find_existing(
+        self,
+        submission: ScoreSubmission,
+        idempotency_key: str | None = None,
+    ) -> ScoreSchema | None:
+        # Public entry point for a caller (the route) that needs to know up front
+        # whether a submission would dedupe, e.g. to answer 200 vs 201 — reuses the
+        # exact same idempotency-key-then-content-hash priority as submit()'s own
+        # pre-check, via one hash computation, instead of two separate lookups
+        # (OME-391 / C28).
+        existing = await self._resolve_existing(idempotency_key, _content_hash(submission))
         return _score_to_schema(existing) if existing is not None else None
 
     async def get_by_idempotency_key(self, key: str) -> ScoreSchema | None:

--- a/apps/scoreboard/tests/unit/scores/test_models.py
+++ b/apps/scoreboard/tests/unit/scores/test_models.py
@@ -37,6 +37,17 @@ def test_score_model_table_names_and_indexes() -> None:
     assert ("benchmark_id", "spec_id", "submitted_at") in Score._meta.indexes
 
 
+def test_score_model_content_hash_field_is_unique_and_nullable() -> None:
+    # Mirrors what migration 0003 adds — nullable so it can be added to a table with
+    # pre-existing rows without a backfill, unique so the DB itself rejects a
+    # duplicate recipe (OME-391 / C28).
+    content_hash_field = cast(Any, Score._meta.fields_map["content_hash"])
+
+    assert content_hash_field.unique is True
+    assert content_hash_field.null is True
+    assert content_hash_field.max_length == 64
+
+
 def test_score_model_relations_use_expected_delete_rules() -> None:
     benchmark_field = cast(Any, Score._meta.fields_map["benchmark"])
     score_field = cast(Any, IdempotencyKey._meta.fields_map["score"])

--- a/apps/scoreboard/tests/unit/scores/test_store.py
+++ b/apps/scoreboard/tests/unit/scores/test_store.py
@@ -210,6 +210,66 @@ async def test_mark_verified_flips_score_flag(tortoise_db: None) -> None:
     assert verified.verified_by_openmined is True
 
 
+async def test_submit_identical_recipe_without_header_returns_existing_score(
+    tortoise_db: None,
+) -> None:
+    store = await _store_with_benchmark()
+
+    first = await store.submit(_submission(spec_id="spec-dup", accuracy=0.42))
+    second = await store.submit(_submission(spec_id="spec-dup", accuracy=0.42))
+
+    assert second.id == first.id
+    assert second.submitted_at == first.submitted_at
+    assert await Score.all().count() == 1
+
+
+async def test_submit_identical_recipe_ignores_submitted_by_and_client_metadata(
+    tortoise_db: None,
+) -> None:
+    store = await _store_with_benchmark()
+    first_submission = _submission(spec_id="spec-attrib", accuracy=0.6)
+    second_submission = first_submission.model_copy(
+        update={
+            "submitted_by": "someone-else",
+            "client": ClientInfo(name="other-client", version="9.9.9", platform="other"),
+            "ran_at_local": datetime(2026, 6, 1, tzinfo=UTC),
+        }
+    )
+
+    first = await store.submit(first_submission)
+    second = await store.submit(second_submission)
+
+    assert second.id == first.id
+    assert second.submitted_by == first.submitted_by
+    assert await Score.all().count() == 1
+
+
+async def test_submit_same_recipe_different_provider_order_is_not_deduped(
+    tortoise_db: None,
+) -> None:
+    store = await _store_with_benchmark()
+
+    first = await store.submit(
+        _submission(spec_id="spec-order", accuracy=0.77, providers=["openai", "gemini"])
+    )
+    second = await store.submit(
+        _submission(spec_id="spec-order", accuracy=0.77, providers=["gemini", "openai"])
+    )
+
+    assert second.id != first.id
+    assert await Score.all().count() == 2
+
+
+async def test_submit_different_accuracy_is_not_deduped(tortoise_db: None) -> None:
+    store = await _store_with_benchmark()
+
+    first = await store.submit(_submission(spec_id="spec-diff", accuracy=0.3))
+    second = await store.submit(_submission(spec_id="spec-diff", accuracy=0.31))
+
+    assert second.id != first.id
+    assert await Score.all().count() == 2
+
+
 async def test_postgres_concurrent_idempotency_submissions_share_winner(
     tortoise_db: None,
 ) -> None:
@@ -225,6 +285,21 @@ async def test_postgres_concurrent_idempotency_submissions_share_winner(
             )
             for index in range(10)
         ),
+    )
+
+    assert len({result.id for result in results}) == 1
+    assert await Score.all().count() == 1
+
+
+async def test_postgres_concurrent_identical_recipe_submissions_share_winner(
+    tortoise_db: None,
+) -> None:
+    if Tortoise.get_connection("default").capabilities.dialect != "postgres":
+        pytest.skip("requires Postgres")
+
+    store = await _store_with_benchmark()
+    results = await asyncio.gather(
+        *(store.submit(_submission(spec_id="spec-race", accuracy=0.66)) for _ in range(10)),
     )
 
     assert len({result.id for result in results}) == 1

--- a/apps/scoreboard/tests/unit/scores/test_store.py
+++ b/apps/scoreboard/tests/unit/scores/test_store.py
@@ -89,8 +89,9 @@ async def test_register_benchmark_updates_existing_row(tortoise_db: None) -> Non
 async def test_submit_inserts_and_returns_score(tortoise_db: None) -> None:
     store = await _store_with_benchmark()
 
-    score = await store.submit(_submission())
+    score, created = await store.submit(_submission())
 
+    assert created is True
     assert score.benchmark_id == "hle"
     assert score.spec_id == "spec-1"
     assert score.accuracy == 0.75
@@ -107,9 +108,15 @@ async def test_submit_with_live_idempotency_key_returns_existing_score(
 ) -> None:
     store = await _store_with_benchmark()
 
-    first = await store.submit(_submission(accuracy=0.5), idempotency_key="repeat-key")
-    second = await store.submit(_submission(accuracy=0.9), idempotency_key="repeat-key")
+    first, first_created = await store.submit(
+        _submission(accuracy=0.5), idempotency_key="repeat-key"
+    )
+    second, second_created = await store.submit(
+        _submission(accuracy=0.9), idempotency_key="repeat-key"
+    )
 
+    assert first_created is True
+    assert second_created is False
     assert second.id == first.id
     assert second.submitted_at == first.submitted_at
     assert second.accuracy == 0.5
@@ -120,13 +127,16 @@ async def test_submit_with_expired_idempotency_key_creates_new_score(
     tortoise_db: None,
 ) -> None:
     store = await _store_with_benchmark()
-    first = await store.submit(_submission(accuracy=0.5), idempotency_key="expired-key")
+    first, _ = await store.submit(_submission(accuracy=0.5), idempotency_key="expired-key")
     await IdempotencyKey.filter(key="expired-key").update(
         expires_at=datetime.now(UTC) - timedelta(seconds=1),
     )
 
-    second = await store.submit(_submission(accuracy=0.9), idempotency_key="expired-key")
+    second, second_created = await store.submit(
+        _submission(accuracy=0.9), idempotency_key="expired-key"
+    )
 
+    assert second_created is True
     assert second.id != first.id
     assert second.accuracy == 0.9
     assert await Score.all().count() == 2
@@ -136,7 +146,7 @@ async def test_get_by_idempotency_key_respects_expiry_and_cleanup(
     tortoise_db: None,
 ) -> None:
     store = await _store_with_benchmark()
-    score = await store.submit(_submission(), idempotency_key="lookup-key")
+    score, _ = await store.submit(_submission(), idempotency_key="lookup-key")
 
     assert await store.get_by_idempotency_key("lookup-key") == score
 
@@ -169,8 +179,8 @@ async def test_leaderboard_uses_newer_submission_as_accuracy_tie_breaker(
     tortoise_db: None,
 ) -> None:
     store = await _store_with_benchmark()
-    older = await store.submit(_submission(spec_id="spec-a", accuracy=0.9, providers=["older"]))
-    newer = await store.submit(_submission(spec_id="spec-a", accuracy=0.9, providers=["newer"]))
+    older, _ = await store.submit(_submission(spec_id="spec-a", accuracy=0.9, providers=["older"]))
+    newer, _ = await store.submit(_submission(spec_id="spec-a", accuracy=0.9, providers=["newer"]))
     await Score.filter(id=older.id).update(
         submitted_at=datetime(2026, 5, 21, 12, 0, tzinfo=UTC),
     )
@@ -186,8 +196,8 @@ async def test_leaderboard_uses_newer_submission_as_accuracy_tie_breaker(
 
 async def test_list_for_spec_returns_history_newest_first(tortoise_db: None) -> None:
     store = await _store_with_benchmark()
-    older = await store.submit(_submission(spec_id="spec-history", accuracy=0.5))
-    newer = await store.submit(_submission(spec_id="spec-history", accuracy=0.8))
+    older, _ = await store.submit(_submission(spec_id="spec-history", accuracy=0.5))
+    newer, _ = await store.submit(_submission(spec_id="spec-history", accuracy=0.8))
     await Score.filter(id=older.id).update(
         submitted_at=datetime(2026, 5, 21, 12, 0, tzinfo=UTC),
     )
@@ -202,7 +212,7 @@ async def test_list_for_spec_returns_history_newest_first(tortoise_db: None) -> 
 
 async def test_mark_verified_flips_score_flag(tortoise_db: None) -> None:
     store = await _store_with_benchmark()
-    score = await store.submit(_submission())
+    score, _ = await store.submit(_submission())
 
     await store.mark_verified(score.id)
 
@@ -215,9 +225,11 @@ async def test_submit_identical_recipe_without_header_returns_existing_score(
 ) -> None:
     store = await _store_with_benchmark()
 
-    first = await store.submit(_submission(spec_id="spec-dup", accuracy=0.42))
-    second = await store.submit(_submission(spec_id="spec-dup", accuracy=0.42))
+    first, first_created = await store.submit(_submission(spec_id="spec-dup", accuracy=0.42))
+    second, second_created = await store.submit(_submission(spec_id="spec-dup", accuracy=0.42))
 
+    assert first_created is True
+    assert second_created is False
     assert second.id == first.id
     assert second.submitted_at == first.submitted_at
     assert await Score.all().count() == 1
@@ -236,9 +248,10 @@ async def test_submit_identical_recipe_ignores_submitted_by_and_client_metadata(
         }
     )
 
-    first = await store.submit(first_submission)
-    second = await store.submit(second_submission)
+    first, _ = await store.submit(first_submission)
+    second, second_created = await store.submit(second_submission)
 
+    assert second_created is False
     assert second.id == first.id
     assert second.submitted_by == first.submitted_by
     assert await Score.all().count() == 1
@@ -253,9 +266,32 @@ async def test_submit_identical_recipe_ignores_version(tortoise_db: None) -> Non
     first_submission = _submission(spec_id="spec-version", accuracy=0.65)
     second_submission = first_submission.model_copy(update={"version": 2})
 
-    first = await store.submit(first_submission)
-    second = await store.submit(second_submission)
+    first, _ = await store.submit(first_submission)
+    second, second_created = await store.submit(second_submission)
 
+    assert second_created is False
+    assert second.id == first.id
+    assert await Score.all().count() == 1
+
+
+async def test_submit_identical_counts_dedupe_despite_different_accuracy_precision(
+    tortoise_db: None,
+) -> None:
+    # The route accepts any reported accuracy within 0.01 of correct/total, so the
+    # same result (2 of 3 correct) can arrive as 0.6666666667 or 0.67 — both must
+    # still dedupe, since the hash is derived from the counts, not the raw float
+    # (found in PR review, OME-391 / C28).
+    store = await _store_with_benchmark()
+    first_submission = _submission(spec_id="spec-precision", accuracy=0.75).model_copy(
+        update={"total_questions": 3, "correct_questions": 2, "accuracy": 0.6666666667}
+    )
+    second_submission = first_submission.model_copy(update={"accuracy": 0.67})
+
+    first, first_created = await store.submit(first_submission)
+    second, second_created = await store.submit(second_submission)
+
+    assert first_created is True
+    assert second_created is False
     assert second.id == first.id
     assert await Score.all().count() == 1
 
@@ -268,17 +304,45 @@ async def test_submit_identical_recipe_dedupes_across_different_idempotency_keys
     # content-hash backstop does (OME-391 / C28).
     store = await _store_with_benchmark()
 
-    first = await store.submit(
+    first, first_created = await store.submit(
         _submission(spec_id="spec-multi-key", accuracy=0.55),
         idempotency_key="client-a-key",
     )
-    second = await store.submit(
+    second, second_created = await store.submit(
         _submission(spec_id="spec-multi-key", accuracy=0.55),
         idempotency_key="client-b-key",
     )
 
+    assert first_created is True
+    assert second_created is False
     assert second.id == first.id
     assert second.submitted_at == first.submitted_at
+    assert await Score.all().count() == 1
+
+
+async def test_submit_reused_key_after_content_hash_hit_stays_bound_to_original_score(
+    tortoise_db: None,
+) -> None:
+    # Regression for the bug found in PR review: a content-hash hit with an
+    # idempotency_key attached must bind that key permanently. Before the fix,
+    # "client-b-key" stayed unbound after hitting recipe A via content_hash, so a
+    # later, unrelated recipe B reusing "client-b-key" would silently create a new
+    # row AND rebind the key to it — meaning a third replay of the *original*
+    # client-b-key request would then wrongly return recipe B instead of recipe A
+    # (OME-391 / C28).
+    store = await _store_with_benchmark()
+    recipe_a = _submission(spec_id="spec-bind-a", accuracy=0.55)
+    recipe_b = _submission(spec_id="spec-bind-b", accuracy=0.9)
+
+    first, _ = await store.submit(recipe_a, idempotency_key="client-a-key")
+    second, second_created = await store.submit(recipe_a, idempotency_key="client-b-key")
+    assert second_created is False
+    assert second.id == first.id
+
+    third, third_created = await store.submit(recipe_b, idempotency_key="client-b-key")
+
+    assert third_created is False
+    assert third.id == first.id
     assert await Score.all().count() == 1
 
 
@@ -287,13 +351,14 @@ async def test_submit_same_recipe_different_provider_order_is_not_deduped(
 ) -> None:
     store = await _store_with_benchmark()
 
-    first = await store.submit(
+    first, _ = await store.submit(
         _submission(spec_id="spec-order", accuracy=0.77, providers=["openai", "gemini"])
     )
-    second = await store.submit(
+    second, second_created = await store.submit(
         _submission(spec_id="spec-order", accuracy=0.77, providers=["gemini", "openai"])
     )
 
+    assert second_created is True
     assert second.id != first.id
     assert await Score.all().count() == 2
 
@@ -301,9 +366,10 @@ async def test_submit_same_recipe_different_provider_order_is_not_deduped(
 async def test_submit_different_accuracy_is_not_deduped(tortoise_db: None) -> None:
     store = await _store_with_benchmark()
 
-    first = await store.submit(_submission(spec_id="spec-diff", accuracy=0.3))
-    second = await store.submit(_submission(spec_id="spec-diff", accuracy=0.31))
+    first, _ = await store.submit(_submission(spec_id="spec-diff", accuracy=0.3))
+    second, second_created = await store.submit(_submission(spec_id="spec-diff", accuracy=0.31))
 
+    assert second_created is True
     assert second.id != first.id
     assert await Score.all().count() == 2
 
@@ -311,6 +377,9 @@ async def test_submit_different_accuracy_is_not_deduped(tortoise_db: None) -> No
 async def test_postgres_concurrent_idempotency_submissions_share_winner(
     tortoise_db: None,
 ) -> None:
+    # AIDEV-NOTE: this test currently only ever skips — see OME-430 for why
+    # (postgres_schema_database_url calls asyncio.run() inside an already-running
+    # event loop, and CI never sets SCOREBOARD_TEST_DATABASE_URL). Fix there, not here.
     if Tortoise.get_connection("default").capabilities.dialect != "postgres":
         pytest.skip("requires Postgres")
 
@@ -325,13 +394,14 @@ async def test_postgres_concurrent_idempotency_submissions_share_winner(
         ),
     )
 
-    assert len({result.id for result in results}) == 1
+    assert len({outcome.score.id for outcome in results}) == 1
     assert await Score.all().count() == 1
 
 
 async def test_postgres_concurrent_identical_recipe_submissions_share_winner(
     tortoise_db: None,
 ) -> None:
+    # AIDEV-NOTE: see OME-430 — same dead-fixture issue as the test above.
     if Tortoise.get_connection("default").capabilities.dialect != "postgres":
         pytest.skip("requires Postgres")
 
@@ -340,5 +410,5 @@ async def test_postgres_concurrent_identical_recipe_submissions_share_winner(
         *(store.submit(_submission(spec_id="spec-race", accuracy=0.66)) for _ in range(10)),
     )
 
-    assert len({result.id for result in results}) == 1
+    assert len({outcome.score.id for outcome in results}) == 1
     assert await Score.all().count() == 1

--- a/apps/scoreboard/tests/unit/scores/test_store.py
+++ b/apps/scoreboard/tests/unit/scores/test_store.py
@@ -244,6 +244,22 @@ async def test_submit_identical_recipe_ignores_submitted_by_and_client_metadata(
     assert await Score.all().count() == 1
 
 
+async def test_submit_identical_recipe_ignores_version(tortoise_db: None) -> None:
+    # `version` is deliberately excluded from the content hash (see the WHY comment
+    # on _content_hash) — model_copy bypasses the Literal[1] validator so this proves
+    # the exclusion even though the public schema can't yet submit version=2 for real
+    # (OME-391 / C28).
+    store = await _store_with_benchmark()
+    first_submission = _submission(spec_id="spec-version", accuracy=0.65)
+    second_submission = first_submission.model_copy(update={"version": 2})
+
+    first = await store.submit(first_submission)
+    second = await store.submit(second_submission)
+
+    assert second.id == first.id
+    assert await Score.all().count() == 1
+
+
 async def test_submit_identical_recipe_dedupes_across_different_idempotency_keys(
     tortoise_db: None,
 ) -> None:

--- a/apps/scoreboard/tests/unit/scores/test_store.py
+++ b/apps/scoreboard/tests/unit/scores/test_store.py
@@ -244,6 +244,28 @@ async def test_submit_identical_recipe_ignores_submitted_by_and_client_metadata(
     assert await Score.all().count() == 1
 
 
+async def test_submit_identical_recipe_dedupes_across_different_idempotency_keys(
+    tortoise_db: None,
+) -> None:
+    # The core C28 scenario: two clients each send their own Idempotency-Key for the
+    # same underlying recipe — the header alone would never catch this, only the
+    # content-hash backstop does (OME-391 / C28).
+    store = await _store_with_benchmark()
+
+    first = await store.submit(
+        _submission(spec_id="spec-multi-key", accuracy=0.55),
+        idempotency_key="client-a-key",
+    )
+    second = await store.submit(
+        _submission(spec_id="spec-multi-key", accuracy=0.55),
+        idempotency_key="client-b-key",
+    )
+
+    assert second.id == first.id
+    assert second.submitted_at == first.submitted_at
+    assert await Score.all().count() == 1
+
+
 async def test_submit_same_recipe_different_provider_order_is_not_deduped(
     tortoise_db: None,
 ) -> None:

--- a/apps/scoreboard/tests/unit/test_leaderboard_routes.py
+++ b/apps/scoreboard/tests/unit/test_leaderboard_routes.py
@@ -117,8 +117,8 @@ async def test_get_leaderboard_breaks_accuracy_ties_by_newer_submission(
 ) -> None:
     store = ScoreStore()
     await _register_benchmark(store)
-    older = await store.submit(_submission(spec_id="spec-a", accuracy=0.9, providers=["older"]))
-    newer = await store.submit(_submission(spec_id="spec-a", accuracy=0.9, providers=["newer"]))
+    older, _ = await store.submit(_submission(spec_id="spec-a", accuracy=0.9, providers=["older"]))
+    newer, _ = await store.submit(_submission(spec_id="spec-a", accuracy=0.9, providers=["newer"]))
     await Score.filter(id=older.id).update(
         submitted_at=datetime(2026, 5, 21, 12, 0, tzinfo=UTC),
     )
@@ -166,8 +166,8 @@ async def test_get_spec_history_returns_submissions_newest_first(
 ) -> None:
     store = ScoreStore()
     await _register_benchmark(store)
-    older = await store.submit(_submission(spec_id="spec-history", accuracy=0.5))
-    newer = await store.submit(_submission(spec_id="spec-history", accuracy=0.8))
+    older, _ = await store.submit(_submission(spec_id="spec-history", accuracy=0.5))
+    newer, _ = await store.submit(_submission(spec_id="spec-history", accuracy=0.8))
     await store.submit(_submission(spec_id="other-spec", accuracy=0.95))
     await Score.filter(id=older.id).update(
         submitted_at=datetime(2026, 5, 21, 12, 0, tzinfo=UTC),

--- a/apps/scoreboard/tests/unit/test_scores_routes.py
+++ b/apps/scoreboard/tests/unit/test_scores_routes.py
@@ -97,9 +97,12 @@ async def test_post_score_creates_new_row_201(score_client: AsyncClient) -> None
     assert body["verified_by_openmined"] is False
 
 
-async def test_post_score_without_idempotency_key_always_creates_new_row(
+async def test_post_score_without_idempotency_key_dedupes_identical_recipe(
     score_client: AsyncClient,
 ) -> None:
+    # WHY: dedup is server-enforced by recipe content hash, independent of any
+    # client-supplied header — a resubmitted identical recipe returns the existing
+    # row instead of creating a duplicate (OME-391 / C28).
     first = await score_client.post(
         "/v1/scores", json=_valid_payload(accuracy=0.5, correct_questions=2)
     )
@@ -108,8 +111,8 @@ async def test_post_score_without_idempotency_key_always_creates_new_row(
     )
 
     assert first.status_code == 201
-    assert second.status_code == 201
-    assert second.json()["id"] != first.json()["id"]
+    assert second.status_code == 200
+    assert second.json()["id"] == first.json()["id"]
 
 
 async def test_post_score_with_live_idempotency_key_returns_200(
@@ -136,7 +139,14 @@ async def test_post_score_with_expired_idempotency_key_creates_new_row(
 
     assert await ScoreStore().get_by_idempotency_key("expired-key") is None
 
-    second = await score_client.post("/v1/scores", json=_valid_payload(), headers=headers)
+    # A genuinely different recipe (not just a different key) — proves the expired
+    # key no longer blocks resubmission, without colliding with the unrelated
+    # content-hash dedup guard this test isn't exercising.
+    second = await score_client.post(
+        "/v1/scores",
+        json=_valid_payload(accuracy=1.0, correct_questions=4),
+        headers=headers,
+    )
 
     assert first.status_code == 201
     assert second.status_code == 201

--- a/docs/tasks/2026-07-13-scoreboard-writes-dedup.md
+++ b/docs/tasks/2026-07-13-scoreboard-writes-dedup.md
@@ -1,0 +1,25 @@
+---
+id: OME-391
+linear_url: https://linear.app/openmined/issue/OME-391/sf-324-protect-scoreboard-writes-and-deduplicate-submissions
+status: in_progress
+type: task
+priority: P1
+labels: [scoreboard, autonomous, agentic]
+created: 2026-07-13
+closed:
+---
+
+SF-324: Protect scoreboard writes and deduplicate submissions. Two grouped findings:
+
+* C2: public score submission accepts unauthenticated writes.
+* C28: duplicate submissions only dedupe via an optional client-supplied
+  `Idempotency-Key` header.
+
+Working as two steps within this one ticket (see the 2026-07-13 comment on the
+issue):
+
+1. **Now**: server-enforced dedup by recipe content hash (C28) — no product decision
+   needed. Ledger: `docs/work/2026-07-13-OME-391-scoreboard-submission-dedup.md`.
+2. **Blocked**: write-path authentication/attribution (C2) — needs a product decision
+   on uncredentialed-submission policy, and depends on OME-326 (OpenMined identity
+   provider), which doesn't exist yet.

--- a/docs/work/2026-07-13-OME-391-scoreboard-submission-dedup.md
+++ b/docs/work/2026-07-13-OME-391-scoreboard-submission-dedup.md
@@ -1,0 +1,98 @@
+---
+ticket: OME-391
+stack: scoreboard
+status: done
+started: 2026-07-13
+finished: 2026-07-13
+---
+
+# OME-391 (step 1 of 2) — server-enforced dedup by recipe content hash
+
+## Intent
+
+C28: duplicate score submissions are only deduplicated when the client supplies an
+optional `Idempotency-Key` header — identical no-header submissions currently create
+duplicate rows and pollute a spec's submission history. Make dedup server-enforced,
+independent of any client-supplied header, by hashing the submission's "recipe"
+(what was actually run and its result), not who submitted it or when.
+
+Step 2 of OME-391 (write-path authentication/attribution, C2) is explicitly deferred —
+posted on the ticket as blocked on a product decision + a dependency on OME-326
+(OpenMined identity provider, not yet built). Not touched in this unit.
+
+## Planned changes
+
+- `apps/scoreboard/src/scoreboard/scores/models/score.py`: add `content_hash`
+  (`CharField(64)`, unique) to `BaseScore`. Migration in the same iteration (rule S1).
+- `apps/scoreboard/src/scoreboard/scores/store.py`: new `_content_hash(submission)` —
+  sha256 hex over `benchmark_id, spec_id, url4_expression, accuracy, total_questions,
+  correct_questions, ran_with_providers` (in submitted order — provider order is part
+  of recipe identity, not sorted away). `ScoreStore.submit`: after the existing
+  idempotency-key fast path, look up by `content_hash` before creating; on a hit,
+  return the existing score (same 200-with-existing-row semantics idempotency already
+  uses). Extend the existing `IntegrityError` race handler to also re-query by
+  `content_hash` (mirrors the existing idempotency-key race-handling pattern).
+- `apps/scoreboard/src/scoreboard/routes/scores.py`: no route-level change expected —
+  dedup stays inside the store; confirm during implementation.
+
+## Test plan
+
+- Two submissions with identical recipe fields but no `Idempotency-Key` header →
+  second call returns 200 with the *same* score id as the first (not a new 201 row).
+- Two submissions with identical recipe fields but different `submitted_by` /
+  `client_*` / `ran_at_local` → still treated as the same recipe (still deduped) —
+  proves the hash is over recipe identity, not the whole row.
+- Two submissions with different `ran_with_providers` order → NOT deduped (treated as
+  distinct) — proves order is preserved, not sorted away.
+- A genuinely different submission (different accuracy) → not deduped, creates a new
+  row (regression: normal submission still works).
+- Concurrent-race safety net: simulate the `IntegrityError` path directly (mirrors the
+  existing idempotency race test) and confirm it resolves to the existing row instead
+  of raising.
+- Migration applies cleanly; second run is a no-op (existing repo convention).
+
+## Acceptance
+
+- Identical-recipe submissions without a header no longer create duplicate rows.
+- All prior tests remain green and unmodified.
+- `run_gates.py scoreboard --skip-append-only` all green.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+  - `apps/scoreboard/src/scoreboard/scores/models/score.py` — added `content_hash`
+    (`CharField(64)`, `unique=True`, `null=True` — nullable so the column can be added
+    to a table with existing rows without a backfill).
+  - `apps/scoreboard/src/scoreboard/scores/migrations/0003_auto_20260713_1505.py` —
+    new migration; verified against a scratch DB seeded with pre-existing rows
+    (clean apply, second run is a no-op).
+  - `apps/scoreboard/src/scoreboard/scores/store.py` — `_content_hash()`;
+    `get_by_content_hash()`; `ScoreStore._resolve_existing()` (shared helper for the
+    pre-insert check and the `IntegrityError` race handler — added during the
+    complexity-gate pass to bring `submit()` back under `PLR0911`/`PLR0912`).
+  - `apps/scoreboard/src/scoreboard/routes/scores.py` — route-level pre-check via
+    `get_by_content_hash()` so a dedup hit answers 200, not 201. Deviation from plan:
+    the plan expected no route change; this was required once testing showed the
+    route didn't know `store.submit()` had resolved to an existing row internally.
+  - `apps/scoreboard/tests/unit/scores/test_store.py` — 5 new tests (4 dedup cases +
+    1 Postgres concurrent-race test).
+  - `apps/scoreboard/tests/unit/test_scores_routes.py` — 2 prior tests modified with
+    explicit user sign-off (see Deviations).
+- **Commits:** this unit's commit (see `git log` on this file's introducing commit;
+  `Refs: OME-391`).
+- **Gates:** `run_gates.py scoreboard --skip-append-only` — ALL GATES GREEN (ruff
+  check, ruff format --check, pyright, pytest). 117 passed, 2 skipped, 88.01% coverage.
+- **Deviations:**
+  - Acceptance criterion "all prior tests remain green and unmodified" was not fully
+    met: `test_post_score_without_idempotency_key_always_creates_new_row` and
+    `test_post_score_with_expired_idempotency_key_creates_new_row` asserted the exact
+    behavior this ticket fixes (no-header duplicates create new rows). Both were
+    rewritten with explicit user sign-off — the first to assert the new dedup
+    behavior (renamed to `..._dedupes_identical_recipe`), the second to use a
+    genuinely different recipe under the same expired key so it still tests what it
+    originally intended (key expiry) without colliding with the new content-hash
+    guard.
+  - Route-level change not anticipated in the plan (see above).
+  - `ScoreStore.submit()` initially exceeded `PLR0911`/`PLR0912`; resolved via
+    `_resolve_existing()` extraction rather than bumping the threshold, per
+    `docs/complexity-baseline.md` convention.

--- a/docs/work/2026-07-13-OME-391-scoreboard-submission-dedup.md
+++ b/docs/work/2026-07-13-OME-391-scoreboard-submission-dedup.md
@@ -87,7 +87,9 @@ posted on the ticket as blocked on a product decision + a dependency on OME-326
 - **Commits:** this unit's commit (see `git log` on this file's introducing commit;
   `Refs: OME-391`).
 - **Gates:** `run_gates.py scoreboard --skip-append-only` — ALL GATES GREEN (ruff
-  check, ruff format --check, pyright, pytest). 117 passed, 2 skipped, 88.01% coverage.
+  check, ruff format --check, pyright, pytest). Post-PR-review: 128 passed, 2
+  skipped, 87.99% coverage (`test_leaderboard_routes.py` also touched — 2 call sites
+  needed unpacking for the new `submit()` tuple return, no behavior change).
 - **Deviations:**
   - Acceptance criterion "all prior tests remain green and unmodified" was not fully
     met: `test_post_score_without_idempotency_key_always_creates_new_row` and
@@ -114,3 +116,36 @@ posted on the ticket as blocked on a product decision + a dependency on OME-326
     relying on it being implied by the no-header tests; (3) documented (comment only)
     that `version` is excluded from the hash as currently a no-op since
     `ScoreSubmission.version` is pinned to `Literal[1]` — revisit if that changes.
+  - PR review (Dmitry) found the earlier "disproportionate" call above was wrong once
+    a real correctness bug was identified, not just an efficiency question — reversed
+    that decision:
+    1. `ScoreStore.submit()` now returns `SubmitOutcome(score, created)`. A
+       content-hash hit with an `idempotency_key` attached now permanently binds that
+       key to the found score via the new `_bind_idempotency_key()` (previously it
+       stayed unbound, so a later, unrelated submission reusing the same key could
+       silently rebind it — breaking "the same key always replays the same original
+       result"). This also removed the route's separate `find_existing()` pre-check
+       entirely — the route now makes one atomic `submit()` call and reads
+       `.created` for the status code, closing a TOCTOU where concurrent identical
+       submissions could both report `201`. Touched ~15 test call sites
+       (`test_store.py`, `test_leaderboard_routes.py`) to unpack the new tuple; added
+       `test_submit_reused_key_after_content_hash_hit_stays_bound_to_original_score`
+       as the regression test (confirmed by manual trace it would have failed
+       pre-fix).
+    2. `_content_hash()` now hashes `correct_questions / total_questions` (recomputed
+       server-side) instead of the client's raw reported `accuracy` — the route
+       accepts any reported value within 0.01 of that ratio, so the same result
+       (e.g. 2/3 correct) could be reported as `0.67` or `0.6666666667` and hash
+       differently, defeating dedup. Added
+       `test_submit_identical_counts_dedupe_despite_different_accuracy_precision`.
+    3. The Postgres concurrent-race tests were confirmed dead (fixture calls
+       `asyncio.run()` inside an already-running event loop; CI never sets
+       `SCOREBOARD_TEST_DATABASE_URL`) — filed OME-430 rather than fixing inline,
+       since it's CI/workflow infrastructure, a separable scope from this ticket's
+       app-code fixes. Left `AIDEV-NOTE`s pointing at OME-430 on both tests.
+  - Two lines in `store.py` remain uncovered (93% file coverage, still 87.99% overall,
+    above the 80% gate): the `IntegrityError` swallow inside `_bind_idempotency_key`
+    and `submit()`'s own race-handler body. Both are concurrency-only branches that
+    have — even before this change — only ever been exercisable by the Postgres
+    concurrent tests, which OME-430 tracks as currently non-functional. Not forcing
+    artificial SQLite-level coverage for a genuine multi-writer race.

--- a/docs/work/2026-07-13-OME-391-scoreboard-submission-dedup.md
+++ b/docs/work/2026-07-13-OME-391-scoreboard-submission-dedup.md
@@ -67,15 +67,21 @@ posted on the ticket as blocked on a product decision + a dependency on OME-326
     new migration; verified against a scratch DB seeded with pre-existing rows
     (clean apply, second run is a no-op).
   - `apps/scoreboard/src/scoreboard/scores/store.py` — `_content_hash()`;
-    `get_by_content_hash()`; `ScoreStore._resolve_existing()` (shared helper for the
-    pre-insert check and the `IntegrityError` race handler — added during the
-    complexity-gate pass to bring `submit()` back under `PLR0911`/`PLR0912`).
+    `ScoreStore._resolve_existing()` (shared helper for the pre-insert check and the
+    `IntegrityError` race handler — added during the complexity-gate pass to bring
+    `submit()` back under `PLR0911`/`PLR0912`); `ScoreStore.find_existing()` (public,
+    added during self-review to replace two separate route-level lookups —
+    `get_by_idempotency_key` + a since-removed `get_by_content_hash` — with one call
+    that reuses `_resolve_existing` and computes the content hash once instead of
+    per-lookup); `_submission_to_kwargs()` now takes the already-computed
+    `content_hash` instead of recomputing it a third time on the insert path.
   - `apps/scoreboard/src/scoreboard/routes/scores.py` — route-level pre-check via
-    `get_by_content_hash()` so a dedup hit answers 200, not 201. Deviation from plan:
-    the plan expected no route change; this was required once testing showed the
-    route didn't know `store.submit()` had resolved to an existing row internally.
-  - `apps/scoreboard/tests/unit/scores/test_store.py` — 5 new tests (4 dedup cases +
-    1 Postgres concurrent-race test).
+    `find_existing()` so a dedup hit answers 200, not 201. Deviation from plan: the
+    plan expected no route change; this was required once testing showed the route
+    didn't know `store.submit()` had resolved to an existing row internally.
+  - `apps/scoreboard/tests/unit/scores/test_store.py` — 6 new tests (5 dedup cases,
+    including one added during self-review for sequential different-idempotency-keys
+    same-recipe dedup, + 1 Postgres concurrent-race test).
   - `apps/scoreboard/tests/unit/test_scores_routes.py` — 2 prior tests modified with
     explicit user sign-off (see Deviations).
 - **Commits:** this unit's commit (see `git log` on this file's introducing commit;
@@ -96,3 +102,15 @@ posted on the ticket as blocked on a product decision + a dependency on OME-326
   - `ScoreStore.submit()` initially exceeded `PLR0911`/`PLR0912`; resolved via
     `_resolve_existing()` extraction rather than bumping the threshold, per
     `docs/complexity-baseline.md` convention.
+  - Self-review (3 rounds) after the initial commit found: (1) redundant
+    content-hash computation/lookups across the route pre-check and `submit()`'s own
+    internal pre-check — partially addressed via `find_existing()` and threading the
+    hash through `_submission_to_kwargs`; the remaining route-vs-`submit()` double
+    pre-check on the genuinely-new-submission path was deliberately left as-is rather
+    than changing `submit()`'s return contract to a `(schema, created)` tuple, since
+    that would ripple through ~30 existing call sites for a sub-millisecond gain —
+    disproportionate to the task; (2) added an explicit test for the sequential
+    different-idempotency-keys-same-recipe scenario (the core C28 case) instead of
+    relying on it being implied by the no-header tests; (3) documented (comment only)
+    that `version` is excluded from the hash as currently a no-op since
+    `ScoreSubmission.version` is pinned to `Literal[1]` — revisit if that changes.


### PR DESCRIPTION
## Summary
- Server-enforced deduplication of score submissions by hashing the submission's "recipe" (benchmark, spec, url4 expression, result numbers, provider order) — independent of the optional client-supplied `Idempotency-Key` header.
- Adds nullable unique `content_hash` column + migration. `ScoreStore.submit()` returns `SubmitOutcome(score, created)` — a content-hash hit with an `idempotency_key` attached now permanently binds that key to the found score, and the route makes one atomic `submit()` call (no separate pre-check) so the reported status code always matches what actually happened, including under a concurrent-duplicate race.
- `_content_hash()` hashes `correct_questions/total_questions`'s derived ratio, not the client's raw reported `accuracy` — so the same result reported at different float precision still dedupes.
- Step 1 of 2 for OME-391 (C28). Step 2 (write-path auth, C2 — placeholder API-key gate) shipped separately in #392. Step 1's Postgres concurrent-race tests are confirmed dead (broken fixture + no CI service) — tracked separately as OME-430 rather than folded into this PR's app-code scope.

## Test plan
- [x] `uv run ruff check` / `ruff format --check` / `pyright` — all clean
- [x] `uv run pytest --cov=scoreboard --cov-fail-under=80` — 128 passed, 2 skipped (Postgres-only, see OME-430), 87.99% coverage
- [x] `run_gates.py scoreboard --skip-append-only` — ALL GATES GREEN
- [x] Migration verified against a scratch DB seeded with pre-existing rows (clean apply, second run is a no-op)
- [x] Self-review (3 rounds) performed post-commit before first review request
- [x] Addressed all 3 findings from Dmitry's review: idempotency-key rebind bug + route TOCTOU (fixed via the atomic `submit()` + key-binding change above), accuracy-precision hash mismatch (fixed via the normalized-ratio change above), dead Postgres tests (filed OME-430)

Refs: OME-391