### PR TITLE
feat(scoreboard): add Plausible analytics to the public portal

### DIFF
--- a/apps/scoreboard/portal/benchmark.html
+++ b/apps/scoreboard/portal/benchmark.html
@@ -14,6 +14,12 @@
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="portal.css">
   <script>(function(){try{var t=localStorage.getItem('sf_theme')||'light';document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <!-- Privacy-friendly analytics by Plausible -->
+  <script async src="https://plausible.io/js/pa-ysspwNldM0r_4o-m1utPa.js"></script>
+  <script>
+    window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+    plausible.init()
+  </script>
 </head>
 <body>
   <div class="rail">

--- a/apps/scoreboard/portal/data.html
+++ b/apps/scoreboard/portal/data.html
@@ -14,6 +14,12 @@
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="portal.css">
   <script>(function(){try{var t=localStorage.getItem('sf_theme')||'light';document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <!-- Privacy-friendly analytics by Plausible -->
+  <script async src="https://plausible.io/js/pa-ysspwNldM0r_4o-m1utPa.js"></script>
+  <script>
+    window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+    plausible.init()
+  </script>
 </head>
 <body>
   <div class="rail">

--- a/apps/scoreboard/portal/index.html
+++ b/apps/scoreboard/portal/index.html
@@ -14,6 +14,12 @@
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="portal.css">
   <script>(function(){try{var t=localStorage.getItem('sf_theme')||'light';document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <!-- Privacy-friendly analytics by Plausible -->
+  <script async src="https://plausible.io/js/pa-ysspwNldM0r_4o-m1utPa.js"></script>
+  <script>
+    window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+    plausible.init()
+  </script>
 </head>
 <body>
   <div class="rail">

--- a/apps/scoreboard/portal/spec.html
+++ b/apps/scoreboard/portal/spec.html
@@ -14,6 +14,12 @@
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="portal.css">
   <script>(function(){try{var t=localStorage.getItem('sf_theme')||'light';document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <!-- Privacy-friendly analytics by Plausible -->
+  <script async src="https://plausible.io/js/pa-ysspwNldM0r_4o-m1utPa.js"></script>
+  <script>
+    window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+    plausible.init()
+  </script>
 </head>
 <body>
   <div class="rail">

--- a/apps/scoreboard/tests/unit/test_portal_static.py
+++ b/apps/scoreboard/tests/unit/test_portal_static.py
@@ -42,6 +42,15 @@ def test_portal_assets_and_pages_are_public(tmp_path: Path) -> None:
             assert response.status_code == 200, path
 
 
+def test_portal_pages_include_plausible_analytics(tmp_path: Path) -> None:
+    # OME-373: traffic/visit analytics on the public board — a future rewrite of any
+    # of these pages must not silently drop the tracking snippet.
+    with TestClient(create_app(_settings(tmp_path))) as client:
+        for path in ("/index.html", "/benchmark.html", "/spec.html", "/data.html"):
+            response = client.get(path)
+            assert "plausible.io/js/pa-ysspwNldM0r_4o-m1utPa.js" in response.text, path
+
+
 def test_api_routes_remain_public_before_root_static_mount(tmp_path: Path) -> None:
     with TestClient(create_app(_settings(tmp_path))) as client:
         assert client.get("/healthz").status_code == 200

--- a/docs/tasks/2026-07-13-plausible-analytics.md
+++ b/docs/tasks/2026-07-13-plausible-analytics.md
@@ -1,0 +1,17 @@
+---
+id: OME-373
+linear_url: https://linear.app/openmined/issue/OME-373/analytics-leaderboard-trafficvisits
+status: in_progress
+type: task
+priority: P2
+labels: [scoreboard, autonomous, agentic]
+created: 2026-07-13
+closed:
+---
+
+Analytics + leaderboard traffic/visits. Bennett confirmed the `scoreboard.screamingface.ai`
+domain was added to OpenMined's existing Plausible plan and supplied the tracking snippet
+over Slack DM on 2026-07-13 — the ticket was blocked on this and is now unblocked.
+
+Wiring the snippet into the four public portal pages (`index.html`, `benchmark.html`,
+`spec.html`, `data.html`). Ledger: `docs/work/2026-07-13-OME-373-plausible-analytics.md`.

--- a/docs/work/2026-07-13-OME-373-plausible-analytics.md
+++ b/docs/work/2026-07-13-OME-373-plausible-analytics.md
@@ -1,0 +1,62 @@
+---
+ticket: OME-373
+stack: scoreboard
+status: done
+started: 2026-07-13
+finished: 2026-07-13
+---
+
+# OME-373 — Plausible analytics on the public scoreboard portal
+
+## Intent
+
+Irina asked for traffic/visit analytics on the leaderboard, to measure whether the
+public claim is landing and whether externals are actually reaching the verified
+board this week. Filip proposed reusing the existing OpenMined Plausible plan
+(previously used for askanyone.ai) for `scoreboard.screamingface.ai` rather than
+standing up a new analytics stack. Bennett (Branding & Marketing Lead, owns the
+Plausible account) confirmed the domain was added to the plan and supplied the
+tracking snippet over Slack DM on 2026-07-13. This unit wires that snippet into the
+portal so it starts collecting data; Bennett verifies once it's live.
+
+## Planned changes
+
+- `apps/scoreboard/portal/index.html`, `benchmark.html`, `spec.html`, `data.html` —
+  insert Bennett's Plausible `<script>` snippet (site id `pa-ysspwNldM0r_4o-m1utPa`)
+  into `<head>`, before `</head>`, in all four pages (they share an identical head
+  boilerplate today — fonts/icon/theme script are already duplicated per-page, so
+  this follows the existing pattern rather than introducing a templating layer for
+  one script tag).
+- `apps/scoreboard/tests/unit/test_portal_static.py` — new test asserting each
+  served HTML page includes the Plausible script tag, so a future portal-page
+  rewrite can't silently drop analytics.
+
+## Test plan
+
+- RED: assert `GET /index.html`, `/benchmark.html`, `/spec.html`, `/data.html` each
+  contain the Plausible script src (`plausible.io/js/pa-ysspwNldM0r_4o-m1utPa.js`) —
+  fails against the current (unmodified) portal HTML.
+- GREEN: insert the snippet into all four pages; same assertion passes.
+- No backend/business logic changes — pure static-asset addition, no migration, no
+  Tortoise-touching code (`tortoise-dev` companion skill's `when` doesn't match).
+
+## Acceptance
+
+- All four public portal pages serve the Plausible snippet in `<head>`.
+- Existing portal tests (`test_portal_static.py`) remain green and unmodified.
+- `run_gates.py scoreboard --skip-append-only` all green.
+- Bennett notified once merged/deployed so he can verify traffic is flowing.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+  - `apps/scoreboard/portal/index.html`, `benchmark.html`, `spec.html`, `data.html` —
+    inserted Bennett's Plausible snippet into `<head>` (all four, exactly as planned).
+  - `apps/scoreboard/tests/unit/test_portal_static.py` — new
+    `test_portal_pages_include_plausible_analytics`, RED confirmed before the HTML
+    edit, GREEN after.
+- **Commits:** this unit's commit (`Refs: OME-373`).
+- **Gates:** `run_gates.py scoreboard --skip-append-only` — ALL GATES GREEN (ruff
+  check, ruff format --check, pyright, pytest). 114 passed, 1 skipped, 88.16%
+  coverage.
+- **Deviations:** none — matched the plan exactly.


### PR DESCRIPTION
## Summary
- Wires Bennett's Plausible tracking snippet (site id `pa-ysspwNldM0r_4o-m1utPa`, added to OpenMined's existing plan for `scoreboard.screamingface.ai`) into all four public portal pages (`index.html`, `benchmark.html`, `spec.html`, `data.html`).
- OME-373: measures whether the public leaderboard claim is landing and whether externals are actually reaching the verified board.
- Snippet inserted verbatim into each page's `<head>` (they already duplicate their head boilerplate — fonts/icon/theme script — so this follows the existing pattern rather than introducing a templating layer for one script tag).

## Test plan
- [x] New test `test_portal_pages_include_plausible_analytics` — RED confirmed before the HTML edit, GREEN after; all prior portal tests remain green and unmodified
- [x] `uv run ruff check` / `ruff format --check` / `pyright` — all clean
- [x] `uv run pytest --cov=scoreboard --cov-fail-under=80` — 114 passed, 1 skipped, 88.16% coverage
- [x] `run_gates.py scoreboard --skip-append-only` — ALL GATES GREEN
- [x] Verified locally: ran the app against a scratch DB, curled all four portal pages, confirmed each serves the snippet; confirmed Bennett's script URL resolves (200, `application/javascript`); confirmed no CSP would block it

## Rollout
`apps/scoreboard` deploys via a manual `scoreboard-v*` tag (not release-please), so merging alone won't put this live. After a deploy tag + Helm rollout, ping Bennett to verify traffic is showing up in Plausible.

Refs: OME-373