### PR TITLE
feat(scoreboard): gate score submission behind a placeholder API key

### DIFF
--- a/apps/scoreboard/DEPLOYMENT.md
+++ b/apps/scoreboard/DEPLOYMENT.md
@@ -136,7 +136,7 @@ curl -fsS http://scoreboard.40.76.107.241.nip.io/healthz
 curl -fsS http://scoreboard.40.76.107.241.nip.io/v1/benchmarks
 ```
 
-Submit a smoke score with an idempotency key:
+Submit a smoke score with an idempotency key. If `SCOREBOARD_SUBMISSION_API_KEY` is set, add `-H "Authorization: Bearer <key>"` or this 401s:
 
 ```bash
 curl -fsS -X POST http://scoreboard.40.76.107.241.nip.io/v1/scores \

--- a/apps/scoreboard/DEPLOYMENT.md
+++ b/apps/scoreboard/DEPLOYMENT.md
@@ -98,6 +98,8 @@ helm upgrade --install scoreboard oci://ghcr.io/openmined/screamingface/charts/s
 
 `values-prod.yaml` sets three app replicas, Traefik ingress, TLS annotations, production CORS for `https://screamingface.ai`, and NetworkPolicy enabled. The chart also sets `FORWARDED_ALLOW_IPS="*"` so uvicorn honors Traefik's forwarded HTTPS scheme for redirects. Adjust `ingress.className` if the production cluster uses a different ingress controller.
 
+Set `SCOREBOARD_SUBMISSION_API_KEY` to gate `POST /v1/scores` (OME-391 / C2) — a placeholder shared key until OME-326 (real identity) exists. Unset, the write path stays open, matching today's behavior. Once set, submitting clients (desktop app, SDK, CI) need `Authorization: Bearer <key>` — coordinate the key distribution before flipping this on in production, since it isn't per-user.
+
 ## Benchmark Seeding
 
 The app chart runs `python -m scoreboard.seed` after install and upgrade. Seed data comes from `.Values.seedBenchmarks.benchmarks` and is passed through `SCOREBOARD_SEED_BENCHMARKS_JSON`.

--- a/apps/scoreboard/README.md
+++ b/apps/scoreboard/README.md
@@ -61,12 +61,13 @@ Settings are read from environment variables with the `SCOREBOARD_` prefix.
 | `SCOREBOARD_CORS_ORIGINS` | `["*"]` | JSON list of allowed CORS origins. |
 | `SCOREBOARD_PORTAL_DIR` | app-local `portal/` | Static portal directory. |
 | `SCOREBOARD_PORTAL_ARTIFACTS_DIR` | app-local `artifacts/` | Public JSONL artifact directory. |
+| `SCOREBOARD_SUBMISSION_API_KEY` | unset | Placeholder gate on `POST /v1/scores` (OME-391 / C2). Unset is a no-op; when set, requests must send `Authorization: Bearer <key>`. Stub until OME-326 (real identity) exists — not per-user. |
 
 `SCOREBOARD_CORS_ORIGINS` defaults to `["*"]` because the scaffold has no authenticated routes and never sets cookies. D-SCORE-007 will tighten this once the leaderboard write path lands.
 
 ## Portal And Public Artifacts
 
-The scoreboard service serves the demo portal at `/`. The portal UI, API routes, and public JSONL artifacts are unauthenticated.
+The scoreboard service serves the demo portal at `/`. The portal UI, GET routes, and public JSONL artifacts are always unauthenticated. `POST /v1/scores` is unauthenticated only while `SCOREBOARD_SUBMISSION_API_KEY` is unset.
 
 Public artifact routes are exact-file allowlisted and served as inline `text/plain`:
 

--- a/apps/scoreboard/src/scoreboard/config.py
+++ b/apps/scoreboard/src/scoreboard/config.py
@@ -35,6 +35,10 @@ class Settings(BaseSettings):
     cors_origins: list[str] = Field(default_factory=lambda: ["*"])
     portal_dir: Path | None = None
     portal_artifacts_dir: Path | None = None
+    # INVARIANT: unset means the submission write-gate is a no-op (OME-391 / C2) —
+    # a placeholder stub until OME-326 (real identity) exists; not per-user, everyone
+    # holding the key looks identical to the server.
+    submission_api_key: str | None = None
 
     @field_validator("database_url")
     @classmethod

--- a/apps/scoreboard/src/scoreboard/config.py
+++ b/apps/scoreboard/src/scoreboard/config.py
@@ -35,9 +35,10 @@ class Settings(BaseSettings):
     cors_origins: list[str] = Field(default_factory=lambda: ["*"])
     portal_dir: Path | None = None
     portal_artifacts_dir: Path | None = None
-    # INVARIANT: unset means the submission write-gate is a no-op (OME-391 / C2) —
-    # a placeholder stub until OME-326 (real identity) exists; not per-user, everyone
-    # holding the key looks identical to the server.
+    # AIDEV-NOTE: TEMPORARY (OME-391 / C2) — delete alongside
+    # routes/scores.py::_require_submission_api_key once OME-326 ships real identity.
+    # INVARIANT: unset means the submission write-gate is a no-op — a placeholder
+    # stub, not per-user; everyone holding the key looks identical to the server.
     submission_api_key: str | None = None
 
     @field_validator("database_url")

--- a/apps/scoreboard/src/scoreboard/routes/scores.py
+++ b/apps/scoreboard/src/scoreboard/routes/scores.py
@@ -1,7 +1,10 @@
 """Public score submission and score lookup routes.
 
-No authentication is required in v1. The verified_by_openmined response field is
-the trust-tier signal for consumers; submitted scores default to unverified.
+Reads are always public. Writes are open by default; setting
+SCOREBOARD_SUBMISSION_API_KEY gates POST /v1/scores behind a shared placeholder key
+(OME-391 / C2) until real per-submitter identity exists (OME-326). The
+verified_by_openmined response field is the trust-tier signal for consumers;
+submitted scores default to unverified regardless of the key.
 """
 
 from __future__ import annotations
@@ -10,9 +13,10 @@ from decimal import Decimal
 from typing import Annotated, Any, cast
 from uuid import UUID
 
-from fastapi import APIRouter, Header, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
 from tortoise.exceptions import OperationalError
 
+from scoreboard.config import Settings
 from scoreboard.scores.models import Benchmark, Score
 from scoreboard.scores.schemas import (
     FieldErrorDetail,
@@ -27,6 +31,26 @@ router = APIRouter(prefix="/v1", tags=["scores"])
 
 ACCURACY_TOLERANCE = Decimal("0.01")
 STORE_UNAVAILABLE_DETAIL = "score store unavailable"
+INVALID_API_KEY_DETAIL = "missing or invalid API key"
+
+
+async def _require_submission_api_key(
+    request: Request,
+    authorization: Annotated[str | None, Header()] = None,
+) -> None:
+    # INVARIANT: SCOREBOARD_SUBMISSION_API_KEY unset means this is a no-op — every
+    # existing deployment/test keeps today's behavior until it's explicitly set
+    # (OME-391 / C2).
+    expected_key = cast(Settings, request.app.state.settings).submission_api_key
+    if expected_key is None:
+        return
+
+    if authorization != f"Bearer {expected_key}":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=INVALID_API_KEY_DETAIL,
+        )
+
 
 SUBMIT_SCORE_RESPONSES: dict[int | str, dict[str, Any]] = {
     status.HTTP_200_OK: {
@@ -36,6 +60,10 @@ SUBMIT_SCORE_RESPONSES: dict[int | str, dict[str, Any]] = {
     status.HTTP_400_BAD_REQUEST: {
         "model": FieldErrorResponse,
         "description": "Field-specific validation error.",
+    },
+    status.HTTP_401_UNAUTHORIZED: {
+        "model": MessageErrorResponse,
+        "description": "Missing or invalid submission API key.",
     },
     status.HTTP_404_NOT_FOUND: {
         "model": FieldErrorResponse,
@@ -66,6 +94,7 @@ def _field_error_detail(field: str, message: str) -> dict[str, str]:
     response_model=ScoreSchema,
     status_code=status.HTTP_201_CREATED,
     responses=SUBMIT_SCORE_RESPONSES,
+    dependencies=[Depends(_require_submission_api_key)],
 )
 async def submit_score(
     submission: ScoreSubmission,
@@ -73,7 +102,7 @@ async def submit_score(
     response: Response,
     idempotency_key: Annotated[str | None, Header(alias="Idempotency-Key")] = None,
 ) -> ScoreSchema:
-    """Create a public unauthenticated score submission."""
+    """Create a score submission; gated by SCOREBOARD_SUBMISSION_API_KEY if set."""
 
     submitted_accuracy = Decimal(str(submission.accuracy))
     expected_accuracy = Decimal(submission.correct_questions) / Decimal(submission.total_questions)

--- a/apps/scoreboard/src/scoreboard/routes/scores.py
+++ b/apps/scoreboard/src/scoreboard/routes/scores.py
@@ -9,6 +9,7 @@ submitted scores default to unverified regardless of the key.
 
 from __future__ import annotations
 
+import hmac
 from decimal import Decimal
 from typing import Annotated, Any, cast
 from uuid import UUID
@@ -38,6 +39,13 @@ async def _require_submission_api_key(
     request: Request,
     authorization: Annotated[str | None, Header()] = None,
 ) -> None:
+    # AIDEV-NOTE: this whole function is a TEMPORARY stub (OME-391 / C2), scoped to
+    # be deleted once OME-326 (real per-user identity) ships. It intentionally does
+    # NOT distinguish submitters — one shared key, everyone looks identical to the
+    # server. When OME-326 lands: delete this function, its Depends() wiring below,
+    # submission_api_key off Settings, and swap in real per-request identity that
+    # also populates ScoreSubmission.submitted_by from something verified instead of
+    # self-reported free text.
     # INVARIANT: SCOREBOARD_SUBMISSION_API_KEY unset means this is a no-op — every
     # existing deployment/test keeps today's behavior until it's explicitly set
     # (OME-391 / C2).
@@ -45,7 +53,9 @@ async def _require_submission_api_key(
     if expected_key is None:
         return
 
-    if authorization != f"Bearer {expected_key}":
+    # WHY: compare_digest instead of != to avoid a timing side-channel on the key.
+    presented = authorization or ""
+    if not hmac.compare_digest(presented, f"Bearer {expected_key}"):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=INVALID_API_KEY_DETAIL,

--- a/apps/scoreboard/tests/unit/test_scores_routes.py
+++ b/apps/scoreboard/tests/unit/test_scores_routes.py
@@ -59,6 +59,32 @@ async def score_client(app_with_benchmark: FastAPI) -> AsyncGenerator[AsyncClien
         yield client
 
 
+@pytest_asyncio.fixture
+async def app_with_api_key(tortoise_db: None) -> FastAPI:
+    settings = Settings(
+        database_url="sqlite://:memory:",
+        cors_origins=[],
+        submission_api_key="test-key",
+    )
+    app = create_app(settings)
+    await Benchmark.create(
+        id="hle",
+        display_name="Humanity's Last Exam",
+        description="Fixture benchmark",
+        dataset_url="https://example.test/hle.jsonl",
+    )
+    return app
+
+
+@pytest_asyncio.fixture
+async def gated_score_client(app_with_api_key: FastAPI) -> AsyncGenerator[AsyncClient, None]:
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_api_key),
+        base_url="http://test",
+    ) as client:
+        yield client
+
+
 async def test_post_score_creates_new_row_201(score_client: AsyncClient) -> None:
     response = await score_client.post("/v1/scores", json=_valid_payload())
 
@@ -220,6 +246,63 @@ async def test_get_score_unknown_id_returns_404(score_client: AsyncClient) -> No
     assert response.json() == {"detail": "score not found"}
 
 
+async def test_post_score_without_configured_api_key_remains_public(
+    score_client: AsyncClient,
+) -> None:
+    # WHY: SCOREBOARD_SUBMISSION_API_KEY unset (local dev, and every fixture above)
+    # must be a true no-op — this is the pre-OME-326 default (OME-391 / C2).
+    response = await score_client.post("/v1/scores", json=_valid_payload())
+
+    assert response.status_code == 201
+
+
+async def test_post_score_with_correct_api_key_succeeds(
+    gated_score_client: AsyncClient,
+) -> None:
+    response = await gated_score_client.post(
+        "/v1/scores",
+        json=_valid_payload(),
+        headers={"Authorization": "Bearer test-key"},
+    )
+
+    assert response.status_code == 201
+
+
+async def test_post_score_missing_api_key_header_returns_401(
+    gated_score_client: AsyncClient,
+) -> None:
+    response = await gated_score_client.post("/v1/scores", json=_valid_payload())
+
+    assert response.status_code == 401
+
+
+async def test_post_score_wrong_api_key_returns_401(
+    gated_score_client: AsyncClient,
+) -> None:
+    response = await gated_score_client.post(
+        "/v1/scores",
+        json=_valid_payload(),
+        headers={"Authorization": "Bearer wrong-key"},
+    )
+
+    assert response.status_code == 401
+
+
+async def test_get_score_remains_public_when_api_key_configured(
+    gated_score_client: AsyncClient,
+) -> None:
+    created = await gated_score_client.post(
+        "/v1/scores",
+        json=_valid_payload(),
+        headers={"Authorization": "Bearer test-key"},
+    )
+
+    response = await gated_score_client.get(f"/v1/scores/{created.json()['id']}")
+
+    assert response.status_code == 200
+    assert response.json()["id"] == created.json()["id"]
+
+
 async def test_openapi_schema_includes_new_endpoints(score_client: AsyncClient) -> None:
     response = await score_client.get("/openapi.json")
 
@@ -239,6 +322,9 @@ async def test_openapi_schema_includes_new_endpoints(score_client: AsyncClient) 
     )
     assert post_score["responses"]["400"]["content"]["application/json"]["schema"]["$ref"].endswith(
         "/FieldErrorResponse",
+    )
+    assert post_score["responses"]["401"]["content"]["application/json"]["schema"]["$ref"].endswith(
+        "/MessageErrorResponse",
     )
     assert post_score["responses"]["404"]["content"]["application/json"]["schema"]["$ref"].endswith(
         "/FieldErrorResponse",

--- a/apps/scoreboard/tests/unit/test_scores_routes.py
+++ b/apps/scoreboard/tests/unit/test_scores_routes.py
@@ -274,6 +274,7 @@ async def test_post_score_missing_api_key_header_returns_401(
     response = await gated_score_client.post("/v1/scores", json=_valid_payload())
 
     assert response.status_code == 401
+    assert response.json() == {"detail": "missing or invalid API key"}
 
 
 async def test_post_score_wrong_api_key_returns_401(
@@ -286,6 +287,7 @@ async def test_post_score_wrong_api_key_returns_401(
     )
 
     assert response.status_code == 401
+    assert response.json() == {"detail": "missing or invalid API key"}
 
 
 async def test_get_score_remains_public_when_api_key_configured(

--- a/docs/work/2026-07-13-OME-391-step2-write-api-key-gate.md
+++ b/docs/work/2026-07-13-OME-391-step2-write-api-key-gate.md
@@ -1,0 +1,77 @@
+---
+ticket: OME-391
+stack: scoreboard
+status: done
+started: 2026-07-13
+finished: 2026-07-13
+---
+
+# OME-391 (step 2 of 2) — placeholder API-key gate on score submission
+
+## Intent
+
+C2: `POST /v1/scores` accepts unauthenticated writes, so fabricated submissions can
+affect public leaderboard integrity. Full identity (OME-326) doesn't exist yet, so
+Irina + Kevin agreed to stub the write-path gate with a single shared placeholder API
+key rather than block on it. Once OME-326 ships, this key check is swapped for real
+per-user identity — `submitted_by` stays self-reported free text for now either way.
+
+This intentionally has no per-user distinction: everyone holding the key looks
+identical to the server. It resolves C2's acceptance criterion ("write path gated by
+an accepted integrity mechanism") without answering the harder identity/attribution
+question, which stays with OME-326.
+
+## Planned changes
+
+- `apps/scoreboard/src/scoreboard/config.py` — add `submission_api_key: str | None =
+  None` to `Settings` (env `SCOREBOARD_SUBMISSION_API_KEY`, same pattern as every
+  other setting here). Unset → gate is a no-op, preserving current behavior for local
+  dev and all existing tests.
+- `apps/scoreboard/src/scoreboard/routes/scores.py` — new `_require_submission_api_key`
+  FastAPI dependency: reads `settings.submission_api_key` off `request.app.state`;
+  if unset, returns immediately; if set, requires `Authorization: Bearer <key>` to
+  match exactly, else `401`. Wired via `Depends()` on `submit_score` only — `GET
+  /v1/scores/{id}` and all other routes stay public reads.
+- No model/schema/migration change — this is a request-time config check, not
+  persisted state.
+
+## Test plan
+
+- Unset key (default `Settings()`, all current fixtures): write without any
+  `Authorization` header still returns 201 — proves backward compatibility, and this
+  is exactly what the entire existing test suite already exercises unmodified.
+- Key configured + correct `Authorization: Bearer <key>` → 201 (happy path).
+- Key configured + missing header → 401.
+- Key configured + wrong key → 401.
+- Key configured + `GET /v1/scores/{id}` without any header → 200 (reads stay public
+  even when the write gate is active — the invariant this whole design protects).
+
+## Acceptance
+
+- `POST /v1/scores` rejects writes with a missing/wrong key once
+  `SCOREBOARD_SUBMISSION_API_KEY` is configured; behavior is unchanged when it isn't.
+- All prior tests remain green and unmodified (no existing test sets the new setting).
+- `run_gates.py scoreboard --skip-append-only` all green.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+  - `apps/scoreboard/src/scoreboard/config.py` — added `submission_api_key: str |
+    None = None` to `Settings`.
+  - `apps/scoreboard/src/scoreboard/routes/scores.py` — `_require_submission_api_key`
+    dependency wired via `Depends()` on `submit_score` only; documented the 401 in
+    `SUBMIT_SCORE_RESPONSES`; updated the two stale docstrings that claimed the write
+    path was unconditionally unauthenticated.
+  - `apps/scoreboard/tests/unit/test_scores_routes.py` — new `app_with_api_key` /
+    `gated_score_client` fixtures; 5 new tests (unset-key no-op, correct key, missing
+    key, wrong key, reads stay public under a configured key) + one added assertion
+    on the pre-existing OpenAPI-schema test for the new 401 response.
+  - `apps/scoreboard/README.md`, `apps/scoreboard/DEPLOYMENT.md` — documented the new
+    env var and its no-op-when-unset / not-per-user semantics for operators.
+- **Commits:** this unit's commit (`Refs: OME-391`).
+- **Gates:** `run_gates.py scoreboard --skip-append-only` — ALL GATES GREEN (ruff
+  check, ruff format --check, pyright, pytest). 118 passed, 1 skipped, 88.30%
+  coverage.
+- **Deviations:** none — matched the plan; all prior tests remained green and
+  unmodified (no existing fixture sets the new setting, so the gate default is a
+  true no-op as designed).


### PR DESCRIPTION
## Summary
- OME-391 Step 2 of 2 (C2): `POST /v1/scores` currently accepts fully unauthenticated writes. Real identity (OME-326) doesn't exist yet, so Irina + Kevin signed off on stubbing the write-path gate with a single shared placeholder API key rather than blocking on it.
- Adds `SCOREBOARD_SUBMISSION_API_KEY` to `Settings`. Unset (default, every current deployment/test) → no-op, current behavior unchanged. Set → `POST /v1/scores` requires `Authorization: Bearer <key>` (constant-time comparison via `hmac.compare_digest`), else `401`. Reads (`GET /v1/scores/{id}`, leaderboard, portal) stay public regardless.
- This is explicitly **not per-user** — everyone holding the key looks identical to the server; `submitted_by` stays self-reported free text until OME-326 provides real identity to swap in. The whole gate is marked `AIDEV-NOTE: TEMPORARY` in `config.py` and `routes/scores.py`, spelling out exactly what to delete/replace once OME-326 ships.
- Note on scope: builds off `main`, independent of the still-open OME-391 Step 1 PR (#390, dedup) — both touch `routes/scores.py`'s `submit_score`, so whichever merges second will need a small rebase.

## Test plan
- [x] New fixtures (`app_with_api_key`/`gated_score_client`) + 5 new tests: unset-key no-op, correct key succeeds, missing key → 401 (asserts body), wrong key → 401 (asserts body), reads stay public under a configured key
- [x] Extended the existing OpenAPI-schema test to cover the new 401 response
- [x] All prior tests remain green and unmodified — no existing fixture sets the new setting, so the gate's default is a true no-op
- [x] `uv run ruff check` / `ruff format --check` / `pyright` — all clean
- [x] `uv run pytest --cov=scoreboard --cov-fail-under=80` — 118 passed, 1 skipped, 88.33% coverage
- [x] `run_gates.py scoreboard --skip-append-only` — ALL GATES GREEN
- [x] 6 rounds of self-review across 2 follow-up commits: hardened the key comparison to constant-time (`hmac.compare_digest`, avoiding a timing side-channel), strengthened the 401 tests to assert response body, and fixed a real gap in `DEPLOYMENT.md`'s smoke-check runbook (missing `Authorization` header would silently 401 an operator following it verbatim once the key is configured)

Refs: OME-391