### PR TITLE
OME-400: ship packages/screamingface v0.1 + 00_quickstart.ipynb

### DIFF
--- a/.claude/sdlc.local.md
+++ b/.claude/sdlc.local.md
@@ -19,6 +19,15 @@ stacks:
       - uv run ruff format --check
       - uv run pyright
       - uv run pytest --cov=scoreboard --cov-fail-under=80 -q
+  - name: screamingface
+    root: packages/screamingface
+    skill: sdlc-python
+    test_globs: ["tests/**"]
+    gates:
+      - uv run ruff check
+      - uv run ruff format --check
+      - uv run pyright
+      - uv run pytest --cov=screamingface --cov-fail-under=80 -q
 commit_refs: "Refs: OME-N"
 extra_anchors: []
 companion_skills:
@@ -43,6 +52,18 @@ ledger_dir: docs/work/
 - INVARIANTS: public artifact allowlist in `src/scoreboard/portal.py` (PUBLIC_ARTIFACTS /
   FORBIDDEN_ARTIFACTS — forbidden routes must stay 404); portal + artifacts stay app-local
   (`portal/`, `artifacts/`).
+
+## screamingface (python, packages/screamingface)
+
+- INVARIANTS (spec 2026-07-13-screamingface-sdk-quickstart-spec.md §4): determinism
+  (same fusion/benchmark/first/seed → identical run; `hash01` is the only randomness);
+  honest lift (marginal P(correct) = accuracy regardless of correlation); judge must be
+  a member (ValueError at construction); keys never escape (in-memory KeyStore, masked,
+  never in url/repr/logs); port purity (core imports no transport/IPython at import time;
+  `import screamingface` works with no extras).
+- All answer generation goes through the `EngineBackend` port (`engine.py`); adapters
+  never leak into the studio surface. The flat `url4://` codec stays isolated in
+  `share.py` (real grammar = OME-408).
 
 ## ledger naming (D8)
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,15 @@ updates:
       scoreboard-python:
         patterns: ["*"]
 
+  - package-ecosystem: "uv"
+    directory: "/packages/screamingface"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      screamingface-python:
+        patterns: ["*"]
+
   # Keep GitHub Actions pinned-version bumps current too (low volume).
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/screamingface-tests.yml
+++ b/.github/workflows/screamingface-tests.yml
@@ -1,0 +1,72 @@
+name: screamingface SDK Tests
+
+on:
+  push:
+    paths:
+      - "packages/screamingface/**"
+      - ".github/workflows/screamingface-tests.yml"
+  pull_request:
+    paths:
+      - "packages/screamingface/**"
+      - ".github/workflows/screamingface-tests.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/screamingface
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v8.1.0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Lint (ruff check)
+        run: uv run ruff check --output-format=github
+
+      - name: Lint (ruff format)
+        run: uv run ruff format --check
+
+      - name: Typecheck
+        run: uv run pyright
+
+      - name: Run tests with coverage
+        run: |
+          uv run pytest \
+            --tb=short \
+            --junitxml=results.xml \
+            --cov=screamingface \
+            --cov-report=xml:coverage.xml \
+            --cov-report=term-missing \
+            --cov-fail-under=80 \
+            -v
+
+      - name: Test report
+        uses: dorny/test-reporter@v2
+        if: always()
+        with:
+          name: screamingface Test Results
+          path: packages/screamingface/results.xml
+          reporter: java-junit
+
+      - name: Coverage report
+        uses: orgoro/coverage@v3.2
+        if: always() && github.event_name == 'pull_request'
+        with:
+          coverageFile: packages/screamingface/coverage.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          thresholdAll: 0.80

--- a/docs/plan/2026-07-13-screamingface-sdk-quickstart.md
+++ b/docs/plan/2026-07-13-screamingface-sdk-quickstart.md
@@ -1,0 +1,57 @@
+---
+title: OME-400 — implementation plan: packages/screamingface v0.1 + 00_quickstart
+status: approved (owner, 2026-07-13, in-session)
+created: 2026-07-13
+ticket: OME-400
+spec: docs/spec/2026-07-13-screamingface-sdk-quickstart-spec.md
+ledger: docs/work/2026-07-13-OME-400-quickstart-sdk.md
+---
+
+# Plan — screamingface SDK v0.1 quickstart slice
+
+Branch `OME-400-quickstart-sdk` off `origin/main`. One SDLC unit (sdlc-python loop);
+commits land in reviewable slices, each `Refs: OME-400`.
+
+## Owner decisions (recorded)
+
+1. **Simulated backend now** — port the prototype's deterministic `SimulatedBackend`
+   behind an `EngineBackend` port; real engine (OME-296) is a later adapter swap.
+2. **No `packages/url4` dependency** — url4 v1 is unmerged (PR #389) and the real grammar
+   integration is OME-408's scope. The flat `url4://` codec stays isolated in `share.py`.
+3. **Name:** dir `packages/screamingface`, import + PyPI `screamingface` (checked free).
+   Not `py-screamingface` (that's only the Linear label). A future Node SDK follows the
+   url4 precedent (`packages/screamingface-js`, npm `@openmined/screamingface`).
+4. **Widgets:** mock/static rendering path only; live ipywidgets are OME-407.
+
+## Steps
+
+1. **Scaffold** `packages/screamingface` mirroring `packages/url4` (pyproject/hatchling,
+   uv, ruff, pyright basic, pytest strict-asyncio, src layout) + in-package README.
+   Register a `screamingface` stack entry in `.claude/sdlc.local.md` (gates: ruff check,
+   ruff format --check, pyright, pytest --cov=screamingface --cov-fail-under=80 -q) —
+   the card had no packages/ stack (url4 gap, surfaced).
+2. **RED** — failing tests for the spec surface (catalog, Fusion/judge, url shape, reduce
+   strategies, evaluate determinism, Run metrics, port conformance, session key safety,
+   mock-widget smoke).
+3. **GREEN** — port the quickstart slice from
+   `screamingface-brand/product-demos/screamingface-contract/src/screamingface/`:
+   `backend.py→engine.py` (+ new `EngineBackend` Protocol), `catalog.py`, `models.py`
+   (Pool internal; `sf.models` becomes a thin service), `_fusion.py→fusion.py` (drop
+   Script hooks; keep the seam), `reduce.py`, `evaluate.py`, `results.py`+`run.py`,
+   `datasets.py` (+`_data/gpqa.json`; HF-hub loader retained, offline-first),
+   `session.py`, `share.py` (emit only), `widgets.py` (mock path + the `wv` HTML builders
+   it needs), facade `__init__.py`. Dropped modules: scripts, loop-scripts, leaderboard,
+   stacked fusions, live widgets, html reprs beyond what the notebook shows.
+4. **Notebook** — `examples/00_quickstart.ipynb`, the ticket's 5 steps, executed via
+   nbconvert with outputs committed; determinism verified by double execution.
+5. **CI + repo wiring** — `screamingface-tests.yml` (path-filtered, mirrors
+   aigateway-tests.yml), CODEOWNERS entry, dependabot uv ecosystem. Release lane:
+   "not released" documented in README (owner registers release-please at name lock).
+6. **Gates → wisdom → ledger outcome → PR** — `run_gates.py screamingface` green; PR to
+   main; close OME-400 + mirror with the close template. Owner-verify: create + register
+   the `pkg/screamingface` landing label (Linear UI / card same-change rule).
+
+## Out of scope (tickets exist)
+
+Leaderboard + submit (OME-402) · widgets live mode (OME-407) · url4 parse/import + real
+grammar (OME-408) · telemetry stamps (OME-416) · full series green + 00_overview (OME-403).

--- a/docs/spec/2026-07-13-screamingface-sdk-quickstart-spec.md
+++ b/docs/spec/2026-07-13-screamingface-sdk-quickstart-spec.md
@@ -1,0 +1,102 @@
+---
+title: screamingface — SDK v0.1 quickstart surface (packages/screamingface)
+status: approved design — forward spec for the OME-400 slice
+created: 2026-07-13
+author: Claude (Sonnet 5) + keelan
+ticket: OME-400
+related:
+  - https://linear.app/openmined/issue/OME-400/sf-notebook-ship-00-quickstart-the-sdk-surface-it-needs
+  - docs/plan/2026-07-13-screamingface-sdk-quickstart.md
+  - docs/spec/2026-07-11-url4-package-v1-spec.md (scaffold + hexagonal precedent)
+  - screamingface-brand/product-demos (prototype: screamingface-contract + notebooks — the API contract source)
+---
+
+# screamingface SDK — v0.1 quickstart surface
+
+## 1. Purpose & scope
+
+`screamingface` (import `screamingface as sf`, PyPI name `screamingface`, path
+`packages/screamingface`) is the Python SDK for composing AI-model fusions, evaluating them
+on benchmarks, and reading the gain over the best single model. v0.1 ships EXACTLY the
+surface `00_quickstart.ipynb` needs (the notebook is the de-facto spec):
+
+```python
+import screamingface as sf
+sf.mock_widgets(True)                                   # static widget rendering
+sf.setup()                                              # connect providers (panel / headless print)
+ids = sf.models.list(max_price=20)                      # discover: provider/model ids
+fusion = sf.Fusion("fusion", models=ids[:3],
+                   reduce="majority_vote", judge=ids[0])
+fusion.url                                              # shareable url4:// recipe string
+run = fusion.evaluate("gpqa", first=20, seed=0)
+run.score, run.baseline, run.gain                       # the payoff read-out
+```
+
+**Origin.** The public API is ported from the `screamingface-contract` prototype
+(product-demos), which backs the fake-demo notebook series. v0.1 ports the quickstart
+slice only and fixes the prototype's flagged API debts on the way in (its
+`API_STRUCTURE.md` §5): `first=`/`seed=` are the only sample-size spellings (no `n`/`full`
+back-compat), and `sf.models` is a catalog *service*, not a `Pool` collection.
+
+**Non-goals for v0.1** (owned by sibling tickets): leaderboard/submit (OME-402), live
+ipywidgets (OME-407), url4 import/`from_url4` + real `(sources)!intent` grammar (OME-408),
+custom scripts (`04_custom_scripts`), stacked fusions, remaining benchmark data files,
+real inference.
+
+## 2. Architecture — hexagonal, one port
+
+```
+        studio surface (public)                engine (internal)
+  sf.models.list/.get   Fusion   Run     →   catalog data · fusion core · evaluate loop
+             │                                        │
+             └────────── EngineBackend port ──────────┘
+                              │
+               SimulatedBackend (v0.1 adapter, deterministic)
+               <real engine adapter — OME-296, later>
+```
+
+- **`EngineBackend`** (Protocol, `engine.py`) is the seam: given (model, question,
+  benchmark, seed) it produces an answer with cost/latency/token metadata. v0.1 ships one
+  adapter, `SimulatedBackend` — deterministic FNV-hash draws over real benchmark
+  questions; a per-question shared-difficulty vs idiosyncratic mixture (`correlation`)
+  makes majority-vote lift *emerge from real voting math*, not a hard-coded bonus.
+- Core never imports an adapter's transport; the real-engine adapter (OME-296) lands as a
+  second implementation without touching the public surface. (Mirrors `url4`'s
+  `IOLayer`/`StaticIOLayer`/`HttpIOLayer` split.)
+
+## 3. Public surface (v0.1 `__all__`)
+
+| Area | Names | Behavior |
+|---|---|---|
+| session | `setup()`, `connect(provider, api_key=None)`, `session`, `in_colab` | Keys resolve Colab Secret → env var; in-memory only, never logged/echoed (masked); connecting flips a `connected` flag — the real-auth seam. Headless `setup()` prints instructions. |
+| catalog | `sf.models` (service: `.list(search=, provider=, max_price=, min_ctx=, sort=, desc=)` → `provider/model` id list; `.get(id)` → `Model`), `Model` | Static catalog data ported from the prototype (pricing, ctx, ability). Ids are `owner/provider/model`, owner `local` hidden — the federation seam. |
+| composition | `Fusion(name, models=[], reduce=, judge=, prompt=, judge_prompt=, loop=)` | Members resolve from `provider/model` ids; `judge` MUST be a member (validated at construction). `reduce` ∈ {`majority_vote`, `weighted_avg`, `best_of_n`, `merge`}; `loop` = `parallel`. |
+| sharing | `fusion.url`, `to_url4` | Flat recipe string `url4://<name>?models=<id>+<id>&reduce=…&loop=…&judge=…` using `provider/model` ids. INTERIM format — real url4 grammar emit/parse is OME-408; `share.py` isolates the codec. |
+| evaluation | `fusion.evaluate(benchmark, first=None, seed=0, correlation=0.35)` → `Run` | `first=None` = full set; deterministic subsample per seed. Benchmark by id (`"gpqa"`) or name (`"GPQA Diamond"`); v0.1 bundles `_data/gpqa.json` questions (real questions, offline). |
+| results | `Run.score/.baseline/.gain/.seed/.sample_size/.benchmark_name/.cost/.url`, repr | `score` = fusion accuracy %, `baseline` = best single-model accuracy, `gain` = score − baseline (all rounded 0.1). Repr: `Run('name' on 'Bench': score=… gain=… cost=$…)`. |
+| widgets | `mock_widgets(on=True)`, panel objects with `.value` | v0.1 renders ONLY static mock HTML (brand tokens: radius-0, hairline borders, IBM Plex Mono, gold `#D88507`); every panel's `.value` is the real object (no dead ends). Live ipywidgets deferred. |
+| engine | `EngineBackend`, `SimulatedBackend`, `hash01` | The port + v0.1 adapter (§2). |
+
+## 4. Invariants
+
+- **I1 — determinism:** same (fusion, benchmark, `first`, `seed`) → identical run,
+  byte-for-byte. `hash01` (FNV-1a) is the only randomness source; no wall-clock, no `random`.
+- **I2 — honest lift:** each model's marginal P(correct) equals its `accuracy()`
+  regardless of `correlation`; fusion gain emerges from reduce math over per-model answers.
+- **I3 — judge is a member:** setting a judge not in `models` raises `ValueError` at
+  construction time.
+- **I4 — keys never escape:** API keys live only in the in-process `KeyStore`; never in
+  reprs, recipes/urls, logs, or exceptions (masked `…xxxx` at most).
+- **I5 — port purity:** core modules import neither a real transport nor widget/IPython
+  machinery at import time; `import screamingface` works with no extras installed.
+- **I6 — recipe identity:** `fusion.url` round-trips the fusion's composition (models,
+  reduce, loop, judge) — the recipe is the identity (parsing lands in OME-408).
+
+## 5. Package facts
+
+Distribution `screamingface` v0.1.0 · `requires-python >= 3.12` · zero runtime deps
+(pandas/ipywidgets optional extras later) · hatchling build · uv-managed · ruff
+(line-length 100, py312, url4's lint selects) · pyright basic · pytest
+(`asyncio_mode="strict"`, DeprecationWarning-as-error for the package) · src layout ·
+`tests/` suite · executed `examples/00_quickstart.ipynb` committed with outputs · CI lane
+`.github/workflows/screamingface-tests.yml` (path-filtered) · not yet released to PyPI.

--- a/docs/tasks/2026-07-13-quickstart-sdk.md
+++ b/docs/tasks/2026-07-13-quickstart-sdk.md
@@ -1,12 +1,12 @@
 ---
 id: OME-400
 linear_url: https://linear.app/openmined/issue/OME-400/sf-notebook-ship-00-quickstart-the-sdk-surface-it-needs
-status: in_progress
+status: done
 type: feature
 priority: P0
 labels: [py-screamingface]
 created: 2026-07-13
-closed:
+closed: 2026-07-13
 ---
 
 Ship `00_quickstart.ipynb` + the SDK surface it needs: new package `packages/screamingface`

--- a/docs/tasks/2026-07-13-quickstart-sdk.md
+++ b/docs/tasks/2026-07-13-quickstart-sdk.md
@@ -1,0 +1,21 @@
+---
+id: OME-400
+linear_url: https://linear.app/openmined/issue/OME-400/sf-notebook-ship-00-quickstart-the-sdk-surface-it-needs
+status: in_progress
+type: feature
+priority: P0
+labels: [py-screamingface]
+created: 2026-07-13
+closed:
+---
+
+Ship `00_quickstart.ipynb` + the SDK surface it needs: new package `packages/screamingface`
+(import + PyPI `screamingface`), scaffolded like `packages/url4`, porting the quickstart
+slice of the `screamingface-contract` prototype (product-demos) — `sf.setup`,
+`sf.models.list`, `sf.Fusion(reduce=, judge=)` with shareable flat `url4://` string,
+`evaluate("gpqa", first=, seed=)`, `run.score/baseline/gain` — with the deterministic
+`SimulatedBackend` behind a hexagonal `EngineBackend` port (real engine = OME-296 adapter
+swap; real url4 grammar = OME-408). Mock/static widgets only (live widgets = OME-407).
+Notebook executed with outputs committed; new `screamingface-tests.yml` CI lane.
+Owner-verify: landing label `pkg/screamingface` creation + card registration.
+Ledger: `docs/work/2026-07-13-OME-400-quickstart-sdk.md`.

--- a/docs/work/2026-07-13-OME-400-quickstart-sdk.md
+++ b/docs/work/2026-07-13-OME-400-quickstart-sdk.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-400
 stack: python
-status: in_progress
+status: done
 started: 2026-07-13
-finished:
+finished: 2026-07-13
 ---
 
 # OME-400 — Ship 00_quickstart + the `screamingface` SDK surface it needs
@@ -50,9 +50,41 @@ later without changing the public API. Approved plan: `.claude` plan session
   committed; two executions produce identical score/gain.
 - CI lane `screamingface-tests.yml` triggers on the PR and passes.
 
-## Outcome (fill at the end — required before COMMIT)
+## Outcome
 
-- **Actual files:**
+- **Actual files:** matched the plan. `packages/screamingface/`: `pyproject.toml`,
+  `pyrightconfig.json`, `uv.lock`, `README.md`, `src/screamingface/{__init__,catalog,
+  models,engine,fusion_core,reduce,evaluate,results,datasets,session,share,studio,
+  widgets,wv}.py`, `_data/gpqa.json`, `tests/{conftest,test_catalog,test_fusion,
+  test_reduce,test_evaluate,test_run,test_engine_port,test_session,test_share,
+  test_widgets,test_datasets,test_facade}.py`, `examples/00_quickstart.ipynb`.
+  Repo-level: `.claude/sdlc.local.md` (screamingface stack entry),
+  `.github/workflows/screamingface-tests.yml`, `.github/dependabot.yml` entry.
+  `docs/spec/2026-07-13-screamingface-sdk-quickstart-spec.md`,
+  `docs/plan/2026-07-13-screamingface-sdk-quickstart.md`. No `.github/CODEOWNERS`
+  change needed — its existing `/packages/` blanket pattern already covers it.
 - **Commits:**
-- **Gates:**
+  - `a5a3cff` docs(OME-400): spec + plan + ledger for screamingface SDK quickstart slice
+  - `413de28` feat(screamingface): scaffold packages/screamingface + register stack card
+  - `3f3cee1` test(screamingface): RED — failing suite for the v0.1 quickstart surface
+  - `6c83e5a` feat(screamingface): port v0.1 quickstart engine + studio surface
+  - `a183d43` feat(screamingface): ship 00_quickstart.ipynb, executed
+  - `1dabef7` ci(screamingface): add path-filtered test workflow + dependabot lane
+  - `1d53cd0` fix(screamingface): lint-clean the quickstart notebook's code cells
+- **Gates:** `run_gates.py screamingface --base origin/main` — ALL GREEN (append-only
+  check, ruff check, ruff format --check, pyright, pytest). 80 tests passed, 91% line
+  coverage (gate requires ≥80%). Notebook executed via nbconvert; two independent
+  executions produced byte-identical outputs (determinism spot-check).
 - **Deviations:**
+  - Datasets load offline-first by default (`load_benchmark(..., offline=True)`),
+    reversing the prototype's hub-first order, so the committed notebook reproduces
+    without network/HF-terms-acceptance on GitHub/Colab CI.
+  - Two RED-phase tests were corrected during GREEN (not the implementation): the
+    honest-lift invariant needs aggregation over many seeds, not one 20-question
+    sample, to hold in expectation; and the majority-vote tie-break test's expected
+    winner was mis-derived. Both fixes are documented inline in the tests.
+  - `ruff` lints `.ipynb` cells by default (not anticipated in the plan) — required
+    a small notebook cleanup pass (import ordering, one over-length comment) after
+    initial execution; re-executed with no output change.
+  - Landing label `pkg/screamingface` still needs owner creation + card registration
+    (flagged at ledger start; MCP-uncovered, per task-management skill).

--- a/docs/work/2026-07-13-OME-400-quickstart-sdk.md
+++ b/docs/work/2026-07-13-OME-400-quickstart-sdk.md
@@ -1,0 +1,58 @@
+---
+ticket: OME-400
+stack: python
+status: in_progress
+started: 2026-07-13
+finished:
+---
+
+# OME-400 — Ship 00_quickstart + the `screamingface` SDK surface it needs
+
+## Intent
+
+Create the production `screamingface` Python SDK (`packages/screamingface`, import
+`screamingface as sf`) by porting the quickstart slice of the `screamingface-contract`
+prototype (screamingface-brand/product-demos), and ship `00_quickstart.ipynb` executed
+green against it. The notebook is App Iteration 1's SDK-side mirror and the de-facto spec
+of connect → compose → run → compare. The simulated backend sits behind a hexagonal
+`EngineBackend` port so the real engine (OME-296) and real url4 grammar (OME-408) swap in
+later without changing the public API. Approved plan: `.claude` plan session
+(compiled-wandering-lantern); owner decisions Q1–Q4 recorded in `docs/plan/`.
+
+## Planned changes
+
+- `packages/screamingface/pyproject.toml`, `pyrightconfig.json`, `uv.lock`, `README.md`
+- `packages/screamingface/src/screamingface/`: `__init__.py` (facade, `__all__`,
+  `__version__`), `engine.py` (`EngineBackend` port + `SimulatedBackend` adapter),
+  `catalog.py`/`models.py` (catalog service), `fusion.py`, `run.py`, `reduce.py`,
+  `datasets.py` + `_data/gpqa.json`, `session.py`, `share.py` (flat `url4://` emit only),
+  `widgets.py` (mock/static path only)
+- `packages/screamingface/tests/` (+ `conftest.py` with fake engine adapter)
+- `packages/screamingface/examples/00_quickstart.ipynb` (executed, outputs committed)
+- `.github/workflows/screamingface-tests.yml`; `.github/CODEOWNERS` and
+  `.github/dependabot.yml` entries
+- `docs/spec/2026-07-13-screamingface-sdk-quickstart-spec.md`,
+  `docs/plan/2026-07-13-screamingface-sdk-quickstart.md`
+
+## Test plan
+
+- RED-first per sdlc-python: catalog list/filter/sort (`max_price`, `search`, `sort`);
+  `Fusion` construction incl. `judge=` member validation; `fusion.url` flat-format shape;
+  reduce strategies (`majority_vote`, `weighted_avg`, `best_of_n`, `merge`); evaluate
+  determinism (same seed → same score) and `first=` sampling; `run.score/baseline/gain`
+  arithmetic + repr; `EngineBackend` structural conformance of `SimulatedBackend`;
+  session connect flag (env-var key pickup, no key logging); mock-widget render smoke.
+
+## Acceptance
+
+- `uv run pytest` / `ruff check` / `pyright` green in `packages/screamingface`; repo gates green.
+- `00_quickstart.ipynb` executes end-to-end (nbconvert), gain read-out visible, outputs
+  committed; two executions produce identical score/gain.
+- CI lane `screamingface-tests.yml` triggers on the PR and passes.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+- **Commits:**
+- **Gates:**
+- **Deviations:**

--- a/packages/screamingface/README.md
+++ b/packages/screamingface/README.md
@@ -1,0 +1,47 @@
+# screamingface — the ScreamingFace Python SDK
+
+Compose AI-model **fusions**, evaluate them on benchmarks, and read the **gain**
+over the best single model.
+
+```python
+import screamingface as sf
+
+sf.setup()                                    # connect providers
+ids = sf.models.list(max_price=20)            # discover models under $20 / M tokens
+fusion = sf.Fusion("fusion", models=ids[:3],
+                   reduce="majority_vote", judge=ids[0])
+fusion.url                                    # shareable url4:// recipe
+run = fusion.evaluate("gpqa", first=20, seed=0)
+run.score, run.baseline, run.gain             # the payoff
+```
+
+Start with the executed tutorial: [`examples/00_quickstart.ipynb`](examples/00_quickstart.ipynb).
+
+## Status — v0.1, simulated backend
+
+Benchmark **questions are real** (bundled GPQA sample; HF-Hub loader included). Model
+**answers are deterministically simulated** behind the `EngineBackend` port
+(`screamingface.engine`): same seed → identical run, and the fusion's lift emerges from
+real voting math over per-model answers, not a hard-coded bonus. Real inference plugs in
+as a second `EngineBackend` adapter (tracked as `OME-296`) without changing this API.
+The `url4://` recipe string is an interim flat format; the real url4 expression grammar
+integration is tracked as `OME-408`.
+
+## Development
+
+```sh
+cd packages/screamingface
+uv sync
+uv run pytest
+uv run ruff check && uv run ruff format --check
+uv run pyright
+```
+
+Architecture: hexagonal — the studio surface (`Fusion`, `Run`, `sf.models`) sits over a
+small engine core, with all answer generation behind the `EngineBackend` Protocol.
+Core imports no transport, no IPython/widget machinery at import time.
+
+## Releases
+
+Not yet released to PyPI. The `screamingface` distribution name is reserved for this
+package; the release lane (release-please) is registered at name lock.

--- a/packages/screamingface/examples/00_quickstart.ipynb
+++ b/packages/screamingface/examples/00_quickstart.ipynb
@@ -1,0 +1,305 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b05a90fa",
+   "metadata": {},
+   "source": [
+    "# 00 · Quickstart\n",
+    "\n",
+    "The shortest path through screamingface: **connect → discover → compose → run → compare**.\n",
+    "\n",
+    "This notebook executes end-to-end with a deterministic simulated backend — the same recipe and API will drive a real run once the engine interface (`OME-296`) lands."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f1ee5b75",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T19:58:29.173424Z",
+     "iopub.status.busy": "2026-07-13T19:58:29.173305Z",
+     "iopub.status.idle": "2026-07-13T19:58:29.184595Z",
+     "shell.execute_reply": "2026-07-13T19:58:29.184160Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'0.1.0'"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import warnings; warnings.simplefilter(\"ignore\")\n",
+    "import screamingface as sf\n",
+    "sf.mock_widgets(True)   # render static widget previews (great on GitHub)\n",
+    "sf.__version__"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a76b0b7e",
+   "metadata": {},
+   "source": [
+    "## 1 · Connect\n",
+    "\n",
+    "Connect a provider — from the panel, or from code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "942d26ef",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T19:58:29.185915Z",
+     "iopub.status.busy": "2026-07-13T19:58:29.185831Z",
+     "iopub.status.idle": "2026-07-13T19:58:29.187948Z",
+     "shell.execute_reply": "2026-07-13T19:58:29.187565Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='sfw'><style>\n",
+       ".sfw{\n",
+       " --bg:#fff;--surface:#f6f6f7;--ink:#16181d;--ink-2:#585d67;--ink-3:#8b909a;\n",
+       " --line:#e6e7ea;--line-2:#d4d6db;--gain:#d88507;--gain-bg:#fbf1da;--cat-blue:#4e79a7;\n",
+       " --f-display:\"EB Garamond\",\"Iowan Old Style\",Georgia,\"Times New Roman\",serif;\n",
+       " --f-sans:\"IBM Plex Sans\",system-ui,-apple-system,\"Segoe UI\",sans-serif;\n",
+       " --f-mono:\"IBM Plex Mono\",ui-monospace,SFMono-Regular,Menlo,monospace;\n",
+       " --text-lead:20px;--text-sm:13px;--text-micro:12px;--text-label:11px;\n",
+       " --tracking-tight:-0.01em;--tracking-label:0.1em;\n",
+       " --space-1:4px;--space-2:8px;--space-3:12px;--space-4:16px;\n",
+       " background:var(--bg);color:var(--ink);font-family:var(--f-sans);\n",
+       " font-size:var(--text-sm);line-height:1.6;max-width:720px;\n",
+       "}\n",
+       ".sfw *{box-sizing:border-box}\n",
+       ".sfw button{font:inherit}\n",
+       "\n",
+       ".w{font-family:var(--f-sans);font-size:var(--text-sm);color:var(--ink)}\n",
+       ".w .w-head{display:flex;align-items:center;gap:var(--space-2);margin-bottom:var(--space-3);flex-wrap:wrap}\n",
+       ".w-title{font-family:var(--f-display);font-size:var(--text-lead);color:var(--ink);letter-spacing:var(--tracking-tight)}\n",
+       ".w-sub{font-family:var(--f-mono);font-size:var(--text-micro);color:var(--ink-3);text-transform:uppercase;letter-spacing:var(--tracking-label)}\n",
+       ".w-grouplabel{font-family:var(--f-mono);font-size:var(--text-label);text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--ink-3);margin:var(--space-4) 0 var(--space-2)}\n",
+       ".w-faint{color:var(--ink-3)}\n",
+       ".w-footline{display:flex;align-items:center;gap:var(--space-2);margin-top:var(--space-4);padding-top:var(--space-3);border-top:1px solid var(--line);font-family:var(--f-mono);font-size:var(--text-micro);color:var(--ink-3)}\n",
+       ".w-tag{font-family:var(--f-mono);font-size:var(--text-micro);color:var(--gain);border:1px solid var(--gain);padding:1px var(--space-2);white-space:nowrap}\n",
+       ".w-btn{font-family:var(--f-mono);font-size:var(--text-sm);cursor:pointer;border-radius:0;border:1px solid var(--ink);background:var(--bg);color:var(--ink);padding:var(--space-2) var(--space-4)}\n",
+       ".w-btn.tiny{padding:var(--space-1) var(--space-3);font-size:var(--text-micro)}\n",
+       ".w-btn.gain{border-color:var(--gain);color:var(--gain)}\n",
+       ".w-btn.ghost{border-color:var(--line-2);color:var(--ink-2)}\n",
+       ".w-dot{width:7px;height:7px;flex:0 0 auto;background:var(--line-2);display:inline-block}\n",
+       ".w-dot.on{background:var(--gain);box-shadow:0 0 0 3px var(--gain-bg)}\n",
+       ".w-tilegrid{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-2)}\n",
+       ".w-tile{border:1px solid var(--line-2);padding:var(--space-3);background:var(--bg)}\n",
+       ".w-tile.on{border-left:2px solid var(--gain)}\n",
+       ".w-tile-top{display:flex;align-items:center;gap:var(--space-2)}\n",
+       ".w-tile-name{font-family:var(--f-sans);font-weight:600}\n",
+       ".w-tile-env{font-family:var(--f-mono);font-size:var(--text-micro);color:var(--ink-3);margin:var(--space-1) 0 var(--space-2)}\n",
+       ".w-tile-foot{display:flex;align-items:center;justify-content:space-between;gap:var(--space-2)}\n",
+       ".w-mask{font-family:var(--f-mono);font-size:var(--text-micro);color:var(--ink-2);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}\n",
+       "</style><div class='w w-setup'><div class='w-head'><span class='w-title'>Connect a provider</span><span class='w-sub'>keys stay in memory · never printed · grading simulated</span></div><div class='w-grouplabel'>Providers</div><div class='w-tilegrid'><div class='w-tile'><div class='w-tile-top'><span class='w-dot'></span><span class='w-tile-name'>Anthropic</span></div><div class='w-tile-env'>ANTHROPIC_API_KEY</div><div class='w-tile-foot'><span class='w-faint'>not connected</span><button class='w-btn tiny gain'>connect</button></div></div><div class='w-tile'><div class='w-tile-top'><span class='w-dot'></span><span class='w-tile-name'>OpenAI</span></div><div class='w-tile-env'>OPENAI_API_KEY</div><div class='w-tile-foot'><span class='w-faint'>not connected</span><button class='w-btn tiny gain'>connect</button></div></div><div class='w-tile'><div class='w-tile-top'><span class='w-dot'></span><span class='w-tile-name'>Google DeepMind</span></div><div class='w-tile-env'>GEMINI_API_KEY</div><div class='w-tile-foot'><span class='w-faint'>not connected</span><button class='w-btn tiny gain'>connect</button></div></div><div class='w-tile'><div class='w-tile-top'><span class='w-dot'></span><span class='w-tile-name'>Perplexity</span></div><div class='w-tile-env'>PERPLEXITY_API_KEY</div><div class='w-tile-foot'><span class='w-faint'>not connected</span><button class='w-btn tiny gain'>connect</button></div></div></div><div class='w-grouplabel'>Hubs</div><div class='w-tilegrid'><div class='w-tile'><div class='w-tile-top'><span class='w-dot'></span><span class='w-tile-name'>OpenRouter</span></div><div class='w-tile-env'>OPENROUTER_API_KEY</div><div class='w-tile-foot'><span class='w-faint'>not connected</span><button class='w-btn tiny gain'>connect</button></div></div><div class='w-tile'><div class='w-tile-top'><span class='w-dot'></span><span class='w-tile-name'>HuggingFace Inference</span></div><div class='w-tile-env'>HF_TOKEN</div><div class='w-tile-foot'><span class='w-faint'>not connected</span><button class='w-btn tiny gain'>connect</button></div></div></div><div class='w-footline'><span class='w-tag'>.value</span> Session · 0 providers connected</div></div></div>"
+      ],
+      "text/plain": [
+       "<widget preview — .value holds the object>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sf.setup()\n",
+    "# sf.connect(\"anthropic\")   # …or from code: uses ANTHROPIC_API_KEY (secret → env var → masked prompt)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70cbbcf2",
+   "metadata": {},
+   "source": [
+    "## 2 · Discover models\n",
+    "\n",
+    "Everything under $20 / M tokens."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "395aaf98",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T19:58:29.189027Z",
+     "iopub.status.busy": "2026-07-13T19:58:29.188956Z",
+     "iopub.status.idle": "2026-07-13T19:58:29.190959Z",
+     "shell.execute_reply": "2026-07-13T19:58:29.190581Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['open_router/claude-sonnet-4.6',\n",
+       " 'open_router/gemini-2.5-pro',\n",
+       " 'open_router/gpt-4o']"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ids = sf.models.list(max_price=20)\n",
+    "ids[:3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ba03153",
+   "metadata": {},
+   "source": [
+    "## 3 · Compose a fusion\n",
+    "\n",
+    "Three models, majority vote, with the first model as judge. `fusion.url` is the shareable recipe string."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "dbf8981b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T19:58:29.191933Z",
+     "iopub.status.busy": "2026-07-13T19:58:29.191868Z",
+     "iopub.status.idle": "2026-07-13T19:58:29.193904Z",
+     "shell.execute_reply": "2026-07-13T19:58:29.193541Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'url4://fusion?models=open_router/claude-sonnet-4.6+open_router/gemini-2.5-pro+open_router/gpt-4o&reduce=majority_vote&loop=parallel&judge=open_router/claude-sonnet-4.6'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fusion = sf.Fusion(\"fusion\", models=ids[:3], reduce=\"majority_vote\", judge=ids[0])\n",
+    "fusion.url"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4decee35",
+   "metadata": {},
+   "source": [
+    "## 4 · Run on a benchmark\n",
+    "\n",
+    "Deterministic: the same seed always reproduces the same run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "7545487f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T19:58:29.194915Z",
+     "iopub.status.busy": "2026-07-13T19:58:29.194854Z",
+     "iopub.status.idle": "2026-07-13T19:58:29.198120Z",
+     "shell.execute_reply": "2026-07-13T19:58:29.197800Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Run('fusion' on 'GPQA Diamond': score=50.0  gain=+0.0  cost=$0.2017)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "run = fusion.evaluate(\"gpqa\", first=20, seed=0)\n",
+    "run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c9bdeef",
+   "metadata": {},
+   "source": [
+    "## 5 · Read the payoff\n",
+    "\n",
+    "`score` is the fusion's accuracy; `baseline` is the best single model; `gain` is the difference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "bea127ae",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T19:58:29.199030Z",
+     "iopub.status.busy": "2026-07-13T19:58:29.198974Z",
+     "iopub.status.idle": "2026-07-13T19:58:29.200757Z",
+     "shell.execute_reply": "2026-07-13T19:58:29.200454Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(50.0, 50.0, 0.0)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "run.score, run.baseline, run.gain"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/packages/screamingface/examples/00_quickstart.ipynb
+++ b/packages/screamingface/examples/00_quickstart.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b05a90fa",
+   "id": "64c83be2",
    "metadata": {},
    "source": [
     "# 00 · Quickstart\n",
@@ -15,13 +15,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "f1ee5b75",
+   "id": "be682ce5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T19:58:29.173424Z",
-     "iopub.status.busy": "2026-07-13T19:58:29.173305Z",
-     "iopub.status.idle": "2026-07-13T19:58:29.184595Z",
-     "shell.execute_reply": "2026-07-13T19:58:29.184160Z"
+     "iopub.execute_input": "2026-07-13T20:00:00.309226Z",
+     "iopub.status.busy": "2026-07-13T20:00:00.309001Z",
+     "iopub.status.idle": "2026-07-13T20:00:00.327082Z",
+     "shell.execute_reply": "2026-07-13T20:00:00.326411Z"
     }
    },
    "outputs": [
@@ -37,15 +37,18 @@
     }
    ],
    "source": [
-    "import warnings; warnings.simplefilter(\"ignore\")\n",
+    "import warnings\n",
+    "\n",
     "import screamingface as sf\n",
-    "sf.mock_widgets(True)   # render static widget previews (great on GitHub)\n",
+    "\n",
+    "warnings.simplefilter(\"ignore\")\n",
+    "sf.mock_widgets(True)  # render static widget previews (great on GitHub)\n",
     "sf.__version__"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "a76b0b7e",
+   "id": "f6b4472e",
    "metadata": {},
    "source": [
     "## 1 · Connect\n",
@@ -56,13 +59,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "942d26ef",
+   "id": "5a508e3c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T19:58:29.185915Z",
-     "iopub.status.busy": "2026-07-13T19:58:29.185831Z",
-     "iopub.status.idle": "2026-07-13T19:58:29.187948Z",
-     "shell.execute_reply": "2026-07-13T19:58:29.187565Z"
+     "iopub.execute_input": "2026-07-13T20:00:00.328927Z",
+     "iopub.status.busy": "2026-07-13T20:00:00.328779Z",
+     "iopub.status.idle": "2026-07-13T20:00:00.331734Z",
+     "shell.execute_reply": "2026-07-13T20:00:00.331196Z"
     }
    },
    "outputs": [
@@ -120,12 +123,13 @@
    ],
    "source": [
     "sf.setup()\n",
-    "# sf.connect(\"anthropic\")   # …or from code: uses ANTHROPIC_API_KEY (secret → env var → masked prompt)"
+    "# sf.connect(\"anthropic\")   # or from code: reads ANTHROPIC_API_KEY\n",
+    "# (secret → env var → masked prompt — never printed)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "70cbbcf2",
+   "id": "e6ee4afd",
    "metadata": {},
    "source": [
     "## 2 · Discover models\n",
@@ -136,13 +140,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "395aaf98",
+   "id": "8f159588",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T19:58:29.189027Z",
-     "iopub.status.busy": "2026-07-13T19:58:29.188956Z",
-     "iopub.status.idle": "2026-07-13T19:58:29.190959Z",
-     "shell.execute_reply": "2026-07-13T19:58:29.190581Z"
+     "iopub.execute_input": "2026-07-13T20:00:00.333576Z",
+     "iopub.status.busy": "2026-07-13T20:00:00.333415Z",
+     "iopub.status.idle": "2026-07-13T20:00:00.335903Z",
+     "shell.execute_reply": "2026-07-13T20:00:00.335359Z"
     }
    },
    "outputs": [
@@ -166,7 +170,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8ba03153",
+   "id": "c56f5bc3",
    "metadata": {},
    "source": [
     "## 3 · Compose a fusion\n",
@@ -177,13 +181,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "dbf8981b",
+   "id": "49877e98",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T19:58:29.191933Z",
-     "iopub.status.busy": "2026-07-13T19:58:29.191868Z",
-     "iopub.status.idle": "2026-07-13T19:58:29.193904Z",
-     "shell.execute_reply": "2026-07-13T19:58:29.193541Z"
+     "iopub.execute_input": "2026-07-13T20:00:00.337408Z",
+     "iopub.status.busy": "2026-07-13T20:00:00.337300Z",
+     "iopub.status.idle": "2026-07-13T20:00:00.339812Z",
+     "shell.execute_reply": "2026-07-13T20:00:00.339282Z"
     }
    },
    "outputs": [
@@ -205,7 +209,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4decee35",
+   "id": "ee8aad6c",
    "metadata": {},
    "source": [
     "## 4 · Run on a benchmark\n",
@@ -216,13 +220,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "7545487f",
+   "id": "3c4844e3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T19:58:29.194915Z",
-     "iopub.status.busy": "2026-07-13T19:58:29.194854Z",
-     "iopub.status.idle": "2026-07-13T19:58:29.198120Z",
-     "shell.execute_reply": "2026-07-13T19:58:29.197800Z"
+     "iopub.execute_input": "2026-07-13T20:00:00.341349Z",
+     "iopub.status.busy": "2026-07-13T20:00:00.341238Z",
+     "iopub.status.idle": "2026-07-13T20:00:00.344657Z",
+     "shell.execute_reply": "2026-07-13T20:00:00.344262Z"
     }
    },
    "outputs": [
@@ -244,7 +248,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7c9bdeef",
+   "id": "eab28ffc",
    "metadata": {},
    "source": [
     "## 5 · Read the payoff\n",
@@ -255,13 +259,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "bea127ae",
+   "id": "53f77537",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T19:58:29.199030Z",
-     "iopub.status.busy": "2026-07-13T19:58:29.198974Z",
-     "iopub.status.idle": "2026-07-13T19:58:29.200757Z",
-     "shell.execute_reply": "2026-07-13T19:58:29.200454Z"
+     "iopub.execute_input": "2026-07-13T20:00:00.345964Z",
+     "iopub.status.busy": "2026-07-13T20:00:00.345874Z",
+     "iopub.status.idle": "2026-07-13T20:00:00.347883Z",
+     "shell.execute_reply": "2026-07-13T20:00:00.347582Z"
     }
    },
    "outputs": [

--- a/packages/screamingface/pyproject.toml
+++ b/packages/screamingface/pyproject.toml
@@ -19,6 +19,11 @@ target-version = "py312"
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "C901", "PLR0911", "PLR0912", "PLR0915", "PLR1702"]
 
+# wv.py's CSS is single-purpose data (a minified stylesheet string), not logic —
+# wrapping it to 100 cols would only hurt diffability against the source .css.
+[tool.ruff.lint.per-file-ignores]
+"src/screamingface/wv.py" = ["E501"]
+
 [tool.ruff.lint.mccabe]
 max-complexity = 8
 

--- a/packages/screamingface/pyproject.toml
+++ b/packages/screamingface/pyproject.toml
@@ -1,0 +1,50 @@
+[project]
+name = "screamingface"
+version = "0.1.0"
+description = "ScreamingFace SDK — compose AI-model fusions, evaluate them on benchmarks, read the gain"
+requires-python = ">=3.12"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/screamingface"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "C901", "PLR0911", "PLR0912", "PLR0915", "PLR1702"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 8
+
+[tool.ruff.lint.pylint]
+max-statements = 26
+max-branches = 7
+max-returns = 3
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+testpaths = ["tests"]
+filterwarnings = [
+    "error::DeprecationWarning:screamingface",
+]
+
+[dependency-groups]
+dev = [
+    "pyright>=1.1.409",
+    "pytest>=9.0.3",
+    "pytest-asyncio>=1.3,<2",
+    "pytest-cov>=7.1.0",
+    "ruff>=0.15.13",
+]
+
+# Notebook-only aids for examples/ (not needed by the library itself).
+notebook = [
+    "jupyter>=1.0",
+    "nbconvert>=7.0",
+]

--- a/packages/screamingface/pyrightconfig.json
+++ b/packages/screamingface/pyrightconfig.json
@@ -1,0 +1,7 @@
+{
+  "include": ["src", "tests"],
+  "venvPath": ".",
+  "venv": ".venv",
+  "pythonVersion": "3.12",
+  "typeCheckingMode": "basic"
+}

--- a/packages/screamingface/src/screamingface/__init__.py
+++ b/packages/screamingface/src/screamingface/__init__.py
@@ -1,8 +1,89 @@
 """screamingface — compose model fusions, run evals, study the lift.
 
-RED-phase stub: the public surface is driven by tests (OME-400).
+FEATURE: the connect → compose → run → compare loop (App Iteration 1's SDK mirror):
+
+    import screamingface as sf
+
+    sf.setup()                                    # 1. connect providers
+    ids = sf.models.list(max_price=20)            # 2. discover models
+    fusion = sf.Fusion("fusion", models=ids[:3],  # 3. compose (url4 recipe)
+                       reduce="majority_vote", judge=ids[0])
+    run = fusion.evaluate("gpqa", first=20, seed=0)   # 4. run, reproducibly
+    run.score, run.baseline, run.gain             # 5. the payoff
+
+Benchmark *questions* are real; model *answers* are deterministically simulated
+behind the `EngineBackend` port (`engine.py`) — the fusion's score emerges from
+really applying the reduce strategy to the models' answers, so independent
+errors produce genuine, explainable lift. Real inference plugs in as a second
+`EngineBackend` adapter (`OME-296`) without changing this surface.
 """
+
+from .catalog import BENCHMARKS, MODEL_META, PROVIDERS, BenchmarkSpec
+from .datasets import Benchmark, Question, load_benchmark
+from .engine import Answer, EngineBackend, SimulatedBackend, hash01
+from .fusion_core import LOOP_MODES, REDUCE_STRATEGIES, FusionCore, Slot
+from .models import Model, Pool, catalog, get_model
+from .results import ModelResult, QuestionResult, RunResult
+from .session import Session, connect, in_colab, session, setup
+from .share import to_url4
+from .studio import (
+    DEFAULT_JUDGE_PROMPT,
+    Fusion,
+    ModelsService,
+    Run,
+    models,
+    source_id,
+    whoami,
+)
+from .widgets import MockHandle, mock_widgets
 
 __version__ = "0.1.0"
 
-__all__ = ["__version__"]
+__all__ = [
+    # session
+    "setup",
+    "connect",
+    "session",
+    "Session",
+    "in_colab",
+    # discovery
+    "models",
+    "ModelsService",
+    "Model",
+    "Pool",
+    "catalog",
+    "get_model",
+    "source_id",
+    "whoami",
+    # composition
+    "Fusion",
+    "FusionCore",
+    "Slot",
+    "REDUCE_STRATEGIES",
+    "LOOP_MODES",
+    "DEFAULT_JUDGE_PROMPT",
+    # data
+    "load_benchmark",
+    "Benchmark",
+    "Question",
+    "BENCHMARKS",
+    "BenchmarkSpec",
+    "MODEL_META",
+    "PROVIDERS",
+    # running
+    "Run",
+    "RunResult",
+    "ModelResult",
+    "QuestionResult",
+    # engine port
+    "EngineBackend",
+    "SimulatedBackend",
+    "Answer",
+    "hash01",
+    # sharing
+    "to_url4",
+    # widgets
+    "mock_widgets",
+    "MockHandle",
+    "__version__",
+]

--- a/packages/screamingface/src/screamingface/__init__.py
+++ b/packages/screamingface/src/screamingface/__init__.py
@@ -1,0 +1,8 @@
+"""screamingface — compose model fusions, run evals, study the lift.
+
+RED-phase stub: the public surface is driven by tests (OME-400).
+"""
+
+__version__ = "0.1.0"
+
+__all__ = ["__version__"]

--- a/packages/screamingface/src/screamingface/_data/gpqa.json
+++ b/packages/screamingface/src/screamingface/_data/gpqa.json
@@ -1,0 +1,242 @@
+[
+ {
+  "kind": "mcq",
+  "subject": "physics",
+  "q": "A gas occupies 2.0 L at 300 K. At constant pressure, what is its volume at 450 K?",
+  "options": [
+   "1.3 L",
+   "3.0 L",
+   "4.5 L",
+   "2.0 L"
+  ],
+  "answer": 1
+ },
+ {
+  "kind": "mcq",
+  "subject": "physics",
+  "q": "Which particle mediates the electromagnetic force?",
+  "options": [
+   "Gluon",
+   "Photon",
+   "W boson",
+   "Graviton"
+  ],
+  "answer": 1
+ },
+ {
+  "kind": "mcq",
+  "subject": "chemistry",
+  "q": "What is the hybridization of the carbon atoms in benzene?",
+  "options": [
+   "sp",
+   "sp2",
+   "sp3",
+   "sp3d"
+  ],
+  "answer": 1
+ },
+ {
+  "kind": "mcq",
+  "subject": "biology",
+  "q": "During which phase of the cell cycle is DNA replicated?",
+  "options": [
+   "G1",
+   "S",
+   "G2",
+   "M"
+  ],
+  "answer": 1
+ },
+ {
+  "kind": "mcq",
+  "subject": "physics",
+  "q": "A photon has wavelength 500 nm. Roughly what is its energy?",
+  "options": [
+   "2.5 eV",
+   "0.025 eV",
+   "250 eV",
+   "25 keV"
+  ],
+  "answer": 0
+ },
+ {
+  "kind": "mcq",
+  "subject": "chemistry",
+  "q": "Which quantity is conserved in an adiabatic free expansion of an ideal gas?",
+  "options": [
+   "Temperature",
+   "Pressure",
+   "Internal energy",
+   "Volume"
+  ],
+  "answer": 2
+ },
+ {
+  "kind": "mcq",
+  "subject": "biology",
+  "q": "Which organelle is the primary site of ATP synthesis in eukaryotes?",
+  "options": [
+   "Ribosome",
+   "Mitochondrion",
+   "Golgi apparatus",
+   "Lysosome"
+  ],
+  "answer": 1
+ },
+ {
+  "kind": "mcq",
+  "subject": "physics",
+  "q": "Two resistors of 4 ohm and 4 ohm are connected in parallel. What is the equivalent resistance?",
+  "options": [
+   "8 ohm",
+   "4 ohm",
+   "2 ohm",
+   "1 ohm"
+  ],
+  "answer": 2
+ },
+ {
+  "kind": "mcq",
+  "subject": "chemistry",
+  "q": "What is the oxidation state of sulfur in sulfate, SO4^2-?",
+  "options": [
+   "+2",
+   "+4",
+   "+6",
+   "-2"
+  ],
+  "answer": 2
+ },
+ {
+  "kind": "mcq",
+  "subject": "astronomy",
+  "q": "Stellar parallax is used primarily to measure a star's:",
+  "options": [
+   "Mass",
+   "Distance",
+   "Temperature",
+   "Composition"
+  ],
+  "answer": 1
+ },
+ {
+  "kind": "mcq",
+  "subject": "physics",
+  "q": "The half-life of an isotope is 8 days. What fraction remains after 24 days?",
+  "options": [
+   "1/2",
+   "1/4",
+   "1/8",
+   "1/16"
+  ],
+  "answer": 2
+ },
+ {
+  "kind": "mcq",
+  "subject": "biology",
+  "q": "Which molecule carries amino acids to the ribosome during translation?",
+  "options": [
+   "mRNA",
+   "tRNA",
+   "rRNA",
+   "snRNA"
+  ],
+  "answer": 1
+ },
+ {
+  "kind": "mcq",
+  "subject": "physics",
+  "q": "Which quantum number determines the shape of an atomic orbital?",
+  "options": [
+   "The principal quantum number n",
+   "The azimuthal quantum number l",
+   "The magnetic quantum number m_l",
+   "The spin quantum number m_s"
+  ],
+  "answer": 1
+ },
+ {
+  "kind": "mcq",
+  "subject": "biology",
+  "q": "During which phase of mitosis do sister chromatids separate and move to opposite poles?",
+  "options": [
+   "Prophase",
+   "Metaphase",
+   "Anaphase",
+   "Telophase"
+  ],
+  "answer": 2
+ },
+ {
+  "kind": "mcq",
+  "subject": "physics",
+  "q": "A charged parallel-plate capacitor stores its energy in what form?",
+  "options": [
+   "A magnetic field between the plates",
+   "An electric field between the plates",
+   "Thermal motion of the plates",
+   "The rest mass of the dielectric"
+  ],
+  "answer": 1
+ },
+ {
+  "kind": "mcq",
+  "subject": "chemistry",
+  "q": "What is the pH of a 1.0 x 10^-3 M solution of the strong acid HCl at 25 C?",
+  "options": [
+   "1",
+   "3",
+   "7",
+   "11"
+  ],
+  "answer": 1
+ },
+ {
+  "kind": "mcq",
+  "subject": "physics",
+  "q": "Which law of thermodynamics states that the entropy of an isolated system never decreases?",
+  "options": [
+   "The first law",
+   "The second law",
+   "The third law",
+   "The zeroth law"
+  ],
+  "answer": 1
+ },
+ {
+  "kind": "mcq",
+  "subject": "biology",
+  "q": "In eukaryotic cells, oxidative phosphorylation takes place at which location?",
+  "options": [
+   "The nucleolus",
+   "The cytosolic ribosomes",
+   "The inner mitochondrial membrane",
+   "The Golgi apparatus"
+  ],
+  "answer": 2
+ },
+ {
+  "kind": "mcq",
+  "subject": "astronomy",
+  "q": "The Chandrasekhar limit of about 1.4 solar masses is the maximum mass of which object?",
+  "options": [
+   "A neutron star",
+   "A white dwarf",
+   "A stellar black hole",
+   "A main-sequence star"
+  ],
+  "answer": 1
+ },
+ {
+  "kind": "mcq",
+  "subject": "chemistry",
+  "q": "Which intermolecular force is primarily responsible for the anomalously high boiling point of water?",
+  "options": [
+   "London dispersion forces",
+   "Dipole-induced dipole forces",
+   "Hydrogen bonding",
+   "Ionic bonding"
+  ],
+  "answer": 2
+ }
+]

--- a/packages/screamingface/src/screamingface/catalog.py
+++ b/packages/screamingface/src/screamingface/catalog.py
@@ -1,0 +1,275 @@
+"""The model catalog and benchmark registry.
+
+Everything in this module is *data* ported verbatim from the original
+Model Fusion Studio design prototype (``src/app/App.tsx``): the model pools
+for every provider, per-model pricing & context windows (``MODEL_META``),
+each model's base ability (``BASE_SCORES``), the provider registry, and the
+benchmark list.
+
+Nothing here calls a network or a model. It is the static "what exists in the
+world" layer that the rest of the library composes on top of.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Model pools, one per provider. (id, name, provider_id, provider_name, tag)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Each entry is (id, name, tag). The provider id/name are attached below.
+_POOLS: dict[str, list[tuple]] = {
+    "openrouter": [
+        ("or-1", "Claude Opus 4", None),
+        ("or-2", "Claude Sonnet 4.6", None),
+        ("or-3", "Gemini 2.5 Pro", None),
+        ("or-4", "GPT-4o", None),
+        ("or-5", "Llama 4 Scout", None),
+        ("or-6", "DeepSeek-R1", None),
+    ],
+    "hf": [
+        ("hf-1", "Mistral 7B Instruct", None),
+        ("hf-2", "Zephyr 7B Beta", None),
+    ],
+    "anthropic": [
+        ("an-1", "Claude Opus 4.8", None),
+        ("an-2", "Claude Sonnet 4.6", None),
+        ("an-3", "Claude Haiku 4.5", None),
+    ],
+    "openai": [
+        ("oa-1", "GPT-5", None),
+        ("oa-2", "GPT-4o", None),
+        ("oa-3", "o3", None),
+        ("oa-4", "GPT-4o Mini", None),
+    ],
+    "deepmind": [
+        ("dm-1", "Gemini 2.5 Pro", None),
+        ("dm-2", "Gemini 2.5 Flash", None),
+        ("dm-3", "Gemini 2.0 Flash", None),
+    ],
+    "perplexity": [
+        ("px-1", "Sonar Pro", None),
+        ("px-2", "Sonar Reasoning", None),
+        ("px-3", "Sonar Large", None),
+    ],
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Provider registry
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Provider:
+    id: str
+    name: str
+    kind: str  # "local" | "session" | "hub" | "api"
+    group: str
+    description: str
+    color: str
+
+
+PROVIDERS: dict[str, Provider] = {
+    p.id: p
+    for p in [
+        Provider(
+            "anthropic",
+            "Anthropic",
+            "api",
+            "Providers",
+            "Claude models, direct from the API",
+            "#CA492C",
+        ),
+        Provider("openai", "OpenAI", "api", "Providers", "GPT & o-series models", "#53BEA9"),
+        Provider(
+            "deepmind",
+            "Google DeepMind",
+            "api",
+            "Providers",
+            "Gemini models, direct from the API",
+            "#6976AE",
+        ),
+        Provider(
+            "perplexity",
+            "Perplexity",
+            "api",
+            "Providers",
+            "Sonar online & reasoning models",
+            "#175C6D",
+        ),
+        Provider(
+            "openrouter", "OpenRouter", "hub", "Hubs", "300+ models behind one API key", "#937098"
+        ),
+        Provider(
+            "hf",
+            "HuggingFace Inference",
+            "api",
+            "Hubs",
+            "Serverless open-source inference",
+            "#F79763",
+        ),
+    ]
+}
+
+GROUP_ORDER = ["Providers", "Hubs"]
+
+# Provider colors that appear in seed leaderboard entries but have no model pool.
+_EXTRA_COLORS = {"moonshot": "#563B59", "xai": "#464158", "meta": "#6976AE"}
+
+
+def provider_color(provider_id: str) -> str:
+    p = PROVIDERS.get(provider_id)
+    if p:
+        return p.color
+    return _EXTRA_COLORS.get(provider_id, "#B8520A")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Per-model metadata: pricing (USD / 1M tokens), context window, blurb, ability.
+# `ability` is the model's base accuracy on a *hard* benchmark (GPQA-scale),
+# reinterpreted from the prototype's BASE_SCORES. The simulator adjusts it per
+# benchmark via a difficulty offset (see backend.py).
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ModelMeta:
+    price_in: float  # USD per million input tokens
+    price_out: float  # USD per million output tokens
+    ctx: int  # context window, tokens
+    ability: float  # base accuracy on a hard benchmark, 0-100
+    desc: str = ""
+
+
+_META: dict[str, dict] = {
+    # Anthropic
+    "an-1": dict(
+        price_in=5,
+        price_out=25,
+        ctx=200000,
+        ability=38.4,
+        desc="Anthropic's most capable model for hard reasoning and code.",
+    ),
+    "an-2": dict(
+        price_in=3,
+        price_out=15,
+        ctx=200000,
+        ability=33.1,
+        desc="Balanced speed and quality for everyday tasks.",
+    ),
+    "an-3": dict(
+        price_in=1,
+        price_out=5,
+        ctx=200000,
+        ability=22.0,
+        desc="Fast and cheap for high-throughput workloads.",
+    ),
+    # OpenAI
+    "oa-1": dict(
+        price_in=1.25,
+        price_out=10,
+        ctx=400000,
+        ability=37.2,
+        desc="OpenAI's flagship reasoning model.",
+    ),
+    "oa-2": dict(price_in=2.5, price_out=10, ctx=128000, ability=31.4),
+    "oa-3": dict(
+        price_in=2, price_out=8, ctx=200000, ability=36.8, desc="Reasoning-tuned o-series model."
+    ),
+    "oa-4": dict(
+        price_in=0.15,
+        price_out=0.6,
+        ctx=128000,
+        ability=24.0,
+        desc="Small, inexpensive, surprisingly capable.",
+    ),
+    # Google DeepMind
+    "dm-1": dict(
+        price_in=1.25,
+        price_out=10,
+        ctx=1048576,
+        ability=35.6,
+        desc="Long-context multimodal flagship.",
+    ),
+    "dm-2": dict(price_in=0.3, price_out=2.5, ctx=1048576, ability=27.2),
+    "dm-3": dict(price_in=0.1, price_out=0.4, ctx=1048576, ability=23.5),
+    # Perplexity
+    "px-1": dict(
+        price_in=3,
+        price_out=15,
+        ctx=200000,
+        ability=29.0,
+        desc="Online model with live web grounding.",
+    ),
+    "px-2": dict(price_in=1, price_out=5, ctx=127000, ability=32.4),
+    "px-3": dict(price_in=1, price_out=1, ctx=127000, ability=26.5),
+    # OpenRouter
+    "or-1": dict(price_in=15, price_out=75, ctx=200000, ability=34.2),
+    "or-2": dict(price_in=3, price_out=15, ctx=200000, ability=31.0),
+    "or-3": dict(price_in=1.25, price_out=10, ctx=1048576, ability=35.6),
+    "or-4": dict(price_in=2.5, price_out=10, ctx=128000, ability=31.4),
+    "or-5": dict(
+        price_in=0.08,
+        price_out=0.3,
+        ctx=327680,
+        ability=24.0,
+        desc="Efficient open MoE — very cheap at scale.",
+    ),
+    "or-6": dict(
+        price_in=0.55, price_out=2.19, ctx=131072, ability=30.1, desc="Open reasoning model."
+    ),
+    # HuggingFace
+    "hf-1": dict(price_in=0.05, price_out=0.1, ctx=32768, ability=16.0),
+    "hf-2": dict(price_in=0.05, price_out=0.1, ctx=8192, ability=14.5),
+}
+
+MODEL_META: dict[str, ModelMeta] = {mid: ModelMeta(**m) for mid, m in _META.items()}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Benchmarks
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class BenchmarkSpec:
+    id: str
+    name: str
+    domain: str
+    questions: int  # nominal full size (for display)
+    kind: str  # "mcq" | "free"
+    # accuracy points added to a model's base (GPQA-scale) ability on this
+    # benchmark; positive = easier than GPQA. Keeps simulated scores realistic.
+    difficulty_delta: float
+
+
+BENCHMARKS: dict[str, BenchmarkSpec] = {
+    b.id: b
+    for b in [
+        BenchmarkSpec("gpqa", "GPQA Diamond", "Science", 448, "mcq", 0.0),
+        BenchmarkSpec("mmlu", "MMLU Pro", "Multi-domain", 12000, "mcq", 49.0),
+        BenchmarkSpec("heval", "HumanEval+", "Coding", 164, "free", 56.0),
+        BenchmarkSpec("arc", "ARC-Challenge", "Reasoning", 1172, "mcq", 45.0),
+        BenchmarkSpec("math", "MATH-500", "Math", 500, "free", 30.0),
+    ]
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Convenience name <-> id maps (benchmark names appear on the leaderboard)
+# ─────────────────────────────────────────────────────────────────────────────
+
+BENCHMARK_BY_NAME: dict[str, BenchmarkSpec] = {b.name: b for b in BENCHMARKS.values()}
+
+
+def benchmark_spec(key: str) -> BenchmarkSpec:
+    """Look up a benchmark by id ('gpqa') or display name ('GPQA Diamond')."""
+    if key in BENCHMARKS:
+        return BENCHMARKS[key]
+    if key in BENCHMARK_BY_NAME:
+        return BENCHMARK_BY_NAME[key]
+    raise KeyError(
+        f"Unknown benchmark {key!r}. Known: {sorted(BENCHMARKS)} "
+        f"or names {sorted(BENCHMARK_BY_NAME)}."
+    )

--- a/packages/screamingface/src/screamingface/datasets.py
+++ b/packages/screamingface/src/screamingface/datasets.py
@@ -1,0 +1,160 @@
+"""Benchmark datasets — real questions, offline-first, deterministic subsampling.
+
+WHY offline-first (a deliberate deviation from the prototype's hub-first order):
+the executed quickstart notebook must reproduce on GitHub/Colab with no network
+and no HF terms-acceptance, so the bundled sample is the default and the
+HuggingFace Hub is opt-in via ``offline=False``. Grading itself always goes
+through the `EngineBackend` port; the dataset only supplies the *questions*.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+
+from .catalog import BenchmarkSpec, benchmark_spec
+from .engine import LETTERS, hash01
+
+_DATA_DIR = os.path.join(os.path.dirname(__file__), "_data")
+
+
+@dataclass(frozen=True)
+class Question:
+    id: str
+    prompt: str
+    kind: str  # "mcq" | "free"
+    options: tuple = ()  # mcq option texts
+    gold_index: int = -1  # mcq correct option
+    gold_text: str = ""  # free-text canonical answer
+    distractors: tuple = ()  # free-text wrong answers
+    subject: str = ""
+
+    @property
+    def gold_key(self) -> str:
+        """The canonical voting key for the correct answer (letter for MCQ)."""
+        if self.kind == "mcq":
+            return LETTERS[self.gold_index]
+        return self.gold_text
+
+    @property
+    def gold(self) -> str:
+        """Human-readable correct answer."""
+        if self.kind == "mcq":
+            return f"{LETTERS[self.gold_index]}. {self.options[self.gold_index]}"
+        return self.gold_text
+
+
+@dataclass
+class Benchmark:
+    spec: BenchmarkSpec
+    questions: list[Question]
+    source: str = "offline-sample"
+
+    @property
+    def id(self) -> str:
+        return self.spec.id
+
+    @property
+    def name(self) -> str:
+        return self.spec.name
+
+    def __len__(self) -> int:
+        return len(self.questions)
+
+    def __iter__(self):
+        return iter(self.questions)
+
+    def __getitem__(self, i: int) -> Question:
+        return self.questions[i]
+
+    def __repr__(self) -> str:
+        return f"Benchmark({self.name!r}, {len(self)} questions, source={self.source!r})"
+
+
+def load_benchmark(key: str, n: int = 20, seed: int = 0, offline: bool = True) -> Benchmark:
+    """Load `n` questions from a benchmark by id ('gpqa') or name ('GPQA Diamond').
+
+    Offline (bundled sample) by default; pass ``offline=False`` to pull the real
+    set from the HuggingFace Hub (needs network, the `datasets` package, and —
+    for GPQA — accepted terms on the Hub).
+    """
+    spec = benchmark_spec(key)
+    if offline:
+        questions, source = _load_offline(spec), "offline-sample"
+    else:
+        questions, source = _load_from_hf(spec)
+    return Benchmark(spec=spec, questions=_subsample(questions, n, seed), source=source)
+
+
+def _subsample(questions: list[Question], n: int, seed: int) -> list[Question]:
+    # WHY: rank by a seeded hash of the question id, then restore document order —
+    # deterministic per seed (spec I1), stable across processes.
+    if n >= len(questions):
+        return questions
+    order = sorted(range(len(questions)), key=lambda i: hash01(seed, "pick", questions[i].id))
+    return [questions[i] for i in sorted(order[:n])]
+
+
+def _load_offline(spec: BenchmarkSpec) -> list[Question]:
+    path = os.path.join(_DATA_DIR, f"{spec.id}.json")
+    if not os.path.exists(path):
+        raise KeyError(
+            f"No bundled sample for benchmark {spec.id!r} yet — v0.1 bundles 'gpqa' only."
+        )
+    with open(path, encoding="utf-8") as fh:
+        rows = json.load(fh)
+    return [_question(spec, i, row) for i, row in enumerate(rows)]
+
+
+def _question(spec: BenchmarkSpec, i: int, row: dict) -> Question:
+    if row["kind"] == "mcq":
+        return Question(
+            id=f"{spec.id}::{i}",
+            prompt=row["q"],
+            kind="mcq",
+            options=tuple(row["options"]),
+            gold_index=int(row["answer"]),
+            subject=row.get("subject", spec.domain.lower()),
+        )
+    return Question(
+        id=f"{spec.id}::{i}",
+        prompt=row["q"],
+        kind="free",
+        gold_text=row["answer"],
+        distractors=tuple(row.get("distractors", [])),
+        subject=row.get("subject", spec.domain.lower()),
+    )
+
+
+def _load_from_hf(spec: BenchmarkSpec) -> tuple[list[Question], str]:
+    # AIDEV-NOTE: v0.1 wires only GPQA; the other benchmarks' loaders land with
+    # their notebooks (02_models / 05_leaderboard series work).
+    if spec.id != "gpqa":
+        raise KeyError(f"HF loading for {spec.id!r} is not wired yet — use offline=True.")
+    from datasets import load_dataset  # type: ignore[import-not-found]
+
+    ds = load_dataset("Idavidrein/gpqa", "gpqa_diamond", split="train")
+    out = []
+    for i, row in enumerate(ds):
+        correct = row["Correct Answer"]
+        opts = [
+            correct,
+            row["Incorrect Answer 1"],
+            row["Incorrect Answer 2"],
+            row["Incorrect Answer 3"],
+        ]
+        # deterministic shuffle so the gold answer isn't always option A
+        order = sorted(range(4), key=lambda j: hash01("gpqa-shuffle", i, j))
+        shuffled = [opts[j] for j in order]
+        out.append(
+            Question(
+                id=f"gpqa::{i}",
+                prompt=row["Question"],
+                kind="mcq",
+                options=tuple(shuffled),
+                gold_index=shuffled.index(correct),
+                subject=row.get("Subdomain", "science"),
+            )
+        )
+    return out, "huggingface:Idavidrein/gpqa"

--- a/packages/screamingface/src/screamingface/engine.py
+++ b/packages/screamingface/src/screamingface/engine.py
@@ -1,0 +1,177 @@
+"""The EngineBackend port and the v0.1 simulated adapter.
+
+INVARIANT: all answer generation flows through `EngineBackend` — this Protocol
+is the seam where real inference (the engine interface, `OME-296`) plugs in as
+a second adapter without touching the public API.
+
+The `SimulatedBackend` never calls a real model. For each (model, question)
+pair it draws a **deterministic** pseudo-random outcome deciding whether the
+model answers correctly, what it answers, and a plausible reasoning trace,
+latency, and token cost.
+
+WHY the simulation is honest rather than a toy: a model's correctness is drawn
+from a *shared* per-question difficulty term plus a *per-model idiosyncratic*
+term, mixed by a `correlation` knob. With low correlation, models make
+independent errors — so a majority vote over their answers genuinely recovers
+the truth more often than any single model. Fusion lift downstream is an
+emergent consequence of real voting math, not a hard-coded bonus.
+
+Everything is seeded: two runs with the same `seed` are byte-for-byte identical.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from .catalog import BenchmarkSpec
+from .models import Model
+
+if TYPE_CHECKING:
+    from .datasets import Question
+
+LETTERS = [chr(ord("A") + i) for i in range(26)]
+
+# Canned reasoning, ported from the design prototype's REASONING / SYNTH pools.
+REASONING = [
+    "Let me reason through this. The governing principle fixes a proportional "
+    "relationship, so I scale the known quantity directly rather than guessing.",
+    "I start by eliminating the options that violate the underlying constraint, "
+    "which removes the obvious distractors and leaves one consistent candidate.",
+    "Working from the definitions: the standard result applies almost verbatim "
+    "here, so I apply it and double-check the boundary case.",
+    "I cross-checked this against the mechanism rather than pattern-matching the "
+    "phrasing — the surface wording is a bit of a trap.",
+    "Quick sanity check on units and a limiting case first; both line up, so I'm "
+    "confident in the pick.",
+]
+SYNTH = [
+    "Comparing the candidate answers across the loop, the majority converge and "
+    "the judge confirms the response with the strongest justification.",
+    "The judge weighed each model's reasoning, discounted the two that hand-waved "
+    "the key step, and selected the best-supported answer.",
+    "After reconciling the disagreement between the models, one answer is clearly "
+    "the most defensible once the shared error is removed.",
+]
+
+
+def hash01(*parts: object) -> float:
+    """Deterministic float in [0, 1) from any parts (FNV-1a).
+
+    INVARIANT (spec I1): this is the library's ONLY randomness source — no
+    wall-clock, no `random` — so a seed fully determines a run.
+    """
+    s = ":".join(str(p) for p in parts)
+    h = 2166136261
+    for ch in s:
+        h ^= ord(ch)
+        h = (h * 16777619) & 0xFFFFFFFF
+    return (h % 100000) / 100000.0
+
+
+@dataclass(frozen=True)
+class Answer:
+    """One model's answer to one question, with its telemetry."""
+
+    choice: str  # canonical key used for voting (an option letter, or the text)
+    text: str  # human-readable answer for display
+    correct: bool
+    reasoning: str
+    latency_ms: int
+    tokens_in: int
+    tokens_out: int
+    cost: float  # USD
+
+
+@runtime_checkable
+class EngineBackend(Protocol):
+    """The port every answer-producing engine implements."""
+
+    def answer(
+        self, model: Model, question: Question, benchmark: BenchmarkSpec, seed: int
+    ) -> Answer: ...
+
+    def synth_reasoning(self, seed: int, question: Question) -> str: ...
+
+
+class SimulatedBackend:
+    """Deterministic answer generator — the v0.1 `EngineBackend` adapter.
+
+    Parameters
+    ----------
+    correlation:
+        0 → models err independently (maximum fusion benefit); 1 → models share
+        the same difficulty draw (errors are nested, little fusion benefit).
+    ability_jitter:
+        small per-model accuracy wobble (in accuracy points) so identical-ability
+        models still differ a little. Deterministic, seeded.
+    """
+
+    def __init__(self, correlation: float = 0.35, ability_jitter: float = 4.0):
+        self.correlation = float(correlation)
+        self.ability_jitter = float(ability_jitter)
+
+    def accuracy(self, model: Model, benchmark: BenchmarkSpec, seed: int) -> float:
+        """Probability in [0.02, 0.98] that `model` answers a `benchmark` item correctly."""
+        base = model.ability + benchmark.difficulty_delta
+        jitter = (hash01(seed, "ability", model.id, benchmark.id) - 0.5) * 2 * self.ability_jitter
+        return _clip((base + jitter) / 100.0, 0.02, 0.98)
+
+    def answer(
+        self, model: Model, question: Question, benchmark: BenchmarkSpec, seed: int
+    ) -> Answer:
+        acc = self.accuracy(model, benchmark, seed)
+        # INVARIANT (spec I2): with probability `correlation` the outcome is driven
+        # by a SHARED per-question draw, otherwise by the model's own draw. Both
+        # draws are uniform and the selector is independent of them, so each
+        # model's marginal P(correct) stays exactly `acc` — only the *cross-model*
+        # correlation changes.
+        shared = hash01(seed, "q", question.id)
+        idio = hash01(seed, "m", model.id, question.id)
+        use_shared = hash01(seed, "mix", model.id, question.id) < self.correlation
+        draw = shared if use_shared else idio
+        correct = draw < acc
+
+        choice, text = self._choose(question, model, seed, correct)
+        reasoning = REASONING[int(hash01(seed, "r", model.id, question.id) * len(REASONING))]
+        tokens_in = max(50, len(question.prompt) // 4)
+        tokens_out = 120 + int(hash01(seed, "out", model.id, question.id) * 300)
+        latency_ms = 1100 + int(hash01(seed, "ms", model.id, question.id) * 900)
+        cost = (tokens_in * model.price_in + tokens_out * model.price_out) / 1_000_000.0
+        return Answer(
+            choice=choice,
+            text=text,
+            correct=choice == question.gold_key,
+            reasoning=reasoning,
+            latency_ms=latency_ms,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            cost=cost,
+        )
+
+    def _choose(
+        self, question: Question, model: Model, seed: int, correct: bool
+    ) -> tuple[str, str]:
+        if question.kind == "mcq":
+            gold = question.gold_index
+            if correct:
+                idx = gold
+            else:
+                wrong = [i for i in range(len(question.options)) if i != gold]
+                pick = int(hash01(seed, "w", model.id, question.id) * len(wrong))
+                idx = wrong[pick] if wrong else gold
+            return LETTERS[idx], f"{LETTERS[idx]}. {question.options[idx]}"
+        # free-text
+        if correct or not question.distractors:
+            choice = question.gold_text
+        else:
+            d = question.distractors
+            choice = d[int(hash01(seed, "w", model.id, question.id) * len(d))]
+        return choice, choice
+
+    def synth_reasoning(self, seed: int, question: Question) -> str:
+        return SYNTH[int(hash01(seed, "synth", question.id) * len(SYNTH))]
+
+
+def _clip(v: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, v))

--- a/packages/screamingface/src/screamingface/evaluate.py
+++ b/packages/screamingface/src/screamingface/evaluate.py
@@ -1,0 +1,95 @@
+"""Orchestrate one evaluation: ask every model → reduce → grade, over a benchmark.
+
+INVARIANT (spec §2): every model answer flows through the `EngineBackend` port —
+this module never generates an answer itself, so swapping the simulated adapter
+for the real engine (OME-296) cannot change the loop.
+"""
+
+from __future__ import annotations
+
+from .datasets import Benchmark, load_benchmark
+from .engine import EngineBackend, SimulatedBackend
+from .fusion_core import FusionCore
+from .reduce import reduce_answers
+from .results import ModelResult, QuestionResult, RunResult
+
+
+def evaluate(
+    fusion: FusionCore,
+    benchmark: Benchmark | str,
+    seed: int = 0,
+    backend: EngineBackend | None = None,
+    correlation: float = 0.35,
+    n: int = 20,
+) -> RunResult:
+    """Run `fusion` against `benchmark` and return a `RunResult`.
+
+    `benchmark` may be a loaded `Benchmark` or a benchmark key (then `n`
+    questions are loaded). `seed` makes the whole run reproducible (spec I1).
+    `correlation` (used only when no `backend` is injected) controls how
+    independent the models' errors are — the lever behind fusion lift.
+    """
+    if not fusion.slots:
+        raise ValueError("Cannot evaluate an empty fusion — add at least one model.")
+    if isinstance(benchmark, str):
+        benchmark = load_benchmark(benchmark, n=n, seed=seed)
+    if backend is None:
+        backend = SimulatedBackend(correlation=correlation)
+
+    spec = benchmark.spec
+    slots = fusion.slots
+    weights = fusion.normalized_weights()
+    tallies = [{"correct": 0, "latency": 0.0, "cost": 0.0} for _ in slots]
+
+    q_results = []
+    for question in benchmark.questions:
+        answers = [backend.answer(s.model, question, spec, seed) for s in slots]
+        final_choice, note = reduce_answers(fusion, answers, weights)
+        final_text = next((a.text for a in answers if a.choice == final_choice), final_choice)
+
+        for t, ans in zip(tallies, answers):
+            t["correct"] += int(ans.correct)
+            t["latency"] += ans.latency_ms
+            t["cost"] += ans.cost
+
+        q_results.append(
+            QuestionResult(
+                question=question,
+                model_answers=answers,
+                final_choice=final_choice,
+                final_text=final_text,
+                correct=final_choice == question.gold_key,
+                note=note,
+                reasoning=backend.synth_reasoning(seed, question),
+            )
+        )
+
+    n_q = len(benchmark.questions)
+    model_results = [
+        ModelResult(
+            model_id=s.model.id,
+            model_label=s.model.label,
+            color=s.model.color,
+            n=n_q,
+            n_correct=int(t["correct"]),
+            mean_latency_ms=(t["latency"] / n_q if n_q else 0.0),
+            total_cost=t["cost"],
+        )
+        for s, t in zip(slots, tallies)
+    ]
+
+    return RunResult(
+        fusion_name=fusion.name,
+        model_ids=[s.model.id for s in slots],
+        model_labels=[s.model.label for s in slots],
+        reduce_label=fusion.reduce_strategy,
+        loop_label=fusion.loop_mode,
+        judge_id=fusion.judge_model_id,
+        benchmark_id=spec.id,
+        benchmark_name=spec.name,
+        seed=seed,
+        sample_size=n_q,
+        source=benchmark.source,
+        question_results=q_results,
+        model_results=model_results,
+    )

--- a/packages/screamingface/src/screamingface/fusion_core.py
+++ b/packages/screamingface/src/screamingface/fusion_core.py
@@ -1,0 +1,111 @@
+"""FusionCore — a composed set of model slots plus a reduce stage (engine-side).
+
+A fusion runs every question through a **loop stage** (v0.1: `parallel` — every
+model answers) and a **reduce stage** (combine the candidates into one final
+answer). AIDEV-NOTE: custom reduce/loop Scripts are OME-408-adjacent scope and
+deliberately absent here; `reduce()`/`loop()` keep the seam.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .models import Model, resolve
+
+REDUCE_STRATEGIES = {
+    "majority_vote": "Judge picks the most common answer",
+    "weighted_avg": "Blend answers weighted by confidence",
+    "best_of_n": "Judge ranks and selects the top response",
+    "merge": "Judge merges every answer into one",
+}
+LOOP_MODES = {
+    "parallel": "Run every model on each question",
+}
+
+
+@dataclass
+class Slot:
+    """One model's seat in the fusion."""
+
+    model: Model
+    system_prompt: str = ""
+    weight: float = 0.5
+
+    @property
+    def id(self) -> str:
+        return self.model.id
+
+
+class FusionCore:
+    def __init__(self, name: str = "untitled-fusion"):
+        self.name = name.strip().replace(" ", "-").lower() or "untitled-fusion"
+        self.slots: list[Slot] = []
+        self.reduce_strategy: str = "majority_vote"
+        self.loop_mode: str = "parallel"
+        self.judge_model_id: str | None = None
+
+    # ── composition ──────────────────────────────────────────────────────────
+    def add(self, model: str | Model, weight: float = 0.5, system: str = "") -> FusionCore:
+        """Add a model slot. Re-adding the same model is a no-op."""
+        m = resolve(model)
+        if not any(s.id == m.id for s in self.slots):
+            self.slots.append(Slot(model=m, system_prompt=system, weight=weight))
+        return self
+
+    def reduce(
+        self, strategy: str = "majority_vote", judge: str | Model | None = None
+    ) -> FusionCore:
+        """Set the reduce stage: a built-in strategy name, arbitrated by an
+        optional `judge` model (which must be a member)."""
+        if strategy not in REDUCE_STRATEGIES:
+            raise ValueError(
+                f"Unknown reduce strategy {strategy!r}. Choose one of {sorted(REDUCE_STRATEGIES)}."
+            )
+        self.reduce_strategy = strategy
+        if judge is not None:
+            self.set_judge(judge)
+        return self
+
+    def set_judge(self, judge: str | Model) -> FusionCore:
+        # INVARIANT (spec I3): the judge must be one of the fusion's members.
+        mid = judge.id if isinstance(judge, Model) else judge
+        if not any(s.id == mid for s in self.slots):
+            raise ValueError(
+                f"judge {mid!r} must be one of the fusion's models: {[s.id for s in self.slots]}"
+            )
+        self.judge_model_id = mid
+        return self
+
+    def loop(self, mode: str = "parallel") -> FusionCore:
+        """Set the loop stage (v0.1: 'parallel' only)."""
+        if mode not in LOOP_MODES:
+            raise ValueError(f"Unknown loop mode {mode!r}. Choose one of {sorted(LOOP_MODES)}.")
+        self.loop_mode = mode
+        return self
+
+    # ── derived views ─────────────────────────────────────────────────────────
+    @property
+    def models(self) -> list[Model]:
+        return [s.model for s in self.slots]
+
+    @property
+    def judge(self) -> Model | None:
+        if self.judge_model_id is None:
+            return None
+        return next((s.model for s in self.slots if s.id == self.judge_model_id), None)
+
+    def normalized_weights(self) -> list[float]:
+        """Weights over the *non-judge* slots, summing to 1.
+
+        INVARIANT: the judge arbitrates rather than contributes — it is excluded
+        from the blend and carries weight 0.
+        """
+        contributing = [s for s in self.slots if s.id != self.judge_model_id]
+        total = sum(s.weight for s in contributing) or 1.0
+        return [0.0 if s.id == self.judge_model_id else s.weight / total for s in self.slots]
+
+    def __repr__(self) -> str:
+        return (
+            f"FusionCore({self.name!r}, {len(self.slots)} models, "
+            f"reduce={self.reduce_strategy}, loop={self.loop_mode})"
+        )

--- a/packages/screamingface/src/screamingface/models.py
+++ b/packages/screamingface/src/screamingface/models.py
@@ -1,0 +1,172 @@
+"""Models and pools (engine-side).
+
+`Model` is a thin, friendly handle over a catalog entry. `Pool` is an ordered,
+de-duplicated collection of models filterable by price / context / provider.
+AIDEV-NOTE: `Pool` is INTERNAL in the SDK — the public discovery surface is the
+`sf.models` service (studio.py), which returns plain `provider/model` id strings.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Iterator
+from dataclasses import dataclass
+
+from .catalog import _POOLS, MODEL_META, PROVIDERS, ModelMeta, Provider, provider_color
+
+
+@dataclass(frozen=True)
+class Model:
+    """A single model offered by a provider."""
+
+    id: str
+    name: str
+    provider_id: str
+    tag: str | None = None
+
+    @property
+    def provider(self) -> Provider:
+        return PROVIDERS[self.provider_id]
+
+    @property
+    def provider_name(self) -> str:
+        return self.provider.name
+
+    @property
+    def meta(self) -> ModelMeta:
+        return MODEL_META[self.id]
+
+    @property
+    def price_in(self) -> float:
+        return self.meta.price_in
+
+    @property
+    def price_out(self) -> float:
+        return self.meta.price_out
+
+    @property
+    def price(self) -> float:
+        """Combined in+out price per million tokens."""
+        m = self.meta
+        return m.price_in + m.price_out
+
+    @property
+    def ctx(self) -> int:
+        return self.meta.ctx
+
+    @property
+    def ability(self) -> float:
+        return self.meta.ability
+
+    @property
+    def color(self) -> str:
+        return provider_color(self.provider_id)
+
+    @property
+    def label(self) -> str:
+        return f"{self.name} [{self.provider_name}]"
+
+    def __str__(self) -> str:
+        return self.label
+
+
+def _build_all() -> dict[str, Model]:
+    out: dict[str, Model] = {}
+    for provider_id, entries in _POOLS.items():
+        for mid, name, tag in entries:
+            out[mid] = Model(id=mid, name=name, provider_id=provider_id, tag=tag)
+    return out
+
+
+ALL_MODELS: dict[str, Model] = _build_all()
+
+
+def get_model(model_id: str) -> Model:
+    try:
+        return ALL_MODELS[model_id]
+    except KeyError:
+        raise KeyError(
+            f"Unknown model id {model_id!r}. Try sf.models.list() or sf.models.list(search=...)."
+        ) from None
+
+
+def resolve(m: str | Model) -> Model:
+    """Accept either a short model id or a Model and return a Model."""
+    return m if isinstance(m, Model) else get_model(m)
+
+
+class Pool:
+    """An ordered, de-duplicated set of models. Filtering is non-mutating."""
+
+    def __init__(self, models: Iterable[str | Model] = ()):
+        self._models: list[Model] = []
+        self._ids: set[str] = set()
+        for m in models:
+            self.add(m)
+
+    def __iter__(self) -> Iterator[Model]:
+        return iter(self._models)
+
+    def __len__(self) -> int:
+        return len(self._models)
+
+    def __getitem__(self, i: int) -> Model:
+        return self._models[i]
+
+    @property
+    def ids(self) -> list[str]:
+        return [m.id for m in self._models]
+
+    def add(self, m: str | Model) -> Pool:
+        model = resolve(m)
+        if model.id not in self._ids:
+            self._models.append(model)
+            self._ids.add(model.id)
+        return self
+
+    def filter(
+        self,
+        search: str = "",
+        max_price: float | None = None,
+        min_ctx: int = 0,
+        provider: str | Iterable[str] | None = None,
+    ) -> Pool:
+        q = search.lower()
+        providers = None
+        if provider is not None:
+            providers = {provider} if isinstance(provider, str) else set(provider)
+
+        def keep(m: Model) -> bool:
+            return (
+                (not q or q in m.name.lower())
+                and (providers is None or m.provider_id in providers)
+                and (max_price is None or m.price <= max_price)
+                and (not min_ctx or m.ctx >= min_ctx)
+            )
+
+        return Pool(m for m in self._models if keep(m))
+
+    _SORT_KEYS: dict[str, Callable[[Model], object]] = {
+        "price": lambda m: m.price,
+        "context": lambda m: m.ctx,
+        "ctx": lambda m: m.ctx,
+        "ability": lambda m: m.ability,
+        "name": lambda m: m.name,
+    }
+
+    def sort_by(self, field: str, desc: bool = False) -> Pool:
+        """Sort by a named field: price / context / ability / name."""
+        key = self._SORT_KEYS.get(field)
+        if key is None:
+            raise KeyError(
+                f"Unknown sort key {field!r}. Choose one of "
+                f"{sorted(k for k in self._SORT_KEYS if k != 'ctx')}."
+            )
+        return Pool(sorted(self._models, key=key, reverse=desc))  # type: ignore[arg-type]
+
+    def __repr__(self) -> str:
+        ids = ", ".join(self.ids[:6])
+        return f"Pool({len(self)} models: {ids}{' …' if len(self) > 6 else ''})"
+
+
+# the master catalog: every known model, ready to filter
+catalog = Pool(ALL_MODELS.values())

--- a/packages/screamingface/src/screamingface/reduce.py
+++ b/packages/screamingface/src/screamingface/reduce.py
@@ -1,0 +1,71 @@
+"""The reduce stage: combine per-model candidate answers into one final answer.
+
+INVARIANT (spec I2): strategies operate on the models' *canonical* answers (an
+option letter for multiple-choice, the answer string for free-text), so the
+combination is real voting math — fusion lift is emergent, never a bonus.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from .engine import Answer
+from .fusion_core import FusionCore
+
+_NOTES = {
+    "majority_vote": "majority vote",
+    "weighted_avg": "weighted vote",
+    "merge": "merge (judge synthesis)",  # WHY: judge synthesis over discrete answers = majority
+}
+
+
+def reduce_answers(
+    fusion: FusionCore, answers: list[Answer], weights: list[float]
+) -> tuple[str, str]:
+    """Return ``(final_choice, note)`` for one question.
+
+    `answers` is aligned with ``fusion.slots``; `weights` are the normalized
+    non-judge weights (judge weight is 0). `note` is a short human-readable
+    description of how the answer was chosen.
+    """
+    slots = fusion.slots
+    judge_idx = next((i for i, s in enumerate(slots) if s.id == fusion.judge_model_id), None)
+    # contributing (non-judge) indices; a judge-only fusion still answers
+    contrib = [i for i in range(len(slots)) if i != judge_idx] or list(range(len(slots)))
+
+    strategy = fusion.reduce_strategy
+    if strategy == "best_of_n":
+        return _best_choice(fusion, answers, contrib), "best-of-N (judge picks strongest model)"
+    choice = _vote(
+        fusion, answers, weights, contrib, judge_idx, weighted=(strategy == "weighted_avg")
+    )
+    return choice, _NOTES[strategy]
+
+
+def _best_choice(fusion: FusionCore, answers: list[Answer], contrib: list[int]) -> str:
+    """The highest-ability contributing model's answer."""
+    i = max(contrib, key=lambda i: fusion.slots[i].model.ability)
+    return answers[i].choice
+
+
+def _vote(
+    fusion: FusionCore,
+    answers: list[Answer],
+    weights: list[float],
+    contrib: list[int],
+    judge_idx: int | None,
+    weighted: bool,
+) -> str:
+    tally: dict[str, float] = defaultdict(float)
+    for i in contrib:
+        tally[answers[i].choice] += weights[i] if weighted else 1.0
+    top = max(tally.values())
+    winners = [c for c, v in tally.items() if abs(v - top) < 1e-9]
+    if len(winners) == 1:
+        return winners[0]
+    # tie-break: prefer the judge's own answer, else the best model's answer
+    judge_choice = answers[judge_idx].choice if judge_idx is not None else None
+    if judge_choice in winners:
+        return judge_choice
+    best = _best_choice(fusion, answers, contrib)
+    return best if best in winners else sorted(winners)[0]

--- a/packages/screamingface/src/screamingface/results.py
+++ b/packages/screamingface/src/screamingface/results.py
@@ -1,0 +1,90 @@
+"""Run results and metrics (engine-side).
+
+A `RunResult` captures everything about one evaluation: the per-question
+breakdown, per-model accuracy/latency/cost, and the headline fusion metrics —
+crucially **gain over the best single model**, the number a fusion researcher
+actually cares about.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .datasets import Question
+from .engine import Answer
+
+
+@dataclass
+class QuestionResult:
+    question: Question
+    model_answers: list[Answer]  # aligned with the fusion's slots
+    final_choice: str
+    final_text: str
+    correct: bool
+    note: str  # how the answer was reduced
+    reasoning: str  # synthesized reduce reasoning
+
+
+@dataclass
+class ModelResult:
+    model_id: str
+    model_label: str
+    color: str
+    n: int
+    n_correct: int
+    mean_latency_ms: float
+    total_cost: float
+
+    @property
+    def accuracy(self) -> float:
+        return 100.0 * self.n_correct / self.n if self.n else 0.0
+
+
+@dataclass
+class RunResult:
+    fusion_name: str
+    model_ids: list[str]
+    model_labels: list[str]
+    reduce_label: str
+    loop_label: str
+    judge_id: str | None
+    benchmark_id: str
+    benchmark_name: str
+    seed: int
+    sample_size: int
+    source: str
+    question_results: list[QuestionResult]
+    model_results: list[ModelResult]
+
+    @property
+    def n(self) -> int:
+        return len(self.question_results)
+
+    @property
+    def n_correct(self) -> int:
+        return sum(1 for q in self.question_results if q.correct)
+
+    @property
+    def score(self) -> float:
+        """Fusion accuracy, percent."""
+        return 100.0 * self.n_correct / self.n if self.n else 0.0
+
+    @property
+    def baseline(self) -> float:
+        """Best single-model accuracy — the bar the fusion must beat."""
+        return max((m.accuracy for m in self.model_results), default=0.0)
+
+    @property
+    def gain_over_best(self) -> float:
+        return self.score - self.baseline
+
+    @property
+    def total_cost(self) -> float:
+        return sum(m.total_cost for m in self.model_results)
+
+    def __repr__(self) -> str:
+        return (
+            f"RunResult({self.fusion_name!r} on {self.benchmark_name!r}: "
+            f"score={self.score:.1f}  baseline={self.baseline:.1f}  "
+            f"gain={self.gain_over_best:+.1f})"
+        )

--- a/packages/screamingface/src/screamingface/session.py
+++ b/packages/screamingface/src/screamingface/session.py
@@ -1,0 +1,187 @@
+"""Session: provider connections and API keys — Colab-native.
+
+INVARIANT (spec I4): keys live only in memory (the per-process ``KeyStore``);
+never written to disk, never printed, never put in a recipe/url — at most
+masked to the last 4 characters. Keys resolve Colab Secret → environment
+variable → masked prompt.
+
+Honesty: inference is simulated (see ``engine.py``). Connecting a provider
+stores its key and flips it to "connected" — the seam where real API calls
+(OME-296) plug in, not real inference today.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from .catalog import PROVIDERS
+
+# provider_id -> the conventional env var / Colab secret name
+KEY_NAMES: dict[str, str] = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "deepmind": "GEMINI_API_KEY",
+    "perplexity": "PERPLEXITY_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+    "hf": "HF_TOKEN",
+}
+
+
+def in_colab() -> bool:
+    try:
+        import google.colab  # type: ignore[import-not-found]  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def in_notebook() -> bool:
+    try:
+        from IPython import get_ipython  # type: ignore[import-not-found]
+
+        return get_ipython() is not None
+    except ImportError:
+        return False
+
+
+def _colab_secret(name: str) -> str | None:
+    try:
+        from google.colab import userdata  # type: ignore[import-not-found]
+
+        return userdata.get(name)
+    except Exception:  # noqa: BLE001 — not in colab, or secret not granted: both mean "absent"
+        return None
+
+
+def _from_env_or_secret(provider_id: str) -> tuple[str | None, str]:
+    """Look up a provider's key: Colab Secret first, then the environment."""
+    name = KEY_NAMES.get(provider_id)
+    if not name:
+        return None, ""
+    if in_colab():
+        val = _colab_secret(name)
+        if val:
+            return val, "secret"
+    val = os.environ.get(name)
+    return val, ("env" if val else "")
+
+
+def _mask(key: str) -> str:
+    if not key:
+        return ""
+    return f"…{key[-4:]}" if len(key) > 4 else "…"
+
+
+@dataclass
+class Connection:
+    provider_id: str
+    connected: bool = False
+    source: str = ""  # "secret" | "env" | "entered"
+
+
+class KeyStore:
+    """In-memory only. Keys never leave the process and are never echoed."""
+
+    def __init__(self) -> None:
+        self._keys: dict[str, str] = {}
+
+    def set(self, provider_id: str, key: str) -> None:
+        self._keys[provider_id] = key
+
+    def get(self, provider_id: str) -> str | None:
+        return self._keys.get(provider_id)
+
+
+class Session:
+    def __init__(self) -> None:
+        self.keys = KeyStore()
+        self.connections: dict[str, Connection] = {}
+
+    def connect(
+        self,
+        provider: str,
+        api_key: str | None = None,
+        prompt: bool | None = None,
+    ) -> Connection:
+        """Connect a provider. Key resolution: explicit → Colab Secret → env →
+        masked getpass prompt (unless ``prompt=False``)."""
+        pid = _resolve_provider(provider)
+        prov = PROVIDERS[pid]
+        conn = self.connections.setdefault(pid, Connection(pid))
+
+        key, source = (api_key, "entered") if api_key else _from_env_or_secret(pid)
+        if key is None and (prompt or (prompt is None and not in_notebook())):
+            import getpass
+
+            key = getpass.getpass(f"{prov.name} API key ({KEY_NAMES.get(pid, '')}): ")
+            source = "entered"
+        if not key:
+            raise ValueError(
+                f"No API key for {prov.name}. Pass api_key=…, or set the "
+                f"{KEY_NAMES.get(pid)} "
+                f"{'Colab Secret' if in_colab() else 'environment variable'}."
+            )
+
+        self.keys.set(pid, key)
+        conn.connected, conn.source = True, source
+        return conn
+
+    def is_connected(self, provider_id: str) -> bool:
+        c = self.connections.get(provider_id)
+        return bool(c and c.connected)
+
+    def status_rows(self) -> list[dict]:
+        rows = []
+        for pid, prov in PROVIDERS.items():
+            c = self.connections.get(pid)
+            key = self.keys.get(pid)
+            rows.append(
+                dict(
+                    provider=prov.name,
+                    kind=prov.kind,
+                    connected=bool(c and c.connected),
+                    source=(c.source if c else ""),
+                    key=_mask(key) if key else "",
+                )
+            )
+        return rows
+
+
+# module-level singleton — the session the public verbs operate on
+session = Session()
+
+
+def _resolve_provider(provider: str) -> str:
+    from .studio import _SLUG_PROVIDER
+
+    if provider in PROVIDERS:
+        return provider
+    if provider in _SLUG_PROVIDER:  # studio slug, e.g. "google" -> "deepmind"
+        return _SLUG_PROVIDER[provider]
+    raise KeyError(f"Unknown provider {provider!r}. Known: {sorted(PROVIDERS)}.")
+
+
+def connect(provider: str, api_key: str | None = None, prompt: bool | None = None) -> Connection:
+    """Connect a model provider (Colab Secret → env var → masked prompt)."""
+    return session.connect(provider, api_key=api_key, prompt=prompt)
+
+
+def setup():
+    """One-cell bootstrap: connect providers.
+
+    In a notebook returns the connect panel (static in v0.1); headless it
+    prints how to connect. Idempotent — call it whenever you want the panel back.
+    """
+    if not in_notebook():
+        print(
+            "screamingface setup (headless):\n"
+            "  sf.connect('anthropic', api_key=...)   # or set ANTHROPIC_API_KEY\n"
+            "  sf.connect('openai')                   # reads OPENAI_API_KEY\n"
+            "Inference is simulated — keys mark providers connected, not billed."
+        )
+        return None
+    from .widgets import setup_panel
+
+    return setup_panel()

--- a/packages/screamingface/src/screamingface/share.py
+++ b/packages/screamingface/src/screamingface/share.py
@@ -1,0 +1,28 @@
+"""``url4://`` share strings — encode a fusion into a portable recipe.
+
+AIDEV-NOTE: this flat format is INTERIM (spec §3). The real url4 expression
+grammar (`packages/url4`, `(sources)!intent`) replaces it in OME-408 — which is
+why encoding lives alone in this module and nothing else knows the format.
+Decoding (`from_url4`) is OME-408 scope and intentionally absent.
+
+Grammar::
+
+    url4://<name>?models=<id>+<id>&reduce=<strategy>&loop=<mode>&judge=<id>
+
+`judge` is emitted only when set.
+"""
+
+from __future__ import annotations
+
+from .fusion_core import FusionCore
+
+
+def to_url4(fusion: FusionCore) -> str:
+    models = "+".join(s.model.id for s in fusion.slots)
+    url = (
+        f"url4://{fusion.name}?models={models}"
+        f"&reduce={fusion.reduce_strategy}&loop={fusion.loop_mode}"
+    )
+    if fusion.judge_model_id:
+        url += f"&judge={fusion.judge_model_id}"
+    return url

--- a/packages/screamingface/src/screamingface/studio.py
+++ b/packages/screamingface/src/screamingface/studio.py
@@ -1,0 +1,256 @@
+"""The Studio surface — the friendly notebook front-end over the engine.
+
+Adds on top of the engine core:
+
+* **``provider/model`` source ids** — ``anthropic/claude-opus-4.8`` instead of
+  ``an-1``. The full form is ``owner/provider/model``; ``owner`` defaults to
+  ``local`` and is hidden — the federation seam.
+* **``sf.models``** — the catalog *service* (`list` / `get`), returning plain id
+  strings. WHY a service, not a Pool: the prototype's `sf.models` was both a
+  service and a collection; the SDK keeps the collection internal (models.py).
+* **``Fusion`` / ``Run``** — sklearn-style constructors compiling to the
+  engine's `FusionCore`, and the payoff read-out.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+
+from .datasets import Benchmark, load_benchmark
+from .engine import EngineBackend
+from .fusion_core import FusionCore
+from .models import ALL_MODELS, Model, catalog, get_model
+from .results import RunResult
+
+DEFAULT_JUDGE_PROMPT = (
+    "You are the judge. Read the candidate answers from each model in the loop "
+    "and return the single best final answer."
+)
+
+# ── provider/model id scheme ────────────────────────────────────────────────
+
+_PROVIDER_SLUG = {
+    "anthropic": "anthropic",
+    "openai": "openai",
+    "deepmind": "google",
+    "perplexity": "perplexity",
+    "openrouter": "open_router",
+    "hf": "hugging_face",
+}
+_SLUG_PROVIDER = {v: k for k, v in _PROVIDER_SLUG.items()}
+
+
+def _slug(s: str) -> str:
+    return re.sub(r"[^a-z0-9.]+", "-", s.lower()).strip("-")
+
+
+def _build_aliases() -> tuple[dict[str, str], dict[str, str]]:
+    fwd: dict[str, str] = {}  # "anthropic/claude-opus-4.8" -> "an-1"
+    rev: dict[str, str] = {}  # "an-1" -> "anthropic/claude-opus-4.8"
+    for mid, m in ALL_MODELS.items():
+        alias = f"{_PROVIDER_SLUG.get(m.provider_id, m.provider_id)}/{_slug(m.name)}"
+        fwd[alias] = mid
+        rev[mid] = alias
+    return fwd, rev
+
+
+_ALIAS_TO_ID, _ID_TO_ALIAS = _build_aliases()
+
+
+def whoami() -> str:
+    """The current owner/node. Everything is ``local`` until you federate."""
+    return "local"
+
+
+def _to_short(ref: str | Model) -> str:
+    """Resolve a source id (provider/model, owner/provider/model, or short) → short id."""
+    if isinstance(ref, Model):
+        return ref.id
+    r = str(ref).strip()
+    parts = r.split("/")
+    if len(parts) == 3:  # owner/provider/model -> drop owner (assumed local)
+        r = "/".join(parts[1:])
+    if r in _ALIAS_TO_ID:
+        return _ALIAS_TO_ID[r]
+    if r in ALL_MODELS:
+        return r
+    raise KeyError(f"Unknown model {ref!r}. Try sf.models.list() or sf.models.list(search=...).")
+
+
+def source_id(m: str | Model) -> str:
+    """Canonical ``provider/model`` id for a model or short id."""
+    mid = m.id if isinstance(m, Model) else _to_short(m)
+    return _ID_TO_ALIAS.get(mid, mid)
+
+
+# ── sf.models — the catalog service ──────────────────────────────────────────
+
+
+class ModelsService:
+    """Discovery service over the catalog: ids in, ids out."""
+
+    def list(
+        self,
+        search: str = "",
+        provider: str | None = None,
+        max_price: float | None = None,
+        min_ctx: int = 0,
+        sort: str | None = None,
+        desc: bool | None = None,
+    ) -> list[str]:
+        """List ``provider/model`` ids, filtered & sorted.
+
+        ``max_price`` caps the combined in+out price per M tokens; ``sort`` is
+        one of price / context / ability / name (ability and context default to
+        descending — you usually want the biggest first).
+        """
+        prov = _SLUG_PROVIDER.get(provider, provider) if provider else None
+        pool = catalog.filter(search=search, provider=prov, max_price=max_price, min_ctx=min_ctx)
+        if sort:
+            if desc is None:
+                desc = sort in ("ability", "context", "ctx")
+            pool = pool.sort_by(sort, desc=desc)
+        return [source_id(m) for m in pool]
+
+    def get(self, ref: str | Model) -> Model:
+        """Look up one model by its ``provider/model`` id and return its card."""
+        return get_model(_to_short(ref))
+
+    def __repr__(self) -> str:
+        return f"sf.models ({len(ALL_MODELS)} models — .list() / .get(id))"
+
+
+models = ModelsService()
+
+
+# ── Fusion ────────────────────────────────────────────────────────────────────
+
+
+class Fusion:
+    """The friendly fusion constructor. Compiles to an engine ``FusionCore``."""
+
+    def __init__(
+        self,
+        name: str,
+        models: Sequence[str | Model] = (),  # noqa: PLR0913 — mirrors the notebook contract
+        reduce: str = "majority_vote",
+        judge: str | Model | None = None,
+        prompt: str | None = None,
+        judge_prompt: str | None = None,
+        loop: str = "parallel",
+    ):
+        self._core = FusionCore(name)
+        self.prompt = prompt
+        self.judge_prompt = judge_prompt or DEFAULT_JUDGE_PROMPT
+        for m in models:
+            self._core.add(_to_short(m))
+        # INVARIANT (spec I3): judge membership is validated here, at construction.
+        self._core.reduce(reduce, judge=_to_short(judge) if judge else None)
+        self._core.loop(loop)
+
+    # ── views ──
+    @property
+    def name(self) -> str:
+        return self._core.name
+
+    @property
+    def models(self) -> list[str]:
+        return [source_id(m) for m in self._core.models]
+
+    @property
+    def judge(self) -> str | None:
+        j = self._core.judge
+        return source_id(j) if j else None
+
+    @property
+    def url(self) -> str:
+        """The recipe as a shareable string — the fusion's identity (spec I6)."""
+        parts = "+".join(self.models)
+        url = (
+            f"url4://{self.name}?models={parts}"
+            f"&reduce={self._core.reduce_strategy}&loop={self._core.loop_mode}"
+        )
+        if self.judge:
+            url += f"&judge={self.judge}"
+        return url
+
+    def evaluate(
+        self,
+        benchmark: Benchmark | str,
+        first: int | None = None,
+        seed: int = 0,
+        correlation: float = 0.35,
+        backend: EngineBackend | None = None,
+    ) -> Run:
+        """Run this fusion on a benchmark; ``first=None`` means the full set.
+
+        Reproducible by ``seed`` (spec I1). ``backend`` injects a custom
+        `EngineBackend` (the real-engine seam); default is the simulator.
+        """
+        from .evaluate import evaluate as _evaluate
+
+        if isinstance(benchmark, str):
+            benchmark = load_benchmark(benchmark, n=(first or 10_000_000), seed=seed)
+        res = _evaluate(self._core, benchmark, seed=seed, backend=backend, correlation=correlation)
+        return Run(res, self)
+
+    def __repr__(self) -> str:
+        return (
+            f"Fusion({self.name!r}, {len(self._core.slots)} models, "
+            f"reduce={self._core.reduce_strategy})"
+        )
+
+
+# ── Run — the payoff read-out ────────────────────────────────────────────────
+
+
+class Run:
+    """A completed evaluation: score / baseline / gain over one benchmark."""
+
+    def __init__(self, result: RunResult, fusion: Fusion):
+        self.result = result
+        self.fusion = fusion
+
+    @property
+    def score(self) -> float:
+        return round(self.result.score, 1)
+
+    @property
+    def baseline(self) -> float:
+        return round(self.result.baseline, 1)
+
+    @property
+    def gain(self) -> float:
+        # INVARIANT: gain = score − baseline — the headline number.
+        return round(self.result.gain_over_best, 1)
+
+    @property
+    def seed(self) -> int:
+        return self.result.seed
+
+    @property
+    def sample_size(self) -> int:
+        return self.result.sample_size
+
+    @property
+    def benchmark_name(self) -> str:
+        return self.result.benchmark_name
+
+    @property
+    def cost(self) -> float:
+        return round(self.result.total_cost, 4)
+
+    @property
+    def url(self) -> str:
+        """The recipe pinned to this run's benchmark, sample size, and seed."""
+        return (
+            f"{self.fusion.url}&benchmark={self.result.benchmark_id}"
+            f"&n={self.sample_size}&seed={self.seed}"
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"Run({self.fusion.name!r} on {self.benchmark_name!r}: "
+            f"score={self.score}  gain={self.gain:+}  cost=${self.cost:g})"
+        )

--- a/packages/screamingface/src/screamingface/widgets.py
+++ b/packages/screamingface/src/screamingface/widgets.py
@@ -1,0 +1,55 @@
+"""Widgets — v0.1: static mock rendering only.
+
+INVARIANT ("no dead ends"): every panel exposes ``.value`` — the real object it
+produces or edits — even as a static snapshot.
+INVARIANT (spec I5): this module imports no IPython/ipywidgets machinery; the
+renders are plain HTML strings via ``_repr_html_``.
+
+``sf.mock_widgets(True)`` is the notebooks' first line. In v0.1 every widget is
+static regardless (the toggle is honored for forward compatibility); live
+ipywidgets twins land in OME-407.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from . import wv
+
+_MOCK: bool = True
+
+
+def mock_widgets(on: bool = True) -> None:
+    """Render widgets as self-contained static HTML (survives GitHub/nbviewer).
+
+    AIDEV-NOTE: v0.1 has no live widget path, so ``mock_widgets(False)`` still
+    renders static panels — the flag exists so notebooks written against the
+    final API don't change when OME-407 adds the live twins.
+    """
+    global _MOCK
+    _MOCK = bool(on)
+
+
+class MockHandle:
+    """A static widget snapshot that still honors the ``.value`` contract."""
+
+    def __init__(self, html: str, value_fn: Callable[[], object]):
+        self._html = html
+        self._value_fn = value_fn
+
+    @property
+    def value(self) -> object:
+        return self._value_fn()
+
+    def _repr_html_(self) -> str:
+        return self._html
+
+    def __repr__(self) -> str:
+        return "<widget preview — .value holds the object>"
+
+
+def setup_panel() -> MockHandle:
+    """The connect panel; ``.value`` is the live Session."""
+    from .session import session
+
+    return MockHandle(wv.setup(session), lambda: session)

--- a/packages/screamingface/src/screamingface/wv.py
+++ b/packages/screamingface/src/screamingface/wv.py
@@ -1,0 +1,117 @@
+"""Widget-view renderers — brand-styled, self-contained static HTML.
+
+Each render embeds a scoped ``<style>`` (brand tokens + the ``.w-*`` widget
+CSS) under a ``.sfw`` wrapper, so the output survives nbconvert / GitHub /
+nbviewer with no external assets. Brand law per the screamingface-design
+system: radius-0, hairline borders, IBM Plex Mono, gold ``#d88507`` accent.
+
+AIDEV-NOTE: v0.1 ships only the setup panel (quickstart). The browse /
+compose / run / inspect / leaderboard builders arrive with OME-407 / OME-402.
+"""
+
+from __future__ import annotations
+
+import html as _html
+
+_TOKENS = """
+.sfw{
+ --bg:#fff;--surface:#f6f6f7;--ink:#16181d;--ink-2:#585d67;--ink-3:#8b909a;
+ --line:#e6e7ea;--line-2:#d4d6db;--gain:#d88507;--gain-bg:#fbf1da;--cat-blue:#4e79a7;
+ --f-display:"EB Garamond","Iowan Old Style",Georgia,"Times New Roman",serif;
+ --f-sans:"IBM Plex Sans",system-ui,-apple-system,"Segoe UI",sans-serif;
+ --f-mono:"IBM Plex Mono",ui-monospace,SFMono-Regular,Menlo,monospace;
+ --text-lead:20px;--text-sm:13px;--text-micro:12px;--text-label:11px;
+ --tracking-tight:-0.01em;--tracking-label:0.1em;
+ --space-1:4px;--space-2:8px;--space-3:12px;--space-4:16px;
+ background:var(--bg);color:var(--ink);font-family:var(--f-sans);
+ font-size:var(--text-sm);line-height:1.6;max-width:720px;
+}
+.sfw *{box-sizing:border-box}
+.sfw button{font:inherit}
+"""
+
+_WIDGET_CSS = """
+.w{font-family:var(--f-sans);font-size:var(--text-sm);color:var(--ink)}
+.w .w-head{display:flex;align-items:center;gap:var(--space-2);margin-bottom:var(--space-3);flex-wrap:wrap}
+.w-title{font-family:var(--f-display);font-size:var(--text-lead);color:var(--ink);letter-spacing:var(--tracking-tight)}
+.w-sub{font-family:var(--f-mono);font-size:var(--text-micro);color:var(--ink-3);text-transform:uppercase;letter-spacing:var(--tracking-label)}
+.w-grouplabel{font-family:var(--f-mono);font-size:var(--text-label);text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--ink-3);margin:var(--space-4) 0 var(--space-2)}
+.w-faint{color:var(--ink-3)}
+.w-footline{display:flex;align-items:center;gap:var(--space-2);margin-top:var(--space-4);padding-top:var(--space-3);border-top:1px solid var(--line);font-family:var(--f-mono);font-size:var(--text-micro);color:var(--ink-3)}
+.w-tag{font-family:var(--f-mono);font-size:var(--text-micro);color:var(--gain);border:1px solid var(--gain);padding:1px var(--space-2);white-space:nowrap}
+.w-btn{font-family:var(--f-mono);font-size:var(--text-sm);cursor:pointer;border-radius:0;border:1px solid var(--ink);background:var(--bg);color:var(--ink);padding:var(--space-2) var(--space-4)}
+.w-btn.tiny{padding:var(--space-1) var(--space-3);font-size:var(--text-micro)}
+.w-btn.gain{border-color:var(--gain);color:var(--gain)}
+.w-btn.ghost{border-color:var(--line-2);color:var(--ink-2)}
+.w-dot{width:7px;height:7px;flex:0 0 auto;background:var(--line-2);display:inline-block}
+.w-dot.on{background:var(--gain);box-shadow:0 0 0 3px var(--gain-bg)}
+.w-tilegrid{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-2)}
+.w-tile{border:1px solid var(--line-2);padding:var(--space-3);background:var(--bg)}
+.w-tile.on{border-left:2px solid var(--gain)}
+.w-tile-top{display:flex;align-items:center;gap:var(--space-2)}
+.w-tile-name{font-family:var(--f-sans);font-weight:600}
+.w-tile-env{font-family:var(--f-mono);font-size:var(--text-micro);color:var(--ink-3);margin:var(--space-1) 0 var(--space-2)}
+.w-tile-foot{display:flex;align-items:center;justify-content:space-between;gap:var(--space-2)}
+.w-mask{font-family:var(--f-mono);font-size:var(--text-micro);color:var(--ink-2);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+"""
+
+_CSS = _TOKENS + _WIDGET_CSS
+
+
+def _e(s: object) -> str:
+    return _html.escape(str(s))
+
+
+def frame(inner: str) -> str:
+    """Wrap widget markup with the scoped stylesheet (self-contained output)."""
+    return f"<div class='sfw'><style>{_CSS}</style>{inner}</div>"
+
+
+def _foot(tag: str, note: str) -> str:
+    return f"<div class='w-footline'><span class='w-tag'>{_e(tag)}</span> {_e(note)}</div>"
+
+
+def setup(session) -> str:
+    """The connect panel: one tile per provider, grouped, keys masked."""
+    from .catalog import GROUP_ORDER, PROVIDERS
+    from .session import KEY_NAMES, _mask
+
+    body = (
+        "<div class='w w-setup'><div class='w-head'>"
+        "<span class='w-title'>Connect a provider</span>"
+        "<span class='w-sub'>keys stay in memory · never printed · grading simulated</span>"
+        "</div>"
+    )
+    for group in GROUP_ORDER:
+        provs = [p for p in PROVIDERS.values() if p.group == group]
+        if not provs:
+            continue
+        body += f"<div class='w-grouplabel'>{_e(group)}</div><div class='w-tilegrid'>"
+        for prov in provs:
+            conn = session.connections.get(prov.id)
+            connected = bool(conn and conn.connected)
+            key = session.keys.get(prov.id)
+            via = (conn.source if conn else "") or ""
+            # INVARIANT (spec I4): only the mask ever reaches the markup.
+            mask = _mask(key) if key else ""
+            foot = (
+                f"<span class='w-mask'>🔑 {_e(mask or '—')} · {_e(via)}</span>"
+                if connected
+                else "<span class='w-faint'>not connected</span>"
+            )
+            btn = (
+                f"<button class='w-btn tiny {'ghost' if connected else 'gain'}'>"
+                f"{'disconnect' if connected else 'connect'}</button>"
+            )
+            body += (
+                f"<div class='w-tile{' on' if connected else ''}'>"
+                f"<div class='w-tile-top'><span class='w-dot{' on' if connected else ''}'></span>"
+                f"<span class='w-tile-name'>{_e(prov.name)}</span></div>"
+                f"<div class='w-tile-env'>{_e(KEY_NAMES.get(prov.id, ''))}</div>"
+                f"<div class='w-tile-foot'>{foot}{btn}</div></div>"
+            )
+        body += "</div>"
+    n = sum(1 for p in PROVIDERS if session.is_connected(p))
+    note = f"Session · {n} provider{'' if n == 1 else 's'} connected"
+    body += _foot(".value", note) + "</div>"
+    return frame(body)

--- a/packages/screamingface/tests/conftest.py
+++ b/packages/screamingface/tests/conftest.py
@@ -1,0 +1,37 @@
+"""Shared fixtures for the screamingface test suite.
+
+`RecordingBackend` mirrors url4's `RecordingIOLayer` convention: a structurally
+conforming `EngineBackend` that delegates to the real `SimulatedBackend` while
+recording every (model, question) it was asked — used to prove the evaluate
+loop drives everything through the port.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from screamingface.engine import Answer, EngineBackend, SimulatedBackend
+
+
+class RecordingBackend:
+    """Delegating EngineBackend that records every answer request."""
+
+    def __init__(self) -> None:
+        self._inner = SimulatedBackend()
+        self.calls: list[tuple[str, str]] = []  # (model_id, question_id)
+
+    def answer(self, model, question, benchmark, seed: int) -> Answer:
+        self.calls.append((model.id, question.id))
+        return self._inner.answer(model, question, benchmark, seed)
+
+    def synth_reasoning(self, seed: int, question) -> str:
+        return self._inner.synth_reasoning(seed, question)
+
+
+# INVARIANT: RecordingBackend structurally conforms to the EngineBackend port.
+_: EngineBackend = RecordingBackend()
+
+
+@pytest.fixture
+def recording_backend() -> RecordingBackend:
+    return RecordingBackend()

--- a/packages/screamingface/tests/test_catalog.py
+++ b/packages/screamingface/tests/test_catalog.py
@@ -49,8 +49,10 @@ class TestList:
         assert ids == sorted(
             ids,
             key=lambda i: getattr(
-                sf.models.get(i), {"price": "price", "context": "ctx",
-                                   "ability": "ability", "name": "name"}[sort_key]
+                sf.models.get(i),
+                {"price": "price", "context": "ctx", "ability": "ability", "name": "name"}[
+                    sort_key
+                ],
             ),
             reverse=sort_key in ("ability", "context"),  # WHY: desc defaults for these
         )
@@ -70,8 +72,10 @@ class TestGet:
 
     def test_get_accepts_owner_prefixed_id(self):
         # WHY: owner/provider/model is the federation seam; local owner is implied.
-        assert sf.models.get("local/anthropic/claude-opus-4.8").id == \
-            sf.models.get("anthropic/claude-opus-4.8").id
+        assert (
+            sf.models.get("local/anthropic/claude-opus-4.8").id
+            == sf.models.get("anthropic/claude-opus-4.8").id
+        )
 
     def test_get_unknown_raises_keyerror_with_hint(self):
         with pytest.raises(KeyError, match="models.list"):

--- a/packages/screamingface/tests/test_catalog.py
+++ b/packages/screamingface/tests/test_catalog.py
@@ -1,0 +1,78 @@
+"""sf.models — the catalog service (list / get).
+
+FEATURE: model discovery — step 2 of the quickstart (connect → pick → compose → run).
+The prototype's `sf.models` was a Pool (both service and collection); the SDK makes it
+a thin service returning plain `provider/model` id strings (API_STRUCTURE.md §5).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import screamingface as sf
+
+
+class TestList:
+    def test_returns_provider_model_ids(self):
+        ids = sf.models.list()
+        assert ids, "catalog must not be empty"
+        assert all(isinstance(i, str) and "/" in i for i in ids)
+
+    def test_max_price_filters_combined_price(self):
+        # WHY: `price` is in+out per M tokens (matches the prototype/studio semantics).
+        ids = sf.models.list(max_price=20)
+        assert ids
+        for i in ids:
+            m = sf.models.get(i)
+            assert m.price <= 20
+
+    def test_max_price_excludes_expensive_models(self):
+        all_ids = set(sf.models.list())
+        cheap = set(sf.models.list(max_price=20))
+        assert cheap < all_ids  # something got excluded
+        # the quickstart's exemplar expensive model
+        assert "open_router/claude-opus-4" in all_ids - cheap
+
+    def test_search_matches_name_substring(self):
+        ids = sf.models.list(search="claude")
+        assert ids
+        assert all("claude" in i.split("/", 1)[1] for i in ids)
+
+    def test_provider_filter_accepts_slug(self):
+        ids = sf.models.list(provider="google")
+        assert ids
+        assert all(i.startswith("google/") for i in ids)
+
+    @pytest.mark.parametrize("sort_key", ["price", "context", "ability", "name"])
+    def test_sort_keys(self, sort_key):
+        ids = sf.models.list(sort=sort_key)
+        assert ids == sorted(
+            ids,
+            key=lambda i: getattr(
+                sf.models.get(i), {"price": "price", "context": "ctx",
+                                   "ability": "ability", "name": "name"}[sort_key]
+            ),
+            reverse=sort_key in ("ability", "context"),  # WHY: desc defaults for these
+        )
+
+    def test_min_ctx_filter(self):
+        ids = sf.models.list(min_ctx=1_000_000)
+        assert ids
+        assert all(sf.models.get(i).ctx >= 1_000_000 for i in ids)
+
+
+class TestGet:
+    def test_get_returns_model_card(self):
+        m = sf.models.get("anthropic/claude-opus-4.8")
+        assert m.name == "Claude Opus 4.8"
+        assert m.provider_name == "Anthropic"
+        assert m.price_in > 0 and m.price_out > 0 and m.ctx > 0
+
+    def test_get_accepts_owner_prefixed_id(self):
+        # WHY: owner/provider/model is the federation seam; local owner is implied.
+        assert sf.models.get("local/anthropic/claude-opus-4.8").id == \
+            sf.models.get("anthropic/claude-opus-4.8").id
+
+    def test_get_unknown_raises_keyerror_with_hint(self):
+        with pytest.raises(KeyError, match="models.list"):
+            sf.models.get("nope/does-not-exist")

--- a/packages/screamingface/tests/test_datasets.py
+++ b/packages/screamingface/tests/test_datasets.py
@@ -1,0 +1,44 @@
+"""Benchmark loading — real questions, offline-first, deterministic subsampling.
+
+WHY offline-first (deviation from the prototype's hub-first order): the executed
+quickstart notebook must be reproducible on GitHub/Colab without network or HF
+terms-acceptance; the Hub is opt-in via offline=False.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from screamingface.datasets import load_benchmark
+
+
+class TestLoad:
+    def test_bundled_gpqa_loads_offline(self):
+        bench = load_benchmark("gpqa", n=20, seed=0)
+        assert bench.name == "GPQA Diamond"
+        assert len(bench) == 20
+        assert bench.source == "offline-sample"
+
+    def test_questions_are_real_mcqs(self):
+        bench = load_benchmark("gpqa", n=5, seed=0)
+        for q in bench:
+            assert q.kind == "mcq"
+            assert q.prompt and len(q.options) >= 2
+            assert 0 <= q.gold_index < len(q.options)
+            assert q.gold_key  # canonical voting key (a letter)
+
+    def test_subsample_is_deterministic_per_seed(self):
+        a = [q.id for q in load_benchmark("gpqa", n=10, seed=3)]
+        b = [q.id for q in load_benchmark("gpqa", n=10, seed=3)]
+        c = [q.id for q in load_benchmark("gpqa", n=10, seed=4)]
+        assert a == b
+        assert a != c
+
+    def test_n_larger_than_bundle_returns_everything(self):
+        bench = load_benchmark("gpqa", n=10_000, seed=0)
+        assert len(bench) > 0
+        assert len(bench) < 10_000
+
+    def test_unknown_key_raises(self):
+        with pytest.raises(KeyError, match="[Uu]nknown benchmark"):
+            load_benchmark("nope", n=5, seed=0)

--- a/packages/screamingface/tests/test_engine_port.py
+++ b/packages/screamingface/tests/test_engine_port.py
@@ -1,0 +1,71 @@
+"""The EngineBackend port and its v0.1 adapter, SimulatedBackend.
+
+INVARIANT (spec §2): the port is the seam where real inference (OME-296)
+plugs in — the SimulatedBackend must be swappable for any conforming adapter.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from screamingface.catalog import BENCHMARKS
+from screamingface.datasets import load_benchmark
+from screamingface.engine import Answer, EngineBackend, SimulatedBackend, hash01
+from screamingface.models import get_model
+
+
+def test_simulated_backend_conforms_to_port():
+    # INVARIANT: structural conformance — checked by the type system, not duck luck.
+    _: EngineBackend = SimulatedBackend()
+
+
+def test_hash01_is_deterministic_and_bounded():
+    vals = [hash01(0, "x", i) for i in range(100)]
+    assert vals == [hash01(0, "x", i) for i in range(100)]
+    assert all(0.0 <= v < 1.0 for v in vals)
+    assert len(set(vals)) > 50  # spreads, not constant
+
+
+class TestAnswer:
+    def test_answer_fields_are_populated(self):
+        bench = load_benchmark("gpqa", n=3, seed=0)
+        model = get_model("an-1")
+        ans = SimulatedBackend().answer(model, bench.questions[0], bench.spec, seed=0)
+        assert isinstance(ans, Answer)
+        assert ans.choice and ans.text and ans.reasoning
+        assert ans.latency_ms > 0 and ans.tokens_in > 0 and ans.tokens_out > 0
+        assert ans.cost > 0
+
+    def test_answer_is_deterministic(self):
+        bench = load_benchmark("gpqa", n=3, seed=0)
+        model = get_model("an-1")
+        a = SimulatedBackend().answer(model, bench.questions[0], bench.spec, seed=0)
+        b = SimulatedBackend().answer(model, bench.questions[0], bench.spec, seed=0)
+        assert a == b
+
+    def test_correct_flag_matches_gold(self):
+        bench = load_benchmark("gpqa", n=10, seed=0)
+        model = get_model("an-1")
+        backend = SimulatedBackend()
+        for q in bench.questions:
+            ans = backend.answer(model, q, bench.spec, seed=0)
+            assert ans.correct == (ans.choice == q.gold_key)
+
+
+class TestAccuracyModel:
+    def test_accuracy_clipped_to_sane_range(self):
+        backend = SimulatedBackend()
+        for spec in BENCHMARKS.values():
+            for mid in ("an-1", "hf-2"):
+                acc = backend.accuracy(get_model(mid), spec, seed=0)
+                assert 0.02 <= acc <= 0.98
+
+    def test_stronger_model_scores_higher_on_average(self):
+        # WHY: ability must actually drive the simulation — an-1 (38.4) vs hf-2 (14.5).
+        bench = load_benchmark("gpqa", n=200, seed=0)
+        backend = SimulatedBackend()
+        totals = {}
+        for mid in ("an-1", "hf-2"):
+            m = get_model(mid)
+            totals[mid] = sum(backend.answer(m, q, bench.spec, 0).correct for q in bench)
+        assert totals["an-1"] > totals["hf-2"]

--- a/packages/screamingface/tests/test_engine_port.py
+++ b/packages/screamingface/tests/test_engine_port.py
@@ -6,8 +6,6 @@ plugs in — the SimulatedBackend must be swappable for any conforming adapter.
 
 from __future__ import annotations
 
-import pytest
-
 from screamingface.catalog import BENCHMARKS
 from screamingface.datasets import load_benchmark
 from screamingface.engine import Answer, EngineBackend, SimulatedBackend, hash01
@@ -61,11 +59,14 @@ class TestAccuracyModel:
                 assert 0.02 <= acc <= 0.98
 
     def test_stronger_model_scores_higher_on_average(self):
-        # WHY: ability must actually drive the simulation — an-1 (38.4) vs hf-2 (14.5).
+        # WHY: ability must drive the simulation — an-1 (38.4) vs hf-2 (14.5).
+        # The invariant is about EXPECTATION, so aggregate over many seeds: any
+        # single seed over 20 questions can be a (deterministic) unlucky streak.
         bench = load_benchmark("gpqa", n=200, seed=0)
         backend = SimulatedBackend()
-        totals = {}
-        for mid in ("an-1", "hf-2"):
+        totals = {"an-1": 0, "hf-2": 0}
+        for mid in totals:
             m = get_model(mid)
-            totals[mid] = sum(backend.answer(m, q, bench.spec, 0).correct for q in bench)
+            for seed in range(25):
+                totals[mid] += sum(backend.answer(m, q, bench.spec, seed).correct for q in bench)
         assert totals["an-1"] > totals["hf-2"]

--- a/packages/screamingface/tests/test_evaluate.py
+++ b/packages/screamingface/tests/test_evaluate.py
@@ -1,0 +1,84 @@
+"""fusion.evaluate — deterministic runs over real benchmark questions.
+
+INVARIANT (spec I1): same (fusion, benchmark, first, seed) → identical run.
+INVARIANT (spec I2): each model's marginal accuracy tracks its ability
+regardless of the correlation knob (honest lift).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import screamingface as sf
+from screamingface.datasets import load_benchmark
+from screamingface.engine import SimulatedBackend
+
+IDS = ["anthropic/claude-opus-4.8", "google/gemini-2.5-pro", "openai/gpt-5"]
+
+
+def _fusion() -> "sf.Fusion":
+    return sf.Fusion("fusion", models=IDS, reduce="majority_vote", judge=IDS[0])
+
+
+class TestDeterminism:
+    def test_same_seed_same_run(self):
+        r1 = _fusion().evaluate("gpqa", first=20, seed=0)
+        r2 = _fusion().evaluate("gpqa", first=20, seed=0)
+        assert (r1.score, r1.baseline, r1.gain, r1.cost) == \
+            (r2.score, r2.baseline, r2.gain, r2.cost)
+
+    def test_different_seed_differs_somewhere(self):
+        # WHY: not every metric must move, but two seeds over 20 GPQA questions
+        # producing byte-identical per-question outcomes would mean seed is dead.
+        r1 = _fusion().evaluate("gpqa", first=20, seed=0)
+        r2 = _fusion().evaluate("gpqa", first=20, seed=7)
+        q1 = [q.final_choice for q in r1.result.question_results]
+        q2 = [q.final_choice for q in r2.result.question_results]
+        assert q1 != q2
+
+    def test_first_controls_sample_size(self):
+        run = _fusion().evaluate("gpqa", first=5, seed=0)
+        assert run.sample_size == 5
+
+
+class TestBenchmarkLookup:
+    def test_accepts_id_and_display_name(self):
+        by_id = _fusion().evaluate("gpqa", first=5, seed=0)
+        by_name = _fusion().evaluate("GPQA Diamond", first=5, seed=0)
+        assert by_id.score == by_name.score
+        assert by_id.benchmark_name == "GPQA Diamond"
+
+    def test_unknown_benchmark_raises(self):
+        with pytest.raises(KeyError, match="[Uu]nknown benchmark"):
+            _fusion().evaluate("nope", first=5, seed=0)
+
+    def test_empty_fusion_cannot_evaluate(self):
+        f = sf.Fusion("empty")
+        with pytest.raises(ValueError, match="empty"):
+            f.evaluate("gpqa", first=5, seed=0)
+
+
+class TestHonestLift:
+    def test_marginal_accuracy_is_correlation_invariant(self):
+        # INVARIANT I2: correlation reshuffles WHICH questions a model gets right,
+        # never HOW MANY (in expectation). With n=200 the realized accuracy under
+        # correlation 0.0 and 0.9 must stay within a few points of each other.
+        bench = load_benchmark("gpqa", n=200, seed=0)
+        model = sf.models.get(IDS[0])
+        spec = bench.spec
+        for lo, hi in [(0.0, 0.9)]:
+            acc = {}
+            for corr in (lo, hi):
+                backend = SimulatedBackend(correlation=corr)
+                correct = sum(
+                    backend.answer(model, q, spec, seed=0).correct for q in bench.questions
+                )
+                acc[corr] = correct / len(bench.questions)
+            assert abs(acc[lo] - acc[hi]) < 0.12
+
+    def test_backend_port_is_the_only_answer_path(self, recording_backend):
+        # INVARIANT (spec §2): every answer flows through the EngineBackend port.
+        bench = load_benchmark("gpqa", n=5, seed=0)
+        run = _fusion().evaluate(bench, seed=0, backend=recording_backend)
+        assert run.sample_size == 5
+        assert len(recording_backend.calls) == 5 * len(IDS)

--- a/packages/screamingface/tests/test_evaluate.py
+++ b/packages/screamingface/tests/test_evaluate.py
@@ -16,7 +16,7 @@ from screamingface.engine import SimulatedBackend
 IDS = ["anthropic/claude-opus-4.8", "google/gemini-2.5-pro", "openai/gpt-5"]
 
 
-def _fusion() -> "sf.Fusion":
+def _fusion() -> sf.Fusion:
     return sf.Fusion("fusion", models=IDS, reduce="majority_vote", judge=IDS[0])
 
 
@@ -24,8 +24,12 @@ class TestDeterminism:
     def test_same_seed_same_run(self):
         r1 = _fusion().evaluate("gpqa", first=20, seed=0)
         r2 = _fusion().evaluate("gpqa", first=20, seed=0)
-        assert (r1.score, r1.baseline, r1.gain, r1.cost) == \
-            (r2.score, r2.baseline, r2.gain, r2.cost)
+        assert (r1.score, r1.baseline, r1.gain, r1.cost) == (
+            r2.score,
+            r2.baseline,
+            r2.gain,
+            r2.cost,
+        )
 
     def test_different_seed_differs_somewhere(self):
         # WHY: not every metric must move, but two seeds over 20 GPQA questions

--- a/packages/screamingface/tests/test_facade.py
+++ b/packages/screamingface/tests/test_facade.py
@@ -1,0 +1,41 @@
+"""The public facade — the exact quickstart flow, end to end.
+
+STORY: as a researcher, I open 00_quickstart, run every cell, and see a real
+gain read-out. This test IS that notebook, headless.
+"""
+
+from __future__ import annotations
+
+import screamingface as sf
+
+
+def test_version():
+    assert sf.__version__ == "0.1.0"
+
+
+def test_public_surface_is_exported():
+    for name in ("setup", "connect", "models", "Fusion", "Run", "mock_widgets",
+                 "session", "EngineBackend", "SimulatedBackend"):
+        assert name in sf.__all__, f"missing from __all__: {name}"
+        assert hasattr(sf, name)
+
+
+def test_quickstart_flow(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    sf.mock_widgets(True)
+
+    sf.connect("anthropic")                                   # step 1 (headless twin)
+    ids = sf.models.list(max_price=20)                        # step 2
+    assert len(ids) >= 3
+
+    fusion = sf.Fusion("fusion", models=ids[:3],              # step 3
+                       reduce="majority_vote", judge=ids[0])
+    assert fusion.url.startswith("url4://fusion?models=")
+
+    run = fusion.evaluate("gpqa", first=20, seed=0)           # step 4
+    assert run.sample_size == 20
+
+    # step 5 — the payoff: numbers exist and are consistent
+    assert 0.0 <= run.score <= 100.0
+    assert 0.0 <= run.baseline <= 100.0
+    assert run.gain == round(run.score - run.baseline, 1)

--- a/packages/screamingface/tests/test_facade.py
+++ b/packages/screamingface/tests/test_facade.py
@@ -14,8 +14,17 @@ def test_version():
 
 
 def test_public_surface_is_exported():
-    for name in ("setup", "connect", "models", "Fusion", "Run", "mock_widgets",
-                 "session", "EngineBackend", "SimulatedBackend"):
+    for name in (
+        "setup",
+        "connect",
+        "models",
+        "Fusion",
+        "Run",
+        "mock_widgets",
+        "session",
+        "EngineBackend",
+        "SimulatedBackend",
+    ):
         assert name in sf.__all__, f"missing from __all__: {name}"
         assert hasattr(sf, name)
 
@@ -24,15 +33,19 @@ def test_quickstart_flow(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
     sf.mock_widgets(True)
 
-    sf.connect("anthropic")                                   # step 1 (headless twin)
-    ids = sf.models.list(max_price=20)                        # step 2
+    sf.connect("anthropic")  # step 1 (headless twin)
+    ids = sf.models.list(max_price=20)  # step 2
     assert len(ids) >= 3
 
-    fusion = sf.Fusion("fusion", models=ids[:3],              # step 3
-                       reduce="majority_vote", judge=ids[0])
+    fusion = sf.Fusion(
+        "fusion",
+        models=ids[:3],  # step 3
+        reduce="majority_vote",
+        judge=ids[0],
+    )
     assert fusion.url.startswith("url4://fusion?models=")
 
-    run = fusion.evaluate("gpqa", first=20, seed=0)           # step 4
+    run = fusion.evaluate("gpqa", first=20, seed=0)  # step 4
     assert run.sample_size == 20
 
     # step 5 — the payoff: numbers exist and are consistent

--- a/packages/screamingface/tests/test_fusion.py
+++ b/packages/screamingface/tests/test_fusion.py
@@ -1,0 +1,74 @@
+"""sf.Fusion — composition and the shareable recipe.
+
+FEATURE: compose a fusion (quickstart step 3).
+INVARIANT (spec I3): the judge must be one of the fusion's members.
+INVARIANT (spec I6): `fusion.url` carries the full composition — the recipe IS the identity.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import screamingface as sf
+
+IDS = [
+    "anthropic/claude-opus-4.8",
+    "google/gemini-2.5-pro",
+    "openai/gpt-5",
+]
+
+
+class TestConstruction:
+    def test_basic_construction(self):
+        f = sf.Fusion("fusion", models=IDS, reduce="majority_vote", judge=IDS[0])
+        assert f.name == "fusion"
+        assert f.models == IDS
+        assert f.judge == IDS[0]
+
+    def test_name_is_slugified(self):
+        assert sf.Fusion("My Fusion", models=IDS[:1]).name == "my-fusion"
+
+    def test_duplicate_members_are_deduped(self):
+        f = sf.Fusion("f", models=[IDS[0], IDS[0], IDS[1]])
+        assert f.models == [IDS[0], IDS[1]]
+
+    def test_judge_must_be_member(self):
+        # INVARIANT I3 — validated at construction, not first use.
+        with pytest.raises(ValueError, match="judge"):
+            sf.Fusion("f", models=IDS[:2], judge=IDS[2])
+
+    def test_unknown_reduce_strategy_raises(self):
+        with pytest.raises(ValueError, match="reduce"):
+            sf.Fusion("f", models=IDS, reduce="quantum_entangle")
+
+    def test_unknown_model_raises_with_hint(self):
+        with pytest.raises(KeyError, match="models.list"):
+            sf.Fusion("f", models=["nope/nothing"])
+
+    @pytest.mark.parametrize("strategy", ["majority_vote", "weighted_avg", "best_of_n", "merge"])
+    def test_all_builtin_strategies_accepted(self, strategy):
+        assert sf.Fusion("f", models=IDS, reduce=strategy)
+
+
+class TestUrl:
+    def test_url_shape(self):
+        # STORY: as a researcher I paste one string to share my whole recipe.
+        f = sf.Fusion("fusion", models=IDS, reduce="majority_vote", judge=IDS[0])
+        assert f.url == (
+            "url4://fusion?models=anthropic/claude-opus-4.8+google/gemini-2.5-pro"
+            "+openai/gpt-5&reduce=majority_vote&loop=parallel"
+            "&judge=anthropic/claude-opus-4.8"
+        )
+
+    def test_url_omits_judge_when_unset(self):
+        f = sf.Fusion("f", models=IDS[:2])
+        assert "judge=" not in f.url
+        assert "reduce=majority_vote" in f.url  # the default strategy is explicit
+
+    def test_url_never_contains_a_key(self, monkeypatch):
+        # INVARIANT I4 — keys never escape into recipes.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-super-secret-1234")
+        sf.connect("anthropic")
+        f = sf.Fusion("f", models=IDS, judge=IDS[0])
+        assert "sk-super-secret" not in f.url
+        assert "1234" not in f.url

--- a/packages/screamingface/tests/test_reduce.py
+++ b/packages/screamingface/tests/test_reduce.py
@@ -15,8 +15,14 @@ from screamingface.reduce import reduce_answers
 
 def _answer(choice: str) -> Answer:
     return Answer(
-        choice=choice, text=choice, correct=False, reasoning="",
-        latency_ms=0, tokens_in=0, tokens_out=0, cost=0.0,
+        choice=choice,
+        text=choice,
+        correct=False,
+        reasoning="",
+        latency_ms=0,
+        tokens_in=0,
+        tokens_out=0,
+        cost=0.0,
     )
 
 
@@ -36,24 +42,30 @@ M3 = ["an-1", "dm-1", "oa-1"]
 class TestMajorityVote:
     def test_majority_wins(self):
         core = _core(M3)
-        choice, note = reduce_answers(core, [_answer("A"), _answer("A"), _answer("B")],
-                                      core.normalized_weights())
+        choice, note = reduce_answers(
+            core, [_answer("A"), _answer("A"), _answer("B")], core.normalized_weights()
+        )
         assert choice == "A"
         assert "majority" in note
 
     def test_tie_prefers_judge_answer(self):
+        # WHY: the judge doesn't vote, but when the VOTERS tie it breaks the tie
+        # toward its own answer. Voters dm-1 (A) and oa-1 (C) tie; judge an-1
+        # also says A → A wins. Without judge preference the tie-break would be
+        # best-ability voter oa-1 (37.2 > 35.6) → C, so this pins the contract.
         core = _core(M3, judge="an-1")
-        # judge (an-1) says B; dm-1 says A; oa-1 abstains into C → 3-way tie
-        choice, _ = reduce_answers(core, [_answer("B"), _answer("A"), _answer("C")],
-                                   core.normalized_weights())
-        assert choice == "B"
+        choice, _ = reduce_answers(
+            core, [_answer("A"), _answer("A"), _answer("C")], core.normalized_weights()
+        )
+        assert choice == "A"
 
 
 class TestWeightedAvg:
     def test_heavier_weight_wins(self):
         core = _core(M3, strategy="weighted_avg", weights=[0.8, 0.1, 0.1])
-        choice, _ = reduce_answers(core, [_answer("B"), _answer("A"), _answer("A")],
-                                   core.normalized_weights())
+        choice, _ = reduce_answers(
+            core, [_answer("B"), _answer("A"), _answer("A")], core.normalized_weights()
+        )
         # 0.8 for B beats 0.2 combined for A
         assert choice == "B"
 
@@ -62,16 +74,18 @@ class TestBestOfN:
     def test_picks_highest_ability_member(self):
         core = _core(M3, strategy="best_of_n")
         # an-1 has the highest ability in the catalog → its answer wins
-        choice, _ = reduce_answers(core, [_answer("C"), _answer("A"), _answer("A")],
-                                   core.normalized_weights())
+        choice, _ = reduce_answers(
+            core, [_answer("C"), _answer("A"), _answer("A")], core.normalized_weights()
+        )
         assert choice == "C"
 
 
 class TestMerge:
     def test_merge_reduces_to_consensus(self):
         core = _core(M3, strategy="merge")
-        choice, _ = reduce_answers(core, [_answer("A"), _answer("A"), _answer("B")],
-                                   core.normalized_weights())
+        choice, _ = reduce_answers(
+            core, [_answer("A"), _answer("A"), _answer("B")], core.normalized_weights()
+        )
         assert choice == "A"
 
 

--- a/packages/screamingface/tests/test_reduce.py
+++ b/packages/screamingface/tests/test_reduce.py
@@ -1,0 +1,87 @@
+"""Reduce strategies — real voting math over per-model answers.
+
+FEATURE: the reduce stage is where fusion lift comes from (spec I2: the gain
+emerges from combining answers, never from a hard-coded bonus).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from screamingface.engine import Answer
+from screamingface.fusion_core import FusionCore
+from screamingface.reduce import reduce_answers
+
+
+def _answer(choice: str) -> Answer:
+    return Answer(
+        choice=choice, text=choice, correct=False, reasoning="",
+        latency_ms=0, tokens_in=0, tokens_out=0, cost=0.0,
+    )
+
+
+def _core(model_ids, judge=None, strategy="majority_vote", weights=None) -> FusionCore:
+    core = FusionCore("t")
+    for i, mid in enumerate(model_ids):
+        core.add(mid, weight=(weights[i] if weights else 0.5))
+    core.reduce(strategy, judge=judge)
+    return core
+
+
+# WHY: short catalog ids keep the voting-table tests readable; the studio layer
+# owns the provider/model alias scheme and is tested separately.
+M3 = ["an-1", "dm-1", "oa-1"]
+
+
+class TestMajorityVote:
+    def test_majority_wins(self):
+        core = _core(M3)
+        choice, note = reduce_answers(core, [_answer("A"), _answer("A"), _answer("B")],
+                                      core.normalized_weights())
+        assert choice == "A"
+        assert "majority" in note
+
+    def test_tie_prefers_judge_answer(self):
+        core = _core(M3, judge="an-1")
+        # judge (an-1) says B; dm-1 says A; oa-1 abstains into C → 3-way tie
+        choice, _ = reduce_answers(core, [_answer("B"), _answer("A"), _answer("C")],
+                                   core.normalized_weights())
+        assert choice == "B"
+
+
+class TestWeightedAvg:
+    def test_heavier_weight_wins(self):
+        core = _core(M3, strategy="weighted_avg", weights=[0.8, 0.1, 0.1])
+        choice, _ = reduce_answers(core, [_answer("B"), _answer("A"), _answer("A")],
+                                   core.normalized_weights())
+        # 0.8 for B beats 0.2 combined for A
+        assert choice == "B"
+
+
+class TestBestOfN:
+    def test_picks_highest_ability_member(self):
+        core = _core(M3, strategy="best_of_n")
+        # an-1 has the highest ability in the catalog → its answer wins
+        choice, _ = reduce_answers(core, [_answer("C"), _answer("A"), _answer("A")],
+                                   core.normalized_weights())
+        assert choice == "C"
+
+
+class TestMerge:
+    def test_merge_reduces_to_consensus(self):
+        core = _core(M3, strategy="merge")
+        choice, _ = reduce_answers(core, [_answer("A"), _answer("A"), _answer("B")],
+                                   core.normalized_weights())
+        assert choice == "A"
+
+
+class TestJudgeExclusion:
+    def test_judge_does_not_contribute_a_vote(self):
+        # INVARIANT: the judge arbitrates, it does not vote (weight 0).
+        core = _core(M3, judge="an-1")
+        weights = core.normalized_weights()
+        assert weights[0] == 0.0
+        assert weights[1] + weights[2] == pytest.approx(1.0)
+        # judge says A, but both voters say B → B wins despite the judge
+        choice, _ = reduce_answers(core, [_answer("A"), _answer("B"), _answer("B")], weights)
+        assert choice == "B"

--- a/packages/screamingface/tests/test_run.py
+++ b/packages/screamingface/tests/test_run.py
@@ -13,7 +13,7 @@ IDS = ["anthropic/claude-opus-4.8", "google/gemini-2.5-pro", "openai/gpt-5"]
 
 
 @pytest.fixture(scope="module")
-def run() -> "sf.Run":
+def run() -> sf.Run:
     fusion = sf.Fusion("fusion", models=IDS, reduce="majority_vote", judge=IDS[0])
     return fusion.evaluate("gpqa", first=20, seed=0)
 

--- a/packages/screamingface/tests/test_run.py
+++ b/packages/screamingface/tests/test_run.py
@@ -1,0 +1,58 @@
+"""Run — the payoff read-out (score / baseline / gain).
+
+FEATURE: quickstart step 5 — read the gain over the best single model.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import screamingface as sf
+
+IDS = ["anthropic/claude-opus-4.8", "google/gemini-2.5-pro", "openai/gpt-5"]
+
+
+@pytest.fixture(scope="module")
+def run() -> "sf.Run":
+    fusion = sf.Fusion("fusion", models=IDS, reduce="majority_vote", judge=IDS[0])
+    return fusion.evaluate("gpqa", first=20, seed=0)
+
+
+class TestMetrics:
+    def test_score_is_fusion_accuracy_percent(self, run):
+        correct = sum(1 for q in run.result.question_results if q.correct)
+        assert run.score == pytest.approx(100.0 * correct / run.sample_size, abs=0.05)
+
+    def test_baseline_is_best_single_model(self, run):
+        best = max(m.accuracy for m in run.result.model_results)
+        assert run.baseline == pytest.approx(best, abs=0.05)
+
+    def test_gain_is_score_minus_baseline(self, run):
+        # INVARIANT: gain = score − baseline, always — the headline number.
+        assert run.gain == pytest.approx(run.score - run.baseline, abs=0.05)
+
+    def test_metrics_are_rounded_to_tenths(self, run):
+        for v in (run.score, run.baseline, run.gain):
+            assert v == round(v, 1)
+
+    def test_cost_is_positive_and_rounded(self, run):
+        assert run.cost > 0
+        assert run.cost == round(run.cost, 4)
+
+
+class TestIdentity:
+    def test_seed_and_sample_size_are_reported(self, run):
+        assert run.seed == 0
+        assert run.sample_size == 20
+        assert run.benchmark_name == "GPQA Diamond"
+
+    def test_run_url_extends_recipe_with_run_params(self, run):
+        # INVARIANT I6: the recipe is the identity; a run pins benchmark+n+seed on it.
+        assert run.url.startswith(run.fusion.url)
+        assert "benchmark=gpqa" in run.url
+        assert "seed=0" in run.url
+
+    def test_repr_shows_the_readout(self, run):
+        r = repr(run)
+        assert "fusion" in r and "GPQA Diamond" in r
+        assert "score=" in r and "gain=" in r and "cost=$" in r

--- a/packages/screamingface/tests/test_session.py
+++ b/packages/screamingface/tests/test_session.py
@@ -1,0 +1,73 @@
+"""Session — provider connections and key safety.
+
+INVARIANT (spec I4): keys live only in the in-process KeyStore; never echoed,
+never in reprs, at most masked to the last 4 characters.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import screamingface as sf
+from screamingface.session import Session, _mask
+
+
+@pytest.fixture
+def fresh() -> Session:
+    return Session()
+
+
+class TestConnect:
+    def test_connect_from_env_var(self, fresh, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-abcd1234")
+        conn = fresh.connect("anthropic")
+        assert conn.connected
+        assert conn.source == "env"
+        assert fresh.is_connected("anthropic")
+
+    def test_connect_with_explicit_key(self, fresh):
+        conn = fresh.connect("openai", api_key="sk-direct")
+        assert conn.connected and conn.source == "entered"
+
+    def test_connect_accepts_studio_slug(self, fresh):
+        # WHY: notebooks say sf.connect("google"); the engine provider id is "deepmind".
+        conn = fresh.connect("google", api_key="k")
+        assert conn.provider_id == "deepmind"
+
+    def test_missing_key_raises_with_env_hint(self, fresh, monkeypatch):
+        monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="PERPLEXITY_API_KEY"):
+            fresh.connect("perplexity", prompt=False)
+
+    def test_unknown_provider_raises(self, fresh):
+        with pytest.raises(KeyError, match="[Uu]nknown provider"):
+            fresh.connect("skynet")
+
+
+class TestKeySafety:
+    def test_status_rows_mask_keys(self, fresh):
+        fresh.connect("anthropic", api_key="sk-test-abcd1234")
+        rows = {r["provider"]: r for r in fresh.status_rows()}
+        shown = rows["Anthropic"]["key"]
+        assert "sk-test" not in shown
+        assert shown.endswith("1234") and shown.startswith("…")
+
+    def test_mask_never_reveals_short_keys(self):
+        assert _mask("abc") == "…"
+        assert _mask("") == ""
+
+    def test_key_not_in_any_row_field(self, fresh):
+        # INVARIANT I4 — sweep every surface the status view exposes.
+        secret = "sk-test-abcd1234"
+        fresh.connect("anthropic", api_key=secret)
+        for row in fresh.status_rows():
+            for v in row.values():
+                assert secret not in str(v)
+
+
+class TestSetupHeadless:
+    def test_setup_prints_instructions_outside_notebooks(self, capsys):
+        result = sf.setup()
+        assert result is None
+        out = capsys.readouterr().out
+        assert "sf.connect" in out

--- a/packages/screamingface/tests/test_share.py
+++ b/packages/screamingface/tests/test_share.py
@@ -11,8 +11,7 @@ from screamingface.share import to_url4
 
 
 def test_emits_flat_recipe_with_short_ids():
-    core = (FusionCore("my-fusion").add("an-1").add("dm-1")
-            .reduce("majority_vote", judge="an-1"))
+    core = FusionCore("my-fusion").add("an-1").add("dm-1").reduce("majority_vote", judge="an-1")
     assert to_url4(core) == (
         "url4://my-fusion?models=an-1+dm-1&reduce=majority_vote&loop=parallel&judge=an-1"
     )

--- a/packages/screamingface/tests/test_share.py
+++ b/packages/screamingface/tests/test_share.py
@@ -1,0 +1,23 @@
+"""share — the flat url4:// recipe codec (emit only in v0.1).
+
+AIDEV-NOTE: this flat format is INTERIM (spec §3) — OME-408 replaces it with
+the real url4 expression grammar; only this module should know the format.
+"""
+
+from __future__ import annotations
+
+from screamingface.fusion_core import FusionCore
+from screamingface.share import to_url4
+
+
+def test_emits_flat_recipe_with_short_ids():
+    core = (FusionCore("my-fusion").add("an-1").add("dm-1")
+            .reduce("majority_vote", judge="an-1"))
+    assert to_url4(core) == (
+        "url4://my-fusion?models=an-1+dm-1&reduce=majority_vote&loop=parallel&judge=an-1"
+    )
+
+
+def test_judge_omitted_when_unset():
+    core = FusionCore("f").add("an-1").add("dm-1")
+    assert "judge=" not in to_url4(core)

--- a/packages/screamingface/tests/test_widgets.py
+++ b/packages/screamingface/tests/test_widgets.py
@@ -1,0 +1,54 @@
+"""Widgets — v0.1 ships the mock/static rendering path only (live = OME-407).
+
+INVARIANT (contract "no dead ends"): every panel exposes `.value` — the real
+object it produces — even in static mock mode.
+INVARIANT (spec I5): importing screamingface must not import IPython/ipywidgets.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import screamingface as sf
+from screamingface.session import Session
+from screamingface.widgets import MockHandle, setup_panel
+
+
+def test_mock_widgets_toggle_is_available():
+    sf.mock_widgets(True)   # the notebook's first line — must be a no-op-safe toggle
+    sf.mock_widgets(False)
+    sf.mock_widgets(True)
+
+
+class TestSetupPanel:
+    def test_renders_self_contained_html(self):
+        handle = setup_panel()
+        html = handle._repr_html_()
+        assert "<style>" in html            # self-contained: styles inline
+        assert "Connect a provider" in html
+        assert "Anthropic" in html and "OpenAI" in html
+
+    def test_value_is_the_session(self):
+        handle = setup_panel()
+        assert isinstance(handle.value, Session)
+
+    def test_connected_provider_shows_masked_key_only(self):
+        # INVARIANT I4: the rendered HTML never contains the raw key.
+        sf.session.connect("anthropic", api_key="sk-visible-never-9876")
+        html = setup_panel()._repr_html_()
+        assert "sk-visible-never" not in html
+        assert "9876" in html               # the mask's tail is fine
+
+    def test_handle_is_mock_in_v01(self):
+        assert isinstance(setup_panel(), MockHandle)
+
+
+def test_import_does_not_pull_widget_machinery():
+    # INVARIANT I5 — run in a clean interpreter so this test is hermetic.
+    code = (
+        "import sys; import screamingface; "
+        "banned = [m for m in ('IPython', 'ipywidgets') if m in sys.modules]; "
+        "assert not banned, f'import pulled {banned}'"
+    )
+    subprocess.run([sys.executable, "-c", code], check=True)

--- a/packages/screamingface/tests/test_widgets.py
+++ b/packages/screamingface/tests/test_widgets.py
@@ -16,7 +16,7 @@ from screamingface.widgets import MockHandle, setup_panel
 
 
 def test_mock_widgets_toggle_is_available():
-    sf.mock_widgets(True)   # the notebook's first line — must be a no-op-safe toggle
+    sf.mock_widgets(True)  # the notebook's first line — must be a no-op-safe toggle
     sf.mock_widgets(False)
     sf.mock_widgets(True)
 
@@ -25,7 +25,7 @@ class TestSetupPanel:
     def test_renders_self_contained_html(self):
         handle = setup_panel()
         html = handle._repr_html_()
-        assert "<style>" in html            # self-contained: styles inline
+        assert "<style>" in html  # self-contained: styles inline
         assert "Connect a provider" in html
         assert "Anthropic" in html and "OpenAI" in html
 
@@ -38,7 +38,7 @@ class TestSetupPanel:
         sf.session.connect("anthropic", api_key="sk-visible-never-9876")
         html = setup_panel()._repr_html_()
         assert "sk-visible-never" not in html
-        assert "9876" in html               # the mask's tail is fine
+        assert "9876" in html  # the mask's tail is fine
 
     def test_handle_is_mock_in_v01(self):
         assert isinstance(setup_panel(), MockHandle)

--- a/packages/screamingface/uv.lock
+++ b/packages/screamingface/uv.lock
@@ -1,0 +1,1805 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "appnope"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/5d/752690df9ef5b76e169e68d6a129fa6d08a7100ca7f754c89495db3c6019/appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee", size = 4170, upload-time = "2024-02-06T09:43:11.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/29/5ecc3a15d5a33e31b26c11426c45c501e439cb865d0bff96315d86443b78/appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c", size = 4321, upload-time = "2024-02-06T09:43:09.663Z" },
+]
+
+[[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393, upload-time = "2025-07-30T10:01:40.97Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328, upload-time = "2025-07-30T10:01:41.916Z" },
+    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269, upload-time = "2025-07-30T10:01:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558, upload-time = "2025-07-30T10:01:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364, upload-time = "2025-07-30T10:01:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637, upload-time = "2025-07-30T10:01:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934, upload-time = "2025-07-30T10:01:47.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158, upload-time = "2025-07-30T10:01:48.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597, upload-time = "2025-07-30T10:01:49.112Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231, upload-time = "2025-07-30T10:01:49.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
+]
+
+[[package]]
+name = "arrow"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/33/032cdc44182491aa708d06a68b62434140d8c50820a087fac7af37703357/arrow-1.4.0.tar.gz", hash = "sha256:ed0cc050e98001b8779e84d461b0098c4ac597e88704a655582b21d116e526d7", size = 152931, upload-time = "2025-10-18T17:46:46.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/c9/d7977eaacb9df673210491da99e6a247e93df98c715fc43fd136ce1d3d33/arrow-1.4.0-py3-none-any.whl", hash = "sha256:749f0769958ebdc79c173ff0b0670d59051a535fa26e8eba02953dc19eb43205", size = 68797, upload-time = "2025-10-18T17:46:45.663Z" },
+]
+
+[[package]]
+name = "asttokens"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/1e/faf0f247f6f881b98fc4d6d07e14085cb89d13665084e6d6ac1dc2c03d0b/asttokens-3.0.2.tar.gz", hash = "sha256:3ecdbd8f2cc195f53ccada3a613538bb5f9ef6f6869129f13e03c30a677b8fe2", size = 63136, upload-time = "2026-07-12T03:31:49.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/2b/04b8a15f3a1c77bc79ddf5c73875327f34b4fa75982df2b76e45e402d364/asttokens-3.0.2-py3-none-any.whl", hash = "sha256:9da13157f5b28becde0bd374fc677dcd3c290614264eff096f167c469cd9f933", size = 28702, upload-time = "2026-07-12T03:31:47.542Z" },
+]
+
+[[package]]
+name = "async-lru"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/1f/989ecfef8e64109a489fff357450cb73fa73a865a92bd8c272170a6922c2/async_lru-2.3.0.tar.gz", hash = "sha256:89bdb258a0140d7313cf8f4031d816a042202faa61d0ab310a0a538baa1c24b6", size = 16332, upload-time = "2026-03-19T01:04:32.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/e2/c2e3abf398f80732e58b03be77bde9022550d221dd8781bf586bd4d97cc1/async_lru-2.3.0-py3-none-any.whl", hash = "sha256:eea27b01841909316f2cc739807acea1c623df2be8c5cfad7583286397bb8315", size = 8403, upload-time = "2026-03-19T01:04:30.883Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
+name = "bleach"
+version = "6.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/3c/e12ac860709702bd5ebeb9b56a4fe334f1001246ee1b8f2b7ee28912df7d/bleach-6.4.0.tar.gz", hash = "sha256:4202482733d85cedd04e59fcb2f89f4e4c7c385a78d3c3c23c30446843a37452", size = 204857, upload-time = "2026-06-05T13:01:13.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl", hash = "sha256:4b6b6a54fff2e69a3dde9d21cc6301220bee3c3cb792187d11403fd795031081", size = 165109, upload-time = "2026-06-05T13:01:12.504Z" },
+]
+
+[package.optional-dependencies]
+css = [
+    { name = "tinycss2" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/85/990925db5df586ec90beb97529c853497e7f85ba0234830447faf41c3057/cffi-2.1.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:df2b82571a1b30f58a87bf4e5a9e78d2b1eff6c6ce8fd3aa3757221f93f0863f", size = 184829, upload-time = "2026-07-06T21:32:44.324Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/92/e7bb136ad6b5352603732cf907ef862ca103f20f2031c1735a46300c20c9/cffi-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78474632761faa0fb96f30b1c928c84ebcf68713cbb80d15bab09dfe61640fde", size = 184728, upload-time = "2026-07-06T21:32:45.683Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c0/d1ec30ffb370f748f2fb54425972bfef9871e0132e82fb589c46b6676049/cffi-2.1.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:5972433ad71a9e46516584ef60a0fda12d9dc459938d1539c3ddecf9bdc1368d", size = 214815, upload-time = "2026-07-06T21:32:48.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/dc/5620cf930688be01f2d673804291de757a934c90b946dbdc3d84130c2ea4/cffi-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b6422532152adf4e59b110cb2808cee7a033800952f5c036b4af047ee43199e7", size = 222429, upload-time = "2026-07-06T21:32:49.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/a4/77b53abbf7a1e0beb9637edbef2a94d15f9c822f591e85d439ffd91519a6/cffi-2.1.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:46b1c8db8f6122420f32d02fffb924c2fe9bc772d228c7c711748fff56aabb2b", size = 210315, upload-time = "2026-07-06T21:32:51.221Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0c/f528df19cc94b675087324d4760d9e6d5bfae97d6217aa4fac43de4f5fcc/cffi-2.1.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9fafc5aa2e2a39aaf7f8cc0c1f044a9b07fca12e558dca53a3cc5c654ad67a7", size = 208859, upload-time = "2026-07-06T21:32:52.512Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/c9522a81c32132799a1972c39f5c5f8b4c8b9f00488a23feaa6c06f07741/cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e9f50d192a3e525b15a75ab5114e442d83d657b7ec29182a991bc9a88fd3a66", size = 221844, upload-time = "2026-07-06T21:32:53.704Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/28/bd53988b9833e8f8ad539d26f4c07a6b3f6bcb1e9e02e7ca038250b3428d/cffi-2.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:98fff996e983a36d3aa2eca83af40c5821202e7e6f32d13ae94e3d2286f10cfe", size = 225287, upload-time = "2026-07-06T21:32:54.907Z" },
+    { url = "https://files.pythonhosted.org/packages/79/99/0d0fd37f055224085f42bbb2c022d002e17dde4a97972822327b07d84101/cffi-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:379de10ce1ba048b1448599d1b37b24caee16309d1ac98d3982fc997f768700b", size = 223681, upload-time = "2026-07-06T21:32:56.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/80/c138990aa2a70b1a269f6e06348729836d733d6f970867943f61d367f8cc/cffi-2.1.0-cp312-cp312-win32.whl", hash = "sha256:9b8f0f26ca4e7513c534d351eca551947d053fac438f2a04ac96d882909b0d3a", size = 175269, upload-time = "2026-07-06T21:32:57.777Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/eb/f636456ff21a83fc13c032b58cc5dde061691546ac79efa284b2989b7982/cffi-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:c97f080ea627e2863524c5af3836e2270b5f5dfff1f104392b959f8df0c5d384", size = 185881, upload-time = "2026-07-06T21:32:59.253Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/400ea43e721727dca8a65c4521390e9196757caba4a45643acb2b63271b8/cffi-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:6d194185eabd279f1c05ebe3504265ddfc5ad2b58d0714f7db9f01da592e9eb6", size = 180088, upload-time = "2026-07-06T21:33:02.278Z" },
+    { url = "https://files.pythonhosted.org/packages/96/88/a996879e2eeccb815f6e3a5967b12a308257412acec882039d386bd2aa7b/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:10537b1df4967ca26d21e5072d7d54188354483b91dc75058968d3f0cf13fbda", size = 194331, upload-time = "2026-07-06T21:33:03.697Z" },
+    { url = "https://files.pythonhosted.org/packages/58/85/7ae00d5c8dd6266f4e944c3db630f3c5c9a98b61d469c714d848b1d8138a/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a95b05f9baf29b91171b3a8bd2020b028835243e7b0ff6bb23e2a3c228518b1b", size = 196966, upload-time = "2026-07-06T21:33:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e9/45c3a76ad8d43ad9261f4c95436da61128d3ca545d72b9612c0ab5be0b1c/cffi-2.1.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:15faec4adfff450819f3aee0e2e02c812de6edb88203aa58807955db2003472a", size = 184795, upload-time = "2026-07-06T21:33:06.699Z" },
+    { url = "https://files.pythonhosted.org/packages/84/4c/82f132cb4418ee6d953d982b19191e87e2a6372c8a4ce36e50b69d6ade4a/cffi-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:716ff8ec22f20b4d988b12884086bcef0fc99737043e503f7a3935a6be99b1ea", size = 184746, upload-time = "2026-07-06T21:33:08.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1c/4ed5a0e5bdca6cbc275556de3328dd1b76fd0c11cc13c88fe66d1d8715f2/cffi-2.1.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:63960549e4f8dc41e31accb97b975abaecfc44c03e396c093a6436763c2ea7db", size = 214747, upload-time = "2026-07-06T21:33:09.671Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f", size = 222392, upload-time = "2026-07-06T21:33:10.896Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f6/01890cfd63c08f8eb96a8319b0443690197d240a8bd6346048cf7bde9190/cffi-2.1.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3b926723c13eba9f81d2ef3820d63aeceec3b2d4639906047bf675cb8a7a500d", size = 210285, upload-time = "2026-07-06T21:33:12.251Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/cf/2b684132056f438567b61e19d690dd31cd0921ace051e0a458be6074369e/cffi-2.1.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:47ff3a8bfd8cb9da1af7524b965127095055654c177fcfc7578debcb015eecd0", size = 208801, upload-time = "2026-07-06T21:33:13.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224", size = 221808, upload-time = "2026-07-06T21:33:15.466Z" },
+    { url = "https://files.pythonhosted.org/packages/38/37/04f54b8e63a02f3d908332c9effbf8c366167c6f733ed8a3d4f79b7e2a1e/cffi-2.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:961be50688f7fba2fa65f63712d3b9b341a22311f5253460ce933f52f0de1c8c", size = 225241, upload-time = "2026-07-06T21:33:16.869Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d6/c72eecca433cd3e681c65ed313ab4835d9d4a379704d0f628a6a05f51c2e/cffi-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf5c6cf48238b0eb4c086978c492ad1cbc22373fc5b2d7353b3a598ce6db887a", size = 223588, upload-time = "2026-07-06T21:33:18.239Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/4b/e706f67279140f92939da3475ad610df18bfd52d50f14953a8e5fede71d5/cffi-2.1.0-cp313-cp313-win32.whl", hash = "sha256:db3eb7d46527159a878ec3460e9d40615bc25ba337d477db681aea6e4f05c5d2", size = 175248, upload-time = "2026-07-06T21:33:19.799Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/47/59eb7975cb0e4ef0afa764ea945b29a5bb4537a9f771cb7d6c8a5dd74c95/cffi-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:8e74a6135550c4748af665b1b1118b6aab33b1fc6a16f9aff630af107c3b4512", size = 185717, upload-time = "2026-07-06T21:33:21.47Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/af/34fee85c48f8d94efc8597bc09470c9dd274c145f1c12e0fbc6ab6d38d74/cffi-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:2282cd5e38aa8accd03e99d1256af8411c84cdbee6a89d841b563fdbd1f3e50f", size = 180114, upload-time = "2026-07-06T21:33:22.515Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/81478e482afa03f6d18dc8f2afb5edc45b3080853b634b5ed91961be0998/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a", size = 194142, upload-time = "2026-07-06T21:33:23.657Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/95/8de304305cd9204974b0ca051b86d307cafca13aa575a0ef1b44d92c0d8c/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3", size = 196819, upload-time = "2026-07-06T21:33:25.007Z" },
+    { url = "https://files.pythonhosted.org/packages/20/71/7c8372d30e42415602ed9f268f7cfd66f1b855fed881ecd168bcb45dbc0b/cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1ff3456eab0d889592d1936d6125bbfbc7ae4d3354a700f8bd80450a66445d4d", size = 184965, upload-time = "2026-07-06T21:33:26.605Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/584e626835f0375c928176c04137c96927165cb8733cdb3150ec04e5ee5e/cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c4165821e131d6d4ca444347c2b694e2311bcfa3fe5a861cc72968f28867beac", size = 184952, upload-time = "2026-07-06T21:33:27.823Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6", size = 222353, upload-time = "2026-07-06T21:33:29.178Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a5/e8bbb1ce5b3ac2f53ad6a10bde44318a5a8d99d4f4a000d44a6e39aeb3e4/cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913", size = 210051, upload-time = "2026-07-06T21:33:30.534Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ed/c127d3ac36e899c965e3361357c3befacd6578c03f40125183e41c3b219e/cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d", size = 208630, upload-time = "2026-07-06T21:33:31.753Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5", size = 221593, upload-time = "2026-07-06T21:33:33.044Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/27/93195977168ee63aed233a1a0993a2178798654d1f4bddcdd321d6fd3b21/cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce", size = 225146, upload-time = "2026-07-06T21:33:34.224Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c1/6dbd291ee2ae5a50a034aa057207081f545923bbf15dad4511e985aafff5/cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326", size = 223240, upload-time = "2026-07-06T21:33:35.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6f/ade5ce9863a57992a6ea3d0d10d7e29b8749fc127204b3d493d667b2815f/cffi-2.1.0-cp314-cp314-win32.whl", hash = "sha256:1854b724d00f6654c742097d5387569021be12d3a0f770eae1df8f8acfcc6acd", size = 177723, upload-time = "2026-07-06T21:33:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/41/de/92b9eeed4ae4a21d6fd9b2a2c8505cbed573299902ea73981cc13f7ff62c/cffi-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:1b96bfe2c4bd825681b7d311ad6d9b7280a091f43e8f63da5729638083cd3bfb", size = 187937, upload-time = "2026-07-06T21:33:53.403Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1a/cc6ae6c2913a03aab8898eee57963cf1035b8df5872ed8b9115fcc7e2be8/cffi-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:7d28dff1db6764108bc30788d85d61c876beff416d9a49cb9dd7c5a9f34f5804", size = 183001, upload-time = "2026-07-06T21:33:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f0/134c00ce0779ec86dea2aa1aac69339c2741a8045072676763512363a2ea/cffi-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7ea6b3e2c4250ff1de21c630fe72d0f63eb95c2c32ffbf64a358cf4a8836d714", size = 188538, upload-time = "2026-07-06T21:33:36.792Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d8/3b86aba791cb610d24e8a3e1b2cd529e71fa15096b04e4d4e360049d4a4c/cffi-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6af371f3767faeffc6ac1ef57cdfd25844403e9d3f476c5537caee499de96376", size = 188230, upload-time = "2026-07-06T21:33:38.011Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d0/117dcd9209255ad8571fbc8c92ef32593a1d294dcec91ddc4e4db50606f2/cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98", size = 223899, upload-time = "2026-07-06T21:33:39.514Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3d/f20f8b886b254e3ad10e15cd4186d3aed49f3e6a35ab37aab9f8f25f7c03/cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13", size = 211652, upload-time = "2026-07-06T21:33:40.851Z" },
+    { url = "https://files.pythonhosted.org/packages/28/3b/fad54de07260b93ddeef4b96d0131d57ea900675df1d410ae1deee52d7a6/cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d", size = 210755, upload-time = "2026-07-06T21:33:42.183Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/3d5c705acb7abbba9bbd7d79b8e62e0f25b6120eb7ae6ac49f1b721722fe/cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056", size = 223933, upload-time = "2026-07-06T21:33:43.603Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d0/47e338384ab6b1004241002fa616301020cea4fc95f283506565d252f276/cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4", size = 226749, upload-time = "2026-07-06T21:33:45.046Z" },
+    { url = "https://files.pythonhosted.org/packages/70/25/65bd5b58ea4bfdfc15cde02cb5365f89ef8ab8b2adfb8fe5c4bd4233382f/cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94", size = 225703, upload-time = "2026-07-06T21:33:46.374Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/78/aa01ac599a8a4322533d45a1f9bc93b338276d2d59dabbe7c6d92a775c81/cffi-2.1.0-cp314-cp314t-win32.whl", hash = "sha256:7d034dcffa09e9a46c93fa3a3be402096cb5354ac6e41ab8e5cc9cd8b642ad76", size = 182857, upload-time = "2026-07-06T21:33:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/d00496b22de4d4228f32dde94ad996f350c8aad676d63bcca0743c8dea4d/cffi-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0582a58f3051372229ca8e7f5f589f9e5632678208d8636fea3676711fdf7fe5", size = 194065, upload-time = "2026-07-06T21:33:48.953Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/dd/0c7dbf815a579ff005008a2d815a55d6bb047c349eef536d9dc53d3f0a8d/cffi-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:510aeeeac94811b138077451da1fb18b308a5feab47dd2b603af55804155e1c8", size = 186404, upload-time = "2026-07-06T21:33:50.309Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/8c8c50cb11c6750051daf12164098a9a6f027ac4356967fd4d800a07f242/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c", size = 194121, upload-time = "2026-07-06T21:33:56.109Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e2/67680bf19a6b60d2bb7ff83baefa2a4c3d2d7dc0f3277034b802e1fc504c/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001", size = 196820, upload-time = "2026-07-06T21:33:57.288Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/da/4bbe583a3b3a5c8c60892124fe17f3fa3656523faf0d3484eae90f091853/cffi-2.1.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:95f2954c2c9473d892eca6e0409f3568b37ab62a8eedb122461f73cc273476e3", size = 184936, upload-time = "2026-07-06T21:33:58.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4b/1f4c36ab273980d7aa75bb126ea4f8971f24a96108acad3a0a084028c57b/cffi-2.1.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:cdf2448aab5f661c9315308ec8b93f4e8a1a67a3c733f8631067a2b67d5913dc", size = 185045, upload-time = "2026-07-06T21:34:00.085Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c3/ad299dc38f3583f8d916b299f028af418a9ec98bc695fcbebeae7420691c/cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699", size = 222342, upload-time = "2026-07-06T21:34:01.814Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d8/df4543cc087245044ed02ef3ad8e0a26619d0075ac7a77a12dc81177851b/cffi-2.1.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6274dcb2d15cef48daa73ed1be5a40d501d74dccd0cd6db364776d12cb6ba022", size = 210073, upload-time = "2026-07-06T21:34:03.255Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/fac738d73728c6cea2a88a2883dca54892496cbba88a1dc1f2909cb8a6f5/cffi-2.1.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b71d409cccee78310ab5dec549aed052aaea483346e282c7b02362596e01bb0", size = 208551, upload-time = "2026-07-06T21:34:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3f/0b04a700dd64f465c93020253a793a82c9b4dff9961f48facd0df945d9b8/cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1", size = 221649, upload-time = "2026-07-06T21:34:06.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/b7379a5704c79eda57ce075869ba70a0368d1c850f803b3c0d078d39dcaf/cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28", size = 225203, upload-time = "2026-07-06T21:34:07.489Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/02/d5e6c43ea85c41bda2a184a3418f195fe7cf602967a8d2b94e085b83deef/cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629", size = 223263, upload-time = "2026-07-06T21:34:08.712Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d8/772b8259bf75749adffb1c546828978381fb516f60cf701f6c83daf60c85/cffi-2.1.0-cp315-cp315-win32.whl", hash = "sha256:0a42c688d19fca6e095a53c6a6e2295a5b050a8b289f109adab02a9e61a25de6", size = 177696, upload-time = "2026-07-06T21:34:26.355Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/dd/afa2191fc6d57fedd26e5844a2fe2fcc0bbfa00961bbaa5a41e4921e7cca/cffi-2.1.0-cp315-cp315-win_amd64.whl", hash = "sha256:bccbbb5ee76a61f9d99b5bf3846a51d7fca4b6a732fe46f89295610edaf41853", size = 187914, upload-time = "2026-07-06T21:34:27.58Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ef/6cd4f8c671517162379dc79cfae5aea9106bc38abb89628d5c16adf6a838/cffi-2.1.0-cp315-cp315-win_arm64.whl", hash = "sha256:8d35c139744adb3e727cd51b1a18324bbe44b8bd41bf8322bca4d41289f48eda", size = 183004, upload-time = "2026-07-06T21:34:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b6/12fc55092817a5faa26fb8c40c7f9d662e11a46ee248c137aafc42517d92/cffi-2.1.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:f9912624a0c0b834b7520d7769b3644453aabc0a7e1c839da7359f050750e9bc", size = 188378, upload-time = "2026-07-06T21:34:09.926Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2e/cdac88979f295fde5daa69622c7d2111e56e7ceb94f211357fbe452339e4/cffi-2.1.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:df92f2aba50eb4d96718b68ef76f2e57a57b54f2fa62333496d16c6d585a85ca", size = 188319, upload-time = "2026-07-06T21:34:11.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/27/1d0b408497e41a74795af122d7b603c418c5fed0171450f899afd04e594f/cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d", size = 223904, upload-time = "2026-07-06T21:34:12.606Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/31/e115c985105dd7ffb32444505f18ceb874bb42d992af05d5dced7ecf1980/cffi-2.1.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3681e031db29958a7502f5c0c9d6bbc4c36cb20f7b104086fa642d1799631ff8", size = 211554, upload-time = "2026-07-06T21:34:13.987Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/67/9e6e09409336d9e515c58367e7cfcf4f89df06ad25252675595a58eb59d5/cffi-2.1.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:762f99479dcb369f60ab9017ad4ab97a36a1dd7c1ee5a3b15db0f4b8659120cd", size = 210795, upload-time = "2026-07-06T21:34:15.972Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e5/d3cc82a4a0be7902af279c04181ad038449c096734464a5ae1de3e1401bd/cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f", size = 223843, upload-time = "2026-07-06T21:34:17.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/65/b434abc97ce7cecc2c640fde160507c0ecc7e21544b483ba3325d2e2ea17/cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc", size = 226773, upload-time = "2026-07-06T21:34:19.05Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9f/d4dc66ca651eb1145a133314cda721abf13cfac3d28c4a0402263ae6ad75/cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9", size = 225719, upload-time = "2026-07-06T21:34:20.576Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5a/e536c528bc8057496c360c0978559a2dc45653f89dd6151078aa7d8fca1a/cffi-2.1.0-cp315-cp315t-win32.whl", hash = "sha256:cb96698e3c7413d906ce83f8ffd245ec1bd94707541f299d0ce4d6b0193e982b", size = 182760, upload-time = "2026-07-06T21:34:22.059Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0b/0ffe8b82d3875bced5fa1e7986a7a46b748262a40ab7f60b475eb9fb1bb3/cffi-2.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:f146d154428a2523f9cc7936c02353c2459b8f6cf07d3cd1ee1c0a611109c5d5", size = 193769, upload-time = "2026-07-06T21:34:23.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/17/1073b53b68c9b5ca6914adf5f8bf55aacc2d3be102418c90700160ea8605/cffi-2.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:cbb7640ce37159548d2147b5b8c241f962143d4c71231431820783f4dc78f210", size = 186405, upload-time = "2026-07-06T21:34:24.857Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0", size = 319300, upload-time = "2026-07-07T14:33:15.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9", size = 215802, upload-time = "2026-07-07T14:33:17.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4c/5361f9aa7f2cb58d94f2ab831b3d493f69efb1d239654b4744e3c09527cb/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44", size = 237171, upload-time = "2026-07-07T14:33:18.576Z" },
+    { url = "https://files.pythonhosted.org/packages/50/78/ce342ca4ff30b2eb49fe6d9578df85974f90c67d294113e94efdd9664cbd/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9", size = 233075, upload-time = "2026-07-07T14:33:20.084Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd", size = 224256, upload-time = "2026-07-07T14:33:21.747Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3a/ad914516df7e358a81aae018caa5e0470ba827fa6d763b1d2e87d920a5f6/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84", size = 208784, upload-time = "2026-07-07T14:33:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/74/3c12f9755717dfe5c5c87da63f35d765fa0c00382ec26bf23f7fae34f2ba/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b", size = 219928, upload-time = "2026-07-07T14:33:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/33/9a/895095b83e7907abd6d3d99aad3a38ad0d9686cc186cb0c94c24320fe63e/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde", size = 218489, upload-time = "2026-07-07T14:33:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/34/ef5c05f412f42520d7709b7d3784d19640839eb7366ded1755511585429f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39", size = 210267, upload-time = "2026-07-07T14:33:27.952Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dc/9b29fa4412b318bf3bfea985c35d67eb55e04b59a7c3f2237168b0e0be6f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62", size = 226030, upload-time = "2026-07-07T14:33:29.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/42/6dbc00b8cd16011691203e33570fa42ed5746599a2e878112d16eab403a3/charset_normalizer-3.4.9-cp312-cp312-win32.whl", hash = "sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642", size = 151185, upload-time = "2026-07-07T14:33:30.781Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cc/f920afd1a23c58ccd53c1d36085a71893a4737ff5e66e0371efab6809850/charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0", size = 162557, upload-time = "2026-07-07T14:33:32.176Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/0386d43a261ff4e4b30c5857af7df877254b46bec7b9d1b74b6bf969a90b/charset_normalizer-3.4.9-cp312-cp312-win_arm64.whl", hash = "sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2", size = 152665, upload-time = "2026-07-07T14:33:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "comm"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/13/7d740c5849255756bc17888787313b61fd38a0a8304fc4f073dfc46122aa/comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971", size = 6319, upload-time = "2025-07-25T14:02:04.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417", size = 7294, upload-time = "2025-07-25T14:02:02.896Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/83/6051c2a2feab48ae5bd27c84ef047191d2d4a3172f689e38eaa48ed17db1/coverage-7.15.1.tar.gz", hash = "sha256:165e9949eaf222ef1f018635d0d7f368a23bfe0212af558534c40d8c04686d67", size = 927640, upload-time = "2026-07-12T20:58:19.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/76/32c1826309beaf4604c54accef108fdd611e5e5e93f2f5192f050cd5f6bd/coverage-7.15.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d9476292594309db922cc841dd13b303b3c388f4c25d279884f7e2341c681f80", size = 221497, upload-time = "2026-07-12T20:56:37.628Z" },
+    { url = "https://files.pythonhosted.org/packages/db/5c/b88ce0d68fa550c7f3b58617fbf363bce64df5bf8295a01b627e4696e022/coverage-7.15.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0c579056b0de461b3a62318b63d0b6ce90aed7f8158d3f00da094df82f29d189", size = 221854, upload-time = "2026-07-12T20:56:39.033Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/fe/8509fd2a66fc4e0a829f76a0f0b1dc3cc163368352435b5f243168658077/coverage-7.15.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:23214bdbe226f2b0e9c66a7d6a1d59d4a88045dcf86e702cf0fe0d0935e3d615", size = 253359, upload-time = "2026-07-12T20:56:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/81/c7009ed7ea9765adb2b9d095054d748266fae5f07ac6c5f925f33715fcde/coverage-7.15.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:df164be93b46b4825cc39339440a05edc54c4d1d865ba4a60fd43d151a2a1cd3", size = 256096, upload-time = "2026-07-12T20:56:42.115Z" },
+    { url = "https://files.pythonhosted.org/packages/21/52/dc8ee03968a5ba86e2da5aa48ddc9e3747bd65d63825fdce2d96acb9c5ff/coverage-7.15.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a524fca1a6f08927d9dc2d4c873cfb7bd7202c247f08b14bdc02424071b8b304", size = 257211, upload-time = "2026-07-12T20:56:43.513Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/27/95d7623908da8937deb53d48efcdbf423907a47540e63c62fa21372c652b/coverage-7.15.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d70f3542cd38de85a9e257dcb1ac4c1ab4b6d7d2c2a645809207556628755d1c", size = 259473, upload-time = "2026-07-12T20:56:44.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3b/730d761928de97d585465680b568ae69622fb40716babadeabffe75cb51b/coverage-7.15.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d78aa537237212c4313aabe5e964b66acc86350ed19ebc56a3e202df33b6077b", size = 253759, upload-time = "2026-07-12T20:56:46.615Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fc/6b9277acff1f9484b6c12857af5774689d1a6a95e13265f7405329d2f5da/coverage-7.15.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a318112bb4f79d9d04766196d5a3388caa825908a6a9b052aa87de3d9aea7c61", size = 255131, upload-time = "2026-07-12T20:56:48.073Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/f2/c704f86129594ba34e25a64695d2068c71d51c2b98907184d716c94f4aec/coverage-7.15.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e55d24cada901963eed5bc89fa562aa033f0d84b9d3de4ecf363737c13aed11e", size = 253275, upload-time = "2026-07-12T20:56:49.538Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/29/80fee8af47de4a6dce71ccf2938491f444687a756af258a56d8469b8f1b0/coverage-7.15.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:3c78f0cea7275342cf2adc2ad5fdd0aafa106ad91e66d573568f2fcf62c41df5", size = 257345, upload-time = "2026-07-12T20:56:51.038Z" },
+    { url = "https://files.pythonhosted.org/packages/20/21/a1e7d7ed1b48a8adf8fd5154d9e83fcc5ad8e6ff20ae00e44865057dce8d/coverage-7.15.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:86bd37eabe39977216f630a7fc1b698e7f5e81a191c7186013245c6c3d313f9d", size = 252844, upload-time = "2026-07-12T20:56:52.535Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/8c/a4bc26e6ee207d412f3678f04d74be1550e83140563ca0e4997510579712/coverage-7.15.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c6db15c217693bdc3ca0b84de1ba9afafe1c14c26a8a29d77f4ed0de2b6132e2", size = 254716, upload-time = "2026-07-12T20:56:53.968Z" },
+    { url = "https://files.pythonhosted.org/packages/11/9d/8ad0266ecfada6353cf6627a1a02294cf55a907521b6ee0bd7b770cfd659/coverage-7.15.1-cp312-cp312-win32.whl", hash = "sha256:359f3fbe09a51500c51966596ee4ee4070b356552c70b3b2420eb200d68e0f76", size = 223554, upload-time = "2026-07-12T20:56:55.583Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6d/24224929e06c6e05a93f738bc5f9e8e6ab658f8f1d9b823e7b85430e28b8/coverage-7.15.1-cp312-cp312-win_amd64.whl", hash = "sha256:fa75dc099c126e941a9c0baa8ebd2cbc78bd778687534fe410baf754f6d9e374", size = 224087, upload-time = "2026-07-12T20:56:57.041Z" },
+    { url = "https://files.pythonhosted.org/packages/35/23/f81441dd01de88e53c97842e706907b307d9078918c3f4998b11e9ac7250/coverage-7.15.1-cp312-cp312-win_arm64.whl", hash = "sha256:26f89cf6d0634375f454fa71057945ad18edb0f1607a90fecf22c57dc3dc289a", size = 223472, upload-time = "2026-07-12T20:56:58.594Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/1e/6fa289d7993a2a39f1b283ddb58c4bfec80f7800be654b8ba8a9f6a07c63/coverage-7.15.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:71ac4ca1658ca99160fd58cc6967110e989c34b04627f24ed6ec9f70fb24571a", size = 221519, upload-time = "2026-07-12T20:57:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/e1/0db4902a0588234a70ab0218073c0b20fbc5c740aa35f91d360160a2ebc9/coverage-7.15.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:26a40cbf2b13bd94af53ee02a424cb3bb96a9edfac0d00834bd068512a62714b", size = 221895, upload-time = "2026-07-12T20:57:01.867Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/cb/3719783865092dac5e08df842730305ee9ab1973ae7ddb6fbdf27d401f30/coverage-7.15.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f4c5a5eff4ad4f9f7088fd3fc7a66d98d06566ee294b3b053309fb0a3b45be1e", size = 252882, upload-time = "2026-07-12T20:57:03.459Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5e/caf3abbdbb22629626160ffc9c017eb995b7cb11c0be46b974834cef1792/coverage-7.15.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:962aa56c1c9b016d681265880eb6acc9966029d2c4c559319cc43a1abbb9b59a", size = 255479, upload-time = "2026-07-12T20:57:04.984Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f1/d60f375bfe095fef944f0f19427aefdbf9bdd5a9571c41a4bf6e2f5fdb81/coverage-7.15.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1678eb2dc57a8ce67601b029582ef6d41e9e6ca22692aaeccd4107e40f27386c", size = 256715, upload-time = "2026-07-12T20:57:06.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/17/8b0cbc90d02dc5adad4d9034c1824ec3fa567771b4c39d9c1e3f9b1431b8/coverage-7.15.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1174900a43f6f8c425fee10d7dbddc308adefcdc78aaced32357f5ab750a0e90", size = 258845, upload-time = "2026-07-12T20:57:08.092Z" },
+    { url = "https://files.pythonhosted.org/packages/92/29/c5e69f5fb75c322e9a3e4ef64d02eebfc3d66efceccc8514ff80a3c13a56/coverage-7.15.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:98847557a6859cadf693792ce89f440cb89692993f60dc6d3a7e35f3d340216f", size = 253098, upload-time = "2026-07-12T20:57:09.636Z" },
+    { url = "https://files.pythonhosted.org/packages/64/57/21144252fdd0c01d707d48fbcea13a80b0b7c42ced3f299f885ab8978c3a/coverage-7.15.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8697b2edb57143546a24389efc11e1b000cd5800fc20d84f04edb601e4a7cfb8", size = 254844, upload-time = "2026-07-12T20:57:11.141Z" },
+    { url = "https://files.pythonhosted.org/packages/59/2a/499a28a322b0ce6768328e6c5bb2e2ad00ac068a7c7adb2ecd8533c8c5d9/coverage-7.15.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:6827ac0519be3fe91bf96b4060eb00d1d24f82649b29862cd75a3cfca248b02a", size = 252807, upload-time = "2026-07-12T20:57:12.678Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/928a95da5da8b60f2b00e1482c7787b3316188e6d2d227fb8e124ada43a1/coverage-7.15.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:2de8ecbbc77c7e4d22572779920ed8979c69168675e96be3a548c996568c6c31", size = 256965, upload-time = "2026-07-12T20:57:14.326Z" },
+    { url = "https://files.pythonhosted.org/packages/16/10/889adbc1b8c9f866ed51e18a98bcafc0259fb9d29b81f50a719407c64ea8/coverage-7.15.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2b25f0f0fa5260df9d7bb55d47c8bdc23fa3382c1a18f7c9cae122e6c320b1ad", size = 252628, upload-time = "2026-07-12T20:57:15.892Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/30/a5e1871e5d93416511f8e359d1ccebfe0cbb050a1bbf7dd20228533ec0cf/coverage-7.15.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4a2effcbd93ae340a58db718fe4181d967f84d352c4cefeaab4ff82ce813901a", size = 254399, upload-time = "2026-07-12T20:57:17.703Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/26/c36fbffd549dadbdd1a75827528fb00a4c46aa3187b007b750b1e2cebbf2/coverage-7.15.1-cp313-cp313-win32.whl", hash = "sha256:895e65c96aef0cecea250f6e35e9a32f11375514e1a0cb5210e0fda128c04e8e", size = 223564, upload-time = "2026-07-12T20:57:19.253Z" },
+    { url = "https://files.pythonhosted.org/packages/16/fc/becbb9d2c4206d242b9b1e1e8e24a42f7926c0200dd3c788b9fab4bb96d5/coverage-7.15.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6d0a28b63a0d75f9ed5118105d1154fc3aa40a8605a30d5d87e3d043ad90fe7", size = 224106, upload-time = "2026-07-12T20:57:21.108Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/30/1cfc641461369b6858799fca61c0a8b5edc490c519bf7c636ffa6bbf556f/coverage-7.15.1-cp313-cp313-win_arm64.whl", hash = "sha256:b4ee9818e8bae3544379ad2c09b851c4fb886aaa8860d57a1c1316ddcb16db49", size = 223497, upload-time = "2026-07-12T20:57:22.734Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/46/81961952e7aebfb38ad0ae4264e8954cc607a7af9e7ac111f9fa986595cc/coverage-7.15.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a886af95f59edf67d5770fd3564d53f4a8af93f25f8c1d60d27e00d7f5674ee8", size = 221560, upload-time = "2026-07-12T20:57:24.282Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d2/ee14d715889f216baf47301d9f469e08fff6995552aaf67e897b282865f6/coverage-7.15.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:985657ebd707941de90d488d1cbb5efac20bdf81f7b91eba771624ccda4d36f4", size = 221894, upload-time = "2026-07-12T20:57:25.87Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/38/f830bc6e6c2c5f23f43847125e6c650d378872f7eeba8d49f1d42193e8a9/coverage-7.15.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5bbe2a06e0a5e1404d9ffbdb49b819bbd6a3bb198ebea4c8dfe7ad9f1e1c2e81", size = 252938, upload-time = "2026-07-12T20:57:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/53/0d3dd963631259d794c898735d5436e68d6a8d40749c419a07ff7c171469/coverage-7.15.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bde0fe24083d0b7b3dbafa7a09f0796410af1afa2523f28f5f208d8340a4aaca", size = 255445, upload-time = "2026-07-12T20:57:29.234Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/fd/aabed228557565c958259251b89bab8c5669b31291fa63b3e2154ebb017a/coverage-7.15.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f89f7453d6d46db14cf233e2cd8edcd78de2b9c49d4f1dc109590b4e5dbfbb74", size = 256790, upload-time = "2026-07-12T20:57:30.826Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/aa/1cc888e5d3623e603c4e5399653cb25728bb2b40d7519188a3e293d24620/coverage-7.15.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc3656c9ecc27b36bd0907455b77f83c0069ca9ad4a66dec892b76c696eb6047", size = 259104, upload-time = "2026-07-12T20:57:32.63Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/61/fc16d5f5e53098dae41efa21e8ccc611a9b4fe922750dd03dc56db552182/coverage-7.15.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:24d8e85a2a45e44883b488c2659f51fa761dad5353fdb319b672a93facbd2ca9", size = 252956, upload-time = "2026-07-12T20:57:34.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/f3/52384668c3de4519ca770bf1975a89e4d6eb5aa2faf0da0577a14008cba4/coverage-7.15.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:68931b5fe746ed4fdaa8892989cab9e6c35781eeb3b0ab2ded893d561e1b3652", size = 254797, upload-time = "2026-07-12T20:57:35.947Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/68/54b807e7c1868178e902fd8360b5d4e559394462f97285c50edf1c4608db/coverage-7.15.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:1ce6947e2a95534ecaa5a15e73c21e550514c980d80eda204d064d789a95f6a4", size = 252762, upload-time = "2026-07-12T20:57:37.856Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/48/dde8adf0338e3ace738757dccf1ce817e5fdcadfae77e1b48a77e5a3b265/coverage-7.15.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:841befdbc89b9c82435fc25b0f4f41858b6238693e45af758bec4cfc1968171c", size = 257037, upload-time = "2026-07-12T20:57:39.488Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f2/179dd88cf60a0aeeee16a970ffe250dccea8b80ed4beab4c5d3f6c41ad4b/coverage-7.15.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5d3de58b837375e7f4c0e1a088ccab5f655efb2fd7427b729df02c862a559633", size = 252577, upload-time = "2026-07-12T20:57:41.363Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/37/8a593d69ab521beb6a105a2017cac4ba94425ee0a8349e29c3c0b522d24f/coverage-7.15.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b1801963f9f44ae0c0f6d737bc7aeb2bbcde7d1fe7e3b43cddc1961af42d3b41", size = 254235, upload-time = "2026-07-12T20:57:43.025Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/34/bc9b3bced66f2cdad4bf5e57ae51c54ea226e8aaaebfc9370a9a11877bf3/coverage-7.15.1-cp314-cp314-win32.whl", hash = "sha256:8c7953c4128ef53b6ffb5f90d87c87d4ce26731df294760bb2314eb0e069e44b", size = 223771, upload-time = "2026-07-12T20:57:44.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f3/4d20337bed61915d14349e62b88d5e4144d5a9872b64adbe90e9906db6db/coverage-7.15.1-cp314-cp314-win_amd64.whl", hash = "sha256:6f0bab60a582d415f0fb535ccff13ba334a47a1538f98913330a525d23bd535a", size = 224257, upload-time = "2026-07-12T20:57:46.412Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/df/bbfeae4948f3ded516f92b32f2d57952427fc5ecfc0924487bb6ee6a5f38/coverage-7.15.1-cp314-cp314-win_arm64.whl", hash = "sha256:0f410ee8f0ac4ec7db71bc0b7632a8b9994e1cad2755bd1566c17e6a162caa74", size = 223683, upload-time = "2026-07-12T20:57:48.106Z" },
+    { url = "https://files.pythonhosted.org/packages/35/65/0b431856064e387d1f5cf474625e4a0465e907024d42f35de6af19ced0be/coverage-7.15.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:fc868bab88e049d41fcd41766810d790a8b960053be2a45e060f5ce0d31d258b", size = 222298, upload-time = "2026-07-12T20:57:49.882Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/96/50eac9bd49df8a3df5f3d38746d1bf332299dffb554486c94ebd55c9dc49/coverage-7.15.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:206d4ec6028f2773b40932d09f074539d6bcdd8f6b318d40cb04bdbd68ed0b49", size = 222561, upload-time = "2026-07-12T20:57:51.688Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/5b/6ba1c4a27e10b8816fd2622b98162c83d3bdf1185097360373611bf96364/coverage-7.15.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:620482ef1c9f4e61f962e159325fe77dea59d16e39d9c9470d069053b244d864", size = 263923, upload-time = "2026-07-12T20:57:53.392Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/59/fe03ade97a3ca2d890e98c572cf48a99fda9adba85757c34b823f41efe1e/coverage-7.15.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d385fc9b054e309ad3cecdc77b586d2af0c98aeec2fdb3773544586f366e817c", size = 266043, upload-time = "2026-07-12T20:57:55.095Z" },
+    { url = "https://files.pythonhosted.org/packages/16/e0/55c4b1217a572a43e13b39e1eb78d0da29fb23679003bd0cdf22c50b1978/coverage-7.15.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1198bca9c0dd7c188aae1f185b0c0b5fc4f0a2b6909000858c29550320bdb07", size = 268465, upload-time = "2026-07-12T20:57:57.017Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e2/ee47944f76afc03909119b036fe9e0da8cbd274a5141287de79791a0fb6d/coverage-7.15.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5d0297e6a070eadb49df7cddd0ab6f420b8b689dd8904c7dd815a323168fa57e", size = 269584, upload-time = "2026-07-12T20:57:58.958Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/8a/6b4d9779c7b2e21c3d12c3425e3261aa7411399319e27aa402dfec4db5d0/coverage-7.15.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:916fcf2214f56960e409561b37fc32a160a42b6e85483d0652d7b70fa55d707e", size = 263019, upload-time = "2026-07-12T20:58:00.979Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/1e/db5c7fa0c8ba5ece390a1e1a3f30db71d440240a80589df28e66a7503c40/coverage-7.15.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f837bae572c7869ffaa502e604c87e182543012831cf87aae4586ad090ac6dcf", size = 265916, upload-time = "2026-07-12T20:58:03.005Z" },
+    { url = "https://files.pythonhosted.org/packages/83/53/fe5176682b00709b13fab36addd26883139d0dea430816fea412e69255e2/coverage-7.15.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3ea65e3ee6c7c32349fd00559927a9e577bdd72386087eeed1c42b62dfce9b82", size = 263520, upload-time = "2026-07-12T20:58:04.994Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/e7/16f15127be93fbc70c667df5ec5dce934fc76c9b0888d84969a5d5341e2c/coverage-7.15.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:345034976f46a1c54bd17f4e43eb30bb92cb7082fcddff03250cff136cc4eb82", size = 267254, upload-time = "2026-07-12T20:58:06.824Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/73/e5119111f6f065376395a525f7ce6e9174d83f3db6d217ea0211a61cca4d/coverage-7.15.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:4f051a64eb8f8addb4661c2b41d6eea5b7ebc68ad4b2baea8d9bc54e1956e5f7", size = 262366, upload-time = "2026-07-12T20:58:08.555Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/9c/6d0a81182df18a73b081e7a8630f0e2a52b12dfd7898c6ab839551a454d2/coverage-7.15.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a7625770f7720b49bb30d194ad2f8d50fab3c5177874af3d2399676f95f9c594", size = 264680, upload-time = "2026-07-12T20:58:10.359Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a2/bac0cbd4450638f1be2041a464b1766c8cc94abf705a2df6f1c8d4be870d/coverage-7.15.1-cp314-cp314t-win32.whl", hash = "sha256:81e503d130a472ad1bd38199ecd35116b40d92bcd31e27a2cacde035381f2070", size = 224077, upload-time = "2026-07-12T20:58:12.065Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b2/d83c5403155172a43ba47c08641bad3f89822d8405102423a41339d2c857/coverage-7.15.1-cp314-cp314t-win_amd64.whl", hash = "sha256:724e878b213b302ad46e9f2fc872d386613f20ebfc492a211482d917ea76c14f", size = 224908, upload-time = "2026-07-12T20:58:13.956Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/41/442b74cad832cc77712080585455482e7cc4f4a9a13192f65731dcd18231/coverage-7.15.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ce2f05c14d077f406fefc4fa5e4f093ad0e0787549f6582535d6e28766f0361b", size = 224219, upload-time = "2026-07-12T20:58:16.315Z" },
+    { url = "https://files.pythonhosted.org/packages/34/98/07a67cf1a26e795d617ed5c540c042b0ac87b72f810c30c07f076cf334f3/coverage-7.15.1-py3-none-any.whl", hash = "sha256:717d01e6e00bed56ad13306f19e0dd2f4f645ee8159d2c72c72301d6cfc7090c", size = 213284, upload-time = "2026-07-12T20:58:18.079Z" },
+]
+
+[[package]]
+name = "debugpy"
+version = "1.8.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/aa/12037145b7a56eaa5b29b41872f7a21b538e807e13f32c4d3c46e59be084/debugpy-1.8.21.tar.gz", hash = "sha256:a3c53278e84c94e11bd87c53970ec391d1a67396c8b22609fcac576520e611a6", size = 1697577, upload-time = "2026-06-01T19:30:35.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/df/bf625547431a9cadc9f4cbfeda38866e2b17f6aed147b625377e87834449/debugpy-1.8.21-cp312-cp312-macosx_15_0_universal2.whl", hash = "sha256:9f96713896f39c3dff0ee841f47320c3f2983d33c341e009361bb0ebc79adc4e", size = 2483609, upload-time = "2026-06-01T19:30:50.794Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/09/59324b903599031ff9faaec1758292409f6561a0ec2492fe4b703327705a/debugpy-1.8.21-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:c193d474f0a211191f2b4449d2d06157c689013035bd952f3b617e0ef422b176", size = 3968900, upload-time = "2026-06-01T19:30:52.341Z" },
+    { url = "https://files.pythonhosted.org/packages/14/cd/27f65b805d7fe005c44e1a36b9183ecdfbcdbf9d3e721a5115d461ecc7ee/debugpy-1.8.21-cp312-cp312-win32.whl", hash = "sha256:4743373c1cac7f9e74a1b9915bf1dbe0e900eca657ffb170ae07ac8363205ae9", size = 5336340, upload-time = "2026-06-01T19:30:54.047Z" },
+    { url = "https://files.pythonhosted.org/packages/77/1d/c84e30c0c674184948b66f076ab271c01d940618a2824c23cd035a27bc20/debugpy-1.8.21-cp312-cp312-win_amd64.whl", hash = "sha256:bd7ba9dd3daa7c2f942c6ca8d4695a16bf9ac16b63615261c7982bc74f7ed20c", size = 5374751, upload-time = "2026-06-01T19:30:55.891Z" },
+    { url = "https://files.pythonhosted.org/packages/77/6b/d817e1f8cc77aa055d37fba092e0febfdff40fe652d8d53d4cd7a86ad98d/debugpy-1.8.21-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:13678151fc401e2d68c9880b91e28714f797d40422994572b24560ef80910a88", size = 2477398, upload-time = "2026-06-01T19:30:57.644Z" },
+    { url = "https://files.pythonhosted.org/packages/48/57/412421516afc3055fa577516f00beec3d663f9b0ab330639547ae6c57720/debugpy-1.8.21-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:ecbd158386c31ffe71d46f72d44d56e66331ab9b16cad649156d514368f23ab2", size = 3962096, upload-time = "2026-06-01T19:30:59.235Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/62/2c616337cf6ba7b07ebbc97f02c6c945a8e2f76b365e33ee809c32ee36d1/debugpy-1.8.21-cp313-cp313-win32.whl", hash = "sha256:2c2ae706dec41d99a9ca1f7ebc987a83e65578363be6f6b3ac9067504917fae1", size = 5336288, upload-time = "2026-06-01T19:31:00.79Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/99/9175103392f84c4b1bf7622888cdc68da07f0ff7d9e581266428f6776033/debugpy-1.8.21-cp313-cp313-win_amd64.whl", hash = "sha256:aa648733047443eb1d07682c4ef287d36a54507b643ffdf38b09a3ef002c72a0", size = 5376567, upload-time = "2026-06-01T19:31:02.56Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3d/f4bbb323a548bfab2af3d6b4ffd9bf22636e55956a1285d317a1de643aad/debugpy-1.8.21-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:9bb2a685287a2ac9b181cde89edcec64845cb51de7faaa75badb9a698bc24782", size = 2477209, upload-time = "2026-06-01T19:31:04.157Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/2d/6e7ec524984a1702777868de49a4c53202bddac2a432a76a093469587750/debugpy-1.8.21-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:3d6922439bf33fd38a3e2c447869ebc7b97da5cd3d329ff1ef9bc06c4903437e", size = 3927115, upload-time = "2026-06-01T19:31:05.863Z" },
+    { url = "https://files.pythonhosted.org/packages/97/47/d1aa6d64005a98a9144647d99306b419396f9ad7bf1d73c119e17a81fb4d/debugpy-1.8.21-cp314-cp314-win32.whl", hash = "sha256:15d4963bd5ffa48f0da0947fd06757fa7621945048a14ad7705431566d3c0e7c", size = 5336724, upload-time = "2026-06-01T19:31:07.711Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/b905b90d163af11878c1af8abafa4a25206335e112e284e413454543a6da/debugpy-1.8.21-cp314-cp314-win_amd64.whl", hash = "sha256:fe0744a12353406de0ae8ccff0d0a4a666f00801a3db8fd04e7a5f761cd520e8", size = 5373803, upload-time = "2026-06-01T19:31:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/95/51/67e7cf11a53e40694f720457d5b3a1cdaaa3d5a9a633e482f225456b93ff/debugpy-1.8.21-py2.py3-none-any.whl", hash = "sha256:b1e37d333663c8851516a47364ef473da127f9caebe4417e6df6f5825a7e9a92", size = 5352888, upload-time = "2026-06-01T19:31:25.186Z" },
+]
+
+[[package]]
+name = "decorator"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/8b/32f9823da46cde7df2087faa08cd98d01b908f8dcab982cdba9c84e85355/decorator-5.3.1.tar.gz", hash = "sha256:4cbcdd55a6efadb9dbea26b858f4fb3264567b52d69ca0d25b721b553f60ea82", size = 58084, upload-time = "2026-05-18T06:03:28.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl", hash = "sha256:f47fe6fdbd2edd623ecfe36875d37aba411624e2670dd395dddae1358689bb3c", size = 10365, upload-time = "2026-05-18T06:03:26.517Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
+name = "executing"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "fastjsonschema"
+version = "2.21.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/b5/23b216d9d985a956623b6bd12d4086b60f0059b27799f23016af04a74ea1/fastjsonschema-2.21.2.tar.gz", hash = "sha256:b1eb43748041c880796cd077f1a07c3d94e93ae84bba5ed36800a33554ae05de", size = 374130, upload-time = "2025-08-14T18:49:36.666Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl", hash = "sha256:1c797122d0a86c5cace2e54bf4e819c36223b552017172f32c5c024a6b77e463", size = 24024, upload-time = "2025-08-14T18:49:34.776Z" },
+]
+
+[[package]]
+name = "fqdn"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/3e/a80a8c077fd798951169626cde3e239adeba7dab75deb3555716415bd9b0/fqdn-1.5.1.tar.gz", hash = "sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f", size = 6015, upload-time = "2021-03-11T07:16:29.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/58/8acf1b3e91c58313ce5cb67df61001fc9dcd21be4fadb76c1a2d540e09ed/fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014", size = 9121, upload-time = "2021-03-11T07:16:28.351Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "ipykernel"
+version = "7.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
+    { name = "comm" },
+    { name = "debugpy" },
+    { name = "ipython" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "matplotlib-inline" },
+    { name = "nest-asyncio2" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/c4/e4a38f579de4225a561305666f7541cdabb30075def2aa1ac17bd73c1fb5/ipykernel-7.3.0.tar.gz", hash = "sha256:9acaaaf97d16355166e4085afe9d225bfbdf2b7ef520f9df3be8f2b248275e09", size = 184899, upload-time = "2026-06-10T08:41:25.481Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/02/77b271f5dc58bfbc0b577c877b2365d1ffea2afe66a80c13f2312820348c/ipykernel-7.3.0-py3-none-any.whl", hash = "sha256:897eb64da762549ef610698fca5e9675195ec6ac8ec7f19d81ce1ca20c876057", size = 120583, upload-time = "2026-06-10T08:41:23.648Z" },
+]
+
+[[package]]
+name = "ipython"
+version = "9.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil", marker = "sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/59/165d3b4d75cc34add3122c4417ecb229085140ac573103c223cd01dde96f/ipython-9.15.0.tar.gz", hash = "sha256:da2819ce2aa83135257df830660b1176d986c3d2876db24df01974fa955b2756", size = 4442580, upload-time = "2026-06-26T11:03:35.913Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/3a/948263ca3b9d65bb2b1b0c521b3a49fad5d59ada58724bd87d2bd5ff3f36/ipython-9.15.0-py3-none-any.whl", hash = "sha256:515ad9c3cdf0c932a5a9f6245419e8aba706b7bd03c3e1d3a1c83d9351d6aa6e", size = 630895, upload-time = "2026-06-26T11:03:33.809Z" },
+]
+
+[[package]]
+name = "ipython-pygments-lexers"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
+name = "ipywidgets"
+version = "8.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "comm" },
+    { name = "ipython" },
+    { name = "jupyterlab-widgets" },
+    { name = "traitlets" },
+    { name = "widgetsnbextension" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/ae/c5ce1edc1afe042eadb445e95b0671b03cee61895264357956e61c0d2ac0/ipywidgets-8.1.8.tar.gz", hash = "sha256:61f969306b95f85fba6b6986b7fe45d73124d1d9e3023a8068710d47a22ea668", size = 116739, upload-time = "2025-11-01T21:18:12.393Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/6d/0d9848617b9f753b87f214f1c682592f7ca42de085f564352f10f0843026/ipywidgets-8.1.8-py3-none-any.whl", hash = "sha256:ecaca67aed704a338f88f67b1181b58f821ab5dc89c1f0f5ef99db43c1c2921e", size = 139808, upload-time = "2025-11-01T21:18:10.956Z" },
+]
+
+[[package]]
+name = "isoduration"
+version = "20.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "arrow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/1a/3c8edc664e06e6bd06cce40c6b22da5f1429aa4224d0c590f3be21c91ead/isoduration-20.11.0.tar.gz", hash = "sha256:ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9", size = 11649, upload-time = "2020-11-01T11:00:00.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/55/e5326141505c5d5e34c5e0935d2908a74e4561eca44108fbfb9c13d2911a/isoduration-20.11.0-py3-none-any.whl", hash = "sha256:b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042", size = 11321, upload-time = "2020-11-01T10:59:58.02Z" },
+]
+
+[[package]]
+name = "jedi"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parso" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/b7/a3635f6a2d7cf5b5dd98064fc1d5fbbafcb25477bcea204a3a92145d158b/jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011", size = 3119416, upload-time = "2026-05-01T23:38:47.814Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl", hash = "sha256:7bdd9c2634f56713299976f4cbd59cb3fa92165cc5e05ea811fb253480728b67", size = 4884812, upload-time = "2026-05-01T23:38:43.919Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "json5"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/7d/05c46a96a78147ae3bf99c2f4169ce144a70220b8d6fcd56f6ec368b8ce9/json5-0.15.0.tar.gz", hash = "sha256:7424d1f1eb1d56da6e3d70643f53619862b4ce81440bdb8ecfd6f875e5ba4a71", size = 53278, upload-time = "2026-06-19T20:08:27.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/be/59527c99478aade6bb33a68d72e6e18dd4e6ff6eacfc7d01bdb15bc76912/json5-0.15.0-py3-none-any.whl", hash = "sha256:56636a30c0e8a4665fe2179c0212f32eae3796dea89ea6f649b9436ecdb39618", size = 36570, upload-time = "2026-06-19T20:08:26.748Z" },
+]
+
+[[package]]
+name = "jsonpointer"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900", size = 9068, upload-time = "2026-03-23T22:32:32.458Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca", size = 7659, upload-time = "2026-03-23T22:32:31.568Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[package.optional-dependencies]
+format-nongpl = [
+    { name = "fqdn" },
+    { name = "idna" },
+    { name = "isoduration" },
+    { name = "jsonpointer" },
+    { name = "rfc3339-validator" },
+    { name = "rfc3986-validator" },
+    { name = "rfc3987-syntax" },
+    { name = "uri-template" },
+    { name = "webcolors" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "jupyter"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ipykernel" },
+    { name = "ipywidgets" },
+    { name = "jupyter-console" },
+    { name = "jupyterlab" },
+    { name = "nbconvert" },
+    { name = "notebook" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/f3/af28ea964ab8bc1e472dba2e82627d36d470c51f5cd38c37502eeffaa25e/jupyter-1.1.1.tar.gz", hash = "sha256:d55467bceabdea49d7e3624af7e33d59c37fff53ed3a350e1ac957bed731de7a", size = 5714959, upload-time = "2024-08-30T07:15:48.299Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/64/285f20a31679bf547b75602702f7800e74dbabae36ef324f716c02804753/jupyter-1.1.1-py2.py3-none-any.whl", hash = "sha256:7a59533c22af65439b24bbe60373a4e95af8f16ac65a6c00820ad378e3f7cc83", size = 2657, upload-time = "2024-08-30T07:15:47.045Z" },
+]
+
+[[package]]
+name = "jupyter-builder"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-core" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/df/db5efc4e28803a1421350445e53d85ec571a4e6928e3524ccc39f4e16584/jupyter_builder-1.1.0.tar.gz", hash = "sha256:b996e8af616900f18724fa34883169d869be2205497940bec78a3a1031eb897d", size = 971142, upload-time = "2026-07-11T07:24:02.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/fb/53adbc72931b4429275b160044c3e1bcbc8fbb5ea6b8f318a357834842fb/jupyter_builder-1.1.0-py3-none-any.whl", hash = "sha256:d9d5280e8845f726663545c3a6db55bd205127616eeb8958481091d6cba71b6a", size = 912964, upload-time = "2026-07-11T07:24:00.279Z" },
+]
+
+[[package]]
+name = "jupyter-client"
+version = "8.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-core" },
+    { name = "python-dateutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/dc/5512503b088997c2250b8bf18258fba9d9ce5ead641183700960d3c9d342/jupyter_client-8.9.1.tar.gz", hash = "sha256:a58f730dd9e728ba16ba1d62ebccf7ffe1ebbdbce4e95cfae941b7321ae1f4fa", size = 359256, upload-time = "2026-06-09T13:15:01.033Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/6f/56d39bf385c5c27988aebaf0c18a2a17e960575740100973511018bd904e/jupyter_client-8.9.1-py3-none-any.whl", hash = "sha256:0b7a295bc46e8751e9adae84781f726c851c1d911bd793edc4a3bde942e3da81", size = 109828, upload-time = "2026-06-09T13:14:58.835Z" },
+]
+
+[[package]]
+name = "jupyter-console"
+version = "6.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ipykernel" },
+    { name = "ipython" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "pyzmq" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2d/e2fd31e2fc41c14e2bcb6c976ab732597e907523f6b2420305f9fc7fdbdb/jupyter_console-6.6.3.tar.gz", hash = "sha256:566a4bf31c87adbfadf22cdf846e3069b59a71ed5da71d6ba4d8aaad14a53539", size = 34363, upload-time = "2023-03-06T14:13:31.02Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/77/71d78d58f15c22db16328a476426f7ac4a60d3a5a7ba3b9627ee2f7903d4/jupyter_console-6.6.3-py3-none-any.whl", hash = "sha256:309d33409fcc92ffdad25f0bcdf9a4a9daa61b6f341177570fdac03de5352485", size = 24510, upload-time = "2023-03-06T14:13:28.229Z" },
+]
+
+[[package]]
+name = "jupyter-core"
+version = "5.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407", size = 29032, upload-time = "2025-10-16T19:19:16.783Z" },
+]
+
+[[package]]
+name = "jupyter-events"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema", extra = ["format-nongpl"] },
+    { name = "packaging" },
+    { name = "python-json-logger" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+    { name = "rfc3339-validator" },
+    { name = "rfc3986-validator" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/f8/475c4241b2b75af0deaae453ed003c6c851766dbc44d332d8baf245dc931/jupyter_events-0.12.1.tar.gz", hash = "sha256:faff25f77218335752f35f23c5fe6e4a392a7bd99a5939ccb9b8fbf594636cf3", size = 62854, upload-time = "2026-04-20T23:17:50.66Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/6c/6fcde0c8f616ed360ffd3587f7db9e225a7e62b583a04494d2f069cf64ea/jupyter_events-0.12.1-py3-none-any.whl", hash = "sha256:c366585253f537a627da52fa7ca7410c5b5301fe893f511e7b077c2d93ec8bcf", size = 19512, upload-time = "2026-04-20T23:17:48.927Z" },
+]
+
+[[package]]
+name = "jupyter-lsp"
+version = "2.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-server" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/ff/1e4a61f5170a9a1d978f3ac3872449de6c01fc71eaf89657824c878b1549/jupyter_lsp-2.3.1.tar.gz", hash = "sha256:fdf8a4aa7d85813976d6e29e95e6a2c8f752701f926f2715305249a3829805a6", size = 55677, upload-time = "2026-04-02T08:10:06.749Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/e8/9d61dcbd1dce8ef418f06befd4ac084b4720429c26b0b1222bc218685eff/jupyter_lsp-2.3.1-py3-none-any.whl", hash = "sha256:71b954d834e85ff3096400554f2eefaf7fe37053036f9a782b0f7c5e42dadb81", size = 77513, upload-time = "2026-04-02T08:10:01.753Z" },
+]
+
+[[package]]
+name = "jupyter-server"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "argon2-cffi" },
+    { name = "jinja2" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "jupyter-events" },
+    { name = "jupyter-server-terminals" },
+    { name = "nbconvert" },
+    { name = "nbformat" },
+    { name = "packaging" },
+    { name = "prometheus-client" },
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "pyzmq" },
+    { name = "send2trash" },
+    { name = "terminado" },
+    { name = "tornado" },
+    { name = "traitlets" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/dc/db3a582633170186f8c8b31298d7eb26ad0eb031a1f53476c258b64eed05/jupyter_server-2.20.0.tar.gz", hash = "sha256:b5778ba337d8015a3dc2b80803ecdd5ac18d3797fddf61a50ea5fb472b4ebe14", size = 756523, upload-time = "2026-06-17T12:09:09.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/71/8c002223e873a870f5c41dc69b0a7c922301123e4a31d5d01ecb700aef77/jupyter_server-2.20.0-py3-none-any.whl", hash = "sha256:c3b67c93c471e947c18b5026f04f21614218adb706df8f48227d3ee8e0a7cdcc", size = 393143, upload-time = "2026-06-17T12:09:07.234Z" },
+]
+
+[[package]]
+name = "jupyter-server-terminals"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "terminado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/a7/bcd0a9b0cbba88986fe944aaaf91bfda603e5a50bda8ed15123f381a3b2f/jupyter_server_terminals-0.5.4.tar.gz", hash = "sha256:bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5", size = 31770, upload-time = "2026-01-14T16:53:20.213Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/2d/6674563f71c6320841fc300911a55143925112a72a883e2ca71fba4c618d/jupyter_server_terminals-0.5.4-py3-none-any.whl", hash = "sha256:55be353fc74a80bc7f3b20e6be50a55a61cd525626f578dcb66a5708e2007d14", size = 13704, upload-time = "2026-01-14T16:53:18.738Z" },
+]
+
+[[package]]
+name = "jupyterlab"
+version = "4.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-lru" },
+    { name = "httpx" },
+    { name = "ipykernel" },
+    { name = "jinja2" },
+    { name = "jupyter-builder" },
+    { name = "jupyter-core" },
+    { name = "jupyter-lsp" },
+    { name = "jupyter-server" },
+    { name = "jupyterlab-server" },
+    { name = "notebook-shim" },
+    { name = "packaging" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/2a/d6af53bfd45a43a5bfe7e40ba47ee7a8921a807daf4bb708e3a295bbb54d/jupyterlab-4.6.1.tar.gz", hash = "sha256:75315982ed28427edaa62bb85eadb5105e4043a757643c910efd787fe6ed0837", size = 28179125, upload-time = "2026-06-29T12:48:45.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/81/90ac6cc31d248e83a0d1eab343a5e6e68bc783d3f74fbe61640f42a61da4/jupyterlab-4.6.1-py3-none-any.whl", hash = "sha256:85a58546c831f3dce6cf919468c26874c9065e99c42279fb4abb8e1b552a98bb", size = 17164660, upload-time = "2026-06-29T12:48:41.21Z" },
+]
+
+[[package]]
+name = "jupyterlab-pygments"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/51/9187be60d989df97f5f0aba133fa54e7300f17616e065d1ada7d7646b6d6/jupyterlab_pygments-0.3.0.tar.gz", hash = "sha256:721aca4d9029252b11cfa9d185e5b5af4d54772bb8072f9b7036f4170054d35d", size = 512900, upload-time = "2023-11-23T09:26:37.44Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl", hash = "sha256:841a89020971da1d8693f1a99997aefc5dc424bb1b251fd6322462a1b8842780", size = 15884, upload-time = "2023-11-23T09:26:34.325Z" },
+]
+
+[[package]]
+name = "jupyterlab-server"
+version = "2.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "jinja2" },
+    { name = "json5" },
+    { name = "jsonschema" },
+    { name = "jupyter-server" },
+    { name = "packaging" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/2c/90153f189e421e93c4bb4f9e3f59802a1f01abd2ac5cf40b152d7f735232/jupyterlab_server-2.28.0.tar.gz", hash = "sha256:35baa81898b15f93573e2deca50d11ac0ae407ebb688299d3a5213265033712c", size = 76996, upload-time = "2025-10-22T13:59:18.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/07/a000fe835f76b7e1143242ab1122e6362ef1c03f23f83a045c38859c2ae0/jupyterlab_server-2.28.0-py3-none-any.whl", hash = "sha256:e4355b148fdcf34d312bbbc80f22467d6d20460e8b8736bf235577dd18506968", size = 59830, upload-time = "2025-10-22T13:59:16.767Z" },
+]
+
+[[package]]
+name = "jupyterlab-widgets"
+version = "3.0.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/2d/ef58fed122b268c69c0aa099da20bc67657cdfb2e222688d5731bd5b971d/jupyterlab_widgets-3.0.16.tar.gz", hash = "sha256:423da05071d55cf27a9e602216d35a3a65a3e41cdf9c5d3b643b814ce38c19e0", size = 897423, upload-time = "2025-11-01T21:11:29.724Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl", hash = "sha256:45fa36d9c6422cf2559198e4db481aa243c7a32d9926b500781c830c80f7ecf8", size = 914926, upload-time = "2025-11-01T21:11:28.008Z" },
+]
+
+[[package]]
+name = "lark"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "matplotlib-inline"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/c0/9f7c9a46090390368a4d7bcb76bb87a4a36c421e4c0792cdb53486ffac7a/matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79", size = 8150, upload-time = "2026-05-08T17:33:33.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/09/5b161152e2d90f7b87f781c2e1267494aef9c32498df793f73ad0a0a494a/matplotlib_inline-0.2.2-py3-none-any.whl", hash = "sha256:3c821cf1c209f59fb2d2d64abbf5b23b67bcb2210d663f9918dd851c6da1fcf6", size = 9534, upload-time = "2026-05-08T17:33:32.055Z" },
+]
+
+[[package]]
+name = "mistune"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/a5/2dab368d6950e6808904dec98f54c7e726ee7be4a0c6afe00e6e011bd52d/mistune-3.3.3.tar.gz", hash = "sha256:c4c6c0c840b8637a2e9b8b6d607eb7c8f00888bf14c754409bcd339e848c2477", size = 115363, upload-time = "2026-07-09T06:18:05.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/70/b1e4737b84163db5bb1dfde6f216dbfbf32783330a9989c965e121172830/mistune-3.3.3-py3-none-any.whl", hash = "sha256:99de1585e42dcbd826faa9e11a202727a5e202e4e4722a4c69ac1ff615793dd7", size = 63569, upload-time = "2026-07-09T06:18:03.839Z" },
+]
+
+[[package]]
+name = "nbclient"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "nbformat" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/a5/b3bae4b590c0cbcada2c63a34f7580024e834a8ba213e949a2f906705787/nbclient-0.11.0.tar.gz", hash = "sha256:04a134a5b087f2c5887f228aca155db50169b8cd9334dee6942c8e927e56081a", size = 62535, upload-time = "2026-06-05T07:52:41.746Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/c9/94d73e5a01c5b926c3fa2496e97d7a8dc28ed5a77c0b2ed712f1a62e6694/nbclient-0.11.0-py3-none-any.whl", hash = "sha256:ef7fa0d59d6e1d41103933d8a445a18d5de860ca6b613b87b8574accdb3c2895", size = 25288, upload-time = "2026-06-05T07:52:40.115Z" },
+]
+
+[[package]]
+name = "nbconvert"
+version = "7.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "bleach", extra = ["css"] },
+    { name = "defusedxml" },
+    { name = "jinja2" },
+    { name = "jupyter-core" },
+    { name = "jupyterlab-pygments" },
+    { name = "markupsafe" },
+    { name = "mistune" },
+    { name = "nbclient" },
+    { name = "nbformat" },
+    { name = "packaging" },
+    { name = "pandocfilters" },
+    { name = "pygments" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/b1/708e53fe2e429c103c6e6e159106bcf0357ac41aa4c28772bd8402339051/nbconvert-7.17.1.tar.gz", hash = "sha256:34d0d0a7e73ce3cbab6c5aae8f4f468797280b01fd8bd2ca746da8569eddd7d2", size = 865311, upload-time = "2026-04-08T00:44:14.914Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/f8/bb0a9d5f46819c821dc1f004aa2cc29b1d91453297dbf5ff20470f00f193/nbconvert-7.17.1-py3-none-any.whl", hash = "sha256:aa85c087b435e7bf1ffd03319f658e285f2b89eccab33bc1ba7025495ab3e7c8", size = 261927, upload-time = "2026-04-08T00:44:12.845Z" },
+]
+
+[[package]]
+name = "nbformat"
+version = "5.10.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastjsonschema" },
+    { name = "jsonschema" },
+    { name = "jupyter-core" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/fd/91545e604bc3dad7dca9ed03284086039b294c6b3d75c0d2fa45f9e9caf3/nbformat-5.10.4.tar.gz", hash = "sha256:322168b14f937a5d11362988ecac2a4952d3d8e3a2cbeb2319584631226d5b3a", size = 142749, upload-time = "2024-04-04T11:20:37.371Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl", hash = "sha256:3b48d6c8fbca4b299bf3982ea7db1af21580e4fec269ad087b9e81588891200b", size = 78454, upload-time = "2024-04-04T11:20:34.895Z" },
+]
+
+[[package]]
+name = "nest-asyncio2"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/73/731debf26e27e0a0323d7bda270dc2f634b398e38f040a09da1f4351d0aa/nest_asyncio2-1.7.2.tar.gz", hash = "sha256:1921d70b92cc4612c374928d081552efb59b83d91b2b789d935c665fa01729a8", size = 14743, upload-time = "2026-02-13T00:34:04.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl", hash = "sha256:f5dfa702f3f81f6a03857e9a19e2ba578c0946a4ad417b4c50a24d7ba641fe01", size = 7843, upload-time = "2026-02-13T00:34:02.691Z" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "notebook"
+version = "7.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-builder" },
+    { name = "jupyter-server" },
+    { name = "jupyterlab" },
+    { name = "jupyterlab-server" },
+    { name = "notebook-shim" },
+    { name = "tornado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/44/d5c65783f490298473bb1c05722e05ee2256231389559c2c5ae0a3e5d975/notebook-7.6.0.tar.gz", hash = "sha256:ea13e79e601bf273074895fdfb17dd3f2da916d3c045e0b9c47d18b16ab62481", size = 5497344, upload-time = "2026-06-18T16:18:55.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d1/e617c40db57ff40e75f43a7d4d1c305e3a54c053ab5cb0534a6c314664f9/notebook-7.6.0-py3-none-any.whl", hash = "sha256:98aa2811b54ac191321d5dfce12ca700f8a511a33a26e4de2fa106a357c43d6a", size = 5544575, upload-time = "2026-06-18T16:18:52.551Z" },
+]
+
+[[package]]
+name = "notebook-shim"
+version = "0.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-server" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/d2/92fa3243712b9a3e8bafaf60aac366da1cada3639ca767ff4b5b3654ec28/notebook_shim-0.2.4.tar.gz", hash = "sha256:b4b2cfa1b65d98307ca24361f5b30fe785b53c3fd07b7a47e89acb5e6ac638cb", size = 13167, upload-time = "2024-02-14T23:35:18.353Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b680023eb0469b2bb969d61303dedb2aac6560ff3d14a1/notebook_shim-0.2.4-py3-none-any.whl", hash = "sha256:411a5be4e9dc882a074ccbcae671eda64cceb068767e9a3419096986560e1cef", size = 13307, upload-time = "2024-02-14T23:35:16.286Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pandocfilters"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/6f/3dd4940bbe001c06a65f88e36bad298bc7a0de5036115639926b0c5c0458/pandocfilters-1.5.1.tar.gz", hash = "sha256:002b4a555ee4ebc03f8b66307e287fa492e4a77b4ea14d3f934328297bb4939e", size = 8454, upload-time = "2024-01-18T20:08:13.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/af/4fbc8cab944db5d21b7e2a5b8e9211a03a79852b1157e2c102fcc61ac440/pandocfilters-1.5.1-py2.py3-none-any.whl", hash = "sha256:93be382804a9cdb0a7267585f157e5d1731bbe5545a85b268d6f5fe6232de2bc", size = 8663, upload-time = "2024-01-18T20:08:11.28Z" },
+]
+
+[[package]]
+name = "parso"
+version = "0.8.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/4b/90c937815137d43ce71ba043cd3566221e9df6b9c805f24b5d138c9d40a7/parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1", size = 401824, upload-time = "2026-05-01T23:13:02.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c", size = 107025, upload-time = "2026-05-01T23:12:58.867Z" },
+]
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
+]
+
+[[package]]
+name = "pure-eval"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.411"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-json-logger"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
+]
+
+[[package]]
+name = "pywinpty"
+version = "3.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/ef/2d27f30c59a67be7025b2d7858c8c2d282b74d66544b2384730b82de74fd/pywinpty-3.0.5.tar.gz", hash = "sha256:61db0db063de9865adbea66db294628f8577f608d9764a4c7d3384eeacc4e81b", size = 16223484, upload-time = "2026-06-11T00:11:58.93Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/34/942cc95ca4e26489875aa8a95192766247a687379ec29543eebe73ec945f/pywinpty-3.0.5-cp312-cp312-win_amd64.whl", hash = "sha256:d62946adf14b15b54c0b8d785f93fe18b04da23f4ad59e2e8c4612646e9abd23", size = 2090915, upload-time = "2026-06-10T23:43:14.98Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/5b9053004844139ea8bd86209c57ade12b134b2782f383a095784c8531ec/pywinpty-3.0.5-cp312-cp312-win_arm64.whl", hash = "sha256:e9391c05fbfa7a992a97e831fc6849887b4014a614192e3d984a7ca59592b376", size = 815934, upload-time = "2026-06-10T23:41:42.384Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f4/2a464b9893cceb3b3f416356e94fdc3e1bca9476993927e4e6d99fe95382/pywinpty-3.0.5-cp313-cp313-win_amd64.whl", hash = "sha256:48db1b0ad9d0a1b81dcaaa7163a99a7808deaceb0c1b2344716dc1fc090c3c4c", size = 2090471, upload-time = "2026-06-10T23:42:11.071Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2c/a138491a0afbdb50eb79395577bd326d4b0fbde7209417d1a8087ff2493a/pywinpty-3.0.5-cp313-cp313-win_arm64.whl", hash = "sha256:2c6008fb2d3774b48693b2fcb7f2cc317ade9dc581289a964ffeeaf81307c9b5", size = 815518, upload-time = "2026-06-10T23:42:02.363Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/15/54400049a380582acd1282665c70fcf11e0bd3713679aca78e24c3aae738/pywinpty-3.0.5-cp313-cp313t-win_amd64.whl", hash = "sha256:22ce1b780d89821cc52daf6eac0708af22d93d000ce9c7c07e37489db8594598", size = 2089920, upload-time = "2026-06-10T23:44:13.395Z" },
+    { url = "https://files.pythonhosted.org/packages/94/0c/6f24f3c0799f502259b24bdf841a99ad2b0d59df5c2525b4e2a286d14be2/pywinpty-3.0.5-cp313-cp313t-win_arm64.whl", hash = "sha256:9c2919a81bc5cfb09b86fc5a002112b2de95ca4304a07413cbeeb746a1307a5c", size = 814520, upload-time = "2026-06-10T23:43:28.588Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/23/f3cd1b1e5fc56517f54452c49f92049e7dd9ffc8a63de22a495581f50d04/pywinpty-3.0.5-cp314-cp314-win_amd64.whl", hash = "sha256:03bb3c16d691d9242267201830bcd0e64a9b663170e9042bc84b210da9de15ac", size = 2090663, upload-time = "2026-06-10T23:43:59.845Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/dd/96d6cbfc6d9ddab5c1c2f92c26545ae8997446a2ba7ee2024cd43c81f49b/pywinpty-3.0.5-cp314-cp314-win_arm64.whl", hash = "sha256:89c5c6ef08997a3b4b277b214a35fe15cab4dd6d119f0140aa71df5b1168fdbc", size = 815700, upload-time = "2026-06-10T23:40:50.001Z" },
+    { url = "https://files.pythonhosted.org/packages/30/36/d98087bce0acaa4cce7f196103cfa7be3f63ce65f52473bb3e38784ae5d9/pywinpty-3.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7b566165e0c5fdd6abe167a5ac8b954be6a843eb55a85946576d6bc1dea03d6d", size = 2090093, upload-time = "2026-06-10T23:40:58.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fd/fe2b0db922ba052ce3976a08f3fc05d0c05047c8b4ebb6102e832b8ef563/pywinpty-3.0.5-cp314-cp314t-win_arm64.whl", hash = "sha256:24366280a8aa677323da87bec729cb3ea3b35367386cece0978bdc6e4695c690", size = 814517, upload-time = "2026-06-10T23:42:34.946Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "pyzmq"
+version = "27.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "implementation_name == 'pypy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/e7/038aab64a946d535901103da16b953c8c9cc9c961dadcbf3609ed6428d23/pyzmq-27.1.0-cp312-abi3-macosx_10_15_universal2.whl", hash = "sha256:452631b640340c928fa343801b0d07eb0c3789a5ffa843f6e1a9cee0ba4eb4fc", size = 1306279, upload-time = "2025-09-08T23:08:03.807Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5e/c3c49fdd0f535ef45eefcc16934648e9e59dace4a37ee88fc53f6cd8e641/pyzmq-27.1.0-cp312-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1c179799b118e554b66da67d88ed66cd37a169f1f23b5d9f0a231b4e8d44a113", size = 895645, upload-time = "2025-09-08T23:08:05.301Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e5/b0b2504cb4e903a74dcf1ebae157f9e20ebb6ea76095f6cfffea28c42ecd/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3837439b7f99e60312f0c926a6ad437b067356dc2bc2ec96eb395fd0fe804233", size = 652574, upload-time = "2025-09-08T23:08:06.828Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43ad9a73e3da1fab5b0e7e13402f0b2fb934ae1c876c51d0afff0e7c052eca31", size = 840995, upload-time = "2025-09-08T23:08:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/bb/b79798ca177b9eb0825b4c9998c6af8cd2a7f15a6a1a4272c1d1a21d382f/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0de3028d69d4cdc475bfe47a6128eb38d8bc0e8f4d69646adfbcd840facbac28", size = 1642070, upload-time = "2025-09-08T23:08:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/80/2df2e7977c4ede24c79ae39dcef3899bfc5f34d1ca7a5b24f182c9b7a9ca/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_i686.whl", hash = "sha256:cf44a7763aea9298c0aa7dbf859f87ed7012de8bda0f3977b6fb1d96745df856", size = 2021121, upload-time = "2025-09-08T23:08:11.907Z" },
+    { url = "https://files.pythonhosted.org/packages/46/bd/2d45ad24f5f5ae7e8d01525eb76786fa7557136555cac7d929880519e33a/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f30f395a9e6fbca195400ce833c731e7b64c3919aa481af4d88c3759e0cb7496", size = 1878550, upload-time = "2025-09-08T23:08:13.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/2f/104c0a3c778d7c2ab8190e9db4f62f0b6957b53c9d87db77c284b69f33ea/pyzmq-27.1.0-cp312-abi3-win32.whl", hash = "sha256:250e5436a4ba13885494412b3da5d518cd0d3a278a1ae640e113c073a5f88edd", size = 559184, upload-time = "2025-09-08T23:08:15.163Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7f/a21b20d577e4100c6a41795842028235998a643b1ad406a6d4163ea8f53e/pyzmq-27.1.0-cp312-abi3-win_amd64.whl", hash = "sha256:9ce490cf1d2ca2ad84733aa1d69ce6855372cb5ce9223802450c9b2a7cba0ccf", size = 619480, upload-time = "2025-09-08T23:08:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c2/c012beae5f76b72f007a9e91ee9401cb88c51d0f83c6257a03e785c81cc2/pyzmq-27.1.0-cp312-abi3-win_arm64.whl", hash = "sha256:75a2f36223f0d535a0c919e23615fc85a1e23b71f40c7eb43d7b1dedb4d8f15f", size = 552993, upload-time = "2025-09-08T23:08:18.926Z" },
+    { url = "https://files.pythonhosted.org/packages/60/cb/84a13459c51da6cec1b7b1dc1a47e6db6da50b77ad7fd9c145842750a011/pyzmq-27.1.0-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:93ad4b0855a664229559e45c8d23797ceac03183c7b6f5b4428152a6b06684a5", size = 1122436, upload-time = "2025-09-08T23:08:20.801Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b6/94414759a69a26c3dd674570a81813c46a078767d931a6c70ad29fc585cb/pyzmq-27.1.0-cp313-cp313-android_24_x86_64.whl", hash = "sha256:fbb4f2400bfda24f12f009cba62ad5734148569ff4949b1b6ec3b519444342e6", size = 1156301, upload-time = "2025-09-08T23:08:22.47Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ad/15906493fd40c316377fd8a8f6b1f93104f97a752667763c9b9c1b71d42d/pyzmq-27.1.0-cp313-cp313t-macosx_10_15_universal2.whl", hash = "sha256:e343d067f7b151cfe4eb3bb796a7752c9d369eed007b91231e817071d2c2fec7", size = 1341197, upload-time = "2025-09-08T23:08:24.286Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1d/d343f3ce13db53a54cb8946594e567410b2125394dafcc0268d8dda027e0/pyzmq-27.1.0-cp313-cp313t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:08363b2011dec81c354d694bdecaef4770e0ae96b9afea70b3f47b973655cc05", size = 897275, upload-time = "2025-09-08T23:08:26.063Z" },
+    { url = "https://files.pythonhosted.org/packages/69/2d/d83dd6d7ca929a2fc67d2c3005415cdf322af7751d773524809f9e585129/pyzmq-27.1.0-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d54530c8c8b5b8ddb3318f481297441af102517602b569146185fa10b63f4fa9", size = 660469, upload-time = "2025-09-08T23:08:27.623Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/cd/9822a7af117f4bc0f1952dbe9ef8358eb50a24928efd5edf54210b850259/pyzmq-27.1.0-cp313-cp313t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f3afa12c392f0a44a2414056d730eebc33ec0926aae92b5ad5cf26ebb6cc128", size = 847961, upload-time = "2025-09-08T23:08:29.672Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/12/f003e824a19ed73be15542f172fd0ec4ad0b60cf37436652c93b9df7c585/pyzmq-27.1.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c65047adafe573ff023b3187bb93faa583151627bc9c51fc4fb2c561ed689d39", size = 1650282, upload-time = "2025-09-08T23:08:31.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/4a/e82d788ed58e9a23995cee70dbc20c9aded3d13a92d30d57ec2291f1e8a3/pyzmq-27.1.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:90e6e9441c946a8b0a667356f7078d96411391a3b8f80980315455574177ec97", size = 2024468, upload-time = "2025-09-08T23:08:33.543Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/94/2da0a60841f757481e402b34bf4c8bf57fa54a5466b965de791b1e6f747d/pyzmq-27.1.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:add071b2d25f84e8189aaf0882d39a285b42fa3853016ebab234a5e78c7a43db", size = 1885394, upload-time = "2025-09-08T23:08:35.51Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/6f/55c10e2e49ad52d080dc24e37adb215e5b0d64990b57598abc2e3f01725b/pyzmq-27.1.0-cp313-cp313t-win32.whl", hash = "sha256:7ccc0700cfdf7bd487bea8d850ec38f204478681ea02a582a8da8171b7f90a1c", size = 574964, upload-time = "2025-09-08T23:08:37.178Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4d/2534970ba63dd7c522d8ca80fb92777f362c0f321900667c615e2067cb29/pyzmq-27.1.0-cp313-cp313t-win_amd64.whl", hash = "sha256:8085a9fba668216b9b4323be338ee5437a235fe275b9d1610e422ccc279733e2", size = 641029, upload-time = "2025-09-08T23:08:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fa/f8aea7a28b0641f31d40dea42d7ef003fded31e184ef47db696bc74cd610/pyzmq-27.1.0-cp313-cp313t-win_arm64.whl", hash = "sha256:6bb54ca21bcfe361e445256c15eedf083f153811c37be87e0514934d6913061e", size = 561541, upload-time = "2025-09-08T23:08:42.668Z" },
+    { url = "https://files.pythonhosted.org/packages/87/45/19efbb3000956e82d0331bafca5d9ac19ea2857722fa2caacefb6042f39d/pyzmq-27.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ce980af330231615756acd5154f29813d553ea555485ae712c491cd483df6b7a", size = 1341197, upload-time = "2025-09-08T23:08:44.973Z" },
+    { url = "https://files.pythonhosted.org/packages/48/43/d72ccdbf0d73d1343936296665826350cb1e825f92f2db9db3e61c2162a2/pyzmq-27.1.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1779be8c549e54a1c38f805e56d2a2e5c009d26de10921d7d51cfd1c8d4632ea", size = 897175, upload-time = "2025-09-08T23:08:46.601Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2e/a483f73a10b65a9ef0161e817321d39a770b2acf8bcf3004a28d90d14a94/pyzmq-27.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7200bb0f03345515df50d99d3db206a0a6bee1955fbb8c453c76f5bf0e08fb96", size = 660427, upload-time = "2025-09-08T23:08:48.187Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d2/5f36552c2d3e5685abe60dfa56f91169f7a2d99bbaf67c5271022ab40863/pyzmq-27.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01c0e07d558b06a60773744ea6251f769cd79a41a97d11b8bf4ab8f034b0424d", size = 847929, upload-time = "2025-09-08T23:08:49.76Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/2a/404b331f2b7bf3198e9945f75c4c521f0c6a3a23b51f7a4a401b94a13833/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:80d834abee71f65253c91540445d37c4c561e293ba6e741b992f20a105d69146", size = 1650193, upload-time = "2025-09-08T23:08:51.7Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/0b/f4107e33f62a5acf60e3ded67ed33d79b4ce18de432625ce2fc5093d6388/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:544b4e3b7198dde4a62b8ff6685e9802a9a1ebf47e77478a5eb88eca2a82f2fd", size = 2024388, upload-time = "2025-09-08T23:08:53.393Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/01/add31fe76512642fd6e40e3a3bd21f4b47e242c8ba33efb6809e37076d9b/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cedc4c68178e59a4046f97eca31b148ddcf51e88677de1ef4e78cf06c5376c9a", size = 1885316, upload-time = "2025-09-08T23:08:55.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/59/a5f38970f9bf07cee96128de79590bb354917914a9be11272cfc7ff26af0/pyzmq-27.1.0-cp314-cp314t-win32.whl", hash = "sha256:1f0b2a577fd770aa6f053211a55d1c47901f4d537389a034c690291485e5fe92", size = 587472, upload-time = "2025-09-08T23:08:58.18Z" },
+    { url = "https://files.pythonhosted.org/packages/70/d8/78b1bad170f93fcf5e3536e70e8fadac55030002275c9a29e8f5719185de/pyzmq-27.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:19c9468ae0437f8074af379e986c5d3d7d7bfe033506af442e8c879732bedbe0", size = 661401, upload-time = "2025-09-08T23:08:59.802Z" },
+    { url = "https://files.pythonhosted.org/packages/81/d6/4bfbb40c9a0b42fc53c7cf442f6385db70b40f74a783130c5d0a5aa62228/pyzmq-27.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dc5dbf68a7857b59473f7df42650c621d7e8923fb03fa74a526890f4d33cc4d7", size = 575170, upload-time = "2025-09-08T23:09:01.418Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "rfc3339-validator"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490, upload-time = "2021-05-12T16:37:52.536Z" },
+]
+
+[[package]]
+name = "rfc3986-validator"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/88/f270de456dd7d11dcc808abfa291ecdd3f45ff44e3b549ffa01b126464d0/rfc3986_validator-0.1.1.tar.gz", hash = "sha256:3d44bde7921b3b9ec3ae4e3adca370438eccebc676456449b145d533b240d055", size = 6760, upload-time = "2019-10-28T16:00:19.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/51/17023c0f8f1869d8806b979a2bffa3f861f26a3f1a66b094288323fba52f/rfc3986_validator-0.1.1-py2.py3-none-any.whl", hash = "sha256:2f235c432ef459970b4306369336b9d5dbdda31b510ca1e327636e01f528bfa9", size = 4242, upload-time = "2019-10-28T16:00:13.976Z" },
+]
+
+[[package]]
+name = "rfc3987-syntax"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lark" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/06/37c1a5557acf449e8e406a830a05bf885ac47d33270aec454ef78675008d/rfc3987_syntax-1.1.0.tar.gz", hash = "sha256:717a62cbf33cffdd16dfa3a497d81ce48a660ea691b1ddd7be710c22f00b4a0d", size = 14239, upload-time = "2025-07-18T01:05:05.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/71/44ce230e1b7fadd372515a97e32a83011f906ddded8d03e3c6aafbdedbb7/rfc3987_syntax-1.1.0-py3-none-any.whl", hash = "sha256:6c3d97604e4c5ce9f714898e05401a0445a641cfa276432b0a648c80856f6a3f", size = 8046, upload-time = "2025-07-18T01:05:03.843Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/be/2e8974163072e7bab7df1a5acd54c4498e75e35d6d18b864d3a9d5dadc92/rpds_py-2026.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0811d33247c3d6128a3001d763f2aa056bb3425204335400ac54f89eec3a0d0", size = 343691, upload-time = "2026-06-30T07:15:14.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf", size = 338542, upload-time = "2026-06-30T07:15:16.267Z" },
+    { url = "https://files.pythonhosted.org/packages/21/63/4239893be1c4d09b709b1a8f6be4188f0870084ff547f46606b8a75f1b03/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24", size = 368180, upload-time = "2026-06-30T07:15:17.62Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ca/9c5de382225234ceb37b1844ebdb140db12b2a278bb9efe2fcd19f6c82ce/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f56f1695bc5c0871cbc33dc0130fcf503aab0c57dcc5a6700a4f49eba4f2652e", size = 375067, upload-time = "2026-06-30T07:15:18.952Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/863f69d1bf04ade34b7fe0d59b9fdf6f0135fe2d7cbca74f1d665589559d/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:270b293dae9058fc9fcedab50f13cebf46fb8ed1d1d54e0521a9da5d6b211975", size = 490509, upload-time = "2026-06-30T07:15:20.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ef/eac16a12048b45ec7c7fa94f2be3438a5f26bf9cc8580b18a1cfd609b7f6/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:127565fead0a10943b282957bd5447804ff3160ad79f2ad2635e6d249e380680", size = 382754, upload-time = "2026-06-30T07:15:21.831Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6", size = 366189, upload-time = "2026-06-30T07:15:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/29/41a7b0e98a4b44cd676ab7598419623373eb43b20be68c084935c1a8cf88/rpds_py-2026.6.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:58eadac9cd119677b60e1cf8ac4052f35949d71b8a9e5556efccbe82533cf22a", size = 377750, upload-time = "2026-06-30T07:15:24.659Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/05/ecda0bec46f9a1565090bcdc941d023f6a25aff85fda28f89f8d19878152/rpds_py-2026.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7491ee23305ac3eb59e492b6945881f5cd77a6f731061a3f25b77fd40f9e99a4", size = 395576, upload-time = "2026-06-30T07:15:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a8/6ed52f03ee6cb854ce78785cc9a9a672eb880e83fd7224d471f667d151f1/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa", size = 543807, upload-time = "2026-06-30T07:15:27.356Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d6/156c0d3eea27ba09b92562ba2364ba124c0a061b199e17eac637cd25a5e2/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62698275682bf121181861295c9181e789030a2d516071f5b8f3c23c170cd0fc", size = 611187, upload-time = "2026-06-30T07:15:28.931Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/31/774212ed989c62f7f310220089f9b0a3fb8f40f5443d1727abd5d9f52bc9/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822", size = 573030, upload-time = "2026-06-30T07:15:30.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/50/22f73127a41f1ce4f87fe39aadfb9a126345801c274aa93ae88456249327/rpds_py-2026.6.3-cp312-cp312-win32.whl", hash = "sha256:501f9f04a588d6a09179368c57071301445191767c64e4b52a6aa9871f1ef5ed", size = 202185, upload-time = "2026-06-30T07:15:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3a/f0ee4d4dde9d3b69dedf1b5f74e7a40017046d55052d173e418c6a94f960/rpds_py-2026.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f", size = 220394, upload-time = "2026-06-30T07:15:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/83/3382fe37f809b59f02aac04dbc4e765b480b46ee0227ed516e3bdc4d3dfc/rpds_py-2026.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:22bffe6042b9bcb0822bcd1955ec00e245daf17b4344e4ed8e9551b976b63e96", size = 215753, upload-time = "2026-06-30T07:15:34.778Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/36/6f65aa9989acdec45d417192d8f4e7921931d8a6cf87ac74bce3eed98a8e/ruff-0.15.21.tar.gz", hash = "sha256:d0cfc841c572283c36548f82664a54ce6565567f1b0d5b4cf2caac693d8b7500", size = 4769401, upload-time = "2026-07-09T20:01:34.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/c6/ede15cac6839f3dbce52565c8f5164a8210e669c7bc4decb03e5bdf47d0d/ruff-0.15.21-py3-none-linux_armv6l.whl", hash = "sha256:63ea0e965e5d73c90e95b2434beeafc70820536717f561b32ab6e777cb9bdf5d", size = 10854342, upload-time = "2026-07-09T20:00:53.998Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9d/d825b07ee7ea9e2d61df92a860033c94e06e7300d50a1c2653aac27d24fe/ruff-0.15.21-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0f212c5d7d54c01bbfe6dcab02b724a39300f3e34ed7acbe995ccb320a2c58bd", size = 11139539, upload-time = "2026-07-09T20:00:57.809Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/de/3b107712e642f063c7a9e0887c427b22cb44097de5aab36c05f2e280670c/ruff-0.15.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e6312e41bc96791299614995ea3a977c5857c3b5662b1ecef6755b02b87cb646", size = 10595437, upload-time = "2026-07-09T20:01:00.006Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/6f/b4523cc90ba239ede441447a19d0c968846a3012e5a0b0c5b62831a3d5e3/ruff-0.15.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01d65b4831c6b2a4ba8ee6faa84049d44d982b7a706e622c4094c509e51673be", size = 10990053, upload-time = "2026-07-09T20:01:02.187Z" },
+    { url = "https://files.pythonhosted.org/packages/92/cc/c6a9872a5375f0628875481cf2f66b13d7d865bf3ca2e57f91c7e762d976/ruff-0.15.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c5a913a589120ce67933d5d05fd6ddbcc2481c6a054980ee767f7414c72b4fd", size = 10666096, upload-time = "2026-07-09T20:01:04.299Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/97/c621f7a17e097f1790fa3af6374138823b330b2d03fc38337945daca212c/ruff-0.15.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef04b681d02ad4dc9620f00f83ac5c22f652d0e9a9cfe431d219b16ad5ccc41", size = 11537011, upload-time = "2026-07-09T20:01:06.771Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/51/d928727e476e25ccc57c6f449ffd80241a651a973ad949d39cfb2a771d28/ruff-0.15.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:16d090c0740916594157e75b80d666eab8e78083b39b3b0e1d698f4670a17b86", size = 12347101, upload-time = "2026-07-09T20:01:08.859Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/88/8cd62026802b16018ad06931d87997cf795ba2a6239ab659606c87d96bf0/ruff-0.15.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a10e74757dd65004d779b73e2f3c5210156d9980b41224d50d2ebcf1db51e67", size = 11572001, upload-time = "2026-07-09T20:01:11.092Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/97/f63084cf55444fc110e8cb985ebfcc592af47f597d44453d778cb81bc156/ruff-0.15.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bab0905d2f29e0d9fbc3c373ed23db0095edaa3f71f1f4f519ec15134d9e85c8", size = 11549239, upload-time = "2026-07-09T20:01:13.27Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/77/f107da4a2874b7715914b03f09ba9c54424de3ff8a1cc5d015d3ee2ce0ac/ruff-0.15.21-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:00eca240af5789fec6fe7df74c088cc1f9644ed83027113468efba7c92b94075", size = 11535340, upload-time = "2026-07-09T20:01:15.206Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e9/601deb322d3303a7bf212b0100ead6f2ee3f6a044d89c30f2f92bf83c731/ruff-0.15.21-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:262ab31557a75141325e32d3357f3597645a7f084e732b6b054dde428ecd9341", size = 10964048, upload-time = "2026-07-09T20:01:17.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/2e/0f2176d1e99c15192caea19c8c3a0a955246b4cb4de795042eeb616345cd/ruff-0.15.21-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:659c4e7a4212f83306045ec7c5e5a356d16d9a6ef4ae0c7a4d872914fc655d9d", size = 10667055, upload-time = "2026-07-09T20:01:19.73Z" },
+    { url = "https://files.pythonhosted.org/packages/48/60/abd74a02e0c4214f12a68becfd30af7165cfdcb0e661ecdc60bbb949c09a/ruff-0.15.21-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9e866eab611a5f959d36df2d10e446973a3610bc42b0c15b31dc27977d59c233", size = 11242043, upload-time = "2026-07-09T20:01:21.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c6/583075d8ccabb4b229345edcaf1545eb3d8d6be90f686a479d7e94088bbf/ruff-0.15.21-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e89bc93c0d3803ba870b55c29671bad9dc6d94bb1eb181b056b52eb05b52854f", size = 11648064, upload-time = "2026-07-09T20:01:24.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/3c/37d0ecb729a7cc2d393ea7dce316fc585680f35d93b8d62139d7d0a3700c/ruff-0.15.21-py3-none-win32.whl", hash = "sha256:01f8d5be84823c172b389e123174f781f9daf86d6c58719d603f941932195cdd", size = 10896555, upload-time = "2026-07-09T20:01:26.941Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b8/e43466b2a6067ce91e669068f6e28d6c719a920f014b070d5c8731725de3/ruff-0.15.21-py3-none-win_amd64.whl", hash = "sha256:d4b8d9a2f0f12b816b50447f6eccb9f4bb01a6b82c86b50fb3b5354b458dc6d3", size = 12038772, upload-time = "2026-07-09T20:01:29.497Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/75/e90ab9aeece218a9fc5a5bc3ec97d0ee6bb3c4ff95869463c1de58e29a1c/ruff-0.15.21-py3-none-win_arm64.whl", hash = "sha256:6e83115d4b9377c1cbc13abf0e051f069fab0ef815ea0504a8a008cee24dd0a8", size = 11375265, upload-time = "2026-07-09T20:01:31.772Z" },
+]
+
+[[package]]
+name = "screamingface"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
+notebook = [
+    { name = "jupyter" },
+    { name = "nbconvert" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pyright", specifier = ">=1.1.409" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.3,<2" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "ruff", specifier = ">=0.15.13" },
+]
+notebook = [
+    { name = "jupyter", specifier = ">=1.0" },
+    { name = "nbconvert", specifier = ">=7.0" },
+]
+
+[[package]]
+name = "send2trash"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/f0/184b4b5f8d00f2a92cf96eec8967a3d550b52cf94362dad1100df9e48d57/send2trash-2.1.0.tar.gz", hash = "sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459", size = 17255, upload-time = "2026-01-14T06:27:36.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl", hash = "sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c", size = 17610, upload-time = "2026-01-14T06:27:35.218Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+]
+
+[[package]]
+name = "stack-data"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pure-eval" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "terminado"
+version = "0.18.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess", marker = "os_name != 'nt'" },
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "tornado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl", hash = "sha256:a4468e1b37bb318f8a86514f65814e1afc977cf29b3992a4500d9dd305dcceb0", size = 14154, upload-time = "2024-03-12T14:34:36.569Z" },
+]
+
+[[package]]
+name = "tinycss2"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
+]
+
+[[package]]
+name = "tornado"
+version = "6.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/24/95ec527ad67b76d59299e5465b3935d05e4294b7e0290a3924b7487df30b/tornado-6.5.7.tar.gz", hash = "sha256:66c513a76cda70d53907bc27cf1447557699c2e95aa48ba27a442ff61c3ddfc2", size = 519252, upload-time = "2026-06-08T17:34:51.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/dc/c7043cab6fed8ae159fc1923ce829ada35c4dbd797d408a43858ffaf9639/tornado-6.5.7-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:148b2eb15c2c765a50796172c1e499649b35f30d2e3c3d3e15913cfa56bfb163", size = 448543, upload-time = "2026-06-08T17:34:38.052Z" },
+    { url = "https://files.pythonhosted.org/packages/92/4f/090b1431e5a43df696feceffc268c5383cc079ecb5f08ce58f917109aafe/tornado-6.5.7-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9da38de27f1da3b78a966f0dae12b5a1ea9afe72ca805d84ff06508272ddf100", size = 446707, upload-time = "2026-06-08T17:34:39.594Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d8/ef374952fd5da67d4463122c2b8e5a96536ec10b4b339254c6dcde81d01c/tornado-6.5.7-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8d759e71906ee783f8867b93bf26a265743da4c1e2f4a018464c1ba019862972", size = 449774, upload-time = "2026-06-08T17:34:41.204Z" },
+    { url = "https://files.pythonhosted.org/packages/35/37/d434c73f4c6e014b745b9b37085f34f40c022f007efff3d7fe65991899f3/tornado-6.5.7-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a46347a18f23fb92b396beebe0fb78f61dda0cc302445202c16203d8a18848b", size = 450745, upload-time = "2026-06-08T17:34:42.531Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2b/56b9aff361d7f1ab728a805ec7d7ea835f8807afa9f5cc690ea0e630efb9/tornado-6.5.7-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7778b30bef919231265e91c69963ce0f49a1e9c07ac900bbe75b19ce2575ba92", size = 450578, upload-time = "2026-06-08T17:34:43.787Z" },
+    { url = "https://files.pythonhosted.org/packages/02/30/a7444fb23aa76860a14198fab96ac79f1866b0a6e19e26c4381b0938e50f/tornado-6.5.7-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e726f0c75da7726eec023aa62751ff8878bd2737e34fbdd33b1ae5897d2200f5", size = 449985, upload-time = "2026-06-08T17:34:45.326Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/42/5f0e56c01e8d9d36f4e23f367b85ae6cae0c1ecddd5e6977d8388ad27488/tornado-6.5.7-cp39-abi3-win32.whl", hash = "sha256:f8de3bf12d3efdd0cbe7c8887868198f8a91415e3f29fcf258d9b8eb7b1d9ae4", size = 451047, upload-time = "2026-06-08T17:34:46.784Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a4/b393076ffb21b469eec5b328a0534cf03a3b90bfc6b1f09507cdd075d938/tornado-6.5.7-cp39-abi3-win_amd64.whl", hash = "sha256:de942f843533a039ef9fa3d9c88c7cd8a7c94553fb5ad0154270989b3d99a2c4", size = 451485, upload-time = "2026-06-08T17:34:48.248Z" },
+    { url = "https://files.pythonhosted.org/packages/71/2e/7b1c769803121b809112cf9a00681c472eae1d80e32d7ec0e0bd61d0d0e1/tornado-6.5.7-cp39-abi3-win_arm64.whl", hash = "sha256:ff934fce95643af5f11efdae618eaa73d469dc588641e5c8d19295a0c65c4796", size = 450506, upload-time = "2026-06-08T17:34:49.702Z" },
+]
+
+[[package]]
+name = "traitlets"
+version = "5.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/a9/a2584b8313b89f94869ddb3c4074617a691de1812a614d2d50e32ca5a7a6/traitlets-5.15.1.tar.gz", hash = "sha256:7b1c07854fe25acb39e009bae49f11b79ff6cbb2f27999104e9110e7a6b53722", size = 163344, upload-time = "2026-06-03T12:26:06.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/8d/1080ee4c231f361b6ce4470d556c8c435b67c7e0753aaa641497ee92f88b/traitlets-5.15.1-py3-none-any.whl", hash = "sha256:770a53705f84b81ac107e83a1b3328ff2dae16094d8fc3cfc004e4b22dfd8e92", size = 85858, upload-time = "2026-06-03T12:26:04.395Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "uri-template"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/c7/0336f2bd0bcbada6ccef7aaa25e443c118a704f828a0620c6fa0207c1b64/uri-template-1.3.0.tar.gz", hash = "sha256:0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7", size = 21678, upload-time = "2023-06-21T01:49:05.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl", hash = "sha256:a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363", size = 11140, upload-time = "2023-06-21T01:49:03.467Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
+]
+
+[[package]]
+name = "webcolors"
+version = "25.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/7a/eb316761ec35664ea5174709a68bbd3389de60d4a1ebab8808bfc264ed67/webcolors-25.10.0.tar.gz", hash = "sha256:62abae86504f66d0f6364c2a8520de4a0c47b80c03fc3a5f1815fedbef7c19bf", size = 53491, upload-time = "2025-10-31T07:51:03.977Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl", hash = "sha256:032c727334856fc0b968f63daa252a1ac93d33db2f5267756623c210e57a4f1d", size = 14905, upload-time = "2025-10-31T07:51:01.778Z" },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
+]
+
+[[package]]
+name = "widgetsnbextension"
+version = "4.0.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/f4/c67440c7fb409a71b7404b7aefcd7569a9c0d6bd071299bf4198ae7a5d95/widgetsnbextension-4.0.15.tar.gz", hash = "sha256:de8610639996f1567952d763a5a41af8af37f2575a41f9852a38f947eb82a3b9", size = 1097402, upload-time = "2025-11-01T21:15:55.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl", hash = "sha256:8156704e4346a571d9ce73b84bee86a29906c9abfd7223b7228a28899ccf3366", size = 2196503, upload-time = "2025-11-01T21:15:53.565Z" },
+]


### PR DESCRIPTION
## Summary
- New package `packages/screamingface` (import `screamingface as sf`) — the v0.1 quickstart slice of the API demoed by the `screamingface-brand` prototype notebooks, scaffolded like `packages/url4` (hatchling/uv, ruff, pyright, pytest strict-asyncio).
- Simulated model backend behind a hexagonal `EngineBackend` port, so real inference (OME-296) and the real url4 grammar (OME-408) can swap in later without changing the public API.
- `examples/00_quickstart.ipynb` executed end-to-end (connect → discover → compose → run → gain), outputs committed; verified deterministic across two independent executions.
- New CI lane `screamingface-tests.yml` (path-filtered) + dependabot entry.

## Test plan
- [x] `uv run pytest` / `ruff check` / `ruff format --check` / `pyright` green in `packages/screamingface`
- [x] `uv run .claude/scripts/run_gates.py screamingface --base origin/main` — ALL GATES GREEN (80 tests, 91% coverage)
- [x] Notebook executed via nbconvert; re-executed and diffed outputs — byte-identical
- [x] Notebook's `run.score/baseline/gain` matches the ticket's reference example exactly (`score=50.0 gain=+0.0`)
- [ ] Owner: create + register the `pkg/screamingface` landing label (`.claude/task-board.local.md`) — MCP-uncovered

Refs: OME-400