### PR TITLE
docs(OME-430): file repo mirror for dead Postgres concurrency tests

### DIFF
--- a/docs/tasks/2026-07-14-postgres-concurrency-tests-cant-run.md
+++ b/docs/tasks/2026-07-14-postgres-concurrency-tests-cant-run.md
@@ -1,0 +1,20 @@
+---
+id: OME-430
+linear_url: https://linear.app/openmined/issue/OME-430/scoreboard-postgres-concurrency-tests-cant-run-asynciorun-inside-an
+status: backlog
+type: task
+priority: P2
+labels: [scoreboard, agentic, autonomous]
+created: 2026-07-14
+closed:
+---
+
+Found while addressing PR #390 review (OME-391): `postgres_schema_database_url` in
+`apps/scoreboard/tests/conftest.py` calls `asyncio.run()` from inside an already-running
+pytest-asyncio event loop, which raises immediately — and CI never sets
+`SCOREBOARD_TEST_DATABASE_URL` anyway, so the two `test_postgres_concurrent_*` tests in
+`test_store.py` have only ever skipped, never actually run.
+
+Fix: convert the fixture to async, add a `postgres:16` CI service, and ideally a
+migration-chain-vs-model-drift check (assert `content_hash`'s unique index exists after
+running real migrations, not `generate_schemas()`). See the Linear issue for full detail.


### PR DESCRIPTION
## Summary
Repo mirror only, per the task-management skill's "every issue gets a docs/tasks mirror written at create" convention — no code change. Full detail on the Linear issue.

Refs: OME-430