### PR TITLE
chore(scoreboard): bump version to 0.1.1 for release

### DIFF
--- a/apps/scoreboard/charts/scoreboard/Chart.yaml
+++ b/apps/scoreboard/charts/scoreboard/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: scoreboard
 description: ScreamingFace benchmark scoreboard
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.1
+appVersion: "0.1.1"

--- a/apps/scoreboard/pyproject.toml
+++ b/apps/scoreboard/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scoreboard"
-version = "0.1.0"
+version = "0.1.1"
 description = "ScreamingFace benchmark scoreboard service"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/scoreboard/src/scoreboard/__init__.py
+++ b/apps/scoreboard/src/scoreboard/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/apps/scoreboard/src/scoreboard/main.py
+++ b/apps/scoreboard/src/scoreboard/main.py
@@ -27,7 +27,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     if settings is None:
         settings = Settings()
 
-    app = FastAPI(title="scoreboard", version="0.1.0", lifespan=_lifespan)
+    app = FastAPI(title="scoreboard", version="0.1.1", lifespan=_lifespan)
     app.state.settings = settings
     app.state.score_store = ScoreStore()
     app.state.baseline_store = BaselineStore()

--- a/apps/scoreboard/uv.lock
+++ b/apps/scoreboard/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "scoreboard"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
Version bump only, no behavior change — prepares a single combined release for the three scoreboard PRs merged today (#391 Plausible analytics, #390 content-hash dedup, #392 placeholder API-key gate). `release-scoreboard.yml`'s tag-verify step requires the git tag's version to exactly match `apps/scoreboard/pyproject.toml`, so this needs to merge before `scoreboard-v0.1.1` can be tagged.

Bumped in lockstep: `pyproject.toml`, `src/scoreboard/__init__.py::__version__`, `main.py`'s `FastAPI(version=...)`, and `charts/scoreboard/Chart.yaml` (`version`/`appVersion`) — `charts/db/Chart.yaml` is the separate demo-Postgres chart, intentionally untouched.

## Test plan
- [x] `uv run ruff check` / `ruff format --check` / `pyright` — all clean
- [x] `uv run pytest --cov=scoreboard --cov-fail-under=80` — 128 passed, 2 skipped, 87.99% coverage
- [x] `helm lint charts/scoreboard` — clean

Refs: OME-373