### PR TITLE
OME-443: url4 Cloud Runner — spec, plan & ticket cascade

### DIFF
--- a/.claude/task-board.local.md
+++ b/.claude/task-board.local.md
@@ -10,40 +10,53 @@ states:
   in_review: "62b4c1a3-752f-456b-bdf6-7ce484959e5d"
   done: "699b96ac-cd89-42db-a717-4f8b291a7388"
   triage: "a6fc6a19-f6fd-4fda-baf6-2d26cc54adae"
-labels:
-  epic_group:  # existing workstream axis (Linear group "Epic", one per issue) — adopted as-is (D10)
-    "url4 Engine": "4cf80371-0eab-48e3-b396-efbf5b4837a7"
-    "AI Gateway": "554a9f5f-0535-4165-be15-60c5385f2c2a"
-    "Eval Runner & Datasets": "f4d5724b-34ab-47f0-b7bd-cfa3d420c0fb"
-    "Results & Runs": "0aff5dce-0a3e-4797-96e8-60b2098ef657"
-    "Leaderboard": "7f2af383-b322-45a6-8d37-cd45a8dcd3e5"
-    "Auth & Subsidized Compute": "016ca5be-1d4b-475f-b19d-cd3a6d43db6b"
-    "Desktop App": "481804a4-453c-4ceb-8a47-6e3745ee440a"
-    "Python SDK": "dced9623-7411-41a3-83f3-3ce817b02cf6"
-    "Multi-turn Ensembles": "2e1ab59e-2806-4d99-96d0-074bbfd1adb4"
-    "SOTA Hunt": "2f3ff3a5-8147-4aad-856c-84dea081fde3"
-    "Compute Budgeting": "81708f79-1d29-4103-b61c-8d23a221ffd7"
-  landing:  # WHERE the work lands — multi-value plain labels; app/desktop + app/cli at name lock
-    "app/aigateway": "70c87650-e737-49e5-8e5e-09d4c9649fab"
-    "app/scoreboard": "035ce6ac-dc2b-4560-86ae-fe93807702b0"
-    "pkg/url4-python-sdk": "65e0b370-12c8-45e4-9b9d-0fb5fe72bac8"
-    "repo": "89353e43-30b4-4e4b-b0a6-d781f9dcfebc"
-  stop:  # D12: STOPs are labels + comment (issue stays In Progress), never new states
-    "blocked ⛔": "f97992bc-7374-44fb-abca-2faf289f915f"
-    "needs-owner": "b2542eee-1aa6-4af3-8b9d-41baa3618fd8"
-  who_acts:  # Linear group — one per issue
-    group: "a5829dd1-ee74-4212-9641-1b3c198778ac"
+labels:  # RECONCILED 2026-07-15 (OME-443) vs live Linear (list_issue_labels). See reconciliation note at bottom.
+  # Product/landing axis — live Linear groups product areas under parent labels (app/pkg/research/extra).
+  # There is NO live "Epic" workstream group anymore; the product area IS the app/* (or research/*) landing label.
+  landing:
+    "aigateway": "f92de050-b7ec-41fe-a14a-d30c0d0be267"              # parent: app
+    "aigateway/deployment": "874aa881-360e-4362-b80a-39c2ae823d97"  # parent: app
+    "scoreboard": "3f8aa7fc-e9a0-461f-8a6b-0bf2dd7cf4d9"            # parent: app
+    "url4-engine": "b9bdd9c0-b03b-47e0-86c9-b3f45305212a"          # parent: app — url4 grammar/parser/DAG exec + cloud runner (apps/runner) until an app/runner label exists
+    "desktop": "cef9d753-9675-4f7d-8ae7-afc7af802887"              # parent: app
+    "desktop/benchmarks": "53bb9d19-95a2-4479-9acd-6ea6423ae251"    # parent: app
+    "desktop/ensemble": "d55512f6-389d-4fc4-877a-6a6be434c4c1"      # parent: app
+    "desktop/eval-runner": "543fbbde-bdd5-430b-8ecd-26f33628bdc3"   # parent: app
+    "desktop/results-runs": "d0e1871e-db73-4ba6-bc7a-fcbfde515e40"  # parent: app
+    "py-screamingface": "8d3dd8bd-5365-4ab7-90d5-9e5317cf3157"      # parent: pkg
+    "url4-python-sdk": "05d3d132-d508-4540-be46-4d10303e117a"       # parent: pkg
+    "multi-turn": "b6926d8f-8693-45a1-bf08-0847bc516e04"            # parent: research
+    "sota": "fad181c4-2834-47e1-9d4d-5b36c9000a49"                  # parent: research
+    "repo-dev-processes": "220d479a-98b5-4b94-95ee-92635db5f0ae"    # parent: extra
+    "auth+subsidies": "8c34e37b-f78f-4983-ae62-8f97ba26c28f"        # parent: extra
+    "repo": "89353e43-30b4-4e4b-b0a6-d781f9dcfebc"                  # ungrouped (process; coexists with repo-dev-processes)
+    "pkg/url4-python-sdk": "65e0b370-12c8-45e4-9b9d-0fb5fe72bac8"   # ungrouped (coexists with url4-python-sdk under pkg)
+    "syft-space": "55b0b894-9717-4a82-9e40-aba3d01922cd"           # ungrouped
+  who_acts:  # Linear group "who-acts" — one per issue (members verified 2026-07-15)
     "design-session": "b23148b7-7779-415d-b1c8-5480fa967067"
     "autonomous": "6c277f7f-e4b3-41c6-b1ba-406781bb84ed"
     "deferred": "24c84d24-251d-42d0-ba0f-d0c174a68809"
-  actor:  # Linear group — MANDATORY, one per issue (D13)
-    group: "4060acd7-9bee-41dc-9e45-da9b432d6f89"
+  actor:  # Linear group "actor" — MANDATORY, one per issue (D13) (members verified 2026-07-15)
     "agentic": "836136d4-994f-457a-9e5e-7f14cf15b4f1"
     "human": "6bb84ba1-b63e-43d6-a061-b80db8565ecf"
-  type_ish:  # existing plain labels, optional tagging
-    "Bug": "834f8e74-7b87-4af7-a8a7-2462451c4b42"
-    "Feature": "67b0111f-30e1-4aa1-bc7f-8ca8f3880890"
-    "Improvement": "923adfec-c4eb-4108-ad1b-aefb3e3bd72a"
+  type:  # Linear group "type" — optional tagging (replaced the former Bug/Feature/Improvement)
+    "decision": "89f24a1e-50fe-43c6-8ba9-bcf0f25d6ab7"  # a LOCKED decision (contract frozen), not code
+    "task": "5fc84240-25d2-4893-85b7-9e12bb0db207"       # mechanical/housekeeping/research — no product behavior change
+  # ── Reconciliation note (2026-07-15, OME-443) ─────────────────────────────────────────────
+  # Labels present in the PRIOR card but ABSENT from live Linear (verified via list_issue_labels):
+  #   - epic_group workstreams (url4 Engine, AI Gateway, Eval Runner & Datasets, Results & Runs,
+  #     Leaderboard, Auth & Subsidized Compute, Desktop App, Python SDK, Multi-turn Ensembles,
+  #     SOTA Hunt, Compute Budgeting): the "Epic"/workstream axis no longer exists; product area
+  #     folded into the app/* + research/* landing labels above.
+  #   - type_ish Bug / Feature / Improvement: replaced by type decision / task.
+  #   - STOP labels "blocked ⛔" and "needs-owner": DO NOT EXIST. The D12 STOP mechanism below is
+  #     currently unbacked. OWNER ACTION: recreate these two labels in the Linear UI, or switch the
+  #     D12 rule to another signal. Until then, record a STOP as a `design-session`/`deferred`
+  #     label + a comment stating the exact question.
+  #   - landing app/aigateway, app/scoreboard IDs were stale; live labels are aigateway / scoreboard
+  #     (parent "app"). repo and pkg/url4-python-sdk IDs were correct and are retained.
+  # who_acts/actor `group:` parent IDs from the prior card were dropped (unverified + unused for
+  # filing, which resolves by member label). Re-add if a group-level operation ever needs them.
 priority: { P1: 2, P2: 3, P3: 4 }  # Linear ints; 1 (Urgent) reserved for incidents
 close_template: |
   Commits: <sha> <message>[, …]

--- a/docs/plan/2026-07-15-url4-cloud-runner.md
+++ b/docs/plan/2026-07-15-url4-cloud-runner.md
@@ -1,0 +1,89 @@
+# url4 Cloud Runner — Implementation Plan
+
+**Ticket:** OME-443 (epic) · **Spec:** `docs/spec/2026-07-15-url4-cloud-runner-spec.md`
+**Goal:** Ship a cloud service that executes url4 ensemble DAGs as long-running (>15 min) distributed jobs — FastAPI control plane (`apps/runner`, port 9107), Docker/k8s `JobRunner` substrate, NATS JetStream event streaming, Postgres session/node state, session tokens, owned-internal vs external node split — delivered single-node-first, then recursion, liveness, external nodes, and k8s/Helm.
+**Architecture:** Wrap the in-process url4 `Executor`; distribute only across `IOLayer.fetch` edges that resolve to internal child sessions (in-process map/lazy/guard stay in-worker with a node-level stop channel). Control plane = trust authority only; clients consume NATS-over-WS directly. See spec §2.
+**Tech stack:** Python 3.12 · uv · hatchling (src-layout) · FastAPI + Pydantic settings · Tortoise ORM (SQLite-local / Postgres-hosted) · NATS JetStream · docker SDK / kubernetes client · pytest + testcontainers · ruff + pyright. Reuses aigateway/scoreboard `create_app`/`db.py`/Dockerfile/Helm patterns.
+
+## Phase P0 — Foundations
+- [ ] **Scaffold `apps/runner`.** src-layout, `create_app`/`_lifespan`, `config.py` (Pydantic, `RUNNER_` prefix), `cli.py`, two-stage uv Dockerfile, `runner-tests.yml` CI lane, CODEOWNERS, dependabot ecosystem, `.claude/sdlc.local.md` stack entry.
+- [ ] **docker-compose local-dev infra.** NATS JetStream + Postgres + control-plane + worker image, healthchecks, one-command bring-up + README.
+
+## Phase SDK — url4 execution seams (`packages/url4`)
+- [ ] **SDK seams (spec §11).** Execution-observation hook (no memo-hot-path touch) · W3C trace/span propagation through `spawn`/`child` · node-level sub-session stop/telemetry channel (in-process map/lazy/guard observable + killable) · streaming-transport extension point. No `spawn` distribution in v1. Grammar-owner review.
+
+## Phase P1 — Single-node happy path (v1)
+- [ ] **Session/node state + Store.** scoreboard-style abstract-Base + domain `Store` Protocol (NOT the credential AES `ORMStore`); **absorbing terminal + single-writer CAS** (spec §3); Tortoise migrations.
+- [ ] **Token + scoped NATS creds.** Hierarchical subject path + descendants-only `>` grant; lineage-from-authed-token; depth/spawn budget; short control-JWT exp + `/refresh`; NATS-JWT exp = `activeDeadlineSeconds`; revoke-on-terminal (spec §5).
+- [ ] **Event envelope + JetStream.** One stream per `trace_id`; **stream-seq dedup**; durable terminal events; `cost.usage` self/subtree with store-side authoritative sum; traceparent-rooted spans (spec §6).
+- [ ] **JobRunner port + Docker adapter.** **Run-once/no-restart** contract; `poll_terminal()` enum + exit; idempotent `stop()`; control-plane watchdog timeout floor (spec §7).
+- [ ] **Worker runtime.** url4 `Executor` on one subtree; NATS pub `.out`/sub `.in`; heartbeat; observation-hook→events; node-level stop wiring.
+- [ ] **Control-plane REST + client NATS-over-WS delivery.** schedule/execute/stop/refresh/status; read-scoped `trace.<id>.node.>` cred to the client; **no WS bridge** (spec §4).
+- [ ] **Docker-compose end-to-end validation.** schedule → attach (NATS-over-WS) → execute → stream logs/telemetry/cost → terminal; testcontainers (NATS+Postgres) + compose smoke; crash-after-success conformance.
+
+## Phase P2 — Recursion (internal children)
+- [ ] **InternalNodeAdapter.** control-plane-only child scheduling; lineage+traceparent from token; consume-only cost fold (no re-publish); **per-tree container-budget admission** (fail-fast); orphan stop-cascade; typed-error passthrough for Guard (spec §8).
+- [ ] **Recursion e2e.** nested ensemble; whole-tree subscription via `trace.<id>.node.>`; cost roll-up authority + span-tree conformance.
+- [ ] **(follow-up) Non-blocking detached-continuation recursion.** break the parent-blocks-on-child limit (deferred).
+
+## Phase P3 — Liveness & death
+- [ ] **Full liveness/death.** 3 signals unified; **singleton reaper** (advisory lock / durable consumer); **fencing** (reject post-terminal publishes); stop-cascade to descendants (spec §9).
+
+## Phase P4 — External nodes & scale limits
+- [ ] **ExternalNodeAdapter.** url4 `GET` only; no lifecycle; cost `UNKNOWN` (not `$0`); best-effort `Link`-header telemetry (spec §10).
+- [ ] **Per-trace concurrency budget** at the aigateway boundary (token-bucket/lease keyed by trace) + content-addressed result-cache hook.
+
+## Phase P5 — Kubernetes & Helm
+- [ ] **K8sJobAdapter.** `backoffLimit:0`/`restartPolicy:Never`; terminal enum from Job conditions + pod reason; `stop()`=delete `propagationPolicy=Background`+grace+reconcile; `logs()/tail()`.
+- [ ] **Helm chart.** clone scoreboard `charts/<app>` + `charts/db`; NATS dependency; deployment/service/ingress/configmap/secret/job-migrate/networkpolicy.
+- [ ] **Helm local-dev validation.** kind/minikube: `helm lint` + `helm template` + install + migrate job + one run through the k8s adapter.
+- [ ] **Release lane.** release-please python entry or manual `runner-v*` tag + `release-runner.yml` (GHCR image + Helm publish).
+
+## Phase process
+- [ ] **Reconcile `.claude/task-board.local.md`** label taxonomy vs live Linear (done this session; closes on commit).
+
+## Ticket cascade (Linear, under OME-443)
+_Filed — IDs below. Landing `url4-engine` unless noted `pkg/url4-python-sdk` (SDK) or `repo` (process); who-acts `autonomous` (·`deferred` for the follow-up); actor `agentic`._
+
+| Phase | Deliverable | OME-# |
+|---|---|---|
+| P0 | Scaffold apps/runner + CI/CODEOWNERS/dependabot/sdlc entry | _(filing)_ |
+| P0 | docker-compose local-dev infra | _(filing)_ |
+| SDK | url4 execution seams (observability + node-stop + traceparent + transport ext) | _(filing)_ |
+| P1 | Session/node state + Store (absorbing terminal CAS) | _(filing)_ |
+| P1 | Token + scoped NATS creds | _(filing)_ |
+| P1 | Event envelope + JetStream | _(filing)_ |
+| P1 | JobRunner port + Docker adapter | _(filing)_ |
+| P1 | Worker runtime | _(filing)_ |
+| P1 | Control-plane REST + NATS-over-WS delivery | _(filing)_ |
+| P1 | Docker-compose e2e validation | _(filing)_ |
+| P2 | InternalNodeAdapter recursion (+ admission budget + orphan cascade) | _(filing)_ |
+| P2 | Recursion e2e | _(filing)_ |
+| P2 | (follow-up) non-blocking continuation | _(filing)_ |
+| P3 | Full liveness/death (reaper singleton + fencing) | _(filing)_ |
+| P4 | ExternalNodeAdapter | _(filing)_ |
+| P4 | Per-trace concurrency budget + result cache hook | _(filing)_ |
+| P5 | K8sJobAdapter | _(filing)_ |
+| P5 | Helm chart | _(filing)_ |
+| P5 | Helm local-dev (kind) validation | _(filing)_ |
+| P5 | Release lane | _(filing)_ |
+| process | Reconcile stale task-board card | _(filing)_ |
+
+## Non-goals / follow-ups
+Distributing in-process fan-out; non-blocking recursion (P2 follow-up); external-GET `Link` telemetry contract (P4); `logs()/tail()` k8s semantics (P5); N1 Enclave GET cache + doctrine F4 (deferred, owner). See spec §14.
+
+## Risks (and how they were retired by the 6-lens validation)
+| Risk | Retired by |
+|---|---|
+| Recursion deadlock (container-per-live-node hold-and-wait) | Per-tree container-budget admission at schedule; blocking recorded as a named limit (spec §8.2). |
+| Terminal-state corruption (exit-0 clobbered to dead; stop-vs-result race) | Absorbing terminal + single-writer CAS; result-vs-death disambiguation (spec §3). |
+| Trace-wide read/forge via `node.*`; cross-trace escalation; cost bomb | Lineage-in-path subjects + descendants-only `>`; lineage-from-token; depth budget (spec §5). |
+| k8s `backoffLimit` default re-executes subtree → double-bill + orphans | JobRunner run-once contract; retry = new session/new trace_id (spec §7). |
+| "Single seam" false — in-process maps invisible/unkillable | Fetch-edges-only granularity + node-level stop channel (spec §2.2, §11). |
+| Duplicate cost, undefined roll-up owner, invalid dedup key | Consume-only parents; store-side `self`-sum authority; JetStream stream-seq dedup (spec §6). |
+| Reconnecting subscriber hangs (terminal not durable) | Durable terminal publish to the replay subject (spec §6.2). |
+| Partitioned worker resurrects output | Heartbeat-reap fences (stop + terminal + ingress rejection) (spec §9). |
+| Reaper races across web replicas | Singleton reaper (advisory lock / durable consumer) (spec §9). |
+| Control plane on the hot path it claims to be off | Client consumes NATS-over-WS directly; bridge deleted (spec §4). |
+| Replayable bearer token in WS query string | Short exp + `/refresh` + state-check + revocation; header/ticket, not query (spec §5). |
+| `ORMStore` misused for non-secret state | scoreboard-style abstract-Base + domain Protocol (spec §2.1). |

--- a/docs/plan/2026-07-15-url4-cloud-runner.md
+++ b/docs/plan/2026-07-15-url4-cloud-runner.md
@@ -47,27 +47,27 @@ _Filed — IDs below. Landing `url4-engine` unless noted `pkg/url4-python-sdk` (
 
 | Phase | Deliverable | OME-# |
 |---|---|---|
-| P0 | Scaffold apps/runner + CI/CODEOWNERS/dependabot/sdlc entry | _(filing)_ |
-| P0 | docker-compose local-dev infra | _(filing)_ |
-| SDK | url4 execution seams (observability + node-stop + traceparent + transport ext) | _(filing)_ |
-| P1 | Session/node state + Store (absorbing terminal CAS) | _(filing)_ |
-| P1 | Token + scoped NATS creds | _(filing)_ |
-| P1 | Event envelope + JetStream | _(filing)_ |
-| P1 | JobRunner port + Docker adapter | _(filing)_ |
-| P1 | Worker runtime | _(filing)_ |
-| P1 | Control-plane REST + NATS-over-WS delivery | _(filing)_ |
-| P1 | Docker-compose e2e validation | _(filing)_ |
-| P2 | InternalNodeAdapter recursion (+ admission budget + orphan cascade) | _(filing)_ |
-| P2 | Recursion e2e | _(filing)_ |
-| P2 | (follow-up) non-blocking continuation | _(filing)_ |
-| P3 | Full liveness/death (reaper singleton + fencing) | _(filing)_ |
-| P4 | ExternalNodeAdapter | _(filing)_ |
-| P4 | Per-trace concurrency budget + result cache hook | _(filing)_ |
-| P5 | K8sJobAdapter | _(filing)_ |
-| P5 | Helm chart | _(filing)_ |
-| P5 | Helm local-dev (kind) validation | _(filing)_ |
-| P5 | Release lane | _(filing)_ |
-| process | Reconcile stale task-board card | _(filing)_ |
+| P0 | Scaffold apps/runner + CI/CODEOWNERS/dependabot/sdlc entry | OME-444 |
+| P0 | docker-compose local-dev infra | OME-445 |
+| SDK | url4 execution seams (observability + node-stop + traceparent + transport ext) | OME-446 |
+| P1 | Session/node state + Store (absorbing terminal CAS) | OME-447 |
+| P1 | Token + scoped NATS creds | OME-448 |
+| P1 | Event envelope + JetStream | OME-449 |
+| P1 | JobRunner port + Docker adapter | OME-450 |
+| P1 | Worker runtime | OME-451 |
+| P1 | Control-plane REST + NATS-over-WS delivery | OME-452 |
+| P1 | Docker-compose e2e validation | OME-453 |
+| P2 | InternalNodeAdapter recursion (+ admission budget + orphan cascade) | OME-454 |
+| P2 | Recursion e2e | OME-455 |
+| P2 | (follow-up) non-blocking continuation | OME-456 |
+| P3 | Full liveness/death (reaper singleton + fencing) | OME-457 |
+| P4 | ExternalNodeAdapter | OME-458 |
+| P4 | Per-trace concurrency budget + result cache hook | OME-459 |
+| P5 | K8sJobAdapter | OME-460 |
+| P5 | Helm chart | OME-461 |
+| P5 | Helm local-dev (kind) validation | OME-462 |
+| P5 | Release lane | OME-463 |
+| process | Reconcile stale task-board card | OME-464 |
 
 ## Non-goals / follow-ups
 Distributing in-process fan-out; non-blocking recursion (P2 follow-up); external-GET `Link` telemetry contract (P4); `logs()/tail()` k8s semantics (P5); N1 Enclave GET cache + doctrine F4 (deferred, owner). See spec §14.

--- a/docs/spec/2026-07-15-url4-cloud-runner-spec.md
+++ b/docs/spec/2026-07-15-url4-cloud-runner-spec.md
@@ -1,0 +1,126 @@
+---
+title: url4 Cloud Runner — technical specification (apps/runner, v1)
+status: proposed — design validated by a 6-lens adversarial review (2026-07-15); implementation not started
+created: 2026-07-15
+author: Claude (Opus 4.8) + Sergey
+ticket: OME-443
+related:
+  - https://linear.app/openmined/issue/OME-443/url4-cloud-runner-distributed-long-running-execution-service-epic
+  - docs/plan/2026-07-15-url4-cloud-runner.md
+  - .claude/skills/url4-engine/SKILL.md (execution & telemetry doctrine — PROPOSED)
+  - packages/url4/ (the in-process engine this service wraps)
+---
+
+# url4 Cloud Runner — technical specification (v1)
+
+## 0. Status
+Proposed. The design was hardened by a 6-lens adversarial validation (distribution, liveness, security, docker↔k8s parity, doctrine conformance, hexagonal/repo-fit) that produced 5 must-fix + 12 should-fix corrections, all folded in below. Owner-approved forks are recorded in §14. Implementation starts per the plan only on explicit approval.
+
+## 1. Purpose & scope
+### 1.1 What it is
+A cloud service that executes **url4 ensemble DAGs as long-running (>15 min) distributed jobs**. It wraps the existing single-process url4 SDK `Executor` and adds the distributed machinery the SDK deliberately lacks: a REST control plane, session/node state, a container job substrate, a durable event bus, session tokens, liveness, and an owned-internal vs external node distinction.
+
+### 1.2 What it provides
+- **Control plane** (`apps/runner`, FastAPI, port 9107): schedule / execute / stop / status over REST; mints session tokens + subject-scoped NATS credentials; hosts the liveness reaper.
+- **Worker** (container image): runs the url4 `Executor` over one node subtree in-process; publishes telemetry to NATS; consumes stop; heartbeats.
+- **`JobRunner` port** with **Docker** and **k8s-`Job`** adapters (one interface, >15 min, run-to-completion).
+- **NATS JetStream**: durable, replayable event log + control channel; clients consume events over NATS-over-WebSocket directly.
+- **Postgres** (Tortoise): session/node state + terminal results.
+
+### 1.3 Non-goals (v1)
+Distributing in-process fan-out (map/lazy/guard) across workers (§6.2); non-blocking recursion (§8.3); k8s/Helm (phase P5); external-node telemetry beyond a best-effort `Link` header (§10, deferred); a url4-native GET/Enclave cache (doctrine N1, deferred — §14).
+
+## 2. Architecture
+### 2.1 Components
+| Component | Responsibility | Reuses |
+|---|---|---|
+| Control plane | REST schedule/execute/stop/status; token + NATS-cred minting; **trust authority only, off the per-event hot path**. | scoreboard `create_app`/`_lifespan`, Pydantic settings, Tortoise `db.py` |
+| Reaper | Singleton liveness component (not a web-process side-effect) — §9. | Postgres advisory lock / JetStream durable consumer |
+| Worker | url4 `Executor` on one subtree; NATS pub `.out`/sub `.in`; heartbeat; node-level stop. | `packages/url4` `run()` + new SDK observation hook |
+| JobRunner | Run one long container to completion, **run-once** (§7). | docker SDK / kubernetes client |
+| NATS JetStream | Durable event log + control + client delivery transport. | — |
+| Postgres | Session/node state registry + terminal results. | aigateway/scoreboard Tortoise pattern (plain abstract-Base, **not** the credential AES `ORMStore`) |
+
+### 2.2 Distribution granularity (corrected)
+The unit of remote execution is a url4 **sub-expression/subtree** run in-process by the existing `Executor`. **Remote distribution occurs only across `IOLayer.fetch` edges that resolve to an internal child session.** In-process fan-out — `MapNode`/`LazyExprNode`/`GuardNode` via `ctx.spawn`/`ctx.execute_node` (local cap `DEFAULT_MAP_CONCURRENCY=8`) — **stays inside one worker** in v1. Each worker is sized for whole-map in-process load, and the SDK exposes a **node-level sub-session telemetry/stop channel** so a runaway in-process map is still observable and killable from the control plane. The earlier "single seam" claim is retracted; the engine's memo table, `TaskGroup`, semaphores, and `Context` chain remain strictly per-worker.
+
+## 3. Session & node state machine
+States: `scheduled → starting → running → {succeeded | failed | dead | stopped | timed_out}`.
+- **Terminal states are absorbing.** Exactly one non-terminal→terminal transition per session, behind a **single-writer compare-and-swap** (`UPDATE … WHERE status IN (<non-terminal>) RETURNING` — scoreboard's optimistic pattern). First terminal wins; every later signal (duplicate delivery, container-exit, late heartbeat) attaches diagnostics only.
+- **`result` vs death disambiguation.** Container-exit is not "dead": exit-0 within grace of a durably-committed `result` **confirms** `succeeded`; non-zero with no committed terminal → `failed`. A committed `result` beats a concurrent stop (late result after commit → no-op; stop before any committed result → `stopped`, late result dropped).
+- Conformance: *crash-after-success yields exactly one terminal transition and one subtree cost total.*
+
+## 4. Control-plane API
+- `POST /sessions` `{url4, ownership}` (+ authenticated parent token on recursion) ⇒ `{session_id, node_id, trace_id, token, subjects, nats_read_cred, exp}`. `trace_id`, `ownership`, and lineage on a child are taken **from the authenticated parent token, never the request body** (§5).
+- `POST /sessions/{id}/execute` — start the run.
+- `POST /sessions/{id}/stop` — publish stop to the node's `.in` + `JobRunner.stop()`; rejected (no-op) against a terminal session.
+- `POST /sessions/{id}/refresh` — re-issue the short-lived control token **iff** the session is still live (§5).
+- `GET /sessions/{id}` — state/status.
+- **Client event delivery:** the client consumes events over **NATS-over-WebSocket** using a read-scoped `trace.<id>.node.>` credential minted by the control plane. There is **no** control-plane WS relay (FastAPI stays off the hot path; deletes a hand-rolled pump).
+
+## 5. Token & NATS subject model
+- **Subjects encode lineage in the path:** `trace.<trace_id>.node.<ancestor>…<self>.out` / `.in`. A parent's subtree read grant is the **`>` multi-token wildcard** on its own path — matching **descendants only, never siblings**. Per-node worker creds carry **no `node.*`** wildcard (which would grant trace-wide read + forge). The trace-wide read (`trace.<id>.node.>`) is minted **only** for the client / durable aggregator.
+- **Token = signed JWT** `{session_id, node_id, trace_id, subject_prefix, scope, depth_budget, exp}`. Lifetimes are decoupled: a **short-exp (~5 min) control JWT** (refreshed via `POST /refresh`, which also re-checks liveness) + a **NATS user-JWT whose exp = `activeDeadlineSeconds`**. Every token check is also a **state check** — WS-connect and child-schedule are rejected against any terminal session; on terminal transition the NATS user is added to the account **revocation list**. The WS credential is carried in a header / short-lived socket ticket, **never** a query string.
+- **Child-schedule authorization:** the control plane derives the child's `trace_id`/`ownership` from the parent token, verifies `parent_session_id == token.session_id`, and refuses when the decrementing **`depth_budget`/`spawn_budget`** claim hits zero (prevents a compromised leaf from spawning a cost bomb; doctrine N4).
+
+## 6. Event & telemetry model
+### 6.1 Signals & envelope
+One `trace_id` per tree. Envelope `{trace_id, span_id, parent_span_id, session_id, node_id, type, ts, stream_seq, payload}`. Three deliberately-separate signals (doctrine O2): `log`, `span` (OTel GenAI `gen_ai.*`, token counts), `cost.usage` (separate taxonomy, `self`/`subtree`). Plus `heartbeat`, lifecycle (`started`, `sigterm`, `terminated`), `result`.
+- **W3C traceparent** is threaded through `POST /sessions` into the child token; a child roots its top span on the parent's fetch-span context and stamps the correct `parent_span_id` (fixes fan-out children collapsing under the session root).
+### 6.2 Delivery & dedup
+- **One JetStream stream per `trace_id`**; the message's **stream sequence** is the dedup identity (forwarded verbatim into the envelope). The app-level `(trace_id, span_id, seq)` idea is discarded (span_id isn't unique per envelope; app-seq isn't unique across per-node publishers).
+- **Durable terminals.** The reaper publishes the terminal envelope **durably to the same subject the client replays** (not just live-relayed) — a replay from seq 0 must always reach a terminal marker; the live path is a latency optimization only (doctrine F2 applied to lifecycle).
+### 6.3 Cost authority
+Under flat direct-publish, a parent is **consume-only**: it subscribes a child's `.out` solely to (a) return the payload to its `Executor` and (b) fold the child's `cost.usage{subtree}` into its own roll-up — it **never re-publishes** child events (doctrine F1 per-hop relay is superseded for the runner). The **authoritative money figure is the store-side sum of `cost.usage{scope:self}`**, deduped by an id that includes scope; parent `subtree` events are advisory. Ordering: a node publishes `result` **after** its `cost.usage{subtree}`.
+
+## 7. JobRunner port
+Contract: **run one container to completion, exactly once — no substrate-level restart.** k8s `backoffLimit: 0` + `restartPolicy: Never`; Docker no `--restart`. Retry is a **control-plane operation that mints a new session with a new `trace_id`** (in-memory url4 state makes in-place re-execution non-idempotent → double-bill + orphan fan-out).
+- `poll_terminal()` returns an enum `{succeeded, failed, timed_out}` + `exit_code`, reconciled **every tick and on startup** (a k8s watch is a latency layer, not the sole source). k8s maps `Job.status.conditions` then pod `terminated.reason` (`Completed`→succeeded, `OOMKilled`/`Error`→failed, `DeadlineExceeded`→timed_out).
+- `stop()` is **idempotent** and tolerant of an already-gone container; k8s deletes with `propagationPolicy=Background` + `gracePeriodSeconds` and reconciles the pod is gone before declaring `stopped`.
+- A **control-plane watchdog** is the timeout floor for **every** adapter (Docker has no native timeout).
+- `logs()/tail()` is an explicit port method with per-adapter guarantees (deferred detail to P5 — §14).
+- Conformance on **both** adapters: a worker crash yields exactly one terminal + one subtree cost total; clean/non-zero/OOM/deadline map to equal terminal enums.
+
+## 8. Recursion (internal children)
+### 8.1 Mechanism
+`InternalNodeAdapter.fetch` for an internal child expr: `POST /sessions` (lineage from the parent token) → subscribe the child's `.out` (descendants-only grant) → `POST execute` → consume-only cost fold (§6.3) → return the final payload to the `Executor`. External children: §10.
+### 8.2 Capacity (owner-approved: blocking + admission)
+Recursion is **blocking** (a parent's `fetch` awaits the child's whole run), so peak demand = **simultaneously-live-node count (~N), not the leaf frontier**. To prevent hold-and-wait deadlock, the control plane makes an **all-or-nothing per-tree container-budget reservation at schedule time** (fail-fast if it would exceed cap C). Parent-blocks-on-child is a **named scaling limit**.
+### 8.3 Cancellation & orphans
+`InternalNodeAdapter.fetch` wraps subscribe/await in `try/finally`; on `CancelledError`/timeout it **synchronously stops the child before re-raising**, and the control plane cascades the stop to the child's descendants (idempotent). `parent_session_id` is a persisted FK; on **any** terminal transition the reaper enumerates live descendants and stops each. Child failures are serialized back as the **original `Url4Error` subclass** (`.code`/`.permanent` intact) so `GuardNode` retry/optional/quorum behaves as in-process.
+
+## 9. Liveness & death
+Three independent signals: (a) **heartbeat timeout** (no `.out` heartbeat within deadline), (b) explicit **`sigterm`/`terminated`**, (c) **`JobRunner.poll_terminal()`** reports exit. The **reaper is a singleton component** (own single-replica deployable **or** every sweep gated behind a Postgres advisory lock / single-consumer JetStream durable) — never an implicit FastAPI-lifespan side-effect racing across web replicas. Heartbeat-timeout reap **fences**: it calls `JobRunner.stop()` with the terminal transition, and the NATS ingress rejects publishes for an already-terminal session (per-session fencing epoch) so a partitioned-but-alive worker cannot resurrect output after the partition heals. All transitions go through the §3 absorbing CAS.
+
+## 10. Owned-internal vs external nodes
+`NodePort` with two adapters; ownership is decided at schedule (from the authenticated context). **Internal** = full lifecycle + NATS telemetry + stop. **External** = url4 `GET` only, no lifecycle control; telemetry is best-effort via the RFC 8288 `Link: /traces/{id}` header, and a non-streaming external node's cost is recorded **`UNKNOWN`, never `$0`** (avoids silently undercounting the tree total). Full external-telemetry contract is P4 (§14).
+
+## 11. SDK seams (packages/url4)
+Added to the SDK as **ports** (core never imports runner adapters): (1) an **execution-observation hook** on `ExecutionContext` surfacing node start/end + logs/spans/cost **without touching the memo hot path**; (2) **W3C trace/span context** propagation through `spawn`/`child`; (3) a **node-level sub-session stop/telemetry channel** so in-process map/lazy/guard subtrees are observable and killable (§2.2); (4) a **streaming-capable transport extension point** the runner's Internal/External adapters plug into. v1 does **not** distribute `spawn`/`execute_node`. SDK public-surface changes get grammar-owner (CODEOWNERS) review.
+
+## 12. Deployment & phasing
+- **P0** scaffold `apps/runner` (src-layout, `create_app`, config, cli, two-stage uv Dockerfile, CI test lane, CODEOWNERS, dependabot, `.claude/sdlc.local.md` entry) · docker-compose (NATS JetStream + Postgres + control-plane + worker).
+- **SDK** the §11 seams.
+- **P1 (v1)** state+store · token+NATS creds · events+JetStream · JobRunner+Docker · worker · control-plane REST + NATS-over-WS delivery · **docker-compose e2e validation**.
+- **P2** internal recursion (adapter + admission budget + orphan cascade + traceparent) · recursion e2e · (follow-up) non-blocking continuation.
+- **P3** full liveness/death (3 signals + singleton reaper + fencing).
+- **P4** external-node adapter · per-trace concurrency budget at the aigateway boundary + content-addressed result cache hook.
+- **P5** k8s Job adapter · Helm chart · **Helm local-dev (kind/minikube) validation** · release lane.
+
+## 13. Testing & conformance
+TDD. Unit: JobRunner adapters (fake docker/k8s), token sign/verify + scope/lineage, event envelope + stream-seq dedup, absorbing-terminal CAS, reaper with fake clock + fencing. Integration: **testcontainers** for NATS + Postgres; **docker-compose e2e** for the single-node happy path; **kind/minikube** for the Helm path. Conformance suite: crash-after-success (one terminal, one cost total), fan-out span-tree via traceparent, cost roll-up authority, stop-cascade to descendants, both-adapter terminal-enum parity.
+
+## 14. Out of scope / deferred (documented so they are not re-litigated)
+- **Distributing in-process fan-out** (map/lazy/guard) — v1 keeps it in-worker (owner-approved fork; §2.2).
+- **Non-blocking recursion** — blocking + admission budget in P2; detached-continuation is a P2 follow-up (owner-approved fork; §8.2).
+- **External-GET `Link`-header telemetry return** (doctrine T2/F3) — locked in P4; record `UNKNOWN` until then.
+- **JobRunner `logs()/tail()`** per-adapter guarantees — P5 (k8s pod-log semantics differ from docker).
+- **Doctrine fork F4** (GET-leaf telemetry return) stays OPEN; runner-v1 has **no** url4-native GET leaf. The **N1 Enclave GET cache** is omitted (fresh container per session) — recorded as an explicit doctrine deviation for the owner, not hardcoded.
+- **Diamond-dep span attribution** (a memoized node with ≥2 demand-parents) — grand total stays correct; per-node attribution refinement (OTel span links + canonical parent) is later work.
+
+## 15. Decisions locked (owner-approved)
+1. Substrate = `JobRunner` port + Docker/k8s-`Job` adapters (not Temporal/Argo), **run-once**.
+2. NATS = hybrid; FastAPI mints subject-scoped creds; workers pub/sub JetStream directly; **client consumes NATS-over-WS directly** (no control-plane bridge).
+3. Child spawn = control-plane-only; lineage from the authenticated token; depth budget.
+4. v1 = single-node happy path; **remote granularity = fetch-edges only**; in-process fan-out stays in-worker with a node-level stop channel.
+5. Recursion = blocking + per-tree container-budget admission; continuation is a follow-up.

--- a/docs/tasks/2026-07-15-url4-cloud-runner.md
+++ b/docs/tasks/2026-07-15-url4-cloud-runner.md
@@ -1,0 +1,20 @@
+---
+id: OME-443
+linear_url: https://linear.app/openmined/issue/OME-443/url4-cloud-runner-distributed-long-running-execution-service-epic
+status: in_progress
+type: epic
+priority: P1
+labels: [url4-engine, pkg/url4-python-sdk, autonomous, agentic]
+created: 2026-07-15
+closed:
+---
+
+# OME-443 — url4 Cloud Runner (epic)
+
+Cloud service that executes url4 ensemble DAGs as long-running (>15 min) distributed jobs: a REST + WebSocket control plane (FastAPI, `apps/runner`, port 9107), a Docker/k8s `JobRunner` substrate, NATS JetStream event streaming, Postgres session/node state, session tokens, and an owned-internal vs external-uncontrolled node distinction.
+
+**Cross-cutting (D9):** lands in the new `apps/runner` service (labeled `url4-engine`) and in observability/streaming seams in `packages/url4` (`pkg/url4-python-sdk`). One sub-issue per SDLC unit.
+
+**Locked decisions:** JobRunner port + Docker/k8s-Job adapters (not Temporal/Argo) · hybrid NATS auth (FastAPI mints subject-scoped creds; workers pub/sub JetStream directly) · control-plane-only child spawn · v1 = single-node happy path.
+
+Spec `docs/spec/2026-07-15-url4-cloud-runner-spec.md` · Plan `docs/plan/2026-07-15-url4-cloud-runner.md` · Ledger `docs/work/2026-07-15-OME-443-url4-cloud-runner.md`. Sub-issues tracked in Linear under this epic.

--- a/docs/work/2026-07-15-OME-443-url4-cloud-runner.md
+++ b/docs/work/2026-07-15-OME-443-url4-cloud-runner.md
@@ -1,0 +1,34 @@
+---
+ticket: OME-443
+stack: repo
+status: in_progress
+started: 2026-07-15
+finished:
+---
+
+# OME-443 — url4 Cloud Runner (epic): spec, plan & ticket cascade
+
+## Intent
+Design → spec → plan the url4 Cloud Runner (a cloud service executing url4 ensemble DAGs as long-running >15 min distributed jobs: FastAPI REST+WS control plane in `apps/runner`, Docker/k8s `JobRunner` substrate, NATS JetStream event streaming, Postgres session/node state, session tokens, owned-internal vs external-uncontrolled node split). File the sub-issue cascade under this epic and reconcile the stale `.claude/task-board.local.md` label taxonomy against live Linear.
+
+## Planned changes
+- `docs/spec/2026-07-15-url4-cloud-runner-spec.md` — the technical spec (folds in the 6-lens validation findings).
+- `docs/plan/2026-07-15-url4-cloud-runner.md` — phased implementation plan.
+- `docs/tasks/2026-07-15-url4-cloud-runner.md` — Linear mirror for OME-443.
+- `.claude/task-board.local.md` — reconcile the `landing` + `type`/`epic_group` label axes to match live Linear IDs.
+- Linear: OME-443 epic (filed) + the SDLC-unit sub-issue cascade.
+
+## Test plan
+Planning unit — no product code. Validation = the 6-lens adversarial-review workflow (`wf_100c27c9-f4d`) + spec self-review + owner plan review before any implementation ticket starts.
+
+## Acceptance
+- Spec + plan written on branch `OME-443-url4-cloud-runner`.
+- Sub-issue cascade filed under OME-443 with verified-live labels (incl. explicit docker-compose and Helm local-dev validation tickets).
+- Card reconciled against live Linear.
+- Owner reviews and approves the plan.
+
+## Outcome (fill at the end — required before COMMIT)
+- **Actual files:** <tbd>
+- **Commits:** <tbd>
+- **Gates:** <tbd — planning unit; N/A or doc lint>
+- **Deviations:** <tbd>


### PR DESCRIPTION
## Summary
Planning artifacts for the **url4 Cloud Runner** epic ([OME-443](https://linear.app/openmined/issue/OME-443/url4-cloud-runner-distributed-long-running-execution-service-epic)) — a cloud service that executes url4 ensemble DAGs as long-running (>15 min) distributed jobs: a FastAPI control plane (`apps/runner`, port 9107), a Docker/k8s `JobRunner` substrate, NATS JetStream event streaming, Postgres session/node state, session tokens, and an owned-internal vs external-uncontrolled node distinction.

**Docs only — no product code.** Implementation lands via the phased sub-issue cascade under the epic.

## Contents
- `docs/spec/2026-07-15-url4-cloud-runner-spec.md` — technical spec; design hardened by a 6-lens adversarial validation (5 must-fix + 12 should-fix folded in).
- `docs/plan/2026-07-15-url4-cloud-runner.md` — phased plan (P0→P5) + ticket cascade + risk register.
- `docs/work/2026-07-15-OME-443-url4-cloud-runner.md` — work ledger · `docs/tasks/2026-07-15-url4-cloud-runner.md` — Linear mirror.
- `.claude/task-board.local.md` — reconciled the drifted label taxonomy against live Linear (the `Epic` workstream group, `Bug/Feature/Improvement` types, and `blocked/needs-owner` STOP labels no longer exist).

## Design decisions (owner-approved)
- `JobRunner` port + Docker/k8s-`Job` adapters (**run-once**), not Temporal/Argo.
- Hybrid NATS: FastAPI mints subject-scoped creds; workers pub/sub JetStream directly; **clients consume NATS-over-WS directly** (control plane off the hot path).
- Control-plane-only child spawn; lineage-in-subject-path security + depth budget.
- v1 = single-node happy path; remote granularity = fetch-edges only (in-process maps stay in-worker).
- Recursion = blocking + per-tree container-budget admission.

## Test plan
Planning docs — no runtime surface. Design validation was the 6-lens adversarial review (see the plan's risk register). Each implementation phase lands as its own SDLC-unit sub-issue with TDD + gates.

## Sub-issues
Cascade filed under [OME-443](https://linear.app/openmined/issue/OME-443/url4-cloud-runner-distributed-long-running-execution-service-epic); see the plan's cascade table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Goa3nEcThYrFhueEmUnUo2
