### PR TITLE
ci(url4): PyPI release CI/CD — Trusted Publishing + packaging metadata (OME-465)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,15 @@ updates:
       scoreboard-python:
         patterns: ["*"]
 
+  - package-ecosystem: "uv"
+    directory: "/packages/url4"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      url4-python:
+        patterns: ["*"]
+
   # Keep GitHub Actions pinned-version bumps current too (low volume).
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/release-url4.yml
+++ b/.github/workflows/release-url4.yml
@@ -1,0 +1,87 @@
+name: Release url4
+
+# Publishes the url4 SDK to PyPI when release-please pushes a `url4-v*` tag.
+#
+# Auth is PyPI Trusted Publishing (OIDC) — no stored token. Before the first real
+# publish an owner must, one time:
+#   1. reserve the `url4` project on PyPI and add a Trusted Publisher →
+#      owner/repo: OpenMined/screamingface, workflow: release-url4.yml, environment: pypi
+#   2. create the `pypi` GitHub Environment (optionally with required reviewers)
+# Until then verify+build still run (packaging is validated); only publish fails.
+
+on:
+  push:
+    tags: ["url4-v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. url4-v0.1.0)"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      tag: ${{ steps.v.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: v
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          VERSION="${TAG#url4-v}"
+          MANIFEST=$(awk -F'"' '/^version[[:space:]]*=/{print $2; exit}' packages/url4/pyproject.toml)
+          if [ "$MANIFEST" != "$VERSION" ]; then
+            echo "::error::tag $TAG implies version $VERSION but packages/url4/pyproject.toml reports $MANIFEST"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: verify
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/url4
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v8.1.0
+      - name: Build sdist + wheel
+        run: uv build --out-dir dist
+      - name: Validate metadata (twine check)
+        run: uvx twine check --strict dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: url4-dist
+          path: packages/url4/dist/
+          if-no-files-found: error
+
+  publish-pypi:
+    needs: [verify, build]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/url4
+    permissions:
+      id-token: write # OIDC token for PyPI Trusted Publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: url4-dist
+          path: dist/
+      - name: Publish to PyPI
+        # Trusted Publishing (OIDC) + PEP 740 attestations (on by default).
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/.github/workflows/url4-tests.yml
+++ b/.github/workflows/url4-tests.yml
@@ -19,6 +19,10 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
     defaults:
       run:
         working-directory: packages/url4
@@ -30,7 +34,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: uv sync
@@ -59,22 +63,36 @@ jobs:
         uses: dorny/test-reporter@v2
         if: always()
         with:
-          name: url4 Test Results
+          name: url4 Test Results (${{ matrix.python-version }})
           path: packages/url4/results.xml
           reporter: java-junit
 
       - name: Coverage report
         uses: orgoro/coverage@v3.2
-        if: always() && github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request' && matrix.python-version == '3.12'
         with:
           coverageFile: packages/url4/coverage.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           thresholdAll: 0.95
 
+  build:
+    name: Build & validate package
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/url4
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v8.1.0
+      - name: Build sdist + wheel
+        run: uv build --out-dir dist
+      - name: Validate metadata (twine check)
+        run: uvx twine check --strict dist/*
+
   cost:
     name: CI cost diff
     if: always()
-    needs: [test]
+    needs: [test, build]
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/docs/plan/2026-07-15-url4-pypi-release-cicd.md
+++ b/docs/plan/2026-07-15-url4-pypi-release-cicd.md
@@ -1,0 +1,73 @@
+# Plan — url4 SDK PyPI release CI/CD (OME-465)
+
+Spec: `docs/spec/2026-07-15-url4-pypi-release-cicd-spec.md`. Already on `main` (not this
+unit): release-please registration of `packages/url4`, the `url4-v*` tag, `url4-tests.yml`.
+
+## Step 1 — Package metadata (`packages/url4/`)
+
+- **`pyproject.toml`** — extend `[project]`:
+  - `readme = "README.md"`, `license = "Apache-2.0"`, `license-files = ["LICENSE"]`
+  - `authors = [{ name = "OpenMined" }]`
+  - `keywords = ["ai", "llm", "ensemble", "dag", "expression-protocol", "url4"]`
+  - `classifiers`: Development Status :: 3 - Alpha; Intended Audience :: Developers;
+    Programming Language :: Python :: 3 / 3.12 / 3.13; Operating System :: OS Independent;
+    Typing :: Typed
+  - `[project.urls]`: Homepage `https://screamingface.ai`, Repository
+    `https://github.com/OpenMined/screamingface`, Issues `.../issues`
+  - Do **not** add a `License ::` classifier (PEP 639 SPDX field supersedes it).
+- **`README.md`** (new) — title, one-liner, install (`pip install url4`), a runnable
+  quickstart (from `src/url4/__init__.py`'s docstring), a short feature list, license line.
+- **`LICENSE`** (new) — copy of the repo-root Apache-2.0 file.
+- **`src/url4/py.typed`** (new, empty) — PEP 561 marker.
+
+## Step 2 — Publish workflow `.github/workflows/release-url4.yml` (new)
+
+- `on: push: tags: ["url4-v*"]` + `workflow_dispatch` (input `tag`).
+- `permissions: contents: read` at top.
+- `verify` job → outputs `version`; asserts tag version == pyproject version
+  (awk the version, mirror `release-aigateway.yml`).
+- `build` job (`needs: verify`, `working-directory: packages/url4`) → `uv build --out-dir
+  dist` + `uvx twine check --strict dist/*` → `actions/upload-artifact` (`if-no-files-found:
+  error`).
+- `publish-pypi` job (`needs: [verify, build]`) → `environment: {name: pypi, url:
+  https://pypi.org/p/url4}`, `permissions: {id-token: write}`, download artifact to `dist/`,
+  `pypa/gh-action-pypi-publish@release/v1` (attestations default-on).
+
+## Step 3 — Harden `.github/workflows/url4-tests.yml`
+
+- `test` job: add `strategy.matrix.python-version: ["3.12", "3.13"]`,
+  `fail-fast: false`; parametrize `setup-python` + the test-report name.
+- New `build` job: checkout → setup-uv → `uv build --out-dir dist` (in `packages/url4`) →
+  `uvx twine check --strict dist/*`.
+- Leave coverage gate at 95% and the `cost` job unchanged.
+
+## Step 4 — Dependabot `.github/dependabot.yml`
+
+- Add a `uv` `updates` entry: `directory: "/packages/url4"`, weekly,
+  `open-pull-requests-limit: 5`, group `url4-python: patterns ["*"]`.
+
+## Verification (Step 5)
+
+Run in `packages/url4`:
+- `uv sync`
+- `uv run ruff check` · `uv run ruff format --check` · `uv run pyright`
+- `uv run pytest --cov=url4 --cov-fail-under=95 -q`
+- `uv build --out-dir dist` → `uvx twine check --strict dist/*` → `unzip -l` the wheel and
+  confirm `url4/py.typed` is present.
+- Validate JSON/YAML: parse `release-please-config.json`, `.release-please-manifest.json`,
+  `.github/dependabot.yml`; `actionlint` on both workflows if available.
+
+## Step 6 — Commit / PR
+
+- Conventional commits, body `Refs: OME-465`; never commit to `main`.
+- Suggested split: `feat(url4): PyPI metadata + py.typed`; `ci(url4): PyPI publish
+  workflow + packaging gate + dependabot`.
+- Open PR; body: summary, test plan, the owner-action checklist (PyPI trusted publisher +
+  `pypi` Environment), CODEOWNERS reviewers (`@sergio-bershadsky @HupBaHa`).
+- Fill ledger Outcome; set OME-465 → In Review; update tasks mirror.
+
+## Owner actions (post-merge, pre-publish)
+
+1. PyPI: reserve `url4`, add Trusted Publisher (repo `OpenMined/screamingface`, workflow
+   `release-url4.yml`, environment `pypi`).
+2. GitHub: create `pypi` Environment.

--- a/docs/spec/2026-07-15-url4-pypi-release-cicd-spec.md
+++ b/docs/spec/2026-07-15-url4-pypi-release-cicd-spec.md
@@ -1,0 +1,111 @@
+# Spec — url4 SDK PyPI release CI/CD (OME-465)
+
+## Problem
+
+`packages/url4` is a pure-Python SDK (hatchling + uv, `requires-python>=3.12`, ~96% test
+coverage). release-please already registers it (`release-please-config.json` + manifest,
+python release-type, `url4-v*` tags) and `url4-tests.yml` gates PRs. But:
+
+1. **No publish workflow reacts to the `url4-v*` tag** — releases are cut (tag
+   `url4-v0.1.0` exists) yet nothing ships to PyPI.
+2. **The package lacks PyPI metadata** — no README (long description), no LICENSE file in
+   the dist, no `py.typed` (so downstreams get no types), no classifiers / project URLs.
+3. **No packaging-validation gate** — a broken build or bad metadata is only discovered at
+   release time.
+
+## Goals
+
+- A secure, standard PyPI publish lane triggered by release-please's `url4-v*` tag.
+- A package that presents correctly on PyPI (name, description, README, license, links)
+  and ships type information.
+- Packaging breakage caught on every PR, not at release.
+- Consistency with the repo's existing release conventions (`aigateway`).
+
+## Non-goals
+
+- Publishing anything now. This lands as a PR; the first real publish is an owner decision.
+- Changing url4's library code or its runtime behavior (that is OME-397's domain).
+- TestPyPI staging (can be added later; omitted to keep the lane simple and honest).
+
+## Design
+
+### Publish authentication — Trusted Publishing (OIDC)
+
+Use PyPI **Trusted Publishing** (OpenID Connect) via `pypa/gh-action-pypi-publish`, not a
+stored API token. GitHub mints a short-lived, workflow-identity-bound OIDC token that PyPI
+exchanges for upload credentials. Rationale (DevOps `ci-cd.md`, `security-devsecops.md`):
+
+- **No long-lived secret** to leak, rotate, or scope — the #1 CI credential-exfil target.
+- Token is bound to `repo + workflow + environment`; unusable elsewhere and expires in
+  minutes.
+- Enables **PEP 740 digital attestations** automatically (provenance: "this artifact was
+  built by our pipeline from this commit").
+
+Trade-off: requires one-time owner setup on PyPI (a Trusted Publisher) + a GitHub
+Environment. That setup is out-of-band and documented as an owner action; the workflow is
+correct and mergeable before it exists (it simply cannot publish until then).
+
+### Release trigger — release-please (already wired)
+
+Mirror `aigateway`: conventional commits drive release-please's per-component release PR;
+merging it bumps `packages/url4/pyproject.toml`, updates the changelog, and pushes tag
+`url4-v<version>`. `release-url4.yml` triggers `on: push: tags: ["url4-v*"]` (plus
+`workflow_dispatch` for manual re-runs). This keeps SemVer discipline and changelog
+automation, and matches the reviewer's mental model of the repo.
+
+### Publish workflow shape — build once, promote the artifact
+
+Three jobs, mirroring `release-aigateway.yml`'s `verify` guard and the PyPA-recommended
+build/publish split:
+
+1. **verify** — recompute the version from the tag and assert it equals
+   `packages/url4/pyproject.toml`'s version (fail otherwise). Guards against a mistagged or
+   drifted release.
+2. **build** — `uv build` (sdist + wheel) once, `twine check --strict`, upload the `dist/`
+   as an artifact. One immutable artifact is what gets published.
+3. **publish-pypi** — `environment: pypi` (protection point), `permissions: id-token:
+   write` (OIDC), download the artifact, `pypa/gh-action-pypi-publish`. No rebuild → the
+   bytes that were validated are the bytes that ship. Attestations default-on.
+
+### Package metadata
+
+Follow current packaging standards (PEP 621 / PEP 639 / PEP 561):
+
+- `readme = "README.md"` — a new README serves as the PyPI long description.
+- `license = "Apache-2.0"` (SPDX expression) + `license-files = ["LICENSE"]`; copy the root
+  Apache-2.0 text into the package so the sdist/wheel carry it. Omit the deprecated
+  `License ::` trove classifier (superseded by the SPDX field).
+- `authors`, `keywords`, `classifiers` (Development Status, audience, Python 3.12/3.13,
+  OS-independent, `Typing :: Typed`), `[project.urls]` (Homepage/Repository/Issues).
+- `src/url4/py.typed` marker so type checkers consume url4's inline types.
+
+### Test gate hardening
+
+Add to `url4-tests.yml`: (a) `3.13` to the Python matrix so the versions claimed in
+`classifiers` are actually tested; (b) a `build` job running `uv build` + `twine
+check --strict` so packaging/metadata regressions fail a PR. Coverage gate stays at 95%
+(actual ~96%), consistent with `sdlc.local.md`.
+
+### Dependabot
+
+Add the `uv` ecosystem for `/packages/url4` (weekly, grouped) so the SDK's dependencies
+stay current like the apps'.
+
+## Security & failure story
+
+- **Least privilege:** workflow default `permissions: contents: read`; only `publish-pypi`
+  gets `id-token: write`; no `packages:`/`contents: write` needed.
+- **No untrusted-code publish:** publish triggers only on maintainer-pushed `url4-v*` tags
+  (and manual dispatch), never on PRs.
+- **Rollback:** PyPI releases are immutable and cannot be re-uploaded; recovery from a bad
+  release is a new patch version (yank the bad one on PyPI). The `verify` job + `twine
+  check` gate exist to prevent shipping a broken artifact in the first place.
+- **What breaks if the OIDC trust is missing:** `publish-pypi` fails at the publish step
+  with an auth error; `verify`/`build` still pass, so packaging validity is confirmed even
+  before the owner configures PyPI.
+
+## Owner actions (out of band, before first publish)
+
+1. Reserve the `url4` PyPI project name; add a Trusted Publisher →
+   `OpenMined/screamingface`, workflow `release-url4.yml`, environment `pypi`.
+2. Create the `pypi` GitHub Environment (optionally required reviewers / branch limits).

--- a/docs/tasks/2026-07-15-url4-pypi-release-cicd.md
+++ b/docs/tasks/2026-07-15-url4-pypi-release-cicd.md
@@ -1,0 +1,15 @@
+---
+id: OME-465
+linear_url: https://linear.app/openmined/issue/OME-465/url4-sdk-pypi-release-cicd-trusted-publishing-release-please
+status: in_progress
+type: task
+priority: P2
+labels: [pkg/url4-python-sdk, autonomous, agentic]
+created: 2026-07-15
+closed:
+---
+
+PyPI release CI/CD for `packages/url4`: `release-url4.yml` (Trusted Publishing / OIDC),
+PyPI metadata (README, LICENSE, `py.typed`, classifiers/urls), a packaging-validation gate
+in `url4-tests.yml`, and a Dependabot `uv` entry. Delivered as a PR; PyPI trusted-publisher
++ `pypi` GitHub Environment remain owner actions.

--- a/docs/work/2026-07-15-OME-465-url4-pypi-release-cicd.md
+++ b/docs/work/2026-07-15-OME-465-url4-pypi-release-cicd.md
@@ -1,0 +1,76 @@
+---
+ticket: OME-465
+stack: url4
+status: in_progress
+started: 2026-07-15
+finished:
+---
+
+# OME-465 — url4 SDK PyPI release CI/CD
+
+## Intent
+
+Give `packages/url4` a production-grade PyPI publish lane so the SDK can ship to PyPI
+under the repo's release conventions. release-please already registers url4 (config +
+manifest) and cuts `url4-v*` tags, and `url4-tests.yml` gates PRs — but there is **no
+workflow that reacts to the tag and publishes**, and the package lacks the metadata a
+clean PyPI release needs (README, LICENSE, `py.typed`, classifiers/urls). This unit adds
+the missing publish workflow (Trusted Publishing / OIDC), the packaging metadata, a
+packaging-validation gate, and Dependabot coverage. No package is published — it lands as
+a PR; the PyPI-side trust + GitHub Environment are owner actions.
+
+## Planned changes
+
+- `packages/url4/pyproject.toml` — add `readme`, SPDX `license` + `license-files`,
+  `authors`, `keywords`, `classifiers` (incl. `Typing :: Typed`), `[project.urls]`.
+- `packages/url4/README.md` (new) — PyPI long description.
+- `packages/url4/LICENSE` (new) — Apache-2.0 copy (so the dist carries its license).
+- `packages/url4/src/url4/py.typed` (new) — ship type information (PEP 561).
+- `.github/workflows/release-url4.yml` (new) — `on: push tags url4-v*` + `workflow_dispatch`;
+  verify → build-once → publish to PyPI via Trusted Publishing under a `pypi` Environment.
+- `.github/workflows/url4-tests.yml` — add 3.13 to the matrix (honestly test claimed
+  versions) + a `build` job (`uv build` + `twine check --strict`) as a packaging gate.
+- `.github/dependabot.yml` — add the `uv` ecosystem for `/packages/url4`.
+
+## Test plan
+
+CI/packaging work — validated by exercising the pipeline locally, not new unit tests:
+
+- `uv build` produces a valid sdist + wheel; wheel contains `url4/py.typed`.
+- `uvx twine check --strict dist/*` passes (valid metadata + long description).
+- url4 gates stay green after the pyproject change: `ruff check`, `ruff format --check`,
+  `pyright`, `pytest --cov=url4 --cov-fail-under=95`.
+- `release-please-config.json` / manifest / `dependabot.yml` remain valid (JSON/YAML parse).
+- `actionlint` clean on the new/changed workflows (if available).
+
+## Acceptance
+
+- [ ] `release-url4.yml`: OIDC Trusted Publishing, `pypi` environment, build-once/promote,
+      no stored PyPI token, PEP 740 attestations on.
+- [ ] Package builds a valid sdist+wheel; `twine check --strict` passes; `py.typed` shipped.
+- [ ] `url4-tests.yml` runs matrix 3.12/3.13 + packaging gate.
+- [ ] Dependabot `uv` entry for `/packages/url4`.
+- [ ] Conventional commits `Refs: OME-465`; nothing pushed to `main`; delivered as a PR.
+
+## Outcome
+
+- **Actual files:** as planned. New: `.github/workflows/release-url4.yml`,
+  `packages/url4/{README.md,LICENSE}`, `packages/url4/src/url4/py.typed`, docs
+  spec/plan/tasks/work. Modified: `packages/url4/pyproject.toml`,
+  `.github/workflows/url4-tests.yml`, `.github/dependabot.yml`. Incidental:
+  `packages/url4/uv.lock` — `uv sync` corrected a stale project-entry version
+  (`0.2.0` → `0.1.0`) to match `pyproject.toml`/manifest/`__version__`.
+- **Commits:** see PR (`ci(url4)` + `feat(url4)` + `docs(OME-465)`), body `Refs: OME-465`.
+- **Gates:** ruff check ✓, ruff format --check ✓ (52 files), pyright 0 errors,
+  pytest 704 passed / coverage 97.06% (gate 95). Packaging: `uv build` sdist+wheel,
+  `twine check --strict` PASSED (both); wheel ships `url4/py.typed` + LICENSE; metadata
+  `License-Expression: Apache-2.0`, `Typing :: Typed`, project URLs. `actionlint` clean on
+  new/changed lines (the one finding — `job.check_run_id` in the pre-existing `cost` job —
+  is inherited unchanged from `aigateway-tests.yml`). JSON/YAML parse OK.
+- **Deviations:** (1) also hardened the existing `url4-tests.yml` (3.13 matrix + packaging
+  gate) beyond the literal "release workflow" ask, as best-practice for a release lane.
+  (2) `uv.lock` version correction noted above. (3) Ticket filed via `linear-cli` at owner
+  direction (card default is Linear-MCP-only).
+- **Follow-up (not blocking):** `src/url4/__init__.py` hardcodes `__version__ = "0.1.0"`
+  independently of `pyproject.toml`; release-please's python strategy updates `__init__`
+  `__version__` by default, so they should stay in sync — worth confirming on the next bump.

--- a/packages/url4/LICENSE
+++ b/packages/url4/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/url4/README.md
+++ b/packages/url4/README.md
@@ -1,0 +1,54 @@
+# url4
+
+**A standalone, framework-free core library for the url4 expression protocol.**
+
+url4 expresses multi-source computation as `(sources)!intent` — *"given this data, do
+this"* — recursively, with `$name` / `$N` references resolved through a lexical scope. An
+expression compiles into an executable **DAG** of typed nodes: each node owns its own logic
+behind a small protocol, independent nodes run in parallel, and nested fragments parse
+lazily inside the node that owns them. All I/O is inverted behind an `IOLayer` port, so the
+core is deterministic and testable.
+
+Part of [ScreamingFace](https://screamingface.ai) by [OpenMined](https://openmined.org).
+
+## Install
+
+```bash
+pip install url4
+```
+
+url4 requires Python 3.12+ and ships type information (PEP 561).
+
+## Quickstart
+
+```python
+from url4 import Client, StaticIOLayer, evaluate_sync
+
+io = StaticIOLayer(fetch_map={"https://x": "some article text"})
+text = "(a=https://x, tone='formal')!'Summarize $a in a $tone tone'"
+
+# scripts and REPLs: one call, no event loop to manage
+print(evaluate_sync(text, io).text)
+
+# async code owns a Client (Client() with no io speaks real HTTP)
+async with Client(io) as client:
+    res = await client.evaluate(text)
+    print(res.request)               # the canonical url4 text that ran
+```
+
+The execution engine — DAG compilation, executor, lowering — lives one level down:
+`from url4.dag import compile_expression, run`.
+
+## Features
+
+- **Expression-as-computation** — `(sources)!intent` with recursive fan-out and `$name`/`$N`
+  lexical references.
+- **Typed DAG** — expressions compile to a graph of typed nodes; independent nodes execute
+  concurrently.
+- **Inverted I/O** — all side effects go through the `IOLayer` port (`StaticIOLayer` for
+  tests/offline, HTTP for real fetches), keeping the core pure and deterministic.
+- **Fully typed** — passes `pyright`; type hints ship to consumers.
+
+## License
+
+Apache-2.0 — see [LICENSE](LICENSE).

--- a/packages/url4/pyproject.toml
+++ b/packages/url4/pyproject.toml
@@ -2,10 +2,29 @@
 name = "url4"
 version = "0.1.0"
 description = "Standalone core library for the url4 expression protocol — grammar, parser, AST, interpreter, and scope"
+readme = "README.md"
 requires-python = ">=3.12"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
+authors = [{ name = "OpenMined" }]
+keywords = ["ai", "llm", "ensemble", "dag", "expression-protocol", "url4"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Typing :: Typed",
+]
 dependencies = [
     "httpx>=0.27",
 ]
+
+[project.urls]
+Homepage = "https://screamingface.ai"
+Repository = "https://github.com/OpenMined/screamingface"
+Issues = "https://github.com/OpenMined/screamingface/issues"
 
 [project.optional-dependencies]
 # Url4Node.serve() — the ASGI app itself is framework-free; only serving needs this.

--- a/packages/url4/uv.lock
+++ b/packages/url4/uv.lock
@@ -306,7 +306,7 @@ wheels = [
 
 [[package]]
 name = "url4"
-version = "0.2.0"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Sets up a production-grade **PyPI release CI/CD** lane for the `packages/url4` SDK
(`OME-465`). release-please already registers url4 and cuts `url4-v*` tags, and
`url4-tests.yml` gates PRs — but nothing published on the tag and the package lacked the
metadata a clean PyPI release needs. This PR adds:

- **`.github/workflows/release-url4.yml`** — publishes to PyPI on `url4-v*` tags via
  **Trusted Publishing (OIDC, no stored token, PEP 740 attestations)** under a `pypi`
  GitHub Environment. Jobs: `verify` (tag == pyproject version) → `build` (build once,
  `twine check --strict`, upload artifact) → `publish-pypi` (`id-token: write`,
  `pypa/gh-action-pypi-publish`). Build-once/promote-the-artifact.
- **PyPI metadata** — `README.md` (long description), `LICENSE` (Apache-2.0 shipped in the
  dist), `src/url4/py.typed` (PEP 561), and PEP 621/639 `pyproject.toml` fields (SPDX
  license, authors, keywords, classifiers incl. `Typing :: Typed`, project URLs).
- **Packaging gate** — `url4-tests.yml` gains a 3.12/3.13 matrix and a `build` job
  (`uv build` + `twine check --strict`) so packaging/metadata breakage fails a PR.
- **Dependabot** — `uv` ecosystem for `/packages/url4`.

Consistent with the `aigateway` release conventions. **No package is published by this
PR.**

## ⚠️ Owner actions required before the first real publish

These are one-time and cannot be done in-repo (the workflow is correct and safe to merge
first — it just won't publish until they exist):

1. **PyPI:** reserve the `url4` project name and add a **Trusted Publisher** → owner/repo
   `OpenMined/screamingface`, workflow `release-url4.yml`, environment `pypi`.
2. **GitHub → Settings → Environments:** create the `pypi` Environment (optionally with
   required reviewers / branch restrictions).

## Test plan

Run locally in `packages/url4` (all green):

- `uv run ruff check` · `ruff format --check` · `uv run pyright` (0 errors)
- `uv run pytest --cov=url4 --cov-fail-under=95` → **704 passed, 97.06%**
- `uv build` → sdist + wheel; `uvx twine check --strict dist/*` → **PASSED** (both)
- Wheel verified to ship `url4/py.typed` + LICENSE; metadata shows
  `License-Expression: Apache-2.0`, `Typing :: Typed`, project URLs, markdown description
- `actionlint` clean on new/changed workflow lines; JSON/YAML configs parse

## Notes

- `uv.lock`: `uv sync` corrected a stale project-entry version (`0.2.0` → `0.1.0`) to match
  `pyproject.toml`/manifest/`__version__`.
- Follow-up (non-blocking): `src/url4/__init__.py` hardcodes `__version__`; release-please's
  python strategy updates it by default — worth confirming stays in sync on the next bump.
- Reviewers per CODEOWNERS: @sergio-bershadsky @HupBaHa (`/packages/` + `/.github/`).

Refs: OME-465
Linear: https://linear.app/openmined/issue/OME-465

