### PR TITLE
feat(scoreboard): wire SCOREBOARD_SUBMISSION_API_KEY as a secret-backed env var

### DIFF
--- a/apps/scoreboard/DEPLOYMENT.md
+++ b/apps/scoreboard/DEPLOYMENT.md
@@ -104,15 +104,17 @@ The chart never takes the raw key value directly — put it in a Secret and poin
 
 ```bash
 kubectl -n scoreboard create secret generic scoreboard-submission-api-key \
-  --from-literal=api-key='<the key value>'
+  --from-literal=SCOREBOARD_SUBMISSION_API_KEY='<the key value>'
 
 helm upgrade scoreboard oci://ghcr.io/openmined/screamingface/charts/scoreboard \
   --namespace scoreboard \
   --reuse-values \
   --set submissionApiKey.existingSecret=scoreboard-submission-api-key \
-  --set submissionApiKey.existingSecretKey=api-key \
+  --set submissionApiKey.existingSecretKey=SCOREBOARD_SUBMISSION_API_KEY \
   --wait
 ```
+
+`values-prod.yaml` already declares this exact Secret/key pair by default, so a production deploy that includes it doesn't need the `--set` flags above at all — they're shown here for the general/non-prod case.
 
 Leaving `submissionApiKey.existingSecret` unset (the default) renders no `SCOREBOARD_SUBMISSION_API_KEY` env var at all — the gate stays a no-op.
 

--- a/apps/scoreboard/DEPLOYMENT.md
+++ b/apps/scoreboard/DEPLOYMENT.md
@@ -100,6 +100,22 @@ helm upgrade --install scoreboard oci://ghcr.io/openmined/screamingface/charts/s
 
 Set `SCOREBOARD_SUBMISSION_API_KEY` to gate `POST /v1/scores` (OME-391 / C2) — a placeholder shared key until OME-326 (real identity) exists. Unset, the write path stays open, matching today's behavior. Once set, submitting clients (desktop app, SDK, CI) need `Authorization: Bearer <key>` — coordinate the key distribution before flipping this on in production, since it isn't per-user.
 
+The chart never takes the raw key value directly — put it in a Secret and point the chart at it, mirroring the `database.existingSecret` pattern:
+
+```bash
+kubectl -n scoreboard create secret generic scoreboard-submission-api-key \
+  --from-literal=api-key='<the key value>'
+
+helm upgrade scoreboard oci://ghcr.io/openmined/screamingface/charts/scoreboard \
+  --namespace scoreboard \
+  --reuse-values \
+  --set submissionApiKey.existingSecret=scoreboard-submission-api-key \
+  --set submissionApiKey.existingSecretKey=api-key \
+  --wait
+```
+
+Leaving `submissionApiKey.existingSecret` unset (the default) renders no `SCOREBOARD_SUBMISSION_API_KEY` env var at all — the gate stays a no-op.
+
 ## Benchmark Seeding
 
 The app chart runs `python -m scoreboard.seed` after install and upgrade. Seed data comes from `.Values.seedBenchmarks.benchmarks` and is passed through `SCOREBOARD_SEED_BENCHMARKS_JSON`.

--- a/apps/scoreboard/charts/scoreboard/templates/deployment.yaml
+++ b/apps/scoreboard/charts/scoreboard/templates/deployment.yaml
@@ -50,6 +50,13 @@ spec:
                 secretKeyRef:
                   name: {{ required "database.existingSecret is required" .Values.database.existingSecret }}
                   key: {{ .Values.database.existingSecretKey }}
+            {{- if .Values.submissionApiKey.existingSecret }}
+            - name: SCOREBOARD_SUBMISSION_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.submissionApiKey.existingSecret }}
+                  key: {{ .Values.submissionApiKey.existingSecretKey }}
+            {{- end }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/apps/scoreboard/charts/scoreboard/values-prod.yaml
+++ b/apps/scoreboard/charts/scoreboard/values-prod.yaml
@@ -8,6 +8,13 @@ database:
   existingSecret: scoreboard-db
   existingSecretKey: database-url
 
+# WHY: declared here (not just passed via --set) so the Secret reference survives every
+# ordinary helm upgrade, rollback, reinstall, and the planned Azure migration, instead of
+# depending on a one-time --set/--reuse-values invocation (OME-467).
+submissionApiKey:
+  existingSecret: scoreboard-submission-api-key
+  existingSecretKey: SCOREBOARD_SUBMISSION_API_KEY
+
 ingress:
   enabled: true
   className: traefik

--- a/apps/scoreboard/charts/scoreboard/values.yaml
+++ b/apps/scoreboard/charts/scoreboard/values.yaml
@@ -43,6 +43,12 @@ database:
   existingSecret: scoreboard-db
   existingSecretKey: database-url
 
+# Optional — unset means SCOREBOARD_SUBMISSION_API_KEY is never set on the pod, so the
+# app-level write gate (OME-391 / C2) stays a no-op, matching today's default behavior.
+submissionApiKey:
+  existingSecret: ""
+  existingSecretKey: ""
+
 service:
   type: ClusterIP
   port: 9106

--- a/docs/work/2026-07-16-OME-391-step3-helm-api-key-secret.md
+++ b/docs/work/2026-07-16-OME-391-step3-helm-api-key-secret.md
@@ -60,4 +60,20 @@ This is a Helm chart, not an app-code change — no pytest coverage applies. Ver
   - `apps/scoreboard/DEPLOYMENT.md` — replaced the existing "coordinate key distribution" note with concrete `kubectl create secret` + `helm upgrade --set` steps.
 - **Commits:** this unit's commit (`Refs: OME-391`).
 - **Gates:** `helm lint charts/scoreboard` clean in 3 configurations (default, `--set submissionApiKey.*`, `--values values-prod.yaml`). `helm template` confirmed: unset → no env entry rendered (unchanged default behavior); set → correct `secretKeyRef` rendered with the given secret/key names.
-- **Deviations:** none — matched the plan exactly.
+- **Deviations:**
+  - Dmitry (review, PR #403) split this into its own sub-issue **OME-467** (parented under
+    OME-391) and requested two changes before merge/deploy, from live evidence: the
+    production Secret is already named `scoreboard-submission-api-key` (key
+    `SCOREBOARD_SUBMISSION_API_KEY`), set via an out-of-band `kubectl set env` that Helm
+    revision 12's values don't own.
+    1. "Keep the rendered `secretKeyRef` required, not `optional: true`" — already true
+       without any change: Kubernetes defaults `secretKeyRef` to required when `optional`
+       is omitted, verified by re-reading the diff (no `optional:` key present anywhere).
+    2. "Ensure the production Secret reference is supplied declaratively on every
+       deploy" — added `submissionApiKey.existingSecret: scoreboard-submission-api-key` /
+       `existingSecretKey: SCOREBOARD_SUBMISSION_API_KEY` directly to `values-prod.yaml`
+       (matching the live Secret exactly), so every production `helm upgrade` renders it
+       automatically — no `--set` flag needed. Verified via `helm template --values
+       values-prod.yaml`.
+  - Going forward, reference **OME-467** (not just OME-391) in commits/PR for this scope,
+    per Dmitry's request.

--- a/docs/work/2026-07-16-OME-391-step3-helm-api-key-secret.md
+++ b/docs/work/2026-07-16-OME-391-step3-helm-api-key-secret.md
@@ -1,0 +1,63 @@
+---
+ticket: OME-391
+stack: scoreboard
+status: done
+started: 2026-07-16
+finished: 2026-07-16
+---
+
+# OME-391 (step 3) — wire SCOREBOARD_SUBMISSION_API_KEY through the Helm chart
+
+## Intent
+
+Step 2 (PR #392) added `Settings.submission_api_key`, read from `SCOREBOARD_SUBMISSION_API_KEY`,
+gating `POST /v1/scores` behind a placeholder shared key. Dmitry has already generated a real
+key and shared it, expecting it usable in production — but the Helm chart has no mechanism to
+set that env var at all. Confirmed via a full read of every file in
+`apps/scoreboard/charts/scoreboard/`: the only secret-injection pattern that exists is
+`database.existingSecret`/`existingSecretKey` for the DB URL; there's no generic
+`extraEnv`/`extraEnvFrom` passthrough. Without this, the only ways to set the key are either
+non-declarative (`kubectl set env`, silently wiped by the next `helm upgrade`) or insecure
+(raw value committed to `values-prod.yaml`).
+
+## Planned changes
+
+- `apps/scoreboard/charts/scoreboard/values.yaml`: add
+  `submissionApiKey: { existingSecret: "", existingSecretKey: "" }` (empty by default — unlike
+  `database.existingSecret`, this one is optional; unset means the gate stays a no-op, matching
+  today's actual production behavior).
+- `apps/scoreboard/charts/scoreboard/templates/deployment.yaml`: add an optional `env` entry for
+  `SCOREBOARD_SUBMISSION_API_KEY` via `secretKeyRef`, rendered only when
+  `.Values.submissionApiKey.existingSecret` is set (`{{- if .Values.submissionApiKey.existingSecret }}`)
+  — no `required`, since this field is optional by design.
+- `apps/scoreboard/DEPLOYMENT.md`: document the new values fields next to the existing
+  `SCOREBOARD_SUBMISSION_API_KEY` note.
+
+## Test plan
+
+This is a Helm chart, not an app-code change — no pytest coverage applies. Verification instead:
+- `helm lint charts/scoreboard` clean, both with and without `submissionApiKey.existingSecret` set.
+- `helm template` with the field unset → confirm no `SCOREBOARD_SUBMISSION_API_KEY` env entry
+  renders (proves the optional-rendering guard works, and default behavior is unchanged).
+- `helm template` with the field set (e.g. `--set submissionApiKey.existingSecret=test-secret
+  --set submissionApiKey.existingSecretKey=api-key`) → confirm the rendered Deployment's `env:`
+  includes a `secretKeyRef` entry for `SCOREBOARD_SUBMISSION_API_KEY` pointing at the given
+  secret/key names.
+
+## Acceptance
+
+- Setting `submissionApiKey.existingSecret`/`existingSecretKey` in values makes
+  `SCOREBOARD_SUBMISSION_API_KEY` available to the pod via a Kubernetes Secret reference —
+  survives `helm upgrade`, never touches git.
+- Leaving it unset renders identically to today (no new env entry, no behavior change).
+- `helm lint` clean in both configurations.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+  - `apps/scoreboard/charts/scoreboard/values.yaml` — added `submissionApiKey.existingSecret`/`existingSecretKey`, both empty by default.
+  - `apps/scoreboard/charts/scoreboard/templates/deployment.yaml` — added the conditional `SCOREBOARD_SUBMISSION_API_KEY` env entry, guarded by `{{- if .Values.submissionApiKey.existingSecret }}`.
+  - `apps/scoreboard/DEPLOYMENT.md` — replaced the existing "coordinate key distribution" note with concrete `kubectl create secret` + `helm upgrade --set` steps.
+- **Commits:** this unit's commit (`Refs: OME-391`).
+- **Gates:** `helm lint charts/scoreboard` clean in 3 configurations (default, `--set submissionApiKey.*`, `--values values-prod.yaml`). `helm template` confirmed: unset → no env entry rendered (unchanged default behavior); set → correct `secretKeyRef` rendered with the given secret/key names.
+- **Deviations:** none — matched the plan exactly.


### PR DESCRIPTION
## Summary
OME-467 (sub-issue of OME-391 Step 3). `Settings.submission_api_key` (Step 2, PR #392) is read from `SCOREBOARD_SUBMISSION_API_KEY`, but the chart had no way to set it — confirmed via a full read of every file in `charts/scoreboard/`, the only secret pattern is `database.existingSecret` for the DB URL, and there's no generic `extraEnv`/`extraEnvFrom` passthrough anywhere.

**Live finding while working this:** the gate is already active in production right now and the key Dmitry generated works correctly (verified via a safe probe — bogus `benchmark_id`, no data written: no header → `401`, with the key → `404` unknown-benchmark, proving it passed auth). But the key was set via an out-of-band `kubectl set env` — Helm revision 12's values don't own that reference, so it doesn't survive a normal `helm upgrade`, rollback, reinstall, or the planned Azure migration. This PR is what makes it durable.

- Added `submissionApiKey.existingSecret`/`existingSecretKey` to `values.yaml`, mirroring `database.existingSecret` — empty/unset by default.
- Wired into `deployment.yaml` as a `secretKeyRef` env entry, guarded so it only renders when `submissionApiKey.existingSecret` is set. No `optional: true` — Kubernetes defaults to required, so a missing/misspelled Secret or key prevents the pod from starting rather than silently reopening writes.
- `values-prod.yaml` now declares the actual live Secret (`scoreboard-submission-api-key` / `SCOREBOARD_SUBMISSION_API_KEY`) so every production deploy renders it automatically — no `--set` flag needed.
- `DEPLOYMENT.md` updated with concrete `kubectl create secret` + `helm upgrade` steps.

## Test plan
- [x] `helm lint charts/scoreboard` clean: default, `--set submissionApiKey.*`, and with `values-prod.yaml`
- [x] `helm template` unset → confirmed no `SCOREBOARD_SUBMISSION_API_KEY` env entry renders (default behavior unchanged)
- [x] `helm template --set submissionApiKey.existingSecret=... --set submissionApiKey.existingSecretKey=...` → confirmed correct `secretKeyRef` renders with the given names
- [x] `helm template --values values-prod.yaml` → confirmed it now renders the real production Secret reference declaratively, with no extra flags
- [x] Live probe against `scoreboard.screamingface.ai` confirms the gate + key already work correctly today — this PR makes that state durable across upgrades rather than changing current behavior

Refs: OME-467