### PR TITLE
docs(OME-365): refresh README + CONTRIBUTING for SDLC, url4, Pages retirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,11 @@
 # Contributing to ScreamingFace
 
-This guide covers running the repo's services from source and the git workflow.
+This guide covers running the repo's code from source and the git workflow.
 
-> The legacy desktop app and plugin server were removed in the July 2026
-> re-foundation (tag `legacy-monorepo-2026-07-08`). The apps below are the
-> active codebase; new desktop/CLI packages will arrive with their own guides.
+> The legacy desktop app and plugin server were removed in the July 2026 re-foundation (tag
+> `legacy-monorepo-2026-07-08`). The stacks below are the active codebase; new desktop/CLI
+> packages will arrive with their own guides. The public website lives in the separate
+> `screamingface-web` repo — it is not part of this monorepo.
 
 ## Prerequisites
 
@@ -21,10 +22,20 @@ cd screamingface
 git config core.hooksPath .githooks   # enables the pre-commit guard (blocks commits to main)
 ```
 
-## Run from source
+## Stacks
 
-Each app is self-contained under `apps/<name>` with its own `pyproject.toml`,
-lockfile, and README.
+The repo is organised as **stacks**, not just apps — each is self-contained with its own
+`pyproject.toml`, lockfile, tests, and README. The stack name is what the tooling takes.
+
+| Stack | Root | What it is |
+|---|---|---|
+| `aigateway` | `apps/aigateway` | LiteLLM-based AI Gateway — provider OAuth, encrypted credential store (service, port 9105) |
+| `scoreboard` | `apps/scoreboard` | Public benchmark scoreboard + demo portal (service, port 9106) |
+| `url4` | `packages/url4` | url4 expression protocol — grammar, parser, AST, interpreter (library) |
+
+The canonical list lives in [`.claude/sdlc.local.md`](.claude/sdlc.local.md).
+
+## Run from source
 
 ```bash
 # AI Gateway — provider OAuth, encrypted credential store (port 9105)
@@ -37,59 +48,117 @@ curl -sf http://localhost:9105/healthz   # liveness check
 cd apps/scoreboard
 uv sync
 uv run scoreboard
+
+# url4 — a library, not a service
+cd packages/url4
+uv sync
 ```
 
 ## Tests, lint, typecheck
 
-Run inside the app you're changing — the same gates CI runs:
+**One command per stack — the gates CI runs, in CI's order, plus one CI doesn't:**
 
 ```bash
-cd apps/<app>
-uv run ruff check          # lint
-uv run ruff format --check # formatting
-uv run pyright             # typecheck
-uv run pytest              # unit tests
+uv run .claude/scripts/run_gates.py <stack>   # aigateway | scoreboard | url4
 ```
 
-Gateway-specific:
+It resolves the stack from [`.claude/sdlc.local.md`](.claude/sdlc.local.md), runs its gates
+from the stack root, and stops at the first failure:
 
-- `apps/aigateway` live tests (`-m live`, real provider OAuth) are skipped in
-  CI. Run them locally, with backends actually connected, before asking to
-  merge changes that touch the gateway request/refresh path.
-- Never import `litellm-enterprise` — CI runs
-  `apps/aigateway/scripts/check_no_enterprise.py` as a guard.
+```
+✓ append-only test check (vs HEAD)
+✓ uv run ruff check                                    # lint
+✓ uv run ruff format --check                           # formatting
+✓ uv run pyright                                       # typecheck
+✓ uv run pytest --cov=<stack> --cov-fail-under=<N> -q  # tests + coverage floor
+ALL GATES GREEN
+```
+
+Coverage floors differ by stack (`url4` is 95, the services are 80) — another reason to use
+the runner rather than reconstructing the command by hand.
+
+The **append-only check** is the runner's own — CI does not run it. It guards prior tests from
+being edited or deleted, so a change can't quietly weaken the suite it inherited. If you
+genuinely must change an existing test, that's a deliberate call to raise in review, not a gate
+to route around — `--skip-append-only` exists for that conversation, and skipping it belongs in
+your PR description. Everything else matches CI step for step
+(`aigateway-tests.yml`, `scoreboard-tests.yml`, `url4-tests.yml`).
+
+An unknown stack fails fast and tells you the real ones:
+
+```
+CONFIG ERROR: stack 'docs' not in .claude/sdlc.local.md (has: aigateway, scoreboard, url4)
+```
+
+Docs-only changes (`README`, `CONTRIBUTING`, `docs/`) have no stack and no CI — there is
+nothing to run.
+
+Stack-specific:
+
+- `apps/aigateway` live tests (`-m live`, real provider OAuth) are skipped in CI. Run them
+  locally, with backends actually connected, before asking to merge changes that touch the
+  gateway request/refresh path.
+- Never import `litellm-enterprise` — the aigateway gates run
+  `scripts/check_no_enterprise.py` as a guard.
 
 ## Git workflow
 
-- **Work item first.** Every unit of work is a Linear issue (`OME-N`) — see the
-  `task-management` skill and the "AI SDLC" section of [`CLAUDE.md`](CLAUDE.md).
-- **Branch naming:** `OME-N-<description>` (e.g. `OME-12-fix-refresh`), where
-  `N` is the Linear work-item number.
-- **Never commit directly to `main`.** The `.githooks/pre-commit` hook (enabled
-  above) blocks it; branch protection enforces it remotely.
-- **Conventional commits.** Use `feat:`, `fix:`, `docs:`, `chore:` etc. —
-  release-please derives version bumps and changelogs from them (`feat:` →
-  minor, `fix:` → patch; `docs:`/`chore:` don't bump). The body carries
-  `Refs: OME-N`.
-- **PRs:** squash-merge after review approval + green required checks. Include
-  the Linear work-item link, a summary, and a test plan in the body.
-- **Architecture is enforced.** DRY/SOLID/hexagonal are mandatory — see the
-  "Architecture Principles" section of [`CLAUDE.md`](CLAUDE.md).
+- **Work item first.** Every unit of work is a Linear issue (`OME-N`) in the **Engineering**
+  team under the **😱 ScreamingFace V1** project. File it before you start.
+- **Label it** (the board relies on these — see the table below).
+- **Branch naming:** `OME-N-<description>` (e.g. `OME-12-fix-refresh`), where `N` is the
+  Linear work-item number. Branch from `main`; this repo squash-merges, so don't stack PRs.
+- **Never commit directly to `main`.** The `.githooks/pre-commit` hook (enabled above) blocks
+  it; branch protection enforces it remotely.
+- **Conventional commits.** Use `feat:`, `fix:`, `docs:`, `chore:` etc. — release-please
+  derives version bumps and changelogs from them (`feat:` → minor, `fix:` → patch;
+  `docs:`/`chore:` don't bump). The body carries `Refs: OME-N`.
+- **PRs:** squash-merge after review approval + green required checks. Include the Linear
+  work-item link, a summary, and a test plan in the body.
+- **Architecture is enforced.** DRY/SOLID/hexagonal are mandatory — see the "Architecture"
+  section of [`CLAUDE.md`](CLAUDE.md).
+
+### Labels when filing from the Linear UI
+
+| Group | Rule | Values |
+|---|---|---|
+| Landing | one, required — where the work lands | `app/aigateway` · `app/scoreboard` · `pkg/url4-python-sdk` · `repo` (process/repo work) |
+| `who-acts` | one, required | `autonomous` (runnable end-to-end) · `design-session` (needs a direction call first) · `deferred` (gated on a named precondition) |
+| `actor` | one, **mandatory** — who executes | `human` · `agentic` |
+| Type | optional | `Bug` · `Feature` · `Improvement` |
+
+Work touching **two or more** `app/*`/`pkg/*` landings is cross-cutting: file a parent epic
+plus one sub-issue per affected stack, rather than a single mega-issue.
+
+If you're blocked mid-flight, add `blocked ⛔` (a hard question) or `needs-owner` (a decision
+or visual check) and comment the exact question — leave the issue In Progress.
+
+### Working with agents
+
+Agent-executed work carries extra discipline — `docs/tasks/` mirrors, `docs/work/` ledgers,
+and spec/plan artifacts under `docs/`. **That chain is agent discipline; it does not bind
+human contributors.** As a human, the list above is the whole contract: issue → branch →
+conventional commits → PR. The agent contract is documented in
+[`.claude/README.md`](.claude/README.md).
 
 ## Releases
 
-- `apps/aigateway` — release-please manages the release PR; merging it tags
-  `aigateway-v*`, which builds the GHCR image + Helm chart
-  (`release-aigateway.yml`).
-- `apps/scoreboard` — manual tag `scoreboard-v*` triggers
-  `release-scoreboard.yml` (GHCR image + Helm chart).
+| Stack | How |
+|---|---|
+| `apps/aigateway` | release-please manages the release PR; merging it tags `aigateway-v*`, which builds the GHCR image + Helm chart (`release-aigateway.yml`). |
+| `apps/scoreboard` | manual tag `scoreboard-v*` triggers `release-scoreboard.yml` (GHCR image + Helm chart). |
+| `packages/url4` | tag `url4-v*` triggers `release-url4.yml` — verify + build + `twine check`, then publish via PyPI Trusted Publishing. The publish step needs a one-time owner setup (PyPI project + Trusted Publisher + the `pypi` GitHub Environment); until that lands, verify and build still run and only publish fails. See the workflow header. |
 
 ## Reference
 
-- **Gateway internals:** `apps/aigateway/README.md` (credential store, secret
-  key, migrations)
-- **Scoreboard internals:** `apps/scoreboard/README.md` (portal, public
-  artifacts)
-- **Repo routing (which app, which CI, who reviews):** the
-  `working-in-this-repo` skill (`.claude/skills/working-in-this-repo/`)
+- **Repo guide** (skills, agents, cards, process, product context, history):
+  [`.claude/README.md`](.claude/README.md) — start here
+- **Repo routing** (which stack, which CI, who reviews): the `working-in-this-repo` skill
+  (`.claude/skills/working-in-this-repo/`)
+- **SDLC artifacts:** [`docs/README.md`](docs/README.md)
+- **Gateway internals:** [`apps/aigateway/README.md`](apps/aigateway/README.md) (credential
+  store, secret key, migrations)
+- **Scoreboard internals:** [`apps/scoreboard/README.md`](apps/scoreboard/README.md) (portal,
+  public artifacts)
+- **url4 SDK:** [`packages/url4/README.md`](packages/url4/README.md)
 - **Legacy reference:** `git checkout legacy-monorepo-2026-07-08`

--- a/README.md
+++ b/README.md
@@ -1,13 +1,7 @@
 # ScreamingFace
 
-An AI ensemble system that routes coding CLI prompts through multiple models (Claude, Gemini, Codex, Ollama) to beat SOTA benchmarks. Built by OpenMined.
-
-> **Repo re-foundation (July 2026).** The legacy desktop app and plugin server
-> were deprecated and removed; the full pre-teardown tree is preserved at the
-> git tag **`legacy-monorepo-2026-07-08`**. New, separately-lifecycled packages
-> (pure-Electron desktop app, Python CLI on PyPI, `url4` SDK) are being built —
-> names are being finalized. Until they land, this repo hosts the two services
-> below.
+An AI ensemble system that routes coding CLI prompts through multiple models (Claude, Gemini,
+Codex, Ollama) to beat SOTA benchmarks. Built by OpenMined — [screamingface.ai](https://screamingface.ai).
 
 ## Monorepo Layout
 
@@ -15,9 +9,16 @@ An AI ensemble system that routes coding CLI prompts through multiple models (Cl
 apps/
   aigateway/   LiteLLM-based AI Gateway — provider OAuth + encrypted credentials (Python, uv)
   scoreboard/  Public benchmark scoreboard service + demo portal (Python, uv)
-packages/      Shared libraries (reserved — url4-python-sdk lands here first)
-docs/          AI-agentic decision records (plans, specs)
+packages/
+  url4/        url4 expression protocol — grammar, parser, AST, interpreter (Python, uv)
+docs/          SDLC artifacts — spec/ plan/ tasks/ work/ diagrams/ (see docs/README.md)
 ```
+
+> **Repo re-foundation (July 2026).** The legacy desktop app and plugin server were deprecated
+> and removed; the full pre-teardown tree is preserved at the git tag
+> **`legacy-monorepo-2026-07-08`**. New, separately-lifecycled packages (pure-Electron desktop
+> app, Python CLI on PyPI) are being built — names are being finalized. The public website
+> lives in the separate `screamingface-web` repo; this monorepo does not publish GitHub Pages.
 
 ## Prerequisites
 
@@ -44,11 +45,10 @@ cd apps/aigateway && uv sync && uv run uvicorn aigateway.main:app --port 9105 --
 cd apps/scoreboard && uv sync && uv run scoreboard
 ```
 
-Test an app (same pattern for both):
+Check a stack — lint, format, typecheck, tests, and coverage in one command:
 
 ```bash
-cd apps/<app>
-uv run ruff check && uv run pyright && uv run pytest
+uv run .claude/scripts/run_gates.py <stack>   # aigateway | scoreboard | url4
 ```
 
 ## More
@@ -56,4 +56,6 @@ uv run ruff check && uv run pyright && uv run pytest
 - **Developing / git workflow** → [`CONTRIBUTING.md`](CONTRIBUTING.md)
 - **Gateway internals** → [`apps/aigateway/README.md`](apps/aigateway/README.md)
 - **Scoreboard internals** → [`apps/scoreboard/README.md`](apps/scoreboard/README.md)
+- **url4 SDK** → [`packages/url4/README.md`](packages/url4/README.md)
+- **Repo guide** (skills, agents, cards, process) → [`.claude/README.md`](.claude/README.md)
 - **Legacy code** (desktop app, plugin server, url4 engine, marketing site, infra) → `git checkout legacy-monorepo-2026-07-08`

--- a/docs/tasks/2026-07-08-docs-refresh-readme-contributing.md
+++ b/docs/tasks/2026-07-08-docs-refresh-readme-contributing.md
@@ -1,15 +1,28 @@
 ---
 id: OME-365
-linear_url: https://linear.app/openmined/issue/OME-365/docs-refresh-readme-contributing-accuracy-after-web-restore-sdlc
-status: todo
+linear_url: https://linear.app/openmined/issue/OME-365/ome-365-docs-refresh-readme-contributing-accuracy-sdlc-url4-landed
+status: done
 type: task
 priority: P1
-labels: [repo, agentic, design-session]
+labels: [repo-dev-processes, agentic, autonomous]
 created: 2026-07-08
-closed:
+closed: 2026-07-17
 ---
 
-README + CONTRIBUTING accuracy fixes from the 2026-07-08 critical review (web/ in layout,
-gate-runner as canonical command, product-pitch-first README, web/public contribution
-path). Gated on the design decision: do mirrors/ledgers/spec-plan artifacts bind human
-contributors or stay agentic-only.
+README + CONTRIBUTING accuracy fixes. Filed 2026-07-08 from the critical review, right after
+the #374 web restore.
+
+**Re-scoped 2026-07-17.** OME-429 (#407) retired the monorepo Pages site, invalidating every
+web item (`web/` is now an empty dir, `deploy-website.yml` is gone, the site lives in
+`screamingface-web`). Dropped: add `web/` to the layout · `web/public` contribution path ·
+"two services" → services + site. Added from drift the ticket predated: `packages/` is no
+longer "reserved" (url4 landed), url4 in Releases, gates framed by stack not app.
+
+**Gating fork resolved (owner):** mirrors/ledgers/spec-plan artifacts are **agentic-only
+discipline** — they do not bind human contributors. CONTRIBUTING documents the light human
+path (issue → branch → conventional commits → PR) and points at `.claude/README.md` for the
+agent contract.
+
+Ledger: `docs/work/2026-07-17-OME-365-docs-refresh.md`. Spawned OME-474 (PyPI name `url4` is
+taken — `pip install url4` installs a different package, so the docs deliberately say nothing
+about installing the SDK).

--- a/docs/tasks/2026-07-17-url4-pypi-name-taken.md
+++ b/docs/tasks/2026-07-17-url4-pypi-name-taken.md
@@ -1,0 +1,24 @@
+---
+id: OME-474
+linear_url: https://linear.app/openmined/issue/OME-474/url4-pypi-name-url4-is-already-taken-release-url4yml-publish-step
+status: backlog
+type: task
+priority: P1
+labels: [pkg/url4-python-sdk, design-session, human]
+created: 2026-07-17
+closed:
+---
+
+`release-url4.yml` (#401, OME-465) tells an owner to "reserve the `url4` project on PyPI" and
+publishes to `https://pypi.org/p/url4` — but that name is already taken by Andrew Trask's
+separate `iamtrask/url4` (v0.1, uploaded 2026-02-22, homepage url4.ai, requires-python >=3.10).
+This repo's `packages/url4` is v0.1.0 / >=3.12 and unpublished. The lane will verify + build
+green and fail at publish on the first `url4-v*` tag; `pip install url4` today installs Trask's
+package, not ours.
+
+Owner fork: Trask adds a Trusted Publisher on the existing project · transfer/co-own to
+OpenMined · or publish under a different name (changing `pyproject.toml` name + the workflow's
+env URL + header).
+
+Found while doing OME-365 (docs refresh), which consequently states nothing about installing
+the SDK. Filed without a workstream `Epic` label — that group is gone from Linear.

--- a/docs/work/2026-07-17-OME-365-docs-refresh.md
+++ b/docs/work/2026-07-17-OME-365-docs-refresh.md
@@ -1,0 +1,111 @@
+---
+ticket: OME-365
+stack: repo
+status: done
+started: 2026-07-17
+finished: 2026-07-17
+---
+
+# OME-365 — Docs refresh: README + CONTRIBUTING accuracy
+
+## Intent
+
+`README.md` and `CONTRIBUTING.md` are the front door for both humans and agents, and neither
+has been touched since 2026-07-08 (`README` at the re-foundation commit #371, `CONTRIBUTING`
+at the OME-358 SDLC-adoption commit #376). The repo moved underneath them: `packages/url4`
+landed with a release lane, `run_gates.py` became the canonical gate command, `docs/` grew a
+real SDLC tree, and OME-429 retired the monorepo Pages site. A contributor following either
+file today is told things that are false.
+
+## Scope re-cut (2026-07-17)
+
+The ticket was filed 2026-07-08 immediately after the #374 web restore, to make the docs
+reflect it. `3f6bfe3` (OME-429, #407) then **retired** the Pages site — `web/` is an empty dir,
+`deploy-website.yml` is gone, CLAUDE.md now states the site lives in `screamingface-web`.
+Three of the original nine items were therefore invalid and are **dropped**; executing them
+would have documented a lane that does not exist:
+
+- ~~README: add `web/` to the layout~~
+- ~~CONTRIBUTING: `web/public` contribution path (edit → PR → auto-deploy on merge)~~
+- ~~README: "two services" → services + site~~ (it *is* two services again)
+
+Added in their place, from drift the original ticket predates:
+
+- README `packages/` line still says "reserved — url4-python-sdk lands here first"; url4 has
+  landed (v0.1.0, LICENSE, README, `py.typed`, release lane `release-url4.yml`). It is **not**
+  on PyPI under that name — see Deviations / OME-474.
+- CONTRIBUTING Releases covers aigateway + scoreboard only; url4 (`url4-v*`) is missing.
+- CONTRIBUTING frames gates as `cd apps/<app>`, silently omitting `packages/url4` — the
+  stacks are `aigateway`, `scoreboard`, `url4` per `.claude/sdlc.local.md`.
+
+**Gating fork resolved (owner, 2026-07-17): agentic-only discipline.** `docs/tasks/` mirrors,
+`docs/work/` ledgers, and spec/plan artifacts bind agents, not humans. CONTRIBUTING documents
+the light human path (issue → branch → conventional commits → PR) and points at
+`.claude/README.md` for the agent contract.
+
+## Planned changes
+
+- `README.md` — screamingface.ai link on the pitch; stale `docs/` line → real tree;
+  `packages/` → url4 landed; test snippet → `run_gates.py <stack>`.
+- `CONTRIBUTING.md` — `run_gates.py <stack>` canonical; stack-not-app framing; url4 in
+  Releases; human path inline; Reference → `.claude/README.md`.
+- `docs/tasks/2026-07-08-docs-refresh-readme-contributing.md` — reconcile drift vs Linear
+  (`status`, `labels`, `linear_url`), then close.
+
+## Test plan
+
+No automated gates exist for this change — stated plainly rather than faked:
+
+- `run_gates.py <stack>` resolves a stack from `.claude/sdlc.local.md` (`aigateway`,
+  `scoreboard`, `url4`). Docs are not a stack → it fail-configs by design.
+- `repo-checks.yml` triggers only on `.claude/skills/sdlc-**`, `.claude/scripts/**`, and its
+  own file. A `README.md`/`CONTRIBUTING.md` PR runs **zero CI**.
+
+Manual verification instead:
+
+- Every command in both files executes as written (each `run_gates.py <stack>` invocation,
+  `uv sync`, the run lines, `git config core.hooksPath`).
+- Every referenced path exists; every link resolves.
+- No stale referent survives: no `web/public`, no `deploy-website.yml`, no `packages/` as
+  "reserved".
+- A human reading CONTRIBUTING top-to-bottom is never told to write a ledger or a mirror.
+
+## Acceptance
+
+- Both files describe the repo as it is at `ad8e809`.
+- The three gate commands run green from a clean checkout.
+- Mirror agrees with Linear and is closed.
+
+## Outcome
+
+- **Actual files:** as planned (`README.md`, `CONTRIBUTING.md`, the OME-365 mirror), plus two
+  unplanned: this ledger and `docs/tasks/2026-07-17-url4-pypi-name-taken.md` (the OME-474
+  mirror — see Deviations).
+- **Commits:** see the PR; single `docs(OME-365):` commit.
+- **Gates:** none apply to the change itself — docs are not a stack, and no CI matches
+  `README.md`/`CONTRIBUTING.md`. What *was* verified, because the docs make claims about it:
+  all three documented gate commands were executed and are green —
+  `run_gates.py url4` ✓, `run_gates.py scoreboard` ✓, `run_gates.py aigateway` ✓ (ALL GATES
+  GREEN each). The documented error path was executed verbatim: `run_gates.py docs` →
+  `CONFIG ERROR: stack 'docs' not in .claude/sdlc.local.md (has: aigateway, scoreboard, url4)`.
+  Every referenced path exists; `screamingface.ai` → 200; the legacy tag resolves.
+
+- **Deviations:**
+  1. **Scope re-cut** (owner-approved, above): 3 web items dropped as invalid post-OME-429;
+     url4/packages items added. The ticket was retitled off "after web restore".
+  2. **Spawned OME-474.** Verifying my own draft `pip install url4` line revealed the PyPI
+     name `url4` belongs to Andrew Trask's separate `iamtrask/url4` (v0.1, 2026-02-22). This
+     repo's `packages/url4` v0.1.0 is unpublished, and `release-url4.yml` instructs an owner
+     to "reserve the `url4` project" — which is impossible. The draft line was removed; both
+     files now say nothing about installing the SDK rather than something false. OME-474
+     carries the owner fork. Its mirror rides in this PR (a mirror is due at create; a
+     dedicated PR for one 15-line file was not worth it).
+  3. **Two of my own drafted claims were wrong and were caught by verification, not review:**
+     "the same gates CI runs, in the same order" (the runner adds an append-only check CI does
+     not run) and a documented `Workstream (Epic)` label row (that group no longer exists in
+     Linear — the OME-474 filing was rejected on it). Both corrected.
+  4. **Label taxonomy drift, left alone (out of scope).** OME-365 carries
+     `repo-dev-processes`, which current `main`'s task-board card no longer registers — its
+     landing set is `app/aigateway`, `app/scoreboard`, `pkg/url4-python-sdk`, `repo`. The
+     mirror now matches Linear. Card/Linear reconcile is an owner action, also needed for the
+     missing `Epic` group.


### PR DESCRIPTION
## Summary

`README.md` and `CONTRIBUTING.md` hadn't been touched since 2026-07-08 and described a repo
that no longer exists. Closes **OME-365**.

**README** — screamingface.ai link on the pitch; `docs/` line → the real SDLC tree
(`spec/ plan/ tasks/ work/ diagrams/`); `packages/` is no longer "reserved" (url4 landed);
gate snippet → `run_gates.py <stack>`; the re-foundation history blockquote demoted below the
layout.

**CONTRIBUTING** — `uv run .claude/scripts/run_gates.py <stack>` presented as the canonical
gate command; framing moved from **apps to stacks**, because `cd apps/<app>` silently omitted
`packages/url4`; url4 added to Releases; Reference points at `.claude/README.md`; the human
path documented inline.

### Gating decision (resolved by owner)

The ticket was blocked since 2026-07-08 on one fork: *do mirrors/ledgers/spec-plan artifacts
bind human contributors, or are they agentic-only?* → **agentic-only discipline.** CONTRIBUTING
now says so explicitly: for a human the contract is issue → branch → conventional commits → PR,
and `.claude/README.md` holds the agent contract.

### Scope re-cut

OME-365 was filed right after the #374 web restore and is titled "after web restore". **OME-429
(#407) has since retired the monorepo Pages site**, so three of its nine items were invalid —
executing them would have documented a lane that doesn't exist:

- ~~add `web/` to the layout~~ — `web/` is an empty dir
- ~~`web/public` contribution path (edit → PR → auto-deploy)~~ — `deploy-website.yml` is gone
- ~~"two services" → services + site~~ — it *is* two services again

Replaced with drift the ticket predated: `packages/` no longer "reserved", url4 in Releases,
stack-not-app framing.

## Test plan

**No gates and no CI apply to this change — stated rather than implied:**

- `run_gates.py` resolves a stack from `.claude/sdlc.local.md` (`aigateway`, `scoreboard`,
  `url4`). Docs are not a stack.
- `repo-checks.yml` matches only `.claude/skills/sdlc-**`, `.claude/scripts/**`, and its own
  file. This PR triggers **zero CI**. Expect no checks.

Because the docs make claims about commands, those commands were **executed**, not assumed:

| Verified | Result |
|---|---|
| `run_gates.py url4` | ✅ ALL GATES GREEN |
| `run_gates.py scoreboard` | ✅ ALL GATES GREEN |
| `run_gates.py aigateway` | ✅ ALL GATES GREEN |
| `run_gates.py docs` (error path, quoted verbatim in the docs) | ✅ `CONFIG ERROR: stack 'docs' not in .claude/sdlc.local.md (has: aigateway, scoreboard, url4)` |
| Every referenced path | ✅ exists |
| `https://screamingface.ai` | ✅ 200 |
| `legacy-monorepo-2026-07-08` | ✅ tag resolves |

Verification caught **two false claims in my own draft**, before review: "the same gates CI
runs, in the same order" (the runner adds an append-only check CI does *not* run) and a
documented `Workstream (Epic)` label row (that group no longer exists in Linear).

## Notes for the reviewer

- **Spawned OME-474 (P1).** Drafting `pip install url4` revealed the PyPI name `url4` belongs
  to Andrew Trask's separate `iamtrask/url4` (v0.1, 2026-02-22, url4.ai, ≥3.10). This repo's
  `packages/url4` is v0.1.0/≥3.12 and unpublished, yet `release-url4.yml` tells an owner to
  *"reserve the `url4` project on PyPI"* — impossible. The lane will build green and fail at
  publish on the first `url4-v*` tag. **Both files therefore say nothing about installing the
  SDK** rather than something false. Its mirror rides in this PR (mirrors are due at create; a
  dedicated PR for one 15-line file wasn't worth it).
- **Owner reconcile still pending** (not touched here): the `Epic`/workstream label group is
  gone from Linear while the task-board card still registers it, and OME-365 carries
  `repo-dev-processes`, which current `main`'s card no longer lists.

Ledger: `docs/work/2026-07-17-OME-365-docs-refresh.md`
