### PR TITLE
docs(skills): rewrite task-management skill 

### DIFF
--- a/.claude/skills/task-management/SKILL.md
+++ b/.claude/skills/task-management/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Use for ANY task/ticket work — creating, triaging, planning, implementing, or closing work items — in this repo. All units of work live as Linear issues (OME-N) in the Engineering team under the 😱 ScreamingFace V1 project, per the .claude/task-board.local.md card. Defines the lifecycle (plan → tickets → owner review → per-ticket SDLC → close), the label taxonomy (workstream Epic group, app/pkg landing, who-acts, mandatory actor), STOP labels, close discipline, docs/tasks mirrors, the Linear MCP command crib, and the Linear rich-text dialect. Invoke at session start, before starting any unit of work, and before filing or closing an issue.
+description: Use for ANY task/ticket work — creating, triaging, planning, implementing, or closing work items. All units of work are Linear issues in the team + project named in .claude/task-board.local.md. Defines the lifecycle, the label taxonomy (single-select landing groups + actor / who-acts / type), STOP statuses, sprint milestones, close discipline, docs/tasks mirrors, the Linear MCP command crib, and the Linear rich-text dialect. Invoke at session start, before starting any unit of work, and before filing or closing an issue.
 user_invocable: true
 ---
 
@@ -7,134 +7,156 @@ user_invocable: true
 
 **Announce at start:** "Using the task-management skill — the Linear work-item lifecycle."
 
+> This skill is workspace-agnostic. Every concrete name — team, project, issue-key prefix,
+> the label groups and their leaves, milestone/sprint names, status names, the
+> `close_template` — resolves from **`.claude/task-board.local.md`** (the "card"). Where this
+> doc shows an example set, it is illustrative; the card is authoritative.
+
 ## Card resolution — before anything
 
-Read `.claude/task-board.local.md` in the project root. **Missing → HARD STOP:** tell the
-user the card is gone and stop — never guess the team, project, states, or label IDs. Every
-`{{…}}` placeholder below resolves from that card. Read the card BODY too — its ticket
-rules bind alongside this skill.
+Read `.claude/task-board.local.md` (at the **repo root** `.claude/`, not beside this skill). **Missing → HARD STOP:** tell the user the card is gone
+and stop — never guess team, project, or label IDs. `{{…}}` placeholders resolve from the
+card; its body rules bind alongside this skill.
 
-**Transport: the Linear MCP plugin ONLY** (`mcp__plugin_linear_linear__*` tools; activate
-via `/mcp`). **API tokens and raw GraphQL are FORBIDDEN.** Operations the MCP cannot
-perform (label/team/state management, issue deletion) are OWNER actions in the Linear UI —
-hand them over with precise steps.
+**Transport: the Linear MCP plugin ONLY** (`mcp__plugin_linear_linear__*`; activate via
+`/mcp`). **API tokens and raw GraphQL are FORBIDDEN.** Agents act **only on issues** — create
+issues; edit an issue's title, applied labels, status, priority, milestone, assignee,
+relations, and comments. **Agents do NOT create, rename, delete, reparent, or edit labels** —
+all label management (and teams, workflow states, templates, integrations, and issue
+deletion) is an **OWNER action in the Linear UI**. When one is needed, hand it over with
+precise steps.
 
-The single task holder is the card's team + project. No parallel boards: session-local todo
-tools are fine for intra-session step tracking, but any unit of work that outlives the
-session MUST be a Linear issue. The work-ledger (`docs/work/`) stays the how/audit record;
-the issue is the what/status record — they cross-reference, they don't duplicate. Every
-issue additionally gets a repo mirror `docs/tasks/YYYY-MM-DD-<name>.md` (frontmatter: id,
-linear_url, asana_url?, status, type, priority, labels, created, closed) — written at
-create, closed at finish; **Linear is the status authority**.
+Single holder = the card's team + project (`{{team}}` · `{{project}}`). No parallel boards.
+Session todos are fine for intra-session tracking; anything that outlives the session is a
+Linear issue. The `docs/work/` ledger is the how/audit record; the issue is the what/status
+record — they cross-reference, never duplicate. Every issue gets a repo mirror
+`docs/tasks/YYYY-MM-DD-<name>.md` (frontmatter: id, linear_url, asana_url?, status, type,
+priority, labels, created, closed). **Linear is the status authority.**
 
-## The label taxonomy (locked — D10/D13)
+## Label taxonomy
 
-- **Workstream** — the existing `Epic` label group (ONE per issue, Linear-enforced):
-  url4 Engine · AI Gateway · Eval Runner & Datasets · Results & Runs · Leaderboard ·
-  Auth & Subsidized Compute · Desktop App · Python SDK · Multi-turn Ensembles · SOTA Hunt ·
-  Compute Budgeting. Apply whenever the work belongs to one. Workstreams are PRODUCT
-  concepts — never mint one for an internal module; additions are coordinated with the
-  project lead and registered in the card in the same change.
-- **Landing (WHERE)** — plain multi-value labels: `app/aigateway`, `app/scoreboard`,
-  `pkg/url4-python-sdk` (more at name lock), or `repo` for repo/process work (no app/pkg).
-- **`who-acts` group** (ONE per issue): `design-session` — a direction fork; agents may
-  PREPARE, never decide · `autonomous` — agent-runnable end-to-end · `deferred` — recorded,
-  gated on a named precondition (state the gate in the body).
-- **`actor` group (ONE per issue, MANDATORY — D13):** `agentic` or `human` — who executes
-  the work. Set at filing; flip if ownership changes.
-- **STOP labels (D12):** existing `blocked ⛔` (hard question pending) and `needs-owner`
-  (only a decision/visual check pending). A STOP = apply the label + comment the exact
-  question; the issue STAYS In Progress; remove the label when resolved. Never add
-  workflow states to the shared team.
-- Optional type tagging via existing plain labels `Bug` / `Feature` / `Improvement`.
-- **Priority** (Linear ints): P1→2 (High, work next) · P2→3 (Medium, queued) · P3→4 (Low,
-  parked); 1 (Urgent) is reserved for incidents. The agent proposes; the owner's setting wins.
+Labels are organized as **single-select groups** — one leaf per group per issue, enforced by
+Linear — and are **two levels deep**; a sub-component is a slash inside the leaf name
+(`desktop/eval-runner`), NOT a real sub-group. The exact groups and leaves live in the card.
+**Agents never mint labels.** Need a new leaf? Propose it to the project lead, who creates it
+in the UI and registers it in the card in the same change — then apply it to issues.
 
-**Cross-cutting rule (D9):** work touching **≥2** `app/*`/`pkg/*` landings → file an
-**epic** (parent issue) carrying its workstream label + ALL affected landing labels, with
-one sub-issue per affected app/package (one SDLC unit each; each sub-issue carries its own
-landing label + the same workstream label). Never a single-app filing, never one mega-ticket.
+- **Landing — WHERE the work lands.** One or more top-level groups partition work by landing
+  type (application vs package vs cross-cutting vs research, etc.). Pick **exactly one leaf**,
+  normally from one group. Leaves carry UI descriptions — trust them.
 
-## The lifecycle
+  > **Example (this workspace's card):** groups `app` / `pkg` / `extra` / `research`, e.g.
+  > `app › desktop`, `app › desktop/eval-runner`, `app › aigateway`, `pkg › <lib>`,
+  > `extra › <cross-cutting>`, `research › <spike>`. Your card defines the real set.
+
+- **`actor` — `agentic` | `human`.** Who executes. Required on **agent-executed / SDLC**
+  items; human-owned roadmap tickets may carry just the landing leaf + assignee (actor = the
+  assignee).
+- **`who-acts` (one, on SDLC items):** `design-session` (direction fork — agents prepare,
+  never decide) · `autonomous` (agent-runnable end-to-end) · `deferred` (gated on a named
+  precondition — state it in the body).
+- **`type` (one, optional):** `decision` (a locked decision, not code) · `task`
+  (mechanical/housekeeping/research — no product-behaviour change). Extend only via the card.
+- **STOP is a STATUS, not a label:** move to the **Blocked** state (hard question pending) or
+  **Needs Owner** state (only a decision/visual check pending) + comment the exact question;
+  move back when resolved.
+- **Blockers are RELATIONS, not prose:** if a ticket waits on another, set a **blocked-by**
+  relation (not just a "Gate:" line) so the dependency graph is real and ordering surfaces.
+- **Priority** (Linear ints): 1 Urgent (launch-blocking) · 2 High · 3 Medium · 4 Low. If the
+  workflow has a dedicated "queued next" state, use that for ordering — not priority — and
+  keep the two distinct. Agent proposes; owner's setting wins.
+
+**Cross-cutting rule:** an issue carries **at most one** landing leaf. Work spanning ≥2
+landings → a parent **epic** + one **sub-issue per landing** (each with its single leaf).
+Two leaves from one group are rejected by Linear — that's the signal to split.
+
+## Two ticketing modes
+
+- **Human-filed (roadmap / epic / decision):** use the Linear **issue templates** the card
+  lists (typically a default Roadmap template, a Cross-cutting Epic template, and a Decision
+  template). The template supplies the body shape and preset labels; the filer adds the
+  landing leaf, milestone, priority, assignee.
+- **Agent-filed SDLC unit:** filed through the MCP per this skill (deliberately **no UI
+  template** — the skill is the template). Carries a landing leaf + `agentic`|`human` + a
+  `who-acts` leaf; runs ledger → RED → GREEN → gates → commit (`Refs: <issue-id>`), then the
+  close-comment.
+
+## Naming & board conventions
+
+- **Title = imperative summary only.** Do **not** prefix titles with the issue ID — Linear
+  shows the ID natively beside every issue. No legacy component prefixes either; the landing
+  leaf carries the component. Leaf names are lowercase-kebab.
+- **Sprints are milestones** (named + owned by the project lead in the card). Product work
+  slots into the active sprint milestone; pure repo/process work takes no milestone.
+- Every issue: one landing leaf + priority; product work also gets milestone + assignee.
+
+## Lifecycle & statuses
 
 ```
-PLAN (docs/plan artifact) ──▶ TICKETS (one issue per SDLC-unit-sized deliverable;
-  multi-unit arcs get a parent epic with sub-issues)
-──▶ OWNER TICKET REVIEW (scope/priority/labels; design-session forks resolved or scheduled)
-──▶ PLAN ONE TICKET ──▶ IMPLEMENT IT (the stack's sdlc-* loop: ledger → RED → GREEN →
-  gates → commit; the ledger names the issue; commit bodies carry `Refs: OME-N`)
-──▶ CLOSE (see close discipline) ──▶ NEXT TICKET
+PLAN (docs/plan) ─▶ TICKETS (one per SDLC-unit; multi-landing → epic + sub-issues)
+─▶ OWNER REVIEW (scope/priority/labels/milestone) ─▶ IMPLEMENT (sdlc-* loop) ─▶ CLOSE ─▶ NEXT
 ```
+The team's workflow states (exact names per the card) follow the shape: **incoming/backlog →
+queued-next → in-progress → in-review → done**, plus the two STOP states (**Blocked**,
+**Needs Owner**) and terminal **Canceled** / **Duplicate**.
 
-- **Status mapping:** Todo → **In Progress** when the ticket's ledger is created → **Done**
-  when the issue closes. `In Review` while the PR awaits review. STOPs are labels (D12),
-  not states. Move status at those moments, not retroactively.
-- **Batching:** several INDEPENDENT tickets may run in one batch (one sdlc-unit-executor
-  per ticket; sequential when they share a stack). Declare the batch up front — each ticket
-  still gets its own ledger, commits, and close comment.
-- **Mid-session discoveries:** new work found while implementing → file the ticket first
-  (30 seconds), then decide: in-scope for the current unit, or leave it. Never let work
-  exist only in a chat transcript.
-- **Milestones** belong to the product project (sprints S0–S5, owned by the project lead).
-  Product work slots into the current sprint milestone with the lead's agreement;
-  repo/process items take no milestone.
+**If GitHub status automation is enabled** (see the card): opening the PR moves the issue to
+*in-review*, merging moves it to *done* (branch names follow `…/<issue-id>-…`;
+`Fixes <issue-id>` in the PR body also closes it). In that case you manually set only the
+*queued-next* and *in-progress* states (in-progress at ledger creation) and the STOP states —
+don't hand-move the in-review/done transitions the PR will drive.
 
 ## Close discipline
 
-An issue closes ONLY with a comment carrying the card's `close_template` filled: commit
-shas + messages, the gates that ran (test counts/baselines), the ledger path(s), deviations,
-and anything the owner must verify visually. Wrap long gate output in a `+++ Gates` …
-`+++` collapsible. Then set state Done and close the `docs/tasks/` mirror (status + closed
-date). Closing without this comment is a process violation.
+Even with GitHub auto-done, an issue is only properly closed with the card's `close_template`
+filled: commit shas + messages, gates that ran (test counts/baselines), ledger path(s),
+deviations, owner-visual-check notes. Long gate output in a `+++ Gates … +++` collapsible.
+Then close the `docs/tasks/` mirror. A merge without the close-comment is an incomplete close.
 
-## Command crib (Linear MCP tools; names resolve via the card)
+## Command crib (Linear MCP)
 
-- **Create:** `save_issue {team: "Engineering", project: "{{project.slug}}", title, description,
-  labels: ["repo"|"app/…", "<workstream>", "autonomous"|…, "agentic"|"human"], priority, parentId?}`
-  → returns the native `OME-N` identifier + URL. NO id parameter on create.
-- **Move state:** `save_issue {id: "OME-N", state: "In Progress" | "In Review" | "Done"}`
-- **STOP / un-STOP:** read current labels (`get_issue`), then `save_issue {id, labels: [<union
-  ± stop label>]}` + `save_comment {issueId: "OME-N", body: "<exact question>"}`
-- **Close comment:** `save_comment {issueId: "OME-N", body: <close_template filled>}`
-- **List/find:** `list_issues {project, label?, state?, query?, parentId?}` · `get_issue {id}`
-- **New label** (only when the card registers it in the same change): `create_issue_label
-  {name, color, description, parent?/isGroup?}`
+- **Create:** `save_issue {team: "{{team}}", project: "{{project.slug}}", title: "<imperative summary>", description, labels: ["<landing leaf>", ("agentic"|"human")?, ("autonomous"|"deferred"|"design-session")?], priority, milestone?, assignee?, parentId?}` → returns the issue ID + URL. NO id on create; NO issue-ID in the title.
+- **Move state (only the non-automated ones):** `save_issue {id, state: "<queued-next>"|"<in-progress>"|"<Blocked>"|"<Needs Owner>"}` (use the card's exact state names)
+- **STOP:** `save_issue {id, state: "<Blocked>"|"<Needs Owner>"}` + `save_comment {issueId, body: "<exact question>"}`
+- **Blocker relation:** `save_issue {id, blockedBy: ["<issue-id>"]}` (append-only; `removeBlockedBy` to clear)
+- **Close:** `save_comment {issueId, body: <close_template>}` (a PR merge usually sets done)
+- **List/find:** `list_issues {project, label?, state?, query?, parentId?}` · `get_issue {id}` (list truncates descriptions ~500 chars — use `get_issue` for full bodies/relations)
+- **New leaf:** OWNER UI action — agents don't create labels. Propose it to the lead; they create it and register it in the card, then you apply it via `save_issue.labels`.
 
-**MCP quirks (encode these in your calls):**
-- `save_issue.labels` **REPLACES the full label set** — always read current labels first
-  and resend the union. Relations (`blockedBy`, `relatedTo`, `links`) are append-only.
-- Send **raw markdown with literal newlines** — never `\n` escape sequences.
-- `assignee` accepts `"me"`, a name, or an email.
+**MCP quirks:**
+- `save_issue.labels` **REPLACES the full set** — `get_issue` first, resend the union.
+  Relations (`blockedBy`, `relatedTo`, `links`) are append-only.
+- Two leaves of one group are rejected/collapsed — the split signal.
+- Raw markdown, **literal newlines** — never `\n` escapes. `assignee` = `"me"`/name/email.
 
-## Linear rich text — the markdown dialect for descriptions & comments
+## Linear conventions we rely on (owner-configured, not MCP; see the card)
 
-- **Headings:** `#`–`####` (H1–H4). Deeper levels don't exist.
-- **Text:** `**bold**`, `_italic_`, `~~strike~~`, `` `inline code` ``. Underline has NO
-  markdown syntax (editor-only) — don't try.
-- **Lists:** `-`/`*`/`+` bullets, `1.` numbered, `- [ ]` checklists (render as interactive
-  checkboxes — good for acceptance lists); all nestable.
-- **Blockquote:** `>` · **Collapsible section:** `+++ Title` on its own line, content,
-  closing `+++` (nestable) — use for long logs/gate output.
-- **Code:** fenced ``` blocks with a language tag; ` ```mermaid ` renders a Mermaid diagram.
-- **Divider:** `---` · **Tables:** GFM pipe tables (keep simple — no spans).
-- **Emoji:** `:name:` · **No HTML** — it is not rendered.
-- **Mentions — SIDE-EFFECTS:** `@displayName` notifies + subscribes that user. Issue
-  references auto-link aggressively: `@OME-123`, pasted issue URLs, AND bare `OME-123`
-  identifiers in plain prose all become issue embeds (verified live) and can create
-  "related to" relations. Wrap IDs in backticks when no link/relation is wanted.
-- **Embeds:** bare YouTube/Loom/Figma/Google-Docs URLs auto-embed; wrap in `[text](url)`
-  to keep a plain link.
+- **Issue templates** for the human-filed modes (Roadmap default · Cross-cutting Epic · Decision).
+- **GitHub integration** auto-transitioning status (in-review on PR open, done on merge), where enabled.
+- **Single-select label groups** enforcing one leaf per axis (the cross-cutting split signal).
+- **Label descriptions** documenting each leaf in the picker — keep them current.
 
-## Anti-patterns — STOP immediately
+## Linear rich text
+
+Headings `#`–`####`; `**bold**` `_italic_` `~~strike~~` `` `code` `` (no underline);
+`-`/`1.`/`- [ ]` lists; `>` quote; **`+++ Title … +++`** collapsible (logs/gates); fenced
+code (` ```mermaid ` renders); `---`; GFM tables; `:emoji:`; **no HTML**. **Refs have
+side-effects:** `@name` notifies; an `@`-prefixed ID, issue URLs, AND a bare issue ID become
+issue embeds + can create relations — wrap IDs in backticks for a plain reference. Bare
+YouTube/Loom/Figma/Docs URLs auto-embed; `[text](url)` keeps a link.
+
+## Anti-patterns — STOP
 
 | Thought | Reality |
 |---|---|
-| "I'll track this in the session todo only." | Outlives the session? It's a Linear issue. File it. |
-| "One big issue for the whole plan." | Decompose: epic parent + SDLC-unit sub-issues. |
-| "It touches two apps but I'll label just one." | D9 STOP: epic + one sub-issue per affected app/package. |
-| "I'll skip the actor label." | D13: `agentic` or `human` is MANDATORY on every item. |
-| "Close it, the code's merged." | No close without the commits+gates+ledger comment. |
-| "It's a design-session ticket but the answer is obvious." | Prepare a proposal; the owner decides. |
-| "I'll mint a label the card doesn't register." | The card is the registry. Register first, same change. |
-| "The MCP can't do it — I'll use the API key." | FORBIDDEN. MCP-uncovered ops are owner UI actions. |
-| "I'll set labels without reading current ones." | `labels` REPLACES the set — read, union, resend. |
+| "Session todo is enough." | Outlives the session? Linear issue. |
+| "One big issue for the plan." | Epic parent + SDLC-unit sub-issues. |
+| "Two landings, one leaf." | Group is single-select — epic + one sub-issue per landing. |
+| "Prefix the title with the issue ID." | Don't — Linear shows the ID; title is the summary. |
+| "Add a `blocked` label." | STOP is a STATUS (Blocked / Needs Owner); waits are blocked-by relations. |
+| "I'll hand-set in-review / done." | If GitHub automation is on, the PR does that — set only queued-next / in-progress / STOP. |
+| "Close it, code's merged." | Merge ≠ close-comment. File commits+gates+ledger. |
+| "design-session, answer's obvious." | Prepare a proposal; owner decides. |
+| "I'll create the label I need." | Agents never create labels — propose it; the lead adds it in the UI + card, then you apply it. |
+| "MCP can't — use the API key." | FORBIDDEN. Uncovered ops are owner UI actions. |
+| "Set labels without reading current." | `labels` REPLACES — read, union, resend. |


### PR DESCRIPTION
## What
  Rewrites `.claude/skills/task-management/SKILL.md` to match the reorganized Linear board
  and makes it workspace-agnostic — every concrete name (team, project, issue-key prefix,
  label groups/leaves, milestone + status names, close_template) now resolves from
  `.claude/task-board.local.md` instead of being hardcoded.

## Why
The board moved from a two-axis label system (an `Epic` "workstream" group **plus** flat
  multi-value `app/*`/`pkg/*` landing labels) to a **single landing taxonomy** of
  single-select groups. STOP moved from labels to statuses, GitHub now auto-transitions
  status, and issue templates were added. The old skill still described the previous model
  (and was pinned to one workspace), so it no longer matched reality.

  ## Key changes
  - **Labels:** single-select **landing groups** (pattern: `app`/`pkg`/`extra`/`research`)
    replace the Epic workstream group + multi-value landing labels — **one leaf per issue**.
    Cross-cutting work → epic + **one sub-issue per landing** (two leaves from one group is
    the split signal).
  - **STOP is a status**, not a label (`Blocked` / `Needs Owner`); "do this next" is a
    queued-next status, not priority.
  - **Blockers are relations** (`blocked-by`), not prose "Gate:" lines.
  - **`actor` de-mandated:** required on agent/SDLC items, optional on human roadmap tickets.
    Type axis is the `type` group (`decision`/`task`); dropped `Bug`/`Feature`/`Improvement`
    and the `repo` label.
  - **Titles = summary only** — no issue-ID prefix (Linear shows the ID natively).
  - **Two ticketing modes:** human-filed via issue templates (Roadmap default / Cross-cutting
    Epic / Decision) vs agent-filed SDLC units by the skill (no UI template).
  - **GitHub auto-status** folded into the lifecycle (PR open → In Review, merge → Done).
  - **Policy — agents act only on issues.** All label/team/workflow-state/template/integration
    management (create, rename, delete, reparent, description-edit) is an owner UI action.
  - **Milestones = card-named sprints** (was hardcoded `S0–S5`).
  - Genericized all concrete names to card placeholders; fixed prior copy corruption
    ("Lie status authority", garbled crib lines, etc.).

  ## Already applied in Linear (out of band, not in this PR)
  Label groups + leaves, full issue re-tagging, the new statuses, per-leaf label descriptions,
  issue templates, and GitHub status automation are already live in the workspace.
