### PR TITLE
feat(aigateway): add OpenRouter BYOK provider (OME-428)

### DIFF
--- a/apps/aigateway/src/aigateway/core/http_status.py
+++ b/apps/aigateway/src/aigateway/core/http_status.py
@@ -1,0 +1,25 @@
+"""Strict HTTP-status validation shared across core and provider plugins.
+
+Provider-neutral: the one place that decides whether an upstream-supplied value
+is a usable HTTP error status. Consolidates three previously-divergent copies
+(OME-428 third-review blocker E).
+"""
+
+from __future__ import annotations
+
+
+def valid_http_error_status(value: object) -> int | None:
+    """Return ``value`` when it is a real HTTP error status (400-599), else None.
+
+    # INVARIANT: exactly ``type(value) is int and 400 <= value <= 599``.
+    # WHY: ``type(... ) is int`` (not ``isinstance``) rejects ``bool`` — a
+    # ``True``/``False`` is an ``int`` subclass and ``int(True) == 1`` is not a
+    # status. Strings, floats (incl. ``nan``/``inf``), and ``Decimal`` are all
+    # rejected: the OpenRouter ``error.code`` schema is integer-only, and
+    # ``"²".isdigit()`` is True while ``int("²")`` raises ValueError (the exact
+    # crash-to-500 this validator exists to prevent), while a fullwidth
+    # ``"４２９"`` would otherwise be silently coerced to 429.
+    """
+    if type(value) is int and 400 <= value <= 599:
+        return value
+    return None

--- a/apps/aigateway/src/aigateway/core/provider_errors.py
+++ b/apps/aigateway/src/aigateway/core/provider_errors.py
@@ -1,0 +1,28 @@
+"""Provider error types shared by core and provider plugins (OME-428 CODE-2).
+
+Provenance matters at the retry decision: a transport failure (litellm raised
+before a response existed) may be retried, but an error a plugin manufactures
+from an already-returned response body means the upstream call happened — and
+may already be billed — so it must never trigger another upstream call.
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException
+
+
+class NonRetryableProviderError(HTTPException):
+    """An error manufactured from an already-returned upstream response.
+
+    # WHY: plugins detect provider failures embedded in nominal HTTP-200
+    # bodies (e.g. OpenRouter's in-body 429). Raising a plain HTTPException
+    # with a retryable status would re-enter the overload-retry loop and
+    # re-dispatch a call that already completed upstream.
+    # INVARIANT: subclasses HTTPException so the routes' dispatch-failure
+    # path (credential marking, error rendering) is unchanged; only the
+    # retry predicate reads the marker.
+    """
+
+    # Read duck-typed by core.retry.is_retryable_status — retry.py stays
+    # stdlib-only by never importing this (fastapi-backed) module.
+    aigw_non_retryable = True

--- a/apps/aigateway/src/aigateway/core/request_hardening.py
+++ b/apps/aigateway/src/aigateway/core/request_hardening.py
@@ -1,0 +1,165 @@
+"""Shared chat-ingress hardening (OME-428, plan D6).
+
+Mode-independent and provider-neutral: applied at the /v1/chat/completions
+ingress for EVERY provider, after JSON parsing and body-shape validation but
+before profile lookup, cache planning, or credential access.
+
+``DISPATCH_CONTROL_FIELDS`` is the known LiteLLM control plane: fields that
+redirect routing (``api_base``/``base_url``/``fallbacks``/``model_list`` are
+credential-exfiltration vectors), smuggle credentials (``api_key``,
+``headers``), disable safety (``ssl_verify``), forge accounting
+(``*_cost_per_*``), or bend dispatch behavior (retry/mock/drop controls).
+Stripping is silent in local mode — legitimate provider fields (OpenRouter
+``provider``/``plugins``/``route``/``models``, tools, sampling params) pass
+through untouched.
+
+``timeout`` is deliberately NOT in the list: gemini/codex/antigravity consume
+it as an ordinary dispatch parameter.
+
+Pure functions only — no FastAPI types — so hosted-mode policy (Checkpoint B)
+can compose the same primitives.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+_CALLBACK_DYNAMIC_FIELDS: frozenset[str] = frozenset(
+    {
+        "langfuse_public_key",
+        "langfuse_secret",
+        "langfuse_secret_key",
+        "langfuse_host",
+        "langfuse_prompt_version",
+        "langsmith_api_key",
+        "langsmith_project",
+        "langsmith_base_url",
+        "langsmith_sampling_rate",
+        "langsmith_tenant_id",
+        "humanloop_api_key",
+        "arize_api_key",
+        "arize_space_key",
+        "arize_space_id",
+        "posthog_api_key",
+        "posthog_host",
+        "braintrust_api_key",
+        "braintrust_project",
+        "braintrust_host",
+        "slack_webhook_url",
+        "lunary_public_key",
+        "turn_off_message_logging",
+    }
+)
+
+_CALLBACK_METADATA_HEADER_FIELDS: frozenset[str] = frozenset(
+    {
+        "litellm-disable-message-redaction",
+        "litellm-enable-message-redaction",
+        "x-litellm-enable-message-redaction",
+    }
+)
+
+DISPATCH_CONTROL_FIELDS: frozenset[str] = frozenset(
+    {
+        "api_key",
+        "api_base",
+        "base_url",
+        "headers",
+        "model_list",
+        "fallbacks",
+        "context_window_fallbacks",
+        "context_window_fallback_dict",
+        "content_policy_fallbacks",
+        "extra_body",
+        "drop_params",
+        "additional_drop_params",
+        "use_litellm_proxy",
+        "custom_llm_provider",
+        "deployment_id",
+        "ssl_verify",
+        "max_retries",
+        "num_retries",
+        "cooldown_time",
+        "no-log",
+        "mock_response",
+        "mock_tool_calls",
+        "mock_timeout",
+        "mock_delay",
+        "provider_specific_header",
+        "input_cost_per_token",
+        "output_cost_per_token",
+        "input_cost_per_second",
+        "output_cost_per_second",
+        # SEC-1: provider/mode-flip flags — litellm 1.87.0 flips onto the azure
+        # branch on `azure: true` (main.py:1398) and flips completion mode on
+        # `text_completion`/`atext_completion` (main.py:1327-1328); same
+        # category as the stripped custom_llm_provider/deployment_id.
+        "azure",
+        "text_completion",
+        "atext_completion",
+        # Blocker A (third review): caller-injectable litellm logging/observability
+        # control-plane. A truthy `litellm_request_debug` makes litellm 1.87.0 log
+        # the raw curl (request data/prompt) and raw response at WARNING — "in all
+        # environments" (litellm_logging.py:1143-1168) — defeating the gateway
+        # sanitizer. `verbose`/`logger_fn`/`litellm_logging_obj` are the sibling
+        # logging hooks read straight from kwargs (main.py:1264-1267). Classified
+        # by behavior, not name: none is an OpenRouter generation parameter, so a
+        # legitimate provider-level option is never caught here.
+        "litellm_request_debug",
+        "verbose",
+        "logger_fn",
+        "litellm_logging_obj",
+        # Request-level callbacks mutate process-global LiteLLM callback lists;
+        # dynamic credentials/hosts can route prompt/response telemetry. Strip
+        # selectors and parameters before any provider sees the body.
+        "callbacks",
+        "success_callback",
+        "failure_callback",
+        "litellm_params",
+        "litellm_metadata",
+        *_CALLBACK_DYNAMIC_FIELDS,
+    }
+)
+
+
+def strip_dispatch_controls(body: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a new body without any LiteLLM control-plane field."""
+    stripped = {key: value for key, value in body.items() if key not in DISPATCH_CONTROL_FIELDS}
+    metadata = stripped.get("metadata")
+    if isinstance(metadata, Mapping):
+        # LiteLLM also resolves callback credentials/hosts from request
+        # metadata. Preserve unrelated provider metadata in a fresh mapping.
+        sanitized_metadata = {
+            key: value for key, value in metadata.items() if key not in _CALLBACK_DYNAMIC_FIELDS
+        }
+        metadata_headers = sanitized_metadata.get("headers")
+        if isinstance(metadata_headers, Mapping):
+            sanitized_metadata["headers"] = {
+                key: value
+                for key, value in metadata_headers.items()
+                if key not in _CALLBACK_METADATA_HEADER_FIELDS
+            }
+        stripped["metadata"] = sanitized_metadata
+    return stripped
+
+
+def chat_body_shape_error(body: object) -> str | None:
+    """Validate the untrusted chat body shape; return an error message or None.
+
+    Guarantees the route can never 500 on malformed input (plan D6): after
+    this returns None, ``model`` is a str, ``messages`` is a list of dicts,
+    and ``stream`` is absent or a real boolean.
+    """
+    if not isinstance(body, dict) or "model" not in body or "messages" not in body:
+        return "model and messages are required"
+    if not isinstance(body["model"], str):
+        return "model must be a string"
+    if not isinstance(body["messages"], list):
+        return "messages must be a list"
+    if any(not isinstance(message, dict) for message in body["messages"]):
+        return "each message must be an object"
+    # bool is checked with `is not` on type: `stream: 1` must not pass as truthy.
+    if "stream" in body and type(body["stream"]) is not bool:
+        return "stream must be a boolean"
+    return None

--- a/apps/aigateway/src/aigateway/core/retry.py
+++ b/apps/aigateway/src/aigateway/core/retry.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -21,6 +21,16 @@ logger = logging.getLogger(__name__)
 
 # 429 rate-limited, 503 service-unavailable, 529 overloaded (Anthropic).
 RETRYABLE_STATUS_CODES = frozenset({429, 503, 529})
+_MAX_RETRY_AFTER_SECONDS = (1 << 63) - 1
+_MAX_RETRY_AFTER_TEXT = str(_MAX_RETRY_AFTER_SECONDS)
+
+
+def _safe_getattr(obj: Any, name: str) -> Any:
+    """Read an untrusted exception attribute without escaping the error path."""
+    try:
+        return getattr(obj, name, None)
+    except Exception:
+        return None
 
 
 @dataclass(frozen=True)
@@ -43,7 +53,7 @@ class RetryPolicy:
 
 
 def _status_code(exc: BaseException) -> int | None:
-    code = getattr(exc, "status_code", None)
+    code = _safe_getattr(exc, "status_code")
     # bool is an int subclass; reject it explicitly.
     if isinstance(code, bool) or not isinstance(code, int):
         return None
@@ -51,20 +61,34 @@ def _status_code(exc: BaseException) -> int | None:
 
 
 def is_retryable_status(exc: BaseException) -> bool:
+    # WHY (OME-428 CODE-2): errors manufactured from an already-returned
+    # upstream payload (core.provider_errors.NonRetryableProviderError) carry
+    # a retryable-looking status_code but the upstream call already happened —
+    # retrying would re-dispatch a possibly-billed request. Duck-typed so this
+    # module stays stdlib-only.
+    if _safe_getattr(exc, "aigw_non_retryable") is True:
+        return False
     return _status_code(exc) in RETRYABLE_STATUS_CODES
 
 
-def _seconds_from_headers(headers: Any) -> float | None:
+def _seconds_from_headers(headers: Any) -> int | None:
     if headers is None:
         return None
     raw = _case_insensitive_header(headers, "retry-after")
     if raw is None:
         return None
-    try:
-        value = float(raw)
-    except (TypeError, ValueError):
-        return None  # HTTP-date form unsupported -> backoff fallback
-    return max(0.0, value)
+    # RFC 9110 delay-seconds = 1*DIGIT: ASCII, unsigned, integral. HTTP-date
+    # remains unsupported and falls through to the next source/backoff.
+    if not isinstance(raw, str) or not raw or not raw.isascii() or not raw.isdecimal():
+        return None
+    normalized = raw.lstrip("0") or "0"
+    if len(normalized) > len(_MAX_RETRY_AFTER_TEXT) or (
+        len(normalized) == len(_MAX_RETRY_AFTER_TEXT) and normalized > _MAX_RETRY_AFTER_TEXT
+    ):
+        # Keep a syntactically valid but absurd hint valid and budget-exceeding;
+        # never let Python's integer digit limit turn it into fallback/retry.
+        return _MAX_RETRY_AFTER_SECONDS
+    return int(normalized)
 
 
 def _case_insensitive_header(headers: Any, name: str) -> Any:
@@ -76,36 +100,45 @@ def _case_insensitive_header(headers: Any, name: str) -> Any:
     A plain ``dict.get("retry-after")`` would miss it and silently drop the
     hint.
     """
+    if not isinstance(headers, Mapping):
+        return None
     target = name.lower()
     try:
         value = headers.get(name)
-    except AttributeError:
+        if value is not None:
+            return value
+        for key, val in headers.items():
+            if isinstance(key, str) and key.lower() == target:
+                return val
+    except Exception:
         return None
-    if value is not None:
-        return value
-    items = getattr(headers, "items", None)
-    if items is None:
-        return None
-    for key, val in items():
-        if isinstance(key, str) and key.lower() == target:
-            return val
     return None
 
 
-def parse_retry_after_seconds(exc: BaseException) -> float | None:
+def parse_retry_after_seconds(exc: BaseException) -> int | None:
     """Read an integer ``Retry-After`` (delta-seconds) off the exception.
 
-    Checks ``exc.response.headers`` first (LiteLLM exceptions) then
-    ``exc.headers`` (FastAPI ``HTTPException`` — how the aigateway provider
-    plugins surface upstream 429s, e.g. the Gemini reset hint). Returns
-    ``None`` for absent/malformed/HTTP-date values so the caller falls back to
-    exponential backoff. Never raises.
+    # WHY (blocker C): litellm 1.87.0 surfaces an OpenRouter transport 429/503's
+    # wire header on ``exc.litellm_response_headers`` — ``exc.response.headers``
+    # is empty there — so that source must be read or the validated hint is lost.
+    # Precedence is fixed and total: ``response.headers`` (httpx canonical) →
+    # ``litellm_response_headers`` (litellm's extracted wire headers) →
+    # ``exc.headers`` (FastAPI ``HTTPException`` — how the plugins surface upstream
+    # 429s, e.g. the Gemini reset hint). The first source yielding a valid integer
+    # wins; that single value drives both the retry sleep and the response header.
+    # Returns ``None`` for absent/invalid/HTTP-date values so the
+    # caller falls back to exponential backoff. Never raises.
     """
-    response_headers = getattr(getattr(exc, "response", None), "headers", None)
-    seconds = _seconds_from_headers(response_headers)
-    if seconds is not None:
-        return seconds
-    return _seconds_from_headers(getattr(exc, "headers", None))
+    response_headers = _safe_getattr(_safe_getattr(exc, "response"), "headers")
+    for headers in (
+        response_headers,
+        _safe_getattr(exc, "litellm_response_headers"),
+        _safe_getattr(exc, "headers"),
+    ):
+        seconds = _seconds_from_headers(headers)
+        if seconds is not None:
+            return seconds
+    return None
 
 
 async def with_overload_retry[T](
@@ -129,17 +162,26 @@ async def with_overload_retry[T](
         except Exception as exc:
             if not is_retryable_status(exc) or attempt >= policy.max_retries:
                 raise
-            delay = parse_retry_after_seconds(exc)
-            if delay is None:
+            retry_after = parse_retry_after_seconds(exc)
+            delay: int | float
+            if retry_after is None:
                 delay = min(
                     policy.backoff_base_seconds * 2**attempt,
                     policy.backoff_max_seconds,
                 )
+            else:
+                delay = retry_after
+            remaining_budget = policy.max_total_wait_seconds - total_waited
+            # Check an integer provider hint before adding float jitter: a very
+            # large but syntactically valid delta-seconds must re-raise the
+            # original overload, not overflow during int-to-float conversion.
+            if delay > remaining_budget:
+                raise
             # Jitter both paths (backoff *and* honored Retry-After): concurrent
             # siblings handed the same reset window must de-synchronise, else
             # they wake in lockstep and re-collide on the next window.
             delay += random.uniform(0.0, policy.jitter_seconds)
-            if total_waited + delay > policy.max_total_wait_seconds:
+            if delay > remaining_budget:
                 raise
             attempt += 1
             total_waited += delay

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/plugin.py
@@ -21,6 +21,7 @@ An API-key-only provider (no OAuth) routed through LiteLLM's built-in
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, cast
 
 from fastapi import HTTPException
@@ -83,6 +84,40 @@ _STRIPPED_CALLER_HEADERS = frozenset(
     }
 )
 
+_LITELLM_GLOBAL_CALLBACK_FIELDS = (
+    "callbacks",
+    "input_callback",
+    "success_callback",
+    "failure_callback",
+    "_async_input_callback",
+    "_async_success_callback",
+    "_async_failure_callback",
+)
+
+_LITELLM_GLOBAL_RULE_FIELDS = ("pre_call_rules", "post_call_rules")
+
+_OPENROUTER_LITELLM_CONTROL_FIELDS = frozenset(
+    {
+        "litellm_credential_name",
+        "guardrails",
+        "guardrail_config",
+        "disable_global_guardrails",
+        "prompt_id",
+        "prompt_variables",
+        "prompt_label",
+        "prompt_version",
+        "caching",
+        "cache_key",
+        "preset_cache_key",
+    }
+)
+
+_OPENROUTER_METADATA_CONTROL_FIELDS = frozenset(
+    {"disable_global_guardrails", "guardrails", "previous_models"}
+)
+
+_OPENROUTER_NESTED_METADATA_CONTROL_FIELDS = frozenset({"disable_global_guardrails", "guardrails"})
+
 
 def _invalid_model_error() -> HTTPException:
     # Gateway-authored message only — never echo the raw caller value.
@@ -96,6 +131,63 @@ def _invalid_model_error() -> HTTPException:
             ),
         },
     )
+
+
+class _UnsafeLiteLLMStateError(HTTPException):
+    """A pre-dispatch global-state conflict that the retry loop must not repeat."""
+
+    aigw_non_retryable = True
+
+
+def _unsafe_litellm_state_error() -> _UnsafeLiteLLMStateError:
+    return _UnsafeLiteLLMStateError(
+        status_code=503,
+        detail={
+            "code": "provider_unavailable",
+            "message": "OpenRouter dispatch is unavailable",
+        },
+    )
+
+
+def _has_unsafe_litellm_global_state(litellm: Any, model: object) -> bool:
+    """Detect process-global controls that can observe or reroute BYOK calls."""
+    aliases = getattr(litellm, "model_alias_map", None)
+    if isinstance(model, str) and isinstance(aliases, Mapping) and model in aliases:
+        return True
+    if getattr(litellm, "model_fallbacks", None):
+        return True
+    if any(bool(getattr(litellm, field, None)) for field in _LITELLM_GLOBAL_RULE_FIELDS):
+        return True
+    for field in _LITELLM_GLOBAL_CALLBACK_FIELDS:
+        callbacks = getattr(litellm, field, None)
+        if callbacks and any(callback != "cache" for callback in callbacks):
+            return True
+    return False
+
+
+def _strip_openrouter_litellm_controls(body: dict[str, Any]) -> dict[str, Any]:
+    """Remove LiteLLM orchestration selectors without changing other providers."""
+    out = {
+        key: value for key, value in body.items() if key not in _OPENROUTER_LITELLM_CONTROL_FIELDS
+    }
+    metadata = out.get("metadata")
+    if not isinstance(metadata, Mapping):
+        return out
+    sanitized_metadata = {
+        key: value
+        for key, value in metadata.items()
+        if key not in _OPENROUTER_METADATA_CONTROL_FIELDS
+    }
+    for nested_key in ("requester_metadata", "user_api_key_metadata"):
+        nested_metadata = sanitized_metadata.get(nested_key)
+        if isinstance(nested_metadata, Mapping):
+            sanitized_metadata[nested_key] = {
+                key: value
+                for key, value in nested_metadata.items()
+                if key not in _OPENROUTER_NESTED_METADATA_CONTROL_FIELDS
+            }
+    out["metadata"] = sanitized_metadata
+    return out
 
 
 def _embedded_error_status(error: Any) -> int | None:
@@ -258,7 +350,7 @@ class OpenRouterProviderPlugin(ProviderPluginBase[OpenRouterPluginSettings]):
         return status_code == 401
 
     def prepare_chat_body(self, body: dict[str, Any]) -> dict[str, Any]:
-        out = dict(body)
+        out = _strip_openrouter_litellm_controls(body)
         model = out.get("model")
         if not isinstance(model, str) or not model.startswith(GATEWAY_MODEL_PREFIX):
             raise _invalid_model_error()
@@ -286,11 +378,24 @@ class OpenRouterProviderPlugin(ProviderPluginBase[OpenRouterPluginSettings]):
     async def chat_completion(self, body: dict[str, Any]) -> Any:
         import litellm
 
+        # INVARIANT: process-global LiteLLM routing and callbacks must never
+        # receive or redirect an account-scoped OpenRouter credential.
+        if _has_unsafe_litellm_global_state(litellm, body.get("model")):
+            raise _unsafe_litellm_state_error()
+
+        dispatch_body = dict(body)
+        # WHY: these gateway-owned values override ambient SSL_VERIFY and
+        # process-global LiteLLM cache state. AIGateway's own encrypted,
+        # account-scoped request cache is handled before this provider call.
+        dispatch_body["ssl_verify"] = True
+        dispatch_body["caching"] = False
+        dispatch_body["cache"] = {"no-cache": True, "no-store": True}
+
         # cast: acompletion's static type is a ModelResponse|CustomStreamWrapper
         # union, but D5 guarantees non-streaming here (stream rejected at the
         # route before dispatch), so model_dump is always present.
         try:
-            response = cast("Any", await litellm.acompletion(**body))
+            response = cast("Any", await litellm.acompletion(**dispatch_body))
         except Exception as exc:
             # WHY (FINDING A): litellm 1.87.0 RAISES while converting a nominal
             # HTTP-200 body that carries a meaningful top-level error — it never

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/plugin.py
@@ -1,0 +1,318 @@
+"""OpenRouter provider plugin (OME-428 Checkpoint A — local BYOK).
+
+An API-key-only provider (no OAuth) routed through LiteLLM's built-in
+``openrouter`` provider. Key design points (validated against litellm 1.87.0):
+
+- Disabled by default (plan D2): a disabled plugin registers no models and
+  returns no API-key strategy, so no key can be stored and every dispatch
+  path fails closed through existing route handling — even for connection
+  rows created while the provider was enabled.
+- Exactly one gateway prefix (plan D8): the gateway ID
+  ``openrouter/<author>/<model>[:variant]`` is passed to LiteLLM unchanged;
+  LiteLLM's provider routing strips the single ``openrouter/`` prefix at the
+  wire, so upstream receives ``<author>/<model>[:variant]`` exactly once.
+  ``prepare_chat_body`` validates the upstream remainder before dispatch and
+  copies the body — it never mutates the caller's dict.
+- Non-streaming in every mode (plan D5): the route rejects ``stream:true``
+  before credentials are read.
+- Only 401 marks the stored credential unusable (plan D9); 402/403/408/429/5xx
+  are provider/billing states and must not invalidate a valid key.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+from fastapi import HTTPException
+
+from aigateway.core.api_key_strategy import ApiKeyStrategy
+from aigateway.core.http_status import valid_http_error_status
+from aigateway.core.plugin_base import (
+    CredentialStrategy,
+    ModelEntry,
+    ProviderPluginBase,
+)
+from aigateway.core.provider_errors import NonRetryableProviderError
+
+from .provenance import converter_error_status, is_http200_body_error
+from .settings import (
+    GATEWAY_MODEL_PREFIX,
+    OpenRouterPluginSettings,
+    is_valid_upstream_model_id,
+)
+
+if TYPE_CHECKING:
+    from aigateway.core.credential_blob.store import CredentialBlobStore
+
+
+def _credential_service_for(profile_name: str) -> str:
+    """Namespace the stored credential slot by provider + profile/connection."""
+    return f"aigateway:openrouter:{profile_name}"
+
+
+# D7: the gateway owns routing — every dispatch goes to the official API base.
+OFFICIAL_API_BASE = "https://openrouter.ai/api/v1"
+
+# D7: trusted attribution, injected AFTER caller-header sanitization so the
+# gateway owns these keys end-to-end. LiteLLM 1.87.0 lets caller headers
+# override its OR_SITE_URL/OR_APP_NAME defaults (openrouter_headers.update),
+# which is exactly why the caller's copies must be dropped first.
+_TRUSTED_ATTRIBUTION = {
+    "HTTP-Referer": "https://screamingface.ai",
+    "X-OpenRouter-Title": "ScreamingFace",
+    "X-Title": "ScreamingFace",
+}
+
+# Caller copies of auth, host/framing, and attribution headers are dropped
+# before the gateway injects its own (D7). Lower-cased for comparison.
+_STRIPPED_CALLER_HEADERS = frozenset(
+    {
+        # auth
+        "authorization",
+        "x-api-key",
+        "proxy-authorization",
+        # host / framing
+        "host",
+        "content-length",
+        "transfer-encoding",
+        # attribution (gateway-owned)
+        "http-referer",
+        "referer",
+        "x-openrouter-title",
+        "x-title",
+    }
+)
+
+
+def _invalid_model_error() -> HTTPException:
+    # Gateway-authored message only — never echo the raw caller value.
+    return HTTPException(
+        status_code=400,
+        detail={
+            "code": "invalid_model",
+            "provider": "openrouter",
+            "message": (
+                "model must be 'openrouter/<author>/<model>' with an optional single ':variant'"
+            ),
+        },
+    )
+
+
+def _embedded_error_status(error: Any) -> int | None:
+    """Extract a numeric HTTP status from an embedded error object, else None.
+
+    # WHY (blocker E): uses the shared strict validator so a string/Unicode/
+    # float/bool ``code`` on the returned-payload scanner path degrades to 502
+    # exactly like it does on the converter-raise and transport paths.
+    """
+    if not isinstance(error, dict):
+        return None
+    for key in ("status", "status_code", "code"):
+        status = valid_http_error_status(error.get(key))
+        if status is not None:
+            return status
+    return None
+
+
+def _top_level_error_is_meaningful(error: Any) -> bool:
+    """Gate for the top-level ``error`` scan (OME-428 CODE-1).
+
+    # WHY: litellm's converter deliberately passes benign top-level error
+    # shapes through as valid 200 responses ("some OpenAI-compatible providers
+    # return empty error objects even on success"); flagging those discards a
+    # paid completion as a 502.
+    # INVARIANT: supersets litellm convert_dict_to_response.py:496-509
+    # (1.87.0) — fires on every shape litellm raises on, PLUS status-keyed
+    # shapes litellm passes through, so an embedded status can never render
+    # as success. Pinned by test_litellm_top_level_error_contract.py.
+    """
+    if error is None:
+        return False
+    if isinstance(error, dict):
+        return (
+            bool(error.get("message", ""))
+            or error.get("code") is not None
+            or error.get("status") is not None
+            or error.get("status_code") is not None
+        )
+    if isinstance(error, str):
+        return bool(error)
+    # Non-dict/non-str non-None: litellm :507-509 treats it as unconditionally
+    # meaningful — bool(error) would diverge on 0/False/[].
+    return True
+
+
+def _find_embedded_error(payload: dict[str, Any]) -> tuple[bool, int | None]:
+    """Detect OpenRouter errors embedded in a nominal HTTP-200 body (D9).
+
+    Inspects the top-level ``error``, each choice's ``error``, and LiteLLM's
+    ``provider_specific_fields`` (``error`` / ``native_finish_reason`` — 1.87.0
+    maps the native reason "error" to "stop", which would otherwise render as
+    success). Returns (found, first numeric 4xx/5xx status or None).
+    """
+    found = False
+    status: int | None = None
+
+    def _inspect(error: Any) -> None:
+        nonlocal found, status
+        if error is None:
+            return
+        found = True
+        if status is None:
+            status = _embedded_error_status(error)
+
+    # CODE-1: only a meaningful top-level error counts; benign shapes on a
+    # billed 200 pass through. The choice/message-level branches below stay
+    # ungated — litellm relocates those without any benign-shape guard.
+    top_level_error = payload.get("error")
+    if _top_level_error_is_meaningful(top_level_error):
+        _inspect(top_level_error)
+    choices = payload.get("choices")
+    for choice in choices if isinstance(choices, list) else []:
+        if not isinstance(choice, dict):
+            continue
+        _inspect(choice.get("error"))
+        for holder in (choice, choice.get("message")):
+            if not isinstance(holder, dict):
+                continue
+            fields = holder.get("provider_specific_fields")
+            if not isinstance(fields, dict):
+                continue
+            _inspect(fields.get("error"))
+            if fields.get("native_finish_reason") == "error":
+                found = True
+    return found, status
+
+
+def _embedded_error_exception(status: int | None) -> HTTPException:
+    """Sanitized gateway error for an embedded provider failure.
+
+    Only the numeric status survives; raw provider message/metadata is
+    discarded. Malformed/status-less embedded errors map to 502 (D9).
+
+    # INVARIANT (CODE-2): the upstream call already returned this payload, so
+    # the error is non-retryable — an embedded 429/503/529 must make exactly
+    # one upstream call. No Retry-After is invented: the embedded JSON schema
+    # was not shown to carry one; validated hints survive only on actual
+    # transport exceptions.
+    """
+    resolved = status if status is not None else 502
+    code = "provider_error"
+    if resolved == 401:
+        code = "auth_required"
+    elif resolved == 400:
+        code = "bad_request"
+    elif resolved == 429:
+        code = "rate_limited"
+    elif resolved >= 500 and status is not None:
+        code = "provider_unavailable"
+    return NonRetryableProviderError(
+        status_code=resolved,
+        detail={"code": code, "message": "OpenRouter reported a provider error"},
+    )
+
+
+class OpenRouterProviderPlugin(ProviderPluginBase[OpenRouterPluginSettings]):
+    custom_llm_provider = "openrouter"
+    settings_cls = OpenRouterPluginSettings
+
+    def register_models(self) -> list[ModelEntry]:
+        if not self.settings.enabled:
+            # D2: a disabled provider exposes no models.
+            return []
+        return [
+            ModelEntry(model_name=slug, litellm_params={"model": slug})
+            for slug in self.settings.default_models
+        ]
+
+    def supports_api_key(self) -> bool:
+        return True
+
+    def supports_chat_streaming(self) -> bool:
+        # D5: enforced in every credential mode; the route rejects stream:true
+        # before _inject_credentials so no credential is ever read for it.
+        return False
+
+    def api_key_strategy_for(
+        self,
+        profile_name: str,
+        *,
+        credential_store: CredentialBlobStore | None = None,
+    ) -> CredentialStrategy | None:
+        if not self.settings.enabled:
+            # D2 fail closed: no strategy means the api-key connection routes
+            # answer 400 api_key_not_supported and chat cannot resolve
+            # credentials, without any provider branch in core.
+            return None
+        return ApiKeyStrategy(
+            profile_name,
+            service=_credential_service_for(profile_name),
+            account="default",
+            header_builder=lambda api_key: {"Authorization": f"Bearer {api_key}"},
+            credential_store=credential_store,
+        )
+
+    def should_mark_profile_error_on_dispatch_status(self, status_code: int) -> bool:
+        # D9: only 401 proves the stored key is bad. 402 (credits), 403
+        # (policy), 408/429/5xx (transient) must not invalidate a valid key.
+        return status_code == 401
+
+    def prepare_chat_body(self, body: dict[str, Any]) -> dict[str, Any]:
+        out = dict(body)
+        model = out.get("model")
+        if not isinstance(model, str) or not model.startswith(GATEWAY_MODEL_PREFIX):
+            raise _invalid_model_error()
+        if not is_valid_upstream_model_id(model[len(GATEWAY_MODEL_PREFIX) :]):
+            raise _invalid_model_error()
+        # Keep the model unchanged: the gateway prefix IS LiteLLM's provider
+        # prefix, so LiteLLM strips it exactly once at the wire (D8).
+        out.pop("api_key", None)  # gateway-owned; injected after this hook
+        extra_headers = out.get("extra_headers")
+        headers: dict[str, Any] = {}
+        if isinstance(extra_headers, dict):
+            headers = {
+                key: value
+                for key, value in extra_headers.items()
+                if str(key).lower() not in _STRIPPED_CALLER_HEADERS
+            }
+        headers.update(_TRUSTED_ATTRIBUTION)
+        out["extra_headers"] = headers
+        # Pinned official base (D7): the ingress strip removed any caller
+        # value; request-local api_base beats every LiteLLM global/env
+        # fallback (litellm 1.87.0 main.py precedence).
+        out["api_base"] = OFFICIAL_API_BASE
+        return out
+
+    async def chat_completion(self, body: dict[str, Any]) -> Any:
+        import litellm
+
+        # cast: acompletion's static type is a ModelResponse|CustomStreamWrapper
+        # union, but D5 guarantees non-streaming here (stream rejected at the
+        # route before dispatch), so model_dump is always present.
+        try:
+            response = cast("Any", await litellm.acompletion(**body))
+        except Exception as exc:
+            # WHY (FINDING A): litellm 1.87.0 RAISES while converting a nominal
+            # HTTP-200 body that carries a meaningful top-level error — it never
+            # returns a payload for _find_embedded_error to scan below. Such an
+            # error came from an already-returned (billable) upstream call, so
+            # route it through the SAME sanitizer as a scanned embedded error:
+            # non-retryable, status sanitized, raw provider text discarded.
+            # INVARIANT: a genuine transport failure is re-raised unchanged so
+            # the shared overload-retry loop (core.retry) still applies to it.
+            if is_http200_body_error(exc):
+                raise _embedded_error_exception(converter_error_status(exc)) from exc
+            raise
+        payload: Any = response.model_dump() if hasattr(response, "model_dump") else response
+        if isinstance(payload, dict):
+            found, status = _find_embedded_error(payload)
+            if found:
+                # A 401 here flows through the route's dispatch-failure path
+                # and marks only the selected connection (D9 local).
+                raise _embedded_error_exception(status)
+        # Return the dumped dict so native usage/cost/generation metadata
+        # reaches the caller byte-for-byte (D10 — URL4 per-leaf telemetry).
+        return payload
+
+
+PLUGIN = OpenRouterProviderPlugin()

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/provenance.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/provenance.py
@@ -1,0 +1,136 @@
+"""LiteLLM-1.87.0 error provenance for the OpenRouter adapter (OME-428).
+
+# WHY: LiteLLM 1.87.0 does NOT return a ``ModelResponse`` when a nominal HTTP-200
+# body carries a meaningful top-level ``error`` — it RAISES while *converting*
+# the body (``RateLimitError``/``ServiceUnavailableError``/``APIError``/
+# ``AuthenticationError``/``BadRequestError``, keyed by status). That error came
+# from an already-returned (billable) upstream call, so it is non-retryable
+# exactly like an error found by scanning a returned payload — yet the plugin's
+# post-return ``_find_embedded_error`` scanner never sees it because no payload
+# is returned. A genuine transport failure raises the SAME outer LiteLLM type
+# with the SAME outer status, so classification by type/status alone is unsafe.
+# This module isolates the LiteLLM-internal signals that positively distinguish
+# a converter-origin raise from a real transport failure.
+#
+# INVARIANT: these are LiteLLM 1.87.0 internals, not a public contract. The shape
+# is pinned by tests/unit/openrouter/test_openrouter_toplevel_conversion_retry.py
+# ::test_litellm_1_87_converter_raise_provenance_shape — a future LiteLLM that
+# changes it fails that test LOUDLY rather than silently mis-routing errors.
+# FAILS CLOSED (blocker F): the classifier has exactly three outcomes and only a
+# PROVEN transport overload is retryable; a proven converter/body error AND an
+# unprovable (ambiguous) error are both non-retryable and sanitized, so a future
+# LiteLLM shape can never be silently retried into an amplified upstream call.
+"""
+
+from __future__ import annotations
+
+import enum
+
+import httpx
+
+from aigateway.core.http_status import valid_http_error_status
+
+# WHY (blocker D): litellm 1.87.0's converter defaults to HTTP 422 when a body
+# error carries no derivable status. 422 is therefore a "no status" sentinel
+# here, not a provider status — and it is not a documented OpenRouter error
+# code — so a converter-context 422 (a status-less body OR an explicit code=422,
+# indistinguishable at this boundary) folds to None -> the caller renders 502.
+_NO_STATUS_SENTINEL = 422
+
+_CONVERTER_OUTER_TYPES = frozenset(
+    {
+        "APIError",
+        "AuthenticationError",
+        "BadRequestError",
+        "InternalServerError",
+        "NotFoundError",
+        "PermissionDeniedError",
+        "RateLimitError",
+        "ServiceUnavailableError",
+        "Timeout",
+    }
+)
+
+
+class ErrorProvenance(enum.Enum):
+    """How a LiteLLM exception originated — the retry decision reads this."""
+
+    TRANSPORT = "transport"  # proven real non-2xx wire failure -> retryable
+    BODY = "body"  # proven converter-origin (HTTP-200 body) -> non-retryable
+    AMBIGUOUS = "ambiguous"  # unprovable -> fail closed -> non-retryable
+
+
+def _cause_chain(exc: BaseException) -> list[BaseException]:
+    """The ``__cause__``/``__context__`` chain, excluding ``exc`` itself.
+
+    Cycle-safe: an ``id``-seen set bounds a self-referential chain.
+    """
+    chain: list[BaseException] = []
+    seen: set[int] = set()
+    current = exc.__cause__ or exc.__context__
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        chain.append(current)
+        current = current.__cause__ or current.__context__
+    return chain
+
+
+def classify_provenance(exc: BaseException) -> ErrorProvenance:
+    """Classify ``exc`` into exactly one of the three provenance outcomes.
+
+    - TRANSPORT — the cause chain contains an ``httpx.HTTPError``.
+    - BODY — a LiteLLM API error has the pinned single, exact bare-Exception
+      converter context with ``status_code`` and ``message`` attributes.
+    - AMBIGUOUS — every other shape, including headers without an httpx chain;
+      unprovable, so the caller treats it as a non-retryable body error.
+    """
+    chain = _cause_chain(exc)
+    if any(isinstance(link, httpx.HTTPError) for link in chain):
+        return ErrorProvenance.TRANSPORT
+    if (
+        type(exc).__module__ == "litellm.exceptions"
+        and type(exc).__name__ in _CONVERTER_OUTER_TYPES
+        and len(chain) == 1
+        and type(chain[0]) is Exception
+        and {"status_code", "message"}.issubset(vars(chain[0]))
+    ):
+        return ErrorProvenance.BODY
+    return ErrorProvenance.AMBIGUOUS
+
+
+def is_http200_body_error(exc: BaseException) -> bool:
+    """True when ``exc`` must be treated as a non-retryable converter/body error.
+
+    True for BODY and AMBIGUOUS, False only for a PROVEN TRANSPORT failure —
+    i.e. the fail-closed policy stated in the module docstring: unprovable
+    provenance is non-retryable.
+    """
+    return classify_provenance(exc) is not ErrorProvenance.TRANSPORT
+
+
+def _context_status(exc: BaseException) -> int | None:
+    """The first validated HTTP error status on the converter-context chain.
+
+    # WHY (blocker D): reads the chained (converter-context) exception's status,
+    # NOT ``exc``'s outer status — a status-less body and an explicit code=400
+    # share the SAME outer BadRequestError(400), but the context distinguishes
+    # them (status-less -> 422 sentinel, explicit-400 -> 400).
+    """
+    if classify_provenance(exc) is not ErrorProvenance.BODY:
+        return None
+    return valid_http_error_status(vars(_cause_chain(exc)[0]).get("status_code"))
+
+
+def converter_error_status(exc: BaseException) -> int | None:
+    """A validated client-facing status for a converter-origin exception, else
+    ``None`` (the caller maps ``None`` to a safe 502).
+
+    Reads the converter-CONTEXT status and folds the 422 "no derivable status"
+    sentinel to ``None`` (blocker D). Distinguishable explicit statuses
+    (400/402/429/500/503) are preserved; a malformed/absent status degrades to
+    502 rather than crashing or emitting an invalid status.
+    """
+    status = _context_status(exc)
+    if status == _NO_STATUS_SENTINEL:
+        return None
+    return status

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/settings.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/settings.py
@@ -1,0 +1,91 @@
+"""Configurable settings for the OpenRouter provider plugin (OME-428).
+
+Disabled by default (plan D2): installing the package must not expose models
+or accept API keys until an operator sets ``AIGW_OPENROUTER_ENABLED=true``.
+
+Model seeds are ``list[str]`` gateway IDs (``openrouter/<author>/<model>``) so
+the whole list is env-overridable as a JSON array via
+``AIGW_OPENROUTER_DEFAULT_MODELS`` — pydantic-settings cannot deserialize a
+frozen ``ModelEntry`` dataclass from an env var. Each gateway ID loses exactly
+one ``openrouter/`` prefix at the LiteLLM wire; the remainder must be a valid
+upstream OpenRouter model ID (plan D8).
+"""
+
+from __future__ import annotations
+
+import re
+
+from pydantic import Field, field_validator
+from pydantic_settings import SettingsConfigDict
+
+from aigateway.core.plugin_base import PluginSettings
+
+GATEWAY_MODEL_PREFIX = "openrouter/"
+
+# D8: ASCII upstream ID `<author>/<model>[:variant]` with exactly two non-empty
+# segments; the author may carry a single leading `~` alias marker. The
+# character classes reject every forbidden shape by construction: Unicode,
+# controls, whitespace, backslashes, percent escapes, URL schemes,
+# query/fragment markers, empty segments, extra slashes/colons, empty variants.
+_UPSTREAM_MODEL_ID_RE = re.compile(
+    r"~?[A-Za-z0-9][A-Za-z0-9._-]*"  # author
+    r"/[A-Za-z0-9][A-Za-z0-9._-]*"  # model base (exactly one '/')
+    r"(:[A-Za-z0-9][A-Za-z0-9._-]*)?"  # optional single non-empty ':variant'
+)
+
+
+def is_valid_upstream_model_id(value: object) -> bool:
+    """True when ``value`` is a syntactically valid upstream OpenRouter model ID.
+
+    Purely syntactic (plan D8): models are bootstrap metadata, not request
+    authorization, so valid unlisted IDs pass and no catalog lookup happens.
+    """
+    return isinstance(value, str) and _UPSTREAM_MODEL_ID_RE.fullmatch(value) is not None
+
+
+def _default_model_slugs() -> list[str]:
+    """URL4 leaf seeds in gateway form — recommended bootstrap metadata (D8).
+
+    All three were present in the live OpenRouter catalog on 2026-07-15;
+    re-check at release. Never treat this list as an authorization boundary.
+    """
+    return [
+        "openrouter/anthropic/claude-fable-5",
+        "openrouter/openai/gpt-5.5",
+        "openrouter/anthropic/claude-opus-4.8",
+    ]
+
+
+def _validate_gateway_slug(slug: str) -> str:
+    """Enforce ``openrouter/<author>/<model>[:variant]`` for configured seeds."""
+    if not slug.startswith(GATEWAY_MODEL_PREFIX):
+        raise ValueError(f"OpenRouter model must start with {GATEWAY_MODEL_PREFIX!r}: {slug!r}")
+    upstream = slug[len(GATEWAY_MODEL_PREFIX) :]
+    if not is_valid_upstream_model_id(upstream):
+        raise ValueError(
+            f"malformed OpenRouter model {slug!r}: expected "
+            "'openrouter/<author>/<model>' with an optional single ':variant'"
+        )
+    return slug
+
+
+class OpenRouterPluginSettings(PluginSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="AIGW_OPENROUTER_",
+        extra="ignore",
+        populate_by_name=True,
+    )
+
+    # Net-new per-provider gate (no other provider has one): discovery still
+    # registers the plugin, but a disabled plugin contributes no models and
+    # returns no credential strategy, so it can neither store keys nor
+    # resolve credentials for dispatch (plan D2 — fail closed in the plugin,
+    # never a provider branch in the loader/registry).
+    enabled: bool = False
+    default_models: list[str] = Field(default_factory=_default_model_slugs)
+
+    @field_validator("default_models")
+    @classmethod
+    def _validate_models(cls, value: list[str]) -> list[str]:
+        # Rejects malformed entries (defaults AND env overrides) at construction.
+        return [_validate_gateway_slug(slug) for slug in value]

--- a/apps/aigateway/src/aigateway/routes/chat.py
+++ b/apps/aigateway/src/aigateway/routes/chat.py
@@ -1,11 +1,14 @@
-"""POST /v1/chat/completions — resolves profile auth + merges defaults, dispatches via LiteLLM."""
+"""POST /v1/chat/completions — resolves profile auth + merges defaults, dispatches via LiteLLM.
+
+Helper seams live in sibling modules (OME-428 Phase 1 split):
+``chat_credentials`` (profile/connection resolution, defaults, credential
+injection) and ``chat_dispatch`` (backpressure, error mapping, request cache,
+streaming). This module keeps only the router and the request orchestration.
+"""
 
 from __future__ import annotations
 
-import json
 import logging
-import math
-from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
 from fastapi import APIRouter, HTTPException, Request, Response
@@ -15,569 +18,61 @@ from litellm.exceptions import (
     APIError,
     AuthenticationError,
     BadRequestError,
+    InternalServerError,
+    NotFoundError,
+    PermissionDeniedError,
     RateLimitError,
     ServiceUnavailableError,
     Timeout,
+    UnprocessableEntityError,
     UnsupportedParamsError,
 )
 
 from ..core.auth.middleware import CurrentAccount
-from ..core.concurrency import effective_provider_limit, provider_slot
-from ..core.credential_strategy_cache import credential_strategy_cache
-from ..core.errors import AuthError, CredentialNotFoundError
-from ..core.oauth.models import OAuthConnection
-from ..core.oauth.store import OAuthConnectionStore, credential_key_for
-from ..core.plugin_base import credential_strategy_from
-from ..core.profile_index import ProfileIndexStore
-from ..core.profile_models import (
-    AuthType,
-    Profile,
-    ProfileDefaults,
-    ProfileState,
-    credential_name_for,
-)
 from ..core.registry import ProviderRegistry
-from ..core.request_cache.keys import (
-    KEY_VERSION,
-    CacheBypass,
-    CacheControls,
-    CacheKeyResult,
-    build_cache_key,
-    parse_cache_controls,
+from ..core.request_cache.keys import parse_cache_controls
+from ..core.request_cache.store import RequestCacheStore
+from ..core.request_hardening import chat_body_shape_error, strip_dispatch_controls
+from .chat_credentials import (
+    _apply_defaults,
+    _credential_target_for_chat,
+    _inject_credentials,
 )
-from ..core.request_cache.store import RequestCacheStore, RequestCacheWrite
-from ..core.retry import RetryPolicy, parse_retry_after_seconds, with_overload_retry
+from .chat_dispatch import (
+    _dispatch_with_backpressure,
+    _litellm_http_exception,
+    _resolve_cache_plan,
+    _safe_dispatch_failure_response,
+    _set_cache_headers,
+    _store_cached_response,
+    _stream,
+    _unknown_provider_exception,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
-_DEFAULT_PROFILE_NAME = "default"
-
-
-_BUCKET_A_FIELDS = (
-    "model",
-    "max_tokens",
-    "temperature",
-    "timeout_seconds",
-    "reasoning_effort",
-)
-
-
-def _has_system_message(body: dict[str, Any]) -> bool:
-    return any(m.get("role") == "system" for m in body.get("messages", []))
-
-
-def _should_apply_profile_default(plugin: Any, field: str) -> bool:
-    checker = getattr(plugin, "should_apply_profile_default", None)
-    return bool(checker(field)) if callable(checker) else True
-
-
-def _allows_chatless_profile(plugin: Any) -> bool:
-    checker = getattr(plugin, "allows_chatless_profile", None)
-    return bool(checker()) if callable(checker) else False
-
-
-def _invalidate_profile_session(plugin: Any, profile_name: str) -> None:
-    invalidator = getattr(plugin, "invalidate_profile_session", None)
-    if callable(invalidator):
-        invalidator(profile_name)
-
-
-def _should_mark_profile_error_on_dispatch_status(plugin: Any, status_code: int) -> bool:
-    checker = getattr(plugin, "should_mark_profile_error_on_dispatch_status", None)
-    return bool(checker(status_code)) if callable(checker) else False
-
-
-def _oauth_connection_store(request: Request) -> OAuthConnectionStore:
-    store = getattr(request.app.state, "oauth_connections", None)
-    if isinstance(store, OAuthConnectionStore):
-        return store
-    store = OAuthConnectionStore()
-    request.app.state.oauth_connections = store
-    return store
-
-
-async def _active_oauth_connection_for_profile(
-    request: Request,
-    *,
-    account_id: str,
-    provider: str,
-    profile_name: str,
-) -> OAuthConnection | None:
-    connections = await _oauth_connection_store(request).list(
-        account_id,
-        provider=provider,
-        status="active",
-    )
-    if not connections:
-        return None
-
-    for connection in connections:
-        if connection.label == profile_name:
-            return connection
-
-    if profile_name == _DEFAULT_PROFILE_NAME and len(connections) == 1:
-        return connections[0]
-
-    if profile_name == _DEFAULT_PROFILE_NAME:
-        raise HTTPException(
-            status_code=409,
-            detail={
-                "code": "connection_ambiguous",
-                "provider": provider,
-                "message": (
-                    "Multiple active connections exist. Select one by setting "
-                    "X-Profile to the connection label."
-                ),
-            },
-        )
-    raise HTTPException(
-        status_code=404,
-        detail={
-            "code": "connection_not_found",
-            "provider": provider,
-            "requested_label": profile_name,
-            "valid_labels": [connection.label for connection in connections],
-        },
-    )
-
-
-async def _credential_target_for_chat(
-    request: Request,
-    *,
-    account_id: str,
-    provider: str,
-    profile_name: str,
-    plugin: Any,
-) -> tuple[Profile | None, OAuthConnection | None, ProfileDefaults]:
-    idx: ProfileIndexStore = request.app.state.profile_index
-    profile = await idx.get(account_id, provider, profile_name)
-    if profile is None:
-        connection = await _active_oauth_connection_for_profile(
-            request,
-            account_id=account_id,
-            provider=provider,
-            profile_name=profile_name,
-        )
-        if connection is not None:
-            return None, connection, ProfileDefaults()
-        if not _allows_chatless_profile(plugin):
-            raise HTTPException(
-                status_code=404,
-                detail={
-                    "code": "profile_not_found",
-                    "provider": provider,
-                    "name": profile_name,
-                },
-            )
-        return None, None, ProfileDefaults()
-
-    if profile.state == ProfileState.PENDING:
-        raise HTTPException(
-            status_code=409,
-            detail={
-                "code": "profile_pending_auth",
-                "provider": provider,
-                "name": profile_name,
-            },
-        )
-    if profile.state == ProfileState.ERROR:
-        raise HTTPException(
-            status_code=401,
-            detail={
-                "code": "auth_required",
-                "provider": provider,
-                "name": profile_name,
-                "reauth_url": f"/v1/auth/{provider}/profiles/{profile_name}",
-            },
-        )
-    return profile, None, profile.defaults
-
-
-def _strategy_for_credential_target(
-    request: Request,
-    plugin: Any,
-    provider: str,
-    *,
-    account_id: str,
-    profile_name: str,
-    profile: Profile | None,
-    connection: OAuthConnection | None,
-) -> tuple[Any, str | None, AuthType]:
-    """Resolve (strategy, credential_name, auth_type) for the chat credential
-    target, branching on the target's auth_type discriminator."""
-    auth_type: AuthType
-    if connection is not None:
-        credential_name = credential_key_for(account_id, connection.id)
-        auth_type = connection.auth_type or "oauth"
-    elif profile is not None:
-        credential_name = credential_name_for(account_id, profile_name)
-        auth_type = profile.auth_type
-    else:
-        return None, None, "oauth"
-    # Share ONE strategy instance per credential across concurrent requests so its
-    # asyncio.Lock single-flights the OAuth refresh (SF-282). Building is only a
-    # constructor call; the cache is evicted on every credential mutation.
-    strategy = credential_strategy_cache(request.app).get_or_create(
-        provider=provider,
-        auth_type=auth_type,
-        credential_name=credential_name,
-        build=lambda: credential_strategy_from(
-            plugin,
-            credential_name,
-            auth_type=auth_type,
-            credential_store=request.app.state.credential_store,
-            http_client_factory=getattr(request.app.state, f"{provider}_http_factory", None),
-        ),
-    )
-    return strategy, credential_name, auth_type
-
-
-def _reauth_url_for(
-    provider: str,
-    profile_name: str,
-    auth_type: AuthType,
-    *,
-    connection_id: str | None = None,
-) -> str:
-    if connection_id is not None and auth_type == "api_key":
-        # An api-key CONNECTION re-keys via its own replace route; never send the
-        # user back to the legacy profile api-key endpoint, which would shadow
-        # connections on chat (SF-291 review F3).
-        return f"/v1/oauth/connections/{connection_id}/api-key"
-    base = f"/v1/auth/{provider}/profiles/{profile_name}"
-    return f"{base}/api-key" if auth_type == "api_key" else base
-
-
-async def _mark_profile_error_fresh(
-    request: Request,
-    *,
-    account_id: str,
-    provider: str,
-    profile_name: str,
-) -> None:
-    """Re-fetch the profile before flipping state so a long-running dispatch
-    never clobbers concurrent index writes (e.g. a PUT api-key changing
-    auth_type/account_label mid-flight) with its stale snapshot."""
-    idx: ProfileIndexStore = request.app.state.profile_index
-    fresh = await idx.get(account_id, provider, profile_name)
-    if fresh is not None:
-        fresh.state = ProfileState.ERROR
-        await idx.upsert(fresh)
-
-
-async def _dispatch_failure_response(
-    request: Request,
-    exc: HTTPException,
-    *,
-    plugin: Any,
-    provider: str,
-    account_id: str,
-    profile_name: str,
-    profile: Profile | None,
-    connection: OAuthConnection | None,
-    credential_name: str | None,
-    auth_type: AuthType,
-) -> HTTPException:
-    """Mark the credential target on auth-meaning dispatch failures.
-
-    Shared by the HTTPException path (custom handlers raise these) and the
-    LiteLLM-exception path (e.g. anthropic AuthenticationError), so a bad
-    stored credential flips the profile/connection to ERROR regardless of
-    which exception family the provider dispatch uses.
-    """
-    if not _should_mark_profile_error_on_dispatch_status(plugin, exc.status_code):
-        return exc
-    # Drop the cached strategy so its (now bad) token isn't reused by the next
-    # request — important under fan-out where many requests share the instance.
-    if credential_name is not None:
-        credential_strategy_cache(request.app).evict(credential_name)
-    detail = exc.detail if isinstance(exc.detail, dict) else {"message": str(exc.detail)}
-    if connection is not None:
-        await _oauth_connection_store(request).mark_error(
-            connection,
-            str(detail.get("message", str(exc.detail))),
-        )
-        if credential_name is not None:
-            _invalidate_profile_session(plugin, credential_name)
-        return exc
-    if profile is None:
-        return exc
-    await _mark_profile_error_fresh(
-        request, account_id=account_id, provider=provider, profile_name=profile_name
-    )
-    if credential_name is not None:
-        _invalidate_profile_session(plugin, credential_name)
-    return HTTPException(
-        status_code=exc.status_code,
-        detail={
-            "code": detail.get("code", "auth_required"),
-            "message": detail.get("message", str(exc.detail)),
-            "reauth_url": detail.get(
-                "reauth_url", _reauth_url_for(provider, profile_name, auth_type)
-            ),
-        },
-    )
-
-
-def _apply_defaults(body: dict[str, Any], defaults: ProfileDefaults, plugin: Any) -> dict[str, Any]:
-    """Body wins per field. Fields the body omits get the profile default."""
-    if (
-        defaults.system_prompt
-        and not _has_system_message(body)
-        and _should_apply_profile_default(plugin, "system_prompt")
-    ):
-        body.setdefault("messages", [])
-        body["messages"] = [
-            {"role": "system", "content": defaults.system_prompt},
-            *body["messages"],
-        ]
-    for field in _BUCKET_A_FIELDS:
-        gateway_field = "timeout" if field == "timeout_seconds" else field
-        if not _should_apply_profile_default(plugin, field):
-            continue
-        value = getattr(defaults, field)
-        if value is not None and gateway_field not in body:
-            body[gateway_field] = value
-    return body
-
-
-def _retry_after_headers(exc: Exception) -> dict[str, str]:
-    seconds = parse_retry_after_seconds(exc)
-    if seconds is None:
-        return {}
-    # delta-seconds is an integer; round up so clients do not retry early.
-    return {"Retry-After": str(math.ceil(seconds))}
-
-
-async def _dispatch_with_backpressure(
-    request: Request,
-    plugin: Any,
-    provider: str,
-    body: dict[str, Any],
-) -> Any:
-    """Run ``plugin.chat_completion`` under the gateway's backpressure stack:
-    a per-provider concurrency slot wrapping the overload-retry loop.
-
-    The slot is held across retries so a provider's concurrent-pressure
-    ceiling includes backoff time — preventing the thundering-herd quota
-    re-exhaustion that pure reactive retry could not solve.
-    """
-    settings = request.app.state.settings
-    async with provider_slot(request.app, provider, effective_provider_limit(settings, provider)):
-        return await with_overload_retry(
-            lambda: plugin.chat_completion(body),
-            policy=RetryPolicy.from_settings(settings),
-        )
-
-
-def _resolve_cache_plan(
-    request: Request,
-    *,
-    account_id: str,
-    profile_name: str,
-    provider: str,
-    body: dict[str, Any],
-    controls: CacheControls,
-) -> tuple[CacheKeyResult | None, str, str]:
-    """Decide cache participation for this request.
-
-    Returns ``(key, status, reason)`` where ``key`` is None whenever the
-    request bypasses the cache. Status/reason feed the X-AIGW-Cache headers.
-    """
-    settings = request.app.state.settings
-    if not settings.request_cache_enabled:
-        return None, "bypass", "disabled"
-    if not controls.use_cache:
-        return None, "bypass", "not_requested"
-    built = build_cache_key(
-        account_id=account_id,
-        profile_name=profile_name,
-        provider=provider,
-        normalized_body=body,
-    )
-    if isinstance(built, CacheBypass):
-        return None, "bypass", built.reason
-    return built, "miss", ""
-
-
-def _set_cache_headers(
-    response: Response, status: str, reason: str, key: CacheKeyResult | None
-) -> None:
-    response.headers["X-AIGW-Cache"] = status
-    if reason:
-        response.headers["X-AIGW-Cache-Reason"] = reason
-    # Hash-derived prefix only — never prompt or response content.
-    if key is not None and status in {"hit", "miss"}:
-        response.headers["X-AIGW-Cache-Key"] = key.key_hash[:12]
-
-
-async def _store_cached_response(
-    request: Request,
-    *,
-    key: CacheKeyResult,
-    account_id: str,
-    result: Any,
-    controls: CacheControls,
-) -> str:
-    """Persist a fresh response when allowed; returns the cache reason."""
-    if controls.no_store:
-        return "no_store"
-    if not isinstance(result, dict):
-        return "unsupported_fields"
-    settings = request.app.state.settings
-    payload_size = len(
-        json.dumps(result, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
-    )
-    if payload_size > settings.request_cache_max_response_bytes:
-        return "too_large"
-    ttl = min(
-        controls.ttl or settings.request_cache_default_ttl_seconds,
-        settings.request_cache_max_ttl_seconds,
-    )
-    store: RequestCacheStore = request.app.state.request_cache_store
-    await store.set(
-        RequestCacheWrite(
-            key_hash=key.key_hash,
-            key_version=KEY_VERSION,
-            account_id=account_id,
-            profile_name=key.profile_name,
-            prompt_hash=key.prompt_hash,
-            provider=key.provider,
-            model=key.model,
-            response=result,
-            response_size_bytes=payload_size,
-            expires_at=datetime.now(UTC) + timedelta(seconds=ttl),
-        )
-    )
-    return "stored"
-
-
-def _litellm_http_exception(exc: Exception) -> HTTPException:
-    status = int(getattr(exc, "status_code", 502) or 502)
-    code = "provider_error"
-    if status == 400:
-        code = "bad_request"
-    elif status == 401:
-        code = "auth_required"
-    elif status == 429:
-        code = "rate_limited"
-    elif status >= 500:
-        code = "provider_unavailable"
-    return HTTPException(
-        status_code=status,
-        detail={"code": code, "message": str(exc)},
-        headers=_retry_after_headers(exc),
-    )
-
-
-async def _inject_credentials(
-    request: Request,
-    *,
-    plugin: Any,
-    provider: str,
-    account_id: str,
-    profile_name: str,
-    profile: Profile | None,
-    connection: OAuthConnection | None,
-    body: dict[str, Any],
-) -> tuple[str | None, AuthType]:
-    """Resolve the profile/connection credential strategy and inject auth
-    into ``body``; returns ``(credential_name, auth_type)`` for later dispatch
-    failure handling. Raises 401 (marking profile/connection errored) when
-    stored credentials are unusable."""
-    strategy, credential_name, auth_type = _strategy_for_credential_target(
-        request,
-        plugin,
-        provider,
-        account_id=account_id,
-        profile_name=profile_name,
-        profile=profile,
-        connection=connection,
-    )
-    if strategy is None and credential_name is not None and auth_type == "api_key":
-        # Never fall through to an unauthenticated dispatch when the target
-        # says api_key but the provider has no API-key strategy (SF-244 F15).
-        raise HTTPException(
-            status_code=400,
-            detail={"code": "api_key_not_supported", "provider": provider},
-        )
-    if strategy is not None:
-        try:
-            headers = await strategy.get_authorization_header()
-        except CredentialNotFoundError as exc:
-            if credential_name is not None:
-                credential_strategy_cache(request.app).evict(credential_name)
-            if connection is not None:
-                await _oauth_connection_store(request).mark_error(connection, str(exc))
-            raise HTTPException(
-                status_code=401,
-                detail={
-                    "code": "auth_required",
-                    "message": str(exc),
-                    "reauth_url": _reauth_url_for(
-                        provider,
-                        profile_name,
-                        auth_type,
-                        connection_id=str(connection.id) if connection is not None else None,
-                    ),
-                },
-            )
-        except AuthError as exc:
-            if credential_name is not None:
-                credential_strategy_cache(request.app).evict(credential_name)
-            if connection is not None:
-                await _oauth_connection_store(request).mark_error(connection, str(exc))
-                if credential_name is not None:
-                    _invalidate_profile_session(plugin, credential_name)
-            elif profile is not None:
-                await _mark_profile_error_fresh(
-                    request,
-                    account_id=account_id,
-                    provider=provider,
-                    profile_name=profile_name,
-                )
-                if credential_name is not None:
-                    _invalidate_profile_session(plugin, credential_name)
-            raise HTTPException(
-                status_code=401,
-                detail={
-                    "code": "auth_required",
-                    "message": str(exc),
-                    "reauth_url": _reauth_url_for(
-                        provider,
-                        profile_name,
-                        auth_type,
-                        connection_id=str(connection.id) if connection is not None else None,
-                    ),
-                },
-            )
-        auth_value = headers.pop("Authorization", None)
-        if auth_value and auth_value.lower().startswith("bearer "):
-            body["api_key"] = auth_value.split(" ", 1)[1]
-        if headers:
-            merged = dict(body.get("extra_headers") or {})
-            merged.update(headers)
-            body["extra_headers"] = merged
-        if connection is not None:
-            await _oauth_connection_store(request).touch_last_used(connection)
-
-    return credential_name, auth_type
-
 
 @router.post("/v1/chat/completions")
 async def chat_completions(request: Request, response: Response, current: CurrentAccount) -> Any:
-    body = await request.json()
-    if not isinstance(body, dict) or "model" not in body or "messages" not in body:
-        raise HTTPException(status_code=400, detail="model and messages are required")
+    try:
+        body = await request.json()
+    except ValueError:
+        # Malformed JSON is untrusted input, not a server fault (OME-428 D6).
+        raise HTTPException(status_code=400, detail="request body must be valid JSON") from None
+    shape_error = chat_body_shape_error(body)
+    if shape_error is not None:
+        raise HTTPException(status_code=400, detail=shape_error)
 
     # Popped immediately so the control object can never reach providers.
     cache_controls = parse_cache_controls(body)
-    # The gateway owns upstream routing. A caller-supplied api_base would make
-    # LiteLLM send the injected credential (API key / OAuth token) to an
-    # arbitrary host — an exfiltration vector (SF-244 audit F03). Providers
-    # that need one (ollama) set their own in prepare_chat_body.
-    body.pop("api_base", None)
+    # The gateway owns upstream routing and credentials. Caller-supplied
+    # LiteLLM control-plane fields (api_key/api_base/base_url/fallbacks/
+    # model_list/...) would let LiteLLM send the injected credential to an
+    # arbitrary host or bend dispatch behavior (SF-244 audit F03, OME-428 D6).
+    # Providers that need an api_base (ollama) set their own in
+    # prepare_chat_body; the gateway credential is injected after this strip.
+    body = strip_dispatch_controls(body)
 
     profile_name = (request.headers.get("X-Profile") or "default").strip() or "default"
     model = body.get("model", "")
@@ -660,7 +155,7 @@ async def chat_completions(request: Request, response: Response, current: Curren
     try:
         provider_response = await _dispatch_with_backpressure(request, plugin, provider, body)
     except HTTPException as exc:
-        raise await _dispatch_failure_response(
+        raise await _safe_dispatch_failure_response(
             request,
             exc,
             plugin=plugin,
@@ -671,18 +166,22 @@ async def chat_completions(request: Request, response: Response, current: Curren
             connection=connection,
             credential_name=credential_name,
             auth_type=auth_type,
-        )
+        ) from None
     except (
         RateLimitError,
         UnsupportedParamsError,
         BadRequestError,
         AuthenticationError,
+        PermissionDeniedError,
+        NotFoundError,
+        UnprocessableEntityError,
+        InternalServerError,
         APIError,
         APIConnectionError,
         ServiceUnavailableError,
         Timeout,
     ) as exc:
-        raise await _dispatch_failure_response(
+        raise await _safe_dispatch_failure_response(
             request,
             _litellm_http_exception(exc),
             plugin=plugin,
@@ -693,7 +192,36 @@ async def chat_completions(request: Request, response: Response, current: Curren
             connection=connection,
             credential_name=credential_name,
             auth_type=auth_type,
-        ) from exc
+        ) from None
+    except Exception as exc:
+        # WHY (OME-428 third-review blocker B): the two branches above enumerate
+        # the curated HTTPException and the KNOWN litellm exception families. Any
+        # OTHER escape (a RuntimeError, a ValueError, a new litellm type, a
+        # malformed-conversion error) must still render a sanitized status — never
+        # an uncontrolled ASGI 500 whose traceback leaks the raw provider
+        # message/prompt.
+        # INVARIANT: an unclassified exception always yields a fixed sanitized
+        # 502 `provider_error`; arbitrary attributes/chains are not trusted and
+        # cannot trigger credential invalidation.
+        logger.error(
+            "unhandled dispatch error type=%s provider=%s account=%s profile=%s",
+            type(exc).__name__,
+            provider,
+            account_id,
+            profile_name,
+        )
+        raise await _safe_dispatch_failure_response(
+            request,
+            _unknown_provider_exception(),
+            plugin=plugin,
+            provider=provider,
+            account_id=account_id,
+            profile_name=profile_name,
+            profile=profile,
+            connection=connection,
+            credential_name=credential_name,
+            auth_type=auth_type,
+        ) from None
     dumpable = cast(Any, provider_response)
     result = dumpable.model_dump() if hasattr(dumpable, "model_dump") else provider_response
 
@@ -717,15 +245,3 @@ async def chat_completions(request: Request, response: Response, current: Curren
             cache_key.key_hash[:12] if cache_key is not None else "",
         )
     return result
-
-
-async def _stream(plugin: Any, body: dict[str, Any]):
-    try:
-        async for chunk in plugin.chat_completion_stream(body):
-            payload = chunk.model_dump() if hasattr(chunk, "model_dump") else chunk
-            yield f"data: {json.dumps(payload)}\n\n"
-        yield "data: [DONE]\n\n"
-    except Exception as exc:
-        logger.exception("stream failed")
-        err = {"error": {"message": str(exc), "type": type(exc).__name__}}
-        yield f"data: {json.dumps(err)}\n\n"

--- a/apps/aigateway/src/aigateway/routes/chat_credentials.py
+++ b/apps/aigateway/src/aigateway/routes/chat_credentials.py
@@ -1,0 +1,352 @@
+"""Credential-side helpers for /v1/chat/completions.
+
+Everything between the incoming request and a dispatch-ready body lives here:
+profile/connection resolution, credential-strategy lookup, profile-defaults
+merging, and credential injection. Split out of routes/chat.py (OME-428
+Phase 1) behind characterization tests; behavior is unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException, Request
+
+from ..core.credential_strategy_cache import credential_strategy_cache
+from ..core.errors import AuthError, CredentialNotFoundError
+from ..core.oauth.models import OAuthConnection
+from ..core.oauth.store import OAuthConnectionStore, credential_key_for
+from ..core.plugin_base import credential_strategy_from
+from ..core.profile_index import ProfileIndexStore
+from ..core.profile_models import (
+    AuthType,
+    Profile,
+    ProfileDefaults,
+    ProfileState,
+    credential_name_for,
+)
+
+_DEFAULT_PROFILE_NAME = "default"
+
+
+_BUCKET_A_FIELDS = (
+    "model",
+    "max_tokens",
+    "temperature",
+    "timeout_seconds",
+    "reasoning_effort",
+)
+
+
+def _has_system_message(body: dict[str, Any]) -> bool:
+    return any(m.get("role") == "system" for m in body.get("messages", []))
+
+
+def _should_apply_profile_default(plugin: Any, field: str) -> bool:
+    checker = getattr(plugin, "should_apply_profile_default", None)
+    return bool(checker(field)) if callable(checker) else True
+
+
+def _allows_chatless_profile(plugin: Any) -> bool:
+    checker = getattr(plugin, "allows_chatless_profile", None)
+    return bool(checker()) if callable(checker) else False
+
+
+def _invalidate_profile_session(plugin: Any, profile_name: str) -> None:
+    invalidator = getattr(plugin, "invalidate_profile_session", None)
+    if callable(invalidator):
+        invalidator(profile_name)
+
+
+def _oauth_connection_store(request: Request) -> OAuthConnectionStore:
+    store = getattr(request.app.state, "oauth_connections", None)
+    if isinstance(store, OAuthConnectionStore):
+        return store
+    store = OAuthConnectionStore()
+    request.app.state.oauth_connections = store
+    return store
+
+
+async def _active_oauth_connection_for_profile(
+    request: Request,
+    *,
+    account_id: str,
+    provider: str,
+    profile_name: str,
+) -> OAuthConnection | None:
+    connections = await _oauth_connection_store(request).list(
+        account_id,
+        provider=provider,
+        status="active",
+    )
+    if not connections:
+        return None
+
+    for connection in connections:
+        if connection.label == profile_name:
+            return connection
+
+    if profile_name == _DEFAULT_PROFILE_NAME and len(connections) == 1:
+        return connections[0]
+
+    if profile_name == _DEFAULT_PROFILE_NAME:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "connection_ambiguous",
+                "provider": provider,
+                "message": (
+                    "Multiple active connections exist. Select one by setting "
+                    "X-Profile to the connection label."
+                ),
+            },
+        )
+    raise HTTPException(
+        status_code=404,
+        detail={
+            "code": "connection_not_found",
+            "provider": provider,
+            "requested_label": profile_name,
+            "valid_labels": [connection.label for connection in connections],
+        },
+    )
+
+
+async def _credential_target_for_chat(
+    request: Request,
+    *,
+    account_id: str,
+    provider: str,
+    profile_name: str,
+    plugin: Any,
+) -> tuple[Profile | None, OAuthConnection | None, ProfileDefaults]:
+    idx: ProfileIndexStore = request.app.state.profile_index
+    profile = await idx.get(account_id, provider, profile_name)
+    if profile is None:
+        connection = await _active_oauth_connection_for_profile(
+            request,
+            account_id=account_id,
+            provider=provider,
+            profile_name=profile_name,
+        )
+        if connection is not None:
+            return None, connection, ProfileDefaults()
+        if not _allows_chatless_profile(plugin):
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "code": "profile_not_found",
+                    "provider": provider,
+                    "name": profile_name,
+                },
+            )
+        return None, None, ProfileDefaults()
+
+    if profile.state == ProfileState.PENDING:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "profile_pending_auth",
+                "provider": provider,
+                "name": profile_name,
+            },
+        )
+    if profile.state == ProfileState.ERROR:
+        raise HTTPException(
+            status_code=401,
+            detail={
+                "code": "auth_required",
+                "provider": provider,
+                "name": profile_name,
+                "reauth_url": f"/v1/auth/{provider}/profiles/{profile_name}",
+            },
+        )
+    return profile, None, profile.defaults
+
+
+def _strategy_for_credential_target(
+    request: Request,
+    plugin: Any,
+    provider: str,
+    *,
+    account_id: str,
+    profile_name: str,
+    profile: Profile | None,
+    connection: OAuthConnection | None,
+) -> tuple[Any, str | None, AuthType]:
+    """Resolve (strategy, credential_name, auth_type) for the chat credential
+    target, branching on the target's auth_type discriminator."""
+    auth_type: AuthType
+    if connection is not None:
+        credential_name = credential_key_for(account_id, connection.id)
+        auth_type = connection.auth_type or "oauth"
+    elif profile is not None:
+        credential_name = credential_name_for(account_id, profile_name)
+        auth_type = profile.auth_type
+    else:
+        return None, None, "oauth"
+    # Share ONE strategy instance per credential across concurrent requests so its
+    # asyncio.Lock single-flights the OAuth refresh (SF-282). Building is only a
+    # constructor call; the cache is evicted on every credential mutation.
+    strategy = credential_strategy_cache(request.app).get_or_create(
+        provider=provider,
+        auth_type=auth_type,
+        credential_name=credential_name,
+        build=lambda: credential_strategy_from(
+            plugin,
+            credential_name,
+            auth_type=auth_type,
+            credential_store=request.app.state.credential_store,
+            http_client_factory=getattr(request.app.state, f"{provider}_http_factory", None),
+        ),
+    )
+    return strategy, credential_name, auth_type
+
+
+def _reauth_url_for(
+    provider: str,
+    profile_name: str,
+    auth_type: AuthType,
+    *,
+    connection_id: str | None = None,
+) -> str:
+    if connection_id is not None and auth_type == "api_key":
+        # An api-key CONNECTION re-keys via its own replace route; never send the
+        # user back to the legacy profile api-key endpoint, which would shadow
+        # connections on chat (SF-291 review F3).
+        return f"/v1/oauth/connections/{connection_id}/api-key"
+    base = f"/v1/auth/{provider}/profiles/{profile_name}"
+    return f"{base}/api-key" if auth_type == "api_key" else base
+
+
+async def _mark_profile_error_fresh(
+    request: Request,
+    *,
+    account_id: str,
+    provider: str,
+    profile_name: str,
+) -> None:
+    """Re-fetch the profile before flipping state so a long-running dispatch
+    never clobbers concurrent index writes (e.g. a PUT api-key changing
+    auth_type/account_label mid-flight) with its stale snapshot."""
+    idx: ProfileIndexStore = request.app.state.profile_index
+    fresh = await idx.get(account_id, provider, profile_name)
+    if fresh is not None:
+        fresh.state = ProfileState.ERROR
+        await idx.upsert(fresh)
+
+
+def _apply_defaults(body: dict[str, Any], defaults: ProfileDefaults, plugin: Any) -> dict[str, Any]:
+    """Body wins per field. Fields the body omits get the profile default."""
+    if (
+        defaults.system_prompt
+        and not _has_system_message(body)
+        and _should_apply_profile_default(plugin, "system_prompt")
+    ):
+        body.setdefault("messages", [])
+        body["messages"] = [
+            {"role": "system", "content": defaults.system_prompt},
+            *body["messages"],
+        ]
+    for field in _BUCKET_A_FIELDS:
+        gateway_field = "timeout" if field == "timeout_seconds" else field
+        if not _should_apply_profile_default(plugin, field):
+            continue
+        value = getattr(defaults, field)
+        if value is not None and gateway_field not in body:
+            body[gateway_field] = value
+    return body
+
+
+async def _inject_credentials(
+    request: Request,
+    *,
+    plugin: Any,
+    provider: str,
+    account_id: str,
+    profile_name: str,
+    profile: Profile | None,
+    connection: OAuthConnection | None,
+    body: dict[str, Any],
+) -> tuple[str | None, AuthType]:
+    """Resolve the profile/connection credential strategy and inject auth
+    into ``body``; returns ``(credential_name, auth_type)`` for later dispatch
+    failure handling. Raises 401 (marking profile/connection errored) when
+    stored credentials are unusable."""
+    strategy, credential_name, auth_type = _strategy_for_credential_target(
+        request,
+        plugin,
+        provider,
+        account_id=account_id,
+        profile_name=profile_name,
+        profile=profile,
+        connection=connection,
+    )
+    if strategy is None and credential_name is not None and auth_type == "api_key":
+        # Never fall through to an unauthenticated dispatch when the target
+        # says api_key but the provider has no API-key strategy (SF-244 F15).
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "api_key_not_supported", "provider": provider},
+        )
+    if strategy is not None:
+        try:
+            headers = await strategy.get_authorization_header()
+        except CredentialNotFoundError as exc:
+            if credential_name is not None:
+                credential_strategy_cache(request.app).evict(credential_name)
+            if connection is not None:
+                await _oauth_connection_store(request).mark_error(connection, str(exc))
+            raise HTTPException(
+                status_code=401,
+                detail={
+                    "code": "auth_required",
+                    "message": str(exc),
+                    "reauth_url": _reauth_url_for(
+                        provider,
+                        profile_name,
+                        auth_type,
+                        connection_id=str(connection.id) if connection is not None else None,
+                    ),
+                },
+            )
+        except AuthError as exc:
+            if credential_name is not None:
+                credential_strategy_cache(request.app).evict(credential_name)
+            if connection is not None:
+                await _oauth_connection_store(request).mark_error(connection, str(exc))
+                if credential_name is not None:
+                    _invalidate_profile_session(plugin, credential_name)
+            elif profile is not None:
+                await _mark_profile_error_fresh(
+                    request,
+                    account_id=account_id,
+                    provider=provider,
+                    profile_name=profile_name,
+                )
+                if credential_name is not None:
+                    _invalidate_profile_session(plugin, credential_name)
+            raise HTTPException(
+                status_code=401,
+                detail={
+                    "code": "auth_required",
+                    "message": str(exc),
+                    "reauth_url": _reauth_url_for(
+                        provider,
+                        profile_name,
+                        auth_type,
+                        connection_id=str(connection.id) if connection is not None else None,
+                    ),
+                },
+            )
+        auth_value = headers.pop("Authorization", None)
+        if auth_value and auth_value.lower().startswith("bearer "):
+            body["api_key"] = auth_value.split(" ", 1)[1]
+        if headers:
+            merged = dict(body.get("extra_headers") or {})
+            merged.update(headers)
+            body["extra_headers"] = merged
+        if connection is not None:
+            await _oauth_connection_store(request).touch_last_used(connection)
+
+    return credential_name, auth_type

--- a/apps/aigateway/src/aigateway/routes/chat_dispatch.py
+++ b/apps/aigateway/src/aigateway/routes/chat_dispatch.py
@@ -1,0 +1,325 @@
+"""Dispatch-side helpers for /v1/chat/completions.
+
+Everything after the body is credential-sealed lives here: backpressure +
+overload retry, LiteLLM-exception → HTTP mapping, dispatch-failure credential
+marking, request-cache planning/persistence, and SSE streaming. Split out of
+routes/chat.py (OME-428 Phase 1) behind characterization tests; behavior is
+unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from fastapi import HTTPException, Request, Response
+
+from ..core.concurrency import effective_provider_limit, provider_slot
+from ..core.credential_strategy_cache import credential_strategy_cache
+from ..core.http_status import valid_http_error_status
+from ..core.oauth.models import OAuthConnection
+from ..core.profile_models import AuthType, Profile
+from ..core.request_cache.keys import (
+    KEY_VERSION,
+    CacheBypass,
+    CacheControls,
+    CacheKeyResult,
+    build_cache_key,
+)
+from ..core.request_cache.store import RequestCacheStore, RequestCacheWrite
+from ..core.retry import RetryPolicy, parse_retry_after_seconds, with_overload_retry
+from .chat_credentials import (
+    _invalidate_profile_session,
+    _mark_profile_error_fresh,
+    _oauth_connection_store,
+    _reauth_url_for,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _should_mark_profile_error_on_dispatch_status(plugin: Any, status_code: int) -> bool:
+    checker = getattr(plugin, "should_mark_profile_error_on_dispatch_status", None)
+    return bool(checker(status_code)) if callable(checker) else False
+
+
+async def _dispatch_failure_response(
+    request: Request,
+    exc: HTTPException,
+    *,
+    plugin: Any,
+    provider: str,
+    account_id: str,
+    profile_name: str,
+    profile: Profile | None,
+    connection: OAuthConnection | None,
+    credential_name: str | None,
+    auth_type: AuthType,
+) -> HTTPException:
+    """Mark the credential target on auth-meaning dispatch failures.
+
+    Shared by the HTTPException path (custom handlers raise these) and the
+    LiteLLM-exception path (e.g. anthropic AuthenticationError), so a bad
+    stored credential flips the profile/connection to ERROR regardless of
+    which exception family the provider dispatch uses.
+    """
+    if not _should_mark_profile_error_on_dispatch_status(plugin, exc.status_code):
+        return exc
+    # Drop the cached strategy so its (now bad) token isn't reused by the next
+    # request — important under fan-out where many requests share the instance.
+    if credential_name is not None:
+        credential_strategy_cache(request.app).evict(credential_name)
+    detail = exc.detail if isinstance(exc.detail, dict) else {"message": str(exc.detail)}
+    if connection is not None:
+        await _oauth_connection_store(request).mark_error(
+            connection,
+            str(detail.get("message", str(exc.detail))),
+        )
+        if credential_name is not None:
+            _invalidate_profile_session(plugin, credential_name)
+        return exc
+    if profile is None:
+        return exc
+    await _mark_profile_error_fresh(
+        request, account_id=account_id, provider=provider, profile_name=profile_name
+    )
+    if credential_name is not None:
+        _invalidate_profile_session(plugin, credential_name)
+    return HTTPException(
+        status_code=exc.status_code,
+        detail={
+            "code": detail.get("code", "auth_required"),
+            "message": detail.get("message", str(exc.detail)),
+            "reauth_url": detail.get(
+                "reauth_url", _reauth_url_for(provider, profile_name, auth_type)
+            ),
+        },
+    )
+
+
+async def _safe_dispatch_failure_response(
+    request: Request,
+    exc: HTTPException,
+    *,
+    plugin: Any,
+    provider: str,
+    account_id: str,
+    profile_name: str,
+    profile: Profile | None,
+    connection: OAuthConnection | None,
+    credential_name: str | None,
+    auth_type: AuthType,
+) -> HTTPException:
+    """Contain secondary failures while rendering/persisting dispatch errors."""
+    try:
+        return await _dispatch_failure_response(
+            request,
+            exc,
+            plugin=plugin,
+            provider=provider,
+            account_id=account_id,
+            profile_name=profile_name,
+            profile=profile,
+            connection=connection,
+            credential_name=credential_name,
+            auth_type=auth_type,
+        )
+    except Exception as failure:
+        logger.error(
+            "dispatch failure handling error type=%s provider=%s account=%s profile=%s",
+            type(failure).__name__,
+            provider,
+            account_id,
+            profile_name,
+        )
+        return _unknown_provider_exception()
+
+
+def _retry_after_headers(exc: Exception) -> dict[str, str]:
+    seconds = parse_retry_after_seconds(exc)
+    if seconds is None:
+        return {}
+    # delta-seconds is an integer; round up so clients do not retry early.
+    return {"Retry-After": str(math.ceil(seconds))}
+
+
+async def _dispatch_with_backpressure(
+    request: Request,
+    plugin: Any,
+    provider: str,
+    body: dict[str, Any],
+) -> Any:
+    """Run ``plugin.chat_completion`` under the gateway's backpressure stack:
+    a per-provider concurrency slot wrapping the overload-retry loop.
+
+    The slot is held across retries so a provider's concurrent-pressure
+    ceiling includes backoff time — preventing the thundering-herd quota
+    re-exhaustion that pure reactive retry could not solve.
+    """
+    settings = request.app.state.settings
+    async with provider_slot(request.app, provider, effective_provider_limit(settings, provider)):
+        return await with_overload_retry(
+            lambda: plugin.chat_completion(body),
+            policy=RetryPolicy.from_settings(settings),
+        )
+
+
+def _resolve_cache_plan(
+    request: Request,
+    *,
+    account_id: str,
+    profile_name: str,
+    provider: str,
+    body: dict[str, Any],
+    controls: CacheControls,
+) -> tuple[CacheKeyResult | None, str, str]:
+    """Decide cache participation for this request.
+
+    Returns ``(key, status, reason)`` where ``key`` is None whenever the
+    request bypasses the cache. Status/reason feed the X-AIGW-Cache headers.
+    """
+    settings = request.app.state.settings
+    if not settings.request_cache_enabled:
+        return None, "bypass", "disabled"
+    if not controls.use_cache:
+        return None, "bypass", "not_requested"
+    built = build_cache_key(
+        account_id=account_id,
+        profile_name=profile_name,
+        provider=provider,
+        normalized_body=body,
+    )
+    if isinstance(built, CacheBypass):
+        return None, "bypass", built.reason
+    return built, "miss", ""
+
+
+def _set_cache_headers(
+    response: Response, status: str, reason: str, key: CacheKeyResult | None
+) -> None:
+    response.headers["X-AIGW-Cache"] = status
+    if reason:
+        response.headers["X-AIGW-Cache-Reason"] = reason
+    # Hash-derived prefix only — never prompt or response content.
+    if key is not None and status in {"hit", "miss"}:
+        response.headers["X-AIGW-Cache-Key"] = key.key_hash[:12]
+
+
+async def _store_cached_response(
+    request: Request,
+    *,
+    key: CacheKeyResult,
+    account_id: str,
+    result: Any,
+    controls: CacheControls,
+) -> str:
+    """Persist a fresh response when allowed; returns the cache reason."""
+    if controls.no_store:
+        return "no_store"
+    if not isinstance(result, dict):
+        return "unsupported_fields"
+    settings = request.app.state.settings
+    payload_size = len(
+        json.dumps(result, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    )
+    if payload_size > settings.request_cache_max_response_bytes:
+        return "too_large"
+    ttl = min(
+        controls.ttl or settings.request_cache_default_ttl_seconds,
+        settings.request_cache_max_ttl_seconds,
+    )
+    store: RequestCacheStore = request.app.state.request_cache_store
+    await store.set(
+        RequestCacheWrite(
+            key_hash=key.key_hash,
+            key_version=KEY_VERSION,
+            account_id=account_id,
+            profile_name=key.profile_name,
+            prompt_hash=key.prompt_hash,
+            provider=key.provider,
+            model=key.model,
+            response=result,
+            response_size_bytes=payload_size,
+            expires_at=datetime.now(UTC) + timedelta(seconds=ttl),
+        )
+    )
+    return "stored"
+
+
+# WHY (FINDING B): the client-facing message is gateway-authored per machine
+# code — NEVER str(exc), which serializes the raw LiteLLM/provider text (and any
+# secret embedded in it) into the response, logs, and (for a 401, via
+# _dispatch_failure_response) persisted connection error state.
+# INVARIANT: this generic sanitizer applies only to RAW LiteLLM/provider
+# exceptions (route Branch B); errors already authored safely by gateway policy
+# (route Branch A HTTPExceptions) keep their curated detail unchanged.
+_PROVIDER_ERROR_MESSAGE = {
+    "bad_request": "The upstream provider rejected the request.",
+    "auth_required": "The stored provider credential was rejected.",
+    "rate_limited": "The upstream provider is rate limiting requests.",
+    "provider_unavailable": "The upstream provider is temporarily unavailable.",
+    "provider_error": "The upstream provider returned an error.",
+}
+
+
+def _sanitized_provider_status(exc: Exception) -> int | None:
+    """A validated provider HTTP error status (400-599), else ``None``.
+
+    # WHY (FINDING B / blocker E): never ``int(status_code)`` — a malformed
+    # provider status (e.g. 'not-a-status' or the Unicode '²') would raise and
+    # 500. One strict shared validator (rejects bool/str/float) is used here and
+    # by the OpenRouter plugin/provenance so the three sites cannot diverge.
+    """
+    try:
+        status = getattr(exc, "status_code", None)
+    except Exception:
+        return None
+    return valid_http_error_status(status)
+
+
+def _provider_error_code(status: int, *, validated: bool) -> str:
+    if status == 400:
+        return "bad_request"
+    if status == 401:
+        return "auth_required"
+    if status == 429:
+        return "rate_limited"
+    if validated and status >= 500:
+        return "provider_unavailable"
+    # An absent/malformed status resolves to 502 but stays "provider_error"
+    # (mirrors the OpenRouter plugin's _embedded_error_exception): only a
+    # provider-validated 5xx earns the more specific "provider_unavailable".
+    return "provider_error"
+
+
+def _litellm_http_exception(exc: Exception) -> HTTPException:
+    status = _sanitized_provider_status(exc)
+    resolved = status if status is not None else 502
+    code = _provider_error_code(resolved, validated=status is not None)
+    return HTTPException(
+        status_code=resolved,
+        detail={"code": code, "message": _PROVIDER_ERROR_MESSAGE[code]},
+        headers=_retry_after_headers(exc),
+    )
+
+
+def _unknown_provider_exception() -> HTTPException:
+    return HTTPException(
+        status_code=502,
+        detail={"code": "provider_error", "message": _PROVIDER_ERROR_MESSAGE["provider_error"]},
+    )
+
+
+async def _stream(plugin: Any, body: dict[str, Any]):
+    try:
+        async for chunk in plugin.chat_completion_stream(body):
+            payload = chunk.model_dump() if hasattr(chunk, "model_dump") else chunk
+            yield f"data: {json.dumps(payload)}\n\n"
+        yield "data: [DONE]\n\n"
+    except Exception as exc:
+        logger.exception("stream failed")
+        err = {"error": {"message": str(exc), "type": type(exc).__name__}}
+        yield f"data: {json.dumps(err)}\n\n"

--- a/apps/aigateway/tests/live/test_openrouter_live.py
+++ b/apps/aigateway/tests/live/test_openrouter_live.py
@@ -1,0 +1,161 @@
+"""End-to-end live BYOK smoke against openrouter.ai (OME-428 Phase 4, optional).
+
+Owner-gated: skipped unless AIGW_LIVE=1 AND AIGW_LIVE_OPENROUTER_KEY is set —
+the key is a real OpenRouter API key supplied by the owner for this run only.
+It is stored through the normal encrypted connection lifecycle (never via env
+fallback inside the gateway: the poisoned-globals contract tests pin that) and
+never echoed by any response.
+
+Model defaults to a cheap upstream and can be overridden with
+AIGW_LIVE_OPENROUTER_MODEL (gateway form: openrouter/<author>/<model>).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from aigateway.main import create_app
+from aigateway.plugins.openrouter_provider import plugin as openrouter_plugin_module
+from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSettings
+
+pytestmark = pytest.mark.live
+
+_CONNECTION_LABEL = "live-openrouter-smoke"
+
+_database_prepared = False
+
+
+def _live_enabled() -> bool:
+    return os.environ.get("AIGW_LIVE") == "1"
+
+
+def _live_openrouter_key() -> str:
+    key = os.environ.get("AIGW_LIVE_OPENROUTER_KEY")
+    if not key:
+        pytest.skip("Live OpenRouter test requires AIGW_LIVE_OPENROUTER_KEY")
+    return key
+
+
+def _live_model() -> str:
+    return os.environ.get("AIGW_LIVE_OPENROUTER_MODEL", "openrouter/openai/gpt-4o-mini")
+
+
+def _prepare_live_database() -> None:
+    global _database_prepared
+    if _database_prepared:
+        return
+
+    app_dir = Path(__file__).resolve().parents[2]
+    command = [sys.executable, "-m", "tortoise", "-c", "aigateway.db.TORTOISE_CONFIG", "migrate"]
+    try:
+        subprocess.run(
+            command,
+            cwd=app_dir,
+            env=os.environ.copy(),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        pytest.fail(
+            "failed to migrate live AIGateway database before OpenRouter live test\n"
+            f"stdout:\n{exc.stdout}\n"
+            f"stderr:\n{exc.stderr}"
+        )
+
+    _database_prepared = True
+
+
+def _live_client() -> TestClient:
+    _prepare_live_database()
+    return TestClient(create_app())
+
+
+def _login_admin(client: TestClient) -> None:
+    password = _live_admin_password()
+    response = client.post("/v1/auth/login", json={"username": "admin", "password": password})
+    assert response.status_code == 200, response.text
+    client.headers.update({"Authorization": f"Bearer {response.json()['token']}"})
+
+
+def _live_admin_password() -> str:
+    password = os.environ.get("AIGW_LIVE_ADMIN_PASSWORD") or os.environ.get(
+        "AIGATEWAY_ADMIN_PASSWORD"
+    )
+    if not password:
+        pytest.skip("Live auth tests require AIGW_LIVE_ADMIN_PASSWORD or AIGATEWAY_ADMIN_PASSWORD")
+    assert password is not None
+    return password
+
+
+def _ensure_connection(client: TestClient, api_key: str) -> None:
+    """Create the smoke connection, or refresh its key so reruns stay green.
+
+    PUT api-key re-activates an errored connection, so a previous failed run
+    (e.g. a revoked key that tripped the local-401 invalidation) self-heals.
+    """
+    listing = client.get("/v1/oauth/connections", params={"provider": "openrouter"})
+    assert listing.status_code == 200, listing.text
+    existing = next(
+        (c for c in listing.json()["connections"] if c["label"] == _CONNECTION_LABEL),
+        None,
+    )
+    if existing is None:
+        created = client.post(
+            "/v1/oauth/connections/api-key",
+            json={"provider": "openrouter", "label": _CONNECTION_LABEL, "api_key": api_key},
+        )
+        assert created.status_code == 201, created.text
+        assert api_key not in created.text  # the key is never echoed
+        return
+    replaced = client.put(
+        f"/v1/oauth/connections/{existing['id']}/api-key",
+        json={"api_key": api_key},
+    )
+    assert replaced.status_code == 200, replaced.text
+    assert api_key not in replaced.text
+
+
+@pytest.mark.skipif(not _live_enabled(), reason="AIGW_LIVE=1 not set")
+def test_openrouter_byok_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
+    api_key = _live_openrouter_key()
+    _live_admin_password()
+    monkeypatch.setattr(
+        openrouter_plugin_module.PLUGIN, "settings", OpenRouterPluginSettings(enabled=True)
+    )
+
+    with _live_client() as client:
+        _login_admin(client)
+        _ensure_connection(client, api_key)
+
+        resp = client.post(
+            "/v1/chat/completions",
+            headers={"X-Profile": _CONNECTION_LABEL},
+            json={
+                "model": _live_model(),
+                "messages": [{"role": "user", "content": "Reply with exactly: PONG"}],
+                "max_tokens": 16,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+
+        # Native metadata survives the gateway (D10): OpenRouter generation id,
+        # text, finish reason, and token usage all present and untouched.
+        assert str(data.get("id", "")), data
+        content = data["choices"][0]["message"]["content"]
+        assert content and content.strip()
+        assert data["choices"][0]["finish_reason"]
+        usage = data.get("usage")
+        assert isinstance(usage, dict), data
+        assert usage.get("prompt_tokens", 0) > 0
+        assert usage.get("completion_tokens", 0) > 0
+
+        # The BYOK credential never appears in any response body.
+        assert api_key not in resp.text

--- a/apps/aigateway/tests/live/test_openrouter_live.py
+++ b/apps/aigateway/tests/live/test_openrouter_live.py
@@ -5,9 +5,6 @@ the key is a real OpenRouter API key supplied by the owner for this run only.
 It is stored through the normal encrypted connection lifecycle (never via env
 fallback inside the gateway: the poisoned-globals contract tests pin that) and
 never echoed by any response.
-
-Model defaults to a cheap upstream and can be overridden with
-AIGW_LIVE_OPENROUTER_MODEL (gateway form: openrouter/<author>/<model>).
 """
 
 from __future__ import annotations
@@ -17,8 +14,13 @@ import subprocess
 import sys
 from pathlib import Path
 
+import httpx
+import litellm
 import pytest
 from fastapi.testclient import TestClient
+from litellm.caching.caching import Cache
+from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
+from litellm.types.utils import CredentialItem
 
 from aigateway.main import create_app
 from aigateway.plugins.openrouter_provider import plugin as openrouter_plugin_module
@@ -35,15 +37,36 @@ def _live_enabled() -> bool:
     return os.environ.get("AIGW_LIVE") == "1"
 
 
+def _disposable_live_enabled() -> bool:
+    # INVARIANT: setting this flag declares that the key will be revoked
+    # immediately after the owner-gated adversarial run.
+    return _live_enabled() and os.environ.get("AIGW_LIVE_OPENROUTER_DISPOSABLE_KEY") == "1"
+
+
 def _live_openrouter_key() -> str:
     key = os.environ.get("AIGW_LIVE_OPENROUTER_KEY")
     if not key:
         pytest.skip("Live OpenRouter test requires AIGW_LIVE_OPENROUTER_KEY")
+    assert key is not None
     return key
 
 
 def _live_model() -> str:
-    return os.environ.get("AIGW_LIVE_OPENROUTER_MODEL", "openrouter/openai/gpt-4o-mini")
+    return os.environ.get("AIGW_LIVE_OPENROUTER_MODEL", "openrouter/google/gemma-4-26b-a4b-it:free")
+
+
+def _disposable_free_model() -> str:
+    if not _disposable_live_enabled():
+        pytest.skip("Disposable-key tests require AIGW_LIVE_OPENROUTER_DISPOSABLE_KEY=1")
+    model = _live_model()
+    if not model.endswith(":free"):
+        pytest.skip("Disposable-key tests require an explicit :free model")
+    return model
+
+
+def _assert_live_key_not_returned(response_text: str, api_key: str) -> None:
+    if api_key in response_text:
+        pytest.fail("OpenRouter credential appeared in the AIGateway response", pytrace=False)
 
 
 def _prepare_live_database() -> None:
@@ -101,7 +124,8 @@ def _ensure_connection(client: TestClient, api_key: str) -> None:
     (e.g. a revoked key that tripped the local-401 invalidation) self-heals.
     """
     listing = client.get("/v1/oauth/connections", params={"provider": "openrouter"})
-    assert listing.status_code == 200, listing.text
+    _assert_live_key_not_returned(listing.text, api_key)
+    assert listing.status_code == 200, f"unexpected listing status: {listing.status_code}"
     existing = next(
         (c for c in listing.json()["connections"] if c["label"] == _CONNECTION_LABEL),
         None,
@@ -111,15 +135,15 @@ def _ensure_connection(client: TestClient, api_key: str) -> None:
             "/v1/oauth/connections/api-key",
             json={"provider": "openrouter", "label": _CONNECTION_LABEL, "api_key": api_key},
         )
-        assert created.status_code == 201, created.text
-        assert api_key not in created.text  # the key is never echoed
+        _assert_live_key_not_returned(created.text, api_key)
+        assert created.status_code == 201, f"unexpected create status: {created.status_code}"
         return
     replaced = client.put(
         f"/v1/oauth/connections/{existing['id']}/api-key",
         json={"api_key": api_key},
     )
-    assert replaced.status_code == 200, replaced.text
-    assert api_key not in replaced.text
+    _assert_live_key_not_returned(replaced.text, api_key)
+    assert replaced.status_code == 200, f"unexpected replace status: {replaced.status_code}"
 
 
 @pytest.mark.skipif(not _live_enabled(), reason="AIGW_LIVE=1 not set")
@@ -143,11 +167,12 @@ def test_openrouter_byok_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
                 "max_tokens": 16,
             },
         )
-        assert resp.status_code == 200, resp.text
+        _assert_live_key_not_returned(resp.text, api_key)
+        assert resp.status_code == 200, f"unexpected completion status: {resp.status_code}"
         data = resp.json()
 
         # Native metadata survives the gateway (D10): OpenRouter generation id,
-        # text, finish reason, and token usage all present and untouched.
+        # text, finish reason, and token usage are all present.
         assert str(data.get("id", "")), data
         content = data["choices"][0]["message"]["content"]
         assert content and content.strip()
@@ -157,5 +182,253 @@ def test_openrouter_byok_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
         assert usage.get("prompt_tokens", 0) > 0
         assert usage.get("completion_tokens", 0) > 0
 
-        # The BYOK credential never appears in any response body.
-        assert api_key not in resp.text
+
+@pytest.mark.skipif(not _live_enabled(), reason="AIGW_LIVE=1 not set")
+def test_openrouter_byok_round_trip_ignores_ambient_and_request_routing_controls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Poisoned caller and ambient routing cannot divert a real BYOK request."""
+    api_key = _live_openrouter_key()
+    model = _live_model()
+    if not model.endswith(":free"):
+        pytest.skip("The additional hardening smoke requires an explicit :free model")
+    _live_admin_password()
+    monkeypatch.setattr(
+        openrouter_plugin_module.PLUGIN, "settings", OpenRouterPluginSettings(enabled=True)
+    )
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-poisoned-openrouter")
+    monkeypatch.setenv("OR_API_KEY", "sk-or-poisoned-or")
+    monkeypatch.setenv("OPENROUTER_API_BASE", "http://127.0.0.1:9/v1")
+
+    with _live_client() as client:
+        _login_admin(client)
+        _ensure_connection(client, api_key)
+
+        resp = client.post(
+            "/v1/chat/completions",
+            headers={"X-Profile": _CONNECTION_LABEL},
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": "Reply with exactly: PONG"}],
+                "max_tokens": 32,
+                "temperature": 0,
+                "api_key": "sk-or-caller-poisoned",
+                "api_base": "http://127.0.0.1:9/v1",
+                "base_url": "http://127.0.0.1:9/v1",
+                "extra_headers": {
+                    "Authorization": "Bearer sk-or-header-poisoned",
+                },
+            },
+        )
+
+        _assert_live_key_not_returned(resp.text, api_key)
+        assert resp.status_code == 200, f"unexpected completion status: {resp.status_code}"
+        data = resp.json()
+        assert str(data.get("id", "")), data
+        assert data["choices"][0]["message"]["content"], data
+        assert data["choices"][0]["finish_reason"], data
+        usage = data.get("usage")
+        assert isinstance(usage, dict), data
+        assert usage.get("prompt_tokens", 0) > 0
+        assert usage.get("completion_tokens", 0) > 0
+
+
+@pytest.mark.skipif(not _live_enabled(), reason="AIGW_LIVE=1 not set")
+def test_disposable_key_named_credential_cannot_leave_openrouter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Block any non-OpenRouter destination before it reaches network transport."""
+    api_key = _live_openrouter_key()
+    model = _disposable_free_model()
+    _live_admin_password()
+    monkeypatch.setattr(
+        openrouter_plugin_module.PLUGIN, "settings", OpenRouterPluginSettings(enabled=True)
+    )
+    original_send = httpx.AsyncClient.send
+    blocked_destinations = 0
+
+    async def official_openrouter_only(self, request, *args, **kwargs):  # noqa: ANN001
+        nonlocal blocked_destinations
+        if request.url.host != "openrouter.ai":
+            blocked_destinations += 1
+            return httpx.Response(418, request=request)
+        return await original_send(self, request, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "send", official_openrouter_only)
+    monkeypatch.setattr(
+        litellm,
+        "credential_list",
+        [
+            CredentialItem(
+                credential_name="disposable-local-sink",
+                credential_info={},
+                credential_values={"base_url": "https://attacker.invalid/v1"},
+            )
+        ],
+    )
+
+    with _live_client() as client:
+        _login_admin(client)
+        _ensure_connection(client, api_key)
+        response = client.post(
+            "/v1/chat/completions",
+            headers={"X-Profile": _CONNECTION_LABEL},
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": "Reply with exactly: PONG"}],
+                "max_tokens": 32,
+                "litellm_credential_name": "disposable-local-sink",
+            },
+        )
+        _assert_live_key_not_returned(response.text, api_key)
+        assert blocked_destinations == 0
+        assert response.status_code == 200, f"unexpected completion status: {response.status_code}"
+
+
+@pytest.mark.skipif(not _live_enabled(), reason="AIGW_LIVE=1 not set")
+def test_disposable_key_unsafe_globals_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api_key = _live_openrouter_key()
+    model = _disposable_free_model()
+    _live_admin_password()
+    monkeypatch.setattr(
+        openrouter_plugin_module.PLUGIN, "settings", OpenRouterPluginSettings(enabled=True)
+    )
+
+    def allow_rule(_input: str) -> bool:
+        return True
+
+    unsafe_states: tuple[tuple[str, object], ...] = (
+        ("model_alias_map", {model: model}),
+        ("callbacks", [object()]),
+        ("pre_call_rules", [allow_rule]),
+        ("post_call_rules", [allow_rule]),
+    )
+
+    with _live_client() as client:
+        _login_admin(client)
+        _ensure_connection(client, api_key)
+        for attribute, value in unsafe_states:
+            original = getattr(litellm, attribute)
+            setattr(litellm, attribute, value)
+            try:
+                response = client.post(
+                    "/v1/chat/completions",
+                    headers={"X-Profile": _CONNECTION_LABEL},
+                    json={
+                        "model": model,
+                        "messages": [{"role": "user", "content": "Reply with exactly: PONG"}],
+                        "max_tokens": 16,
+                    },
+                )
+            finally:
+                setattr(litellm, attribute, original)
+            _assert_live_key_not_returned(response.text, api_key)
+            assert response.status_code == 503
+            assert response.json() == {
+                "detail": {
+                    "code": "provider_unavailable",
+                    "message": "OpenRouter dispatch is unavailable",
+                }
+            }
+
+
+@pytest.mark.skipif(not _live_enabled(), reason="AIGW_LIVE=1 not set")
+def test_disposable_key_retries_synthetic_503_then_reaches_openrouter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api_key = _live_openrouter_key()
+    model = _disposable_free_model()
+    _live_admin_password()
+    monkeypatch.setattr(
+        openrouter_plugin_module.PLUGIN, "settings", OpenRouterPluginSettings(enabled=True)
+    )
+    original_send = httpx.AsyncClient.send
+    calls = 0
+
+    async def send_with_first_attempt_failure(self, request, *args, **kwargs):  # noqa: ANN001
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(
+                503,
+                headers={"Retry-After": "0"},
+                json={"error": {"code": 503, "message": "synthetic disposable-key retry"}},
+                request=request,
+            )
+        return await original_send(self, request, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "send", send_with_first_attempt_failure)
+    with _live_client() as client:
+        _login_admin(client)
+        _ensure_connection(client, api_key)
+        response = client.post(
+            "/v1/chat/completions",
+            headers={"X-Profile": _CONNECTION_LABEL},
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": "Reply with exactly: PONG"}],
+                "max_tokens": 32,
+            },
+        )
+        _assert_live_key_not_returned(response.text, api_key)
+        assert response.status_code == 200, f"unexpected completion status: {response.status_code}"
+        assert calls == 2
+
+
+@pytest.mark.skipif(not _live_enabled(), reason="AIGW_LIVE=1 not set")
+def test_disposable_key_bypasses_global_litellm_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api_key = _live_openrouter_key()
+    model = _disposable_free_model()
+    _live_admin_password()
+    monkeypatch.setattr(
+        openrouter_plugin_module.PLUGIN, "settings", OpenRouterPluginSettings(enabled=True)
+    )
+    callback_fields = (
+        "callbacks",
+        "input_callback",
+        "success_callback",
+        "failure_callback",
+        "_async_input_callback",
+        "_async_success_callback",
+        "_async_failure_callback",
+    )
+    callback_snapshots = {field: list(getattr(litellm, field)) for field in callback_fields}
+    original_cache = litellm.cache
+    monkeypatch.setattr(litellm, "cache", Cache())
+
+    try:
+        with _live_client() as client:
+            try:
+                _login_admin(client)
+                _ensure_connection(client, api_key)
+                responses = [
+                    client.post(
+                        "/v1/chat/completions",
+                        headers={"X-Profile": _CONNECTION_LABEL},
+                        json={
+                            "model": model,
+                            "messages": [{"role": "user", "content": "Reply with exactly: PONG"}],
+                            "max_tokens": 32,
+                            "temperature": 0,
+                        },
+                    )
+                    for _ in range(2)
+                ]
+                for response in responses:
+                    _assert_live_key_not_returned(response.text, api_key)
+                    assert response.status_code == 200, (
+                        f"unexpected completion status: {response.status_code}"
+                    )
+                assert responses[0].json()["id"] != responses[1].json()["id"]
+            finally:
+                portal = client.portal
+                assert portal is not None
+                portal.call(GLOBAL_LOGGING_WORKER.flush)
+    finally:
+        for field, snapshot in callback_snapshots.items():
+            getattr(litellm, field)[:] = snapshot
+        litellm.cache = original_cache

--- a/apps/aigateway/tests/unit/core/test_http_status.py
+++ b/apps/aigateway/tests/unit/core/test_http_status.py
@@ -1,0 +1,63 @@
+"""Strict provider HTTP-status validation (OME-428 third-review blocker E).
+
+# STORY: as the gateway, I accept an upstream provider's numeric error status
+# only when it is a real integer in the HTTP error range, so that a string,
+# a Unicode digit, a float, or a bool can never crash rendering or smuggle an
+# invalid status to the client.
+# INVARIANT: exactly `type(value) is int and 400 <= value <= 599`. `isdigit()`
+# is a trap: `"²".isdigit()` is True but `int("²")` raises ValueError, and the
+# fullwidth `"４２９"` is silently accepted by `int()`.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from aigateway.core.http_status import valid_http_error_status
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        # Valid integer statuses in range.
+        (400, 400),
+        (401, 401),
+        (402, 402),
+        (429, 429),
+        (500, 500),
+        (503, 503),
+        (599, 599),
+        # Out of the error range.
+        (399, None),
+        (200, None),
+        (600, None),
+        (0, None),
+        (-1, None),
+        # bool is an int subclass — must be rejected (int(True) == 1).
+        (True, None),
+        (False, None),
+        # Strings are rejected wholesale (integer-only contract).
+        ("429", None),
+        ("0429", None),
+        ("not-a-status", None),
+        ("", None),
+        # Unicode-digit hazards: isdigit() is True but these are not valid ints.
+        ("²", None),  # int("²") would raise ValueError
+        ("４２９", None),  # fullwidth digits: int() would silently accept -> 429
+        # Floats (incl. non-finite) are rejected.
+        (429.0, None),
+        (float("nan"), None),
+        (float("inf"), None),
+        (float("-inf"), None),
+        # Decimal and other numeric-likes are rejected.
+        (Decimal("429"), None),
+        # None / arbitrary objects.
+        (None, None),
+        (object(), None),
+        ([429], None),
+    ],
+)
+def test_valid_http_error_status(value: object, expected: int | None) -> None:
+    assert valid_http_error_status(value) == expected

--- a/apps/aigateway/tests/unit/core/test_litellm_http_exception_sanitize.py
+++ b/apps/aigateway/tests/unit/core/test_litellm_http_exception_sanitize.py
@@ -1,0 +1,95 @@
+"""Generic LiteLLM-exception → HTTPException rendering (OME-428 second-review
+FINDING B).
+
+``_litellm_http_exception`` renders genuine transport exceptions (route Branch B)
+into the client-facing HTTPException. It must:
+
+- derive the HTTP status by VALIDATION, never a bare ``int(status_code)`` — a
+  malformed provider status (e.g. the string 'not-a-status') currently raises
+  ``ValueError`` → HTTP 500; a bool or out-of-range value currently passes
+  through as an invalid status. All of these must degrade to a safe 502.
+- author its own per-code message and NEVER echo ``str(exc)``, which carries the
+  raw provider/LiteLLM text (and any secret embedded in it).
+
+INVARIANT: raw exception text, prompts, bodies, headers, and secrets must not
+reach clients, logs, or persisted error state; dispatch policy derives only
+from a sanitized status + Retry-After.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+from fastapi import HTTPException
+
+from aigateway.routes.chat_dispatch import _litellm_http_exception
+
+_SECRET = "SECRET-raw-provider-text-with-key-sk-or-v1-leak"
+
+
+class _FakeLLMError(Exception):
+    """Minimal stand-in for a LiteLLM transport exception: a ``status_code``
+    attribute plus a raw message (what ``str(exc)`` would expose)."""
+
+    def __init__(self, status_code: object, message: str) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _detail(out: HTTPException) -> dict[str, Any]:
+    # HTTPException.detail is typed str by starlette; the gateway always builds a
+    # dict here — cast so subscripting type-checks.
+    return cast("dict[str, Any]", out.detail)
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_code"),
+    [
+        (400, "bad_request"),
+        (401, "auth_required"),
+        (402, "provider_error"),
+        (429, "rate_limited"),
+        (500, "provider_unavailable"),
+        (503, "provider_unavailable"),
+        (529, "provider_unavailable"),
+    ],
+)
+def test_recognized_status_maps_to_code_without_leaking_raw_text(
+    status: int, expected_code: str
+) -> None:
+    out = _litellm_http_exception(_FakeLLMError(status, f"{_SECRET} {status}"))
+    detail = _detail(out)
+    assert out.status_code == status
+    assert detail["code"] == expected_code
+    # Gateway-authored message only — the raw provider text must never surface.
+    assert _SECRET not in detail["message"]
+    assert str(detail["message"])  # a non-empty, human-readable message exists
+
+
+def test_malformed_string_status_degrades_to_502_never_raises() -> None:
+    # Current code: int('not-a-status') → ValueError → unhandled → HTTP 500.
+    out = _litellm_http_exception(_FakeLLMError("not-a-status", _SECRET))
+    detail = _detail(out)
+    assert out.status_code == 502
+    assert detail["code"] == "provider_error"
+    assert _SECRET not in detail["message"]
+
+
+def test_bool_status_is_rejected_to_502() -> None:
+    # bool is an int subclass; int(True) == 1 would render an invalid HTTP status.
+    out = _litellm_http_exception(_FakeLLMError(True, _SECRET))
+    assert out.status_code == 502
+
+
+@pytest.mark.parametrize("status", [0, 1, 200, 399, 600, 999, -5])
+def test_out_of_range_status_degrades_to_502(status: int) -> None:
+    out = _litellm_http_exception(_FakeLLMError(status, _SECRET))
+    assert out.status_code == 502
+    assert _SECRET not in _detail(out)["message"]
+
+
+def test_missing_status_defaults_to_502() -> None:
+    out = _litellm_http_exception(Exception(_SECRET))
+    assert out.status_code == 502
+    assert _SECRET not in _detail(out)["message"]

--- a/apps/aigateway/tests/unit/core/test_provider_errors.py
+++ b/apps/aigateway/tests/unit/core/test_provider_errors.py
@@ -1,0 +1,59 @@
+"""Non-retryable provenance for provider-manufactured errors (OME-428 CODE-2).
+
+An error a plugin manufactures from an already-returned upstream response
+(e.g. an embedded 429 inside a nominal HTTP-200 body) must never re-enter the
+overload-retry loop: the upstream call already happened and may already be
+billed. Actual transport failures (real 429/503 exceptions) keep retrying.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from aigateway.core.provider_errors import NonRetryableProviderError
+from aigateway.core.retry import RetryPolicy, is_retryable_status, with_overload_retry
+
+
+def _policy() -> RetryPolicy:
+    return RetryPolicy(
+        max_retries=3,
+        backoff_base_seconds=0.0,
+        backoff_max_seconds=0.0,
+        max_total_wait_seconds=30.0,
+        jitter_seconds=0.0,
+    )
+
+
+def test_marked_error_is_an_http_exception() -> None:
+    # INVARIANT: routes/chat.py catches HTTPException on the dispatch-failure
+    # path (credential marking); the marker type must stay isinstance-compatible.
+    exc = NonRetryableProviderError(status_code=429, detail={"code": "rate_limited"})
+    assert isinstance(exc, HTTPException)
+    assert exc.status_code == 429
+    assert exc.detail == {"code": "rate_limited"}
+
+
+@pytest.mark.parametrize("status", [429, 503, 529])
+def test_marked_overload_statuses_are_not_retryable(status: int) -> None:
+    assert is_retryable_status(NonRetryableProviderError(status_code=status, detail={})) is False
+
+
+@pytest.mark.parametrize("status", [429, 503, 529])
+def test_plain_http_exception_overload_statuses_stay_retryable(status: int) -> None:
+    # Control: the provenance marker, not the exception type, disables retry —
+    # transport-shaped HTTPExceptions from other plugins keep the retry loop.
+    assert is_retryable_status(HTTPException(status_code=status, detail={})) is True
+
+
+@pytest.mark.asyncio
+async def test_marked_error_dispatches_exactly_once() -> None:
+    calls = {"n": 0}
+
+    async def dispatch() -> str:
+        calls["n"] += 1
+        raise NonRetryableProviderError(status_code=429, detail={"code": "rate_limited"})
+
+    with pytest.raises(NonRetryableProviderError):
+        await with_overload_retry(dispatch, policy=_policy())
+    assert calls["n"] == 1

--- a/apps/aigateway/tests/unit/core/test_request_hardening.py
+++ b/apps/aigateway/tests/unit/core/test_request_hardening.py
@@ -1,0 +1,358 @@
+"""Shared chat-ingress hardening (OME-428 Phase 3, plan D6).
+
+Mode-independent and provider-neutral: the /v1/chat/completions ingress strips
+the known LiteLLM control plane for EVERY provider and validates untrusted
+body shapes so malformed input can never produce a route-level 500. The HTTP
+tests exercise the anthropic path on purpose — the hardening must not be
+OpenRouter-specific.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from litellm.litellm_core_utils import initialize_dynamic_callback_params
+
+from aigateway.core.profile_index import ProfileIndexStore
+from aigateway.core.profile_models import (
+    Profile,
+    ProfileState,
+    credential_name_for,
+    profile_id_for,
+)
+from aigateway.core.request_hardening import (
+    DISPATCH_CONTROL_FIELDS,
+    chat_body_shape_error,
+    strip_dispatch_controls,
+)
+from aigateway.plugins.anthropic_provider.auth import credential_service_for
+
+# The D6 control plane: the implementation plan's verbatim list plus the SEC-1
+# review extension (azure/text_completion/atext_completion mode-flip flags).
+# Pinned exactly so an accidental addition or removal shows up as a test diff.
+_D6_CONTROL_FIELDS = {
+    "api_key",
+    "api_base",
+    "base_url",
+    "headers",
+    "model_list",
+    "fallbacks",
+    "context_window_fallbacks",
+    "context_window_fallback_dict",
+    "content_policy_fallbacks",
+    "extra_body",
+    "drop_params",
+    "additional_drop_params",
+    "use_litellm_proxy",
+    "custom_llm_provider",
+    "deployment_id",
+    "ssl_verify",
+    "max_retries",
+    "num_retries",
+    "cooldown_time",
+    "no-log",
+    "mock_response",
+    "mock_tool_calls",
+    "mock_timeout",
+    "mock_delay",
+    "provider_specific_header",
+    "input_cost_per_token",
+    "output_cost_per_token",
+    "input_cost_per_second",
+    "output_cost_per_second",
+    # SEC-1: provider/mode-flip flags (litellm 1.87.0 main.py:1327-1328, :1398) —
+    # same category as the already-stripped custom_llm_provider/deployment_id.
+    "azure",
+    "text_completion",
+    "atext_completion",
+    # Third-review blocker A: caller-injectable litellm logging/observability
+    # control-plane. litellm 1.87.0 escalates raw curl/prompt/response logging to
+    # WARNING on a truthy `litellm_request_debug` (litellm_logging.py:1143-1168);
+    # `verbose`/`logger_fn`/`litellm_logging_obj` are the sibling logging hooks
+    # read from kwargs (main.py:1264-1267). None is an OpenRouter generation
+    # parameter. Owner-ratified pin extension (2026-07-20).
+    "litellm_request_debug",
+    "verbose",
+    "logger_fn",
+    "litellm_logging_obj",
+    # Follow-up: request-selected callbacks mutate process-global LiteLLM state,
+    # and their dynamic credentials/hosts can receive prompt/response data.
+    "callbacks",
+    "success_callback",
+    "failure_callback",
+    "litellm_params",
+    "litellm_metadata",
+    "turn_off_message_logging",
+    "langfuse_public_key",
+    "langfuse_secret",
+    "langfuse_secret_key",
+    "langfuse_host",
+    "langfuse_prompt_version",
+    "langsmith_api_key",
+    "langsmith_project",
+    "langsmith_base_url",
+    "langsmith_sampling_rate",
+    "langsmith_tenant_id",
+    "humanloop_api_key",
+    "arize_api_key",
+    "arize_space_key",
+    "arize_space_id",
+    "posthog_api_key",
+    "posthog_host",
+    "braintrust_api_key",
+    "braintrust_project",
+    "braintrust_host",
+    "slack_webhook_url",
+    "lunary_public_key",
+}
+
+
+def test_strip_list_is_exactly_the_d6_control_plane() -> None:
+    assert DISPATCH_CONTROL_FIELDS == frozenset(_D6_CONTROL_FIELDS)
+
+
+def test_mode_flip_flags_are_stripped_before_dispatch() -> None:
+    """SEC-1: `azure: true` flips litellm onto its azure branch and
+    `text_completion`/`atext_completion` flip the completion mode — a caller
+    must not be able to bend dispatch any more than via the stripped
+    `custom_llm_provider`/`deployment_id`."""
+    body: dict[str, object] = {
+        "model": "openrouter/a/b",
+        "messages": [],
+        "azure": True,
+        "text_completion": True,
+        "atext_completion": True,
+    }
+    assert set(strip_dispatch_controls(body)) == {"model", "messages"}
+
+
+def test_strip_removes_every_control_field() -> None:
+    body: dict[str, object] = {field: "attacker" for field in _D6_CONTROL_FIELDS}
+    body["model"] = "anthropic/claude-sonnet-4-5"
+    body["messages"] = [{"role": "user", "content": "hi"}]
+    stripped = strip_dispatch_controls(body)
+    assert set(stripped) == {"model", "messages"}
+
+
+def test_strip_removes_nested_callback_metadata_without_mutating_input() -> None:
+    body = {
+        "model": "openrouter/a/b",
+        "messages": [],
+        "metadata": {
+            "trace_id": "safe-provider-metadata",
+            "langfuse_host": "https://attacker.invalid",
+            "posthog_api_key": "attacker-key",
+            "turn_off_message_logging": False,
+            "headers": {
+                "litellm-disable-message-redaction": True,
+                "x-trace": "safe-header-metadata",
+            },
+        },
+    }
+
+    stripped = strip_dispatch_controls(body)
+
+    assert stripped["metadata"] == {
+        "trace_id": "safe-provider-metadata",
+        "headers": {"x-trace": "safe-header-metadata"},
+    }
+    assert body["metadata"] == {
+        "trace_id": "safe-provider-metadata",
+        "langfuse_host": "https://attacker.invalid",
+        "posthog_api_key": "attacker-key",
+        "turn_off_message_logging": False,
+        "headers": {
+            "litellm-disable-message-redaction": True,
+            "x-trace": "safe-header-metadata",
+        },
+    }
+
+
+def test_strip_removes_litellm_metadata_alias_entirely() -> None:
+    body = {
+        "model": "openrouter/a/b",
+        "messages": [],
+        "litellm_metadata": {
+            "headers": {"litellm-disable-message-redaction": True},
+            "langfuse_host": "https://attacker.invalid",
+        },
+    }
+    assert set(strip_dispatch_controls(body)) == {"model", "messages"}
+
+
+def test_litellm_dynamic_callback_parameter_set_is_covered() -> None:
+    supported = set(getattr(initialize_dynamic_callback_params, "_supported_callback_params"))
+    assert supported <= DISPATCH_CONTROL_FIELDS
+
+
+def test_strip_preserves_ordinary_and_provider_fields() -> None:
+    body = {
+        "model": "openrouter/anthropic/claude-fable-5",
+        "messages": [{"role": "user", "content": "hi"}],
+        "temperature": 0.5,
+        "max_tokens": 128,
+        "timeout": 30,  # deliberately NOT stripped: gemini/codex/antigravity consume it
+        "extra_headers": {"x-custom": "1"},
+        "provider": {"order": ["anthropic"]},
+        "plugins": [{"id": "web"}],
+        "route": "fallback",
+        "models": ["anthropic/claude-opus-4.8"],
+        "tools": [{"type": "function"}],
+        "stream": False,
+    }
+    assert strip_dispatch_controls(body) == body
+
+
+def test_strip_returns_a_new_dict_without_mutating_the_input() -> None:
+    body = {"model": "a/b", "messages": [], "fallbacks": ["x"]}
+    stripped = strip_dispatch_controls(body)
+    assert stripped is not body
+    assert body["fallbacks"] == ["x"]
+    assert "fallbacks" not in stripped
+
+
+@pytest.mark.parametrize(
+    ("body", "error"),
+    [
+        (None, "model and messages are required"),
+        ([1, 2], "model and messages are required"),
+        ("text", "model and messages are required"),
+        ({}, "model and messages are required"),
+        ({"model": "a/b"}, "model and messages are required"),
+        ({"messages": []}, "model and messages are required"),
+        ({"model": 42, "messages": []}, "model must be a string"),
+        ({"model": "a/b", "messages": "hi"}, "messages must be a list"),
+        ({"model": "a/b", "messages": [{"role": "user"}, 42]}, "each message must be an object"),
+        ({"model": "a/b", "messages": [], "stream": "yes"}, "stream must be a boolean"),
+        ({"model": "a/b", "messages": [], "stream": 1}, "stream must be a boolean"),
+        ({"model": "a/b", "messages": []}, None),
+        ({"model": "a/b", "messages": [{"role": "user", "content": "hi"}]}, None),
+        ({"model": "a/b", "messages": [], "stream": True}, None),
+        ({"model": "a/b", "messages": [], "stream": False}, None),
+    ],
+)
+def test_chat_body_shape_error(body: object, error: str | None) -> None:
+    assert chat_body_shape_error(body) == error
+
+
+# --- HTTP surface: untrusted input can never 500, controls never dispatch ---
+
+
+def _account_id(client) -> str:
+    return client.get("/v1/auth/me").json()["id"]
+
+
+def _seed_authenticated_profile(credential_blobs, account_id: str) -> None:
+    credential_blobs.write(
+        credential_service_for(credential_name_for(account_id, "default")),
+        "default",
+        json.dumps(
+            {
+                "access_token": "tok",
+                "refresh_token": "rt",
+                "expires_at_ms": int(time.time() * 1000) + 3_600_000,
+                "token_type": "Bearer",
+            }
+        ),
+    )
+
+
+async def _seed_anthropic_profile(credential_blobs, account_id: str) -> None:
+    _seed_authenticated_profile(credential_blobs, account_id)
+    idx = ProfileIndexStore(credential_store=credential_blobs.store)
+    await idx.upsert(
+        Profile(
+            id=profile_id_for(account_id, "anthropic", "default"),
+            account_id=account_id,
+            provider="anthropic",
+            name="default",
+            state=ProfileState.AUTHENTICATED,
+        )
+    )
+
+
+def test_chat_malformed_json_returns_400_not_500(authenticated_client) -> None:
+    resp = authenticated_client.post(
+        "/v1/chat/completions",
+        content=b'{"model": "anthropic/claude",',
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "request body must be valid JSON"
+
+
+@pytest.mark.parametrize(
+    ("body", "error"),
+    [
+        ({"model": 42, "messages": []}, "model must be a string"),
+        ({"model": "anthropic/claude", "messages": {"role": "user"}}, "messages must be a list"),
+        ({"model": "anthropic/claude", "messages": [17]}, "each message must be an object"),
+        (
+            {"model": "anthropic/claude", "messages": [], "stream": "yes"},
+            "stream must be a boolean",
+        ),
+    ],
+)
+def test_chat_shape_violations_return_400(authenticated_client, body: dict, error: str) -> None:
+    resp = authenticated_client.post("/v1/chat/completions", json=body)
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == error
+
+
+@pytest.mark.asyncio
+async def test_chat_strips_litellm_controls_for_every_provider(
+    credential_blobs, authenticated_client
+) -> None:
+    """Caller-supplied LiteLLM control-plane fields never reach a provider
+    dispatch (anthropic here), while the gateway's own injected credential
+    replaces the caller's api_key."""
+    account_id = _account_id(authenticated_client)
+    await _seed_anthropic_profile(credential_blobs, account_id)
+
+    captured: dict = {}
+
+    async def fake_chat_completion(_self, body):
+        captured.update(body)
+        return SimpleNamespace(
+            model_dump=lambda: {"id": "x", "choices": [{"message": {"content": "ok"}}]}
+        )
+
+    with patch(
+        "aigateway.plugins.anthropic_provider.plugin.AnthropicProviderPlugin.chat_completion",
+        fake_chat_completion,
+    ):
+        resp = authenticated_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "anthropic/claude-sonnet-4-5",
+                "messages": [{"role": "user", "content": "hi"}],
+                "api_key": "sk-evil-caller",
+                "api_base": "https://evil.example",
+                "base_url": "https://evil.example",
+                "model_list": [{"model_name": "x"}],
+                "fallbacks": [{"model": "y", "api_base": "https://evil.example"}],
+                "num_retries": 99,
+                "mock_response": "pwned",
+                "custom_llm_provider": "evil",
+                "input_cost_per_token": 0,
+            },
+        )
+
+    assert resp.status_code == 200, resp.text
+    for field in (
+        "api_base",
+        "base_url",
+        "model_list",
+        "fallbacks",
+        "num_retries",
+        "mock_response",
+        "custom_llm_provider",
+        "input_cost_per_token",
+    ):
+        assert field not in captured
+    # The caller's key was stripped at ingress; the injected credential won.
+    assert captured["api_key"] != "sk-evil-caller"

--- a/apps/aigateway/tests/unit/core/test_retry_after_finite.py
+++ b/apps/aigateway/tests/unit/core/test_retry_after_finite.py
@@ -1,0 +1,68 @@
+"""Retry-After parsing rejects non-finite values (OME-428 second-review FINDING C).
+
+``_seconds_from_headers`` currently accepts ``float("Infinity")`` / ``float("1e309")``
+→ ``inf`` and ``float("NaN")`` → ``nan``. Downstream:
+
+- ``_retry_after_headers`` calls ``math.ceil(inf)`` → ``OverflowError`` → HTTP 500.
+- ``nan`` slips through ``max(0.0, nan)`` → ``0.0`` → an *invented* ``Retry-After: 0``
+  that the provider never sent.
+
+Only a non-negative ASCII integer delta-seconds value is supported; anything else
+must return ``None`` so the caller falls back to bounded exponential backoff and no
+``Retry-After`` header is fabricated.
+
+INVARIANT: preserve a validated Retry-After; never fabricate one from a
+malformed/non-finite value.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aigateway.core.retry import parse_retry_after_seconds
+from aigateway.routes.chat_dispatch import _retry_after_headers
+
+
+class _HeaderExc(Exception):
+    """A FastAPI-style exception exposing ``.headers`` (how the aigateway plugins
+    surface upstream Retry-After hints)."""
+
+    def __init__(self, retry_after: str) -> None:
+        super().__init__("upstream")
+        self.headers = {"Retry-After": retry_after}
+
+
+@pytest.mark.parametrize("raw", ["Infinity", "inf", "1e309", "-1e309", "NaN", "nan"])
+def test_non_finite_retry_after_is_rejected(raw: str) -> None:
+    # Non-finite (or overflowing) values are not a valid delta-seconds hint.
+    assert parse_retry_after_seconds(_HeaderExc(raw)) is None
+
+
+@pytest.mark.parametrize("raw", ["not-a-number", "", "soon"])
+def test_unparseable_retry_after_is_rejected(raw: str) -> None:
+    assert parse_retry_after_seconds(_HeaderExc(raw)) is None
+
+
+@pytest.mark.parametrize(("raw", "expected"), [("7", 7.0), ("0", 0.0)])
+def test_integer_retry_after_is_preserved(raw: str, expected: float) -> None:
+    assert parse_retry_after_seconds(_HeaderExc(raw)) == expected
+
+
+@pytest.mark.parametrize("raw", ["-5", "+7", "3.2", "1e3", "４２９"])
+def test_non_integer_delta_seconds_are_rejected(raw: str) -> None:
+    assert parse_retry_after_seconds(_HeaderExc(raw)) is None
+
+
+def test_retry_after_header_not_fabricated_for_non_finite() -> None:
+    # Current code: math.ceil(inf) → OverflowError → HTTP 500.
+    assert _retry_after_headers(_HeaderExc("Infinity")) == {}
+
+
+def test_retry_after_header_not_fabricated_for_nan() -> None:
+    # Current code: nan → max(0.0, nan) → 0.0 → invented "Retry-After: 0".
+    assert _retry_after_headers(_HeaderExc("NaN")) == {}
+
+
+def test_retry_after_header_preserves_integer() -> None:
+    assert _retry_after_headers(_HeaderExc("3.2")) == {}
+    assert _retry_after_headers(_HeaderExc("7")) == {"Retry-After": "7"}

--- a/apps/aigateway/tests/unit/core/test_retry_after_sources.py
+++ b/apps/aigateway/tests/unit/core/test_retry_after_sources.py
@@ -1,0 +1,116 @@
+"""Retry-After header sources + precedence (OME-428 third-review blocker C).
+
+# STORY: as the gateway I must honor an upstream provider's validated
+# ``Retry-After`` on a real transport 429/503 so clients back off correctly.
+# INVARIANT: litellm 1.87.0 exposes the wire header on
+# ``exc.litellm_response_headers`` (``exc.response.headers`` is empty for its
+# OpenRouter transport errors), so the parser must read that source. Precedence
+# is fixed and total: ``response.headers`` → ``litellm_response_headers`` →
+# ``exc.headers`` (the FastAPI ``HTTPException`` path). Only an ASCII integer
+# delta-seconds is a valid hint; an embedded HTTP-200 error (no headers) never
+# fabricates one.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from aigateway.core.retry import RetryPolicy, parse_retry_after_seconds, with_overload_retry
+
+
+def _exc(**attrs: object) -> BaseException:
+    exc = RuntimeError("boom")
+    for key, value in attrs.items():
+        setattr(exc, key, value)
+    return exc
+
+
+def test_litellm_response_headers_is_honored() -> None:
+    # The real litellm-1.87.0 OpenRouter transport shape: wire header only on
+    # litellm_response_headers; no usable response.headers.
+    exc = _exc(litellm_response_headers={"retry-after": "7"})
+    assert parse_retry_after_seconds(exc) == 7.0
+
+
+def test_response_headers_take_precedence_over_litellm_response_headers() -> None:
+    exc = _exc(
+        response=SimpleNamespace(headers={"retry-after": "3"}),
+        litellm_response_headers={"retry-after": "5"},
+    )
+    assert parse_retry_after_seconds(exc) == 3.0
+
+
+def test_litellm_response_headers_take_precedence_over_exc_headers() -> None:
+    exc = _exc(
+        litellm_response_headers={"retry-after": "5"},
+        headers={"Retry-After": "9"},
+    )
+    assert parse_retry_after_seconds(exc) == 5.0
+
+
+def test_exc_headers_still_read_for_httpexception_path() -> None:
+    # Regression: the FastAPI HTTPException path (case-insensitive key) still works.
+    exc = _exc(headers={"Retry-After": "4"})
+    assert parse_retry_after_seconds(exc) == 4.0
+
+
+def test_no_headers_anywhere_returns_none() -> None:
+    # An embedded HTTP-200 error carries no headers -> never fabricate a hint.
+    assert parse_retry_after_seconds(_exc()) is None
+
+
+def test_non_finite_in_litellm_response_headers_is_rejected() -> None:
+    exc = _exc(litellm_response_headers={"retry-after": "Infinity"})
+    assert parse_retry_after_seconds(exc) is None
+
+
+def test_malformed_litellm_response_header_falls_back_to_none() -> None:
+    exc = _exc(litellm_response_headers={"retry-after": "soon"})
+    assert parse_retry_after_seconds(exc) is None
+
+
+@pytest.mark.parametrize(("raw", "expected"), [("0", 0.0), ("7", 7.0)])
+def test_parsed_value_is_the_validated_delta_seconds(raw: str, expected: float) -> None:
+    exc = _exc(litellm_response_headers={"retry-after": raw})
+    assert parse_retry_after_seconds(exc) == expected
+
+
+@pytest.mark.parametrize("raw", ["-3", "+7", "1.5", "1e3", "４２９"])
+def test_non_integer_delta_seconds_are_rejected(raw: str) -> None:
+    exc = _exc(litellm_response_headers={"retry-after": raw})
+    assert parse_retry_after_seconds(exc) is None
+
+
+def test_invalid_earlier_source_does_not_hide_valid_later_source() -> None:
+    exc = _exc(
+        response=SimpleNamespace(headers={"retry-after": "-1"}),
+        litellm_response_headers={"retry-after": "7"},
+    )
+    assert parse_retry_after_seconds(exc) == 7.0
+
+
+@pytest.mark.parametrize("digits", [309, 5_000])
+@pytest.mark.asyncio
+async def test_large_integer_hint_exceeding_budget_raises_original_without_overflow(
+    digits: int,
+) -> None:
+    exc = _exc(
+        status_code=429,
+        response=SimpleNamespace(headers={"retry-after": "9" * digits}),
+    )
+    calls = {"n": 0}
+
+    async def dispatch() -> None:
+        calls["n"] += 1
+        raise exc
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await with_overload_retry(
+            dispatch,
+            policy=RetryPolicy(max_retries=3, max_total_wait_seconds=30.0),
+        )
+
+    assert excinfo.value is exc
+    assert calls["n"] == 1

--- a/apps/aigateway/tests/unit/openrouter/test_chat_debug_control_strip.py
+++ b/apps/aigateway/tests/unit/openrouter/test_chat_debug_control_strip.py
@@ -1,0 +1,182 @@
+"""Caller-controlled litellm debug/logging controls are stripped at ingress
+(OME-428 third-review blocker A).
+
+# STORY: as an attacker (or a careless client) I must not be able to set a
+# request-body field that makes litellm 1.87.0 escalate raw prompt/curl/response
+# logging to WARNING (litellm_logging.py:1143-1168) — that bypasses the gateway
+# sanitizer and leaks the prompt/provider body into logs "in all environments".
+# INVARIANT: none of the litellm observability/logging control-plane fields may
+# reach ``litellm.acompletion(**body)``; a conformant OpenAI-compatible client
+# never sends them, and none is an OpenRouter generation parameter.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import patch
+
+import httpx
+import litellm
+import pytest
+from litellm import utils as litellm_utils
+from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
+
+from aigateway.plugins.openrouter_provider import plugin as openrouter_plugin_module
+from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSettings
+
+_KEY = "sk-or-v1-debug"
+_MODEL = "openrouter/anthropic/claude-fable-5"
+
+# The caller-injectable litellm logging/control-plane kwargs found by the
+# blocker-A audit of litellm 1.87.0 (all read straight from kwargs and reachable
+# via ``litellm.acompletion(**body)``):
+#   litellm_request_debug  main.py:1631 -> litellm_logging.py:1143-1168
+#                          (logs raw curl/response at WARNING)
+#   verbose                main.py:1265 (per-call verbose logging escalation)
+#   logger_fn              main.py:1264 (caller-supplied logging callback hook)
+#   litellm_logging_obj    main.py:1267 (internal logging-object override)
+_DEBUG_CONTROL_FIELDS = (
+    "litellm_request_debug",
+    "verbose",
+    "logger_fn",
+    "litellm_logging_obj",
+    "callbacks",
+    "success_callback",
+    "failure_callback",
+    "litellm_params",
+    "litellm_metadata",
+    "turn_off_message_logging",
+    "langfuse_host",
+    "posthog_api_key",
+)
+
+
+@pytest.fixture()
+def enabled_openrouter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        openrouter_plugin_module.PLUGIN, "settings", OpenRouterPluginSettings(enabled=True)
+    )
+
+
+def _create_connection(client, label: str) -> None:
+    resp = client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "openrouter", "label": label, "api_key": _KEY},
+    )
+    assert resp.status_code == 201, resp.text
+
+
+def _capturing_acompletion(captured: dict):
+    async def fake_acompletion(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            model_dump=lambda: {
+                "id": "gen-ok",
+                "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+            }
+        )
+
+    return fake_acompletion
+
+
+def test_debug_logging_controls_never_reach_dispatch(
+    enabled_openrouter, credential_blobs, authenticated_client
+) -> None:
+    _create_connection(authenticated_client, "work-or")
+
+    captured: dict = {}
+    body = {
+        "model": _MODEL,
+        "messages": [{"role": "user", "content": "hi"}],
+        "litellm_request_debug": True,
+        "verbose": True,
+        "logger_fn": "attacker-callback",
+        "litellm_logging_obj": {"attacker": "obj"},
+        "callbacks": ["anthropic_cache_control_hook"],
+        "success_callback": ["posthog"],
+        "failure_callback": ["posthog"],
+        "litellm_params": {"metadata": {"posthog_host": "https://attacker.invalid"}},
+        "litellm_metadata": {
+            "headers": {"litellm-disable-message-redaction": True},
+        },
+        "turn_off_message_logging": False,
+        "langfuse_host": "https://attacker.invalid",
+        "posthog_api_key": "attacker-key",
+        "metadata": {
+            "trace_id": "safe-provider-metadata",
+            "langfuse_secret": "attacker-secret",
+        },
+    }
+    with patch("litellm.acompletion", _capturing_acompletion(captured)):
+        resp = authenticated_client.post("/v1/chat/completions", json=body)
+
+    # The debug fields must not break dispatch...
+    assert resp.status_code == 200, resp.text
+    # ...and none of them may reach litellm, where they would flip raw logging on.
+    for field in _DEBUG_CONTROL_FIELDS:
+        assert field not in captured, f"{field} reached litellm.acompletion (raw-logging leak)"
+    # The legitimate generation fields still pass through.
+    assert captured["model"] == _MODEL
+    assert captured["messages"] == [{"role": "user", "content": "hi"}]
+    assert captured["metadata"] == {"trace_id": "safe-provider-metadata"}
+
+
+def test_callback_selector_cannot_mutate_litellm_global_callback_state(
+    enabled_openrouter,
+    credential_blobs,
+    authenticated_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _create_connection(authenticated_client, "work-or")
+    # The SDK singleton can retain callbacks from a closed loop between tests.
+    GLOBAL_LOGGING_WORKER._flush_on_exit()
+    assert isinstance(litellm_utils.callback_list, list)
+    callback_lists: tuple[list[Any], ...] = (
+        cast("list[Any]", litellm.callbacks),
+        cast("list[Any]", litellm.input_callback),
+        cast("list[Any]", litellm.success_callback),
+        cast("list[Any]", litellm.failure_callback),
+        cast("list[Any]", litellm._async_input_callback),
+        cast("list[Any]", litellm._async_success_callback),
+        cast("list[Any]", litellm._async_failure_callback),
+        cast("list[Any]", litellm_utils.callback_list),
+    )
+    snapshots = [list(callbacks) for callbacks in callback_lists]
+    for callbacks in callback_lists:
+        callbacks.clear()
+
+    async def fake_send(self, request, *args, **kwargs):  # noqa: ANN001
+        return httpx.Response(
+            200,
+            json={
+                "id": "gen-ok",
+                "model": "anthropic/claude-fable-5",
+                "choices": [
+                    {
+                        "index": 0,
+                        "finish_reason": "stop",
+                        "message": {"role": "assistant", "content": "ok"},
+                    }
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            },
+            request=request,
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "send", fake_send)
+    try:
+        resp = authenticated_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": _MODEL,
+                "messages": [{"role": "user", "content": "hi"}],
+                "callbacks": ["anthropic_cache_control_hook"],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        assert all(not callbacks for callbacks in callback_lists)
+    finally:
+        authenticated_client.portal.call(GLOBAL_LOGGING_WORKER.flush)
+        for callbacks, snapshot in zip(callback_lists, snapshots, strict=True):
+            callbacks[:] = snapshot

--- a/apps/aigateway/tests/unit/openrouter/test_chat_exception_boundary.py
+++ b/apps/aigateway/tests/unit/openrouter/test_chat_exception_boundary.py
@@ -1,0 +1,209 @@
+"""The non-streaming dispatch path has a full exception boundary
+(OME-428 third-review blocker B).
+
+# STORY: as the gateway I must never turn an unexpected exception (a
+# RuntimeError, a ValueError, a new litellm exception type, a malformed
+# conversion) into an uncontrolled HTTP 500 with an ASGI traceback that leaks
+# the raw provider message/prompt. Every non-streaming dispatch failure renders
+# a sanitized status.
+# INVARIANT: an exception that is neither a curated HTTPException nor a known
+# litellm type still yields a sanitized 502 `provider_error`; the raw text never
+# reaches the response, the logs, or persisted connection error state; and the
+# credential is invalidated ONLY when the sanitized status proves 401 (never for
+# a generic 502).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import pytest
+from fastapi import HTTPException
+
+from aigateway.core.oauth.store import OAuthConnectionStore
+from aigateway.plugins.openrouter_provider import plugin as openrouter_plugin_module
+from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSettings
+
+_KEY = "sk-or-v1-boundary"
+_MODEL = "openrouter/anthropic/claude-fable-5"
+
+
+@pytest.fixture()
+def enabled_openrouter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        openrouter_plugin_module.PLUGIN, "settings", OpenRouterPluginSettings(enabled=True)
+    )
+
+
+@contextmanager
+def _server_errors_as_responses(client) -> Iterator[None]:
+    transport = client._transport
+    previous = transport.raise_server_exceptions
+    transport.raise_server_exceptions = False
+    try:
+        yield
+    finally:
+        transport.raise_server_exceptions = previous
+
+
+def _account_id(client) -> str:
+    return client.get("/v1/auth/me").json()["id"]
+
+
+def _create_connection(client, label: str) -> None:
+    resp = client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "openrouter", "label": label, "api_key": _KEY},
+    )
+    assert resp.status_code == 201, resp.text
+
+
+def _active_labels(client, account_id: str) -> list[str]:
+    async def _list() -> list[str]:
+        connections = await OAuthConnectionStore().list(
+            account_id, provider="openrouter", status="active"
+        )
+        return sorted(connection.label for connection in connections)
+
+    return client.portal.call(_list)
+
+
+def _post_chat(client):
+    return client.post(
+        "/v1/chat/completions",
+        json={"model": _MODEL, "messages": [{"role": "user", "content": "hi"}]},
+    )
+
+
+def test_unknown_exception_becomes_sanitized_502_without_leak(
+    enabled_openrouter,
+    credential_blobs,
+    authenticated_client,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unexpected exception that escapes the plugin (neither an HTTPException
+    nor a known litellm type) is rendered as a sanitized 502, never a 500, and
+    its raw text reaches neither the response nor the logs."""
+    _create_connection(authenticated_client, "work-or")
+    account_id = _account_id(authenticated_client)
+    secret = "SECRET-raw-runtime-detail-9931"
+
+    async def _boom(_self, _body):
+        raise RuntimeError(secret)
+
+    # AIDEV-NOTE: patch the CLASS method, never the PLUGIN instance. `getattr`
+    # on the instance resolves `chat_completion` via the class, so a
+    # `monkeypatch.setattr(PLUGIN, ...)` restores by re-`setattr` — leaving a
+    # shadowing bound method in `PLUGIN.__dict__` that survives teardown and
+    # corrupts later tests that patch the class method (e.g. the BYOK e2e test).
+    monkeypatch.setattr(openrouter_plugin_module.OpenRouterProviderPlugin, "chat_completion", _boom)
+
+    with (
+        caplog.at_level(logging.DEBUG, logger="aigateway"),
+        _server_errors_as_responses(authenticated_client),
+    ):
+        resp = _post_chat(authenticated_client)
+
+    assert resp.status_code == 502
+    assert resp.status_code != 500
+    assert resp.json()["detail"]["code"] == "provider_error"
+    # Raw exception text must not leak into the response or the logs.
+    assert secret not in resp.text
+    assert secret not in caplog.text
+    # A generic 502 is not a 401 -> the stored connection stays active.
+    assert _active_labels(authenticated_client, account_id) == ["work-or"]
+
+
+def test_unknown_status_attribute_cannot_trigger_credential_invalidation(
+    enabled_openrouter,
+    credential_blobs,
+    authenticated_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _create_connection(authenticated_client, "work-or")
+    account_id = _account_id(authenticated_client)
+    exc = RuntimeError("unclassified")
+    exc.status_code = 401  # type: ignore[attr-defined]
+
+    async def _boom(_self, _body):
+        raise exc
+
+    monkeypatch.setattr(openrouter_plugin_module.OpenRouterProviderPlugin, "chat_completion", _boom)
+    resp = _post_chat(authenticated_client)
+
+    assert resp.status_code == 502
+    assert resp.json()["detail"]["code"] == "provider_error"
+    assert _active_labels(authenticated_client, account_id) == ["work-or"]
+
+
+def test_throwing_exception_properties_cannot_escape_terminal_boundary(
+    enabled_openrouter,
+    credential_blobs,
+    authenticated_client,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _create_connection(authenticated_client, "work-or")
+    secret = "SECRET-throwing-property"
+
+    class RaisingStatus(RuntimeError):
+        @property
+        def status_code(self):
+            raise ValueError(secret)
+
+    async def _boom(_self, _body):
+        raise RaisingStatus("outer")
+
+    monkeypatch.setattr(openrouter_plugin_module.OpenRouterProviderPlugin, "chat_completion", _boom)
+    with (
+        caplog.at_level(logging.DEBUG, logger="aigateway"),
+        _server_errors_as_responses(authenticated_client),
+    ):
+        resp = _post_chat(authenticated_client)
+
+    assert resp.status_code == 502
+    assert resp.json()["detail"]["code"] == "provider_error"
+    assert secret not in resp.text
+    assert secret not in caplog.text
+
+
+def test_credential_failure_persistence_error_is_sanitized_502(
+    enabled_openrouter,
+    credential_blobs,
+    authenticated_client,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _create_connection(authenticated_client, "work-or")
+    account_id = _account_id(authenticated_client)
+    secret = "SECRET-persistence-failure"
+
+    async def _auth_failure(_self, _body):
+        raise HTTPException(
+            status_code=401,
+            detail={"code": "auth_required", "message": "Authentication required"},
+        )
+
+    async def _mark_error_failure(_self, _connection, _message):
+        raise RuntimeError(secret)
+
+    monkeypatch.setattr(
+        openrouter_plugin_module.OpenRouterProviderPlugin,
+        "chat_completion",
+        _auth_failure,
+    )
+    monkeypatch.setattr(OAuthConnectionStore, "mark_error", _mark_error_failure)
+    with (
+        caplog.at_level(logging.DEBUG, logger="aigateway"),
+        _server_errors_as_responses(authenticated_client),
+    ):
+        resp = _post_chat(authenticated_client)
+
+    assert resp.status_code == 502
+    assert resp.json()["detail"]["code"] == "provider_error"
+    assert secret not in resp.text
+    assert secret not in caplog.text
+    assert _active_labels(authenticated_client, account_id) == ["work-or"]

--- a/apps/aigateway/tests/unit/openrouter/test_litellm_top_level_error_contract.py
+++ b/apps/aigateway/tests/unit/openrouter/test_litellm_top_level_error_contract.py
@@ -1,0 +1,104 @@
+"""Pinning contract: the CODE-1 gate supersets litellm's top-level error guard.
+
+Drives litellm's REAL converter (``convert_to_model_response_object``,
+convert_dict_to_response.py:488-525 in 1.87.0) so an upgrade that changes the
+benign-shape guard (:491-509) fails loudly here instead of silently shifting
+which payloads reach the plugin's top-level scan.
+
+One-way implication: every top-level ``error`` shape the converter raises on
+must fire ``_top_level_error_is_meaningful``; the benign trio the converter
+passes through must stay silent. The gate is deliberately a SUPERSET —
+status-keyed shapes litellm passes (``{"status": 429}``) still fire, so an
+embedded status can never render as a 200 success.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
+    convert_to_model_response_object,
+)
+from litellm.types.utils import ModelResponse
+
+from aigateway.plugins.openrouter_provider.plugin import _top_level_error_is_meaningful
+
+
+def _payload_with(error: Any) -> dict[str, Any]:
+    return {
+        "id": "gen-contract",
+        "created": 1,
+        "model": "anthropic/claude-fable-5",
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": "ok"},
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        "error": error,
+    }
+
+
+def _converter_raises(payload: dict[str, Any]) -> bool:
+    try:
+        convert_to_model_response_object(
+            response_object=payload,
+            model_response_object=ModelResponse(),
+            response_type="completion",
+            stream=False,
+        )
+    except Exception:  # noqa: BLE001 — litellm raises a bare Exception here by design
+        return True
+    return False
+
+
+# Shapes litellm's guard raises on (meaningful): the gate MUST fire on all.
+_MEANINGFUL = [
+    {"message": "boom"},
+    {"message": {"nested": "detail"}},
+    {"code": 429},
+    {"code": 402, "message": "Insufficient credits"},
+    {"code": "not-a-status", "message": "boom"},
+    "opaque failure string",
+    123,  # non-dict/non-str → litellm raises unconditionally …
+    0,  # … even when falsy — which is why the gate must not use bool(error)
+]
+
+# The benign trio litellm deliberately passes through (:491-509).
+_BENIGN = [
+    {},
+    "",
+    {"code": None, "message": ""},
+]
+
+# Superset cases: litellm passes them, but the gate still fires so a
+# status-keyed error can never masquerade as success.
+_STATUS_KEYED = [
+    {"status": 429},
+    {"status_code": 503},
+]
+
+
+@pytest.mark.parametrize("error", _MEANINGFUL)
+def test_gate_fires_on_everything_litellm_raises_on(error: Any) -> None:
+    assert _converter_raises(_payload_with(error)) is True
+    assert _top_level_error_is_meaningful(error) is True
+
+
+@pytest.mark.parametrize("error", _BENIGN)
+def test_benign_trio_passes_litellm_and_stays_silent(error: Any) -> None:
+    assert _converter_raises(_payload_with(error)) is False
+    assert _top_level_error_is_meaningful(error) is False
+
+
+@pytest.mark.parametrize("error", _STATUS_KEYED)
+def test_status_keyed_shapes_fire_the_gate_despite_litellm_passing(error: Any) -> None:
+    assert _converter_raises(_payload_with(error)) is False
+    assert _top_level_error_is_meaningful(error) is True
+
+
+def test_none_error_is_not_meaningful() -> None:
+    assert _top_level_error_is_meaningful(None) is False

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_benign_error.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_benign_error.py
@@ -1,0 +1,115 @@
+"""Benign top-level ``error`` shapes pass through as paid successes (CODE-1).
+
+litellm 1.87.0's converter (convert_dict_to_response.py:491-509) deliberately
+returns a valid ModelResponse for benign top-level error shapes — "some
+OpenAI-compatible providers return empty error objects even on success". The
+gateway must not turn such a billed 200 into a 502: the payload (including
+native usage/cost — D10) reaches the caller intact and the stored key is
+never invalidated.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from aigateway.core.oauth.store import OAuthConnectionStore
+from aigateway.plugins.openrouter_provider import plugin as openrouter_plugin_module
+from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSettings
+
+_KEY = "sk-or-v1-benign"
+_MODEL = "openrouter/anthropic/claude-fable-5"
+
+_VALID_CHOICES = [
+    {
+        "index": 0,
+        "finish_reason": "stop",
+        "message": {"role": "assistant", "content": "hello"},
+    }
+]
+
+
+@pytest.fixture()
+def enabled_openrouter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        openrouter_plugin_module.PLUGIN, "settings", OpenRouterPluginSettings(enabled=True)
+    )
+
+
+def _account_id(client) -> str:
+    return client.get("/v1/auth/me").json()["id"]
+
+
+def _create_connection(client, label: str) -> None:
+    resp = client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "openrouter", "label": label, "api_key": _KEY},
+    )
+    assert resp.status_code == 201, resp.text
+
+
+def _active_labels(client, account_id: str) -> list[str]:
+    async def _list() -> list[str]:
+        connections = await OAuthConnectionStore().list(
+            account_id, provider="openrouter", status="active"
+        )
+        return sorted(connection.label for connection in connections)
+
+    return client.portal.call(_list)
+
+
+def _post_chat(client):
+    return client.post(
+        "/v1/chat/completions",
+        json={"model": _MODEL, "messages": [{"role": "user", "content": "hi"}]},
+    )
+
+
+def _returning_acompletion(payload: dict):
+    async def fake_acompletion(**_kwargs):
+        return SimpleNamespace(model_dump=lambda: payload)
+
+    return fake_acompletion
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        # The benign trio litellm's converter passes through (:491-509) …
+        {"id": "gen-b1", "choices": _VALID_CHOICES, "error": {}},
+        {"id": "gen-b2", "choices": _VALID_CHOICES, "error": ""},
+        {"id": "gen-b3", "choices": _VALID_CHOICES, "error": {"code": None, "message": ""}},
+        # … and the paid-success case: full native usage/cost alongside error:{}.
+        {
+            "id": "gen-b4",
+            "model": "anthropic/claude-fable-5",
+            "provider": "Anthropic",
+            "choices": _VALID_CHOICES,
+            "error": {},
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+                "cost": 0.00021,
+                "cost_details": {"upstream_inference_cost": 0.0002},
+                "is_byok": True,
+            },
+        },
+    ],
+)
+def test_benign_top_level_error_returns_the_paid_payload_intact(
+    enabled_openrouter, credential_blobs, authenticated_client, payload: dict
+) -> None:
+    account_id = _account_id(authenticated_client)
+    _create_connection(authenticated_client, "work-or")
+
+    with patch("litellm.acompletion", _returning_acompletion(payload)):
+        resp = _post_chat(authenticated_client)
+
+    # STORY: as a BYOK user I paid for this completion — the gateway must not
+    # discard it as a 502 because the upstream attached a benign error object.
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == payload
+    assert _active_labels(authenticated_client, account_id) == ["work-or"]

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_control_plane_isolation.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_control_plane_isolation.py
@@ -1,0 +1,289 @@
+"""OpenRouter BYOK is isolated from LiteLLM's orchestration control plane."""
+
+from __future__ import annotations
+
+from collections import UserDict
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import litellm
+import pytest
+from litellm.caching.caching import Cache
+from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
+from litellm.types.utils import CredentialItem
+
+from aigateway.plugins.openrouter_provider import plugin as openrouter_plugin_module
+from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSettings
+
+_KEY = "sk-or-v1-control-plane"
+_MODEL = "openrouter/anthropic/claude-fable-5"
+
+
+@pytest.fixture()
+def enabled_openrouter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        openrouter_plugin_module.PLUGIN, "settings", OpenRouterPluginSettings(enabled=True)
+    )
+
+
+def _create_connection(client) -> None:
+    response = client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "openrouter", "label": "isolated-openrouter", "api_key": _KEY},
+    )
+    assert response.status_code == 201, response.text
+
+
+def _request(client, **overrides):
+    body = {
+        "model": _MODEL,
+        "messages": [{"role": "user", "content": "hi"}],
+        **overrides,
+    }
+    return client.post(
+        "/v1/chat/completions",
+        headers={"X-Profile": "isolated-openrouter"},
+        json=body,
+    )
+
+
+def _successful_acompletion(captured: dict | None = None):
+    async def fake_acompletion(**kwargs):
+        if captured is not None:
+            captured.update(kwargs)
+        return SimpleNamespace(
+            model_dump=lambda: {
+                "id": "gen-isolated",
+                "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+            }
+        )
+
+    return fake_acompletion
+
+
+def _wire_response(request: httpx.Request, generation_id: str) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "id": generation_id,
+            "model": "anthropic/claude-fable-5",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": "ok"},
+                }
+            ],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        },
+        request=request,
+    )
+
+
+def test_litellm_orchestration_controls_never_reach_dispatch(
+    enabled_openrouter, credential_blobs, authenticated_client
+) -> None:
+    _create_connection(authenticated_client)
+    captured: dict = {}
+    controls = {
+        "litellm_credential_name": "attacker-credential",
+        "guardrails": ["attacker-guardrail"],
+        "guardrail_config": {"mode": "attacker"},
+        "disable_global_guardrails": True,
+        "prompt_id": "attacker-prompt",
+        "prompt_variables": {"secret": "attacker"},
+        "prompt_label": "attacker-label",
+        "prompt_version": 7,
+        "caching": True,
+        "cache_key": "shared-attacker-key",
+        "preset_cache_key": "shared-attacker-preset",
+    }
+    metadata = {
+        "trace_id": "safe-trace",
+        "guardrails": ["attacker-guardrail"],
+        "disable_global_guardrails": True,
+        "requester_metadata": {
+            "disable_global_guardrails": True,
+            "guardrails": ["attacker-guardrail"],
+            "tenant": "safe-tenant",
+        },
+        "user_api_key_metadata": {
+            "disable_global_guardrails": True,
+            "guardrails": ["attacker-guardrail"],
+            "team": "safe-team",
+        },
+        "previous_models": [{"model": "attacker-fallback"}],
+    }
+
+    with patch("litellm.acompletion", _successful_acompletion(captured)):
+        response = _request(authenticated_client, **controls, metadata=metadata)
+
+    assert response.status_code == 200, response.text
+    for field in controls.keys() - {"caching"}:
+        assert field not in captured
+    assert captured["caching"] is False
+    assert captured["metadata"] == {
+        "trace_id": "safe-trace",
+        "requester_metadata": {"tenant": "safe-tenant"},
+        "user_api_key_metadata": {"team": "safe-team"},
+    }
+
+
+def test_openrouter_pins_tls_and_disables_litellm_cache(
+    enabled_openrouter, credential_blobs, authenticated_client
+) -> None:
+    _create_connection(authenticated_client)
+    captured: dict = {}
+
+    with patch("litellm.acompletion", _successful_acompletion(captured)):
+        response = _request(authenticated_client)
+
+    assert response.status_code == 200, response.text
+    assert captured["ssl_verify"] is True
+    assert captured["caching"] is False
+    assert captured["cache"] == {"no-cache": True, "no-store": True}
+
+
+@pytest.mark.parametrize(
+    "attribute,value",
+    [
+        ("model_alias_map", {_MODEL: "replicate/attacker/model"}),
+        ("model_alias_map", UserDict({_MODEL: "replicate/attacker/model"})),
+        ("model_fallbacks", [{_MODEL: ["replicate/attacker/model"]}]),
+        ("callbacks", [object()]),
+        ("input_callback", [object()]),
+        ("success_callback", ["attacker-callback"]),
+        ("failure_callback", ["attacker-callback"]),
+        ("_async_input_callback", [object()]),
+        ("_async_success_callback", [object()]),
+        ("_async_failure_callback", [object()]),
+        ("pre_call_rules", [object()]),
+        ("post_call_rules", [object()]),
+    ],
+)
+def test_unsafe_global_state_fails_closed_before_dispatch(
+    enabled_openrouter,
+    credential_blobs,
+    authenticated_client,
+    monkeypatch: pytest.MonkeyPatch,
+    attribute: str,
+    value: object,
+) -> None:
+    _create_connection(authenticated_client)
+    monkeypatch.setattr(litellm, attribute, value)
+    dispatch = AsyncMock(side_effect=AssertionError("upstream dispatch must not run"))
+
+    with patch("litellm.acompletion", dispatch):
+        response = _request(authenticated_client)
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "detail": {
+            "code": "provider_unavailable",
+            "message": "OpenRouter dispatch is unavailable",
+        }
+    }
+    assert _KEY not in response.text
+    dispatch.assert_not_awaited()
+
+
+def test_unrelated_global_alias_does_not_block_openrouter(
+    enabled_openrouter,
+    credential_blobs,
+    authenticated_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _create_connection(authenticated_client)
+    monkeypatch.setattr(litellm, "model_alias_map", {"anthropic/unrelated": "other/model"})
+
+    with patch("litellm.acompletion", _successful_acompletion()):
+        response = _request(authenticated_client)
+
+    assert response.status_code == 200, response.text
+
+
+def test_named_credential_cannot_override_real_litellm_wire_destination(
+    enabled_openrouter,
+    credential_blobs,
+    authenticated_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _create_connection(authenticated_client)
+    monkeypatch.setattr(
+        litellm,
+        "credential_list",
+        [
+            CredentialItem(
+                credential_name="attacker-credential",
+                credential_info={},
+                credential_values={
+                    "api_key": "attacker-key",
+                    "base_url": "https://attacker.invalid/v1",
+                },
+            )
+        ],
+    )
+    captured: list[httpx.Request] = []
+
+    async def fake_send(self, request, *args, **kwargs):  # noqa: ANN001
+        captured.append(request)
+        return _wire_response(request, "gen-official-destination")
+
+    monkeypatch.setattr(httpx.AsyncClient, "send", fake_send)
+    monkeypatch.setenv("SSL_VERIFY", "False")
+    try:
+        response = _request(
+            authenticated_client,
+            litellm_credential_name="attacker-credential",
+        )
+        assert response.status_code == 200, response.text
+        assert len(captured) == 1
+        wire_request = captured[0]
+        assert wire_request.url.host == "openrouter.ai"
+        assert wire_request.url.path == "/api/v1/chat/completions"
+        assert wire_request.headers["authorization"] == f"Bearer {_KEY}"
+        assert "attacker" not in str(wire_request.url)
+        assert "attacker-key" not in str(dict(wire_request.headers))
+    finally:
+        authenticated_client.portal.call(GLOBAL_LOGGING_WORKER.flush)
+
+
+def test_global_litellm_cache_is_bypassed_on_real_completion_path(
+    enabled_openrouter,
+    credential_blobs,
+    authenticated_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _create_connection(authenticated_client)
+    callback_fields = (
+        "callbacks",
+        "input_callback",
+        "success_callback",
+        "failure_callback",
+        "_async_input_callback",
+        "_async_success_callback",
+        "_async_failure_callback",
+    )
+    callback_snapshots = {field: list(getattr(litellm, field)) for field in callback_fields}
+    monkeypatch.setattr(litellm, "cache", Cache())
+    calls = 0
+
+    async def fake_send(self, request, *args, **kwargs):  # noqa: ANN001
+        nonlocal calls
+        calls += 1
+        return _wire_response(request, f"gen-wire-{calls}")
+
+    monkeypatch.setattr(httpx.AsyncClient, "send", fake_send)
+    try:
+        first = _request(authenticated_client)
+        second = _request(authenticated_client)
+        assert first.status_code == 200, first.text
+        assert second.status_code == 200, second.text
+        assert calls == 2
+        assert first.json()["id"] == "gen-wire-1"
+        assert second.json()["id"] == "gen-wire-2"
+    finally:
+        authenticated_client.portal.call(GLOBAL_LOGGING_WORKER.flush)
+        for field, snapshot in callback_snapshots.items():
+            getattr(litellm, field)[:] = snapshot

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_dispatch.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_dispatch.py
@@ -1,0 +1,232 @@
+"""OpenRouter plugin surface + BYOK dispatch wiring (OME-428 Phase 2).
+
+Pins plan decisions D1 (normal auto-discovered provider), D2 (disabled by
+default fails closed), D5 (non-streaming), D8 (exactly one gateway prefix,
+validated upstream ID), and the account-scoped ApiKeyStrategy lifecycle.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from aigateway.core.api_key_strategy import ApiKeyStrategy
+from aigateway.plugins.openrouter_provider import plugin as openrouter_plugin_module
+from aigateway.plugins.openrouter_provider.plugin import OpenRouterProviderPlugin
+from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSettings
+
+_SEEDS = [
+    "openrouter/anthropic/claude-fable-5",
+    "openrouter/openai/gpt-5.5",
+    "openrouter/anthropic/claude-opus-4.8",
+]
+
+
+def _plugin(*, enabled: bool) -> OpenRouterProviderPlugin:
+    return OpenRouterProviderPlugin(OpenRouterPluginSettings(enabled=enabled))
+
+
+# --- D1: normal auto-discovery, no loader/registry edits ---
+
+
+def test_plugin_is_autodiscovered_into_registry(client) -> None:
+    assert client.app.state.providers.get("openrouter") is not None
+
+
+# --- D2: disabled by default contributes nothing and fails closed ---
+
+
+def test_register_models_empty_when_disabled() -> None:
+    assert _plugin(enabled=False).register_models() == []
+
+
+def test_register_models_seeds_when_enabled() -> None:
+    entries = _plugin(enabled=True).register_models()
+    assert [entry.model_name for entry in entries] == _SEEDS
+    for entry in entries:
+        assert entry.litellm_params == {"model": entry.model_name}
+
+
+def test_api_key_strategy_none_when_disabled() -> None:
+    assert _plugin(enabled=False).api_key_strategy_for("default") is None
+
+
+def test_api_key_strategy_when_enabled_is_account_scoped() -> None:
+    strategy = _plugin(enabled=True).api_key_strategy_for("work-openrouter")
+    assert isinstance(strategy, ApiKeyStrategy)
+    assert strategy.credential_service() == "aigateway:openrouter:work-openrouter"
+    assert strategy.credential_account() == "default"
+
+
+def test_disabled_provider_rejects_api_key_connection_creation(authenticated_client) -> None:
+    resp = authenticated_client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "openrouter", "label": "work", "api_key": "sk-or-v1-x"},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["code"] == "api_key_not_supported"
+
+
+def test_disabled_provider_chat_fails_closed_with_404(authenticated_client) -> None:
+    resp = authenticated_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "openrouter/anthropic/claude-fable-5",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["code"] == "profile_not_found"
+
+
+# --- capabilities: D5 non-streaming, api-key-only, no chatless dispatch ---
+
+
+def test_capability_matrix() -> None:
+    plugin = _plugin(enabled=True)
+    assert plugin.supports_api_key() is True
+    assert plugin.supports_chat_streaming() is False
+    assert plugin.allows_chatless_profile() is False
+    assert plugin.oauth_config() is None
+
+
+@pytest.mark.parametrize(
+    ("status_code", "should_mark"),
+    [
+        (401, True),
+        (400, False),
+        (402, False),
+        (403, False),
+        (408, False),
+        (429, False),
+        (500, False),
+        (503, False),
+    ],
+)
+def test_only_401_marks_credential_errored(status_code: int, should_mark: bool) -> None:
+    plugin = _plugin(enabled=True)
+    assert plugin.should_mark_profile_error_on_dispatch_status(status_code) is should_mark
+
+
+# --- D8: exactly one gateway prefix, validated upstream remainder ---
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "openrouter/anthropic/claude-fable-5",
+        "openrouter/mistralai/devstral-2.1:free",  # valid unlisted + variant
+        "openrouter/openrouter/auto",  # router slug is ordinary syntax in BYOK
+    ],
+)
+def test_prepare_chat_body_accepts_valid_models_unchanged(model: str) -> None:
+    plugin = _plugin(enabled=True)
+    body = {"model": model, "messages": [{"role": "user", "content": "hi"}]}
+    out = plugin.prepare_chat_body(body)
+    assert out is not body  # copy, never mutate the caller's dict
+    assert out["model"] == model  # LiteLLM strips the single gateway prefix at the wire
+    assert out["messages"] == body["messages"]
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "anthropic/claude-fable-5",  # missing gateway prefix
+        "openrouter/anthropic",  # one upstream segment
+        "openrouter/a/b/c",  # extra slash
+        "openrouter/ä/b",  # Unicode
+        "openrouter/a/b:",  # empty variant
+        "openrouter/",  # empty upstream
+        None,  # non-string
+        7,
+    ],
+)
+def test_prepare_chat_body_rejects_invalid_models(model: object) -> None:
+    plugin = _plugin(enabled=True)
+    with pytest.raises(HTTPException) as excinfo:
+        plugin.prepare_chat_body({"model": model, "messages": []})
+    assert excinfo.value.status_code == 400
+    detail = cast("dict[str, Any]", excinfo.value.detail)
+    assert detail["code"] == "invalid_model"
+
+
+# --- BYOK lifecycle end-to-end: connection create -> encrypted blob -> dispatch ---
+
+
+@pytest.fixture()
+def enabled_openrouter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        openrouter_plugin_module.PLUGIN, "settings", OpenRouterPluginSettings(enabled=True)
+    )
+
+
+def test_chat_openrouter_byok_end_to_end(
+    enabled_openrouter, credential_blobs, authenticated_client
+) -> None:
+    """Enabled plugin: the api-key connection route stores the key encrypted,
+    and chat resolves it into body["api_key"] with the model untranslated
+    (single gateway prefix) for LiteLLM's openrouter provider."""
+    create = authenticated_client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "openrouter", "label": "work-openrouter", "api_key": "sk-or-v1-test"},
+    )
+    assert create.status_code == 201, create.text
+    assert create.json()["provider"] == "openrouter"
+    assert "sk-or-v1-test" not in create.text  # key is never echoed
+
+    captured: dict = {}
+
+    async def fake_chat_completion(_self, body):
+        captured.update(body)
+        return SimpleNamespace(
+            model_dump=lambda: {"id": "or-1", "choices": [{"message": {"content": "ok"}}]}
+        )
+
+    with patch(
+        "aigateway.plugins.openrouter_provider.plugin.OpenRouterProviderPlugin.chat_completion",
+        fake_chat_completion,
+    ):
+        resp = authenticated_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "openrouter/anthropic/claude-fable-5",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert captured["model"] == "openrouter/anthropic/claude-fable-5"
+    assert captured["api_key"] == "sk-or-v1-test"
+
+
+def test_chat_openrouter_stream_rejected_before_dispatch(
+    enabled_openrouter, credential_blobs, authenticated_client
+) -> None:
+    """D5: stream:true fails with streaming_not_supported and never dispatches."""
+    create = authenticated_client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "openrouter", "label": "work-openrouter", "api_key": "sk-or-v1-test"},
+    )
+    assert create.status_code == 201, create.text
+
+    with patch(
+        "aigateway.plugins.openrouter_provider.plugin.OpenRouterProviderPlugin.chat_completion",
+    ) as dispatched:
+        resp = authenticated_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "openrouter/anthropic/claude-fable-5",
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": True,
+            },
+        )
+
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert detail["code"] == "streaming_not_supported"
+    assert detail["provider"] == "openrouter"
+    dispatched.assert_not_called()

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_embedded_retry.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_embedded_retry.py
@@ -1,0 +1,257 @@
+"""Embedded-vs-transport retry provenance (OME-428 CODE-2, plan D7/D9).
+
+An error embedded in an already-returned HTTP-200 body means the upstream call
+happened (and may already be billed): the gateway must NOT dispatch again —
+exactly one upstream call, and no invented Retry-After for embedded JSON.
+Actual transport 429/503 failures keep the shared overload-retry loop and
+surface the provider's validated ``Retry-After`` on the final response.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import httpx
+import pytest
+from litellm.exceptions import RateLimitError, ServiceUnavailableError
+
+from aigateway.core.oauth.store import OAuthConnectionStore
+from aigateway.plugins.openrouter_provider import plugin as openrouter_plugin_module
+from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSettings
+
+_KEY = "sk-or-v1-retry"
+_MODEL = "openrouter/anthropic/claude-fable-5"
+
+
+@pytest.fixture()
+def enabled_openrouter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        openrouter_plugin_module.PLUGIN, "settings", OpenRouterPluginSettings(enabled=True)
+    )
+
+
+@pytest.fixture()
+def fast_retries(authenticated_client, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Zero out backoff/jitter so any retry loop runs instantly; the retry
+    COUNT (the behavior under test) is unaffected."""
+    settings = authenticated_client.app.state.settings
+    monkeypatch.setattr(settings, "retry_backoff_base_seconds", 0.0)
+    monkeypatch.setattr(settings, "retry_jitter_seconds", 0.0)
+
+
+def _account_id(client) -> str:
+    return client.get("/v1/auth/me").json()["id"]
+
+
+def _create_connection(client, label: str) -> None:
+    resp = client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "openrouter", "label": label, "api_key": _KEY},
+    )
+    assert resp.status_code == 201, resp.text
+
+
+def _active_labels(client, account_id: str) -> list[str]:
+    async def _list() -> list[str]:
+        connections = await OAuthConnectionStore().list(
+            account_id, provider="openrouter", status="active"
+        )
+        return sorted(connection.label for connection in connections)
+
+    return client.portal.call(_list)
+
+
+def _post_chat(client, *, profile: str | None = None):
+    headers = {"X-Profile": profile} if profile is not None else {}
+    return client.post(
+        "/v1/chat/completions",
+        headers=headers,
+        json={"model": _MODEL, "messages": [{"role": "user", "content": "hi"}]},
+    )
+
+
+def _counting_payload_acompletion(payload: dict, calls: dict):
+    async def fake_acompletion(**_kwargs):
+        calls["n"] += 1
+        return SimpleNamespace(model_dump=lambda: payload)
+
+    return fake_acompletion
+
+
+def _counting_raising_acompletion(make_exc, calls: dict):
+    async def fake_acompletion(**_kwargs):
+        calls["n"] += 1
+        raise make_exc()
+
+    return fake_acompletion
+
+
+# --- Embedded errors: the upstream call already happened — never dispatch again ---
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_code"),
+    [(429, "rate_limited"), (503, "provider_unavailable"), (529, "provider_unavailable")],
+)
+def test_embedded_overload_status_makes_exactly_one_upstream_call(
+    enabled_openrouter,
+    fast_retries,
+    credential_blobs,
+    authenticated_client,
+    status: int,
+    expected_code: str,
+) -> None:
+    account_id = _account_id(authenticated_client)
+    _create_connection(authenticated_client, "work-or")
+
+    calls = {"n": 0}
+    payload = {
+        "id": f"gen-e{status}",
+        "choices": [],
+        "error": {"code": status, "message": "upstream overload"},
+    }
+    with patch("litellm.acompletion", _counting_payload_acompletion(payload, calls)):
+        resp = _post_chat(authenticated_client)
+
+    # INVARIANT (corrected findings): an error discovered after a response has
+    # returned may not trigger another upstream call — exactly one dispatch.
+    assert calls["n"] == 1
+    assert resp.status_code == status
+    assert resp.json()["detail"]["code"] == expected_code
+    # The embedded-error schema was not shown to carry Retry-After; the
+    # gateway must not invent one.
+    assert "retry-after" not in resp.headers
+    assert _active_labels(authenticated_client, account_id) == ["work-or"]
+
+
+def test_embedded_401_makes_one_call_and_invalidates_only_selected_connection(
+    enabled_openrouter, fast_retries, credential_blobs, authenticated_client
+) -> None:
+    account_id = _account_id(authenticated_client)
+    _create_connection(authenticated_client, "work-or")
+    _create_connection(authenticated_client, "backup-or")
+
+    calls = {"n": 0}
+    payload = {"id": "gen-e401", "choices": [], "error": {"code": 401, "message": "bad key"}}
+    with patch("litellm.acompletion", _counting_payload_acompletion(payload, calls)):
+        resp = _post_chat(authenticated_client, profile="work-or")
+
+    assert calls["n"] == 1
+    assert resp.status_code == 401
+    assert resp.json()["detail"]["code"] == "auth_required"
+    # D9 local: only the selected connection flips to error.
+    assert _active_labels(authenticated_client, account_id) == ["backup-or"]
+
+
+# --- Transport failures: the shared retry loop + validated Retry-After survive ---
+
+
+# WHY (third-review blockers C + F): a REAL litellm-1.87.0 OpenRouter transport
+# error exposes the wire ``Retry-After`` on ``exc.litellm_response_headers`` (its
+# ``response.headers`` is empty) and carries an ``httpx.HTTPError`` cause. The
+# cause is the positive transport proof; headers alone are metadata, not
+# provenance. These fixtures were hardened to that real shape (owner-ratified
+# 2026-07-20): the retry-count and Retry-After assertions below are unchanged.
+def _with_wire_headers(exc, retry_after: str):
+    exc.litellm_response_headers = {"retry-after": retry_after}
+    status = exc.status_code
+    request = httpx.Request("POST", "https://openrouter.ai/api/v1")
+    exc.__cause__ = httpx.HTTPStatusError(
+        str(status),
+        request=request,
+        response=httpx.Response(status, request=request),
+    )
+    return exc
+
+
+def _transport_429() -> RateLimitError:
+    return _with_wire_headers(
+        RateLimitError(
+            message="limited",
+            llm_provider="openrouter",
+            model=_MODEL,
+            response=httpx.Response(
+                429, request=httpx.Request("POST", "https://openrouter.ai/api/v1")
+            ),
+        ),
+        "0",
+    )
+
+
+def _transport_503() -> ServiceUnavailableError:
+    return _with_wire_headers(
+        ServiceUnavailableError(
+            message="overloaded",
+            llm_provider="openrouter",
+            model=_MODEL,
+            response=httpx.Response(
+                503, request=httpx.Request("POST", "https://openrouter.ai/api/v1")
+            ),
+        ),
+        "0",
+    )
+
+
+def _ambiguous_overload() -> RateLimitError:
+    """A 429-looking error with NO ``litellm_response_headers`` and NO cause
+    chain: provenance is unprovable. This is the shape a synthetic/hand-built
+    exception (or a future litellm variant) takes — the fail-closed policy
+    (blocker F) must treat it as non-retryable, never as transport."""
+    return RateLimitError(
+        message="ambiguous",
+        llm_provider="openrouter",
+        model=_MODEL,
+        response=httpx.Response(429, request=httpx.Request("POST", "https://openrouter.ai/api/v1")),
+    )
+
+
+@pytest.mark.parametrize(("status", "make_exc"), [(429, _transport_429), (503, _transport_503)])
+def test_transport_overload_keeps_shared_retries_and_validated_retry_after(
+    enabled_openrouter,
+    fast_retries,
+    credential_blobs,
+    authenticated_client,
+    status: int,
+    make_exc,
+) -> None:
+    """A real transport 429/503 (litellm exception from a failed wire call) must
+    keep the full shared retry budget and surface the provider's validated
+    Retry-After hint on the final response — CODE-2 narrows retry only by
+    provenance, never for genuine transport failures."""
+    account_id = _account_id(authenticated_client)
+    _create_connection(authenticated_client, "work-or")
+    settings = authenticated_client.app.state.settings
+
+    calls = {"n": 0}
+    with patch("litellm.acompletion", _counting_raising_acompletion(make_exc, calls)):
+        resp = _post_chat(authenticated_client)
+
+    assert calls["n"] == 1 + settings.retry_max_attempts
+    assert resp.status_code == status
+    # The provider's integer Retry-After survives validation end-to-end
+    # (surfaced from litellm_response_headers — blocker C).
+    assert resp.headers["retry-after"] == "0"
+    assert _active_labels(authenticated_client, account_id) == ["work-or"]
+
+
+def test_ambiguous_provenance_is_non_retryable_and_sanitized(
+    enabled_openrouter, fast_retries, credential_blobs, authenticated_client
+) -> None:
+    """An overload-looking error with no PROVABLE transport provenance (no
+    litellm_response_headers, no cause chain) is treated as a non-retryable
+    body error: exactly one dispatch, a sanitized 502, and no fabricated
+    Retry-After. Fail-closed policy (blocker F) — a future litellm shape can
+    never be silently retried into an amplified upstream call."""
+    account_id = _account_id(authenticated_client)
+    _create_connection(authenticated_client, "work-or")
+
+    calls = {"n": 0}
+    with patch("litellm.acompletion", _counting_raising_acompletion(_ambiguous_overload, calls)):
+        resp = _post_chat(authenticated_client)
+
+    assert calls["n"] == 1  # NOT retried
+    assert resp.status_code == 502  # converter_error_status -> None -> sanitized 502
+    assert resp.json()["detail"]["code"] == "provider_error"
+    assert "retry-after" not in resp.headers
+    assert _active_labels(authenticated_client, account_id) == ["work-or"]

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_embedded_retry_conversion.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_embedded_retry_conversion.py
@@ -1,0 +1,188 @@
+"""Real-conversion regression: embedded choice-level errors stay non-retryable.
+
+`test_openrouter_embedded_retry.py` pins the retry boundary with a synthetic
+top-level ``error`` payload — but through REAL litellm 1.87.0 a meaningful
+top-level error never reaches the plugin scan (the converter raises first, and
+the mapped exception follows the transport path). The production-reachable
+embedded path is the CHOICE level: litellm relocates ``choices[].error`` into
+``provider_specific_fields.error`` and normalizes ``finish_reason: "error"``
+to ``"stop"`` (keeping ``native_finish_reason: "error"``).
+
+This file drives raw OpenRouter bodies through the real
+``convert_to_model_response_object`` and returns the resulting
+``ModelResponse`` from mocked ``acompletion``, pinning on the reachable path:
+exactly one upstream call per embedded 429/503/529, the sanitized
+status/code mapping, no invented Retry-After, and choice-level 401
+invalidating only the selected connection (CODE-2, plan D7/D9).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
+    convert_to_model_response_object,
+)
+from litellm.types.utils import ModelResponse
+
+from aigateway.core.oauth.store import OAuthConnectionStore
+from aigateway.plugins.openrouter_provider import plugin as openrouter_plugin_module
+from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSettings
+
+_KEY = "sk-or-v1-conv"
+_MODEL = "openrouter/anthropic/claude-fable-5"
+
+
+@pytest.fixture()
+def enabled_openrouter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        openrouter_plugin_module.PLUGIN, "settings", OpenRouterPluginSettings(enabled=True)
+    )
+
+
+@pytest.fixture()
+def fast_retries(authenticated_client, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Zero out backoff/jitter so a retry regression fails fast instead of
+    sleeping; the call COUNT under test is unaffected."""
+    settings = authenticated_client.app.state.settings
+    monkeypatch.setattr(settings, "retry_backoff_base_seconds", 0.0)
+    monkeypatch.setattr(settings, "retry_jitter_seconds", 0.0)
+
+
+def _account_id(client) -> str:
+    return client.get("/v1/auth/me").json()["id"]
+
+
+def _create_connection(client, label: str) -> None:
+    resp = client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "openrouter", "label": label, "api_key": _KEY},
+    )
+    assert resp.status_code == 201, resp.text
+
+
+def _active_labels(client, account_id: str) -> list[str]:
+    async def _list() -> list[str]:
+        connections = await OAuthConnectionStore().list(
+            account_id, provider="openrouter", status="active"
+        )
+        return sorted(connection.label for connection in connections)
+
+    return client.portal.call(_list)
+
+
+def _post_chat(client, *, profile: str | None = None):
+    headers = {"X-Profile": profile} if profile is not None else {}
+    return client.post(
+        "/v1/chat/completions",
+        headers=headers,
+        json={"model": _MODEL, "messages": [{"role": "user", "content": "hi"}]},
+    )
+
+
+def _raw_openrouter_choice_error(status: int) -> dict[str, Any]:
+    """The real OpenRouter non-streaming embedded-error shape: the error rides
+    inside the choice alongside partial output, with finish_reason "error"."""
+    return {
+        "id": f"gen-conv-{status}",
+        "created": 1,
+        "model": "anthropic/claude-fable-5",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "partial output"},
+                "finish_reason": "error",
+                "error": {"code": status, "message": "Provider returned error"},
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+
+
+def _really_converted(raw: dict[str, Any]) -> ModelResponse:
+    converted = convert_to_model_response_object(
+        response_object=raw,
+        model_response_object=ModelResponse(),
+        response_type="completion",
+        stream=False,
+    )
+    # Narrow litellm's union return: non-streaming "completion" always yields
+    # a ModelResponse.
+    assert isinstance(converted, ModelResponse)
+    return converted
+
+
+def _counting_converted_acompletion(raw: dict[str, Any], calls: dict):
+    async def fake_acompletion(**_kwargs):
+        calls["n"] += 1
+        # A fresh, genuinely-converted ModelResponse per upstream attempt —
+        # exactly what litellm.acompletion hands the plugin in production.
+        return _really_converted(raw)
+
+    return fake_acompletion
+
+
+def test_real_conversion_relocates_choice_error_and_masks_finish_reason() -> None:
+    """Premise pin: if a litellm upgrade stops relocating choices[].error into
+    provider_specific_fields (or stops masking finish_reason "error" as
+    "stop"), the retry tests below would silently test the wrong path — fail
+    loudly here instead."""
+    dumped = _really_converted(_raw_openrouter_choice_error(429)).model_dump()
+    choice = dumped["choices"][0]
+    assert choice["finish_reason"] == "stop"
+    assert "error" not in choice
+    fields = choice["provider_specific_fields"]
+    assert fields["error"] == {"code": 429, "message": "Provider returned error"}
+    assert fields["native_finish_reason"] == "error"
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_code"),
+    [(429, "rate_limited"), (503, "provider_unavailable"), (529, "provider_unavailable")],
+)
+def test_embedded_choice_error_via_real_conversion_makes_exactly_one_call(
+    enabled_openrouter,
+    fast_retries,
+    credential_blobs,
+    authenticated_client,
+    status: int,
+    expected_code: str,
+) -> None:
+    account_id = _account_id(authenticated_client)
+    _create_connection(authenticated_client, "work-or")
+
+    calls = {"n": 0}
+    raw = _raw_openrouter_choice_error(status)
+    with patch("litellm.acompletion", _counting_converted_acompletion(raw, calls)):
+        resp = _post_chat(authenticated_client)
+
+    # INVARIANT (CODE-2): the upstream call already returned this payload —
+    # an embedded 429/503/529 must make exactly one upstream call.
+    assert calls["n"] == 1
+    assert resp.status_code == status
+    assert resp.json()["detail"]["code"] == expected_code
+    # Sanitized: raw provider text never echoes; no Retry-After is invented.
+    assert "Provider returned error" not in resp.text
+    assert "retry-after" not in resp.headers
+    assert _active_labels(authenticated_client, account_id) == ["work-or"]
+
+
+def test_embedded_choice_401_via_real_conversion_invalidates_only_selected(
+    enabled_openrouter, fast_retries, credential_blobs, authenticated_client
+) -> None:
+    account_id = _account_id(authenticated_client)
+    _create_connection(authenticated_client, "work-or")
+    _create_connection(authenticated_client, "backup-or")
+
+    calls = {"n": 0}
+    raw = _raw_openrouter_choice_error(401)
+    with patch("litellm.acompletion", _counting_converted_acompletion(raw, calls)):
+        resp = _post_chat(authenticated_client, profile="work-or")
+
+    assert calls["n"] == 1
+    assert resp.status_code == 401
+    assert resp.json()["detail"]["code"] == "auth_required"
+    # D9 local: only the selected connection flips to error.
+    assert _active_labels(authenticated_client, account_id) == ["backup-or"]

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_error_policy.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_error_policy.py
@@ -1,0 +1,475 @@
+"""OpenRouter local BYOK error policy (OME-428 Phase 4, plan D9/D10).
+
+Pins: a dispatch 401 invalidates ONLY the selected account connection;
+402/403/408/429/5xx never invalidate a valid key; embedded errors inside a
+nominal HTTP-200 body surface as sanitized gateway errors (numeric status
+through the sanitizer, malformed/status-less -> 502, raw provider
+message/metadata discarded); and native usage/cost/generation metadata
+survives untouched (D10 — URL4 per-leaf telemetry depends on it).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from litellm.exceptions import (
+    APIError,
+    AuthenticationError,
+    InternalServerError,
+    NotFoundError,
+    PermissionDeniedError,
+    RateLimitError,
+    ServiceUnavailableError,
+    Timeout,
+    UnprocessableEntityError,
+)
+
+from aigateway.core.oauth.store import OAuthConnectionStore
+from aigateway.plugins.openrouter_provider import plugin as openrouter_plugin_module
+from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSettings
+
+_KEY = "sk-or-v1-err"
+_MODEL = "openrouter/anthropic/claude-fable-5"
+
+
+@pytest.fixture()
+def enabled_openrouter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        openrouter_plugin_module.PLUGIN, "settings", OpenRouterPluginSettings(enabled=True)
+    )
+
+
+def _account_id(client) -> str:
+    return client.get("/v1/auth/me").json()["id"]
+
+
+def _create_connection(client, label: str) -> None:
+    resp = client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "openrouter", "label": label, "api_key": _KEY},
+    )
+    assert resp.status_code == 201, resp.text
+
+
+def _active_labels(client, account_id: str) -> list[str]:
+    async def _list() -> list[str]:
+        connections = await OAuthConnectionStore().list(
+            account_id, provider="openrouter", status="active"
+        )
+        return sorted(connection.label for connection in connections)
+
+    return client.portal.call(_list)
+
+
+def _post_chat(client, *, profile: str | None = None):
+    headers = {"X-Profile": profile} if profile is not None else {}
+    return client.post(
+        "/v1/chat/completions",
+        headers=headers,
+        json={"model": _MODEL, "messages": [{"role": "user", "content": "hi"}]},
+    )
+
+
+def _raising_acompletion(exc: Exception):
+    async def fake_acompletion(**_kwargs):
+        raise exc
+
+    return fake_acompletion
+
+
+def _returning_acompletion(payload: dict):
+    async def fake_acompletion(**_kwargs):
+        return SimpleNamespace(model_dump=lambda: payload)
+
+    return fake_acompletion
+
+
+_WIRE_REQUEST = httpx.Request("POST", "https://openrouter.ai/api/v1")
+
+
+def _as_transport(exc: Exception, *, wire_status: int | None) -> Exception:
+    """Attach the provenance signals a REAL litellm OpenRouter transport failure
+    carries, so the fail-closed classifier PROVES transport and the error keeps
+    its true status + invalidation policy.
+
+    # WHY (third-review blocker F, owner-ratified 2026-07-20): litellm wraps a
+    # genuine wire failure by chaining ``httpx.HTTPStatusError`` (reachable via
+    # Python's ``__cause__`` chain — the classifier walks ``__cause__``/
+    # ``__context__``) AND, when a response exists, surfacing the wire headers on
+    # ``litellm_response_headers``. Both signals are attached — not one alone.
+    # A litellm exception built directly in a test carries NEITHER, so without
+    # this it would read as ambiguous -> sanitized 502; that is a unit-test
+    # artifact, never a production shape (real transport always carries both).
+    """
+    if wire_status is not None:
+        response = httpx.Response(wire_status, request=_WIRE_REQUEST)
+        exc.__cause__ = httpx.HTTPStatusError(
+            f"{wire_status}", request=_WIRE_REQUEST, response=response
+        )
+        exc.litellm_response_headers = dict(response.headers)  # type: ignore[attr-defined]
+    else:
+        # A client-side timeout/connect error chains an httpx transport error but
+        # has no wire response, so no response headers exist to surface.
+        exc.__cause__ = httpx.ReadTimeout("timed out", request=_WIRE_REQUEST)
+    return exc
+
+
+# --- D9 local: 401 invalidates only the selected connection ---
+
+
+def test_dispatch_401_marks_only_selected_connection(
+    enabled_openrouter, credential_blobs, authenticated_client
+) -> None:
+    account_id = _account_id(authenticated_client)
+    _create_connection(authenticated_client, "work-or")
+    _create_connection(authenticated_client, "backup-or")
+
+    exc = _as_transport(
+        AuthenticationError(
+            message="Invalid credentials",
+            llm_provider="openrouter",
+            model=_MODEL,
+        ),
+        wire_status=401,
+    )
+    with patch("litellm.acompletion", _raising_acompletion(exc)):
+        resp = _post_chat(authenticated_client, profile="work-or")
+
+    assert resp.status_code == 401
+    assert resp.json()["detail"]["code"] == "auth_required"
+    # Only the selected connection flipped to error; the other stays usable.
+    assert _active_labels(authenticated_client, account_id) == ["backup-or"]
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected_status"),
+    [
+        (
+            _as_transport(
+                APIError(
+                    status_code=402,
+                    message="Payment Required",
+                    llm_provider="openrouter",
+                    model=_MODEL,
+                ),
+                wire_status=402,
+            ),
+            402,
+        ),
+        (
+            _as_transport(
+                APIError(
+                    status_code=403,
+                    message="Forbidden",
+                    llm_provider="openrouter",
+                    model=_MODEL,
+                ),
+                wire_status=403,
+            ),
+            403,
+        ),
+        (
+            _as_transport(
+                PermissionDeniedError(
+                    message="Forbidden",
+                    llm_provider="openrouter",
+                    model=_MODEL,
+                    response=httpx.Response(403, request=_WIRE_REQUEST),
+                ),
+                wire_status=403,
+            ),
+            403,
+        ),
+        (
+            _as_transport(
+                NotFoundError(
+                    message="Not Found",
+                    llm_provider="openrouter",
+                    model=_MODEL,
+                    response=httpx.Response(404, request=_WIRE_REQUEST),
+                ),
+                wire_status=404,
+            ),
+            404,
+        ),
+        (
+            _as_transport(
+                UnprocessableEntityError(
+                    message="Unprocessable Entity",
+                    llm_provider="openrouter",
+                    model=_MODEL,
+                    response=httpx.Response(422, request=_WIRE_REQUEST),
+                ),
+                wire_status=422,
+            ),
+            422,
+        ),
+        (
+            _as_transport(
+                InternalServerError(
+                    message="Internal Server Error",
+                    llm_provider="openrouter",
+                    model=_MODEL,
+                    response=httpx.Response(500, request=_WIRE_REQUEST),
+                ),
+                wire_status=500,
+            ),
+            500,
+        ),
+        (
+            _as_transport(
+                Timeout(message="timed out", model=_MODEL, llm_provider="openrouter"),
+                wire_status=None,
+            ),
+            408,
+        ),
+        (
+            _as_transport(
+                RateLimitError(
+                    message="limited",
+                    llm_provider="openrouter",
+                    model=_MODEL,
+                    response=httpx.Response(429, request=_WIRE_REQUEST),
+                ),
+                wire_status=429,
+            ),
+            429,
+        ),
+        (
+            _as_transport(
+                ServiceUnavailableError(
+                    message="overloaded",
+                    llm_provider="openrouter",
+                    model=_MODEL,
+                    response=httpx.Response(503, request=_WIRE_REQUEST),
+                ),
+                wire_status=503,
+            ),
+            503,
+        ),
+    ],
+)
+def test_non_401_failures_never_invalidate_the_key(
+    enabled_openrouter, credential_blobs, authenticated_client, exc: Exception, expected_status: int
+) -> None:
+    account_id = _account_id(authenticated_client)
+    _create_connection(authenticated_client, "work-or")
+
+    with (
+        patch("litellm.acompletion", _raising_acompletion(exc)),
+        patch("aigateway.core.retry.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        resp = _post_chat(authenticated_client)
+
+    assert resp.status_code == expected_status
+    assert _active_labels(authenticated_client, account_id) == ["work-or"]
+
+
+def test_signalless_ambiguous_exception_is_non_retryable_sanitized_502(
+    enabled_openrouter, credential_blobs, authenticated_client
+) -> None:
+    """A litellm exception with NO provenance signals — no ``__cause__``/
+    ``__context__`` chain and no ``litellm_response_headers`` — is unprovable.
+    The fail-closed classifier (blocker F) treats it as a non-retryable body
+    error: exactly ONE dispatch, a sanitized 502 ``provider_error``, no
+    fabricated Retry-After, and no credential invalidation — even though its
+    status LOOKS like a retryable 429. This is the shape a future litellm
+    variant could take; it must never be silently retried into an amplified,
+    already-billed upstream call. Contrast the transport fixtures above, which
+    carry the wire signals ``_as_transport`` attaches."""
+    account_id = _account_id(authenticated_client)
+    _create_connection(authenticated_client, "work-or")
+
+    # 429-looking, but built directly: no chain and no litellm_response_headers.
+    exc = RateLimitError(
+        message="ambiguous",
+        llm_provider="openrouter",
+        model=_MODEL,
+        response=httpx.Response(429, request=_WIRE_REQUEST),
+    )
+    calls = {"n": 0}
+
+    async def _counting(**_kwargs):
+        calls["n"] += 1
+        raise exc
+
+    with (
+        patch("litellm.acompletion", _counting),
+        patch("aigateway.core.retry.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        resp = _post_chat(authenticated_client)
+
+    assert calls["n"] == 1  # NOT retried despite a 429-looking status
+    assert resp.status_code == 502
+    assert resp.json()["detail"]["code"] == "provider_error"
+    assert "retry-after" not in resp.headers
+    assert _active_labels(authenticated_client, account_id) == ["work-or"]
+
+
+def test_arbitrary_chained_status_is_ambiguous_502_without_invalidation(
+    enabled_openrouter, credential_blobs, authenticated_client
+) -> None:
+    account_id = _account_id(authenticated_client)
+    _create_connection(authenticated_client, "work-or")
+    context = Exception("unrelated")
+    context.status_code = 401  # type: ignore[attr-defined]
+    outer = RuntimeError("unclassified")
+    outer.__cause__ = context
+    calls = {"n": 0}
+
+    async def _counting(**_kwargs):
+        calls["n"] += 1
+        raise outer
+
+    with patch("litellm.acompletion", _counting):
+        resp = _post_chat(authenticated_client)
+
+    assert calls["n"] == 1
+    assert resp.status_code == 502
+    assert resp.json()["detail"]["code"] == "provider_error"
+    assert _active_labels(authenticated_client, account_id) == ["work-or"]
+
+
+# --- D9: embedded HTTP-200 errors are sanitized, numeric status preserved ---
+
+
+def test_embedded_top_level_error_is_sanitized_and_does_not_invalidate(
+    enabled_openrouter, credential_blobs, authenticated_client
+) -> None:
+    account_id = _account_id(authenticated_client)
+    _create_connection(authenticated_client, "work-or")
+
+    payload = {
+        "id": "gen-1",
+        "choices": [],
+        "error": {
+            "code": 402,
+            "message": "Insufficient credits: topping up at https://internal",
+            "metadata": {"provider_name": "secret-internal-router"},
+        },
+    }
+    with patch("litellm.acompletion", _returning_acompletion(payload)):
+        resp = _post_chat(authenticated_client)
+
+    assert resp.status_code == 402
+    assert resp.json()["detail"]["code"] == "provider_error"
+    # Raw provider message/metadata is discarded, never echoed.
+    assert "Insufficient credits" not in resp.text
+    assert "secret-internal-router" not in resp.text
+    assert _active_labels(authenticated_client, account_id) == ["work-or"]
+
+
+def test_embedded_401_error_marks_the_selected_connection(
+    enabled_openrouter, credential_blobs, authenticated_client
+) -> None:
+    account_id = _account_id(authenticated_client)
+    _create_connection(authenticated_client, "work-or")
+
+    payload = {"id": "gen-2", "choices": [], "error": {"code": 401, "message": "User not found."}}
+    with patch("litellm.acompletion", _returning_acompletion(payload)):
+        resp = _post_chat(authenticated_client)
+
+    assert resp.status_code == 401
+    assert resp.json()["detail"]["code"] == "auth_required"
+    assert "User not found" not in resp.text
+    assert _active_labels(authenticated_client, account_id) == []
+
+
+def test_embedded_choice_error_with_native_finish_reason_maps_status(
+    enabled_openrouter, credential_blobs, authenticated_client
+) -> None:
+    """LiteLLM 1.87.0 maps native finish_reason "error" to "stop"; the gateway
+    must still surface the failure instead of rendering it as success."""
+    _create_connection(authenticated_client, "work-or")
+
+    payload = {
+        "id": "gen-3",
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": ""},
+                "provider_specific_fields": {"native_finish_reason": "error"},
+                "error": {"code": 502, "message": "Provider returned error: upstream boom"},
+            }
+        ],
+    }
+    with patch("litellm.acompletion", _returning_acompletion(payload)):
+        resp = _post_chat(authenticated_client)
+
+    assert resp.status_code == 502
+    assert resp.json()["detail"]["code"] == "provider_unavailable"
+    assert "upstream boom" not in resp.text
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"id": "gen-4", "choices": [], "error": {"message": "boom without status"}},
+        {"id": "gen-5", "choices": [], "error": {"code": "not-a-status", "message": "boom"}},
+        {"id": "gen-6", "choices": [], "error": "opaque failure string"},
+        {
+            "id": "gen-7",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": ""},
+                    "provider_specific_fields": {"native_finish_reason": "error"},
+                }
+            ],
+        },
+    ],
+)
+def test_embedded_statusless_or_malformed_errors_map_to_502(
+    enabled_openrouter, credential_blobs, authenticated_client, payload: dict
+) -> None:
+    account_id = _account_id(authenticated_client)
+    _create_connection(authenticated_client, "work-or")
+
+    with patch("litellm.acompletion", _returning_acompletion(payload)):
+        resp = _post_chat(authenticated_client)
+
+    assert resp.status_code == 502
+    assert resp.json()["detail"]["code"] == "provider_error"
+    assert "boom" not in resp.text
+    assert _active_labels(authenticated_client, account_id) == ["work-or"]
+
+
+# --- D10: native usage/cost/metadata pass through untouched ---
+
+
+def test_native_usage_cost_and_metadata_preserved(
+    enabled_openrouter, credential_blobs, authenticated_client
+) -> None:
+    _create_connection(authenticated_client, "work-or")
+
+    payload = {
+        "id": "gen-or-123456",
+        "model": "anthropic/claude-fable-5",
+        "provider": "Anthropic",
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": "hello"},
+                "provider_specific_fields": {"native_finish_reason": "end_turn"},
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+            "cost": 0.00021,
+            "cost_details": {"upstream_inference_cost": 0.0002},
+            "is_byok": True,
+        },
+    }
+    with patch("litellm.acompletion", _returning_acompletion(payload)):
+        resp = _post_chat(authenticated_client)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == payload

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_litellm_contract.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_litellm_contract.py
@@ -1,0 +1,83 @@
+"""Poisoned LiteLLM global/env fallback contracts (OME-428 Phase 3).
+
+LiteLLM 1.87.0 resolves OpenRouter credentials request-locally FIRST
+(main.py: request api_key beats litellm.api_key -> litellm.openrouter_key ->
+env OPENROUTER_API_KEY -> OR_API_KEY; request api_base beats litellm.api_base
+-> env OPENROUTER_API_BASE; caller headers beat OR_SITE_URL/OR_APP_NAME
+attribution defaults). These tests poison EVERY fallback and prove the
+gateway always supplies request-local values at the acompletion boundary, so
+none of the poisoned globals can ever be consulted for a BYOK dispatch."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import litellm
+import pytest
+
+from aigateway.plugins.openrouter_provider import plugin as openrouter_plugin_module
+from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSettings
+
+_OFFICIAL_API_BASE = "https://openrouter.ai/api/v1"
+_KEY = "sk-or-v1-byok"
+_POISON = "sk-or-poisoned"
+
+
+@pytest.fixture()
+def enabled_openrouter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        openrouter_plugin_module.PLUGIN, "settings", OpenRouterPluginSettings(enabled=True)
+    )
+
+
+@pytest.fixture()
+def poisoned_litellm_globals(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(litellm, "api_key", f"{_POISON}-litellm-api-key")
+    monkeypatch.setattr(litellm, "openrouter_key", f"{_POISON}-litellm-openrouter-key")
+    monkeypatch.setattr(litellm, "api_base", "https://poisoned.example/litellm")
+    monkeypatch.setenv("OPENROUTER_API_KEY", f"{_POISON}-env-openrouter")
+    monkeypatch.setenv("OR_API_KEY", f"{_POISON}-env-or")
+    monkeypatch.setenv("OPENROUTER_API_BASE", "https://poisoned.example/env")
+    monkeypatch.setenv("OR_SITE_URL", "https://poisoned.example/site")
+    monkeypatch.setenv("OR_APP_NAME", "poisoned-app")
+
+
+def test_request_local_credentials_beat_poisoned_globals(
+    enabled_openrouter, poisoned_litellm_globals, credential_blobs, authenticated_client
+) -> None:
+    create = authenticated_client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "openrouter", "label": "work-openrouter", "api_key": _KEY},
+    )
+    assert create.status_code == 201, create.text
+
+    captured: dict = {}
+
+    async def fake_acompletion(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            model_dump=lambda: {"id": "or-1", "choices": [{"message": {"content": "ok"}}]}
+        )
+
+    with patch("litellm.acompletion", fake_acompletion):
+        resp = authenticated_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "openrouter/anthropic/claude-fable-5",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+
+    assert resp.status_code == 200, resp.text
+    # Request-local values are present at the acompletion boundary, so none
+    # of LiteLLM's global/env fallbacks can be consulted (verified against
+    # litellm 1.87.0 main.py precedence).
+    assert captured["api_key"] == _KEY
+    assert captured["api_base"] == _OFFICIAL_API_BASE
+    headers = captured["extra_headers"]
+    assert headers["HTTP-Referer"] == "https://screamingface.ai"
+    assert headers["X-OpenRouter-Title"] == "ScreamingFace"
+    assert headers["X-Title"] == "ScreamingFace"
+    assert "poisoned" not in json.dumps(captured)

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_provenance.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_provenance.py
@@ -1,0 +1,134 @@
+"""litellm-1.87.0 error-provenance state machine (OME-428 third-review blockers D + F).
+
+# STORY: as the gateway I retry ONLY a proven real transport overload; a
+# converter-origin (HTTP-200 body) error or an unprovable/ambiguous error is
+# non-retryable and sanitized — so a future litellm shape can never be silently
+# retried into an amplified, already-billed upstream call.
+# INVARIANT: three explicit outcomes — TRANSPORT (proven wire failure),
+# BODY (proven converter-origin), AMBIGUOUS (unprovable -> fail closed ->
+# treated as body). ``is_http200_body_error`` is True for BODY and AMBIGUOUS.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from litellm.exceptions import APIError
+
+from aigateway.plugins.openrouter_provider.provenance import (
+    ErrorProvenance,
+    classify_provenance,
+    converter_error_status,
+    is_http200_body_error,
+)
+
+
+def _exc(message: str = "boom", *, status: object = None) -> Exception:
+    exc = Exception(message)
+    if status is not None:
+        exc.status_code = status  # type: ignore[attr-defined]
+    return exc
+
+
+def _chained(outer: BaseException, cause: BaseException) -> BaseException:
+    outer.__cause__ = cause
+    return outer
+
+
+def _converter_exc(context_status: object) -> APIError:
+    context = Exception()
+    context.status_code = context_status  # type: ignore[attr-defined]
+    context.message = "provider body error"  # type: ignore[attr-defined]
+    outer = APIError(
+        status_code=400,
+        message="mapped converter error",
+        llm_provider="openrouter",
+        model="openrouter/example/model",
+    )
+    outer.__cause__ = context
+    return outer
+
+
+# --- classify_provenance: the state machine ---
+
+
+def test_headers_without_httpx_chain_are_ambiguous() -> None:
+    exc = _exc()
+    exc.litellm_response_headers = {"retry-after": "7"}  # type: ignore[attr-defined]
+    assert classify_provenance(exc) is ErrorProvenance.AMBIGUOUS
+    assert is_http200_body_error(exc) is True
+
+
+def test_httpx_error_in_chain_is_transport() -> None:
+    wire = httpx.HTTPStatusError(
+        "429",
+        request=httpx.Request("POST", "https://openrouter.ai/api/v1"),
+        response=httpx.Response(429, request=httpx.Request("POST", "https://openrouter.ai/api/v1")),
+    )
+    exc = _chained(_exc(), wire)
+    assert classify_provenance(exc) is ErrorProvenance.TRANSPORT
+    assert is_http200_body_error(exc) is False
+
+
+def test_bare_exception_cause_is_body() -> None:
+    # litellm's converter raises `from` a bare (non-httpx) Exception.
+    exc = _converter_exc(429)
+    assert classify_provenance(exc) is ErrorProvenance.BODY
+    assert is_http200_body_error(exc) is True
+
+
+def test_no_chain_is_ambiguous_and_non_retryable() -> None:
+    # No wire headers, no cause chain: unprovable -> fail closed (blocker F).
+    exc = _exc()
+    assert classify_provenance(exc) is ErrorProvenance.AMBIGUOUS
+    assert is_http200_body_error(exc) is True
+
+
+def test_cyclic_chain_terminates_and_is_non_retryable() -> None:
+    a = _exc("a")
+    b = _exc("b")
+    a.__cause__ = b
+    b.__cause__ = a  # cycle: the walker must not hang
+    assert classify_provenance(a) is ErrorProvenance.AMBIGUOUS
+    assert is_http200_body_error(a) is True
+
+
+def test_headers_do_not_override_exact_converter_shape() -> None:
+    exc = _converter_exc(429)
+    exc.litellm_response_headers = {"retry-after": "1"}  # type: ignore[attr-defined]
+    assert classify_provenance(exc) is ErrorProvenance.BODY
+
+
+def test_arbitrary_non_httpx_chain_is_ambiguous_and_status_is_not_trusted() -> None:
+    exc = _chained(RuntimeError("outer"), _exc("unrelated", status=401))
+    assert classify_provenance(exc) is ErrorProvenance.AMBIGUOUS
+    assert converter_error_status(exc) is None
+
+
+# --- converter_error_status: context status + 422 fold (blocker D) ---
+
+
+@pytest.mark.parametrize(
+    ("context_status", "expected"),
+    [
+        (400, 400),
+        (402, 402),
+        (429, 429),
+        (500, 500),
+        (503, 503),
+        (422, None),  # litellm "no derivable status" sentinel -> None -> 502
+        ("429", None),  # string is rejected by the strict validator
+        ("²", None),  # Unicode-digit hazard: never crashes
+        (None, None),
+    ],
+)
+def test_converter_error_status_reads_context_and_folds_422(
+    context_status: object, expected: int | None
+) -> None:
+    exc = _converter_exc(context_status)
+    assert converter_error_status(exc) == expected
+
+
+def test_converter_error_status_without_chain_is_none() -> None:
+    # An ambiguous error has no derivable status -> None -> caller renders 502.
+    assert converter_error_status(_exc()) is None

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_security.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_security.py
@@ -1,0 +1,176 @@
+"""OpenRouter dispatch security wire contracts (OME-428 Phase 3, plan D6/D7).
+
+These run the REAL OpenRouterProviderPlugin.chat_completion and capture the
+kwargs handed to ``litellm.acompletion`` — the last gateway-controlled point
+before the wire — proving pinned api_base, trusted attribution, control
+stripping, and legitimate-field passthrough at dispatch."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from aigateway.plugins.openrouter_provider import plugin as openrouter_plugin_module
+from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSettings
+
+_OFFICIAL_API_BASE = "https://openrouter.ai/api/v1"
+_KEY = "sk-or-v1-test"
+
+
+@pytest.fixture()
+def enabled_openrouter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        openrouter_plugin_module.PLUGIN, "settings", OpenRouterPluginSettings(enabled=True)
+    )
+
+
+def _create_connection(client) -> None:
+    resp = client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "openrouter", "label": "work-openrouter", "api_key": _KEY},
+    )
+    assert resp.status_code == 201, resp.text
+
+
+def _fake_acompletion(captured: dict):
+    async def fake_acompletion(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            model_dump=lambda: {"id": "or-1", "choices": [{"message": {"content": "ok"}}]}
+        )
+
+    return fake_acompletion
+
+
+def _post_chat(client, body: dict):
+    payload = {
+        "model": "openrouter/anthropic/claude-fable-5",
+        "messages": [{"role": "user", "content": "hi"}],
+        **body,
+    }
+    return client.post("/v1/chat/completions", json=payload)
+
+
+def test_dispatch_pins_official_api_base_over_caller_values(
+    enabled_openrouter, credential_blobs, authenticated_client
+) -> None:
+    _create_connection(authenticated_client)
+    captured: dict = {}
+    with patch("litellm.acompletion", _fake_acompletion(captured)):
+        resp = _post_chat(
+            authenticated_client,
+            {"api_base": "https://evil.example/api", "base_url": "https://evil.example"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert captured["api_base"] == _OFFICIAL_API_BASE
+    assert "base_url" not in captured
+
+
+def test_trusted_attribution_overrides_caller_headers(
+    enabled_openrouter, credential_blobs, authenticated_client
+) -> None:
+    """Caller attribution/auth headers are dropped; the gateway's trusted
+    identity is injected (D7). LiteLLM lets caller headers override its
+    OR_SITE_URL/OR_APP_NAME defaults, so the gateway must own these keys."""
+    _create_connection(authenticated_client)
+    captured: dict = {}
+    with patch("litellm.acompletion", _fake_acompletion(captured)):
+        resp = _post_chat(
+            authenticated_client,
+            {
+                "extra_headers": {
+                    "HTTP-Referer": "https://evil.example",
+                    "Referer": "https://evil.example",
+                    "X-OpenRouter-Title": "evil",
+                    "x-title": "evil",
+                    "Authorization": "Bearer sk-evil",
+                    "X-Api-Key": "sk-evil",
+                    "X-Trace-Id": "trace-123",  # ordinary caller header survives
+                }
+            },
+        )
+    assert resp.status_code == 200, resp.text
+    headers = captured["extra_headers"]
+    assert headers["HTTP-Referer"] == "https://screamingface.ai"
+    assert headers["X-OpenRouter-Title"] == "ScreamingFace"
+    assert headers["X-Title"] == "ScreamingFace"
+    assert headers["X-Trace-Id"] == "trace-123"
+    assert "evil" not in json.dumps(headers).lower()
+    assert not any(key.lower() in {"authorization", "x-api-key"} for key in headers)
+
+
+def test_nested_fallbacks_and_model_list_never_reach_litellm(
+    enabled_openrouter, credential_blobs, authenticated_client
+) -> None:
+    """Regression for the nested-redirect exfiltration path: fallbacks /
+    model_list would make LiteLLM re-dispatch with attacker-controlled
+    api_base entries. They must be gone by the acompletion call."""
+    _create_connection(authenticated_client)
+    captured: dict = {}
+    with patch("litellm.acompletion", _fake_acompletion(captured)):
+        resp = _post_chat(
+            authenticated_client,
+            {
+                "fallbacks": [
+                    {
+                        "model": "openrouter/anthropic/claude-fable-5",
+                        "api_base": "https://evil.example",
+                    }
+                ],
+                "model_list": [
+                    {
+                        "model_name": "openrouter/anthropic/claude-fable-5",
+                        "litellm_params": {"api_base": "https://evil.example"},
+                    }
+                ],
+                "context_window_fallbacks": [{"model": "x"}],
+            },
+        )
+    assert resp.status_code == 200, resp.text
+    assert "fallbacks" not in captured
+    assert "model_list" not in captured
+    assert "context_window_fallbacks" not in captured
+    assert "evil.example" not in json.dumps({k: v for k, v in captured.items() if k != "api_key"})
+    assert captured["api_base"] == _OFFICIAL_API_BASE
+
+
+def test_ordinary_openrouter_fields_pass_through(
+    enabled_openrouter, credential_blobs, authenticated_client
+) -> None:
+    """D7 local BYOK: legitimate OpenRouter extensions survive to dispatch."""
+    _create_connection(authenticated_client)
+    captured: dict = {}
+    provider_prefs = {"order": ["anthropic"], "allow_fallbacks": False}
+    with patch("litellm.acompletion", _fake_acompletion(captured)):
+        resp = _post_chat(
+            authenticated_client,
+            {
+                "provider": provider_prefs,
+                "plugins": [{"id": "web"}],
+                "route": "fallback",
+                "models": ["openrouter/anthropic/claude-opus-4.8"],
+                "temperature": 0.25,
+                "max_tokens": 64,
+            },
+        )
+    assert resp.status_code == 200, resp.text
+    assert captured["provider"] == provider_prefs
+    assert captured["plugins"] == [{"id": "web"}]
+    assert captured["route"] == "fallback"
+    assert captured["models"] == ["openrouter/anthropic/claude-opus-4.8"]
+    assert captured["temperature"] == 0.25
+    assert captured["max_tokens"] == 64
+
+
+def test_caller_api_key_never_reaches_dispatch(
+    enabled_openrouter, credential_blobs, authenticated_client
+) -> None:
+    _create_connection(authenticated_client)
+    captured: dict = {}
+    with patch("litellm.acompletion", _fake_acompletion(captured)):
+        resp = _post_chat(authenticated_client, {"api_key": "sk-evil-caller"})
+    assert resp.status_code == 200, resp.text
+    assert captured["api_key"] == _KEY

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_settings.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_settings.py
@@ -1,0 +1,104 @@
+"""OpenRouter plugin settings (OME-428 Phase 2, plan D2/D8).
+
+Pins: disabled-by-default, env overrides via AIGW_OPENROUTER_*, the three URL4
+seed gateway IDs, and the D8 upstream model-ID syntax validator.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from aigateway.plugins.openrouter_provider.settings import (
+    OpenRouterPluginSettings,
+    is_valid_upstream_model_id,
+)
+
+_SEEDS = [
+    "openrouter/anthropic/claude-fable-5",
+    "openrouter/openai/gpt-5.5",
+    "openrouter/anthropic/claude-opus-4.8",
+]
+
+
+def test_enabled_defaults_false() -> None:
+    assert OpenRouterPluginSettings().enabled is False
+
+
+def test_default_models_are_the_three_seeds() -> None:
+    assert OpenRouterPluginSettings().default_models == _SEEDS
+
+
+def test_enabled_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AIGW_OPENROUTER_ENABLED", "true")
+    assert OpenRouterPluginSettings().enabled is True
+
+
+def test_default_models_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "AIGW_OPENROUTER_DEFAULT_MODELS",
+        '["openrouter/mistralai/mistral-large-3"]',
+    )
+    assert OpenRouterPluginSettings().default_models == ["openrouter/mistralai/mistral-large-3"]
+
+
+def test_env_override_with_malformed_model_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AIGW_OPENROUTER_DEFAULT_MODELS", '["openrouter/justoneword"]')
+    with pytest.raises(ValidationError):
+        OpenRouterPluginSettings()
+
+
+def test_models_without_gateway_prefix_rejected() -> None:
+    with pytest.raises(ValidationError):
+        OpenRouterPluginSettings(default_models=["anthropic/claude-fable-5"])
+
+
+@pytest.mark.parametrize(
+    "upstream",
+    [
+        "anthropic/claude-fable-5",
+        "openai/gpt-5.5",  # dots in the model base
+        "anthropic/claude-opus-4.8",
+        "openrouter/free",  # special router is syntactically ordinary (BYOK allows it)
+        "openrouter/free:thinking",
+        "mistralai/devstral-2.1:free",  # dotted base + variant
+        "~legacy-author/some_model",  # ~ alias marker, underscore
+        "a/b",  # minimal two segments
+        "a1/b2:nitro",
+    ],
+)
+def test_valid_upstream_model_ids(upstream: str) -> None:
+    assert is_valid_upstream_model_id(upstream) is True
+
+
+@pytest.mark.parametrize(
+    "upstream",
+    [
+        "",  # empty
+        "anthropic",  # one segment
+        "a/b/c",  # extra slash
+        "a//b",  # empty middle segment
+        "/b",  # empty author
+        "a/",  # empty model
+        "a/b:",  # empty variant
+        "a/b:c:d",  # extra colon
+        ":free",  # no base
+        "~/model",  # ~ without author characters
+        "a b/c",  # whitespace
+        "a\tb/c",  # control/tab
+        "ä/b",  # Unicode author
+        "a/претрен",  # Unicode model
+        "a\\b/c",  # backslash
+        "a%20b/c",  # percent escape
+        "https://evil.example/x",  # scheme
+        "a/b?x=1",  # query marker
+        "a/b#frag",  # fragment marker
+        ".hidden/model",  # author must start alphanumeric
+        "a/-model",  # model must start alphanumeric
+        "a/b:-variant",  # variant must start alphanumeric
+        42,  # non-string
+        None,
+    ],
+)
+def test_invalid_upstream_model_ids(upstream: object) -> None:
+    assert is_valid_upstream_model_id(upstream) is False

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_toplevel_conversion_retry.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_toplevel_conversion_retry.py
@@ -1,0 +1,398 @@
+"""Top-level HTTP-200 body errors that litellm raises DURING conversion
+(OME-428 Checkpoint A, second-review FINDING A).
+
+litellm 1.87.0 does not return a ``ModelResponse`` when a nominal HTTP-200 body
+carries a meaningful top-level ``error`` — it *raises* while converting the body
+(``RateLimitError``/``ServiceUnavailableError``/``APIError``/``AuthenticationError``
+/``BadRequestError`` by status). The upstream call already completed and may be
+billed, so — exactly like an error found by scanning a returned payload — it must
+be non-retryable (exactly one upstream POST) and fully sanitized. The plugin's
+post-return ``_find_embedded_error`` scanner structurally cannot see this because
+no payload is ever returned; the interception must happen where the raise occurs.
+
+These tests drive REAL ``litellm.acompletion`` (no acompletion stub) with a
+mocked wire (``httpx.AsyncClient.send``) so the litellm-1.87.0 converter-raise
+behavior is exercised end-to-end through the gateway retry loop and route.
+
+INVARIANT: an error derived from a nominal HTTP-200 payload is non-retryable —
+exactly one dispatch — and no raw provider text reaches the client, logs, or
+persisted error state.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+import httpx
+import litellm
+import pytest
+
+from aigateway.core.oauth.store import OAuthConnectionStore
+from aigateway.plugins.openrouter_provider import plugin as openrouter_plugin_module
+from aigateway.plugins.openrouter_provider.provenance import ErrorProvenance, classify_provenance
+from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSettings
+
+_KEY = "sk-or-v1-conv"
+_MODEL = "openrouter/anthropic/claude-fable-5"
+# Raw provider text that must NEVER surface to the client / logs / persisted state.
+_SECRET = "SECRET-provider-detail-do-not-leak"
+
+
+@pytest.fixture()
+def enabled_openrouter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        openrouter_plugin_module.PLUGIN, "settings", OpenRouterPluginSettings(enabled=True)
+    )
+
+
+@pytest.fixture()
+def fast_retries(authenticated_client, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Zero backoff/jitter so any retry loop runs instantly; the retry COUNT
+    (the behavior under test) is unaffected."""
+    settings = authenticated_client.app.state.settings
+    monkeypatch.setattr(settings, "retry_backoff_base_seconds", 0.0)
+    monkeypatch.setattr(settings, "retry_jitter_seconds", 0.0)
+
+
+@contextmanager
+def _server_errors_as_responses(client) -> Iterator[None]:
+    """Surface unhandled server exceptions as 500 responses instead of raising,
+    so a test can assert the *current* broken behavior (e.g. int('not-a-status')
+    → ValueError → 500) turns into a controlled status after the fix."""
+    transport = getattr(client, "_transport")
+    previous = transport.raise_server_exceptions
+    transport.raise_server_exceptions = False
+    try:
+        yield
+    finally:
+        transport.raise_server_exceptions = previous
+
+
+def _account_id(client) -> str:
+    return client.get("/v1/auth/me").json()["id"]
+
+
+def _create_connection(client, label: str) -> None:
+    resp = client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "openrouter", "label": label, "api_key": _KEY},
+    )
+    assert resp.status_code == 201, resp.text
+
+
+def _active_labels(client, account_id: str) -> list[str]:
+    async def _list() -> list[str]:
+        connections = await OAuthConnectionStore().list(
+            account_id, provider="openrouter", status="active"
+        )
+        return sorted(connection.label for connection in connections)
+
+    return client.portal.call(_list)
+
+
+def _post_chat(client, *, profile: str | None = None):
+    headers = {"X-Profile": profile} if profile is not None else {}
+    return client.post(
+        "/v1/chat/completions",
+        headers=headers,
+        json={"model": _MODEL, "messages": [{"role": "user", "content": "hi"}]},
+    )
+
+
+def _wire_response(status: int, body: dict[str, Any], retry_after: str | None = None):
+    headers = {"content-type": "application/json"}
+    if retry_after is not None:
+        headers["retry-after"] = retry_after
+    return httpx.Response(
+        status_code=status,
+        headers=headers,
+        content=json.dumps(body).encode(),
+        request=httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions"),
+    )
+
+
+def _counting_wire(make_response, calls: dict, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch the httpx send used by litellm so REAL litellm.acompletion runs and
+    the litellm-1.87.0 converter-raise path is exercised. Counts POST dispatches."""
+
+    async def fake_send(self, request, *args, **kwargs):  # noqa: ANN001
+        if request.method == "POST":
+            calls["n"] += 1
+        return make_response()
+
+    monkeypatch.setattr(httpx.AsyncClient, "send", fake_send)
+
+
+def _top_level_error(status: int | str | None, message: str) -> dict[str, Any]:
+    error: dict[str, Any] = {"message": message}
+    if status is not None:
+        error["code"] = status
+    return {"error": error}
+
+
+# --- FINDING A: converter-raised overload statuses make EXACTLY ONE dispatch ---
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_code"),
+    [(429, "rate_limited"), (503, "provider_unavailable"), (529, "provider_unavailable")],
+)
+def test_toplevel_overload_converts_to_single_dispatch(
+    enabled_openrouter,
+    fast_retries,
+    credential_blobs,
+    authenticated_client,
+    monkeypatch: pytest.MonkeyPatch,
+    status: int,
+    expected_code: str,
+) -> None:
+    account_id = _account_id(authenticated_client)
+    _create_connection(authenticated_client, "work-or")
+
+    calls = {"n": 0}
+    _counting_wire(
+        lambda: _wire_response(200, _top_level_error(status, _SECRET)), calls, monkeypatch
+    )
+    resp = _post_chat(authenticated_client)
+
+    # INVARIANT (FINDING A): a top-level error in a nominal HTTP-200 body is
+    # non-retryable — litellm already consumed the (billable) upstream call.
+    # Current code retries it (1 + retry_max_attempts dispatches) → amplification.
+    assert calls["n"] == 1
+    assert resp.status_code == status
+    assert resp.json()["detail"]["code"] == expected_code
+    # No Retry-After invented for an in-body error (no validated transport hint).
+    assert "retry-after" not in resp.headers
+    # Raw provider text must never reach the client.
+    assert _SECRET not in resp.text
+    assert _active_labels(authenticated_client, account_id) == ["work-or"]
+
+
+def test_toplevel_auth_error_single_dispatch_sanitized_and_scoped(
+    enabled_openrouter,
+    fast_retries,
+    credential_blobs,
+    authenticated_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = _account_id(authenticated_client)
+    _create_connection(authenticated_client, "work-or")
+    _create_connection(authenticated_client, "backup-or")
+
+    calls = {"n": 0}
+    _counting_wire(lambda: _wire_response(200, _top_level_error(401, _SECRET)), calls, monkeypatch)
+    resp = _post_chat(authenticated_client, profile="work-or")
+
+    assert calls["n"] == 1
+    assert resp.status_code == 401
+    assert resp.json()["detail"]["code"] == "auth_required"
+    # Gateway-authored message only — the raw provider text (which for a 401 is
+    # also persisted into connection error state) must never leak.
+    assert _SECRET not in resp.text
+    # D9 local: only the selected connection flips to error.
+    assert _active_labels(authenticated_client, account_id) == ["backup-or"]
+
+
+def test_toplevel_malformed_status_sanitized_to_502_never_500(
+    enabled_openrouter,
+    fast_retries,
+    credential_blobs,
+    authenticated_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _create_connection(authenticated_client, "work-or")
+
+    calls = {"n": 0}
+    # litellm maps a non-numeric top-level code to APIError(status_code='not-a-status').
+    # Current _litellm_http_exception does int('not-a-status') → ValueError → HTTP 500.
+    _counting_wire(
+        lambda: _wire_response(200, _top_level_error("not-a-status", _SECRET)), calls, monkeypatch
+    )
+    with _server_errors_as_responses(authenticated_client):
+        resp = _post_chat(authenticated_client)
+
+    assert calls["n"] == 1
+    assert resp.status_code == 502
+    assert resp.status_code != 500
+    assert resp.json()["detail"]["code"] == "provider_error"
+    assert _SECRET not in resp.text
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_status", "expected_code"),
+    [
+        (400, 400, "bad_request"),
+        (402, 402, "provider_error"),
+        (403, 403, "provider_error"),
+        (408, 408, "provider_error"),
+        (500, 500, "provider_unavailable"),
+        (502, 502, "provider_unavailable"),
+    ],
+)
+def test_toplevel_billing_and_client_statuses_single_dispatch_sanitized(
+    enabled_openrouter,
+    fast_retries,
+    credential_blobs,
+    authenticated_client,
+    monkeypatch: pytest.MonkeyPatch,
+    status: int,
+    expected_status: int,
+    expected_code: str,
+) -> None:
+    _create_connection(authenticated_client, "work-or")
+
+    calls = {"n": 0}
+    _counting_wire(
+        lambda: _wire_response(200, _top_level_error(status, _SECRET)), calls, monkeypatch
+    )
+    resp = _post_chat(authenticated_client)
+
+    assert calls["n"] == 1
+    assert resp.status_code == expected_status
+    assert resp.json()["detail"]["code"] == expected_code
+    assert _SECRET not in resp.text
+
+
+def test_toplevel_statusless_is_sanitized_and_single_dispatch(
+    enabled_openrouter,
+    fast_retries,
+    credential_blobs,
+    authenticated_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A status-less top-level error maps to EXACTLY a sanitized 502
+    ``provider_error`` (blocker D), no raw text leak, exactly one dispatch.
+
+    # WHY: the OUTER exception is BadRequestError(400) for BOTH a status-less
+    # body and an explicit code=400 — but the CONVERTER-CONTEXT status (the
+    # chained exception's status_code) distinguishes them: status-less carries
+    # litellm 1.87.0's 422 "no derivable status" default, explicit-400 carries
+    # 400. converter_error_status reads the context and folds 422 -> None -> 502,
+    # so a status-less body no longer masquerades as a client 400."""
+    _create_connection(authenticated_client, "work-or")
+
+    calls = {"n": 0}
+    _counting_wire(lambda: _wire_response(200, _top_level_error(None, _SECRET)), calls, monkeypatch)
+    with _server_errors_as_responses(authenticated_client):
+        resp = _post_chat(authenticated_client)
+
+    assert calls["n"] == 1
+    assert resp.status_code == 502
+    assert resp.json()["detail"]["code"] == "provider_error"
+    assert _SECRET not in resp.text
+
+
+def test_toplevel_explicit_422_folds_to_sanitized_502(
+    enabled_openrouter,
+    fast_retries,
+    credential_blobs,
+    authenticated_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit embedded ``code: 422`` folds to a sanitized 502 (blocker D,
+    owner-ratified).
+
+    # WHY: 422 is litellm 1.87.0's "no derivable status" default AND is not a
+    # documented OpenRouter error code, so at the converter-raise boundary an
+    # explicit 422 is indistinguishable from a status-less body. Rather than
+    # surface a status OpenRouter never sends, both fold to 502 provider_error.
+    # (Distinguishable explicit statuses — 400/402/429/500/503 — are preserved.)"""
+    _create_connection(authenticated_client, "work-or")
+
+    calls = {"n": 0}
+    _counting_wire(lambda: _wire_response(200, _top_level_error(422, _SECRET)), calls, monkeypatch)
+    with _server_errors_as_responses(authenticated_client):
+        resp = _post_chat(authenticated_client)
+
+    assert calls["n"] == 1
+    assert resp.status_code == 502
+    assert resp.json()["detail"]["code"] == "provider_error"
+    assert _SECRET not in resp.text
+
+
+# --- CONTROL: genuine transport failures keep the shared retry budget ---
+
+
+@pytest.mark.parametrize("status", [429, 503])
+def test_transport_overload_still_retries_full_budget(
+    enabled_openrouter,
+    fast_retries,
+    credential_blobs,
+    authenticated_client,
+    monkeypatch: pytest.MonkeyPatch,
+    status: int,
+) -> None:
+    """A real non-2xx wire failure (litellm raises WITH populated
+    ``litellm_response_headers`` and an httpx cause) must retain the full shared
+    retry budget — the FINDING A fix narrows retry only for converter-origin
+    errors, never for genuine transport failures."""
+    _create_connection(authenticated_client, "work-or")
+    settings = authenticated_client.app.state.settings
+
+    calls = {"n": 0}
+    _counting_wire(
+        lambda: _wire_response(status, {"error": {"code": status, "message": "real transport"}}),
+        calls,
+        monkeypatch,
+    )
+    resp = _post_chat(authenticated_client)
+
+    assert calls["n"] == 1 + settings.retry_max_attempts
+    assert resp.status_code == status
+
+
+# --- PREMISE PIN: guard the litellm-1.87.0 provenance shape the fix relies on ---
+
+
+def test_litellm_1_87_converter_raise_provenance_shape() -> None:
+    """Pin the litellm-1.87.0 behavior the provenance discriminator depends on,
+    so a future litellm upgrade that changes it fails LOUDLY here rather than
+    silently mis-routing converter-origin errors as retryable transport.
+
+    Converter-origin (HTTP-200 body): ``litellm_response_headers is None`` and a
+    chained bare-Exception context with no ``httpx.HTTPError`` in the chain.
+    Genuine transport (non-2xx wire): ``litellm_response_headers`` is populated."""
+
+    async def _raise(make_response) -> Exception:
+        async def fake_send(self, request, *args, **kwargs):  # noqa: ANN001
+            return make_response()
+
+        import unittest.mock
+
+        with unittest.mock.patch.object(httpx.AsyncClient, "send", fake_send):
+            try:
+                await litellm.acompletion(
+                    model=_MODEL,
+                    messages=[{"role": "user", "content": "hi"}],
+                    api_key="sk-or-v1-pin",
+                    api_base="https://openrouter.ai/api/v1",
+                )
+            except Exception as exc:  # noqa: BLE001
+                return exc
+        raise AssertionError("litellm did not raise")
+
+    import asyncio
+
+    converter = asyncio.run(_raise(lambda: _wire_response(200, _top_level_error(429, "x"))))
+    transport = asyncio.run(
+        _raise(lambda: _wire_response(429, {"error": {"code": 429, "message": "x"}}, "7"))
+    )
+
+    # Converter-origin: no wire headers, chained bare Exception, no httpx error.
+    assert getattr(converter, "litellm_response_headers", None) is None
+    assert converter.__context__ is not None or converter.__cause__ is not None
+    chain = []
+    cur: BaseException | None = converter.__cause__ or converter.__context__
+    while cur is not None and cur not in chain:
+        chain.append(cur)
+        cur = cur.__cause__ or cur.__context__
+    assert not any(isinstance(link, httpx.HTTPError) for link in chain)
+
+    assert classify_provenance(converter) is ErrorProvenance.BODY
+
+    # Transport: litellm attaches wire headers and chains an httpx error.
+    assert getattr(transport, "litellm_response_headers", None) is not None
+    assert classify_provenance(transport) is ErrorProvenance.TRANSPORT

--- a/apps/aigateway/tests/unit/test_chat_split_characterization.py
+++ b/apps/aigateway/tests/unit/test_chat_split_characterization.py
@@ -1,0 +1,273 @@
+"""Characterization tests for /v1/chat/completions seams (OME-428 Phase 1).
+
+These pin route behavior that is NOT already covered by test_chat_x_profile.py
+or test_chat_request_cache.py, before routes/chat.py is split into
+chat_credentials.py + chat_dispatch.py. Every test exercises the HTTP surface
+only — no imports from aigateway.routes.chat — so the mechanical split cannot
+invalidate them. They must be green before AND after the split.
+
+Deliberately NOT pinned here: malformed (non-JSON) request bodies — today they
+escape as a route-level 500 and OME-428 Phase 3 request hardening intentionally
+changes that to a 400.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from litellm.exceptions import BadRequestError, ServiceUnavailableError
+
+from aigateway.core.profile_index import ProfileIndexStore
+from aigateway.core.profile_models import (
+    Profile,
+    ProfileState,
+    credential_name_for,
+    profile_id_for,
+)
+from aigateway.plugins.anthropic_provider.auth import credential_service_for
+
+
+def _account_id(client) -> str:
+    return client.get("/v1/auth/me").json()["id"]
+
+
+def _seed_authenticated_profile(credential_blobs, account_id: str) -> None:
+    credential_blobs.write(
+        credential_service_for(credential_name_for(account_id, "default")),
+        "default",
+        json.dumps(
+            {
+                "access_token": "tok",
+                "refresh_token": "rt",
+                "expires_at_ms": int(time.time() * 1000) + 3_600_000,
+                "token_type": "Bearer",
+            }
+        ),
+    )
+
+
+async def _seed_anthropic_profile(credential_blobs, account_id: str) -> None:
+    _seed_authenticated_profile(credential_blobs, account_id)
+    idx = ProfileIndexStore(credential_store=credential_blobs.store)
+    await idx.upsert(
+        Profile(
+            id=profile_id_for(account_id, "anthropic", "default"),
+            account_id=account_id,
+            provider="anthropic",
+            name="default",
+            state=ProfileState.AUTHENTICATED,
+        )
+    )
+
+
+# --- request-shape validation (raised before any credential resolution) ---
+
+
+def test_chat_400_when_model_missing(authenticated_client) -> None:
+    resp = authenticated_client.post(
+        "/v1/chat/completions",
+        json={"messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "model and messages are required"
+
+
+def test_chat_400_when_messages_missing(authenticated_client) -> None:
+    resp = authenticated_client.post(
+        "/v1/chat/completions",
+        json={"model": "anthropic/claude-sonnet-4-5"},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "model and messages are required"
+
+
+def test_chat_400_when_body_is_not_an_object(authenticated_client) -> None:
+    resp = authenticated_client.post(
+        "/v1/chat/completions",
+        json=["model", "messages"],
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "model and messages are required"
+
+
+def test_chat_400_when_model_not_provider_prefixed(authenticated_client) -> None:
+    resp = authenticated_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "claude-sonnet-4-5",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "model must be provider-prefixed"
+
+
+def test_chat_400_when_provider_unknown(authenticated_client) -> None:
+    resp = authenticated_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "nosuchprovider/some-model",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "unknown provider: nosuchprovider"
+
+
+# --- litellm exception → HTTP mapping through the dispatch seam ---
+
+
+@pytest.mark.asyncio
+async def test_chat_persistent_service_unavailable_maps_provider_unavailable(
+    credential_blobs, authenticated_client
+) -> None:
+    """A 503 that survives every retry surfaces as provider_unavailable."""
+    account_id = _account_id(authenticated_client)
+    await _seed_anthropic_profile(credential_blobs, account_id)
+
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    response = httpx.Response(503, request=request)
+    calls = {"n": 0}
+
+    async def always_unavailable(_self, _body):
+        calls["n"] += 1
+        raise ServiceUnavailableError(
+            "overloaded",
+            llm_provider="anthropic",
+            model="anthropic/claude-sonnet-4-5",
+            response=response,
+        )
+
+    with (
+        patch(
+            "aigateway.plugins.anthropic_provider.plugin.AnthropicProviderPlugin.chat_completion",
+            always_unavailable,
+        ),
+        patch("aigateway.core.retry.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        resp = authenticated_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "anthropic/claude-sonnet-4-5",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+
+    assert resp.status_code == 503
+    assert resp.json()["detail"]["code"] == "provider_unavailable"
+    assert calls["n"] == 4  # 1 initial + 3 retries (default AIGW_RETRY_MAX_ATTEMPTS=3)
+
+
+@pytest.mark.asyncio
+async def test_chat_bad_request_error_maps_bad_request_without_retry(
+    credential_blobs, authenticated_client
+) -> None:
+    """A provider 400 is terminal: mapped to bad_request and never retried."""
+    account_id = _account_id(authenticated_client)
+    await _seed_anthropic_profile(credential_blobs, account_id)
+
+    calls = {"n": 0}
+
+    async def always_bad_request(_self, _body):
+        calls["n"] += 1
+        raise BadRequestError(
+            "unsupported parameter combination",
+            model="anthropic/claude-sonnet-4-5",
+            llm_provider="anthropic",
+        )
+
+    with (
+        patch(
+            "aigateway.plugins.anthropic_provider.plugin.AnthropicProviderPlugin.chat_completion",
+            always_bad_request,
+        ),
+        patch("aigateway.core.retry.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        resp = authenticated_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "anthropic/claude-sonnet-4-5",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert detail["code"] == "bad_request"
+    # OME-428 FINDING B (ratified Confidence-Gate change): the generic
+    # LiteLLM-exception sanitizer no longer serializes str(exc) — raw provider
+    # text must not reach clients/logs/persisted errors. The machine code is
+    # preserved; the message is gateway-authored.
+    assert "unsupported parameter combination" not in detail["message"]
+    assert detail["message"]  # a gateway-authored, non-empty message remains
+    assert calls["n"] == 1
+
+
+# --- successful dispatch render path ---
+
+
+@pytest.mark.asyncio
+async def test_chat_success_dumps_model_and_sets_bypass_headers(
+    credential_blobs, authenticated_client
+) -> None:
+    """Responses with model_dump are serialized via it; with the request cache
+    disabled (default) every response carries bypass/disabled cache headers."""
+    account_id = _account_id(authenticated_client)
+    await _seed_anthropic_profile(credential_blobs, account_id)
+
+    payload = {"id": "resp-1", "choices": [{"message": {"content": "ok"}}]}
+
+    async def fake_chat_completion(_self, _body):
+        return SimpleNamespace(model_dump=lambda: payload)
+
+    with patch(
+        "aigateway.plugins.anthropic_provider.plugin.AnthropicProviderPlugin.chat_completion",
+        fake_chat_completion,
+    ):
+        resp = authenticated_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "anthropic/claude-sonnet-4-5",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+
+    assert resp.status_code == 200
+    assert resp.json() == payload
+    assert resp.headers["x-aigw-cache"] == "bypass"
+    assert resp.headers["x-aigw-cache-reason"] == "disabled"
+    assert "x-aigw-cache-key" not in resp.headers
+
+
+@pytest.mark.asyncio
+async def test_chat_success_passes_plain_dict_response_through(
+    credential_blobs, authenticated_client
+) -> None:
+    """Provider responses without model_dump are returned verbatim."""
+    account_id = _account_id(authenticated_client)
+    await _seed_anthropic_profile(credential_blobs, account_id)
+
+    payload = {"id": "raw-1", "choices": [{"message": {"content": "raw"}}]}
+
+    async def fake_chat_completion(_self, _body):
+        return payload
+
+    with patch(
+        "aigateway.plugins.anthropic_provider.plugin.AnthropicProviderPlugin.chat_completion",
+        fake_chat_completion,
+    ):
+        resp = authenticated_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "anthropic/claude-sonnet-4-5",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+
+    assert resp.status_code == 200
+    assert resp.json() == payload

--- a/docs/tasks/aigw/2026-07-17-OME-428-openrouter-support-in-the-ai-gateway.md
+++ b/docs/tasks/aigw/2026-07-17-OME-428-openrouter-support-in-the-ai-gateway.md
@@ -1,0 +1,52 @@
+---
+id: OME-428
+linear_url: https://linear.app/openmined/issue/OME-428/ome-428-openrouter-support-in-the-ai-gateway
+status: in_progress
+type: Feature
+priority: High
+labels: [aigateway]
+created: 2026-07-13
+closed:
+---
+
+# OME-428 - OpenRouter support in the AI Gateway
+
+Add first-class OpenRouter support and a provider-neutral credential-mode contract in two
+independently releasable checkpoints.
+
+## Checkpoint A - local BYOK
+
+**Status: done.**
+
+- Disabled-by-default OpenRouter provider discovered through the existing provider registry.
+- Account-scoped API-key connections use the existing encrypted credential store; no new schema,
+  migration, secret backend, or dependency was added.
+- Non-streaming chat dispatch uses the pinned official OpenRouter API base, validated
+  `openrouter/<author>/<model>` IDs, and gateway-owned attribution headers.
+- Shared ingress strips caller-controlled routing, credentials, retries, fallbacks, logging,
+  callbacks, telemetry destinations, and message-redaction controls before provider dispatch.
+- OpenRouter errors are sanitized without raw provider text. Only positive HTTP transport evidence
+  can retry; converter/body and ambiguous errors are non-retryable. Unknown exceptions return a
+  fixed 502, and only a proven 401 invalidates the selected connection.
+- `Retry-After` supports unsigned ASCII integer delta-seconds with bounded retries and total wait.
+- Native usage, cost, generation identifiers, and BYOK metadata remain available to callers.
+
+Validation: focused security/error suite `131 passed`; full non-live suite `1020 passed, 29
+skipped` without warnings; lint, formatting, type checking, enterprise-import guard, append-only
+test check against `main`, and coverage threshold all passed.
+
+Live OpenRouter smoke testing is owner-gated and remains required before broad BYOK release, but is
+not a merge gate for Checkpoint A.
+
+## Checkpoint B - hosted OpenRouter
+
+**Status: pending.**
+
+- Add the shared `local_byok | hosted_shared` credential-mode contract.
+- Guard hosted credential routes and provide deployment-managed OpenRouter credentials.
+- Add hosted admission/policy and deployment secret wiring.
+
+Hugging Face support remains owned by OME-394.
+
+Implementation record:
+`docs/work/aigw/2026-07-17-OME-428-openrouter-byok-checkpoint-a.md`.

--- a/docs/work/aigw/2026-07-17-OME-428-openrouter-byok-checkpoint-a.md
+++ b/docs/work/aigw/2026-07-17-OME-428-openrouter-byok-checkpoint-a.md
@@ -1,0 +1,83 @@
+---
+ticket: OME-428
+stack: aigateway
+status: done
+started: 2026-07-17
+finished: 2026-07-20
+---
+
+# OME-428 - Checkpoint A: BYOK OpenRouter provider
+
+## Intent
+
+Ship an independently releasable OpenRouter provider using account-scoped encrypted API keys and
+the existing AIGateway provider interfaces. Keep hosted credentials, deployment policy, and other
+providers outside this checkpoint.
+
+## Delivered
+
+- Added a disabled-by-default `openrouter` provider with environment-backed settings, registry
+  discovery, account-scoped `ApiKeyStrategy`, and seed model registration.
+- Kept upstream model IDs in the form `openrouter/<author>/<model>` and pinned dispatch to
+  `https://openrouter.ai/api/v1` after ingress has removed caller routing overrides.
+- Rejected streaming before credential access; Checkpoint A supports non-streaming chat only.
+- Added gateway-owned OpenRouter attribution headers while stripping caller attempts to override
+  authorization, host, or attribution values.
+- Split chat credential and dispatch responsibilities into cohesive route modules; every touched
+  Python source file remains below 450 lines.
+- Preserved native usage, cost details, generation identifiers, and BYOK metadata in successful
+  responses.
+
+## Security And Error Contracts
+
+- The gateway owns credentials and upstream routing. Shared ingress strips LiteLLM control-plane
+  fields for credentials, bases, fallbacks, retries, callbacks, logging, telemetry credentials and
+  hosts, and message-redaction controls. Nested metadata is copied before unsafe keys are removed,
+  so caller input is not mutated and unrelated provider metadata survives.
+- Local API keys remain in the existing encrypted credential store. No plaintext credential is
+  logged, returned, placed in a cache key, or persisted as provider error detail.
+- Provider error responses use gateway-authored messages. Raw exception text, provider metadata,
+  prompts, and secrets are not serialized or logged by the route error boundary.
+- Only an `httpx.HTTPError` cause proves a transport failure. The pinned LiteLLM converter shape
+  identifies an already-returned HTTP-200 body error; all other shapes are ambiguous. Body and
+  ambiguous errors are non-retryable to avoid duplicate billable dispatches.
+- Known LiteLLM HTTP exceptions preserve validated 4xx/5xx status codes. Unknown exceptions and
+  hostile exception properties fail closed to a sanitized 502. Secondary failures while updating
+  credential state are also contained as sanitized 502 responses.
+- Only a proven 401 marks the selected account connection errored. 402, 403, 408, 429, and 5xx
+  responses do not invalidate a usable key.
+- Retryable transport statuses are 429, 503, and 529. `Retry-After` source precedence is
+  `response.headers`, `litellm_response_headers`, then exception headers. The accepted form is one
+  or more unsigned ASCII digits; invalid earlier sources do not hide a valid later source. Values
+  beyond the supported integer range remain budget-exceeding instead of falling back to another
+  dispatch.
+
+## Architecture
+
+- Shared request hardening, HTTP-status validation, retry policy, and provider-error markers live
+  in `aigateway.core`.
+- OpenRouter model validation, attribution, embedded-error handling, and LiteLLM provenance remain
+  provider-local.
+- The existing credential strategy, OAuth connection store, request cache, and provider registry
+  interfaces remain unchanged.
+- No ORM model, schema, migration, dependency, lockfile, hosted mode, billing, or cache contract
+  changed in this checkpoint.
+
+## Verification
+
+- Focused security and error regression suite: `131 passed`.
+- Full non-live AIGateway suite: `1020 passed, 29 skipped`, without warnings.
+- Append-only test check against `main`, lint, formatting, type checking, no-enterprise import
+  guard, and full pytest coverage threshold: all passed.
+- Real LiteLLM conversion and callback behavior is exercised with mocked HTTP transport. Tests pin
+  converter-vs-transport provenance, single-dispatch body errors, bounded overload retries,
+  callback-state isolation, sanitized failures, and selected-connection invalidation.
+
+## Residual And Out Of Scope
+
+- Live OpenRouter smoke testing was not run because it requires owner approval and a real API key.
+  It remains required before broad BYOK release.
+- Operator-enabled LiteLLM DEBUG logging can include raw request or response data. Callers cannot
+  enable it through the chat body; deployments handling sensitive prompts must keep it disabled.
+- Hosted shared credentials and deployment admission policy are Checkpoint B. Hugging Face support
+  is tracked separately by OME-394.


### PR DESCRIPTION
## Description
Adds Checkpoint A of [OME-428](https://linear.app/openmined/issue/OME-428/ome-428-openrouter-support-in-the-ai-gateway): an account-scoped OpenRouter BYOK provider for AIGateway.

- Stores OpenRouter API keys through the existing encrypted credential lifecycle.
- Preserves OpenRouter model IDs, provider routing parameters, usage, cost details, and generation metadata.
- Pins the official OpenRouter endpoint, trusted attribution, TLS verification, and request-local credentials.
- Rejects streaming before credential access and sanitizes provider failures without leaking prompts, responses, or secrets.
- Isolates BYOK dispatch from LiteLLM credential selectors, aliases, fallbacks, prompt managers, guardrails, callbacks, rules, and process-global cache state.
- Keeps hosted shared credentials and deployment admission policy outside this checkpoint.

Refs: OME-428

## Affected Dependencies
No new dependencies or lockfile changes. The implementation uses the existing frozen LiteLLM 1.87.0, FastAPI, and Tortoise ORM stack.

## How has this been tested?
- `uv run .claude/scripts/run_gates.py aigateway --base main`: all gates green, including append-only tests, Ruff, formatting, Pyright, enterprise-import guard, coverage, and the full non-live suite (`1037 passed, 1 skipped`).
- Focused OpenRouter/security/retry suite: `245 passed`.
- Complete OpenRouter unit suite: `180 passed`.
- Safe replacement-key smoke through authenticated AIGateway using `openrouter/google/gemma-4-26b-a4b-it:free`: `2 passed, 4 disposable tests skipped`.
- Owner-gated disposable-key adversarial matrix on the same free model: `6 passed`, covering poisoned routing, named-credential redirect prevention, global alias/callback/rule fail-closed behavior, bounded 503 retry, and global LiteLLM cache bypass.

Reproduce non-live verification from the repository root:

```bash
uv run .claude/scripts/run_gates.py aigateway --base main
```

Optional safe live smoke from `apps/aigateway` requires `AIGW_LIVE_OPENROUTER_KEY` and an admin password:

```bash
AIGW_LIVE=1 AIGW_LIVE_OPENROUTER_MODEL="openrouter/google/gemma-4-26b-a4b-it:free" uv run pytest tests/live/test_openrouter_live.py -q
```

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests