### PR TITLE
fix(desktop): run frontend hooks from package directory

### DIFF
--- a/apps/screamingface-studio/src-tauri/tauri.conf.json
+++ b/apps/screamingface-studio/src-tauri/tauri.conf.json
@@ -6,8 +6,8 @@
   "build": {
     "frontendDist": "../frontend/out",
     "devUrl": "http://localhost:3000",
-    "beforeDevCommand": "npm --prefix frontend run dev",
-    "beforeBuildCommand": "npm --prefix frontend run build"
+    "beforeDevCommand": "npm run dev",
+    "beforeBuildCommand": "npm run build"
   },
   "app": {
     "windows": [],


### PR DESCRIPTION
## Summary
- run Tauri frontend hooks from the frontend package directory
- remove the redundant npm prefix from development and build commands

## Validation
- npm run build
- cargo check --locked