### PR TITLE
feat(aigateway): add actionable API key validation

### DIFF
--- a/apps/aigateway/src/aigateway/core/api_key_validation.py
+++ b/apps/aigateway/src/aigateway/core/api_key_validation.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Protocol
+
+
+class ApiKeyValidationState(StrEnum):
+    VALID = "valid"
+    INVALID = "invalid"
+    EXPIRED = "expired"
+    NO_QUOTA = "no_quota"
+    PERMISSION_DENIED = "permission_denied"
+    RATE_LIMITED = "rate_limited"
+    UNAVAILABLE = "unavailable"
+    MISCONFIGURED = "misconfigured"
+
+
+class ApiKeyValidationStage(StrEnum):
+    AUTHENTICATION = "authentication"
+    READINESS = "readiness"
+
+
+_MESSAGES = {
+    ApiKeyValidationState.VALID: "API key is valid and ready for inference.",
+    ApiKeyValidationState.INVALID: "The provider rejected this API key. Check or replace it.",
+    ApiKeyValidationState.EXPIRED: "This API key has expired. Create a new key.",
+    ApiKeyValidationState.NO_QUOTA: (
+        "This API key has no available credits or spending limit. Add credits or raise its limit."
+    ),
+    ApiKeyValidationState.PERMISSION_DENIED: (
+        "The API key is valid but cannot use the validation model."
+    ),
+    ApiKeyValidationState.RATE_LIMITED: ("The provider rate-limited validation. Try again later."),
+    ApiKeyValidationState.UNAVAILABLE: (
+        "The provider could not complete validation. Try again later."
+    ),
+    ApiKeyValidationState.MISCONFIGURED: (
+        "API-key validation is not configured for this provider. Contact the gateway operator."
+    ),
+}
+
+_RETRYABLE_STATES = frozenset(
+    {
+        ApiKeyValidationState.RATE_LIMITED,
+        ApiKeyValidationState.UNAVAILABLE,
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ApiKeyValidationResult:
+    state: ApiKeyValidationState
+    stage: ApiKeyValidationStage | None = None
+    retry_after_seconds: int | None = None
+    probe_model: str | None = None
+
+    @property
+    def retryable(self) -> bool:
+        return self.state in _RETRYABLE_STATES
+
+
+class ApiKeyValidator(Protocol):
+    async def validate(self, api_key: str) -> ApiKeyValidationResult: ...
+
+
+def api_key_validation_message(state: ApiKeyValidationState) -> str:
+    """Return stable gateway-authored copy; provider text never enters the public contract."""
+    return _MESSAGES[state]

--- a/apps/aigateway/src/aigateway/core/api_key_validation_http.py
+++ b/apps/aigateway/src/aigateway/core/api_key_validation_http.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+_MAX_RESPONSE_BYTES = 64 * 1024
+_REQUEST_TIMEOUT_SECONDS = 5.0
+_TOTAL_TIMEOUT_SECONDS = 10.0
+_MAX_RETRY_AFTER_SECONDS = 2_147_483_647
+
+
+class ApiKeyValidationTransportError(Exception):
+    """Sanitized transport/response failure with no upstream text or secret material."""
+
+
+@dataclass(frozen=True, slots=True)
+class BoundedJsonResponse:
+    status_code: int
+    payload: Any | None
+    retry_after_seconds: int | None
+
+
+def _retry_after_seconds(value: str | None) -> int | None:
+    if value is None or not value.isascii() or not value.isdecimal():
+        return None
+    parsed = int(value)
+    if not 0 < parsed <= _MAX_RETRY_AFTER_SECONDS:
+        return None
+    return parsed
+
+
+class ValidationHttpSession:
+    """One bounded, request-local HTTP client shared by both validation stages."""
+
+    def __init__(self, *, transport: httpx.AsyncBaseTransport | None = None) -> None:
+        self._transport = transport
+        self._client: httpx.AsyncClient | None = None
+        self._deadline: float | None = None
+
+    async def __aenter__(self) -> ValidationHttpSession:
+        # INVARIANT: trust_env=False on the transport too (not just the client) so
+        # ambient SSL_CERT_FILE/SSL_CERT_DIR and proxy env cannot rebind the verified
+        # CA bundle or route validation through an unexpected proxy.
+        transport = self._transport or httpx.AsyncHTTPTransport(
+            retries=0, verify=True, trust_env=False
+        )
+        self._client = httpx.AsyncClient(
+            transport=transport,
+            timeout=httpx.Timeout(_REQUEST_TIMEOUT_SECONDS),
+            follow_redirects=False,
+            trust_env=False,
+            verify=True,
+        )
+        self._deadline = asyncio.get_running_loop().time() + _TOTAL_TIMEOUT_SECONDS
+        return self
+
+    async def __aexit__(self, _exc_type, _exc, _tb) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+        self._client = None
+        self._deadline = None
+
+    async def request_json(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        params: dict[str, str | int] | None = None,
+        json_body: Any | None = None,
+    ) -> BoundedJsonResponse:
+        client = self._client
+        deadline = self._deadline
+        if client is None or deadline is None:
+            raise RuntimeError("ValidationHttpSession must be entered before use")
+
+        remaining = deadline - asyncio.get_running_loop().time()
+        timeout = min(_REQUEST_TIMEOUT_SECONDS, remaining)
+        if timeout <= 0:
+            raise ApiKeyValidationTransportError from None
+
+        request_headers = dict(headers or {})
+        # INVARIANT: raw identity bytes keep the 64 KiB memory bound enforceable.
+        request_headers["Accept-Encoding"] = "identity"
+
+        try:
+            async with asyncio.timeout(timeout):
+                async with client.stream(
+                    method,
+                    url,
+                    headers=request_headers,
+                    params=params,
+                    json=json_body,
+                    follow_redirects=False,
+                    timeout=httpx.Timeout(_REQUEST_TIMEOUT_SECONDS),
+                ) as response:
+                    content_encoding = response.headers.get("content-encoding")
+                    if content_encoding is not None and content_encoding.lower() != "identity":
+                        raise ApiKeyValidationTransportError from None
+                    content_length = response.headers.get("content-length")
+                    if content_length is not None:
+                        try:
+                            declared_length = int(content_length)
+                        except ValueError:
+                            declared_length = 0
+                        if declared_length > _MAX_RESPONSE_BYTES:
+                            raise ApiKeyValidationTransportError from None
+
+                    body = bytearray()
+                    if response.is_stream_consumed:
+                        # Mock/custom transports may return a pre-buffered response.
+                        if len(response.content) > _MAX_RESPONSE_BYTES:
+                            raise ApiKeyValidationTransportError from None
+                        body.extend(response.content)
+                    else:
+                        async for chunk in response.aiter_raw(chunk_size=8192):
+                            if len(chunk) > _MAX_RESPONSE_BYTES - len(body):
+                                raise ApiKeyValidationTransportError from None
+                            body.extend(chunk)
+
+                    payload: Any | None = None
+                    if body:
+                        payload = json.loads(body)
+                    return BoundedJsonResponse(
+                        status_code=response.status_code,
+                        payload=payload,
+                        retry_after_seconds=_retry_after_seconds(
+                            response.headers.get("retry-after")
+                        ),
+                    )
+        except ApiKeyValidationTransportError:
+            raise
+        except (RecursionError, TimeoutError, httpx.HTTPError, ValueError):
+            # INVARIANT: provider exception text can contain credentials or raw response data.
+            # RecursionError guards json.loads on a deeply nested (but small) body; it must be
+            # sanitized like any other parse/transport failure, never escape raw to the caller.
+            raise ApiKeyValidationTransportError from None

--- a/apps/aigateway/src/aigateway/core/api_key_validation_http.py
+++ b/apps/aigateway/src/aigateway/core/api_key_validation_http.py
@@ -11,6 +11,9 @@ _MAX_RESPONSE_BYTES = 64 * 1024
 _REQUEST_TIMEOUT_SECONDS = 5.0
 _TOTAL_TIMEOUT_SECONDS = 10.0
 _MAX_RETRY_AFTER_SECONDS = 2_147_483_647
+# WHY: an ASCII-decimal Retry-After within range is at most this many digits; a longer string
+# cannot satisfy the range check, so it is rejected before int() (see _retry_after_seconds).
+_MAX_RETRY_AFTER_DIGITS = len(str(_MAX_RETRY_AFTER_SECONDS))
 
 
 class ApiKeyValidationTransportError(Exception):
@@ -24,13 +27,27 @@ class BoundedJsonResponse:
     retry_after_seconds: int | None
 
 
+def bounded_retry_after_seconds(value: int) -> int | None:
+    """Return a positive delta-seconds hint within the supported range, else None.
+
+    INVARIANT: ONE upper bound governs every Retry-After source — the numeric HTTP header
+    parsed here and provider-structured hints (e.g. Gemini RetryInfo.retryDelay) — so no
+    parser can emit an out-of-range or overflowing retry hint.
+    """
+    if not 0 < value <= _MAX_RETRY_AFTER_SECONDS:
+        return None
+    return value
+
+
 def _retry_after_seconds(value: str | None) -> int | None:
     if value is None or not value.isascii() or not value.isdecimal():
         return None
-    parsed = int(value)
-    if not 0 < parsed <= _MAX_RETRY_AFTER_SECONDS:
+    # WHY: bound the digit count before int(). CPython raises ValueError converting a string
+    # longer than sys.int_info.default_max_str_digits (4300 default); caught by the sanitizing
+    # except in request_json, that would downgrade a valid 429 to a transport error.
+    if len(value) > _MAX_RETRY_AFTER_DIGITS:
         return None
-    return parsed
+    return bounded_retry_after_seconds(int(value))
 
 
 class ValidationHttpSession:
@@ -134,8 +151,19 @@ class ValidationHttpSession:
                     )
         except ApiKeyValidationTransportError:
             raise
-        except (RecursionError, TimeoutError, httpx.HTTPError, ValueError):
+        except (
+            RecursionError,
+            TimeoutError,
+            ValueError,
+            httpx.HTTPError,
+            httpx.InvalidURL,
+            httpx.CookieConflict,
+            httpx.StreamError,
+        ):
             # INVARIANT: provider exception text can contain credentials or raw response data.
             # RecursionError guards json.loads on a deeply nested (but small) body; it must be
             # sanitized like any other parse/transport failure, never escape raw to the caller.
+            # WHY: httpx.InvalidURL/CookieConflict (Exception) and StreamError (RuntimeError)
+            # are NOT httpx.HTTPError subclasses, so they need explicit entries here; a blanket
+            # ``except Exception`` is deliberately avoided so it cannot conceal a programming bug.
             raise ApiKeyValidationTransportError from None

--- a/apps/aigateway/src/aigateway/core/api_key_validation_service.py
+++ b/apps/aigateway/src/aigateway/core/api_key_validation_service.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from .api_key_validation import (
+    ApiKeyValidationResult,
+    ApiKeyValidationStage,
+    ApiKeyValidationState,
+    ApiKeyValidator,
+)
+
+
+class SupportsApiKeyValidation(Protocol):
+    def api_key_validator(self) -> ApiKeyValidator | None: ...
+
+
+class ApiKeyValidationService:
+    async def validate(
+        self,
+        plugin: SupportsApiKeyValidation,
+        _provider: str,
+        api_key: str,
+    ) -> ApiKeyValidationResult | None:
+        validator = plugin.api_key_validator()
+        if validator is None:
+            return None
+        result = await validator.validate(api_key)
+        # INVARIANT: a provider plugin cannot authorize persistence after auth alone.
+        if (
+            result.state is ApiKeyValidationState.VALID
+            and result.stage is not ApiKeyValidationStage.READINESS
+        ):
+            return ApiKeyValidationResult(ApiKeyValidationState.MISCONFIGURED)
+        return result

--- a/apps/aigateway/src/aigateway/core/oauth/schemas.py
+++ b/apps/aigateway/src/aigateway/core/oauth/schemas.py
@@ -4,8 +4,9 @@ from datetime import datetime
 from typing import Annotated, Any, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
+from ..api_key_validation import ApiKeyValidationStage, ApiKeyValidationState
 from ..profile_models import AuthType
 from .identity import AccountIdentity
 
@@ -49,15 +50,36 @@ class PatchOAuthConnectionRequest(BaseModel):
 class CreateApiKeyConnectionRequest(BaseModel):
     """Create an api-key-authenticated connection (no OAuth round-trip)."""
 
+    model_config = ConfigDict(hide_input_in_errors=True)
+
     provider: str
     label: OAuthConnectionLabel | None = None
-    api_key: str
+    api_key: SecretStr
 
 
 class SetConnectionApiKeyRequest(BaseModel):
     """Replace the stored API key on an existing api-key connection."""
 
-    api_key: str
+    model_config = ConfigDict(hide_input_in_errors=True)
+
+    api_key: SecretStr
+
+
+class ValidateApiKeyRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid", hide_input_in_errors=True)
+
+    provider: str
+    api_key: SecretStr
+
+
+class ApiKeyValidationResponse(BaseModel):
+    provider: str
+    state: ApiKeyValidationState
+    message: str
+    retryable: bool
+    stage: ApiKeyValidationStage | None = None
+    retry_after_seconds: int | None = None
+    probe_model: str | None = None
 
 
 class OAuthConnectionTokenResponse(BaseModel):

--- a/apps/aigateway/src/aigateway/core/oauth/store.py
+++ b/apps/aigateway/src/aigateway/core/oauth/store.py
@@ -138,6 +138,19 @@ class OAuthConnectionStore:
             status="active",
         ).first()
 
+    async def label_exists(
+        self,
+        account_id: str | UUID,
+        provider: str,
+        label: str,
+    ) -> bool:
+        """Check the same all-status label tuple enforced by the database constraint."""
+        return await OAuthConnection.filter(
+            account_id=account_id,
+            provider=provider,
+            label=label,
+        ).exists()
+
     async def complete(
         self,
         connection: OAuthConnection,
@@ -157,28 +170,119 @@ class OAuthConnectionStore:
         await connection.save()
         return connection
 
-    async def mark_error(self, connection: OAuthConnection, message: str) -> OAuthConnection:
-        connection.status = "error"
-        connection.error_message = message
-        fields = ["status", "error_message"]
+    async def complete_pending(
+        self,
+        connection: OAuthConnection,
+        *,
+        label: str,
+        identity: AccountIdentity | None,
+    ) -> OAuthConnection | None:
+        """Activate a connection only while this OAuth callback still owns pending state."""
+        refreshed_at = datetime.now(UTC)
+        updates: dict = {
+            "label": label,
+            "status": "active",
+            "error_message": None,
+            "last_refreshed_at": refreshed_at,
+        }
+        if identity is not None:
+            updates.update(
+                identity_sub=identity.sub,
+                identity_email=identity.email,
+                identity_name=identity.name,
+                identity_raw=identity.raw,
+            )
+        updated = await OAuthConnection.filter(
+            id=connection.id,
+            account_id=connection.account_id,
+            status="pending",
+        ).update(**updates)
+        if updated != 1:
+            return None
+        for field, value in updates.items():
+            setattr(connection, field, value)
+        return connection
+
+    async def mark_error(self, connection: OAuthConnection, message: str) -> OAuthConnection | None:
+        updates: dict[str, object] = {"status": "error", "error_message": message}
         # OAuth connections are superseded by a fresh re-auth, so the old row's
         # label/identity are cleared. An api-key connection is re-keyed IN PLACE
         # (Replace key), so its label and identity must survive the error state
         # to stay recoverable (SF-291 review RF2-1).
         if connection.auth_type != "api_key":
-            connection.label = f"error:{connection.id}"
-            connection.identity_sub = None
-            fields += ["label", "identity_sub"]
-        await connection.save(update_fields=fields)
+            updates["label"] = f"error:{connection.id}"
+            updates["identity_sub"] = None
+        updated = await OAuthConnection.filter(
+            id=connection.id,
+            account_id=connection.account_id,
+            status="active",
+        ).update(**updates)
+        if updated != 1:
+            return None
+        for field, value in updates.items():
+            setattr(connection, field, value)
         return connection
 
-    async def reactivate(self, connection: OAuthConnection) -> OAuthConnection:
+    async def mark_pending_error(
+        self,
+        connection: OAuthConnection,
+        message: str,
+    ) -> OAuthConnection | None:
+        """Mark an OAuth connection error only while its callback still owns pending state."""
+        label = f"error:{connection.id}"
+        updated = await OAuthConnection.filter(
+            id=connection.id,
+            account_id=connection.account_id,
+            status="pending",
+        ).update(
+            label=label,
+            identity_sub=None,
+            status="error",
+            error_message=message,
+        )
+        if updated != 1:
+            return None
+        connection.label = label
+        connection.identity_sub = None
+        connection.status = "error"
+        connection.error_message = message
+        return connection
+
+    async def patch_active_label(
+        self,
+        connection: OAuthConnection,
+        label: str,
+    ) -> OAuthConnection | None:
+        """Update a label only while the connection remains active."""
+        updated = await OAuthConnection.filter(
+            id=connection.id,
+            account_id=connection.account_id,
+            status="active",
+        ).update(label=label)
+        if updated != 1:
+            return None
+        connection.label = label
+        return connection
+
+    async def reactivate(self, connection: OAuthConnection) -> OAuthConnection | None:
         """Return an errored connection to active after its credential is
-        replaced (SF-291 review RF2-1)."""
+        replaced, unless a concurrent lifecycle operation made it ineligible."""
+        refreshed_at = datetime.now(UTC)
+        updated = await OAuthConnection.filter(
+            id=connection.id,
+            account_id=connection.account_id,
+            auth_type="api_key",
+            status__in=("active", "error"),
+        ).update(
+            status="active",
+            error_message=None,
+            last_refreshed_at=refreshed_at,
+        )
+        if updated != 1:
+            return None
         connection.status = "active"
         connection.error_message = None
-        connection.last_refreshed_at = datetime.now(UTC)
-        await connection.save(update_fields=["status", "error_message", "last_refreshed_at"])
+        connection.last_refreshed_at = refreshed_at
         return connection
 
     async def mark_revoked(

--- a/apps/aigateway/src/aigateway/core/oauth/store.py
+++ b/apps/aigateway/src/aigateway/core/oauth/store.py
@@ -203,6 +203,46 @@ class OAuthConnectionStore:
             setattr(connection, field, value)
         return connection
 
+    async def complete_active(
+        self,
+        connection: OAuthConnection,
+        *,
+        label: str,
+        identity: AccountIdentity | None,
+    ) -> OAuthConnection | None:
+        """Republish a refreshed connection only while it is still active.
+
+        INVARIANT (OME-307 H-1): a manual refresh reads the row, runs the provider network call,
+        then republishes. A delete/revoke that commits during that window must WIN. Fencing the
+        write on ``status="active"`` (same idiom as ``complete_pending``) makes the republish
+        update zero rows once the row leaves ``active``; the caller surfaces a conflict instead of
+        resurrecting a revoked/deleted connection back to ``active``.
+        """
+        refreshed_at = datetime.now(UTC)
+        updates: dict = {
+            "label": label,
+            "status": "active",
+            "error_message": None,
+            "last_refreshed_at": refreshed_at,
+        }
+        if identity is not None:
+            updates.update(
+                identity_sub=identity.sub,
+                identity_email=identity.email,
+                identity_name=identity.name,
+                identity_raw=identity.raw,
+            )
+        updated = await OAuthConnection.filter(
+            id=connection.id,
+            account_id=connection.account_id,
+            status="active",
+        ).update(**updates)
+        if updated != 1:
+            return None
+        for field, value in updates.items():
+            setattr(connection, field, value)
+        return connection
+
     async def mark_error(self, connection: OAuthConnection, message: str) -> OAuthConnection | None:
         updates: dict[str, object] = {"status": "error", "error_message": message}
         # OAuth connections are superseded by a fresh re-auth, so the old row's

--- a/apps/aigateway/src/aigateway/core/pending_auth.py
+++ b/apps/aigateway/src/aigateway/core/pending_auth.py
@@ -15,6 +15,10 @@ class PendingAuthEntry:
     connection_id: str | None = None
     requested_label: str | None = None
     compatibility_profile_name: str | None = None
+    # WHY: the ownership generation this flow claimed at begin_pending (OME-307 Blocker 1).
+    # The callback presents it to authenticate_pending so a superseded flow loses inside the
+    # durable CAS. None for connection flows (which do not publish a pending profile).
+    oauth_generation: int | None = None
 
 
 class PendingAuthTable:
@@ -27,15 +31,29 @@ class PendingAuthTable:
     def put(self, state: str, entry: PendingAuthEntry) -> None:
         self._entries[state] = (entry, time.monotonic())
 
-    def pop_for_profile(self, account_id: str, provider: str, profile_name: str) -> list[str]:
+    def pop_for_profile(
+        self,
+        account_id: str,
+        provider: str,
+        profile_name: str,
+        *,
+        exclude_state: str | None = None,
+    ) -> list[str]:
         """Remove pending entries for the same account/provider/profile.
 
         Returns the removed states so callers can tear down any state-scoped
         loopback listeners without disturbing unrelated in-flight profiles.
+
+        INVARIANT (OME-307 Blocker 5): ``exclude_state`` protects the caller's OWN
+        just-published flow. ``start_oauth`` publishes its pending profile FIRST, then calls
+        this to supersede older flows — passing its fresh state as ``exclude_state`` so it does
+        not evict itself while tearing down the flows it replaced.
         """
         removed: list[str] = []
         now = time.monotonic()
         for state, (entry, ts) in list(self._entries.items()):
+            if state == exclude_state:
+                continue
             expired = now - ts > self._ttl
             matches = (
                 entry.account_id == account_id

--- a/apps/aigateway/src/aigateway/core/plugin_base.py
+++ b/apps/aigateway/src/aigateway/core/plugin_base.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from .api_key_validation import ApiKeyValidator
+
 if TYPE_CHECKING:
     from .credential_blob.store import CredentialBlobStore
     from .oauth.identity import AccountIdentity
@@ -134,6 +136,10 @@ class ProviderPluginBase[TSettings: PluginSettings](ABC):
     ) -> CredentialStrategy | None:
         """Return a per-profile API-key strategy, or None when the provider
         does not support API-key auth (e.g. codex subscription endpoints)."""
+        return None
+
+    def api_key_validator(self) -> ApiKeyValidator | None:
+        """Return an operational API-key validator, or None when unavailable."""
         return None
 
     def credential_strategy_for(

--- a/apps/aigateway/src/aigateway/core/profile_index.py
+++ b/apps/aigateway/src/aigateway/core/profile_index.py
@@ -163,6 +163,11 @@ class ProfileIndexStore:
                 changes = {
                     "state": profile.state,
                     "auth_type": profile.auth_type,
+                    # WHY (OME-307 M-1): publish last_refreshed_at inside this SAME CAS so it
+                    # joins mark_authenticated_error's ownership fence. Omitting it left the row
+                    # at the pending None, letting a stale refresh-failure carrying that None
+                    # error the freshly re-authenticated owner.
+                    "last_refreshed_at": profile.last_refreshed_at,
                 }
                 if account_label is not None:
                     changes["account_label"] = account_label

--- a/apps/aigateway/src/aigateway/core/profile_index.py
+++ b/apps/aigateway/src/aigateway/core/profile_index.py
@@ -2,15 +2,20 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import datetime
 
 from .credential_blob.store import CredentialBlobStore, ORMStore
-from .profile_models import Profile, ProfileIndex
+from .profile_models import AuthType, Profile, ProfileDefaults, ProfileIndex, ProfileState
 
 logger = logging.getLogger(__name__)
 
 INDEX_CREDENTIAL_SERVICE = "aigateway:index"
 _LEGACY_INDEX_ACCOUNT = "default"
 _INDEX_ACCOUNT_PREFIX = "account:"
+
+
+class ProfileTransitionConflict(RuntimeError):
+    """Raised when a stale authentication flow no longer owns a pending profile."""
 
 
 def _index_account_for(account_id: str) -> str:
@@ -47,7 +52,17 @@ class ProfileIndexStore:
         legacy = ProfileIndex.model_validate_json(raw)
         return ProfileIndex(profiles=[p for p in legacy.profiles if p.account_id == account_id])
 
-    async def upsert(self, profile: Profile) -> None:
+    async def upsert(self, profile: Profile, *, require_present: bool = False) -> None:
+        """Insert or replace ``profile`` in its account index row.
+
+        INVARIANT: when ``require_present`` (the caller observed the profile as existing when
+        its operation began), a concurrent delete that removed it WINS — publication raises
+        ``ProfileTransitionConflict`` instead of silently resurrecting deleted state (OME-307
+        Unit 3). The presence check runs INSIDE the mutator, so it is re-evaluated against the
+        latest committed index on every ``ORMStore.mutate`` CAS retry; the index-row CAS is the
+        sole cross-worker serializer. Default ``False`` keeps first-time API-key/OAuth creates
+        and error-marking writes unconditional.
+        """
         if not profile.account_id:
             raise ValueError("profile.account_id is required")
 
@@ -58,6 +73,8 @@ class ProfileIndexStore:
                 # WHY: legacy installs used one global row; seed the account row lazily
                 # so existing profiles survive the storage-shape split.
                 idx = legacy_seed if raw is None else ProfileIndex.model_validate_json(raw)
+                if require_present and not any(p.id == profile.id for p in idx.profiles):
+                    raise ProfileTransitionConflict("profile was concurrently deleted")
                 idx.profiles = [p for p in idx.profiles if p.id != profile.id] + [profile]
                 return idx.model_dump_json()
 
@@ -66,6 +83,206 @@ class ProfileIndexStore:
                 _index_account_for(profile.account_id),
                 mutate,
             )
+
+    async def begin_pending(self, profile: Profile) -> int:
+        """Publish ``profile`` as pending and claim a fresh ownership generation.
+
+        Returns the generation assigned to THIS operation. INVARIANT (OME-307 Blocker 1):
+        the profile row and its ownership generation are written in ONE atomic index-row CAS,
+        so a later ``begin_pending`` for the same profile strictly supersedes this one. The
+        generation the caller receives is the token it must later present to
+        ``authenticate_pending``; a stale caller whose generation was bumped loses even though
+        the row is still PENDING. The generation is an internal nonce — never surfaced via API.
+        """
+        if not profile.account_id:
+            raise ValueError("profile.account_id is required")
+
+        assigned: dict[str, int] = {}
+        async with self._lock:
+            legacy_seed = await self._read_legacy_account_index(profile.account_id)
+
+            def mutate(raw: str | None) -> str:
+                idx = legacy_seed if raw is None else ProfileIndex.model_validate_json(raw)
+                generation = idx.oauth_generations.get(profile.id, 0) + 1
+                idx.oauth_generations[profile.id] = generation
+                idx.profiles = [p for p in idx.profiles if p.id != profile.id] + [profile]
+                # On a CAS retry mutate() re-runs against the latest committed row, so the
+                # last (successful) run's generation is the one that is durably stored.
+                assigned["generation"] = generation
+                return idx.model_dump_json()
+
+            await self._store.mutate(
+                INDEX_CREDENTIAL_SERVICE,
+                _index_account_for(profile.account_id),
+                mutate,
+            )
+        return assigned["generation"]
+
+    async def authenticate_pending(
+        self,
+        profile: Profile,
+        *,
+        expected_generation: int | None = None,
+        account_label: str | None = None,
+    ) -> None:
+        """Atomically replace a still-pending profile with its authenticated form.
+
+        INVARIANT: exactly ONE conditional durable publication under a SINGLE process-
+        lock acquisition. The optimistic CAS below (guarded on the current ciphertext by
+        ``ORMStore.mutate``) is the sole cross-worker serializer; the process ``_lock`` is
+        only a same-process convenience. The lock is released before the caller's
+        enclosing transaction commits and is never re-acquired afterwards, so a second
+        writer can never invert the application-lock / index-row-lock order (OME-307
+        Unit 1 — a trailing ``upsert`` here previously deadlocked concurrent OAuth
+        callbacks on PostgreSQL).
+
+        INVARIANT (OME-307 Blocker 1): when ``expected_generation`` is supplied, OWNERSHIP is
+        enforced INSIDE this same atomic CAS — not by a separate in-memory precheck. A stale
+        flow whose generation was superseded by a newer ``begin_pending`` loses here even
+        though the row is still PENDING, closing the check-then-act TOCTOU window. The
+        ``state is PENDING`` guard remains as defense in depth for the case where a newer flow
+        (or an API-key write) has already committed a non-pending state.
+        """
+        if not profile.account_id:
+            raise ValueError("profile.account_id is required")
+
+        async with self._lock:
+            legacy_seed = await self._read_legacy_account_index(profile.account_id)
+
+            def mutate(raw: str | None) -> str:
+                idx = legacy_seed if raw is None else ProfileIndex.model_validate_json(raw)
+                current = next((item for item in idx.profiles if item.id == profile.id), None)
+                # INVARIANT: a consumed OAuth callback cannot overwrite a later API-key choice.
+                if current is None or current.state is not ProfileState.PENDING:
+                    raise ProfileTransitionConflict("profile is no longer pending")
+                if (
+                    expected_generation is not None
+                    and idx.oauth_generations.get(profile.id) != expected_generation
+                ):
+                    raise ProfileTransitionConflict("a newer OAuth flow owns this pending profile")
+                changes = {
+                    "state": profile.state,
+                    "auth_type": profile.auth_type,
+                }
+                if account_label is not None:
+                    changes["account_label"] = account_label
+                published = current.model_copy(update=changes)
+                # INVARIANT: merge lifecycle fields into the row validated by this CAS. A
+                # metadata PATCH that committed after the callback's earlier read must survive.
+                idx.profiles = [item for item in idx.profiles if item.id != profile.id] + [
+                    published
+                ]
+                return idx.model_dump_json()
+
+            await self._store.mutate(
+                INDEX_CREDENTIAL_SERVICE,
+                _index_account_for(profile.account_id),
+                mutate,
+            )
+
+    async def mark_pending_error(self, profile_id: str, *, expected_generation: int) -> None:
+        """Transition a still-owned pending profile to ERROR under ONE atomic index CAS.
+
+        INVARIANT (OME-307 Blocker 2): mark ERROR only if the profile is still present, still
+        PENDING, and still owned by ``expected_generation``. A newer OAuth flow, a committed
+        API-key write, or a delete means this failed operation no longer owns the row, so the
+        stale failure raises ``ProfileTransitionConflict`` (the caller treats it as "not mine,
+        nothing to mark") rather than corrupting the newer state. The presence check is
+        require_present — a deleted profile is NEVER recreated. All three conditions are checked
+        inside the mutator so they re-evaluate on every ``ORMStore.mutate`` CAS retry.
+        """
+        account_id = _account_id_from_profile_id(profile_id)
+
+        async with self._lock:
+            legacy_seed = await self._read_legacy_account_index(account_id)
+
+            def mutate(raw: str | None) -> str:
+                idx = legacy_seed if raw is None else ProfileIndex.model_validate_json(raw)
+                current = next((p for p in idx.profiles if p.id == profile_id), None)
+                if current is None or current.state is not ProfileState.PENDING:
+                    raise ProfileTransitionConflict(
+                        "profile is not a pending profile this operation owns"
+                    )
+                if idx.oauth_generations.get(profile_id) != expected_generation:
+                    raise ProfileTransitionConflict("a newer OAuth flow owns this pending profile")
+                errored = current.model_copy(update={"state": ProfileState.ERROR})
+                idx.profiles = [p for p in idx.profiles if p.id != profile_id] + [errored]
+                return idx.model_dump_json()
+
+            await self._store.mutate(
+                INDEX_CREDENTIAL_SERVICE,
+                _index_account_for(account_id),
+                mutate,
+            )
+
+    async def mark_authenticated_error(
+        self,
+        profile_id: str,
+        *,
+        expected_auth_type: AuthType,
+        expected_last_refreshed_at: datetime | None,
+    ) -> None:
+        """Mark ERROR only if the authenticated credential version still owns the profile."""
+        account_id = _account_id_from_profile_id(profile_id)
+
+        async with self._lock:
+            legacy_seed = await self._read_legacy_account_index(account_id)
+
+            def mutate(raw: str | None) -> str:
+                idx = legacy_seed if raw is None else ProfileIndex.model_validate_json(raw)
+                current = next((p for p in idx.profiles if p.id == profile_id), None)
+                if (
+                    current is None
+                    or current.state is not ProfileState.AUTHENTICATED
+                    or current.auth_type != expected_auth_type
+                    or current.last_refreshed_at != expected_last_refreshed_at
+                ):
+                    raise ProfileTransitionConflict("profile credential owner changed")
+                errored = current.model_copy(update={"state": ProfileState.ERROR})
+                idx.profiles = [p for p in idx.profiles if p.id != profile_id] + [errored]
+                return idx.model_dump_json()
+
+            await self._store.mutate(
+                INDEX_CREDENTIAL_SERVICE,
+                _index_account_for(account_id),
+                mutate,
+            )
+
+    async def update_metadata(
+        self,
+        profile_id: str,
+        *,
+        defaults: ProfileDefaults | None = None,
+        account_label: str | None = None,
+    ) -> Profile:
+        """Patch non-lifecycle fields against the latest present profile atomically."""
+        account_id = _account_id_from_profile_id(profile_id)
+        updated: dict[str, Profile] = {}
+
+        async with self._lock:
+            legacy_seed = await self._read_legacy_account_index(account_id)
+
+            def mutate(raw: str | None) -> str:
+                idx = legacy_seed if raw is None else ProfileIndex.model_validate_json(raw)
+                current = next((p for p in idx.profiles if p.id == profile_id), None)
+                if current is None:
+                    raise ProfileTransitionConflict("profile was concurrently deleted")
+                changes = {}
+                if defaults is not None:
+                    changes["defaults"] = defaults
+                if account_label is not None:
+                    changes["account_label"] = account_label
+                patched = current.model_copy(update=changes)
+                idx.profiles = [p for p in idx.profiles if p.id != profile_id] + [patched]
+                updated["profile"] = patched
+                return idx.model_dump_json()
+
+            await self._store.mutate(
+                INDEX_CREDENTIAL_SERVICE,
+                _index_account_for(account_id),
+                mutate,
+            )
+        return updated["profile"]
 
     async def remove(self, profile_id: str) -> None:
         account_id = _account_id_from_profile_id(profile_id)
@@ -76,6 +293,10 @@ class ProfileIndexStore:
             def mutate(raw: str | None) -> str:
                 idx = legacy_seed if raw is None else ProfileIndex.model_validate_json(raw)
                 idx.profiles = [p for p in idx.profiles if p.id != profile_id]
+                # INVARIANT: retain the last generation as an internal tombstone. Reusing an old
+                # number after delete/recreate would let a callback consumed before the delete
+                # authenticate the new pending profile. Presence/state checks still prevent a
+                # deleted profile from being authenticated or marked ERROR.
                 return idx.model_dump_json()
 
             await self._store.mutate(

--- a/apps/aigateway/src/aigateway/core/profile_models.py
+++ b/apps/aigateway/src/aigateway/core/profile_models.py
@@ -50,3 +50,10 @@ class Profile(BaseModel):
 class ProfileIndex(BaseModel):
     version: int = 1
     profiles: list[Profile] = Field(default_factory=list)
+    # WHY: OAuth ownership tokens (profile_id -> monotonic generation) live in the index
+    # document so the ownership decision is atomic with the pending->authenticated CAS
+    # (OME-307 Blocker 1). INVARIANT: this map is an internal operation nonce store — the
+    # ProfileIndex is never returned through the API (only individual Profiles are), so the
+    # generation never leaks. Kept as a sibling map (not a Profile field) precisely to avoid
+    # exposing it via ``Profile.model_dump``.
+    oauth_generations: dict[str, int] = Field(default_factory=dict)

--- a/apps/aigateway/src/aigateway/main.py
+++ b/apps/aigateway/src/aigateway/main.py
@@ -13,6 +13,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
 from .config import Settings
+from .core.api_key_validation_service import ApiKeyValidationService
 from .core.auth.bootstrap_admin import ensure_admin_account
 from .core.auth.jwt_secret import get_or_create_jwt_secret
 from .core.auth.local_only import AuthDisabledLocalOnlyMiddleware
@@ -29,7 +30,16 @@ from .core.registry import ProviderRegistry
 from .core.request_cache.store import TortoiseRequestCacheStore
 from .core.secrets.factory import build_secret_store, set_active_secret_store
 from .db import close_db, init_db
-from .routes import accounts, auth, auth_session, chat, health, models, oauth_connections
+from .routes import (
+    accounts,
+    api_key_validation,
+    auth,
+    auth_session,
+    chat,
+    health,
+    models,
+    oauth_connections,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -220,6 +230,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     registry = ProviderRegistry()
     load_plugins(registry)
     app.state.providers = registry
+    app.state.api_key_validation_service = ApiKeyValidationService()
 
     # Test-only OAuth endpoint hooks are gated by env vars so they only activate
     # in e2e harnesses. Credential storage itself is always DB-backed.
@@ -242,6 +253,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     app.include_router(auth_session.router)
     app.include_router(accounts.router)
+    app.include_router(api_key_validation.router)
     app.include_router(auth.router)
     app.include_router(oauth_connections.router)
     app.include_router(health.router)

--- a/apps/aigateway/src/aigateway/plugins/anthropic_provider/api_key_validation.py
+++ b/apps/aigateway/src/aigateway/plugins/anthropic_provider/api_key_validation.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import httpx
+
+from aigateway.core.api_key_validation import (
+    ApiKeyValidationResult,
+    ApiKeyValidationStage,
+    ApiKeyValidationState,
+)
+from aigateway.core.api_key_validation_http import (
+    ApiKeyValidationTransportError,
+    BoundedJsonResponse,
+    ValidationHttpSession,
+)
+from aigateway.core.plugin_base import ModelEntry
+
+from .settings import AnthropicPluginSettings
+
+_API_BASE = "https://api.anthropic.com/v1"
+_PREFERRED_MODEL = "claude-haiku-4-5"
+
+
+def _result(
+    state: ApiKeyValidationState,
+    stage: ApiKeyValidationStage | None,
+    *,
+    response: BoundedJsonResponse | None = None,
+    probe_model: str | None = None,
+) -> ApiKeyValidationResult:
+    retry_after = None
+    if state is ApiKeyValidationState.RATE_LIMITED and response is not None:
+        retry_after = response.retry_after_seconds
+    return ApiKeyValidationResult(
+        state=state,
+        stage=stage,
+        retry_after_seconds=retry_after,
+        probe_model=probe_model,
+    )
+
+
+def _classify(
+    response: BoundedJsonResponse,
+    stage: ApiKeyValidationStage,
+    probe_model: str,
+) -> ApiKeyValidationResult:
+    payload = response.payload
+    if response.status_code == 200:
+        if not isinstance(payload, dict):
+            return _result(ApiKeyValidationState.UNAVAILABLE, stage, probe_model=probe_model)
+        if stage is ApiKeyValidationStage.AUTHENTICATION:
+            success = isinstance(payload.get("data"), list)
+        else:
+            success = payload.get("type") == "message" and isinstance(payload.get("content"), list)
+        return _result(
+            ApiKeyValidationState.VALID if success else ApiKeyValidationState.UNAVAILABLE,
+            stage,
+            probe_model=probe_model,
+        )
+
+    error = payload.get("error") if isinstance(payload, dict) else None
+    raw_error_type = error.get("type") if isinstance(error, dict) else None
+    error_type = raw_error_type if isinstance(raw_error_type, str) else None
+    # WHY: classify only provider evidence with an unambiguous actionable meaning;
+    # 400 invalid_request_error can also describe request or account policy failures.
+    mapping: dict[tuple[int, str], ApiKeyValidationState] = {
+        (401, "authentication_error"): ApiKeyValidationState.INVALID,
+        (402, "billing_error"): ApiKeyValidationState.NO_QUOTA,
+        (403, "permission_error"): ApiKeyValidationState.PERMISSION_DENIED,
+        (429, "rate_limit_error"): ApiKeyValidationState.RATE_LIMITED,
+    }
+    state = mapping.get((response.status_code, error_type)) if error_type is not None else None
+    if state is None:
+        state = ApiKeyValidationState.UNAVAILABLE
+    return _result(state, stage, response=response, probe_model=probe_model)
+
+
+def _effective_model(
+    settings: AnthropicPluginSettings,
+    registered_models: list[ModelEntry],
+) -> tuple[str, str] | None:
+    by_name = {entry.model_name: entry for entry in registered_models}
+    selected = settings.validation_model
+    if selected is None:
+        selected = _PREFERRED_MODEL if _PREFERRED_MODEL in by_name else next(iter(by_name), None)
+    entry = by_name.get(selected) if selected is not None else None
+    if entry is None:
+        return None
+    upstream = entry.litellm_params.get("model")
+    if not isinstance(upstream, str) or not upstream.startswith("anthropic/"):
+        return None
+    stripped = upstream.removeprefix("anthropic/")
+    if not stripped or stripped.startswith("anthropic/"):
+        return None
+    return entry.model_name, stripped
+
+
+class AnthropicApiKeyValidator:
+    def __init__(
+        self,
+        *,
+        settings: AnthropicPluginSettings,
+        registered_models: list[ModelEntry],
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._settings = settings
+        self._registered_models = registered_models
+        self._transport = transport
+
+    async def validate(self, api_key: str) -> ApiKeyValidationResult:
+        model = _effective_model(self._settings, self._registered_models)
+        if model is None:
+            return _result(ApiKeyValidationState.MISCONFIGURED, None)
+        probe_model, upstream_model = model
+        headers = {
+            "x-api-key": api_key,
+            "anthropic-version": self._settings.api_version,
+        }
+
+        async with ValidationHttpSession(transport=self._transport) as session:
+            try:
+                auth_response = await session.request_json(
+                    "GET",
+                    f"{_API_BASE}/models",
+                    headers=headers,
+                    params={"limit": 1},
+                )
+            except ApiKeyValidationTransportError:
+                return _result(
+                    ApiKeyValidationState.UNAVAILABLE,
+                    ApiKeyValidationStage.AUTHENTICATION,
+                    probe_model=probe_model,
+                )
+            auth_result = _classify(
+                auth_response,
+                ApiKeyValidationStage.AUTHENTICATION,
+                probe_model,
+            )
+            if auth_result.state is not ApiKeyValidationState.VALID:
+                return auth_result
+
+            try:
+                readiness_response = await session.request_json(
+                    "POST",
+                    f"{_API_BASE}/messages",
+                    headers=headers,
+                    json_body={
+                        "model": upstream_model,
+                        "max_tokens": 1,
+                        "stream": False,
+                        "messages": [{"role": "user", "content": "ping"}],
+                    },
+                )
+            except ApiKeyValidationTransportError:
+                return _result(
+                    ApiKeyValidationState.UNAVAILABLE,
+                    ApiKeyValidationStage.READINESS,
+                    probe_model=probe_model,
+                )
+            return _classify(
+                readiness_response,
+                ApiKeyValidationStage.READINESS,
+                probe_model,
+            )

--- a/apps/aigateway/src/aigateway/plugins/anthropic_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/anthropic_provider/plugin.py
@@ -4,6 +4,7 @@ from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
 
 from aigateway.core.api_key_strategy import ApiKeyStrategy
+from aigateway.core.api_key_validation import ApiKeyValidator
 from aigateway.core.oauth.identity import AccountIdentity
 from aigateway.core.plugin_base import (
     CredentialStrategy,
@@ -13,6 +14,7 @@ from aigateway.core.plugin_base import (
     ProviderPluginBase,
 )
 
+from .api_key_validation import AnthropicApiKeyValidator
 from .auth import AnthropicOAuth, credential_service_for, exchange_authorization_code
 from .bootstrap import bootstrap_from_claude_code
 from .chat_handler import chat_completion, chat_completion_stream
@@ -76,6 +78,12 @@ class AnthropicProviderPlugin(ProviderPluginBase[AnthropicPluginSettings]):
             account=self.settings.keychain_account,
             header_builder=_api_key_headers,
             credential_store=credential_store,
+        )
+
+    def api_key_validator(self) -> ApiKeyValidator:
+        return AnthropicApiKeyValidator(
+            settings=self.settings,
+            registered_models=self.register_models(),
         )
 
     def should_mark_profile_error_on_dispatch_status(self, status_code: int) -> bool:

--- a/apps/aigateway/src/aigateway/plugins/anthropic_provider/settings.py
+++ b/apps/aigateway/src/aigateway/plugins/anthropic_provider/settings.py
@@ -71,6 +71,7 @@ class AnthropicPluginSettings(PluginSettings):
     )
 
     models: list[ModelEntry] = Field(default_factory=_default_models)
+    validation_model: str | None = None
 
     claude_code_keychain_service: str = "Claude Code-credentials"
     keychain_account: str = "default"

--- a/apps/aigateway/src/aigateway/plugins/gemini_provider/api_key_validation.py
+++ b/apps/aigateway/src/aigateway/plugins/gemini_provider/api_key_validation.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import math
+import re
+from typing import Any
+
+import httpx
+
+from aigateway.core.api_key_validation import (
+    ApiKeyValidationResult,
+    ApiKeyValidationStage,
+    ApiKeyValidationState,
+)
+from aigateway.core.api_key_validation_http import (
+    ApiKeyValidationTransportError,
+    BoundedJsonResponse,
+    ValidationHttpSession,
+)
+from aigateway.core.plugin_base import ModelEntry
+
+from .message_adapter import build_generate_content_body, strip_provider_prefix
+from .settings import GeminiPluginSettings
+
+_API_BASE = "https://generativelanguage.googleapis.com/v1beta"
+_PREFERRED_MODEL = "gemini-cli/gemini-3.1-flash-lite"
+_ERROR_INFO_TYPE = "type.googleapis.com/google.rpc.ErrorInfo"
+_RETRY_INFO_TYPE = "type.googleapis.com/google.rpc.RetryInfo"
+_BLOCKED_REASONS = frozenset(
+    {
+        "SERVICE_DISABLED",
+        "API_KEY_SERVICE_BLOCKED",
+        "API_KEY_HTTP_REFERRER_BLOCKED",
+        "API_KEY_IP_ADDRESS_BLOCKED",
+        "API_KEY_ANDROID_APP_BLOCKED",
+        "API_KEY_IOS_APP_BLOCKED",
+    }
+)
+_DURATION_RE = re.compile(r"^(\d+(?:\.\d+)?)s$")
+
+
+def _result(
+    state: ApiKeyValidationState,
+    stage: ApiKeyValidationStage | None,
+    *,
+    retry_after_seconds: int | None = None,
+    probe_model: str | None = None,
+) -> ApiKeyValidationResult:
+    return ApiKeyValidationResult(
+        state=state,
+        stage=stage,
+        retry_after_seconds=retry_after_seconds,
+        probe_model=probe_model,
+    )
+
+
+def _details(payload: Any) -> tuple[str | None, list[dict[str, Any]]]:
+    error = payload.get("error") if isinstance(payload, dict) else None
+    if not isinstance(error, dict):
+        return None, []
+    status = error.get("status")
+    raw_details = error.get("details")
+    details = (
+        [item for item in raw_details if isinstance(item, dict)]
+        if isinstance(raw_details, list)
+        else []
+    )
+    return status if isinstance(status, str) else None, details
+
+
+def _error_info(details: list[dict[str, Any]]) -> tuple[str | None, str | None]:
+    for detail in details:
+        if detail.get("@type") != _ERROR_INFO_TYPE:
+            continue
+        reason = detail.get("reason")
+        domain = detail.get("domain")
+        return (
+            reason if isinstance(reason, str) else None,
+            domain if isinstance(domain, str) else None,
+        )
+    return None, None
+
+
+def _structured_retry_after(details: list[dict[str, Any]]) -> int | None:
+    for detail in details:
+        if detail.get("@type") != _RETRY_INFO_TYPE:
+            continue
+        value = detail.get("retryDelay")
+        match = _DURATION_RE.fullmatch(value) if isinstance(value, str) else None
+        if match is None:
+            return None
+        seconds = float(match.group(1))
+        if not math.isfinite(seconds) or seconds <= 0:
+            return None
+        return math.ceil(seconds)
+    return None
+
+
+def _classify(
+    response: BoundedJsonResponse,
+    stage: ApiKeyValidationStage,
+    probe_model: str,
+) -> ApiKeyValidationResult:
+    payload = response.payload
+    if response.status_code == 200:
+        if not isinstance(payload, dict):
+            return _result(ApiKeyValidationState.UNAVAILABLE, stage, probe_model=probe_model)
+        field = "models" if stage is ApiKeyValidationStage.AUTHENTICATION else "candidates"
+        value = payload.get(field)
+        success = isinstance(value, list) and (
+            stage is ApiKeyValidationStage.AUTHENTICATION or bool(value)
+        )
+        return _result(
+            ApiKeyValidationState.VALID if success else ApiKeyValidationState.UNAVAILABLE,
+            stage,
+            probe_model=probe_model,
+        )
+
+    status, details = _details(payload)
+    reason, domain = _error_info(details)
+    if response.status_code == 401 and status == "UNAUTHENTICATED":
+        state = ApiKeyValidationState.INVALID
+    elif response.status_code == 403 and status == "PERMISSION_DENIED":
+        state = ApiKeyValidationState.PERMISSION_DENIED
+    elif (
+        response.status_code == 400
+        and status == "INVALID_ARGUMENT"
+        and reason == "API_KEY_INVALID"
+        and domain == "googleapis.com"
+    ):
+        state = ApiKeyValidationState.INVALID
+    elif (
+        reason in _BLOCKED_REASONS
+        and domain == "googleapis.com"
+        and (
+            (response.status_code == 400 and status in ("INVALID_ARGUMENT", "FAILED_PRECONDITION"))
+            or (response.status_code == 403 and status == "PERMISSION_DENIED")
+        )
+    ):
+        state = ApiKeyValidationState.PERMISSION_DENIED
+    elif response.status_code == 429 and status == "RESOURCE_EXHAUSTED":
+        state = ApiKeyValidationState.RATE_LIMITED
+    else:
+        state = ApiKeyValidationState.UNAVAILABLE
+
+    retry_after = None
+    if state is ApiKeyValidationState.RATE_LIMITED:
+        retry_after = _structured_retry_after(details) or response.retry_after_seconds
+    return _result(
+        state,
+        stage,
+        retry_after_seconds=retry_after,
+        probe_model=probe_model,
+    )
+
+
+def _effective_model(
+    settings: GeminiPluginSettings,
+    registered_models: list[ModelEntry],
+) -> tuple[str, str] | None:
+    by_name = {entry.model_name: entry for entry in registered_models}
+    selected = settings.validation_model
+    if selected is None:
+        selected = _PREFERRED_MODEL if _PREFERRED_MODEL in by_name else next(iter(by_name), None)
+    entry = by_name.get(selected) if selected is not None else None
+    if entry is None:
+        return None
+    upstream = entry.litellm_params.get("model")
+    if not isinstance(upstream, str) or not upstream.startswith("gemini-cli/"):
+        return None
+    stripped = strip_provider_prefix(upstream)
+    if not stripped or "/" in stripped:
+        return None
+    return entry.model_name, stripped
+
+
+class GeminiApiKeyValidator:
+    def __init__(
+        self,
+        *,
+        settings: GeminiPluginSettings,
+        registered_models: list[ModelEntry],
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._settings = settings
+        self._registered_models = registered_models
+        self._transport = transport
+
+    async def validate(self, api_key: str) -> ApiKeyValidationResult:
+        model = _effective_model(self._settings, self._registered_models)
+        if model is None:
+            return _result(ApiKeyValidationState.MISCONFIGURED, None)
+        probe_model, upstream_model = model
+        headers = {"x-goog-api-key": api_key}
+
+        async with ValidationHttpSession(transport=self._transport) as session:
+            try:
+                auth_response = await session.request_json(
+                    "GET",
+                    f"{_API_BASE}/models",
+                    headers=headers,
+                    params={"pageSize": 1},
+                )
+            except ApiKeyValidationTransportError:
+                return _result(
+                    ApiKeyValidationState.UNAVAILABLE,
+                    ApiKeyValidationStage.AUTHENTICATION,
+                    probe_model=probe_model,
+                )
+            auth_result = _classify(
+                auth_response,
+                ApiKeyValidationStage.AUTHENTICATION,
+                probe_model,
+            )
+            if auth_result.state is not ApiKeyValidationState.VALID:
+                return auth_result
+
+            body = build_generate_content_body(
+                [{"role": "user", "content": "ping"}],
+                {"max_tokens": 1},
+            )
+            try:
+                readiness_response = await session.request_json(
+                    "POST",
+                    f"{_API_BASE}/models/{upstream_model}:generateContent",
+                    headers=headers,
+                    json_body=body,
+                )
+            except ApiKeyValidationTransportError:
+                return _result(
+                    ApiKeyValidationState.UNAVAILABLE,
+                    ApiKeyValidationStage.READINESS,
+                    probe_model=probe_model,
+                )
+            return _classify(
+                readiness_response,
+                ApiKeyValidationStage.READINESS,
+                probe_model,
+            )

--- a/apps/aigateway/src/aigateway/plugins/gemini_provider/api_key_validation.py
+++ b/apps/aigateway/src/aigateway/plugins/gemini_provider/api_key_validation.py
@@ -15,6 +15,7 @@ from aigateway.core.api_key_validation_http import (
     ApiKeyValidationTransportError,
     BoundedJsonResponse,
     ValidationHttpSession,
+    bounded_retry_after_seconds,
 )
 from aigateway.core.plugin_base import ModelEntry
 
@@ -36,6 +37,10 @@ _BLOCKED_REASONS = frozenset(
     }
 )
 _DURATION_RE = re.compile(r"^(\d+(?:\.\d+)?)s$")
+# WHY (OME-307 L-1): the readiness probe interpolates the upstream model id into the request
+# URL path, so it must be restricted to model-id-safe characters (no control chars, spaces,
+# ':' or '/') that would otherwise raise httpx.InvalidURL mid-probe.
+_SAFE_MODEL_ID = re.compile(r"[A-Za-z0-9._-]+")
 
 
 def _result(
@@ -91,7 +96,7 @@ def _structured_retry_after(details: list[dict[str, Any]]) -> int | None:
         seconds = float(match.group(1))
         if not math.isfinite(seconds) or seconds <= 0:
             return None
-        return math.ceil(seconds)
+        return bounded_retry_after_seconds(math.ceil(seconds))
     return None
 
 
@@ -168,7 +173,9 @@ def _effective_model(
     if not isinstance(upstream, str) or not upstream.startswith("gemini-cli/"):
         return None
     stripped = strip_provider_prefix(upstream)
-    if not stripped or "/" in stripped:
+    # WHY (OME-307 L-1): reject a URL-unsafe model id as a local misconfiguration before any
+    # network call instead of emitting a malformed readiness URL. Subsumes the earlier "/" check.
+    if not _SAFE_MODEL_ID.fullmatch(stripped):
         return None
     return entry.model_name, stripped
 

--- a/apps/aigateway/src/aigateway/plugins/gemini_provider/models.py
+++ b/apps/aigateway/src/aigateway/plugins/gemini_provider/models.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 from aigateway.core.plugin_base import ModelEntry
 
+# gemini-3.1-flash-lite leads the list as the minimal stable readiness-probe default
+# (see api_key_validation._PREFERRED_MODEL). gemini-2.0-flash was removed: Google shut it
+# down on 2026-06-01, so advertising it would route chat and validation to a dead model.
 _MODEL_SLUGS = [
+    "gemini-3.1-flash-lite",
     "gemini-2.5-pro",
     "gemini-2.5-flash",
     "gemini-2.5-flash-lite",
-    "gemini-2.0-flash",
 ]
 
 MODELS: list[ModelEntry] = [

--- a/apps/aigateway/src/aigateway/plugins/gemini_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/gemini_provider/plugin.py
@@ -8,6 +8,7 @@ from litellm.llms.custom_llm import CustomLLMError
 from litellm.types.utils import ModelResponse
 
 from aigateway.core.api_key_strategy import ApiKeyStrategy
+from aigateway.core.api_key_validation import ApiKeyValidator
 from aigateway.core.google_code_assist import (
     account_label_from_credentials,
     extract_account_identity,
@@ -21,6 +22,7 @@ from aigateway.core.plugin_base import (
     ProviderPluginBase,
 )
 
+from .api_key_validation import GeminiApiKeyValidator
 from .auth import (
     CLIENT_AUTH_HEADER_NAMES,
     GeminiOAuth,
@@ -37,6 +39,7 @@ from .oauth_config import (
     GEMINI_SCOPES,
     GEMINI_TOKEN_URL,
 )
+from .settings import GeminiPluginSettings
 
 if TYPE_CHECKING:
     from aigateway.core.credential_blob.store import CredentialBlobStore
@@ -70,8 +73,9 @@ def _detail_for_error(exc: CustomLLMError) -> dict[str, str]:
     return {"code": code, "message": exc.message}
 
 
-class GeminiProviderPlugin(ProviderPluginBase):
+class GeminiProviderPlugin(ProviderPluginBase[GeminiPluginSettings]):
     custom_llm_provider = "gemini-cli"
+    settings_cls = GeminiPluginSettings
 
     def credential_service_provider(self) -> str:
         return "gemini"
@@ -121,6 +125,12 @@ class GeminiProviderPlugin(ProviderPluginBase):
             account="default",
             header_builder=lambda api_key: {"x-goog-api-key": api_key},
             credential_store=credential_store,
+        )
+
+    def api_key_validator(self) -> ApiKeyValidator:
+        return GeminiApiKeyValidator(
+            settings=self.settings,
+            registered_models=self.register_models(),
         )
 
     async def exchange_oauth_code(self, request: OAuthCodeExchangeRequest) -> dict[str, Any]:

--- a/apps/aigateway/src/aigateway/plugins/gemini_provider/settings.py
+++ b/apps/aigateway/src/aigateway/plugins/gemini_provider/settings.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pydantic_settings import SettingsConfigDict
+
+from aigateway.core.plugin_base import PluginSettings
+
+
+class GeminiPluginSettings(PluginSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="AIGW_GEMINI_",
+        extra="ignore",
+        populate_by_name=True,
+    )
+
+    # WHY: operators retarget the readiness probe to any registered gemini-cli model
+    # via AIGW_GEMINI_VALIDATION_MODEL without a code deploy. None means "use the
+    # registered stable default"; the validator (_effective_model) owns that fallback
+    # and resolves the value only through registered models, so an unregistered
+    # selection becomes MISCONFIGURED before any network I/O.
+    validation_model: str | None = None

--- a/apps/aigateway/src/aigateway/plugins/huggingface_provider/api_key_validation.py
+++ b/apps/aigateway/src/aigateway/plugins/huggingface_provider/api_key_validation.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import httpx
+
+from aigateway.core.api_key_validation import (
+    ApiKeyValidationResult,
+    ApiKeyValidationStage,
+    ApiKeyValidationState,
+)
+from aigateway.core.api_key_validation_http import (
+    ApiKeyValidationTransportError,
+    BoundedJsonResponse,
+    ValidationHttpSession,
+)
+
+from .settings import HuggingFacePluginSettings
+
+_IDENTITY_URL = "https://huggingface.co/api/whoami-v2"
+_READINESS_URL = "https://router.huggingface.co/v1/chat/completions"
+# WHY: default readiness probe must be ungated so validation never requires a
+# per-model license acceptance. gpt-oss-120b is Apache-2.0 (no gate) and the
+# :cerebras route is the explicit, test-pinned provider choice. It is the first
+# entry in default_models, so this is also the first-seed fallback.
+_PREFERRED_MODEL = "huggingface/openai/gpt-oss-120b:cerebras"
+
+
+def _result(
+    state: ApiKeyValidationState,
+    stage: ApiKeyValidationStage | None,
+    *,
+    response: BoundedJsonResponse | None = None,
+    probe_model: str | None = None,
+) -> ApiKeyValidationResult:
+    retry_after = None
+    if state is ApiKeyValidationState.RATE_LIMITED and response is not None:
+        retry_after = response.retry_after_seconds
+    return ApiKeyValidationResult(
+        state=state,
+        stage=stage,
+        retry_after_seconds=retry_after,
+        probe_model=probe_model,
+    )
+
+
+def _classify(
+    response: BoundedJsonResponse,
+    stage: ApiKeyValidationStage,
+    probe_model: str,
+) -> ApiKeyValidationResult:
+    payload = response.payload
+    if response.status_code == 200:
+        if not isinstance(payload, dict):
+            success = False
+        elif stage is ApiKeyValidationStage.AUTHENTICATION:
+            name = payload.get("name")
+            success = isinstance(name, str) and bool(name) and isinstance(payload.get("auth"), dict)
+        else:
+            choices = payload.get("choices")
+            success = isinstance(choices, list) and bool(choices)
+        return _result(
+            ApiKeyValidationState.VALID if success else ApiKeyValidationState.UNAVAILABLE,
+            stage,
+            probe_model=probe_model,
+        )
+
+    if response.status_code == 401:
+        state = (
+            ApiKeyValidationState.INVALID
+            if stage is ApiKeyValidationStage.AUTHENTICATION
+            else ApiKeyValidationState.PERMISSION_DENIED
+        )
+    elif response.status_code == 402:
+        state = ApiKeyValidationState.NO_QUOTA
+    elif response.status_code == 403:
+        state = ApiKeyValidationState.PERMISSION_DENIED
+    elif response.status_code == 429:
+        state = ApiKeyValidationState.RATE_LIMITED
+    else:
+        state = ApiKeyValidationState.UNAVAILABLE
+    return _result(state, stage, response=response, probe_model=probe_model)
+
+
+def _effective_model(settings: HuggingFacePluginSettings) -> tuple[str, str] | None:
+    selected = settings.validation_model
+    if selected is None:
+        selected = (
+            _PREFERRED_MODEL
+            if _PREFERRED_MODEL in settings.default_models
+            else next(iter(settings.default_models), None)
+        )
+    if selected is None or selected not in settings.default_models:
+        return None
+    upstream = selected.removeprefix("huggingface/")
+    if not upstream or upstream == selected:
+        return None
+    return selected, upstream
+
+
+class HuggingFaceApiKeyValidator:
+    def __init__(
+        self,
+        *,
+        settings: HuggingFacePluginSettings,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._settings = settings
+        self._transport = transport
+
+    async def validate(self, api_key: str) -> ApiKeyValidationResult:
+        model = _effective_model(self._settings)
+        if model is None:
+            return _result(ApiKeyValidationState.MISCONFIGURED, None)
+        probe_model, upstream_model = model
+        headers = {"Authorization": f"Bearer {api_key}"}
+
+        async with ValidationHttpSession(transport=self._transport) as session:
+            try:
+                auth_response = await session.request_json(
+                    "GET",
+                    _IDENTITY_URL,
+                    headers=headers,
+                )
+            except ApiKeyValidationTransportError:
+                return _result(
+                    ApiKeyValidationState.UNAVAILABLE,
+                    ApiKeyValidationStage.AUTHENTICATION,
+                    probe_model=probe_model,
+                )
+            auth_result = _classify(
+                auth_response,
+                ApiKeyValidationStage.AUTHENTICATION,
+                probe_model,
+            )
+            if auth_result.state is not ApiKeyValidationState.VALID:
+                return auth_result
+
+            try:
+                readiness_response = await session.request_json(
+                    "POST",
+                    _READINESS_URL,
+                    headers=headers,
+                    json_body={
+                        "model": upstream_model,
+                        "max_tokens": 1,
+                        "stream": False,
+                        "messages": [{"role": "user", "content": "ping"}],
+                    },
+                )
+            except ApiKeyValidationTransportError:
+                return _result(
+                    ApiKeyValidationState.UNAVAILABLE,
+                    ApiKeyValidationStage.READINESS,
+                    probe_model=probe_model,
+                )
+            return _classify(
+                readiness_response,
+                ApiKeyValidationStage.READINESS,
+                probe_model,
+            )

--- a/apps/aigateway/src/aigateway/plugins/huggingface_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/huggingface_provider/plugin.py
@@ -23,12 +23,14 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from aigateway.core.api_key_strategy import ApiKeyStrategy
+from aigateway.core.api_key_validation import ApiKeyValidator
 from aigateway.core.plugin_base import (
     CredentialStrategy,
     ModelEntry,
     ProviderPluginBase,
 )
 
+from .api_key_validation import HuggingFaceApiKeyValidator
 from .settings import HuggingFacePluginSettings
 
 if TYPE_CHECKING:
@@ -71,6 +73,9 @@ class HuggingFaceProviderPlugin(ProviderPluginBase[HuggingFacePluginSettings]):
             header_builder=lambda api_key: {"Authorization": f"Bearer {api_key}"},
             credential_store=credential_store,
         )
+
+    def api_key_validator(self) -> ApiKeyValidator:
+        return HuggingFaceApiKeyValidator(settings=self.settings)
 
     def should_mark_profile_error_on_dispatch_status(self, status_code: int) -> bool:
         # 401 => bad/missing token (invalidate). 403 is ambiguous (model-access vs

--- a/apps/aigateway/src/aigateway/plugins/huggingface_provider/settings.py
+++ b/apps/aigateway/src/aigateway/plugins/huggingface_provider/settings.py
@@ -74,6 +74,7 @@ class HuggingFacePluginSettings(PluginSettings):
 
     default_models: list[str] = Field(default_factory=_default_model_slugs)
     router_api_base: str = _ROUTER_API_BASE
+    validation_model: str | None = None
 
     @field_validator("default_models")
     @classmethod

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/api_key_validation.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/api_key_validation.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import httpx
+
+from aigateway.core.api_key_validation import (
+    ApiKeyValidationResult,
+    ApiKeyValidationStage,
+    ApiKeyValidationState,
+)
+from aigateway.core.api_key_validation_http import (
+    ApiKeyValidationTransportError,
+    BoundedJsonResponse,
+    ValidationHttpSession,
+)
+
+from .response_errors import EmbeddedOpenRouterError, find_raw_error
+from .settings import GATEWAY_MODEL_PREFIX, OpenRouterPluginSettings, is_valid_upstream_model_id
+
+_API_BASE = "https://openrouter.ai/api/v1"
+_INTERNAL_DEFAULT_MODEL = "openrouter/openrouter/free"
+
+
+def _result(
+    state: ApiKeyValidationState,
+    stage: ApiKeyValidationStage | None,
+    *,
+    response: BoundedJsonResponse | None = None,
+    probe_model: str | None = None,
+) -> ApiKeyValidationResult:
+    retry_after = None
+    if state is ApiKeyValidationState.RATE_LIMITED and response is not None:
+        retry_after = response.retry_after_seconds
+    return ApiKeyValidationResult(
+        state=state,
+        stage=stage,
+        retry_after_seconds=retry_after,
+        probe_model=probe_model,
+    )
+
+
+def _state_from_error(
+    status: int,
+    embedded: EmbeddedOpenRouterError,
+    stage: ApiKeyValidationStage,
+) -> ApiKeyValidationState:
+    error_type_mapping = {
+        "authentication": (401, ApiKeyValidationState.INVALID),
+        "payment_required": (402, ApiKeyValidationState.NO_QUOTA),
+        "permission_denied": (403, ApiKeyValidationState.PERMISSION_DENIED),
+        "rate_limit_exceeded": (429, ApiKeyValidationState.RATE_LIMITED),
+    }
+    typed_evidence = (
+        error_type_mapping.get(embedded.error_type) if embedded.error_type is not None else None
+    )
+    if typed_evidence is not None:
+        expected_status, typed_state = typed_evidence
+        contradictory = (
+            (embedded.status is not None and embedded.status != expected_status)
+            or (status != 200 and status != expected_status)
+            or (stage is ApiKeyValidationStage.AUTHENTICATION and expected_status == 402)
+        )
+        if contradictory:
+            return ApiKeyValidationState.UNAVAILABLE
+        return typed_state
+    if embedded.error_type is not None:
+        return ApiKeyValidationState.UNAVAILABLE
+    if status != 200 and embedded.status is not None and embedded.status != status:
+        return ApiKeyValidationState.UNAVAILABLE
+    resolved_status = embedded.status or status
+    if resolved_status == 401:
+        state = ApiKeyValidationState.INVALID
+    elif resolved_status == 402:
+        state = (
+            ApiKeyValidationState.NO_QUOTA
+            if stage is ApiKeyValidationStage.READINESS
+            else ApiKeyValidationState.UNAVAILABLE
+        )
+    elif resolved_status == 403:
+        state = ApiKeyValidationState.PERMISSION_DENIED
+    elif resolved_status == 429:
+        state = ApiKeyValidationState.RATE_LIMITED
+    elif stage is ApiKeyValidationStage.READINESS and resolved_status in (400, 404):
+        state = ApiKeyValidationState.MISCONFIGURED
+    else:
+        state = ApiKeyValidationState.UNAVAILABLE
+    return state
+
+
+def _classify(
+    response: BoundedJsonResponse,
+    stage: ApiKeyValidationStage,
+    probe_model: str,
+) -> ApiKeyValidationResult:
+    payload = response.payload
+    embedded = find_raw_error(payload) if isinstance(payload, dict) else EmbeddedOpenRouterError()
+    if response.status_code == 200 and not embedded.found:
+        if not isinstance(payload, dict):
+            success = False
+        elif stage is ApiKeyValidationStage.AUTHENTICATION:
+            success = isinstance(payload.get("data"), dict)
+        else:
+            choices = payload.get("choices")
+            success = isinstance(choices, list) and bool(choices)
+        return _result(
+            ApiKeyValidationState.VALID if success else ApiKeyValidationState.UNAVAILABLE,
+            stage,
+            probe_model=probe_model,
+        )
+
+    state = _state_from_error(response.status_code, embedded, stage)
+    return _result(state, stage, response=response, probe_model=probe_model)
+
+
+def _effective_model(settings: OpenRouterPluginSettings) -> tuple[str, str] | None:
+    selected = settings.validation_model
+    explicitly_set = "validation_model" in settings.model_fields_set
+    # WHY: the hidden free router is the built-in readiness probe, not an advertised model seed.
+    if (
+        explicitly_set
+        and selected != _INTERNAL_DEFAULT_MODEL
+        and selected not in settings.default_models
+    ):
+        return None
+    if not selected.startswith(GATEWAY_MODEL_PREFIX):
+        return None
+    upstream = selected[len(GATEWAY_MODEL_PREFIX) :]
+    if not is_valid_upstream_model_id(upstream):
+        return None
+    return selected, upstream
+
+
+class OpenRouterApiKeyValidator:
+    def __init__(
+        self,
+        *,
+        settings: OpenRouterPluginSettings,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._settings = settings
+        self._transport = transport
+
+    async def validate(self, api_key: str) -> ApiKeyValidationResult:
+        model = _effective_model(self._settings)
+        if model is None:
+            return _result(ApiKeyValidationState.MISCONFIGURED, None)
+        probe_model, upstream_model = model
+        headers = {"Authorization": f"Bearer {api_key}"}
+
+        async with ValidationHttpSession(transport=self._transport) as session:
+            try:
+                auth_response = await session.request_json(
+                    "GET",
+                    f"{_API_BASE}/key",
+                    headers=headers,
+                )
+            except ApiKeyValidationTransportError:
+                return _result(
+                    ApiKeyValidationState.UNAVAILABLE,
+                    ApiKeyValidationStage.AUTHENTICATION,
+                    probe_model=probe_model,
+                )
+            auth_result = _classify(
+                auth_response,
+                ApiKeyValidationStage.AUTHENTICATION,
+                probe_model,
+            )
+            if auth_result.state is not ApiKeyValidationState.VALID:
+                return auth_result
+
+            try:
+                readiness_response = await session.request_json(
+                    "POST",
+                    f"{_API_BASE}/chat/completions",
+                    headers=headers,
+                    json_body={
+                        "model": upstream_model,
+                        "max_tokens": 1,
+                        "stream": False,
+                        "messages": [{"role": "user", "content": "ping"}],
+                    },
+                )
+            except ApiKeyValidationTransportError:
+                return _result(
+                    ApiKeyValidationState.UNAVAILABLE,
+                    ApiKeyValidationStage.READINESS,
+                    probe_model=probe_model,
+                )
+            return _classify(
+                readiness_response,
+                ApiKeyValidationStage.READINESS,
+                probe_model,
+            )

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/api_key_validation.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/api_key_validation.py
@@ -18,6 +18,38 @@ from .settings import GATEWAY_MODEL_PREFIX, OpenRouterPluginSettings, is_valid_u
 
 _API_BASE = "https://openrouter.ai/api/v1"
 _INTERNAL_DEFAULT_MODEL = "openrouter/openrouter/free"
+# WHY (OME-307 M-2): every OpenRouter typed error is only trustworthy when it rides on the HTTP
+# status it implies, so each maps to (expected_status, actionable_state) and is honoured ONLY when
+# the status evidence agrees (see _typed_error_evidence + _state_from_error). authentication /
+# payment_required / permission_denied / rate_limit_exceeded are valid at any stage; not_found /
+# invalid_request indict the readiness PROBE MODEL (gateway-controlled, not the key) and so map to
+# MISCONFIGURED, but ONLY on the readiness stage.
+_TYPED_ERROR_EVIDENCE: dict[str, tuple[int, ApiKeyValidationState]] = {
+    "authentication": (401, ApiKeyValidationState.INVALID),
+    "payment_required": (402, ApiKeyValidationState.NO_QUOTA),
+    "permission_denied": (403, ApiKeyValidationState.PERMISSION_DENIED),
+    "rate_limit_exceeded": (429, ApiKeyValidationState.RATE_LIMITED),
+}
+_READINESS_TYPED_ERROR_EVIDENCE: dict[str, tuple[int, ApiKeyValidationState]] = {
+    "not_found": (404, ApiKeyValidationState.MISCONFIGURED),
+    "invalid_request": (400, ApiKeyValidationState.MISCONFIGURED),
+}
+
+
+def _typed_error_evidence(
+    error_type: str | None,
+    stage: ApiKeyValidationStage,
+) -> tuple[int, ApiKeyValidationState] | None:
+    if error_type is None:
+        return None
+    evidence = _TYPED_ERROR_EVIDENCE.get(error_type)
+    if evidence is not None:
+        return evidence
+    # INVARIANT (OME-307 M-2): not_found/invalid_request are actionable ONLY on the readiness probe;
+    # at the authentication stage they stay non-actionable and fall through to UNAVAILABLE.
+    if stage is ApiKeyValidationStage.READINESS:
+        return _READINESS_TYPED_ERROR_EVIDENCE.get(error_type)
+    return None
 
 
 def _result(
@@ -43,17 +75,13 @@ def _state_from_error(
     embedded: EmbeddedOpenRouterError,
     stage: ApiKeyValidationStage,
 ) -> ApiKeyValidationState:
-    error_type_mapping = {
-        "authentication": (401, ApiKeyValidationState.INVALID),
-        "payment_required": (402, ApiKeyValidationState.NO_QUOTA),
-        "permission_denied": (403, ApiKeyValidationState.PERMISSION_DENIED),
-        "rate_limit_exceeded": (429, ApiKeyValidationState.RATE_LIMITED),
-    }
-    typed_evidence = (
-        error_type_mapping.get(embedded.error_type) if embedded.error_type is not None else None
-    )
+    typed_evidence = _typed_error_evidence(embedded.error_type, stage)
     if typed_evidence is not None:
         expected_status, typed_state = typed_evidence
+        # INVARIANT (OME-307 M-2): honour the typed state ONLY when the HTTP evidence agrees. The
+        # outer status must be 200 (embedded-only error) or the expected status; the embedded
+        # status, when present, must equal the expected status. Any contradiction is treated as an
+        # upstream fault -> UNAVAILABLE (conservative), never an actionable state on bad evidence.
         contradictory = (
             (embedded.status is not None and embedded.status != expected_status)
             or (status != 200 and status != expected_status)

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/plugin.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, Any, cast
 from fastapi import HTTPException
 
 from aigateway.core.api_key_strategy import ApiKeyStrategy
-from aigateway.core.http_status import valid_http_error_status
+from aigateway.core.api_key_validation import ApiKeyValidator
 from aigateway.core.plugin_base import (
     CredentialStrategy,
     ModelEntry,
@@ -35,7 +35,17 @@ from aigateway.core.plugin_base import (
 )
 from aigateway.core.provider_errors import NonRetryableProviderError
 
+from .api_key_validation import OpenRouterApiKeyValidator
 from .provenance import converter_error_status, is_http200_body_error
+from .response_errors import (
+    _embedded_error_status as _embedded_error_status,
+)
+from .response_errors import (
+    _find_embedded_error,
+)
+from .response_errors import (
+    _top_level_error_is_meaningful as _top_level_error_is_meaningful,
+)
 from .settings import (
     GATEWAY_MODEL_PREFIX,
     OpenRouterPluginSettings,
@@ -190,92 +200,6 @@ def _strip_openrouter_litellm_controls(body: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
-def _embedded_error_status(error: Any) -> int | None:
-    """Extract a numeric HTTP status from an embedded error object, else None.
-
-    # WHY (blocker E): uses the shared strict validator so a string/Unicode/
-    # float/bool ``code`` on the returned-payload scanner path degrades to 502
-    # exactly like it does on the converter-raise and transport paths.
-    """
-    if not isinstance(error, dict):
-        return None
-    for key in ("status", "status_code", "code"):
-        status = valid_http_error_status(error.get(key))
-        if status is not None:
-            return status
-    return None
-
-
-def _top_level_error_is_meaningful(error: Any) -> bool:
-    """Gate for the top-level ``error`` scan (OME-428 CODE-1).
-
-    # WHY: litellm's converter deliberately passes benign top-level error
-    # shapes through as valid 200 responses ("some OpenAI-compatible providers
-    # return empty error objects even on success"); flagging those discards a
-    # paid completion as a 502.
-    # INVARIANT: supersets litellm convert_dict_to_response.py:496-509
-    # (1.87.0) — fires on every shape litellm raises on, PLUS status-keyed
-    # shapes litellm passes through, so an embedded status can never render
-    # as success. Pinned by test_litellm_top_level_error_contract.py.
-    """
-    if error is None:
-        return False
-    if isinstance(error, dict):
-        return (
-            bool(error.get("message", ""))
-            or error.get("code") is not None
-            or error.get("status") is not None
-            or error.get("status_code") is not None
-        )
-    if isinstance(error, str):
-        return bool(error)
-    # Non-dict/non-str non-None: litellm :507-509 treats it as unconditionally
-    # meaningful — bool(error) would diverge on 0/False/[].
-    return True
-
-
-def _find_embedded_error(payload: dict[str, Any]) -> tuple[bool, int | None]:
-    """Detect OpenRouter errors embedded in a nominal HTTP-200 body (D9).
-
-    Inspects the top-level ``error``, each choice's ``error``, and LiteLLM's
-    ``provider_specific_fields`` (``error`` / ``native_finish_reason`` — 1.87.0
-    maps the native reason "error" to "stop", which would otherwise render as
-    success). Returns (found, first numeric 4xx/5xx status or None).
-    """
-    found = False
-    status: int | None = None
-
-    def _inspect(error: Any) -> None:
-        nonlocal found, status
-        if error is None:
-            return
-        found = True
-        if status is None:
-            status = _embedded_error_status(error)
-
-    # CODE-1: only a meaningful top-level error counts; benign shapes on a
-    # billed 200 pass through. The choice/message-level branches below stay
-    # ungated — litellm relocates those without any benign-shape guard.
-    top_level_error = payload.get("error")
-    if _top_level_error_is_meaningful(top_level_error):
-        _inspect(top_level_error)
-    choices = payload.get("choices")
-    for choice in choices if isinstance(choices, list) else []:
-        if not isinstance(choice, dict):
-            continue
-        _inspect(choice.get("error"))
-        for holder in (choice, choice.get("message")):
-            if not isinstance(holder, dict):
-                continue
-            fields = holder.get("provider_specific_fields")
-            if not isinstance(fields, dict):
-                continue
-            _inspect(fields.get("error"))
-            if fields.get("native_finish_reason") == "error":
-                found = True
-    return found, status
-
-
 def _embedded_error_exception(status: int | None) -> HTTPException:
     """Sanitized gateway error for an embedded provider failure.
 
@@ -343,6 +267,11 @@ class OpenRouterProviderPlugin(ProviderPluginBase[OpenRouterPluginSettings]):
             header_builder=lambda api_key: {"Authorization": f"Bearer {api_key}"},
             credential_store=credential_store,
         )
+
+    def api_key_validator(self) -> ApiKeyValidator | None:
+        if not self.settings.enabled:
+            return None
+        return OpenRouterApiKeyValidator(settings=self.settings)
 
     def should_mark_profile_error_on_dispatch_status(self, status_code: int) -> bool:
         # D9: only 401 proves the stored key is bad. 402 (credits), 403

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/response_errors.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/response_errors.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from aigateway.core.http_status import valid_http_error_status
+
+_ERROR_TYPES = frozenset(
+    {
+        "authentication",
+        "permission_denied",
+        "payment_required",
+        "rate_limit_exceeded",
+        "provider_overloaded",
+        "provider_unavailable",
+        "invalid_request",
+        "not_found",
+        "server",
+        "timeout",
+        "unmapped",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class EmbeddedOpenRouterError:
+    found: bool = False
+    status: int | None = None
+    error_type: str | None = None
+
+
+def _embedded_error_status(error: Any) -> int | None:
+    if not isinstance(error, dict):
+        return None
+    for key in ("status", "status_code", "code"):
+        status = valid_http_error_status(error.get(key))
+        if status is not None:
+            return status
+    return None
+
+
+def _top_level_error_is_meaningful(error: Any) -> bool:
+    """Match LiteLLM's benign top-level error exception without weakening status checks."""
+    if error is None:
+        return False
+    if isinstance(error, dict):
+        return (
+            bool(error.get("message", ""))
+            or error.get("code") is not None
+            or error.get("status") is not None
+            or error.get("status_code") is not None
+        )
+    if isinstance(error, str):
+        return bool(error)
+    return True
+
+
+def _error_type(error: Any) -> str | None:
+    metadata = error.get("metadata") if isinstance(error, dict) else None
+    value = metadata.get("error_type") if isinstance(metadata, dict) else None
+    return value if isinstance(value, str) and value in _ERROR_TYPES else None
+
+
+def _with_error(current: EmbeddedOpenRouterError, error: Any) -> EmbeddedOpenRouterError:
+    return EmbeddedOpenRouterError(
+        found=True,
+        status=current.status if current.status is not None else _embedded_error_status(error),
+        error_type=current.error_type if current.error_type is not None else _error_type(error),
+    )
+
+
+def _with_first_raw_error(
+    current: EmbeddedOpenRouterError,
+    error: Any,
+) -> EmbeddedOpenRouterError:
+    if current.found:
+        return current
+    return EmbeddedOpenRouterError(
+        found=True,
+        status=_embedded_error_status(error),
+        error_type=_error_type(error),
+    )
+
+
+def find_converted_error(payload: dict[str, Any]) -> EmbeddedOpenRouterError:
+    """Inspect the LiteLLM-converted response shape used by normal chat dispatch."""
+    result = EmbeddedOpenRouterError()
+    top_level_error = payload.get("error")
+    if _top_level_error_is_meaningful(top_level_error):
+        result = _with_error(result, top_level_error)
+
+    choices = payload.get("choices")
+    for choice in choices if isinstance(choices, list) else []:
+        if not isinstance(choice, dict):
+            continue
+        if choice.get("error") is not None:
+            result = _with_error(result, choice.get("error"))
+        for holder in (choice, choice.get("message")):
+            if not isinstance(holder, dict):
+                continue
+            fields = holder.get("provider_specific_fields")
+            if not isinstance(fields, dict):
+                continue
+            if fields.get("error") is not None:
+                result = _with_error(result, fields.get("error"))
+            if fields.get("native_finish_reason") == "error":
+                result = EmbeddedOpenRouterError(
+                    found=True,
+                    status=result.status,
+                    error_type=result.error_type,
+                )
+    return result
+
+
+def find_raw_error(payload: dict[str, Any]) -> EmbeddedOpenRouterError:
+    """Inspect direct OpenRouter HTTP JSON before LiteLLM conversion."""
+    result = EmbeddedOpenRouterError()
+    top_level_error = payload.get("error")
+    if _top_level_error_is_meaningful(top_level_error):
+        result = _with_first_raw_error(result, top_level_error)
+
+    choices = payload.get("choices")
+    for choice in choices if isinstance(choices, list) else []:
+        if not isinstance(choice, dict):
+            continue
+        if choice.get("error") is not None:
+            result = _with_first_raw_error(result, choice.get("error"))
+        if choice.get("finish_reason") == "error":
+            result = EmbeddedOpenRouterError(
+                found=True,
+                status=result.status,
+                error_type=result.error_type,
+            )
+    return result
+
+
+def _find_embedded_error(payload: dict[str, Any]) -> tuple[bool, int | None]:
+    """Compatibility shape retained for existing OpenRouter chat handling."""
+    result = find_converted_error(payload)
+    return result.found, result.status

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/settings.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/settings.py
@@ -83,6 +83,7 @@ class OpenRouterPluginSettings(PluginSettings):
     # never a provider branch in the loader/registry).
     enabled: bool = False
     default_models: list[str] = Field(default_factory=_default_model_slugs)
+    validation_model: str = "openrouter/openrouter/free"
 
     @field_validator("default_models")
     @classmethod

--- a/apps/aigateway/src/aigateway/routes/api_key_validation.py
+++ b/apps/aigateway/src/aigateway/routes/api_key_validation.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import SecretStr
+
+from aigateway.core.api_key_validation import (
+    ApiKeyValidationResult,
+    ApiKeyValidationState,
+    api_key_validation_message,
+)
+from aigateway.core.auth.middleware import CurrentAccount
+from aigateway.core.oauth.schemas import ApiKeyValidationResponse, ValidateApiKeyRequest
+
+router = APIRouter()
+
+_MUTATION_ERRORS = {
+    ApiKeyValidationState.INVALID: (422, "api_key_invalid"),
+    ApiKeyValidationState.EXPIRED: (422, "api_key_expired"),
+    ApiKeyValidationState.NO_QUOTA: (402, "api_key_no_quota"),
+    ApiKeyValidationState.PERMISSION_DENIED: (403, "api_key_permission_denied"),
+    ApiKeyValidationState.RATE_LIMITED: (429, "api_key_validation_rate_limited"),
+    ApiKeyValidationState.UNAVAILABLE: (503, "api_key_validation_unavailable"),
+    ApiKeyValidationState.MISCONFIGURED: (503, "api_key_validation_misconfigured"),
+}
+
+
+def normalize_api_key(raw_key: SecretStr) -> str:
+    api_key = raw_key.get_secret_value().strip()
+    if len(api_key) < 8:
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "invalid_api_key", "message": "api_key is missing or too short"},
+        )
+    return api_key
+
+
+def api_key_validation_response(
+    provider: str,
+    result: ApiKeyValidationResult,
+) -> ApiKeyValidationResponse:
+    return ApiKeyValidationResponse(
+        provider=provider,
+        state=result.state,
+        message=api_key_validation_message(result.state),
+        retryable=result.retryable,
+        stage=result.stage,
+        retry_after_seconds=result.retry_after_seconds,
+        probe_model=result.probe_model,
+    )
+
+
+def _unsupported(provider: str) -> HTTPException:
+    return HTTPException(
+        status_code=400,
+        detail={"code": "api_key_not_supported", "provider": provider},
+    )
+
+
+async def run_api_key_validation(
+    request: Request,
+    plugin,
+    provider: str,
+    api_key: str,
+) -> ApiKeyValidationResult:
+    result = await request.app.state.api_key_validation_service.validate(
+        plugin,
+        provider,
+        api_key,
+    )
+    if result is None:
+        raise _unsupported(provider)
+    return result
+
+
+async def require_valid_api_key(
+    request: Request,
+    plugin,
+    provider: str,
+    api_key: str,
+) -> None:
+    result = await run_api_key_validation(request, plugin, provider, api_key)
+    if result.state is ApiKeyValidationState.VALID:
+        return
+    status_code, code = _MUTATION_ERRORS[result.state]
+    detail = {
+        "code": code,
+        "provider": provider,
+        "state": result.state,
+        "message": api_key_validation_message(result.state),
+        "retryable": result.retryable,
+        "stage": result.stage,
+        "retry_after_seconds": result.retry_after_seconds,
+        "probe_model": result.probe_model,
+    }
+    headers = None
+    if result.retry_after_seconds is not None and result.retry_after_seconds > 0:
+        headers = {"Retry-After": str(result.retry_after_seconds)}
+    raise HTTPException(status_code=status_code, detail=detail, headers=headers)
+
+
+@router.post(
+    "/v1/oauth/connections/api-key/validate",
+    response_model=ApiKeyValidationResponse,
+)
+async def validate_api_key(
+    body: ValidateApiKeyRequest,
+    request: Request,
+    _current: CurrentAccount,
+) -> ApiKeyValidationResponse:
+    """Validate authentication and readiness; the minimal inference may consume quota or credit."""
+    plugin = request.app.state.providers.get(body.provider)
+    if plugin is None:
+        raise HTTPException(
+            status_code=404,
+            detail={"code": "unknown_provider", "provider": body.provider},
+        )
+    api_key = normalize_api_key(body.api_key)
+    result = await run_api_key_validation(request, plugin, body.provider, api_key)
+    return api_key_validation_response(body.provider, result)

--- a/apps/aigateway/src/aigateway/routes/auth.py
+++ b/apps/aigateway/src/aigateway/routes/auth.py
@@ -14,8 +14,9 @@ from uuid import uuid4
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, SecretStr
 from tortoise.exceptions import IntegrityError
+from tortoise.transactions import in_transaction
 
 from ..core.auth.middleware import CurrentAccount
 from ..core.credential_blob.store import CredentialBlobMutationConflict
@@ -33,7 +34,7 @@ from ..core.plugin_base import (
     credential_service_provider_for,
     credential_strategy_from,
 )
-from ..core.profile_index import ProfileIndexStore
+from ..core.profile_index import ProfileIndexStore, ProfileTransitionConflict
 from ..core.profile_models import (
     AuthType,
     Profile,
@@ -42,6 +43,7 @@ from ..core.profile_models import (
     credential_name_for,
     profile_id_for,
 )
+from .api_key_validation import normalize_api_key, require_valid_api_key
 from .credential_persistence import (
     SupportsCredentialPersistence,
     SupportsCredentialSlot,
@@ -514,38 +516,15 @@ async def start_oauth(
     profile_id = profile_id_for(account_id, provider, body.name)
     code_verifier, code_challenge = generate_pkce()
     state = generate_state()
+
+    # Bind the redirect (for loopback, a listener keyed by ``state``) BEFORE superseding any
+    # older flow for this profile: a redirect-setup failure must leave the previous flow
+    # untouched rather than destroy it for a flow that never started (OME-307 Blocker 5).
     redirect_uri: str | None = None
     if body.redirect_uri is not None:
         redirect_uri = await _redirect_uri_for(request, provider, cfg, state, body.redirect_uri)
-    for stale_state in _pending(request).pop_for_profile(account_id, provider, body.name):
-        await _close_loopback_callback(request.app, stale_state)
     if redirect_uri is None:
         redirect_uri = await _redirect_uri_for(request, provider, cfg, state)
-
-    _pending(request).put(
-        state,
-        PendingAuthEntry(
-            account_id=account_id,
-            provider=provider,
-            profile_name=body.name,
-            profile_id=profile_id,
-            code_verifier=code_verifier,
-            redirect_uri=redirect_uri,
-        ),
-    )
-
-    params = {
-        "response_type": "code",
-        "client_id": cfg.client_id,
-        "redirect_uri": redirect_uri,
-        "scope": " ".join(cfg.scopes),
-        "code_challenge": code_challenge,
-        "code_challenge_method": "S256",
-        "state": state,
-    }
-    if cfg.extra_authorize_params:
-        params.update(cfg.extra_authorize_params)
-    authorize_url = f"{cfg.authorize_url}?{urlencode(params)}"
 
     # Update the existing profile in place instead of replacing it wholesale:
     # an api_key profile keeps its auth_type/account_label/defaults until the
@@ -564,7 +543,50 @@ async def start_oauth(
     profile.state = ProfileState.PENDING
     if body.defaults is not None:
         profile.defaults = body.defaults
-    await _index_store(request).upsert(profile)
+
+    # INVARIANT (OME-307 Blockers 1 & 5): durably publish THIS flow — its pending profile and a
+    # fresh ownership generation — in one atomic index CAS BEFORE irreversibly superseding any
+    # older flow. On failure, tear down only this flow's own loopback listener and re-raise; the
+    # older flow stays completable and no invisible pending flow is stranded. begin_pending is
+    # what assigns the ownership generation the callback later presents to authenticate_pending.
+    try:
+        generation = await _index_store(request).begin_pending(profile)
+    except Exception:
+        await _close_loopback_callback(request.app, state)
+        raise
+
+    _pending(request).put(
+        state,
+        PendingAuthEntry(
+            account_id=account_id,
+            provider=provider,
+            profile_name=body.name,
+            profile_id=profile_id,
+            code_verifier=code_verifier,
+            redirect_uri=redirect_uri,
+            oauth_generation=generation,
+        ),
+    )
+
+    # Only now that this flow is fully published: supersede older flows for the same profile,
+    # excluding this flow's own freshly-published state (Blocker 5).
+    for stale_state in _pending(request).pop_for_profile(
+        account_id, provider, body.name, exclude_state=state
+    ):
+        await _close_loopback_callback(request.app, stale_state)
+
+    params = {
+        "response_type": "code",
+        "client_id": cfg.client_id,
+        "redirect_uri": redirect_uri,
+        "scope": " ".join(cfg.scopes),
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+    }
+    if cfg.extra_authorize_params:
+        params.update(cfg.extra_authorize_params)
+    authorize_url = f"{cfg.authorize_url}?{urlencode(params)}"
 
     return {
         "profile_id": profile_id,
@@ -696,66 +718,69 @@ async def _complete_oauth_for_app(
     # first await that can race another callback using the same code.
     pending = _pending_or_unknown(pending_table.pop(state))
     try:
-        creds = await _exchange_oauth_code_for_pending(app, plugin, provider, code, state, pending)
-    except NotImplementedError as exc:
-        await _mark_oauth_completion_error(app, pending, "provider_does_not_use_oauth", state)
-        raise HTTPException(
-            status_code=400,
-            detail={"code": "provider_does_not_use_oauth", "provider": provider},
-        ) from exc
-    except Exception:
-        await _mark_oauth_completion_error(app, pending, "OAuth code exchange failed", state)
-        raise
-    profile_credential_slot: tuple[object, str, str, str | None, str | None] | None = None
-    if pending.connection_id is None:
-        # WHY: the credential slot and profile index are separate stores, so OAuth
-        # profile completion must snapshot and compensate around the index write.
-        credential_store = _credential_store_for_app(app)
-        slot = cast(SupportsCredentialSlot, strategy)
-        credential_service = slot.credential_service()
-        credential_account = slot.credential_account()
-        previous_credential = await credential_store.read(credential_service, credential_account)
         try:
-            await persist_credentials_or_503(
-                slot,
-                creds,
-                description="OAuth profile credentials",
+            creds = await _exchange_oauth_code_for_pending(
+                app, plugin, provider, code, state, pending
             )
-        except HTTPException:
-            await _mark_oauth_completion_error(app, pending, "credential_store_unavailable", state)
+        except NotImplementedError as exc:
+            await _mark_oauth_completion_error(app, pending, "provider_does_not_use_oauth", state)
+            raise HTTPException(
+                status_code=400,
+                detail={"code": "provider_does_not_use_oauth", "provider": provider},
+            ) from exc
+        except Exception:
+            await _mark_oauth_completion_error(app, pending, "OAuth code exchange failed", state)
             raise
-        written_credential = await credential_store.read(credential_service, credential_account)
-        profile_credential_slot = (
-            credential_store,
-            credential_service,
-            credential_account,
-            previous_credential,
-            written_credential,
-        )
-        _invalidate_profile_session(app, plugin, pending.account_id, pending.profile_name)
-
-    try:
-        await _mark_profile_authenticated(app, pending, plugin, creds)
-    except Exception:
-        if profile_credential_slot is not None:
-            (
-                credential_store,
-                credential_service,
-                credential_account,
-                previous_credential,
-                written_credential,
-            ) = profile_credential_slot
-            await _restore_credential_slot_after_failure(
-                credential_store,
-                credential_service,
-                credential_account,
-                expected_credential=written_credential,
-                previous_credential=previous_credential,
-                description="OAuth profile",
-            )
+        if pending.connection_id is None:
+            slot = cast(SupportsCredentialSlot, strategy)
+            try:
+                # WHY: token exchange stays outside the transaction; only profile + credential
+                # publication is atomic. The always-present account index row is mutated first,
+                # matching API-key set/delete's lock order; the optional credential row follows.
+                # The generation CAS rejects stale callbacks before they can write credentials.
+                async with in_transaction():
+                    await _mark_profile_authenticated(
+                        app,
+                        pending,
+                        plugin,
+                        creds,
+                        require_pending=True,
+                    )
+                    await persist_credentials_or_503(
+                        slot,
+                        creds,
+                        description="OAuth profile credentials",
+                    )
+            except ProfileTransitionConflict as exc:
+                await _close_loopback_callback(app, state)
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "code": "profile_auth_conflict",
+                        "provider": pending.provider,
+                        "profile": pending.profile_name,
+                    },
+                ) from exc
+            except HTTPException:
+                await _mark_oauth_completion_error(
+                    app, pending, "credential_store_unavailable", state
+                )
+                raise
+            _invalidate_profile_session(app, plugin, pending.account_id, pending.profile_name)
+        else:
+            await _mark_profile_authenticated(app, pending, plugin, creds)
+        await _record_oauth_connection_completion(app, pending, plugin, creds)
+        await _close_loopback_callback(app, state)
+    except asyncio.CancelledError:
+        # INVARIANT (OME-307 Blocker 5): a callback cancellation must never strand the profile
+        # pending. We consumed the state before the first await above; on cancellation the
+        # enclosing transaction (if any) rolls back, and we re-publish the consumed state
+        # SYNCHRONOUSLY so the flow stays completable via retry. Python 3.12
+        # ``asyncio.CancelledError`` is a ``BaseException`` that escapes the ``except Exception``
+        # handlers above; ``put`` is synchronous so it finishes even while the task unwinds.
+        # AIDEV-NOTE: cleanup-then-re-raise — the cancellation is NEVER caught-and-suppressed.
+        pending_table.put(state, pending)
         raise
-    await _record_oauth_connection_completion(app, pending, plugin, creds)
-    await _close_loopback_callback(app, state)
 
 
 def _pending_or_unknown(pending: PendingAuthEntry | None) -> PendingAuthEntry:
@@ -803,27 +828,58 @@ async def _mark_oauth_completion_error(
     connection_message: str,
     state: str,
 ) -> None:
-    await _mark_profile_error(app, pending.account_id, pending.provider, pending.profile_name)
+    # INVARIANT (OME-307 Blocker 2): only a PROFILE flow that claimed an ownership generation
+    # can own a pending profile. Mark its error CONDITIONALLY on that generation so a stale
+    # failure cannot clobber a newer owner, overwrite a committed API-key profile, or resurrect
+    # a deleted profile. Connection flows are handled separately by _mark_connection_error.
+    if pending.connection_id is None and pending.oauth_generation is not None:
+        await _mark_profile_error(app, pending.profile_id, pending.oauth_generation)
     await _mark_connection_error(app, pending, connection_message)
     await _close_loopback_callback(app, state)
 
 
-async def _mark_profile_authenticated(app, pending: PendingAuthEntry, plugin, creds: dict) -> None:
-    profile = await _index_store_for_app(app).get(
+async def _mark_profile_authenticated(
+    app,
+    pending: PendingAuthEntry,
+    plugin,
+    creds: dict,
+    *,
+    require_pending: bool = False,
+) -> None:
+    index = _index_store_for_app(app)
+    profile = await index.get(
         pending.account_id,
         pending.provider,
         pending.profile_name,
     )
     if profile is None:
+        if require_pending:
+            raise ProfileTransitionConflict("profile no longer exists")
         return
+    if require_pending and profile.state is not ProfileState.PENDING:
+        raise ProfileTransitionConflict("profile is no longer pending")
     profile.state = ProfileState.AUTHENTICATED
     # A completed OAuth round-trip overwrites the credential slot, so the
     # discriminator must flip back even if the profile was api_key before.
     profile.auth_type = "oauth"
+    profile.last_refreshed_at = datetime.now(UTC)
     label = plugin.account_label_from_credentials(creds)
     if label is not None:
         profile.account_label = label
-    await _index_store_for_app(app).upsert(profile)
+    if require_pending:
+        # INVARIANT (OME-307 Blocker 1): bind publication to THIS OAuth operation by presenting
+        # the ownership generation this flow claimed at begin_pending. Ownership is decided
+        # INSIDE authenticate_pending's atomic durable CAS — a superseded flow loses even though
+        # the row is still PENDING — closing the check-then-act TOCTOU that a separate in-memory
+        # precheck left open. The state==PENDING guard inside the CAS remains defense in depth
+        # for a newer flow (or API-key write) that has already committed a non-pending state.
+        await index.authenticate_pending(
+            profile,
+            expected_generation=pending.oauth_generation,
+            account_label=label,
+        )
+    else:
+        await index.upsert(profile)
 
 
 def _credential_name_for_pending(pending: PendingAuthEntry) -> str:
@@ -838,7 +894,9 @@ async def _mark_connection_error(app, pending: PendingAuthEntry, message: str) -
     store = OAuthConnectionStore()
     connection = await store.get(pending.account_id, pending.connection_id)
     if connection is not None:
-        await store.mark_error(connection, message)
+        # INVARIANT: only this callback's still-pending connection may transition to ERROR.
+        # A concurrent DELETE or successful activation owns any non-pending row and wins.
+        await store.mark_pending_error(connection, message)
     credential_strategy_cache(app).evict(
         credential_key_for(pending.account_id, pending.connection_id)
     )
@@ -867,61 +925,6 @@ async def _persist_connection_credentials(
     credential_strategy_cache(app).evict(credential_key_for(account_id, connection_id))
 
 
-async def _delete_connection_strategy_credentials(
-    app,
-    plugin,
-    provider: str,
-    account_id: str,
-    connection_id: str,
-) -> None:
-    strategy = _credential_strategy_for_credential_name(
-        app,
-        plugin,
-        provider,
-        credential_key_for(account_id, connection_id),
-    )
-    if strategy is None:
-        return
-    strategy_for_log = cast(SupportsCredentialPersistence, strategy)
-    try:
-        await strategy.delete_credentials()
-    except Exception as exc:
-        # Best-effort compensation: never mask the activation-conflict response.
-        logger.error(
-            "Failed to delete OAuth connection credentials for service %s during compensation: %s",
-            strategy_for_log.credential_service(),
-            type(exc).__name__,
-        )
-
-
-async def _restore_credential_slot_after_failure(
-    credential_store,
-    credential_service: str,
-    credential_account: str,
-    *,
-    expected_credential: str | None,
-    previous_credential: str | None,
-    description: str,
-) -> None:
-    def restore_if_unchanged(current: str | None) -> str | None:
-        # INVARIANT: compensate only our own credential write; a concurrent writer wins.
-        if current != expected_credential:
-            return current
-        return previous_credential
-
-    try:
-        await credential_store.mutate(credential_service, credential_account, restore_if_unchanged)
-    except Exception as compensation_exc:
-        # Double-fault signal: the original error still propagates to the caller.
-        logger.error(
-            "Failed to compensate %s credential slot %s/%s after profile-index failure: %s",
-            description,
-            credential_service,
-            credential_account,
-            type(compensation_exc).__name__,
-        )
-
-
 async def _record_oauth_connection_completion(
     app,
     pending: PendingAuthEntry,
@@ -946,23 +949,28 @@ async def _record_oauth_connection_completion(
 
     connection = await _connection_for_pending(store, pending, plugin, label)
     try:
-        await _persist_connection_credentials(
-            app,
-            plugin,
-            pending.provider,
-            pending.account_id,
-            str(connection.id),
-            creds,
-        )
-        await store.complete(connection, label=label, identity=identity)
+        # INVARIANT: connection lifecycle operations lock the stable connection row before the
+        # optional credential row. The pending-only CAS and credential write commit together, so
+        # a concurrent DELETE wins without credential orphaning or stale-row resurrection.
+        async with in_transaction():
+            activated = await store.complete_pending(connection, label=label, identity=identity)
+            if activated is None:
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "code": "connection_conflict",
+                        "provider": pending.provider,
+                    },
+                )
+            await _persist_connection_credentials(
+                app,
+                plugin,
+                pending.provider,
+                pending.account_id,
+                str(activated.id),
+                creds,
+            )
     except IntegrityError as exc:
-        await _delete_connection_strategy_credentials(
-            app,
-            plugin,
-            pending.provider,
-            pending.account_id,
-            str(connection.id),
-        )
         await store.mark_revoked(connection, "connection_conflict")
         raise HTTPException(
             status_code=409,
@@ -970,17 +978,10 @@ async def _record_oauth_connection_completion(
         ) from exc
     except HTTPException as exc:
         if exc.status_code == 503:
-            await store.mark_error(connection, "credential_store_unavailable")
+            await store.mark_pending_error(connection, "credential_store_unavailable")
         raise
     except Exception as exc:
-        await _delete_connection_strategy_credentials(
-            app,
-            plugin,
-            pending.provider,
-            pending.account_id,
-            str(connection.id),
-        )
-        await store.mark_error(connection, "connection_activation_failed")
+        await store.mark_pending_error(connection, "connection_activation_failed")
         raise HTTPException(
             status_code=503,
             detail={
@@ -1102,11 +1103,17 @@ def _connection_label(pending: PendingAuthEntry, plugin, creds: dict, identity) 
     return pending.compatibility_profile_name or pending.profile_name
 
 
-async def _mark_profile_error(app, account_id: str, provider: str, name: str) -> None:
-    p = await _index_store_for_app(app).get(account_id, provider, name)
-    if p is not None:
-        p.state = ProfileState.ERROR
-        await _index_store_for_app(app).upsert(p)
+async def _mark_profile_error(app, profile_id: str, expected_generation: int) -> None:
+    # INVARIANT (OME-307 Blocker 2): a stale OAuth failure marks ERROR only while it still owns
+    # the pending profile (same generation, still present, still PENDING). If ownership moved
+    # on — newer flow, committed api_key, or delete — mark_pending_error raises and we do
+    # nothing rather than corrupt the newer state or recreate a deleted profile.
+    try:
+        await _index_store_for_app(app).mark_pending_error(
+            profile_id, expected_generation=expected_generation
+        )
+    except ProfileTransitionConflict:
+        pass
 
 
 async def _generic_callback(provider: str, code: str, state: str, request: Request):
@@ -1168,16 +1175,24 @@ async def patch_profile(
     p = await idx.get(str(current.id), provider, name)
     if p is None:
         raise HTTPException(status_code=404, detail={"code": "profile_not_found"})
-    if body.defaults is not None:
-        p.defaults = body.defaults
-    if body.account_label is not None:
-        p.account_label = body.account_label
-    await idx.upsert(p)
+    try:
+        p = await idx.update_metadata(
+            p.id,
+            defaults=body.defaults,
+            account_label=body.account_label,
+        )
+    except ProfileTransitionConflict as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "profile_conflict", "provider": provider, "profile": name},
+        ) from exc
     return p.model_dump(mode="json")
 
 
 class SetApiKeyRequest(BaseModel):
-    api_key: str
+    model_config = ConfigDict(hide_input_in_errors=True)
+
+    api_key: SecretStr
     defaults: ProfileDefaults | None = None
 
 
@@ -1203,12 +1218,7 @@ async def set_profile_api_key(
         raise HTTPException(
             status_code=404, detail={"code": "unknown_provider", "provider": provider}
         )
-    api_key = body.api_key.strip()
-    if len(api_key) < 8:
-        raise HTTPException(
-            status_code=400,
-            detail={"code": "invalid_api_key", "message": "api_key is missing or too short"},
-        )
+    api_key = normalize_api_key(body.api_key)
     account_id = str(current.id)
     strategy = _credential_strategy_for_app(
         request.app, plugin, provider, account_id, name, auth_type="api_key"
@@ -1219,14 +1229,13 @@ async def set_profile_api_key(
             detail={"code": "api_key_not_supported", "provider": provider},
         )
 
-    # Cancel any in-flight OAuth flow for this profile: a late callback
-    # (pending TTL is 600s) would otherwise silently overwrite the key we are
-    # about to store (SF-244 audit F10). Mirrors start_oauth's stale cleanup.
-    for stale_state in _pending(request).pop_for_profile(account_id, provider, name):
-        await _close_loopback_callback(request.app, stale_state)
+    await require_valid_api_key(request, plugin, provider, api_key)
 
     idx = _index_store(request)
     profile = await idx.get(account_id, provider, name)
+    # INVARIANT (OME-307 Unit 3): if we observed an existing profile, publication must not
+    # resurrect it should a concurrent delete remove it before we commit (delete wins).
+    profile_observed = profile is not None
     if profile is None:
         profile = Profile(
             id=profile_id_for(account_id, provider, name),
@@ -1242,29 +1251,53 @@ async def set_profile_api_key(
     profile.account_label = f"API key ····{api_key[-4:]}"
     profile.scopes = []  # OAuth scopes are meaningless for API-key auth (F24)
 
-    credential_store = _credential_store_for_app(request.app)
     strategy_for_slot = cast(SupportsCredentialSlot, strategy)
-    credential_service = strategy_for_slot.credential_service()
-    credential_account = strategy_for_slot.credential_account()
-    previous_credential = await credential_store.read(credential_service, credential_account)
-    await persist_credentials_or_503(
-        strategy_for_slot,
-        {"auth_type": "api_key", "api_key": api_key},
-        description="API-key credentials",
-    )
-    written_credential = await credential_store.read(credential_service, credential_account)
+    # WHY: the credential blob and profile index share the Tortoise connection; publish both
+    # in one short transaction so readers never observe a committed mixed auth type.
+    # INVARIANT (OME-307 Blocker 3): the index-row CAS runs FIRST, the credential write SECOND —
+    # ONE consistent lock order shared with delete_profile. The account index row is the sole
+    # ALWAYS-PRESENT row, so it is the only row that serializes a concurrent delete; the
+    # credential row may be absent, and a missing-row operation takes no lock under READ
+    # COMMITTED. Publishing the index first means a racing delete that removed the profile makes
+    # require_present raise BEFORE any credential is written, so nothing is orphaned or resurrected.
+    # INVARIANT (OME-307 Blocker 4): transaction rollback is the SOLE atomicity mechanism here.
+    # ORMStore writes through the transaction's connection, so a failed OR cancelled publication
+    # (including a 3.12 CancelledError, a BaseException) rolls back BOTH the index upsert and the
+    # credential write. There is deliberately NO out-of-transaction compensation: a second,
+    # post-rollback credential mutate is redundant with rollback AND could race a concurrent
+    # writer that legitimately owns the slot (an ABA clobber). Any exception other than the
+    # delete-wins conflict propagates unchanged so the enclosing txn rolls back and re-raises.
     try:
-        await idx.upsert(profile)
-    except Exception:
-        await _restore_credential_slot_after_failure(
-            credential_store,
-            credential_service,
-            credential_account,
-            expected_credential=written_credential,
-            previous_credential=previous_credential,
-            description="API-key",
-        )
-        raise
+        async with in_transaction():
+            # INVARIANT (OME-307 Unit 3): an observed-existing profile publishes conditionally
+            # so a concurrent delete WINS (no resurrection); a first-time key stays an
+            # unconditional create. Splitting the call keeps `upsert(profile)` — the create
+            # contract — untouched for the common path.
+            if profile_observed:
+                await idx.upsert(profile, require_present=True)
+            else:
+                await idx.upsert(profile)
+            await persist_credentials_or_503(
+                strategy_for_slot,
+                {"auth_type": "api_key", "api_key": api_key},
+                description="API-key credentials",
+            )
+    except ProfileTransitionConflict as exc:
+        # A concurrent delete removed the profile we were updating: delete wins, so the
+        # rolled-back publication surfaces as a retryable conflict rather than a 500.
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "profile_conflict", "provider": provider, "profile": name},
+        ) from exc
+    # INVARIANT (OME-307 Unit 5): only after the API-key publication COMMITS do we
+    # irreversibly cancel any in-flight OAuth flow for this profile. A late OAuth callback is
+    # already rejected by authenticate_pending's pending-state CAS (it rolls back and returns
+    # 409), so this pop is cleanup, not correctness. Deferring it past the commit means a
+    # failed or cancelled publication above (including a 3.12 CancelledError, a BaseException)
+    # leaves the older OAuth flow usable and orphans no credential. Closing loopback listeners
+    # is network I/O and stays outside the transaction (SF-244 audit F10 stale cleanup).
+    for stale_state in _pending(request).pop_for_profile(account_id, provider, name):
+        await _close_loopback_callback(request.app, stale_state)
     _invalidate_profile_session(request.app, plugin, account_id, name)
     return profile.model_dump(mode="json")
 
@@ -1275,16 +1308,27 @@ async def delete_profile(provider: str, name: str, request: Request, current: Cu
     if plugin is None:
         raise HTTPException(status_code=404, detail={"code": "unknown_provider"})
     account_id = str(current.id)
-    p = await _index_store(request).get(account_id, provider, name)
+    idx = _index_store(request)
+    p = await idx.get(account_id, provider, name)
     if p is None:
         raise HTTPException(status_code=404, detail={"code": "profile_not_found"})
     strategy = _credential_strategy_for_app(
         request.app, plugin, provider, account_id, name, auth_type=p.auth_type
     )
-    if strategy is not None:
-        await strategy.delete_credentials()
+    # INVARIANT (OME-307 Unit 3 + Blocker 3): publish the profile-index removal and the
+    # credential deletion in ONE transaction so a committed delete never leaves an orphan
+    # credential (a blob with no profile). The index-row CAS runs FIRST: it is the sole
+    # ALWAYS-PRESENT row, so it is the only row that serializes a concurrent api-key set. The
+    # credential row may be ABSENT (e.g. a pending/errored OAuth profile), and a missing-row
+    # DELETE takes NO lock under READ COMMITTED — so serializing on it would let a racing set
+    # slip an INSERT past this delete and orphan a credential. Rollback keeps blob + index
+    # coherent on any failure.
+    async with in_transaction():
+        await idx.remove(p.id)
+        if strategy is not None:
+            await strategy.delete_credentials()
+    # Cache invalidation follows the durable boundary so it reflects the committed delete.
     _invalidate_profile_session(request.app, plugin, account_id, name)
-    await _index_store(request).remove(p.id)
 
 
 @router.post("/v1/auth/{provider}/profiles/{name}/refresh")

--- a/apps/aigateway/src/aigateway/routes/auth.py
+++ b/apps/aigateway/src/aigateway/routes/auth.py
@@ -134,11 +134,30 @@ async def _profile_refresh_lifecycle(
     name: str,
 ) -> AsyncIterator[None]:
     """Shared profile state updates around provider-owned credential refresh."""
+    # INVARIANT (OME-307 H-1): a manual refresh reads the profile, runs the provider network call,
+    # then publishes the result. A delete that commits during that network window must WIN — a
+    # deleted profile is never resurrected. The success branch publishes only while the profile
+    # remains PRESENT (require_present); the error branch additionally fences on the snapshot below
+    # (auth_type + last_refreshed_at) so a deleted/superseded profile is not recreated as a ghost
+    # ERROR row. SCOPE (guard-now): require_present is presence-only, so a concurrent
+    # re-authentication that keeps the profile present is NOT fenced out on the success path — the
+    # stronger prepare-then-publish ownership split is deferred, outside this DELETE scope.
+    expected_auth_type = profile.auth_type
+    expected_last_refreshed_at = profile.last_refreshed_at
     try:
         yield
     except (CredentialNotFoundError, AuthError) as exc:
-        profile.state = ProfileState.ERROR
-        await _index_store(request).upsert(profile)
+        # Error branch: fence on ownership and swallow a lost race (mirrors
+        # chat_credentials._mark_profile_error_fresh) so a profile deleted or superseded during the
+        # network window is never recreated as a ghost ERROR row.
+        try:
+            await _index_store(request).mark_authenticated_error(
+                profile.id,
+                expected_auth_type=expected_auth_type,
+                expected_last_refreshed_at=expected_last_refreshed_at,
+            )
+        except ProfileTransitionConflict:
+            pass
         _invalidate_profile_session(request.app, plugin, account_id, name)
         raise HTTPException(
             status_code=401,
@@ -149,9 +168,19 @@ async def _profile_refresh_lifecycle(
             },
         ) from exc
     else:
+        # Success branch: publish only while the profile still exists (require_present). A profile
+        # deleted during the network window makes this raise -> 409 instead of resurrecting it as
+        # an AUTHENTICATED row.
         profile.state = ProfileState.AUTHENTICATED
         profile.last_refreshed_at = datetime.now(UTC)
-        await _index_store(request).upsert(profile)
+        try:
+            await _index_store(request).upsert(profile, require_present=True)
+        except ProfileTransitionConflict as exc:
+            _invalidate_profile_session(request.app, plugin, account_id, name)
+            raise HTTPException(
+                status_code=409,
+                detail={"code": "profile_conflict", "provider": provider, "profile": name},
+            ) from exc
         _invalidate_profile_session(request.app, plugin, account_id, name)
 
 

--- a/apps/aigateway/src/aigateway/routes/chat_credentials.py
+++ b/apps/aigateway/src/aigateway/routes/chat_credentials.py
@@ -17,7 +17,7 @@ from ..core.errors import AuthError, CredentialNotFoundError
 from ..core.oauth.models import OAuthConnection
 from ..core.oauth.store import OAuthConnectionStore, credential_key_for
 from ..core.plugin_base import credential_strategy_from
-from ..core.profile_index import ProfileIndexStore
+from ..core.profile_index import ProfileIndexStore, ProfileTransitionConflict
 from ..core.profile_models import (
     AuthType,
     Profile,
@@ -222,18 +222,18 @@ def _reauth_url_for(
 async def _mark_profile_error_fresh(
     request: Request,
     *,
-    account_id: str,
-    provider: str,
-    profile_name: str,
+    profile: Profile,
 ) -> None:
-    """Re-fetch the profile before flipping state so a long-running dispatch
-    never clobbers concurrent index writes (e.g. a PUT api-key changing
-    auth_type/account_label mid-flight) with its stale snapshot."""
+    """Mark only the authenticated credential version used by this request."""
     idx: ProfileIndexStore = request.app.state.profile_index
-    fresh = await idx.get(account_id, provider, profile_name)
-    if fresh is not None:
-        fresh.state = ProfileState.ERROR
-        await idx.upsert(fresh)
+    try:
+        await idx.mark_authenticated_error(
+            profile.id,
+            expected_auth_type=profile.auth_type,
+            expected_last_refreshed_at=profile.last_refreshed_at,
+        )
+    except ProfileTransitionConflict:
+        pass
 
 
 def _apply_defaults(body: dict[str, Any], defaults: ProfileDefaults, plugin: Any) -> dict[str, Any]:
@@ -320,9 +320,7 @@ async def _inject_credentials(
             elif profile is not None:
                 await _mark_profile_error_fresh(
                     request,
-                    account_id=account_id,
-                    provider=provider,
-                    profile_name=profile_name,
+                    profile=profile,
                 )
                 if credential_name is not None:
                     _invalidate_profile_session(plugin, credential_name)

--- a/apps/aigateway/src/aigateway/routes/chat_dispatch.py
+++ b/apps/aigateway/src/aigateway/routes/chat_dispatch.py
@@ -83,9 +83,7 @@ async def _dispatch_failure_response(
         return exc
     if profile is None:
         return exc
-    await _mark_profile_error_fresh(
-        request, account_id=account_id, provider=provider, profile_name=profile_name
-    )
+    await _mark_profile_error_fresh(request, profile=profile)
     if credential_name is not None:
         _invalidate_profile_session(plugin, credential_name)
     return HTTPException(

--- a/apps/aigateway/src/aigateway/routes/oauth_connections.py
+++ b/apps/aigateway/src/aigateway/routes/oauth_connections.py
@@ -458,12 +458,17 @@ async def refresh_connection(
     # Manual refresh wrote new tokens to the store; drop the cached instance so the
     # chat path rebuilds and reads them (SF-282).
     credential_strategy_cache(request.app).evict(credential_name)
-    connection = await store.complete(
+    # INVARIANT (OME-307 H-1): republish CONDITIONALLY on the still-active row. A delete or revoke
+    # that raced this refresh's network window wins — complete_active updates zero rows and returns
+    # None, and we 409 instead of flipping a revoked/deleted connection back to active.
+    refreshed = await store.complete_active(
         connection,
         label=connection.label,
         identity=response_from_connection(connection).account,
     )
-    return response_from_connection(connection)
+    if refreshed is None:
+        raise HTTPException(status_code=409, detail={"code": "connection_conflict"})
+    return response_from_connection(refreshed)
 
 
 def _store(request: Request) -> OAuthConnectionStore:

--- a/apps/aigateway/src/aigateway/routes/oauth_connections.py
+++ b/apps/aigateway/src/aigateway/routes/oauth_connections.py
@@ -6,6 +6,7 @@ from uuid import UUID, uuid4
 
 from fastapi import APIRouter, HTTPException, Request
 from tortoise.exceptions import IntegrityError
+from tortoise.transactions import in_transaction
 
 from aigateway.core.auth.middleware import CurrentAccount
 from aigateway.core.credential_strategy_cache import credential_strategy_cache
@@ -33,6 +34,7 @@ from aigateway.core.oauth_pkce import generate_pkce, generate_state
 from aigateway.core.pending_auth import PendingAuthEntry
 from aigateway.core.plugin_base import credential_service_provider_for, credential_strategy_from
 
+from .api_key_validation import normalize_api_key, require_valid_api_key
 from .auth import _redirect_uri_for
 from .credential_persistence import persist_credentials_or_503
 
@@ -169,7 +171,7 @@ async def create_api_key_connection(
         raise HTTPException(
             status_code=404, detail={"code": "unknown_provider", "provider": body.provider}
         )
-    api_key = _validate_api_key(body.api_key)
+    api_key = normalize_api_key(body.api_key)
     account_id = str(current.id)
     connection_id = uuid4()
     # Build the strategy BEFORE creating any row: a provider that does not
@@ -193,34 +195,38 @@ async def create_api_key_connection(
         )
     label = body.label or f"api-key-{connection_id}"
     store = _store(request)
-    if await store.find_by_label(account_id, body.provider, label) is not None:
+    if await store.label_exists(account_id, body.provider, label):
         raise HTTPException(
             status_code=409,
             detail={"code": "label_conflict", "provider": body.provider, "label": label},
         )
-    # Persist the key BEFORE activating the row so a credential-write failure
-    # never leaves an active connection with no credential (SF-291 review F4).
-    # The blob slot is keyed by the already-generated connection_id — exactly
-    # the slot the chat path reads.
-    await _persist_api_key_credentials(strategy, api_key)
+    await require_valid_api_key(request, plugin, body.provider, api_key)
+    # WHY (OME-307 Unit 4): persist the key and create the connection row in ONE short
+    # transaction so ROLLBACK — not best-effort except-cleanup — is the atomicity mechanism.
+    # A row failure (or a cancellation after the blob write) unwinds the credential write with
+    # it, so neither an active connection-without-credential nor an orphan
+    # credential-without-connection can ever commit. This matters most for cancellation: a
+    # 3.12 asyncio.CancelledError is a BaseException an `except Exception` compensation could
+    # never catch, but the transaction boundary rolls it back regardless. Persist runs before
+    # the row inside the transaction, writing the blob slot keyed by the already-generated
+    # connection_id — the exact slot the chat path reads (SF-291 review F4 ordering).
     try:
-        connection = await store.create_api_key(
-            account_id=account_id,
-            provider=body.provider,
-            label=label,
-            connection_id=connection_id,
-            credential_provider=credential_service_provider_for(plugin, body.provider),
-        )
-    except Exception as exc:
-        # The row could not be created — drop the orphan blob so no credential
-        # is left without a connection pointing at it.
-        await strategy.delete_credentials()
-        if isinstance(exc, IntegrityError):
-            raise HTTPException(
-                status_code=409,
-                detail={"code": "label_conflict", "provider": body.provider, "label": label},
-            ) from exc
-        raise
+        async with in_transaction():
+            await _persist_api_key_credentials(strategy, api_key)
+            connection = await store.create_api_key(
+                account_id=account_id,
+                provider=body.provider,
+                label=label,
+                connection_id=connection_id,
+                credential_provider=credential_service_provider_for(plugin, body.provider),
+            )
+    except IntegrityError as exc:
+        # Duplicate label lost the race with a concurrent create. The transaction already
+        # rolled the blob back, so no orphan remains — just surface the retryable conflict.
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "label_conflict", "provider": body.provider, "label": label},
+        ) from exc
     credential_strategy_cache(request.app).evict(credential_key_for(account_id, connection_id))
     return response_from_connection(connection)
 
@@ -253,7 +259,7 @@ async def set_connection_api_key(
                 "message": "Connection does not use API-key authentication",
             },
         )
-    api_key = _validate_api_key(body.api_key)
+    api_key = normalize_api_key(body.api_key)
     plugin = request.app.state.providers.get(connection.provider)
     if plugin is None:
         raise HTTPException(
@@ -271,11 +277,45 @@ async def set_connection_api_key(
             status_code=400,
             detail={"code": "api_key_not_supported", "provider": connection.provider},
         )
-    await _persist_api_key_credentials(strategy, api_key)
+    await require_valid_api_key(request, plugin, connection.provider, api_key)
+
+    # WHY: validation is intentionally outside the transaction; only the short publication
+    # boundary is serialized. Re-checking eligibility inside it prevents a stale validation
+    # result from undoing a concurrent delete/revoke, and rollback keeps blob + row coherent.
+    # INVARIANT (OME-307 Blocker 3): serialize on the ALWAYS-PRESENT connection row FIRST, then
+    # write the credential blob SECOND — ONE consistent lock order shared with delete_connection.
+    # reactivate is a conditional UPDATE (status IN active,error) that takes the connection-row
+    # lock; a concurrent delete that revoked the row makes it match 0 rows, so we 409 and roll
+    # back BEFORE writing any credential. The credential row may be ABSENT, and a missing-row
+    # write/delete takes no lock under READ COMMITTED, so it can never serialize the race — only
+    # the always-present connection row can. Persisting first would let a concurrent delete's
+    # missing-row credential delete no-op, then our commit would orphan a credential under a
+    # revoked connection.
+    async with in_transaction():
+        latest_connection = await store.get(account_id, connection_id)
+        if (
+            latest_connection is None
+            or latest_connection.auth_type != "api_key"
+            or latest_connection.status not in ("active", "error")
+        ):
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "connection_conflict",
+                    "message": "Connection changed during API-key validation",
+                },
+            )
+        connection = await store.reactivate(latest_connection)
+        if connection is None:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "connection_conflict",
+                    "message": "Connection changed during API-key validation",
+                },
+            )
+        await _persist_api_key_credentials(strategy, api_key)
     credential_strategy_cache(request.app).evict(credential_key_for(account_id, connection.id))
-    # Replacing the key clears any prior error and returns the connection to
-    # active (recovery path).
-    connection = await store.reactivate(connection)
     return response_from_connection(connection)
 
 
@@ -292,26 +332,39 @@ async def patch_connection(
         raise HTTPException(status_code=404, detail={"code": "connection_not_found"})
     if connection.status != "active":
         raise HTTPException(status_code=409, detail={"code": "connection_not_active"})
-    if body.label is not None:
-        connection.label = body.label
+    if body.label is None:
+        return response_from_connection(connection)
     try:
-        await connection.save()
+        patched = await store.patch_active_label(connection, body.label)
     except IntegrityError as exc:
         raise HTTPException(
             status_code=409,
             detail={"code": "label_conflict", "provider": connection.provider, "label": body.label},
         ) from exc
-    return response_from_connection(connection)
+    if patched is None:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "connection_conflict", "message": "Connection changed during patch"},
+        )
+    return response_from_connection(patched)
 
 
 @router.delete("/v1/oauth/connections/{connection_id}", status_code=204)
 async def delete_connection(connection_id: UUID, request: Request, current: CurrentAccount) -> None:
     store = _store(request)
-    connection = await store.get(str(current.id), connection_id)
-    if connection is None:
-        raise HTTPException(status_code=404, detail={"code": "connection_not_found"})
-    await _delete_credentials(request, connection.credential_locator)
-    await store.mark_revoked(connection)
+    async with in_transaction():
+        connection = await store.get(str(current.id), connection_id)
+        if connection is None:
+            raise HTTPException(status_code=404, detail={"code": "connection_not_found"})
+        # INVARIANT (OME-307 Blocker 3): mark the ALWAYS-PRESENT connection row revoked FIRST
+        # (mark_revoked UPDATEs by PK and takes its row lock, held until commit), THEN delete the
+        # credential blob SECOND — ONE consistent lock order shared with set_connection_api_key.
+        # The credential row may be ABSENT; a missing-row delete takes no lock under READ
+        # COMMITTED, so it cannot serialize a concurrent set. Locking the connection row first
+        # forces a racing set to observe the revoke (its reactivate CAS matches 0 rows and 409s),
+        # so nothing is orphaned or resurrected.
+        await store.mark_revoked(connection)
+        await _delete_credentials(request, connection.credential_locator)
     # Evict the shared cached strategy so a deleted connection's still-valid token
     # can't keep being served from memory (SF-282).
     credential_strategy_cache(request.app).evict(credential_key_for(str(current.id), connection_id))
@@ -444,20 +497,6 @@ async def _delete_credentials(request: Request, locator: dict) -> None:
     account = locator.get("account")
     if isinstance(service, str) and isinstance(account, str):
         await request.app.state.credential_store.delete(service, account)
-
-
-def _validate_api_key(raw_key: str) -> str:
-    """Normalize and length-check a raw API key (the one rule shared verbatim by
-    the create and replace endpoints). Raises 400 ``invalid_api_key`` if too
-    short. Kept tiny on purpose: each endpoint's provider/strategy resolution
-    stays inline because the two flows order those checks differently."""
-    api_key = raw_key.strip()
-    if len(api_key) < 8:
-        raise HTTPException(
-            status_code=400,
-            detail={"code": "invalid_api_key", "message": "api_key is missing or too short"},
-        )
-    return api_key
 
 
 async def _persist_api_key_credentials(strategy, api_key: str) -> None:

--- a/apps/aigateway/tests/integration/test_lifecycle_postgres_races.py
+++ b/apps/aigateway/tests/integration/test_lifecycle_postgres_races.py
@@ -25,8 +25,10 @@ from aigateway.core.api_key_validation import (
     ApiKeyValidationStage,
     ApiKeyValidationState,
 )
+from aigateway.core.credential_strategy_cache import credential_strategy_cache
 from aigateway.core.oauth.store import (
     OAuthConnectionStore,
+    credential_key_for,
     credential_locator_for,
 )
 from aigateway.core.profile_models import credential_name_for
@@ -429,3 +431,161 @@ def test_connection_absent_credential_delete_set_commit_orders_on_postgres(
     assert deleted.status_code == 204
     assert pg_client.get(f"/v1/oauth/connections/{set_first}").json()["status"] == "revoked"
     assert _connection_credential(pg_client, account_id, set_first) is None
+
+
+def test_connection_refresh_republish_loses_to_committed_revoke_on_postgres(
+    pg_client: TestClient,
+    monkeypatch,
+) -> None:
+    """OME-307 H-1 — a manual connection refresh republish loses to a concurrent committed revoke.
+
+    FEATURE: manual OAuth connection refresh with delete/revoke-race safety.
+    STORY: as an operator, when I refresh a connection that another request revokes mid-flight, the
+    refresh must fail rather than silently resurrect the revoked connection.
+    INVARIANT (OME-307 H-1): complete_active() is a status-fenced conditional UPDATE. When a revoke
+    commits on an independent transaction during the refresh's provider-network window, the
+    republish UPDATE (WHERE status='active') WAITS on the revoked row's lock, RE-EVALUATES after
+    the revoke commits, matches ZERO rows, and returns None -> the route 409s instead of activating.
+    """
+    account_id = pg_client.get("/v1/auth/me").json()["id"]
+
+    async def _seed_active_oauth_connection(label: str) -> UUID:
+        store = OAuthConnectionStore()
+        connection_id = uuid4()
+        connection = await store.create_pending(
+            account_id=account_id,
+            provider="anthropic",
+            label=label,
+            connection_id=connection_id,
+        )
+        await store.complete(connection, label=label, identity=None)
+        return connection_id
+
+    portal = pg_client.portal
+    if portal is None:
+        raise AssertionError("TestClient portal is not active")
+    connection_id: UUID = portal.call(_seed_active_oauth_connection, f"refresh-revoke-{uuid4()}")
+
+    # refresh_connection resolves its strategy from the shared cache; pre-seed a no-op strategy so
+    # the provider-network step is a nop and the test isolates the complete_active CAS race. This is
+    # the same cache-seeding idiom the single-loop unit test uses.
+    class _NoopRefreshStrategy:
+        async def refresh_credentials(self) -> None:
+            return None
+
+    credential_strategy_cache(_app(pg_client)).get_or_create(
+        provider="anthropic",
+        auth_type="oauth",
+        credential_name=credential_key_for(account_id, connection_id),
+        build=lambda: _NoopRefreshStrategy(),
+    )
+
+    mark_revoked = OAuthConnectionStore.mark_revoked
+    complete_active = OAuthConnectionStore.complete_active
+    revoke_holds_row = threading.Event()
+    refresh_reached_cas = threading.Event()
+    release_revoke = threading.Event()
+
+    async def _holding_revoke(self, connection, *args, **kwargs):
+        # Runs inside delete_connection's in_transaction(): mark_revoked UPDATEs the row by PK and
+        # holds its row lock until we release and the transaction commits.
+        revoked = await mark_revoked(self, connection, *args, **kwargs)
+        revoke_holds_row.set()
+        if not await asyncio.to_thread(release_revoke.wait, 10):
+            raise TimeoutError("connection revoke was not released")
+        return revoked
+
+    async def _attempting_complete_active(self, connection, **kwargs):
+        # Signal just before the status-fenced UPDATE, which then blocks on the revoke's row lock.
+        refresh_reached_cas.set()
+        return await complete_active(self, connection, **kwargs)
+
+    monkeypatch.setattr(OAuthConnectionStore, "mark_revoked", _holding_revoke)
+    monkeypatch.setattr(OAuthConnectionStore, "complete_active", _attempting_complete_active)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        revoking = executor.submit(pg_client.delete, f"/v1/oauth/connections/{connection_id}")
+        assert revoke_holds_row.wait(10), "revoke never took the connection-row lock"
+        refreshing = executor.submit(
+            pg_client.post, f"/v1/oauth/connections/{connection_id}/refresh"
+        )
+        assert refresh_reached_cas.wait(10), "refresh never reached the complete_active CAS"
+        release_revoke.set()
+        revoked = revoking.result(timeout=10)
+        refreshed = refreshing.result(timeout=10)
+
+    assert revoked.status_code == 204
+    assert refreshed.status_code == 409
+    assert refreshed.json()["detail"]["code"] == "connection_conflict"
+    # Not resurrected: the conditional update matched zero rows, so the row stays revoked.
+    assert pg_client.get(f"/v1/oauth/connections/{connection_id}").json()["status"] == "revoked"
+    assert _connection_credential(pg_client, account_id, connection_id) is None
+
+
+def test_profile_refresh_publication_loses_to_committed_delete_on_postgres(
+    pg_client: TestClient,
+    monkeypatch,
+) -> None:
+    """OME-307 H-1 — profile refresh success-publish loses to a concurrent committed delete.
+
+    FEATURE: manual profile refresh with delete-race safety.
+    INVARIANT (OME-307 H-1): the success branch publishes with upsert(require_present=True). When a
+    DELETE commits on an independent transaction during the refresh's provider-network window, the
+    publication's require_present CAS WAITS on the profile-index row lock, RE-EVALUATES after the
+    delete commits, finds the row ABSENT, and raises ProfileTransitionConflict -> the route 409s
+    instead of resurrecting the profile as AUTHENTICATED.
+    """
+    account_id = pg_client.get("/v1/auth/me").json()["id"]
+    name = f"refresh-delete-{uuid4()}"
+    assert pg_client.post("/v1/auth/anthropic/profiles", json={"name": name}).status_code == 201
+
+    # refresh_profile builds its strategy via credential_strategy_from (not the shared cache), so
+    # substitute a no-op strategy to isolate the require_present publication CAS from the network.
+    class _NoopProfileStrategy:
+        async def refresh_credentials(self) -> None:
+            return None
+
+        async def delete_credentials(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "aigateway.routes.auth.credential_strategy_from",
+        lambda *args, **kwargs: _NoopProfileStrategy(),
+    )
+
+    index = _app(pg_client).state.profile_index
+    remove = index.remove
+    upsert = index.upsert
+    delete_holds_index = threading.Event()
+    refresh_reached_publish = threading.Event()
+    release_delete = threading.Event()
+
+    async def _holding_remove(profile_id: str) -> None:
+        # Runs inside delete_profile's in_transaction(): remove DELETEs the index row by PK,
+        # holding its row lock until we release and the transaction commits.
+        await remove(profile_id)
+        delete_holds_index.set()
+        if not await asyncio.to_thread(release_delete.wait, 10):
+            raise TimeoutError("profile delete was not released")
+
+    async def _attempting_upsert(*args, **kwargs):
+        # Signal just before require_present publishes, which then blocks on the delete's row lock.
+        refresh_reached_publish.set()
+        return await upsert(*args, **kwargs)
+
+    monkeypatch.setattr(index, "remove", _holding_remove)
+    monkeypatch.setattr(index, "upsert", _attempting_upsert)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        deleting = executor.submit(pg_client.delete, f"/v1/auth/anthropic/profiles/{name}")
+        assert delete_holds_index.wait(10), "delete never took the profile-index row lock"
+        refreshing = executor.submit(pg_client.post, f"/v1/auth/anthropic/profiles/{name}/refresh")
+        assert refresh_reached_publish.wait(10), "refresh never reached the require_present publish"
+        release_delete.set()
+        deleted = deleting.result(timeout=10)
+        refreshed = refreshing.result(timeout=10)
+
+    assert deleted.status_code == 204
+    assert refreshed.status_code == 409
+    assert refreshed.json()["detail"]["code"] == "profile_conflict"
+    # Not resurrected: the row stays deleted, so the require_present publication found no row.
+    assert pg_client.get(f"/v1/auth/anthropic/profiles/{name}").status_code == 404
+    assert _profile_credential(pg_client, account_id, name) is None

--- a/apps/aigateway/tests/integration/test_lifecycle_postgres_races.py
+++ b/apps/aigateway/tests/integration/test_lifecycle_postgres_races.py
@@ -1,0 +1,431 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import os
+import subprocess
+import sys
+import threading
+from collections.abc import Generator
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from urllib.parse import quote
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+from testcontainers.postgres import PostgresContainer  # type: ignore[import-untyped]
+
+from aigateway.config import Settings
+from aigateway.core.api_key_validation import (
+    ApiKeyValidationResult,
+    ApiKeyValidationStage,
+    ApiKeyValidationState,
+)
+from aigateway.core.oauth.store import (
+    OAuthConnectionStore,
+    credential_locator_for,
+)
+from aigateway.core.profile_models import credential_name_for
+from aigateway.main import create_app
+from aigateway.plugins.anthropic_provider.auth import credential_service_for
+
+pytestmark = pytest.mark.needs_postgres
+
+_APP_DIR = Path(__file__).resolve().parents[2]
+_API_KEY = "sk-ant-api03-postgres-race-key-1234"
+
+
+class _ValidValidationService:
+    async def validate(self, _plugin, _provider: str, _api_key: str) -> ApiKeyValidationResult:
+        return ApiKeyValidationResult(
+            ApiKeyValidationState.VALID,
+            stage=ApiKeyValidationStage.READINESS,
+        )
+
+
+@pytest.fixture(scope="module")
+def postgres_database_url() -> Generator[str, None, None]:
+    if os.environ.get("AIGW_TEST_PG") != "1":
+        pytest.skip("AIGW_TEST_PG=1 not set")
+    with PostgresContainer("postgres:16-alpine", driver=None) as postgres:
+        database_url = (
+            f"postgres://{postgres.username}:{quote(postgres.password, safe='')}"
+            f"@{postgres.get_container_host_ip()}:{postgres.get_exposed_port(5432)}"
+            f"/{postgres.dbname}"
+        )
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "tortoise",
+                "-c",
+                "aigateway.db.TORTOISE_CONFIG",
+                "migrate",
+            ],
+            cwd=_APP_DIR,
+            env={**os.environ, "AIGATEWAY_DATABASE_URL": database_url},
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        yield database_url
+
+
+@pytest.fixture
+def pg_client(postgres_database_url: str) -> Generator[TestClient, None, None]:
+    settings = Settings(
+        database_url=SecretStr(postgres_database_url),
+        admin_password=SecretStr("test-admin-password"),
+        jwt_secret=SecretStr("x" * 32),
+        provisioning_token=SecretStr("p" * 32),
+        secret_key=SecretStr(base64.b64encode(b"k" * 32).decode()),
+    )
+    app = create_app(settings)
+    with TestClient(app) as client:
+        login = client.post(
+            "/v1/auth/login",
+            json={"username": "admin", "password": "test-admin-password"},
+        )
+        assert login.status_code == 200, login.text
+        client.headers.update({"Authorization": f"Bearer {login.json()['token']}"})
+        app.state.api_key_validation_service = _ValidValidationService()
+        yield client
+
+
+def _token_factory(token: str):
+    async def _handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "access_token": token,
+                "refresh_token": f"refresh-{token}",
+                "expires_in": 3600,
+                "token_type": "Bearer",
+            },
+        )
+
+    return lambda: httpx.AsyncClient(
+        transport=httpx.MockTransport(_handler),
+        timeout=httpx.Timeout(5.0),
+    )
+
+
+def _app(client: TestClient) -> FastAPI:
+    app = client.app
+    if not isinstance(app, FastAPI):
+        raise AssertionError("TestClient is not running the expected FastAPI app")
+    return app
+
+
+def _read_credential(client: TestClient, service: str, account: str) -> str | None:
+    portal = client.portal
+    if portal is None:
+        raise AssertionError("TestClient portal is not active")
+    value = portal.call(_app(client).state.credential_store.read, service, account)
+    if value is not None and not isinstance(value, str):
+        raise AssertionError("credential store returned a non-string value")
+    return value
+
+
+def _failing_token_factory():
+    async def _handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"error": "invalid_grant"})
+
+    return lambda: httpx.AsyncClient(
+        transport=httpx.MockTransport(_handler),
+        timeout=httpx.Timeout(5.0),
+    )
+
+
+def _profile_credential(client: TestClient, account_id: str, name: str) -> str | None:
+    service = credential_service_for(credential_name_for(account_id, name))
+    return _read_credential(client, service, "default")
+
+
+def _connection_credential(client: TestClient, account_id: str, connection_id: UUID) -> str | None:
+    locator = credential_locator_for("anthropic", account_id, connection_id)
+    return _read_credential(client, locator["service"], locator["account"])
+
+
+def test_postcondition_owner_check_and_cas_are_atomic_on_postgres(
+    pg_client: TestClient,
+    monkeypatch,
+) -> None:
+    name = f"ownership-{uuid4()}"
+    account_id = pg_client.get("/v1/auth/me").json()["id"]
+    _app(pg_client).state.anthropic_http_factory = _token_factory("oauth-A-token")
+    start_a = pg_client.post("/v1/auth/anthropic/profiles", json={"name": name})
+    index = _app(pg_client).state.profile_index
+    authenticate_pending = index.authenticate_pending
+    cas_reached = threading.Event()
+    release_cas = threading.Event()
+
+    async def _pause_before_cas(profile, **kwargs) -> None:
+        cas_reached.set()
+        if not await asyncio.to_thread(release_cas.wait, 10):
+            raise TimeoutError("profile CAS was not released")
+        await authenticate_pending(profile, **kwargs)
+
+    monkeypatch.setattr(index, "authenticate_pending", _pause_before_cas)
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        callback_a = executor.submit(
+            pg_client.get,
+            "/v1/auth/anthropic/callback",
+            params={"code": "code-A", "state": start_a.json()["state"]},
+            follow_redirects=False,
+        )
+        assert cas_reached.wait(10), "A never reached its production durable-CAS boundary"
+        start_b = pg_client.post("/v1/auth/anthropic/profiles", json={"name": name})
+        release_cas.set()
+        response_a = callback_a.result(timeout=10)
+
+    assert start_b.status_code == 201
+    assert response_a.status_code == 409
+    assert response_a.json()["detail"]["code"] == "profile_auth_conflict"
+    assert _profile_credential(pg_client, account_id, name) is None
+    assert pg_client.get(f"/v1/auth/anthropic/profiles/{name}").json()["state"] == "pending"
+
+    _app(pg_client).state.anthropic_http_factory = _token_factory("oauth-B-token")
+    response_b = pg_client.get(
+        "/v1/auth/anthropic/callback",
+        params={"code": "code-B", "state": start_b.json()["state"]},
+        follow_redirects=False,
+    )
+    assert response_b.status_code == 200
+
+
+def test_stale_error_read_before_delete_cannot_resurrect_profile_on_postgres(
+    pg_client: TestClient,
+    monkeypatch,
+) -> None:
+    name = f"error-delete-{uuid4()}"
+    account_id = pg_client.get("/v1/auth/me").json()["id"]
+    _app(pg_client).state.anthropic_http_factory = _failing_token_factory()
+    started = pg_client.post("/v1/auth/anthropic/profiles", json={"name": name})
+    index = _app(pg_client).state.profile_index
+    mark_pending_error = index.mark_pending_error
+    error_precondition_read = threading.Event()
+    release_error_cas = threading.Event()
+
+    async def _pause_after_error_precondition(profile_id: str, **kwargs) -> None:
+        observed = await index.get(account_id, "anthropic", name)
+        assert observed is not None and observed.state.value == "pending"
+        error_precondition_read.set()
+        if not await asyncio.to_thread(release_error_cas.wait, 10):
+            raise TimeoutError("error CAS was not released")
+        await mark_pending_error(profile_id, **kwargs)
+
+    monkeypatch.setattr(index, "mark_pending_error", _pause_after_error_precondition)
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        callback = executor.submit(
+            pg_client.get,
+            "/callback",
+            params={"code": "bad-code", "state": started.json()["state"]},
+            follow_redirects=False,
+        )
+        assert error_precondition_read.wait(10), "failure path never read its pending profile"
+        deleted = pg_client.delete(f"/v1/auth/anthropic/profiles/{name}")
+        release_error_cas.set()
+        failed = callback.result(timeout=10)
+
+    assert deleted.status_code == 204
+    assert failed.status_code == 500
+    assert pg_client.get(f"/v1/auth/anthropic/profiles/{name}").status_code == 404
+    assert _profile_credential(pg_client, account_id, name) is None
+
+
+def test_profile_absent_credential_delete_set_commit_orders_on_postgres(
+    pg_client: TestClient,
+    monkeypatch,
+) -> None:
+    account_id = pg_client.get("/v1/auth/me").json()["id"]
+    index = _app(pg_client).state.profile_index
+
+    delete_first = f"profile-delete-first-{uuid4()}"
+    assert (
+        pg_client.post("/v1/auth/anthropic/profiles", json={"name": delete_first}).status_code
+        == 201
+    )
+    remove = index.remove
+    upsert = index.upsert
+    delete_holds_index = threading.Event()
+    set_attempted_index = threading.Event()
+    release_delete = threading.Event()
+
+    async def _holding_remove(profile_id: str) -> None:
+        await remove(profile_id)
+        delete_holds_index.set()
+        if not await asyncio.to_thread(release_delete.wait, 10):
+            raise TimeoutError("profile delete was not released")
+
+    async def _attempting_upsert(*args, **kwargs) -> None:
+        set_attempted_index.set()
+        await upsert(*args, **kwargs)
+
+    monkeypatch.setattr(index, "remove", _holding_remove)
+    monkeypatch.setattr(index, "upsert", _attempting_upsert)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        deleting = executor.submit(
+            pg_client.delete,
+            f"/v1/auth/anthropic/profiles/{delete_first}",
+        )
+        assert delete_holds_index.wait(10)
+        setting = executor.submit(
+            pg_client.put,
+            f"/v1/auth/anthropic/profiles/{delete_first}/api-key",
+            json={"api_key": _API_KEY},
+        )
+        assert set_attempted_index.wait(10)
+        release_delete.set()
+        deleted = deleting.result(timeout=10)
+        set_result = setting.result(timeout=10)
+
+    assert deleted.status_code == 204
+    assert set_result.status_code == 409
+    assert pg_client.get(f"/v1/auth/anthropic/profiles/{delete_first}").status_code == 404
+    assert _profile_credential(pg_client, account_id, delete_first) is None
+
+    monkeypatch.setattr(index, "remove", remove)
+    monkeypatch.setattr(index, "upsert", upsert)
+    set_first = f"profile-set-first-{uuid4()}"
+    assert (
+        pg_client.post("/v1/auth/anthropic/profiles", json={"name": set_first}).status_code == 201
+    )
+    set_holds_index = threading.Event()
+    delete_attempted_index = threading.Event()
+    release_set = threading.Event()
+
+    async def _holding_upsert(*args, **kwargs) -> None:
+        await upsert(*args, **kwargs)
+        set_holds_index.set()
+        if not await asyncio.to_thread(release_set.wait, 10):
+            raise TimeoutError("profile set was not released")
+
+    async def _attempting_remove(profile_id: str) -> None:
+        delete_attempted_index.set()
+        await remove(profile_id)
+
+    monkeypatch.setattr(index, "upsert", _holding_upsert)
+    monkeypatch.setattr(index, "remove", _attempting_remove)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        setting = executor.submit(
+            pg_client.put,
+            f"/v1/auth/anthropic/profiles/{set_first}/api-key",
+            json={"api_key": _API_KEY},
+        )
+        assert set_holds_index.wait(10)
+        deleting = executor.submit(
+            pg_client.delete,
+            f"/v1/auth/anthropic/profiles/{set_first}",
+        )
+        assert delete_attempted_index.wait(10)
+        release_set.set()
+        set_result = setting.result(timeout=10)
+        deleted = deleting.result(timeout=10)
+
+    assert set_result.status_code == 200
+    assert deleted.status_code == 204
+    assert pg_client.get(f"/v1/auth/anthropic/profiles/{set_first}").status_code == 404
+    assert _profile_credential(pg_client, account_id, set_first) is None
+
+
+def test_connection_absent_credential_delete_set_commit_orders_on_postgres(
+    pg_client: TestClient,
+    monkeypatch,
+) -> None:
+    account_id = pg_client.get("/v1/auth/me").json()["id"]
+
+    async def _seed_errored_connection(label: str) -> UUID:
+        store = OAuthConnectionStore()
+        connection_id = uuid4()
+        connection = await store.create_api_key(
+            account_id=account_id,
+            provider="anthropic",
+            label=label,
+            connection_id=connection_id,
+        )
+        await store.mark_error(connection, "credential absent")
+        return connection_id
+
+    portal = pg_client.portal
+    if portal is None:
+        raise AssertionError("TestClient portal is not active")
+    delete_first: UUID = portal.call(_seed_errored_connection, f"conn-delete-first-{uuid4()}")
+    mark_revoked = OAuthConnectionStore.mark_revoked
+    reactivate = OAuthConnectionStore.reactivate
+    delete_holds_connection = threading.Event()
+    set_attempted_connection = threading.Event()
+    release_delete = threading.Event()
+
+    async def _holding_revoke(self, connection, *args, **kwargs):
+        revoked = await mark_revoked(self, connection, *args, **kwargs)
+        delete_holds_connection.set()
+        if not await asyncio.to_thread(release_delete.wait, 10):
+            raise TimeoutError("connection delete was not released")
+        return revoked
+
+    async def _attempting_reactivate(self, connection):
+        set_attempted_connection.set()
+        return await reactivate(self, connection)
+
+    monkeypatch.setattr(OAuthConnectionStore, "mark_revoked", _holding_revoke)
+    monkeypatch.setattr(OAuthConnectionStore, "reactivate", _attempting_reactivate)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        deleting = executor.submit(pg_client.delete, f"/v1/oauth/connections/{delete_first}")
+        assert delete_holds_connection.wait(10)
+        setting = executor.submit(
+            pg_client.put,
+            f"/v1/oauth/connections/{delete_first}/api-key",
+            json={"api_key": _API_KEY},
+        )
+        assert set_attempted_connection.wait(10)
+        release_delete.set()
+        deleted = deleting.result(timeout=10)
+        set_result = setting.result(timeout=10)
+
+    assert deleted.status_code == 204
+    assert set_result.status_code == 409
+    assert pg_client.get(f"/v1/oauth/connections/{delete_first}").json()["status"] == "revoked"
+    assert _connection_credential(pg_client, account_id, delete_first) is None
+
+    monkeypatch.setattr(OAuthConnectionStore, "mark_revoked", mark_revoked)
+    monkeypatch.setattr(OAuthConnectionStore, "reactivate", reactivate)
+    set_first: UUID = portal.call(_seed_errored_connection, f"conn-set-first-{uuid4()}")
+    set_holds_connection = threading.Event()
+    delete_attempted_connection = threading.Event()
+    release_set = threading.Event()
+
+    async def _holding_reactivate(self, connection):
+        activated = await reactivate(self, connection)
+        set_holds_connection.set()
+        if not await asyncio.to_thread(release_set.wait, 10):
+            raise TimeoutError("connection set was not released")
+        return activated
+
+    async def _attempting_revoke(self, connection, *args, **kwargs):
+        delete_attempted_connection.set()
+        return await mark_revoked(self, connection, *args, **kwargs)
+
+    monkeypatch.setattr(OAuthConnectionStore, "reactivate", _holding_reactivate)
+    monkeypatch.setattr(OAuthConnectionStore, "mark_revoked", _attempting_revoke)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        setting = executor.submit(
+            pg_client.put,
+            f"/v1/oauth/connections/{set_first}/api-key",
+            json={"api_key": _API_KEY},
+        )
+        assert set_holds_connection.wait(10)
+        deleting = executor.submit(pg_client.delete, f"/v1/oauth/connections/{set_first}")
+        assert delete_attempted_connection.wait(10)
+        release_set.set()
+        set_result = setting.result(timeout=10)
+        deleted = deleting.result(timeout=10)
+
+    assert set_result.status_code == 200
+    assert deleted.status_code == 204
+    assert pg_client.get(f"/v1/oauth/connections/{set_first}").json()["status"] == "revoked"
+    assert _connection_credential(pg_client, account_id, set_first) is None

--- a/apps/aigateway/tests/unit/_pg_mvcc_store.py
+++ b/apps/aigateway/tests/unit/_pg_mvcc_store.py
@@ -1,0 +1,136 @@
+"""Test-support double: a credential/index store modelling PostgreSQL READ COMMITTED.
+
+WHY: the gateway unit harness is SQLite-only and serializes whole transactions on one
+connection, so it cannot exhibit the per-row interleaving that OME-307 Blocker 3 needs. This
+double models the specific PostgreSQL behaviours that make the delete-wins race real:
+
+- MVCC snapshot visibility — another transaction's uncommitted INSERT is INVISIBLE, so a
+  concurrent DELETE of that key finds nothing.
+- Missing-row DELETE takes NO lock (there is no row to lock), so it cannot serialize a
+  concurrent INSERT of the same key.
+- INSERT / UPDATE / index-mutate take that key's row lock, held until COMMIT (a waiter blocks).
+- COMMIT publishes the transaction's own writes then releases its locks; ROLLBACK discards
+  them.
+
+INVARIANT: because a missing-row DELETE takes no lock, two transactions can only be serialized
+by a row that is ALWAYS PRESENT (the account index row / the connection row). A production
+ordering that locks the credential row FIRST cannot serialize when that row is absent — which
+is exactly the orphan/resurrection this double exposes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import contextvars
+from collections import defaultdict
+from collections.abc import AsyncIterator, Callable
+
+# Per-task transaction scratch (task-local under asyncio, mirroring one pooled connection per
+# task pinned by in_transaction()): the pending write-set and the row locks held until COMMIT.
+_txn: contextvars.ContextVar[dict | None] = contextvars.ContextVar("_mvcc_txn", default=None)
+
+_DELETED = object()  # tombstone in a transaction's pending write-set
+
+
+class MvccRowStore:
+    """Credential/index store double: PostgreSQL READ COMMITTED row locking + MVCC + rollback."""
+
+    def __init__(self) -> None:
+        self.committed: dict[tuple[str, str], str] = {}
+        self._locks: dict[tuple[str, str], asyncio.Lock] = defaultdict(asyncio.Lock)
+
+    @contextlib.asynccontextmanager
+    async def transaction(self) -> AsyncIterator[None]:
+        txn: dict = {"pending": {}, "held": []}
+        token = _txn.set(txn)
+        try:
+            yield
+        except BaseException:
+            raise  # ROLLBACK: pending write-set discarded; locks released in finally.
+        else:
+            # COMMIT: publish this txn's writes, THEN release locks so a waiter that acquires
+            # the lock next observes the committed value (as a real backend would).
+            for key, value in txn["pending"].items():
+                if value is _DELETED:
+                    self.committed.pop(key, None)
+                else:
+                    self.committed[key] = value
+        finally:
+            _txn.reset(token)
+            for lock in txn["held"]:
+                lock.release()
+
+    def _visible(self, txn: dict | None, key: tuple[str, str]) -> str | None:
+        # READ COMMITTED: the transaction sees its own pending writes over the committed base.
+        if txn is not None and key in txn["pending"]:
+            value = txn["pending"][key]
+            return None if value is _DELETED else value
+        return self.committed.get(key)
+
+    async def _acquire(self, txn: dict | None, key: tuple[str, str]) -> asyncio.Lock | None:
+        lock = self._locks[key]
+        if txn is None:
+            await lock.acquire()  # autocommit statement: caller releases at statement end
+            return lock
+        if lock not in txn["held"]:
+            await lock.acquire()
+            txn["held"].append(lock)  # inside a txn: held until COMMIT
+        return None
+
+    async def read(self, service: str, account: str) -> str | None:
+        await asyncio.sleep(0)
+        return self._visible(_txn.get(), (service, account))
+
+    async def write(self, service: str, account: str, value: str) -> None:
+        # INSERT (absent) or UPDATE (present): both take the key's row lock.
+        key = (service, account)
+        txn = _txn.get()
+        autolock = await self._acquire(txn, key)
+        await asyncio.sleep(0)
+        if txn is None:
+            self.committed[key] = value
+            autolock.release()  # type: ignore[union-attr]
+        else:
+            txn["pending"][key] = value
+
+    async def delete(self, service: str, account: str) -> None:
+        key = (service, account)
+        txn = _txn.get()
+        await asyncio.sleep(0)
+        # INVARIANT: a DELETE of a row not visible to this snapshot takes NO lock and no-ops —
+        # this is the missing-row DELETE at the heart of Blocker 3.
+        if self._visible(txn, key) is None:
+            return
+        autolock = await self._acquire(txn, key)
+        await asyncio.sleep(0)
+        if self._visible(txn, key) is None:  # EvalPlanQual: a just-committed delete wins.
+            if autolock is not None:
+                autolock.release()
+            return
+        if txn is None:
+            self.committed.pop(key, None)
+            autolock.release()  # type: ignore[union-attr]
+        else:
+            txn["pending"][key] = _DELETED
+
+    async def mutate(
+        self, service: str, account: str, mutator: Callable[[str | None], str | None]
+    ) -> None:
+        # UPDATE of an always-present row with a read-modify-write mutator (the index-row CAS).
+        key = (service, account)
+        txn = _txn.get()
+        autolock = await self._acquire(txn, key)
+        try:
+            await asyncio.sleep(0)  # yield between SELECT and UPDATE as real I/O would
+            next_value = mutator(self._visible(txn, key))  # mutator may raise (conflict)
+            if txn is None:
+                if next_value is None:
+                    self.committed.pop(key, None)
+                else:
+                    self.committed[key] = next_value
+            else:
+                txn["pending"][key] = _DELETED if next_value is None else next_value
+        finally:
+            if txn is None and autolock is not None:
+                autolock.release()

--- a/apps/aigateway/tests/unit/anthropic/test_api_key_validation.py
+++ b/apps/aigateway/tests/unit/anthropic/test_api_key_validation.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+
+import httpx
+import pytest
+
+from aigateway.core.api_key_validation import (
+    ApiKeyValidationStage,
+    ApiKeyValidationState,
+)
+from aigateway.core.plugin_base import ModelEntry
+from aigateway.plugins.anthropic_provider.api_key_validation import AnthropicApiKeyValidator
+from aigateway.plugins.anthropic_provider.settings import AnthropicPluginSettings
+
+_KEY = "sk-ant-api03-synthetic-validation-secret"
+
+
+def _validator(
+    responses: Iterable[httpx.Response],
+    *,
+    settings: AnthropicPluginSettings | None = None,
+    models: list[ModelEntry] | None = None,
+) -> tuple[AnthropicApiKeyValidator, list[httpx.Request]]:
+    queued = list(responses)
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return queued.pop(0)
+
+    effective_settings = settings or AnthropicPluginSettings()
+    return (
+        AnthropicApiKeyValidator(
+            settings=effective_settings,
+            registered_models=models if models is not None else list(effective_settings.models),
+            transport=httpx.MockTransport(handler),
+        ),
+        requests,
+    )
+
+
+@pytest.mark.asyncio
+async def test_anthropic_validation_requires_both_stages() -> None:
+    validator, requests = _validator(
+        [
+            httpx.Response(200, json={"data": []}),
+            httpx.Response(200, json={"type": "message", "content": []}),
+        ]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.VALID
+    assert result.stage is ApiKeyValidationStage.READINESS
+    assert result.probe_model == "claude-haiku-4-5"
+    assert [request.method for request in requests] == ["GET", "POST"]
+    assert str(requests[0].url) == "https://api.anthropic.com/v1/models?limit=1"
+    assert str(requests[1].url) == "https://api.anthropic.com/v1/messages"
+    assert requests[0].headers["x-api-key"] == _KEY
+    assert requests[0].headers["anthropic-version"] == "2023-06-01"
+    body = json.loads(requests[1].content)
+    assert body == {
+        "model": "claude-haiku-4-5",
+        "max_tokens": 1,
+        "stream": False,
+        "messages": [{"role": "user", "content": "ping"}],
+    }
+
+
+@pytest.mark.parametrize(
+    ("status", "error_type", "state"),
+    [
+        (401, "authentication_error", ApiKeyValidationState.INVALID),
+        (402, "billing_error", ApiKeyValidationState.NO_QUOTA),
+        (403, "permission_error", ApiKeyValidationState.PERMISSION_DENIED),
+        (429, "rate_limit_error", ApiKeyValidationState.RATE_LIMITED),
+        (529, "overloaded_error", ApiKeyValidationState.UNAVAILABLE),
+    ],
+)
+@pytest.mark.asyncio
+async def test_anthropic_auth_failure_is_structured_and_skips_readiness(
+    status: int,
+    error_type: str,
+    state: ApiKeyValidationState,
+) -> None:
+    validator, requests = _validator(
+        [
+            httpx.Response(
+                status,
+                headers={"retry-after": "11"},
+                json={"type": "error", "error": {"type": error_type, "message": _KEY}},
+            )
+        ]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is state
+    assert result.stage is ApiKeyValidationStage.AUTHENTICATION
+    assert result.retry_after_seconds == (
+        11 if state is ApiKeyValidationState.RATE_LIMITED else None
+    )
+    assert len(requests) == 1
+    assert _KEY not in repr(result)
+
+
+@pytest.mark.asyncio
+async def test_anthropic_does_not_guess_from_status_or_prose() -> None:
+    validator, requests = _validator(
+        [httpx.Response(401, json={"error": {"type": "unknown", "message": "expired"}})]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.UNAVAILABLE
+    assert result.stage is ApiKeyValidationStage.AUTHENTICATION
+    assert len(requests) == 1
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [{}, {"data": {}}, {"data": "not-a-list"}],
+)
+@pytest.mark.asyncio
+async def test_anthropic_rejects_malformed_auth_success(payload: object) -> None:
+    validator, requests = _validator([httpx.Response(200, json=payload)])
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.UNAVAILABLE
+    assert result.stage is ApiKeyValidationStage.AUTHENTICATION
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_anthropic_validation_model_override_uses_registered_upstream_mapping() -> None:
+    models = [
+        ModelEntry(model_name="custom-alias", litellm_params={"model": "anthropic/custom-model"})
+    ]
+    settings = AnthropicPluginSettings(models=models, validation_model="custom-alias")
+    validator, requests = _validator(
+        [
+            httpx.Response(200, json={"data": []}),
+            httpx.Response(200, json={"type": "message", "content": []}),
+        ],
+        settings=settings,
+        models=models,
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.VALID
+    assert result.probe_model == "custom-alias"
+    assert json.loads(requests[1].content)["model"] == "custom-model"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_unregistered_validation_model_is_local_misconfiguration() -> None:
+    settings = AnthropicPluginSettings(validation_model="missing")
+    validator, requests = _validator([], settings=settings)
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.MISCONFIGURED
+    assert result.stage is None
+    assert requests == []
+
+
+@pytest.mark.asyncio
+async def test_anthropic_rejects_malformed_readiness_success() -> None:
+    validator, _requests = _validator(
+        [
+            httpx.Response(200, json={"data": []}),
+            httpx.Response(200, json={"type": "message", "content": {}}),
+        ]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.UNAVAILABLE
+    assert result.stage is ApiKeyValidationStage.READINESS
+
+
+@pytest.mark.parametrize(
+    "stage",
+    [ApiKeyValidationStage.AUTHENTICATION, ApiKeyValidationStage.READINESS],
+)
+@pytest.mark.asyncio
+async def test_anthropic_invalid_request_does_not_guess_low_credit(
+    stage: ApiKeyValidationStage,
+) -> None:
+    responses = []
+    if stage is ApiKeyValidationStage.READINESS:
+        responses.append(httpx.Response(200, json={"data": []}))
+    responses.append(
+        httpx.Response(
+            400,
+            json={
+                "type": "error",
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "credit balance is too low",
+                },
+            },
+        )
+    )
+    validator, requests = _validator(responses)
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.UNAVAILABLE
+    assert result.stage is stage
+    assert len(requests) == (1 if stage is ApiKeyValidationStage.AUTHENTICATION else 2)

--- a/apps/aigateway/tests/unit/conftest.py
+++ b/apps/aigateway/tests/unit/conftest.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_UNIT_ROOT = Path(__file__).resolve().parent
+# AIDEV-NOTE: keep new API-key validation tests in new modules outside this frozen allowlist
+# so they exercise the real validation service unless they install an explicit test double.
+_LEGACY_API_KEY_ROUTE_MODULES = frozenset(
+    {
+        "test_api_key_routes.py",
+        "test_auth_routes.py",
+        "test_oauth_connection_api_key_routes.py",
+        "huggingface/test_huggingface_gateway_acceptance.py",
+        "openrouter/test_chat_debug_control_strip.py",
+        "openrouter/test_chat_exception_boundary.py",
+        "openrouter/test_openrouter_benign_error.py",
+        "openrouter/test_openrouter_control_plane_isolation.py",
+        "openrouter/test_openrouter_dispatch.py",
+        "openrouter/test_openrouter_embedded_retry.py",
+        "openrouter/test_openrouter_embedded_retry_conversion.py",
+        "openrouter/test_openrouter_error_policy.py",
+        "openrouter/test_openrouter_litellm_contract.py",
+        "openrouter/test_openrouter_security.py",
+        "openrouter/test_openrouter_toplevel_conversion_retry.py",
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def _legacy_api_key_validation_success(
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    relative_path = Path(request.node.path).resolve().relative_to(_UNIT_ROOT).as_posix()
+    if relative_path not in _LEGACY_API_KEY_ROUTE_MODULES:
+        return
+
+    from aigateway.core.api_key_validation import (
+        ApiKeyValidationResult,
+        ApiKeyValidationStage,
+        ApiKeyValidationState,
+    )
+    from aigateway.core.api_key_validation_service import ApiKeyValidationService
+
+    async def _valid(
+        _self: ApiKeyValidationService,
+        _plugin: Any,
+        _provider: str,
+        _api_key: str,
+    ) -> ApiKeyValidationResult:
+        return ApiKeyValidationResult(
+            state=ApiKeyValidationState.VALID,
+            stage=ApiKeyValidationStage.READINESS,
+        )
+
+    # INVARIANT: only frozen pre-OME-307 modules receive this compatibility success.
+    monkeypatch.setattr(ApiKeyValidationService, "validate", _valid)

--- a/apps/aigateway/tests/unit/gemini/test_api_key_validation.py
+++ b/apps/aigateway/tests/unit/gemini/test_api_key_validation.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+
+import httpx
+import pytest
+
+from aigateway.core.api_key_validation import (
+    ApiKeyValidationStage,
+    ApiKeyValidationState,
+)
+from aigateway.core.plugin_base import ModelEntry
+from aigateway.plugins.gemini_provider.api_key_validation import GeminiApiKeyValidator
+from aigateway.plugins.gemini_provider.models import MODELS
+from aigateway.plugins.gemini_provider.settings import GeminiPluginSettings
+
+_KEY = "AIzaSySyntheticValidationSecret"
+_ERROR_INFO = "type.googleapis.com/google.rpc.ErrorInfo"
+
+
+def _validator(
+    responses: Iterable[httpx.Response],
+    *,
+    models: list[ModelEntry] | None = None,
+    settings: GeminiPluginSettings | None = None,
+) -> tuple[GeminiApiKeyValidator, list[httpx.Request]]:
+    queued = list(responses)
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return queued.pop(0)
+
+    return (
+        GeminiApiKeyValidator(
+            settings=settings or GeminiPluginSettings(validation_model=None),
+            registered_models=list(MODELS) if models is None else models,
+            transport=httpx.MockTransport(handler),
+        ),
+        requests,
+    )
+
+
+def _error(
+    status: str,
+    *,
+    reason: str | None = None,
+    domain: str = "googleapis.com",
+    retry_delay: str | None = None,
+) -> dict:
+    details: list[dict[str, str]] = []
+    if reason is not None:
+        details.append({"@type": _ERROR_INFO, "reason": reason, "domain": domain})
+    if retry_delay is not None:
+        details.append(
+            {
+                "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                "retryDelay": retry_delay,
+            }
+        )
+    return {"error": {"status": status, "message": _KEY, "details": details}}
+
+
+@pytest.mark.asyncio
+async def test_gemini_validation_requires_both_stages() -> None:
+    validator, requests = _validator(
+        [
+            httpx.Response(200, json={"models": []}),
+            httpx.Response(200, json={"candidates": [{"content": {"parts": []}}]}),
+        ]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.VALID
+    assert result.stage is ApiKeyValidationStage.READINESS
+    assert result.probe_model == "gemini-cli/gemini-3.1-flash-lite"
+    assert str(requests[0].url) == (
+        "https://generativelanguage.googleapis.com/v1beta/models?pageSize=1"
+    )
+    assert str(requests[1].url) == (
+        "https://generativelanguage.googleapis.com/v1beta/models/"
+        "gemini-3.1-flash-lite:generateContent"
+    )
+    assert requests[0].headers["x-goog-api-key"] == _KEY
+    body = json.loads(requests[1].content)
+    assert body == {
+        "contents": [{"role": "user", "parts": [{"text": "ping"}]}],
+        "generationConfig": {"maxOutputTokens": 1},
+    }
+    assert "stream" not in body
+
+
+@pytest.mark.parametrize(
+    ("reason", "state"),
+    [
+        ("API_KEY_INVALID", ApiKeyValidationState.INVALID),
+        ("SERVICE_DISABLED", ApiKeyValidationState.PERMISSION_DENIED),
+        ("API_KEY_SERVICE_BLOCKED", ApiKeyValidationState.PERMISSION_DENIED),
+        ("API_KEY_HTTP_REFERRER_BLOCKED", ApiKeyValidationState.PERMISSION_DENIED),
+        ("API_KEY_IP_ADDRESS_BLOCKED", ApiKeyValidationState.PERMISSION_DENIED),
+        ("API_KEY_ANDROID_APP_BLOCKED", ApiKeyValidationState.PERMISSION_DENIED),
+        ("API_KEY_IOS_APP_BLOCKED", ApiKeyValidationState.PERMISSION_DENIED),
+    ],
+)
+@pytest.mark.asyncio
+async def test_gemini_uses_allowlisted_error_info(
+    reason: str, state: ApiKeyValidationState
+) -> None:
+    validator, requests = _validator(
+        [httpx.Response(400, json=_error("INVALID_ARGUMENT", reason=reason))]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is state
+    assert result.stage is ApiKeyValidationStage.AUTHENTICATION
+    assert len(requests) == 1
+    assert _KEY not in repr(result)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        _error("INVALID_ARGUMENT", reason="API_KEY_INVALID", domain="attacker.invalid"),
+        _error("INVALID_ARGUMENT", reason="UNKNOWN"),
+        _error("FAILED_PRECONDITION", reason="API_KEY_INVALID"),
+        {"error": {"status": "INVALID_ARGUMENT", "message": "API_KEY_INVALID"}},
+    ],
+)
+@pytest.mark.asyncio
+async def test_gemini_does_not_guess_from_partial_evidence(payload: dict) -> None:
+    validator, requests = _validator([httpx.Response(400, json=payload)])
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.UNAVAILABLE
+    assert result.stage is ApiKeyValidationStage.AUTHENTICATION
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_gemini_resource_exhausted_uses_structured_retry_info() -> None:
+    validator, _requests = _validator(
+        [
+            httpx.Response(
+                429,
+                headers={"retry-after": "9"},
+                json=_error("RESOURCE_EXHAUSTED", retry_delay="3.2s"),
+            )
+        ]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.RATE_LIMITED
+    assert result.retry_after_seconds == 4
+
+
+@pytest.mark.asyncio
+async def test_gemini_structured_permission_denied() -> None:
+    validator, _requests = _validator([httpx.Response(403, json=_error("PERMISSION_DENIED"))])
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.PERMISSION_DENIED
+
+
+@pytest.mark.asyncio
+async def test_gemini_structured_unauthenticated_401_is_invalid() -> None:
+    validator, requests = _validator([httpx.Response(401, json=_error("UNAUTHENTICATED"))])
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.INVALID
+    assert result.stage is ApiKeyValidationStage.AUTHENTICATION
+    assert len(requests) == 1
+    assert _KEY not in repr(result)
+
+
+@pytest.mark.asyncio
+async def test_gemini_unstructured_429_is_unavailable() -> None:
+    validator, _requests = _validator([httpx.Response(429, json={"error": {}})])
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_gemini_rejects_blocked_reason_on_contradictory_status() -> None:
+    validator, _requests = _validator(
+        [httpx.Response(503, json=_error("INTERNAL", reason="SERVICE_DISABLED"))]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_gemini_rejects_malformed_readiness_success() -> None:
+    validator, _requests = _validator(
+        [
+            httpx.Response(200, json={"models": []}),
+            httpx.Response(200, json={"candidates": []}),
+        ]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.UNAVAILABLE
+    assert result.stage is ApiKeyValidationStage.READINESS
+
+
+@pytest.mark.parametrize("payload", [{}, {"models": {}}, {"models": "bad"}])
+@pytest.mark.asyncio
+async def test_gemini_rejects_malformed_auth_success(payload: dict) -> None:
+    validator, requests = _validator([httpx.Response(200, json=payload)])
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.UNAVAILABLE
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_gemini_missing_validation_model_is_local_misconfiguration() -> None:
+    validator, requests = _validator([], models=[])
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.MISCONFIGURED
+    assert result.stage is None
+    assert requests == []
+
+
+@pytest.mark.asyncio
+async def test_gemini_registered_override_resolves_to_that_model() -> None:
+    validator, requests = _validator(
+        [
+            httpx.Response(200, json={"models": []}),
+            httpx.Response(200, json={"candidates": [{"content": {"parts": []}}]}),
+        ],
+        settings=GeminiPluginSettings(validation_model="gemini-cli/gemini-2.5-pro"),
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.VALID
+    assert result.probe_model == "gemini-cli/gemini-2.5-pro"
+    assert str(requests[1].url) == (
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent"
+    )
+
+
+@pytest.mark.asyncio
+async def test_gemini_unregistered_override_is_misconfiguration_without_io() -> None:
+    validator, requests = _validator(
+        [],
+        settings=GeminiPluginSettings(validation_model="gemini-cli/gemini-does-not-exist"),
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.MISCONFIGURED
+    assert result.stage is None
+    assert requests == []

--- a/apps/aigateway/tests/unit/gemini/test_api_key_validation.py
+++ b/apps/aigateway/tests/unit/gemini/test_api_key_validation.py
@@ -267,3 +267,48 @@ async def test_gemini_unregistered_override_is_misconfiguration_without_io() -> 
     assert result.state is ApiKeyValidationState.MISCONFIGURED
     assert result.stage is None
     assert requests == []
+
+
+@pytest.mark.parametrize(
+    ("retry_delay", "expected"),
+    [
+        ("3.2s", 4),
+        ("2147483647s", 2147483647),
+        ("2147483648s", None),
+        ("99999999999999999999s", None),
+    ],
+)
+@pytest.mark.asyncio
+async def test_gemini_structured_retry_after_is_bounded(
+    retry_delay: str, expected: int | None
+) -> None:
+    # WHY (OME-307 N-2): the structured RetryInfo.retryDelay shares the numeric Retry-After
+    # ceiling. An out-of-range value degrades to "no hint" instead of emitting an absurd
+    # (and, before this bound, effectively unbounded) retry hint.
+    validator, _requests = _validator(
+        [httpx.Response(429, json=_error("RESOURCE_EXHAUSTED", retry_delay=retry_delay))]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.RATE_LIMITED
+    assert result.retry_after_seconds == expected
+
+
+@pytest.mark.parametrize(
+    "unsafe",
+    ["gemini-cli/bad\x00model", "gemini-cli/bad model", "gemini-cli/bad:model"],
+)
+@pytest.mark.asyncio
+async def test_gemini_unsafe_model_id_is_misconfiguration_without_io(unsafe: str) -> None:
+    # WHY (OME-307 L-1): the readiness probe interpolates the model id into the request URL
+    # path; a URL-unsafe id would raise httpx.InvalidURL mid-probe. Reject it as a local
+    # misconfiguration before any network call rather than emit a malformed request.
+    entry = ModelEntry(model_name=unsafe, litellm_params={"model": unsafe})
+    validator, requests = _validator([], models=[entry])
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.MISCONFIGURED
+    assert result.stage is None
+    assert requests == []

--- a/apps/aigateway/tests/unit/gemini/test_settings.py
+++ b/apps/aigateway/tests/unit/gemini/test_settings.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import os
+
+from aigateway.plugins.gemini_provider.api_key_validation import GeminiApiKeyValidator
+from aigateway.plugins.gemini_provider.models import MODELS
+from aigateway.plugins.gemini_provider.plugin import GeminiProviderPlugin
+from aigateway.plugins.gemini_provider.settings import GeminiPluginSettings
+
+
+def _clear_gemini_env(monkeypatch) -> None:
+    for key in list(os.environ):
+        if key.startswith("AIGW_GEMINI_"):
+            monkeypatch.delenv(key, raising=False)
+
+
+def test_gemini_settings_default_validation_model_is_none(monkeypatch) -> None:
+    _clear_gemini_env(monkeypatch)
+
+    settings = GeminiPluginSettings()
+
+    # WHY: None means "use the registered stable probe default" — the validator,
+    # not settings, owns the fallback so an unset operator gets gemini-3.1-flash-lite.
+    assert settings.validation_model is None
+
+
+def test_gemini_settings_env_override_sets_validation_model(monkeypatch) -> None:
+    _clear_gemini_env(monkeypatch)
+    monkeypatch.setenv("AIGW_GEMINI_VALIDATION_MODEL", "gemini-cli/gemini-2.5-pro")
+
+    settings = GeminiPluginSettings()
+
+    assert settings.validation_model == "gemini-cli/gemini-2.5-pro"
+
+
+def test_gemini_settings_constructor_overrides_env(monkeypatch) -> None:
+    _clear_gemini_env(monkeypatch)
+    monkeypatch.setenv("AIGW_GEMINI_VALIDATION_MODEL", "gemini-cli/gemini-2.5-pro")
+
+    settings = GeminiPluginSettings(validation_model="gemini-cli/gemini-2.5-flash")
+
+    assert settings.validation_model == "gemini-cli/gemini-2.5-flash"
+
+
+def test_gemini_registers_stable_probe_and_drops_shutdown_model() -> None:
+    names = [entry.model_name for entry in MODELS]
+
+    # The current stable lite model is registered as the probe default...
+    assert "gemini-cli/gemini-3.1-flash-lite" in names
+    # ...and the model Google shut down on 2026-06-01 is no longer advertised.
+    assert "gemini-cli/gemini-2.0-flash" not in names
+
+
+def test_gemini_provider_passes_settings_and_models_to_validator() -> None:
+    settings = GeminiPluginSettings(validation_model="gemini-cli/gemini-2.5-pro")
+    plugin = GeminiProviderPlugin(settings=settings)
+
+    validator = plugin.api_key_validator()
+
+    assert isinstance(validator, GeminiApiKeyValidator)
+    # One settings instance and the plugin's registered models flow into the validator.
+    assert validator._settings is settings
+    assert validator._registered_models == plugin.register_models()

--- a/apps/aigateway/tests/unit/huggingface/test_api_key_validation.py
+++ b/apps/aigateway/tests/unit/huggingface/test_api_key_validation.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+
+import httpx
+import pytest
+
+from aigateway.core.api_key_validation import (
+    ApiKeyValidationStage,
+    ApiKeyValidationState,
+)
+from aigateway.plugins.huggingface_provider.api_key_validation import HuggingFaceApiKeyValidator
+from aigateway.plugins.huggingface_provider.settings import HuggingFacePluginSettings
+
+_KEY = "hf_synthetic_validation_secret"
+
+
+def _validator(
+    responses: Iterable[httpx.Response],
+    *,
+    settings: HuggingFacePluginSettings | None = None,
+) -> tuple[HuggingFaceApiKeyValidator, list[httpx.Request]]:
+    queued = list(responses)
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return queued.pop(0)
+
+    return (
+        HuggingFaceApiKeyValidator(
+            settings=settings or HuggingFacePluginSettings(),
+            transport=httpx.MockTransport(handler),
+        ),
+        requests,
+    )
+
+
+@pytest.mark.asyncio
+async def test_huggingface_validation_requires_identity_and_readiness() -> None:
+    settings = HuggingFacePluginSettings(router_api_base="https://attacker.invalid/v1")
+    validator, requests = _validator(
+        [
+            httpx.Response(200, json={"name": "test-user", "auth": {"type": "access_token"}}),
+            httpx.Response(200, json={"choices": [{"message": {"content": "ok"}}]}),
+        ],
+        settings=settings,
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.VALID
+    assert result.stage is ApiKeyValidationStage.READINESS
+    assert result.probe_model == "huggingface/openai/gpt-oss-120b:cerebras"
+    assert str(requests[0].url) == "https://huggingface.co/api/whoami-v2"
+    assert str(requests[1].url) == "https://router.huggingface.co/v1/chat/completions"
+    assert all(request.headers["authorization"] == f"Bearer {_KEY}" for request in requests)
+    assert json.loads(requests[1].content) == {
+        "model": "openai/gpt-oss-120b:cerebras",
+        "max_tokens": 1,
+        "stream": False,
+        "messages": [{"role": "user", "content": "ping"}],
+    }
+
+
+@pytest.mark.parametrize(
+    ("stage", "status", "state"),
+    [
+        (ApiKeyValidationStage.AUTHENTICATION, 401, ApiKeyValidationState.INVALID),
+        (ApiKeyValidationStage.AUTHENTICATION, 402, ApiKeyValidationState.NO_QUOTA),
+        (ApiKeyValidationStage.AUTHENTICATION, 403, ApiKeyValidationState.PERMISSION_DENIED),
+        (ApiKeyValidationStage.AUTHENTICATION, 429, ApiKeyValidationState.RATE_LIMITED),
+        (ApiKeyValidationStage.AUTHENTICATION, 503, ApiKeyValidationState.UNAVAILABLE),
+        (ApiKeyValidationStage.READINESS, 401, ApiKeyValidationState.PERMISSION_DENIED),
+        (ApiKeyValidationStage.READINESS, 402, ApiKeyValidationState.NO_QUOTA),
+        (ApiKeyValidationStage.READINESS, 403, ApiKeyValidationState.PERMISSION_DENIED),
+        (ApiKeyValidationStage.READINESS, 429, ApiKeyValidationState.RATE_LIMITED),
+        (ApiKeyValidationStage.READINESS, 503, ApiKeyValidationState.UNAVAILABLE),
+    ],
+)
+@pytest.mark.asyncio
+async def test_huggingface_classifies_status_by_stage(
+    stage: ApiKeyValidationStage,
+    status: int,
+    state: ApiKeyValidationState,
+) -> None:
+    responses = []
+    if stage is ApiKeyValidationStage.READINESS:
+        responses.append(
+            httpx.Response(200, json={"name": "test-user", "auth": {"type": "access_token"}})
+        )
+    responses.append(httpx.Response(status, headers={"retry-after": "13"}, json={"error": _KEY}))
+    validator, requests = _validator(responses)
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is state
+    assert result.stage is stage
+    assert result.retry_after_seconds == (
+        13 if state is ApiKeyValidationState.RATE_LIMITED else None
+    )
+    assert len(requests) == (2 if stage is ApiKeyValidationStage.READINESS else 1)
+    assert _KEY not in repr(result)
+
+
+@pytest.mark.parametrize("payload", [{}, {"name": ""}, {"name": "user", "auth": None}])
+@pytest.mark.asyncio
+async def test_huggingface_rejects_malformed_identity(payload: dict) -> None:
+    validator, requests = _validator([httpx.Response(200, json=payload)])
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.UNAVAILABLE
+    assert result.stage is ApiKeyValidationStage.AUTHENTICATION
+    assert len(requests) == 1
+
+
+@pytest.mark.parametrize("name", [1, True, {"value": "user"}, ["user"]])
+@pytest.mark.asyncio
+async def test_huggingface_rejects_non_string_identity_name(name: object) -> None:
+    validator, requests = _validator(
+        [
+            httpx.Response(200, json={"name": name, "auth": {}}),
+            httpx.Response(200, json={"choices": [{}]}),
+        ]
+    )
+
+    result = await validator.validate(_KEY)
+
+    # INVARIANT: malformed identity metadata cannot advance to the readiness probe.
+    assert result.state is ApiKeyValidationState.UNAVAILABLE
+    assert result.stage is ApiKeyValidationStage.AUTHENTICATION
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_huggingface_custom_registered_validation_model() -> None:
+    settings = HuggingFacePluginSettings(
+        default_models=["huggingface/org/model:provider"],
+        validation_model="huggingface/org/model:provider",
+    )
+    validator, requests = _validator(
+        [
+            httpx.Response(200, json={"name": "user", "auth": {}}),
+            httpx.Response(200, json={"choices": [{}]}),
+        ],
+        settings=settings,
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.VALID
+    assert result.probe_model == "huggingface/org/model:provider"
+    assert json.loads(requests[1].content)["model"] == "org/model:provider"
+
+
+@pytest.mark.parametrize(
+    "settings",
+    [
+        HuggingFacePluginSettings(default_models=[]),
+        HuggingFacePluginSettings(validation_model="huggingface/missing/model"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_huggingface_invalid_model_selection_is_local_misconfiguration(
+    settings: HuggingFacePluginSettings,
+) -> None:
+    validator, requests = _validator([], settings=settings)
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.MISCONFIGURED
+    assert result.stage is None
+    assert requests == []
+
+
+@pytest.mark.asyncio
+async def test_huggingface_rejects_malformed_readiness_success() -> None:
+    validator, _requests = _validator(
+        [
+            httpx.Response(200, json={"name": "user", "auth": {}}),
+            httpx.Response(200, json={"choices": []}),
+        ]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.UNAVAILABLE
+    assert result.stage is ApiKeyValidationStage.READINESS

--- a/apps/aigateway/tests/unit/openrouter/test_api_key_validation.py
+++ b/apps/aigateway/tests/unit/openrouter/test_api_key_validation.py
@@ -346,3 +346,129 @@ def test_disabled_openrouter_has_no_operational_validator() -> None:
         OpenRouterProviderPlugin(OpenRouterPluginSettings(enabled=True)).api_key_validator()
         is not None
     )
+
+
+@pytest.mark.parametrize(
+    ("status", "error_type"),
+    [(404, "not_found"), (400, "invalid_request")],
+)
+@pytest.mark.asyncio
+async def test_openrouter_readiness_probe_error_type_is_misconfigured(
+    status: int, error_type: str
+) -> None:
+    # WHY (OME-307 M-2): on the readiness probe a typed not_found/invalid_request indicts the
+    # PROBE MODEL, not the key, so it must classify MISCONFIGURED. Before the fix the generic
+    # "typed error_type -> UNAVAILABLE" fallback fired first and hid the actionable state.
+    validator, requests = _validator(
+        [
+            httpx.Response(200, json={"data": {}}),
+            httpx.Response(
+                status,
+                json={
+                    "error": {
+                        "code": status,
+                        "message": _KEY,
+                        "metadata": {"error_type": error_type},
+                    }
+                },
+            ),
+        ]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.MISCONFIGURED
+    assert result.stage is ApiKeyValidationStage.READINESS
+    assert len(requests) == 2
+    assert _KEY not in repr(result)
+
+
+@pytest.mark.asyncio
+async def test_openrouter_authentication_not_found_type_stays_unavailable() -> None:
+    # The readiness-only misconfiguration rule must NOT leak into the authentication stage,
+    # where a not_found type is unexpected and non-actionable.
+    validator, requests = _validator(
+        [
+            httpx.Response(
+                404, json={"error": {"code": 404, "metadata": {"error_type": "not_found"}}}
+            )
+        ]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.UNAVAILABLE
+    assert result.stage is ApiKeyValidationStage.AUTHENTICATION
+    assert len(requests) == 1
+
+
+@pytest.mark.parametrize(
+    ("outer_status", "error"),
+    [
+        # 5xx outer status: a not_found/invalid_request hint on a server error is untrustworthy.
+        (500, {"code": 500, "metadata": {"error_type": "not_found"}}),
+        (503, {"metadata": {"error_type": "not_found"}}),  # embedded status absent, outer 5xx
+        (500, {"code": 500, "metadata": {"error_type": "invalid_request"}}),
+        # outer/embedded statuses disagree (the reviewer's outer-500 / embedded-404 case).
+        (500, {"code": 404, "metadata": {"error_type": "not_found"}}),
+        # outer looks fine (200) but the embedded status contradicts the typed hint.
+        (200, {"code": 500, "metadata": {"error_type": "invalid_request"}}),
+        (200, {"code": 404, "metadata": {"error_type": "invalid_request"}}),  # 404 != expected 400
+    ],
+)
+@pytest.mark.asyncio
+async def test_openrouter_readiness_typed_error_contradictory_status_is_unavailable(
+    outer_status: int, error: dict
+) -> None:
+    # WHY (OME-307 M-2 follow-up): not_found/invalid_request only indict the probe MODEL when the
+    # HTTP evidence AGREES (not_found<->404, invalid_request<->400, outer status 200-or-expected,
+    # embedded status absent-or-expected). A 5xx outer status, or an embedded status that disagrees,
+    # signals an upstream fault rather than a gateway misconfiguration, so it must classify
+    # UNAVAILABLE instead of the actionable MISCONFIGURED.
+    error = {**error, "message": _KEY}
+    validator, requests = _validator(
+        [
+            httpx.Response(200, json={"data": {}}),
+            httpx.Response(outer_status, json={"error": error}),
+        ]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.UNAVAILABLE
+    assert result.stage is ApiKeyValidationStage.READINESS
+    assert len(requests) == 2
+    assert _KEY not in repr(result)
+
+
+@pytest.mark.parametrize(
+    ("outer_status", "embedded_code", "error_type"),
+    [
+        (200, 404, "not_found"),  # outer 200, embedded status carries the 404
+        (404, None, "not_found"),  # outer matches expected, embedded status absent
+        (200, 400, "invalid_request"),
+        (400, None, "invalid_request"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_openrouter_readiness_typed_error_consistent_status_is_misconfigured(
+    outer_status: int, embedded_code: int | None, error_type: str
+) -> None:
+    # WHY (OME-307 M-2 follow-up): the readiness MISCONFIGURED classification must SURVIVE when the
+    # evidence is consistent -- an outer status of 200-or-expected and an embedded status that is
+    # absent or matches the type -- so the tightened contradiction check does not over-restrict.
+    error: dict = {"message": _KEY, "metadata": {"error_type": error_type}}
+    if embedded_code is not None:
+        error["code"] = embedded_code
+    validator, requests = _validator(
+        [
+            httpx.Response(200, json={"data": {}}),
+            httpx.Response(outer_status, json={"error": error}),
+        ]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.MISCONFIGURED
+    assert result.stage is ApiKeyValidationStage.READINESS
+    assert len(requests) == 2

--- a/apps/aigateway/tests/unit/openrouter/test_api_key_validation.py
+++ b/apps/aigateway/tests/unit/openrouter/test_api_key_validation.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+
+import httpx
+import pytest
+
+from aigateway.core.api_key_validation import (
+    ApiKeyValidationStage,
+    ApiKeyValidationState,
+)
+from aigateway.plugins.openrouter_provider.api_key_validation import OpenRouterApiKeyValidator
+from aigateway.plugins.openrouter_provider.plugin import OpenRouterProviderPlugin
+from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSettings
+
+_KEY = "sk-or-v1-synthetic-validation-secret"
+
+
+def _validator(
+    responses: Iterable[httpx.Response],
+    *,
+    settings: OpenRouterPluginSettings | None = None,
+) -> tuple[OpenRouterApiKeyValidator, list[httpx.Request]]:
+    queued = list(responses)
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return queued.pop(0)
+
+    return (
+        OpenRouterApiKeyValidator(
+            settings=settings or OpenRouterPluginSettings(enabled=True),
+            transport=httpx.MockTransport(handler),
+        ),
+        requests,
+    )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_validation_uses_hidden_free_router() -> None:
+    settings = OpenRouterPluginSettings(enabled=True)
+    validator, requests = _validator(
+        [
+            httpx.Response(200, json={"data": {"limit_remaining": None, "label": "private"}}),
+            httpx.Response(200, json={"choices": [{"message": {"content": "ok"}}]}),
+        ],
+        settings=settings,
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.VALID
+    assert result.stage is ApiKeyValidationStage.READINESS
+    assert result.probe_model == "openrouter/openrouter/free"
+    assert "openrouter/openrouter/free" not in settings.default_models
+    assert str(requests[0].url) == "https://openrouter.ai/api/v1/key"
+    assert str(requests[1].url) == "https://openrouter.ai/api/v1/chat/completions"
+    assert all(request.headers["authorization"] == f"Bearer {_KEY}" for request in requests)
+    assert json.loads(requests[1].content) == {
+        "model": "openrouter/free",
+        "max_tokens": 1,
+        "stream": False,
+        "messages": [{"role": "user", "content": "ping"}],
+    }
+    assert "private" not in repr(result)
+
+
+@pytest.mark.asyncio
+async def test_openrouter_zero_paid_limit_does_not_block_free_readiness() -> None:
+    validator, requests = _validator(
+        [
+            httpx.Response(200, json={"data": {"limit_remaining": 0}}),
+            httpx.Response(200, json={"choices": [{}]}),
+        ]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.VALID
+    assert len(requests) == 2
+
+
+@pytest.mark.parametrize(
+    ("stage", "status", "state"),
+    [
+        (ApiKeyValidationStage.AUTHENTICATION, 401, ApiKeyValidationState.INVALID),
+        (ApiKeyValidationStage.AUTHENTICATION, 402, ApiKeyValidationState.UNAVAILABLE),
+        (ApiKeyValidationStage.AUTHENTICATION, 403, ApiKeyValidationState.PERMISSION_DENIED),
+        (ApiKeyValidationStage.AUTHENTICATION, 429, ApiKeyValidationState.RATE_LIMITED),
+        (ApiKeyValidationStage.AUTHENTICATION, 503, ApiKeyValidationState.UNAVAILABLE),
+        (ApiKeyValidationStage.READINESS, 401, ApiKeyValidationState.INVALID),
+        (ApiKeyValidationStage.READINESS, 402, ApiKeyValidationState.NO_QUOTA),
+        (ApiKeyValidationStage.READINESS, 403, ApiKeyValidationState.PERMISSION_DENIED),
+        (ApiKeyValidationStage.READINESS, 400, ApiKeyValidationState.MISCONFIGURED),
+        (ApiKeyValidationStage.READINESS, 404, ApiKeyValidationState.MISCONFIGURED),
+        (ApiKeyValidationStage.READINESS, 429, ApiKeyValidationState.RATE_LIMITED),
+        (ApiKeyValidationStage.READINESS, 503, ApiKeyValidationState.UNAVAILABLE),
+    ],
+)
+@pytest.mark.asyncio
+async def test_openrouter_classifies_http_errors(
+    stage: ApiKeyValidationStage,
+    status: int,
+    state: ApiKeyValidationState,
+) -> None:
+    responses = []
+    if stage is ApiKeyValidationStage.READINESS:
+        responses.append(httpx.Response(200, json={"data": {}}))
+    responses.append(
+        httpx.Response(
+            status,
+            headers={"retry-after": "17"},
+            json={"error": {"code": status, "message": _KEY}},
+        )
+    )
+    validator, requests = _validator(responses)
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is state
+    assert result.stage is stage
+    assert result.retry_after_seconds == (
+        17 if state is ApiKeyValidationState.RATE_LIMITED else None
+    )
+    assert len(requests) == (2 if stage is ApiKeyValidationStage.READINESS else 1)
+    assert _KEY not in repr(result)
+
+
+@pytest.mark.parametrize(
+    ("error", "state"),
+    [
+        (
+            {"code": 429, "metadata": {"error_type": "rate_limit_exceeded"}},
+            ApiKeyValidationState.RATE_LIMITED,
+        ),
+        (
+            {"code": 402, "metadata": {"error_type": "payment_required"}},
+            ApiKeyValidationState.NO_QUOTA,
+        ),
+        (
+            {"code": 403, "metadata": {"error_type": "permission_denied"}},
+            ApiKeyValidationState.PERMISSION_DENIED,
+        ),
+        ({"code": 503}, ApiKeyValidationState.UNAVAILABLE),
+    ],
+)
+@pytest.mark.asyncio
+async def test_openrouter_rejects_embedded_http_200_errors(
+    error: dict,
+    state: ApiKeyValidationState,
+) -> None:
+    validator, requests = _validator(
+        [
+            httpx.Response(200, json={"data": {}}),
+            httpx.Response(200, json={"choices": [{"finish_reason": "error", "error": error}]}),
+        ]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is state
+    assert result.stage is ApiKeyValidationStage.READINESS
+    assert len(requests) == 2
+
+
+@pytest.mark.parametrize(
+    ("error", "state"),
+    [
+        (
+            {"code": 402, "metadata": {"error_type": "payment_required"}},
+            ApiKeyValidationState.NO_QUOTA,
+        ),
+        (
+            {"code": 429, "metadata": {"error_type": "rate_limit_exceeded"}},
+            ApiKeyValidationState.RATE_LIMITED,
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_openrouter_rejects_top_level_embedded_http_200_errors(
+    error: dict,
+    state: ApiKeyValidationState,
+) -> None:
+    validator, requests = _validator(
+        [
+            httpx.Response(200, json={"data": {}}),
+            httpx.Response(200, json={"error": error, "choices": [{}]}),
+        ]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is state
+    assert result.stage is ApiKeyValidationStage.READINESS
+    assert len(requests) == 2
+    assert _KEY not in repr(result)
+
+
+@pytest.mark.asyncio
+async def test_openrouter_finish_only_error_is_unavailable() -> None:
+    validator, _requests = _validator(
+        [
+            httpx.Response(200, json={"data": {}}),
+            httpx.Response(200, json={"choices": [{"finish_reason": "error"}]}),
+        ]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_openrouter_contradictory_embedded_evidence_is_unavailable() -> None:
+    validator, _requests = _validator(
+        [
+            httpx.Response(200, json={"data": {}}),
+            httpx.Response(
+                200,
+                json={
+                    "choices": [
+                        {
+                            "error": {
+                                "code": 503,
+                                "metadata": {"error_type": "permission_denied"},
+                            }
+                        }
+                    ]
+                },
+            ),
+        ]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_openrouter_non_actionable_type_overrides_misleading_status() -> None:
+    validator, _requests = _validator(
+        [
+            httpx.Response(200, json={"data": {}}),
+            httpx.Response(
+                200,
+                json={
+                    "choices": [
+                        {
+                            "error": {
+                                "code": 403,
+                                "metadata": {"error_type": "provider_unavailable"},
+                            }
+                        }
+                    ]
+                },
+            ),
+        ]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_openrouter_rejects_malformed_readiness_success() -> None:
+    validator, _requests = _validator(
+        [
+            httpx.Response(200, json={"data": {}}),
+            httpx.Response(200, json={"choices": []}),
+        ]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.UNAVAILABLE
+    assert result.stage is ApiKeyValidationStage.READINESS
+
+
+@pytest.mark.asyncio
+async def test_openrouter_explicit_registered_validation_model() -> None:
+    settings = OpenRouterPluginSettings(
+        enabled=True,
+        validation_model="openrouter/anthropic/claude-fable-5",
+    )
+    validator, requests = _validator(
+        [
+            httpx.Response(200, json={"data": {}}),
+            httpx.Response(200, json={"choices": [{}]}),
+        ],
+        settings=settings,
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.VALID
+    assert json.loads(requests[1].content)["model"] == "anthropic/claude-fable-5"
+
+
+@pytest.mark.asyncio
+async def test_openrouter_explicit_internal_default_is_valid() -> None:
+    settings = OpenRouterPluginSettings(
+        enabled=True,
+        validation_model="openrouter/openrouter/free",
+    )
+    validator, requests = _validator(
+        [
+            httpx.Response(200, json={"data": {}}),
+            httpx.Response(200, json={"choices": [{}]}),
+        ],
+        settings=settings,
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.VALID
+    assert result.probe_model == "openrouter/openrouter/free"
+    assert json.loads(requests[1].content)["model"] == "openrouter/free"
+
+
+@pytest.mark.parametrize(
+    "validation_model",
+    ["openrouter/missing/model", "bad-model", ""],
+)
+@pytest.mark.asyncio
+async def test_openrouter_explicit_unregistered_model_is_misconfigured(
+    validation_model: str,
+) -> None:
+    settings = OpenRouterPluginSettings(enabled=True, validation_model=validation_model)
+    validator, requests = _validator([], settings=settings)
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.MISCONFIGURED
+    assert requests == []
+
+
+def test_disabled_openrouter_has_no_operational_validator() -> None:
+    assert (
+        OpenRouterProviderPlugin(OpenRouterPluginSettings(enabled=False)).api_key_validator()
+        is None
+    )
+    assert (
+        OpenRouterProviderPlugin(OpenRouterPluginSettings(enabled=True)).api_key_validator()
+        is not None
+    )

--- a/apps/aigateway/tests/unit/openrouter/test_response_errors.py
+++ b/apps/aigateway/tests/unit/openrouter/test_response_errors.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import pytest
+
+from aigateway.plugins.openrouter_provider.response_errors import (
+    find_converted_error,
+    find_raw_error,
+)
+
+
+@pytest.mark.parametrize("value", [None, {}, "", {"code": None, "message": ""}])
+def test_benign_top_level_error_is_not_a_failure(value: object) -> None:
+    assert find_raw_error({"error": value}).found is False
+    assert find_converted_error({"error": value}).found is False
+
+
+def test_raw_error_extracts_status_and_allowlisted_type() -> None:
+    error = find_raw_error(
+        {
+            "error": {
+                "code": 429,
+                "message": "must not survive",
+                "metadata": {
+                    "error_type": "rate_limit_exceeded",
+                    "provider_code": "must-not-survive",
+                },
+            }
+        }
+    )
+
+    assert error.found is True
+    assert error.status == 429
+    assert error.error_type == "rate_limit_exceeded"
+    assert "must" not in repr(error)
+
+
+def test_raw_error_detects_choice_error_and_finish_reason() -> None:
+    with_error = find_raw_error(
+        {"choices": [{"error": {"code": 402, "metadata": {"error_type": "payment_required"}}}]}
+    )
+    finish_only = find_raw_error({"choices": [{"finish_reason": "error"}]})
+
+    assert (with_error.found, with_error.status, with_error.error_type) == (
+        True,
+        402,
+        "payment_required",
+    )
+    assert (finish_only.found, finish_only.status, finish_only.error_type) == (True, None, None)
+
+
+def test_converted_error_preserves_litellm_specific_fields() -> None:
+    converted = find_converted_error(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "provider_specific_fields": {
+                            "error": {"code": 503},
+                            "native_finish_reason": "error",
+                        }
+                    }
+                }
+            ]
+        }
+    )
+
+    assert (converted.found, converted.status) == (True, 503)
+
+
+def test_raw_error_ignores_litellm_only_fields() -> None:
+    raw = find_raw_error(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "provider_specific_fields": {
+                            "error": {"code": 503},
+                            "native_finish_reason": "error",
+                        }
+                    }
+                }
+            ]
+        }
+    )
+
+    assert raw.found is False
+
+
+def test_raw_error_does_not_merge_evidence_from_separate_errors() -> None:
+    raw = find_raw_error(
+        {
+            "error": {"code": 503},
+            "choices": [{"error": {"metadata": {"error_type": "permission_denied"}}}],
+        }
+    )
+
+    assert raw.status == 503
+    assert raw.error_type is None
+
+
+@pytest.mark.parametrize("code", [True, 399, 600, 429.0, "429", "４２９"])
+def test_embedded_status_must_be_a_strict_http_error(code: object) -> None:
+    error = find_raw_error({"error": {"code": code}})
+
+    assert error.found is True
+    assert error.status is None

--- a/apps/aigateway/tests/unit/test_api_key_connection_races.py
+++ b/apps/aigateway/tests/unit/test_api_key_connection_races.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from uuid import UUID
+
+import pytest
+
+from aigateway.core.api_key_validation import (
+    ApiKeyValidationResult,
+    ApiKeyValidationStage,
+    ApiKeyValidationState,
+)
+from aigateway.core.oauth.store import OAuthConnectionStore, credential_key_for
+from aigateway.plugins.anthropic_provider.auth import (
+    credential_service_for as anthropic_service_for,
+)
+
+_KEY_A = "sk-ant-api03-race-existing-key"
+_KEY_B = "sk-ant-api03-race-replacement-key"
+
+
+@dataclass
+class _BlockingValidationService:
+    started: threading.Event = field(default_factory=threading.Event)
+    release: threading.Event = field(default_factory=threading.Event)
+
+    async def validate(self, _plugin, _provider: str, api_key: str) -> ApiKeyValidationResult:
+        if api_key == _KEY_B:
+            self.started.set()
+            if not await asyncio.to_thread(self.release.wait, 5):
+                raise TimeoutError("replacement validation was not released")
+        return ApiKeyValidationResult(
+            ApiKeyValidationState.VALID,
+            stage=ApiKeyValidationStage.READINESS,
+        )
+
+
+def _connection_blob(credential_blobs, data: dict) -> dict | None:
+    service = anthropic_service_for(credential_key_for(data["account_id"], data["id"]))
+    raw = credential_blobs.read(service, "default")
+    return None if raw is None else json.loads(raw)
+
+
+def test_delete_wins_over_inflight_key_replacement(
+    authenticated_client,
+    credential_blobs,
+) -> None:
+    service = _BlockingValidationService()
+    authenticated_client.app.state.api_key_validation_service = service
+    created_response = authenticated_client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "anthropic", "label": "race", "api_key": _KEY_A},
+    )
+    assert created_response.status_code == 201
+    created = created_response.json()
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        replacement = executor.submit(
+            authenticated_client.put,
+            f"/v1/oauth/connections/{created['id']}/api-key",
+            json={"api_key": _KEY_B},
+        )
+        assert service.started.wait(5), "replacement never reached validation"
+
+        deleted = authenticated_client.delete(f"/v1/oauth/connections/{created['id']}")
+        service.release.set()
+        replaced = replacement.result(timeout=5)
+
+    assert deleted.status_code == 204
+    assert replaced.status_code == 409
+    assert replaced.json()["detail"]["code"] == "connection_conflict"
+    after = authenticated_client.get(f"/v1/oauth/connections/{created['id']}").json()
+    # INVARIANT: an older validation result cannot undo a completed delete.
+    assert after["status"] == "revoked"
+    assert _connection_blob(credential_blobs, created) is None
+
+
+def test_reactivation_conflict_rolls_back_replacement_blob(
+    authenticated_client,
+    credential_blobs,
+    monkeypatch,
+) -> None:
+    service = _BlockingValidationService()
+    service.release.set()
+    authenticated_client.app.state.api_key_validation_service = service
+    created_response = authenticated_client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "anthropic", "label": "rollback", "api_key": _KEY_A},
+    )
+    assert created_response.status_code == 201
+    created = created_response.json()
+
+    async def lose_reactivation_race(
+        _self: OAuthConnectionStore,
+        _connection,
+    ) -> None:
+        return None
+
+    monkeypatch.setattr(OAuthConnectionStore, "reactivate", lose_reactivation_race)
+
+    replaced = authenticated_client.put(
+        f"/v1/oauth/connections/{created['id']}/api-key",
+        json={"api_key": _KEY_B},
+    )
+
+    assert replaced.status_code == 409
+    assert replaced.json()["detail"]["code"] == "connection_conflict"
+    # INVARIANT: transaction rollback restores the exact pre-replacement credential.
+    assert _connection_blob(credential_blobs, created) == {
+        "auth_type": "api_key",
+        "api_key": _KEY_A,
+    }
+
+
+def test_create_connection_cancelled_after_blob_write_commits_neither_row_nor_blob(
+    authenticated_client,
+    credential_blobs,
+    monkeypatch,
+) -> None:
+    """OME-307 Unit 4: create persists the key and creates the connection row in ONE
+    transaction, so a cancellation AFTER the blob write but before the row commits rolls
+    BOTH back.
+
+    INVARIANT: transaction rollback — not best-effort ``except`` cleanup — is the atomicity
+    mechanism. ``asyncio.CancelledError`` is a ``BaseException`` in 3.12, so an
+    ``except Exception`` compensation could never drop the orphan blob; only unwinding the
+    transaction boundary can. Neither an active connection-without-credential nor an orphan
+    credential-without-connection may ever commit.
+    """
+    service = _BlockingValidationService()
+    service.release.set()
+    authenticated_client.app.state.api_key_validation_service = service
+    account_id = authenticated_client.get("/v1/auth/me").json()["id"]
+
+    captured: dict[str, UUID] = {}
+
+    async def _cancel_after_blob(_self, **kwargs) -> None:
+        # Row creation runs only AFTER the in-transaction credential write, so cancelling
+        # here models "cancelled after the blob write, before the row commits".
+        captured["connection_id"] = kwargs["connection_id"]
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(OAuthConnectionStore, "create_api_key", _cancel_after_blob)
+
+    # The sync TestClient surfaces an in-request asyncio.CancelledError as the
+    # concurrent.futures variant once it crosses the blocking-portal boundary.
+    with pytest.raises(concurrent.futures.CancelledError):
+        authenticated_client.post(
+            "/v1/oauth/connections/api-key",
+            json={"provider": "anthropic", "label": "cancelled", "api_key": _KEY_A},
+        )
+    assert "connection_id" in captured, "row creation never ran after the blob write"
+
+    # Rollback dropped the in-transaction blob write — no orphan credential survived.
+    blob_service = anthropic_service_for(credential_key_for(account_id, captured["connection_id"]))
+    assert credential_blobs.read(blob_service, "default") is None
+    # And no connection row committed (it rolled back with the blob).
+    assert (
+        authenticated_client.get(f"/v1/oauth/connections/{captured['connection_id']}").status_code
+        == 404
+    )

--- a/apps/aigateway/tests/unit/test_api_key_connection_validation.py
+++ b/apps/aigateway/tests/unit/test_api_key_connection_validation.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from aigateway.core.api_key_validation import (
+    ApiKeyValidationResult,
+    ApiKeyValidationStage,
+    ApiKeyValidationState,
+)
+from aigateway.core.credential_strategy_cache import credential_strategy_cache
+
+_KEY = "sk-ant-api03-synthetic-connection-secret"
+
+
+@dataclass
+class _StubValidationService:
+    result: ApiKeyValidationResult | None
+    calls: list[tuple[str, str]] = field(default_factory=list)
+
+    async def validate(self, _plugin, provider: str, api_key: str):
+        self.calls.append((provider, api_key))
+        return self.result
+
+
+@pytest.mark.parametrize(
+    ("state", "status_code", "code"),
+    [
+        (ApiKeyValidationState.INVALID, 422, "api_key_invalid"),
+        (ApiKeyValidationState.EXPIRED, 422, "api_key_expired"),
+        (ApiKeyValidationState.NO_QUOTA, 402, "api_key_no_quota"),
+        (ApiKeyValidationState.PERMISSION_DENIED, 403, "api_key_permission_denied"),
+        (ApiKeyValidationState.RATE_LIMITED, 429, "api_key_validation_rate_limited"),
+        (ApiKeyValidationState.UNAVAILABLE, 503, "api_key_validation_unavailable"),
+        (ApiKeyValidationState.MISCONFIGURED, 503, "api_key_validation_misconfigured"),
+    ],
+)
+def test_create_maps_every_non_valid_state_without_persistence(
+    authenticated_client,
+    state: ApiKeyValidationState,
+    status_code: int,
+    code: str,
+) -> None:
+    retry_after = 23 if state is ApiKeyValidationState.RATE_LIMITED else None
+    service = _StubValidationService(
+        ApiKeyValidationResult(
+            state=state,
+            stage=ApiKeyValidationStage.AUTHENTICATION,
+            retry_after_seconds=retry_after,
+        )
+    )
+    authenticated_client.app.state.api_key_validation_service = service
+
+    response = authenticated_client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "anthropic", "label": f"state-{state}", "api_key": _KEY},
+    )
+
+    assert response.status_code == status_code
+    assert response.json()["detail"]["code"] == code
+    assert response.headers.get("retry-after") == ("23" if retry_after is not None else None)
+    assert service.calls == [("anthropic", _KEY)]
+    assert authenticated_client.get("/v1/oauth/connections").json()["connections"] == []
+
+
+def test_create_runs_label_conflict_gate_before_validation(authenticated_client) -> None:
+    service = _StubValidationService(
+        ApiKeyValidationResult(
+            state=ApiKeyValidationState.VALID,
+            stage=ApiKeyValidationStage.READINESS,
+        )
+    )
+    authenticated_client.app.state.api_key_validation_service = service
+    first = authenticated_client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "anthropic", "label": "duplicate", "api_key": _KEY},
+    )
+    assert first.status_code == 201
+    service.calls.clear()
+
+    second = authenticated_client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "anthropic", "label": "duplicate", "api_key": _KEY},
+    )
+
+    assert second.status_code == 409
+    assert second.json()["detail"]["code"] == "label_conflict"
+    assert service.calls == []
+
+
+def test_unsupported_provider_gate_precedes_validation(authenticated_client) -> None:
+    service = _StubValidationService(
+        ApiKeyValidationResult(
+            state=ApiKeyValidationState.VALID,
+            stage=ApiKeyValidationStage.READINESS,
+        )
+    )
+    authenticated_client.app.state.api_key_validation_service = service
+
+    response = authenticated_client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "codex", "label": "unsupported", "api_key": _KEY},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "api_key_not_supported"
+    assert service.calls == []
+
+
+def test_create_validation_failure_precedes_blob_and_cache_mutation(
+    authenticated_client,
+    monkeypatch,
+) -> None:
+    service = _StubValidationService(
+        ApiKeyValidationResult(
+            state=ApiKeyValidationState.INVALID,
+            stage=ApiKeyValidationStage.AUTHENTICATION,
+        )
+    )
+    authenticated_client.app.state.api_key_validation_service = service
+
+    async def forbidden_write(*_args, **_kwargs):
+        raise AssertionError("validation failure must not write credentials")
+
+    def forbidden_evict(*_args, **_kwargs):
+        raise AssertionError("validation failure must not evict credential cache")
+
+    monkeypatch.setattr(authenticated_client.app.state.credential_store, "write", forbidden_write)
+    monkeypatch.setattr(
+        credential_strategy_cache(authenticated_client.app),
+        "evict",
+        forbidden_evict,
+    )
+
+    response = authenticated_client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "anthropic", "label": "no-side-effects", "api_key": _KEY},
+    )
+
+    assert response.status_code == 422

--- a/apps/aigateway/tests/unit/test_api_key_routes.py
+++ b/apps/aigateway/tests/unit/test_api_key_routes.py
@@ -6,14 +6,17 @@ probe (which decrypts through the same master key as the app's ORMStore).
 
 from __future__ import annotations
 
+import asyncio
 import json
-import logging
+import threading
 from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 
 import httpx
 import pytest
 
+import aigateway.routes.auth as auth_module
 from aigateway.core.credential_blob.store import CredentialBlobMutationConflict
 from aigateway.core.profile_index import ProfileIndexStore
 from aigateway.core.profile_models import (
@@ -146,51 +149,6 @@ def test_set_api_key_profile_index_conflict_returns_retryable_503(
     assert credential_blobs.read(service, "default") is None
 
 
-def test_set_api_key_delete_compensation_failure_is_sanitized(
-    authenticated_client, monkeypatch, caplog
-) -> None:
-    leak_marker = "sk-ant-api03-compensation-secret-that-must-not-leak"
-
-    async def _boom(_profile) -> None:
-        raise RuntimeError("profile index unavailable")
-
-    async def _mutate_failure(_service: str, _account: str, _mutator) -> None:
-        raise RuntimeError(f"delete failed for {leak_marker}")
-
-    monkeypatch.setattr(authenticated_client.app.state.profile_index, "upsert", _boom)
-    monkeypatch.setattr(authenticated_client.app.state.credential_store, "mutate", _mutate_failure)
-    caplog.set_level(logging.ERROR, logger="aigateway.routes.auth")
-
-    with _server_errors_as_responses(authenticated_client):
-        resp = _put_api_key(authenticated_client, "anthropic", "keyed", ANTHROPIC_KEY)
-
-    assert resp.status_code == 500
-    assert "Failed to compensate API-key credential slot" in caplog.text
-    assert "RuntimeError" in caplog.text
-    assert ANTHROPIC_KEY not in caplog.text
-    assert leak_marker not in caplog.text
-
-
-def test_set_api_key_compensation_preserves_concurrent_slot_write(
-    authenticated_client, credential_blobs, monkeypatch
-) -> None:
-    account_id = _account_id(authenticated_client)
-    service = credential_service_for(credential_name_for(account_id, "keyed"))
-    concurrent = json.dumps({"auth_type": "api_key", "api_key": "sk-ant-api03-other-5678"})
-
-    async def _boom(_profile) -> None:
-        credential_blobs.write(service, "default", concurrent)
-        raise RuntimeError("profile index unavailable")
-
-    monkeypatch.setattr(authenticated_client.app.state.profile_index, "upsert", _boom)
-
-    with _server_errors_as_responses(authenticated_client):
-        resp = _put_api_key(authenticated_client, "anthropic", "keyed", ANTHROPIC_KEY)
-
-    assert resp.status_code == 500
-    assert credential_blobs.read(service, "default") == concurrent
-
-
 @pytest.mark.asyncio
 async def test_set_api_key_restores_oauth_blob_when_profile_index_update_fails(
     authenticated_client, credential_blobs, monkeypatch
@@ -220,7 +178,9 @@ async def test_set_api_key_restores_oauth_blob_when_profile_index_update_fails(
     )
     credential_blobs.write(service, "default", previous)
 
-    async def _boom(_profile) -> None:
+    # Faithful double of ProfileIndexStore.upsert: the observed-existing update path passes
+    # require_present=True (OME-307 Unit 3), so the stub tolerates that keyword.
+    async def _boom(_profile, **_kwargs) -> None:
         raise RuntimeError("profile index unavailable")
 
     monkeypatch.setattr(authenticated_client.app.state.profile_index, "upsert", _boom)
@@ -236,9 +196,19 @@ async def test_set_api_key_restores_oauth_blob_when_profile_index_update_fails(
 
 
 @pytest.mark.asyncio
-async def test_set_api_key_restore_compensation_failure_is_sanitized(
-    authenticated_client, credential_blobs, monkeypatch, caplog
+async def test_set_api_key_failure_preserves_concurrent_slot_write_via_rollback(
+    authenticated_client, credential_blobs, monkeypatch
 ) -> None:
+    """OME-307 Blocker 4: transaction rollback is the SOLE atomicity mechanism for a failed
+    API-key publication. There is deliberately NO post-rollback credential compensation — a
+    second, out-of-transaction mutate would be redundant with rollback AND could clobber a
+    concurrent task that legitimately owns the same slot (an ABA defect). Replaces the retired
+    compensation-sanitization tests: a value a CONCURRENT owner committed to the shared slot
+    must survive the failed publication untouched, and no compensating mutate may run.
+
+    STORY: as an operator whose key rotation on a profile fails mid-publish, a teammate's
+    concurrent, successful write to the same slot is never silently reverted by my failure.
+    """
     account_id = _account_id(authenticated_client)
     idx = ProfileIndexStore(credential_store=credential_blobs.store)
     await idx.upsert(
@@ -248,39 +218,147 @@ async def test_set_api_key_restore_compensation_failure_is_sanitized(
             provider="anthropic",
             name="default",
             state=ProfileState.AUTHENTICATED,
-            auth_type="oauth",
+            auth_type="api_key",
         )
     )
     service = credential_service_for(credential_name_for(account_id, "default"))
-    previous = json.dumps(
-        {
-            "access_token": "oauth-tok",
-            "refresh_token": "oauth-rt",
-            "expires_at_ms": 1,
-            "token_type": "Bearer",
-        }
+    # The value a concurrent owner committed to the shared slot; it must NOT be clobbered.
+    concurrent_owned = json.dumps(
+        {"auth_type": "api_key", "api_key": "sk-ant-api03-concurrent-owner-9999"}
     )
-    credential_blobs.write(service, "default", previous)
-    leak_marker = "sk-ant-api03-restore-secret-that-must-not-leak"
+    credential_blobs.write(service, "default", concurrent_owned)
 
-    async def _boom(_profile) -> None:
+    # Faithful double of ProfileIndexStore.upsert: the observed-existing update path passes
+    # require_present=True (OME-307 Unit 3), so the stub tolerates that keyword.
+    async def _boom(_profile, **_kwargs) -> None:
         raise RuntimeError("profile index unavailable")
 
-    async def _mutate_failure(_service: str, _account: str, _mutator) -> None:
-        raise RuntimeError(f"restore failed for {leak_marker}")
+    # INVARIANT: a failed publication performs NO out-of-transaction credential mutate. The spy
+    # records every call, so a reintroduced post-rollback compensation would fail this test.
+    mutate_calls: list[tuple[str, str]] = []
+    real_mutate = authenticated_client.app.state.credential_store.mutate
+
+    async def _spy_mutate(svc: str, acct: str, mutator) -> None:
+        mutate_calls.append((svc, acct))
+        return await real_mutate(svc, acct, mutator)
 
     monkeypatch.setattr(authenticated_client.app.state.profile_index, "upsert", _boom)
-    monkeypatch.setattr(authenticated_client.app.state.credential_store, "mutate", _mutate_failure)
-    caplog.set_level(logging.ERROR, logger="aigateway.routes.auth")
+    monkeypatch.setattr(authenticated_client.app.state.credential_store, "mutate", _spy_mutate)
 
     with _server_errors_as_responses(authenticated_client):
         resp = _put_api_key(authenticated_client, "anthropic", "default", ANTHROPIC_KEY)
 
     assert resp.status_code == 500
-    assert "Failed to compensate API-key credential slot" in caplog.text
-    assert "RuntimeError" in caplog.text
-    assert ANTHROPIC_KEY not in caplog.text
-    assert leak_marker not in caplog.text
+    # Rollback alone preserved the concurrent owner's value; no compensation ran to clobber it.
+    assert credential_blobs.read(service, "default") == concurrent_owned
+    assert mutate_calls == []
+    # Neither the caller's key nor the concurrent owner's key leaks into the response.
+    assert ANTHROPIC_KEY not in resp.text
+    assert "9999" not in resp.text
+
+
+def test_set_api_key_rollback_does_not_compensate_over_same_key_external_commit(
+    authenticated_client,
+    credential_blobs,
+    monkeypatch,
+) -> None:
+    """S2's identical key must survive after S1 rolls back and handles its failure.
+
+    INVARIANT: plaintext equality cannot prove write ownership. Any post-rollback compensation
+    from S1 is delayed until S2 commits the same key, making the ABA clobber deterministic if
+    compensation is ever reintroduced.
+    """
+    account_id = _account_id(authenticated_client)
+    previous_key = "sk-ant-api03-previous-key-0000"
+    assert (
+        _put_api_key(authenticated_client, "anthropic", "default", previous_key).status_code == 200
+    )
+    service = credential_service_for(credential_name_for(account_id, "default"))
+
+    s1_wrote = threading.Event()
+    release_s1_failure = threading.Event()
+    s2_completed = threading.Event()
+    persist_count = 0
+    persist_count_lock = threading.Lock()
+    compensation_calls: list[str] = []
+    s1_task = None
+    s1_initial_write = False
+    persist_credentials = auth_module.persist_credentials_or_503
+    credential_store = authenticated_client.app.state.credential_store
+    write = credential_store.write
+    delete = credential_store.delete
+    mutate = credential_store.mutate
+
+    async def _fail_first_after_write(*args, **kwargs) -> None:
+        nonlocal persist_count, s1_initial_write, s1_task
+        with persist_count_lock:
+            persist_count += 1
+            call_number = persist_count
+        if call_number == 1:
+            s1_task = asyncio.current_task()
+            s1_initial_write = True
+        await persist_credentials(*args, **kwargs)
+        if call_number == 1:
+            s1_initial_write = False
+            s1_wrote.set()
+            if not await asyncio.to_thread(release_s1_failure.wait, 5):
+                raise TimeoutError("S1 failure was not released")
+            raise RuntimeError("S1 publication failed after its transactional write")
+
+    async def _record_s1_compensation(operation: str, service_name: str) -> None:
+        if service_name == service and asyncio.current_task() is s1_task and not s1_initial_write:
+            compensation_calls.append(operation)
+            if not await asyncio.to_thread(s2_completed.wait, 5):
+                raise TimeoutError("S2 did not commit before compensation")
+
+    async def _delay_compensating_write(service_name, account, value) -> None:
+        await _record_s1_compensation("write", service_name)
+        await write(service_name, account, value)
+
+    async def _delay_compensating_delete(service_name, account) -> None:
+        await _record_s1_compensation("delete", service_name)
+        await delete(service_name, account)
+
+    async def _delay_compensating_mutate(service_name, account, mutator) -> None:
+        await _record_s1_compensation("mutate", service_name)
+        await mutate(service_name, account, mutator)
+
+    monkeypatch.setattr(auth_module, "persist_credentials_or_503", _fail_first_after_write)
+    monkeypatch.setattr(credential_store, "write", _delay_compensating_write)
+    monkeypatch.setattr(credential_store, "delete", _delay_compensating_delete)
+    monkeypatch.setattr(credential_store, "mutate", _delay_compensating_mutate)
+
+    with (
+        _server_errors_as_responses(authenticated_client),
+        ThreadPoolExecutor(max_workers=2) as executor,
+    ):
+        request_s1 = executor.submit(
+            _put_api_key,
+            authenticated_client,
+            "anthropic",
+            "default",
+            ANTHROPIC_KEY,
+        )
+        assert s1_wrote.wait(5), "S1 never wrote its transactional credential"
+        request_s2 = executor.submit(
+            _put_api_key,
+            authenticated_client,
+            "anthropic",
+            "default",
+            ANTHROPIC_KEY,
+        )
+        release_s1_failure.set()
+        response_s2 = request_s2.result(timeout=10)
+        s2_completed.set()
+        response_s1 = request_s1.result(timeout=10)
+
+    assert response_s1.status_code == 500
+    assert response_s2.status_code == 200
+    assert compensation_calls == []
+    assert json.loads(credential_blobs.read(service, "default")) == {
+        "auth_type": "api_key",
+        "api_key": ANTHROPIC_KEY,
+    }
 
 
 @pytest.mark.asyncio

--- a/apps/aigateway/tests/unit/test_api_key_validation_contract.py
+++ b/apps/aigateway/tests/unit/test_api_key_validation_contract.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from aigateway.core.api_key_validation import (
+    ApiKeyValidationResult,
+    ApiKeyValidationStage,
+    ApiKeyValidationState,
+    api_key_validation_message,
+)
+from aigateway.core.plugin_base import ModelEntry, PluginSettings, ProviderPluginBase
+
+
+@pytest.mark.parametrize(
+    ("state", "value", "retryable"),
+    [
+        (ApiKeyValidationState.VALID, "valid", False),
+        (ApiKeyValidationState.INVALID, "invalid", False),
+        (ApiKeyValidationState.EXPIRED, "expired", False),
+        (ApiKeyValidationState.NO_QUOTA, "no_quota", False),
+        (ApiKeyValidationState.PERMISSION_DENIED, "permission_denied", False),
+        (ApiKeyValidationState.RATE_LIMITED, "rate_limited", True),
+        (ApiKeyValidationState.UNAVAILABLE, "unavailable", True),
+        (ApiKeyValidationState.MISCONFIGURED, "misconfigured", False),
+    ],
+)
+def test_validation_states_have_stable_values_and_retryability(
+    state: ApiKeyValidationState,
+    value: str,
+    retryable: bool,
+) -> None:
+    result = ApiKeyValidationResult(state=state)
+
+    assert state.value == value
+    assert result.retryable is retryable
+
+
+@pytest.mark.parametrize(
+    ("state", "message"),
+    [
+        (ApiKeyValidationState.VALID, "API key is valid and ready for inference."),
+        (
+            ApiKeyValidationState.INVALID,
+            "The provider rejected this API key. Check or replace it.",
+        ),
+        (ApiKeyValidationState.EXPIRED, "This API key has expired. Create a new key."),
+        (
+            ApiKeyValidationState.NO_QUOTA,
+            "This API key has no available credits or spending limit. "
+            "Add credits or raise its limit.",
+        ),
+        (
+            ApiKeyValidationState.PERMISSION_DENIED,
+            "The API key is valid but cannot use the validation model.",
+        ),
+        (
+            ApiKeyValidationState.RATE_LIMITED,
+            "The provider rate-limited validation. Try again later.",
+        ),
+        (
+            ApiKeyValidationState.UNAVAILABLE,
+            "The provider could not complete validation. Try again later.",
+        ),
+        (
+            ApiKeyValidationState.MISCONFIGURED,
+            "API-key validation is not configured for this provider. Contact the gateway operator.",
+        ),
+    ],
+)
+def test_validation_messages_are_gateway_owned(
+    state: ApiKeyValidationState,
+    message: str,
+) -> None:
+    assert api_key_validation_message(state) == message
+
+
+def test_validation_result_is_immutable() -> None:
+    result = ApiKeyValidationResult(
+        state=ApiKeyValidationState.RATE_LIMITED,
+        stage=ApiKeyValidationStage.AUTHENTICATION,
+        retry_after_seconds=60,
+        probe_model="provider/model",
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        setattr(result, "retry_after_seconds", 1)
+
+
+class _UnsupportedPlugin(ProviderPluginBase[PluginSettings]):
+    def register_models(self) -> list[ModelEntry]:
+        return []
+
+
+def test_provider_base_has_no_api_key_validator_by_default() -> None:
+    assert _UnsupportedPlugin().api_key_validator() is None

--- a/apps/aigateway/tests/unit/test_api_key_validation_http.py
+++ b/apps/aigateway/tests/unit/test_api_key_validation_http.py
@@ -323,3 +323,66 @@ async def test_validation_session_caps_genuinely_streamed_body_incrementally() -
 
     # Stops once the 64 KiB bound is crossed instead of buffering the whole stream.
     assert 0 < stream.yielded < 16
+
+
+@pytest.mark.asyncio
+async def test_validation_session_degrades_overlong_retry_after_without_transport_error() -> None:
+    # WHY (OME-307 N-1): a Retry-After longer than CPython's int-string conversion limit
+    # (sys.int_info.default_max_str_digits, 4300 by default) must not raise inside int() and
+    # get swallowed by the sanitizing except, which would downgrade a real 429 to a transport
+    # error (UNAVAILABLE). It degrades to "no hint" and preserves the rate-limit status.
+    transport = httpx.MockTransport(
+        lambda _request: httpx.Response(
+            429, headers={"retry-after": "9" * 5000}, json={"error": {}}
+        )
+    )
+
+    async with ValidationHttpSession(transport=transport) as session:
+        response = await session.request_json("GET", "https://provider.example/key")
+
+    assert response.status_code == 429
+    assert response.retry_after_seconds is None
+
+
+@pytest.mark.asyncio
+async def test_validation_session_preserves_retry_after_at_upper_bound() -> None:
+    transport = httpx.MockTransport(
+        lambda _request: httpx.Response(
+            429, headers={"retry-after": "2147483647"}, json={"error": {}}
+        )
+    )
+
+    async with ValidationHttpSession(transport=transport) as session:
+        response = await session.request_json("GET", "https://provider.example/key")
+
+    assert response.retry_after_seconds == 2147483647
+
+
+@pytest.mark.asyncio
+async def test_validation_session_sanitizes_invalid_url() -> None:
+    # WHY (OME-307 L-1): httpx.InvalidURL derives from Exception, NOT httpx.HTTPError, so it
+    # escaped the sanitizing except and could surface a raw URL to the caller. A control
+    # character in an interpolated model URL reaches this path (verified on httpx 0.28.1).
+    transport = httpx.MockTransport(lambda _request: httpx.Response(200, json={}))
+
+    async with ValidationHttpSession(transport=transport) as session:
+        with pytest.raises(ApiKeyValidationTransportError):
+            await session.request_json("GET", "http://\x00host/models/x:generateContent")
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [httpx.CookieConflict("ambiguous cookie"), httpx.StreamError("stream misuse")],
+)
+@pytest.mark.asyncio
+async def test_validation_session_sanitizes_non_httperror_httpx_exceptions(
+    exc: Exception,
+) -> None:
+    # httpx.CookieConflict derives from Exception and httpx.StreamError from RuntimeError;
+    # neither is an httpx.HTTPError, so both must be caught explicitly, never escape raw.
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise exc
+
+    async with ValidationHttpSession(transport=httpx.MockTransport(handler)) as session:
+        with pytest.raises(ApiKeyValidationTransportError):
+            await session.request_json("GET", "https://provider.example/key")

--- a/apps/aigateway/tests/unit/test_api_key_validation_http.py
+++ b/apps/aigateway/tests/unit/test_api_key_validation_http.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import asyncio
+import gzip
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+
+from aigateway.core.api_key_validation_http import (
+    ApiKeyValidationTransportError,
+    ValidationHttpSession,
+)
+
+
+class _ChunkStream(httpx.AsyncByteStream):
+    """A genuinely streamed (not pre-buffered) response body.
+
+    ``httpx.Response(stream=...)`` with this leaves ``is_stream_consumed`` False,
+    so ``ValidationHttpSession`` takes the incremental ``aiter_raw`` branch rather
+    than the pre-buffered ``response.content`` branch that MockTransport exercises.
+    """
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+        self.yielded = 0
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            self.yielded += 1
+            yield chunk
+
+    async def aclose(self) -> None:
+        return None
+
+
+class _StreamingTransport(httpx.AsyncBaseTransport):
+    def __init__(self, stream: httpx.AsyncByteStream) -> None:
+        self._stream = stream
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=self._stream)
+
+
+class _SlowDripStream(httpx.AsyncByteStream):
+    def __init__(self) -> None:
+        self.yielded = 0
+        self.closed = False
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        self.yielded += 1
+        yield b'{"data":'
+        await asyncio.Event().wait()
+        self.yielded += 1
+        yield b"[]}"
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_validation_session_returns_bounded_json_without_following_redirects() -> None:
+    calls: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        return httpx.Response(302, headers={"location": "https://attacker.invalid/steal"})
+
+    async with ValidationHttpSession(transport=httpx.MockTransport(handler)) as session:
+        response = await session.request_json("GET", "https://provider.example/key")
+
+    assert response.status_code == 302
+    assert response.payload is None
+    assert [str(request.url) for request in calls] == ["https://provider.example/key"]
+    assert calls[0].headers["accept-encoding"] == "identity"
+
+
+@pytest.mark.asyncio
+async def test_validation_session_parses_json_once_with_safe_headers() -> None:
+    transport = httpx.MockTransport(
+        lambda _request: httpx.Response(
+            200,
+            headers={"retry-after": "7", "authorization": "must-not-survive"},
+            json={"data": []},
+        )
+    )
+
+    async with ValidationHttpSession(transport=transport) as session:
+        response = await session.request_json("GET", "https://provider.example/key")
+
+    assert response.status_code == 200
+    assert response.payload == {"data": []}
+    assert response.retry_after_seconds == 7
+    assert not hasattr(response, "headers")
+
+
+@pytest.mark.asyncio
+async def test_validation_session_rejects_oversized_streamed_body() -> None:
+    transport = httpx.MockTransport(
+        lambda _request: httpx.Response(200, content=b'"' + (b"x" * 65536) + b'"')
+    )
+
+    async with ValidationHttpSession(transport=transport) as session:
+        with pytest.raises(ApiKeyValidationTransportError):
+            await session.request_json("GET", "https://provider.example/key")
+
+
+@pytest.mark.asyncio
+async def test_validation_session_rejects_declared_oversized_body_before_reading() -> None:
+    transport = httpx.MockTransport(
+        lambda _request: httpx.Response(
+            200,
+            headers={"content-length": "65537"},
+            content=b"{}",
+        )
+    )
+
+    async with ValidationHttpSession(transport=transport) as session:
+        with pytest.raises(ApiKeyValidationTransportError):
+            await session.request_json("GET", "https://provider.example/key")
+
+
+@pytest.mark.asyncio
+async def test_validation_session_rejects_malformed_json() -> None:
+    transport = httpx.MockTransport(lambda _request: httpx.Response(200, content=b"not-json"))
+
+    async with ValidationHttpSession(transport=transport) as session:
+        with pytest.raises(ApiKeyValidationTransportError):
+            await session.request_json("GET", "https://provider.example/key")
+
+
+@pytest.mark.asyncio
+async def test_validation_session_does_not_retry_transport_failures() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        raise httpx.ConnectError("offline", request=request)
+
+    async with ValidationHttpSession(transport=httpx.MockTransport(handler)) as session:
+        with pytest.raises(ApiKeyValidationTransportError):
+            await session.request_json("GET", "https://provider.example/key")
+
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_validation_session_propagates_external_cancellation() -> None:
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        raise asyncio.CancelledError
+
+    async with ValidationHttpSession(transport=httpx.MockTransport(handler)) as session:
+        with pytest.raises(asyncio.CancelledError):
+            await session.request_json("GET", "https://provider.example/key")
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "1.5", "tomorrow", "2147483648"])
+@pytest.mark.asyncio
+async def test_validation_session_rejects_unsafe_retry_after(value: str) -> None:
+    transport = httpx.MockTransport(
+        lambda _request: httpx.Response(429, headers={"retry-after": value}, json={"error": {}})
+    )
+
+    async with ValidationHttpSession(transport=transport) as session:
+        response = await session.request_json("GET", "https://provider.example/key")
+
+    assert response.retry_after_seconds is None
+
+
+@pytest.mark.asyncio
+async def test_validation_session_enforces_total_deadline(monkeypatch) -> None:
+    from aigateway.core import api_key_validation_http
+
+    monkeypatch.setattr(api_key_validation_http, "_REQUEST_TIMEOUT_SECONDS", 0.1)
+    monkeypatch.setattr(api_key_validation_http, "_TOTAL_TIMEOUT_SECONDS", 0.01)
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        await asyncio.sleep(0.02)
+        return httpx.Response(200, json={})
+
+    async with ValidationHttpSession(transport=httpx.MockTransport(handler)) as session:
+        with pytest.raises(ApiKeyValidationTransportError):
+            await session.request_json("GET", "https://provider.example/key")
+
+
+@pytest.mark.asyncio
+async def test_validation_session_deadline_covers_slow_stream_body(monkeypatch) -> None:
+    from aigateway.core import api_key_validation_http
+
+    monkeypatch.setattr(api_key_validation_http, "_REQUEST_TIMEOUT_SECONDS", 0.1)
+    monkeypatch.setattr(api_key_validation_http, "_TOTAL_TIMEOUT_SECONDS", 0.01)
+    stream = _SlowDripStream()
+
+    async with ValidationHttpSession(transport=_StreamingTransport(stream)) as session:
+        with pytest.raises(ApiKeyValidationTransportError):
+            await session.request_json("GET", "https://provider.example/key")
+
+    assert stream.yielded == 1
+    assert stream.closed is True
+
+
+@pytest.mark.asyncio
+async def test_validation_session_caps_decoded_compressed_body() -> None:
+    compressed = gzip.compress(b'"' + (b"x" * 65536) + b'"')
+    transport = httpx.MockTransport(
+        lambda _request: httpx.Response(
+            200,
+            headers={"content-encoding": "gzip"},
+            content=compressed,
+        )
+    )
+
+    async with ValidationHttpSession(transport=transport) as session:
+        with pytest.raises(ApiKeyValidationTransportError):
+            await session.request_json("GET", "https://provider.example/key")
+
+
+class _ClosingTransport(httpx.AsyncBaseTransport):
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={}, request=request)
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_validation_session_closes_request_local_transport() -> None:
+    transport = _ClosingTransport()
+
+    async with ValidationHttpSession(transport=transport) as session:
+        await session.request_json("GET", "https://provider.example/key")
+
+    assert transport.closed is True
+
+
+@pytest.mark.asyncio
+async def test_validation_session_production_transport_disables_ambient_controls(
+    monkeypatch,
+) -> None:
+    from aigateway.core import api_key_validation_http
+
+    transport_options: dict[str, object] = {}
+    client_options: dict[str, object] = {}
+    original_client = httpx.AsyncClient
+
+    def transport_factory(**kwargs):
+        transport_options.update(kwargs)
+        return httpx.MockTransport(lambda _request: httpx.Response(200, json={}))
+
+    def client_factory(**kwargs):
+        client_options.update(kwargs)
+        return original_client(**kwargs)
+
+    monkeypatch.setattr(api_key_validation_http.httpx, "AsyncHTTPTransport", transport_factory)
+    monkeypatch.setattr(api_key_validation_http.httpx, "AsyncClient", client_factory)
+
+    async with ValidationHttpSession():
+        pass
+
+    # The transport itself must also disable ambient env: trust_env=True would let
+    # SSL_CERT_FILE / SSL_CERT_DIR (and proxy env) rebind the verified CA bundle.
+    assert transport_options == {"retries": 0, "verify": True, "trust_env": False}
+    assert client_options["trust_env"] is False
+    assert client_options["follow_redirects"] is False
+    assert client_options["verify"] is True
+
+
+@pytest.mark.asyncio
+async def test_validation_session_shares_one_absolute_deadline(monkeypatch) -> None:
+    from aigateway.core import api_key_validation_http
+
+    monkeypatch.setattr(api_key_validation_http, "_REQUEST_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(api_key_validation_http, "_TOTAL_TIMEOUT_SECONDS", 0.03)
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        await asyncio.sleep(0.02)
+        return httpx.Response(200, json={})
+
+    async with ValidationHttpSession(transport=httpx.MockTransport(handler)) as session:
+        first = await session.request_json("GET", "https://provider.example/auth")
+        assert first.status_code == 200
+        with pytest.raises(ApiKeyValidationTransportError):
+            await session.request_json("POST", "https://provider.example/readiness")
+
+
+@pytest.mark.asyncio
+async def test_validation_session_sanitizes_deeply_nested_json() -> None:
+    # Under 64 KiB but nested far past the JSON recursion limit: json.loads raises
+    # RecursionError, which must be sanitized to a transport error, not escape raw.
+    depth = 20_000
+    payload = b"[" * depth + b"]" * depth
+    assert len(payload) < 64 * 1024
+    transport = httpx.MockTransport(lambda _request: httpx.Response(200, content=payload))
+
+    async with ValidationHttpSession(transport=transport) as session:
+        with pytest.raises(ApiKeyValidationTransportError):
+            await session.request_json("GET", "https://provider.example/key")
+
+
+@pytest.mark.asyncio
+async def test_validation_session_reads_genuinely_streamed_body() -> None:
+    stream = _ChunkStream([b'{"da', b'ta": ', b"[]}"])
+
+    async with ValidationHttpSession(transport=_StreamingTransport(stream)) as session:
+        response = await session.request_json("GET", "https://provider.example/key")
+
+    assert response.payload == {"data": []}
+    # Proves the incremental aiter_raw branch ran (a pre-buffered body yields nothing here).
+    assert stream.yielded == 3
+
+
+@pytest.mark.asyncio
+async def test_validation_session_caps_genuinely_streamed_body_incrementally() -> None:
+    stream = _ChunkStream([b"x" * 8192 for _ in range(16)])
+
+    async with ValidationHttpSession(transport=_StreamingTransport(stream)) as session:
+        with pytest.raises(ApiKeyValidationTransportError):
+            await session.request_json("GET", "https://provider.example/key")
+
+    # Stops once the 64 KiB bound is crossed instead of buffering the whole stream.
+    assert 0 < stream.yielded < 16

--- a/apps/aigateway/tests/unit/test_api_key_validation_isolation.py
+++ b/apps/aigateway/tests/unit/test_api_key_validation_isolation.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import httpx
+import pytest
+
+from aigateway.core.api_key_validation import (
+    ApiKeyValidationStage,
+    ApiKeyValidationState,
+)
+from aigateway.plugins.anthropic_provider.api_key_validation import AnthropicApiKeyValidator
+from aigateway.plugins.anthropic_provider.settings import AnthropicPluginSettings
+from aigateway.plugins.huggingface_provider.api_key_validation import HuggingFaceApiKeyValidator
+from aigateway.plugins.huggingface_provider.settings import HuggingFacePluginSettings
+
+_ANTHROPIC_KEY = "sk-ant-api03-parallel-isolation-secret"
+_HUGGINGFACE_KEY = "hf_parallel_isolation_secret"
+
+
+class _OverlapBarrier:
+    def __init__(self) -> None:
+        self.arrivals = 0
+        self._ready = asyncio.Event()
+
+    async def wait(self) -> None:
+        self.arrivals += 1
+        if self.arrivals == 2:
+            self._ready.set()
+        await self._ready.wait()
+
+
+@pytest.mark.asyncio
+async def test_parallel_validations_isolate_keys_clients_results_and_logs(caplog) -> None:
+    barrier = _OverlapBarrier()
+    anthropic_requests: list[httpx.Request] = []
+    huggingface_requests: list[httpx.Request] = []
+
+    async def anthropic_handler(request: httpx.Request) -> httpx.Response:
+        anthropic_requests.append(request)
+        if len(anthropic_requests) == 1:
+            await barrier.wait()
+            return httpx.Response(200, json={"data": []})
+        return httpx.Response(200, json={"type": "message", "content": []})
+
+    async def huggingface_handler(request: httpx.Request) -> httpx.Response:
+        huggingface_requests.append(request)
+        await barrier.wait()
+        return httpx.Response(401, json={"error": "invalid"})
+
+    anthropic_settings = AnthropicPluginSettings()
+    anthropic = AnthropicApiKeyValidator(
+        settings=anthropic_settings,
+        registered_models=list(anthropic_settings.models),
+        transport=httpx.MockTransport(anthropic_handler),
+    )
+    huggingface = HuggingFaceApiKeyValidator(
+        settings=HuggingFacePluginSettings(),
+        transport=httpx.MockTransport(huggingface_handler),
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        anthropic_result, huggingface_result = await asyncio.gather(
+            anthropic.validate(_ANTHROPIC_KEY),
+            huggingface.validate(_HUGGINGFACE_KEY),
+        )
+
+    assert barrier.arrivals == 2
+    assert anthropic_result.state is ApiKeyValidationState.VALID
+    assert anthropic_result.stage is ApiKeyValidationStage.READINESS
+    assert huggingface_result.state is ApiKeyValidationState.INVALID
+    assert huggingface_result.stage is ApiKeyValidationStage.AUTHENTICATION
+    assert [request.url.host for request in anthropic_requests] == ["api.anthropic.com"] * 2
+    assert [request.url.host for request in huggingface_requests] == ["huggingface.co"]
+    assert all(request.headers["x-api-key"] == _ANTHROPIC_KEY for request in anthropic_requests)
+    assert all(
+        request.headers["authorization"] == f"Bearer {_HUGGINGFACE_KEY}"
+        for request in huggingface_requests
+    )
+    evidence = caplog.text + repr(anthropic_result) + repr(huggingface_result)
+    assert _ANTHROPIC_KEY not in evidence
+    assert _HUGGINGFACE_KEY not in evidence

--- a/apps/aigateway/tests/unit/test_api_key_validation_routes.py
+++ b/apps/aigateway/tests/unit/test_api_key_validation_routes.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from aigateway.core.api_key_validation import (
+    ApiKeyValidationResult,
+    ApiKeyValidationStage,
+    ApiKeyValidationState,
+)
+from aigateway.core.api_key_validation_service import ApiKeyValidationService
+from aigateway.core.credential_strategy_cache import credential_strategy_cache
+
+_KEY = "sk-ant-api03-synthetic-route-secret"
+
+
+@dataclass
+class _StubValidationService:
+    result: ApiKeyValidationResult | None
+    calls: list[tuple[str, str]] = field(default_factory=list)
+
+    async def validate(self, _plugin, provider: str, api_key: str):
+        self.calls.append((provider, api_key))
+        return self.result
+
+
+def _install(authenticated_client, result: ApiKeyValidationResult | None) -> _StubValidationService:
+    service = _StubValidationService(result)
+    authenticated_client.app.state.api_key_validation_service = service
+    return service
+
+
+def test_validation_endpoint_returns_stable_non_persisting_result(
+    authenticated_client,
+    monkeypatch,
+) -> None:
+    service = _install(
+        authenticated_client,
+        ApiKeyValidationResult(
+            state=ApiKeyValidationState.RATE_LIMITED,
+            stage=ApiKeyValidationStage.READINESS,
+            retry_after_seconds=12,
+            probe_model="claude-haiku-4-5",
+        ),
+    )
+
+    def forbidden_sync(*_args, **_kwargs):
+        raise AssertionError("validation endpoint must not mutate local state")
+
+    async def forbidden_async(*_args, **_kwargs):
+        raise AssertionError("validation endpoint must not persist state")
+
+    monkeypatch.setattr(
+        authenticated_client.app.state.pending_auth, "pop_for_profile", forbidden_sync
+    )
+    monkeypatch.setattr(authenticated_client.app.state.profile_index, "upsert", forbidden_async)
+    monkeypatch.setattr(authenticated_client.app.state.credential_store, "write", forbidden_async)
+    monkeypatch.setattr(
+        credential_strategy_cache(authenticated_client.app), "evict", forbidden_sync
+    )
+
+    response = authenticated_client.post(
+        "/v1/oauth/connections/api-key/validate",
+        json={"provider": "anthropic", "api_key": _KEY},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "provider": "anthropic",
+        "state": "rate_limited",
+        "message": "The provider rate-limited validation. Try again later.",
+        "retryable": True,
+        "stage": "readiness",
+        "retry_after_seconds": 12,
+        "probe_model": "claude-haiku-4-5",
+    }
+    assert service.calls == [("anthropic", _KEY)]
+    assert authenticated_client.get("/v1/oauth/connections").json()["connections"] == []
+
+
+def test_validation_endpoint_rejects_short_key_without_service_call(authenticated_client) -> None:
+    service = _install(authenticated_client, ApiKeyValidationResult(ApiKeyValidationState.VALID))
+
+    response = authenticated_client.post(
+        "/v1/oauth/connections/api-key/validate",
+        json={"provider": "anthropic", "api_key": "short"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "invalid_api_key"
+    assert service.calls == []
+
+
+def test_validation_endpoint_hides_secret_on_schema_error(authenticated_client) -> None:
+    response = authenticated_client.post(
+        "/v1/oauth/connections/api-key/validate",
+        json={"api_key": _KEY},
+    )
+
+    assert response.status_code == 422
+    assert _KEY not in response.text
+
+
+def test_disabled_openrouter_is_unsupported_without_network(authenticated_client) -> None:
+    authenticated_client.app.state.api_key_validation_service = ApiKeyValidationService()
+
+    response = authenticated_client.post(
+        "/v1/oauth/connections/api-key/validate",
+        json={"provider": "openrouter", "api_key": "sk-or-v1-synthetic"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == {
+        "code": "api_key_not_supported",
+        "provider": "openrouter",
+    }
+
+
+def test_create_non_valid_key_returns_actionable_error_without_row(authenticated_client) -> None:
+    service = _install(
+        authenticated_client,
+        ApiKeyValidationResult(
+            state=ApiKeyValidationState.INVALID,
+            stage=ApiKeyValidationStage.AUTHENTICATION,
+        ),
+    )
+
+    response = authenticated_client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "anthropic", "label": "invalid", "api_key": _KEY},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == {
+        "code": "api_key_invalid",
+        "provider": "anthropic",
+        "state": "invalid",
+        "message": "The provider rejected this API key. Check or replace it.",
+        "retryable": False,
+        "stage": "authentication",
+        "retry_after_seconds": None,
+        "probe_model": None,
+    }
+    assert service.calls == [("anthropic", _KEY)]
+    assert authenticated_client.get("/v1/oauth/connections").json()["connections"] == []
+
+
+def test_replace_non_valid_key_preserves_existing_connection_and_blob(
+    authenticated_client,
+    credential_blobs,
+    monkeypatch,
+) -> None:
+    service = _install(
+        authenticated_client,
+        ApiKeyValidationResult(
+            state=ApiKeyValidationState.VALID,
+            stage=ApiKeyValidationStage.READINESS,
+        ),
+    )
+    created = authenticated_client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "anthropic", "label": "replace", "api_key": _KEY},
+    ).json()
+    locator = created["credential_locator"]
+    before = credential_blobs.read(locator["service"], locator["account"])
+    service.result = ApiKeyValidationResult(
+        state=ApiKeyValidationState.NO_QUOTA,
+        stage=ApiKeyValidationStage.READINESS,
+        probe_model="claude-haiku-4-5",
+    )
+
+    def forbidden_evict(*_args, **_kwargs):
+        raise AssertionError("validation failure must not evict credential cache")
+
+    monkeypatch.setattr(
+        credential_strategy_cache(authenticated_client.app),
+        "evict",
+        forbidden_evict,
+    )
+
+    response = authenticated_client.put(
+        f"/v1/oauth/connections/{created['id']}/api-key",
+        json={"api_key": "sk-ant-api03-new-secret"},
+    )
+
+    assert response.status_code == 402
+    assert response.json()["detail"]["code"] == "api_key_no_quota"
+    assert credential_blobs.read(locator["service"], locator["account"]) == before
+    after = authenticated_client.get(f"/v1/oauth/connections/{created['id']}").json()
+    assert after == created
+
+
+def test_profile_non_valid_key_does_not_create_profile(authenticated_client) -> None:
+    service = _install(
+        authenticated_client,
+        ApiKeyValidationResult(
+            state=ApiKeyValidationState.UNAVAILABLE,
+            stage=ApiKeyValidationStage.AUTHENTICATION,
+        ),
+    )
+
+    response = authenticated_client.put(
+        "/v1/auth/anthropic/profiles/invalid/api-key",
+        json={"api_key": _KEY},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["code"] == "api_key_validation_unavailable"
+    assert authenticated_client.get("/v1/auth/anthropic/profiles/invalid").status_code == 404
+    assert service.calls == [("anthropic", _KEY)]
+
+
+def test_validation_endpoint_requires_authentication(client) -> None:
+    response = client.post(
+        "/v1/oauth/connections/api-key/validate",
+        json={"provider": "anthropic", "api_key": _KEY},
+    )
+
+    assert response.status_code == 401
+
+
+def test_validation_endpoint_documents_readiness_cost(authenticated_client) -> None:
+    operation = authenticated_client.get("/openapi.json").json()["paths"][
+        "/v1/oauth/connections/api-key/validate"
+    ]["post"]
+
+    description = operation.get("description", "").lower()
+    # INVARIANT: callers can discover that validation performs billable upstream work.
+    assert "readiness" in description
+    assert "quota" in description
+    assert "credit" in description
+
+
+def test_validation_endpoint_rejects_unknown_provider_before_service(
+    authenticated_client,
+) -> None:
+    service = _install(
+        authenticated_client,
+        ApiKeyValidationResult(ApiKeyValidationState.VALID),
+    )
+
+    response = authenticated_client.post(
+        "/v1/oauth/connections/api-key/validate",
+        json={"provider": "unknown", "api_key": _KEY},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == {"code": "unknown_provider", "provider": "unknown"}
+    assert service.calls == []

--- a/apps/aigateway/tests/unit/test_api_key_validation_service.py
+++ b/apps/aigateway/tests/unit/test_api_key_validation_service.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from aigateway.core.api_key_validation import (
+    ApiKeyValidationResult,
+    ApiKeyValidationStage,
+    ApiKeyValidationState,
+    ApiKeyValidator,
+)
+from aigateway.core.api_key_validation_service import ApiKeyValidationService
+from aigateway.plugins.anthropic_provider.api_key_validation import AnthropicApiKeyValidator
+from aigateway.plugins.anthropic_provider.plugin import AnthropicProviderPlugin
+from aigateway.plugins.gemini_provider.api_key_validation import GeminiApiKeyValidator
+from aigateway.plugins.gemini_provider.plugin import GeminiProviderPlugin
+from aigateway.plugins.huggingface_provider.api_key_validation import HuggingFaceApiKeyValidator
+from aigateway.plugins.huggingface_provider.plugin import HuggingFaceProviderPlugin
+
+
+class _NoValidatorPlugin:
+    def api_key_validator(self):
+        return None
+
+
+@dataclass
+class _RecordingValidator:
+    keys: list[str]
+
+    async def validate(self, api_key: str) -> ApiKeyValidationResult:
+        self.keys.append(api_key)
+        return ApiKeyValidationResult(
+            state=ApiKeyValidationState.VALID,
+            stage=ApiKeyValidationStage.READINESS,
+            probe_model="provider/model",
+        )
+
+
+class _Plugin:
+    def __init__(self, validator: _RecordingValidator) -> None:
+        self.validator = validator
+        self.calls = 0
+
+    def api_key_validator(self) -> _RecordingValidator:
+        self.calls += 1
+        return self.validator
+
+
+@dataclass
+class _StaticValidator:
+    result: ApiKeyValidationResult
+
+    async def validate(self, api_key: str) -> ApiKeyValidationResult:
+        del api_key
+        return self.result
+
+
+class _StaticPlugin:
+    def __init__(self, result: ApiKeyValidationResult) -> None:
+        self.validator = _StaticValidator(result)
+
+    def api_key_validator(self) -> ApiKeyValidator:
+        return self.validator
+
+
+@pytest.mark.asyncio
+async def test_service_returns_none_without_operational_validator() -> None:
+    result = await ApiKeyValidationService().validate(
+        _NoValidatorPlugin(),
+        "unsupported",
+        "synthetic-secret",
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_service_resolves_validator_once_and_forwards_key() -> None:
+    validator = _RecordingValidator(keys=[])
+    plugin = _Plugin(validator)
+
+    result = await ApiKeyValidationService().validate(
+        plugin,
+        "provider",
+        "synthetic-secret",
+    )
+
+    assert result == ApiKeyValidationResult(
+        state=ApiKeyValidationState.VALID,
+        stage=ApiKeyValidationStage.READINESS,
+        probe_model="provider/model",
+    )
+    assert plugin.calls == 1
+    assert validator.keys == ["synthetic-secret"]
+
+
+@pytest.mark.parametrize("stage", [None, ApiKeyValidationStage.AUTHENTICATION])
+@pytest.mark.asyncio
+async def test_service_rejects_valid_without_readiness(
+    stage: ApiKeyValidationStage | None,
+) -> None:
+    result = await ApiKeyValidationService().validate(
+        _StaticPlugin(ApiKeyValidationResult(ApiKeyValidationState.VALID, stage=stage)),
+        "provider",
+        "synthetic-secret",
+    )
+
+    # INVARIANT: no plugin can authorize persistence without completing readiness.
+    assert result == ApiKeyValidationResult(ApiKeyValidationState.MISCONFIGURED)
+
+
+@pytest.mark.parametrize(
+    ("plugin", "validator_type"),
+    [
+        (AnthropicProviderPlugin(), AnthropicApiKeyValidator),
+        (GeminiProviderPlugin(), GeminiApiKeyValidator),
+        (HuggingFaceProviderPlugin(), HuggingFaceApiKeyValidator),
+    ],
+)
+def test_builtin_plugins_expose_their_operational_validator(plugin, validator_type) -> None:
+    assert isinstance(plugin.api_key_validator(), validator_type)

--- a/apps/aigateway/tests/unit/test_api_key_validation_writer_integration.py
+++ b/apps/aigateway/tests/unit/test_api_key_validation_writer_integration.py
@@ -1,0 +1,285 @@
+"""Deterministic unstubbed backstops for the three API-key writers (OME-307 D1/F3).
+
+FEATURE: mandatory API-key validation before any credential write.
+STORY: as an operator, when I create/replace an API-key connection or set a profile
+API key, a bad key is rejected before anything is persisted, and a good key is stored.
+
+Unlike the frozen route tests (which stub ``ApiKeyValidationService.validate`` via the
+conftest allowlist), this module runs the REAL chain end to end:
+route -> ``require_valid_api_key`` -> real ``ApiKeyValidationService`` -> real Anthropic
+validator -> bounded ``ValidationHttpSession`` -> a deterministic mock transport. Only the
+outermost HTTP transport is replaced, so no real network I/O occurs. This module is
+deliberately kept OUT of the ``conftest`` compatibility allowlist.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from aigateway.core.oauth.store import credential_key_for
+from aigateway.core.profile_models import credential_name_for
+from aigateway.plugins.anthropic_provider.auth import (
+    credential_service_for as anthropic_service_for,
+)
+
+_KEY_A = "sk-ant-api03-alpha-integration-key"
+_KEY_B = "sk-ant-api03-beta-integration-key"
+
+
+def _auth_ok() -> httpx.Response:
+    return httpx.Response(200, json={"data": []})
+
+
+def _readiness_ok() -> httpx.Response:
+    return httpx.Response(200, json={"type": "message", "content": []})
+
+
+def _auth_reject() -> httpx.Response:
+    # 401 authentication_error is the evidence for INVALID; the route maps it to 422.
+    return httpx.Response(
+        401,
+        json={"type": "error", "error": {"type": "authentication_error", "message": "bad key"}},
+    )
+
+
+class _Responder:
+    """Serves queued upstream responses to the real validator's mock transport."""
+
+    def __init__(self) -> None:
+        self.queue: list[httpx.Response] = []
+        self.requests: list[httpx.Request] = []
+
+    def handle(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        return self.queue.pop(0)
+
+
+@pytest.fixture
+def anthropic_transport(monkeypatch) -> _Responder:
+    responder = _Responder()
+
+    def _factory(**_kwargs) -> httpx.MockTransport:
+        # WHY: replace only the outermost production transport so the real validator,
+        # session, bounding, and classifier all run against canned responses.
+        return httpx.MockTransport(responder.handle)
+
+    monkeypatch.setattr(
+        "aigateway.core.api_key_validation_http.httpx.AsyncHTTPTransport",
+        _factory,
+    )
+    return responder
+
+
+def _create_connection(client, *, api_key: str, label: str):
+    return client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "anthropic", "api_key": api_key, "label": label},
+    )
+
+
+def _connection_blob(credential_blobs, data: dict) -> dict | None:
+    service = anthropic_service_for(credential_key_for(data["account_id"], data["id"]))
+    raw = credential_blobs.read(service, "default")
+    return None if raw is None else json.loads(raw)
+
+
+def _profile_blob(client, credential_blobs, name: str) -> dict | None:
+    account_id = client.get("/v1/auth/me").json()["id"]
+    service = anthropic_service_for(credential_name_for(account_id, name))
+    raw = credential_blobs.read(service, "default")
+    return None if raw is None else json.loads(raw)
+
+
+# --- Writer 1: connection create ------------------------------------------------
+
+
+def test_connection_create_valid_persists_after_real_validation(
+    authenticated_client, anthropic_transport, credential_blobs
+) -> None:
+    anthropic_transport.queue = [_auth_ok(), _readiness_ok()]
+
+    resp = _create_connection(authenticated_client, api_key=_KEY_A, label="work")
+
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["status"] == "active"
+    # Both stages of the real two-stage validation ran.
+    assert [r.method for r in anthropic_transport.requests] == ["GET", "POST"]
+    # The key was written to exactly the chat-read slot, encrypted.
+    assert _connection_blob(credential_blobs, data) == {"auth_type": "api_key", "api_key": _KEY_A}
+    assert _KEY_A not in resp.text
+
+
+def test_connection_create_invalid_writes_nothing(
+    authenticated_client, anthropic_transport
+) -> None:
+    anthropic_transport.queue = [_auth_reject()]
+
+    resp = _create_connection(authenticated_client, api_key=_KEY_A, label="work")
+
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["code"] == "api_key_invalid"
+    # Auth-stage rejection short-circuits: readiness is never attempted.
+    assert [r.method for r in anthropic_transport.requests] == ["GET"]
+    # No connection row was created.
+    listing = authenticated_client.get("/v1/oauth/connections")
+    assert listing.json()["connections"] == []
+
+
+def test_connection_create_transport_error_is_sanitized_and_writes_nothing(
+    authenticated_client, anthropic_transport
+) -> None:
+    anthropic_transport.queue = [httpx.Response(200, content=b"not-json")]
+
+    resp = _create_connection(authenticated_client, api_key=_KEY_A, label="work")
+
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == {
+        "code": "api_key_validation_unavailable",
+        "provider": "anthropic",
+        "message": "The provider could not complete validation. Try again later.",
+        "state": "unavailable",
+        "stage": "authentication",
+        "retryable": True,
+        "retry_after_seconds": None,
+        "probe_model": "claude-haiku-4-5",
+    }
+    assert _KEY_A not in resp.text
+    assert [r.method for r in anthropic_transport.requests] == ["GET"]
+    assert authenticated_client.get("/v1/oauth/connections").json()["connections"] == []
+
+
+# --- Writer 2: connection replace -----------------------------------------------
+
+
+def test_connection_replace_valid_swaps_stored_key(
+    authenticated_client, anthropic_transport, credential_blobs
+) -> None:
+    anthropic_transport.queue = [_auth_ok(), _readiness_ok()]
+    created = _create_connection(authenticated_client, api_key=_KEY_A, label="work").json()
+
+    anthropic_transport.queue = [_auth_ok(), _readiness_ok()]
+    resp = authenticated_client.put(
+        f"/v1/oauth/connections/{created['id']}/api-key",
+        json={"api_key": _KEY_B},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "active"
+    assert [r.method for r in anthropic_transport.requests] == ["GET", "POST", "GET", "POST"]
+    assert anthropic_transport.queue == []
+    assert _connection_blob(credential_blobs, created) == {
+        "auth_type": "api_key",
+        "api_key": _KEY_B,
+    }
+
+
+def test_connection_replace_invalid_preserves_previous_key(
+    authenticated_client, anthropic_transport, credential_blobs
+) -> None:
+    anthropic_transport.queue = [_auth_ok(), _readiness_ok()]
+    created = _create_connection(authenticated_client, api_key=_KEY_A, label="work").json()
+
+    anthropic_transport.queue = [_auth_reject()]
+    resp = authenticated_client.put(
+        f"/v1/oauth/connections/{created['id']}/api-key",
+        json={"api_key": _KEY_B},
+    )
+
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["code"] == "api_key_invalid"
+    assert [r.method for r in anthropic_transport.requests] == ["GET", "POST", "GET"]
+    assert anthropic_transport.queue == []
+    # The prior blob survives unchanged; the rejected key is never stored.
+    assert _connection_blob(credential_blobs, created) == {
+        "auth_type": "api_key",
+        "api_key": _KEY_A,
+    }
+    connection = next(
+        item
+        for item in authenticated_client.get("/v1/oauth/connections").json()["connections"]
+        if item["id"] == created["id"]
+    )
+    assert connection["status"] == "active"
+    assert connection["label"] == "work"
+    assert _KEY_B not in resp.text
+
+
+# --- Writer 3: profile API-key set ----------------------------------------------
+
+
+def test_profile_set_valid_authenticates_profile(
+    authenticated_client, anthropic_transport, credential_blobs
+) -> None:
+    anthropic_transport.queue = [_auth_ok(), _readiness_ok()]
+
+    resp = authenticated_client.put(
+        "/v1/auth/anthropic/profiles/work/api-key",
+        json={"api_key": _KEY_A},
+    )
+
+    assert resp.status_code == 200, resp.text
+    profile = authenticated_client.get("/v1/auth/anthropic/profiles/work")
+    assert profile.status_code == 200
+    assert profile.json()["state"] == "authenticated"
+    assert [r.method for r in anthropic_transport.requests] == ["GET", "POST"]
+    assert anthropic_transport.queue == []
+    account_id = authenticated_client.get("/v1/auth/me").json()["id"]
+    service = anthropic_service_for(credential_name_for(account_id, "work"))
+    assert json.loads(credential_blobs.read(service, "default")) == {
+        "auth_type": "api_key",
+        "api_key": _KEY_A,
+    }
+    assert _KEY_A not in resp.text
+
+
+def test_profile_set_invalid_does_not_create_profile(
+    authenticated_client, anthropic_transport, credential_blobs
+) -> None:
+    anthropic_transport.queue = [_auth_reject()]
+
+    resp = authenticated_client.put(
+        "/v1/auth/anthropic/profiles/reject-me/api-key",
+        json={"api_key": _KEY_A},
+    )
+
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["code"] == "api_key_invalid"
+    # The profile index is not mutated by a rejected key.
+    missing = authenticated_client.get("/v1/auth/anthropic/profiles/reject-me")
+    assert missing.status_code == 404
+    assert _profile_blob(authenticated_client, credential_blobs, "reject-me") is None
+    assert [r.method for r in anthropic_transport.requests] == ["GET"]
+    assert anthropic_transport.queue == []
+    assert _KEY_A not in resp.text
+
+
+def test_profile_set_invalid_preserves_existing_profile_and_key(
+    authenticated_client, anthropic_transport, credential_blobs
+) -> None:
+    anthropic_transport.queue = [_auth_ok(), _readiness_ok()]
+    created = authenticated_client.put(
+        "/v1/auth/anthropic/profiles/work/api-key",
+        json={"api_key": _KEY_A, "defaults": {"temperature": 0.2}},
+    )
+    assert created.status_code == 200
+    before_profile = created.json()
+
+    anthropic_transport.queue = [_auth_reject()]
+    resp = authenticated_client.put(
+        "/v1/auth/anthropic/profiles/work/api-key",
+        json={"api_key": _KEY_B, "defaults": {"temperature": 0.9}},
+    )
+
+    assert resp.status_code == 422
+    assert authenticated_client.get("/v1/auth/anthropic/profiles/work").json() == before_profile
+    assert _profile_blob(authenticated_client, credential_blobs, "work") == {
+        "auth_type": "api_key",
+        "api_key": _KEY_A,
+    }
+    assert [r.method for r in anthropic_transport.requests] == ["GET", "POST", "GET"]
+    assert anthropic_transport.queue == []
+    assert _KEY_B not in resp.text

--- a/apps/aigateway/tests/unit/test_auth_routes.py
+++ b/apps/aigateway/tests/unit/test_auth_routes.py
@@ -19,6 +19,7 @@ from tortoise import Tortoise
 from tortoise.exceptions import IntegrityError, OperationalError
 
 from aigateway.core.credential_blob.store import CredentialBlobMutationConflict
+from aigateway.core.errors import AuthError
 from aigateway.core.pending_auth import PendingAuthEntry
 from aigateway.core.plugin_base import OAuthCodeExchangeRequest, OAuthConfig
 from aigateway.core.profile_index import ProfileIndexStore
@@ -1951,3 +1952,98 @@ def test_delete_profile_invalidates_provider_profile_session(client_with_index) 
     assert resp.status_code == 204
     credential_name = credential_name_for(account_id, "delete-session")
     assert plugin.invalidated_profiles == [credential_name, credential_name]
+
+
+@pytest.mark.asyncio
+async def test_refresh_success_does_not_resurrect_a_concurrently_deleted_profile(
+    client_with_index,
+) -> None:
+    """OME-307 H-1 — a successful refresh after a concurrent delete must NOT resurrect it.
+
+    FEATURE: manual OAuth profile refresh with delete-race safety.
+    STORY: as a user who deletes a profile while its refresh is mid-flight, the delete wins —
+    the refresh's successful token write must not recreate the profile I removed.
+
+    INVARIANT (OME-307 H-1): the success branch publishes conditionally (require_present=True),
+    so a profile deleted during the provider network window makes the publication raise
+    ProfileTransitionConflict -> 409 instead of resurrecting an AUTHENTICATED row.
+    """
+    client, credential_blobs = client_with_index
+    account_id = _account_id(client)
+    plugin = _GenericOAuthPlugin()
+    client.app.state.providers._plugins["generic"] = plugin
+
+    # WHY: seed through a FRESH probe-backed store bound to THIS (test) event loop. Awaiting the
+    # app's profile_index here would bind its asyncio.Lock to the test loop; the route then
+    # deadlocks re-entering that lock from the TestClient portal loop while this coroutine is
+    # parked inside the synchronous client.post below.
+    seed_idx = ProfileIndexStore(credential_store=credential_blobs.store)
+    profile_id = profile_id_for(account_id, "generic", "race-refresh")
+    await seed_idx.upsert(
+        Profile(
+            id=profile_id,
+            account_id=account_id,
+            provider="generic",
+            name="race-refresh",
+            state=ProfileState.AUTHENTICATED,
+        )
+    )
+
+    async def _delete_then_succeed() -> None:
+        # A concurrent DELETE commits during the provider network window. Remove through the APP
+        # store, which the route also uses on the portal loop, so the require_present publish
+        # observes the row gone.
+        await client.app.state.profile_index.remove(profile_id)
+
+    plugin.strategy.refresh_credentials = _delete_then_succeed
+
+    resp = client.post("/v1/auth/generic/profiles/race-refresh/refresh")
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["code"] == "profile_conflict"
+    # Not resurrected: the deleted profile is still gone from the user's view.
+    assert client.get("/v1/auth/generic/profiles/race-refresh").status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_refresh_failure_does_not_resurrect_a_concurrently_deleted_profile(
+    client_with_index,
+) -> None:
+    """OME-307 H-1 — a FAILED refresh after a concurrent delete must NOT leave a ghost row.
+
+    INVARIANT (OME-307 H-1): the error branch marks the profile through the CAS-gated
+    mark_authenticated_error and swallows ProfileTransitionConflict, so a profile deleted during
+    the network window is never recreated as a ghost ERROR row (mirrors
+    chat_credentials._mark_profile_error_fresh).
+    """
+    client, credential_blobs = client_with_index
+    account_id = _account_id(client)
+    plugin = _GenericOAuthPlugin()
+    client.app.state.providers._plugins["generic"] = plugin
+
+    # WHY: seed via a fresh probe-backed store (test loop); never await the app's profile_index
+    # here — its lock would bind to the test loop and deadlock the portal-loop route.
+    seed_idx = ProfileIndexStore(credential_store=credential_blobs.store)
+    profile_id = profile_id_for(account_id, "generic", "race-refresh-fail")
+    await seed_idx.upsert(
+        Profile(
+            id=profile_id,
+            account_id=account_id,
+            provider="generic",
+            name="race-refresh-fail",
+            state=ProfileState.AUTHENTICATED,
+        )
+    )
+
+    async def _delete_then_fail() -> None:
+        await client.app.state.profile_index.remove(profile_id)
+        raise AuthError("refresh token rejected")
+
+    plugin.strategy.refresh_credentials = _delete_then_fail
+
+    resp = client.post("/v1/auth/generic/profiles/race-refresh-fail/refresh")
+
+    assert resp.status_code == 401
+    assert resp.json()["detail"]["code"] == "auth_required"
+    # No ghost row: the deleted profile was not recreated in ERROR state.
+    assert client.get("/v1/auth/generic/profiles/race-refresh-fail").status_code == 404

--- a/apps/aigateway/tests/unit/test_auth_routes.py
+++ b/apps/aigateway/tests/unit/test_auth_routes.py
@@ -4,8 +4,10 @@ import asyncio
 import base64
 import json
 import logging
+import threading
 import time
 from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from typing import cast
 from urllib.parse import parse_qs, urlparse
@@ -547,6 +549,18 @@ async def _seed_pending_profile(
     name: str,
     state: str,
 ) -> None:
+    # Mirror the real start_oauth: publish the pending profile AND claim an ownership
+    # generation via begin_pending, then record that generation on the pending entry so the
+    # callback presents it to authenticate_pending / mark_pending_error (OME-307 Blocker 1).
+    generation = await client.app.state.profile_index.begin_pending(
+        Profile(
+            id=profile_id_for(account_id, provider, name),
+            account_id=account_id,
+            provider=provider,
+            name=name,
+            state=ProfileState.PENDING,
+        )
+    )
     client.app.state.pending_auth.put(
         state,
         PendingAuthEntry(
@@ -556,16 +570,8 @@ async def _seed_pending_profile(
             profile_id=profile_id_for(account_id, provider, name),
             code_verifier="verifier",
             redirect_uri="http://localhost:1455/callback",
+            oauth_generation=generation,
         ),
-    )
-    await client.app.state.profile_index.upsert(
-        Profile(
-            id=profile_id_for(account_id, provider, name),
-            account_id=account_id,
-            provider=provider,
-            name=name,
-            state=ProfileState.PENDING,
-        )
     )
 
 
@@ -911,7 +917,92 @@ def test_connection_exchange_uses_redirect_uri_override(client_with_index) -> No
     assert plugin.exchange_request.redirect_uri == redirect_uri
 
 
-def test_connection_completion_deletes_credentials_when_activation_conflicts(
+def test_connection_delete_wins_over_stalled_oauth_completion(client_with_index) -> None:
+    """A callback consumed before DELETE must not reactivate the revoked connection.
+
+    INVARIANT: OAuth activation conditionally transitions the stable connection row before
+    writing credentials in the same transaction. Once DELETE commits revoked, the callback
+    conflicts without writing an orphan credential.
+    """
+    client, _ = client_with_index
+    exchange_started = threading.Event()
+    release_exchange = threading.Event()
+
+    class _BlockingConnectionOAuthPlugin(_GenericOAuthPlugin):
+        async def exchange_oauth_code(self, request: OAuthCodeExchangeRequest) -> dict:
+            exchange_started.set()
+            if not await asyncio.to_thread(release_exchange.wait, 5):
+                raise TimeoutError("OAuth exchange was not released")
+            return await super().exchange_oauth_code(request)
+
+    plugin = _BlockingConnectionOAuthPlugin()
+    client.app.state.providers._plugins["generic"] = plugin
+    start = client.post(
+        "/v1/oauth/connections",
+        json={"provider": "generic", "label": "delete-race"},
+    )
+    assert start.status_code == 201
+    connection_id = start.json()["connection_id"]
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        callback = executor.submit(
+            client.post,
+            "/v1/auth/generic/exchange-code",
+            json={"code": "generic-code", "state": start.json()["state"]},
+        )
+        assert exchange_started.wait(5), "callback never consumed state and reached exchange"
+        deleted = client.delete(f"/v1/oauth/connections/{connection_id}")
+        release_exchange.set()
+        completed = callback.result(timeout=5)
+
+    assert deleted.status_code == 204
+    assert completed.status_code == 409
+    assert completed.json()["detail"]["code"] == "connection_conflict"
+    assert plugin.strategy.creds is None
+    assert client.get(f"/v1/oauth/connections/{connection_id}").json()["status"] == "revoked"
+
+
+def test_connection_delete_wins_over_stalled_oauth_failure(client_with_index) -> None:
+    """A stale exchange failure must not rewrite a committed revoke to ERROR."""
+    client, _ = client_with_index
+    exchange_started = threading.Event()
+    release_exchange = threading.Event()
+
+    class _FailingConnectionOAuthPlugin(_GenericOAuthPlugin):
+        async def exchange_oauth_code(self, request: OAuthCodeExchangeRequest) -> dict:
+            self.exchange_request = request
+            exchange_started.set()
+            if not await asyncio.to_thread(release_exchange.wait, 5):
+                raise TimeoutError("OAuth exchange failure was not released")
+            raise RuntimeError("provider rejected the consumed code")
+
+    plugin = _FailingConnectionOAuthPlugin()
+    client.app.state.providers._plugins["generic"] = plugin
+    start = client.post(
+        "/v1/oauth/connections",
+        json={"provider": "generic", "label": "delete-failure-race"},
+    )
+    connection_id = start.json()["connection_id"]
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        callback = executor.submit(
+            client.get,
+            "/callback",
+            params={"code": "generic-code", "state": start.json()["state"]},
+            follow_redirects=False,
+        )
+        assert exchange_started.wait(5), "callback never consumed state and reached exchange"
+        deleted = client.delete(f"/v1/oauth/connections/{connection_id}")
+        release_exchange.set()
+        failed = callback.result(timeout=5)
+
+    assert deleted.status_code == 204
+    assert failed.status_code == 500
+    assert client.get(f"/v1/oauth/connections/{connection_id}").json()["status"] == "revoked"
+    assert plugin.strategy.creds is None
+
+
+def test_connection_completion_writes_no_credentials_when_activation_conflicts(
     client_with_index, monkeypatch
 ) -> None:
     client, _ = client_with_index
@@ -922,7 +1013,7 @@ def test_connection_completion_deletes_credentials_when_activation_conflicts(
         raise IntegrityError("simulated connection race")
 
     monkeypatch.setattr(
-        "aigateway.routes.auth.OAuthConnectionStore.complete",
+        "aigateway.routes.auth.OAuthConnectionStore.complete_pending",
         complete_conflict,
     )
 
@@ -939,11 +1030,11 @@ def test_connection_completion_deletes_credentials_when_activation_conflicts(
 
     assert resp.status_code == 409
     assert resp.json()["detail"]["code"] == "connection_conflict"
-    assert plugin.strategy.creds is not None
-    assert plugin.strategy.deleted is True
+    assert plugin.strategy.creds is None
+    assert plugin.strategy.deleted is False
 
 
-def test_connection_completion_non_integrity_failure_deletes_credentials_and_marks_error(
+def test_connection_completion_non_integrity_failure_writes_no_credentials_and_marks_error(
     client_with_index, monkeypatch
 ) -> None:
     client, _ = client_with_index
@@ -955,7 +1046,7 @@ def test_connection_completion_non_integrity_failure_deletes_credentials_and_mar
         raise OperationalError(f"database locked while handling {leak_marker}")
 
     monkeypatch.setattr(
-        "aigateway.routes.auth.OAuthConnectionStore.complete",
+        "aigateway.routes.auth.OAuthConnectionStore.complete_pending",
         complete_failure,
     )
 
@@ -975,14 +1066,14 @@ def test_connection_completion_non_integrity_failure_deletes_credentials_and_mar
     assert resp.status_code == 503
     assert resp.json()["detail"]["code"] == "connection_activation_failed"
     assert leak_marker not in resp.text
-    assert plugin.strategy.creds is not None
-    assert plugin.strategy.deleted is True
+    assert plugin.strategy.creds is None
+    assert plugin.strategy.deleted is False
     connection = client.get(f"/v1/oauth/connections/{connection_id}").json()
     assert connection["status"] == "error"
     assert leak_marker not in json.dumps(connection)
 
 
-def test_connection_completion_delete_compensation_failure_is_sanitized(
+def test_connection_completion_conflict_needs_no_delete_compensation(
     client_with_index, monkeypatch, caplog
 ) -> None:
     client, _ = client_with_index
@@ -997,7 +1088,7 @@ def test_connection_completion_delete_compensation_failure_is_sanitized(
         raise RuntimeError(f"delete failed for {leak_marker}")
 
     monkeypatch.setattr(
-        "aigateway.routes.auth.OAuthConnectionStore.complete",
+        "aigateway.routes.auth.OAuthConnectionStore.complete_pending",
         complete_conflict,
     )
     monkeypatch.setattr(plugin.strategy, "delete_credentials", delete_failure)
@@ -1016,8 +1107,9 @@ def test_connection_completion_delete_compensation_failure_is_sanitized(
 
     assert resp.status_code == 409
     assert resp.json()["detail"]["code"] == "connection_conflict"
-    assert "Failed to delete OAuth connection credentials" in caplog.text
-    assert "RuntimeError" in caplog.text
+    assert plugin.strategy.creds is None
+    assert plugin.strategy.deleted is False
+    assert "Failed to delete OAuth connection credentials" not in caplog.text
     assert leak_marker not in caplog.text
 
 
@@ -1099,10 +1191,15 @@ def test_profile_oauth_profile_index_conflict_returns_sanitized_503_html(
     start = client.post("/v1/auth/generic/profiles", json={"name": "index-conflict"})
     assert start.status_code == 201
 
-    async def upsert_conflict(_profile) -> None:
+    async def authenticate_conflict(_profile, **_kwargs) -> None:
         raise CredentialBlobMutationConflict("forced contention")
 
-    monkeypatch.setattr(client.app.state.profile_index, "upsert", upsert_conflict)
+    # WHY: on the OAuth callback path a CAS conflict surfaces from the sole publication
+    # boundary, authenticate_pending() (OME-307 Unit 1); inject there, not at the removed
+    # trailing upsert() seam.
+    monkeypatch.setattr(
+        client.app.state.profile_index, "authenticate_pending", authenticate_conflict
+    )
     auth_header = client.headers.pop("Authorization")
     try:
         with _server_errors_as_responses(client):
@@ -1328,10 +1425,14 @@ def test_callback_restores_api_key_blob_when_profile_index_update_fails(
     start = client.post("/v1/auth/anthropic/profiles", json={"name": "default"})
     state = start.json()["state"]
 
-    async def _boom(_profile) -> None:
+    async def _boom(_profile, **_kwargs) -> None:
         raise RuntimeError("profile index unavailable")
 
-    monkeypatch.setattr(client.app.state.profile_index, "upsert", _boom)
+    # WHY: inject at the real callback publication boundary. The OAuth callback path
+    # authenticates a pending profile via authenticate_pending(); its failure must roll
+    # the credential write back with it (OME-307 Unit 1 removed the redundant trailing
+    # upsert() that this fault used to ride).
+    monkeypatch.setattr(client.app.state.profile_index, "authenticate_pending", _boom)
     auth_header = client.headers.pop("Authorization")
     try:
         with _server_errors_as_responses(client):

--- a/apps/aigateway/tests/unit/test_connection_delete_set_race.py
+++ b/apps/aigateway/tests/unit/test_connection_delete_set_race.py
@@ -1,0 +1,246 @@
+"""OME-307 Blocker 3 — atomic connection revoke/delete versus a racing API-key replace.
+
+FEATURE: deleting an api-key connection (connection row + credential blob) and replacing the
+API key on that same connection (``set_connection_api_key``).
+STORY: as a user who deletes a connection while an API-key replace for that same connection is
+still in flight, the delete wins cleanly — no encrypted credential is left behind under a
+revoked connection, and the older replace does not silently reactivate the connection I just
+deleted.
+
+INVARIANT: ``set_connection_api_key`` and ``delete_connection`` each publish the
+connection-row transition and the credential blob write/delete in ONE transaction, in ONE
+consistent lock order — the ALWAYS-PRESENT connection row FIRST, the credential blob SECOND.
+Serializing on the credential row instead fails when that row is ABSENT: a missing-row delete
+takes no lock under READ COMMITTED, so it cannot serialize a concurrent INSERT, orphaning a
+credential under a revoked connection. This is the connection analogue of the profile
+delete/set-api-key race in ``test_profile_delete_set_race.py``.
+
+WHY a store double: the gateway unit harness is SQLite-only and serializes whole transactions
+on one connection, so it cannot exhibit the PostgreSQL per-row interleaving this race needs. In
+production the connection row (``oauth_connections``) and the credential blob
+(``credential_blobs``) live in the SAME database and are published in ONE ``in_transaction()``,
+so they share one MVCC snapshot and lock manager — modelled here as two keys in one
+``MvccRowStore``. The connection-row operations transcribe the VERIFIED production semantics:
+``OAuthConnectionStore.reactivate`` is a conditional CAS (``UPDATE ... WHERE status IN
+('active','error')``; 0 rows -> ``None`` -> the route raises 409 -> rollback) and
+``OAuthConnectionStore.mark_revoked`` is an unconditional ``UPDATE`` by primary key. The real
+methods' sequential behaviour is guarded by the route-level tests in
+``test_api_key_connection_races.py``; this file guards the per-row lock-ordering invariant those
+serialized tests cannot exercise.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from uuid import uuid4
+
+import pytest
+
+from aigateway.core.oauth.store import OAuthConnectionStore
+
+from ._pg_mvcc_store import MvccRowStore
+
+# The always-present connection row and the (possibly-absent) credential blob slot the chat
+# path reads for this connection. Only their identity as distinct contended rows matters.
+_CONN_SERVICE = "aigateway:oauth:connection"
+_CONN_ACCOUNT = "account-1:conn-1"
+_CRED_SERVICE = "aigateway:anthropic:cred"
+_CRED_ACCOUNT = "account-1:conn-1"
+
+
+class _ReactivateConflict(Exception):
+    """Models ``OAuthConnectionStore.reactivate`` matching 0 rows (connection concurrently
+    revoked): the conditional UPDATE changes nothing, the route receives ``None`` and raises
+    409, and the transaction rolls back. Raised from inside ``mutate`` so the transaction
+    unwinds exactly as the route's 409 does — the credential write never commits."""
+
+
+def _status_of(raw: str | None) -> str | None:
+    return None if raw is None else json.loads(raw)["status"]
+
+
+def _reactivate(current: str | None) -> str:
+    # WHY: transcribes OAuthConnectionStore.reactivate — UPDATE ... WHERE status IN
+    # ('active','error'). A concurrently-revoked row matches nothing, which the route maps to a
+    # 409; here that is a raise so the enclosing transaction rolls back the same way.
+    if _status_of(current) not in ("active", "error"):
+        raise _ReactivateConflict
+    return json.dumps({"status": "active"})
+
+
+async def _seed_connection_without_credential(store: MvccRowStore) -> None:
+    # An errored api-key connection legitimately has a connection row but NO credential blob —
+    # the credential-absent precondition the review requires. The always-present connection row
+    # is seeded; the credential row is deliberately NOT written.
+    await store.write(_CONN_SERVICE, _CONN_ACCOUNT, json.dumps({"status": "error"}))
+
+
+@pytest.mark.asyncio
+async def test_conn_delete_wins_over_set_when_delete_commits_first_credential_absent() -> None:
+    """Credential row ABSENT, ``delete_connection`` commits first.
+
+    Production ordering under test (connection-row transition FIRST, credential SECOND):
+
+      1. DELETE acquires the always-present connection-row lock (``mark_revoked``), then its
+         credential delete finds NO credential row (absent) — a no-op that takes no lock — and
+         COMMITS. Connection revoked.
+      2. SET was blocked on the connection-row lock; it now runs ``reactivate``, re-evaluates
+         the committed status, finds it revoked, and raises (the route's 409) — it must NOT
+         reactivate the revoked connection, and its API-key blob write is never committed.
+
+    Final state: connection revoked, credential absent — delete wins, no orphan, no
+    resurrection. Serializing on the credential row instead would fail: the missing-row delete
+    takes no lock, so SET's later INSERT would not be serialized and would orphan a credential.
+    """
+    store = MvccRowStore()
+    await _seed_connection_without_credential(store)
+    delete_holds_conn = asyncio.Event()
+
+    async def delete_op() -> None:
+        async with store.transaction():
+            # mark_revoked: unconditional UPDATE by PK on the always-present connection row.
+            await store.write(_CONN_SERVICE, _CONN_ACCOUNT, json.dumps({"status": "revoked"}))
+            delete_holds_conn.set()
+            await store.delete(_CRED_SERVICE, _CRED_ACCOUNT)  # credential SECOND (absent -> no-op)
+
+    async def set_op() -> None:
+        await delete_holds_conn.wait()  # DELETE takes the connection-row lock first
+        async with store.transaction():
+            await store.mutate(_CONN_SERVICE, _CONN_ACCOUNT, _reactivate)  # blocks, then conflicts
+            await store.write(_CRED_SERVICE, _CRED_ACCOUNT, "api-key-blob")
+
+    results = await asyncio.gather(delete_op(), set_op(), return_exceptions=True)
+
+    assert results[0] is None, f"delete unexpectedly failed: {results[0]!r}"
+    assert isinstance(results[1], _ReactivateConflict), (
+        f"set must abort rather than reactivate, got {results[1]!r}"
+    )
+    assert _status_of(store.committed.get((_CONN_SERVICE, _CONN_ACCOUNT))) == "revoked"
+    assert store.committed.get((_CRED_SERVICE, _CRED_ACCOUNT)) is None  # no orphan credential
+
+
+@pytest.mark.asyncio
+async def test_conn_delete_wins_over_set_when_set_commits_first_credential_absent() -> None:
+    """Credential row ABSENT, the API-key ``set`` commits first.
+
+    Production ordering under test (connection-row transition FIRST, credential SECOND):
+
+      1. SET acquires the connection-row lock (``reactivate`` -> active), writes (INSERTs) its
+         credential blob, and COMMITS.
+      2. DELETE was blocked on the connection-row lock; it now marks the connection revoked and
+         — because SET's credential blob is now COMMITTED and visible — deletes it too, then
+         COMMITS.
+
+    Final state: connection revoked, credential gone — the later delete still cleans up SET's
+    blob, so no orphan survives. This is the commit order the credential-first ordering handles
+    correctly only when the blob already exists; here it is created mid-race.
+    """
+    store = MvccRowStore()
+    await _seed_connection_without_credential(store)
+    set_holds_conn = asyncio.Event()
+
+    async def set_op() -> None:
+        async with store.transaction():
+            await store.mutate(_CONN_SERVICE, _CONN_ACCOUNT, _reactivate)  # conn-row CAS FIRST
+            set_holds_conn.set()
+            await store.write(_CRED_SERVICE, _CRED_ACCOUNT, "api-key-blob")  # credential SECOND
+
+    async def delete_op() -> None:
+        await set_holds_conn.wait()  # SET takes the connection-row lock first
+        async with store.transaction():
+            # mark_revoked blocks until SET commits, then revokes by PK.
+            await store.write(_CONN_SERVICE, _CONN_ACCOUNT, json.dumps({"status": "revoked"}))
+            await store.delete(_CRED_SERVICE, _CRED_ACCOUNT)  # SET's blob now visible -> deleted
+
+    results = await asyncio.gather(set_op(), delete_op(), return_exceptions=True)
+
+    assert results[0] is None, f"set unexpectedly failed: {results[0]!r}"
+    assert results[1] is None, f"delete unexpectedly failed: {results[1]!r}"
+    assert _status_of(store.committed.get((_CONN_SERVICE, _CONN_ACCOUNT))) == "revoked"
+    assert store.committed.get((_CRED_SERVICE, _CRED_ACCOUNT)) is None  # no orphan credential
+
+
+def test_connection_delete_wins_over_stale_patch(
+    authenticated_client,
+    monkeypatch,
+) -> None:
+    """PATCH must condition its label update on the connection remaining active."""
+    account_id = authenticated_client.get("/v1/auth/me").json()["id"]
+    connection_id = uuid4()
+
+    async def _seed_active_connection() -> None:
+        store = OAuthConnectionStore()
+        connection = await store.create_pending(
+            account_id=account_id,
+            provider="anthropic",
+            label="before-patch",
+            connection_id=connection_id,
+        )
+        await store.complete(connection, label="before-patch", identity=None)
+
+    authenticated_client.portal.call(_seed_active_connection)
+    get_connection = OAuthConnectionStore.get
+    patch_read = threading.Event()
+    release_patch = threading.Event()
+    get_count = 0
+    get_count_lock = threading.Lock()
+
+    async def _stall_first_get(self, *args, **kwargs):
+        nonlocal get_count
+        connection = await get_connection(self, *args, **kwargs)
+        with get_count_lock:
+            get_count += 1
+            call_number = get_count
+        if call_number == 1:
+            patch_read.set()
+            if not await asyncio.to_thread(release_patch.wait, 5):
+                raise TimeoutError("connection PATCH was not released")
+        return connection
+
+    monkeypatch.setattr(OAuthConnectionStore, "get", _stall_first_get)
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        patch = executor.submit(
+            authenticated_client.patch,
+            f"/v1/oauth/connections/{connection_id}",
+            json={"label": "after-patch"},
+        )
+        assert patch_read.wait(5), "PATCH never read its stale connection snapshot"
+        deleted = authenticated_client.delete(f"/v1/oauth/connections/{connection_id}")
+        release_patch.set()
+        patched = patch.result(timeout=5)
+
+    assert deleted.status_code == 204
+    assert patched.status_code == 409
+    after = authenticated_client.get(f"/v1/oauth/connections/{connection_id}").json()
+    assert after["status"] == "revoked"
+
+
+def test_connection_delete_wins_over_stale_active_error(
+    authenticated_client,
+) -> None:
+    """An established request failure cannot rewrite a revoked row to ERROR."""
+    account_id = authenticated_client.get("/v1/auth/me").json()["id"]
+    connection_id = uuid4()
+
+    async def _seed_and_read_stale():
+        store = OAuthConnectionStore()
+        connection = await store.create_api_key(
+            account_id=account_id,
+            provider="anthropic",
+            label="stale-error",
+            connection_id=connection_id,
+        )
+        return store, connection
+
+    store, stale = authenticated_client.portal.call(_seed_and_read_stale)
+    deleted = authenticated_client.delete(f"/v1/oauth/connections/{connection_id}")
+    marked = authenticated_client.portal.call(store.mark_error, stale, "credential rejected")
+
+    assert deleted.status_code == 204
+    assert marked is None
+    assert authenticated_client.get(f"/v1/oauth/connections/{connection_id}").json()["status"] == (
+        "revoked"
+    )

--- a/apps/aigateway/tests/unit/test_oauth_connection_label_exists.py
+++ b/apps/aigateway/tests/unit/test_oauth_connection_label_exists.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from aigateway.core.oauth.store import OAuthConnectionStore
+
+
+@pytest.mark.parametrize("status", ["pending", "active", "error"])
+def test_label_exists_checks_every_non_revoked_status(authenticated_client, status: str) -> None:
+    account_id = authenticated_client.get("/v1/auth/me").json()["id"]
+    label = f"label-{status}"
+
+    async def scenario() -> bool:
+        store = OAuthConnectionStore()
+        if status == "pending":
+            await store.create_pending(
+                account_id=account_id,
+                provider="anthropic",
+                label=label,
+                connection_id=uuid4(),
+            )
+        else:
+            connection = await store.create_api_key(
+                account_id=account_id,
+                provider="anthropic",
+                label=label,
+                connection_id=uuid4(),
+            )
+            if status == "error":
+                await store.mark_error(connection, "synthetic")
+        return await store.label_exists(account_id, "anthropic", label)
+
+    assert authenticated_client.portal.call(scenario) is True
+
+
+def test_label_exists_is_account_and_provider_scoped(authenticated_client) -> None:
+    account_id = authenticated_client.get("/v1/auth/me").json()["id"]
+
+    async def scenario() -> tuple[bool, bool]:
+        store = OAuthConnectionStore()
+        await store.create_pending(
+            account_id=account_id,
+            provider="anthropic",
+            label="scoped",
+            connection_id=uuid4(),
+        )
+        return (
+            await store.label_exists(account_id, "gemini-cli", "scoped"),
+            await store.label_exists(uuid4(), "anthropic", "scoped"),
+        )
+
+    assert authenticated_client.portal.call(scenario) == (False, False)
+
+
+@pytest.mark.parametrize("status", ["expired", "revoked"])
+def test_label_exists_includes_terminal_statuses(authenticated_client, status: str) -> None:
+    account_id = authenticated_client.get("/v1/auth/me").json()["id"]
+
+    async def scenario() -> bool:
+        store = OAuthConnectionStore()
+        connection = await store.create_api_key(
+            account_id=account_id,
+            provider="anthropic",
+            label=f"terminal-{status}",
+            connection_id=uuid4(),
+        )
+        connection.status = status
+        await connection.save(update_fields=["status"])
+        return await store.label_exists(account_id, "anthropic", f"terminal-{status}")
+
+    assert authenticated_client.portal.call(scenario) is True

--- a/apps/aigateway/tests/unit/test_oauth_connection_store.py
+++ b/apps/aigateway/tests/unit/test_oauth_connection_store.py
@@ -48,3 +48,61 @@ async def test_store_creates_lists_and_scopes_connections() -> None:
         ] == [connection_id]
         assert await store.get(bob.id, connection_id) is None
         assert await store.list(bob.id) == []
+
+
+@pytest.mark.asyncio
+async def test_complete_active_republishes_metadata_for_an_active_connection() -> None:
+    """OME-307 H-1 — complete_active republishes metadata while the connection is active."""
+    async with tortoise_test_context(["aigateway.core.auth.models", "aigateway.core.oauth.models"]):
+        alice = await Account.create(username="alice", password_hash="hash")
+        store = OAuthConnectionStore()
+        connection_id = uuid4()
+        connection = await store.create_pending(
+            account_id=alice.id,
+            provider="codex",
+            label="pending",
+            connection_id=connection_id,
+        )
+        active = await store.complete(connection, label="old-label", identity=None)
+
+        result = await store.complete_active(active, label="new-label", identity=None)
+
+        assert result is not None
+        assert result.status == "active"
+        assert result.label == "new-label"
+        reread = await store.get(alice.id, connection_id)
+        assert reread is not None
+        assert reread.label == "new-label"
+        assert reread.last_refreshed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_complete_active_does_not_reactivate_a_revoked_connection() -> None:
+    """OME-307 H-1 — a refresh republish must not resurrect a revoked connection.
+
+    INVARIANT (OME-307 H-1): complete_active republishes only while the row is still 'active'. A
+    concurrent revoke/delete during the refresh network window moves the row out of 'active', so
+    the status-fenced CAS updates zero rows and returns None — the refresh surfaces a conflict
+    instead of flipping a revoked connection back to active (mirrors complete_pending's fence).
+    """
+    async with tortoise_test_context(["aigateway.core.auth.models", "aigateway.core.oauth.models"]):
+        alice = await Account.create(username="alice", password_hash="hash")
+        store = OAuthConnectionStore()
+        connection_id = uuid4()
+        connection = await store.create_pending(
+            account_id=alice.id,
+            provider="codex",
+            label="pending",
+            connection_id=connection_id,
+        )
+        active = await store.complete(connection, label="codex@example.com", identity=None)
+
+        # A concurrent revoke commits during the refresh network window.
+        await store.mark_revoked(active)
+
+        result = await store.complete_active(active, label="codex@example.com", identity=None)
+
+        assert result is None
+        reread = await store.get(alice.id, connection_id)
+        assert reread is not None
+        assert reread.status == "revoked"

--- a/apps/aigateway/tests/unit/test_oauth_connections_routes.py
+++ b/apps/aigateway/tests/unit/test_oauth_connections_routes.py
@@ -709,3 +709,45 @@ def test_token_endpoint_updates_last_refreshed_at_after_a_refresh(
     ]
     assert after is not None
     assert after != before
+
+
+def test_refresh_does_not_resurrect_a_concurrently_revoked_connection(
+    authenticated_client, credential_blobs
+) -> None:
+    """OME-307 H-1 — connection refresh 409s instead of reactivating a revoked row.
+
+    FEATURE: manual OAuth connection refresh with delete/revoke-race safety.
+    INVARIANT (OME-307 H-1): the success republish is status-fenced on 'active', so a connection
+    revoked (or deleted) during the provider network window makes the refresh return 409 instead
+    of flipping it back to active.
+    """
+    _ = credential_blobs
+    connection_id = _connect_anthropic(authenticated_client, "refresh-revoke-race")
+    account_id = _account_id(authenticated_client)
+    store = authenticated_client.app.state.oauth_connections
+
+    class _RevokingStrategy:
+        async def refresh_credentials(self) -> None:
+            # A concurrent revoke commits during the provider network window. This runs INSIDE the
+            # route on the TestClient portal loop, so the store's Tortoise access stays single-loop.
+            conn = await store.get(account_id, connection_id)
+            await store.mark_revoked(conn)
+
+    cache = credential_strategy_cache(authenticated_client.app)
+    key = credential_key_for(account_id, connection_id)
+    cache.get_or_create(
+        provider="anthropic",
+        auth_type="oauth",
+        credential_name=key,
+        build=lambda: _RevokingStrategy(),
+    )
+
+    resp = authenticated_client.post(f"/v1/oauth/connections/{connection_id}/refresh")
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["code"] == "connection_conflict"
+    # Not resurrected: the revoked row stays inactive, so a follow-up refresh is rejected at the
+    # status gate before any strategy runs — proving complete_active did not flip it to 'active'.
+    again = authenticated_client.post(f"/v1/oauth/connections/{connection_id}/refresh")
+    assert again.status_code == 409
+    assert again.json()["detail"]["code"] == "connection_not_active"

--- a/apps/aigateway/tests/unit/test_profile_api_key_cancellation_ordering.py
+++ b/apps/aigateway/tests/unit/test_profile_api_key_cancellation_ordering.py
@@ -1,0 +1,168 @@
+"""OME-307 Unit 5 — pending-OAuth cancellation ordering in ``set_profile_api_key``.
+
+FEATURE: switching a profile from an in-flight OAuth login to a raw API key.
+STORY: as a user who started an OAuth login for a profile and then tries an API key that
+fails to persist (transient store error, or the request is cancelled), my original OAuth
+login must still be completable — the failed API-key attempt must not strand the profile.
+
+INVARIANT: ``set_profile_api_key`` must not irreversibly cancel pending OAuth state (pop
+the pending entry, close the loopback listener) until the API-key credential+profile
+publication COMMITS. Publication runs in one short transaction; a failed or cancelled
+publication rolls back the credential and never reaches the pending-state teardown, so the
+older OAuth flow remains usable and no orphan credential is left behind. Because Python
+3.12 ``asyncio.CancelledError`` derives from ``BaseException``, the ordering — not a
+best-effort ``except`` — is what guarantees this for both failures and cancellations.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import json
+import threading
+
+import httpx
+import pytest
+
+from aigateway.core.api_key_validation import (
+    ApiKeyValidationResult,
+    ApiKeyValidationStage,
+    ApiKeyValidationState,
+)
+from aigateway.core.profile_models import credential_name_for
+from aigateway.plugins.anthropic_provider.auth import credential_service_for
+
+_API_KEY = "sk-ant-api03-cancellation-ordering-key"
+
+
+class _ValidValidationService:
+    async def validate(self, _plugin, _provider: str, _api_key: str) -> ApiKeyValidationResult:
+        return ApiKeyValidationResult(
+            ApiKeyValidationState.VALID,
+            stage=ApiKeyValidationStage.READINESS,
+        )
+
+
+def _token_factory(token: str):
+    async def token_handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "access_token": token,
+                "refresh_token": f"refresh-{token}",
+                "expires_in": 3600,
+                "token_type": "Bearer",
+            },
+        )
+
+    return lambda: httpx.AsyncClient(
+        transport=httpx.MockTransport(token_handler), timeout=httpx.Timeout(5.0)
+    )
+
+
+def _start_pending_oauth(client) -> tuple[str, str]:
+    """Start an OAuth flow for profile ``work`` and return (state, credential service)."""
+    client.app.state.api_key_validation_service = _ValidValidationService()
+    started = client.post("/v1/auth/anthropic/profiles", json={"name": "work"})
+    assert started.status_code == 201
+    account_id = client.get("/v1/auth/me").json()["id"]
+    service = credential_service_for(credential_name_for(account_id, "work"))
+    return started.json()["state"], service
+
+
+def _complete_oauth(client, state: str, token: str) -> httpx.Response:
+    client.app.state.anthropic_http_factory = _token_factory(token)
+    return client.get(
+        "/v1/auth/anthropic/callback",
+        params={"code": "oauth-code", "state": state},
+        follow_redirects=False,
+    )
+
+
+def test_failed_api_key_publication_preserves_pending_oauth_flow(
+    authenticated_client,
+    credential_blobs,
+    monkeypatch,
+) -> None:
+    """Schedule: OAuth flow is pending; an API-key set fails at the durable index write
+    (after the blob write, inside the transaction). The rollback+compensation must leave
+    no orphan credential AND leave the OAuth flow intact so it can still complete."""
+    state_oauth, service = _start_pending_oauth(authenticated_client)
+
+    index = authenticated_client.app.state.profile_index
+    original_upsert = index.upsert
+
+    async def _boom(_profile, **_kwargs):
+        # INVARIANT: fail at the real durable boundary (index publication), after the
+        # credential blob has been written inside the transaction. The pending profile is
+        # observed-existing, so the caller passes require_present=True (OME-307 Unit 3).
+        raise RuntimeError("simulated profile-index write failure")
+
+    monkeypatch.setattr(index, "upsert", _boom)
+    # The publication raises inside the transaction, so nothing commits. (The TestClient
+    # re-raises an unhandled server error rather than returning a synthesized 500.)
+    with pytest.raises(RuntimeError, match="simulated profile-index write failure"):
+        authenticated_client.put(
+            "/v1/auth/anthropic/profiles/work/api-key",
+            json={"api_key": _API_KEY},
+        )
+    monkeypatch.setattr(index, "upsert", original_upsert)
+
+    # No orphan credential survived the rolled-back, non-committed publication.
+    assert credential_blobs.read(service, "default") is None
+    # The profile was never re-authenticated as api_key; it is still the pending OAuth one.
+    profile = authenticated_client.get("/v1/auth/anthropic/profiles/work").json()
+    assert profile["state"] == "pending"
+
+    # The pending OAuth flow remains usable and completes with its own credentials.
+    callback = _complete_oauth(authenticated_client, state_oauth, "oauth-after-failure")
+    assert callback.status_code == 200
+    authenticated = authenticated_client.get("/v1/auth/anthropic/profiles/work").json()
+    assert authenticated["state"] == "authenticated"
+    assert authenticated["auth_type"] == "oauth"
+    blob = json.loads(credential_blobs.read(service, "default"))
+    assert blob["access_token"] == "oauth-after-failure"
+
+
+def test_cancelled_api_key_publication_preserves_pending_oauth_flow(
+    authenticated_client,
+    credential_blobs,
+    monkeypatch,
+) -> None:
+    """Same ordering guarantee under cancellation: ``asyncio.CancelledError`` is a
+    ``BaseException`` in 3.12, so only performing the pending-state teardown AFTER commit
+    keeps the OAuth flow alive when the publication task is cancelled mid-transaction."""
+    state_oauth, service = _start_pending_oauth(authenticated_client)
+
+    index = authenticated_client.app.state.profile_index
+    original_upsert = index.upsert
+    reached = threading.Event()
+
+    async def _cancel(_profile, **_kwargs):
+        reached.set()
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(index, "upsert", _cancel)
+    # The sync TestClient surfaces an in-request asyncio.CancelledError as the
+    # concurrent.futures variant once it crosses the blocking-portal boundary.
+    with pytest.raises(concurrent.futures.CancelledError):
+        authenticated_client.put(
+            "/v1/auth/anthropic/profiles/work/api-key",
+            json={"api_key": _API_KEY},
+        )
+    assert reached.is_set(), "publication never reached the durable index write"
+    monkeypatch.setattr(index, "upsert", original_upsert)
+
+    # Cancellation left no orphan credential (invariant: cancellation cannot orphan a blob).
+    assert credential_blobs.read(service, "default") is None
+    profile = authenticated_client.get("/v1/auth/anthropic/profiles/work").json()
+    assert profile["state"] == "pending"
+
+    # The OAuth flow survived the cancelled API-key attempt and still completes.
+    callback = _complete_oauth(authenticated_client, state_oauth, "oauth-after-cancel")
+    assert callback.status_code == 200
+    authenticated = authenticated_client.get("/v1/auth/anthropic/profiles/work").json()
+    assert authenticated["state"] == "authenticated"
+    assert authenticated["auth_type"] == "oauth"
+    blob = json.loads(credential_blobs.read(service, "default"))
+    assert blob["access_token"] == "oauth-after-cancel"

--- a/apps/aigateway/tests/unit/test_profile_api_key_races.py
+++ b/apps/aigateway/tests/unit/test_profile_api_key_races.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+
+import httpx
+
+from aigateway.core.api_key_validation import (
+    ApiKeyValidationResult,
+    ApiKeyValidationStage,
+    ApiKeyValidationState,
+)
+from aigateway.core.profile_models import credential_name_for
+from aigateway.plugins.anthropic_provider.auth import credential_service_for
+
+_API_KEY = "sk-ant-api03-profile-race-key"
+
+
+@dataclass
+class _ValidValidationService:
+    async def validate(self, _plugin, _provider: str, _api_key: str) -> ApiKeyValidationResult:
+        return ApiKeyValidationResult(
+            ApiKeyValidationState.VALID,
+            stage=ApiKeyValidationStage.READINESS,
+        )
+
+
+def test_profile_api_key_wins_over_older_inflight_oauth_callback(
+    authenticated_client,
+    credential_blobs,
+) -> None:
+    exchange_started = threading.Event()
+    release_exchange = threading.Event()
+
+    async def token_handler(_request: httpx.Request) -> httpx.Response:
+        exchange_started.set()
+        if not await asyncio.to_thread(release_exchange.wait, 5):
+            raise TimeoutError("OAuth exchange was not released")
+        return httpx.Response(
+            200,
+            json={
+                "access_token": "oauth-access-token",
+                "refresh_token": "oauth-refresh-token",
+                "expires_in": 3600,
+                "token_type": "Bearer",
+            },
+        )
+
+    authenticated_client.app.state.anthropic_http_factory = lambda: httpx.AsyncClient(
+        transport=httpx.MockTransport(token_handler),
+        timeout=httpx.Timeout(5.0),
+    )
+    authenticated_client.app.state.api_key_validation_service = _ValidValidationService()
+    started = authenticated_client.post(
+        "/v1/auth/anthropic/profiles",
+        json={"name": "work"},
+    )
+    assert started.status_code == 201
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        callback = executor.submit(
+            authenticated_client.get,
+            "/v1/auth/anthropic/callback",
+            params={"code": "oauth-code", "state": started.json()["state"]},
+            follow_redirects=False,
+        )
+        assert exchange_started.wait(5), "callback never reached token exchange"
+
+        api_key_response = authenticated_client.put(
+            "/v1/auth/anthropic/profiles/work/api-key",
+            json={"api_key": _API_KEY},
+        )
+        release_exchange.set()
+        callback_response = callback.result(timeout=5)
+
+    assert api_key_response.status_code == 200
+    assert callback_response.status_code == 409
+    assert callback_response.json()["detail"]["code"] == "profile_auth_conflict"
+    profile = authenticated_client.get("/v1/auth/anthropic/profiles/work").json()
+    # INVARIANT: the later explicit API-key choice wins as one coherent profile/blob state.
+    assert profile["auth_type"] == "api_key"
+    assert profile["state"] == "authenticated"
+    account_id = authenticated_client.get("/v1/auth/me").json()["id"]
+    service = credential_service_for(credential_name_for(account_id, "work"))
+    blob = credential_blobs.read(service, "default")
+    assert json.loads(blob) == {"auth_type": "api_key", "api_key": _API_KEY}

--- a/apps/aigateway/tests/unit/test_profile_api_key_validation.py
+++ b/apps/aigateway/tests/unit/test_profile_api_key_validation.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+from aigateway.core.api_key_validation import (
+    ApiKeyValidationResult,
+    ApiKeyValidationStage,
+    ApiKeyValidationState,
+)
+from aigateway.core.profile_models import credential_name_for
+from aigateway.plugins.anthropic_provider.auth import credential_service_for
+
+_OLD_KEY = "sk-ant-api03-existing-profile-secret"
+_NEW_KEY = "sk-ant-api03-rejected-profile-secret"
+
+
+@dataclass
+class _StubValidationService:
+    result: ApiKeyValidationResult
+
+    async def validate(self, _plugin, _provider: str, _api_key: str):
+        return self.result
+
+
+def test_profile_validation_failure_precedes_every_side_effect(
+    authenticated_client,
+    credential_blobs,
+    monkeypatch,
+) -> None:
+    service = _StubValidationService(
+        ApiKeyValidationResult(
+            state=ApiKeyValidationState.VALID,
+            stage=ApiKeyValidationStage.READINESS,
+        )
+    )
+    authenticated_client.app.state.api_key_validation_service = service
+    created = authenticated_client.put(
+        "/v1/auth/anthropic/profiles/work/api-key",
+        json={
+            "api_key": _OLD_KEY,
+            "defaults": {"temperature": 0.2},
+        },
+    )
+    assert created.status_code == 200
+    before_profile = created.json()
+    account_id = authenticated_client.get("/v1/auth/me").json()["id"]
+    credential_service = credential_service_for(credential_name_for(account_id, "work"))
+    before_blob = credential_blobs.read(credential_service, "default")
+    assert json.loads(before_blob)["api_key"] == _OLD_KEY
+
+    service.result = ApiKeyValidationResult(
+        state=ApiKeyValidationState.INVALID,
+        stage=ApiKeyValidationStage.AUTHENTICATION,
+    )
+
+    def forbidden_pending_call(*_args, **_kwargs):
+        raise AssertionError("pending OAuth state must not be touched")
+
+    async def forbidden_upsert(*_args, **_kwargs):
+        raise AssertionError("profile index must not be touched")
+
+    async def forbidden_write(*_args, **_kwargs):
+        raise AssertionError("credential blob must not be touched")
+
+    monkeypatch.setattr(
+        authenticated_client.app.state.pending_auth,
+        "pop_for_profile",
+        forbidden_pending_call,
+    )
+    monkeypatch.setattr(authenticated_client.app.state.profile_index, "upsert", forbidden_upsert)
+    monkeypatch.setattr(authenticated_client.app.state.credential_store, "write", forbidden_write)
+    plugin = authenticated_client.app.state.providers.get("anthropic")
+    monkeypatch.setattr(plugin, "invalidate_profile_session", forbidden_pending_call)
+
+    response = authenticated_client.put(
+        "/v1/auth/anthropic/profiles/work/api-key",
+        json={
+            "api_key": _NEW_KEY,
+            "defaults": {"temperature": 0.9},
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "api_key_invalid"
+    assert _NEW_KEY not in response.text
+    assert authenticated_client.get("/v1/auth/anthropic/profiles/work").json() == before_profile
+    assert credential_blobs.read(credential_service, "default") == before_blob

--- a/apps/aigateway/tests/unit/test_profile_delete_set_race.py
+++ b/apps/aigateway/tests/unit/test_profile_delete_set_race.py
@@ -1,0 +1,446 @@
+"""OME-307 Unit 3 — atomic profile deletion versus a racing API-key set.
+
+FEATURE: deleting a profile (credential blob + profile-index entry) and setting an API key
+on the same profile.
+STORY: as a user who deletes a profile while an API-key set for that same profile is still
+in flight, the delete wins cleanly — no encrypted credential is left behind with no profile,
+and the older API-key writer does not silently resurrect the profile I just deleted.
+
+INVARIANT: credential deletion and profile-index removal are published in ONE transaction,
+so a committed delete never leaves an orphan credential. An API-key publication that
+observed the profile as existing must NOT recreate it if a concurrent delete removed it
+first; it aborts with ProfileTransitionConflict (the retryable conflict), and its own
+credential write rolls back. This is the profile analogue of the connection delete /
+set-api-key CAS the codebase already relies on.
+
+WHY a store double: the gateway test harness is SQLite-only and serializes whole
+transactions on one connection, so it cannot exhibit the PostgreSQL per-row interleaving
+this race needs (review requirement). ``_PostgresRowLockStore`` models the relevant PostgreSQL
+READ COMMITTED behavior — an UPDATE/DELETE inside a transaction takes that row's lock until
+COMMIT, and the transaction rolls back its own row writes on failure — so two independent
+tasks contend exactly as two PostgreSQL backends would, on the same event loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import contextvars
+import threading
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from aigateway.core.profile_index import (
+    INDEX_CREDENTIAL_SERVICE,
+    ProfileIndexStore,
+    ProfileTransitionConflict,
+)
+from aigateway.core.profile_models import (
+    Profile,
+    ProfileState,
+    credential_name_for,
+    profile_id_for,
+)
+from aigateway.plugins.anthropic_provider.auth import credential_service_for
+
+from ._pg_mvcc_store import MvccRowStore
+
+_API_KEY = "sk-ant-api03-delete-set-race-key"
+
+
+class _ValidValidationService:
+    async def validate(self, _plugin, _provider: str, _api_key):
+        from aigateway.core.api_key_validation import (
+            ApiKeyValidationResult,
+            ApiKeyValidationStage,
+            ApiKeyValidationState,
+        )
+
+        return ApiKeyValidationResult(
+            ApiKeyValidationState.VALID, stage=ApiKeyValidationStage.READINESS
+        )
+
+
+ACCOUNT_ID = "account-1"
+# A stand-in for the profile's credential-blob slot (the chat path's real slot); only its
+# identity as a distinct contended row matters for modelling the race.
+CRED_SERVICE = "aigateway:anthropic:cred"
+CRED_ACCOUNT = "default"
+
+# Per-task transaction scratch: row locks held until commit plus the pre-images needed to
+# roll back this task's own writes. A ContextVar is task-local under asyncio, mirroring how
+# in_transaction() pins one pooled connection per task.
+_open_txn: contextvars.ContextVar[dict | None] = contextvars.ContextVar("_open_txn", default=None)
+
+
+class _PostgresRowLockStore:
+    """Credential-store double modelling PostgreSQL READ COMMITTED row locking + rollback."""
+
+    def __init__(self) -> None:
+        self.data: dict[tuple[str, str], str] = {}
+        self._row_locks: dict[tuple[str, str], asyncio.Lock] = defaultdict(asyncio.Lock)
+
+    @contextlib.asynccontextmanager
+    async def transaction(self):
+        # WHY: models ``async with in_transaction()``. Row locks taken by mutate() during the
+        # body are held until this block exits (COMMIT); on failure the block's own writes are
+        # rolled back from their recorded pre-images before the locks release.
+        txn: dict = {"held": [], "undo": {}}
+        token = _open_txn.set(txn)
+        try:
+            yield
+        except BaseException:
+            for key, prior in txn["undo"].items():
+                if prior is None:
+                    self.data.pop(key, None)
+                else:
+                    self.data[key] = prior
+            raise
+        finally:
+            _open_txn.reset(token)
+            for lock in txn["held"]:
+                lock.release()
+
+    async def read(self, service: str, account: str) -> str | None:
+        await asyncio.sleep(0)
+        return self.data.get((service, account))
+
+    async def write(self, service: str, account: str, value: str) -> None:
+        await asyncio.sleep(0)
+        self.data[(service, account)] = value
+
+    async def delete(self, service: str, account: str) -> None:
+        await asyncio.sleep(0)
+        self.data.pop((service, account), None)
+
+    async def mutate(self, service, account, mutator) -> None:
+        key = (service, account)
+        row_lock = self._row_locks[key]
+        txn = _open_txn.get()
+        reused = txn is not None and row_lock in txn["held"]
+        if not reused:
+            # UPDATE/DELETE takes the row lock (blocks while another txn holds it uncommitted).
+            await row_lock.acquire()
+        try:
+            await asyncio.sleep(0)  # yield between "SELECT" and "UPDATE" as real I/O would
+            prior = self.data.get(key)
+            if txn is not None and key not in txn["undo"]:
+                txn["undo"][key] = prior  # record pre-image once, for rollback
+            next_value = mutator(prior)
+            if next_value is None:
+                self.data.pop(key, None)
+            else:
+                self.data[key] = next_value
+        finally:
+            if txn is None:
+                row_lock.release()  # autocommit statement: released at statement end
+            elif not reused:
+                txn["held"].append(row_lock)  # inside a txn: hold until COMMIT
+
+
+def _authenticated_oauth(name: str) -> Profile:
+    return Profile(
+        id=profile_id_for(ACCOUNT_ID, "anthropic", name),
+        account_id=ACCOUNT_ID,
+        provider="anthropic",
+        name=name,
+        state=ProfileState.AUTHENTICATED,
+        auth_type="oauth",
+    )
+
+
+def _api_key(name: str) -> Profile:
+    return Profile(
+        id=profile_id_for(ACCOUNT_ID, "anthropic", name),
+        account_id=ACCOUNT_ID,
+        provider="anthropic",
+        name=name,
+        state=ProfileState.AUTHENTICATED,
+        auth_type="api_key",
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_delete_and_api_key_set_leaves_no_orphan_or_resurrection() -> None:
+    """Concrete schedule (delete grabs the credential row lock first, deterministically):
+
+      1. DELETE opens its transaction and takes the credential row lock (its credential
+         delete), then yields.
+      2. SET opens its transaction and blocks acquiring the same credential row lock.
+      3. DELETE removes the profile-index entry and COMMITS, releasing both row locks.
+      4. SET wins the credential row lock, writes its API-key blob, then its profile-index
+         publication observes the profile already gone. Because SET observed the profile as
+         existing when it began, it must NOT resurrect it: it raises ProfileTransitionConflict
+         and its transaction rolls back the API-key blob it just wrote.
+
+    Final committed state: profile gone, credential gone — delete won with no orphan.
+    """
+    store = _PostgresRowLockStore()
+    index = ProfileIndexStore(credential_store=store)
+
+    await index.upsert(_authenticated_oauth("work"))
+    await store.write(CRED_SERVICE, CRED_ACCOUNT, "oauth-token-blob")
+    profile_id = profile_id_for(ACCOUNT_ID, "anthropic", "work")
+
+    async def delete_op() -> None:
+        # Mirror delete_profile: credential delete + index removal in one transaction.
+        async with store.transaction():
+            await store.mutate(CRED_SERVICE, CRED_ACCOUNT, lambda _current: None)
+            await index.remove(profile_id)
+
+    async def set_op() -> None:
+        # Mirror set_profile_api_key updating an OBSERVED-existing profile: persist the
+        # API-key blob, then publish conditionally so a concurrent delete wins.
+        async with store.transaction():
+            await store.mutate(CRED_SERVICE, CRED_ACCOUNT, lambda _current: "api-key-blob")
+            await index.upsert(_api_key("work"), require_present=True)
+
+    results = await asyncio.gather(delete_op(), set_op(), return_exceptions=True)
+
+    assert results[0] is None, f"delete unexpectedly failed: {results[0]!r}"
+    assert isinstance(results[1], ProfileTransitionConflict), (
+        f"set should abort rather than resurrect, got {results[1]!r}"
+    )
+    # Delete won cleanly: profile removed AND no orphan credential blob survived.
+    assert await index.get(ACCOUNT_ID, "anthropic", "work") is None
+    assert store.data.get((CRED_SERVICE, CRED_ACCOUNT)) is None
+    assert (INDEX_CREDENTIAL_SERVICE, f"account:{ACCOUNT_ID}") in store.data
+
+
+@pytest.mark.asyncio
+async def test_api_key_publication_still_creates_a_genuinely_new_profile() -> None:
+    """require_present must gate ONLY the update path: a first-time API-key set (the profile
+    was never observed) still creates the profile — absence is not a conflict there."""
+    store = _PostgresRowLockStore()
+    index = ProfileIndexStore(credential_store=store)
+
+    # No prior profile: a fresh create passes require_present=False.
+    await index.upsert(_api_key("fresh"), require_present=False)
+    assert await index.get(ACCOUNT_ID, "anthropic", "fresh") is not None
+
+    # And updating an existing profile with require_present=True succeeds when it is present.
+    await index.upsert(_authenticated_oauth("fresh"), require_present=True)
+    updated = await index.get(ACCOUNT_ID, "anthropic", "fresh")
+    assert updated is not None
+    assert updated.auth_type == "oauth"
+
+
+async def _seed_oauth_profile_without_credential(store) -> str:
+    """Seed an index row holding an OAuth profile whose credential slot is ABSENT.
+
+    A pending/errored OAuth profile legitimately has an index entry but no credential blob —
+    the credential-absent state the review requires. The index row (always present) is seeded;
+    the credential row is deliberately NOT written.
+    """
+    seeder = ProfileIndexStore(credential_store=store)
+    await seeder.upsert(_authenticated_oauth("work"))
+    return profile_id_for(ACCOUNT_ID, "anthropic", "work")
+
+
+@pytest.mark.asyncio
+async def test_delete_wins_over_set_when_delete_commits_first_credential_absent() -> None:
+    """OME-307 Blocker 3 — credential row ABSENT, ``delete_profile`` commits first.
+
+    Production ordering under test (index-row CAS FIRST, credential write/delete SECOND):
+
+      1. DELETE acquires the always-present index-row lock and removes the profile, then its
+         credential delete finds NO credential row (absent) — a no-op that takes no lock — and
+         COMMITS. Profile gone.
+      2. SET was blocked on the index-row lock; it now runs and re-evaluates require_present
+         against the committed index. The profile is gone, so it raises
+         ProfileTransitionConflict and rolls back — it must NOT resurrect the deleted profile
+         and its API-key blob write is never committed.
+
+    Final state: profile gone, credential absent — delete wins, no orphan, no resurrection.
+    Serializing on the credential row instead would fail here: the missing-row delete takes no
+    lock, so SET's later INSERT would not be serialized and would orphan a credential.
+    """
+    store = MvccRowStore()
+    profile_id = await _seed_oauth_profile_without_credential(store)
+    index_del = ProfileIndexStore(credential_store=store)
+    index_set = ProfileIndexStore(credential_store=store)
+    delete_holds_index = asyncio.Event()
+
+    async def delete_op() -> None:
+        async with store.transaction():
+            await index_del.remove(profile_id)  # index-row CAS FIRST (always-present row)
+            delete_holds_index.set()
+            await store.delete(CRED_SERVICE, CRED_ACCOUNT)  # credential SECOND (absent -> no-op)
+
+    async def set_op() -> None:
+        await delete_holds_index.wait()  # DELETE takes the index-row lock first, deterministically
+        async with store.transaction():
+            await index_set.upsert(_api_key("work"), require_present=True)  # blocks, then conflicts
+            await store.write(CRED_SERVICE, CRED_ACCOUNT, "api-key-blob")
+
+    results = await asyncio.gather(delete_op(), set_op(), return_exceptions=True)
+
+    assert results[0] is None, f"delete unexpectedly failed: {results[0]!r}"
+    assert isinstance(results[1], ProfileTransitionConflict), (
+        f"set must abort rather than resurrect, got {results[1]!r}"
+    )
+    assert await index_set.get(ACCOUNT_ID, "anthropic", "work") is None
+    assert store.committed.get((CRED_SERVICE, CRED_ACCOUNT)) is None  # no orphan credential
+    assert (INDEX_CREDENTIAL_SERVICE, f"account:{ACCOUNT_ID}") in store.committed
+
+
+@pytest.mark.asyncio
+async def test_delete_wins_over_set_when_set_commits_first_credential_absent() -> None:
+    """OME-307 Blocker 3 — credential row ABSENT, the API-key ``set`` commits first.
+
+    Production ordering under test (index-row CAS FIRST, credential write/delete SECOND):
+
+      1. SET acquires the index-row lock, updates the profile to api_key, writes (INSERTs) its
+         credential blob, and COMMITS.
+      2. DELETE was blocked on the index-row lock; it now removes the profile and — because
+         SET's credential blob is now COMMITTED and visible — deletes it too, then COMMITS.
+
+    Final state: profile gone, credential gone — the later delete still cleans up SET's blob,
+    so no orphan survives. This is the commit order the credential-first ordering handles
+    correctly only when the blob already exists; here it is created mid-race.
+    """
+    store = MvccRowStore()
+    profile_id = await _seed_oauth_profile_without_credential(store)
+    index_set = ProfileIndexStore(credential_store=store)
+    index_del = ProfileIndexStore(credential_store=store)
+    set_holds_index = asyncio.Event()
+
+    async def set_op() -> None:
+        async with store.transaction():
+            await index_set.upsert(_api_key("work"), require_present=True)  # index-row CAS FIRST
+            set_holds_index.set()
+            await store.write(CRED_SERVICE, CRED_ACCOUNT, "api-key-blob")  # credential SECOND
+
+    async def delete_op() -> None:
+        await set_holds_index.wait()  # SET takes the index-row lock first, deterministically
+        async with store.transaction():
+            await index_del.remove(profile_id)  # blocks until SET commits, then removes
+            await store.delete(CRED_SERVICE, CRED_ACCOUNT)  # SET's blob now visible -> deleted
+
+    results = await asyncio.gather(set_op(), delete_op(), return_exceptions=True)
+
+    assert results[0] is None, f"set unexpectedly failed: {results[0]!r}"
+    assert results[1] is None, f"delete unexpectedly failed: {results[1]!r}"
+    assert await index_del.get(ACCOUNT_ID, "anthropic", "work") is None
+    assert store.committed.get((CRED_SERVICE, CRED_ACCOUNT)) is None  # no orphan credential
+    assert (INDEX_CREDENTIAL_SERVICE, f"account:{ACCOUNT_ID}") in store.committed
+
+
+def test_delete_profile_route_removes_both_credential_blob_and_index_entry(
+    authenticated_client,
+    credential_blobs,
+) -> None:
+    """Route-level counterpart to the store-double race, over the real HTTP path + ORMStore.
+
+    INVARIANT (OME-307 Unit 3): ``delete_profile`` publishes the credential deletion and the
+    profile-index removal in ONE transaction, so after a delete NEITHER the encrypted
+    credential blob NOR the index entry survives — a committed delete never leaves an orphan
+    credential. This guards the real transaction wiring the store-double race cannot exercise.
+    """
+    authenticated_client.app.state.api_key_validation_service = _ValidValidationService()
+    account_id = authenticated_client.get("/v1/auth/me").json()["id"]
+    service = credential_service_for(credential_name_for(account_id, "work"))
+
+    created = authenticated_client.put(
+        "/v1/auth/anthropic/profiles/work/api-key",
+        json={"api_key": _API_KEY},
+    )
+    assert created.status_code == 200
+    # Both halves of the durable state exist before the delete.
+    assert credential_blobs.read(service, "default") is not None
+    assert authenticated_client.get("/v1/auth/anthropic/profiles/work").status_code == 200
+
+    deleted = authenticated_client.delete("/v1/auth/anthropic/profiles/work")
+    assert deleted.status_code == 204
+
+    # The atomic delete removed BOTH profile and blob state — no orphan credential remains.
+    assert credential_blobs.read(service, "default") is None
+    assert authenticated_client.get("/v1/auth/anthropic/profiles/work").status_code == 404
+
+
+def test_delete_wins_over_stale_profile_patch(
+    authenticated_client,
+    credential_blobs,
+    monkeypatch,
+) -> None:
+    """PATCH must not resurrect the whole profile snapshot it read before DELETE."""
+    authenticated_client.app.state.api_key_validation_service = _ValidValidationService()
+    created = authenticated_client.put(
+        "/v1/auth/anthropic/profiles/work/api-key",
+        json={"api_key": _API_KEY},
+    )
+    assert created.status_code == 200
+    account_id = authenticated_client.get("/v1/auth/me").json()["id"]
+    service = credential_service_for(credential_name_for(account_id, "work"))
+    index = authenticated_client.app.state.profile_index
+    get_profile = index.get
+    patch_read = threading.Event()
+    release_patch = threading.Event()
+    get_count = 0
+    get_count_lock = threading.Lock()
+
+    async def _stall_first_get(*args, **kwargs):
+        nonlocal get_count
+        profile = await get_profile(*args, **kwargs)
+        with get_count_lock:
+            get_count += 1
+            call_number = get_count
+        if call_number == 1:
+            patch_read.set()
+            if not await asyncio.to_thread(release_patch.wait, 5):
+                raise TimeoutError("profile PATCH was not released")
+        return profile
+
+    monkeypatch.setattr(index, "get", _stall_first_get)
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        patch = executor.submit(
+            authenticated_client.patch,
+            "/v1/auth/anthropic/profiles/work",
+            json={"account_label": "stale-label"},
+        )
+        assert patch_read.wait(5), "PATCH never read its stale profile snapshot"
+        deleted = authenticated_client.delete("/v1/auth/anthropic/profiles/work")
+        release_patch.set()
+        patched = patch.result(timeout=5)
+
+    assert deleted.status_code == 204
+    assert patched.status_code == 409
+    assert authenticated_client.get("/v1/auth/anthropic/profiles/work").status_code == 404
+    assert credential_blobs.read(service, "default") is None
+
+
+@pytest.mark.asyncio
+async def test_stale_dispatch_error_cannot_delete_win_or_mark_newer_same_auth_owner() -> None:
+    """Error publication must compare the credential version it actually used."""
+    store = MvccRowStore()
+    index = ProfileIndexStore(credential_store=store)
+    profile_id = profile_id_for(ACCOUNT_ID, "anthropic", "work")
+    old_refreshed_at = datetime.now(UTC) - timedelta(minutes=1)
+    old = _api_key("work").model_copy(update={"last_refreshed_at": old_refreshed_at})
+    await index.upsert(old)
+
+    await index.remove(profile_id)
+    with pytest.raises(ProfileTransitionConflict):
+        await index.mark_authenticated_error(
+            profile_id,
+            expected_auth_type="api_key",
+            expected_last_refreshed_at=old_refreshed_at,
+        )
+    assert await index.get(ACCOUNT_ID, "anthropic", "work") is None
+
+    newer_refreshed_at = datetime.now(UTC)
+    newer = old.model_copy(update={"last_refreshed_at": newer_refreshed_at})
+    await index.upsert(newer)
+    with pytest.raises(ProfileTransitionConflict):
+        await index.mark_authenticated_error(
+            profile_id,
+            expected_auth_type="api_key",
+            expected_last_refreshed_at=old_refreshed_at,
+        )
+    survivor = await index.get(ACCOUNT_ID, "anthropic", "work")
+    assert survivor is not None
+    assert survivor.state is ProfileState.AUTHENTICATED
+    assert survivor.last_refreshed_at == newer_refreshed_at

--- a/apps/aigateway/tests/unit/test_profile_index.py
+++ b/apps/aigateway/tests/unit/test_profile_index.py
@@ -9,7 +9,11 @@ from tortoise import Tortoise
 import aigateway.core.credential_blob.store as credential_blob_store
 from aigateway.core.credential_blob.model import CredentialBlob
 from aigateway.core.credential_blob.store import CredentialBlobMutationConflict, ORMStore
-from aigateway.core.profile_index import INDEX_CREDENTIAL_SERVICE, ProfileIndexStore
+from aigateway.core.profile_index import (
+    INDEX_CREDENTIAL_SERVICE,
+    ProfileIndexStore,
+    ProfileTransitionConflict,
+)
 from aigateway.core.profile_models import (
     Profile,
     ProfileDefaults,
@@ -109,7 +113,9 @@ def test_profile_round_trips_through_json() -> None:
 def test_profile_index_serializes_with_version() -> None:
     idx = ProfileIndex(version=1, profiles=[])
     data = idx.model_dump()
-    assert data == {"version": 1, "profiles": []}
+    # oauth_generations carries the per-profile OAuth ownership nonces (OME-307 Blocker 1);
+    # it defaults to an empty map and is part of the durable index document.
+    assert data == {"version": 1, "profiles": [], "oauth_generations": {}}
 
 
 @pytest.mark.asyncio
@@ -576,3 +582,118 @@ async def test_isolated_orm_stores_preserve_concurrent_remove_and_upsert(
     profiles = await seed_store.list(ACCOUNT_ID)
     assert {p.name for p in profiles} == {"keep", "add"}
     assert barrier.encrypt_calls >= 3
+
+
+@pytest.mark.asyncio
+async def test_authenticate_pending_rejects_superseded_generation(credential_blobs) -> None:
+    """OME-307 Blocker 1 — ownership lives INSIDE the durable publication CAS.
+
+    FEATURE: profile OAuth authentication with concurrent-flow safety.
+    STORY: as a user who restarts an OAuth login for a profile while an earlier attempt is
+    still exchanging its code, the earlier (stale) attempt must not hijack the profile the
+    new attempt now owns.
+
+    INVARIANT: a stale OAuth flow whose ownership generation was superseded by a newer
+    ``start_oauth`` for the same profile LOSES its publication even though the durable row is
+    still PENDING. A generic ``state == pending`` CAS cannot see the newer owner; binding a
+    per-operation generation into the SAME atomic CAS makes the stale flow fail with
+    ``ProfileTransitionConflict`` while the newer owner keeps the pending profile and can still
+    complete. The generation is an operation nonce and never leaves the index document, so it
+    is never exposed through the profile API.
+    """
+    store = ProfileIndexStore(credential_store=credential_blobs.store)
+    pending = Profile(
+        id=profile_id_for(ACCOUNT_ID, "anthropic", "work"),
+        account_id=ACCOUNT_ID,
+        provider="anthropic",
+        name="work",
+        state=ProfileState.PENDING,
+    )
+
+    generation_a = await store.begin_pending(pending)
+    generation_b = await store.begin_pending(pending)  # a newer start_oauth supersedes flow A
+    assert generation_b != generation_a
+
+    authenticated = pending.model_copy(update={"state": ProfileState.AUTHENTICATED})
+
+    # Flow A publishes with its now-stale generation: it must lose even though state==PENDING.
+    with pytest.raises(ProfileTransitionConflict):
+        await store.authenticate_pending(authenticated, expected_generation=generation_a)
+    still_pending = await store.get(ACCOUNT_ID, "anthropic", "work")
+    assert still_pending is not None
+    assert still_pending.state is ProfileState.PENDING  # A wrote nothing
+
+    # Flow B — the current owner — publishes with its generation and wins.
+    await store.authenticate_pending(authenticated, expected_generation=generation_b)
+    published = await store.get(ACCOUNT_ID, "anthropic", "work")
+    assert published is not None
+    assert published.state is ProfileState.AUTHENTICATED
+
+
+@pytest.mark.asyncio
+async def test_mark_pending_error_only_marks_still_owned_pending_profile(credential_blobs) -> None:
+    """OME-307 Blocker 2 — a stale OAuth failure must not corrupt a newer owner.
+
+    FEATURE: profile OAuth authentication with concurrent-flow safety.
+    INVARIANT: ``mark_pending_error`` transitions PENDING->ERROR only if the profile is still
+    present, still PENDING, and still owned by the failing operation's generation. Three stale
+    schedules must each be rejected with ``ProfileTransitionConflict`` and leave the newer
+    state intact: a newer OAuth flow, a committed API-key profile, and a deleted profile (which
+    must never be resurrected).
+    """
+    store = ProfileIndexStore(credential_store=credential_blobs.store)
+    profile_id = profile_id_for(ACCOUNT_ID, "anthropic", "work")
+    pending = Profile(
+        id=profile_id,
+        account_id=ACCOUNT_ID,
+        provider="anthropic",
+        name="work",
+        state=ProfileState.PENDING,
+    )
+
+    # Schedule 1 — a newer OAuth flow (B) supersedes A before A's failure fires.
+    generation_a = await store.begin_pending(pending)
+    await store.begin_pending(pending)  # flow B claims a newer generation
+    with pytest.raises(ProfileTransitionConflict):
+        await store.mark_pending_error(profile_id, expected_generation=generation_a)
+    survivor = await store.get(ACCOUNT_ID, "anthropic", "work")
+    assert survivor is not None
+    assert survivor.state is ProfileState.PENDING  # B's pending profile untouched
+
+    # Schedule 2 — a committed API-key profile replaced the pending flow before A failed.
+    generation_a2 = await store.begin_pending(pending)
+    await store.upsert(
+        pending.model_copy(update={"state": ProfileState.AUTHENTICATED, "auth_type": "api_key"})
+    )
+    with pytest.raises(ProfileTransitionConflict):
+        await store.mark_pending_error(profile_id, expected_generation=generation_a2)
+    survivor = await store.get(ACCOUNT_ID, "anthropic", "work")
+    assert survivor is not None
+    assert survivor.state is ProfileState.AUTHENTICATED
+    assert survivor.auth_type == "api_key"
+
+    # Schedule 3 — the profile was deleted before A failed: never resurrect it.
+    generation_a3 = await store.begin_pending(pending)
+    await store.remove(profile_id)
+    with pytest.raises(ProfileTransitionConflict):
+        await store.mark_pending_error(profile_id, expected_generation=generation_a3)
+    assert await store.get(ACCOUNT_ID, "anthropic", "work") is None  # no resurrection
+
+
+@pytest.mark.asyncio
+async def test_mark_pending_error_marks_owned_pending_profile(credential_blobs) -> None:
+    """The still-owning failing flow transitions its own pending profile to ERROR."""
+    store = ProfileIndexStore(credential_store=credential_blobs.store)
+    profile_id = profile_id_for(ACCOUNT_ID, "anthropic", "work")
+    pending = Profile(
+        id=profile_id,
+        account_id=ACCOUNT_ID,
+        provider="anthropic",
+        name="work",
+        state=ProfileState.PENDING,
+    )
+    generation = await store.begin_pending(pending)
+    await store.mark_pending_error(profile_id, expected_generation=generation)
+    errored = await store.get(ACCOUNT_ID, "anthropic", "work")
+    assert errored is not None
+    assert errored.state is ProfileState.ERROR

--- a/apps/aigateway/tests/unit/test_profile_index.py
+++ b/apps/aigateway/tests/unit/test_profile_index.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime
 
 import pytest
 import pytest_asyncio
@@ -694,6 +695,76 @@ async def test_mark_pending_error_marks_owned_pending_profile(credential_blobs) 
     )
     generation = await store.begin_pending(pending)
     await store.mark_pending_error(profile_id, expected_generation=generation)
+    errored = await store.get(ACCOUNT_ID, "anthropic", "work")
+    assert errored is not None
+    assert errored.state is ProfileState.ERROR
+
+
+@pytest.mark.asyncio
+async def test_authenticate_pending_publishes_last_refreshed_at_into_owner_fence(
+    credential_blobs,
+) -> None:
+    """OME-307 M-1 — the authenticated owner's refresh timestamp must survive publication.
+
+    FEATURE: profile OAuth authentication with concurrent-refresh safety.
+    STORY: as a user who re-authenticates a profile via OAuth while an earlier credential
+    refresh is still in flight, the earlier refresh's failure must not error the profile I
+    just re-authenticated.
+
+    INVARIANT: ``authenticate_pending`` publishes ``last_refreshed_at`` inside the SAME atomic
+    CAS that flips PENDING->AUTHENTICATED, so the timestamp joins ``mark_authenticated_error``'s
+    ownership fence (state + auth_type + last_refreshed_at). A stale refresh-failure carrying
+    the pre-re-auth timestamp (here the pending row's ``None``) can then no longer match the
+    fence: it is rejected with ``ProfileTransitionConflict`` and the freshly authenticated
+    profile stays AUTHENTICATED. Dropping the field at publication would leave the row at the
+    stale ``None`` and let the stale failure win.
+    """
+    store = ProfileIndexStore(credential_store=credential_blobs.store)
+    pending = Profile(
+        id=profile_id_for(ACCOUNT_ID, "anthropic", "work"),
+        account_id=ACCOUNT_ID,
+        provider="anthropic",
+        name="work",
+        state=ProfileState.PENDING,
+    )
+    generation = await store.begin_pending(pending)
+
+    # The OAuth callback stamps a fresh refresh time on the authenticated form it publishes.
+    refreshed_at = datetime(2026, 7, 23, 12, 0, 0, tzinfo=UTC)
+    authenticated = pending.model_copy(
+        update={
+            "state": ProfileState.AUTHENTICATED,
+            "auth_type": "oauth",
+            "last_refreshed_at": refreshed_at,
+        }
+    )
+    await store.authenticate_pending(authenticated, expected_generation=generation)
+
+    published = await store.get(ACCOUNT_ID, "anthropic", "work")
+    assert published is not None
+    assert published.state is ProfileState.AUTHENTICATED
+    # The owner's refresh timestamp is durably published, not dropped to the pending ``None``.
+    assert published.last_refreshed_at == refreshed_at
+
+    # A stale refresh-failure that read the profile BEFORE re-auth (last_refreshed_at is None)
+    # must NOT be able to error the new owner.
+    with pytest.raises(ProfileTransitionConflict):
+        await store.mark_authenticated_error(
+            published.id,
+            expected_auth_type="oauth",
+            expected_last_refreshed_at=None,
+        )
+    still_authenticated = await store.get(ACCOUNT_ID, "anthropic", "work")
+    assert still_authenticated is not None
+    assert still_authenticated.state is ProfileState.AUTHENTICATED
+
+    # The CURRENT owner (matching timestamp) can still legitimately error it — proving the
+    # fence stayed functional, not merely always-closed.
+    await store.mark_authenticated_error(
+        published.id,
+        expected_auth_type="oauth",
+        expected_last_refreshed_at=refreshed_at,
+    )
     errored = await store.get(ACCOUNT_ID, "anthropic", "work")
     assert errored is not None
     assert errored.state is ProfileState.ERROR

--- a/apps/aigateway/tests/unit/test_profile_oauth_flow_ownership.py
+++ b/apps/aigateway/tests/unit/test_profile_oauth_flow_ownership.py
@@ -1,0 +1,615 @@
+"""OME-307 Unit 2 — OAuth flow generation ownership.
+
+FEATURE: profile OAuth authentication with concurrent-flow safety.
+STORY: as a user who restarts an OAuth login for a profile while an earlier attempt is
+still exchanging its code, the earlier (stale) attempt must not hijack the profile the
+new attempt now owns.
+
+INVARIANT: pending-profile publication is bound to the CURRENT OAuth operation, not
+merely to ``profile.state == pending``. A stale callback whose operation has been
+superseded by a newer pending flow for the same account/provider/profile receives the
+retryable ``profile_auth_conflict`` (409) and modifies neither the credential nor the
+profile owned by the newer flow. The profile-state CAS remains as defense in depth for
+the case where the newer flow has already committed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import json
+import threading
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+
+import httpx
+import pytest
+
+import aigateway.routes.auth as auth_module
+from aigateway.core.profile_index import ProfileIndexStore, ProfileTransitionConflict
+from aigateway.core.profile_models import Profile, ProfileState, credential_name_for, profile_id_for
+from aigateway.plugins.anthropic_provider.auth import credential_service_for
+
+from ._pg_mvcc_store import MvccRowStore
+
+
+@contextmanager
+def _server_errors_as_responses(client) -> Iterator[None]:
+    """Return unhandled route exceptions as 500 responses (as the ASGI server would) instead
+    of re-raising them into the sync TestClient's calling thread."""
+    transport = getattr(client, "_transport")
+    previous = transport.raise_server_exceptions
+    transport.raise_server_exceptions = False
+    try:
+        yield
+    finally:
+        transport.raise_server_exceptions = previous
+
+
+def _token_factory(
+    token: str,
+    *,
+    stall: threading.Event | None = None,
+    started: threading.Event | None = None,
+):
+    async def token_handler(_request: httpx.Request) -> httpx.Response:
+        if started is not None:
+            started.set()
+        if stall is not None and not await asyncio.to_thread(stall.wait, 5):
+            raise TimeoutError("OAuth exchange was not released")
+        return httpx.Response(
+            200,
+            json={
+                "access_token": token,
+                "refresh_token": f"refresh-{token}",
+                "expires_in": 3600,
+                "token_type": "Bearer",
+            },
+        )
+
+    return lambda: httpx.AsyncClient(
+        transport=httpx.MockTransport(token_handler), timeout=httpx.Timeout(5.0)
+    )
+
+
+def _failing_token_factory(
+    *,
+    stall: threading.Event | None = None,
+    started: threading.Event | None = None,
+    sentinel: str = "SENSITIVE-PROVIDER-BODY",
+):
+    async def token_handler(_request: httpx.Request) -> httpx.Response:
+        if started is not None:
+            started.set()
+        if stall is not None and not await asyncio.to_thread(stall.wait, 5):
+            raise TimeoutError("OAuth exchange was not released")
+        # A provider-side failure whose body carries a sentinel we assert never leaks.
+        return httpx.Response(400, json={"error": "invalid_grant", "detail": sentinel})
+
+    return lambda: httpx.AsyncClient(
+        transport=httpx.MockTransport(token_handler), timeout=httpx.Timeout(5.0)
+    )
+
+
+class _ValidValidationService:
+    async def validate(self, _plugin, _provider: str, _api_key):
+        from aigateway.core.api_key_validation import (
+            ApiKeyValidationResult,
+            ApiKeyValidationStage,
+            ApiKeyValidationState,
+        )
+
+        return ApiKeyValidationResult(
+            ApiKeyValidationState.VALID,
+            stage=ApiKeyValidationStage.READINESS,
+        )
+
+
+def test_stale_oauth_callback_does_not_publish_into_newer_flow(
+    authenticated_client,
+    credential_blobs,
+) -> None:
+    """Concrete schedule:
+
+    1. Flow A starts (POST /profiles) and its callback stalls during token exchange
+       (A has already consumed its own pending state before the exchange await).
+    2. Flow B starts for the SAME account/provider/profile, creating a new pending
+       operation that now owns the profile.
+    3. Flow A is released and resumes; its publication must be rejected with a retryable
+       409 profile_auth_conflict, leaving no orphan credential and B still the owner.
+    4. Flow B completes and wins.
+    """
+    exchange_started = threading.Event()
+    release_exchange = threading.Event()
+    authenticated_client.app.state.anthropic_http_factory = _token_factory(
+        "oauth-A-token", stall=release_exchange, started=exchange_started
+    )
+
+    start_a = authenticated_client.post("/v1/auth/anthropic/profiles", json={"name": "work"})
+    assert start_a.status_code == 201
+    state_a = start_a.json()["state"]
+
+    account_id = authenticated_client.get("/v1/auth/me").json()["id"]
+    service = credential_service_for(credential_name_for(account_id, "work"))
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        callback_a = executor.submit(
+            authenticated_client.get,
+            "/v1/auth/anthropic/callback",
+            params={"code": "code-A", "state": state_a},
+            follow_redirects=False,
+        )
+        assert exchange_started.wait(5), "flow A never reached token exchange"
+
+        # Flow B starts for the same profile while A is stalled: B is now the owner.
+        start_b = authenticated_client.post("/v1/auth/anthropic/profiles", json={"name": "work"})
+        assert start_b.status_code == 201
+        state_b = start_b.json()["state"]
+
+        release_exchange.set()
+        response_a = callback_a.result(timeout=5)
+
+    # Flow A is stale: retryable conflict, and it published nothing of B's.
+    assert response_a.status_code == 409
+    assert response_a.json()["detail"]["code"] == "profile_auth_conflict"
+    assert "oauth-A-token" not in response_a.text
+    profile = authenticated_client.get("/v1/auth/anthropic/profiles/work").json()
+    assert profile["state"] == "pending"  # still B's pending profile
+    # INVARIANT: a rejected stale publication leaves no orphan credential behind.
+    assert credential_blobs.read(service, "default") is None
+
+    # Flow B remains the owner and completes successfully with its own credentials.
+    authenticated_client.app.state.anthropic_http_factory = _token_factory("oauth-B-token")
+    response_b = authenticated_client.get(
+        "/v1/auth/anthropic/callback",
+        params={"code": "code-B", "state": state_b},
+        follow_redirects=False,
+    )
+    assert response_b.status_code == 200
+    profile_b = authenticated_client.get("/v1/auth/anthropic/profiles/work").json()
+    assert profile_b["state"] == "authenticated"
+    assert profile_b["auth_type"] == "oauth"
+    assert "oauth-B-token" in json.loads(credential_blobs.read(service, "default"))["access_token"]
+
+
+def test_oauth_callback_cancellation_restores_consumed_pending_state(
+    authenticated_client,
+    credential_blobs,
+    monkeypatch,
+) -> None:
+    """OME-307 Blocker 5 — a cancelled callback must not strand the profile pending.
+
+    Schedule:
+    1. Flow A starts (POST /profiles) and publishes its pending profile + ownership generation.
+    2. A's callback consumes (pops) its pending state, then a ``BaseException`` cancellation
+       fires during the token-exchange await (Python 3.12 ``asyncio.CancelledError`` escapes
+       ``except Exception``).
+    3. The consumed state MUST be re-published synchronously so the flow stays retryable, and
+       the cancellation MUST propagate (cleanup, never suppress). The profile is untouched
+       (still pending) and no credential is written.
+    4. A retry of the SAME flow, with a working exchange, completes successfully — proving the
+       restored state carried the original ownership generation.
+
+    Against the pre-fix code the state is popped before the exchange await and never restored,
+    so the flow is unrecoverable (``peek`` returns ``None``) — this test is RED there.
+    """
+    authenticated_client.app.state.anthropic_http_factory = _token_factory("oauth-A-token")
+
+    start = authenticated_client.post("/v1/auth/anthropic/profiles", json={"name": "work"})
+    assert start.status_code == 201
+    state = start.json()["state"]
+    account_id = authenticated_client.get("/v1/auth/me").json()["id"]
+    service = credential_service_for(credential_name_for(account_id, "work"))
+
+    async def _cancel_during_exchange(*_args, **_kwargs):
+        # A cooperative cancellation at the network await — the realistic callback cancel window.
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(auth_module, "_exchange_oauth_code_for_pending", _cancel_during_exchange)
+
+    with pytest.raises((concurrent.futures.CancelledError, asyncio.CancelledError)) as excinfo:
+        authenticated_client.get(
+            "/v1/auth/anthropic/callback",
+            params={"code": "code-A", "state": state},
+            follow_redirects=False,
+        )
+    # The cancellation propagated to the caller — it was not caught-and-suppressed.
+    assert isinstance(excinfo.value, (concurrent.futures.CancelledError, asyncio.CancelledError))
+
+    # INVARIANT (Blocker 5): the consumed state is restored, so the flow is still completable.
+    assert authenticated_client.app.state.pending_auth.peek(state) is not None
+    # The profile is untouched and no credential was written or corrupted.
+    profile = authenticated_client.get("/v1/auth/anthropic/profiles/work").json()
+    assert profile["state"] == "pending"
+    assert credential_blobs.read(service, "default") is None
+
+    # Retrying the SAME flow with a working exchange completes — the restored entry still owns it.
+    monkeypatch.undo()
+    authenticated_client.app.state.anthropic_http_factory = _token_factory("oauth-A-token")
+    retry = authenticated_client.get(
+        "/v1/auth/anthropic/callback",
+        params={"code": "code-A", "state": state},
+        follow_redirects=False,
+    )
+    assert retry.status_code == 200
+    profile_done = authenticated_client.get("/v1/auth/anthropic/profiles/work").json()
+    assert profile_done["state"] == "authenticated"
+    assert profile_done["auth_type"] == "oauth"
+    assert "oauth-A-token" in json.loads(credential_blobs.read(service, "default"))["access_token"]
+
+
+def test_oauth_start_does_not_supersede_older_flow_until_publication_succeeds(
+    authenticated_client,
+    credential_blobs,
+    monkeypatch,
+) -> None:
+    """OME-307 Blocker 5 — a NEW start must not irreversibly supersede an older flow until it has
+    itself been fully published.
+
+    Schedule:
+    1. Flow A starts and owns a completable pending profile.
+    2. Flow B starts for the SAME profile, but its ``begin_pending`` publication fails.
+    3. B's failure must be atomic: A's pending flow is left intact (it is superseded only AFTER
+       B publishes), so A can still complete.
+
+    If ``start_oauth`` evicted older flows BEFORE publishing the new one, A would be destroyed by
+    a flow that never started — this test is RED under that (inverted) ordering.
+    """
+    authenticated_client.app.state.anthropic_http_factory = _token_factory("oauth-A-token")
+
+    start_a = authenticated_client.post("/v1/auth/anthropic/profiles", json={"name": "work"})
+    assert start_a.status_code == 201
+    state_a = start_a.json()["state"]
+    account_id = authenticated_client.get("/v1/auth/me").json()["id"]
+    service = credential_service_for(credential_name_for(account_id, "work"))
+
+    async def _failing_begin_pending(_profile):
+        raise RuntimeError("index publication failed")
+
+    monkeypatch.setattr(
+        authenticated_client.app.state.profile_index, "begin_pending", _failing_begin_pending
+    )
+
+    with _server_errors_as_responses(authenticated_client):
+        start_b = authenticated_client.post("/v1/auth/anthropic/profiles", json={"name": "work"})
+    assert start_b.status_code == 500
+
+    # INVARIANT (Blocker 5): A is untouched — it was NOT superseded by B's failed publication.
+    assert authenticated_client.app.state.pending_auth.peek(state_a) is not None
+
+    # A completes successfully, proving its flow survived B's failed start intact.
+    monkeypatch.undo()
+    response_a = authenticated_client.get(
+        "/v1/auth/anthropic/callback",
+        params={"code": "code-A", "state": state_a},
+        follow_redirects=False,
+    )
+    assert response_a.status_code == 200
+    profile_a = authenticated_client.get("/v1/auth/anthropic/profiles/work").json()
+    assert profile_a["state"] == "authenticated"
+    assert "oauth-A-token" in json.loads(credential_blobs.read(service, "default"))["access_token"]
+
+
+def test_stale_oauth_failure_does_not_corrupt_newer_owner(
+    authenticated_client,
+    credential_blobs,
+) -> None:
+    """OME-307 Blocker 2 — a stale OAuth FAILURE must not corrupt the newer owner.
+
+    Schedule:
+    1. Flow A starts and its callback stalls during token exchange.
+    2. Flow B starts for the same profile and becomes the pending owner (a newer generation).
+    3. Flow A's exchange then fails. Its failure handler must mark the profile ERROR only if A
+       still owns the pending profile — since B now owns it, A's failure is a no-op. An
+       unconditional error-upsert (the pre-fix behavior) would instead flip B's pending profile
+       to ERROR, and B's later completion would then 409 (``state != pending``). The provider
+       failure body must also never leak into the sanitized callback response.
+    """
+    exchange_started = threading.Event()
+    release_exchange = threading.Event()
+    sentinel = "SENSITIVE-PROVIDER-BODY"
+    authenticated_client.app.state.anthropic_http_factory = _failing_token_factory(
+        stall=release_exchange, started=exchange_started, sentinel=sentinel
+    )
+
+    start_a = authenticated_client.post("/v1/auth/anthropic/profiles", json={"name": "work"})
+    assert start_a.status_code == 201
+    state_a = start_a.json()["state"]
+    account_id = authenticated_client.get("/v1/auth/me").json()["id"]
+    service = credential_service_for(credential_name_for(account_id, "work"))
+
+    with (
+        _server_errors_as_responses(authenticated_client),
+        ThreadPoolExecutor(max_workers=1) as executor,
+    ):
+        callback_a = executor.submit(
+            authenticated_client.get,
+            "/v1/auth/anthropic/callback",
+            params={"code": "code-A", "state": state_a},
+            follow_redirects=False,
+        )
+        assert exchange_started.wait(5), "flow A never reached token exchange"
+
+        # Flow B starts and becomes the pending owner while A is stalled.
+        start_b = authenticated_client.post("/v1/auth/anthropic/profiles", json={"name": "work"})
+        assert start_b.status_code == 201
+        state_b = start_b.json()["state"]
+
+        release_exchange.set()
+        response_a = callback_a.result(timeout=5)
+
+    # A failed, sanitized — no provider body leaked into the response.
+    assert response_a.status_code == 500
+    assert sentinel not in response_a.text
+    # B still owns a PENDING profile — A's stale failure did NOT mark it ERROR.
+    profile = authenticated_client.get("/v1/auth/anthropic/profiles/work").json()
+    assert profile["state"] == "pending"
+    assert credential_blobs.read(service, "default") is None  # no credential written or corrupted
+
+    # B completes and wins — impossible if A had marked the profile ERROR.
+    authenticated_client.app.state.anthropic_http_factory = _token_factory("oauth-B-token")
+    response_b = authenticated_client.get(
+        "/v1/auth/anthropic/callback",
+        params={"code": "code-B", "state": state_b},
+        follow_redirects=False,
+    )
+    assert response_b.status_code == 200
+    profile_b = authenticated_client.get("/v1/auth/anthropic/profiles/work").json()
+    assert profile_b["state"] == "authenticated"
+    assert profile_b["auth_type"] == "oauth"
+    assert "oauth-B-token" in json.loads(credential_blobs.read(service, "default"))["access_token"]
+
+
+def test_stale_oauth_failure_does_not_corrupt_committed_api_key(
+    authenticated_client,
+    credential_blobs,
+) -> None:
+    """A failed callback cannot flip a newer API-key profile to ERROR."""
+    exchange_started = threading.Event()
+    release_exchange = threading.Event()
+    authenticated_client.app.state.anthropic_http_factory = _failing_token_factory(
+        stall=release_exchange,
+        started=exchange_started,
+    )
+    start = authenticated_client.post("/v1/auth/anthropic/profiles", json={"name": "work"})
+    account_id = authenticated_client.get("/v1/auth/me").json()["id"]
+    service = credential_service_for(credential_name_for(account_id, "work"))
+    api_key = "sk-ant-api03-newer-api-key-1234"
+    authenticated_client.app.state.api_key_validation_service = _ValidValidationService()
+
+    with (
+        _server_errors_as_responses(authenticated_client),
+        ThreadPoolExecutor(max_workers=1) as executor,
+    ):
+        callback = executor.submit(
+            authenticated_client.get,
+            "/v1/auth/anthropic/callback",
+            params={"code": "code-A", "state": start.json()["state"]},
+            follow_redirects=False,
+        )
+        assert exchange_started.wait(5), "flow A never consumed state and reached exchange"
+        set_key = authenticated_client.put(
+            "/v1/auth/anthropic/profiles/work/api-key",
+            json={"api_key": api_key},
+        )
+        release_exchange.set()
+        failed = callback.result(timeout=5)
+
+    assert set_key.status_code == 200
+    assert failed.status_code == 500
+    profile = authenticated_client.get("/v1/auth/anthropic/profiles/work").json()
+    assert profile["state"] == "authenticated"
+    assert profile["auth_type"] == "api_key"
+    assert json.loads(credential_blobs.read(service, "default")) == {
+        "auth_type": "api_key",
+        "api_key": api_key,
+    }
+
+
+def test_stale_oauth_failure_does_not_resurrect_deleted_profile(
+    authenticated_client,
+    credential_blobs,
+) -> None:
+    """A failed callback cannot recreate a profile after DELETE commits."""
+    exchange_started = threading.Event()
+    release_exchange = threading.Event()
+    authenticated_client.app.state.anthropic_http_factory = _failing_token_factory(
+        stall=release_exchange,
+        started=exchange_started,
+    )
+    start = authenticated_client.post("/v1/auth/anthropic/profiles", json={"name": "work"})
+    account_id = authenticated_client.get("/v1/auth/me").json()["id"]
+    service = credential_service_for(credential_name_for(account_id, "work"))
+
+    with (
+        _server_errors_as_responses(authenticated_client),
+        ThreadPoolExecutor(max_workers=1) as executor,
+    ):
+        callback = executor.submit(
+            authenticated_client.get,
+            "/v1/auth/anthropic/callback",
+            params={"code": "code-A", "state": start.json()["state"]},
+            follow_redirects=False,
+        )
+        assert exchange_started.wait(5), "flow A never consumed state and reached exchange"
+        deleted = authenticated_client.delete("/v1/auth/anthropic/profiles/work")
+        release_exchange.set()
+        failed = callback.result(timeout=5)
+
+    assert deleted.status_code == 204
+    assert failed.status_code == 500
+    assert authenticated_client.get("/v1/auth/anthropic/profiles/work").status_code == 404
+    assert credential_blobs.read(service, "default") is None
+
+
+def test_oauth_redirect_failure_leaves_older_flow_usable(
+    authenticated_client,
+    credential_blobs,
+    monkeypatch,
+) -> None:
+    """A replacement that cannot prepare its redirect never supersedes flow A."""
+    authenticated_client.app.state.anthropic_http_factory = _token_factory("oauth-A-token")
+    start_a = authenticated_client.post("/v1/auth/anthropic/profiles", json={"name": "work"})
+    state_a = start_a.json()["state"]
+    account_id = authenticated_client.get("/v1/auth/me").json()["id"]
+    service = credential_service_for(credential_name_for(account_id, "work"))
+
+    async def _redirect_failure(*_args, **_kwargs):
+        raise RuntimeError("loopback listener unavailable")
+
+    monkeypatch.setattr(auth_module, "_redirect_uri_for", _redirect_failure)
+    with _server_errors_as_responses(authenticated_client):
+        start_b = authenticated_client.post(
+            "/v1/auth/anthropic/profiles",
+            json={"name": "work", "redirect_uri": "http://localhost:9105/callback"},
+        )
+    assert start_b.status_code == 500
+    assert authenticated_client.app.state.pending_auth.peek(state_a) is not None
+
+    monkeypatch.undo()
+    completed_a = authenticated_client.get(
+        "/v1/auth/anthropic/callback",
+        params={"code": "code-A", "state": state_a},
+        follow_redirects=False,
+    )
+    assert completed_a.status_code == 200
+    assert "oauth-A-token" in json.loads(credential_blobs.read(service, "default"))["access_token"]
+
+
+@pytest.mark.asyncio
+async def test_newer_flow_published_after_success_precondition_owns_durable_cas() -> None:
+    """Pause A at the durable-CAS boundary, then let B claim the profile.
+
+    INVARIANT: the generation comparison belongs to the same durable mutation that publishes
+    AUTHENTICATED. A precondition checked immediately before this boundary cannot authorize A
+    after B has durably claimed a newer generation.
+    """
+    account_id = "account-1"
+    profile_id = profile_id_for(account_id, "anthropic", "work")
+    store = MvccRowStore()
+    index_a = ProfileIndexStore(credential_store=store)
+    index_b = ProfileIndexStore(credential_store=store)
+    pending = Profile(
+        id=profile_id,
+        account_id=account_id,
+        provider="anthropic",
+        name="work",
+        state=ProfileState.PENDING,
+    )
+    generation_a = await index_a.begin_pending(pending)
+    a_checked_precondition = asyncio.Event()
+    release_a = asyncio.Event()
+    credential_key = ("aigateway:anthropic:work", "default")
+
+    async def publish_a() -> None:
+        observed = await index_a.get(account_id, "anthropic", "work")
+        assert observed is not None and observed.state is ProfileState.PENDING
+        a_checked_precondition.set()
+        await release_a.wait()
+        authenticated = pending.model_copy(update={"state": ProfileState.AUTHENTICATED})
+        async with store.transaction():
+            await index_a.authenticate_pending(authenticated, expected_generation=generation_a)
+            await store.write(*credential_key, "oauth-A-token")
+
+    task_a = asyncio.create_task(publish_a())
+    await a_checked_precondition.wait()
+    generation_b = await index_b.begin_pending(pending)
+    release_a.set()
+    result_a = (await asyncio.gather(task_a, return_exceptions=True))[0]
+
+    assert isinstance(result_a, ProfileTransitionConflict)
+    assert store.committed.get(credential_key) is None
+    current = await index_b.get(account_id, "anthropic", "work")
+    assert current is not None and current.state is ProfileState.PENDING
+
+    authenticated_b = pending.model_copy(update={"state": ProfileState.AUTHENTICATED})
+    async with store.transaction():
+        await index_b.authenticate_pending(authenticated_b, expected_generation=generation_b)
+        await store.write(*credential_key, "oauth-B-token")
+    assert store.committed[credential_key] == "oauth-B-token"
+
+
+@pytest.mark.asyncio
+async def test_oauth_completion_preserves_metadata_patch_committed_before_cas() -> None:
+    """Lifecycle publication must merge into the latest profile, not replace its metadata."""
+    account_id = "account-1"
+    profile_id = profile_id_for(account_id, "anthropic", "work")
+    store = MvccRowStore()
+    index = ProfileIndexStore(credential_store=store)
+    pending = Profile(
+        id=profile_id,
+        account_id=account_id,
+        provider="anthropic",
+        name="work",
+        state=ProfileState.PENDING,
+    )
+    generation = await index.begin_pending(pending)
+    stale_for_callback = await index.get(account_id, "anthropic", "work")
+    assert stale_for_callback is not None
+
+    patched_defaults = stale_for_callback.defaults.model_copy(update={"max_tokens": 2048})
+    await index.update_metadata(profile_id, defaults=patched_defaults)
+    stale_for_callback.state = ProfileState.AUTHENTICATED
+    stale_for_callback.auth_type = "oauth"
+    await index.authenticate_pending(
+        stale_for_callback,
+        expected_generation=generation,
+    )
+
+    completed = await index.get(account_id, "anthropic", "work")
+    assert completed is not None
+    assert completed.state is ProfileState.AUTHENTICATED
+    assert completed.defaults.max_tokens == 2048
+
+
+def test_delete_recreate_does_not_reuse_oauth_generation(
+    authenticated_client,
+    credential_blobs,
+) -> None:
+    """A consumed callback must stay stale across delete and recreation of the same profile id.
+
+    INVARIANT: delete removes public profile state but retains the internal monotonic generation
+    tombstone. Reusing generation 1 would let A authenticate B's recreated pending profile.
+    """
+    exchange_started = threading.Event()
+    release_exchange = threading.Event()
+    authenticated_client.app.state.anthropic_http_factory = _token_factory(
+        "oauth-A-token", stall=release_exchange, started=exchange_started
+    )
+    start_a = authenticated_client.post("/v1/auth/anthropic/profiles", json={"name": "work"})
+    state_a = start_a.json()["state"]
+    account_id = authenticated_client.get("/v1/auth/me").json()["id"]
+    service = credential_service_for(credential_name_for(account_id, "work"))
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        callback_a = executor.submit(
+            authenticated_client.get,
+            "/v1/auth/anthropic/callback",
+            params={"code": "code-A", "state": state_a},
+            follow_redirects=False,
+        )
+        assert exchange_started.wait(5), "flow A never consumed its state and reached exchange"
+
+        deleted = authenticated_client.delete("/v1/auth/anthropic/profiles/work")
+        assert deleted.status_code == 204
+        start_b = authenticated_client.post("/v1/auth/anthropic/profiles", json={"name": "work"})
+        assert start_b.status_code == 201
+        state_b = start_b.json()["state"]
+
+        release_exchange.set()
+        response_a = callback_a.result(timeout=5)
+
+    assert response_a.status_code == 409
+    assert response_a.json()["detail"]["code"] == "profile_auth_conflict"
+    assert credential_blobs.read(service, "default") is None
+    assert authenticated_client.get("/v1/auth/anthropic/profiles/work").json()["state"] == "pending"
+
+    authenticated_client.app.state.anthropic_http_factory = _token_factory("oauth-B-token")
+    response_b = authenticated_client.get(
+        "/v1/auth/anthropic/callback",
+        params={"code": "code-B", "state": state_b},
+        follow_redirects=False,
+    )
+    assert response_b.status_code == 200
+    assert "oauth-B-token" in json.loads(credential_blobs.read(service, "default"))["access_token"]

--- a/apps/aigateway/tests/unit/test_profile_publication_locking.py
+++ b/apps/aigateway/tests/unit/test_profile_publication_locking.py
@@ -1,0 +1,233 @@
+"""OME-307 Unit 1 — profile publication must not deadlock under PostgreSQL row locking.
+
+FEATURE: OAuth/API-key profile publication (credential blob + profile-index write).
+STORY: as an operator completing two profile authentications for the same account on a
+PostgreSQL-backed gateway worker, both publications complete instead of deadlocking.
+
+INVARIANT: ``ProfileIndexStore.authenticate_pending`` performs exactly ONE conditional
+durable publication under a SINGLE acquisition of the process ``asyncio.Lock``. It must
+never RELEASE that lock and then RE-ACQUIRE it while the enclosing OAuth transaction
+(``routes/auth.py`` ``_complete_oauth_for_app`` → ``in_transaction()``) still holds the
+profile-index row lock. A second acquisition inverts the application-lock / database-
+row-lock order between two concurrent writers and deadlocks: on PostgreSQL the waiter
+that holds the process lock is blocked *in-process*, invisible to the database deadlock
+detector, so nothing ever breaks the cycle.
+
+WHY a store double: the gateway test harness is SQLite-only (``conftest``), and SQLite
+serializes whole transactions on one global connection lock, so it *cannot* exhibit the
+PostgreSQL per-row inversion — using it as evidence would be unsound (review requirement).
+``_PostgresRowLockStore`` below models the relevant PostgreSQL READ COMMITTED behavior: an UPDATE
+(``mutate``) executed inside a transaction takes that row's lock and holds it until the
+transaction COMMITs, so an independent task's UPDATE on the same row blocks until the
+first commits — exactly as two PostgreSQL backends contend. No database or service is
+added; this runs on the same event loop as every other unit test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import contextvars
+from collections import defaultdict
+
+import httpx
+import pytest
+
+import aigateway.routes.auth as auth_module
+from aigateway.core.profile_index import INDEX_CREDENTIAL_SERVICE, ProfileIndexStore
+from aigateway.core.profile_models import (
+    Profile,
+    ProfileState,
+    profile_id_for,
+)
+
+ACCOUNT_ID = "account-1"
+
+# Per-task transaction scratch: the list of row locks acquired by the current task's
+# open transaction, released together on commit. A ContextVar is task-local under
+# asyncio (each task runs with its own copy), which mirrors how ``in_transaction()``
+# pins one pooled connection per task.
+_open_txn: contextvars.ContextVar[list[asyncio.Lock] | None] = contextvars.ContextVar(
+    "_open_txn", default=None
+)
+
+
+class _PostgresRowLockStore:
+    """Credential-store double modelling PostgreSQL READ COMMITTED row locking.
+
+    ``ProfileIndexStore`` read-modify-writes the account index row through ``mutate``.
+    On PostgreSQL the conditional UPDATE inside the enclosing transaction takes a row
+    lock held until COMMIT; we reproduce that so two independent tasks contend on the
+    row exactly as two PG backends would.
+    """
+
+    def __init__(self) -> None:
+        self.data: dict[tuple[str, str], str] = {}
+        self._row_locks: dict[tuple[str, str], asyncio.Lock] = defaultdict(asyncio.Lock)
+
+    @contextlib.asynccontextmanager
+    async def transaction(self):
+        # WHY: models ``async with in_transaction()`` around the publication. Row locks
+        # acquired by mutate() during the body are held until this block exits (COMMIT).
+        held: list[asyncio.Lock] = []
+        token = _open_txn.set(held)
+        try:
+            yield
+        finally:
+            _open_txn.reset(token)
+            for lock in held:
+                lock.release()
+
+    async def read(self, service: str, account: str) -> str | None:
+        await asyncio.sleep(0)  # force interleaving between read and write, like real I/O
+        return self.data.get((service, account))
+
+    async def write(self, service: str, account: str, value: str) -> None:
+        await asyncio.sleep(0)
+        self.data[(service, account)] = value
+
+    async def delete(self, service: str, account: str) -> None:
+        self.data.pop((service, account), None)
+
+    async def mutate(self, service, account, mutator) -> None:
+        key = (service, account)
+        row_lock = self._row_locks[key]
+        held = _open_txn.get()
+        reused = held is not None and row_lock in held
+        if not reused:
+            # UPDATE takes the row lock (blocks if another txn holds it uncommitted).
+            await row_lock.acquire()
+        try:
+            await asyncio.sleep(0)  # yield between "SELECT" and "UPDATE" as real I/O would
+            next_value = mutator(self.data.get(key))
+            if next_value is None:
+                self.data.pop(key, None)
+            else:
+                self.data[key] = next_value
+        finally:
+            if held is None:
+                row_lock.release()  # autocommit statement: lock released at statement end
+            elif not reused:
+                held.append(row_lock)  # inside a txn: hold until COMMIT
+
+
+def _pending(name: str) -> Profile:
+    return Profile(
+        id=profile_id_for(ACCOUNT_ID, "anthropic", name),
+        account_id=ACCOUNT_ID,
+        provider="anthropic",
+        name=name,
+        state=ProfileState.PENDING,
+    )
+
+
+def _authenticated(name: str) -> Profile:
+    return Profile(
+        id=profile_id_for(ACCOUNT_ID, "anthropic", name),
+        account_id=ACCOUNT_ID,
+        provider="anthropic",
+        name=name,
+        state=ProfileState.AUTHENTICATED,
+        auth_type="oauth",
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_pending_publications_do_not_deadlock() -> None:
+    """Two OAuth callbacks for the same account, publishing inside their own PostgreSQL
+    transactions, must both complete.
+
+    Concrete schedule the pre-fix code deadlocks on:
+      1. Task A acquires the process lock, then yields inside its first index read.
+      2. Task B starts, blocks acquiring the same process lock (FIFO waiter).
+      3. Task A's conditional mutate takes the index ROW lock (held until A commits),
+         then A releases the process lock at the end of its ``async with`` block.
+      4. B (the queued waiter) wins the process lock ahead of A.
+      5. Pre-fix ONLY: A now re-enters ``self.upsert`` and blocks re-acquiring the
+         process lock (held by B).
+      6. B's mutate blocks on the index row lock (held by A's uncommitted transaction).
+      => A waits on the process lock (B holds it); B waits on the row lock (A's txn
+         holds it). The cycle is invisible to PostgreSQL — permanent deadlock.
+    With a single acquisition (post-fix) A releases the process lock before it commits
+    and never needs it again, so B always makes progress.
+    """
+    store = _PostgresRowLockStore()
+    index = ProfileIndexStore(credential_store=store)
+
+    # Seed two still-pending profiles on the same account index row (no contention yet).
+    await index.upsert(_pending("one"))
+    await index.upsert(_pending("two"))
+
+    async def publish(profile: Profile) -> None:
+        # Mirror _complete_oauth_for_app: publication runs inside the DB transaction.
+        async with store.transaction():
+            await index.authenticate_pending(profile)
+
+    try:
+        await asyncio.wait_for(
+            asyncio.gather(publish(_authenticated("one")), publish(_authenticated("two"))),
+            timeout=3.0,
+        )
+    except TimeoutError:  # pragma: no cover - only hit against the pre-fix code
+        pytest.fail(
+            "profile publication deadlocked: authenticate_pending re-acquired the "
+            "process lock while the enclosing transaction still held the index row "
+            "lock (OME-307 Unit 1 lock-order inversion)"
+        )
+
+    # Both pending profiles were durably authenticated, and exactly one index row exists.
+    both = {p.name: p.state for p in await index.list(ACCOUNT_ID)}
+    assert both == {"one": ProfileState.AUTHENTICATED, "two": ProfileState.AUTHENTICATED}
+    assert (INDEX_CREDENTIAL_SERVICE, f"account:{ACCOUNT_ID}") in store.data
+
+
+def test_oauth_profile_completion_locks_index_before_optional_credential(
+    authenticated_client,
+    monkeypatch,
+) -> None:
+    """OAuth completion must share profile set/delete's stable-row-first lock order.
+
+    INVARIANT: every profile lifecycle transaction mutates the always-present account index row
+    before touching the optional credential row. Credential-first OAuth completion can deadlock
+    against index-first API-key set/delete on PostgreSQL.
+    """
+    calls: list[str] = []
+    index = authenticated_client.app.state.profile_index
+    authenticate_pending = index.authenticate_pending
+    persist_credentials = auth_module.persist_credentials_or_503
+
+    async def _record_index(profile, **kwargs) -> None:
+        calls.append("index")
+        await authenticate_pending(profile, **kwargs)
+
+    async def _record_credential(*args, **kwargs) -> None:
+        if kwargs.get("description") == "OAuth profile credentials":
+            calls.append("credential")
+        await persist_credentials(*args, **kwargs)
+
+    async def _token_handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "access_token": "oauth-token",
+                "refresh_token": "refresh-token",
+                "expires_in": 3600,
+                "token_type": "Bearer",
+            },
+        )
+
+    monkeypatch.setattr(index, "authenticate_pending", _record_index)
+    monkeypatch.setattr(auth_module, "persist_credentials_or_503", _record_credential)
+    authenticated_client.app.state.anthropic_http_factory = lambda: httpx.AsyncClient(
+        transport=httpx.MockTransport(_token_handler), timeout=httpx.Timeout(5.0)
+    )
+
+    started = authenticated_client.post("/v1/auth/anthropic/profiles", json={"name": "work"})
+    completed = authenticated_client.get(
+        "/v1/auth/anthropic/callback",
+        params={"code": "code", "state": started.json()["state"]},
+        follow_redirects=False,
+    )
+
+    assert completed.status_code == 200
+    assert calls == ["index", "credential"]


### PR DESCRIPTION
## Description

Implements actionable API-key validation for AIGateway so invalid, unauthorized, quota-limited, rate-limited, misconfigured, and unavailable provider credentials fail before persistence or runtime dispatch.

Key changes:

- Adds a provider-neutral two-stage authentication and readiness validation contract.
- Implements provider validation for Anthropic, Gemini, Hugging Face, and enabled OpenRouter BYOK.
- Adds the dedicated validation endpoint and enforces validation before connection create, connection key replacement, and profile API-key assignment.
- Bounds and sanitizes validation transport responses, retry hints, and provider errors without exposing credentials or raw provider payloads.
- Hardens OAuth/profile publication against stale callbacks, concurrent replacement, and delete/revoke races.
- Adds deterministic lifecycle coverage plus real PostgreSQL race coverage.

Linear: https://linear.app/openmined/issue/OME-307/ome-307-api-key-validation-with-actionable-states

Known follow-ups remain intentionally separate: full prepare-then-publish OAuth refresh ownership is tracked by OME-578, and streaming SSE error sanitization is tracked by OME-577.

## Affected Dependencies

None. This PR does not add dependencies or database migrations.

## How has this been tested?

- `uv run ruff check`
- `uv run ruff format --check`
- `uv run pyright`
- `uv run python scripts/check_no_enterprise.py`
- `uv run pytest --cov=aigateway --cov-fail-under=80 -q`
- `AIGW_TEST_PG=1 uv run pytest tests/integration/test_lifecycle_postgres_races.py -q` (`6 passed`)
- Focused OpenRouter validation suite (`43 passed`)
- Focused lifecycle and profile suites (`166 passed`)

The file-level append-only check is intentionally skipped for this iteration under explicit owner approval. Eight previously committed test files receive additions only with zero deleted lines; no existing assertion, setup, expected behavior, or test case was removed, rewritten, weakened, or skipped.

## Checklist

- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests