### PR TITLE
chore(github): add Product public docs code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,9 @@
 /apps/aigateway/                 @HupBaHa
 /apps/scoreboard/                @HupBaHa
 
+# Product public docs
+/public-docs/                    @IrinaMBejan
+
 # Shared libraries (url4 SDK and friends land here)
 /packages/                       @sergio-bershadsky @HupBaHa
 


### PR DESCRIPTION
Adds a CODEOWNERS entry assigning `/public-docs/` to @IrinaMBejan for product-owned public documentation.

```
# Product public docs
/public-docs/                    @IrinaMBejan
```

The comment "Product public docs" documents the intent per request.