### PR TITLE
fix(aigateway): sanitize streaming provider errors

### DIFF
--- a/apps/aigateway/src/aigateway/routes/chat_dispatch.py
+++ b/apps/aigateway/src/aigateway/routes/chat_dispatch.py
@@ -318,6 +318,16 @@ async def _stream(plugin: Any, body: dict[str, Any]):
             yield f"data: {json.dumps(payload)}\n\n"
         yield "data: [DONE]\n\n"
     except Exception as exc:
-        logger.exception("stream failed")
-        err = {"error": {"message": str(exc), "type": type(exc).__name__}}
+        # INVARIANT: provider-controlled exception text and traceback data stay out of logs.
+        logger.error(
+            "stream failed type=%s plugin=%s",
+            type(exc).__name__,
+            type(plugin).__name__,
+        )
+        err = {
+            "error": {
+                "code": "provider_error",
+                "message": _PROVIDER_ERROR_MESSAGE["provider_error"],
+            }
+        }
         yield f"data: {json.dumps(err)}\n\n"

--- a/apps/aigateway/tests/unit/test_chat_streaming_errors.py
+++ b/apps/aigateway/tests/unit/test_chat_streaming_errors.py
@@ -1,0 +1,127 @@
+"""Regression tests for provider exceptions in SSE streaming."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from aigateway.routes.chat_dispatch import _stream
+
+
+@pytest.mark.asyncio
+async def test_streaming_provider_error_after_successful_chunk_is_sanitized() -> None:
+    """A provider failure after one chunk must redact raw exception details."""
+
+    class FakeAuthError(Exception):
+        pass
+
+    class _FakePlugin:
+        async def chat_completion_stream(self, body: dict[str, str]):
+            del body
+            yield {"choices": [{"delta": {"content": "ok"}}]}
+            raise FakeAuthError("STREAM_SENTINEL_SECRET=bad-token")
+
+    frames = [frame async for frame in _stream(_FakePlugin(), {})]
+
+    expected_chunk = json.dumps({"choices": [{"delta": {"content": "ok"}}]})
+    expected_error_frame = (
+        'data: {"error": {'
+        '"code": "provider_error", "message": "The upstream provider returned an error."}}\n\n'
+    )
+
+    assert frames[0] == f"data: {expected_chunk}\n\n"
+    assert frames[1] == expected_error_frame
+    output = "".join(frames)
+    assert "STREAM_SENTINEL_SECRET" not in output
+    assert "FakeAuthError" not in output
+
+
+@pytest.mark.asyncio
+async def test_streaming_provider_error_before_first_chunk_is_sanitized() -> None:
+    """A provider failure before first chunk yields only the gateway error frame."""
+
+    class FakeProviderError(Exception):
+        pass
+
+    class _FakePlugin:
+        async def chat_completion_stream(self, body: dict[str, str]):
+            del body
+            if False:
+                yield {"choices": [{"delta": {"content": "never"}}]}
+            raise FakeProviderError(
+                "provider body text with STACK_TRACE_STREAM_SENTINEL_SECRET=bad-token"
+            )
+
+    frames = [frame async for frame in _stream(_FakePlugin(), {})]
+
+    expected_error_frame = (
+        'data: {"error": {'
+        '"code": "provider_error", "message": "The upstream provider returned an error."}}\n\n'
+    )
+
+    assert frames == [expected_error_frame]
+    output = "".join(frames)
+    assert "[DONE]" not in output
+    assert "provider body text" not in output
+    assert "STREAM_SENTINEL_SECRET" not in output
+    assert "FakeProviderError" not in output
+
+
+@pytest.mark.asyncio
+async def test_streaming_provider_error_after_chunk_omits_raw_provider_and_secrets(
+    caplog,
+) -> None:
+    provider_body = "provider body text with STREAM_LOG_SECRET_OME577"
+
+    class FakeProviderError(RuntimeError):
+        pass
+
+    class _FakePlugin:
+        async def chat_completion_stream(self, body: dict[str, str]):
+            del body
+            yield {"choices": [{"delta": {"content": "ok"}}]}
+            raise FakeProviderError(provider_body)
+
+    with caplog.at_level(logging.ERROR, logger="aigateway.routes.chat_dispatch"):
+        frames = [frame async for frame in _stream(_FakePlugin(), {})]
+
+    expected_chunk = json.dumps({"choices": [{"delta": {"content": "ok"}}]})
+    expected_error_frame = (
+        'data: {"error": {'
+        '"code": "provider_error", "message": "The upstream provider returned an error."}}\n\n'
+    )
+
+    assert frames == [f"data: {expected_chunk}\n\n", expected_error_frame]
+    output = "".join(frames)
+    assert "[DONE]" not in output
+    assert provider_body not in output
+    assert "STREAM_LOG_SECRET_OME577" not in output
+    assert "FakeProviderError" not in output
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert all("STREAM_LOG_SECRET_OME577" not in message for message in messages)
+    assert all(provider_body not in message for message in messages)
+    assert all("Traceback" not in message for message in messages)
+    assert "STREAM_LOG_SECRET_OME577" not in caplog.text
+    assert provider_body not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
+    assert any("stream failed" in message for message in messages)
+    assert any("type=FakeProviderError" in message for message in messages)
+    assert any("plugin=_FakePlugin" in message for message in messages)
+
+
+@pytest.mark.asyncio
+async def test_streaming_success_still_emits_done_after_chunks() -> None:
+    """The normal streaming contract remains unchanged on success."""
+
+    class _FakePlugin:
+        async def chat_completion_stream(self, body: dict[str, str]):
+            del body
+            yield {"choices": [{"delta": {"content": "ok"}}]}
+
+    frames = [frame async for frame in _stream(_FakePlugin(), {})]
+
+    expected_chunk = json.dumps({"choices": [{"delta": {"content": "ok"}}]})
+    assert frames == [f"data: {expected_chunk}\n\n", "data: [DONE]\n\n"]

--- a/docs/work/2026-07-23-OME-577-sanitize-streaming-sse-errors.md
+++ b/docs/work/2026-07-23-OME-577-sanitize-streaming-sse-errors.md
@@ -1,0 +1,40 @@
+---
+ticket: OME-577
+stack: aigateway
+status: done
+started: 2026-07-23
+finished: 2026-07-23
+---
+
+# OME-577 - Sanitize provider errors in streaming SSE responses
+
+## Intent
+
+Make the streaming chat failure boundary match the non-streaming security contract: clients receive only stable gateway-authored error data, while raw provider messages and exception class names remain server-side.
+
+## Planned changes
+
+- Modify `apps/aigateway/src/aigateway/routes/chat_dispatch.py` to emit a fixed streaming error code and message.
+- Add `apps/aigateway/tests/unit/test_chat_streaming_errors.py` with focused SSE disclosure regressions.
+- Update this ledger with actual files, verification, and deviations before commit.
+
+## Test plan
+
+- Add a failing test where a stream emits one valid chunk and then raises an exception containing sentinel secret/provider text.
+- Assert the successful frame remains unchanged, the terminal error frame has only the stable gateway code/message, no raw text or exception class escapes, and `[DONE]` is not emitted after failure.
+- Cover failures representing authentication and generic provider exceptions.
+- Run the focused streaming tests and the complete AIGateway quality gates.
+
+## Acceptance
+
+- Streaming error frames contain only gateway-authored `provider_error` code/message fields.
+- Raw provider text, exception messages, exception class names, credentials, and sentinel secrets never appear in SSE output.
+- Detailed exception context remains in server-side logging.
+- Existing successful streaming and non-streaming behavior remains unchanged.
+
+## Outcome (fill at the end - required before COMMIT)
+
+- **Actual files:** `apps/aigateway/src/aigateway/routes/chat_dispatch.py`, `apps/aigateway/tests/unit/test_chat_streaming_errors.py`, and this ledger.
+- **Commits:** `fix(aigateway): sanitize streaming provider errors` (this commit).
+- **Verification:** focused streaming tests `4 passed`; related route/provider tests `60 passed`; existing non-streaming sanitization tests `21 passed`; all required AIGateway quality gates passed, including append-only checks, lint, formatting, type checking, enterprise-import protection, full tests, and coverage.
+- **Deviations:** review found that server-side logs still included provider-controlled exception text after client SSE sanitization. The final implementation sanitizes both SSE output and server logs, preserves safe type/plugin context, and covers formatted-traceback and hostile exception-string behavior. No product-scope deviation remains.


### PR DESCRIPTION
## Description

Sanitizes provider failures emitted through streaming SSE responses so clients receive only a stable gateway-authored `provider_error` code and message.

The change also keeps provider-controlled exception text and traceback data out of server logs while retaining safe exception-type and plugin context. Successful chunks and the normal `[DONE]` terminator remain unchanged.

Addresses [OME-577](https://linear.app/openmined/issue/OME-577/sanitize-provider-errors-in-streaming-sse-responses).

## Affected Dependencies

None.

## How has this been tested?

- Added four focused streaming regression tests covering failures before and after the first chunk, authentication-shaped and generic provider errors, client/log redaction, and successful completion.
- Related route and streaming-provider coverage: 60 passed.
- Existing non-streaming sanitization coverage: 21 passed.
- All required AIGateway quality gates passed, including append-only checks, lint, formatting, type checking, enterprise-import protection, full tests, and coverage.

To reproduce, run the standard AIGateway quality gate suite from the repository root.

## Checklist

- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
