### PR TITLE
ci(public-docs): deploy to the docs VM via GitHub Action

### DIFF
--- a/.github/workflows/deploy-public-docs.yml
+++ b/.github/workflows/deploy-public-docs.yml
@@ -1,0 +1,40 @@
+name: Deploy public-docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "public-docs/**"
+      - ".github/workflows/deploy-public-docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-public-docs
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Build
+        working-directory: public-docs
+        run: npm ci && npm run build
+
+      - name: Rsync dist to VM
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DOCS_VM_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "${{ secrets.DOCS_VM_HOST }}" >> ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key "${{ secrets.DOCS_VM_USER }}@${{ secrets.DOCS_VM_HOST }}" 'mkdir -p ~/screamingface/public-docs/dist'
+          rsync -az --delete -e "ssh -i ~/.ssh/deploy_key" \
+            public-docs/dist/ "${{ secrets.DOCS_VM_USER }}@${{ secrets.DOCS_VM_HOST }}:~/screamingface/public-docs/dist/"

--- a/docs/tasks/2026-07-26-deploy-public-docs-to-vm.md
+++ b/docs/tasks/2026-07-26-deploy-public-docs-to-vm.md
@@ -1,0 +1,21 @@
+---
+id: OME-547
+linear_url: https://linear.app/openmined/issue/OME-547
+asana_url:
+status: in_progress
+type: task
+labels: [repo]
+created: 2026-07-26
+closed:
+---
+
+# Deploy the docs skeleton to a VM + GitHub Action
+
+Auto-deploy `public-docs` to the docs VM, served at `docs.screamingface.ai` on
+merge to `main` via `.github/workflows/deploy-public-docs.yml`. Temporary
+password gate during the skeleton phase (credentials shared privately).
+
+Ledger: docs/work/2026-07-26-OME-547-deploy-public-docs-to-vm.md
+
+> Labels/priority here are best-effort — Linear is the status authority and the
+> MCP was unavailable this session to read the live values.

--- a/docs/work/2026-07-26-OME-547-deploy-public-docs-to-vm.md
+++ b/docs/work/2026-07-26-OME-547-deploy-public-docs-to-vm.md
@@ -1,0 +1,53 @@
+---
+ticket: OME-547
+stack: repo
+status: in_progress
+started: 2026-07-26
+finished:
+---
+
+# OME-547 — Deploy the docs skeleton to a VM + GitHub Action
+
+## Intent
+
+Auto-deploy the `public-docs` static site to the docs VM on merge to `main`,
+served over HTTPS at `docs.screamingface.ai`, so merged docs PRs can be reviewed
+live. Gated for now behind a **temporary** password (shared privately) to keep the
+skeleton out of public view; to be removed later. VM host/user/key are kept out of
+the repo (Actions secrets `DOCS_VM_*`), since this repo may be made public.
+
+## What was built (in the repo)
+
+- **`.github/workflows/deploy-public-docs.yml`** — on push to `main` (paths
+  `public-docs/**`) + `workflow_dispatch`: builds in the runner
+  (`npm ci && npm run build`) and `rsync --delete`s `public-docs/dist/` to the VM
+  at `~/screamingface/public-docs/dist`. Auth via secrets `DOCS_VM_HOST` /
+  `DOCS_VM_USER` / `DOCS_VM_SSH_KEY`.
+
+## Applied on the VM (owner action, not in the repo)
+
+- Caddy site block: `docs.screamingface.ai` → `file_server` on
+  `~/screamingface/public-docs/dist` + SPA fallback + gzip. Includes a **temporary**
+  `basicauth` keep-out gate (login shared privately) — removable by deleting the
+  `basicauth` block + reloading Caddy. (This VM runs Caddy < 2.8, so the directive is
+  `basicauth`, one word.)
+- Repo secrets set. DNS record + Caddy reload still pending.
+
+## Test plan
+
+- Local: `npm run build && npm run preview`.
+- Transfer: run the Action → `ls ~/screamingface/public-docs/dist` on the VM.
+- Live: point `docs.screamingface.ai` at the VM → Caddy auto-TLS → verify HTTPS + login.
+
+## Acceptance
+
+- Merge to `main` touching `public-docs/**` deploys the built site to the VM.
+- `https://docs.screamingface.ai` serves the docs (temporary password gate active).
+
+## Outcome (fill at close)
+
+- **Files:** `.github/workflows/deploy-public-docs.yml`
+- **Commits:** pending
+- **Gates:** workflow YAML valid (ruby parse) + `bash -n` on the rsync step OK.
+- **Deviations:** none — built as planned.
+- **Status:** not live yet — pending commit + merge, DNS record, Caddy reload.

--- a/public-docs/README.md
+++ b/public-docs/README.md
@@ -50,3 +50,83 @@ npm run format       # prettier --write src/
 
 Type checking uses a single `tsconfig.json` (extends `@vue/tsconfig`), covering `src/**`
 and the config files.
+
+## Deployment
+
+`public-docs` is served as a static site from a shared docs VM at
+**https://docs.screamingface.ai**, behind a **temporary** password gate. On merge to
+`main` touching `public-docs/**`, the GitHub Action
+[`deploy-public-docs.yml`](../.github/workflows/deploy-public-docs.yml) builds the site
+and `rsync`s `dist/` to the VM, where Caddy serves it (`file_server`). Later merges
+redeploy automatically; a manual run is available via the Action's **Run workflow** button.
+
+> **Infra values are not committed** (this repo may be made public). The VM host, user,
+> and SSH key are the repo Actions secrets **`DOCS_VM_HOST`** / **`DOCS_VM_USER`** /
+> **`DOCS_VM_SSH_KEY`**; the deploy login is shared with the team privately. Fill the
+> placeholders below — `<vm-host>`, `<vm-user>`, `<vm-key>` — from those.
+
+- **Served from (on the VM):** `~/screamingface/public-docs/dist`
+
+### SSH access
+
+You need the VM's private key (shared out-of-band). Either pass `-i ~/.ssh/<vm-key>.pem`
+on each command, or add a portable alias to your `~/.ssh/config` and use `docs-vm`:
+
+```
+Host docs-vm
+    HostName <vm-host>
+    User <vm-user>
+    IdentityFile ~/.ssh/<vm-key>.pem
+```
+
+### Manual deploy (one-off, from your machine)
+
+Run in `public-docs/`:
+
+```sh
+npm run build
+rsync -az --delete -e "ssh -i ~/.ssh/<vm-key>.pem" \
+  dist/ <vm-user>@<vm-host>:~/screamingface/public-docs/dist/
+
+# verify it landed
+ssh -i ~/.ssh/<vm-key>.pem <vm-user>@<vm-host> 'ls ~/screamingface/public-docs/dist'
+```
+
+### Dev preview (the exact prod app, locally)
+
+The VM's Caddy config also serves the same `dist/` on a **loopback-only**
+`http://localhost:8080` block — a shared snippet, so it is byte-for-byte the prod app
+(same files + password gate), just private. Reach it with an SSH tunnel (nothing is
+exposed publicly):
+
+```sh
+ssh -i ~/.ssh/<vm-key>.pem -N -L 8080:localhost:8080 <vm-user>@<vm-host>
+# then open http://localhost:8080  (log in with the shared credentials)
+```
+
+### Caddy config (on the VM, `/etc/caddy/Caddyfile`)
+
+A shared snippet imported by both the prod domain and the dev loopback block:
+
+```
+(screamingface_docs) {
+	root * /home/<vm-user>/screamingface/public-docs/dist
+	file_server
+	try_files {path} /index.html
+	encode gzip
+	basicauth {
+		<login-email>  <bcrypt-hash>   # caddy hash-password --plaintext '<password>'
+	}
+}
+docs.screamingface.ai { import screamingface_docs }
+http://localhost:8080  { import screamingface_docs }
+```
+
+Apply with `sudo caddy validate --config /etc/caddy/Caddyfile && sudo systemctl reload caddy`.
+This VM runs Caddy < 2.8, so the directive is **`basicauth`** (one word), not `basic_auth`.
+
+### Remaining for go-live
+
+- **DNS:** point `docs.screamingface.ai` at the VM (A record → the `DOCS_VM_HOST` value).
+  Caddy is already configured (and retrying ACME), so it auto-provisions TLS the moment
+  DNS resolves — then `https://docs.screamingface.ai` serves the app behind the gate.


### PR DESCRIPTION
## Summary

Auto-deploy the `public-docs` static site to the shared docs VM on merge to `main`, served over HTTPS at `docs.screamingface.ai` behind a temporary password gate. Adds the deploy workflow, the OME-547 ledger + tasks mirror, and a Deployment section in the README.

Fixes OME-547

**Asana:** N/A — technical work is tracked in Linear.

## Components touched

- `public-docs` (docs site) — new deploy workflow + README Deployment section. No app source changed.
- `.github/workflows/deploy-public-docs.yml` — root-level workflow, scoped to `public-docs/**`.

How it works: on push to `main` touching `public-docs/**` (or `workflow_dispatch`), the runner builds (`npm ci && npm run build`) and `rsync --delete`s `dist/` to the VM (host/user/key from the `DOCS_VM_*` secrets — nothing sensitive committed). Caddy on the VM serves it statically (`file_server`) with a temporary `basicauth` gate; it also serves an identical loopback-only `localhost:8080` dev block via a shared snippet.

## Test plan

- [x] Workflow YAML valid (parse) + `bash -n` on the rsync step
- [x] `public-docs` builds (`npm run build`) and was deployed to the VM via local rsync; serving + auth verified through the `localhost:8080` tunnel (200 with creds, 401 without)
- [ ] Full Action run verified after merge (first `push` to `main` triggers it)
- [ ] Python/gateway gates — N/A (no Python touched)

## Cross-service notes

The Caddy site block + repo secrets are already applied on the VM. **Remaining owner action for go-live: add DNS `docs.screamingface.ai → <VM>`** — Caddy is configured and retrying ACME, so TLS auto-provisions once DNS resolves. The `letmein` gate is temporary (keep-out during the skeleton phase). VM IP/user/login are intentionally kept out of the repo (secrets + shared privately), since this repo may be made public.