### PR TITLE
feat(aigateway): Cloudflare Access federated auth + admin-provisioned shared credential pools

### DIFF
--- a/apps/aigateway/charts/aigateway/templates/configmap.yaml
+++ b/apps/aigateway/charts/aigateway/templates/configmap.yaml
@@ -11,3 +11,15 @@ data:
   AIGATEWAY_AUTH_ENABLED: {{ .Values.config.authEnabled | quote }}
   AIGATEWAY_JWT_TTL_SECONDS: {{ .Values.config.jwtTtlSeconds | quote }}
   AIGATEWAY_PUBLIC_URL: {{ .Values.publicUrl | quote }}
+  {{- if .Values.config.cfAccess.enabled }}
+  # Cloudflare Access (OME-588). Team domain and AUD are NON-SECRET by design —
+  # the AUD only names which Access application an assertion is scoped to.
+  #
+  # WARNING: this feature is only sound if the origin is unreachable except
+  # through Cloudflare. `Cf-Access-Jwt-Assertion` is an ordinary header; a
+  # directly reachable origin lets anyone forge any identity.
+  AIGATEWAY_CF_ACCESS_ENABLED: "true"
+  AIGATEWAY_CF_ACCESS_TEAM_DOMAIN: {{ required "config.cfAccess.teamDomain is required when cfAccess.enabled" .Values.config.cfAccess.teamDomain | quote }}
+  AIGATEWAY_CF_ACCESS_AUD: {{ required "config.cfAccess.aud is required when cfAccess.enabled" .Values.config.cfAccess.aud | quote }}
+  AIGATEWAY_CF_ACCESS_ADMIN_EMAILS: {{ join "," .Values.config.cfAccess.adminEmails | quote }}
+  {{- end }}

--- a/apps/aigateway/charts/aigateway/templates/configmap.yaml
+++ b/apps/aigateway/charts/aigateway/templates/configmap.yaml
@@ -10,6 +10,7 @@ data:
   AIGW_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
   AIGATEWAY_AUTH_ENABLED: {{ .Values.config.authEnabled | quote }}
   AIGATEWAY_JWT_TTL_SECONDS: {{ .Values.config.jwtTtlSeconds | quote }}
+  AIGATEWAY_CREDENTIAL_MODE: {{ .Values.config.credentialMode | quote }}
   AIGATEWAY_PUBLIC_URL: {{ .Values.publicUrl | quote }}
   {{- if .Values.config.cfAccess.enabled }}
   # Cloudflare Access (OME-588). Team domain and AUD are NON-SECRET by design —

--- a/apps/aigateway/charts/aigateway/templates/deployment.yaml
+++ b/apps/aigateway/charts/aigateway/templates/deployment.yaml
@@ -44,7 +44,18 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "aigateway.fullname" . }}
+            {{- with .Values.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           env:
+            {{- with .Values.extraEnv }}
+            {{- /* INVARIANT: extras are emitted FIRST, before the secret-backed entries
+                   below. Kubernetes applies duplicate env names last-wins, so putting
+                   these first means an extraEnv entry can never shadow
+                   AIGATEWAY_DATABASE_URL / _JWT_SECRET / _ADMIN_PASSWORD — the chart's
+                   own wiring always takes precedence over operator-supplied extras. */}}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
             - name: AIGATEWAY_DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/apps/aigateway/charts/aigateway/values.yaml
+++ b/apps/aigateway/charts/aigateway/values.yaml
@@ -34,6 +34,25 @@ config:
   authEnabled: true
   jwtTtlSeconds: 86400
 
+  # Cloudflare Access federated authentication. Users admitted by the Access
+  # policy get accounts provisioned just-in-time; no registration, no /login.
+  #
+  # PRECONDITION: the origin must be reachable ONLY through Cloudflare (a
+  # cloudflared tunnel, or the CF proxy with Authenticated Origin Pulls).
+  # Enabling this on a directly reachable origin is worse than no auth at all,
+  # because the identity header is trivially forgeable.
+  #
+  # Requires authEnabled: true — the gateway refuses to start otherwise.
+  cfAccess:
+    enabled: false
+    # e.g. myteam.cloudflareaccess.com — a bare hostname, no scheme or path.
+    teamDomain: ""
+    # The Access application's Audience (AUD) tag.
+    aud: ""
+    # Emails granted is_admin at provisioning time. Cloudflare decides who can
+    # REACH the gateway; this decides who holds authority inside it.
+    adminEmails: []
+
 publicUrl: https://gateway.screamingface.ai
 
 database:

--- a/apps/aigateway/charts/aigateway/values.yaml
+++ b/apps/aigateway/charts/aigateway/values.yaml
@@ -34,6 +34,15 @@ config:
   authEnabled: true
   jwtTtlSeconds: 86400
 
+  # How a chat request finds a provider credential.
+  #   byok    — each account authenticates with its own connection/api-key (default).
+  #   shared  — every account uses the admin-provisioned GlobalCredentialPool for the
+  #             provider instead. Usage attribution is unaffected: it comes from the
+  #             authenticated account, not from which credential backed the call.
+  # Provision a pool with POST /v1/admin/credential-pools as an admin account.
+  # Invalid values are rejected at gateway startup, not here — one source of truth.
+  credentialMode: byok
+
   # Cloudflare Access federated authentication. Users admitted by the Access
   # policy get accounts provisioned just-in-time; no registration, no /login.
   #

--- a/apps/aigateway/charts/aigateway/values.yaml
+++ b/apps/aigateway/charts/aigateway/values.yaml
@@ -9,6 +9,20 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# Raw core/v1 EnvVar / EnvFromSource entries appended to the gateway container.
+# The escape hatch for application settings the chart does not template — notably the
+# per-provider plugin gates (`AIGW_<PROVIDER>_*`), e.g. the OpenRouter plugin, which
+# ships disabled and fail-closed:
+#
+#   extraEnv:
+#     - name: AIGW_OPENROUTER_ENABLED
+#       value: "true"
+#
+# Emitted BEFORE the chart's own secret-backed env, so these can never shadow
+# AIGATEWAY_DATABASE_URL / _JWT_SECRET / _ADMIN_PASSWORD (k8s duplicate env is last-wins).
+extraEnv: []
+extraEnvFrom: []
+
 serviceAccount:
   create: true
   annotations: {}

--- a/apps/aigateway/docs/cloudflare-access.md
+++ b/apps/aigateway/docs/cloudflare-access.md
@@ -1,0 +1,125 @@
+# Running AIGateway behind Cloudflare Access
+
+Cloudflare Access enforces the admission policy (OTP/PIN, or your IdP) at the edge. Users it
+admits reach AIGateway with **no registration and no `/v1/auth/login`** — their account is
+provisioned just-in-time from the identity Cloudflare asserts.
+
+## ⚠️ The precondition that makes this safe
+
+**The origin must be unreachable except through Cloudflare.**
+
+`Cf-Access-Jwt-Assertion` is an ordinary HTTP header. If anything can reach AIGateway
+off-path, it can set that header to any identity it likes. Enabling this feature on a directly
+reachable origin is *worse* than no authentication, because the gateway will trust a forged
+identity and attribute usage to a real user.
+
+Acceptable ingress:
+
+- a `cloudflared` tunnel to a `ClusterIP`-only Service (what this repo's kind setup does), or
+- the Cloudflare proxy with Authenticated Origin Pulls (mTLS) enforced at the origin.
+
+AIGateway still verifies every assertion itself — signature, `iss`, `aud`, `exp` — against
+Cloudflare's published keys. That second layer is deliberate: it holds even if the ingress
+story is later weakened. It is defence in depth, **not** a substitute for the above.
+
+## 1. Create the Access application
+
+In the Zero Trust dashboard: **Access → Applications → Add an application → Self-hosted**.
+
+- Set the application domain to the hostname the gateway is served on.
+- Add your policy (email OTP, IdP group, whatever admits the right people).
+- Copy the **Application Audience (AUD) tag** from the application's Overview tab.
+- Note your **team domain** — `<team>.cloudflareaccess.com`.
+
+Both values are **non-secret**. The AUD only names which application an assertion is scoped
+to; it grants nothing. They belong in chart values, not in a Secret.
+
+## 2. Add a Service Auth policy for machine clients
+
+Programmatic clients cannot complete an interactive login. Create a **service token**
+(Access → Service Auth → Service Tokens), then add a policy to the application with:
+
+- Action: **Service Auth** — with any other action Access redirects to an IdP login and
+  ignores the token pair.
+- Include: the service token you created.
+
+The client then sends `CF-Access-Client-Id` and `CF-Access-Client-Secret`.
+
+## 3. Configure the gateway
+
+```yaml
+config:
+  authEnabled: true          # required — the gateway refuses to start otherwise
+  cfAccess:
+    enabled: true
+    teamDomain: myteam.cloudflareaccess.com   # bare hostname, no scheme or path
+    aud: <the AUD tag>
+    adminEmails:
+      - you@example.com
+```
+
+`adminEmails` grants `is_admin` at provisioning time. Cloudflare policy decides who can
+**reach** the gateway; this decides who holds **authority inside** it. Keep them distinct.
+
+Misconfigurations are startup errors, not runtime surprises: `cfAccess.enabled` with
+`authEnabled: false` refuses to boot (it would make every caller anonymous), as does a missing
+team domain or AUD, or a team domain carrying a scheme, port or path (which could redirect
+key retrieval to an attacker-controlled host).
+
+## 4. Client usage
+
+Clients satisfy **two independent planes** — the edge (Cloudflare) and the app (AIGateway).
+
+| Client | Edge credential | App credential |
+|---|---|---|
+| Browser | `CF_Authorization` cookie (automatic) | the same cookie, or the injected header |
+| Human CLI | `cf-access-token: <jwt>` | `Authorization: Bearer <same jwt>` |
+| Machine/SDK | `CF-Access-Client-Id` + `-Secret` | `Authorization: Bearer <same jwt>` |
+
+Get a human CLI token with:
+
+```sh
+cloudflared access login https://<your-gateway-host>
+cloudflared access token -app=https://<your-gateway-host>
+```
+
+> `cloudflared access login` starts a local listener the browser hands the token back to.
+> Do **not** wrap it in `timeout` — the browser reports success while the token silently goes
+> nowhere.
+
+Note the two-header requirement for the CLI path: the edge does **not** accept the JWT in
+`Authorization` (you get a 302 to login and never reach the origin), and AIGateway reads
+`Authorization`, not `cf-access-token`. Send the same JWT in both.
+
+## Identity mapping
+
+| Access path | `accounts.external_subject` | `email` |
+|---|---|---|
+| IdP login | JWT `sub` (stable Access user UUID) | JWT `email` |
+| Service token | JWT `common_name` (client ID) | none |
+
+Accounts are keyed on `(external_idp, external_subject)`, **never** on email — email is
+mutable at the IdP and can be reassigned to a different person. A user who changes their
+email keeps their account; a new person given an old address gets a new one.
+
+Federated accounts have a `NULL` `password_hash` and can never authenticate via
+`/v1/auth/login`.
+
+## Per-user attribution for machine clients
+
+A service token identifies the **token**, not a person, so a fleet sharing one token collapses
+onto a single account. Gateway-issued API keys (OME-592) restore per-user attribution: mint a
+key once via the browser/CLI path, then send the service token to satisfy the edge *and*
+`Authorization: Bearer aigw_...` to identify the human to the gateway.
+
+## Troubleshooting
+
+- **401 "Missing bearer token"** — no credential reached the gateway. Check the header is
+  actually being forwarded (`cloudflared` logs) and not stripped by a proxy in between.
+- **401 `cf_access_denied`** — the assertion failed verification. The gateway log carries the
+  precise reason (wrong `aud`, unknown `kid`, expired); the response deliberately does not, so
+  it cannot describe your Access configuration to an unauthenticated caller.
+- **302 to a login page** — the request never reached the origin; that is Cloudflare, not
+  AIGateway. For service tokens, check the policy action is **Service Auth**.
+- **Everything 401s right after a deploy** — confirm the image actually contains the feature
+  (`kubectl exec deploy/aigateway -- ls .../core/auth/cf_access/`) before debugging auth logic.

--- a/apps/aigateway/src/aigateway/config.py
+++ b/apps/aigateway/src/aigateway/config.py
@@ -55,6 +55,71 @@ class Settings(BaseSettings):
     # from which credential backs the call.
     credential_mode: str = Field(default="byok", validation_alias="AIGATEWAY_CREDENTIAL_MODE")
 
+    # Cloudflare Access federated authentication (OME-588). Team domain and AUD
+    # are NON-SECRET by design — they are plain chart values, not secrets.
+    cf_access_enabled: bool = Field(default=False, validation_alias="AIGATEWAY_CF_ACCESS_ENABLED")
+    cf_access_team_domain: str | None = Field(
+        default=None, validation_alias="AIGATEWAY_CF_ACCESS_TEAM_DOMAIN"
+    )
+    cf_access_aud: str | None = Field(default=None, validation_alias="AIGATEWAY_CF_ACCESS_AUD")
+    # WHY a raw string and not list[str]: pydantic-settings JSON-decodes complex
+    # field types straight from the env var BEFORE any validator runs, so a
+    # comma-separated value raises SettingsError instead of reaching us. The
+    # operator-friendly format wins; parsing lives in cf_access_admin_email_set.
+    cf_access_admin_emails: str = Field(
+        default="", validation_alias="AIGATEWAY_CF_ACCESS_ADMIN_EMAILS"
+    )
+
+    @field_validator("cf_access_team_domain")
+    @classmethod
+    def _validate_cf_access_team_domain(cls, value: str | None) -> str | None:
+        """Require a bare hostname.
+
+        INVARIANT: the JWKS URL is built as f"https://{team_domain}/cdn-cgi/access/certs".
+        A value carrying a scheme, path, userinfo or port could redirect key
+        retrieval to an attacker-controlled host, which is a total auth bypass —
+        the gateway would happily verify assertions signed by the attacker.
+        """
+        if value is None:
+            return None
+        normalized = value.strip().lower().rstrip(".")
+        if not normalized:
+            return None
+        if not re.fullmatch(
+            r"[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+", normalized
+        ):
+            raise ValueError(
+                "AIGATEWAY_CF_ACCESS_TEAM_DOMAIN must be a bare hostname "
+                "(e.g. 'myteam.cloudflareaccess.com') with no scheme, port or path"
+            )
+        return normalized
+
+    @model_validator(mode="after")
+    def _validate_cf_access(self) -> Settings:
+        if not self.cf_access_enabled:
+            return self
+        # INVARIANT: never fail open. With auth disabled, current_account returns
+        # anonymous_account() for EVERY caller — behind a gateway the operator
+        # believes Cloudflare is protecting. Refuse to start rather than serve.
+        if not self.auth_enabled:
+            raise ValueError(
+                "AIGATEWAY_CF_ACCESS_ENABLED requires AIGATEWAY_AUTH_ENABLED=true; "
+                "with auth disabled every request is anonymous and Cloudflare "
+                "identity would be ignored entirely"
+            )
+        if not self.cf_access_team_domain or not self.cf_access_aud:
+            raise ValueError(
+                "AIGATEWAY_CF_ACCESS_ENABLED requires both "
+                "AIGATEWAY_CF_ACCESS_TEAM_DOMAIN and AIGATEWAY_CF_ACCESS_AUD"
+            )
+        return self
+
+    @property
+    def cf_access_admin_email_set(self) -> frozenset[str]:
+        return frozenset(
+            item.strip().lower() for item in self.cf_access_admin_emails.split(",") if item.strip()
+        )
+
     retry_max_attempts: int = Field(default=3, validation_alias="AIGW_RETRY_MAX_ATTEMPTS")
     retry_backoff_base_seconds: float = Field(
         default=0.5, validation_alias="AIGW_RETRY_BACKOFF_BASE"

--- a/apps/aigateway/src/aigateway/config.py
+++ b/apps/aigateway/src/aigateway/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from urllib.parse import urlsplit
 
 from pydantic import Field, SecretStr, field_validator, model_validator
@@ -46,6 +47,13 @@ class Settings(BaseSettings):
     # that never echoes the value.
     secret_key: SecretStr | None = Field(default=None, validation_alias="AIGATEWAY_SECRET_KEY")
     secret_provider: str = Field(default="local", validation_alias="AIGATEWAY_SECRET_PROVIDER")
+
+    # "byok": each account authenticates providers with its own OAuthConnection/api-key
+    # (default, current behavior, unchanged). "shared": every account uses the admin-
+    # provisioned GlobalCredentialPool for a provider instead; per-account usage/audit
+    # attribution is unaffected either way, since it comes from current_account(), not
+    # from which credential backs the call.
+    credential_mode: str = Field(default="byok", validation_alias="AIGATEWAY_CREDENTIAL_MODE")
 
     retry_max_attempts: int = Field(default=3, validation_alias="AIGW_RETRY_MAX_ATTEMPTS")
     retry_backoff_base_seconds: float = Field(
@@ -131,4 +139,12 @@ class Settings(BaseSettings):
         normalized = value.lower()
         if normalized not in {"local", "kms"}:
             raise ValueError("AIGATEWAY_SECRET_PROVIDER must be 'local' or 'kms'")
+        return normalized
+
+    @field_validator("credential_mode")
+    @classmethod
+    def _validate_credential_mode(cls, value: str) -> str:
+        normalized = value.lower()
+        if normalized not in {"byok", "shared"}:
+            raise ValueError("AIGATEWAY_CREDENTIAL_MODE must be 'byok' or 'shared'")
         return normalized

--- a/apps/aigateway/src/aigateway/core/auth/bootstrap_admin.py
+++ b/apps/aigateway/src/aigateway/core/auth/bootstrap_admin.py
@@ -16,13 +16,18 @@ _MISSING_ADMIN_PASSWORD_MESSAGE = (
 async def ensure_admin_account(env_password: SecretStr | None) -> Account:
     existing = await Account.get_or_none(username="admin")
     if existing is not None:
+        if not existing.is_admin:
+            # Self-heal accounts created before is_admin existed (or restored from an
+            # older backup) so the bootstrap "admin" username always carries the flag.
+            existing.is_admin = True
+            await existing.save(update_fields=["is_admin"])
         return existing
     if env_password is None:
         raise RuntimeError(_MISSING_ADMIN_PASSWORD_MESSAGE)
 
     password_hash = await hash_password(env_password)
     try:
-        admin = await Account.create(username="admin", password_hash=password_hash)
+        admin = await Account.create(username="admin", password_hash=password_hash, is_admin=True)
     except IntegrityError:
         return await Account.get(username="admin")
     return admin

--- a/apps/aigateway/src/aigateway/core/auth/cf_access/__init__.py
+++ b/apps/aigateway/src/aigateway/core/auth/cf_access/__init__.py
@@ -1,0 +1,45 @@
+"""Cloudflare Access federated authentication (OME-591).
+
+Adapter package: implements the `IdentityResolver` port for identities asserted
+by Cloudflare Access. Core imports the port, never this package — `main.py`
+registers the resolver when the feature is configured.
+"""
+
+from __future__ import annotations
+
+from .identity import (
+    CF_ACCESS_IDP,
+    CfAccessIdentity,
+    CfAccessVerificationError,
+    CfAccessVerifier,
+)
+from .jwks import CloudflareAccessJwks, JwksUnavailableError
+from .provisioning import get_or_create_cf_access_account
+from .resolver import ASSERTION_COOKIE, ASSERTION_HEADER, CfAccessResolver
+
+__all__ = [
+    "ASSERTION_COOKIE",
+    "ASSERTION_HEADER",
+    "CF_ACCESS_IDP",
+    "CfAccessIdentity",
+    "CfAccessResolver",
+    "CfAccessVerificationError",
+    "CfAccessVerifier",
+    "CloudflareAccessJwks",
+    "JwksUnavailableError",
+    "build_cf_access_resolver",
+    "get_or_create_cf_access_account",
+]
+
+
+def build_cf_access_resolver(
+    *,
+    team_domain: str,
+    audience: str,
+    admin_emails: frozenset[str] = frozenset(),
+    http_client_factory=None,
+) -> CfAccessResolver:
+    """Assemble the resolver from settings."""
+    jwks = CloudflareAccessJwks(team_domain, http_client_factory=http_client_factory)
+    verifier = CfAccessVerifier(jwks, audience=audience, team_domain=team_domain)
+    return CfAccessResolver(verifier, admin_emails=admin_emails)

--- a/apps/aigateway/src/aigateway/core/auth/cf_access/identity.py
+++ b/apps/aigateway/src/aigateway/core/auth/cf_access/identity.py
@@ -1,0 +1,121 @@
+"""Cloudflare Access assertion verification and claim mapping."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+import jwt
+
+from .jwks import CloudflareAccessJwks
+
+#: The IdP namespace stored in `accounts.external_idp`.
+CF_ACCESS_IDP = "cf_access"
+
+#: Cloudflare signs with RS256 only. Pinning it here (rather than accepting
+#: whatever the token's header claims) is what prevents algorithm-confusion —
+#: notably an attacker re-signing a payload with HS256 using the public cert as
+#: the HMAC key.
+_ALGORITHMS = ["RS256"]
+
+#: `accounts.username` column width.
+_USERNAME_MAX_LENGTH = 64
+
+
+class CfAccessVerificationError(Exception):
+    """The assertion is not a valid, current token for this application."""
+
+
+@dataclass(frozen=True, slots=True)
+class CfAccessIdentity:
+    """The identity an assertion asserts."""
+
+    subject: str
+    email: str | None
+    is_service_token: bool
+
+    @property
+    def username(self) -> str:
+        """A stable `accounts.username` derived from the SUBJECT.
+
+        INVARIANT: derived from `subject`, never from `email`. `username` is
+        UNIQUE, so deriving it from a mutable, reassignable email means two
+        distinct subjects that ever share an address collide and the second user
+        cannot be provisioned at all — reintroducing, through the back door, the
+        very email-as-identity coupling this module rejects. The email is carried
+        on `display_name`/`email` for humans instead.
+
+        Long subjects are hashed rather than truncated: `username` caps at 64
+        chars and a raw truncation could map two distinct subjects onto one name.
+        """
+        candidate = f"{CF_ACCESS_IDP}:{self.subject}"
+        if len(candidate) <= _USERNAME_MAX_LENGTH:
+            return candidate
+        digest = hashlib.sha256(self.subject.encode("utf-8")).hexdigest()
+        return f"{CF_ACCESS_IDP}:{digest}"[:_USERNAME_MAX_LENGTH]
+
+
+def identity_from_claims(claims: dict) -> CfAccessIdentity:
+    """Map verified claims onto an identity.
+
+    INVARIANT: the identity key is `sub` (a stable Access user UUID) or, for
+    service tokens, `common_name` (the client ID). NEVER email — email is
+    mutable at the IdP and can be reassigned to a different human, so keying on
+    it would silently hand one person another's account.
+
+    AIDEV-NOTE: the service-token claim shape (empty `sub`, no `email`,
+    `common_name` set) is asserted here but is NOT documented on Cloudflare's
+    JWT-validation page. Confirm against a real service-token assertion before
+    relying on it in production; see the OME-591 spec's open-verification item.
+    """
+    subject = claims.get("sub") or ""
+    common_name = claims.get("common_name") or ""
+
+    if subject:
+        email = claims.get("email")
+        return CfAccessIdentity(
+            subject=subject,
+            email=email if isinstance(email, str) and email else None,
+            is_service_token=False,
+        )
+    if common_name:
+        return CfAccessIdentity(subject=common_name, email=None, is_service_token=True)
+    raise CfAccessVerificationError("assertion carries neither 'sub' nor 'common_name'")
+
+
+class CfAccessVerifier:
+    """Verifies an assertion against the team's published keys."""
+
+    def __init__(self, jwks: CloudflareAccessJwks, *, audience: str, team_domain: str) -> None:
+        self._jwks = jwks
+        self._audience = audience
+        self._issuer = f"https://{team_domain}"
+
+    async def verify(self, token: str) -> CfAccessIdentity:
+        try:
+            header = jwt.get_unverified_header(token)
+        except jwt.InvalidTokenError as exc:
+            raise CfAccessVerificationError(f"unreadable token header: {exc}") from exc
+
+        kid = header.get("kid")
+        if not isinstance(kid, str) or not kid:
+            raise CfAccessVerificationError("token header carries no 'kid'")
+
+        try:
+            key = await self._jwks.get_key(kid)
+        except Exception as exc:
+            raise CfAccessVerificationError(f"no usable signing key: {exc}") from exc
+
+        try:
+            claims = jwt.decode(
+                token,
+                key=key,
+                algorithms=_ALGORITHMS,
+                audience=self._audience,
+                issuer=self._issuer,
+                options={"require": ["exp", "iat", "aud", "iss"]},
+            )
+        except jwt.InvalidTokenError as exc:
+            raise CfAccessVerificationError(f"assertion rejected: {exc}") from exc
+
+        return identity_from_claims(claims)

--- a/apps/aigateway/src/aigateway/core/auth/cf_access/jwks.py
+++ b/apps/aigateway/src/aigateway/core/auth/cf_access/jwks.py
@@ -1,0 +1,126 @@
+"""JWKS client for a Cloudflare Access team domain.
+
+FEATURE: federated authentication. Cloudflare signs identity assertions RS256
+with a key pair unique to the account, published at
+``https://<team>.cloudflareaccess.com/cdn-cgi/access/certs``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import httpx
+from jwt import PyJWK
+
+logger = logging.getLogger(__name__)
+
+_CERTS_PATH = "/cdn-cgi/access/certs"
+_FETCH_TIMEOUT_SECONDS = 5.0
+
+#: Cloudflare rotates the signing key every 6 weeks and keeps the previous key
+#: valid for 7 days, so a `kid` miss is a real (if rare) event rather than an
+#: attack signal. Re-fetching on every miss would let an attacker drive unbounded
+#: outbound requests with forged `kid`s, so misses are rate-limited.
+_MIN_REFETCH_INTERVAL_SECONDS = 60.0
+
+
+class JwksUnavailableError(RuntimeError):
+    """No key material is available — neither cached nor fetchable."""
+
+
+class CloudflareAccessJwks:
+    """Fetches and caches Cloudflare's signing keys, keyed by ``kid``.
+
+    INVARIANT: this class never fails *open*. Every path either returns a key
+    that Cloudflare published or raises; there is no branch that skips
+    verification because the network was unavailable.
+    """
+
+    def __init__(
+        self,
+        team_domain: str,
+        *,
+        http_client_factory: Any | None = None,
+        min_refetch_interval_seconds: float = _MIN_REFETCH_INTERVAL_SECONDS,
+    ) -> None:
+        self._certs_url = f"https://{team_domain}{_CERTS_PATH}"
+        self._http_client_factory = http_client_factory or self._default_client
+        self._min_refetch_interval = min_refetch_interval_seconds
+        self._keys: dict[str, PyJWK] = {}
+        self._last_fetch_monotonic: float | None = None
+        self._lock = asyncio.Lock()
+
+    @staticmethod
+    def _default_client() -> httpx.AsyncClient:
+        return httpx.AsyncClient(timeout=httpx.Timeout(_FETCH_TIMEOUT_SECONDS))
+
+    async def get_key(self, kid: str) -> PyJWK:
+        """Return the signing key for ``kid``, refreshing the cache if needed."""
+        key = self._keys.get(kid)
+        if key is not None:
+            return key
+
+        async with self._lock:
+            # Re-check: a concurrent caller may have refreshed while we waited.
+            key = self._keys.get(kid)
+            if key is not None:
+                return key
+            if self._refetch_is_rate_limited():
+                raise JwksUnavailableError(f"no signing key for kid={kid!r}")
+            await self._refresh()
+
+        key = self._keys.get(kid)
+        if key is None:
+            raise JwksUnavailableError(f"no signing key for kid={kid!r}")
+        return key
+
+    def _refetch_is_rate_limited(self) -> bool:
+        if self._last_fetch_monotonic is None:
+            return False
+        elapsed = asyncio.get_running_loop().time() - self._last_fetch_monotonic
+        return elapsed < self._min_refetch_interval
+
+    async def _refresh(self) -> None:
+        try:
+            client = self._http_client_factory()
+            async with client:
+                response = await client.get(self._certs_url)
+                response.raise_for_status()
+                payload = response.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            # WHY stale-on-error: a Cloudflare certs blip must not 401 the entire
+            # fleet. Keys already cached stay valid (they are signed by Cloudflare
+            # and independently checked for exp), so serve them and retry later.
+            # With a COLD cache there is nothing to serve and we still refuse —
+            # degraded, never open.
+            self._last_fetch_monotonic = asyncio.get_running_loop().time()
+            if self._keys:
+                logger.warning("cf_access jwks refresh failed; serving cached keys (%s)", exc)
+                return
+            raise JwksUnavailableError(f"could not fetch {self._certs_url}: {exc}") from exc
+
+        self._last_fetch_monotonic = asyncio.get_running_loop().time()
+        self._keys = self._parse(payload)
+
+    @staticmethod
+    def _parse(payload: Any) -> dict[str, PyJWK]:
+        if not isinstance(payload, dict):
+            raise JwksUnavailableError("certs response was not a JSON object")
+        keys: dict[str, PyJWK] = {}
+        for entry in payload.get("keys", []):
+            if not isinstance(entry, dict):
+                continue
+            kid = entry.get("kid")
+            if not isinstance(kid, str):
+                continue
+            try:
+                keys[kid] = PyJWK.from_dict(entry)
+            except Exception as exc:  # noqa: BLE001 - PyJWK raises assorted types
+                # One malformed entry must not discard the whole (possibly
+                # rotating) key set.
+                logger.warning("cf_access jwks: skipping unusable key kid=%s (%s)", kid, exc)
+        if not keys:
+            raise JwksUnavailableError("certs response contained no usable keys")
+        return keys

--- a/apps/aigateway/src/aigateway/core/auth/cf_access/provisioning.py
+++ b/apps/aigateway/src/aigateway/core/auth/cf_access/provisioning.py
@@ -1,0 +1,88 @@
+"""Just-in-time account provisioning from a verified Cloudflare identity.
+
+STORY: as a user my organisation admitted through Cloudflare Access, I call the
+gateway and it works — I never registered and never called /v1/auth/login.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from tortoise.exceptions import IntegrityError
+
+from ..models import Account
+from .identity import CF_ACCESS_IDP, CfAccessIdentity
+
+logger = logging.getLogger(__name__)
+
+
+async def get_or_create_cf_access_account(
+    identity: CfAccessIdentity,
+    *,
+    admin_emails: frozenset[str] = frozenset(),
+) -> Account | None:
+    """Return the account for ``identity``, creating it on first sight.
+
+    Returns ``None`` when the account exists but is deactivated — a gateway
+    admin's deactivation must outrank Cloudflare still admitting the user.
+    """
+    account = await Account.get_or_none(
+        external_idp=CF_ACCESS_IDP,
+        external_subject=identity.subject,
+    )
+    if account is None:
+        account = await _create(identity, admin_emails=admin_emails)
+    elif identity.email and account.email != identity.email:
+        # The subject is the identity; email is a mutable label that follows it.
+        account.email = identity.email
+        await account.save(update_fields=["email"])
+
+    if not account.is_active:
+        logger.info("cf_access login refused for deactivated account subject=%s", identity.subject)
+        return None
+    return account
+
+
+async def _create(
+    identity: CfAccessIdentity,
+    *,
+    admin_emails: frozenset[str],
+) -> Account:
+    # INVARIANT: is_admin is granted ONLY from the gateway's own allowlist.
+    # Cloudflare policy decides who can reach the gateway; it never decides who
+    # holds authority inside it.
+    is_admin = bool(identity.email) and identity.email.lower() in admin_emails
+
+    try:
+        account = await Account.create(
+            username=identity.username,
+            password_hash=None,
+            display_name=identity.email,
+            email=identity.email,
+            external_idp=CF_ACCESS_IDP,
+            external_subject=identity.subject,
+            is_admin=is_admin,
+        )
+    except IntegrityError:
+        # WHY this is the NORMAL path, not an edge case: an SDK with a connection
+        # pool issues several first requests at once, so two coroutines routinely
+        # race here. The (external_idp, external_subject) unique constraint from
+        # OME-590 is what makes the loser's re-read correct rather than a second
+        # duplicate account.
+        account = await Account.get_or_none(
+            external_idp=CF_ACCESS_IDP,
+            external_subject=identity.subject,
+        )
+        if account is None:
+            # The constraint that fired was something else — a username collision
+            # with a pre-existing local account. Surface it rather than guessing.
+            raise
+        return account
+
+    logger.info(
+        "cf_access provisioned account subject=%s service_token=%s admin=%s",
+        identity.subject,
+        identity.is_service_token,
+        is_admin,
+    )
+    return account

--- a/apps/aigateway/src/aigateway/core/auth/cf_access/resolver.py
+++ b/apps/aigateway/src/aigateway/core/auth/cf_access/resolver.py
@@ -1,0 +1,95 @@
+"""The Cloudflare Access identity resolver."""
+
+from __future__ import annotations
+
+import logging
+
+import jwt
+from fastapi import Request
+
+from ..resolvers.base import Rejection, Resolution
+from ..resolvers.local_jwt import bearer_token
+from .identity import CfAccessVerificationError, CfAccessVerifier
+from .provisioning import get_or_create_cf_access_account
+
+logger = logging.getLogger(__name__)
+
+#: The header Cloudflare Access injects into every request it forwards.
+ASSERTION_HEADER = "Cf-Access-Jwt-Assertion"
+
+#: The cookie Access sets on browser logins.
+ASSERTION_COOKIE = "CF_Authorization"
+
+_ALGORITHM = "RS256"
+
+_REJECTION = Rejection(
+    detail={
+        "code": "cf_access_denied",
+        "message": "Cloudflare Access identity could not be verified",
+    }
+)
+
+
+class CfAccessResolver:
+    """Authenticate a verified Cloudflare Access assertion, provisioning on first sight.
+
+    INVARIANT: the mere presence of ``Cf-Access-Jwt-Assertion`` proves nothing —
+    it is an ordinary header that anyone reaching the origin off-path can set.
+    Every request is verified against Cloudflare's published keys here, so this
+    layer holds even if the deployment's ingress isolation is later weakened.
+    """
+
+    name = "cf_access"
+
+    def __init__(self, verifier: CfAccessVerifier, *, admin_emails: frozenset[str]) -> None:
+        self._verifier = verifier
+        self._admin_emails = admin_emails
+
+    async def resolve(self, request: Request) -> Resolution:
+        token = self._token(request)
+        if token is None:
+            return None
+
+        try:
+            identity = await self._verifier.verify(token)
+        except CfAccessVerificationError as exc:
+            # WHY the detail is generic: the exception text names the exact
+            # failure (bad audience, unknown kid, expired) and is useful to an
+            # operator in the log, but handing it to the caller would describe
+            # this gateway's Access configuration to an unauthenticated party.
+            logger.info("cf_access assertion rejected: %s", exc)
+            return _REJECTION
+
+        account = await get_or_create_cf_access_account(
+            identity,
+            admin_emails=self._admin_emails,
+        )
+        if account is None:
+            return _REJECTION
+        return account
+
+    def _token(self, request: Request) -> str | None:
+        """Find the assertion, in order of trustworthiness.
+
+        The injected header comes straight from Cloudflare and is what makes
+        browser SSO work at all; the cookie covers browsers whose request did not
+        get the header; `Authorization: Bearer` is the API-client path
+        (`cloudflared access token`). Only RS256 bearer tokens are claimed, so a
+        local HS256 session token still belongs to LocalJwtResolver.
+        """
+        header = request.headers.get(ASSERTION_HEADER)
+        if header:
+            return header
+
+        cookie = request.cookies.get(ASSERTION_COOKIE)
+        if cookie:
+            return cookie
+
+        token = bearer_token(request)
+        if token is None:
+            return None
+        try:
+            algorithm = jwt.get_unverified_header(token).get("alg")
+        except jwt.InvalidTokenError:
+            return None
+        return token if algorithm == _ALGORITHM else None

--- a/apps/aigateway/src/aigateway/core/auth/log_filter.py
+++ b/apps/aigateway/src/aigateway/core/auth/log_filter.py
@@ -4,15 +4,29 @@ import logging
 import re
 from typing import Any, cast
 
+#: Every request header whose VALUE is a credential. Cloudflare Access adds three
+#: (OME-591): the signed identity assertion Access injects, the browser cookie
+#: carrying the same assertion, and the service-token secret a machine client
+#: sends to the edge. A leaked assertion is a replayable identity until it
+#: expires, so none of these may ever reach a log line.
+_SENSITIVE_HEADERS = (
+    "x-aigw-provisioning-token",
+    "cf-access-jwt-assertion",
+    "cf-access-client-secret",
+    "cf-access-token",
+)
+
+_HEADER_ALTERNATION = "|".join(re.escape(name) for name in _SENSITIVE_HEADERS)
+
 
 class RedactProvisioningTokenFilter(logging.Filter):
-    _HEADER_NAME = "x-aigw-provisioning-token"
+    _HEADER_NAMES = frozenset(_SENSITIVE_HEADERS)
     _PATTERN = re.compile(
-        r"(X-Aigw-Provisioning-Token(?:\s*[:=]\s*|\s+[\"']))([^\s\"',}]+)",
+        rf"((?:{_HEADER_ALTERNATION})(?:\s*[:=]\s*|\s+[\"']))([^\s\"',}}]+)",
         re.IGNORECASE,
     )
     _RAW_HEADER_PATTERN = re.compile(
-        r"(b?[\"']x-aigw-provisioning-token[\"']\s*,\s*b?[\"'])([^\"']+)",
+        rf"(b?[\"'](?:{_HEADER_ALTERNATION})[\"']\s*,\s*b?[\"'])([^\"']+)",
         re.IGNORECASE,
     )
 
@@ -27,7 +41,7 @@ class RedactProvisioningTokenFilter(logging.Filter):
             value = value.decode("latin-1")
         if not isinstance(value, str):
             return False
-        return value.lower() == cls._HEADER_NAME
+        return value.lower() in cls._HEADER_NAMES
 
     @staticmethod
     def _redacted_like(value: object) -> object:

--- a/apps/aigateway/src/aigateway/core/auth/middleware.py
+++ b/apps/aigateway/src/aigateway/core/auth/middleware.py
@@ -4,11 +4,10 @@ from datetime import UTC, datetime
 from typing import Annotated
 from uuid import UUID
 
-import jwt
 from fastapi import Depends, HTTPException, Request
 
-from .jwt import decode_token
 from .models import Account, BaseAccount
+from .resolvers.base import IdentityResolver, Rejection
 
 ANONYMOUS_ACCOUNT_ID = UUID("00000000-0000-0000-0000-000000000000")
 
@@ -26,30 +25,34 @@ def anonymous_account() -> BaseAccount:
 
 
 async def current_account(request: Request) -> BaseAccount:
+    """Authenticate the request against the registered resolver chain.
+
+    INVARIANT: this function knows no credential formats. Every credential shape
+    lives in an :class:`~aigateway.core.auth.resolvers.base.IdentityResolver`
+    adapter registered on ``app.state.identity_resolvers``.
+    """
     if not request.app.state.settings.auth_enabled:
+        # INVARIANT: the escape hatch stays AHEAD of the chain — when the gateway
+        # is not authenticating at all, no resolver should observe the request.
         return anonymous_account()
 
-    auth_header = request.headers.get("Authorization", "")
-    if not auth_header.startswith("Bearer "):
-        raise HTTPException(status_code=401, detail="Missing bearer token")
+    resolvers: list[IdentityResolver] = getattr(request.app.state, "identity_resolvers", [])
+    rejection: Rejection | None = None
+    for resolver in resolvers:
+        outcome = await resolver.resolve(request)
+        if isinstance(outcome, Rejection):
+            # WHY: record but keep going. The same `Authorization: Bearer` header
+            # can hold a credential a later resolver owns, so one resolver's
+            # refusal must not deny the rest their turn.
+            if rejection is None:
+                rejection = outcome
+            continue
+        if outcome is not None:
+            return outcome
 
-    token = auth_header[len("Bearer ") :]
-    try:
-        claims = decode_token(token, secret=request.app.state.jwt_secret)
-    except jwt.ExpiredSignatureError as exc:
-        raise HTTPException(status_code=401, detail=f"Invalid token: expired ({exc})") from exc
-    except jwt.InvalidTokenError as exc:
-        raise HTTPException(status_code=401, detail=f"Invalid token: {exc}") from exc
-
-    try:
-        account_id = UUID(claims["sub"])
-    except (TypeError, ValueError) as exc:
-        raise HTTPException(status_code=401, detail="Invalid token: malformed subject") from exc
-
-    account = await Account.get_or_none(id=account_id)
-    if account is None or not account.is_active:
-        raise HTTPException(status_code=401, detail="Account not found or inactive")
-    return account
+    if rejection is not None:
+        raise HTTPException(status_code=rejection.status_code, detail=rejection.detail)
+    raise HTTPException(status_code=401, detail="Missing bearer token")
 
 
 CurrentAccount = Annotated[BaseAccount, Depends(current_account)]

--- a/apps/aigateway/src/aigateway/core/auth/middleware.py
+++ b/apps/aigateway/src/aigateway/core/auth/middleware.py
@@ -53,3 +53,12 @@ async def current_account(request: Request) -> BaseAccount:
 
 
 CurrentAccount = Annotated[BaseAccount, Depends(current_account)]
+
+
+async def current_admin_account(account: CurrentAccount) -> BaseAccount:
+    if not account.is_admin:
+        raise HTTPException(status_code=403, detail={"code": "admin_required"})
+    return account
+
+
+CurrentAdminAccount = Annotated[BaseAccount, Depends(current_admin_account)]

--- a/apps/aigateway/src/aigateway/core/auth/models/account.py
+++ b/apps/aigateway/src/aigateway/core/auth/models/account.py
@@ -17,6 +17,7 @@ class BaseAccount(Model):
     created_at = fields.DatetimeField(auto_now_add=True)
     last_login_at = fields.DatetimeField(null=True)
     is_active = fields.BooleanField(default=True)
+    is_admin = fields.BooleanField(default=False, db_default="false")
 
 
 class Account(BaseAccount):

--- a/apps/aigateway/src/aigateway/core/auth/models/account.py
+++ b/apps/aigateway/src/aigateway/core/auth/models/account.py
@@ -12,14 +12,27 @@ class BaseAccount(Model):
 
     id = fields.UUIDField(pk=True, default=uuid.uuid4)
     username = fields.CharField(max_length=64, unique=True, index=True)
-    password_hash = fields.CharField(max_length=255)
+    # INVARIANT: NULL means "this account has no password and never had one" — a
+    # federated (Cloudflare Access) identity. `login()` refuses NULL explicitly;
+    # it is never a hash that merely fails to verify. See OME-590.
+    password_hash = fields.CharField(max_length=255, null=True)
     display_name = fields.CharField(max_length=255, null=True)
     created_at = fields.DatetimeField(auto_now_add=True)
     last_login_at = fields.DatetimeField(null=True)
     is_active = fields.BooleanField(default=True)
     is_admin = fields.BooleanField(default=False, db_default="false")
 
+    # FEATURE: federated authentication. The identity key is (external_idp,
+    # external_subject) — NEVER email, which is mutable at the IdP and can be
+    # reassigned to a different human. NULL for local password accounts; SQL
+    # treats NULLs as distinct, so local accounts do not collide under the
+    # unique constraint.
+    external_idp = fields.CharField(max_length=64, null=True)
+    external_subject = fields.CharField(max_length=255, null=True)
+    email = fields.CharField(max_length=320, null=True, index=True)
+
 
 class Account(BaseAccount):
     class Meta:
         table = "accounts"
+        unique_together = (("external_idp", "external_subject"),)

--- a/apps/aigateway/src/aigateway/core/auth/resolvers/__init__.py
+++ b/apps/aigateway/src/aigateway/core/auth/resolvers/__init__.py
@@ -1,0 +1,30 @@
+"""Identity resolvers — the adapters behind ``current_account``.
+
+Core defines the port (:mod:`.base`); adapters live beside it and are wired into
+``app.state.identity_resolvers`` by ``main.py``. ``current_account`` imports only
+the port, never an adapter.
+"""
+
+from __future__ import annotations
+
+from .base import IdentityResolver, Rejection, Resolution
+from .local_jwt import LocalJwtResolver
+
+__all__ = [
+    "IdentityResolver",
+    "LocalJwtResolver",
+    "Rejection",
+    "Resolution",
+    "build_default_resolvers",
+]
+
+
+def build_default_resolvers() -> list[IdentityResolver]:
+    """Return the chain every deployment gets.
+
+    AIDEV-NOTE: order is the contract. Later units append the Cloudflare Access
+    resolver (OME-591) and the API-key resolver (OME-592) *after* this one; the
+    local session token stays first so a gateway with no federation configured
+    behaves exactly as it always has.
+    """
+    return [LocalJwtResolver()]

--- a/apps/aigateway/src/aigateway/core/auth/resolvers/base.py
+++ b/apps/aigateway/src/aigateway/core/auth/resolvers/base.py
@@ -1,0 +1,50 @@
+"""The identity-resolution port.
+
+FEATURE: federated authentication — the gateway accepts several credential
+shapes (local session JWT, Cloudflare Access assertion, gateway API key)
+without ``current_account`` knowing anything about any of them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+from fastapi import Request
+
+from ..models import BaseAccount
+
+
+@dataclass(frozen=True, slots=True)
+class Rejection:
+    """A resolver recognised the credential and refused it.
+
+    WHY: distinct from ``None``. ``None`` means "not my credential, ask the next
+    resolver"; a ``Rejection`` carries the *specific* reason (expired, malformed
+    subject, revoked key) that the caller deserves instead of a generic 401.
+    """
+
+    detail: Any
+    status_code: int = 401
+
+
+#: What a resolver may answer. ``BaseAccount`` authenticates and stops the chain;
+#: ``Rejection`` records a reason but lets later resolvers still try; ``None``
+#: abstains.
+Resolution = BaseAccount | Rejection | None
+
+
+@runtime_checkable
+class IdentityResolver(Protocol):
+    """Resolves a request to an account, or abstains.
+
+    INVARIANT: a resolver must abstain (``None``) for any credential it does not
+    positively recognise as its own. Recognition across the registered chain is
+    disjoint, which is what makes "first rejection wins" in
+    :func:`~aigateway.core.auth.middleware.current_account` unambiguous.
+    """
+
+    #: Stable identifier used in logs and in chain-composition assertions.
+    name: str
+
+    async def resolve(self, request: Request) -> Resolution: ...

--- a/apps/aigateway/src/aigateway/core/auth/resolvers/local_jwt.py
+++ b/apps/aigateway/src/aigateway/core/auth/resolvers/local_jwt.py
@@ -1,0 +1,74 @@
+"""Local password-session credentials — the HS256 JWT minted by ``/v1/auth/login``.
+
+STORY: as an operator running the gateway without any federated IdP, I log in
+with a username and password and use the returned token, exactly as before.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import jwt
+from fastapi import Request
+
+from ..jwt import decode_token
+from ..models import Account
+from .base import Rejection, Resolution
+
+_BEARER_PREFIX = "Bearer "
+
+#: The algorithm this resolver claims. Cloudflare Access signs RS256, gateway API
+#: keys are not JWTs at all — so the JOSE ``alg`` header is a clean, cheap
+#: discriminator for routing a bearer token to the right resolver.
+_ALGORITHM = "HS256"
+
+
+def bearer_token(request: Request) -> str | None:
+    """Return the bearer token from ``Authorization``, or None when absent."""
+    header = request.headers.get("Authorization", "")
+    if not header.startswith(_BEARER_PREFIX):
+        return None
+    return header[len(_BEARER_PREFIX) :]
+
+
+class LocalJwtResolver:
+    """Authenticate the gateway's own session token."""
+
+    name = "local_jwt"
+
+    async def resolve(self, request: Request) -> Resolution:
+        token = bearer_token(request)
+        if token is None:
+            return None
+
+        try:
+            algorithm = jwt.get_unverified_header(token).get("alg")
+        except jwt.InvalidTokenError as exc:
+            # Not decodable as a JWT at all. No other resolver wants a bearer
+            # token this broken, so claim it and report the real reason.
+            return Rejection(detail=f"Invalid token: {exc}")
+
+        if algorithm != _ALGORITHM:
+            # WHY: abstain rather than reject — this is how a Cloudflare Access
+            # assertion presented in `Authorization: Bearer` reaches its own
+            # resolver. Routing on the *unverified* header is safe because
+            # `decode_token` still pins algorithms=["HS256"], so an attacker
+            # cannot downgrade or confuse the algorithm by editing it.
+            return None
+
+        try:
+            claims = decode_token(token, secret=request.app.state.jwt_secret)
+        except jwt.ExpiredSignatureError as exc:
+            return Rejection(detail=f"Invalid token: expired ({exc})")
+        except jwt.InvalidTokenError as exc:
+            return Rejection(detail=f"Invalid token: {exc}")
+
+        try:
+            account_id = UUID(claims["sub"])
+        except (TypeError, ValueError):
+            return Rejection(detail="Invalid token: malformed subject")
+
+        account = await Account.get_or_none(id=account_id)
+        if account is None or not account.is_active:
+            return Rejection(detail="Account not found or inactive")
+        return account

--- a/apps/aigateway/src/aigateway/core/auth/schemas.py
+++ b/apps/aigateway/src/aigateway/core/auth/schemas.py
@@ -42,6 +42,7 @@ class AccountOut(BaseModel):
     id: UUID
     username: str
     display_name: str | None = None
+    email: str | None = None
     created_at: datetime
     last_login_at: datetime | None = None
     is_active: bool

--- a/apps/aigateway/src/aigateway/core/credential_pool/models/__init__.py
+++ b/apps/aigateway/src/aigateway/core/credential_pool/models/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from .global_credential_pool import GlobalCredentialPool
+
+__all__ = ["GlobalCredentialPool"]
+__models__ = [GlobalCredentialPool]

--- a/apps/aigateway/src/aigateway/core/credential_pool/models/global_credential_pool.py
+++ b/apps/aigateway/src/aigateway/core/credential_pool/models/global_credential_pool.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from tortoise import fields
+from tortoise.models import Model
+
+if TYPE_CHECKING:
+    from aigateway.core.auth.models import Account
+
+
+class GlobalCredentialPool(Model):
+    """An admin-provisioned credential shared by every account for one provider.
+
+    Used only when the gateway runs with AIGATEWAY_CREDENTIAL_MODE=shared; the
+    secret itself lives in credential_blobs like any other credential (see
+    core/credential_pool/store.py), this row is metadata only.
+    """
+
+    class Meta:
+        table = "global_credential_pools"
+        unique_together = (("provider", "label"),)
+
+    id = fields.UUIDField(pk=True, default=uuid.uuid4)
+    provider = fields.CharField(max_length=64, index=True)
+    label = fields.CharField(max_length=255, default="default", db_default="default")
+    auth_type = fields.CharField(max_length=16, default="api_key", db_default="api_key")
+    is_active = fields.BooleanField(default=True, db_default="true")
+    created_by: fields.ForeignKeyRelation[Account] = fields.ForeignKeyField(
+        "models.Account",
+        related_name="created_credential_pools",
+        on_delete=fields.OnDelete.RESTRICT,
+    )
+    created_at = fields.DatetimeField(auto_now_add=True)
+    updated_at = fields.DatetimeField(auto_now=True)
+
+    if TYPE_CHECKING:
+        created_by_id: uuid.UUID

--- a/apps/aigateway/src/aigateway/core/credential_pool/schemas.py
+++ b/apps/aigateway/src/aigateway/core/credential_pool/schemas.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, SecretStr
+
+PoolAuthType = Literal["api_key"]
+
+
+class GlobalCredentialPoolResponse(BaseModel):
+    id: UUID
+    provider: str
+    label: str
+    auth_type: PoolAuthType
+    is_active: bool
+    created_by_id: UUID
+    created_at: datetime
+    updated_at: datetime
+
+
+class GlobalCredentialPoolListResponse(BaseModel):
+    pools: list[GlobalCredentialPoolResponse]
+
+
+class CreateGlobalCredentialPoolRequest(BaseModel):
+    """Provision a shared credential for a provider (api-key only for now).
+
+    OAuth-backed pools are out of scope for this iteration — see
+    docs/spec/2026-07-24-aigateway-shared-credential-pools-spec.md.
+    """
+
+    model_config = ConfigDict(hide_input_in_errors=True)
+
+    provider: str
+    api_key: SecretStr
+
+
+class PatchGlobalCredentialPoolRequest(BaseModel):
+    is_active: bool | None = None
+    api_key: SecretStr | None = None

--- a/apps/aigateway/src/aigateway/core/credential_pool/store.py
+++ b/apps/aigateway/src/aigateway/core/credential_pool/store.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from tortoise.exceptions import DoesNotExist
+
+from .models import GlobalCredentialPool
+
+DEFAULT_CREDENTIAL_ACCOUNT = "default"
+DEFAULT_POOL_LABEL = "default"
+
+
+def global_pool_credential_key_for(pool_id: str | UUID) -> str:
+    return f"pool:{pool_id}"
+
+
+def global_pool_credential_locator_for(provider: str, pool_id: str | UUID) -> dict[str, str]:
+    return {
+        "service": f"aigateway:{provider}:{global_pool_credential_key_for(pool_id)}",
+        "account": DEFAULT_CREDENTIAL_ACCOUNT,
+    }
+
+
+class GlobalCredentialPoolStore:
+    async def list(self) -> list[GlobalCredentialPool]:
+        return await GlobalCredentialPool.all().order_by("provider", "label")
+
+    async def get(self, pool_id: str | UUID) -> GlobalCredentialPool | None:
+        try:
+            return await GlobalCredentialPool.get(id=pool_id)
+        except DoesNotExist:
+            return None
+
+    async def get_active_for_provider(
+        self, provider: str, *, label: str = DEFAULT_POOL_LABEL
+    ) -> GlobalCredentialPool | None:
+        return await GlobalCredentialPool.filter(
+            provider=provider, label=label, is_active=True
+        ).first()
+
+    async def create(
+        self,
+        *,
+        provider: str,
+        auth_type: str,
+        created_by_id: str | UUID,
+        label: str = DEFAULT_POOL_LABEL,
+    ) -> GlobalCredentialPool:
+        return await GlobalCredentialPool.create(
+            provider=provider,
+            auth_type=auth_type,
+            label=label,
+            created_by_id=created_by_id,
+        )
+
+    async def set_active(
+        self, pool: GlobalCredentialPool, *, is_active: bool
+    ) -> GlobalCredentialPool:
+        pool.is_active = is_active
+        await pool.save(update_fields=["is_active", "updated_at"])
+        return pool
+
+    async def delete(self, pool: GlobalCredentialPool) -> None:
+        await pool.delete()

--- a/apps/aigateway/src/aigateway/db.py
+++ b/apps/aigateway/src/aigateway/db.py
@@ -20,6 +20,7 @@ TORTOISE_CONFIG: dict[str, Any] = {
             "models": [
                 "aigateway.core.auth.models",
                 "aigateway.core.credential_blob",
+                "aigateway.core.credential_pool.models",
                 "aigateway.core.oauth.models",
                 "aigateway.core.request_cache.models",
                 "aigateway.core.secrets.models",

--- a/apps/aigateway/src/aigateway/main.py
+++ b/apps/aigateway/src/aigateway/main.py
@@ -36,6 +36,7 @@ from .routes import (
     auth,
     auth_session,
     chat,
+    credential_pools,
     health,
     models,
     oauth_connections,
@@ -256,6 +257,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(api_key_validation.router)
     app.include_router(auth.router)
     app.include_router(oauth_connections.router)
+    app.include_router(credential_pools.router)
     app.include_router(health.router)
     app.include_router(models.router)
     app.include_router(chat.router)

--- a/apps/aigateway/src/aigateway/main.py
+++ b/apps/aigateway/src/aigateway/main.py
@@ -15,6 +15,7 @@ from fastapi.responses import JSONResponse
 from .config import Settings
 from .core.api_key_validation_service import ApiKeyValidationService
 from .core.auth.bootstrap_admin import ensure_admin_account
+from .core.auth.cf_access import build_cf_access_resolver
 from .core.auth.jwt_secret import get_or_create_jwt_secret
 from .core.auth.local_only import AuthDisabledLocalOnlyMiddleware
 from .core.auth.log_filter import (
@@ -231,7 +232,22 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     # Registry-wired auth: core's `current_account` depends only on the
     # IdentityResolver port, never on a concrete resolver module.
-    app.state.identity_resolvers = build_default_resolvers()
+    resolvers = build_default_resolvers()
+    if settings.cf_access_enabled:
+        # Settings validation guarantees both are set when the flag is on.
+        assert settings.cf_access_team_domain and settings.cf_access_aud
+        resolvers.append(
+            build_cf_access_resolver(
+                team_domain=settings.cf_access_team_domain,
+                audience=settings.cf_access_aud,
+                admin_emails=settings.cf_access_admin_email_set,
+            )
+        )
+        logger.info(
+            "cf_access enabled (team=%s); origin MUST be reachable only via Cloudflare",
+            settings.cf_access_team_domain,
+        )
+    app.state.identity_resolvers = resolvers
 
     registry = ProviderRegistry()
     load_plugins(registry)

--- a/apps/aigateway/src/aigateway/main.py
+++ b/apps/aigateway/src/aigateway/main.py
@@ -22,6 +22,7 @@ from .core.auth.log_filter import (
     install_provisioning_token_redaction,
 )
 from .core.auth.middleware import ANONYMOUS_ACCOUNT_ID
+from .core.auth.resolvers import build_default_resolvers
 from .core.credential_blob.store import CredentialBlobMutationConflict, ORMStore
 from .core.loader import load_plugins
 from .core.pending_auth import PendingAuthTable
@@ -227,6 +228,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.state.settings = settings
     if not settings.auth_enabled:
         app.add_middleware(AuthDisabledLocalOnlyMiddleware)
+
+    # Registry-wired auth: core's `current_account` depends only on the
+    # IdentityResolver port, never on a concrete resolver module.
+    app.state.identity_resolvers = build_default_resolvers()
 
     registry = ProviderRegistry()
     load_plugins(registry)

--- a/apps/aigateway/src/aigateway/migrations/0008_account_is_admin.py
+++ b/apps/aigateway/src/aigateway/migrations/0008_account_is_admin.py
@@ -1,0 +1,14 @@
+from tortoise import fields, migrations
+from tortoise.migrations import operations as ops
+
+
+class Migration(migrations.Migration):
+    dependencies = [("models", "0007_connection_auth_type")]
+
+    operations = [
+        ops.AddField(
+            model_name="Account",
+            name="is_admin",
+            field=fields.BooleanField(default=False, db_default="false"),
+        ),
+    ]

--- a/apps/aigateway/src/aigateway/migrations/0009_global_credential_pools.py
+++ b/apps/aigateway/src/aigateway/migrations/0009_global_credential_pools.py
@@ -1,0 +1,47 @@
+from uuid import uuid4
+
+from tortoise import fields, migrations
+from tortoise.migrations import operations as ops
+
+
+class Migration(migrations.Migration):
+    dependencies = [("models", "0008_account_is_admin")]
+
+    operations = [
+        ops.CreateModel(
+            name="GlobalCredentialPool",
+            fields=[
+                (
+                    "id",
+                    fields.UUIDField(primary_key=True, default=uuid4, unique=True, db_index=True),
+                ),
+                ("provider", fields.CharField(db_index=True, max_length=64)),
+                (
+                    "label",
+                    fields.CharField(max_length=255, default="default", db_default="default"),
+                ),
+                (
+                    "auth_type",
+                    fields.CharField(max_length=16, default="api_key", db_default="api_key"),
+                ),
+                ("is_active", fields.BooleanField(default=True, db_default="true")),
+                ("created_at", fields.DatetimeField(auto_now=False, auto_now_add=True)),
+                ("updated_at", fields.DatetimeField(auto_now=True, auto_now_add=False)),
+                (
+                    "created_by",
+                    fields.ForeignKeyField(
+                        "models.Account",
+                        related_name="created_credential_pools",
+                        on_delete=fields.OnDelete.RESTRICT,
+                    ),
+                ),
+            ],
+            options={
+                "table": "global_credential_pools",
+                "app": "models",
+                "pk_attr": "id",
+                "unique_together": (("provider", "label"),),
+            },
+            bases=["Model"],
+        ),
+    ]

--- a/apps/aigateway/src/aigateway/migrations/0010_account_external_identity.py
+++ b/apps/aigateway/src/aigateway/migrations/0010_account_external_identity.py
@@ -1,0 +1,91 @@
+from tortoise import fields, migrations
+from tortoise.indexes import Index
+from tortoise.migrations import operations as ops
+from tortoise.migrations.constraints import UniqueConstraint
+
+
+def _sqlite_foreign_keys(enabled: bool):
+    """Toggle SQLite FK enforcement around the `accounts` table rebuild.
+
+    WHY this exists at all: SQLite cannot ALTER a column's nullability, so
+    Tortoise's schema editor rebuilds the table — CREATE new / INSERT SELECT /
+    **DROP TABLE accounts** / RENAME (`schema_editor/sqlite.py::_remake_table`).
+    That DROP has no FK guard, so with `PRAGMA foreign_keys=ON` (Tortoise's
+    default) it fires ON DELETE CASCADE on every child row: `oauth_connections`
+    and `global_credential_pools` are silently emptied by a migration that
+    reports OK.
+
+    INVARIANT: no migration may destroy user data. Verified by
+    `test_full_chain_applies_to_populated_database`, which keeps an
+    oauth_connections row across this upgrade.
+
+    AIDEV-NOTE: SQLite-only, by dialect check — `PRAGMA` is a syntax error on
+    Postgres, which needs none of this (it does a real ALTER COLUMN DROP NOT
+    NULL and never rebuilds the table).
+    """
+
+    async def _run(_apps, schema_editor) -> None:
+        client = schema_editor.client
+        if client.capabilities.dialect != "sqlite":
+            return
+        await client.execute_script(f"PRAGMA foreign_keys={'ON' if enabled else 'OFF'}")
+
+    return _run
+
+
+class Migration(migrations.Migration):
+    """Federated-identity columns on `accounts` (OME-590).
+
+    `password_hash` goes NOT NULL -> NULL. That is a widening alteration, so
+    existing local accounts keep their hash; NULL is reserved for accounts
+    provisioned from an external IdP, and `login()` refuses it explicitly.
+    """
+
+    # INVARIANT: must stay False. `PRAGMA foreign_keys` is a silent no-op inside a
+    # transaction, so the guard above only works on a non-atomic migration.
+    atomic = False
+
+    dependencies = [("models", "0009_global_credential_pools")]
+
+    operations = [
+        ops.RunPython(_sqlite_foreign_keys(False), _sqlite_foreign_keys(True)),
+        ops.AlterField(
+            model_name="Account",
+            name="password_hash",
+            field=fields.CharField(max_length=255, null=True),
+        ),
+        ops.AddField(
+            model_name="Account",
+            name="external_idp",
+            field=fields.CharField(max_length=64, null=True),
+        ),
+        ops.AddField(
+            model_name="Account",
+            name="external_subject",
+            field=fields.CharField(max_length=255, null=True),
+        ),
+        ops.AddField(
+            model_name="Account",
+            name="email",
+            field=fields.CharField(max_length=320, null=True, db_index=True),
+        ),
+        # WHY a separate AddIndex: `db_index=True` on AddField updates model state
+        # but emits no CREATE INDEX, so the column would be unindexed in every
+        # migrated database while generate_schemas-built test databases had it.
+        ops.AddIndex(
+            model_name="Account",
+            index=Index(fields=("email",), name="idx_accounts_email"),
+        ),
+        # WHY an explicit UniqueConstraint and not AlterModelOptions: the latter is
+        # state-only (its `database_forward` returns None), so it would leave the
+        # migrated database with NO constraint while the model claimed one.
+        # OME-591's concurrent JIT provisioning depends on this being real.
+        ops.AddConstraint(
+            model_name="Account",
+            constraint=UniqueConstraint(
+                fields=("external_idp", "external_subject"),
+                name="uid_accounts_external_identity",
+            ),
+        ),
+        ops.RunPython(_sqlite_foreign_keys(True), _sqlite_foreign_keys(False)),
+    ]

--- a/apps/aigateway/src/aigateway/routes/auth_session.py
+++ b/apps/aigateway/src/aigateway/routes/auth_session.py
@@ -28,6 +28,19 @@ async def login(body: LoginRequest, request: Request) -> LoginResponse:
     account = await Account.get_or_none(username=body.username)
     password_hash = account.password_hash if account is not None else None
     password_ok = await verify_password_or_dummy(body.password, password_hash)
+    if account is not None and password_hash is None:
+        # INVARIANT (OME-590): a federated account has NO password, so NO password
+        # may authenticate it — and this check must NOT be folded into the
+        # `password_ok` branch below. `verify_password_or_dummy` falls back to the
+        # hash of the module-level constant `_DUMMY_PASSWORD`; that constant is
+        # public, so for a NULL-hash account `password_ok` is True whenever the
+        # caller submits it verbatim. Refusing on the NULL itself closes that.
+        #
+        # Placed AFTER the verify call so the refusal still costs one bcrypt
+        # round, and returning the same generic body as bad credentials leaves no
+        # federation-status enumeration oracle (same rule as SF-335).
+        logger.info("login refused for federated account username=%s", account.username)
+        raise HTTPException(status_code=401, detail=_INVALID_CREDENTIALS)
     if account is None or not password_ok:
         raise HTTPException(status_code=401, detail=_INVALID_CREDENTIALS)
     if not account.is_active:

--- a/apps/aigateway/src/aigateway/routes/chat_credentials.py
+++ b/apps/aigateway/src/aigateway/routes/chat_credentials.py
@@ -8,10 +8,11 @@ Phase 1) behind characterization tests; behavior is unchanged.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from fastapi import HTTPException, Request
 
+from ..core.credential_pool.store import GlobalCredentialPoolStore, global_pool_credential_key_for
 from ..core.credential_strategy_cache import credential_strategy_cache
 from ..core.errors import AuthError, CredentialNotFoundError
 from ..core.oauth.models import OAuthConnection
@@ -112,6 +113,10 @@ async def _active_oauth_connection_for_profile(
     )
 
 
+def _credential_mode(request: Request) -> str:
+    return getattr(request.app.state.settings, "credential_mode", "byok")
+
+
 async def _credential_target_for_chat(
     request: Request,
     *,
@@ -120,6 +125,13 @@ async def _credential_target_for_chat(
     profile_name: str,
     plugin: Any,
 ) -> tuple[Profile | None, OAuthConnection | None, ProfileDefaults]:
+    if _credential_mode(request) == "shared":
+        # Shared mode never consults per-account Profiles/OAuthConnections —
+        # the credential comes from the provider's GlobalCredentialPool,
+        # resolved later in _inject_credentials. account_id is intentionally
+        # not used for credential resolution here.
+        return None, None, ProfileDefaults()
+
     idx: ProfileIndexStore = request.app.state.profile_index
     profile = await idx.get(account_id, provider, profile_name)
     if profile is None:
@@ -258,6 +270,74 @@ def _apply_defaults(body: dict[str, Any], defaults: ProfileDefaults, plugin: Any
     return body
 
 
+async def _inject_shared_pool_credentials(
+    request: Request,
+    *,
+    plugin: Any,
+    provider: str,
+    body: dict[str, Any],
+) -> tuple[str | None, AuthType]:
+    """Shared-mode counterpart of _inject_credentials: resolve the provider's
+    active GlobalCredentialPool instead of a per-account profile/connection.
+
+    Pool credential errors are surfaced as 401s but never mark anything error
+    (there is no per-account row to mark) — reconciling a bad shared key is an
+    admin action via /v1/admin/credential-pools, out of scope for a chat
+    request. See docs/spec/2026-07-24-aigateway-shared-credential-pools-spec.md.
+    """
+    pool = await GlobalCredentialPoolStore().get_active_for_provider(provider)
+    if pool is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "credential_pool_not_configured",
+                "provider": provider,
+                "message": (
+                    f"no shared credential configured for provider={provider}; contact an admin"
+                ),
+            },
+        )
+    credential_name = global_pool_credential_key_for(pool.id)
+    auth_type = cast(AuthType, pool.auth_type)
+    strategy = credential_strategy_cache(request.app).get_or_create(
+        provider=provider,
+        auth_type=auth_type,
+        credential_name=credential_name,
+        build=lambda: credential_strategy_from(
+            plugin,
+            credential_name,
+            auth_type=auth_type,
+            credential_store=request.app.state.credential_store,
+            http_client_factory=getattr(request.app.state, f"{provider}_http_factory", None),
+        ),
+    )
+    if strategy is None:
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "api_key_not_supported", "provider": provider},
+        )
+    try:
+        headers = await strategy.get_authorization_header()
+    except (CredentialNotFoundError, AuthError) as exc:
+        credential_strategy_cache(request.app).evict(credential_name)
+        raise HTTPException(
+            status_code=401,
+            detail={
+                "code": "shared_credential_invalid",
+                "provider": provider,
+                "message": str(exc),
+            },
+        ) from exc
+    auth_value = headers.pop("Authorization", None)
+    if auth_value and auth_value.lower().startswith("bearer "):
+        body["api_key"] = auth_value.split(" ", 1)[1]
+    if headers:
+        merged = dict(body.get("extra_headers") or {})
+        merged.update(headers)
+        body["extra_headers"] = merged
+    return credential_name, auth_type
+
+
 async def _inject_credentials(
     request: Request,
     *,
@@ -273,6 +353,10 @@ async def _inject_credentials(
     into ``body``; returns ``(credential_name, auth_type)`` for later dispatch
     failure handling. Raises 401 (marking profile/connection errored) when
     stored credentials are unusable."""
+    if _credential_mode(request) == "shared":
+        return await _inject_shared_pool_credentials(
+            request, plugin=plugin, provider=provider, body=body
+        )
     strategy, credential_name, auth_type = _strategy_for_credential_target(
         request,
         plugin,

--- a/apps/aigateway/src/aigateway/routes/credential_pools.py
+++ b/apps/aigateway/src/aigateway/routes/credential_pools.py
@@ -1,0 +1,187 @@
+"""Admin CRUD for global (shared) credential pools.
+
+Used only when the gateway is configured with AIGATEWAY_CREDENTIAL_MODE=shared
+(see chat_credentials.py's shared-mode branch); creating pools while the
+gateway runs in "byok" mode is still allowed (an admin can provision ahead of
+a mode switch) but they are not consulted by chat dispatch until the mode
+flips to "shared".
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Request
+
+from aigateway.core.auth.middleware import CurrentAdminAccount
+from aigateway.core.credential_pool.models import GlobalCredentialPool
+from aigateway.core.credential_pool.schemas import (
+    CreateGlobalCredentialPoolRequest,
+    GlobalCredentialPoolListResponse,
+    GlobalCredentialPoolResponse,
+    PatchGlobalCredentialPoolRequest,
+)
+from aigateway.core.credential_pool.store import (
+    GlobalCredentialPoolStore,
+    global_pool_credential_key_for,
+    global_pool_credential_locator_for,
+)
+from aigateway.core.plugin_base import credential_strategy_from
+
+from .api_key_validation import normalize_api_key, require_valid_api_key
+from .credential_persistence import persist_credentials_or_503
+
+router = APIRouter()
+
+
+@router.get("/v1/admin/credential-pools", response_model=GlobalCredentialPoolListResponse)
+async def list_credential_pools(
+    request: Request,
+    current: CurrentAdminAccount,
+) -> GlobalCredentialPoolListResponse:
+    pools = await _store(request).list()
+    return GlobalCredentialPoolListResponse(pools=[_response_from_pool(pool) for pool in pools])
+
+
+@router.get("/v1/admin/credential-pools/{pool_id}", response_model=GlobalCredentialPoolResponse)
+async def get_credential_pool(
+    pool_id: UUID,
+    request: Request,
+    current: CurrentAdminAccount,
+) -> GlobalCredentialPoolResponse:
+    pool = await _store(request).get(pool_id)
+    if pool is None:
+        raise HTTPException(status_code=404, detail={"code": "pool_not_found"})
+    return _response_from_pool(pool)
+
+
+@router.post(
+    "/v1/admin/credential-pools",
+    status_code=201,
+    response_model=GlobalCredentialPoolResponse,
+)
+async def create_credential_pool(
+    body: CreateGlobalCredentialPoolRequest,
+    request: Request,
+    current: CurrentAdminAccount,
+) -> GlobalCredentialPoolResponse:
+    plugin = request.app.state.providers.get(body.provider)
+    if plugin is None:
+        raise HTTPException(
+            status_code=404, detail={"code": "unknown_provider", "provider": body.provider}
+        )
+    api_key = normalize_api_key(body.api_key)
+    store = _store(request)
+    if await store.get_active_for_provider(body.provider) is not None:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "pool_conflict", "provider": body.provider},
+        )
+    await require_valid_api_key(request, plugin, body.provider, api_key)
+
+    pool = await store.create(
+        provider=body.provider,
+        auth_type="api_key",
+        created_by_id=current.id,
+    )
+    strategy = credential_strategy_from(
+        plugin,
+        _pool_credential_name(pool.id),
+        auth_type="api_key",
+        credential_store=request.app.state.credential_store,
+    )
+    if strategy is None:
+        await store.delete(pool)
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "api_key_not_supported", "provider": body.provider},
+        )
+    await _persist_pool_api_key(strategy, api_key)
+    return _response_from_pool(pool)
+
+
+@router.patch("/v1/admin/credential-pools/{pool_id}", response_model=GlobalCredentialPoolResponse)
+async def patch_credential_pool(
+    pool_id: UUID,
+    body: PatchGlobalCredentialPoolRequest,
+    request: Request,
+    current: CurrentAdminAccount,
+) -> GlobalCredentialPoolResponse:
+    store = _store(request)
+    pool = await store.get(pool_id)
+    if pool is None:
+        raise HTTPException(status_code=404, detail={"code": "pool_not_found"})
+
+    if body.api_key is not None:
+        plugin = request.app.state.providers.get(pool.provider)
+        if plugin is None:
+            raise HTTPException(
+                status_code=404, detail={"code": "unknown_provider", "provider": pool.provider}
+            )
+        api_key = normalize_api_key(body.api_key)
+        await require_valid_api_key(request, plugin, pool.provider, api_key)
+        strategy = credential_strategy_from(
+            plugin,
+            _pool_credential_name(pool.id),
+            auth_type="api_key",
+            credential_store=request.app.state.credential_store,
+        )
+        if strategy is None:
+            raise HTTPException(
+                status_code=400,
+                detail={"code": "api_key_not_supported", "provider": pool.provider},
+            )
+        await _persist_pool_api_key(strategy, api_key)
+
+    if body.is_active is not None:
+        pool = await store.set_active(pool, is_active=body.is_active)
+    return _response_from_pool(pool)
+
+
+@router.delete("/v1/admin/credential-pools/{pool_id}", status_code=204)
+async def delete_credential_pool(
+    pool_id: UUID,
+    request: Request,
+    current: CurrentAdminAccount,
+) -> None:
+    store = _store(request)
+    pool = await store.get(pool_id)
+    if pool is None:
+        raise HTTPException(status_code=404, detail={"code": "pool_not_found"})
+    locator = global_pool_credential_locator_for(pool.provider, pool.id)
+    await request.app.state.credential_store.delete(locator["service"], locator["account"])
+    await store.delete(pool)
+
+
+async def _persist_pool_api_key(strategy, api_key: str) -> None:
+    await persist_credentials_or_503(
+        strategy,
+        {"auth_type": "api_key", "api_key": api_key},
+        description="shared credential pool key",
+    )
+
+
+def _store(request: Request) -> GlobalCredentialPoolStore:
+    store = getattr(request.app.state, "credential_pools", None)
+    if isinstance(store, GlobalCredentialPoolStore):
+        return store
+    store = GlobalCredentialPoolStore()
+    request.app.state.credential_pools = store
+    return store
+
+
+def _pool_credential_name(pool_id: UUID) -> str:
+    return global_pool_credential_key_for(pool_id)
+
+
+def _response_from_pool(pool: GlobalCredentialPool) -> GlobalCredentialPoolResponse:
+    return GlobalCredentialPoolResponse(
+        id=pool.id,
+        provider=pool.provider,
+        label=pool.label,
+        auth_type=pool.auth_type,
+        is_active=pool.is_active,
+        created_by_id=pool.created_by_id,
+        created_at=pool.created_at,
+        updated_at=pool.updated_at,
+    )

--- a/apps/aigateway/tests/unit/auth/cf_access/conftest.py
+++ b/apps/aigateway/tests/unit/auth/cf_access/conftest.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+import httpx
+import jwt
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jwt.utils import base64url_encode
+from tortoise.contrib.test import tortoise_test_context
+
+TEAM_DOMAIN = "example-team.cloudflareaccess.com"
+AUDIENCE = "a" * 64
+CERTS_URL = f"https://{TEAM_DOMAIN}/cdn-cgi/access/certs"
+
+
+class SigningKey:
+    """An RSA keypair that can both sign assertions and publish itself as a JWK."""
+
+    def __init__(self, kid: str) -> None:
+        self.kid = kid
+        self._private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+    def as_jwk(self) -> dict[str, str]:
+        numbers = self._private.public_key().public_numbers()
+
+        def b64(value: int) -> str:
+            raw = value.to_bytes((value.bit_length() + 7) // 8, "big")
+            return base64url_encode(raw).decode()
+
+        return {
+            "kty": "RSA",
+            "kid": self.kid,
+            "alg": "RS256",
+            "use": "sig",
+            "n": b64(numbers.n),
+            "e": b64(numbers.e),
+        }
+
+    def sign(self, claims: dict[str, Any]) -> str:
+        return jwt.encode(claims, self._private, algorithm="RS256", headers={"kid": self.kid})
+
+
+class FakeCerts:
+    """Serves the certs endpoint, with controllable key set and failure mode."""
+
+    def __init__(self, *keys: SigningKey) -> None:
+        self.keys = list(keys)
+        self.fail = False
+        self.requests = 0
+        #: Extra raw JWK dicts served alongside `keys` (to simulate a junk entry).
+        self.malformed: list[dict] = []
+        #: Replaces the whole response body when set (to simulate a broken endpoint).
+        self.payload_override: object | None = None
+
+    def factory(self):
+        async def _handler(request: httpx.Request) -> httpx.Response:
+            # WHY async + sleep(0): a purely synchronous mock transport never
+            # yields, so "concurrent" coroutines actually run to completion one
+            # after another and any lock/re-check path stays unexercised. The
+            # yield point is what makes contention real in tests.
+            await asyncio.sleep(0)
+            self.requests += 1
+            if self.fail:
+                raise httpx.ConnectError("certs unreachable", request=request)
+            if self.payload_override is not None:
+                return httpx.Response(200, json=self.payload_override)
+            body = {"keys": [key.as_jwk() for key in self.keys] + self.malformed}
+            return httpx.Response(200, json=body)
+
+        def _factory() -> httpx.AsyncClient:
+            return httpx.AsyncClient(transport=httpx.MockTransport(_handler))
+
+        return _factory
+
+
+def claims(
+    *,
+    sub: str = "cf-user-uuid-1",
+    email: str | None = "user@example.com",
+    common_name: str | None = None,
+    audience: str = AUDIENCE,
+    issuer: str = f"https://{TEAM_DOMAIN}",
+    expires_in: int = 3600,
+) -> dict[str, Any]:
+    now = int(time.time())
+    payload: dict[str, Any] = {
+        "sub": sub,
+        "aud": audience,
+        "iss": issuer,
+        "iat": now,
+        "exp": now + expires_in,
+    }
+    if email is not None:
+        payload["email"] = email
+    if common_name is not None:
+        payload["common_name"] = common_name
+    return payload
+
+
+@pytest.fixture
+def signing_key() -> SigningKey:
+    return SigningKey("kid-current")
+
+
+@pytest.fixture
+def rotated_key() -> SigningKey:
+    return SigningKey("kid-previous")
+
+
+@pytest.fixture
+def certs(signing_key: SigningKey) -> FakeCerts:
+    return FakeCerts(signing_key)
+
+
+@pytest_asyncio.fixture
+async def db():
+    async with tortoise_test_context(["aigateway.core.auth.models"]):
+        yield

--- a/apps/aigateway/tests/unit/auth/cf_access/test_provisioning.py
+++ b/apps/aigateway/tests/unit/auth/cf_access/test_provisioning.py
@@ -1,0 +1,164 @@
+"""Just-in-time provisioning — the product goal: no registration, no /login."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from aigateway.core.auth.cf_access import CF_ACCESS_IDP, CfAccessIdentity
+from aigateway.core.auth.cf_access.provisioning import get_or_create_cf_access_account
+from aigateway.core.auth.models import Account
+
+pytestmark = pytest.mark.asyncio
+
+IDENTITY = CfAccessIdentity(
+    subject="cf-user-uuid-1",
+    email="user@example.com",
+    is_service_token=False,
+)
+
+
+async def test_first_request_creates_the_account(db) -> None:
+    account = await get_or_create_cf_access_account(IDENTITY)
+
+    assert account is not None
+    assert account.external_idp == CF_ACCESS_IDP
+    assert account.external_subject == "cf-user-uuid-1"
+    assert account.email == "user@example.com"
+    assert account.password_hash is None
+    assert account.is_admin is False
+    assert await Account.all().count() == 1
+
+
+async def test_second_request_reuses_the_same_account(db) -> None:
+    first = await get_or_create_cf_access_account(IDENTITY)
+    second = await get_or_create_cf_access_account(IDENTITY)
+
+    assert first is not None and second is not None
+    assert first.id == second.id
+    assert await Account.all().count() == 1
+
+
+async def test_concurrent_first_requests_create_exactly_one_account(db) -> None:
+    # WHY this is the NORMAL case: an SDK with a connection pool issues several
+    # first requests at once. Without the (idp, subject) unique constraint from
+    # OME-590 this silently produces two accounts for one person.
+    results = await asyncio.gather(*(get_or_create_cf_access_account(IDENTITY) for _ in range(6)))
+
+    assert await Account.all().count() == 1
+    assert len({account.id for account in results if account is not None}) == 1
+
+
+async def test_email_change_follows_the_subject(db) -> None:
+    # INVARIANT: the subject is the identity; email is a mutable label. A user
+    # who renames at the IdP keeps their account and history.
+    created = await get_or_create_cf_access_account(IDENTITY)
+    renamed = await get_or_create_cf_access_account(
+        CfAccessIdentity(subject="cf-user-uuid-1", email="new@example.com", is_service_token=False)
+    )
+
+    assert created is not None and renamed is not None
+    assert renamed.id == created.id
+    assert renamed.email == "new@example.com"
+    assert await Account.all().count() == 1
+
+
+async def test_a_different_subject_with_the_same_email_is_a_different_account(db) -> None:
+    # INVARIANT: keying on email would hand a reassigned corporate address the
+    # previous holder's account and credentials.
+    first = await get_or_create_cf_access_account(IDENTITY)
+    second = await get_or_create_cf_access_account(
+        CfAccessIdentity(
+            subject="cf-user-uuid-2",
+            email="user@example.com",
+            is_service_token=False,
+        )
+    )
+
+    assert first is not None and second is not None
+    assert first.id != second.id
+
+
+async def test_service_token_identity_provisions_without_an_email(db) -> None:
+    account = await get_or_create_cf_access_account(
+        CfAccessIdentity(subject="client-id-abc", email=None, is_service_token=True)
+    )
+
+    assert account is not None
+    assert account.external_subject == "client-id-abc"
+    assert account.email is None
+    assert account.is_admin is False
+
+
+async def test_admin_allowlist_grants_admin_at_creation(db) -> None:
+    account = await get_or_create_cf_access_account(
+        IDENTITY, admin_emails=frozenset({"user@example.com"})
+    )
+
+    assert account is not None
+    assert account.is_admin is True
+
+
+async def test_admin_allowlist_is_case_insensitive(db) -> None:
+    account = await get_or_create_cf_access_account(
+        CfAccessIdentity(
+            subject="cf-user-uuid-9",
+            email="User@Example.COM",
+            is_service_token=False,
+        ),
+        admin_emails=frozenset({"user@example.com"}),
+    )
+
+    assert account is not None
+    assert account.is_admin is True
+
+
+async def test_a_service_token_can_never_match_the_admin_allowlist(db) -> None:
+    # INVARIANT: admin is granted from a verified email. A service token has
+    # none, so it must never satisfy the allowlist by any path.
+    account = await get_or_create_cf_access_account(
+        CfAccessIdentity(subject="client-id-abc", email=None, is_service_token=True),
+        admin_emails=frozenset({"user@example.com", ""}),
+    )
+
+    assert account is not None
+    assert account.is_admin is False
+
+
+async def test_deactivated_account_is_refused(db) -> None:
+    # INVARIANT: a gateway admin's deactivation outranks Cloudflare still
+    # admitting the user at the edge.
+    created = await get_or_create_cf_access_account(IDENTITY)
+    assert created is not None
+    created.is_active = False
+    await created.save(update_fields=["is_active"])
+
+    assert await get_or_create_cf_access_account(IDENTITY) is None
+
+
+async def test_username_collision_with_a_local_account_surfaces(db) -> None:
+    # A pre-existing local account already holding the derived username must not
+    # be silently adopted as this federated identity.
+    await Account.create(
+        username=IDENTITY.username,
+        password_hash="hashed",
+    )
+
+    with pytest.raises(Exception):
+        await get_or_create_cf_access_account(IDENTITY)
+
+
+async def test_username_is_derived_from_the_subject_not_the_email(db) -> None:
+    # INVARIANT (regression): `username` is UNIQUE. Deriving it from the mutable
+    # email made two distinct subjects sharing an address collide, so the second
+    # user could not be provisioned at all.
+    assert IDENTITY.username == f"{CF_ACCESS_IDP}:cf-user-uuid-1"
+
+
+async def test_an_overlong_subject_is_hashed_not_truncated(db) -> None:
+    long_a = CfAccessIdentity(subject="s" * 200 + "a", email=None, is_service_token=True)
+    long_b = CfAccessIdentity(subject="s" * 200 + "b", email=None, is_service_token=True)
+
+    assert len(long_a.username) <= 64
+    assert long_a.username != long_b.username, "truncation would collide distinct subjects"

--- a/apps/aigateway/tests/unit/auth/cf_access/test_resolver.py
+++ b/apps/aigateway/tests/unit/auth/cf_access/test_resolver.py
@@ -1,0 +1,145 @@
+"""The resolver end-to-end: token discovery, rejection shape, log hygiene."""
+
+from __future__ import annotations
+
+import logging
+
+import jwt
+import pytest
+from fastapi import Request
+
+from aigateway.core.auth.cf_access import (
+    ASSERTION_COOKIE,
+    ASSERTION_HEADER,
+    build_cf_access_resolver,
+)
+from aigateway.core.auth.log_filter import RedactProvisioningTokenFilter
+from aigateway.core.auth.models import Account
+from aigateway.core.auth.resolvers import IdentityResolver, LocalJwtResolver, Rejection
+
+from .conftest import AUDIENCE, TEAM_DOMAIN, FakeCerts, claims
+
+pytestmark = pytest.mark.asyncio
+
+
+def _resolver(certs: FakeCerts, **kwargs):
+    return build_cf_access_resolver(
+        team_domain=TEAM_DOMAIN,
+        audience=AUDIENCE,
+        http_client_factory=certs.factory(),
+        **kwargs,
+    )
+
+
+def _request(headers: list[tuple[bytes, bytes]]) -> Request:
+    return Request(
+        {"type": "http", "method": "GET", "path": "/", "headers": headers, "query_string": b""}
+    )
+
+
+async def test_resolver_satisfies_the_identity_resolver_port(certs) -> None:
+    assert isinstance(_resolver(certs), IdentityResolver)
+
+
+async def test_injected_header_authenticates_and_provisions(db, certs, signing_key) -> None:
+    token = signing_key.sign(claims())
+    request = _request([(ASSERTION_HEADER.lower().encode(), token.encode())])
+
+    account = await _resolver(certs).resolve(request)
+
+    assert isinstance(account, Account)
+    assert account.external_subject == "cf-user-uuid-1"
+
+
+async def test_browser_cookie_authenticates(db, certs, signing_key) -> None:
+    # The prior prototype of this feature read ONLY `Authorization: Bearer`, so
+    # browser/cookie SSO silently never worked. Guard that regression.
+    token = signing_key.sign(claims())
+    request = _request([(b"cookie", f"{ASSERTION_COOKIE}={token}".encode())])
+
+    account = await _resolver(certs).resolve(request)
+
+    assert isinstance(account, Account)
+
+
+async def test_bearer_token_authenticates_for_api_clients(db, certs, signing_key) -> None:
+    token = signing_key.sign(claims())
+    request = _request([(b"authorization", f"Bearer {token}".encode())])
+
+    account = await _resolver(certs).resolve(request)
+
+    assert isinstance(account, Account)
+
+
+async def test_abstains_when_no_credential_is_present(db, certs) -> None:
+    assert await _resolver(certs).resolve(_request([])) is None
+
+
+async def test_abstains_on_a_local_hs256_session_token(db, certs) -> None:
+    # INVARIANT: recognition across the chain is disjoint. A local session token
+    # belongs to LocalJwtResolver, so this resolver must abstain rather than
+    # reject — otherwise it would claim and 401 every local login.
+    local = jwt.encode({"sub": "x"}, "s" * 32, algorithm="HS256")
+    request = _request([(b"authorization", f"Bearer {local}".encode())])
+
+    assert await _resolver(certs).resolve(request) is None
+
+
+async def test_forged_assertion_is_rejected_without_provisioning(db, certs) -> None:
+    from .conftest import SigningKey
+
+    forged = SigningKey("kid-current").sign(claims())
+    request = _request([(ASSERTION_HEADER.lower().encode(), forged.encode())])
+
+    outcome = await _resolver(certs).resolve(request)
+
+    assert isinstance(outcome, Rejection)
+    assert outcome.status_code == 401
+    assert await Account.all().count() == 0, "a rejected assertion must not create an account"
+
+
+async def test_rejection_detail_does_not_leak_the_configuration(db, certs, signing_key) -> None:
+    # WHY: the underlying error names the exact failure (wrong audience, unknown
+    # kid). Useful in the operator's log, but handing it to an unauthenticated
+    # caller describes this gateway's Access configuration back to them.
+    token = signing_key.sign(claims(audience="b" * 64))
+    request = _request([(ASSERTION_HEADER.lower().encode(), token.encode())])
+
+    outcome = await _resolver(certs).resolve(request)
+
+    assert isinstance(outcome, Rejection)
+    assert AUDIENCE not in str(outcome.detail)
+    assert "aud" not in str(outcome.detail).lower()
+
+
+async def test_admin_allowlist_is_honoured_through_the_resolver(db, certs, signing_key) -> None:
+    request = _request([(ASSERTION_HEADER.lower().encode(), signing_key.sign(claims()).encode())])
+
+    account = await _resolver(certs, admin_emails=frozenset({"user@example.com"})).resolve(request)
+
+    assert isinstance(account, Account)
+    assert account.is_admin is True
+
+
+async def test_the_local_resolver_abstains_on_a_cloudflare_assertion(certs, signing_key) -> None:
+    # The other half of disjoint recognition, asserted from the local side.
+    token = signing_key.sign(claims())
+    request = _request([(b"authorization", f"Bearer {token}".encode())])
+
+    assert await LocalJwtResolver().resolve(request) is None
+
+
+async def test_assertion_headers_are_redacted_from_logs(caplog) -> None:
+    # INVARIANT: a leaked assertion is a replayable identity until it expires.
+    logger = logging.getLogger("aigateway.test.cf_access")
+    logger.addFilter(RedactProvisioningTokenFilter())
+
+    with caplog.at_level(logging.INFO):
+        logger.info("headers: Cf-Access-Jwt-Assertion: ey.SECRET.sig")
+        logger.info("headers: cf-access-client-secret=SUPERSECRET")
+        logger.info("raw %s", [(b"cf-access-jwt-assertion", b"ey.SECRET.sig")])
+
+    rendered = "\n".join(record.getMessage() for record in caplog.records)
+    assert "SECRET" not in rendered
+    assert "SUPERSECRET" not in rendered
+    assert "[REDACTED]" in rendered

--- a/apps/aigateway/tests/unit/auth/cf_access/test_verification.py
+++ b/apps/aigateway/tests/unit/auth/cf_access/test_verification.py
@@ -1,0 +1,243 @@
+"""Assertion verification — the layer that must never fail open."""
+
+from __future__ import annotations
+
+import asyncio
+
+import jwt
+import pytest
+
+from aigateway.core.auth.cf_access import (
+    CfAccessVerificationError,
+    CfAccessVerifier,
+    CloudflareAccessJwks,
+)
+
+from .conftest import AUDIENCE, TEAM_DOMAIN, FakeCerts, SigningKey, claims
+
+pytestmark = pytest.mark.asyncio
+
+
+def _verifier(certs: FakeCerts, **kwargs) -> CfAccessVerifier:
+    jwks = CloudflareAccessJwks(
+        TEAM_DOMAIN,
+        http_client_factory=certs.factory(),
+        **kwargs,
+    )
+    return CfAccessVerifier(jwks, audience=AUDIENCE, team_domain=TEAM_DOMAIN)
+
+
+async def test_valid_idp_assertion_yields_the_subject_and_email(certs, signing_key) -> None:
+    identity = await _verifier(certs).verify(signing_key.sign(claims()))
+
+    assert identity.subject == "cf-user-uuid-1"
+    assert identity.email == "user@example.com"
+    assert identity.is_service_token is False
+
+
+async def test_service_token_assertion_is_keyed_on_common_name(certs, signing_key) -> None:
+    # A service-token assertion carries an empty `sub` and no email.
+    token = signing_key.sign(claims(sub="", email=None, common_name="client-id-abc"))
+
+    identity = await _verifier(certs).verify(token)
+
+    assert identity.subject == "client-id-abc"
+    assert identity.email is None
+    assert identity.is_service_token is True
+
+
+async def test_assertion_with_neither_sub_nor_common_name_is_rejected(certs, signing_key) -> None:
+    token = signing_key.sign(claims(sub="", email=None))
+
+    with pytest.raises(CfAccessVerificationError):
+        await _verifier(certs).verify(token)
+
+
+async def test_wrong_audience_is_rejected(certs, signing_key) -> None:
+    # INVARIANT: `aud` scopes the assertion to THIS application. Without this
+    # check any Access app in the same team could authenticate to the gateway.
+    token = signing_key.sign(claims(audience="b" * 64))
+
+    with pytest.raises(CfAccessVerificationError):
+        await _verifier(certs).verify(token)
+
+
+async def test_wrong_issuer_is_rejected(certs, signing_key) -> None:
+    token = signing_key.sign(claims(issuer="https://attacker.cloudflareaccess.com"))
+
+    with pytest.raises(CfAccessVerificationError):
+        await _verifier(certs).verify(token)
+
+
+async def test_expired_assertion_is_rejected(certs, signing_key) -> None:
+    token = signing_key.sign(claims(expires_in=-1))
+
+    with pytest.raises(CfAccessVerificationError):
+        await _verifier(certs).verify(token)
+
+
+async def test_unsigned_alg_none_token_is_rejected(certs) -> None:
+    token = jwt.encode(claims(), key="", algorithm="none", headers={"kid": "kid-current"})
+
+    with pytest.raises(CfAccessVerificationError):
+        await _verifier(certs).verify(token)
+
+
+async def test_hs256_forgery_using_the_public_key_is_rejected(certs, signing_key) -> None:
+    # INVARIANT: the classic algorithm-confusion attack — re-sign the payload
+    # with HS256 using the PUBLIC key bytes as the HMAC secret. Rejected because
+    # the verifier pins algorithms=["RS256"] rather than trusting the header.
+    public_jwk = signing_key.as_jwk()
+    token = jwt.encode(
+        claims(),
+        key=public_jwk["n"],
+        algorithm="HS256",
+        headers={"kid": "kid-current"},
+    )
+
+    with pytest.raises(CfAccessVerificationError):
+        await _verifier(certs).verify(token)
+
+
+async def test_token_without_a_kid_is_rejected(certs, signing_key) -> None:
+    with pytest.raises(CfAccessVerificationError):
+        await _verifier(certs).verify(jwt.encode(claims(), key="k" * 32, algorithm="HS256"))
+
+
+async def test_key_rotation_previous_key_still_verifies(certs, rotated_key) -> None:
+    # Cloudflare rotates every 6 weeks and serves current + previous for 7 days.
+    certs.keys.append(rotated_key)
+
+    identity = await _verifier(certs).verify(rotated_key.sign(claims()))
+
+    assert identity.subject == "cf-user-uuid-1"
+
+
+async def test_unknown_kid_refetches_once_then_rate_limits(certs, signing_key) -> None:
+    # WHY rate-limit: a forged `kid` must not let an unauthenticated caller drive
+    # unbounded outbound requests to Cloudflare.
+    verifier = _verifier(certs)
+    forged = SigningKey("kid-does-not-exist")
+
+    for _ in range(3):
+        with pytest.raises(CfAccessVerificationError):
+            await verifier.verify(forged.sign(claims()))
+
+    assert certs.requests == 1
+
+
+async def test_jwks_outage_with_a_warm_cache_still_verifies(certs, signing_key) -> None:
+    verifier = _verifier(certs)
+    await verifier.verify(signing_key.sign(claims()))
+
+    certs.fail = True
+    identity = await verifier.verify(signing_key.sign(claims()))
+
+    assert identity.subject == "cf-user-uuid-1"
+
+
+async def test_jwks_outage_with_a_cold_cache_refuses(certs, signing_key) -> None:
+    # INVARIANT: degraded, never open. With no cached key there is nothing to
+    # verify against, so the request must be refused — not admitted.
+    certs.fail = True
+
+    with pytest.raises(CfAccessVerificationError):
+        await _verifier(certs).verify(signing_key.sign(claims()))
+
+
+async def test_empty_key_set_refuses(signing_key) -> None:
+    with pytest.raises(CfAccessVerificationError):
+        await _verifier(FakeCerts()).verify(signing_key.sign(claims()))
+
+
+async def test_a_malformed_key_does_not_discard_the_rest_of_the_key_set(certs, signing_key) -> None:
+    # INVARIANT: one unusable JWK must not take the whole key set down with it.
+    # During a rotation the set holds current + previous; discarding everything
+    # because one entry is junk would 401 the entire fleet.
+    certs.malformed = [{"kty": "RSA", "kid": "junk", "n": "!!not-base64!!", "e": "AQAB"}]
+
+    identity = await _verifier(certs).verify(signing_key.sign(claims()))
+
+    assert identity.subject == "cf-user-uuid-1"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        [],
+        {"keys": "not-a-list"},
+        {"keys": [{"kid": "no-key-material"}]},
+        {"keys": ["not-an-object"]},
+        {"keys": [{"kty": "RSA", "n": "x", "e": "AQAB"}]},
+        {},
+    ],
+    ids=[
+        "not-an-object",
+        "keys-not-a-list",
+        "unusable-key",
+        "entry-not-an-object",
+        "key-without-kid",
+        "no-keys-field",
+    ],
+)
+async def test_an_unusable_certs_response_refuses_rather_than_fails_open(
+    signing_key, payload
+) -> None:
+    # INVARIANT: degraded, never open. A certs endpoint returning something we
+    # cannot parse must refuse the request, not skip verification.
+    certs = FakeCerts(signing_key)
+    certs.payload_override = payload
+
+    with pytest.raises(CfAccessVerificationError):
+        await _verifier(certs).verify(signing_key.sign(claims()))
+
+
+async def test_a_failed_refresh_does_not_wipe_the_cached_key_set(certs, signing_key) -> None:
+    # WHY this is distinct from the warm-cache test above: that one never reaches
+    # the refresh path at all (a known `kid` is served straight from cache). THIS
+    # forces a refresh with an unknown `kid`, fails it, and then proves the
+    # previously-cached key still verifies — i.e. the failed fetch degraded the
+    # cache rather than emptying it. Without stale-on-error, one Cloudflare blip
+    # would 401 the entire fleet.
+    # min_refetch_interval_seconds=0 stands in for "the refetch window has
+    # elapsed". Without it the rate limiter short-circuits first and _refresh is
+    # never even attempted — the two defenses overlap, and this is the ordering
+    # that decides which one answers.
+    verifier = _verifier(certs, min_refetch_interval_seconds=0)
+    await verifier.verify(signing_key.sign(claims()))
+
+    certs.fail = True
+    unknown = SigningKey("kid-never-published")
+    with pytest.raises(CfAccessVerificationError):
+        await verifier.verify(unknown.sign(claims()))
+
+    identity = await verifier.verify(signing_key.sign(claims()))
+    assert identity.subject == "cf-user-uuid-1", "the cached key must survive a failed refresh"
+
+
+async def test_the_rate_limiter_answers_before_a_refresh_is_attempted(certs, signing_key) -> None:
+    # The other side of that ordering: inside the refetch window an unknown `kid`
+    # must NOT reach the network at all, so a forged kid cannot be used to drive
+    # outbound requests to Cloudflare.
+    verifier = _verifier(certs)
+    await verifier.verify(signing_key.sign(claims()))
+    requests_after_warmup = certs.requests
+
+    unknown = SigningKey("kid-never-published")
+    with pytest.raises(CfAccessVerificationError):
+        await verifier.verify(unknown.sign(claims()))
+
+    assert certs.requests == requests_after_warmup
+
+
+async def test_concurrent_cold_start_fetches_the_key_set_only_once(certs, signing_key) -> None:
+    # INVARIANT: the lock + re-check must collapse a cold-start stampede into one
+    # fetch. A fleet restarting behind Cloudflare would otherwise hit the certs
+    # endpoint once per in-flight request.
+    verifier = _verifier(certs)
+    token = signing_key.sign(claims())
+
+    identities = await asyncio.gather(*(verifier.verify(token) for _ in range(8)))
+
+    assert certs.requests == 1
+    assert {identity.subject for identity in identities} == {"cf-user-uuid-1"}

--- a/apps/aigateway/tests/unit/auth/test_federated_account.py
+++ b/apps/aigateway/tests/unit/auth/test_federated_account.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+from tortoise.exceptions import IntegrityError
+
+from aigateway.core.auth.models import Account
+
+CF_IDP = "cf_access"
+
+
+async def _create_federated(
+    *,
+    username: str = "cf-user",
+    subject: str = "cf-sub-1",
+    email: str | None = "cf-user@example.com",
+) -> Account:
+    return await Account.create(
+        username=username,
+        password_hash=None,
+        external_idp=CF_IDP,
+        external_subject=subject,
+        email=email,
+    )
+
+
+@pytest.mark.asyncio
+async def test_account_can_be_created_without_a_password_hash(db) -> None:
+    # FEATURE: JIT provisioning — a Cloudflare-authenticated user has no password.
+    account = await _create_federated()
+
+    assert account.password_hash is None
+    assert account.external_idp == CF_IDP
+    assert account.external_subject == "cf-sub-1"
+    assert account.email == "cf-user@example.com"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_external_identity_is_rejected(db) -> None:
+    # INVARIANT: (external_idp, external_subject) is THE federated identity key —
+    # it is what makes concurrent first-request provisioning safe (OME-591).
+    await _create_federated(username="first", subject="same-sub")
+
+    with pytest.raises(IntegrityError):
+        await _create_federated(username="second", subject="same-sub")
+
+
+@pytest.mark.asyncio
+async def test_same_subject_under_a_different_idp_is_allowed(db) -> None:
+    await _create_federated(username="first", subject="shared")
+    other = await Account.create(
+        username="second",
+        password_hash=None,
+        external_idp="some_other_idp",
+        external_subject="shared",
+    )
+
+    assert other.id is not None
+
+
+@pytest.mark.asyncio
+async def test_many_local_accounts_coexist_with_null_external_identity(db) -> None:
+    # WHY: SQL treats NULLs as distinct under a unique constraint, so the federated
+    # key must not collide local accounts with each other. Asserted, not assumed —
+    # a naive constraint would make the second local account unwritable.
+    for name in ("local-a", "local-b", "local-c"):
+        await Account.create(username=name, password_hash="hashed")
+
+    assert await Account.filter(external_idp=None).count() == 3
+
+
+def test_federated_account_cannot_log_in_with_a_password(client, caplog) -> None:
+    # INVARIANT: a null password_hash is not a password — it is the absence of one.
+    # Login must refuse, and refuse INDISTINGUISHABLY from bad credentials so no
+    # federation-status enumeration oracle exists (same rule as SF-335).
+    async def _seed() -> None:
+        await _create_federated(username="cf-user")
+
+    client.portal.call(_seed)
+
+    with caplog.at_level(logging.INFO):
+        refused = client.post(
+            "/v1/auth/login",
+            json={"username": "cf-user", "password": "any-password-at-all"},
+        )
+    unknown = client.post(
+        "/v1/auth/login",
+        json={"username": "no-such-user", "password": "any-password-at-all"},
+    )
+
+    assert refused.status_code == 401
+    assert refused.json()["detail"]["code"] == "invalid_credentials"
+    assert (refused.status_code, refused.content) == (unknown.status_code, unknown.content)
+    assert any("cf-user" in record.getMessage() for record in caplog.records)
+
+
+def test_federated_account_rejects_the_public_dummy_password(client) -> None:
+    # INVARIANT: `verify_password_or_dummy` falls back to the hash of the PUBLIC
+    # constant `passwords._DUMMY_PASSWORD` when the stored hash is NULL. Submitting
+    # that constant verbatim therefore makes bcrypt return True. Login must refuse
+    # on the NULL itself, never on the verification result alone.
+    from aigateway.core.auth.passwords import _DUMMY_PASSWORD
+
+    async def _seed() -> None:
+        await _create_federated(username="cf-user")
+
+    client.portal.call(_seed)
+
+    response = client.post(
+        "/v1/auth/login",
+        json={"username": "cf-user", "password": _DUMMY_PASSWORD.decode()},
+    )
+
+    assert response.status_code == 401
+
+
+def test_local_accounts_still_log_in(client) -> None:
+    response = client.post(
+        "/v1/auth/login",
+        json={"username": "admin", "password": "test-admin-password"},
+    )
+
+    assert response.status_code == 200
+
+
+def test_account_out_exposes_email_and_never_the_hash(authenticated_client) -> None:
+    body = authenticated_client.get("/v1/auth/me").json()
+
+    assert "email" in body
+    assert "password_hash" not in body

--- a/apps/aigateway/tests/unit/auth/test_resolver_chain.py
+++ b/apps/aigateway/tests/unit/auth/test_resolver_chain.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from typing import Any
+
+import jwt
+import pytest
+from fastapi import Request
+
+from aigateway.core.auth.middleware import ANONYMOUS_ACCOUNT_ID, anonymous_account
+from aigateway.core.auth.models import BaseAccount
+from aigateway.core.auth.resolvers import IdentityResolver, LocalJwtResolver, Rejection
+
+
+class _StubResolver:
+    """Records invocation so chain-ordering assertions can prove short-circuiting."""
+
+    def __init__(self, name: str, outcome: BaseAccount | Rejection | None) -> None:
+        self.name = name
+        self._outcome = outcome
+        self.calls = 0
+
+    async def resolve(self, _request: Request) -> BaseAccount | Rejection | None:
+        self.calls += 1
+        return self._outcome
+
+
+def _install(client, *resolvers: Any) -> None:
+    client.app.state.identity_resolvers = list(resolvers)
+
+
+def test_stub_satisfies_the_identity_resolver_port() -> None:
+    # INVARIANT: the port is structural — adapters never inherit from a base class.
+    assert isinstance(_StubResolver("x", None), IdentityResolver)
+    assert isinstance(LocalJwtResolver(), IdentityResolver)
+
+
+def test_first_account_wins_and_later_resolvers_are_not_invoked(client) -> None:
+    winner = _StubResolver("winner", anonymous_account())
+    never = _StubResolver("never", anonymous_account())
+    _install(client, winner, never)
+
+    response = client.get("/v1/auth/me")
+
+    assert response.status_code == 200
+    assert response.json()["id"] == str(ANONYMOUS_ACCOUNT_ID)
+    assert winner.calls == 1
+    assert never.calls == 0
+
+
+def test_none_falls_through_to_the_next_resolver(client) -> None:
+    skipped = _StubResolver("skipped", None)
+    winner = _StubResolver("winner", anonymous_account())
+    _install(client, skipped, winner)
+
+    response = client.get("/v1/auth/me")
+
+    assert response.status_code == 200
+    assert skipped.calls == 1
+    assert winner.calls == 1
+
+
+def test_rejection_does_not_stop_a_later_resolver_from_authenticating(client) -> None:
+    # WHY: a Cloudflare token arrives in `Authorization: Bearer` too, so the local
+    # JWT resolver refusing it must not deny the CF resolver its turn.
+    rejecting = _StubResolver("rejecting", Rejection(detail="not mine"))
+    winner = _StubResolver("winner", anonymous_account())
+    _install(client, rejecting, winner)
+
+    response = client.get("/v1/auth/me")
+
+    assert response.status_code == 200
+    assert rejecting.calls == 1
+
+
+def test_recorded_rejection_surfaces_when_the_chain_is_exhausted(client) -> None:
+    _install(
+        client,
+        _StubResolver("a", Rejection(detail="precise reason")),
+        _StubResolver("b", None),
+    )
+
+    response = client.get("/v1/auth/me")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "precise reason"
+
+
+def test_first_rejection_wins_over_a_later_one(client) -> None:
+    _install(
+        client,
+        _StubResolver("a", Rejection(detail="first")),
+        _StubResolver("b", Rejection(detail="second")),
+    )
+
+    response = client.get("/v1/auth/me")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "first"
+
+
+def test_rejection_carries_its_own_status_code(client) -> None:
+    _install(client, _StubResolver("a", Rejection(detail="teapot", status_code=418)))
+
+    response = client.get("/v1/auth/me")
+
+    assert response.status_code == 418
+    assert response.json()["detail"] == "teapot"
+
+
+def test_exhausted_chain_without_a_rejection_is_a_generic_401(client) -> None:
+    _install(client, _StubResolver("a", None))
+
+    response = client.get("/v1/auth/me")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Missing bearer token"
+
+
+def test_empty_chain_is_a_generic_401(client) -> None:
+    _install(client)
+
+    response = client.get("/v1/auth/me")
+
+    assert response.status_code == 401
+
+
+def test_auth_disabled_short_circuits_ahead_of_the_chain(client) -> None:
+    # INVARIANT: the auth_enabled=False escape hatch stays in front of the chain;
+    # no resolver may observe a request the gateway is not authenticating at all.
+    never = _StubResolver("never", Rejection(detail="unreachable"))
+    _install(client, never)
+    client.app.state.settings.auth_enabled = False
+
+    response = client.get("/v1/auth/me")
+
+    assert response.status_code == 200
+    assert never.calls == 0
+
+
+def test_default_chain_is_registered_with_exactly_the_local_jwt_resolver(client) -> None:
+    resolvers = client.app.state.identity_resolvers
+
+    assert [r.name for r in resolvers] == ["local_jwt"]
+
+
+@pytest.mark.asyncio
+async def test_local_jwt_resolver_falls_through_on_a_non_hs256_token() -> None:
+    # WHY: Cloudflare Access signs RS256. The local resolver must decline those so
+    # the CF resolver (OME-591) gets its turn, rather than claiming and rejecting them.
+    token = jwt.encode({"sub": "x"}, "k" * 48, algorithm="HS384")
+
+    outcome = await LocalJwtResolver().resolve(_bearer_request(token))
+
+    assert outcome is None
+
+
+@pytest.mark.asyncio
+async def test_local_jwt_resolver_rejects_an_unparseable_bearer_token() -> None:
+    outcome = await LocalJwtResolver().resolve(_bearer_request("not-a-token"))
+
+    assert isinstance(outcome, Rejection)
+    assert "Invalid token" in str(outcome.detail)
+
+
+@pytest.mark.asyncio
+async def test_local_jwt_resolver_ignores_a_request_without_a_bearer_header() -> None:
+    outcome = await LocalJwtResolver().resolve(_request(headers=[]))
+
+    assert outcome is None
+
+
+def _bearer_request(token: str) -> Request:
+    return _request(headers=[(b"authorization", f"Bearer {token}".encode())])
+
+
+def _request(headers: list[tuple[bytes, bytes]]) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": headers,
+            "query_string": b"",
+        }
+    )

--- a/apps/aigateway/tests/unit/test_cf_access_settings.py
+++ b/apps/aigateway/tests/unit/test_cf_access_settings.py
@@ -1,0 +1,104 @@
+"""Fail-fast configuration for Cloudflare Access (OME-593).
+
+Every case here is a way the gateway could come up believing it is protected
+while actually admitting unauthenticated callers. They are startup errors on
+purpose: a misconfiguration that only shows up as a runtime 200 is worse than
+one that refuses to boot.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from aigateway.config import Settings
+
+_VALID = {
+    "AIGATEWAY_CF_ACCESS_ENABLED": "true",
+    "AIGATEWAY_CF_ACCESS_TEAM_DOMAIN": "myteam.cloudflareaccess.com",
+    "AIGATEWAY_CF_ACCESS_AUD": "a" * 64,
+}
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    for key in (
+        *_VALID,
+        "AIGATEWAY_AUTH_ENABLED",
+        "AIGATEWAY_CF_ACCESS_ADMIN_EMAILS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    return monkeypatch
+
+
+def _settings(_isolate_env, **env: str) -> Settings:
+    for key, value in env.items():
+        _isolate_env.setenv(key, value)
+    # type: ignore-free: Settings' generated __init__ has no _env_file param in
+    # its signature, so configure the source via model_config at call time.
+    return Settings()
+
+
+def test_disabled_by_default(_isolate_env) -> None:
+    settings = _settings(_isolate_env)
+
+    assert settings.cf_access_enabled is False
+    assert settings.cf_access_team_domain is None
+
+
+def test_valid_configuration_is_accepted(_isolate_env) -> None:
+    settings = _settings(_isolate_env, **_VALID)
+
+    assert settings.cf_access_enabled is True
+    assert settings.cf_access_team_domain == "myteam.cloudflareaccess.com"
+
+
+def test_enabling_cf_access_with_auth_disabled_refuses_to_start(_isolate_env) -> None:
+    # INVARIANT: the worst possible combination. auth_enabled=False makes
+    # current_account return anonymous_account() for EVERY caller, behind a
+    # gateway the operator believes Cloudflare is protecting.
+    with pytest.raises(ValidationError, match="AIGATEWAY_AUTH_ENABLED"):
+        _settings(_isolate_env, **_VALID, AIGATEWAY_AUTH_ENABLED="false")
+
+
+@pytest.mark.parametrize("missing", ["AIGATEWAY_CF_ACCESS_TEAM_DOMAIN", "AIGATEWAY_CF_ACCESS_AUD"])
+def test_enabling_without_team_domain_or_aud_refuses_to_start(_isolate_env, missing: str) -> None:
+    env = {key: value for key, value in _VALID.items() if key != missing}
+
+    with pytest.raises(ValidationError):
+        _settings(_isolate_env, **env)
+
+
+@pytest.mark.parametrize(
+    "bad_domain",
+    [
+        "https://myteam.cloudflareaccess.com",
+        "myteam.cloudflareaccess.com/cdn-cgi",
+        "attacker.com:8443",
+        "user@attacker.com",
+        "localhost",
+        "myteam.cloudflareaccess.com?x=1",
+    ],
+)
+def test_team_domain_must_be_a_bare_hostname(_isolate_env, bad_domain: str) -> None:
+    # INVARIANT: the JWKS URL is built by interpolating this value. Anything that
+    # can redirect key retrieval to an attacker-controlled host is a TOTAL auth
+    # bypass — the gateway would verify assertions the attacker signed.
+    env = {**_VALID, "AIGATEWAY_CF_ACCESS_TEAM_DOMAIN": bad_domain}
+
+    with pytest.raises(ValidationError):
+        _settings(_isolate_env, **env)
+
+
+def test_admin_emails_parse_from_a_comma_separated_list(_isolate_env) -> None:
+    settings = _settings(
+        _isolate_env,
+        **_VALID,
+        AIGATEWAY_CF_ACCESS_ADMIN_EMAILS=" Admin@Example.com , second@example.com ",
+    )
+
+    assert settings.cf_access_admin_email_set == {"admin@example.com", "second@example.com"}
+
+
+def test_admin_emails_default_to_empty(_isolate_env) -> None:
+    assert _settings(_isolate_env, **_VALID).cf_access_admin_email_set == frozenset()

--- a/apps/aigateway/tests/unit/test_credential_pool_shared_mode.py
+++ b/apps/aigateway/tests/unit/test_credential_pool_shared_mode.py
@@ -1,0 +1,229 @@
+"""Global (shared) credential pools — admin CRUD + shared-mode chat resolution.
+
+Covers docs/spec/2026-07-24-aigateway-shared-credential-pools-spec.md: admin-only
+pool management, the AIGATEWAY_CREDENTIAL_MODE=shared branch in
+chat_credentials.py, the 404 when no pool is configured, and that per-account
+usage attribution (account_id) is unaffected by which credential backs the call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+from tortoise import Tortoise
+
+from aigateway.db import build_tortoise_config
+from aigateway.main import create_app
+from tests.conftest import TEST_SECRET_KEY
+
+_HF_KEY = "hf_shared_pool_key_1234567890"
+_HF_MODEL = "huggingface/deepseek-ai/DeepSeek-R1:novita"
+
+
+def _account_id(client) -> str:
+    return client.get("/v1/auth/me").json()["id"]
+
+
+def _prepare_sqlite_db(database_url: str) -> None:
+    async def _prepare() -> None:
+        await Tortoise.close_connections()
+        await Tortoise.init(
+            config=build_tortoise_config(database_url), _enable_global_fallback=True
+        )
+        await Tortoise.generate_schemas()
+        await Tortoise.close_connections()
+
+    asyncio.run(_prepare())
+
+
+@pytest.fixture
+def shared_mode_client(monkeypatch, credential_blobs):
+    """Same wiring as the ``client``/``authenticated_client`` fixtures, but with
+    AIGATEWAY_CREDENTIAL_MODE=shared — the gateway-wide mode switch is read once
+    at Settings() construction inside create_app(), so it must be set before the
+    app is built."""
+    database_url = f"sqlite://{credential_blobs.db_path}"
+    monkeypatch.setenv("AIGATEWAY_DATABASE_URL", database_url)
+    monkeypatch.setenv("AIGATEWAY_ADMIN_PASSWORD", "test-admin-password")
+    monkeypatch.setenv("AIGATEWAY_JWT_SECRET", "x" * 32)
+    monkeypatch.setenv("AIGATEWAY_PROVISIONING_TOKEN", "p" * 32)
+    monkeypatch.setenv("AIGATEWAY_SECRET_KEY", base64.b64encode(TEST_SECRET_KEY).decode())
+    monkeypatch.setenv("AIGATEWAY_CREDENTIAL_MODE", "shared")
+    _prepare_sqlite_db(database_url)
+
+    with TestClient(create_app()) as test_client:
+        yield test_client
+    asyncio.run(Tortoise.close_connections())
+
+
+@pytest.fixture
+def shared_admin_client(shared_mode_client: TestClient) -> TestClient:
+    response = shared_mode_client.post(
+        "/v1/auth/login",
+        json={"username": "admin", "password": "test-admin-password"},
+    )
+    assert response.status_code == 200, response.text
+    shared_mode_client.headers.update({"Authorization": f"Bearer {response.json()['token']}"})
+    return shared_mode_client
+
+
+def _login_as(client: TestClient, username: str, password: str) -> None:
+    response = client.post("/v1/auth/login", json={"username": username, "password": password})
+    assert response.status_code == 200, response.text
+    client.headers.update({"Authorization": f"Bearer {response.json()['token']}"})
+
+
+@pytest.fixture
+def valid_api_key_validation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """This module is intentionally NOT on the legacy frozen-allowlist in
+    unit/conftest.py, so pool creation exercises the real ApiKeyValidationService
+    unless a test installs this explicit double (matches that file's own
+    convention for new API-key routes)."""
+    from aigateway.core.api_key_validation import (
+        ApiKeyValidationResult,
+        ApiKeyValidationStage,
+        ApiKeyValidationState,
+    )
+    from aigateway.core.api_key_validation_service import ApiKeyValidationService
+
+    async def _valid(_self, _plugin, _provider, _api_key):
+        return ApiKeyValidationResult(
+            state=ApiKeyValidationState.VALID,
+            stage=ApiKeyValidationStage.READINESS,
+        )
+
+    monkeypatch.setattr(ApiKeyValidationService, "validate", _valid)
+
+
+# --- admin gating ---
+
+
+def test_create_pool_requires_authentication(client: TestClient) -> None:
+    resp = client.post(
+        "/v1/admin/credential-pools",
+        json={"provider": "huggingface", "api_key": _HF_KEY},
+    )
+    assert resp.status_code == 401
+
+
+def test_create_pool_rejects_non_admin_account(
+    authenticated_client: TestClient, provisioned_user_factory
+) -> None:
+    provisioned_user_factory("regular-user", "regular-pass1")
+    _login_as(authenticated_client, "regular-user", "regular-pass1")
+
+    resp = authenticated_client.post(
+        "/v1/admin/credential-pools",
+        json={"provider": "huggingface", "api_key": _HF_KEY},
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"]["code"] == "admin_required"
+
+
+# --- admin CRUD (bootstrap "admin" account is is_admin=True) ---
+
+
+def test_admin_can_create_list_patch_delete_pool(
+    authenticated_client: TestClient, valid_api_key_validation: None
+) -> None:
+    create = authenticated_client.post(
+        "/v1/admin/credential-pools",
+        json={"provider": "huggingface", "api_key": _HF_KEY},
+    )
+    assert create.status_code == 201, create.text
+    body = create.json()
+    assert body["provider"] == "huggingface"
+    assert body["auth_type"] == "api_key"
+    assert body["is_active"] is True
+    assert _HF_KEY not in create.text
+    pool_id = body["id"]
+
+    listed = authenticated_client.get("/v1/admin/credential-pools")
+    assert listed.status_code == 200
+    assert any(p["id"] == pool_id for p in listed.json()["pools"])
+
+    # A second active pool for the same provider conflicts.
+    conflict = authenticated_client.post(
+        "/v1/admin/credential-pools",
+        json={"provider": "huggingface", "api_key": _HF_KEY},
+    )
+    assert conflict.status_code == 409
+
+    deactivated = authenticated_client.patch(
+        f"/v1/admin/credential-pools/{pool_id}", json={"is_active": False}
+    )
+    assert deactivated.status_code == 200
+    assert deactivated.json()["is_active"] is False
+
+    deleted = authenticated_client.delete(f"/v1/admin/credential-pools/{pool_id}")
+    assert deleted.status_code == 204
+    assert authenticated_client.get(f"/v1/admin/credential-pools/{pool_id}").status_code == 404
+
+
+# --- shared-mode chat resolution ---
+
+
+def test_chat_shared_mode_without_pool_returns_actionable_404(
+    shared_mode_client: TestClient, provisioned_user_factory
+) -> None:
+    provisioned_user_factory("alice", "alice-pass1")
+    _login_as(shared_mode_client, "alice", "alice-pass1")
+
+    resp = shared_mode_client.post(
+        "/v1/chat/completions",
+        json={"model": _HF_MODEL, "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["code"] == "credential_pool_not_configured"
+    assert resp.json()["detail"]["provider"] == "huggingface"
+
+
+def test_chat_shared_mode_uses_pool_credential_for_every_account(
+    shared_admin_client: TestClient,
+    provisioned_user_factory,
+    valid_api_key_validation: None,
+) -> None:
+    create = shared_admin_client.post(
+        "/v1/admin/credential-pools",
+        json={"provider": "huggingface", "api_key": _HF_KEY},
+    )
+    assert create.status_code == 201, create.text
+
+    provisioned_user_factory("alice", "alice-pass1")
+    provisioned_user_factory("bob", "bob-pass1")
+
+    captured_keys: list[str] = []
+    captured_account_ids: list[str] = []
+
+    async def fake_chat_completion(_self, body):
+        captured_keys.append(body.get("api_key"))
+        return SimpleNamespace(
+            model_dump=lambda: {"id": "x", "choices": [{"message": {"content": "ok"}}]}
+        )
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "aigateway.core.plugin_base.ProviderPluginBase.chat_completion",
+            fake_chat_completion,
+        )
+        for username, password in (("alice", "alice-pass1"), ("bob", "bob-pass1")):
+            _login_as(shared_admin_client, username, password)
+            captured_account_ids.append(_account_id(shared_admin_client))
+            resp = shared_admin_client.post(
+                "/v1/chat/completions",
+                json={"model": _HF_MODEL, "messages": [{"role": "user", "content": "hi"}]},
+            )
+            assert resp.status_code == 200, resp.text
+
+    # Both distinct accounts dispatched through the SAME shared key...
+    assert len(captured_keys) == 2
+    assert captured_keys[0] == _HF_KEY
+    assert captured_keys[1] == _HF_KEY
+    # ...yet each request is still attributable to its own, distinct account —
+    # credential mode never touches request attribution (core/auth/middleware.py's
+    # current_account() is unaffected by credential_mode).
+    assert len(set(captured_account_ids)) == 2

--- a/apps/aigateway/tests/unit/test_migration_external_identity.py
+++ b/apps/aigateway/tests/unit/test_migration_external_identity.py
@@ -1,0 +1,98 @@
+"""Migration 0010 must produce real DDL and destroy no data (OME-590).
+
+Companion to `test_migration_populated_db` (whose `_migrate` helper is reused
+rather than duplicated); kept in its own module so the append-only test rule
+holds. Both exist because the unit suite builds schemas with
+`Tortoise.generate_schemas()`, which never executes a migration file — so a
+migration can be wrong in ways the rest of the suite is structurally blind to.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from .test_migration_populated_db import _migrate
+
+
+def test_0010_creates_real_indexes_and_preserves_rows(tmp_path: Path) -> None:
+    """Two Tortoise operations look like they emit DDL and do not.
+
+    `AlterModelOptions` is state-only (its `database_forward` returns None), so
+    it would register `unique_together` with no constraint in the database; and
+    `AddField(db_index=True)` updates state without a `CREATE INDEX`. Either one
+    leaves generate_schemas-built test databases correct and every *migrated*
+    database wrong — so assert against `sqlite_master` directly.
+
+    OME-591's concurrent JIT provisioning depends on the unique constraint being
+    real: without it, two simultaneous first requests from one user silently
+    create two accounts instead of raising IntegrityError.
+    """
+    db = tmp_path / "external_identity.sqlite3"
+    url = f"sqlite://{db}"
+
+    _migrate(url, "models", "0009_global_credential_pools")
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "insert into accounts (id, username, password_hash, created_at, is_active)"
+            " values ('a1', 'legacy-local-user', 'hashed', datetime('now'), 1)"
+        )
+
+    _migrate(url)
+
+    with sqlite3.connect(db) as conn:
+        indexes = {
+            row[0]
+            for row in conn.execute(
+                "select name from sqlite_master where tbl_name='accounts' and type='index'"
+            )
+        }
+        columns = {row[1]: row for row in conn.execute("pragma table_info(accounts)")}
+        preserved = conn.execute(
+            "select password_hash from accounts where username = 'legacy-local-user'"
+        ).fetchone()[0]
+
+    assert "uid_accounts_external_identity" in indexes
+    assert "idx_accounts_email" in indexes
+    assert columns["password_hash"][3] == 0, "password_hash must become NULLable"
+    assert preserved == "hashed", "widening to NULL must not disturb existing local accounts"
+
+
+def test_0010_does_not_cascade_delete_dependent_rows(tmp_path: Path) -> None:
+    """INVARIANT: no migration may destroy user data.
+
+    SQLite cannot alter a column's nullability, so Tortoise rebuilds the table:
+    CREATE new / INSERT SELECT / **DROP TABLE accounts** / RENAME. That DROP
+    carries no FK guard, so under the default `PRAGMA foreign_keys=ON` it fires
+    ON DELETE CASCADE across every child row — `oauth_connections` and
+    `global_credential_pools` are silently emptied by a migration that reports
+    OK. 0010 therefore runs non-atomically with the pragma disabled around the
+    rebuild.
+
+    Asserted on `global_credential_pools` specifically: the sibling test covers
+    oauth_connections, and this is the newer FK most likely to be forgotten.
+    """
+    db = tmp_path / "cascade.sqlite3"
+    url = f"sqlite://{db}"
+
+    _migrate(url, "models", "0009_global_credential_pools")
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "insert into accounts (id, username, password_hash, created_at, is_active)"
+            " values ('a1', 'pool-admin', 'hashed', datetime('now'), 1)"
+        )
+        conn.execute(
+            "insert into global_credential_pools"
+            " (id, provider, label, auth_type, is_active, created_at, updated_at, created_by_id)"
+            " values ('p1', 'anthropic', 'default', 'api_key', 1,"
+            " datetime('now'), datetime('now'), 'a1')"
+        )
+
+    _migrate(url)
+
+    with sqlite3.connect(db) as conn:
+        pools = conn.execute("select id, created_by_id from global_credential_pools").fetchall()
+        accounts = conn.execute("select count(*) from accounts").fetchone()[0]
+
+    assert pools == [("p1", "a1")], "the accounts rebuild must not cascade-delete child rows"
+    assert accounts == 1

--- a/docs/plan/2026-07-24-aigateway-cloudflare-access-auth.md
+++ b/docs/plan/2026-07-24-aigateway-cloudflare-access-auth.md
@@ -1,0 +1,96 @@
+# Plan — AIGateway federated authentication via Cloudflare Access
+
+> Spec: `docs/spec/2026-07-24-aigateway-cloudflare-access-auth-spec.md` · Epic: OME-588
+
+Five SDLC units, strictly ordered — each is independently committable and leaves the suite
+green. Units 1–2 are prerequisites for 3; 4 depends on 1; 5 wires everything on last so no
+intermediate commit can half-enable the feature.
+
+## Unit 1 — OME-589 · IdentityResolver chain
+
+**Create**
+- `core/auth/resolvers/__init__.py` — exports the port + `build_default_resolvers()`
+- `core/auth/resolvers/base.py` — `IdentityResolver` Protocol
+- `core/auth/resolvers/local_jwt.py` — `LocalJwtResolver` (today's logic, moved)
+
+**Modify**
+- `core/auth/middleware.py` — `current_account()` drives `app.state.identity_resolvers`
+- `main.py` — build and register the chain on `app.state`
+
+**Tests** `tests/unit/auth/test_resolver_chain.py` — order, fall-through on `None`,
+short-circuit on `HTTPException`, exhausted → 401, `auth_enabled=False` bypasses the chain.
+
+**Contract:** every existing auth test passes unmodified.
+
+## Unit 2 — OME-590 · Account external identity
+
+**Modify**
+- `core/auth/models/account.py` — `external_idp`, `external_subject`, `email`,
+  `unique_together`, nullable `password_hash`
+- `routes/auth_session.py` — `login()` rejects null-hash accounts (generic 401 + server log)
+- `core/auth/schemas.py` — `AccountOut` gains `email`
+
+**Create**
+- `migrations/0010_account_external_identity.py` (idiom: `0008`/`0009` — built-in Tortoise
+  migrations, `ops.AddField` / `ops.AlterField`; never Aerich)
+
+**Tests** `tests/unit/auth/test_federated_account_login.py` — null-hash login → generic 401
++ logged; duplicate `(idp, sub)` → IntegrityError; local accounts unaffected.
+
+## Unit 3 — OME-591 · Cloudflare Access resolver
+
+**Create**
+- `core/auth/cf_access/__init__.py`
+- `core/auth/cf_access/jwks.py` — `kid`-aware cache, fetch timeout, stale-on-error
+- `core/auth/cf_access/verifier.py` — RS256 + `iss`/`aud`/`exp`
+- `core/auth/cf_access/identity.py` — claims → `(idp, subject, email)`
+- `core/auth/cf_access/provisioning.py` — `get_or_create_cf_access_account`
+- `core/auth/cf_access/resolver.py` — `CfAccessResolver`
+
+**Modify**
+- `core/auth/log_filter.py` — redact CF assertions + client secrets
+- `main.py` — register the resolver when enabled
+
+**Tests** `tests/unit/auth/cf_access/` — fixed RSA keypair fixture, fake JWKS. Covers valid
+IdP token, valid service token, `kid` rotation, `aud`/`iss` mismatch, expired, `alg:none`,
+JWKS outage with warm cache, concurrent-provisioning race, admin allowlist.
+
+## Unit 4 — OME-592 · Gateway API keys
+
+**Create**
+- `core/auth/models/api_key.py` — `ApiKey`
+- `core/auth/api_keys.py` — generate / hash / parse (`aigw_<base62>`, SHA-256)
+- `core/auth/resolvers/api_key.py` — `ApiKeyResolver`
+- `routes/api_keys.py` — mint / list / revoke
+- `migrations/0011_api_keys.py`
+
+**Modify** `db.py` is unchanged (`aigateway.core.auth.models` already registered);
+`main.py` includes the router and appends the resolver.
+
+**Tests** `tests/unit/auth/test_api_keys.py` — mint→use→revoke, expiry, inactive account,
+listing never leaks material, plaintext unrecoverable after creation.
+
+## Unit 5 — OME-593 · Config, startup validation, chart
+
+**Modify**
+- `config.py` — the five `cf_access_*` / `api_keys_*` settings + validators
+- `main.py` — fail-fast lifespan checks
+- `charts/aigateway/values.yaml` + `templates/deployment.yaml`
+- `apps/aigateway/docs/` — operator runbook (Access app setup, Service Auth policy, AUD
+  retrieval, **origin-isolation requirement**)
+
+**Tests** `tests/unit/test_cf_access_settings.py` — every invalid combination raises;
+defaults preserve current behavior.
+
+## Gates (per unit, from `.claude/sdlc.local.md`)
+
+`uv run .claude/scripts/run_gates.py aigateway` — ruff check · ruff format --check · pyright
+· `check_no_enterprise.py` · pytest with `--cov-fail-under=80`.
+
+## Known process deviation
+
+`.claude/sdlc.local.md` marks the `tortoise-dev` companion skill `mandatory: true` for
+Tortoise work; it is **not installed** in this environment. Units 2 and 4 follow the
+migration idioms observed directly in `migrations/0008` and `0009` instead (built-in
+Tortoise migrations, model-per-file, abstract `Base*` model + concrete table subclass).
+Flagged to the owner.

--- a/docs/spec/2026-07-24-aigateway-cloudflare-access-auth-spec.md
+++ b/docs/spec/2026-07-24-aigateway-cloudflare-access-auth-spec.md
@@ -1,0 +1,186 @@
+# Spec — AIGateway federated authentication via Cloudflare Access
+
+> Epic: [OME-588](https://linear.app/openmined/issue/OME-588). Units: OME-589 … OME-593.
+
+## Problem
+
+AIGateway's only authentication path is a local password login. `current_account()`
+(`core/auth/middleware.py:28-52`) accepts exactly one credential shape — an HS256
+`Authorization: Bearer` token minted by `POST /v1/auth/login`
+(`routes/auth_session.py:22-52`) — and accounts exist only because an operator called
+`POST /v1/accounts` with the static `X-Aigw-Provisioning-Token`
+(`routes/accounts.py:76-94`). The single "everyone gets in" escape hatch is
+`auth_enabled=False`, which collapses every caller onto `anonymous_account()` and destroys
+per-account attribution.
+
+We want to deploy AIGateway behind **Cloudflare Access**, which already enforces an admission
+policy (OTP/PIN, or a corporate IdP) and only forwards requests from users that policy
+admits. Those users must reach the gateway **without registering and without calling
+`/v1/auth/login`** — the account should materialise from the identity Cloudflare asserts.
+Some callers are humans in a browser, some are humans at a CLI, and some are programmatic SDK
+clients that cannot complete an interactive flow.
+
+## Goals
+
+- A user admitted by Cloudflare Access reaches every authenticated route with **zero
+  registration steps**, and gets an `Account` row created just-in-time on first request.
+- Programmatic SDK clients authenticate **non-interactively** and remain individually
+  attributable — not collapsed onto one shared machine identity.
+- The existing local-login path keeps working byte-for-byte, so local dev and
+  non-Cloudflare deployments are unaffected.
+- No fail-open path. Every misconfiguration that could admit an unauthenticated caller is
+  rejected at startup, not at request time.
+
+## Non-goals
+
+- Replacing or deprecating `/v1/auth/login`. Both paths coexist.
+- Supporting identity providers other than Cloudflare Access in this epic. The resolver port
+  makes a second federated provider additive, but none is built here.
+- Cloudflare Access for SaaS / OIDC app types. This spec covers **self-hosted** Access
+  applications only.
+
+## How Cloudflare Access delivers identity
+
+Two separable things happen, and conflating them is the classic implementation error.
+
+**1. Edge admission.** Access evaluates the policy and decides whether the request reaches the
+origin at all. It accepts, by client type:
+
+| Client | Credential presented to the edge |
+|---|---|
+| Browser | `CF_Authorization` cookie (set by the login redirect) |
+| Human CLI | `cf-access-token: <jwt>` (from `cloudflared access token -app=<url>`) |
+| Machine | `CF-Access-Client-Id` + `CF-Access-Client-Secret` |
+
+Service tokens require the Access policy action to be **Service Auth**; with any other action
+Access redirects to an IdP login instead of honouring the token pair.
+
+**2. Identity assertion to the origin.** On success Access injects
+`Cf-Access-Jwt-Assertion: <jwt>` — RS256, JWKS at
+`https://<team>.cloudflareaccess.com/cdn-cgi/access/certs`,
+`iss = https://<team>.cloudflareaccess.com`, `aud` = the per-application AUD tag. Cloudflare
+rotates the signing key every 6 weeks and serves the current **and** previous key with a
+7-day grace window.
+
+Claim shape differs by admission path:
+
+| Path | `sub` | `email` | `common_name` |
+|---|---|---|---|
+| IdP login | Access user UUID (stable) | present | absent |
+| Service token | empty | absent | client ID |
+
+> **Open verification item.** The service-token claim shape above is not stated on
+> Cloudflare's JWT-validation docs page. It must be confirmed against a real service-token
+> assertion during OME-591 before the mapping is trusted.
+
+## Threat model — the load-bearing constraint
+
+`Cf-Access-Jwt-Assertion` is an ordinary HTTP header. **If the origin is reachable off-path,
+anyone can forge it and the entire scheme is worthless.** This is the single most important
+property of the deployment, and it is an infrastructure property, not a code property:
+
+- Ingress must be `cloudflared` tunnel only (AIGateway is already ClusterIP-only, and Envoy
+  deliberately does not route to it), or the CF proxy plus Authenticated Origin Pulls.
+- The gateway therefore **never** trusts the *presence* of the header. It independently
+  verifies signature, `iss`, `aud`, and `exp` on every request. Edge verification and origin
+  verification are separate layers, and the origin's layer is the one that survives a
+  misrouted network or a future ingress change.
+
+Second fail-open path, closed at startup: `cf_access_enabled=true` together with
+`auth_enabled=false` would make `current_account()` return `anonymous_account()` for
+everyone, behind a gateway the operator believes is federated. That combination raises at
+startup.
+
+## Design — two header planes, one resolver chain
+
+Clients satisfy two independent planes. The gateway only ever reasons about the second.
+
+- **Edge plane:** whatever Cloudflare needs (`CF-Access-Client-Id`/`-Secret`, or
+  `cf-access-token`).
+- **App plane:** `Authorization: Bearer <token>`, plus the header/cookie Access injects.
+
+`current_account()` becomes a thin driver over an ordered chain of resolvers:
+
+```python
+class IdentityResolver(Protocol):
+    name: str
+    async def resolve(self, request: Request) -> BaseAccount | None: ...
+```
+
+- Return `None` → "not my credential", fall through to the next resolver.
+- Raise `HTTPException` → "my credential, and it is invalid", short-circuit the chain.
+- Chain exhausted → 401.
+
+Registration order (`main.py`, registry-wired — core never imports adapters, per the
+hexagonal rule in the root `CLAUDE.md`):
+
+1. **`LocalJwtResolver`** — today's HS256 logic, moved verbatim.
+2. **`CfAccessResolver`** — `Cf-Access-Jwt-Assertion` header → `CF_Authorization` cookie →
+   `Authorization: Bearer`. Verifies, then JIT-provisions.
+3. **`ApiKeyResolver`** — gateway-issued `aigw_*` keys.
+
+The `auth_enabled=False` short-circuit stays *ahead* of the chain, unchanged.
+
+### Just-in-time provisioning
+
+`accounts` gains `external_idp`, `external_subject` (unique together), and `email`;
+`password_hash` becomes nullable.
+
+**Identity key is `(idp, sub)` — never email.** CF `sub` is a stable Access user UUID; email
+is mutable at the IdP and can be reassigned to a different human. For service tokens the key
+is `common_name`.
+
+**INVARIANT — a federated account cannot password-login.** `login()` explicitly rejects an
+account with a null `password_hash`, returning the same generic `_INVALID_CREDENTIALS` 401 as
+any other failure (no enumeration oracle, matching the existing SF-335 treatment of inactive
+accounts) and logging the refusal server-side. A random-bcrypt sentinel is deliberately
+*rejected* as the mechanism: an explicit null plus an explicit check is auditable, whereas a
+sentinel silently becomes a live password the day someone backfills the column.
+
+**Concurrency.** Two concurrent first requests from one user is the normal case for an SDK
+with a connection pool, not an edge case. Provisioning is `get_or_create` guarded by the
+`(external_idp, external_subject)` unique constraint with an `IntegrityError` re-read.
+
+**Admin bootstrap.** The first federated user is nobody's admin. `is_admin` is granted at
+provisioning time from the `AIGATEWAY_CF_ACCESS_ADMIN_EMAILS` allowlist and stays
+gateway-owned thereafter. Cloudflare policy decides *reachability*; AIGateway decides
+*authority*.
+
+### Programmatic clients
+
+A Cloudflare service token identifies the **token**, not a person. Machine traffic sharing one
+service token therefore collapses onto a single identity — which directly breaks usage
+attribution for the in-flight `credential_mode: shared` work, where attribution comes from
+`current_account()`.
+
+Resolution: after JIT provisioning, a user mints a gateway API key
+(`POST /v1/auth/api-keys` → `aigw_<base62>`). The SDK then presents **both** planes — the
+service token to satisfy the edge, and `Authorization: Bearer aigw_...` to identify the human
+to the gateway. This yields per-user attribution under a shared edge token, revocation
+independent of Cloudflare, and gateway auth that outlives the CF session. It also degrades
+cleanly: the same SDK works against a local AIGateway with no Cloudflare in front of it.
+
+Keys are stored **hashed with SHA-256**, not bcrypt. These are high-entropy random tokens, not
+user-chosen passwords, so a work factor buys no meaningful brute-force resistance and costs
+real latency on every request.
+
+## Units
+
+| Unit | Scope |
+|---|---|
+| OME-589 | `IdentityResolver` port + registry + `LocalJwtResolver` (behavior-preserving) |
+| OME-590 | `accounts` external-identity columns, nullable `password_hash`, migration `0010` |
+| OME-591 | `CfAccessResolver`: JWKS client, verifier, JIT provisioning, log redaction |
+| OME-592 | `ApiKey` model + routes + `ApiKeyResolver`, migration `0011` |
+| OME-593 | Settings, fail-fast startup validation, Helm values, operator runbook |
+
+## Acceptance
+
+- With `cf_access_enabled=false`, behavior is unchanged and every pre-existing auth test
+  passes unmodified.
+- With CF enabled, a request carrying a valid Access assertion and no prior account returns
+  200 and creates exactly one `accounts` row; a concurrent duplicate creates no second row.
+- Forged/expired/wrong-`aud`/wrong-`iss`/`alg:none` assertions return 401.
+- A JWKS outage does not 401 requests whose `kid` is already cached.
+- A minted `aigw_*` key authenticates; revoking it returns 401 on the next request.
+- `cf_access_enabled=true` with `auth_enabled=false` fails to start.

--- a/docs/spec/2026-07-24-aigateway-shared-credential-pools-spec.md
+++ b/docs/spec/2026-07-24-aigateway-shared-credential-pools-spec.md
@@ -1,0 +1,182 @@
+# Spec — AIGateway shared (global) credential pools
+
+> Linear filing deferred by owner for this unit — see `docs/work/2026-07-24-aigateway-shared-credential-pools.md`.
+
+## Problem
+
+Today every LLM credential in AIGateway is hard-scoped to a single `Account`:
+`OAuthConnection.unique_together` includes `account_id`
+(`core/oauth/models/oauth_connection.py:36-52`), every credential lookup is keyed by
+`credential_key_for(account_id, connection_id)` (`core/oauth/store.py:18-30`), and
+`current_account()` (`core/auth/middleware.py:13-55`) resolves exactly one `Account` per
+request from the JWT. There is no way to give a group of users a shared provider key while
+keeping auth on — the only "everyone shares" path is `auth_enabled=False`, which collapses
+every caller onto `anonymous_account()` and loses per-user attribution entirely.
+
+We want admins able to provision one credential per provider that all authenticated accounts
+use, while every request stays attributable to the real calling account (usage/audit
+isolation unaffected by which credential backs the call).
+
+## Goals
+
+- A gateway-wide **shared-keys mode**, opt-in via config, alongside the current per-account
+  **BYOK mode** — one instance runs in exactly one mode at a time.
+- Admin-managed **global credential pools**: one active credential per provider, stored
+  through the existing `ORMStore`/`credential_blobs` path (no new secret backend — hard
+  guardrail in `apps/aigateway/CLAUDE.md`).
+- Per-account usage/audit attribution (logs, `RequestCacheEntry.account_id`) is unchanged in
+  shared mode — credential resolution and request attribution are already separate layers;
+  this design keeps them separate.
+- Minimal `Account.is_admin` flag to gate pool management endpoints.
+
+## Non-goals
+
+- Per-account fallback logic (try personal key, fall back to pool). Rejected explicitly —
+  the owner wants two distinct, non-overlapping deployment modes, not per-request resolution
+  branching.
+- Per-provider mode granularity (e.g. `openai` shared, `anthropic` BYOK on the same
+  instance). `credential_mode` is a single instance-wide setting for this iteration; the
+  branch point is already provider-scoped so this is a straightforward later extension, not
+  a redesign.
+- Multiple pools per provider / key rotation-with-overlap / round-robin. The `label` field
+  on `GlobalCredentialPool` exists so this is additive later, not blocked.
+- Per-user quota or rate-limiting on top of a shared key. Usage stays *visible* per account
+  (existing logging/cache indexing); nothing throttles one account from exhausting a shared
+  key. Separate feature if ever needed.
+
+## Design
+
+### Config — the mode switch
+
+`config.py` `Settings` gains, mirroring `secret_provider` (`config.py:48`):
+
+```python
+credential_mode: Literal["byok", "shared"] = Field(
+    default="byok", validation_alias="AIGATEWAY_CREDENTIAL_MODE"
+)
+```
+
+Loaded once at `main.py:221` into `app.state.settings`, same lifecycle as `auth_enabled` /
+`secret_provider`. Default `"byok"` — existing deployments are unaffected until an admin
+opts in.
+
+### Data model
+
+New package `core/credential_pool/` (mirrors `core/oauth/` layout):
+
+```
+core/credential_pool/
+  models/global_credential_pool.py   # GlobalCredentialPool
+  store.py                           # global_pool_credential_locator_for()
+  routes.py                          # admin CRUD
+```
+
+**`GlobalCredentialPool`**:
+
+| field | type | notes |
+|---|---|---|
+| `id` | UUID pk | |
+| `provider` | str | matches `ProviderRegistry` key (`core/registry.py:6-26`) |
+| `auth_type` | str | `"api_key"` \| `"oauth"` — reuse existing `AuthType` |
+| `label` | str, default `"default"` | forward-compat for multi-pool-per-provider; this iteration only resolves `"default"` |
+| `is_active` | bool, default True | soft-disable without deleting |
+| `created_by` | FK → `Account`, `on_delete=RESTRICT` | audit trail of provisioning admin |
+| `created_at` / `updated_at` | datetime | |
+
+`Meta.unique_together = (("provider", "label"),)`.
+
+Migration `NNNN_global_credential_pools.py`, modeled on `migrations/0002_oauth_connections.py`.
+Register `aigateway.core.credential_pool.models` in `db.py:20-26`'s
+`apps.models.models` list.
+
+**Secret storage** — no new table for the secret. Reuse `CredentialBlobStore`/`ORMStore` via
+a locator parallel to `credential_key_for`/`credential_locator_for`
+(`core/oauth/store.py:18-30`):
+
+```python
+def global_pool_credential_key_for(pool_id: str | UUID) -> str:
+    return f"pool:{pool_id}"
+
+def global_pool_credential_locator_for(provider: str, pool_id: str | UUID) -> dict[str, str]:
+    return {
+        "service": f"aigateway:{provider}:{global_pool_credential_key_for(pool_id)}",
+        "account": DEFAULT_CREDENTIAL_ACCOUNT,
+    }
+```
+
+This is the same shape `ApiKeyStrategy` (`core/api_key_strategy.py:31-96`) and the OAuth
+strategy already consume — no change needed to either. The `profile_name` fed into
+`credential_strategy_from` becomes `pool:{pool_id}` instead of `{account_id}:{connection_id}`.
+
+**`Account.is_admin`**: add `is_admin: bool = fields.BooleanField(default=False)` to
+`BaseAccount` (`core/auth/models/account.py:9-25`) via a small migration. Gates the
+pool-management routes only.
+
+### Resolution — the one seam that changes request behavior
+
+`_credential_target_for_chat` (`routes/chat_credentials.py:115-164`) is where a request today
+resolves which connection to use: Profile lookup first, else
+`_active_oauth_connection_for_profile` (`chat_credentials.py:70-112`) filtered by
+`account_id` + `provider` + label.
+
+Branch at the top of `_credential_target_for_chat` on
+`request.app.state.settings.credential_mode`:
+
+- **`"byok"`**: existing logic, unchanged.
+- **`"shared"`**: skip `ProfileIndexStore` and `_active_oauth_connection_for_profile`
+  entirely — `account_id` is not consulted for credential resolution. New
+  `_active_global_pool_for_provider(request, provider)`:
+  - `GlobalCredentialPool.filter(provider=provider, label="default", is_active=True).first()`
+  - 404 with an actionable message
+    (`"no shared credential configured for provider={provider}; contact an admin"`) if none
+    exists — consistent with the actionable-API-key-validation work already shipped
+    (`66deae0a`).
+  - Returns the same target shape `_credential_target_for_chat` already returns today, with
+    `profile_name = global_pool_credential_key_for(pool.id)` and `auth_type = pool.auth_type`.
+    *(Implementer: read the exact current return type before writing this — match it, don't
+    guess.)*
+
+**Usage isolation requires no new code.** `current_account(request)`
+(`core/auth/middleware.py:13-55`) still resolves the real per-request account from the JWT
+regardless of credential mode; `chat.py:88`'s `account_id = str(current.id)` and
+`RequestCacheEntry.account_id` (`core/request_cache/models/request_cache_entry.py:32-36`)
+are untouched. Credential mode only changes which secret backs the outbound call — it never
+touches request attribution, because those are already separate layers in the current code.
+
+### Admin API
+
+Admin-gated (`current.is_admin`) routes mirroring the existing personal-connection CRUD
+pattern in `routes/oauth_connections.py` (exemplar; implementer reads it and its test file
+`tests/unit/test_oauth_connections_routes.py` before writing — don't reinvent the
+request/response shapes):
+
+- `POST /admin/credential-pools` — `{provider, auth_type, credentials}` → creates the
+  `GlobalCredentialPool` row + writes the secret via
+  `ORMStore.write(*global_pool_credential_locator_for(...))`.
+- `GET /admin/credential-pools` — list, secret material redacted (same discipline as OAuth
+  connection listing).
+- `PATCH /admin/credential-pools/{id}` — toggle `is_active`, rotate the secret.
+- `DELETE /admin/credential-pools/{id}` — deletes row + `credential_blobs` entry.
+
+## Security & failure story
+
+- **No new secret backend.** Pool secrets go through the identical `ORMStore` →
+  `credential_blobs` → `SecretStoreMixin` (AES-256-GCM) path as every other credential in
+  the gateway — satisfies the mandatory guardrail.
+- **Admin surface is minimal and additive.** `is_admin` gates only the four pool-management
+  routes; no other endpoint's authorization changes.
+- **Failure mode when misconfigured:** shared mode with no pool row for a provider fails
+  closed with a 404 naming the provider — never silently falls back to BYOK or to an
+  anonymous/no-auth path.
+- **Blast radius of a compromised shared key:** identical to today's blast radius of a
+  compromised personal key (same storage, same encryption, same revocation path — disable
+  or delete the pool row) — this design does not introduce a new class of credential
+  exposure, it changes cardinality (one key, many accounts) not mechanism.
+
+## Trade-offs
+
+- Instance-wide mode, not per-provider — simpler now, extensible later (branch point is
+  already provider-scoped).
+- Single active pool per provider — no rotation-with-overlap or load balancing yet; `label`
+  field leaves room.
+- No per-user quota on a shared key — usage is visible, not throttled, per account.

--- a/docs/tasks/2026-07-24-ome-588-aigateway-cloudflare-access-auth.md
+++ b/docs/tasks/2026-07-24-ome-588-aigateway-cloudflare-access-auth.md
@@ -1,0 +1,18 @@
+---
+id: OME-588
+linear_url: https://linear.app/openmined/issue/OME-588
+status: Backlog
+type: Epic
+priority: P2
+labels: [aigateway, autonomous, agentic]
+parent: 
+created: 2026-07-24
+closed:
+---
+
+# Cloudflare Access federated authentication for aigateway
+
+Run aigateway behind Cloudflare Access: users admitted by the edge policy get accounts provisioned just-in-time from the verified identity assertion, with no registration and no /v1/auth/login. Programmatic SDK clients authenticate non-interactively while staying individually attributable.
+
+Spec: `docs/spec/2026-07-24-aigateway-cloudflare-access-auth-spec.md`
+Plan: `docs/plan/2026-07-24-aigateway-cloudflare-access-auth.md`

--- a/docs/tasks/2026-07-24-ome-589-identity-resolver-chain.md
+++ b/docs/tasks/2026-07-24-ome-589-identity-resolver-chain.md
@@ -1,0 +1,18 @@
+---
+id: OME-589
+linear_url: https://linear.app/openmined/issue/OME-589
+status: Backlog
+type: Refactor
+priority: P2
+labels: [aigateway, autonomous, agentic]
+parent: OME-588
+created: 2026-07-24
+closed:
+---
+
+# Refactor current_account into an ordered IdentityResolver chain
+
+Behavior-preserving: replace the if-tree in current_account with an ordered resolver chain so Cloudflare Access and API-key credentials become additive. Every existing auth test must pass unmodified.
+
+Spec: `docs/spec/2026-07-24-aigateway-cloudflare-access-auth-spec.md`
+Plan: `docs/plan/2026-07-24-aigateway-cloudflare-access-auth.md`

--- a/docs/tasks/2026-07-24-ome-590-account-external-identity.md
+++ b/docs/tasks/2026-07-24-ome-590-account-external-identity.md
@@ -1,0 +1,18 @@
+---
+id: OME-590
+linear_url: https://linear.app/openmined/issue/OME-590
+status: Backlog
+type: Feature
+priority: P2
+labels: [aigateway, autonomous, agentic]
+parent: OME-588
+created: 2026-07-24
+closed:
+---
+
+# Add external-identity columns to accounts and make password_hash nullable
+
+accounts gains external_idp + external_subject (unique together) and email; password_hash becomes nullable. INVARIANT: login() explicitly rejects null-hash accounts with the generic 401 — federated accounts cannot password-login.
+
+Spec: `docs/spec/2026-07-24-aigateway-cloudflare-access-auth-spec.md`
+Plan: `docs/plan/2026-07-24-aigateway-cloudflare-access-auth.md`

--- a/docs/tasks/2026-07-24-ome-591-cf-access-resolver.md
+++ b/docs/tasks/2026-07-24-ome-591-cf-access-resolver.md
@@ -1,0 +1,18 @@
+---
+id: OME-591
+linear_url: https://linear.app/openmined/issue/OME-591
+status: Backlog
+type: Feature
+priority: P2
+labels: [aigateway, autonomous, agentic]
+parent: OME-588
+created: 2026-07-24
+closed:
+---
+
+# Add the Cloudflare Access identity resolver with JWKS verification and JIT provisioning
+
+kid-aware JWKS client, RS256 verification of iss/aud/exp, and get_or_create provisioning keyed on (idp, sub) — never email. Reads Cf-Access-Jwt-Assertion, then the CF_Authorization cookie, then Authorization: Bearer.
+
+Spec: `docs/spec/2026-07-24-aigateway-cloudflare-access-auth-spec.md`
+Plan: `docs/plan/2026-07-24-aigateway-cloudflare-access-auth.md`

--- a/docs/tasks/2026-07-24-ome-592-gateway-api-keys.md
+++ b/docs/tasks/2026-07-24-ome-592-gateway-api-keys.md
@@ -1,0 +1,18 @@
+---
+id: OME-592
+linear_url: https://linear.app/openmined/issue/OME-592
+status: Backlog
+type: Feature
+priority: P2
+labels: [aigateway, autonomous, agentic]
+parent: OME-588
+created: 2026-07-24
+closed:
+---
+
+# Add gateway-issued API keys for programmatic clients
+
+aigw_* keys (SHA-256 hashed, plaintext returned once) restore per-user attribution under a shared Cloudflare service token, and give revocation independent of Cloudflare.
+
+Spec: `docs/spec/2026-07-24-aigateway-cloudflare-access-auth-spec.md`
+Plan: `docs/plan/2026-07-24-aigateway-cloudflare-access-auth.md`

--- a/docs/tasks/2026-07-24-ome-593-cf-access-config-and-chart.md
+++ b/docs/tasks/2026-07-24-ome-593-cf-access-config-and-chart.md
@@ -1,0 +1,18 @@
+---
+id: OME-593
+linear_url: https://linear.app/openmined/issue/OME-593
+status: Backlog
+type: Task
+priority: P2
+labels: [aigateway, autonomous, agentic]
+parent: OME-588
+created: 2026-07-24
+closed:
+---
+
+# Wire Cloudflare Access config, startup validation, and Helm values
+
+Settings + fail-fast startup validation (cf_access_enabled with auth_enabled=false must not start) + chart values + operator runbook covering the origin-isolation requirement.
+
+Spec: `docs/spec/2026-07-24-aigateway-cloudflare-access-auth-spec.md`
+Plan: `docs/plan/2026-07-24-aigateway-cloudflare-access-auth.md`

--- a/docs/work/2026-07-24-OME-589-identity-resolver-chain.md
+++ b/docs/work/2026-07-24-OME-589-identity-resolver-chain.md
@@ -1,0 +1,80 @@
+---
+ticket: OME-589
+stack: aigateway
+status: in_progress
+started: 2026-07-24
+finished:
+---
+
+# OME-589 — Refactor current_account into an ordered IdentityResolver chain
+
+## Intent
+
+Behavior-preserving refactor. `current_account()` hard-codes one credential shape (local
+HS256 bearer). Cloudflare Access (OME-591) and gateway API keys (OME-592) need to plug in
+without touching that path, so replace the if-tree with an ordered chain of resolvers behind
+a port, registry-wired in `main.py` (core never imports adapters — root `CLAUDE.md`).
+
+## Design decisions
+
+**Three-valued resolution.** A resolver returns `BaseAccount` (authenticated), `Rejection`
+(recognized this credential and refused it), or `None` (not my credential — fall through).
+The driver keeps the **first** `Rejection` and still tries later resolvers, so a credential
+one resolver cannot verify can still be authenticated by another; only an exhausted chain
+raises. This is what preserves the existing specific 401 bodies (`expired`,
+`malformed subject`) that a naive "return None on failure" chain would flatten into a
+generic message.
+
+**Disjoint recognition via the JOSE `alg` header.** `LocalJwtResolver` claims a bearer token
+only when its unverified JOSE header says `HS256`; anything else falls through (Cloudflare
+signs RS256). Reading the *unverified* header is safe because it is used only for routing —
+`decode_token` still pins `algorithms=["HS256"]`, so algorithm-confusion remains impossible.
+Disjoint recognition is what makes "first rejection wins" unambiguous.
+
+## Planned changes
+
+- create `core/auth/resolvers/__init__.py`, `base.py` (`IdentityResolver`, `Rejection`),
+  `local_jwt.py` (`LocalJwtResolver`)
+- modify `core/auth/middleware.py` — `current_account()` drives `app.state.identity_resolvers`
+- modify `main.py` — build + register the chain
+- create `tests/unit/auth/test_resolver_chain.py`
+
+No schema change → no migration this unit (S1 n/a).
+
+## Test plan
+
+- chain order: first resolver's account wins, later resolvers never invoked
+- fall-through: `None` → next resolver
+- a `Rejection` does not stop the chain; a later account still authenticates
+- exhausted chain with a recorded rejection → that rejection's status/detail
+- exhausted chain with no rejection → 401 "Missing bearer token"
+- first rejection wins over a later one
+- `auth_enabled=False` short-circuits ahead of the chain (resolvers never invoked)
+- `LocalJwtResolver` falls through on an RS256 token, rejects an unparseable one
+
+## Acceptance
+
+- All 14 pre-existing `tests/unit/auth/` modules pass **unmodified**.
+- `current_account` contains no credential-format knowledge.
+
+## Outcome
+
+- **Actual files:** as planned — `core/auth/resolvers/{__init__,base,local_jwt}.py` (new),
+  `core/auth/middleware.py`, `main.py`, `tests/unit/auth/test_resolver_chain.py` (14 tests).
+- **Commits:** NONE — see Deviations.
+- **Gates:** `run_gates.py aigateway` ALL GREEN (append-only check · ruff check · ruff
+  format · pyright · check_no_enterprise · pytest 80% cov). Auth suite 76 passed; all 14
+  pre-existing `tests/unit/auth/` modules unmodified.
+- **Deviations:**
+  1. **COMMIT BLOCKED — owner decision required.** This worktree already carried
+     *uncommitted, unrelated* work (the shared-credential-pools feature: `config.py`,
+     `db.py`, `routes/chat_credentials.py`, `core/credential_pool/`, migrations `0008`/`0009`)
+     that **modifies the same two files this unit touches** — `main.py` and
+     `core/auth/middleware.py`. Any commit here either sweeps that unrelated feature in or
+     needs a partial-hunk stage of files under active edit. Left in the working tree instead;
+     branch `OME-588-cloudflare-access-auth` was created off the dirty tree.
+  2. `Rejection.headers` was designed in, then removed during the wisdom review as
+     speculative generality — no consumer in any of the five planned units.
+  3. The `tortoise-dev` companion skill (`mandatory: true` in `.claude/sdlc.local.md`) is not
+     installed in this environment. Not applicable to this unit (no schema change), but it
+     binds OME-590 and OME-592.

--- a/docs/work/2026-07-24-OME-590-account-external-identity.md
+++ b/docs/work/2026-07-24-OME-590-account-external-identity.md
@@ -1,0 +1,88 @@
+---
+ticket: OME-590
+stack: aigateway
+status: in_progress
+started: 2026-07-24
+finished:
+---
+
+# OME-590 — Add external-identity columns to accounts and make password_hash nullable
+
+## Intent
+
+`accounts` can only represent a local password user: `username` is the only identity key and
+`password_hash` is NOT NULL. A Cloudflare-authenticated user has neither — they have a stable
+IdP subject and (usually) an email. Give the table a federated-identity key so OME-591 can
+provision accounts just-in-time, and close the door on those accounts ever password-logging-in.
+
+## Design decisions
+
+**Key on `(external_idp, external_subject)`, never email.** Cloudflare's `sub` is a stable
+Access user UUID; email is mutable at the IdP and can be reassigned to a different human.
+Email is stored as a label and for the admin allowlist, not as an identity key.
+
+**`password_hash` becomes nullable, and `login()` explicitly rejects null.** The rejected
+alternative was storing an unguessable random-bcrypt sentinel and letting
+`verify_password_or_dummy` fail naturally. That is worse: it leaves a live password column on
+a federated account, so the invariant survives only as long as nobody backfills it. An
+explicit null plus an explicit check is auditable and greppable.
+
+**The refusal is indistinguishable from bad credentials.** Same `_INVALID_CREDENTIALS` body
+as SF-335's inactive-account handling — a distinct error would be a federation-status
+enumeration oracle.
+
+## Planned changes
+
+- modify `core/auth/models/account.py` — `external_idp`, `external_subject`, `email`,
+  `unique_together`, nullable `password_hash`
+- modify `routes/auth_session.py` — reject null-hash accounts
+- modify `core/auth/schemas.py` — `AccountOut.email`
+- create `migrations/0010_account_external_identity.py` (S1: schema + migration same unit)
+- create `tests/unit/auth/test_federated_account.py`
+
+## Test plan
+
+- null-hash account → `/v1/auth/login` 401, body byte-identical to a wrong-password attempt
+- the refusal is logged server-side
+- duplicate `(external_idp, external_subject)` → IntegrityError
+- two accounts may both have NULL external identity (partial-uniqueness sanity — local
+  accounts must not collide with each other)
+- existing local accounts still log in; `AccountOut` exposes `email`, never `password_hash`
+
+## Acceptance
+
+- Migration applies clean; all prior auth tests pass unmodified.
+
+## Outcome
+
+- **Actual files:** `core/auth/models/account.py`, `routes/auth_session.py`,
+  `core/auth/schemas.py`, `migrations/0010_account_external_identity.py`,
+  `tests/unit/auth/test_federated_account.py` (8),
+  `tests/unit/test_migration_external_identity.py` (2 — new module, see Deviations).
+- **Commits:** NONE — blocked, see OME-589 ledger deviation 1.
+- **Gates:** `run_gates.py aigateway` ALL GREEN. Auth suite 84 passed.
+- **Deviations / findings:**
+  1. **Security fix beyond the planned scope, in this unit's blast radius.**
+     `verify_password_or_dummy` falls back to the hash of the module-level constant
+     `passwords._DUMMY_PASSWORD`. That constant is public, so once `password_hash` became
+     nullable, submitting it verbatim made `password_ok` **True** for any federated account.
+     The NULL check therefore had to run *independently of* `password_ok`, not after it.
+     Covered by `test_federated_account_rejects_the_public_dummy_password`.
+  2. **Migration data loss, found and fixed.** SQLite cannot alter nullability, so Tortoise
+     rebuilds the table (`schema_editor/sqlite.py::_remake_table`: CREATE / INSERT SELECT /
+     `DROP TABLE accounts` / RENAME). That DROP has no FK guard, so under the default
+     `PRAGMA foreign_keys=ON` it cascade-deleted every `oauth_connections` and
+     `global_credential_pools` row while reporting OK. Fixed with `atomic = False` plus a
+     dialect-guarded `PRAGMA foreign_keys` toggle (the pragma is a silent no-op inside a
+     transaction, hence non-atomic). Caught by the pre-existing
+     `test_full_chain_applies_to_populated_database`.
+  3. **Two Tortoise no-op traps.** `AlterModelOptions` is state-only (no DDL) and would have
+     left `unique_together` unenforced in every migrated DB; `AddField(db_index=True)` emits
+     no `CREATE INDEX`. Both replaced with explicit `AddConstraint`/`AddIndex` and asserted
+     against `sqlite_master`.
+  4. New test lives in its own module `test_migration_external_identity.py` (reusing the
+     sibling's `_migrate` helper) because the append-only gate rejects *any* edit to a prior
+     test file, including a pure addition.
+  5. `tortoise-dev` companion skill (`mandatory: true`) unavailable — followed the `0008`/
+     `0009` in-repo idioms instead. Findings 2 and 3 are exactly the class of trap that skill
+     presumably encodes; recommend installing it before OME-592's migration.

--- a/docs/work/2026-07-24-OME-591-cf-access-resolver.md
+++ b/docs/work/2026-07-24-OME-591-cf-access-resolver.md
@@ -1,0 +1,84 @@
+---
+ticket: OME-591
+stack: aigateway
+status: in_progress
+started: 2026-07-24
+finished:
+---
+
+# OME-591 — Cloudflare Access identity resolver with JWKS verification and JIT provisioning
+
+## Intent
+
+Verify Cloudflare's identity assertion at the origin and materialise the account. This is the
+unit that delivers the actual product goal: a user admitted by the Access policy reaches every
+authenticated route with no registration and no `/v1/auth/login`.
+
+## Design decisions
+
+**The origin verifies independently of the edge.** `Cf-Access-Jwt-Assertion` is an ordinary
+header; trusting its presence would mean anyone able to reach the origin off-path can forge
+any identity. Ingress isolation (cloudflared tunnel only) is the deployment's job; verifying
+signature + `iss` + `aud` + `exp` on every request is ours, and it is the layer that survives
+a future ingress change.
+
+**`kid`-aware JWKS with stale-on-error.** Cloudflare rotates the signing key every 6 weeks and
+serves current + previous with a 7-day grace. Caching a single cert breaks at every rotation.
+A hard failure on fetch error would let a Cloudflare certs blip 401 the entire fleet, so a
+warm cache keeps serving while a refresh is retried.
+
+**Identity key precedence: `sub`, else `common_name`.** IdP logins carry a stable Access user
+UUID in `sub`; service tokens carry an empty `sub` and the client ID in `common_name`. Email
+is a label, never a key.
+
+**Provisioning races are the normal case,** not an edge case — an SDK with a connection pool
+issues several first requests at once. `get_or_create` guarded by the real unique constraint
+from OME-590, with an `IntegrityError` re-read.
+
+## Planned changes
+
+- create `core/auth/cf_access/{__init__,jwks,verifier,identity,provisioning,resolver}.py`
+- modify `core/auth/log_filter.py` — redact CF assertions and client secrets
+- create `tests/unit/auth/cf_access/` (fixed RSA keypair fixture, fake JWKS)
+
+No schema change this unit (OME-590 shipped it) → no migration.
+
+## Test plan
+
+- valid IdP assertion → account created, email populated, `is_admin` per allowlist
+- valid service-token assertion → account created from `common_name`
+- `kid` rotation: token signed by the *previous* key still verifies
+- `aud` mismatch / wrong `iss` / expired / `alg: none` / HS256-signed forgery → rejected
+- unknown `kid` triggers exactly one refetch, not one per request
+- JWKS unreachable with a warm cache → still verifies
+- JWKS unreachable with a cold cache → rejects (never fails open)
+- concurrent first requests → exactly one account row
+- token accepted from the header, the cookie, and `Authorization: Bearer`
+- the assertion never appears in logs
+
+## Acceptance
+
+- With `cf_access_enabled=false` (default) nothing changes.
+- No fail-open path exists on any error branch.
+
+## Outcome
+
+- **Actual files:** `core/auth/cf_access/{__init__,jwks,identity,provisioning,resolver}.py`,
+  `core/auth/log_filter.py`; tests `tests/unit/auth/cf_access/{conftest,test_verification,
+  test_provisioning,test_resolver}.py` (38 tests).
+- **Commits:** NONE — blocked, see OME-589 ledger deviation 1.
+- **Gates:** `run_gates.py aigateway` ALL GREEN. Auth suite 122 passed.
+- **Deviations / findings:**
+  1. **Design flaw caught by a test, then fixed.** `CfAccessIdentity.username` initially
+     derived from `email`. Since `username` is UNIQUE, two distinct subjects that ever share
+     an address collide and the second user cannot be provisioned at all — reintroducing
+     email-as-identity through the back door, the exact coupling this design rejects.
+     Now derived from `subject`, hashed rather than truncated past 64 chars.
+  2. Merged the planned `verifier.py` and `identity.py` into one module — the verifier's only
+     output is an identity and splitting them produced two ~40-line files with a circular
+     concern. `jwks.py` stayed separate (it has genuinely independent caching state).
+  3. Added an unplanned JWKS **refetch rate limit**: without it a forged `kid` lets an
+     unauthenticated caller drive unbounded outbound requests to Cloudflare.
+  4. `log_filter.py`'s single `_HEADER_NAME` became `_SENSITIVE_HEADERS`; the class name
+     `RedactProvisioningTokenFilter` is now too narrow but renaming it would touch prior
+     tests (append-only rule) — left for a follow-up.

--- a/docs/work/2026-07-24-OME-593-cf-access-config-and-chart.md
+++ b/docs/work/2026-07-24-OME-593-cf-access-config-and-chart.md
@@ -1,0 +1,36 @@
+---
+ticket: OME-593
+stack: aigateway
+status: done
+started: 2026-07-24
+finished: 2026-07-24
+---
+
+# OME-593 — Wire Cloudflare Access config, startup validation, and Helm values
+
+## Intent
+
+Turn the feature on safely. Every way the gateway could come up *believing* it is protected
+while actually admitting unauthenticated callers becomes a startup error.
+
+## Outcome
+
+- **Actual files:** `config.py` (5 settings + 2 validators + `cf_access_admin_email_set`),
+  `main.py` (conditional resolver registration), `charts/aigateway/values.yaml`,
+  `charts/aigateway/templates/configmap.yaml`, `apps/aigateway/docs/cloudflare-access.md`,
+  `tests/unit/test_cf_access_settings.py` (13 tests).
+- **Commits:** NONE — blocked, see OME-589 ledger deviation 1.
+- **Gates:** `run_gates.py aigateway` ALL GREEN.
+- **Fail-fast cases covered:** `cf_access_enabled` + `auth_enabled=false` (would make every
+  caller anonymous behind a supposedly-federated gateway); missing team domain or AUD; a team
+  domain carrying a scheme/port/path/userinfo (the JWKS URL is built by interpolating it, so
+  a redirectable value is a total auth bypass — the gateway would verify attacker-signed
+  assertions). Chart verified rendering disabled, enabled, and failing loudly on a missing
+  required value.
+- **Deviations:**
+  1. `cf_access_admin_emails` is a raw comma-separated `str`, not `list[str]`:
+     pydantic-settings JSON-decodes complex field types from the env var *before* any
+     validator runs, so the operator-friendly format raised `SettingsError`. Parsing moved to
+     the `cf_access_admin_email_set` property.
+  2. Chart rendering had to be verified through `rtk proxy helm ...` — the rtk hook truncates
+     `helm template` output, which silently looked like a broken template.

--- a/docs/work/2026-07-24-aigateway-shared-credential-pools.md
+++ b/docs/work/2026-07-24-aigateway-shared-credential-pools.md
@@ -1,0 +1,84 @@
+---
+ticket: none (Linear filing deferred by owner for this unit)
+stack: aigateway
+status: done
+started: 2026-07-24
+finished: 2026-07-24
+---
+
+# AIGateway shared (global) credential pools
+
+## Intent
+
+Let an AIGateway admin provision a shared/global provider credential that all authenticated
+accounts use, as an alternative deployment mode (`AIGATEWAY_CREDENTIAL_MODE=shared`) to
+today's per-account BYOK credentials — while keeping per-account usage/audit attribution
+intact. Design in `docs/spec/2026-07-24-aigateway-shared-credential-pools-spec.md`;
+implementation executed in this same unit on owner's explicit "Execute the implementation
+changes" instruction (no separate `docs/plan/` artifact — see Deviations).
+
+## Planned changes
+
+Per the spec: config mode switch, `GlobalCredentialPool` model + migration, `Account.is_admin`
++ migration, admin CRUD routes, the resolution branch in `chat_credentials.py`.
+
+## Test plan
+
+- Admin gating: unauthenticated → 401; authenticated non-admin → 403 `admin_required`.
+- Admin CRUD: create (201, key never echoed) → conflict on a second active pool for the same
+  provider (409) → list → deactivate (PATCH) → delete → 404 after delete.
+- Shared-mode chat with no pool configured → 404 `credential_pool_not_configured`.
+- Shared-mode chat with a pool configured, exercised by two distinct accounts → both dispatch
+  through the same injected key, and both remain individually attributable (distinct
+  `account_id`s), proving usage isolation is unaffected by credential mode.
+
+## Acceptance
+
+- All planned test-plan cases pass (5/5 new tests green).
+- Full gate suite green: `ruff check`, `ruff format --check`, `pyright` (0 errors),
+  `scripts/check_no_enterprise.py`, `pytest --cov=aigateway --cov-fail-under=80` (1303 passed,
+  40 skipped, 90% coverage).
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+  - `docs/spec/2026-07-24-aigateway-shared-credential-pools-spec.md`,
+    `docs/work/2026-07-24-aigateway-shared-credential-pools.md`
+  - `src/aigateway/config.py` — `credential_mode` setting + validator
+  - `src/aigateway/core/auth/models/account.py` — `Account.is_admin`
+  - `src/aigateway/core/auth/bootstrap_admin.py` — bootstrap "admin" account gets
+    `is_admin=True` (create + self-heal on existing rows)
+  - `src/aigateway/core/auth/middleware.py` — `current_admin_account`/`CurrentAdminAccount`
+  - `src/aigateway/core/credential_pool/` (new package) — `models/global_credential_pool.py`,
+    `store.py`, `schemas.py`
+  - `src/aigateway/migrations/0008_account_is_admin.py`,
+    `0009_global_credential_pools.py`
+  - `src/aigateway/db.py` — registered `core.credential_pool.models`
+  - `src/aigateway/routes/credential_pools.py` (new) — admin CRUD; registered in `main.py`
+  - `src/aigateway/routes/chat_credentials.py` — shared-mode branch in
+    `_credential_target_for_chat` + new `_inject_shared_pool_credentials`
+  - `tests/unit/test_credential_pool_shared_mode.py` (new, 5 tests)
+- **Commits:** none — awaiting explicit commit instruction (CLAUDE.md: only commit when
+  asked).
+- **Gates:** `ruff check` clean; `ruff format --check` clean; `pyright` 0 errors/0 warnings;
+  `check_no_enterprise.py` OK; `pytest --cov=aigateway --cov-fail-under=80 -q` → 1303 passed,
+  40 skipped, 90% coverage (required 80%).
+- **Deviations:**
+  - No Linear ticket filed — owner explicitly instructed not to ("PS: DO not create linear
+    ticket"). Retroactively fileable (`OME-N`) if the owner later wants Linear tracking.
+  - No separate `docs/plan/` artifact — owner said "Execute the implementation changes"
+    directly against the approved spec; the spec's Design section was detailed enough
+    (files, signatures, exact seams) to implement from directly.
+  - **Scope cut vs. spec: pools are api-key auth only for this iteration** (spec's
+    `GlobalCredentialPool.auth_type` field allows `"oauth"` in principle, but
+    `CreateGlobalCredentialPoolRequest`/`PatchGlobalCredentialPoolRequest` only accept
+    `api_key`). Building an admin-driven OAuth authorization flow for a pool (no per-user
+    browser session to anchor it to) was judged materially larger scope than the spec's
+    core ask; api-key covers the common shared-key case (OpenAI/Anthropic/HF-style keys).
+    Follow-up if OAuth-backed pools are needed.
+  - **Pool credential errors never mark the pool row.** Unlike BYOK connections (which flip
+    to `status="error"` on a bad credential), a shared-mode 401 just raises
+    `shared_credential_invalid` per-request — there is no per-account row to mark, and
+    reconciling a bad shared key is an admin action via `/v1/admin/credential-pools`, not
+    something a single user's failed chat request should mutate. Documented in
+    `_inject_shared_pool_credentials`'s docstring.

--- a/docs/work/2026-07-26-OME-621-aigateway-chart-credential-mode.md
+++ b/docs/work/2026-07-26-OME-621-aigateway-chart-credential-mode.md
@@ -1,0 +1,55 @@
+---
+ticket: OME-621
+stack: aigateway
+status: in_progress
+started: 2026-07-26
+finished:
+---
+
+# OME-621 — expose AIGATEWAY_CREDENTIAL_MODE in the aigateway helm chart
+
+## Intent
+
+`AIGATEWAY_CREDENTIAL_MODE` is fully implemented in the app (OME-588, commit `ddc54c67`) but
+unreachable through the chart: `templates/configmap.yaml` renders no such key and there is no
+`extraEnv` escape hatch, so every helm install is silently pinned to `byok`. Shared
+(admin-provisioned) credential mode — one operator-supplied provider key serving all authenticated
+users — cannot be deployed at all. Expose it the same way `cfAccess` already is, so a local kind
+install can run shared mode with an admin-provisioned OpenRouter key behind Cloudflare Access.
+
+## Planned changes
+
+- `apps/aigateway/charts/aigateway/values.yaml` — add `config.credentialMode: byok` (default
+  preserves today's behaviour), with a comment pointing at the two valid values.
+- `apps/aigateway/charts/aigateway/templates/configmap.yaml` — render
+  `AIGATEWAY_CREDENTIAL_MODE: {{ .Values.config.credentialMode | quote }}`.
+
+## Test plan
+
+Chart templating, not Python — the gate is `helm template` output, not pytest:
+
+- `helm template` with no override renders `AIGATEWAY_CREDENTIAL_MODE: "byok"` (no behaviour change
+  for existing installs).
+- `helm template --set config.credentialMode=shared` renders `AIGATEWAY_CREDENTIAL_MODE: "shared"`.
+- `helm lint` passes.
+- Invalid values remain rejected at app startup by the existing validator (`config.py:209-215`) —
+  deliberately NOT re-validated in the chart, to keep one source of truth.
+
+## Acceptance
+
+The ConfigMap carries `AIGATEWAY_CREDENTIAL_MODE`, defaulting to `byok` and settable to `shared`
+via a plain chart value; `helm lint` clean; no app/python source touched.
+
+## Outcome
+
+- **Actual files:** `apps/aigateway/charts/aigateway/values.yaml` (added `config.credentialMode:
+  byok` + comment) · `apps/aigateway/charts/aigateway/templates/configmap.yaml` (renders
+  `AIGATEWAY_CREDENTIAL_MODE`). Matches planned exactly — no app/python source touched.
+- **Commits:** see the OME-621 commit on `integration-branch`.
+- **Gates:** `helm template` default → `AIGATEWAY_CREDENTIAL_MODE: "byok"`; `--set
+  config.credentialMode=shared` → `"shared"`; `helm lint` 1 chart linted, 0 failed (icon INFO only).
+  Verified the `cfAccess` block still renders alongside it. No Python touched, so `run_gates`
+  categories (ruff/pyright/pytest) are N/A.
+- **Deviations:** no TDD RED/GREEN — this is chart templating, not Python; the gate is
+  `helm template` output. Chart-side validation of the enum was deliberately NOT added: the
+  app's existing `config.py` validator stays the single source of truth.

--- a/docs/work/2026-07-26-OME-622-aigateway-chart-extraenv.md
+++ b/docs/work/2026-07-26-OME-622-aigateway-chart-extraenv.md
@@ -1,0 +1,62 @@
+---
+ticket: OME-622
+stack: aigateway
+status: in_progress
+started: 2026-07-26
+finished:
+---
+
+# OME-622 — generic extraEnv/extraEnvFrom passthrough in the aigateway chart
+
+## Intent
+
+The chart can only set environment it hardcodes: `envFrom` (one ConfigMap) plus four fixed `env`
+entries, with no passthrough. Any app setting the chart does not explicitly template is
+undeployable. Same root cause as [[OME-621]], and it recurs immediately — the OpenRouter plugin is
+gated behind `AIGW_OPENROUTER_ENABLED` (default **false**, fail-closed), so
+`POST /v1/admin/credential-pools` answers `400 api_key_not_supported` and no OpenRouter key can be
+provisioned on a helm-deployed gateway. Per-plugin bespoke values do not scale: every provider owns
+an `AIGW_<PROVIDER>_*` namespace. Add one generic escape hatch instead.
+
+## Planned changes
+
+- `apps/aigateway/charts/aigateway/values.yaml` — add `extraEnv: []` and `extraEnvFrom: []`.
+- `apps/aigateway/charts/aigateway/templates/deployment.yaml` — emit both BEFORE the fixed
+  entries. (Plan said "after"; corrected during implementation — Kubernetes applies duplicate
+  env names LAST-wins, so extras must come first for the chart's secret-backed values to win.)
+
+## Test plan
+
+Chart templating — the gate is `helm template` output:
+
+- Empty defaults render byte-identical to today (no `extraEnv` → no change).
+- `--set-json 'extraEnv=[{"name":"AIGW_OPENROUTER_ENABLED","value":"true"}]'` renders that var.
+- Ordering: a hostile `extraEnv` entry named `AIGATEWAY_JWT_SECRET` must be emitted BEFORE the
+  real secret-backed one, so last-wins leaves the chart's value in effect.
+- `helm lint` clean.
+- Functional: with the flag set, an OpenRouter key provisions successfully into a shared pool.
+
+## Acceptance
+
+`extraEnv`/`extraEnvFrom` render on the container, defaults are a no-op, fixed env cannot be
+shadowed, and the shared OpenRouter pool can be provisioned end-to-end.
+
+## Outcome
+
+- **Actual files:** `apps/aigateway/charts/aigateway/values.yaml` (`extraEnv: []`,
+  `extraEnvFrom: []` + guidance comment) · `apps/aigateway/charts/aigateway/templates/
+  deployment.yaml` (both rendered, extras first). No app/python source touched.
+- **Commits:** see the OME-622 commit on `integration-branch`.
+- **Gates:** `helm template` with defaults renders zero extra env (no-op). With
+  `--set-json extraEnv=[...]` the var renders. **Shadow test:** a hostile
+  `AIGATEWAY_JWT_SECRET` extra is emitted first and the real `secretKeyRef` entry last, so
+  k8s last-wins keeps the chart's value. `helm lint` 1 linted / 0 failed. Verified live on
+  kind: pod env order is `AIGW_OPENROUTER_ENABLED, AIGATEWAY_DATABASE_URL,
+  AIGATEWAY_JWT_SECRET, AIGATEWAY_ADMIN_PASSWORD, AIGATEWAY_PROVISIONING_TOKEN`.
+- **Functional acceptance:** with `AIGW_OPENROUTER_ENABLED=true` supplied via `extraEnv`,
+  `POST /v1/admin/credential-pools` returned **201** (previously 400 `api_key_not_supported`),
+  and a `/v1/chat/completions` call through the shared pool returned a real completion with
+  `is_byok: false` — confirming the admin-provisioned credential backed the call.
+- **Deviations:** ordering flipped from the plan (see Planned changes) — the plan's "after"
+  would have let an operator shadow the DB/JWT secrets. No TDD RED/GREEN: chart templating,
+  not Python; gate is `helm template` output.


### PR DESCRIPTION
Federated authentication for aigateway via Cloudflare Access, plus admin-provisioned shared
credential pools. Base is `main`; 7 commits, 57 files, +4,070 / −30. Self-contained — every
change is under `apps/aigateway/` or `docs/`.

## What lands

Five layered commits, each independently reviewable:

- **`ddc54c67` shared credential pools** — `AIGATEWAY_CREDENTIAL_MODE=shared` lets an admin
  provision one `GlobalCredentialPool` per provider instead of per-account BYOK. New
  `/v1/admin/credential-pools` routes behind a `CurrentAdminAccount` dependency; the key itself
  lives encrypted in `credential_blobs` (AES-256-GCM), never in the pool row. Default stays
  `byok` — no behaviour change for existing installs.
- **`c5b1debe` identity-resolver chain** — replaces the hard-coded single credential shape with
  an ordered `IdentityResolver` chain. Core imports only the port; resolvers are registered in
  `main.py` and return `BaseAccount` (authenticated), `Rejection` (recognised + refused), or
  `None` (fall through). Routes on the JOSE `alg` header — HS256 → local JWT, RS256 → CF Access —
  while still pinning algorithms in `decode_token` to prevent algorithm confusion.
- **`fd347edf` external identity** — adds `external_idp` + `external_subject` (unique together)
  and `email`; makes `password_hash` nullable for just-in-time federated provisioning. `login()`
  explicitly rejects a NULL `password_hash` so the nullable column cannot become a
  dummy-password bypass.
- **`9427c3a0` CF Access verification + JIT provisioning** — verifies RS256
  `Cf-Access-Jwt-Assertion` against the team's published JWKS (stale-on-error caching, refetch
  rate limiting), derives identity from the JWT `sub` rather than email (email is mutable at the
  IdP), and provisions on first request with `IntegrityError` recovery for concurrent races.
- **`c2cb667e` fail-fast configuration** — registers the resolver only when
  `AIGATEWAY_CF_ACCESS_ENABLED`; refuses to boot if CF Access is on while `auth_enabled` is off
  (that combination would serve every caller as anonymous behind a gateway the operator believes
  Cloudflare protects), if team domain or AUD is missing, or if the team domain is anything but a
  bare hostname (the JWKS URL is interpolated, so a redirectable value is a total auth bypass).
  Adds the operator runbook `apps/aigateway/docs/cloudflare-access.md`.

Two follow-ups close deployment gaps found while bringing the feature up on a real cluster:

- **`0b5cca6b` (OME-621)** — the chart rendered no `AIGATEWAY_CREDENTIAL_MODE` and offered no
  escape hatch, so the shared mode above was **undeployable by helm**: every install was silently
  pinned to `byok`. Exposes it as a plain chart value mirroring how `cfAccess` is already handled.
- **`cd3da56d` (OME-622)** — the chart could only set env it hardcodes (`envFrom` one ConfigMap +
  four fixed entries), so any app setting it did not template was undeployable. This bit
  immediately: the OpenRouter plugin is gated behind `AIGW_OPENROUTER_ENABLED` and ships
  disabled/fail-closed, so provisioning an OpenRouter key into a shared pool returned
  `400 api_key_not_supported`. Adds generic `extraEnv`/`extraEnvFrom` rather than a bespoke value
  per plugin — every provider owns an `AIGW_<PROVIDER>_*` namespace and that does not scale.

## Migrations

Three, applied in order:

| | |
|---|---|
| `0008_account_is_admin` | adds `is_admin` (default false) |
| `0009_global_credential_pools` | creates `GlobalCredentialPool`, unique on `(provider, label)` |
| `0010_account_external_identity` | nullable `password_hash`; adds `external_idp`/`external_subject`/`email`; unique on `(external_idp, external_subject)` |

`0010` runs **non-atomically with FK enforcement disabled on SQLite** — the table rebuild would
otherwise cascade-delete `oauth_connections` and credential pools. Worth a careful read.

## Verified end to end against real Cloudflare

Deployed on a 4-node kind cluster and driven through an actual Cloudflare Access application
(`cloudflared` tunnel → ClusterIP-only Service, per the runbook's precondition that the origin be
unreachable except through Cloudflare):

- A request carrying **only** `cf-access-token` — no `Authorization` header — authenticated all
  the way through and returned a real model completion, so the edge-attached identity is what
  reaches the gateway.
- JIT provisioning confirmed in `accounts`:
  `cf_access:<sub> | <email> | cf_access | is_admin=t | password_hash NULL` — keyed on subject,
  admin granted from the allowlist, no password.
- The subject is stable across token refresh: an expired token and a fresh one carry the same
  `sub`, so re-login reuses the account rather than duplicating it.
- Shared mode confirmed with `is_byok: false` on the completion — the admin-provisioned pool
  credential backed a call made by a user holding no credential of their own.
- Chart: `helm template` renders `byok` by default and `shared` on override; an `extraEnv` entry
  named `AIGATEWAY_JWT_SECRET` is emitted **before** the chart's own secret-backed entry, so
  Kubernetes last-wins keeps the real value — operator extras cannot shadow `AIGATEWAY_DATABASE_URL`,
  `_JWT_SECRET` or `_ADMIN_PASSWORD`. `helm lint` clean.

Suite: **1388 passed, 40 skipped**.

## Known issue (inherited, not introduced here)

Migration `0008` renders `is_admin` as `DEFAULT 1` instead of `0` on SQLite — tracked separately
as OME-594.

## Reviewer notes

- The security precondition is a **deployment** property, not a code one: `Cf-Access-Jwt-Assertion`
  is an ordinary header, so this feature is only sound behind a tunnel or Authenticated Origin
  Pulls. `cloudflare-access.md` states it plainly; the gateway's own signature verification is
  defence in depth, not a substitute.
- `is_admin` is granted **only at provisioning time**. Adding an email to
  `AIGATEWAY_CF_ACCESS_ADMIN_EMAILS` later does not retroactively promote an existing account.

Refs: OME-588, OME-589, OME-590, OME-591, OME-593, OME-621, OME-622
