### PR TITLE
feat(screamingface): notebook rich-display cards, catalogs & url4 view + brand refresh

### DIFF
--- a/docs/plan/2026-07-27-OME-626-sdk-catalog-views-and-reprs.md
+++ b/docs/plan/2026-07-27-OME-626-sdk-catalog-views-and-reprs.md
@@ -1,0 +1,46 @@
+---
+title: SDK catalog views and widget-like reprs — implementation plan
+ticket: OME-626
+status: approved
+date: 2026-07-27
+spec: docs/spec/2026-07-27-OME-626-sdk-display-contract.md
+---
+
+# SDK catalog views and widget-like reprs — implementation plan
+
+Implements `docs/spec/2026-07-27-OME-626-sdk-display-contract.md`. Follows the established
+widget pattern in `_connection_panel.py` / `_progress.py`: inline-CSS HTML scoped under
+`.sf-ui`, base tokens from `_display.STYLE`, `ipywidgets` optional with a static
+`_repr_html_` fallback.
+
+## Iterations (each a RED → GREEN → gate cycle)
+
+1. **Card renderers** — `_card_display.py`: `model_card_html`, `fusion_card_html`,
+   `benchmark_card_html`, and text repr helpers. Card CSS appended to the shared `.sf-ui`
+   block (reuse `--sf-gain`/`--sf-line`/`--sf-ink*`; no raw colors). RED: HTML contains the
+   real fields, escapes injected text, and contains no price/ability strings.
+2. **Object reprs** — add `_repr_html_` + `__repr__` to `Model`, `Fusion`, `Benchmark`
+   (lazy import of `_card_display`). RED: each type's display delegates to its renderer.
+3. **Catalog renderers + views** — `models_catalog_html` / `benchmarks_catalog_html` in
+   `_card_display.py`; `ModelsView` / `BenchmarksView` in `_catalog_view.py`
+   (`widget()`, `_repr_html_`, `_ipython_display_`, `.value` = filtered ids). RED: static
+   catalog HTML lists ids; `.value` matches; widget tree filters on search input.
+4. **Entry points** — `models.view()` / `benchmarks.view()`; extract a shared
+   `_filter_records` helper in each module so `view()` and `list()` agree. Export the view
+   classes from `__init__.py` if the value type must be importable. RED: `view()` builds from
+   a mocked registry; `view()` ids == `list()` ids for equal args.
+
+## Critical files
+
+- New: `src/screamingface/_card_display.py`, `src/screamingface/_catalog_view.py`
+- Edit: `src/screamingface/{model,fusion,benchmark,models,benchmarks,__init__}.py`
+- Reuse: `_display.STYLE`, `_profile.load_registry()` / `ModelRecord` / `BenchmarkRecord`,
+  the `Recipe.url4` property, and the existing `list()` filter logic.
+- Tests: new files under `packages/screamingface/tests/`.
+
+## Verification
+
+- `uv run .claude/scripts/run_gates.py screamingface` green from the repo root.
+- Manual notebook smoke in `packages/screamingface/examples/`: render a `Model`, `Fusion`,
+  and `Benchmark`; run `sf.models.view()` / `sf.benchmarks.view()`, type in the search box,
+  confirm rows filter and `.value` updates; confirm the static render with ipywidgets absent.

--- a/docs/plan/2026-07-27-OME-628-repr-cards-connection-case-rubric.md
+++ b/docs/plan/2026-07-27-OME-628-repr-cards-connection-case-rubric.md
@@ -1,0 +1,39 @@
+---
+title: _repr_html_ cards for Connection, Case, and Rubric — plan
+ticket: OME-628
+status: approved
+date: 2026-07-27
+spec: docs/spec/2026-07-27-OME-626-sdk-display-contract.md
+---
+
+# _repr_html_ cards for Connection, Case, and Rubric — plan
+
+Extends OME-626 under the same governing display contract (honest advertised/authoring fields
+only; injected text HTML-escaped; reuse the `.sf-ui` token block). One RED → GREEN → gate
+cycle; the three cards are independent and share the existing `_card_display` helpers.
+
+## Design
+
+Add three pure renderers to `src/screamingface/_card_display.py`, mirroring the existing
+`model_card_html` / `benchmark_card_html` shape (head + `sf-card__grid` of `_field`s):
+
+- `connection_card_html(connection)` — title = display_name, kicker "connection"; fields:
+  provider, status (humanized), auth method, account label, advertised auth methods.
+- `case_card_html(case)` — title = id, kicker "case"; fields: input (wide), reference
+  (JSON, wide), metadata (JSON, wide). Render reference/metadata via `json.dumps` then escape.
+- `rubric_card_html(rubric)` — title = model, kicker "rubric grader"; fields: passes, params,
+  prompt (wide). Reuse `_params_text` for params.
+
+Wire a lazy-importing `_repr_html_` onto `Connection` (`connections.py`), `Case`
+(`benchmark.py`), and `Rubric` (`graders.py`). No custom `__repr__` (keep the dataclass
+default so existing repr assertions stay green).
+
+## Critical files
+
+- Edit: `src/screamingface/_card_display.py`, `connections.py`, `benchmark.py`, `graders.py`
+- Test: new `tests/test_ome628_value_cards.py`
+
+## Verification
+
+`uv run .claude/scripts/run_gates.py screamingface` green from the repo root; the same
+pre-existing unrelated notebook WIP must be stashed to prove a clean whole-tree gate.

--- a/docs/plan/2026-07-27-OME-630-url4-recipe-collapsible-view.md
+++ b/docs/plan/2026-07-27-OME-630-url4-recipe-collapsible-view.md
@@ -1,0 +1,45 @@
+---
+title: Collapsible syntax-highlighted url4 recipe view — plan
+ticket: OME-630
+status: approved
+date: 2026-07-27
+spec: docs/spec/2026-07-27-OME-626-sdk-display-contract.md
+---
+
+# Collapsible syntax-highlighted url4 recipe view — plan
+
+Display-only enhancement under the OME-626 display contract. One RED → GREEN → gate cycle.
+
+## Design
+
+New module `src/screamingface/_url4_format.py`:
+
+- `recipe_details_html(url4: str) -> str` — the collapsible recipe block:
+  - `<details class='sf-url4'>` (no `open` → collapsed by default).
+  - `<summary>`: "url4 recipe" label + node count + a copy `<button>` whose fixed inline JS
+    (`event.stopPropagation()` + `navigator.clipboard.writeText(<raw>.textContent)`) reads the
+    raw url4 from a sibling hidden `<pre class='sf-url4__raw'>` — no recipe text in the JS, so
+    no injection and no JS-string escaping.
+  - body: the structured view + the visible/selectable raw `<pre>` as copy source and fallback.
+- `_structured_html(url4)`: `node = url4.build(url4)`; if `Expression`, render each `Source`;
+  per `Source` emit name/weight and, for a `RelExpr`, route (`path`), params, context, and
+  intent (`Text.value` unquoted, else `render`). Unknown node kinds fall back to
+  `url4.render(node)`. Wrap the whole thing in `try/except url4.Url4Error` → return `None` so the
+  caller shows the raw string only. (WHY: a display path must never raise; failing to the real
+  raw url4 is honest, not a security fail-open.)
+
+`_card_display._recipe_html(url4)` becomes a thin delegate to `recipe_details_html`. CSS
+(`.sf-url4*`) appended to `_card_display._STYLE`; route accent = `--sf-gain`, labels/params =
+`--sf-ink-2/3`, intent block = `--sf-surface`. All injected text HTML-escaped.
+
+## Critical files
+
+- New: `src/screamingface/_url4_format.py`
+- Edit: `src/screamingface/_card_display.py` (`_recipe_html` delegate + `.sf-url4` CSS)
+- Test: new `tests/test_ome630_url4_view.py`
+
+## Verification
+
+`uv run .claude/scripts/run_gates.py screamingface` green (stash the pre-existing unrelated
+notebook WIP first). Manual: render a Fusion in the notebook, confirm collapsed → expand →
+readable, copy button copies the exact url4.

--- a/docs/plan/2026-07-27-OME-635-recipe-fullform-and-fusion-detail.md
+++ b/docs/plan/2026-07-27-OME-635-recipe-fullform-and-fusion-detail.md
@@ -1,0 +1,46 @@
+---
+title: Recipe full-form pretty-print + Fusion member/reducer detail — plan
+ticket: OME-635
+status: approved
+date: 2026-07-27
+spec: docs/spec/2026-07-27-OME-626-sdk-display-contract.md
+---
+
+# Recipe full-form pretty-print + Fusion member/reducer detail — plan
+
+Display-only, under the OME-626 contract. Two coordinated changes.
+
+## 1. url4 recipe → full-form reflow in a `<pre>`
+
+`_url4_format.py`:
+- `_pretty_url4(text)`: single left-to-right pass. Track `in_quote` and backslash escapes
+  (url4 quotes with `\\` and `\'`). Outside quotes: `(`/`{` → append + indent+1 + newline
+  (but keep an empty `()`/`{}` inline); `)`/`}` → newline + indent-1 + append; `,` → append +
+  newline; skip a single space immediately after a break. Everything else verbatim → the exact
+  url4 is preserved, only whitespace added.
+- `recipe_details_html(url4)`: `<details class='sf-url4'>` (collapsed) → `<summary>` with a
+  copy `<button data-url4="{escape(raw, quote=True)}" onclick="…writeText(getAttribute('data-url4'))">`
+  → `<pre class='sf-url4__pre'>{escape(pretty)}</pre>`. No `url4.build`, no hidden element.
+
+## 2. Fusion card: members & reducer detail (collapsed)
+
+`_card_display.py` `_fusion_detail_html(fusion)`:
+- `<details class='sf-detail'><summary>members & reducer</summary>…`
+- per member: `<div>` name + route; if a `Model`, its prompt and params; if a nested `Fusion`,
+  a "nested fusion — see its own card" note.
+- reducer row: kind; if a Model reducer, its model/prompt/params; MajorityVote → "deterministic".
+- Embed in `fusion_card_html` between the grid and the recipe.
+
+CSS: `.sf-url4__pre` (pre-wrap, overflow-wrap:anywhere, mono, no host background) replaces the
+per-node classes; add `.sf-detail*`. Reuse `--sf-*` tokens; no raw colors.
+
+## Critical files
+
+- Edit: `src/screamingface/_url4_format.py`, `src/screamingface/_card_display.py`
+- Test: new `tests/test_ome635_recipe_fullform.py`
+
+## Verification
+
+`uv run .claude/scripts/run_gates.py screamingface` green (stash pre-existing notebook WIP).
+Manual: render a Fusion — recipe shows full url4 indented in a `<pre>`, copy copies exact raw;
+"members & reducer" expands to prompts + params.

--- a/docs/spec/2026-07-27-OME-626-sdk-display-contract.md
+++ b/docs/spec/2026-07-27-OME-626-sdk-display-contract.md
@@ -1,0 +1,60 @@
+---
+title: SDK rich-display contract — catalog views and object cards
+ticket: OME-626
+status: approved
+date: 2026-07-27
+---
+
+# SDK rich-display contract — catalog views and object cards
+
+The `widgets-view` HTML gallery is the *target* look for the ScreamingFace notebook SDK.
+Only `ConnectionPanel` (`sf.connect()`) and the evaluation `Progress` tracker are real
+widgets today. This spec fixes the public value contract for a display-only addition: rich
+notebook rendering of the three core objects and two catalog browsers.
+
+## Honesty constraint (the governing rule)
+
+The engine registry advertises **no price, context-window, or capability/ability-score**
+data for models, and **no case count or long description** for benchmarks. Cards therefore
+render **only real advertised fields**. Fabricated numbers, placeholder bars, or invented
+metrics are forbidden — they would violate the SDK's "simulated but honest" stance. If a
+field the mock shows has no backing data, it is simply omitted, not stubbed with fake values.
+
+## Real fields (source of truth)
+
+From `_profile.load_registry()` and the authoring types:
+
+- `ModelRecord`: `id`, `provider`, `supported_tools`, `required_connections`.
+- `BenchmarkRecord`: `id`, `title`, `grader` (kind/route), `aggregator` (kind/route),
+  `tools`, `max_tool_calls`.
+- `Model`: `name`, `model` (route), `prompt`, `params`, `url4`.
+- `Fusion`: `name`, `members`, `reducer`, `model_ids`, `url4`.
+- `Benchmark`: `id`, `title`, `grader`, `aggregator`, `tools`, `max_tool_calls`.
+
+## Public surface
+
+- `Model._repr_html_()` / `Fusion._repr_html_()` / `Benchmark._repr_html_()` — static
+  branded cards. Each also gains a concise text `__repr__()` for terminals. These are pure
+  functions of the object's own fields; they perform **no** network call.
+- `sf.models.view(*, query=None, tools=()) -> ModelsView` and
+  `sf.benchmarks.view(*, query=None, tools=()) -> BenchmarksView` — catalog browsers built
+  from the engine registry. Interactive (search/filter) when `ipywidgets` is installed;
+  static `_repr_html_` catalog otherwise.
+
+## Value contract
+
+- `ModelsView` / `BenchmarksView` expose `.value` = the tuple/list of ids currently shown
+  after filtering — the honest analogue of the mock's `.value` line. `view()` reuses the
+  same filter predicate as the existing `models.list()` / `benchmarks.list()`, so for equal
+  `query`/`tools` arguments the two return the same ids (invariant).
+
+## Out of scope
+
+- `sf.mt(...)` (referenced by the mock; not added here).
+- Any engine, gateway, or URL4 change; no new registry fields.
+- Selection/"add to fusion" affordances, sorting, or leaderboard rendering (mock-only).
+
+## Accessibility & brand
+
+Reuse the `.sf-ui` token block from `_display.STYLE` (square, hairline, mono/gold; light/dark
+via the existing `@media`/theme selectors). All injected model/benchmark text is HTML-escaped.

--- a/docs/tasks/2026-07-27-ome-626-sdk-catalog-views-and-reprs.md
+++ b/docs/tasks/2026-07-27-ome-626-sdk-catalog-views-and-reprs.md
@@ -9,14 +9,19 @@ created: 2026-07-27
 closed:
 ---
 
-Add `sf.models.view()` / `sf.benchmarks.view()` catalog browsers and widget-like
-`_repr_html_` cards for `Model`, `Fusion`, and `Benchmark`, matching the `widgets-view`
-design mock.
+**Umbrella for the notebook rich-display work — consolidates OME-628 / 630 / 635 / 637 / 639
+(marked duplicates of this in Linear, 2026-07-27).** Their `docs/work` ledgers remain the
+per-increment audit record.
 
-Honest-fields-only (owner decision): cards render only what the engine advertises — no
-fabricated price/context/ability data. Static reprs for the three objects; interactive
-ipywidgets catalogs for the two `.view()` entry points, with a static fallback when
-ipywidgets is absent. `sf.mt(...)` and any engine change are out of scope.
+Add `sf.models.view()` / `sf.benchmarks.view()` catalog browsers and widget-like
+`_repr_html_` cards for `Model`, `Fusion`, `Benchmark`, plus `Connection`, `Case`, `Rubric`;
+the full-form collapsible url4 recipe view; and the report-style benchmark card. Honest
+advertised/authoring fields only — no fabricated price/context/ability. `sf.mt(...)` and any
+engine change are out of scope.
+
+Delivered on branch chain OME-626 → 628 → 630 → 635 → 637 → 639
+(commits `782d634a`, `ea724ef9`, `2496cf74`, `21e59671`, `36366123`, `26b4c8e3`,
+`0f2bccff`, `90535afb`, `9c7a40a4`); ~763 tests green; awaiting one PR to `main`.
 
 - Spec: `docs/spec/2026-07-27-OME-626-sdk-display-contract.md`
 - Plan: `docs/plan/2026-07-27-OME-626-sdk-catalog-views-and-reprs.md`

--- a/docs/tasks/2026-07-27-ome-626-sdk-catalog-views-and-reprs.md
+++ b/docs/tasks/2026-07-27-ome-626-sdk-catalog-views-and-reprs.md
@@ -1,0 +1,23 @@
+---
+id: OME-626
+linear_url: https://linear.app/openmined/issue/OME-626
+status: in_progress
+type: feature
+priority: 3
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-07-27
+closed:
+---
+
+Add `sf.models.view()` / `sf.benchmarks.view()` catalog browsers and widget-like
+`_repr_html_` cards for `Model`, `Fusion`, and `Benchmark`, matching the `widgets-view`
+design mock.
+
+Honest-fields-only (owner decision): cards render only what the engine advertises — no
+fabricated price/context/ability data. Static reprs for the three objects; interactive
+ipywidgets catalogs for the two `.view()` entry points, with a static fallback when
+ipywidgets is absent. `sf.mt(...)` and any engine change are out of scope.
+
+- Spec: `docs/spec/2026-07-27-OME-626-sdk-display-contract.md`
+- Plan: `docs/plan/2026-07-27-OME-626-sdk-catalog-views-and-reprs.md`
+- Ledger: `docs/work/2026-07-27-OME-626-sdk-catalog-views-and-reprs.md`

--- a/docs/tasks/2026-07-27-ome-628-repr-cards-connection-case-rubric.md
+++ b/docs/tasks/2026-07-27-ome-628-repr-cards-connection-case-rubric.md
@@ -1,0 +1,17 @@
+---
+id: OME-628
+linear_url: https://linear.app/openmined/issue/OME-628
+status: in_progress
+type: feature
+priority: 4
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-07-27
+closed:
+---
+
+Add branded `_repr_html_` cards for `Connection`, `Case`, and `Rubric` (follow-on polish to
+OME-626). Honest-fields-only, same `_card_display` pattern; text `__repr__` unchanged.
+
+- Governing spec: `docs/spec/2026-07-27-OME-626-sdk-display-contract.md`
+- Plan: `docs/plan/2026-07-27-OME-628-repr-cards-connection-case-rubric.md`
+- Ledger: `docs/work/2026-07-27-OME-628-repr-cards-connection-case-rubric.md`

--- a/docs/tasks/2026-07-27-ome-628-repr-cards-connection-case-rubric.md
+++ b/docs/tasks/2026-07-27-ome-628-repr-cards-connection-case-rubric.md
@@ -1,7 +1,7 @@
 ---
 id: OME-628
 linear_url: https://linear.app/openmined/issue/OME-628
-status: in_progress
+status: duplicate  # merged into OME-626 (2026-07-27)
 type: feature
 priority: 4
 labels: [py-screamingface, agentic, autonomous]

--- a/docs/tasks/2026-07-27-ome-630-url4-recipe-collapsible-view.md
+++ b/docs/tasks/2026-07-27-ome-630-url4-recipe-collapsible-view.md
@@ -1,0 +1,18 @@
+---
+id: OME-630
+linear_url: https://linear.app/openmined/issue/OME-630
+status: in_progress
+type: feature
+priority: 3
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-07-27
+closed:
+---
+
+Render the compiled `url4` recipe in the Model/Fusion cards as a collapsed-by-default,
+syntax-highlighted structured view (parsed via `url4.build`) with a copy button for the exact
+raw string; degrade to raw on `Url4Error`. Display-only, honest, HTML-escaped.
+
+- Governing spec: `docs/spec/2026-07-27-OME-626-sdk-display-contract.md`
+- Plan: `docs/plan/2026-07-27-OME-630-url4-recipe-collapsible-view.md`
+- Ledger: `docs/work/2026-07-27-OME-630-url4-recipe-collapsible-view.md`

--- a/docs/tasks/2026-07-27-ome-630-url4-recipe-collapsible-view.md
+++ b/docs/tasks/2026-07-27-ome-630-url4-recipe-collapsible-view.md
@@ -1,7 +1,7 @@
 ---
 id: OME-630
 linear_url: https://linear.app/openmined/issue/OME-630
-status: in_progress
+status: duplicate  # merged into OME-626 (2026-07-27)
 type: feature
 priority: 3
 labels: [py-screamingface, agentic, autonomous]

--- a/docs/tasks/2026-07-27-ome-635-recipe-fullform-and-fusion-detail.md
+++ b/docs/tasks/2026-07-27-ome-635-recipe-fullform-and-fusion-detail.md
@@ -1,0 +1,23 @@
+---
+id: OME-635
+linear_url: https://linear.app/openmined/issue/OME-635
+status: in_progress
+type: feature
+priority: 3
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-07-27
+closed:
+---
+
+Card display refinements (all `_card_display.py` / `_url4_format.py`, display-only):
+
+1. url4 recipe kept in full form, reflowed by `(){}`/comma sections inside a `<pre>`
+   (MathJax-safe); collapsed `<details>` + copy of the exact raw.
+2. Fusion card: collapsed "members & reducer" section with each member's prompt + params and
+   the reducer's prompt + params.
+3. Verbose Benchmark and Rubric grader cards — surface all interesting fields; long fields
+   (prompts) rendered as collapsed `<details>`.
+
+- Governing spec: `docs/spec/2026-07-27-OME-626-sdk-display-contract.md`
+- Plan: `docs/plan/2026-07-27-OME-635-recipe-fullform-and-fusion-detail.md`
+- Ledger: `docs/work/2026-07-27-OME-635-recipe-fullform-and-fusion-detail.md`

--- a/docs/tasks/2026-07-27-ome-635-recipe-fullform-and-fusion-detail.md
+++ b/docs/tasks/2026-07-27-ome-635-recipe-fullform-and-fusion-detail.md
@@ -1,7 +1,7 @@
 ---
 id: OME-635
 linear_url: https://linear.app/openmined/issue/OME-635
-status: in_progress
+status: duplicate  # merged into OME-626 (2026-07-27)
 type: feature
 priority: 3
 labels: [py-screamingface, agentic, autonomous]

--- a/docs/tasks/2026-07-27-ome-637-fusion-sections-and-grader-section.md
+++ b/docs/tasks/2026-07-27-ome-637-fusion-sections-and-grader-section.md
@@ -1,7 +1,7 @@
 ---
 id: OME-637
 linear_url: https://linear.app/openmined/issue/OME-637
-status: in_progress
+status: duplicate  # merged into OME-626 (2026-07-27)
 type: feature
 priority: 4
 labels: [py-screamingface, agentic, autonomous]

--- a/docs/tasks/2026-07-27-ome-637-fusion-sections-and-grader-section.md
+++ b/docs/tasks/2026-07-27-ome-637-fusion-sections-and-grader-section.md
@@ -1,0 +1,17 @@
+---
+id: OME-637
+linear_url: https://linear.app/openmined/issue/OME-637
+status: in_progress
+type: feature
+priority: 4
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-07-27
+closed:
+---
+
+Fusion card: separate, always-visible "members" and "reducer" sections (not one collapsed
+block). Benchmark card: grader gets its own always-visible section so its collapsible prompt
+is clear. Long prompts still collapse. Display-only refinement of OME-635.
+
+- Governing spec: `docs/spec/2026-07-27-OME-626-sdk-display-contract.md`
+- Ledger: `docs/work/2026-07-27-OME-637-fusion-sections-and-grader-section.md`

--- a/docs/tasks/2026-07-27-ome-639-benchmark-card-visual.md
+++ b/docs/tasks/2026-07-27-ome-639-benchmark-card-visual.md
@@ -1,0 +1,17 @@
+---
+id: OME-639
+linear_url: https://linear.app/openmined/issue/OME-639
+status: in_progress
+type: feature
+priority: 3
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-07-27
+closed:
+---
+
+Elevate the Benchmark card to the evaluation Report widget's visual language: header + mono
+big-number stat grid (aggregator / grader / passes / max tool calls), tools as chips, restyled
+grader + engine-routes sections. Brand-compliant, display-only.
+
+- Governing spec: `docs/spec/2026-07-27-OME-626-sdk-display-contract.md`
+- Ledger: `docs/work/2026-07-27-OME-639-benchmark-card-visual.md`

--- a/docs/tasks/2026-07-27-ome-639-benchmark-card-visual.md
+++ b/docs/tasks/2026-07-27-ome-639-benchmark-card-visual.md
@@ -1,7 +1,7 @@
 ---
 id: OME-639
 linear_url: https://linear.app/openmined/issue/OME-639
-status: in_progress
+status: duplicate  # merged into OME-626 (2026-07-27)
 type: feature
 priority: 3
 labels: [py-screamingface, agentic, autonomous]

--- a/docs/tasks/2026-07-27-ome-641-brand-refresh.md
+++ b/docs/tasks/2026-07-27-ome-641-brand-refresh.md
@@ -1,0 +1,18 @@
+---
+id: OME-641
+linear_url: https://linear.app/openmined/issue/OME-641
+status: in_progress
+type: feature
+priority: 3
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-07-27
+closed:
+---
+
+Refresh the SDK notebook widgets to the current `screamingface-brand`: gold gain (was green),
+the gold→blue fusion-signature gradient (card-scoped), EB Garamond serif titles, and the real
+brand webfonts via `@import` (with fallback stacks). Applies across cards + report + progress +
+connection panel; connection panel stays gradient-free. Display-only.
+
+- Governing spec: `docs/spec/2026-07-27-OME-626-sdk-display-contract.md`
+- Ledger: `docs/work/2026-07-27-OME-641-brand-refresh.md`

--- a/docs/work/2026-07-27-OME-626-sdk-catalog-views-and-reprs.md
+++ b/docs/work/2026-07-27-OME-626-sdk-catalog-views-and-reprs.md
@@ -1,0 +1,87 @@
+---
+ticket: OME-626
+stack: screamingface
+status: done
+started: 2026-07-27
+finished: 2026-07-27
+---
+
+# OME-626 — SDK catalog views and widget-like reprs for Model/Fusion/Benchmark
+
+## Intent
+
+Give the notebook SDK a branded rich display for its core objects, matching the
+`widgets-view` design mock. Today evaluating a `Model`, `Fusion`, or `Benchmark` in a cell
+prints the bare frozen-dataclass `repr`, and there is no way to browse the engine catalog
+visually. This unit adds:
+
+- static `_repr_html_()` cards (plus a text `__repr__` fallback) on `Model`, `Fusion`, and
+  `Benchmark`; and
+- `sf.models.view()` / `sf.benchmarks.view()` interactive ipywidgets catalogs (search/filter),
+  modeled on the existing `ConnectionPanel`, with a static `_repr_html_` fallback when
+  ipywidgets is absent.
+
+**Honesty constraint (owner-approved):** the engine advertises no price, context-window, or
+ability-score data. The mock's price/context/ability bars have no backing data, so cards show
+**only real advertised fields** — never fabricated numbers. This keeps the SDK's
+"simulated but honest" stance intact.
+
+## Planned changes
+
+- New `src/screamingface/_card_display.py` — pure HTML functions
+  (`model_card_html`, `fusion_card_html`, `benchmark_card_html`,
+  `models_catalog_html`, `benchmarks_catalog_html`) + text repr helpers; card CSS appended to
+  the shared `.sf-ui` token block from `_display.STYLE`.
+- New `src/screamingface/_catalog_view.py` — `ModelsView` / `BenchmarksView` widget classes
+  (`widget()`, `_repr_html_()`, `_ipython_display_()`), `.value` = filtered ids.
+- Edit `model.py`, `fusion.py`, `benchmark.py` — add `_repr_html_` + `__repr__` (lazy import
+  of `_card_display` to avoid cycles).
+- Edit `models.py`, `benchmarks.py` — add `view(*, query=None, tools=())`; extract a shared
+  `_filter_records` helper so `view()` and `list()` agree exactly.
+- Edit `__init__.py` — export `ModelsView` / `BenchmarksView` if the value type needs to be
+  importable.
+- New tests under `tests/`.
+
+## Test plan (RED first)
+
+- `Model/Fusion/Benchmark._repr_html_` contain the real fields (id/route/provider/prompt/
+  params/url4 for Model; name/reducer/members/model_ids/url4 for Fusion; id/title/grader/
+  aggregator/tools/max_tool_calls for Benchmark) and contain **no** fabricated price/ability
+  text; injected values are HTML-escaped (XSS), mirroring the connection-panel tests.
+- `models.view()`/`benchmarks.view()` build from a mocked registry (`httpx.MockTransport`);
+  `.value` equals the filtered ids; static fallback renders when ipywidgets is absent; the
+  search box narrows rows when ipywidgets is present.
+- `view()` and `list()` return the same ids for the same `query`/`tools` args (invariant).
+
+## Acceptance
+
+- Evaluating a `Model`, `Fusion`, or `Benchmark` in a notebook renders a branded card.
+- `sf.models.view()` / `sf.benchmarks.view()` render a searchable catalog (static fallback
+  without ipywidgets).
+- No fabricated metrics anywhere in the output.
+- Full `screamingface` gates green (ruff/format/pyright/pytest ≥95% cov, engine suite,
+  contract fixtures, notebook check, build).
+
+## Outcome
+
+- **Actual files:** as planned. New `src/screamingface/_card_display.py` (card + catalog HTML
+  renderers) and `src/screamingface/_catalog_view.py` (`ModelsView`/`BenchmarksView`).
+  Added `_repr_html_` to `model.py`, `fusion.py`, `benchmark.py`. Added `view()` +
+  `_filtered_models`/`_filtered_benchmarks` to `models.py`/`benchmarks.py` (shared with
+  `list()`). New test module `tests/test_ome626_display.py` (13 tests). `__init__.py` was
+  **not** changed — the view classes did not need top-level export.
+- **Commit:** feat(screamingface): add catalog views and widget-like reprs (Refs: OME-626).
+- **Gates:** `run_gates.py screamingface` → ALL GATES GREEN (append-only, ruff, format,
+  pyright, SDK pytest ≥95%, engine pytest ≥95%, contract fixtures, notebook check, build).
+  Full SDK suite 733 + 13 new = 746 passing.
+- **Deviations:**
+  - No custom `__repr__` added. The frozen-dataclass-generated `__repr__` already gives a
+    concise text repr and satisfies the existing contract test
+    (`test_phase1_values.py::test_fusion_repr_is_compact...` asserts a member route appears);
+    a hand-written repr risked breaking that append-only test for no gain. `_repr_html_` is
+    the notebook display hook, which is the actual requirement.
+  - The full whole-tree gate initially failed on 7 pre-existing, unrelated modified example
+    notebooks (OME-400 WIP already dirty at session start). Per owner decision these were
+    `git stash`-ed to prove a fully green gate on the OME-626-only tree, the OME-626 files
+    were committed alone, and the stash was restored — no unrelated change was committed or
+    discarded.

--- a/docs/work/2026-07-27-OME-628-repr-cards-connection-case-rubric.md
+++ b/docs/work/2026-07-27-OME-628-repr-cards-connection-case-rubric.md
@@ -1,0 +1,50 @@
+---
+ticket: OME-628
+stack: screamingface
+status: done
+started: 2026-07-27
+finished: 2026-07-27
+---
+
+# OME-628 — _repr_html_ cards for Connection, Case, and Rubric
+
+## Intent
+
+Follow-on polish to OME-626. Three more public value objects print a bare dataclass repr in a
+notebook; give each a branded `_repr_html_` card using the same renderers and honesty contract
+as OME-626. Governing spec: `docs/spec/2026-07-27-OME-626-sdk-display-contract.md`
+(honest advertised/authoring fields only — no fabricated metrics; injected text HTML-escaped).
+
+## Planned changes
+
+- `src/screamingface/_card_display.py` — add `connection_card_html`, `case_card_html`,
+  `rubric_card_html` (pure functions, reuse `_STYLE`, `_field`, `_recipe_html`).
+- `src/screamingface/connections.py` — `Connection._repr_html_` (lazy import).
+- `src/screamingface/benchmark.py` — `Case._repr_html_` (lazy import).
+- `src/screamingface/graders.py` — `Rubric._repr_html_` (lazy import).
+- `tests/test_ome628_value_cards.py` — new tests.
+
+## Test plan (RED first)
+
+- `Connection._repr_html_` shows display_name, provider, status, auth_method, account_label;
+  escapes an injected account_label; no fabricated metrics.
+- `Case._repr_html_` shows id, input, reference, metadata; escapes an injected input.
+- `Rubric._repr_html_` shows model, passes, prompt, params; escapes an injected prompt.
+- Text `__repr__` unchanged (dataclass default) — existing repr assertions stay green.
+
+## Acceptance
+
+- Each of the three renders a branded card in a notebook; no fabricated data; text escaped.
+- Full `screamingface` gates green.
+
+## Outcome
+
+- **Actual files:** as planned. Added `connection_card_html` / `case_card_html` /
+  `rubric_card_html` (+ `_json` helper) to `_card_display.py`; added `_repr_html_` to
+  `Connection` (`connections.py`), `Case` (`benchmark.py`), and `Rubric` (`graders.py`).
+  New `tests/test_ome628_value_cards.py` (6 tests).
+- **Commit:** feat(screamingface): add repr cards for Connection, Case, Rubric (Refs: OME-628).
+- **Gates:** `run_gates.py screamingface` → ALL GATES GREEN. Full SDK suite 733 + 6 new = 739.
+- **Deviations:** none for the code. As in OME-626, the 7 pre-existing unrelated example
+  notebooks (OME-400 WIP) were `git stash`-ed to prove a clean whole-tree gate, only the
+  OME-628 files were committed, and the stash was restored.

--- a/docs/work/2026-07-27-OME-630-url4-recipe-collapsible-view.md
+++ b/docs/work/2026-07-27-OME-630-url4-recipe-collapsible-view.md
@@ -60,3 +60,13 @@ contract (honest fields, HTML-escaped, `.sf-ui` tokens).
     remains the selectable copy source.
   - As before, the 7 pre-existing unrelated example notebooks (OME-400 WIP) were stashed to
     prove a clean whole-tree gate; only OME-630 files committed; stash restored.
+
+## Follow-up fix — 2026-07-27 (pre-merge)
+
+User reported the recipe struct overflowing horizontally with a gold highlight. Investigation:
+the gold is **JupyterLab's Find/search highlight** (`--jp-search-selected-match-background-color:
+#f5c800`) landing on matched text in the output — not SDK styling; it clears when the Find bar
+is closed. The real defect was the flex node containers (`display:flex;flex-direction:column`)
+defaulting to `min-width:auto`, letting long routes/structs push past the card edge. Fixed by
+adding `min-width:0` to `.sf-url4__body/__nodes/__node`; long content now wraps. Guarded by
+`test_recipe_nodes_wrap_long_content_instead_of_overflowing`. Second commit on the same branch.

--- a/docs/work/2026-07-27-OME-630-url4-recipe-collapsible-view.md
+++ b/docs/work/2026-07-27-OME-630-url4-recipe-collapsible-view.md
@@ -1,0 +1,62 @@
+---
+ticket: OME-630
+stack: screamingface
+status: done
+started: 2026-07-27
+finished: 2026-07-27
+---
+
+# OME-630 — collapsible, syntax-highlighted url4 recipe view
+
+## Intent
+
+The Model and Fusion cards show the compiled `url4` recipe as one long unreadable line.
+Parse it with `url4.build(...)` and render a structured, syntax-highlighted, collapsed-by-default
+view with a copy button for the exact raw string. Display-only; governed by the OME-626 display
+contract (honest fields, HTML-escaped, `.sf-ui` tokens).
+
+## Design
+
+- New `_url4_format.py` (keep `_card_display.py` under 450 lines): `recipe_details_html(url4)` →
+  a `<details>` (collapsed) whose body is the structured AST view; a copy button reads the raw
+  url4 from a hidden `<pre>` (fixed JS, no interpolation → no injection, no escaping headaches).
+  Parse via `url4.build`; walk `Expression.sources`; per `Source` show name/weight, and for a
+  `RelExpr` the route/params/context/intent; `StructObject.raw` and other nodes fall back to
+  `url4.render(node)`. On `url4.Url4Error`, fall back to the raw string (today's behavior).
+- `_card_display._recipe_html` delegates to the new formatter (Model + Fusion cards use it).
+- CSS: add `.sf-url4*` classes to `_STYLE` (route = gain accent, params/labels = ink-2/3,
+  intent = surface block); no raw colors.
+
+## Test plan (RED first)
+
+- A compiled Fusion recipe renders a `<details>` without `open` (collapsed); contains a copy
+  button; the raw url4 appears verbatim (copy source) and each member route + a param key show
+  in the structured view; intent text is present and HTML-escaped.
+- A recipe whose intent contains HTML is escaped in the structured view.
+- `recipe_details_html("not a url4 %%%")` (unparseable) falls back to the raw string inside the
+  details and does not raise.
+- Model card and Fusion card HTML both contain the `<details class='sf-url4'>` wrapper.
+
+## Acceptance
+
+- Recipe is collapsed by default, expands to a readable structured view, copy button copies the
+  exact url4, unparseable input degrades to raw. Full `screamingface` gates green.
+
+## Outcome
+
+- **Actual files:** as planned. New `src/screamingface/_url4_format.py`
+  (`recipe_details_html` + AST walker over `url4.build`); `_card_display._recipe_html`
+  delegates to it and `.sf-url4*` CSS added to `_STYLE`. New `tests/test_ome630_url4_view.py`
+  (5 tests).
+- **Commit:** feat(screamingface): render url4 recipe as a collapsible view (Refs: OME-630).
+- **Gates:** `run_gates.py screamingface` → ALL GATES GREEN. Full SDK suite 739 + 5 new = 744.
+- **Deviations:**
+  - `_source_html` accepts `url4.Node` (not `Source`) and renders any non-Source via the value
+    path — `Expression.sources` is typed `Node`; this keeps pyright honest and the display
+    crash-proof.
+  - Copy button uses fixed inline JS reading the raw recipe from a sibling hidden `<pre>` via
+    textContent (no recipe interpolation → no injection/escaping issue). Works in trusted
+    notebook output / VS Code / nbconvert; where a frontend strips inline JS the raw `<pre>`
+    remains the selectable copy source.
+  - As before, the 7 pre-existing unrelated example notebooks (OME-400 WIP) were stashed to
+    prove a clean whole-tree gate; only OME-630 files committed; stash restored.

--- a/docs/work/2026-07-27-OME-635-recipe-fullform-and-fusion-detail.md
+++ b/docs/work/2026-07-27-OME-635-recipe-fullform-and-fusion-detail.md
@@ -1,0 +1,74 @@
+---
+ticket: OME-635
+stack: screamingface
+status: done
+started: 2026-07-27
+finished: 2026-07-27
+---
+
+# OME-635 — recipe full-form pretty-print + Fusion member/reducer detail
+
+## Intent
+
+User feedback on the OME-630 recipe view: keep the url4 in its **full form** (don't extract
+params/prompt into labelled fields) and just reflow it by bracket/section boundaries; and add
+the members'/reducer's prompts + params to the Fusion card as a collapsed section. Also fixes
+the `$…$` MathJax hazard (JupyterLab runs a latexTypesetter on HTML output) by rendering the
+recipe inside a `<pre>` (MathJax skips pre/code).
+
+## Planned changes
+
+- `_url4_format.py`: replace `_structured_html` (AST field extraction) with `_pretty_url4`
+  (quote/backslash-aware reflow that indents on `(){}` and top-level `,`, keeping every other
+  character verbatim). `recipe_details_html` renders the reflow inside `<pre class='sf-url4__pre'>`;
+  copy button copies the exact raw via a `data-url4` attribute (no hidden element). Drop the
+  `url4.build`/Url4Error path (string reflow cannot raise).
+- `_card_display.py`: add `_fusion_detail_html(fusion)` — a collapsed `<details>` listing each
+  member's prompt + params and the reducer's prompt + params; embed it in `fusion_card_html`.
+  Update `.sf-url4*` CSS (pre) and add `.sf-detail*` classes.
+- `_card_display.py` (scope 3, added per user): a shared `_prompt_field`/`_collapsible` helper
+  that renders long text (prompts) as a collapsed `<details>` with a short preview; make the
+  **Benchmark card verbose** — grader (Rubric → model/passes/params/prompt-collapsed),
+  aggregator, tools, max_tool_calls, source (engine vs N local cases), engine routes
+  (collapsed); make the **Rubric card** collapse its prompt; Model/Fusion prompts use the same
+  collapsible.
+- Tests: new `tests/test_ome635_recipe_fullform.py` + benchmark/grader verbosity assertions.
+
+## Test plan (RED first)
+
+- `_pretty_url4`: brackets indent; top-level commas break; a quoted intent containing
+  `,`, `(`, `)`, and an escaped `\'` is preserved verbatim (no breaks inside the quote).
+- `recipe_details_html`: output contains `<pre`, the copy button carries the exact raw in
+  `data-url4`, collapsed by default; the full recipe text (minus added whitespace) is present.
+- Fusion card: contains a collapsed "members" detail with a member prompt and a param, and the
+  reducer's prompt (Model reducer) / "deterministic" (MajorityVote).
+
+## Acceptance
+
+- Recipe shows the full url4, indented by sections, inside a `<pre>`; copy copies exact raw.
+- Fusion card exposes member/reducer prompts+params collapsed. Full gates green.
+
+## Outcome
+
+- **Actual files:** new `src/screamingface/_card_style.py` (stylesheet split out to keep
+  `_card_display.py` under 450 lines); `_url4_format.py` rewritten to a quote/escape-aware
+  string reflow (`_pretty_url4` + `_copy_quoted`); `_card_display.py` — imported stylesheet,
+  `_long_value`/`_prompt_block` collapsers, `_fusion_detail_html`/`_member_detail`/
+  `_reducer_detail`, verbose `benchmark_card_html` (`_grader_detail`, `_benchmark_source`,
+  `_benchmark_routes`), Model/Rubric prompt collapse. New `tests/test_ome635_recipe_fullform.py`
+  (12 tests).
+- **Commit:** feat(screamingface): full-form url4 reflow + verbose fusion/benchmark cards
+  (Refs: OME-635).
+- **Gates:** `run_gates.py screamingface --skip-append-only` → ALL GATES GREEN. Full SDK suite
+  742 prior + 12 new = 754 passing.
+- **Deviations:**
+  - **Append-only skip (owner-directed).** The user explicitly redirected the recipe design
+    ("keep the url4 in full form instead of extracting params/prompt"), which supersedes two
+    same-session, unmerged OME-630 tests. `test_ome630_url4_view.py` (structured-view
+    assertions → full-form) and `test_ome630_recipe_wrap.py` (flex min-width → `<pre>` wrap)
+    were updated to the new behavior; the gate ran with `--skip-append-only`. No merged/other
+    test was touched.
+  - Investigated the reported "gold band": `#f5c800` is JupyterLab's sole search-match color
+    (inline `!important`); rendering the recipe in a `<pre>` also removes it from the
+    `latexTypesetter`'s reach so `$member_*` is shown literally. Any residual gold is the Find
+    highlight (user-side).

--- a/docs/work/2026-07-27-OME-637-fusion-sections-and-grader-section.md
+++ b/docs/work/2026-07-27-OME-637-fusion-sections-and-grader-section.md
@@ -1,0 +1,50 @@
+---
+ticket: OME-637
+stack: screamingface
+status: done
+started: 2026-07-27
+finished: 2026-07-27
+---
+
+# OME-637 — separate always-visible members/reducer sections; grader section
+
+## Intent
+
+User feedback on OME-635 cards: make the Fusion card's members and reducer **separate,
+always-visible** sections (not one collapsed block), and give the Benchmark grader its own
+always-visible section so its (collapsible) prompt is unmistakable. Long prompts still collapse.
+
+## Planned changes
+
+- `_card_style.py`: add `.sf-section` / `.sf-section__title` (always-visible detail section);
+  drop the `.sf-detail` collapsed-wrapper styling (keep item styles).
+- `_card_display.py`: `_fusion_detail_html` → two sections (`_section("members", items)` and
+  `_section("reducer", reducer_body)`), no `<details>`. `benchmark_card_html` → move grader into
+  `_section("grader", _grader_detail(...))`; keep scalars in the grid; keep engine routes as a
+  collapsed `<details>`.
+- Tests: update the OME-635 fusion test (was "collapsed combined") and add OME-637 assertions
+  (separate section titles, not wrapped in `<details>`, grader prompt still collapsible).
+
+## Test plan (RED first)
+
+- Fusion card contains separate `members` and `reducer` section titles and is NOT wrapped in a
+  `<details class='sf-detail'>`; member/reducer long prompts collapse.
+- Benchmark card has a `grader` section; a long Rubric prompt renders `<details class='sf-more'>`.
+
+## Acceptance
+
+- Members and reducer show as separate, uncollapsed sections; grader prompt collapsible in its
+  own section. Full gates green.
+
+## Outcome
+
+- **Actual files:** `_card_style.py` (added `.sf-section`/`.sf-section__title`, replaced the
+  `.sf-detail` collapsed wrapper); `_card_display.py` (`_section` helper; `_fusion_detail_html`
+  → two always-visible sections; benchmark grader moved out of the grid into a `grader`
+  section). New `tests/test_ome637_sections.py` (2 tests); updated the OME-635 fusion test.
+- **Commit:** feat(screamingface): separate members/reducer sections + grader section
+  (Refs: OME-637).
+- **Gates:** `run_gates.py screamingface --skip-append-only` → ALL GATES GREEN. 754 + 2 = 756.
+- **Deviations:** append-only skip — updated one same-session unmerged OME-635 fusion test to
+  the new (uncollapsed, separate-sections) behavior per the user's request. Confirmed the grader
+  prompt was already collapsible; the change gives it its own section so it's unmistakable.

--- a/docs/work/2026-07-27-OME-637-fusion-sections-and-grader-section.md
+++ b/docs/work/2026-07-27-OME-637-fusion-sections-and-grader-section.md
@@ -48,3 +48,13 @@ always-visible section so its (collapsible) prompt is unmistakable. Long prompts
 - **Deviations:** append-only skip — updated one same-session unmerged OME-635 fusion test to
   the new (uncollapsed, separate-sections) behavior per the user's request. Confirmed the grader
   prompt was already collapsible; the change gives it its own section so it's unmistakable.
+
+## Follow-up fix — 2026-07-27 (spacing)
+
+User: double line between source and grader, none between grader and engine routes. Cause: the
+grid kept a `border-bottom` while each `.sf-section` also adds `margin-top` + `border-top`
+(→ two lines), and engine routes had reverted to an unstyled `.sf-detail` wrapper (→ no line).
+Fix: dropped `.sf-card__grid` bottom border (the following section's top border is now the sole
+separator), added a `border-top` to `.sf-card__recipe`, and made engine routes a
+`<details class='sf-section'>` (separated + collapsible). Guarded by `tests/test_ome637_spacing.py`.
+Second commit on the branch; full gate green (append-only clean — new test file only).

--- a/docs/work/2026-07-27-OME-637-fusion-sections-and-grader-section.md
+++ b/docs/work/2026-07-27-OME-637-fusion-sections-and-grader-section.md
@@ -58,3 +58,9 @@ Fix: dropped `.sf-card__grid` bottom border (the following section's top border 
 separator), added a `border-top` to `.sf-card__recipe`, and made engine routes a
 `<details class='sf-section'>` (separated + collapsible). Guarded by `tests/test_ome637_spacing.py`.
 Second commit on the branch; full gate green (append-only clean — new test file only).
+
+## Follow-up — 2026-07-27 (drop source field)
+
+User: drop the "source — engine-advertised…/N local cases" line from the benchmark card.
+Removed the `source` field and the `_benchmark_source` helper; updated two same-session
+unmerged OME-635 benchmark assertions (`--skip-append-only`). Third commit on the branch.

--- a/docs/work/2026-07-27-OME-639-benchmark-card-visual.md
+++ b/docs/work/2026-07-27-OME-639-benchmark-card-visual.md
@@ -1,0 +1,53 @@
+---
+ticket: OME-639
+stack: screamingface
+status: done
+started: 2026-07-27
+finished: 2026-07-27
+---
+
+# OME-639 — elevate the benchmark card to the evaluate/report visual language
+
+## Intent
+
+Bring the Benchmark card up to the polish of the evaluation Report widget
+(`_report_display.py`): a clean header + a mono **big-number stat grid** with hairline
+dividers and uppercase mono labels, tools as chips, and restyled grader + engine-routes
+sections. Brand-compliant (screamingface-design): near-monochrome, square, hairline, mono
+labels, light+dark equal; gain reserved for a win (none here).
+
+## Planned changes
+
+- `_card_style.py`: add `.sf-stats` / `.sf-stat` / `.sf-stat__k` / `.sf-stat__v` (mirroring the
+  report widget's stat grid), `.sf-chips` / `.sf-chip`, and `.sf-card__meta`.
+- `_card_display.py` `benchmark_card_html`: header (title + id meta), a 4-up stat grid
+  (aggregator / grader / passes / max tool calls), a tools chip row, a grader section
+  (model + params + collapsible prompt, or "deterministic"), and the collapsible engine-routes
+  section. Add `_grader_section_body` (model/params/prompt without repeating the kind).
+- Tests: new `tests/test_ome639_benchmark_card.py`.
+
+## Test plan (RED first)
+
+- Benchmark card contains `.sf-stats` with labels aggregator/grader/passes/max tool calls and
+  the right values (mean, rubric, 5, 12); tools render as `.sf-chip`s.
+- Rubric grader section shows the model + collapsible prompt; ExactChoice shows "deterministic".
+- No fabricated data; injected text escaped; both prior card tests still pass.
+
+## Acceptance
+
+- Benchmark card visually matches the report language (stat grid, sections, chips). Gates green.
+
+## Outcome
+
+- **Actual files:** `_card_style.py` (added `.sf-card__meta`, `.sf-stats`/`.sf-stat`/`.sf-stat__k`/
+  `.sf-stat__v` mirroring the report stat grid + a 2-col mobile breakpoint, `.sf-chips`/
+  `.sf-chip`); `_card_display.py` (rewrote `benchmark_card_html` → header + stat grid + tool
+  chips + grader section + engine routes; added `_stat`/`_tool_chips`/`_grader_section_body`;
+  removed the now-dead `_grader_detail`). New `tests/test_ome639_benchmark_card.py` (5 tests).
+- **Commit:** feat(screamingface): elevate benchmark card to the report visual language
+  (Refs: OME-639).
+- **Gates:** `run_gates.py screamingface --skip-append-only` → ALL GREEN. 758 + 5 = 763.
+- **Deviations:** append-only skip — the stat grid shows passes as a value ("5"), so two
+  same-session unmerged assertions that expected "N passes" (OME-635, OME-637) were updated to
+  `>N</div>`. Brand self-check: near-monochrome (no gain used — a static benchmark encodes no
+  win), square, hairline, mono labels, tokens only, light+dark via the shared `.sf-ui` block.

--- a/docs/work/2026-07-27-OME-641-brand-refresh.md
+++ b/docs/work/2026-07-27-OME-641-brand-refresh.md
@@ -1,0 +1,65 @@
+---
+ticket: OME-641
+stack: screamingface
+status: done
+started: 2026-07-27
+finished: 2026-07-27
+---
+
+# OME-641 — refresh SDK notebook widgets to the current brand
+
+## Intent
+
+Align the SDK's notebook visual system to the current `screamingface-brand` and make the
+cards genuinely appealing (owner: full brand refresh). The brand evolved: gain is now **gold**
+(was green), the signature is a **gold→blue** gradient sampled from the 😱, and display type is
+**EB Garamond** serif.
+
+## Planned changes
+
+- `_display.py` `STYLE` (shared `.sf-ui`): `@import` brand webfonts (EB Garamond 500, IBM Plex
+  Sans/Mono) with fallback stacks; add `--sf-display`/`--sf-sans`/`--sf-mono`; change `--sf-gain`
+  (+ `--sf-gain-bg`) green→gold in both light and dark. Body uses `var(--sf-sans)`.
+- `_card_style.py`: serif card titles (`--sf-display`); define `--sf-gain-grad` (gold→blue,
+  scoped to card style only — keeps the connection panel gradient-free); add `.sf-card__accent`
+  (gradient) / `.sf-card__accent--solid` (gold) top bars; refine.
+- `_card_display.py`: prepend an accent bar to each card — gradient on Fusion, solid gold on
+  Model/Benchmark/Connection/Case/Rubric.
+- `_report_display.py` / `_connection_panel.py` / `_progress.py`: serif-ize the titles; gold gain
+  inherited automatically.
+- Tests: new `tests/test_ome641_brand_refresh.py`.
+
+## Test plan (RED first)
+
+- Shared STYLE: `--sf-gain` value is a gold hex (not the old green `#0f7a3d`); an `@import` of
+  the brand fonts is present; `--sf-display` defined.
+- `_card_style`: `--sf-gain-grad` gold→blue gradient present; card title uses `var(--sf-display)`.
+- Fusion card contains the gradient accent; Model/Benchmark contain the solid gold accent.
+- Connection panel HTML still contains no `linear-gradient` and no `purple` (regression guard).
+
+## Acceptance
+
+- All widgets render in the current brand (gold, serif titles, real fonts online); Fusion shows
+  the gold→blue signature; connection panel stays gradient-free. Full gates green.
+
+## Outcome
+
+- **Actual files:** `_display.py` (rewrote STYLE: `@import` brand webfonts, `--sf-display`/
+  `--sf-sans`/`--sf-mono` vars, `--sf-gain` green→gold in light+dark; body font kept as the
+  literal IBM Plex Sans stack so the prior report visual-rules test stays valid); `_card_style.py`
+  (card-scoped `--sf-gain-grad` gold→blue, `.sf-card__accent`(+`--solid`), serif card + catalog
+  titles); `_card_display.py` (accent bar on every card — gradient on Fusion, solid gold on the
+  rest); `_report_display.py` + `_connection_panel.py` (serif titles). New
+  `tests/test_ome641_brand_refresh.py` (4 tests).
+- **Commit:** feat(screamingface): refresh notebook widgets to the current brand (Refs: OME-641).
+- **Gates:** `run_gates.py screamingface` → ALL GATES GREEN (append-only clean — only a new test
+  file added). 763 + 4 new = 767 tests.
+- **Deviations:**
+  - Kept `.sf-ui` body `font-family` as the literal IBM Plex Sans stack (not `var(--sf-sans)`)
+    so the existing cross-phase report test (`test_report_display` asserts the literal) keeps
+    passing while the serif `--sf-display` var drives titles. No prior test was modified.
+  - Fusion gradient token is card-scoped (not in shared STYLE) so the connection panel stays
+    gradient-free (its "no linear-gradient" contract holds). Gold→blue only; no purple — the
+    rationale comment moved out of the shipped CSS to avoid the literal word in output.
+  - Brand self-check: gold gain, gold→blue signature (Fusion), serif titles, real fonts via
+    `@import` with fallbacks, square, hairline, light+dark equal.

--- a/docs/work/2026-07-27-OME-641-brand-refresh.md
+++ b/docs/work/2026-07-27-OME-641-brand-refresh.md
@@ -63,3 +63,14 @@ cards genuinely appealing (owner: full brand refresh). The brand evolved: gain i
     rationale comment moved out of the shipped CSS to avoid the literal word in output.
   - Brand self-check: gold gain, gold→blue signature (Fusion), serif titles, real fonts via
     `@import` with fallbacks, square, hairline, light+dark equal.
+
+## Follow-up — 2026-07-27 (clear titles + color on connections/models/benchmarks)
+
+User feedback: the EB Garamond serif titles read weird. Reverted card/catalog/report/connection
+titles to the prior clear sans (IBM Plex Sans, 15/16/13px, weight 600) and dropped the now-unused
+EB Garamond font (and `--sf-display`/`--sf-sans`/`--sf-mono` vars); the real IBM Plex Sans/Mono
+still load via `@import`. Also added brand color to the three requested surfaces: gold-bordered
+`.sf-chip`s (models = provider + tool chips; benchmarks = tool chips; benchmark card tools too),
+a solid-gold accent bar on the models/benchmarks catalogs and on the connection panel (solid —
+the panel stays gradient-free). Updated the OME-641 test to the clear-title reality + catalog/
+connection color assertions (`--skip-append-only`, same-session test).

--- a/packages/screamingface/src/screamingface/_card_display.py
+++ b/packages/screamingface/src/screamingface/_card_display.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from screamingface.fusion import Fusion
     from screamingface.graders import Grader, Rubric
     from screamingface.model import Model
+    from screamingface.tools import Tool
 
 # A prompt/route longer than this collapses into a <details>; shorter renders inline.
 _LONG_LIMIT = 140
@@ -134,25 +135,55 @@ def fusion_card_html(fusion: Fusion) -> str:
 
 
 def benchmark_card_html(benchmark: Benchmark) -> str:
-    """Render one Benchmark verbosely: every interesting field, long ones collapsed."""
+    """Render one Benchmark in the evaluate/report visual language: header + stat grid."""
 
-    tools = ", ".join(tool.id for tool in benchmark.tools) or "none"
+    passes = getattr(benchmark.grader, "passes", None)
     tool_calls = "—" if benchmark.max_tool_calls is None else str(benchmark.max_tool_calls)
-    fields = "".join(
+    stats = "".join(
         (
-            _field("id", _mono(benchmark.id)),
-            _field("aggregator", escape(benchmark.aggregator.kind.replace("_", " "))),
-            _field("tools", _mono(tools)),
-            _field("max tool calls", escape(tool_calls)),
+            _stat("aggregator", benchmark.aggregator.kind.replace("_", " ")),
+            _stat("grader", benchmark.grader.kind.replace("_", " ")),
+            _stat("passes", "—" if passes is None else str(passes)),
+            _stat("max tool calls", tool_calls),
         )
     )
     return (
         f"{_STYLE}<div class='sf-ui sf-card' aria-label='ScreamingFace benchmark'>"
-        f"<div class='sf-card__head'><span class='sf-card__title'>{escape(benchmark.title)}</span>"
+        "<div class='sf-card__head'><div>"
+        f"<span class='sf-card__title'>{escape(benchmark.title)}</span>"
+        f"<div class='sf-card__meta'>{escape(benchmark.id)}</div></div>"
         "<span class='sf-card__kicker'>benchmark</span></div>"
-        f"<div class='sf-card__grid'>{fields}</div>"
-        f"{_section('grader', _grader_detail(benchmark.grader))}"
+        f"<div class='sf-stats'>{stats}</div>"
+        f"{_tool_chips(benchmark.tools)}"
+        f"{_section('grader', _grader_section_body(benchmark.grader))}"
         f"{_benchmark_routes(benchmark)}</div>"
+    )
+
+
+def _stat(label: str, value: str) -> str:
+    return (
+        f"<div class='sf-stat'><div class='sf-stat__k'>{escape(label)}</div>"
+        f"<div class='sf-stat__v'>{escape(value)}</div></div>"
+    )
+
+
+def _tool_chips(tools: Sequence[Tool]) -> str:
+    if not tools:
+        return ""
+    chips = "".join(f"<span class='sf-chip'>{escape(str(tool.id))}</span>" for tool in tools)
+    return f"<div class='sf-chips'>{chips}</div>"
+
+
+def _grader_section_body(grader: Grader) -> str:
+    model = getattr(grader, "model", None)
+    kind = str(getattr(grader, "kind", "grader")).replace("_", " ")
+    if model is None:  # deterministic grader (e.g. ExactChoice)
+        return f"{escape(kind)} <span class='sf-card__hint'>(deterministic)</span>"
+    params = _params_text(getattr(grader, "params", {}))
+    return (
+        f"<div class='sf-detail__params'>model {_mono(str(model))}</div>"
+        f"<div class='sf-detail__params'>params: {params}</div>"
+        f"{_prompt_block(str(getattr(grader, 'prompt', '')))}"
     )
 
 
@@ -303,23 +334,6 @@ def _reducer_detail(reducer: object) -> str:
         f"<div class='sf-detail__route'>{escape(str(route))}</div>"
         f"<div class='sf-detail__params'>params: {params}</div>"
         f"{_prompt_block(str(getattr(reducer, 'prompt', '')))}</div>"
-    )
-
-
-def _grader_detail(grader: Grader) -> str:
-    kind = str(getattr(grader, "kind", "grader")).replace("_", " ")
-    model = getattr(grader, "model", None)
-    if model is None:  # deterministic grader (e.g. ExactChoice)
-        return f"{escape(kind)} <span class='sf-card__hint'>(deterministic)</span>"
-    passes = getattr(grader, "passes", None)
-    head = f"{escape(kind)} · model {_mono(str(model))}"
-    if passes is not None:
-        head += f" · {passes} pass{'' if passes == 1 else 'es'}"
-    params = _params_text(getattr(grader, "params", {}))
-    return (
-        f"<div class='sf-detail__params'>{head}</div>"
-        f"<div class='sf-detail__params'>params: {params}</div>"
-        f"{_prompt_block(str(getattr(grader, 'prompt', '')))}"
     )
 
 

--- a/packages/screamingface/src/screamingface/_card_display.py
+++ b/packages/screamingface/src/screamingface/_card_display.py
@@ -79,9 +79,9 @@ _STYLE = (
   border:1px solid var(--sf-line-2);background:var(--sf-bg);color:var(--sf-ink-2);
   padding:2px 8px;font:11px/1 "IBM Plex Mono",ui-monospace,monospace}
 .sf-url4__copy:hover{border-color:var(--sf-ink-3);color:var(--sf-ink)}
-.sf-url4__body{margin-top:8px}
-.sf-url4__nodes{display:flex;flex-direction:column;gap:6px}
-.sf-url4__node{border-left:2px solid var(--sf-line-2);padding:1px 0 1px 10px}
+.sf-url4__body{margin-top:8px;min-width:0}
+.sf-url4__nodes{display:flex;flex-direction:column;gap:6px;min-width:0}
+.sf-url4__node{border-left:2px solid var(--sf-line-2);padding:1px 0 1px 10px;min-width:0}
 .sf-url4__nhead{display:flex;align-items:baseline;gap:8px}
 .sf-url4__name{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px;
   font-weight:600;color:var(--sf-gain)}

--- a/packages/screamingface/src/screamingface/_card_display.py
+++ b/packages/screamingface/src/screamingface/_card_display.py
@@ -144,7 +144,6 @@ def benchmark_card_html(benchmark: Benchmark) -> str:
             _field("aggregator", escape(benchmark.aggregator.kind.replace("_", " "))),
             _field("tools", _mono(tools)),
             _field("max tool calls", escape(tool_calls)),
-            _field("source", escape(_benchmark_source(benchmark)), wide=True),
         )
     )
     return (
@@ -322,15 +321,6 @@ def _grader_detail(grader: Grader) -> str:
         f"<div class='sf-detail__params'>params: {params}</div>"
         f"{_prompt_block(str(getattr(grader, 'prompt', '')))}"
     )
-
-
-def _benchmark_source(benchmark: Benchmark) -> str:
-    source = benchmark._case_source
-    if source is None:
-        return "engine-advertised — cases resolved by the engine"
-    if isinstance(source, tuple):
-        return f"{len(source)} local case{'' if len(source) == 1 else 's'}"
-    return "local — lazy case producer"
 
 
 def _benchmark_routes(benchmark: Benchmark) -> str:

--- a/packages/screamingface/src/screamingface/_card_display.py
+++ b/packages/screamingface/src/screamingface/_card_display.py
@@ -97,6 +97,7 @@ def model_card_html(model: Model) -> str:
     )
     return (
         f"{_STYLE}<div class='sf-ui sf-card' aria-label='ScreamingFace model'>"
+        "<div class='sf-card__accent sf-card__accent--solid'></div>"
         f"<div class='sf-card__head'><span class='sf-card__title'>{escape(model.name)}</span>"
         "<span class='sf-card__kicker'>model</span></div>"
         f"<div class='sf-card__grid'>{fields}</div>"
@@ -126,6 +127,7 @@ def fusion_card_html(fusion: Fusion) -> str:
     )
     return (
         f"{_STYLE}<div class='sf-ui sf-card' aria-label='ScreamingFace fusion'>"
+        "<div class='sf-card__accent'></div>"
         f"<div class='sf-card__head'><span class='sf-card__title'>{escape(fusion.name)}</span>"
         "<span class='sf-card__kicker'>fusion</span></div>"
         f"<div class='sf-card__grid'>{fields}</div>"
@@ -149,6 +151,7 @@ def benchmark_card_html(benchmark: Benchmark) -> str:
     )
     return (
         f"{_STYLE}<div class='sf-ui sf-card' aria-label='ScreamingFace benchmark'>"
+        "<div class='sf-card__accent sf-card__accent--solid'></div>"
         "<div class='sf-card__head'><div>"
         f"<span class='sf-card__title'>{escape(benchmark.title)}</span>"
         f"<div class='sf-card__meta'>{escape(benchmark.id)}</div></div>"
@@ -207,6 +210,7 @@ def connection_card_html(connection: Connection) -> str:
     )
     return (
         f"{_STYLE}<div class='sf-ui sf-card' aria-label='ScreamingFace connection'>"
+        "<div class='sf-card__accent sf-card__accent--solid'></div>"
         f"<div class='sf-card__head'>"
         f"<span class='sf-card__title'>{escape(connection.display_name)}</span>"
         "<span class='sf-card__kicker'>connection</span></div>"
@@ -234,6 +238,7 @@ def case_card_html(case: Case) -> str:
     )
     return (
         f"{_STYLE}<div class='sf-ui sf-card' aria-label='ScreamingFace case'>"
+        "<div class='sf-card__accent sf-card__accent--solid'></div>"
         f"<div class='sf-card__head'><span class='sf-card__title'>{escape(case.id)}</span>"
         "<span class='sf-card__kicker'>case</span></div>"
         f"<div class='sf-card__grid'>{fields}</div></div>"
@@ -253,6 +258,7 @@ def rubric_card_html(rubric: Rubric) -> str:
     )
     return (
         f"{_STYLE}<div class='sf-ui sf-card' aria-label='ScreamingFace rubric grader'>"
+        "<div class='sf-card__accent sf-card__accent--solid'></div>"
         f"<div class='sf-card__head'><span class='sf-card__title'>{escape(rubric.model)}</span>"
         "<span class='sf-card__kicker'>rubric grader</span></div>"
         f"<div class='sf-card__grid'>{fields}</div></div>"

--- a/packages/screamingface/src/screamingface/_card_display.py
+++ b/packages/screamingface/src/screamingface/_card_display.py
@@ -70,6 +70,36 @@ _STYLE = (
   color:var(--sf-ink)!important;
   font:12px/1 "IBM Plex Mono",ui-monospace,monospace!important}
 .sf-catalog-widget .widget-text{width:auto!important;margin:8px 12px!important}
+.sf-url4{border:0}
+.sf-url4__summary{cursor:pointer;display:flex;align-items:center;gap:8px;list-style:none}
+.sf-url4__summary::-webkit-details-marker{display:none}
+.sf-url4__summary::before{content:'▸';color:var(--sf-ink-3);font-size:10px}
+.sf-url4[open] .sf-url4__summary::before{content:'▾'}
+.sf-url4__copy{margin-left:auto;cursor:pointer;border-radius:0;
+  border:1px solid var(--sf-line-2);background:var(--sf-bg);color:var(--sf-ink-2);
+  padding:2px 8px;font:11px/1 "IBM Plex Mono",ui-monospace,monospace}
+.sf-url4__copy:hover{border-color:var(--sf-ink-3);color:var(--sf-ink)}
+.sf-url4__body{margin-top:8px}
+.sf-url4__nodes{display:flex;flex-direction:column;gap:6px}
+.sf-url4__node{border-left:2px solid var(--sf-line-2);padding:1px 0 1px 10px}
+.sf-url4__nhead{display:flex;align-items:baseline;gap:8px}
+.sf-url4__name{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px;
+  font-weight:600;color:var(--sf-gain)}
+.sf-url4__weight{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:10px;
+  color:var(--sf-ink-3)}
+.sf-url4__route{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px;
+  color:var(--sf-ink);overflow-wrap:anywhere}
+.sf-url4__param,.sf-url4__ctx,.sf-url4__leaf,.sf-url4__struct{
+  font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11px;color:var(--sf-ink-2);
+  padding-left:10px;overflow-wrap:anywhere}
+.sf-url4__struct{white-space:pre-wrap}
+.sf-url4__pk{color:var(--sf-ink-3)}
+.sf-url4__intent{font-size:12px;color:var(--sf-ink-2);background:var(--sf-surface);
+  padding:4px 8px;margin-top:2px;white-space:pre-wrap;overflow-wrap:anywhere}
+.sf-url4__output{margin-top:6px;font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11px}
+.sf-url4__raw{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11px;
+  color:var(--sf-ink-3);white-space:pre-wrap;overflow-wrap:anywhere;
+  margin:8px 0 0;background:transparent;border:0;padding:0}
 </style>"""
 )
 
@@ -242,11 +272,10 @@ def _json(value: object) -> str:
     return json.dumps(value, ensure_ascii=False, sort_keys=True)
 
 
-def _recipe_html(url4: str) -> str:
-    return (
-        "<div class='sf-card__recipe'><div class='sf-card__k'>url4</div>"
-        f"<code>{escape(url4)}</code></div>"
-    )
+def _recipe_html(recipe_url4: str) -> str:
+    from screamingface._url4_format import recipe_details_html
+
+    return f"<div class='sf-card__recipe'>{recipe_details_html(recipe_url4)}</div>"
 
 
 def _member_row(member: object) -> str:

--- a/packages/screamingface/src/screamingface/_card_display.py
+++ b/packages/screamingface/src/screamingface/_card_display.py
@@ -13,95 +13,18 @@ from collections.abc import Mapping, Sequence
 from html import escape
 from typing import TYPE_CHECKING
 
-from screamingface._display import STYLE
+from screamingface._card_style import CARD_STYLE as _STYLE
 
 if TYPE_CHECKING:
     from screamingface._profile import BenchmarkRecord, ModelRecord
     from screamingface.benchmark import Benchmark, Case
     from screamingface.connections import Connection
     from screamingface.fusion import Fusion
-    from screamingface.graders import Rubric
+    from screamingface.graders import Grader, Rubric
     from screamingface.model import Model
 
-_STYLE = (
-    STYLE
-    + """<style>
-.sf-card{border:1px solid var(--sf-line-2);background:var(--sf-bg)}
-.sf-card__head{display:flex;align-items:baseline;gap:8px;padding:10px 12px;
-  border-bottom:1px solid var(--sf-line)}
-.sf-card__title{font-size:15px;font-weight:600}
-.sf-card__kicker{margin-left:auto;font-family:"IBM Plex Mono",ui-monospace,monospace;
-  font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--sf-gain)}
-.sf-card__grid{display:grid;grid-template-columns:1fr 1fr;gap:1px;background:var(--sf-line);
-  border-bottom:1px solid var(--sf-line)}
-.sf-card__field{background:var(--sf-bg);padding:8px 12px;min-width:0}
-.sf-card__field.wide{grid-column:1 / -1}
-.sf-card__k{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:10px;
-  letter-spacing:.08em;text-transform:uppercase;color:var(--sf-ink-3)}
-.sf-card__v{margin-top:2px;overflow-wrap:anywhere}
-.sf-card__hint{color:var(--sf-ink-3)}
-.sf-card__list{margin:2px 0 0;padding:0;list-style:none}
-.sf-card__list li{padding:1px 0}
-.sf-card__recipe{padding:8px 12px;background:var(--sf-surface)}
-.sf-card__recipe code{display:block;margin-top:2px;font-size:11px;
-  font-family:"IBM Plex Mono",ui-monospace,monospace;color:var(--sf-ink);
-  white-space:pre-wrap;overflow-wrap:anywhere;background:transparent;border:0;padding:0}
-.sf-mono{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px}
-.sf-catalog{border:1px solid var(--sf-line-2)}
-.sf-catalog-widget.widget-vbox{border:0!important;box-shadow:none!important}
-.sf-catalog__head{display:flex;align-items:center;gap:8px;height:44px;padding:0 12px;
-  border-bottom:1px solid var(--sf-line-2)}
-.sf-catalog__title{font-size:13px;font-weight:600}
-.sf-catalog__count{margin-left:auto;font-family:"IBM Plex Mono",ui-monospace,monospace;
-  font-size:11px;color:var(--sf-ink-3)}
-.sf-catalog__row{display:grid;grid-template-columns:minmax(0,2fr) 1fr;gap:12px;
-  align-items:center;padding:8px 12px;border-bottom:1px solid var(--sf-line)}
-.sf-catalog__row:last-child{border-bottom:0}
-.sf-catalog__id{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px;
-  font-weight:600;overflow-wrap:anywhere}
-.sf-catalog__sub{color:var(--sf-ink-2)}
-.sf-catalog__meta{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11px;
-  color:var(--sf-ink-3);text-align:right;overflow-wrap:anywhere}
-.sf-catalog__empty{padding:16px 12px;color:var(--sf-ink-3);text-align:center;
-  font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px}
-.sf-catalog-widget .widget-text input{border-radius:0!important;box-shadow:none!important;
-  background-image:none!important;height:32px!important;padding:0 8px!important;
-  border:1px solid var(--sf-line-2)!important;background:var(--sf-bg)!important;
-  color:var(--sf-ink)!important;
-  font:12px/1 "IBM Plex Mono",ui-monospace,monospace!important}
-.sf-catalog-widget .widget-text{width:auto!important;margin:8px 12px!important}
-.sf-url4{border:0}
-.sf-url4__summary{cursor:pointer;display:flex;align-items:center;gap:8px;list-style:none}
-.sf-url4__summary::-webkit-details-marker{display:none}
-.sf-url4__summary::before{content:'▸';color:var(--sf-ink-3);font-size:10px}
-.sf-url4[open] .sf-url4__summary::before{content:'▾'}
-.sf-url4__copy{margin-left:auto;cursor:pointer;border-radius:0;
-  border:1px solid var(--sf-line-2);background:var(--sf-bg);color:var(--sf-ink-2);
-  padding:2px 8px;font:11px/1 "IBM Plex Mono",ui-monospace,monospace}
-.sf-url4__copy:hover{border-color:var(--sf-ink-3);color:var(--sf-ink)}
-.sf-url4__body{margin-top:8px;min-width:0}
-.sf-url4__nodes{display:flex;flex-direction:column;gap:6px;min-width:0}
-.sf-url4__node{border-left:2px solid var(--sf-line-2);padding:1px 0 1px 10px;min-width:0}
-.sf-url4__nhead{display:flex;align-items:baseline;gap:8px}
-.sf-url4__name{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px;
-  font-weight:600;color:var(--sf-gain)}
-.sf-url4__weight{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:10px;
-  color:var(--sf-ink-3)}
-.sf-url4__route{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px;
-  color:var(--sf-ink);overflow-wrap:anywhere}
-.sf-url4__param,.sf-url4__ctx,.sf-url4__leaf,.sf-url4__struct{
-  font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11px;color:var(--sf-ink-2);
-  padding-left:10px;overflow-wrap:anywhere}
-.sf-url4__struct{white-space:pre-wrap}
-.sf-url4__pk{color:var(--sf-ink-3)}
-.sf-url4__intent{font-size:12px;color:var(--sf-ink-2);background:var(--sf-surface);
-  padding:4px 8px;margin-top:2px;white-space:pre-wrap;overflow-wrap:anywhere}
-.sf-url4__output{margin-top:6px;font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11px}
-.sf-url4__raw{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11px;
-  color:var(--sf-ink-3);white-space:pre-wrap;overflow-wrap:anywhere;
-  margin:8px 0 0;background:transparent;border:0;padding:0}
-</style>"""
-)
+# A prompt/route longer than this collapses into a <details>; shorter renders inline.
+_LONG_LIMIT = 140
 
 
 def _field(label: str, value_html: str, *, wide: bool = False) -> str:
@@ -125,14 +48,49 @@ def _params_text(params: Mapping[str, object]) -> str:
     return escape(", ".join(f"{key}={value}" for key, value in params.items()))
 
 
+def _mono(text: str) -> str:
+    return f"<span class='sf-mono'>{escape(text)}</span>"
+
+
+def _long_value(text: str) -> str:
+    """A field VALUE (no label): inline when short, else a collapsed <details> with a preview."""
+
+    if len(text) <= _LONG_LIMIT:
+        return escape(text)
+    preview = escape(" ".join(text[:90].split())) + "…"
+    return (
+        "<details class='sf-more'><summary class='sf-summary'>"
+        f"<span class='sf-more__preview'>{preview}</span>"
+        f"<span class='sf-card__hint'> · {len(text)} chars</span></summary>"
+        f"<div class='sf-more__full'>{escape(text)}</div></details>"
+    )
+
+
+def _prompt_block(prompt: str, *, label: str = "prompt") -> str:
+    """A LABELLED prompt line for detail sections: inline when short, else collapsed."""
+
+    if not prompt:
+        return ""
+    if len(prompt) <= _LONG_LIMIT:
+        return f"<div class='sf-detail__params'>{escape(label)}: {escape(prompt)}</div>"
+    preview = escape(" ".join(prompt[:90].split())) + "…"
+    return (
+        "<details class='sf-more'><summary class='sf-summary'>"
+        f"<span class='sf-card__k'>{escape(label)}</span> "
+        f"<span class='sf-more__preview'>{preview}</span>"
+        f"<span class='sf-card__hint'> · {len(prompt)} chars</span></summary>"
+        f"<div class='sf-more__full'>{escape(prompt)}</div></details>"
+    )
+
+
 def model_card_html(model: Model) -> str:
     """Render one Model as a branded card of its real authoring fields."""
 
     fields = "".join(
         (
-            _field("route", f"<span class='sf-mono'>{escape(model.model)}</span>"),
+            _field("route", _mono(model.model)),
             _field("provider", escape(_provider_of(model.model))),
-            _field("prompt", escape(model.prompt), wide=True),
+            _field("prompt", _long_value(model.prompt), wide=True),
             _field("params", _params_text(model.params), wide=True),
         )
     )
@@ -170,29 +128,32 @@ def fusion_card_html(fusion: Fusion) -> str:
         f"<div class='sf-card__head'><span class='sf-card__title'>{escape(fusion.name)}</span>"
         "<span class='sf-card__kicker'>fusion</span></div>"
         f"<div class='sf-card__grid'>{fields}</div>"
+        f"{_fusion_detail_html(fusion)}"
         f"{_recipe_html(fusion.url4)}</div>"
     )
 
 
 def benchmark_card_html(benchmark: Benchmark) -> str:
-    """Render one Benchmark as a branded card of its real definition fields."""
+    """Render one Benchmark verbosely: every interesting field, long ones collapsed."""
 
     tools = ", ".join(tool.id for tool in benchmark.tools) or "none"
     tool_calls = "—" if benchmark.max_tool_calls is None else str(benchmark.max_tool_calls)
     fields = "".join(
         (
-            _field("id", f"<span class='sf-mono'>{escape(benchmark.id)}</span>"),
-            _field("grader", escape(benchmark.grader.kind.replace("_", " "))),
+            _field("id", _mono(benchmark.id)),
             _field("aggregator", escape(benchmark.aggregator.kind.replace("_", " "))),
+            _field("tools", _mono(tools)),
             _field("max tool calls", escape(tool_calls)),
-            _field("tools", f"<span class='sf-mono'>{escape(tools)}</span>", wide=True),
+            _field("source", escape(_benchmark_source(benchmark)), wide=True),
+            _field("grader", _grader_detail(benchmark.grader), wide=True),
         )
     )
     return (
         f"{_STYLE}<div class='sf-ui sf-card' aria-label='ScreamingFace benchmark'>"
         f"<div class='sf-card__head'><span class='sf-card__title'>{escape(benchmark.title)}</span>"
         "<span class='sf-card__kicker'>benchmark</span></div>"
-        f"<div class='sf-card__grid'>{fields}</div></div>"
+        f"<div class='sf-card__grid'>{fields}</div>"
+        f"{_benchmark_routes(benchmark)}</div>"
     )
 
 
@@ -254,10 +215,10 @@ def rubric_card_html(rubric: Rubric) -> str:
 
     fields = "".join(
         (
-            _field("model", f"<span class='sf-mono'>{escape(rubric.model)}</span>"),
+            _field("model", _mono(rubric.model)),
             _field("passes", str(rubric.passes)),
             _field("params", _params_text(rubric.params), wide=True),
-            _field("prompt", escape(rubric.prompt), wide=True),
+            _field("prompt", _long_value(rubric.prompt), wide=True),
         )
     )
     return (
@@ -293,6 +254,101 @@ def _reducer_label(reducer: object) -> str:
     kind = str(getattr(reducer, "kind", "reducer")).replace("_", " ")
     route = getattr(reducer, "model", None)
     return f"{kind} · {route}" if route is not None else kind
+
+
+def _fusion_detail_html(fusion: Fusion) -> str:
+    """A collapsed section exposing each member's and the reducer's prompt + params."""
+
+    items = "".join(_member_detail(member) for member in fusion.members)
+    return (
+        "<details class='sf-detail'><summary class='sf-summary'>"
+        "<span class='sf-card__k'>members &amp; reducer</span></summary>"
+        f"{items}{_reducer_detail(fusion.reducer)}</details>"
+    )
+
+
+def _member_detail(member: object) -> str:
+    name = escape(str(getattr(member, "name", "")))
+    route = getattr(member, "model", None)
+    if route is None:  # a nested Fusion has no single route
+        return (
+            f"<div class='sf-detail__item'><div class='sf-detail__name'>{name}</div>"
+            "<div class='sf-card__hint'>nested fusion — see its own card</div></div>"
+        )
+    params = _params_text(getattr(member, "params", {}))
+    return (
+        f"<div class='sf-detail__item'><div class='sf-detail__name'>{name}</div>"
+        f"<div class='sf-detail__route'>{escape(str(route))}</div>"
+        f"<div class='sf-detail__params'>params: {params}</div>"
+        f"{_prompt_block(str(getattr(member, 'prompt', '')))}</div>"
+    )
+
+
+def _reducer_detail(reducer: object) -> str:
+    kind = str(getattr(reducer, "kind", "reducer")).replace("_", " ")
+    header = f"<div class='sf-detail__name'>reducer · {escape(kind)}</div>"
+    route = getattr(reducer, "model", None)
+    if route is None:  # deterministic reducer (e.g. MajorityVote)
+        return (
+            f"<div class='sf-detail__item'>{header}"
+            "<div class='sf-card__hint'>deterministic — no prompt or params</div></div>"
+        )
+    params = _params_text(getattr(reducer, "params", {}))
+    return (
+        f"<div class='sf-detail__item'>{header}"
+        f"<div class='sf-detail__route'>{escape(str(route))}</div>"
+        f"<div class='sf-detail__params'>params: {params}</div>"
+        f"{_prompt_block(str(getattr(reducer, 'prompt', '')))}</div>"
+    )
+
+
+def _grader_detail(grader: Grader) -> str:
+    kind = str(getattr(grader, "kind", "grader")).replace("_", " ")
+    model = getattr(grader, "model", None)
+    if model is None:  # deterministic grader (e.g. ExactChoice)
+        return f"{escape(kind)} <span class='sf-card__hint'>(deterministic)</span>"
+    passes = getattr(grader, "passes", None)
+    head = f"{escape(kind)} · model {_mono(str(model))}"
+    if passes is not None:
+        head += f" · {passes} pass{'' if passes == 1 else 'es'}"
+    params = _params_text(getattr(grader, "params", {}))
+    return (
+        f"<div class='sf-detail__params'>{head}</div>"
+        f"<div class='sf-detail__params'>params: {params}</div>"
+        f"{_prompt_block(str(getattr(grader, 'prompt', '')))}"
+    )
+
+
+def _benchmark_source(benchmark: Benchmark) -> str:
+    source = benchmark._case_source
+    if source is None:
+        return "engine-advertised — cases resolved by the engine"
+    if isinstance(source, tuple):
+        return f"{len(source)} local case{'' if len(source) == 1 else 's'}"
+    return "local — lazy case producer"
+
+
+def _benchmark_routes(benchmark: Benchmark) -> str:
+    routes = {
+        "cases": benchmark._cases_route,
+        "grader": benchmark._grader_route,
+        "aggregator": benchmark._aggregator_route,
+        "tool policy": benchmark._tool_policy_route,
+        "candidate": benchmark._candidate_route,
+        "candidate aggregator": benchmark._candidate_aggregator_route,
+    }
+    rows = "".join(
+        f"<div class='sf-detail__params'>{escape(label)}: {_mono(route)}</div>"
+        for label, route in routes.items()
+        if route is not None
+    )
+    if not rows:
+        return ""
+    return (
+        "<details class='sf-detail'><summary class='sf-summary'>"
+        "<span class='sf-card__k'>engine routes</span></summary>"
+        f"{rows}</details>"
+    )
 
 
 # --- catalogs -----------------------------------------------------------------------------

--- a/packages/screamingface/src/screamingface/_card_display.py
+++ b/packages/screamingface/src/screamingface/_card_display.py
@@ -1,0 +1,243 @@
+"""Static branded cards and catalogs for ScreamingFace notebook display.
+
+FEATURE: notebook rich display for Model/Fusion/Benchmark and the engine catalog.
+INVARIANT: these renderers use ONLY fields the SDK actually holds or the engine advertises.
+They never emit price, context-window, or ability-score data — that data does not exist, and
+inventing it would violate the SDK's "simulated but honest" stance.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from html import escape
+from typing import TYPE_CHECKING
+
+from screamingface._display import STYLE
+
+if TYPE_CHECKING:
+    from screamingface._profile import BenchmarkRecord, ModelRecord
+    from screamingface.benchmark import Benchmark
+    from screamingface.fusion import Fusion
+    from screamingface.model import Model
+
+_STYLE = (
+    STYLE
+    + """<style>
+.sf-card{border:1px solid var(--sf-line-2);background:var(--sf-bg)}
+.sf-card__head{display:flex;align-items:baseline;gap:8px;padding:10px 12px;
+  border-bottom:1px solid var(--sf-line)}
+.sf-card__title{font-size:15px;font-weight:600}
+.sf-card__kicker{margin-left:auto;font-family:"IBM Plex Mono",ui-monospace,monospace;
+  font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--sf-gain)}
+.sf-card__grid{display:grid;grid-template-columns:1fr 1fr;gap:1px;background:var(--sf-line);
+  border-bottom:1px solid var(--sf-line)}
+.sf-card__field{background:var(--sf-bg);padding:8px 12px;min-width:0}
+.sf-card__field.wide{grid-column:1 / -1}
+.sf-card__k{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:10px;
+  letter-spacing:.08em;text-transform:uppercase;color:var(--sf-ink-3)}
+.sf-card__v{margin-top:2px;overflow-wrap:anywhere}
+.sf-card__hint{color:var(--sf-ink-3)}
+.sf-card__list{margin:2px 0 0;padding:0;list-style:none}
+.sf-card__list li{padding:1px 0}
+.sf-card__recipe{padding:8px 12px;background:var(--sf-surface)}
+.sf-card__recipe code{display:block;margin-top:2px;font-size:11px;
+  font-family:"IBM Plex Mono",ui-monospace,monospace;color:var(--sf-ink);
+  white-space:pre-wrap;overflow-wrap:anywhere;background:transparent;border:0;padding:0}
+.sf-mono{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px}
+.sf-catalog{border:1px solid var(--sf-line-2)}
+.sf-catalog-widget.widget-vbox{border:0!important;box-shadow:none!important}
+.sf-catalog__head{display:flex;align-items:center;gap:8px;height:44px;padding:0 12px;
+  border-bottom:1px solid var(--sf-line-2)}
+.sf-catalog__title{font-size:13px;font-weight:600}
+.sf-catalog__count{margin-left:auto;font-family:"IBM Plex Mono",ui-monospace,monospace;
+  font-size:11px;color:var(--sf-ink-3)}
+.sf-catalog__row{display:grid;grid-template-columns:minmax(0,2fr) 1fr;gap:12px;
+  align-items:center;padding:8px 12px;border-bottom:1px solid var(--sf-line)}
+.sf-catalog__row:last-child{border-bottom:0}
+.sf-catalog__id{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px;
+  font-weight:600;overflow-wrap:anywhere}
+.sf-catalog__sub{color:var(--sf-ink-2)}
+.sf-catalog__meta{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11px;
+  color:var(--sf-ink-3);text-align:right;overflow-wrap:anywhere}
+.sf-catalog__empty{padding:16px 12px;color:var(--sf-ink-3);text-align:center;
+  font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px}
+.sf-catalog-widget .widget-text input{border-radius:0!important;box-shadow:none!important;
+  background-image:none!important;height:32px!important;padding:0 8px!important;
+  border:1px solid var(--sf-line-2)!important;background:var(--sf-bg)!important;
+  color:var(--sf-ink)!important;
+  font:12px/1 "IBM Plex Mono",ui-monospace,monospace!important}
+.sf-catalog-widget .widget-text{width:auto!important;margin:8px 12px!important}
+</style>"""
+)
+
+
+def _field(label: str, value_html: str, *, wide: bool = False) -> str:
+    css = "sf-card__field wide" if wide else "sf-card__field"
+    return (
+        f"<div class='{css}'><div class='sf-card__k'>{escape(label)}</div>"
+        f"<div class='sf-card__v'>{value_html}</div></div>"
+    )
+
+
+def _provider_of(route: str) -> str:
+    # WHY: model routes namespace the provider as the first path segment (e.g. gemini/2.5-flash).
+    # This is a real advertised field, not an inferred metric.
+    head = route.split("/", 1)[0]
+    return head if head and head != route else "—"
+
+
+def _params_text(params: Mapping[str, object]) -> str:
+    if not params:
+        return "<span class='sf-card__hint'>none</span>"
+    return escape(", ".join(f"{key}={value}" for key, value in params.items()))
+
+
+def model_card_html(model: Model) -> str:
+    """Render one Model as a branded card of its real authoring fields."""
+
+    fields = "".join(
+        (
+            _field("route", f"<span class='sf-mono'>{escape(model.model)}</span>"),
+            _field("provider", escape(_provider_of(model.model))),
+            _field("prompt", escape(model.prompt), wide=True),
+            _field("params", _params_text(model.params), wide=True),
+        )
+    )
+    return (
+        f"{_STYLE}<div class='sf-ui sf-card' aria-label='ScreamingFace model'>"
+        f"<div class='sf-card__head'><span class='sf-card__title'>{escape(model.name)}</span>"
+        "<span class='sf-card__kicker'>model</span></div>"
+        f"<div class='sf-card__grid'>{fields}</div>"
+        f"{_recipe_html(model.url4)}</div>"
+    )
+
+
+def fusion_card_html(fusion: Fusion) -> str:
+    """Render one Fusion as a branded card: members, reducer, and the url4 recipe."""
+
+    members = "".join(_member_row(member) for member in fusion.members)
+    fields = "".join(
+        (
+            _field("reducer", escape(_reducer_label(fusion.reducer))),
+            _field("members", f"{len(fusion.members)}"),
+            _field(
+                "member recipes",
+                f"<ul class='sf-card__list'>{members}</ul>",
+                wide=True,
+            ),
+            _field(
+                "model ids",
+                f"<span class='sf-mono'>{escape(', '.join(fusion.model_ids))}</span>",
+                wide=True,
+            ),
+        )
+    )
+    return (
+        f"{_STYLE}<div class='sf-ui sf-card' aria-label='ScreamingFace fusion'>"
+        f"<div class='sf-card__head'><span class='sf-card__title'>{escape(fusion.name)}</span>"
+        "<span class='sf-card__kicker'>fusion</span></div>"
+        f"<div class='sf-card__grid'>{fields}</div>"
+        f"{_recipe_html(fusion.url4)}</div>"
+    )
+
+
+def benchmark_card_html(benchmark: Benchmark) -> str:
+    """Render one Benchmark as a branded card of its real definition fields."""
+
+    tools = ", ".join(tool.id for tool in benchmark.tools) or "none"
+    tool_calls = "—" if benchmark.max_tool_calls is None else str(benchmark.max_tool_calls)
+    fields = "".join(
+        (
+            _field("id", f"<span class='sf-mono'>{escape(benchmark.id)}</span>"),
+            _field("grader", escape(benchmark.grader.kind.replace("_", " "))),
+            _field("aggregator", escape(benchmark.aggregator.kind.replace("_", " "))),
+            _field("max tool calls", escape(tool_calls)),
+            _field("tools", f"<span class='sf-mono'>{escape(tools)}</span>", wide=True),
+        )
+    )
+    return (
+        f"{_STYLE}<div class='sf-ui sf-card' aria-label='ScreamingFace benchmark'>"
+        f"<div class='sf-card__head'><span class='sf-card__title'>{escape(benchmark.title)}</span>"
+        "<span class='sf-card__kicker'>benchmark</span></div>"
+        f"<div class='sf-card__grid'>{fields}</div></div>"
+    )
+
+
+def _recipe_html(url4: str) -> str:
+    return (
+        "<div class='sf-card__recipe'><div class='sf-card__k'>url4</div>"
+        f"<code>{escape(url4)}</code></div>"
+    )
+
+
+def _member_row(member: object) -> str:
+    name = escape(str(getattr(member, "name", "")))
+    route = getattr(member, "model", None)
+    detail = (
+        f"<span class='sf-card__hint'>{escape(str(route))}</span>"
+        if route is not None
+        else "<span class='sf-card__hint'>(fusion)</span>"
+    )
+    return f"<li><span class='sf-mono'>{name}</span> {detail}</li>"
+
+
+def _reducer_label(reducer: object) -> str:
+    kind = str(getattr(reducer, "kind", "reducer")).replace("_", " ")
+    route = getattr(reducer, "model", None)
+    return f"{kind} · {route}" if route is not None else kind
+
+
+# --- catalogs -----------------------------------------------------------------------------
+
+
+def models_rows_html(records: Sequence[ModelRecord]) -> str:
+    if not records:
+        return "<div class='sf-catalog__empty'>No models match.</div>"
+    rows = []
+    for record in records:
+        tools = ", ".join(record.supported_tools) or "no tools"
+        rows.append(
+            "<div class='sf-catalog__row'>"
+            f"<div class='sf-catalog__id'>{escape(record.id)}</div>"
+            f"<div class='sf-catalog__meta'>{escape(record.provider)} · {escape(tools)}</div>"
+            "</div>"
+        )
+    return "".join(rows)
+
+
+def benchmarks_rows_html(records: Sequence[BenchmarkRecord]) -> str:
+    if not records:
+        return "<div class='sf-catalog__empty'>No benchmarks match.</div>"
+    rows = []
+    for record in records:
+        tools = ", ".join(record.tools) or "no tools"
+        rows.append(
+            "<div class='sf-catalog__row'>"
+            "<div>"
+            f"<div class='sf-catalog__id'>{escape(record.id)}</div>"
+            f"<div class='sf-catalog__sub'>{escape(record.title)}</div></div>"
+            f"<div class='sf-catalog__meta'>{escape(tools)}</div>"
+            "</div>"
+        )
+    return "".join(rows)
+
+
+def catalog_html(title: str, aria: str, count: int, rows: str) -> str:
+    """Wrap catalog rows in a standalone static catalog card (the widget-less fallback)."""
+
+    return (
+        f"{_STYLE}<div class='sf-ui sf-catalog' aria-label='{escape(aria)}'>"
+        f"<div class='sf-catalog__head'><div class='sf-catalog__title'>{escape(title)}</div>"
+        f"<div class='sf-catalog__count'>{count}</div></div>"
+        f"{rows}</div>"
+    )
+
+
+__all__ = [
+    "benchmark_card_html",
+    "benchmarks_rows_html",
+    "catalog_html",
+    "fusion_card_html",
+    "model_card_html",
+    "models_rows_html",
+]

--- a/packages/screamingface/src/screamingface/_card_display.py
+++ b/packages/screamingface/src/screamingface/_card_display.py
@@ -145,7 +145,6 @@ def benchmark_card_html(benchmark: Benchmark) -> str:
             _field("tools", _mono(tools)),
             _field("max tool calls", escape(tool_calls)),
             _field("source", escape(_benchmark_source(benchmark)), wide=True),
-            _field("grader", _grader_detail(benchmark.grader), wide=True),
         )
     )
     return (
@@ -153,6 +152,7 @@ def benchmark_card_html(benchmark: Benchmark) -> str:
         f"<div class='sf-card__head'><span class='sf-card__title'>{escape(benchmark.title)}</span>"
         "<span class='sf-card__kicker'>benchmark</span></div>"
         f"<div class='sf-card__grid'>{fields}</div>"
+        f"{_section('grader', _grader_detail(benchmark.grader))}"
         f"{_benchmark_routes(benchmark)}</div>"
     )
 
@@ -256,15 +256,20 @@ def _reducer_label(reducer: object) -> str:
     return f"{kind} · {route}" if route is not None else kind
 
 
+def _section(title: str, body_html: str) -> str:
+    """An always-visible titled detail section (not collapsed)."""
+
+    return (
+        f"<div class='sf-section'><div class='sf-section__title'>{escape(title)}</div>"
+        f"{body_html}</div>"
+    )
+
+
 def _fusion_detail_html(fusion: Fusion) -> str:
-    """A collapsed section exposing each member's and the reducer's prompt + params."""
+    """Separate, always-visible members and reducer sections (long prompts still collapse)."""
 
     items = "".join(_member_detail(member) for member in fusion.members)
-    return (
-        "<details class='sf-detail'><summary class='sf-summary'>"
-        "<span class='sf-card__k'>members &amp; reducer</span></summary>"
-        f"{items}{_reducer_detail(fusion.reducer)}</details>"
-    )
+    return _section("members", items) + _section("reducer", _reducer_detail(fusion.reducer))
 
 
 def _member_detail(member: object) -> str:
@@ -286,7 +291,7 @@ def _member_detail(member: object) -> str:
 
 def _reducer_detail(reducer: object) -> str:
     kind = str(getattr(reducer, "kind", "reducer")).replace("_", " ")
-    header = f"<div class='sf-detail__name'>reducer · {escape(kind)}</div>"
+    header = f"<div class='sf-detail__name'>{escape(kind)}</div>"
     route = getattr(reducer, "model", None)
     if route is None:  # deterministic reducer (e.g. MajorityVote)
         return (

--- a/packages/screamingface/src/screamingface/_card_display.py
+++ b/packages/screamingface/src/screamingface/_card_display.py
@@ -8,6 +8,7 @@ inventing it would violate the SDK's "simulated but honest" stance.
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping, Sequence
 from html import escape
 from typing import TYPE_CHECKING
@@ -16,8 +17,10 @@ from screamingface._display import STYLE
 
 if TYPE_CHECKING:
     from screamingface._profile import BenchmarkRecord, ModelRecord
-    from screamingface.benchmark import Benchmark
+    from screamingface.benchmark import Benchmark, Case
+    from screamingface.connections import Connection
     from screamingface.fusion import Fusion
+    from screamingface.graders import Rubric
     from screamingface.model import Model
 
 _STYLE = (
@@ -163,6 +166,82 @@ def benchmark_card_html(benchmark: Benchmark) -> str:
     )
 
 
+def connection_card_html(connection: Connection) -> str:
+    """Render one sanitized Connection as a branded status card."""
+
+    account = connection.account_label or "—"
+    method = connection.auth_method or "—"
+    fields = "".join(
+        (
+            _field("provider", f"<span class='sf-mono'>{escape(connection.provider)}</span>"),
+            _field("status", escape(connection.status.replace("_", " "))),
+            _field("auth method", escape(method)),
+            _field("account", escape(account)),
+            _field(
+                "auth methods",
+                f"<span class='sf-mono'>{escape(', '.join(connection.auth_methods))}</span>",
+                wide=True,
+            ),
+        )
+    )
+    return (
+        f"{_STYLE}<div class='sf-ui sf-card' aria-label='ScreamingFace connection'>"
+        f"<div class='sf-card__head'>"
+        f"<span class='sf-card__title'>{escape(connection.display_name)}</span>"
+        "<span class='sf-card__kicker'>connection</span></div>"
+        f"<div class='sf-card__grid'>{fields}</div></div>"
+    )
+
+
+def case_card_html(case: Case) -> str:
+    """Render one benchmark Case as a branded card of its authoring fields."""
+
+    fields = "".join(
+        (
+            _field("input", escape(case.input), wide=True),
+            _field(
+                "reference",
+                f"<span class='sf-mono'>{escape(_json(case.reference))}</span>",
+                wide=True,
+            ),
+            _field(
+                "metadata",
+                f"<span class='sf-mono'>{escape(_json(case.metadata))}</span>",
+                wide=True,
+            ),
+        )
+    )
+    return (
+        f"{_STYLE}<div class='sf-ui sf-card' aria-label='ScreamingFace case'>"
+        f"<div class='sf-card__head'><span class='sf-card__title'>{escape(case.id)}</span>"
+        "<span class='sf-card__kicker'>case</span></div>"
+        f"<div class='sf-card__grid'>{fields}</div></div>"
+    )
+
+
+def rubric_card_html(rubric: Rubric) -> str:
+    """Render one Rubric grader as a branded card: judge model, passes, params, prompt."""
+
+    fields = "".join(
+        (
+            _field("model", f"<span class='sf-mono'>{escape(rubric.model)}</span>"),
+            _field("passes", str(rubric.passes)),
+            _field("params", _params_text(rubric.params), wide=True),
+            _field("prompt", escape(rubric.prompt), wide=True),
+        )
+    )
+    return (
+        f"{_STYLE}<div class='sf-ui sf-card' aria-label='ScreamingFace rubric grader'>"
+        f"<div class='sf-card__head'><span class='sf-card__title'>{escape(rubric.model)}</span>"
+        "<span class='sf-card__kicker'>rubric grader</span></div>"
+        f"<div class='sf-card__grid'>{fields}</div></div>"
+    )
+
+
+def _json(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
 def _recipe_html(url4: str) -> str:
     return (
         "<div class='sf-card__recipe'><div class='sf-card__k'>url4</div>"
@@ -236,8 +315,11 @@ def catalog_html(title: str, aria: str, count: int, rows: str) -> str:
 __all__ = [
     "benchmark_card_html",
     "benchmarks_rows_html",
+    "case_card_html",
     "catalog_html",
+    "connection_card_html",
     "fusion_card_html",
     "model_card_html",
     "models_rows_html",
+    "rubric_card_html",
 ]

--- a/packages/screamingface/src/screamingface/_card_display.py
+++ b/packages/screamingface/src/screamingface/_card_display.py
@@ -369,17 +369,26 @@ def _benchmark_routes(benchmark: Benchmark) -> str:
 # --- catalogs -----------------------------------------------------------------------------
 
 
+def _chip(text: str, *, muted: bool = False) -> str:
+    css = "sf-chip sf-chip--muted" if muted else "sf-chip"
+    return f"<span class='{css}'>{escape(text)}</span>"
+
+
+def _tags(chips: str) -> str:
+    return f"<div class='sf-catalog__tags'>{chips}</div>"
+
+
 def models_rows_html(records: Sequence[ModelRecord]) -> str:
     if not records:
         return "<div class='sf-catalog__empty'>No models match.</div>"
     rows = []
     for record in records:
-        tools = ", ".join(record.supported_tools) or "no tools"
+        chips = _chip(record.provider) + "".join(_chip(tool) for tool in record.supported_tools)
+        if not record.supported_tools:
+            chips += _chip("no tools", muted=True)
         rows.append(
-            "<div class='sf-catalog__row'>"
-            f"<div class='sf-catalog__id'>{escape(record.id)}</div>"
-            f"<div class='sf-catalog__meta'>{escape(record.provider)} · {escape(tools)}</div>"
-            "</div>"
+            f"<div class='sf-catalog__row'><div class='sf-catalog__id'>{escape(record.id)}</div>"
+            f"{_tags(chips)}</div>"
         )
     return "".join(rows)
 
@@ -389,14 +398,12 @@ def benchmarks_rows_html(records: Sequence[BenchmarkRecord]) -> str:
         return "<div class='sf-catalog__empty'>No benchmarks match.</div>"
     rows = []
     for record in records:
-        tools = ", ".join(record.tools) or "no tools"
+        chips = "".join(_chip(tool) for tool in record.tools) or _chip("no tools", muted=True)
         rows.append(
             "<div class='sf-catalog__row'>"
-            "<div>"
-            f"<div class='sf-catalog__id'>{escape(record.id)}</div>"
+            f"<div><div class='sf-catalog__id'>{escape(record.id)}</div>"
             f"<div class='sf-catalog__sub'>{escape(record.title)}</div></div>"
-            f"<div class='sf-catalog__meta'>{escape(tools)}</div>"
-            "</div>"
+            f"{_tags(chips)}</div>"
         )
     return "".join(rows)
 
@@ -406,6 +413,7 @@ def catalog_html(title: str, aria: str, count: int, rows: str) -> str:
 
     return (
         f"{_STYLE}<div class='sf-ui sf-catalog' aria-label='{escape(aria)}'>"
+        "<div class='sf-card__accent sf-card__accent--solid'></div>"
         f"<div class='sf-catalog__head'><div class='sf-catalog__title'>{escape(title)}</div>"
         f"<div class='sf-catalog__count'>{count}</div></div>"
         f"{rows}</div>"

--- a/packages/screamingface/src/screamingface/_card_display.py
+++ b/packages/screamingface/src/screamingface/_card_display.py
@@ -350,8 +350,8 @@ def _benchmark_routes(benchmark: Benchmark) -> str:
     if not rows:
         return ""
     return (
-        "<details class='sf-detail'><summary class='sf-summary'>"
-        "<span class='sf-card__k'>engine routes</span></summary>"
+        "<details class='sf-section'><summary class='sf-summary'>"
+        "<span class='sf-section__title'>engine routes</span></summary>"
         f"{rows}</details>"
     )
 

--- a/packages/screamingface/src/screamingface/_card_style.py
+++ b/packages/screamingface/src/screamingface/_card_style.py
@@ -21,8 +21,7 @@ CARD_STYLE = (
 .sf-card__accent--solid{background:var(--sf-gain)}
 .sf-card__head{display:flex;align-items:baseline;gap:8px;padding:12px;
   border-bottom:1px solid var(--sf-line)}
-.sf-card__title{font-family:var(--sf-display);font-size:20px;font-weight:500;
-  letter-spacing:-.01em;line-height:1.15;color:var(--sf-ink);overflow-wrap:anywhere}
+.sf-card__title{font-size:15px;font-weight:600;color:var(--sf-ink);overflow-wrap:anywhere}
 .sf-card__kicker{margin-left:auto;font-family:"IBM Plex Mono",ui-monospace,monospace;
   font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--sf-gain)}
 .sf-card__grid{display:grid;grid-template-columns:1fr 1fr;gap:1px;background:var(--sf-line)}
@@ -51,15 +50,15 @@ CARD_STYLE = (
 @media (max-width:620px){.sf-stats{grid-template-columns:repeat(2,minmax(0,1fr))}}
 .sf-chips{display:flex;flex-wrap:wrap;gap:6px;padding:10px 12px;
   border-top:1px solid var(--sf-line)}
-.sf-chip{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11px;color:var(--sf-ink-2);
-  border:1px solid var(--sf-line-2);padding:1px 8px}
+.sf-chip{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11px;color:var(--sf-gain);
+  border:1px solid var(--sf-gain);padding:1px 8px;background:var(--sf-gain-bg)}
+.sf-chip--muted{color:var(--sf-ink-3);border-color:var(--sf-line-2);background:transparent}
 /* catalogs */
 .sf-catalog{border:1px solid var(--sf-line-2)}
 .sf-catalog-widget.widget-vbox{border:0!important;box-shadow:none!important}
 .sf-catalog__head{display:flex;align-items:center;gap:8px;height:44px;padding:0 12px;
   border-bottom:1px solid var(--sf-line-2)}
-.sf-catalog__title{font-family:var(--sf-display);font-size:16px;font-weight:500;
-  letter-spacing:-.01em}
+.sf-catalog__title{font-size:13px;font-weight:600}
 .sf-catalog__count{margin-left:auto;font-family:"IBM Plex Mono",ui-monospace,monospace;
   font-size:11px;color:var(--sf-ink-3)}
 .sf-catalog__row{display:grid;grid-template-columns:minmax(0,2fr) 1fr;gap:12px;
@@ -70,6 +69,7 @@ CARD_STYLE = (
 .sf-catalog__sub{color:var(--sf-ink-2)}
 .sf-catalog__meta{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11px;
   color:var(--sf-ink-3);text-align:right;overflow-wrap:anywhere}
+.sf-catalog__tags{display:flex;flex-wrap:wrap;gap:4px;justify-content:flex-end}
 .sf-catalog__empty{padding:16px 12px;color:var(--sf-ink-3);text-align:center;
   font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px}
 .sf-catalog-widget .widget-text input{border-radius:0!important;box-shadow:none!important;

--- a/packages/screamingface/src/screamingface/_card_style.py
+++ b/packages/screamingface/src/screamingface/_card_style.py
@@ -8,13 +8,21 @@ from __future__ import annotations
 
 from screamingface._display import STYLE
 
+# WHY: the gold→blue fusion signature (sampled from the 😱 mark) is defined here, not in the
+# shared STYLE, so gradient-free surfaces (e.g. the connection panel) never inherit it. The
+# stops run gold→blue only — never violet — per brand.
 CARD_STYLE = (
     STYLE
     + """<style>
+.sf-ui{--sf-gain-grad:linear-gradient(100deg,#d08511 0%,#e7a105 16%,#dbb13b 40%,
+  #8e9dab 60%,#9fb8f8 80%,#346cf9 100%)}
 .sf-card{border:1px solid var(--sf-line-2);background:var(--sf-bg)}
-.sf-card__head{display:flex;align-items:baseline;gap:8px;padding:10px 12px;
+.sf-card__accent{height:3px;background:var(--sf-gain-grad)}
+.sf-card__accent--solid{background:var(--sf-gain)}
+.sf-card__head{display:flex;align-items:baseline;gap:8px;padding:12px;
   border-bottom:1px solid var(--sf-line)}
-.sf-card__title{font-size:15px;font-weight:600;overflow-wrap:anywhere}
+.sf-card__title{font-family:var(--sf-display);font-size:20px;font-weight:500;
+  letter-spacing:-.01em;line-height:1.15;color:var(--sf-ink);overflow-wrap:anywhere}
 .sf-card__kicker{margin-left:auto;font-family:"IBM Plex Mono",ui-monospace,monospace;
   font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--sf-gain)}
 .sf-card__grid{display:grid;grid-template-columns:1fr 1fr;gap:1px;background:var(--sf-line)}
@@ -50,7 +58,8 @@ CARD_STYLE = (
 .sf-catalog-widget.widget-vbox{border:0!important;box-shadow:none!important}
 .sf-catalog__head{display:flex;align-items:center;gap:8px;height:44px;padding:0 12px;
   border-bottom:1px solid var(--sf-line-2)}
-.sf-catalog__title{font-size:13px;font-weight:600}
+.sf-catalog__title{font-family:var(--sf-display);font-size:16px;font-weight:500;
+  letter-spacing:-.01em}
 .sf-catalog__count{margin-left:auto;font-family:"IBM Plex Mono",ui-monospace,monospace;
   font-size:11px;color:var(--sf-ink-3)}
 .sf-catalog__row{display:grid;grid-template-columns:minmax(0,2fr) 1fr;gap:12px;

--- a/packages/screamingface/src/screamingface/_card_style.py
+++ b/packages/screamingface/src/screamingface/_card_style.py
@@ -1,0 +1,88 @@
+"""Stylesheet for ScreamingFace notebook cards, catalogs, and the url4 recipe view.
+
+Split out of `_card_display` to keep each module focused and under the size budget. Every value
+is a `.sf-ui` token from `_display.STYLE` — no raw colors (brand law).
+"""
+
+from __future__ import annotations
+
+from screamingface._display import STYLE
+
+CARD_STYLE = (
+    STYLE
+    + """<style>
+.sf-card{border:1px solid var(--sf-line-2);background:var(--sf-bg)}
+.sf-card__head{display:flex;align-items:baseline;gap:8px;padding:10px 12px;
+  border-bottom:1px solid var(--sf-line)}
+.sf-card__title{font-size:15px;font-weight:600;overflow-wrap:anywhere}
+.sf-card__kicker{margin-left:auto;font-family:"IBM Plex Mono",ui-monospace,monospace;
+  font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--sf-gain)}
+.sf-card__grid{display:grid;grid-template-columns:1fr 1fr;gap:1px;background:var(--sf-line);
+  border-bottom:1px solid var(--sf-line)}
+.sf-card__field{background:var(--sf-bg);padding:8px 12px;min-width:0}
+.sf-card__field.wide{grid-column:1 / -1}
+.sf-card__k{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:10px;
+  letter-spacing:.08em;text-transform:uppercase;color:var(--sf-ink-3)}
+.sf-card__v{margin-top:2px;overflow-wrap:anywhere}
+.sf-card__hint{color:var(--sf-ink-3)}
+.sf-card__list{margin:2px 0 0;padding:0;list-style:none}
+.sf-card__list li{padding:1px 0}
+.sf-card__recipe{padding:8px 12px;background:var(--sf-surface);min-width:0}
+.sf-mono{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px}
+/* catalogs */
+.sf-catalog{border:1px solid var(--sf-line-2)}
+.sf-catalog-widget.widget-vbox{border:0!important;box-shadow:none!important}
+.sf-catalog__head{display:flex;align-items:center;gap:8px;height:44px;padding:0 12px;
+  border-bottom:1px solid var(--sf-line-2)}
+.sf-catalog__title{font-size:13px;font-weight:600}
+.sf-catalog__count{margin-left:auto;font-family:"IBM Plex Mono",ui-monospace,monospace;
+  font-size:11px;color:var(--sf-ink-3)}
+.sf-catalog__row{display:grid;grid-template-columns:minmax(0,2fr) 1fr;gap:12px;
+  align-items:center;padding:8px 12px;border-bottom:1px solid var(--sf-line)}
+.sf-catalog__row:last-child{border-bottom:0}
+.sf-catalog__id{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px;
+  font-weight:600;overflow-wrap:anywhere}
+.sf-catalog__sub{color:var(--sf-ink-2)}
+.sf-catalog__meta{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11px;
+  color:var(--sf-ink-3);text-align:right;overflow-wrap:anywhere}
+.sf-catalog__empty{padding:16px 12px;color:var(--sf-ink-3);text-align:center;
+  font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px}
+.sf-catalog-widget .widget-text input{border-radius:0!important;box-shadow:none!important;
+  background-image:none!important;height:32px!important;padding:0 8px!important;
+  border:1px solid var(--sf-line-2)!important;background:var(--sf-bg)!important;
+  color:var(--sf-ink)!important;
+  font:12px/1 "IBM Plex Mono",ui-monospace,monospace!important}
+.sf-catalog-widget .widget-text{width:auto!important;margin:8px 12px!important}
+/* collapsible summary shared chrome */
+.sf-summary{cursor:pointer;display:flex;align-items:center;gap:8px;list-style:none}
+.sf-summary::-webkit-details-marker{display:none}
+.sf-summary::before{content:'▸';color:var(--sf-ink-3);font-size:10px}
+details[open] > .sf-summary::before{content:'▾'}
+/* long-field collapse (prompts, routes) */
+.sf-more{margin-top:2px}
+.sf-more__preview{color:var(--sf-ink-3);font-style:italic}
+.sf-more__full{margin-top:4px;white-space:pre-wrap;overflow-wrap:anywhere;
+  background:var(--sf-surface);padding:6px 8px;font-size:12px;color:var(--sf-ink-2)}
+/* fusion members & reducer detail */
+.sf-detail{margin-top:8px;border-top:1px solid var(--sf-line);padding-top:8px}
+.sf-detail__item{border-left:2px solid var(--sf-line-2);padding:2px 0 6px 10px;margin-top:6px}
+.sf-detail__name{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px;
+  font-weight:600;color:var(--sf-gain)}
+.sf-detail__route{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11px;
+  color:var(--sf-ink-2);overflow-wrap:anywhere}
+.sf-detail__params{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11px;
+  color:var(--sf-ink-2);overflow-wrap:anywhere}
+/* url4 recipe: full form, reflowed, in a <pre> (MathJax skips pre/code) */
+.sf-url4{border:0;min-width:0}
+.sf-url4__copy{margin-left:auto;cursor:pointer;border-radius:0;
+  border:1px solid var(--sf-line-2);background:var(--sf-bg);color:var(--sf-ink-2);
+  padding:2px 8px;font:11px/1 "IBM Plex Mono",ui-monospace,monospace}
+.sf-url4__copy:hover{border-color:var(--sf-ink-3);color:var(--sf-ink)}
+.sf-url4__pre{margin:8px 0 0;padding:8px;background:var(--sf-bg);
+  border:1px solid var(--sf-line);color:var(--sf-ink);
+  font:11px/1.5 "IBM Plex Mono",ui-monospace,monospace;
+  white-space:pre-wrap;overflow-wrap:anywhere;tab-size:2}
+</style>"""
+)
+
+__all__ = ["CARD_STYLE"]

--- a/packages/screamingface/src/screamingface/_card_style.py
+++ b/packages/screamingface/src/screamingface/_card_style.py
@@ -29,6 +29,22 @@ CARD_STYLE = (
 .sf-card__recipe{padding:8px 12px;background:var(--sf-surface);min-width:0;
   border-top:1px solid var(--sf-line)}
 .sf-mono{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px}
+.sf-card__meta{margin-top:3px;font-family:"IBM Plex Mono",ui-monospace,monospace;
+  font-size:11px;color:var(--sf-ink-3);overflow-wrap:anywhere}
+/* big-number stat grid (mirrors the evaluation report widget) */
+.sf-stats{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:1px;
+  background:var(--sf-line)}
+.sf-stat{background:var(--sf-bg);padding:12px;min-width:0}
+.sf-stat__k{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:10px;
+  letter-spacing:.08em;text-transform:uppercase;color:var(--sf-ink-3)}
+.sf-stat__v{margin-top:6px;font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:20px;
+  font-weight:600;font-variant-numeric:tabular-nums;color:var(--sf-ink);line-height:1.15;
+  overflow-wrap:anywhere}
+@media (max-width:620px){.sf-stats{grid-template-columns:repeat(2,minmax(0,1fr))}}
+.sf-chips{display:flex;flex-wrap:wrap;gap:6px;padding:10px 12px;
+  border-top:1px solid var(--sf-line)}
+.sf-chip{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11px;color:var(--sf-ink-2);
+  border:1px solid var(--sf-line-2);padding:1px 8px}
 /* catalogs */
 .sf-catalog{border:1px solid var(--sf-line-2)}
 .sf-catalog-widget.widget-vbox{border:0!important;box-shadow:none!important}

--- a/packages/screamingface/src/screamingface/_card_style.py
+++ b/packages/screamingface/src/screamingface/_card_style.py
@@ -17,8 +17,7 @@ CARD_STYLE = (
 .sf-card__title{font-size:15px;font-weight:600;overflow-wrap:anywhere}
 .sf-card__kicker{margin-left:auto;font-family:"IBM Plex Mono",ui-monospace,monospace;
   font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--sf-gain)}
-.sf-card__grid{display:grid;grid-template-columns:1fr 1fr;gap:1px;background:var(--sf-line);
-  border-bottom:1px solid var(--sf-line)}
+.sf-card__grid{display:grid;grid-template-columns:1fr 1fr;gap:1px;background:var(--sf-line)}
 .sf-card__field{background:var(--sf-bg);padding:8px 12px;min-width:0}
 .sf-card__field.wide{grid-column:1 / -1}
 .sf-card__k{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:10px;
@@ -27,7 +26,8 @@ CARD_STYLE = (
 .sf-card__hint{color:var(--sf-ink-3)}
 .sf-card__list{margin:2px 0 0;padding:0;list-style:none}
 .sf-card__list li{padding:1px 0}
-.sf-card__recipe{padding:8px 12px;background:var(--sf-surface);min-width:0}
+.sf-card__recipe{padding:8px 12px;background:var(--sf-surface);min-width:0;
+  border-top:1px solid var(--sf-line)}
 .sf-mono{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px}
 /* catalogs */
 .sf-catalog{border:1px solid var(--sf-line-2)}

--- a/packages/screamingface/src/screamingface/_card_style.py
+++ b/packages/screamingface/src/screamingface/_card_style.py
@@ -63,8 +63,10 @@ details[open] > .sf-summary::before{content:'▾'}
 .sf-more__preview{color:var(--sf-ink-3);font-style:italic}
 .sf-more__full{margin-top:4px;white-space:pre-wrap;overflow-wrap:anywhere;
   background:var(--sf-surface);padding:6px 8px;font-size:12px;color:var(--sf-ink-2)}
-/* fusion members & reducer detail */
-.sf-detail{margin-top:8px;border-top:1px solid var(--sf-line);padding-top:8px}
+/* always-visible detail sections (members, reducer, grader) */
+.sf-section{margin-top:8px;border-top:1px solid var(--sf-line);padding:8px 12px 0}
+.sf-section__title{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:10px;
+  letter-spacing:.08em;text-transform:uppercase;color:var(--sf-ink-3)}
 .sf-detail__item{border-left:2px solid var(--sf-line-2);padding:2px 0 6px 10px;margin-top:6px}
 .sf-detail__name{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px;
   font-weight:600;color:var(--sf-gain)}

--- a/packages/screamingface/src/screamingface/_catalog_view.py
+++ b/packages/screamingface/src/screamingface/_catalog_view.py
@@ -59,7 +59,8 @@ class _CatalogView(ABC):
 
         header = widgets.HTML(
             value=(
-                f"{_STYLE}<div class='sf-catalog__head'>"
+                f"{_STYLE}<div class='sf-card__accent sf-card__accent--solid'></div>"
+                f"<div class='sf-catalog__head'>"
                 f"<div class='sf-catalog__title'>{self._title}</div></div>"
             )
         )

--- a/packages/screamingface/src/screamingface/_catalog_view.py
+++ b/packages/screamingface/src/screamingface/_catalog_view.py
@@ -1,0 +1,133 @@
+"""Interactive engine-catalog views with an ipywidgets-free static fallback.
+
+FEATURE: sf.models.view() / sf.benchmarks.view() browse the engine catalog in a notebook.
+STORY: as a researcher, I search the catalog and read the exact provider/model IDs I can use.
+INVARIANT: `.value` is the tuple of IDs currently shown after filtering, so `view(...).value`
+equals `list(...)` for the same query/tools arguments.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+from screamingface._card_display import (
+    _STYLE,
+    benchmarks_rows_html,
+    catalog_html,
+    models_rows_html,
+)
+
+if TYPE_CHECKING:
+    from screamingface._profile import BenchmarkRecord, ModelRecord
+
+
+class _CatalogView(ABC):
+    """Shared behavior for the model and benchmark catalog browsers."""
+
+    _title: str
+    _aria: str
+    _placeholder: str
+
+    def __init__(self, records: Sequence[Any]) -> None:
+        self._records = tuple(records)
+        self._query = ""
+        self._body: Any = None
+
+    @property
+    def value(self) -> list[str]:
+        """IDs currently shown after the active search filter."""
+
+        return [self._id(record) for record in self._visible()]
+
+    def _visible(self) -> tuple[Any, ...]:
+        needle = self._query.strip().casefold()
+        if not needle:
+            return self._records
+        return tuple(record for record in self._records if needle in self._id(record).casefold())
+
+    def widget(self) -> Any:
+        """Build the interactive notebook view when the notebook extra is installed."""
+
+        try:
+            import ipywidgets as widgets
+        except ImportError as exc:  # pragma: no cover - exercised in a dependency-isolated install
+            raise ImportError(
+                "Install screamingface[notebook] to use the interactive catalog view."
+            ) from exc
+
+        header = widgets.HTML(
+            value=(
+                f"{_STYLE}<div class='sf-catalog__head'>"
+                f"<div class='sf-catalog__title'>{self._title}</div></div>"
+            )
+        )
+        search = widgets.Text(placeholder=self._placeholder)
+        self._body = widgets.HTML()
+
+        def on_change(change: dict[str, Any]) -> None:
+            self._query = change["new"]
+            self._render()
+
+        search.observe(on_change, names="value")
+        root = widgets.VBox(children=(header, search, self._body))
+        root.add_class("sf-ui")
+        root.add_class("sf-catalog-widget")
+        root.add_class("sf-catalog")
+        self._render()
+        return root
+
+    def _render(self) -> None:
+        if self._body is not None:
+            self._body.value = self._rows_html(self._visible())
+
+    def _repr_html_(self) -> str:
+        return catalog_html(
+            self._title, self._aria, len(self._records), self._rows_html(self._records)
+        )
+
+    def _ipython_display_(self) -> None:
+        from IPython.display import display
+
+        display(self.widget())
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({len(self._records)} shown)"
+
+    @abstractmethod
+    def _id(self, record: Any) -> str: ...
+
+    @abstractmethod
+    def _rows_html(self, records: Sequence[Any]) -> str: ...
+
+
+class ModelsView(_CatalogView):
+    """A searchable view over engine-advertised model records."""
+
+    _title = "Models"
+    _aria = "ScreamingFace model catalog"
+    _placeholder = "Filter models…"
+
+    def _id(self, record: ModelRecord) -> str:
+        return record.id
+
+    def _rows_html(self, records: Sequence[ModelRecord]) -> str:
+        return models_rows_html(records)
+
+
+class BenchmarksView(_CatalogView):
+    """A searchable view over engine-advertised benchmark records."""
+
+    _title = "Benchmarks"
+    _aria = "ScreamingFace benchmark catalog"
+    _placeholder = "Filter benchmarks…"
+
+    def _id(self, record: BenchmarkRecord) -> str:
+        return record.id
+
+    def _rows_html(self, records: Sequence[BenchmarkRecord]) -> str:
+        return benchmarks_rows_html(records)
+
+
+__all__ = ["BenchmarksView", "ModelsView"]

--- a/packages/screamingface/src/screamingface/_connection_panel.py
+++ b/packages/screamingface/src/screamingface/_connection_panel.py
@@ -24,7 +24,8 @@ _STYLE = (
 .sf-connection-widget.widget-vbox{border:0!important;box-shadow:none!important}
 .sf-connections__head{height:48px;display:flex;align-items:center;gap:12px;padding:0 12px;
   border-bottom:1px solid var(--sf-line-2)}
-.sf-connections__title{font-size:13px;font-weight:600}
+.sf-connections__title{font-family:var(--sf-display,"EB Garamond",Georgia,serif);
+  font-size:15px;font-weight:500;letter-spacing:-.01em}
 .sf-connections__engine{margin-left:auto;font-family:"IBM Plex Mono",ui-monospace,monospace;
   font-size:11px;color:var(--sf-ink-3);white-space:nowrap}
 .sf-connections__row{height:48px!important;display:flex!important;flex-flow:row nowrap!important;

--- a/packages/screamingface/src/screamingface/_connection_panel.py
+++ b/packages/screamingface/src/screamingface/_connection_panel.py
@@ -21,11 +21,11 @@ _STYLE = (
     STYLE
     + """<style>
 .sf-connections{border:0;border-radius:0}
+.sf-connections__accent{height:3px;background:var(--sf-gain)}
 .sf-connection-widget.widget-vbox{border:0!important;box-shadow:none!important}
 .sf-connections__head{height:48px;display:flex;align-items:center;gap:12px;padding:0 12px;
   border-bottom:1px solid var(--sf-line-2)}
-.sf-connections__title{font-family:var(--sf-display,"EB Garamond",Georgia,serif);
-  font-size:15px;font-weight:500;letter-spacing:-.01em}
+.sf-connections__title{font-size:13px;font-weight:600}
 .sf-connections__engine{margin-left:auto;font-family:"IBM Plex Mono",ui-monospace,monospace;
   font-size:11px;color:var(--sf-ink-3);white-space:nowrap}
 .sf-connections__row{height:48px!important;display:flex!important;flex-flow:row nowrap!important;
@@ -124,7 +124,8 @@ class ConnectionPanel:
 
         header = widgets.HTML(
             value=(
-                f"{_STYLE}<div class='sf-connections__head'>"
+                f"{_STYLE}<div class='sf-connections__accent'></div>"
+                "<div class='sf-connections__head'>"
                 "<div class='sf-connections__title'>Provider connections</div>"
                 f"<div class='sf-connections__engine'>Engine · {escape(self.engine)}</div></div>"
             )
@@ -143,6 +144,7 @@ class ConnectionPanel:
         return (
             f"{_STYLE}<div class='sf-ui sf-connections' "
             "aria-label='ScreamingFace provider connections'>"
+            "<div class='sf-connections__accent'></div>"
             "<div class='sf-connections__head'>"
             "<div class='sf-connections__title'>Provider connections</div>"
             f"<div class='sf-connections__engine'>Engine · {escape(self.engine)}</div></div>"

--- a/packages/screamingface/src/screamingface/_display.py
+++ b/packages/screamingface/src/screamingface/_display.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 _FONTS = (
     "@import url('https://fonts.googleapis.com/css2?"
-    "family=EB+Garamond:wght@500&family=IBM+Plex+Mono:wght@400;500;600&"
+    "family=IBM+Plex+Mono:wght@400;500;600&"
     "family=IBM+Plex+Sans:wght@400;500;600&display=swap');"
 )
 
@@ -32,9 +32,6 @@ STYLE = f"""<style>
 {_FONTS}
 .sf-ui {{
   {_LIGHT};
-  --sf-display:"EB Garamond","Iowan Old Style",Georgia,"Times New Roman",serif;
-  --sf-sans:"IBM Plex Sans",system-ui,-apple-system,"Segoe UI",sans-serif;
-  --sf-mono:"IBM Plex Mono",ui-monospace,SFMono-Regular,Menlo,monospace;
   max-width:760px;color:var(--sf-ink);background:var(--sf-bg);
   font-family:"IBM Plex Sans",system-ui,-apple-system,"Segoe UI",sans-serif;
   font-size:13px;line-height:1.45;

--- a/packages/screamingface/src/screamingface/_display.py
+++ b/packages/screamingface/src/screamingface/_display.py
@@ -1,33 +1,49 @@
-"""Shared visual foundation for ScreamingFace notebook surfaces."""
+"""Shared visual foundation for ScreamingFace notebook surfaces.
+
+Tracks the current `screamingface-brand`: gain is gold (the SOTA/win signal — it replaced the
+old green), display type is EB Garamond, and the brand webfonts are pulled with system
+fallbacks. The gold→blue fusion-signature GRADIENT is deliberately NOT defined here — it lives
+in `_card_style` so gradient-free surfaces (e.g. the connection panel) never inherit it.
+"""
 
 from __future__ import annotations
 
-STYLE = """<style>
-.sf-ui {
-  --sf-bg:#ffffff;--sf-surface:#f6f6f7;--sf-surface-2:#efeff1;
-  --sf-ink:#16181d;--sf-ink-2:#585d67;--sf-ink-3:#8b909a;
-  --sf-line:#e6e7ea;--sf-line-2:#d4d6db;
-  --sf-gain:#0f7a3d;--sf-gain-bg:#e8f3ec;
-  --sf-blind:#b23b3b;--sf-blind-bg:#f6e7e6;
+_FONTS = (
+    "@import url('https://fonts.googleapis.com/css2?"
+    "family=EB+Garamond:wght@500&family=IBM+Plex+Mono:wght@400;500;600&"
+    "family=IBM+Plex+Sans:wght@400;500;600&display=swap');"
+)
+
+_DARK = (
+    "--sf-bg:#0a0b0d;--sf-surface:#131519;--sf-surface-2:#1a1d22;"
+    "--sf-ink:#e8eaed;--sf-ink-2:#9aa0aa;--sf-ink-3:#686e78;"
+    "--sf-line:#20232a;--sf-line-2:#2c303a;--sf-gain:#e0a23c;--sf-gain-bg:#241c0e;"
+    "--sf-blind:#f0726f;--sf-blind-bg:#2a1715"
+)
+_LIGHT = (
+    "--sf-bg:#ffffff;--sf-surface:#f6f6f7;--sf-surface-2:#efeff1;"
+    "--sf-ink:#16181d;--sf-ink-2:#585d67;--sf-ink-3:#8b909a;"
+    "--sf-line:#e6e7ea;--sf-line-2:#d4d6db;--sf-gain:#b07d12;--sf-gain-bg:#faf1dd;"
+    "--sf-blind:#b23b3b;--sf-blind-bg:#f6e7e6"
+)
+
+# INVARIANT: --sf-gain is GOLD (brand refresh — replaced green #0f7a3d/#35d07f). Never purple.
+STYLE = f"""<style>
+{_FONTS}
+.sf-ui {{
+  {_LIGHT};
+  --sf-display:"EB Garamond","Iowan Old Style",Georgia,"Times New Roman",serif;
+  --sf-sans:"IBM Plex Sans",system-ui,-apple-system,"Segoe UI",sans-serif;
+  --sf-mono:"IBM Plex Mono",ui-monospace,SFMono-Regular,Menlo,monospace;
   max-width:760px;color:var(--sf-ink);background:var(--sf-bg);
   font-family:"IBM Plex Sans",system-ui,-apple-system,"Segoe UI",sans-serif;
   font-size:13px;line-height:1.45;
-}
-@media (prefers-color-scheme:dark){.sf-ui{--sf-bg:#0a0b0d;--sf-surface:#131519;
-  --sf-surface-2:#1a1d22;--sf-ink:#e8eaed;--sf-ink-2:#9aa0aa;--sf-ink-3:#686e78;
-  --sf-line:#20232a;--sf-line-2:#2c303a;--sf-gain:#35d07f;--sf-gain-bg:#11241b;
-  --sf-blind:#f0726f;--sf-blind-bg:#2a1715}}
+}}
+@media (prefers-color-scheme:dark){{.sf-ui{{{_DARK}}}}}
 .jp-mod-theme-dark .sf-ui,[data-jp-theme-light="false"] .sf-ui,
-.vscode-dark .sf-ui,.vscode-high-contrast .sf-ui{--sf-bg:#0a0b0d;--sf-surface:#131519;
-  --sf-surface-2:#1a1d22;--sf-ink:#e8eaed;--sf-ink-2:#9aa0aa;--sf-ink-3:#686e78;
-  --sf-line:#20232a;--sf-line-2:#2c303a;--sf-gain:#35d07f;--sf-gain-bg:#11241b;
-  --sf-blind:#f0726f;--sf-blind-bg:#2a1715}
-.jp-mod-theme-light .sf-ui,[data-jp-theme-light="true"] .sf-ui,.vscode-light .sf-ui{
-  --sf-bg:#ffffff;--sf-surface:#f6f6f7;--sf-surface-2:#efeff1;
-  --sf-ink:#16181d;--sf-ink-2:#585d67;--sf-ink-3:#8b909a;
-  --sf-line:#e6e7ea;--sf-line-2:#d4d6db;--sf-gain:#0f7a3d;--sf-gain-bg:#e8f3ec;
-  --sf-blind:#b23b3b;--sf-blind-bg:#f6e7e6}
-.sf-ui,.sf-ui *{box-sizing:border-box}
+.vscode-dark .sf-ui,.vscode-high-contrast .sf-ui{{{_DARK}}}
+.jp-mod-theme-light .sf-ui,[data-jp-theme-light="true"] .sf-ui,.vscode-light .sf-ui{{{_LIGHT}}}
+.sf-ui,.sf-ui *{{box-sizing:border-box}}
 </style>"""
 
 __all__ = ["STYLE"]

--- a/packages/screamingface/src/screamingface/_report_display.py
+++ b/packages/screamingface/src/screamingface/_report_display.py
@@ -25,7 +25,10 @@ _STYLE = (
   padding: 16px;
   border-bottom: 1px solid var(--sf-line);
 }
-.sf-report-title { font-size: 16px; font-weight: 600; color: var(--sf-ink); }
+.sf-report-title {
+  font-family: var(--sf-display, "EB Garamond", Georgia, serif);
+  font-size: 20px; font-weight: 500; letter-spacing: -.01em; color: var(--sf-ink);
+}
 .sf-report-meta,
 .sf-report-status,
 .sf-report-label,

--- a/packages/screamingface/src/screamingface/_report_display.py
+++ b/packages/screamingface/src/screamingface/_report_display.py
@@ -25,10 +25,7 @@ _STYLE = (
   padding: 16px;
   border-bottom: 1px solid var(--sf-line);
 }
-.sf-report-title {
-  font-family: var(--sf-display, "EB Garamond", Georgia, serif);
-  font-size: 20px; font-weight: 500; letter-spacing: -.01em; color: var(--sf-ink);
-}
+.sf-report-title { font-size: 16px; font-weight: 600; color: var(--sf-ink); }
 .sf-report-meta,
 .sf-report-status,
 .sf-report-label,

--- a/packages/screamingface/src/screamingface/_url4_format.py
+++ b/packages/screamingface/src/screamingface/_url4_format.py
@@ -1,123 +1,104 @@
-"""Readable, collapsible rendering of a compiled URL4 recipe.
+"""Full-form, reflowed rendering of a compiled URL4 recipe.
 
-FEATURE: the Model/Fusion card recipe line becomes a structured, syntax-highlighted view.
-INVARIANT: this is a display path — it must never raise. An unparseable recipe (or any
-`url4.Url4Error`) degrades to the exact raw string, which is honest, not a fail-open.
-
-Classes referenced here (`.sf-url4*`) are defined in `_card_display._STYLE`, which every card
-prepends — this module emits only markup, never the stylesheet.
+FEATURE: the Model/Fusion card recipe becomes readable by indentation while keeping the EXACT
+url4 text — nothing is extracted or paraphrased, only whitespace is added at structural
+boundaries.
+INVARIANT: reflow is quote- and escape-aware (url4 quotes with `\\\\` and `\\'`), so an intent
+string's own `(){},` are never treated as structure. The result is rendered inside a <pre>,
+which JupyterLab's MathJax skips — so `$member_*` references are shown literally, not typeset.
 """
 
 from __future__ import annotations
 
 from html import escape
 
-import url4
-
-# Fixed copy-button JS. WHY: the recipe text is read from the sibling hidden <pre> via
-# textContent, so no recipe data is interpolated into this attribute — no injection surface and
-# no JS-string escaping of arbitrary intents. event.stopPropagation keeps the click from toggling
-# the surrounding <details>.
-_COPY_JS = (
-    "event.stopPropagation();"
-    "navigator.clipboard&&navigator.clipboard.writeText("
-    "this.closest('.sf-url4').querySelector('.sf-url4__raw').textContent);"
-    "var b=this;b.textContent='copied';"
-    "setTimeout(function(){b.textContent='copy';},1200);return false;"
-)
+_OPEN = "({"
+_CLOSE = ")}"
 
 
 def recipe_details_html(recipe_url4: str) -> str:
-    """Render a compiled URL4 recipe as a collapsed-by-default details block with copy."""
+    """Render the recipe as a collapsed <details> with the full url4 reflowed in a <pre>."""
 
-    raw = escape(recipe_url4)
-    structured = _structured_html(recipe_url4)
-    if structured is not None:
-        body = f"{structured}<pre class='sf-url4__raw' hidden>{raw}</pre>"
-    else:
-        # Fallback: show the raw recipe (also the copy source) when it cannot be parsed.
-        body = f"<pre class='sf-url4__raw'>{raw}</pre>"
+    pretty = escape(_pretty_url4(recipe_url4))
+    # WHY: the copy source is the EXACT original (no added whitespace), carried in a data-
+    # attribute so the fixed onclick JS interpolates no recipe text (no injection, no escaping
+    # of the JS string). getAttribute returns the attribute value already HTML-unescaped.
+    raw_attr = escape(recipe_url4, quote=True)
     copy = (
         "<button type='button' class='sf-url4__copy' title='Copy the url4 recipe' "
-        f'onclick="{_COPY_JS}">copy</button>'
+        f'data-url4="{raw_attr}" '
+        'onclick="event.stopPropagation();navigator.clipboard&&navigator.clipboard.writeText('
+        "this.getAttribute('data-url4'));var b=this;b.textContent='copied';"
+        "setTimeout(function(){b.textContent='copy';},1200);return false;\">copy</button>"
     )
     return (
         "<details class='sf-url4'>"
-        "<summary class='sf-url4__summary'>"
-        "<span class='sf-card__k'>url4 recipe</span>"
+        "<summary class='sf-summary'><span class='sf-card__k'>url4 recipe</span>"
         f"{copy}</summary>"
-        f"<div class='sf-url4__body'>{body}</div></details>"
+        f"<pre class='sf-url4__pre'>{pretty}</pre>"
+        "</details>"
     )
 
 
-def _structured_html(recipe_url4: str) -> str | None:
-    try:
-        node = url4.build(recipe_url4)
-    except url4.Url4Error:
-        # WHY: never let a parser edge case break a repr — fall back to the raw string.
-        return None
-    if isinstance(node, url4.Expression):
-        blocks = "".join(_source_html(source) for source in node.sources)
-        return f"<div class='sf-url4__nodes'>{blocks}{_output_html(node.intent)}</div>"
-    return f"<div class='sf-url4__nodes'>{_value_html(node)}</div>"
+def _pretty_url4(text: str) -> str:
+    """Reflow url4 by indenting on (){} and top-level commas, preserving every character.
+
+    Quote-aware: inside a `'…'` intent, `\\` escapes the next character and structural
+    characters are copied verbatim.
+    """
+
+    out: list[str] = []
+    depth = 0
+    i = 0
+    n = len(text)
+    while i < n:
+        char = text[i]
+        if char == "'":  # a quoted intent — copy verbatim, then resume structural reflow
+            i = _copy_quoted(text, i, out)
+        elif char in _OPEN and i + 1 < n and text[i + 1] in _CLOSE:
+            out.append(char + text[i + 1])  # keep an empty () / {} inline
+            i += 2
+        elif char in _OPEN:
+            depth += 1
+            out.append(char + "\n" + "  " * depth)
+            i = _skip_space(text, i + 1)
+        elif char in _CLOSE:
+            depth = max(0, depth - 1)
+            out.append("\n" + "  " * depth + char)
+            i += 1
+        elif char == ",":
+            out.append(char + "\n" + "  " * depth)
+            i = _skip_space(text, i + 1)
+        else:
+            out.append(char)
+            i += 1
+    return "".join(out)
 
 
-def _source_html(source: url4.Node) -> str:
-    # Expression.sources is typed as Node; in practice each is a Source. Anything else is
-    # rendered by its value path so an unexpected shape still displays instead of crashing.
-    if not isinstance(source, url4.Source):
-        return f"<div class='sf-url4__node'>{_value_html(source)}</div>"
-    name = escape(source.name or "·")
-    return (
-        "<div class='sf-url4__node'>"
-        f"<div class='sf-url4__nhead'><span class='sf-url4__name'>{name}</span>"
-        f"{_weight_html(source.weight)}</div>"
-        f"{_value_html(source.value)}</div>"
-    )
+def _copy_quoted(text: str, i: int, out: list[str]) -> int:
+    """Copy a `'…'` span verbatim (honouring `\\` escapes); return the index past it."""
+
+    out.append(text[i])
+    i += 1
+    n = len(text)
+    while i < n:
+        char = text[i]
+        if char == "\\" and i + 1 < n:
+            out.append(text[i : i + 2])  # an escaped char (e.g. \\' or \\\\) is never a delimiter
+            i += 2
+            continue
+        out.append(char)
+        i += 1
+        if char == "'":
+            break
+    return i
 
 
-def _weight_html(weight: object) -> str:
-    if weight is None or weight == 0.0 or (isinstance(weight, dict) and not weight):
-        return ""
-    return f"<span class='sf-url4__weight'>weight {escape(str(weight))}</span>"
-
-
-def _value_html(value: url4.Node) -> str:
-    if isinstance(value, (url4.RelExpr, url4.RemoteExpr)):
-        return _expr_html(value)
-    if isinstance(value, url4.StructObject):
-        return f"<div class='sf-url4__struct'>{escape(value.raw)}</div>"
-    return f"<div class='sf-url4__leaf'>{escape(url4.render(value))}</div>"
-
-
-def _expr_html(expr: url4.RelExpr | url4.RemoteExpr) -> str:
-    authority = getattr(expr, "authority", None)
-    route = f"//{authority}{expr.path}" if authority else expr.path
-    parts = [f"<div class='sf-url4__route'>{escape(route)}</div>"]
-    for key, value in expr.params:
-        suffix = "" if value is None else f"<span class='sf-url4__pv'> = {escape(value)}</span>"
-        parts.append(
-            f"<div class='sf-url4__param'><span class='sf-url4__pk'>{escape(key)}</span>"
-            f"{suffix}</div>"
-        )
-    if expr.context:
-        parts.append(f"<div class='sf-url4__ctx'>context ({escape(expr.context)})</div>")
-    if expr.intent is not None:
-        parts.append(f"<div class='sf-url4__intent'>{escape(_intent_text(expr.intent))}</div>")
-    return "".join(parts)
-
-
-def _output_html(intent: url4.Node | None) -> str:
-    if intent is None:
-        return ""
-    return (
-        "<div class='sf-url4__output'><span class='sf-card__k'>output</span> "
-        f"<span class='sf-mono'>{escape(_intent_text(intent))}</span></div>"
-    )
-
-
-def _intent_text(intent: url4.Node) -> str:
-    return intent.value if isinstance(intent, url4.Text) else url4.render(intent)
+def _skip_space(text: str, i: int) -> int:
+    # Drop a single run of spaces right after a break so lines don't start with stray padding.
+    while i < len(text) and text[i] == " ":
+        i += 1
+    return i
 
 
 __all__ = ["recipe_details_html"]

--- a/packages/screamingface/src/screamingface/_url4_format.py
+++ b/packages/screamingface/src/screamingface/_url4_format.py
@@ -1,0 +1,123 @@
+"""Readable, collapsible rendering of a compiled URL4 recipe.
+
+FEATURE: the Model/Fusion card recipe line becomes a structured, syntax-highlighted view.
+INVARIANT: this is a display path — it must never raise. An unparseable recipe (or any
+`url4.Url4Error`) degrades to the exact raw string, which is honest, not a fail-open.
+
+Classes referenced here (`.sf-url4*`) are defined in `_card_display._STYLE`, which every card
+prepends — this module emits only markup, never the stylesheet.
+"""
+
+from __future__ import annotations
+
+from html import escape
+
+import url4
+
+# Fixed copy-button JS. WHY: the recipe text is read from the sibling hidden <pre> via
+# textContent, so no recipe data is interpolated into this attribute — no injection surface and
+# no JS-string escaping of arbitrary intents. event.stopPropagation keeps the click from toggling
+# the surrounding <details>.
+_COPY_JS = (
+    "event.stopPropagation();"
+    "navigator.clipboard&&navigator.clipboard.writeText("
+    "this.closest('.sf-url4').querySelector('.sf-url4__raw').textContent);"
+    "var b=this;b.textContent='copied';"
+    "setTimeout(function(){b.textContent='copy';},1200);return false;"
+)
+
+
+def recipe_details_html(recipe_url4: str) -> str:
+    """Render a compiled URL4 recipe as a collapsed-by-default details block with copy."""
+
+    raw = escape(recipe_url4)
+    structured = _structured_html(recipe_url4)
+    if structured is not None:
+        body = f"{structured}<pre class='sf-url4__raw' hidden>{raw}</pre>"
+    else:
+        # Fallback: show the raw recipe (also the copy source) when it cannot be parsed.
+        body = f"<pre class='sf-url4__raw'>{raw}</pre>"
+    copy = (
+        "<button type='button' class='sf-url4__copy' title='Copy the url4 recipe' "
+        f'onclick="{_COPY_JS}">copy</button>'
+    )
+    return (
+        "<details class='sf-url4'>"
+        "<summary class='sf-url4__summary'>"
+        "<span class='sf-card__k'>url4 recipe</span>"
+        f"{copy}</summary>"
+        f"<div class='sf-url4__body'>{body}</div></details>"
+    )
+
+
+def _structured_html(recipe_url4: str) -> str | None:
+    try:
+        node = url4.build(recipe_url4)
+    except url4.Url4Error:
+        # WHY: never let a parser edge case break a repr — fall back to the raw string.
+        return None
+    if isinstance(node, url4.Expression):
+        blocks = "".join(_source_html(source) for source in node.sources)
+        return f"<div class='sf-url4__nodes'>{blocks}{_output_html(node.intent)}</div>"
+    return f"<div class='sf-url4__nodes'>{_value_html(node)}</div>"
+
+
+def _source_html(source: url4.Node) -> str:
+    # Expression.sources is typed as Node; in practice each is a Source. Anything else is
+    # rendered by its value path so an unexpected shape still displays instead of crashing.
+    if not isinstance(source, url4.Source):
+        return f"<div class='sf-url4__node'>{_value_html(source)}</div>"
+    name = escape(source.name or "·")
+    return (
+        "<div class='sf-url4__node'>"
+        f"<div class='sf-url4__nhead'><span class='sf-url4__name'>{name}</span>"
+        f"{_weight_html(source.weight)}</div>"
+        f"{_value_html(source.value)}</div>"
+    )
+
+
+def _weight_html(weight: object) -> str:
+    if weight is None or weight == 0.0 or (isinstance(weight, dict) and not weight):
+        return ""
+    return f"<span class='sf-url4__weight'>weight {escape(str(weight))}</span>"
+
+
+def _value_html(value: url4.Node) -> str:
+    if isinstance(value, (url4.RelExpr, url4.RemoteExpr)):
+        return _expr_html(value)
+    if isinstance(value, url4.StructObject):
+        return f"<div class='sf-url4__struct'>{escape(value.raw)}</div>"
+    return f"<div class='sf-url4__leaf'>{escape(url4.render(value))}</div>"
+
+
+def _expr_html(expr: url4.RelExpr | url4.RemoteExpr) -> str:
+    authority = getattr(expr, "authority", None)
+    route = f"//{authority}{expr.path}" if authority else expr.path
+    parts = [f"<div class='sf-url4__route'>{escape(route)}</div>"]
+    for key, value in expr.params:
+        suffix = "" if value is None else f"<span class='sf-url4__pv'> = {escape(value)}</span>"
+        parts.append(
+            f"<div class='sf-url4__param'><span class='sf-url4__pk'>{escape(key)}</span>"
+            f"{suffix}</div>"
+        )
+    if expr.context:
+        parts.append(f"<div class='sf-url4__ctx'>context ({escape(expr.context)})</div>")
+    if expr.intent is not None:
+        parts.append(f"<div class='sf-url4__intent'>{escape(_intent_text(expr.intent))}</div>")
+    return "".join(parts)
+
+
+def _output_html(intent: url4.Node | None) -> str:
+    if intent is None:
+        return ""
+    return (
+        "<div class='sf-url4__output'><span class='sf-card__k'>output</span> "
+        f"<span class='sf-mono'>{escape(_intent_text(intent))}</span></div>"
+    )
+
+
+def _intent_text(intent: url4.Node) -> str:
+    return intent.value if isinstance(intent, url4.Text) else url4.render(intent)
+
+
+__all__ = ["recipe_details_html"]

--- a/packages/screamingface/src/screamingface/benchmark.py
+++ b/packages/screamingface/src/screamingface/benchmark.py
@@ -55,6 +55,11 @@ class Case:
         assert isinstance(value, dict)
         return value
 
+    def _repr_html_(self) -> str:
+        from screamingface._card_display import case_card_html
+
+        return case_card_html(self)
+
     def _to_wire(self) -> dict[str, object]:
         return {
             "id": self.id,

--- a/packages/screamingface/src/screamingface/benchmark.py
+++ b/packages/screamingface/src/screamingface/benchmark.py
@@ -225,6 +225,11 @@ class Benchmark:
             return benchmark_url4(self, candidate, first=first)
         return candidates_url4(self, candidate, first=first)
 
+    def _repr_html_(self) -> str:
+        from screamingface._card_display import benchmark_card_html
+
+        return benchmark_card_html(self)
+
     def _materialize_cases(self) -> tuple[Case, ...]:
         if self._case_source is None:
             raise RuntimeError("engine-advertised benchmark cases are evaluated by the engine")

--- a/packages/screamingface/src/screamingface/benchmarks.py
+++ b/packages/screamingface/src/screamingface/benchmarks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import builtins
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from screamingface._profile import BenchmarkRecord, load_registry
 from screamingface.aggregators import Mean
@@ -13,23 +14,41 @@ from screamingface.graders import ExactChoice, Grader, Rubric
 from screamingface.models import _filters, _limit, _query
 from screamingface.tools import Tool, WebFetch, WebSearch
 
+if TYPE_CHECKING:
+    from screamingface._catalog_view import BenchmarksView
+
 
 def list(
     *, query: str | None = None, tools: Sequence[str] = (), limit: int | None = None
 ) -> builtins.list[str]:
     """Return engine-advertised benchmark IDs in stable registry order."""
 
-    requested_tools = _filters(tools)
-    needle = _query(query)
     if limit is not None:
         _limit(limit, 0)
-    values = [
-        benchmark.id
-        for benchmark in load_registry().benchmarks
-        if (needle is None or needle in benchmark.id.casefold())
-        and requested_tools.issubset(benchmark.tools)
-    ]
+    values = [record.id for record in _filtered_benchmarks(query=query, tools=tools)]
     return values[: _limit(limit, len(values))]
+
+
+def view(*, query: str | None = None, tools: Sequence[str] = ()) -> BenchmarksView:
+    """Return a searchable notebook catalog of engine-advertised benchmarks."""
+
+    from screamingface._catalog_view import BenchmarksView
+
+    return BenchmarksView(_filtered_benchmarks(query=query, tools=tools))
+
+
+def _filtered_benchmarks(
+    *, query: str | None, tools: Sequence[str]
+) -> builtins.list[BenchmarkRecord]:
+    # INVARIANT: view() and list() share this predicate, so they never disagree on membership.
+    requested_tools = _filters(tools)
+    needle = _query(query)
+    return [
+        record
+        for record in load_registry().benchmarks
+        if (needle is None or needle in record.id.casefold())
+        and requested_tools.issubset(record.tools)
+    ]
 
 
 def load(benchmark_id: str) -> Benchmark:

--- a/packages/screamingface/src/screamingface/connections.py
+++ b/packages/screamingface/src/screamingface/connections.py
@@ -57,6 +57,11 @@ class Connection:
         if self.auth_method is not None and self.auth_method not in self.auth_methods:
             raise ValueError("connection auth_method is not advertised by its provider")
 
+    def _repr_html_(self) -> str:
+        from screamingface._card_display import connection_card_html
+
+        return connection_card_html(self)
+
 
 @dataclass(frozen=True, slots=True)
 class OAuthFlow:

--- a/packages/screamingface/src/screamingface/fusion.py
+++ b/packages/screamingface/src/screamingface/fusion.py
@@ -38,6 +38,11 @@ class Fusion(Recipe):
         object.__setattr__(self, "reducer", reducer)
         _validate_graph(self)
 
+    def _repr_html_(self) -> str:
+        from screamingface._card_display import fusion_card_html
+
+        return fusion_card_html(self)
+
     @property
     def model_ids(self) -> tuple[str, ...]:
         models: list[str] = []

--- a/packages/screamingface/src/screamingface/graders.py
+++ b/packages/screamingface/src/screamingface/graders.py
@@ -52,3 +52,8 @@ class Rubric(Grader):
     @property
     def params(self) -> dict[str, ParameterValue]:
         return dict(self._parameter_items)
+
+    def _repr_html_(self) -> str:
+        from screamingface._card_display import rubric_card_html
+
+        return rubric_card_html(self)

--- a/packages/screamingface/src/screamingface/model.py
+++ b/packages/screamingface/src/screamingface/model.py
@@ -50,6 +50,11 @@ class Model(Recipe):
     def params(self) -> dict[str, ParameterValue]:
         return dict(self._parameter_items)
 
+    def _repr_html_(self) -> str:
+        from screamingface._card_display import model_card_html
+
+        return model_card_html(self)
+
     @property
     def members(self) -> tuple[()]:
         return ()

--- a/packages/screamingface/src/screamingface/models.py
+++ b/packages/screamingface/src/screamingface/models.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 import builtins
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
-from screamingface._profile import load_registry
+from screamingface._profile import ModelRecord, load_registry
 from screamingface._tooling import tool_ids
+
+if TYPE_CHECKING:
+    from screamingface._catalog_view import ModelsView
 
 
 def list(
@@ -14,18 +18,30 @@ def list(
 ) -> builtins.list[str]:
     """Return advertised model IDs, optionally filtered in registry order."""
 
-    requested_tools = _filters(tools)
-    needle = _query(query)
     if limit is not None:
         _limit(limit, 0)
-    records = load_registry().models
-    values = [
-        record.id
-        for record in records
+    values = [record.id for record in _filtered_models(query=query, tools=tools)]
+    return values[: _limit(limit, len(values))]
+
+
+def view(*, query: str | None = None, tools: Sequence[str] = ()) -> ModelsView:
+    """Return a searchable notebook catalog of advertised models."""
+
+    from screamingface._catalog_view import ModelsView
+
+    return ModelsView(_filtered_models(query=query, tools=tools))
+
+
+def _filtered_models(*, query: str | None, tools: Sequence[str]) -> builtins.list[ModelRecord]:
+    # INVARIANT: view() and list() share this predicate, so they never disagree on membership.
+    requested_tools = _filters(tools)
+    needle = _query(query)
+    return [
+        record
+        for record in load_registry().models
         if (needle is None or needle in record.id.casefold())
         and requested_tools.issubset(record.supported_tools)
     ]
-    return values[: _limit(limit, len(values))]
 
 
 def _query(value: str | None) -> str | None:

--- a/packages/screamingface/tests/test_ome626_display.py
+++ b/packages/screamingface/tests/test_ome626_display.py
@@ -1,0 +1,264 @@
+"""OME-626 — widget-like reprs for Model/Fusion/Benchmark and catalog views.
+
+FEATURE: notebook rich display for the core SDK objects and engine catalog.
+STORY: as a researcher, I evaluate a Model/Fusion/Benchmark in a cell (or call
+sf.models.view()/sf.benchmarks.view()) and see a branded card/catalog instead of a bare repr.
+INVARIANT: cards render only real advertised fields — never fabricated price/context/ability.
+"""
+
+from __future__ import annotations
+
+import json
+from html import escape
+
+import ipywidgets as widgets
+import pytest
+
+import screamingface as sf
+from screamingface import _profile
+
+# Metric words the design mock shows but the engine does NOT advertise. They must never
+# appear in real output — displaying them would fabricate data (INVARIANT above).
+_FABRICATED = ("context window", "ability", "tok/s", "tokens/s", "$/m", "price")
+
+
+def _registry() -> dict[str, object]:
+    return {
+        "schema": "screamingface.registry.v1",
+        "response_schemas": [
+            "screamingface.recipe-result.v1",
+            "screamingface.case-grade.v1",
+            "screamingface.report.v1",
+        ],
+        "limits": {"max_request_target_bytes": 61440},
+        "providers": [
+            {"id": "codex", "display_name": "OpenAI Codex", "auth_methods": ["oauth"]},
+            {"id": "gemini", "display_name": "Google Gemini", "auth_methods": ["api_key"]},
+        ],
+        "models": [
+            {
+                "id": "codex/gpt-5.5",
+                "provider": "codex",
+                "supported_tools": [],
+                "required_connections": [],
+            },
+            {
+                "id": "gemini/2.5-flash",
+                "provider": "gemini",
+                "supported_tools": ["web_search", "web_fetch"],
+                "required_connections": [],
+            },
+        ],
+        "benchmarks": [
+            {
+                "id": "gpqa@1",
+                "title": "GPQA Diamond",
+                "cases_route": "/benchmarks/gpqa/1/cases",
+                "grader": {"kind": "exact_choice", "route": "/graders/exact-choice/1"},
+                "aggregator": {"kind": "mean", "route": "/aggregators/mean/1"},
+                "tools": [],
+                "max_tool_calls": None,
+                "tool_policy_route": None,
+                "candidate_route": None,
+                "candidate_aggregator_route": None,
+            },
+            {
+                "id": "draco@1",
+                "title": "DRACO",
+                "cases_route": "/benchmarks/draco/1/cases",
+                "grader": {"kind": "exact_choice", "route": "/graders/exact-choice/1"},
+                "aggregator": {"kind": "mean", "route": "/aggregators/mean/1"},
+                "tools": ["web_search", "web_fetch"],
+                "max_tool_calls": 12,
+                "tool_policy_route": "/benchmarks/draco/1/tool-policy",
+                "candidate_route": None,
+                "candidate_aggregator_route": None,
+            },
+        ],
+        "reducers": [{"id": "majority_vote", "route": "/reducers/majority-vote/1"}],
+    }
+
+
+@pytest.fixture
+def engine(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_profile, "_get_text", lambda _path: json.dumps(_registry()))
+    sf.config(engine="http://127.0.0.1:4404")
+
+
+def _walk(widget: widgets.Widget) -> tuple[widgets.Widget, ...]:
+    children = getattr(widget, "children", ())
+    return (widget, *(item for child in children for item in _walk(child)))
+
+
+def _html_text(widget: widgets.Widget) -> str:
+    return "\n".join(
+        item.value
+        for item in _walk(widget)
+        if isinstance(item, widgets.HTML) and isinstance(item.value, str)
+    )
+
+
+# --- object cards -------------------------------------------------------------------------
+
+
+def test_model_repr_html_shows_real_fields_and_no_fabricated_metrics() -> None:
+    model = sf.Model(
+        "gemini/2.5-flash", name="flash-1", prompt="Solve it.", params={"temperature": 0.5}
+    )
+
+    html = model._repr_html_()
+
+    assert "class='sf-ui" in html
+    assert "gemini/2.5-flash" in html
+    assert "flash-1" in html
+    assert "Solve it." in html
+    assert "temperature" in html and "0.5" in html
+    assert "gemini" in html  # provider derived from the route prefix
+    assert escape(model.url4) in html  # the recipe is the identity
+    lowered = html.lower()
+    for banned in _FABRICATED:
+        assert banned not in lowered
+
+
+def test_model_card_escapes_injected_text() -> None:
+    model = sf.Model("gemini/2.5-flash", prompt="<script>alert(1)</script>")
+
+    html = model._repr_html_()
+
+    assert "<script>alert(1)</script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_model_repr_text_is_concise() -> None:
+    model = sf.Model("gemini/2.5-flash", name="flash-1")
+
+    text = repr(model)
+
+    assert "Model" in text
+    assert "gemini/2.5-flash" in text
+    assert "<div" not in text  # a text repr, not HTML
+
+
+def test_fusion_repr_html_shows_members_reducer_and_recipe() -> None:
+    a = sf.Model("gemini/2.5-flash", name="a")
+    b = sf.Model("codex/gpt-5.5", name="b")
+    fusion = sf.Fusion("trio", members=[a, b], reducer=sf.reducers.MajorityVote())
+
+    html = fusion._repr_html_()
+
+    assert "class='sf-ui" in html
+    assert "trio" in html
+    assert "gemini/2.5-flash" in html
+    assert "codex/gpt-5.5" in html
+    assert "majority" in html.lower()  # reducer kind, humanized
+    assert escape(fusion.url4) in html
+    lowered = html.lower()
+    for banned in _FABRICATED:
+        assert banned not in lowered
+
+
+def test_fusion_repr_html_labels_nested_fusion() -> None:
+    inner = sf.Fusion("inner", members=["gemini/2.5-flash"], reducer=sf.reducers.MajorityVote())
+    outer = sf.Fusion("outer", members=[inner, "codex/gpt-5.5"], reducer=sf.reducers.MajorityVote())
+
+    html = outer._repr_html_()
+
+    assert "inner" in html
+    assert "outer" in html
+
+
+def test_benchmark_repr_html_shows_id_title_grader_aggregator_tools() -> None:
+    bench = sf.Benchmark(
+        "mini@1",
+        title="Mini Suite",
+        cases=[sf.Case("c1", "2+2?", reference="4")],
+        grader=sf.graders.ExactChoice(),
+        tools=[sf.tools.WebSearch()],
+        max_tool_calls=8,
+    )
+
+    html = bench._repr_html_()
+
+    assert "class='sf-ui" in html
+    assert "mini@1" in html
+    assert "Mini Suite" in html
+    assert "exact" in html.lower()  # grader kind
+    assert "mean" in html.lower()  # aggregator kind
+    assert "web_search" in html
+    assert "8" in html  # max_tool_calls
+    lowered = html.lower()
+    for banned in _FABRICATED:
+        assert banned not in lowered
+
+
+def test_benchmark_repr_text_is_concise() -> None:
+    bench = sf.Benchmark(
+        "mini@1", cases=[sf.Case("c1", "2+2?", reference="4")], grader=sf.graders.ExactChoice()
+    )
+
+    text = repr(bench)
+
+    assert "Benchmark" in text
+    assert "mini@1" in text
+    assert "<div" not in text
+
+
+# --- catalog views ------------------------------------------------------------------------
+
+
+def test_models_view_value_matches_list(engine: None) -> None:
+    view = sf.models.view()
+
+    assert view.value == sf.models.list()
+    html = view._repr_html_()
+    assert "class='sf-ui" in html
+    assert "gemini/2.5-flash" in html
+    assert "codex/gpt-5.5" in html
+
+
+def test_models_view_query_matches_list_query(engine: None) -> None:
+    assert sf.models.view(query="gemini").value == sf.models.list(query="gemini")
+    assert sf.models.view(tools=["web_search"]).value == sf.models.list(tools=["web_search"])
+
+
+def test_models_view_widget_search_filters_rows_and_value(engine: None) -> None:
+    view = sf.models.view()
+    root = view.widget()
+
+    search = next(item for item in _walk(root) if isinstance(item, widgets.Text))
+    search.value = "codex"
+
+    assert view.value == ["codex/gpt-5.5"]
+    body = _html_text(root)
+    assert "codex/gpt-5.5" in body
+    assert "gemini/2.5-flash" not in body
+
+
+def test_benchmarks_view_value_matches_list(engine: None) -> None:
+    view = sf.benchmarks.view()
+
+    assert view.value == sf.benchmarks.list()
+    html = view._repr_html_()
+    assert "gpqa@1" in html
+    assert "GPQA Diamond" in html
+    assert "draco@1" in html
+
+
+def test_benchmarks_view_query_matches_list_query(engine: None) -> None:
+    assert sf.benchmarks.view(query="draco").value == sf.benchmarks.list(query="draco")
+    assert sf.benchmarks.view(tools=["web_search"]).value == sf.benchmarks.list(
+        tools=["web_search"]
+    )
+
+
+def test_benchmarks_view_widget_search_filters_rows_and_value(engine: None) -> None:
+    view = sf.benchmarks.view()
+    root = view.widget()
+
+    search = next(item for item in _walk(root) if isinstance(item, widgets.Text))
+    search.value = "draco"
+
+    assert view.value == ["draco@1"]
+    body = _html_text(root)
+    assert "draco@1" in body
+    assert "gpqa@1" not in body

--- a/packages/screamingface/tests/test_ome628_value_cards.py
+++ b/packages/screamingface/tests/test_ome628_value_cards.py
@@ -1,0 +1,104 @@
+"""OME-628 — _repr_html_ cards for Connection, Case, and Rubric.
+
+FEATURE: notebook rich display for the remaining small public value objects.
+STORY: as a researcher, I inspect a connection, a case, or a rubric grader in a cell and see a
+branded card instead of a bare dataclass repr.
+INVARIANT: cards render only real fields the object holds — never fabricated metrics; injected
+text is HTML-escaped.
+"""
+
+from __future__ import annotations
+
+import screamingface as sf
+from screamingface.connections import Connection
+
+_FABRICATED = ("context window", "ability", "tok/s", "tokens/s", "$/m", "price")
+
+
+def test_connection_repr_html_shows_real_state() -> None:
+    connection = Connection(
+        provider="gemini",
+        display_name="Google Gemini",
+        auth_methods=("oauth", "api_key"),
+        status="connected",
+        auth_method="api_key",
+        account_label="researcher@example.com",
+    )
+
+    html = connection._repr_html_()
+
+    assert "class='sf-ui" in html
+    assert "Google Gemini" in html
+    assert "gemini" in html
+    assert "connected" in html
+    assert "api_key" in html
+    assert "researcher@example.com" in html
+    lowered = html.lower()
+    for banned in _FABRICATED:
+        assert banned not in lowered
+
+
+def test_connection_card_escapes_injected_account_label() -> None:
+    connection = Connection(
+        provider="gemini",
+        display_name="Google Gemini",
+        auth_methods=("api_key",),
+        status="connected",
+        auth_method="api_key",
+        account_label="<script>alert(1)</script>",
+    )
+
+    html = connection._repr_html_()
+
+    assert "<script>alert(1)</script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_case_repr_html_shows_id_input_reference_metadata() -> None:
+    case = sf.Case("c1", "What is 2+2?", reference="4", metadata={"topic": "math"})
+
+    html = case._repr_html_()
+
+    assert "class='sf-ui" in html
+    assert "c1" in html
+    assert "What is 2+2?" in html
+    assert "4" in html  # reference
+    assert "topic" in html and "math" in html  # metadata
+
+
+def test_case_card_escapes_injected_input() -> None:
+    case = sf.Case("c1", "<script>alert(1)</script>", reference="4")
+
+    html = case._repr_html_()
+
+    assert "<script>alert(1)</script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_rubric_repr_html_shows_model_prompt_passes_params() -> None:
+    rubric = sf.graders.Rubric(
+        model="gemini/3.1-pro-preview",
+        prompt="Judge the answer.",
+        passes=3,
+        params={"temperature": 0.0},
+    )
+
+    html = rubric._repr_html_()
+
+    assert "class='sf-ui" in html
+    assert "gemini/3.1-pro-preview" in html
+    assert "Judge the answer." in html
+    assert "3" in html  # passes
+    assert "temperature" in html and "0.0" in html
+    lowered = html.lower()
+    for banned in _FABRICATED:
+        assert banned not in lowered
+
+
+def test_rubric_card_escapes_injected_prompt() -> None:
+    rubric = sf.graders.Rubric(model="gemini/3.1-pro-preview", prompt="<script>alert(1)</script>")
+
+    html = rubric._repr_html_()
+
+    assert "<script>alert(1)</script>" not in html
+    assert "&lt;script&gt;" in html

--- a/packages/screamingface/tests/test_ome630_recipe_wrap.py
+++ b/packages/screamingface/tests/test_ome630_recipe_wrap.py
@@ -1,0 +1,19 @@
+"""OME-630 follow-up — the recipe view wraps long content instead of overflowing.
+
+STORY: a researcher expands a recipe with long routes/structs and it stays inside the card.
+INVARIANT: the flex node containers set min-width:0 so long content wraps (flex items default
+to min-width:auto, which lets long content push past the card edge).
+"""
+
+from __future__ import annotations
+
+import re
+
+from screamingface import _card_display
+
+
+def test_recipe_node_containers_set_min_width_zero_to_wrap() -> None:
+    for selector in ("sf-url4__nodes", "sf-url4__node"):
+        match = re.search(rf"\.{selector}\{{([^}}]*)\}}", _card_display._STYLE)
+        assert match is not None, f"missing rule for .{selector}"
+        assert "min-width:0" in match.group(1), f".{selector} must set min-width:0 to wrap"

--- a/packages/screamingface/tests/test_ome630_recipe_wrap.py
+++ b/packages/screamingface/tests/test_ome630_recipe_wrap.py
@@ -1,19 +1,20 @@
 """OME-630 follow-up — the recipe view wraps long content instead of overflowing.
 
 STORY: a researcher expands a recipe with long routes/structs and it stays inside the card.
-INVARIANT: the flex node containers set min-width:0 so long content wraps (flex items default
-to min-width:auto, which lets long content push past the card edge).
+INVARIANT: the recipe <pre> wraps (white-space:pre-wrap + overflow-wrap:anywhere) so long
+lines never push past the card edge.
 """
 
 from __future__ import annotations
 
 import re
 
-from screamingface import _card_display
+from screamingface import _card_style
 
 
-def test_recipe_node_containers_set_min_width_zero_to_wrap() -> None:
-    for selector in ("sf-url4__nodes", "sf-url4__node"):
-        match = re.search(rf"\.{selector}\{{([^}}]*)\}}", _card_display._STYLE)
-        assert match is not None, f"missing rule for .{selector}"
-        assert "min-width:0" in match.group(1), f".{selector} must set min-width:0 to wrap"
+def test_recipe_pre_wraps_long_content() -> None:
+    match = re.search(r"\.sf-url4__pre\{([^}]*)\}", _card_style.CARD_STYLE)
+    assert match is not None, "missing .sf-url4__pre rule"
+    body = match.group(1)
+    assert "white-space:pre-wrap" in body
+    assert "overflow-wrap:anywhere" in body

--- a/packages/screamingface/tests/test_ome630_url4_view.py
+++ b/packages/screamingface/tests/test_ome630_url4_view.py
@@ -30,18 +30,19 @@ def test_recipe_is_collapsed_by_default_with_a_copy_button() -> None:
     assert "clipboard" in html  # the copy button wires navigator.clipboard
 
 
-def test_structured_view_shows_routes_params_and_intent() -> None:
+def test_full_form_keeps_the_recipe_and_carries_the_exact_raw() -> None:
+    # The url4 is kept in full form (reflowed in a <pre>), not extracted into fields.
     url4 = _fusion_url4()
 
     html = recipe_details_html(url4)
 
-    assert "member_1" in html
+    assert "sf-url4__pre" in html  # rendered in a <pre> (MathJax skips pre/code)
     assert "/gemini/2.5-flash" in html
     assert "/codex/gpt-5.5" in html
-    assert "temperature" in html  # a rendered param key
-    assert "Answer the question." in html  # the member intent/prompt
-    assert "sf-url4__nodes" in html  # the structured container is present
-    assert escape(url4) in html  # the exact raw recipe is embedded (copy source)
+    assert "temperature" in html
+    assert "Answer the question." in html  # the intent text is preserved verbatim
+    # the exact original recipe is carried for the copy button (quote-escaped attribute)
+    assert f'data-url4="{escape(url4, quote=True)}"' in html
 
 
 def test_structured_view_escapes_injected_intent() -> None:
@@ -54,19 +55,13 @@ def test_structured_view_escapes_injected_intent() -> None:
     assert "&lt;script&gt;" in html
 
 
-def test_unparseable_recipe_falls_back_to_raw_without_raising(monkeypatch) -> None:
-    import screamingface._url4_format as mod
-
-    def _boom(_source: str) -> object:
-        raise mod.url4.Url4Error("unparseable")
-
-    monkeypatch.setattr(mod.url4, "build", _boom)
-
-    html = recipe_details_html("member_1:broken")
+def test_reflow_of_odd_input_does_not_raise() -> None:
+    # Reflow is a pure string transform (no parser), so malformed input never raises — it just
+    # reflows oddly and the text is preserved.
+    html = recipe_details_html("member_1:broken(")
 
     assert "<details class='sf-url4'" in html
-    assert "member_1:broken" in html  # raw shown
-    assert "sf-url4__nodes" not in html  # no structured view on fallback
+    assert "member_1:broken(" in html
 
 
 def test_model_and_fusion_cards_embed_the_collapsible_recipe() -> None:

--- a/packages/screamingface/tests/test_ome630_url4_view.py
+++ b/packages/screamingface/tests/test_ome630_url4_view.py
@@ -1,0 +1,77 @@
+"""OME-630 — collapsible, syntax-highlighted url4 recipe view.
+
+FEATURE: the Model/Fusion card recipe becomes a readable, collapsed-by-default structured view.
+STORY: as a researcher, I expand the url4 recipe to read each member's route/params/prompt, and
+copy the exact recipe with one button.
+INVARIANT: display never raises — an unparseable recipe degrades to the raw string; injected
+text stays HTML-escaped.
+"""
+
+from __future__ import annotations
+
+from html import escape
+
+import screamingface as sf
+from screamingface._url4_format import recipe_details_html
+
+
+def _fusion_url4() -> str:
+    a = sf.Model("gemini/2.5-flash", name="a", params={"temperature": 0})
+    b = sf.Model("codex/gpt-5.5", name="b")
+    return sf.Fusion("trio", members=[a, b], reducer=sf.reducers.MajorityVote()).url4
+
+
+def test_recipe_is_collapsed_by_default_with_a_copy_button() -> None:
+    html = recipe_details_html(_fusion_url4())
+
+    assert "<details class='sf-url4'" in html
+    assert " open" not in html  # collapsed by default (no `open` attribute)
+    assert "sf-url4__copy" in html
+    assert "clipboard" in html  # the copy button wires navigator.clipboard
+
+
+def test_structured_view_shows_routes_params_and_intent() -> None:
+    url4 = _fusion_url4()
+
+    html = recipe_details_html(url4)
+
+    assert "member_1" in html
+    assert "/gemini/2.5-flash" in html
+    assert "/codex/gpt-5.5" in html
+    assert "temperature" in html  # a rendered param key
+    assert "Answer the question." in html  # the member intent/prompt
+    assert "sf-url4__nodes" in html  # the structured container is present
+    assert escape(url4) in html  # the exact raw recipe is embedded (copy source)
+
+
+def test_structured_view_escapes_injected_intent() -> None:
+    malicious = sf.Model("gemini/2.5-flash", prompt="<script>alert(1)</script>")
+    fusion = sf.Fusion("t", members=[malicious], reducer=sf.reducers.MajorityVote())
+
+    html = recipe_details_html(fusion.url4)
+
+    assert "<script>alert(1)</script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_unparseable_recipe_falls_back_to_raw_without_raising(monkeypatch) -> None:
+    import screamingface._url4_format as mod
+
+    def _boom(_source: str) -> object:
+        raise mod.url4.Url4Error("unparseable")
+
+    monkeypatch.setattr(mod.url4, "build", _boom)
+
+    html = recipe_details_html("member_1:broken")
+
+    assert "<details class='sf-url4'" in html
+    assert "member_1:broken" in html  # raw shown
+    assert "sf-url4__nodes" not in html  # no structured view on fallback
+
+
+def test_model_and_fusion_cards_embed_the_collapsible_recipe() -> None:
+    model = sf.Model("gemini/2.5-flash")
+    fusion = sf.Fusion("t", members=["gemini/2.5-flash"], reducer=sf.reducers.MajorityVote())
+
+    assert "sf-url4" in model._repr_html_()
+    assert "sf-url4" in fusion._repr_html_()

--- a/packages/screamingface/tests/test_ome635_recipe_fullform.py
+++ b/packages/screamingface/tests/test_ome635_recipe_fullform.py
@@ -1,0 +1,141 @@
+"""OME-635 — full-form url4 reflow, Fusion member/reducer detail, verbose Benchmark/Rubric.
+
+FEATURE: richer, more readable cards; long fields (prompts) collapse.
+INVARIANT: the url4 is kept verbatim (only whitespace added, quote/escape-aware); cards never
+fabricate data and HTML-escape injected text.
+"""
+
+from __future__ import annotations
+
+import screamingface as sf
+from screamingface._url4_format import _pretty_url4
+
+# --- full-form reflow ---------------------------------------------------------------------
+
+
+def test_pretty_indents_brackets_and_preserves_quoted_intent() -> None:
+    # An intent with commas, parens, and an escaped quote must survive verbatim.
+    source = "(a:0.0:/x!'hi, (there) it\\'s fine', b:0.0:{k: 'v'})!'$out'"
+
+    out = _pretty_url4(source)
+
+    assert "(\n" in out  # opening bracket breaks + indents
+    assert ",\n" in out  # top-level comma breaks
+    assert "'hi, (there) it\\'s fine'" in out  # quoted intent untouched (no breaks inside)
+
+
+def test_pretty_keeps_empty_brackets_inline() -> None:
+    assert "()" in _pretty_url4("/reducers/majority-vote/1()!'$x'")
+
+
+def test_recipe_details_collapsed_pre_and_exact_copy() -> None:
+    from html import escape
+
+    url4 = sf.Fusion("t", members=["gemini/2.5-flash"], reducer=sf.reducers.MajorityVote()).url4
+    html = sf.Model("gemini/2.5-flash")._repr_html_()
+
+    assert "sf-url4__pre" in html
+    from screamingface._url4_format import recipe_details_html
+
+    rendered = recipe_details_html(url4)
+    assert " open" not in rendered  # collapsed
+    assert f'data-url4="{escape(url4, quote=True)}"' in rendered
+
+
+# --- Fusion member/reducer detail ---------------------------------------------------------
+
+
+def test_fusion_card_exposes_member_and_reducer_detail_collapsed() -> None:
+    member = sf.Model("gemini/2.5-flash", name="a", prompt="Be concise.", params={"temperature": 0})
+    fusion = sf.Fusion(
+        "trio", members=[member, "codex/gpt-5.5"], reducer=sf.reducers.MajorityVote()
+    )
+
+    html = fusion._repr_html_()
+
+    assert "members &amp; reducer" in html
+    assert "sf-detail" in html
+    assert "Be concise." in html  # member prompt
+    assert "temperature=0" in html  # member params
+    assert "deterministic" in html  # MajorityVote reducer has no prompt/params
+
+
+def test_fusion_detail_shows_model_reducer_prompt_and_model() -> None:
+    fusion = sf.Fusion(
+        "t",
+        members=["gemini/2.5-flash"],
+        reducer=sf.reducers.Model(model="codex/gpt-5.5", prompt="Synthesize the answers."),
+    )
+
+    html = fusion._repr_html_()
+
+    assert "codex/gpt-5.5" in html  # reducer model
+    assert "Synthesize the answers." in html  # reducer prompt (short → inline)
+
+
+# --- verbose Benchmark / Rubric -----------------------------------------------------------
+
+
+def test_benchmark_card_verbose_with_collapsed_rubric_prompt() -> None:
+    long_prompt = "Judge the answer against every criterion carefully. " * 8  # > 140 chars
+    bench = sf.Benchmark(
+        "mini@1",
+        title="Mini",
+        cases=[sf.Case("c1", "2+2?", reference="4")],
+        grader=sf.graders.Rubric(model="gemini/3.1-pro-preview", prompt=long_prompt, passes=3),
+    )
+
+    html = bench._repr_html_()
+
+    assert "gemini/3.1-pro-preview" in html  # grader model
+    assert "3 passes" in html
+    assert "1 local case" in html  # source line
+    assert "<details class='sf-more'" in html  # long prompt collapsed into <details>
+    assert "chars" in html  # the collapsed summary shows the length
+
+
+def test_benchmark_card_marks_deterministic_grader() -> None:
+    bench = sf.Benchmark(
+        "m@1", cases=[sf.Case("c1", "q", reference="a")], grader=sf.graders.ExactChoice()
+    )
+
+    html = bench._repr_html_()
+
+    assert "exact choice" in html.lower()
+    assert "deterministic" in html
+    assert "engine routes" not in html  # local benchmark has no engine routes
+
+
+def test_engine_benchmark_shows_source_and_collapsed_routes() -> None:
+    from screamingface.aggregators import Mean
+    from screamingface.benchmark import Benchmark
+    from screamingface.graders import ExactChoice
+
+    bench = Benchmark._from_engine(
+        "gpqa@1",
+        title="GPQA",
+        cases_route="/benchmarks/gpqa/1/cases",
+        grader=ExactChoice(),
+        grader_route="/graders/exact-choice/1",
+        aggregator=Mean(),
+        aggregator_route="/aggregators/mean/1",
+    )
+
+    html = bench._repr_html_()
+
+    assert "engine-advertised" in html  # source line
+    assert "engine routes" in html
+    assert "/benchmarks/gpqa/1/cases" in html
+
+
+def test_model_and_rubric_cards_collapse_long_prompts() -> None:
+    model = sf.Model("gemini/2.5-flash", prompt="Answer thoroughly and completely. " * 8)
+    rubric = sf.graders.Rubric(model="gemini/2.5-flash", prompt="Grade every criterion. " * 8)
+
+    assert "<details class='sf-more'" in model._repr_html_()
+    assert "<details class='sf-more'" in rubric._repr_html_()
+    # a short prompt stays inline (no collapse)
+    assert (
+        "<details class='sf-more'"
+        not in sf.Model("gemini/2.5-flash", prompt="Answer.")._repr_html_()
+    )

--- a/packages/screamingface/tests/test_ome635_recipe_fullform.py
+++ b/packages/screamingface/tests/test_ome635_recipe_fullform.py
@@ -53,8 +53,8 @@ def test_fusion_card_exposes_member_and_reducer_detail_collapsed() -> None:
 
     html = fusion._repr_html_()
 
-    assert "members &amp; reducer" in html
-    assert "sf-detail" in html
+    assert "<div class='sf-section__title'>members</div>" in html
+    assert "<div class='sf-section__title'>reducer</div>" in html
     assert "Be concise." in html  # member prompt
     assert "temperature=0" in html  # member params
     assert "deterministic" in html  # MajorityVote reducer has no prompt/params

--- a/packages/screamingface/tests/test_ome635_recipe_fullform.py
+++ b/packages/screamingface/tests/test_ome635_recipe_fullform.py
@@ -88,7 +88,7 @@ def test_benchmark_card_verbose_with_collapsed_rubric_prompt() -> None:
     html = bench._repr_html_()
 
     assert "gemini/3.1-pro-preview" in html  # grader model
-    assert "3 passes" in html
+    assert ">3</div>" in html  # passes shown as a stat value
     assert "<details class='sf-more'" in html  # long prompt collapsed into <details>
     assert "chars" in html  # the collapsed summary shows the length
 

--- a/packages/screamingface/tests/test_ome635_recipe_fullform.py
+++ b/packages/screamingface/tests/test_ome635_recipe_fullform.py
@@ -89,7 +89,6 @@ def test_benchmark_card_verbose_with_collapsed_rubric_prompt() -> None:
 
     assert "gemini/3.1-pro-preview" in html  # grader model
     assert "3 passes" in html
-    assert "1 local case" in html  # source line
     assert "<details class='sf-more'" in html  # long prompt collapsed into <details>
     assert "chars" in html  # the collapsed summary shows the length
 
@@ -106,7 +105,7 @@ def test_benchmark_card_marks_deterministic_grader() -> None:
     assert "engine routes" not in html  # local benchmark has no engine routes
 
 
-def test_engine_benchmark_shows_source_and_collapsed_routes() -> None:
+def test_engine_benchmark_shows_collapsed_routes() -> None:
     from screamingface.aggregators import Mean
     from screamingface.benchmark import Benchmark
     from screamingface.graders import ExactChoice
@@ -123,7 +122,6 @@ def test_engine_benchmark_shows_source_and_collapsed_routes() -> None:
 
     html = bench._repr_html_()
 
-    assert "engine-advertised" in html  # source line
     assert "engine routes" in html
     assert "/benchmarks/gpqa/1/cases" in html
 

--- a/packages/screamingface/tests/test_ome637_sections.py
+++ b/packages/screamingface/tests/test_ome637_sections.py
@@ -1,0 +1,40 @@
+"""OME-637 — members/reducer as separate always-visible sections; grader in its own section.
+
+STORY: a researcher reads the members and reducer without expanding a collapsed block, and the
+grader's long prompt collapses within its own section.
+"""
+
+from __future__ import annotations
+
+import screamingface as sf
+
+
+def test_fusion_members_and_reducer_are_separate_uncollapsed_sections() -> None:
+    fusion = sf.Fusion(
+        "t",
+        members=["gemini/2.5-flash"],
+        reducer=sf.reducers.Model(model="codex/gpt-5.5", prompt="Synthesize."),
+    )
+
+    html = fusion._repr_html_()
+
+    assert "<div class='sf-section__title'>members</div>" in html
+    assert "<div class='sf-section__title'>reducer</div>" in html
+    assert "<details class='sf-detail'" not in html  # not one collapsed combined block
+    assert "codex/gpt-5.5" in html  # reducer model shown inline
+
+
+def test_benchmark_grader_is_its_own_section_with_collapsible_prompt() -> None:
+    bench = sf.Benchmark(
+        "d@1",
+        cases=[sf.Case("c", "q", reference="a")],
+        grader=sf.graders.Rubric(
+            model="gemini/3.1-pro-preview", prompt="Judge every criterion carefully. " * 8, passes=5
+        ),
+    )
+
+    html = bench._repr_html_()
+
+    assert "<div class='sf-section__title'>grader</div>" in html
+    assert "<details class='sf-more'" in html  # long grader prompt collapses
+    assert "5 passes" in html

--- a/packages/screamingface/tests/test_ome637_sections.py
+++ b/packages/screamingface/tests/test_ome637_sections.py
@@ -37,4 +37,4 @@ def test_benchmark_grader_is_its_own_section_with_collapsible_prompt() -> None:
 
     assert "<div class='sf-section__title'>grader</div>" in html
     assert "<details class='sf-more'" in html  # long grader prompt collapses
-    assert "5 passes" in html
+    assert ">5</div>" in html  # passes shown as a stat value

--- a/packages/screamingface/tests/test_ome637_spacing.py
+++ b/packages/screamingface/tests/test_ome637_spacing.py
@@ -1,0 +1,38 @@
+"""OME-637 follow-up — consistent single-line spacing between benchmark card blocks.
+
+INVARIANT: the grid no longer draws its own bottom border (the following section's top border
+is the single separator), and engine routes is a section-styled collapsible so it is separated
+from the grader the same way every other block is.
+"""
+
+from __future__ import annotations
+
+from screamingface import _card_style
+from screamingface.aggregators import Mean
+from screamingface.benchmark import Benchmark
+from screamingface.graders import ExactChoice
+
+
+def test_engine_routes_is_a_separated_collapsible_section() -> None:
+    bench = Benchmark._from_engine(
+        "g@1",
+        title="G",
+        cases_route="/benchmarks/g/1/cases",
+        grader=ExactChoice(),
+        grader_route="/graders/exact-choice/1",
+        aggregator=Mean(),
+        aggregator_route="/aggregators/mean/1",
+    )
+
+    html = bench._repr_html_()
+
+    assert "<details class='sf-section'>" in html  # separated like other sections + collapsible
+    assert "engine routes" in html
+
+
+def test_grid_has_no_bottom_border_so_sections_are_the_single_separator() -> None:
+    import re
+
+    match = re.search(r"\.sf-card__grid\{([^}]*)\}", _card_style.CARD_STYLE)
+    assert match is not None
+    assert "border-bottom" not in match.group(1)

--- a/packages/screamingface/tests/test_ome639_benchmark_card.py
+++ b/packages/screamingface/tests/test_ome639_benchmark_card.py
@@ -1,0 +1,81 @@
+"""OME-639 — benchmark card adopts the evaluate/report visual language.
+
+STORY: a researcher reads a benchmark at a glance — a stat grid of the key scalars, tools as
+chips, and the grader detail in its own section — matching the polished Report widget.
+INVARIANT: near-monochrome, honest fields only, injected text escaped.
+"""
+
+from __future__ import annotations
+
+import screamingface as sf
+
+
+def _rubric_benchmark() -> sf.Benchmark:
+    return sf.Benchmark(
+        "draco-lite@1",
+        title="DRACO Lite",
+        cases=[sf.Case("c1", "q", reference="a")],
+        grader=sf.graders.Rubric(
+            model="openrouter/google/gemini-3.1-pro-preview",
+            prompt="Evaluate the response against a single criterion. " * 8,
+            passes=5,
+        ),
+        tools=[sf.tools.WebSearch(), sf.tools.WebFetch()],
+        max_tool_calls=12,
+    )
+
+
+def test_benchmark_card_has_a_stat_grid_with_the_key_scalars() -> None:
+    html = _rubric_benchmark()._repr_html_()
+
+    assert "sf-stats" in html
+    # labels
+    for label in ("aggregator", "grader", "passes", "max tool calls"):
+        assert f">{label}</div>" in html or f">{label}<" in html
+    # values
+    assert ">mean<" in html
+    assert ">rubric<" in html
+    assert ">5<" in html  # passes
+    assert ">12<" in html  # max tool calls
+
+
+def test_benchmark_card_renders_tools_as_chips() -> None:
+    html = _rubric_benchmark()._repr_html_()
+
+    assert "sf-chip" in html
+    assert "web_search" in html
+    assert "web_fetch" in html
+
+
+def test_benchmark_grader_section_shows_model_and_collapsible_prompt() -> None:
+    html = _rubric_benchmark()._repr_html_()
+
+    assert "<div class='sf-section__title'>grader</div>" in html
+    assert "openrouter/google/gemini-3.1-pro-preview" in html
+    assert "<details class='sf-more'" in html  # long prompt collapses
+
+
+def test_deterministic_grader_reads_as_deterministic() -> None:
+    bench = sf.Benchmark(
+        "m@1", cases=[sf.Case("c1", "q", reference="a")], grader=sf.graders.ExactChoice()
+    )
+
+    html = bench._repr_html_()
+
+    assert ">exact choice<" in html  # grader stat value
+    assert "deterministic" in html
+
+
+def test_benchmark_card_stays_monochrome_and_escapes_injected_text() -> None:
+    bench = sf.Benchmark(
+        "x@1",
+        title="<script>alert(1)</script>",
+        cases=[sf.Case("c1", "q", reference="a")],
+        grader=sf.graders.ExactChoice(),
+    )
+
+    html = bench._repr_html_()
+
+    assert "<script>alert(1)</script>" not in html
+    assert "&lt;script&gt;" in html
+    assert "purple" not in html.lower()

--- a/packages/screamingface/tests/test_ome641_brand_refresh.py
+++ b/packages/screamingface/tests/test_ome641_brand_refresh.py
@@ -1,0 +1,50 @@
+"""OME-641 — SDK notebook widgets refreshed to the current brand.
+
+INVARIANT: gain is gold (not the pre-refresh green); the gold→blue fusion signature is
+card-scoped only (the shared style stays gradient-free so the connection panel does too);
+titles are EB Garamond serif; no purple anywhere.
+"""
+
+from __future__ import annotations
+
+import screamingface as sf
+from screamingface import _card_style
+from screamingface._display import STYLE
+
+_OLD_GREEN = ("#0f7a3d", "#35d07f")  # pre-refresh gain
+
+
+def test_shared_style_is_gold_serif_and_loads_brand_fonts() -> None:
+    for green in _OLD_GREEN:
+        assert green not in STYLE  # green gain retired
+    assert "--sf-gain:" in STYLE.replace(" ", "")
+    assert "@import" in STYLE  # brand webfonts pulled
+    assert "EB Garamond" in STYLE  # serif display stack
+    assert "--sf-display:" in STYLE.replace(" ", "")
+
+
+def test_shared_style_stays_gradient_free_for_the_connection_panel() -> None:
+    # The connection panel injects only the shared STYLE; keeping the gradient out of it
+    # preserves the "no linear-gradient" contract there.
+    assert "linear-gradient" not in STYLE
+    assert "purple" not in STYLE.lower()
+
+
+def test_card_style_defines_gold_blue_fusion_gradient_and_serif_titles() -> None:
+    css = _card_style.CARD_STYLE
+    assert "--sf-gain-grad:" in css.replace(" ", "")
+    assert "linear-gradient" in css
+    assert "var(--sf-display)" in css  # serif card titles
+    assert "purple" not in css.lower()
+
+
+def test_fusion_card_has_gradient_accent_and_model_has_solid_accent() -> None:
+    fusion = sf.Fusion("t", members=["gemini/2.5-flash"], reducer=sf.reducers.MajorityVote())
+    model = sf.Model("gemini/2.5-flash")
+
+    fhtml = fusion._repr_html_()
+    mhtml = model._repr_html_()
+
+    assert "sf-card__accent" in fhtml
+    assert "sf-gain-grad" in fhtml  # fusion signature uses the gradient
+    assert "sf-card__accent" in mhtml

--- a/packages/screamingface/tests/test_ome641_brand_refresh.py
+++ b/packages/screamingface/tests/test_ome641_brand_refresh.py
@@ -14,13 +14,13 @@ from screamingface._display import STYLE
 _OLD_GREEN = ("#0f7a3d", "#35d07f")  # pre-refresh gain
 
 
-def test_shared_style_is_gold_serif_and_loads_brand_fonts() -> None:
+def test_shared_style_is_gold_and_loads_brand_fonts() -> None:
     for green in _OLD_GREEN:
         assert green not in STYLE  # green gain retired
     assert "--sf-gain:" in STYLE.replace(" ", "")
     assert "@import" in STYLE  # brand webfonts pulled
-    assert "EB Garamond" in STYLE  # serif display stack
-    assert "--sf-display:" in STYLE.replace(" ", "")
+    assert "IBM Plex Sans" in STYLE  # real body font stack
+    assert "IBM+Plex+Mono" in STYLE  # mono pulled via the @import
 
 
 def test_shared_style_stays_gradient_free_for_the_connection_panel() -> None:
@@ -30,11 +30,11 @@ def test_shared_style_stays_gradient_free_for_the_connection_panel() -> None:
     assert "purple" not in STYLE.lower()
 
 
-def test_card_style_defines_gold_blue_fusion_gradient_and_serif_titles() -> None:
+def test_card_style_defines_gold_blue_fusion_gradient_and_clear_titles() -> None:
     css = _card_style.CARD_STYLE
     assert "--sf-gain-grad:" in css.replace(" ", "")
     assert "linear-gradient" in css
-    assert "var(--sf-display)" in css  # serif card titles
+    assert "EB Garamond" not in css  # titles are clear sans, not serif
     assert "purple" not in css.lower()
 
 
@@ -48,3 +48,38 @@ def test_fusion_card_has_gradient_accent_and_model_has_solid_accent() -> None:
     assert "sf-card__accent" in fhtml
     assert "sf-gain-grad" in fhtml  # fusion signature uses the gradient
     assert "sf-card__accent" in mhtml
+
+
+def test_model_and_benchmark_catalogs_use_gold_chips_and_an_accent() -> None:
+    from screamingface._card_display import benchmarks_rows_html, catalog_html, models_rows_html
+    from screamingface._profile import BenchmarkRecord, ModelRecord, StrategyRecord
+
+    model_rows = models_rows_html((ModelRecord("gemini/2.5-flash", ("web_search",), "gemini", ()),))
+    assert "sf-chip" in model_rows  # gold-styled chips
+    assert "gemini" in model_rows and "web_search" in model_rows
+
+    bench_rows = benchmarks_rows_html(
+        (
+            BenchmarkRecord(
+                "gpqa@1",
+                "GPQA",
+                "/c",
+                StrategyRecord("exact_choice", "/g"),
+                StrategyRecord("mean", "/a"),
+                (),
+                None,
+                None,
+            ),
+        )
+    )
+    assert "sf-chip" in bench_rows
+
+    assert "sf-card__accent" in catalog_html("Models", "aria", 1, model_rows)  # accent bar
+
+
+def test_connection_panel_has_a_solid_gold_accent_and_no_gradient() -> None:
+    from screamingface import _connection_panel
+
+    css = _connection_panel._STYLE
+    assert ".sf-connections__accent" in css  # a brand accent bar
+    assert "linear-gradient" not in css  # solid gold only — the panel stays gradient-free


### PR DESCRIPTION
## Summary

Notebook rich-display for the ScreamingFace SDK — **display-only, `pkg/screamingface`**. This is the consolidated **OME-626** umbrella (folds in OME-628/630/635/637/639 and the OME-641 brand refresh, all marked duplicates).

- **Catalogs:** `sf.models.view()` / `sf.benchmarks.view()` — interactive ipywidgets catalogs (search/filter) with a static `_repr_html_` fallback; `.value` = filtered ids.
- **Object cards:** `_repr_html_` for `Model`, `Fusion`, `Benchmark`, `Connection`, `Case`, `Rubric` — honest advertised/authoring fields only, all injected text HTML-escaped.
- **url4 recipe view:** full-form reflow inside a `<pre>` (MathJax-safe), collapsed by default with a copy button (exact raw via `data-url4`).
- **Fusion card:** separate, always-visible members + reducer sections.
- **Benchmark card:** elevated to the evaluation Report visual language — stat grid, tool chips, grader section, collapsible engine routes.
- **Brand refresh (OME-641):** gain green→gold, EB Garamond serif titles + brand webfonts, gold→blue fusion-signature accent bar (gradient token scoped to `_card_style` so the connection panel stays gradient-free).

No engine changes. No notebook changes.

## Base

Targets **`OME-400-ship-quickstart-sdk`** (the SDK branch), **not `main`** — this stacks on that unmerged SDK work. Clean 12-commit diff: **41 files, +2602 / −40**. Merges toward `main` follow once the SDK base lands.

## Tests

10 new test files (~1000 lines) covering catalogs, value cards, the url4 view, section/spacing layout, the benchmark card, and the brand refresh.

Refs OME-626