### PR TITLE
chore: add @itstauq as CODEOWNER for apps/screamingface-studio

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,7 @@
 # Deployable apps
 /apps/aigateway/                 @HupBaHa
 /apps/scoreboard/                @HupBaHa
+/apps/screamingface-studio/      @itstauq
 /apps/url4-cloud/                @sergio-bershadsky
 
 # Product public docs


### PR DESCRIPTION
## Summary
Adds `apps/screamingface-studio` to `.github/CODEOWNERS`, routing its review requests to **@itstauq**. The app previously had no explicit entry and inherited the default `*` owners (@sergio-bershadsky @HupBaHa).

## Change
- `.github/CODEOWNERS`: one new line in the *Deployable apps* block —
  `/apps/screamingface-studio/  @itstauq`

## Ownership / reviewer note
- This is a `.github/` change (owned by @sergio-bershadsky @HupBaHa) — flagging per the repo convention.
- Effect: studio-path review requests now route **solely to @itstauq** (last-match override for that path only); every other path is unchanged.
- Takes effect only if @itstauq is a collaborator with repo access — GitHub silently ignores unknown handles.

## Test plan
- CODEOWNERS syntax + last-match placement verified locally.
- Post-merge: a PR touching `apps/screamingface-studio/**` should auto-request @itstauq.

🤖 Generated with [Claude Code](https://claude.com/claude-code)