### PR TITLE
ci(scoreboard): add scoreboard to release-please so its release workflow can fire

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,6 @@
 {
   "apps/aigateway": "0.2.0",
   "packages/url4": "1.0.0",
-  "apps/url4-cloud": "0.1.0"
+  "apps/url4-cloud": "0.1.0",
+  "apps/scoreboard": "0.1.1"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -39,6 +39,14 @@
       "tag-separator": "-",
       "include-component-in-tag": true,
       "version-file": "apps/url4-cloud/pyproject.toml"
+    },
+    "apps/scoreboard": {
+      "release-type": "python",
+      "package-name": "scoreboard",
+      "component": "scoreboard",
+      "tag-separator": "-",
+      "include-component-in-tag": true,
+      "version-file": "apps/scoreboard/pyproject.toml"
     }
   }
 }


### PR DESCRIPTION
From the platform team (context: the platform onboarding thread, #413).

**The gap:** `release-scoreboard.yml` triggers on `scoreboard-v*` tags — but `apps/scoreboard` was never added to `release-please-config.json`, so no release PR has ever opened, no tag has ever been minted, and the workflow has never run. Scoreboard has never published an image or chart.

**The fix (2 files, ~10 lines):** a package block mirroring aigateway's, plus seeding the manifest at the current `pyproject.toml` version (`0.1.1`).

**What happens after merge:** the next scoreboard-touching conventional commit opens a release PR; merging it mints `scoreboard-v0.1.2`; your existing release workflow builds and publishes the image + chart — exactly like aigateway does today. Nothing else about your flow changes.