### PR TITLE
ci: dev image builds on merge to main (main-<shortsha>) for aigateway, scoreboard, url4-cloud

### DIFF
--- a/.github/workflows/dev-build-aigateway.yml
+++ b/.github/workflows/dev-build-aigateway.yml
@@ -1,0 +1,41 @@
+# Dev image on every merge to main (path-filtered): immutable main-<shortsha> tags
+# so a dev environment can track main automatically. Release builds are untouched
+# — this never tags 'latest' and never publishes charts. Single-arch (amd64) for
+# speed; dev clusters are amd64.
+name: Dev build aigateway
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/aigateway/**"
+  workflow_dispatch:
+permissions:
+  contents: read
+  packages: write
+concurrency:
+  group: dev-build-aigateway-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: sha
+        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          # Context is the repo root — matches the release workflows (url4-cloud's
+          # Dockerfile COPYs packages/url4 from outside its own directory).
+          context: .
+          file: apps/aigateway/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/openmined/screamingface-aigateway:main-${{ steps.sha.outputs.short }}
+          cache-from: type=gha,scope=dev-aigateway
+          cache-to: type=gha,scope=dev-aigateway,mode=max

--- a/.github/workflows/dev-build-scoreboard.yml
+++ b/.github/workflows/dev-build-scoreboard.yml
@@ -1,0 +1,41 @@
+# Dev image on every merge to main (path-filtered): immutable main-<shortsha> tags
+# so a dev environment can track main automatically. Release builds are untouched
+# — this never tags 'latest' and never publishes charts. Single-arch (amd64) for
+# speed; dev clusters are amd64.
+name: Dev build scoreboard
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/scoreboard/**"
+  workflow_dispatch:
+permissions:
+  contents: read
+  packages: write
+concurrency:
+  group: dev-build-scoreboard-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: sha
+        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          # Context is the repo root — matches the release workflows (url4-cloud's
+          # Dockerfile COPYs packages/url4 from outside its own directory).
+          context: .
+          file: apps/scoreboard/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/openmined/screamingface-scoreboard:main-${{ steps.sha.outputs.short }}
+          cache-from: type=gha,scope=dev-scoreboard
+          cache-to: type=gha,scope=dev-scoreboard,mode=max

--- a/.github/workflows/dev-build-url4-cloud.yml
+++ b/.github/workflows/dev-build-url4-cloud.yml
@@ -1,0 +1,42 @@
+# Dev image on every merge to main (path-filtered): immutable main-<shortsha> tags
+# so a dev environment can track main automatically. Release builds are untouched
+# — this never tags 'latest' and never publishes charts. Single-arch (amd64) for
+# speed; dev clusters are amd64.
+name: Dev build url4-cloud
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/url4-cloud/**"
+      - "packages/url4/**"
+  workflow_dispatch:
+permissions:
+  contents: read
+  packages: write
+concurrency:
+  group: dev-build-url4-cloud-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: sha
+        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          # Context is the repo root — matches the release workflows (url4-cloud's
+          # Dockerfile COPYs packages/url4 from outside its own directory).
+          context: .
+          file: apps/url4-cloud/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/openmined/screamingface-url4-cloud:main-${{ steps.sha.outputs.short }}
+          cache-from: type=gha,scope=dev-url4-cloud
+          cache-to: type=gha,scope=dev-url4-cloud,mode=max


### PR DESCRIPTION
From the platform team. **Why:** the platform's dev environment updates itself from your `main` — which needs an image per merge. Today images only exist on releases.

**What this adds:** three small per-app workflows (matching your per-app convention). On merge to `main`, path-filtered, each builds the app's existing Dockerfile and pushes **one immutable tag**: `ghcr.io/openmined/screamingface-<app>:main-<shortsha>`.

**Deliberately boring:** repo-root build context matching your release jobs (url4-cloud's Dockerfile copies `packages/url4`, so its workflow also triggers on that path) · amd64-only for speed · GHA build cache · **never `latest`**, never charts — your release flow is untouched. Zero effect on anything until the platform starts consuming the tags.