### PR TITLE
feat(aigateway/chart): render AIGATEWAY_SECRET_KEY from the auth secret + extraEnv passthrough

### DIFF
--- a/apps/aigateway/charts/aigateway/templates/deployment.yaml
+++ b/apps/aigateway/charts/aigateway/templates/deployment.yaml
@@ -66,6 +66,20 @@ spec:
                   name: {{ include "aigateway.authSecretName" . }}
                   key: {{ .Values.auth.provisioningTokenKey }}
                   optional: true
+            {{- if .Values.auth.secretKeyKey }}
+            # AIGATEWAY_SECRET_KEY: the AES-256-GCM master key for credential_blobs.
+            # Hosted/multi-replica deployments MUST set this (README §security) — without
+            # it each process mints its own key and credentials written by one replica
+            # are unreadable by another. Opt-in: render only when secretKeyKey is set.
+            - name: AIGATEWAY_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "aigateway.authSecretName" . }}
+                  key: {{ .Values.auth.secretKeyKey }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/apps/aigateway/charts/aigateway/values.yaml
+++ b/apps/aigateway/charts/aigateway/values.yaml
@@ -49,6 +49,14 @@ auth:
   adminPasswordKey: admin-password
   provisioningToken: ""
   provisioningTokenKey: provisioning-token
+  # Key (inside existingSecret) holding the AES master key for credential_blobs
+  # (env AIGATEWAY_SECRET_KEY; base64 of exactly 32 bytes). Empty = not rendered
+  # (single-replica dev keeps today's behavior). Set for any hosted deployment.
+  secretKeyKey: ""
+
+# Extra environment variables appended verbatim to the container (e.g. provider
+# enablement flags such as AIGW_OPENROUTER_ENABLED). List of EnvVar objects.
+extraEnv: []
 
 service:
   type: ClusterIP


### PR DESCRIPTION
From the platform team. Closes the two chart gaps the deploy guide (`url4-deploy.md` §4.2/§8.1) currently works around with a **post-install `kubectl patch`**:

1. **`AIGATEWAY_SECRET_KEY`** — mandatory for any hosted/multi-replica deployment (each process otherwise mints its own AES key, and credentials written by one replica are unreadable by another) — but the chart had no way to render it. Now: `auth.secretKeyKey: "secret-key"` renders the env from the existing auth secret. **Opt-in; empty default; default render verified byte-identical.**
2. **Provider flags** (e.g. `AIGW_OPENROUTER_ENABLED`) — no values hook existed. Now: `extraEnv` appends verbatim `EnvVar` objects.

**Why chart-native matters:** under GitOps (Argo), a hand-applied patch is drift that reconciliation silently erases — and an aigateway restart without the key regenerates one, making every stored provider credential undecryptable. The env must come from the chart.

*Note:* touches `values.yaml`, as does #444 — whichever merges second takes a trivial rebase (`deployment.yaml` is untouched by #444, so the gap this fixes remains either way).