### PR TITLE
ci: push dev images to the platform registry (ACR) alongside GHCR

### DIFF
--- a/.github/workflows/dev-build-aigateway.yml
+++ b/.github/workflows/dev-build-aigateway.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write # OIDC → Azure; no stored credentials
 concurrency:
   group: dev-build-aigateway-${{ github.ref }}
   cancel-in-progress: true
@@ -28,6 +29,16 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # Platform registry (ACR) — the dev cluster pulls from here. OIDC only:
+      # sp-screamingface-ci is federated to this repo's main branch and holds
+      # AcrPush on acropenmined and nothing else. No secrets are stored here;
+      # the three vars below are non-secret identifiers.
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      - run: az acr login --name acropenmined
       - uses: docker/build-push-action@v6
         with:
           # Context is the repo root — matches the release workflows (url4-cloud's
@@ -36,6 +47,8 @@ jobs:
           file: apps/aigateway/Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ghcr.io/openmined/screamingface-aigateway:main-${{ steps.sha.outputs.short }}
+          tags: |
+            ghcr.io/openmined/screamingface-aigateway:main-${{ steps.sha.outputs.short }}
+            acropenmined.azurecr.io/screamingface-aigateway:main-${{ steps.sha.outputs.short }}
           cache-from: type=gha,scope=dev-aigateway
           cache-to: type=gha,scope=dev-aigateway,mode=max

--- a/.github/workflows/dev-build-scoreboard.yml
+++ b/.github/workflows/dev-build-scoreboard.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write # OIDC → Azure; no stored credentials
 concurrency:
   group: dev-build-scoreboard-${{ github.ref }}
   cancel-in-progress: true
@@ -28,6 +29,16 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # Platform registry (ACR) — the dev cluster pulls from here. OIDC only:
+      # sp-screamingface-ci is federated to this repo's main branch and holds
+      # AcrPush on acropenmined and nothing else. No secrets are stored here;
+      # the three vars below are non-secret identifiers.
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      - run: az acr login --name acropenmined
       - uses: docker/build-push-action@v6
         with:
           # Context is the repo root — matches the release workflows (url4-cloud's
@@ -36,6 +47,8 @@ jobs:
           file: apps/scoreboard/Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ghcr.io/openmined/screamingface-scoreboard:main-${{ steps.sha.outputs.short }}
+          tags: |
+            ghcr.io/openmined/screamingface-scoreboard:main-${{ steps.sha.outputs.short }}
+            acropenmined.azurecr.io/screamingface-scoreboard:main-${{ steps.sha.outputs.short }}
           cache-from: type=gha,scope=dev-scoreboard
           cache-to: type=gha,scope=dev-scoreboard,mode=max

--- a/.github/workflows/dev-build-url4-cloud.yml
+++ b/.github/workflows/dev-build-url4-cloud.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write # OIDC → Azure; no stored credentials
 concurrency:
   group: dev-build-url4-cloud-${{ github.ref }}
   cancel-in-progress: true
@@ -29,6 +30,16 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # Platform registry (ACR) — the dev cluster pulls from here. OIDC only:
+      # sp-screamingface-ci is federated to this repo's main branch and holds
+      # AcrPush on acropenmined and nothing else. No secrets are stored here;
+      # the three vars below are non-secret identifiers.
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      - run: az acr login --name acropenmined
       - uses: docker/build-push-action@v6
         with:
           # Context is the repo root — matches the release workflows (url4-cloud's
@@ -37,6 +48,8 @@ jobs:
           file: apps/url4-cloud/Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ghcr.io/openmined/screamingface-url4-cloud:main-${{ steps.sha.outputs.short }}
+          tags: |
+            ghcr.io/openmined/screamingface-url4-cloud:main-${{ steps.sha.outputs.short }}
+            acropenmined.azurecr.io/screamingface-url4-cloud:main-${{ steps.sha.outputs.short }}
           cache-from: type=gha,scope=dev-url4-cloud
           cache-to: type=gha,scope=dev-url4-cloud,mode=max


### PR DESCRIPTION
Dev images currently land in GHCR only, and the dev cluster pulls from Azure Container Registry — so nothing built on `main` can actually be deployed without a manual copy step on the platform side.

The original plan was for the platform to mirror GHCR → ACR out-of-band, leaving your CI untouched. That turned out not to be possible: the OpenMined org forbids classic PATs, GitHub's container registry doesn't support fine-grained ones, and GitHub App installation tokens are rejected by the registry by design (a package's access list has entries for users, teams and repositories — none for an app installation). Inside your workflow the built-in `GITHUB_TOKEN` already has the access this whole problem is about, which makes pushing from here the simplest correct fix — and it means the cluster never has to hold a GitHub credential at all.

## What changes

In each of the three `dev-build-*` workflows:

- `permissions:` gains `id-token: write` (needed for OIDC).
- Two steps before the build: `azure/login@v2` and `az acr login`.
- The existing `build-push-action` gains one more tag, so the **same build** publishes to both registries.

No second build, no extra cache, and no change to triggers, path filters, tag formats, or any release workflow.

## On credentials

There are none to store. Auth is GitHub OIDC — Azure trusts a token GitHub mints for *this repo's main branch*, exchanged at runtime for a short-lived credential. The three `vars` referenced are non-secret identifiers, not secrets:

| Variable | What it is |
|---|---|
| `AZURE_CLIENT_ID` | the `sp-screamingface-ci` identity, created for this repo |
| `AZURE_TENANT_ID` | OpenMined's Azure tenant |
| `AZURE_SUBSCRIPTION_ID` | the platform subscription |

That identity holds `AcrPush` on one registry and nothing else — no reader, no subscription-scope access, no state access. It was provisioned for this purpose and is already federated to `repo:OpenMined/screamingface:ref:refs/heads/main`, so this PR grants nothing new.

## One trade-off worth naming

As written, an Azure-side outage would fail these dev-build runs, since both pushes share a single step. If you'd rather your build never depend on our registry, we can split the ACR push into a separate `continue-on-error` step — say the word and we'll amend. We went with the simpler form because a silent mirror failure is worse for us than a loud build failure is for you, but it's your CI and your call.

## Test

Merge to `main` touching any of the three app paths → the run should show both tags pushed. Images built before this lands won't appear in ACR; each workflow keeps its `workflow_dispatch` trigger, so a manual run backfills them.
