### PR TITLE
feat(url4-cloud): run DRACO as a url4 expression on the Runner (OME-712)

### DIFF
--- a/.github/workflows/dev-build-url4-cloud.yml
+++ b/.github/workflows/dev-build-url4-cloud.yml
@@ -19,6 +19,8 @@ concurrency:
 jobs:
   image:
     runs-on: ubuntu-latest
+    outputs:
+      short: ${{ steps.sha.outputs.short }}
     steps:
       - uses: actions/checkout@v4
       - id: sha
@@ -40,3 +42,39 @@ jobs:
           tags: ghcr.io/openmined/screamingface-url4-cloud:main-${{ steps.sha.outputs.short }}
           cache-from: type=gha,scope=dev-url4-cloud
           cache-to: type=gha,scope=dev-url4-cloud,mode=max
+
+  # The BENCHMARK image: the engine above plus one benchmark's declared world (dataset, private
+  # rubrics, generated [data] table). A Runner Job runs this instead of the App image when
+  # `runner.image.repository` points at it; the control plane never does, so a rubric never lands
+  # on the pod that terminates client connections.
+  #
+  # WHY a second job rather than a second `docker/build-push-action` step in the first: it must
+  # not run unless the base actually PUBLISHED. `needs:` gives that ordering, and `BASE` is the
+  # exact digest-bearing tag the previous job pushed — never a floating tag, so the pair can never
+  # drift apart mid-rollout.
+  benchmark-image:
+    needs: image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/url4-cloud/Dockerfile.benchmark
+          platforms: linux/amd64
+          push: true
+          # AIDEV-NOTE: this build DOWNLOADS the dataset from HuggingFace (`prepare.py` calls
+          # `load_dataset`), so it needs egress and is slower than the base build. It carries the
+          # WHOLE dataset by design — the truncating build arg was removed 2026-08-02 so a partial
+          # image can never be mistaken for a full one.
+          build-args: |
+            BASE=ghcr.io/openmined/screamingface-url4-cloud:main-${{ needs.image.outputs.short }}
+          tags: ghcr.io/openmined/screamingface-url4-cloud-benchmark:main-${{ needs.image.outputs.short }}
+          cache-from: type=gha,scope=dev-url4-cloud-benchmark
+          cache-to: type=gha,scope=dev-url4-cloud-benchmark,mode=max

--- a/.github/workflows/release-url4-cloud.yml
+++ b/.github/workflows/release-url4-cloud.yml
@@ -79,6 +79,57 @@ jobs:
             org.opencontainers.image.version=${{ needs.verify.outputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}
 
+  # The BENCHMARK image: the engine above plus one benchmark's declared world — the dataset, the
+  # PRIVATE weighted rubrics, and the generated `[data]` table. A Runner Job runs this when
+  # `runner.image.repository` names it; the control plane never does, so a rubric never lands on
+  # the pod that terminates client connections.
+  #
+  # WHY a separate job rather than another step in `image`: it must not run unless the base
+  # actually published, and `BASE` must be the exact VERSIONED tag that job pushed — never
+  # `latest`, or a release could layer a dataset onto whichever engine happened to be current.
+  # That pairing is what lets a published score name the engine it was produced by.
+  benchmark-image:
+    needs: [verify, image]
+    runs-on: ubuntu-latest
+    env:
+      REPO: ghcr.io/openmined/screamingface-url4-cloud-benchmark
+      BASE: ghcr.io/openmined/screamingface-url4-cloud
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/url4-cloud/Dockerfile.benchmark
+          # AIDEV-NOTE: this build DOWNLOADS the dataset from HuggingFace (`prepare.py` calls
+          # `load_dataset`), so unlike every other job here it needs egress to a third party and
+          # can fail for reasons outside this repo. It also carries the WHOLE dataset by design —
+          # the truncating build arg was removed 2026-08-02 so a partial image can never be
+          # mistaken for a full one. Measured cost of that choice: 2.1 MB on a 369 MB image.
+          #
+          # Multi-arch matches the base: `runner.image.tag` defaults to the App image's resolved
+          # tag, so a narrower benchmark image would break exactly the arm64 clusters the base
+          # supports. The arm64 leg runs `prepare` under emulation and is the slow half.
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            BASE=${{ env.BASE }}:${{ needs.verify.outputs.version }}
+          tags: |
+            ${{ env.REPO }}:${{ needs.verify.outputs.version }}
+            ${{ env.REPO }}:latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ needs.verify.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
   chart:
     # NOTE: the chart is LINTED only. OCI Helm publishing is DEFERRED until the NATS dependency in
     # apps/url4-cloud/deploy/helm/Chart.yaml is pinned + vendored — it is a placeholder today
@@ -94,7 +145,7 @@ jobs:
         run: helm lint apps/url4-cloud/deploy/helm
 
   release:
-    needs: [verify, image, chart]
+    needs: [verify, image, benchmark-image, chart]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -109,6 +160,13 @@ jobs:
             the separate runner image is merged in as of this release):
             ```
             docker pull ghcr.io/openmined/screamingface-url4-cloud:${{ needs.verify.outputs.version }}
+            ```
+
+            Benchmark image — the same engine plus DRACO's dataset and its private rubrics. Point
+            Runner Jobs at it with `runner.image.repository`; the control plane must keep running
+            the image above, so a rubric never reaches the pod that terminates client connections:
+            ```
+            docker pull ghcr.io/openmined/screamingface-url4-cloud-benchmark:${{ needs.verify.outputs.version }}
             ```
 
             Helm chart: OCI publish deferred until the NATS dependency is pinned (see OME-567).

--- a/apps/aigateway/README.md
+++ b/apps/aigateway/README.md
@@ -53,12 +53,23 @@ uv sync
 
 # Apply migrations for a persistent local DB. Re-running is safe.
 # If your DB URL is in .env, export it first: set -a && source .env && set +a
-uv run tortoise -c aigateway.db.TORTOISE_CONFIG migrate
+uv run aigateway migrate
 
 uv run uvicorn aigateway.main:app --port 9105 --reload
 
 # Sanity check
 curl -sf http://localhost:9105/healthz
+```
+
+`aigateway migrate` runs the same `python -m tortoise -c aigateway.db.TORTOISE_CONFIG migrate`
+command the Helm chart's pre-install/pre-upgrade Job runs
+(`charts/aigateway/templates/job-migrate.yaml`) — the same path production already applies,
+reachable without remembering the module invocation. It also works through the Docker image's
+`ENTRYPOINT ["aigateway"]`, which has no equivalent Job outside Helm:
+
+```bash
+docker run --rm -e AIGATEWAY_DATABASE_URL=... aigateway:dev migrate
+docker run -e AIGATEWAY_DATABASE_URL=... -p 9105:9105 aigateway:dev
 ```
 
 On first boot with auth enabled, set `AIGATEWAY_ADMIN_PASSWORD` to choose the

--- a/apps/aigateway/src/aigateway/cli.py
+++ b/apps/aigateway/src/aigateway/cli.py
@@ -1,11 +1,28 @@
 from __future__ import annotations
 
+import argparse
+import subprocess
+import sys
+
 import uvicorn
 
 from .config import Settings
 
+# WHY: identical to the Helm chart's pre-install/pre-upgrade migrate Job
+# (charts/aigateway/templates/job-migrate.yaml) — local/Docker runs the same
+# migration path production already applies, instead of a second bootstrap
+# mechanism that could drift from it.
+_MIGRATE_COMMAND = [
+    sys.executable,
+    "-m",
+    "tortoise",
+    "-c",
+    "aigateway.db.TORTOISE_CONFIG",
+    "migrate",
+]
 
-def main() -> None:
+
+def _serve() -> None:
     settings = Settings()
     uvicorn.run(
         "aigateway.main:app",
@@ -13,6 +30,25 @@ def main() -> None:
         port=settings.port,
         log_level=settings.log_level,
     )
+
+
+def _migrate() -> None:
+    result = subprocess.run(_MIGRATE_COMMAND, check=False)
+    if result.returncode != 0:
+        raise SystemExit(result.returncode)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="aigateway")
+    subparsers = parser.add_subparsers(dest="command")
+    subparsers.add_parser("serve", help="Run the HTTP server (default).")
+    subparsers.add_parser("migrate", help="Apply pending Tortoise migrations, then exit.")
+    args = parser.parse_args(argv)
+
+    if args.command == "migrate":
+        _migrate()
+    else:
+        _serve()
 
 
 if __name__ == "__main__":

--- a/apps/aigateway/src/aigateway/core/standard_parameters.py
+++ b/apps/aigateway/src/aigateway/core/standard_parameters.py
@@ -69,6 +69,26 @@ LOGPROBS_SCHEMA = ParameterSchema(type="boolean")
 # its log probability. OpenAI's documented range is an integer 0..20 INCLUSIVE; a value
 # outside it, a boolean, or a non-integer fails closed at classification.
 TOP_LOGPROBS_SCHEMA = ParameterSchema(type="integer", minimum=0, maximum=20)
+# ``web_search``: ask the PROVIDER to retrieve before answering. A plain boolean on purpose.
+#
+# Providers spell server-side retrieval differently and each spelling is an extensibility
+# ENVELOPE — OpenRouter's is `plugins: [...]`, a list of arbitrary provider extensions. An
+# envelope cannot be meaningfully bounded, because carrying anything is the point of it, so a
+# rule enabling one authorizes a path and forwards nested JSON verbatim: exactly what OME-646
+# removed. A boolean is bounded COMPLETELY, and the provider translates it into its own
+# spelling in `prepare_chat_body`, where a gateway-owned value is assigned rather than merged.
+#
+# This is the shared vocabulary, so the word is provider-agnostic: any provider that can
+# retrieve enables the same field, and one that cannot simply does not — a caller asking then
+# gets a named 400 from the authority on capability, rather than silence.
+WEB_SEARCH_SCHEMA = ParameterSchema(type="boolean")
+# ``web_search_excluded_domains``: domains the provider must not retrieve from.
+#
+# INVARIANT: this can only ever ADD to the deployment's own exclusions — a provider composes
+# the two as a UNION (see the OpenRouter plugin). A caller can tighten the guard and can never
+# loosen it, which is what keeps it a guard: the motivating case is a benchmark candidate that
+# must not retrieve the rubric it is being graded against.
+WEB_SEARCH_EXCLUDED_DOMAINS_SCHEMA = ParameterSchema(type="array", item_type="string")
 
 
 def direct_rule(

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/parameters.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/parameters.py
@@ -29,6 +29,8 @@ from aigateway.core.standard_parameters import (
     TEMPERATURE_SCHEMA,
     TOP_LOGPROBS_SCHEMA,
     TOP_P_SCHEMA,
+    WEB_SEARCH_EXCLUDED_DOMAINS_SCHEMA,
+    WEB_SEARCH_SCHEMA,
     direct_rule,
     function_calling_rules,
     provider_native_rule,
@@ -51,7 +53,27 @@ OPENROUTER_TOP_K_SCHEMA = ParameterSchema(type="integer", minimum=0)
 # WITH tool_choice.
 _TOOL_CAPABILITIES: tuple[ToolCapability, ...] = (
     ToolCapability(tool_type="function", provider_support="supported", gateway_status="enabled"),
+    # AIDEV-NOTE: `openrouter:web_search` / `openrouter:web_fetch` are deliberately ABSENT.
+    # OpenRouter documents them as a server-tool surface and ACCEPTS them with HTTP 200 — but
+    # measured against the live API on 2026-07-31 they are silently INERT: zero `annotations`,
+    # no web-search line in `cost_details`, and an answer written from the model's training
+    # cutoff. Server-side web search is reached through the `web_search` rule below, which
+    # `plugin.prepare_chat_body` translates into the field that actually retrieves. Enabling a
+    # tool type the provider ignores would authorize a request that costs normal money and never
+    # searches — the worst failure shape, because it returns 200 and reads like a real answer.
 )
+
+# --- server-side web search --------------------------------------------------
+# OpenRouter retrieves through `plugins: [{"id": "web", ...}]`, and `plugins` stays REFUSED as a
+# caller path (OME-646, pinned by `test_openrouter_security`). That is not an obstacle worked
+# around here — it is correct, and the reason is worth stating: `plugins` is an extensibility
+# ENVELOPE. Carrying arbitrary provider extensions is its entire purpose, so no schema can bound
+# it without defeating it, and a rule enabling it forwards nested JSON verbatim.
+#
+# The caller instead says `web_search: true` — bounded completely, because it is a boolean — and
+# `plugin.prepare_chat_body` ASSIGNS the `plugins` payload from gateway-owned policy, the same
+# two-layer shape `provider` already uses: the classifier refuses the native field, the provider
+# sets it. The caller can never reach the envelope.
 
 _RULES: tuple[ParameterProjectionRule, ...] = (
     direct_rule(
@@ -125,6 +147,20 @@ _RULES: tuple[ParameterProjectionRule, ...] = (
     ),
     # OME-583: tools + tool_choice (OpenAI-native, §9 proof).
     *function_calling_rules(_TOOL_CAPABILITIES, auth_modes=_AUTH, projection_revision=_REVISION),
+    # Server-side web search — the caller-facing half. `direct` is the ADDRESSING kind, not the
+    # wire shape: `prepare_chat_body` consumes both fields and emits `plugins` in their place,
+    # so neither name reaches OpenRouter. Verified live 2026-07-31 (litellm 1.87.0) that the
+    # emitted `plugins` retrieves: same prompt, with it a current cited answer, without it the
+    # model's training cutoff.
+    direct_rule(
+        "web_search", auth_modes=_AUTH, schema=WEB_SEARCH_SCHEMA, projection_revision=_REVISION
+    ),
+    direct_rule(
+        "web_search_excluded_domains",
+        auth_modes=_AUTH,
+        schema=WEB_SEARCH_EXCLUDED_DOMAINS_SCHEMA,
+        projection_revision=_REVISION,
+    ),
 )
 
 

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/plugin.py
@@ -154,6 +154,29 @@ WEB_SEARCH_EXCLUDED_DOMAINS_PARAM = "web_search_excluded_domains"
 # among them, despite being valid on the inert `openrouter:web_search` tools surface.
 _WEB_SEARCH_POLICY: dict[str, object] = {"id": "web", "engine": "native"}
 
+EXCLUDE_DOMAINS_KEY = "exclude_domains"
+"""OpenRouter's wire spelling for the blocklist. NOT `excluded_domains`.
+
+AIDEV-NOTE: this was `excluded_domains` from `26858fc1` until 2026-07-31, and it silently did
+NOTHING for that whole time. OpenRouter does not validate the `plugins` envelope — a deliberately
+invented key returns HTTP 200 exactly like a real one (measured) — so the wrong spelling produced
+a normal answer, a normal bill, and zero exclusion. Every benchmark candidate could reach the
+rubric it was being graded against, which INFLATES scores and therefore never looks like a bug.
+
+MEASURED 2026-07-31, live, against `google/gemini-3-flash-preview` (exa) and `openai/gpt-5.5`
+(native), counting citations from hosts we asked to exclude:
+
+    exclude_domains  = every cited host  ->  0 blocked-host citations   (both engines)
+    excluded_domains = every cited host  ->  unchanged from baseline    (both engines)
+    exclude_domains  = one host          ->  that host alone disappears (rules out search noise)
+
+INVARIANT: a status code can never verify this key. Assert on an EFFECT — annotations, cost, or a
+changed answer. `test_the_wire_key_is_openrouters_spelling` pins the name so a rename fails loudly
+instead of quietly restoring the bug. The documented keys are `engine`, `max_results`,
+`search_prompt`, `include_domains` and `exclude_domains`; path prefixes and wildcards are
+supported values (`openai.com/blog`, `*.substack.com`).
+"""
+
 
 def _apply_web_search(body: dict[str, Any], settings: Any) -> None:
     """Translate the caller's `web_search` intent into OpenRouter's `plugins` envelope.
@@ -173,7 +196,7 @@ def _apply_web_search(body: dict[str, Any], settings: Any) -> None:
     excluded = sorted({*deployment_excluded, *caller_excluded})
     plugin = dict(_WEB_SEARCH_POLICY)
     if excluded:
-        plugin["excluded_domains"] = excluded
+        plugin[EXCLUDE_DOMAINS_KEY] = excluded
     # Assignment, never a merge — as with `provider`. A `plugins` that somehow survived the
     # classifier must not be extended by this, only replaced.
     body["plugins"] = [plugin]

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/plugin.py
@@ -22,7 +22,7 @@ An API-key-only provider (no OAuth) routed through LiteLLM's built-in
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from aigateway.core.api_key_strategy import ApiKeyStrategy
 from aigateway.core.api_key_validation import ApiKeyValidator
@@ -178,7 +178,20 @@ supported values (`openai.com/blog`, `*.substack.com`).
 """
 
 
-def _apply_web_search(body: dict[str, Any], settings: Any) -> None:
+class _WebSearchSettings(Protocol):
+    """The ONE setting `_apply_web_search` reads.
+
+    A Protocol rather than `Any`: this function assembles a security-relevant blocklist, and an
+    untyped parameter means the type checker cannot tell a renamed setting from a missing one —
+    the failure mode being an empty deployment list, i.e. a guard that silently does nothing.
+    Structural, so the plugin's real settings object and a test's minimal stub both satisfy it
+    without either importing the other.
+    """
+
+    web_search_excluded_domains: list[str]
+
+
+def _apply_web_search(body: dict[str, Any], settings: _WebSearchSettings) -> None:
     """Translate the caller's `web_search` intent into OpenRouter's `plugins` envelope.
 
     INVARIANT: both caller-facing keys are POPPED. Neither is an OpenRouter field, and leaving
@@ -192,8 +205,7 @@ def _apply_web_search(body: dict[str, Any], settings: Any) -> None:
     caller_excluded = body.pop(WEB_SEARCH_EXCLUDED_DOMAINS_PARAM, None) or []
     if wanted is not True:
         return
-    deployment_excluded = list(getattr(settings, "web_search_excluded_domains", None) or [])
-    excluded = sorted({*deployment_excluded, *caller_excluded})
+    excluded = sorted({*settings.web_search_excluded_domains, *caller_excluded})
     plugin = dict(_WEB_SEARCH_POLICY)
     if excluded:
         plugin[EXCLUDE_DOMAINS_KEY] = excluded

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/plugin.py
@@ -140,6 +140,45 @@ _TRUSTED_ATTRIBUTION = {
 # installed version — if it ever changes, strictness would vanish silently.
 _STRICT_ROUTING_PROVIDER = {"require_parameters": True}
 
+# --- server-side web search: caller intent -> the provider's native envelope ------------------
+#
+# The caller says `web_search: true`. OpenRouter's spelling is `plugins: [{"id": "web", ...}]`,
+# an extensibility envelope that stays REFUSED as a caller path (OME-646) — so the translation
+# happens HERE, in the same hook and by the same rule as `provider`: the gateway ASSIGNS the
+# native field, the caller can never reach it.
+WEB_SEARCH_PARAM = "web_search"
+WEB_SEARCH_EXCLUDED_DOMAINS_PARAM = "web_search_excluded_domains"
+
+# Gateway-owned plugin options. `native` routes to each provider's own search engine — one of
+# exactly five OpenRouter accepts (native|exa|firecrawl|parallel|perplexity); `auto` is NOT
+# among them, despite being valid on the inert `openrouter:web_search` tools surface.
+_WEB_SEARCH_POLICY: dict[str, object] = {"id": "web", "engine": "native"}
+
+
+def _apply_web_search(body: dict[str, Any], settings: Any) -> None:
+    """Translate the caller's `web_search` intent into OpenRouter's `plugins` envelope.
+
+    INVARIANT: both caller-facing keys are POPPED. Neither is an OpenRouter field, and leaving
+    one on the body would reach the wire as an unknown parameter.
+
+    INVARIANT: exclusions are a UNION of the deployment's own list and the caller's, so a caller
+    can only ever TIGHTEN the guard. The motivating case is a benchmark candidate that must not
+    retrieve the rubric it is graded against — a blocklist a caller could shorten is not one.
+    """
+    wanted = body.pop(WEB_SEARCH_PARAM, None)
+    caller_excluded = body.pop(WEB_SEARCH_EXCLUDED_DOMAINS_PARAM, None) or []
+    if wanted is not True:
+        return
+    deployment_excluded = list(getattr(settings, "web_search_excluded_domains", None) or [])
+    excluded = sorted({*deployment_excluded, *caller_excluded})
+    plugin = dict(_WEB_SEARCH_POLICY)
+    if excluded:
+        plugin["excluded_domains"] = excluded
+    # Assignment, never a merge — as with `provider`. A `plugins` that somehow survived the
+    # classifier must not be extended by this, only replaced.
+    body["plugins"] = [plugin]
+
+
 # Caller copies of auth, host/framing, and attribution headers are dropped
 # before the gateway injects its own (D7). Lower-cased for comparison.
 _STRIPPED_CALLER_HEADERS = frozenset(
@@ -263,7 +302,15 @@ class OpenRouterProviderPlugin(ProviderPluginBase[OpenRouterPluginSettings]):
                 source=LOCAL_SOURCE,
             )
             + direct_parameter_observations(
-                ("response_format", "n", "logprobs", "top_logprobs"), source=LOCAL_SOURCE
+                (
+                    "response_format",
+                    "n",
+                    "logprobs",
+                    "top_logprobs",
+                    "web_search",
+                    "web_search_excluded_domains",
+                ),
+                source=LOCAL_SOURCE,
             )
         )
 
@@ -348,6 +395,7 @@ class OpenRouterProviderPlugin(ProviderPluginBase[OpenRouterPluginSettings]):
         # that ever slipped through survive. A fresh dict per request keeps one caller
         # from mutating the policy the next one gets.
         out["provider"] = dict(_STRICT_ROUTING_PROVIDER)
+        _apply_web_search(out, self.settings)
         return out
 
     async def chat_completion(self, body: dict[str, Any]) -> Any:

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/settings.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/settings.py
@@ -46,13 +46,18 @@ def is_valid_upstream_model_id(value: object) -> bool:
 def _default_model_slugs() -> list[str]:
     """URL4 leaf seeds in gateway form — recommended bootstrap metadata (D8).
 
-    All three were present in the live OpenRouter catalog on 2026-07-15;
-    re-check at release. Never treat this list as an authorization boundary.
+    All were present in the live OpenRouter catalog on 2026-07-15 (the judge added
+    2026-07-31); re-check at release. Never treat this list as an authorization boundary.
     """
     return [
         "openrouter/anthropic/claude-fable-5",
         "openrouter/openai/gpt-5.5",
         "openrouter/anthropic/claude-opus-4.8",
+        # AIDEV-NOTE: the DRACO benchmark judge. arXiv:2602.11685 §4.2 PINS it, and the
+        # benchmarks repo warns that a different judge materially changes the scores — so it is
+        # seeded here rather than left to a deployment. `apps/url4-cloud/url4.toml` declares the
+        # matching route; `test_declared_models_match_aigateway.py` fails if the two drift.
+        "openrouter/google/gemini-3.1-pro-preview",
     ]
 
 

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/settings.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/settings.py
@@ -47,7 +47,8 @@ def _default_model_slugs() -> list[str]:
     """URL4 leaf seeds in gateway form — recommended bootstrap metadata (D8).
 
     All were present in the live OpenRouter catalog on 2026-07-15 (the judge added
-    2026-07-31); re-check at release. Never treat this list as an authorization boundary.
+    2026-07-31, the remaining DRACO lineup the same day); re-check at release. Never treat this
+    list as an authorization boundary.
 
     Validation here is purely SYNTACTIC (`is_valid_upstream_model_id`, D8) — nothing checks a
     slug against the live catalog, so a typo in one of these surfaces as a dispatch failure
@@ -62,6 +63,17 @@ def _default_model_slugs() -> list[str]:
         # seeded here rather than left to a deployment. `apps/url4-cloud/url4.toml` declares the
         # matching route; `test_declared_models_match_aigateway.py` fails if the two drift.
         "openrouter/google/gemini-3.1-pro-preview",
+        # AIDEV-NOTE: the rest of the DRACO candidate lineup — the four models that appear in
+        # `screamingface-benchmarks/benchmarks_config/draco.yaml` but nowhere above. Seeded for
+        # the same reason as the judge: the BENCHMARK pins its lineup (7 solos + 9 fusions, whose
+        # published scores are per-configuration), so which models exist is not a deployment
+        # choice. Without these, `budget_trio`, `pareto_cross`, `pareto_lean`, `beat_runner_up`
+        # and `best_open_source` cannot be addressed at all — routing is exact-match, so an
+        # undeclared model is not a degraded run, it is a `ResolutionError`.
+        "openrouter/google/gemini-3-flash-preview",
+        "openrouter/moonshotai/kimi-k2.6",
+        "openrouter/deepseek/deepseek-v4-pro",
+        "openrouter/qwen/qwen3.6-plus",
     ]
 
 

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/settings.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/settings.py
@@ -48,6 +48,10 @@ def _default_model_slugs() -> list[str]:
 
     All were present in the live OpenRouter catalog on 2026-07-15 (the judge added
     2026-07-31); re-check at release. Never treat this list as an authorization boundary.
+
+    Validation here is purely SYNTACTIC (`is_valid_upstream_model_id`, D8) — nothing checks a
+    slug against the live catalog, so a typo in one of these surfaces as a dispatch failure
+    inside a user's expression, not at boot. Re-checking at release is the only guard.
     """
     return [
         "openrouter/anthropic/claude-fable-5",
@@ -89,6 +93,12 @@ class OpenRouterPluginSettings(PluginSettings):
     enabled: bool = False
     default_models: list[str] = Field(default_factory=_default_model_slugs)
     validation_model: str = "openrouter/openrouter/free"
+    # Domains server-side web search must never retrieve from, for EVERY caller of this
+    # deployment. A caller's own `web_search_excluded_domains` is UNIONed with this, never
+    # substituted for it, so a caller can tighten the guard and can never loosen it — which is
+    # what keeps it a guard rather than a suggestion. Empty by default: exclusions are a
+    # deployment policy, and inventing one here would silently shape everyone's retrieval.
+    web_search_excluded_domains: list[str] = Field(default_factory=list)
 
     @field_validator("default_models")
     @classmethod

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_dispatch.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_dispatch.py
@@ -19,10 +19,14 @@ from aigateway.plugins.openrouter_provider import plugin as openrouter_plugin_mo
 from aigateway.plugins.openrouter_provider.plugin import OpenRouterProviderPlugin
 from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSettings
 
+# AIDEV-NOTE: a hand-copy of `_default_model_slugs()`. It duplicates production ON PURPOSE — the
+# point is to fail when the seed list changes, which a shared import would hide. Adding a seed is
+# therefore expected to touch this pin; the judge below was added 2026-07-31 for DRACO.
 _SEEDS = [
     "openrouter/anthropic/claude-fable-5",
     "openrouter/openai/gpt-5.5",
     "openrouter/anthropic/claude-opus-4.8",
+    "openrouter/google/gemini-3.1-pro-preview",
 ]
 
 

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_dispatch.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_dispatch.py
@@ -27,6 +27,11 @@ _SEEDS = [
     "openrouter/openai/gpt-5.5",
     "openrouter/anthropic/claude-opus-4.8",
     "openrouter/google/gemini-3.1-pro-preview",
+    # The rest of the DRACO candidate lineup, added 2026-07-31.
+    "openrouter/google/gemini-3-flash-preview",
+    "openrouter/moonshotai/kimi-k2.6",
+    "openrouter/deepseek/deepseek-v4-pro",
+    "openrouter/qwen/qwen3.6-plus",
 ]
 
 

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_settings.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_settings.py
@@ -14,10 +14,14 @@ from aigateway.plugins.openrouter_provider.settings import (
     is_valid_upstream_model_id,
 )
 
+# AIDEV-NOTE: a hand-copy of `_default_model_slugs()`. It duplicates production ON PURPOSE — the
+# point is to fail when the seed list changes, which a shared import would hide. Adding a seed is
+# therefore expected to touch this pin; the judge below was added 2026-07-31 for DRACO.
 _SEEDS = [
     "openrouter/anthropic/claude-fable-5",
     "openrouter/openai/gpt-5.5",
     "openrouter/anthropic/claude-opus-4.8",
+    "openrouter/google/gemini-3.1-pro-preview",
 ]
 
 
@@ -25,7 +29,7 @@ def test_enabled_defaults_false() -> None:
     assert OpenRouterPluginSettings().enabled is False
 
 
-def test_default_models_are_the_three_seeds() -> None:
+def test_default_models_are_exactly_the_declared_seeds() -> None:
     assert OpenRouterPluginSettings().default_models == _SEEDS
 
 

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_settings.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_settings.py
@@ -22,6 +22,11 @@ _SEEDS = [
     "openrouter/openai/gpt-5.5",
     "openrouter/anthropic/claude-opus-4.8",
     "openrouter/google/gemini-3.1-pro-preview",
+    # The rest of the DRACO candidate lineup, added 2026-07-31.
+    "openrouter/google/gemini-3-flash-preview",
+    "openrouter/moonshotai/kimi-k2.6",
+    "openrouter/deepseek/deepseek-v4-pro",
+    "openrouter/qwen/qwen3.6-plus",
 ]
 
 

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_web_plugin.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_web_plugin.py
@@ -1,0 +1,162 @@
+"""Server-side web search: caller intent in, the provider's native envelope out.
+
+FEATURE: a caller asks OpenRouter to retrieve before answering with `web_search: true`.
+STORY: as a benchmark author, a published retrieval-bearing score was produced on the provider's
+own search; a client-side loop over a different backend is a different experiment.
+
+WHY the caller does NOT send `plugins` — OpenRouter's own spelling. `plugins` is an
+extensibility ENVELOPE: carrying arbitrary provider extensions is its whole purpose, so no
+schema can bound it without defeating it, and OME-646 removed it for exactly that reason. It
+stays refused (`test_openrouter_security`). The caller sends a BOOLEAN, which is bounded
+completely, and `prepare_chat_body` assigns the envelope from gateway-owned policy — the same
+two-layer shape `provider` already uses.
+
+WHY not `tools: [{"type": "openrouter:web_search"}]` either — measured against the live API on
+2026-07-31, same model and prompt: that spelling returns HTTP 200 with zero `annotations`, no
+web-search line in `cost_details`, and an answer from the model's training cutoff. The emitted
+`plugins` returned 4 annotations at ~255x the cost with current facts. A surface that 200s
+without working is the worst failure shape available, so both halves are pinned here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aigateway.plugins.openrouter_provider.parameters import (
+    openrouter_chat_parameter_rules,
+    openrouter_chat_parameter_tools,
+)
+from aigateway.plugins.openrouter_provider.plugin import _apply_web_search
+
+_MODEL = "openrouter/google/gemini-3-flash-preview"
+
+
+class _Settings:
+    def __init__(self, excluded: list[str] | None = None) -> None:
+        self.web_search_excluded_domains = excluded or []
+
+
+def _rule(path: str):
+    for rule in openrouter_chat_parameter_rules(model=_MODEL, auth_type="api_key"):
+        if rule.request_path == path:
+            return rule
+    return None
+
+
+def _prepared(body: dict[str, Any], settings: _Settings | None = None) -> dict[str, Any]:
+    out = dict(body)
+    _apply_web_search(out, settings or _Settings())
+    return out
+
+
+# --- the caller-facing contract --------------------------------------------------
+
+
+def test_web_search_is_enabled_as_a_plain_boolean() -> None:
+    """A boolean is bounded COMPLETELY — there is no nested JSON for a caller to smuggle."""
+    rule = _rule("web_search")
+
+    assert rule is not None
+    assert rule.parameter_schema is not None
+    assert rule.parameter_schema.type == "boolean"
+
+
+def test_caller_exclusions_are_a_bounded_string_array() -> None:
+    rule = _rule("web_search_excluded_domains")
+
+    assert rule is not None
+    assert rule.parameter_schema is not None
+    assert rule.parameter_schema.type == "array"
+    assert rule.parameter_schema.item_type == "string"
+
+
+def test_the_native_envelope_stays_refused_as_a_caller_path() -> None:
+    """INVARIANT: enabling web search must not re-open `plugins`. If this ever passes with a
+    rule present, a caller can hand OpenRouter arbitrary extensions again."""
+    assert _rule("plugins") is None
+
+
+def test_the_routing_controls_ome_646_removed_stay_removed() -> None:
+    for path in ("provider", "route", "models"):
+        assert _rule(path) is None, path
+
+
+def test_the_inert_server_tool_types_stay_unadvertised() -> None:
+    """`tools_schema` gates each item's `type`, so leaving these out is what makes a caller
+    sending one fail closed instead of paying for a silent no-op."""
+    enabled = {
+        tool.tool_type
+        for tool in openrouter_chat_parameter_tools(model=_MODEL, auth_type="api_key")
+    }
+
+    assert "openrouter:web_search" not in enabled
+    assert "openrouter:web_fetch" not in enabled
+    assert "function" in enabled
+
+
+# --- the translation -------------------------------------------------------------
+
+
+def test_true_becomes_the_providers_web_plugin() -> None:
+    out = _prepared({"web_search": True})
+
+    assert out["plugins"] == [{"id": "web", "engine": "native"}]
+
+
+def test_the_caller_facing_keys_never_reach_the_wire() -> None:
+    """Neither is an OpenRouter field; leaving one on the body sends an unknown parameter."""
+    out = _prepared({"web_search": True, "web_search_excluded_domains": ["a.test"]})
+
+    assert "web_search" not in out
+    assert "web_search_excluded_domains" not in out
+
+
+def test_false_and_absent_both_send_no_plugin() -> None:
+    assert "plugins" not in _prepared({"web_search": False})
+    assert "plugins" not in _prepared({})
+
+
+def test_exclusions_alone_do_not_switch_retrieval_on() -> None:
+    """Only `web_search` decides. Otherwise a stray exclusions list would silently start
+    retrieving — and paying."""
+    out = _prepared({"web_search_excluded_domains": ["a.test"]})
+
+    assert "plugins" not in out
+    assert "web_search_excluded_domains" not in out
+
+
+# --- the exclusion union ---------------------------------------------------------
+
+
+def test_deployment_exclusions_apply_without_the_caller_asking() -> None:
+    out = _prepared({"web_search": True}, _Settings(["rubric.test"]))
+
+    assert out["plugins"][0]["excluded_domains"] == ["rubric.test"]
+
+
+def test_caller_exclusions_are_added_to_the_deployments() -> None:
+    out = _prepared(
+        {"web_search": True, "web_search_excluded_domains": ["extra.test"]},
+        _Settings(["rubric.test"]),
+    )
+
+    assert out["plugins"][0]["excluded_domains"] == ["extra.test", "rubric.test"]
+
+
+def test_a_caller_cannot_drop_a_deployment_exclusion() -> None:
+    """INVARIANT: UNION, never substitution. The motivating case is a benchmark candidate that
+    must not retrieve the rubric it is graded against — a guard a caller can shorten is not a
+    guard, and the caller supplying its own list is exactly when it would try."""
+    out = _prepared(
+        {"web_search": True, "web_search_excluded_domains": ["unrelated.test"]},
+        _Settings(["rubric.test"]),
+    )
+
+    assert "rubric.test" in out["plugins"][0]["excluded_domains"]
+
+
+def test_no_exclusions_omits_the_field_rather_than_sending_an_empty_list() -> None:
+    """An empty list reads to the provider as 'exclude nothing' rather than 'use your default'."""
+    out = _prepared({"web_search": True})
+
+    assert "excluded_domains" not in out["plugins"][0]

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_web_plugin.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_web_plugin.py
@@ -26,7 +26,7 @@ from aigateway.plugins.openrouter_provider.parameters import (
     openrouter_chat_parameter_rules,
     openrouter_chat_parameter_tools,
 )
-from aigateway.plugins.openrouter_provider.plugin import _apply_web_search
+from aigateway.plugins.openrouter_provider.plugin import EXCLUDE_DOMAINS_KEY, _apply_web_search
 
 _MODEL = "openrouter/google/gemini-3-flash-preview"
 
@@ -131,7 +131,7 @@ def test_exclusions_alone_do_not_switch_retrieval_on() -> None:
 def test_deployment_exclusions_apply_without_the_caller_asking() -> None:
     out = _prepared({"web_search": True}, _Settings(["rubric.test"]))
 
-    assert out["plugins"][0]["excluded_domains"] == ["rubric.test"]
+    assert out["plugins"][0]["exclude_domains"] == ["rubric.test"]
 
 
 def test_caller_exclusions_are_added_to_the_deployments() -> None:
@@ -140,7 +140,7 @@ def test_caller_exclusions_are_added_to_the_deployments() -> None:
         _Settings(["rubric.test"]),
     )
 
-    assert out["plugins"][0]["excluded_domains"] == ["extra.test", "rubric.test"]
+    assert out["plugins"][0]["exclude_domains"] == ["extra.test", "rubric.test"]
 
 
 def test_a_caller_cannot_drop_a_deployment_exclusion() -> None:
@@ -152,11 +152,36 @@ def test_a_caller_cannot_drop_a_deployment_exclusion() -> None:
         _Settings(["rubric.test"]),
     )
 
-    assert "rubric.test" in out["plugins"][0]["excluded_domains"]
+    assert "rubric.test" in out["plugins"][0]["exclude_domains"]
 
 
 def test_no_exclusions_omits_the_field_rather_than_sending_an_empty_list() -> None:
     """An empty list reads to the provider as 'exclude nothing' rather than 'use your default'."""
     out = _prepared({"web_search": True})
 
+    # Both spellings: the emitted one must be absent, and the historical typo must never return.
+    assert EXCLUDE_DOMAINS_KEY not in out["plugins"][0]
+    assert "excluded_domains" not in out["plugins"][0]
+
+
+def test_the_wire_key_is_openrouters_spelling() -> None:
+    """INVARIANT: the blocklist rides `exclude_domains`. `excluded_domains` is IGNORED.
+
+    This is pinned by name because no status code can catch it. OpenRouter does not validate the
+    `plugins` envelope — an invented key returns HTTP 200 exactly like a real one — so the wrong
+    spelling produced a normal answer, a normal bill, and no exclusion at all, from `26858fc1`
+    until 2026-07-31.
+
+    MEASURED live on both engines: `exclude_domains` drove blocked-host citations to zero, while
+    `excluded_domains` left them identical to baseline. Excluding a single host removed exactly
+    that host, which is what rules out search noise as the explanation.
+
+    A benchmark candidate that can reach its own rubric scores HIGHER, so this failure never looks
+    like a bug from the outside. If a future change renames this key, this test fails loudly
+    instead of the guard going quiet again.
+    """
+    out = _prepared({"web_search": True}, _Settings(["rubric.test"]))
+
+    assert EXCLUDE_DOMAINS_KEY == "exclude_domains"
+    assert out["plugins"][0]["exclude_domains"] == ["rubric.test"]
     assert "excluded_domains" not in out["plugins"][0]

--- a/apps/aigateway/tests/unit/test_cli.py
+++ b/apps/aigateway/tests/unit/test_cli.py
@@ -1,0 +1,62 @@
+"""`aigateway migrate` — the local/Docker path to the Helm migrate Job's command.
+
+FEATURE: local dev and plain-Docker runs of aigateway have no schema-bootstrap path outside
+Helm's pre-install/pre-upgrade Job. `aigateway migrate` runs the identical command that Job
+runs, so a fresh SQLite DB stops failing with "no such table: credential_blobs" on first boot.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from aigateway import cli
+
+
+def test_migrate_runs_the_same_command_the_helm_job_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def _fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert kwargs == {"check": False}
+        calls.append(command)
+        return subprocess.CompletedProcess(command, returncode=0)
+
+    monkeypatch.setattr(cli.subprocess, "run", _fake_run)
+
+    cli.main(["migrate"])
+
+    assert calls == [
+        [sys.executable, "-m", "tortoise", "-c", "aigateway.db.TORTOISE_CONFIG", "migrate"]
+    ]
+
+
+def test_migrate_raises_on_a_nonzero_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, returncode=1)
+
+    monkeypatch.setattr(cli.subprocess, "run", _fake_run)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["migrate"])
+    assert exc_info.value.code == 1
+
+
+def test_no_argv_serves_rather_than_migrating(monkeypatch: pytest.MonkeyPatch) -> None:
+    serve = MagicMock()
+    monkeypatch.setattr(cli, "_serve", serve)
+
+    cli.main([])
+
+    serve.assert_called_once()
+
+
+def test_the_serve_subcommand_also_serves(monkeypatch: pytest.MonkeyPatch) -> None:
+    serve = MagicMock()
+    monkeypatch.setattr(cli, "_serve", serve)
+
+    cli.main(["serve"])
+
+    serve.assert_called_once()

--- a/apps/url4-cloud/Dockerfile.benchmark
+++ b/apps/url4-cloud/Dockerfile.benchmark
@@ -3,8 +3,21 @@
 #
 #   docker build -f apps/url4-cloud/Dockerfile -t url4-cloud:dev .
 #   docker build -f apps/url4-cloud/Dockerfile.benchmark \
-#       --build-arg BASE=url4-cloud:dev --build-arg LIMIT=5 \
-#       -t url4-cloud-draco:dev .
+#       --build-arg BASE=url4-cloud:dev \
+#       -t url4-cloud-benchmark:dev .
+#
+# INVARIANT: a benchmark image carries the WHOLE dataset. There is deliberately no build arg to
+# truncate it.
+#
+# WHY (removed 2026-08-02): run size is an EXPRESSION concern — `…!'case';iteration.slice=0:5`
+# picks how many declared cases a run touches, needs no rebuild, and lives inside the recipe
+# identity the scoreboard hashes. A build-time cap addressed the same need one layer down and
+# produced a DIFFERENT ARTIFACT THAT LOOKS IDENTICAL: same tags, a manifest still advertising
+# `cases: 100`, and nothing in the result recording the truncation — so a partial run was
+# indistinguishable from a full one, in the flattering direction. It also bought almost nothing,
+# because `load_dataset` downloads the full split regardless and only the file writes were
+# skipped. `prepare --limit` still exists for a local generator run; it just cannot shape a
+# deployable image any more.
 #
 # WHY a SEPARATE image layered on the base rather than a stage in the main Dockerfile:
 #
@@ -29,7 +42,6 @@ ARG BASE=url4-cloud:dev
 # --- build stage: download the dataset, emit the declared world -----------------------------
 FROM ${BASE} AS prepare
 ARG BENCHMARK=draco
-ARG LIMIT=""
 ARG ROUTE_PREFIX=/draco
 # root only for the build stage; the runtime image below drops back to uid 1000.
 USER 0
@@ -44,8 +56,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN mkdir -p /opt/benchmarks/${BENCHMARK} \
  && /app/apps/url4-cloud/.venv/bin/python -m url4_cloud.benchmarks.${BENCHMARK}.prepare \
       --out /opt/benchmarks/${BENCHMARK} \
-      --route-prefix ${ROUTE_PREFIX} \
-      ${LIMIT:+--limit ${LIMIT}}
+      --route-prefix ${ROUTE_PREFIX}
 # Merge the generated [data] fragment into the reviewed base config and VALIDATE the result with
 # the runner's own parser. A route collision or an unusable world fails the BUILD here, rather
 # than at Job boot — after a client has already minted a token and attached a WebSocket.

--- a/apps/url4-cloud/Dockerfile.benchmark
+++ b/apps/url4-cloud/Dockerfile.benchmark
@@ -1,0 +1,75 @@
+# syntax=docker/dockerfile:1.7
+# A BENCHMARK image — the url4-cloud runner plus one benchmark's declared world.
+#
+#   docker build -f apps/url4-cloud/Dockerfile -t url4-cloud:dev .
+#   docker build -f apps/url4-cloud/Dockerfile.benchmark \
+#       --build-arg BASE=url4-cloud:dev --build-arg LIMIT=5 \
+#       -t url4-cloud-draco:dev .
+#
+# WHY a SEPARATE image layered on the base rather than a stage in the main Dockerfile:
+#
+#   - the default url4-cloud image stays dataset-free. Baking DRACO into it would put ~40
+#     rubrics per case into every deployment, including ones that never benchmark;
+#   - a dataset revision rebuilds THIS image only, so benchmark releases do not force an
+#     engine release (and cannot silently change the engine a published score was produced by);
+#   - `datasets` (and its pyarrow tail) is installed in a build stage that is thrown away — the
+#     runtime image never carries it. `prepare.py` imports it through `importlib` for exactly
+#     this reason.
+#
+# INVARIANT: build context is the REPO ROOT, like the base image — `prepare` runs from the
+# installed package, which path-depends on `packages/url4`.
+#
+# TRADEOFF worth revisiting: the dataset is welded to an image, so adding a benchmark means a
+# rebuild and anyone who can pull the image has the rubrics. The alternative is a mounted volume
+# plus `URL4_RUNNER_CONFIG` pointing beside it — which needs a volume the Job spec does not have
+# today (read-only rootfs, one emptyDir at /tmp). Decide before this leaves experimentation.
+
+ARG BASE=url4-cloud:dev
+
+# --- build stage: download the dataset, emit the declared world -----------------------------
+FROM ${BASE} AS prepare
+ARG BENCHMARK=draco
+ARG LIMIT=""
+ARG ROUTE_PREFIX=/draco
+# root only for the build stage; the runtime image below drops back to uid 1000.
+USER 0
+WORKDIR /app/apps/url4-cloud
+# WHY `uv` is copied in rather than `python -m pip`: the base image's venv is uv-created, so it
+# carries NO pip, and the runtime stage never installed the uv binary either — `python -m pip`
+# fails with "No module named pip". Copying the same tool the base image builds with keeps one
+# installer across both Dockerfiles.
+COPY --from=ghcr.io/astral-sh/uv:python3.12-bookworm-slim /usr/local/bin/uv /usr/local/bin/uv
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --python /app/apps/url4-cloud/.venv/bin/python --quiet "datasets>=2.19"
+RUN mkdir -p /opt/benchmarks/${BENCHMARK} \
+ && /app/apps/url4-cloud/.venv/bin/python -m url4_cloud.benchmarks.${BENCHMARK}.prepare \
+      --out /opt/benchmarks/${BENCHMARK} \
+      --route-prefix ${ROUTE_PREFIX} \
+      ${LIMIT:+--limit ${LIMIT}}
+# Merge the generated [data] fragment into the reviewed base config and VALIDATE the result with
+# the runner's own parser. A route collision or an unusable world fails the BUILD here, rather
+# than at Job boot — after a client has already minted a token and attached a WebSocket.
+RUN /app/apps/url4-cloud/.venv/bin/python -m url4_cloud.runner.merge_config \
+      --base /app/apps/url4-cloud/url4.toml \
+      --fragment /opt/benchmarks/${BENCHMARK}/url4.data.toml \
+      --out /opt/benchmarks/${BENCHMARK}/url4.merged.toml
+
+# --- runtime: the base image + the artifacts and merged config -------------------------------
+FROM ${BASE} AS runtime
+ARG BENCHMARK=draco
+LABEL org.opencontainers.image.title="url4-cloud-benchmark" \
+      org.opencontainers.image.description="url4-cloud runner with a benchmark's declared world"
+USER 0
+# `rubrics/` ships too — `aggregate.py` reads it off disk. It is deliberately NOT declared as a
+# [data] route (see prepare.render_data_table): the weights must be unreachable from an
+# expression, or a judge prompt could be handed the thing it is being kept blind to.
+COPY --from=prepare --chown=1000:1000 /opt/benchmarks /opt/benchmarks
+COPY --from=prepare --chown=1000:1000 \
+     /opt/benchmarks/${BENCHMARK}/url4.merged.toml /etc/url4/url4.toml
+# The aggregate script resolves its rubrics from here. Set in the IMAGE rather than in
+# `url4.toml` so the path travels with the artifacts it points at — a config literal made the two
+# disagree the moment the runner ran outside the image.
+ENV URL4_BENCHMARK_RUBRICS=/opt/benchmarks/${BENCHMARK}/rubrics
+USER 1000
+# Unchanged from the base: `url4-cloud` (serve) by default, `["url4-cloud","run"]` for a Job.
+CMD ["url4-cloud"]

--- a/apps/url4-cloud/deploy/helm/README.md
+++ b/apps/url4-cloud/deploy/helm/README.md
@@ -6,11 +6,25 @@ the App **Deployment · Service · ConfigMap · Secret**, one of two edge object
 (**ServiceAccount · Role · RoleBinding**) that lets the App schedule Runner Jobs in its own
 namespace.
 
-**One image, two modes.** The Deployment runs `url4-cloud` (which defaults to `serve`); every
-Runner Job runs the **same** image with `command: ["url4-cloud", "run"]`. There is no second
-`runner.image` block and no separate template helper for it any more — `URL4_CLOUD_RUNNER_IMAGE`
-renders from the App's own `image:` block via `url4-cloud.image`, so the two can no longer drift
-out of version alignment.
+**One image, two modes — by default.** The Deployment runs `url4-cloud` (which defaults to
+`serve`); every Runner Job runs the **same** image with `command: ["url4-cloud", "run"]`.
+`URL4_CLOUD_RUNNER_IMAGE` renders via `url4-cloud.runnerImage`, which falls back to the App's own
+`image:` block, so by default the two cannot drift out of version alignment.
+
+**Splitting the Runner image.** `runner.image` overrides it, for the one case that needs it: a
+benchmark image (`Dockerfile.benchmark`) bakes a dataset **and its private rubrics** onto the base.
+The Runner executes the run and reads them; the control plane terminates client connections, so a
+rubric on its disk is one bug away from reaching the client it is being withheld from.
+
+```yaml
+runner:
+  image:
+    repository: ghcr.io/openmined/screamingface-url4-cloud-draco   # tag omitted on purpose
+```
+
+`runner.image.tag` defaults to the **App image's resolved tag**, not `latest` — a benchmark image
+is built `FROM` a specific base tag, so overriding `repository` alone keeps the pair moving as one
+version. Set `tag` as well only for a staged rollout, which knowingly opts out of that pairing.
 
 ## Install
 
@@ -114,11 +128,12 @@ maintained as a second definition.)
 
 What the App schedules:
 
-- the App's **own image** in run mode — `command: ["url4-cloud", "run"]`, pinned in
+- the App's own image in run mode by default — `command: ["url4-cloud", "run"]`, pinned in
   `url4_cloud.adapters.k8s` rather than in values: the command is the mode switch and nothing
   else, so a chart override could only ever name a mode the image does not have. The image
-  reference itself stays a value (`URL4_CLOUD_RUNNER_IMAGE`, rendered from `image:`) so a staged
-  rollout can still pin Jobs to a different tag than the Deployment
+  reference itself stays a value (`URL4_CLOUD_RUNNER_IMAGE`, rendered via
+  `url4-cloud.runnerImage`) so a staged rollout can pin Jobs to a different tag than the
+  Deployment, and `runner.image` can point them at a benchmark image entirely (see above)
 - run-once — `backoffLimit: 0`, `restartPolicy: Never` (retry = new token, new job; spec §2.3)
 - `activeDeadlineSeconds` = `config.jobDeadlineS`, surfacing as `timed_out`
 - `enableServiceLinks: false` — kubelet's legacy Docker-link vars would export

--- a/apps/url4-cloud/deploy/helm/README.md
+++ b/apps/url4-cloud/deploy/helm/README.md
@@ -19,7 +19,7 @@ rubric on its disk is one bug away from reaching the client it is being withheld
 ```yaml
 runner:
   image:
-    repository: ghcr.io/openmined/screamingface-url4-cloud-draco   # tag omitted on purpose
+    repository: ghcr.io/openmined/screamingface-url4-cloud-benchmark   # tag omitted on purpose
 ```
 
 `runner.image.tag` defaults to the **App image's resolved tag**, not `latest` — a benchmark image

--- a/apps/url4-cloud/deploy/helm/templates/_helpers.tpl
+++ b/apps/url4-cloud/deploy/helm/templates/_helpers.tpl
@@ -54,6 +54,14 @@ The ONLY intended override is a benchmark image (`Dockerfile.benchmark`), which 
 — including the private rubrics — onto the base. The Runner executes the run and needs them; the
 control plane terminates client connections and must never hold a rubric on disk.
 
+WHY `repository` falls back to the APP's repository plus `-benchmark` rather than to the app
+repository itself: a Runner needs a benchmark image (the plain engine declares no `[data]` routes),
+and the default has to survive a MIRROR. Carrying the full public path in `values.yaml` made the
+override always truthy, so this fallback was unreachable and `--set image.repository=...` moved the
+control plane to a private registry while leaving every Job pointing at ghcr.io — a clean install
+whose first submitted run ImagePullBackOffs. Deriving keeps `186271ca`'s default and lets one
+override move both. An operator whose benchmark image is named otherwise still sets it explicitly.
+
 WHY `tag` falls back to the APP's resolved tag rather than to `latest`: a benchmark image is built
 `FROM` a specific base tag, so the two are a matched pair. Overriding `repository` alone therefore
 keeps the Job and the App on one version — which is the drift protection the merged-image design
@@ -61,7 +69,7 @@ was built for, kept intact while allowing the split payload.
 */}}
 {{- define "url4-cloud.runnerImage" -}}
 {{- $override := (.Values.runner).image | default dict -}}
-{{- $repo := $override.repository | default .Values.image.repository -}}
+{{- $repo := $override.repository | default (printf "%s-benchmark" .Values.image.repository) -}}
 {{- $tag := $override.tag | default (default .Chart.AppVersion .Values.image.tag) -}}
 {{- printf "%s:%s" $repo $tag -}}
 {{- end -}}

--- a/apps/url4-cloud/deploy/helm/templates/_helpers.tpl
+++ b/apps/url4-cloud/deploy/helm/templates/_helpers.tpl
@@ -47,6 +47,26 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/*
+The image a Runner Job runs. Defaults to the App's own image (one artifact, two modes); a
+deployment may override it to ship a Job-only payload the control plane must not carry.
+
+The ONLY intended override is a benchmark image (`Dockerfile.benchmark`), which layers a dataset
+— including the private rubrics — onto the base. The Runner executes the run and needs them; the
+control plane terminates client connections and must never hold a rubric on disk.
+
+WHY `tag` falls back to the APP's resolved tag rather than to `latest`: a benchmark image is built
+`FROM` a specific base tag, so the two are a matched pair. Overriding `repository` alone therefore
+keeps the Job and the App on one version — which is the drift protection the merged-image design
+was built for, kept intact while allowing the split payload.
+*/}}
+{{- define "url4-cloud.runnerImage" -}}
+{{- $override := (.Values.runner).image | default dict -}}
+{{- $repo := $override.repository | default .Values.image.repository -}}
+{{- $tag := $override.tag | default (default .Chart.AppVersion .Values.image.tag) -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+
+{{/*
 Where the App reaches NATS.
 
 WHY a helper and not a plain value: the previous default hardcoded `nats://url4-cloud-nats:4222`,

--- a/apps/url4-cloud/deploy/helm/templates/configmap.yaml
+++ b/apps/url4-cloud/deploy/helm/templates/configmap.yaml
@@ -17,12 +17,14 @@ data:
   # INVARIANT: Jobs are created in the release namespace only — this must match the namespace the
   # Role/RoleBinding bind, or the App's ServiceAccount is not authorized to create them.
   URL4_CLOUD_NAMESPACE: {{ .Release.Namespace | quote }}
-  # The Job runs THIS SAME image in its run mode (`url4-cloud run`) — one artifact, two modes.
-  # WHY the App is told its own image rather than discovering it: a process cannot reliably read
+  # The image every Runner Job runs, in its run mode (`url4-cloud run`).
+  # WHY the App is told an image rather than discovering it: a process cannot reliably read
   # back the image reference it was started from (that lives in the pod spec, needs RBAC on pods,
-  # and the Downward API does not expose it). Rendering the same `image:` the Deployment gets is
-  # what keeps the Job and the App on one version through an upgrade.
-  URL4_CLOUD_RUNNER_IMAGE: {{ include "url4-cloud.image" . | quote }}
+  # and the Downward API does not expose it).
+  # Defaults to the Deployment's own `image:` — one artifact, two modes, on one version through an
+  # upgrade. `runner.image` overrides it for a Job-only payload (a benchmark dataset) that must not
+  # reach the control plane; see the helper for why the tag stays paired.
+  URL4_CLOUD_RUNNER_IMAGE: {{ include "url4-cloud.runnerImage" . | quote }}
   {{- with .Values.runner.resources }}
   # The Runner's own requests/limits. Carried as JSON because a ConfigMap value is a string and
   # pydantic-settings parses complex fields as JSON — so the k8s `resources` block travels

--- a/apps/url4-cloud/deploy/helm/values.schema.json
+++ b/apps/url4-cloud/deploy/helm/values.schema.json
@@ -83,7 +83,7 @@
           "properties": {
             "repository": {
               "type": "string",
-              "description": "Empty = use .Values.image.repository. Set ONLY to give Runner Jobs a payload the control plane must not carry (a benchmark image, which bakes in the private rubrics)."
+              "description": "Empty = `<image.repository>-benchmark`, so mirroring the chart into a private registry moves the Runner Job image with the App image. Set ONLY when the benchmark image is not named `<app>-benchmark`. It must never equal image.repository: that image bakes in the private rubrics the control plane must not carry."
             },
             "tag": {
               "type": "string",

--- a/apps/url4-cloud/deploy/helm/values.schema.json
+++ b/apps/url4-cloud/deploy/helm/values.schema.json
@@ -78,6 +78,20 @@
           ],
           "description": "Mirrors url4_cloud.config.RunnerBackend. `none` deploys an App that cannot schedule and answers 503 to every run."
         },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "description": "Empty = use .Values.image.repository. Set ONLY to give Runner Jobs a payload the control plane must not carry (a benchmark image, which bakes in the private rubrics)."
+            },
+            "tag": {
+              "type": "string",
+              "description": "Empty = the App image's resolved tag, so overriding repository alone keeps the pair on one version (a benchmark image is built FROM a specific base tag). Set this too only for a staged rollout."
+            }
+          },
+          "additionalProperties": false
+        },
         "resources": {
           "type": "object"
         },

--- a/apps/url4-cloud/deploy/helm/values.yaml
+++ b/apps/url4-cloud/deploy/helm/values.yaml
@@ -293,8 +293,13 @@ runner:
   #     image:
   #       repository: ghcr.io/openmined/screamingface-url4-cloud
   #
+  # `repository` is DERIVED, not written out: empty means `<image.repository>-benchmark`. It was
+  # a literal public path, which made the override always set and the derivation unreachable — so
+  # `--set image.repository=registry.internal/...` mirrored the control plane and left every Job
+  # pointing at ghcr.io. That install succeeds and the first submitted run ImagePullBackOffs.
+  # Empty keeps the benchmark-image default AND lets it travel with the registry.
   image:
-    repository: ghcr.io/openmined/screamingface-url4-cloud-benchmark
+    repository: ""   # "" => "<image.repository>-benchmark"
     tag: ""          # "" => the App image's resolved tag
   #
   # NOTE: there is deliberately no `command` here either. The Job's command is the mode switch

--- a/apps/url4-cloud/deploy/helm/values.yaml
+++ b/apps/url4-cloud/deploy/helm/values.yaml
@@ -20,11 +20,13 @@
 # size one against.
 replicaCount: 1
 
-# ONE image, used two ways: the Deployment runs it as the control plane (`url4-cloud serve`),
-# and every Runner Job runs the SAME image in run mode (`url4-cloud run`) — see
-# `URL4_CLOUD_RUNNER_IMAGE` in configmap.yaml. There is no second `runner.image` block any more;
-# the two artifacts were merged, so they cannot drift out of version alignment. Build-time OCI
-# labels the image should carry are listed in README.md (org.opencontainers.image.*).
+# ONE image, used two ways BY DEFAULT: the Deployment runs it as the control plane
+# (`url4-cloud serve`), and every Runner Job runs the same image in run mode (`url4-cloud run`) —
+# see `URL4_CLOUD_RUNNER_IMAGE` in configmap.yaml. The two artifacts were merged so they cannot
+# drift out of version alignment. `runner.image` below can point Jobs at a DIFFERENT image when
+# they need a payload the control plane must not carry (a benchmark dataset); it keeps this tag
+# unless explicitly told otherwise, so the pair still moves as one. Build-time OCI labels the
+# image should carry are listed in README.md (org.opencontainers.image.*).
 image:
   repository: ghcr.io/openmined/screamingface-url4-cloud
   tag: ""            # defaults to .Chart.AppVersion
@@ -260,9 +262,26 @@ runner:
   # Which JobRunner substrate the App schedules on (url4_cloud.config.RunnerBackend). `k8s` is the
   # point of this chart; `none` degrades the App to a token-minting NATS bridge that cannot run.
   backend: k8s
-  # NOTE: there is deliberately no `image` here any more. A Runner Job runs the App's OWN image
-  # (the `image:` block at the top of this file) in its run mode, so there is nothing left to
-  # configure separately — and nothing that can drift out of version alignment during an upgrade.
+  # OPTIONAL override of the image Runner Jobs run. Unset (the default) => a Job runs the App's
+  # OWN image (the `image:` block at the top of this file) in its run mode: one artifact, two
+  # modes, nothing that can drift out of version alignment during an upgrade.
+  #
+  # Set this ONLY to give the Runner a payload the control plane must not carry — today that means
+  # a benchmark image (`Dockerfile.benchmark`), which bakes in a dataset AND its private rubrics.
+  # The Runner executes the run and reads them; the control plane terminates client connections,
+  # so a rubric on its disk is one bug away from reaching the client it is being kept from.
+  #
+  # `tag` defaults to the APP image's resolved tag, not to `latest`: a benchmark image is built
+  # `FROM` a specific base tag, so overriding `repository` alone keeps the pair on one version.
+  # Overriding `tag` too opts out of that and is for a staged rollout only.
+  #
+  #   runner:
+  #     image:
+  #       repository: ghcr.io/openmined/screamingface-url4-cloud-draco
+  #
+  image:
+    repository: ""   # "" => .Values.image.repository
+    tag: ""          # "" => the App image's resolved tag
   #
   # NOTE: there is deliberately no `command` here either. The Job's command is the mode switch
   # `["url4-cloud", "run"]`, pinned in code beside the Job spec that uses it

--- a/apps/url4-cloud/deploy/helm/values.yaml
+++ b/apps/url4-cloud/deploy/helm/values.yaml
@@ -20,13 +20,17 @@
 # size one against.
 replicaCount: 1
 
-# ONE image, used two ways BY DEFAULT: the Deployment runs it as the control plane
-# (`url4-cloud serve`), and every Runner Job runs the same image in run mode (`url4-cloud run`) —
-# see `URL4_CLOUD_RUNNER_IMAGE` in configmap.yaml. The two artifacts were merged so they cannot
-# drift out of version alignment. `runner.image` below can point Jobs at a DIFFERENT image when
-# they need a payload the control plane must not carry (a benchmark dataset); it keeps this tag
-# unless explicitly told otherwise, so the pair still moves as one. Build-time OCI labels the
-# image should carry are listed in README.md (org.opencontainers.image.*).
+# The CONTROL PLANE's image, and only the control plane's: the Deployment runs it as
+# `url4-cloud serve`. Runner Jobs deliberately run a DIFFERENT image — see `runner.image` below.
+#
+# WHY the split, when both modes live in one codebase: the benchmark image carries the private
+# weighted rubrics a Runner has to read, and the control plane is the process that terminates
+# CLIENT connections. Keeping the answer key off that pod means a bug there cannot leak it. The
+# two images still move as one version — `runner.image.tag` defaults to this tag — so the merged
+# build that prevented drift is preserved without putting rubrics where clients are served.
+#
+# Build-time OCI labels the image should carry are listed in README.md
+# (org.opencontainers.image.*).
 image:
   repository: ghcr.io/openmined/screamingface-url4-cloud
   tag: ""            # defaults to .Chart.AppVersion
@@ -262,25 +266,35 @@ runner:
   # Which JobRunner substrate the App schedules on (url4_cloud.config.RunnerBackend). `k8s` is the
   # point of this chart; `none` degrades the App to a token-minting NATS bridge that cannot run.
   backend: k8s
-  # OPTIONAL override of the image Runner Jobs run. Unset (the default) => a Job runs the App's
-  # OWN image (the `image:` block at the top of this file) in its run mode: one artifact, two
-  # modes, nothing that can drift out of version alignment during an upgrade.
+  # The image Runner Jobs run — the BENCHMARK image by default, not the App image.
   #
-  # Set this ONLY to give the Runner a payload the control plane must not carry — today that means
-  # a benchmark image (`Dockerfile.benchmark`), which bakes in a dataset AND its private rubrics.
-  # The Runner executes the run and reads them; the control plane terminates client connections,
-  # so a rubric on its disk is one bug away from reaching the client it is being kept from.
+  # WHY this is the default rather than an opt-in: a Runner exists to execute a benchmark, and a
+  # benchmark cannot run on the plain engine image. That image declares no `[data]` routes, so the
+  # first expression fails with
+  #   `endpoint_not_found: node 'aigateway' has no ... data route at '/draco/cases'`
+  # (measured on a real Job, 2026-08-02). Loud rather than silent, but it is a whole deployment
+  # that cannot run a single case, discovered at the first submitted run instead of at install.
+  # Defaulting the other way makes the working configuration the one you get by not thinking.
   #
-  # `tag` defaults to the APP image's resolved tag, not to `latest`: a benchmark image is built
-  # `FROM` a specific base tag, so overriding `repository` alone keeps the pair on one version.
-  # Overriding `tag` too opts out of that and is for a staged rollout only.
+  # INVARIANT: the control plane must NOT run this image. It bakes in the dataset AND its private
+  # weighted rubrics — the answer key. The Runner reads them to score; the control plane
+  # terminates client connections, so a rubric on that pod is one bug away from reaching the
+  # client it is being kept from. That asymmetry is the whole reason there are two images.
+  #
+  # `tag` defaults to the APP image's resolved tag, not to `latest`: the benchmark image is built
+  # `FROM` a specific base tag, so leaving this empty keeps engine and dataset on one version and
+  # lets a published score name the engine that produced it. Overriding `tag` opts out of that and
+  # is for a staged rollout only.
+  #
+  # A deployment that runs NO benchmarks (a plain url4 execution service) should point this back
+  # at the App image, which is the one case where the two are interchangeable:
   #
   #   runner:
   #     image:
-  #       repository: ghcr.io/openmined/screamingface-url4-cloud-draco
+  #       repository: ghcr.io/openmined/screamingface-url4-cloud
   #
   image:
-    repository: ""   # "" => .Values.image.repository
+    repository: ghcr.io/openmined/screamingface-url4-cloud-benchmark
     tag: ""          # "" => the App image's resolved tag
   #
   # NOTE: there is deliberately no `command` here either. The Job's command is the mode switch

--- a/apps/url4-cloud/src/url4_cloud/app.py
+++ b/apps/url4-cloud/src/url4_cloud/app.py
@@ -21,7 +21,7 @@ from url4_cloud.catalog.cache import CatalogService
 from url4_cloud.config import INSECURE_DEFAULT_JWT_SECRET, Settings
 from url4_cloud.metrics import MetricsMiddleware, build_metrics, register_catalog_metrics
 from url4_cloud.ops import router as ops_router
-from url4_cloud.rest import SubscriberGate, catalog_router
+from url4_cloud.rest import SubscriberGate, benchmarks_router, catalog_router
 from url4_cloud.rest import router as rest_router
 from url4_cloud.schemas import customize_openapi
 from url4_cloud.ws import ConnectionRegistry
@@ -71,6 +71,7 @@ def create_app(
     app.include_router(router)
     app.include_router(rest_router)
     app.include_router(catalog_router)
+    app.include_router(benchmarks_router)
     app.include_router(ws_router)
     app.include_router(ops_router)
     app.mount("/diagrams", StaticFiles(directory=_DIAGRAMS_DIR), name="diagrams")

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/__init__.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/__init__.py
@@ -1,0 +1,7 @@
+"""Benchmark assets baked into the Runner image.
+
+Neither the control plane nor the run mode imports this package: its modules are executed as
+SUBPROCESSES by declared `[commands]` routes (see `runner/config.CommandSpec`). It therefore
+imports nothing from either half and nothing from the url4 engine — it is a shared leaf by
+construction, and the layering gate treats it as one.
+"""

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/__init__.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/__init__.py
@@ -1,0 +1,8 @@
+"""DRACO — Perplexity's research-quality rubric benchmark (`perplexity-ai/draco`).
+
+Ground truth is a WEIGHTED RUBRIC, not a reference answer: ~40 criteria grouped into sections,
+where a NEGATIVE weight marks behaviour the answer must not show. Text-similarity metrics are
+meaningless here; only a judge reading the rubric can produce a score.
+
+Reference: arXiv:2602.11685 §4.2 · `screamingface-benchmarks/docs/draco-benchmark-anatomy.md`
+"""

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/aggregate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/aggregate.py
@@ -20,12 +20,27 @@ INVARIANT — the scoring formulas mirror `screamingface-benchmarks/benchmarking
 (arXiv:2602.11685 §4.2) EXACTLY. Do not "improve" them. A different formula is a different
 benchmark, and a leaderboard number computed here must mean what the paper says it means.
 
-AIDEV-NOTE — PROTOCOL CAVEAT. The paper's `official` grading mode issues ONE judge call PER
-CRITERION (~40 criteria × 3 runs per case), and the judge never sees the weights or the sibling
-criteria. The url4 expression this reducer serves makes ONE judge call per case, which is the
-paper's `chunked` mode. Chunked scores are fine for iteration and MUST NOT be published as
-"DRACO-reproduced". Reproducing the official protocol needs a per-criterion fan-out that the
-current expression shape does not express.
+The expression this reducer serves runs the paper's `official` grading mode: ONE judge call per
+CRITERION, `judge_runs` independent passes, and the judge blind to the weights and to the sibling
+criteria. The per-criterion fan-out is the middle iteration level over `/draco/criteria/$item.id`
+(see the `[commands]` section of `url4.toml`); it became expressible once an outer `$name` could
+reach into an iteration body.
+
+AIDEV-NOTE — PROTOCOL CAVEATS, the two ways a run here still differs from the paper:
+
+* `judge_reasoning: "low"` (arXiv:2602.11685 §4.2) is NOT carried. `reasoning_effort` is absent
+  from the OpenRouter plugin's rule set, and the gateway fails closed on an unknown parameter, so
+  sending it would turn every judge call into a 400 rather than a deviation. `judge_temperature`
+  and `max_tokens` DO reach the model.
+* Retrieval is enabled on the three routes a SOLO or `fable_plus_gpt` candidate answers with
+  (`native_web_search`, verified live), but NOT on the four models added for `budget_trio`,
+  `pareto_cross`, `pareto_lean`, `beat_runner_up` and `best_open_source` — those are declared
+  and unverified, so they answer from weights alone. DRACO is a deep-research benchmark and the
+  paper treats retrieval as mandatory, so a score for those five configurations is not
+  comparable to the reference chart.
+
+Neither is visible in the numbers this module emits. A score published as "DRACO-reproduced"
+has to state both.
 """
 
 from __future__ import annotations

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/aggregate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/aggregate.py
@@ -336,17 +336,23 @@ def aggregate(
     if not isinstance(rows, list):
         raise AggregateError(f"reducer payload must be a JSON array, got {type(rows).__name__}")
 
+    # Harvested ONCE, before scoring: the mapping guard below needs to know which rows carry an
+    # echoed id, and re-scanning a multi-hundred-KB payload to find out would double the only
+    # expensive step in this module.
+    harvested = [harvest_verdicts(raw) for raw in rows]
+    _require_verifiable_mapping(harvested, rubrics)
+
     case_results: list[dict[str, Any]] = []
     failures: list[dict[str, Any]] = []
-    for index, raw in enumerate(rows):
-        verdicts = harvest_verdicts(raw)
+    for index, verdicts in enumerate(harvested):
         if not verdicts:
             failures.append({"index": index, "reason": "no judge verdicts in row"})
             continue
-        # WHY position is a legitimate fallback: the BENCHMARK produced the case list, and row
-        # order is preserved — `iteration.on_error=collect` substitutes an error object in place
-        # rather than dropping a row. The echoed id still wins when present, because it survives
-        # a future change to row ordering that position would not.
+        # WHY position is a legitimate fallback HERE: `_require_verifiable_mapping` has already
+        # established that the rows ARE the whole declared case set, and row order is preserved —
+        # `iteration.on_error=collect` substitutes an error object in place rather than dropping a
+        # row. The echoed id still wins when present, because it survives a change to row ordering
+        # that position would not.
         case_id = case_id_of(verdicts)
         if case_id is None:
             case_id = index + 1
@@ -371,6 +377,38 @@ def aggregate(
         "case_results": case_results,
         "failures": failures,
     }
+
+
+def _require_verifiable_mapping(
+    harvested: Sequence[Sequence[Mapping[str, Any]]],
+    rubrics: Mapping[int, Mapping[str, Any]],
+) -> None:
+    """Refuse to score against a case -> rubric mapping that cannot be proven.
+
+    INVARIANT: row POSITION identifies a case only when the rows are the whole declared set.
+    `iteration.on_error=collect` preserves order and substitutes an error object in place, so
+    index N is case N+1 — but `;iteration.slice=10:20` hands us cases 11-20 at positions 1-10,
+    and `on_error=skip` drops rows outright. Either way every case would be scored against the
+    WRONG rubric, with no `failures` entry and a `terminated: succeeded` run carrying a plausible
+    number. That is reachable from the DOCUMENTED path: `Dockerfile.benchmark` removed its
+    build-time case cap specifically to make `;iteration.slice` the way to size a run.
+
+    The row count is the signal. It cannot tell us the slice OFFSET — nothing in the payload can —
+    so the only honest response is to stop rather than to guess, and to name the two ways out.
+
+    A row that produced no verdicts is exempt: it becomes a `failures` entry and never reaches a
+    rubric, so counting it here would turn a partial judge failure into a dead run.
+    """
+    positional = sum(1 for verdicts in harvested if verdicts and case_id_of(verdicts) is None)
+    if not positional or len(harvested) == len(rubrics):
+        return
+    raise AggregateError(
+        f"the case->rubric mapping is unverifiable: {positional} row(s) carry no echoed "
+        f"case_id, and the payload holds {len(harvested)} row(s) against {len(rubrics)} "
+        "declared rubric(s). Row position identifies a case only when the rows are the whole "
+        "declared set, and nothing in the payload records a slice offset. Either have the judge "
+        "echo case_id in each verdict (it is preferred whenever present), or score the full set."
+    )
 
 
 def _as_int(value: Any) -> int | None:

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/aggregate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/aggregate.py
@@ -8,8 +8,13 @@ Invoked as a declared `[commands]` route in the reducer position::
 
     (…iteration…)!/benchmark(aggregate)!'x'
 
-    context ("aggregate")  →  {context}, also stdin
-    intent (row array)     →  {intent}, the JSON array of every row's judge output
+    context ("aggregate")  →  `--operation {context}`, in argv
+    intent (row array)     →  STDIN, the JSON array of every row's judge output
+
+The payload arrives on the PIPE because a single argv token is capped by the kernel at
+`MAX_ARG_STRLEN` (131,072 bytes) — the route declares `stdin = "intent"` and the engine pipes it.
+Passing it as `--args {intent}` failed with `OSError [Errno 7]` at exec, in the single-digit
+case counts, long before a 100-case run.
 
 INVARIANT — the scoring formulas mirror `screamingface-benchmarks/benchmarking/graders/rubric.py`
 (arXiv:2602.11685 §4.2) EXACTLY. Do not "improve" them. A different formula is a different
@@ -415,7 +420,15 @@ def load_rubrics(directory: Path) -> dict[int, dict[str, Any]]:
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="draco-aggregate", description=__doc__)
     parser.add_argument("--operation", default="aggregate", help="the {context} token")
-    parser.add_argument("--args", default="[]", help="the {intent} payload — the JSON row array")
+    # INVARIANT: the row array arrives on STDIN, not in argv. A single argv token is capped by
+    # the kernel at MAX_ARG_STRLEN (131,072 bytes) regardless of ARG_MAX, and exec fails outright
+    # with OSError [Errno 7] rather than truncating — which a 100-case run crosses at roughly the
+    # fourth case. The route declares `stdin = "intent"` and the engine pipes it here.
+    #
+    # `--args` stays as an explicit OVERRIDE so the script remains hand-runnable and testable.
+    # It defaults to None rather than "[]" on purpose: an absent payload must be distinguishable
+    # from an empty one, or an unreadable pipe scores as a clean zero-case success.
+    parser.add_argument("--args", default=None, help="the row array; read from stdin when omitted")
     parser.add_argument("--rubrics", type=Path, default=None)
     parser.add_argument("--benchmark-id", default="draco")
     args = parser.parse_args(argv)
@@ -423,8 +436,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.operation.strip() != "aggregate":
         print(f"unsupported operation {args.operation!r}", file=sys.stderr)
         return 2
+    payload = sys.stdin.read() if args.args is None else args.args
     try:
-        result = aggregate(args.args, load_rubrics(rubrics_dir(args.rubrics)), args.benchmark_id)
+        result = aggregate(payload, load_rubrics(rubrics_dir(args.rubrics)), args.benchmark_id)
     except AggregateError as exc:
         print(str(exc), file=sys.stderr)
         return 1

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/aggregate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/aggregate.py
@@ -1,0 +1,437 @@
+"""The DRACO cross-row reducer — per-criterion verdicts in, `CandidateResult` out.
+
+FEATURE: one url4 expression per Candidate ends in a cross-row reduce that turns every case's
+judge verdicts into one scored result.
+STORY: as a researcher, the number I publish is the DRACO paper's `normalized_score`.
+
+Invoked as a declared `[commands]` route in the reducer position::
+
+    (…iteration…)!/benchmark(aggregate)!'x'
+
+    context ("aggregate")  →  {context}, also stdin
+    intent (row array)     →  {intent}, the JSON array of every row's judge output
+
+INVARIANT — the scoring formulas mirror `screamingface-benchmarks/benchmarking/graders/rubric.py`
+(arXiv:2602.11685 §4.2) EXACTLY. Do not "improve" them. A different formula is a different
+benchmark, and a leaderboard number computed here must mean what the paper says it means.
+
+AIDEV-NOTE — PROTOCOL CAVEAT. The paper's `official` grading mode issues ONE judge call PER
+CRITERION (~40 criteria × 3 runs per case), and the judge never sees the weights or the sibling
+criteria. The url4 expression this reducer serves makes ONE judge call per case, which is the
+paper's `chunked` mode. Chunked scores are fine for iteration and MUST NOT be published as
+"DRACO-reproduced". Reproducing the official protocol needs a per-criterion fan-out that the
+current expression shape does not express.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+from collections.abc import Iterator, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+DEFAULT_RUBRICS_DIR = "/opt/benchmarks/draco/rubrics"
+"""Where a BENCHMARK IMAGE puts them (see Dockerfile.benchmark). Only a fallback.
+
+INVARIANT: the path is OPERATOR-controlled — argv, then `URL4_BENCHMARK_RUBRICS`, then this.
+It is never taken from the expression: a caller-supplied path would let any run point the
+aggregator at any file on the Job's disk.
+"""
+
+RUBRICS_DIR_ENV = "URL4_BENCHMARK_RUBRICS"
+
+_VERDICT_SPAN_RE = re.compile(r"\{[^{}]*criterion_status[^{}]*\}")
+"""A balanced, non-nested ``{...}`` span mentioning ``criterion_status``.
+
+Deliberately non-recursive: a verdict is a FLAT object, so refusing nested braces keeps the
+scan from swallowing the surrounding scaffolding when the judge emits something unexpected.
+"""
+
+
+class AggregateError(ValueError):
+    """The reducer's input is unusable — raised before any scoring."""
+
+
+# --- rubric walking -------------------------------------------------------------
+
+
+def flatten_criteria(rubric: Mapping[str, Any]) -> Iterator[dict[str, Any]]:
+    """Walk ``{"sections": [{"criteria": [...]}]}`` into criteria with their axis attached.
+
+    The axis is the section's ``id``, falling back to its ``title`` — it is what
+    :func:`axis_scores` groups by, and what the paper calls a rubric section (Factual Accuracy,
+    Breadth & Depth, Presentation Quality, Citation Quality).
+    """
+    for section in rubric.get("sections", []):
+        axis = section.get("id") or section.get("title") or "unknown"
+        for criterion in section.get("criteria") or []:
+            row = dict(criterion)
+            row.setdefault("weight", 0)
+            row["axis"] = axis
+            yield row
+
+
+# --- the paper's three metrics --------------------------------------------------
+
+
+def normalized_score(rubric: Mapping[str, Any], verdicts: Mapping[str, bool]) -> float:
+    """Weight-aware score in [0, 1] — ``clamp(Σ MET·w / Σ w⁺)``.
+
+    A MET positive criterion rewards; a MET NEGATIVE criterion penalises (its weight is negative,
+    so it subtracts). The denominator is the positive weights ALONE — the maximum reachable
+    numerator, i.e. every positive MET and every negative UNMET.
+
+    An all-negative rubric is undefined in the paper; 0.0 is returned rather than interpolating a
+    harness-specific fallback that would drift from published numbers.
+    """
+    weighted_sum = 0.0
+    denom_pos = 0.0
+    for criterion in flatten_criteria(rubric):
+        weight = float(criterion.get("weight", 0))
+        met = bool(verdicts.get(criterion["id"], False))
+        if weight > 0:
+            denom_pos += weight
+            if met:
+                weighted_sum += weight
+        elif weight < 0 and met:
+            weighted_sum += weight  # negative: subtracts
+    if denom_pos <= 0:
+        return 0.0
+    return max(0.0, min(1.0, weighted_sum / denom_pos))
+
+
+def pass_rate(rubric: Mapping[str, Any], verdicts: Mapping[str, bool]) -> float:
+    """Unweighted fraction of criteria handled correctly.
+
+    Correct means MET for a positive criterion and UNMET for a negative one — an anti-pattern
+    successfully avoided counts exactly as much as a requirement met.
+    """
+    n_correct = 0
+    n_total = 0
+    for criterion in flatten_criteria(rubric):
+        weight = float(criterion.get("weight", 0))
+        met = bool(verdicts.get(criterion["id"], False))
+        if (weight >= 0 and met) or (weight < 0 and not met):
+            n_correct += 1
+        n_total += 1
+    return (n_correct / n_total) if n_total else 0.0
+
+
+def axis_scores(rubric: Mapping[str, Any], verdicts: Mapping[str, bool]) -> dict[str, float]:
+    """:func:`normalized_score` recomputed per rubric section."""
+    by_axis: dict[str, list[float]] = defaultdict(lambda: [0.0, 0.0])  # [achieved, achievable]
+    for criterion in flatten_criteria(rubric):
+        weight = float(criterion.get("weight", 0))
+        met = bool(verdicts.get(criterion["id"], False))
+        achieved, achievable = by_axis[criterion["axis"]]
+        if weight >= 0:
+            achievable += weight
+            if met:
+                achieved += weight
+        elif met:
+            achieved += weight
+        by_axis[criterion["axis"]] = [achieved, achievable]
+    return {
+        axis: (max(0.0, min(1.0, achieved / achievable)) if achievable > 0 else 0.0)
+        for axis, (achieved, achievable) in by_axis.items()
+    }
+
+
+def _restrict(rubric: Mapping[str, Any], judged_ids: Sequence[str]) -> dict[str, Any]:
+    """The rubric minus criteria that produced no verdict.
+
+    INVARIANT: an unjudged criterion drops out of BOTH numerator and denominator. Scoring it as
+    UNMET instead would keep its weight in the denominator, so a judge parse or transport failure
+    would deflate the score in proportion to the failure rate — a benchmark that reports lower
+    numbers when the harness is flaky, which is worse than reporting fewer cases.
+    """
+    keep = set(judged_ids)
+    return {
+        "sections": [
+            {
+                **section,
+                "criteria": [c for c in (section.get("criteria") or []) if c.get("id") in keep],
+            }
+            for section in rubric.get("sections", [])
+        ]
+    }
+
+
+def score_case(rubric: Mapping[str, Any], runs: Sequence[Mapping[str, bool]]) -> dict[str, Any]:
+    """Score every judge PASS independently, then report the mean and the spread.
+
+    INVARIANT: the paper scores each pass and then means the passes (§4.2). Majority-voting the
+    verdicts first would collapse judge disagreement before it reaches the score, and the spread
+    is the judge-stability signal — a high sd means the passes disagreed, which a single averaged
+    number destroys.
+
+    The spread is the POPULATION standard deviation, matching the harness's ``np.std`` default.
+    """
+    total = sum(1 for _ in flatten_criteria(rubric))
+    scored = [_score_one_run(rubric, verdicts, total) for verdicts in runs]
+    if not scored:
+        return {
+            "normalized_score": 0.0,
+            "normalized_score_sd": 0.0,
+            "pass_rate": 0.0,
+            "axis_scores": {},
+            "coverage": 0.0,
+            "n_runs": 0,
+        }
+    axes: dict[str, list[float]] = defaultdict(list)
+    for run in scored:
+        for axis, value in run["axis_scores"].items():
+            axes[axis].append(value)
+    norms = [run["normalized_score"] for run in scored]
+    return {
+        "normalized_score": round(_avg(norms), 4),
+        "normalized_score_sd": round(_stdev(norms), 4),
+        "pass_rate": round(_avg([run["pass_rate"] for run in scored]), 4),
+        "axis_scores": {axis: round(_avg(v), 4) for axis, v in axes.items()},
+        "coverage": round(_avg([run["coverage"] for run in scored]), 4),
+        "n_runs": len(scored),
+    }
+
+
+def _score_one_run(
+    rubric: Mapping[str, Any], verdicts: Mapping[str, bool], total: int
+) -> dict[str, Any]:
+    restricted = _restrict(rubric, list(verdicts))
+    return {
+        "normalized_score": normalized_score(restricted, verdicts),
+        "pass_rate": pass_rate(restricted, verdicts),
+        "axis_scores": axis_scores(restricted, verdicts),
+        "coverage": (len(verdicts) / total) if total else 0.0,
+    }
+
+
+def _avg(values: Sequence[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _stdev(values: Sequence[float]) -> float:
+    if len(values) < 2:
+        return 0.0
+    mean = _avg(values)
+    return (sum((v - mean) ** 2 for v in values) / len(values)) ** 0.5
+
+
+# --- harvesting verdicts out of the nested payload -------------------------------
+
+
+def harvest_verdicts(row: Any) -> list[dict[str, Any]]:
+    """Every judge verdict in one case's row, in order.
+
+    The row is prose-wrapped once per nesting level (case → criteria → runs), and each level
+    JSON-escapes the one below it, so the verdicts sit at varying escape depths inside one
+    string.
+
+    INVARIANT: the scaffolding is NEVER parsed. Only balanced ``{...}`` spans carrying
+    ``criterion_status`` are read; everything between them is ignored. The prose framing is an
+    engine formatting detail that has already changed once during this design — a regex over it
+    would be a contract that breaks silently, whereas an absent verdict is loudly absent.
+    """
+    out: list[dict[str, Any]] = []
+    for span in _VERDICT_SPAN_RE.finditer(_as_text_row(row)):
+        verdict = _decode_escaped(span.group(0))
+        if isinstance(verdict, dict) and "criterion_status" in verdict:
+            out.append(verdict)
+    return out
+
+
+def _as_text_row(row: Any) -> str:
+    return row if isinstance(row, str) else json.dumps(row)
+
+
+def _decode_escaped(span: str, max_depth: int = 4) -> Any:
+    """Parse a span that may be escaped several levels deep, unescaping one level at a time."""
+    text = span
+    for _ in range(max_depth):
+        try:
+            return json.loads(text)
+        except (TypeError, ValueError):
+            unescaped = text.replace("\\\\", "\\").replace('\\"', '"')
+            if unescaped == text:
+                return None
+            text = unescaped
+    return None
+
+
+def group_runs(verdicts: Sequence[Mapping[str, Any]]) -> list[dict[str, bool]]:
+    """Split flat verdicts into one dict per judge PASS, by order of appearance per criterion.
+
+    INVARIANT: the paper scores each pass independently and then means the passes (§4.2).
+    Majority-voting the verdicts first would collapse judge disagreement before it reaches the
+    score and would make the reported spread meaningless — the spread IS the stability signal.
+
+    A criterion with fewer verdicts than the others simply has no entry in the later runs, so
+    it drops out of those runs' rubrics rather than becoming an UNMET.
+    """
+    seen: dict[str, int] = defaultdict(int)
+    runs: list[dict[str, bool]] = []
+    for verdict in verdicts:
+        criterion_id = verdict.get("criterion_id") or verdict.get("id")
+        if criterion_id is None:
+            continue
+        key = str(criterion_id)
+        index = seen[key]
+        seen[key] += 1
+        while len(runs) <= index:
+            runs.append({})
+        runs[index][key] = str(verdict.get("criterion_status", "")).upper() == "MET"
+    return runs
+
+
+def case_id_of(verdicts: Sequence[Mapping[str, Any]]) -> int | None:
+    """The case id the judge echoed, if any — ``None`` falls back to row position."""
+    for verdict in verdicts:
+        case_id = _as_int(verdict.get("case_id"))
+        if case_id is not None:
+            return case_id
+    return None
+
+
+# --- the reduction ---------------------------------------------------------------
+
+
+def aggregate(
+    rows_json: str, rubrics: Mapping[int, Mapping[str, Any]], benchmark_id: str
+) -> dict[str, Any]:
+    """Reduce the row array into a `CandidateResult` — one row per case.
+
+    INVARIANT: a case that produced no verdicts is EXCLUDED from the mean and named in
+    ``failures`` — never scored 0.0. Scoring it zero would penalise the Candidate for a harness
+    failure, the same class of error as counting an unjudged criterion as UNMET.
+    """
+    try:
+        rows = json.loads(rows_json)
+    except (TypeError, ValueError) as exc:
+        raise AggregateError(f"reducer payload is not JSON: {exc}") from None
+    if not isinstance(rows, list):
+        raise AggregateError(f"reducer payload must be a JSON array, got {type(rows).__name__}")
+
+    case_results: list[dict[str, Any]] = []
+    failures: list[dict[str, Any]] = []
+    for index, raw in enumerate(rows):
+        verdicts = harvest_verdicts(raw)
+        if not verdicts:
+            failures.append({"index": index, "reason": "no judge verdicts in row"})
+            continue
+        # WHY position is a legitimate fallback: the BENCHMARK produced the case list, and row
+        # order is preserved — `iteration.on_error=collect` substitutes an error object in place
+        # rather than dropping a row. The echoed id still wins when present, because it survives
+        # a future change to row ordering that position would not.
+        case_id = case_id_of(verdicts)
+        if case_id is None:
+            case_id = index + 1
+        rubric = rubrics.get(case_id)
+        if rubric is None:
+            failures.append({"index": index, "case_id": case_id, "reason": "unknown case_id"})
+            continue
+        case_results.append({"case_id": case_id, **score_case(rubric, group_runs(verdicts))})
+
+    return {
+        "benchmark_id": benchmark_id,
+        "case_count": len(case_results),
+        "score": _mean(case_results, "normalized_score"),
+        "metrics": {
+            "normalized_score": _mean(case_results, "normalized_score"),
+            "normalized_score_sd": _mean(case_results, "normalized_score_sd"),
+            "pass_rate": _mean(case_results, "pass_rate"),
+            "coverage": _mean(case_results, "coverage"),
+            "n_runs": max((int(c["n_runs"]) for c in case_results), default=0),
+        },
+        "axis_scores": _mean_axes(case_results),
+        "case_results": case_results,
+        "failures": failures,
+    }
+
+
+def _as_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _mean(case_results: Sequence[Mapping[str, Any]], key: str) -> float:
+    if not case_results:
+        return 0.0
+    return round(sum(float(c[key]) for c in case_results) / len(case_results), 4)
+
+
+def _mean_axes(case_results: Sequence[Mapping[str, Any]]) -> dict[str, float]:
+    totals: dict[str, list[float]] = defaultdict(list)
+    for case in case_results:
+        for axis, score in case["axis_scores"].items():
+            totals[axis].append(float(score))
+    return {axis: round(sum(v) / len(v), 4) for axis, v in totals.items()}
+
+
+# --- CLI --------------------------------------------------------------------------
+
+
+def rubrics_dir(explicit: Path | None) -> Path:
+    """Resolve where the rubrics live: argv, then the environment, then the image default.
+
+    The `[data]` routes get their absolute paths from `prepare --out`, so the rubrics path has to
+    come from the same deployment. Baking it into `url4.toml` made the two disagree the moment
+    the runner ran anywhere but the image.
+    """
+    if explicit is not None:
+        return explicit
+    return Path(os.environ.get(RUBRICS_DIR_ENV) or DEFAULT_RUBRICS_DIR)
+
+
+def load_rubrics(directory: Path) -> dict[int, dict[str, Any]]:
+    """Load ``<directory>/<case_id>.json`` for every rubric on disk.
+
+    The rubrics are PRIVATE: they live only in the image and are read here, never returned to a
+    client. Only the case id crosses the wire.
+
+    INVARIANT: an absent or empty directory RAISES. Returning ``{}`` makes every case an
+    "unknown case_id" failure, which reaches the client as a terminated-succeeded run carrying a
+    plausible zero score — observed live, from a path that pointed into the image while the
+    runner ran outside it. A misconfigured path must be loud.
+    """
+    rubrics: dict[int, dict[str, Any]] = {}
+    for path in sorted(directory.glob("*.json")) if directory.is_dir() else []:
+        case_id = _as_int(path.stem)
+        if case_id is not None:
+            rubrics[case_id] = json.loads(path.read_text(encoding="utf-8"))
+    if not rubrics:
+        raise AggregateError(
+            f"no rubrics under {str(directory)!r} — set {RUBRICS_DIR_ENV} (or pass --rubrics) to "
+            "the directory this benchmark's `prepare` wrote"
+        )
+    return rubrics
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="draco-aggregate", description=__doc__)
+    parser.add_argument("--operation", default="aggregate", help="the {context} token")
+    parser.add_argument("--args", default="[]", help="the {intent} payload — the JSON row array")
+    parser.add_argument("--rubrics", type=Path, default=None)
+    parser.add_argument("--benchmark-id", default="draco")
+    args = parser.parse_args(argv)
+
+    if args.operation.strip() != "aggregate":
+        print(f"unsupported operation {args.operation!r}", file=sys.stderr)
+        return 2
+    try:
+        result = aggregate(args.args, load_rubrics(rubrics_dir(args.rubrics)), args.benchmark_id)
+    except AggregateError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    # stdout IS the route's result — nothing else may be printed here.
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - process entrypoint
+    raise SystemExit(main())

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/aggregate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/aggregate.py
@@ -32,12 +32,13 @@ AIDEV-NOTE — PROTOCOL CAVEATS, the two ways a run here still differs from the 
   from the OpenRouter plugin's rule set, and the gateway fails closed on an unknown parameter, so
   sending it would turn every judge call into a 400 rather than a deviation. `judge_temperature`
   and `max_tokens` DO reach the model.
-* Retrieval is enabled on the three routes a SOLO or `fable_plus_gpt` candidate answers with
-  (`native_web_search`, verified live), but NOT on the four models added for `budget_trio`,
-  `pareto_cross`, `pareto_lean`, `beat_runner_up` and `best_open_source` — those are declared
-  and unverified, so they answer from weights alone. DRACO is a deep-research benchmark and the
-  paper treats retrieval as mandatory, so a score for those five configurations is not
-  comparable to the reference chart.
+* Retrieval reaches EVERY answering route as of 2026-08-02, but by TWO different mechanisms
+  (owner decision, same date): provider-side `native_web_search` on the OpenRouter routes that
+  support it, and the runner-driven Tavily loop on `kimi-k2.6`, `deepseek-v4-pro` and
+  `qwen3.6-plus`, which answer `404` to native search. Both honour the same declared blocklist —
+  verified live on both paths — but they are not the same search product, so a candidate that
+  answered through Tavily and one that answered natively did not read the same web. A comparison
+  ACROSS those two groups carries that caveat; the reference chart used neither exactly.
 
 Neither is visible in the numbers this module emits. A score published as "DRACO-reproduced"
 has to state both.

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/prepare.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/prepare.py
@@ -49,7 +49,16 @@ EXCLUDED_DOMAINS = (
     "huggingface.co/datasets/perplexity-ai/draco",
     "openrouter.ai/blog/announcements/fusion-beats-frontier",
     "paperswithcode.com/dataset/draco",
+    # Upstream's entry, kept verbatim so our list stays comparable with the reference harness.
+    # It is a MONTH PREFIX (arXiv ids are YYMM.NNNNN), so it blocks all of September 2025.
     "arxiv.org/abs/2509",
+    # The DRACO paper ITSELF — "DRACO: a Cross-Domain Benchmark for Deep Research Accuracy,
+    # Completeness, and Objectivity", submitted 2026-02-12 (verified against arXiv 2026-07-31).
+    # WHY this is a separate entry: the upstream prefix above covers 2025-09 and the paper is
+    # 2026-02, so upstream blocks a month that holds nothing and leaves the paper reachable. A
+    # candidate reading the benchmark's own paper is the leak this list exists to stop, and it
+    # INFLATES the score, so it never looks like a bug.
+    "arxiv.org/abs/2602.11685",
 )
 """The blocklist a DRACO candidate answers under, copied from
 `screamingface-benchmarks/benchmarks_config/draco.yaml`.
@@ -65,11 +74,16 @@ claimed path prefixes could not match; that reading came from a probe run while 
 still emitting the WRONG WIRE KEY (`excluded_domains` for `exclude_domains`), so it measured the
 typo rather than the value shape. Retracted.
 
-AIDEV-NOTE — one CONTENT question is still open. `arxiv.org/abs/2509` is annotated "DRACO paper
-preprint range" upstream, but the paper is cited as arXiv:**2602.11685** throughout this repo, so
-that entry may guard the wrong range. The benchmarks repo itself calls the whole list "our best
-guess" — OpenRouter never published theirs. Because the policy is DATA, correcting it is an
-artifact edit rather than a code release.
+RESOLVED 2026-07-31 — upstream's `arxiv.org/abs/2509` is annotated "DRACO paper preprint range"
+but arXiv ids are `YYMM.NNNNN`, so it covers September 2025 while the paper is **2602.11685**,
+submitted 2026-02-12 (verified against arXiv). Upstream therefore blocks a month that holds
+nothing and leaves the paper itself reachable. Both entries are kept: theirs so the list stays
+comparable with the reference harness, ours so the guard actually holds.
+
+AIDEV-NOTE: the benchmarks repo calls the whole list "our best guess" — OpenRouter never
+published theirs — so treat it as a floor, not a ceiling. Extend it from the audit logs in eval
+JSONLs (`tool_calls` in metadata) as real leak sources turn up. Because the policy is DATA,
+each addition is an artifact edit rather than a code release.
 """
 
 

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/prepare.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/prepare.py
@@ -1,0 +1,186 @@
+"""Build DRACO's declared world — download the dataset, emit artifacts and the `[data]` table.
+
+Run at IMAGE BUILD time, never at run time: a Job's rootfs is read-only apart from `/tmp`, it
+holds no HuggingFace credential, and `[data]` routes are exact-match with no wildcard form, so
+every artifact must already be declared before the Job starts.
+
+    uv run python -m url4_cloud.benchmarks.draco.prepare --out /opt/benchmarks/draco --limit 5
+
+Emits::
+
+    <out>/cases.json           [{"id": …, "input": …}]  — the ONLY thing a client ever sees
+    <out>/criteria/<id>.json   [{id, requirement}]      — WEIGHT-FREE, what the judge reads
+    <out>/rubrics/<id>.json    the weighted rubric      — private, read by `aggregate.py`
+    <out>/url4.data.toml       the [data] table         — merged into the image's url4.toml
+
+INVARIANT — the judge NEVER sees weights. `grading_mode: "official"` (arXiv:2602.11685 §4.2)
+judges one criterion at a time, blind to its weight and to its siblings; a judge that can see a
+weight can infer how much a criterion is worth and bias toward the expensive ones. The weights
+therefore live ONLY in `rubrics/`, which `aggregate.py` reads after the judging is done.
+
+INVARIANT — `cases.json` carries NO rubric. The whole privacy boundary of the design is that the
+client receives case ids and inputs while the rubric stays in the image, so a Candidate cannot be
+tuned against the answer key. Adding the rubric column here would silently defeat it.
+
+Dataset: `perplexity-ai/draco` (arXiv:2602.11685). Column mapping mirrors
+`screamingface-benchmarks/benchmarks_config/draco.yaml`:
+
+    problem → the research prompt   ·   answer → the weighted rubric JSON   ·   domain → metadata
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+DATASET = "perplexity-ai/draco"
+COLUMN_QUESTION = "problem"
+COLUMN_RUBRIC = "answer"
+COLUMN_DOMAIN = "domain"
+
+
+class PrepareError(RuntimeError):
+    """The dataset could not be turned into a declared world."""
+
+
+def load_rows(dataset: str = DATASET, limit: int | None = None) -> list[dict[str, Any]]:
+    """Download the dataset and return its rows.
+
+    `datasets` is NOT a dependency of url4-cloud. This module runs at image BUILD time on a
+    machine that has it; the Job that later serves the artifacts needs only the emitted files.
+
+    # WHY `importlib` rather than a plain import: the same pattern `url4.peer.server` uses for
+    # its optional uvicorn extra. A static import would make an optional build-time package look
+    # like a hard dependency to every reader and to the type checker, for a module that a
+    # deployed Job never imports at all.
+    """
+    try:
+        datasets_mod = importlib.import_module("datasets")
+    except ModuleNotFoundError as exc:
+        raise PrepareError(
+            "the `datasets` package is required to prepare a benchmark — "
+            "`uv pip install datasets` in the build environment"
+        ) from exc
+
+    loaded = datasets_mod.load_dataset(dataset)
+    rows: list[dict[str, Any]] = []
+    for split in loaded:  # null split in draco.yaml means "all splits"
+        for row in loaded[split]:
+            rows.append(dict(row))
+            if limit is not None and len(rows) >= limit:
+                return rows
+    return rows
+
+
+def parse_rubric(raw: Any, case_id: int) -> dict[str, Any]:
+    """Decode the `answer` column into the rubric object the grader walks.
+
+    The column is a JSON STRING holding ``{"sections": [{"criteria": [...]}]}``. A rubric that
+    flattens to zero criteria is rejected loudly: it would score every answer 0.0 while looking
+    like a successful run.
+    """
+    rubric = json.loads(raw) if isinstance(raw, str) else raw
+    if not isinstance(rubric, dict) or "sections" not in rubric:
+        got = list(rubric)[:5] if isinstance(rubric, dict) else type(rubric).__name__
+        raise PrepareError(
+            f"case {case_id}: rubric has no 'sections' key — got {got}. A flat criteria list "
+            "is a different grader (healthbench_rubric), not this one."
+        )
+    n_criteria = sum(len(s.get("criteria") or []) for s in rubric["sections"])
+    if n_criteria == 0:
+        raise PrepareError(f"case {case_id}: rubric flattened to 0 criteria")
+    return rubric
+
+
+def judge_criteria(rubric: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """The criteria as the JUDGE sees them — id and requirement, never the weight.
+
+    See the module INVARIANT: `official` grading shows one criterion at a time with no weight,
+    so anything extra here is a protocol violation that no test downstream would catch.
+    """
+    return [
+        {"id": criterion.get("id"), "requirement": criterion.get("requirement", "")}
+        for section in rubric.get("sections", [])
+        for criterion in section.get("criteria") or []
+    ]
+
+
+def build(rows: Sequence[dict[str, Any]], out: Path, route_prefix: str) -> dict[str, Any]:
+    """Write `cases.json`, the rubric files, and the generated `[data]` table."""
+    rubric_dir = out / "rubrics"
+    criteria_dir = out / "criteria"
+    rubric_dir.mkdir(parents=True, exist_ok=True)
+    criteria_dir.mkdir(parents=True, exist_ok=True)
+
+    cases: list[dict[str, Any]] = []
+    for index, row in enumerate(rows):
+        case_id = index + 1  # 1-based and stable for a given dataset order
+        question = row.get(COLUMN_QUESTION)
+        if not question:
+            raise PrepareError(f"case {case_id}: empty {COLUMN_QUESTION!r} column")
+        rubric = parse_rubric(row.get(COLUMN_RUBRIC), case_id)
+        (rubric_dir / f"{case_id}.json").write_text(json.dumps(rubric, indent=1), encoding="utf-8")
+        (criteria_dir / f"{case_id}.json").write_text(
+            json.dumps(judge_criteria(rubric)), encoding="utf-8"
+        )
+        cases.append(
+            {"id": case_id, "input": question, "domain": row.get(COLUMN_DOMAIN) or "unknown"}
+        )
+
+    (out / "cases.json").write_text(json.dumps(cases), encoding="utf-8")
+    (out / "url4.data.toml").write_text(render_data_table(cases, out, route_prefix), "utf-8")
+    return {"cases": len(cases), "out": str(out)}
+
+
+def render_data_table(cases: Sequence[dict[str, Any]], out: Path, route_prefix: str) -> str:
+    """Render the `[data]` table — one entry per artifact, because routing is exact-match.
+
+    Rubrics are declared as `file` providers rather than inline values so an operator can edit
+    one in a running node without a rebuild, and so the table stays readable at 100+ cases.
+    """
+    lines = [
+        "# GENERATED by url4_cloud.benchmarks.draco.prepare — do not edit by hand.",
+        f"# {len(cases)} case(s) from {DATASET}. Regenerate after any dataset change.",
+        "#",
+        "# Routing is exact-match: there is no wildcard form, so every artifact is declared.",
+        "",
+        "[data]",
+        f'"{route_prefix}/cases" = '
+        f'{{ file = "{out}/cases.json", media_type = "application/json" }}',
+    ]
+    # Only the JUDGE-facing criteria are declared as routes. `rubrics/` is deliberately NOT
+    # addressable: it carries the weights, and an expression that could fetch one could feed it
+    # to the judge. `aggregate.py` reads it off disk instead.
+    lines.extend(
+        f'"{route_prefix}/criteria/{case["id"]}" = '
+        f'{{ file = "{out}/criteria/{case["id"]}.json", media_type = "application/json" }}'
+        for case in cases
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="draco-prepare", description=__doc__)
+    parser.add_argument("--out", type=Path, default=Path("/opt/benchmarks/draco"))
+    parser.add_argument("--dataset", default=DATASET)
+    parser.add_argument("--limit", type=int, default=None, help="cap the case count (probes)")
+    parser.add_argument("--route-prefix", default="/draco", help="url4 path prefix for artifacts")
+    args = parser.parse_args(argv)
+
+    try:
+        summary = build(load_rows(args.dataset, args.limit), args.out, args.route_prefix)
+    except PrepareError as exc:
+        print(f"prepare failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(summary))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - process entrypoint
+    raise SystemExit(main())

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/prepare.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/prepare.py
@@ -38,6 +38,13 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
+# INVARIANT: ONE walker of the `{"sections": [{"criteria": […]}]}` shape, shared with the scorer.
+# This module decides which criteria the JUDGE is shown and `aggregate` decides which criteria the
+# denominator counts, so the two must enumerate the same set or `coverage` is wrong BY
+# CONSTRUCTION — and a run built on two different walks still reports success with a plausible
+# score. Intra-package import: both are leaves of `benchmarks/`, which imports neither app half.
+from url4_cloud.benchmarks.draco.aggregate import flatten_criteria
+
 DATASET = "perplexity-ai/draco"
 COLUMN_QUESTION = "problem"
 COLUMN_RUBRIC = "answer"
@@ -149,8 +156,7 @@ def parse_rubric(raw: Any, case_id: int) -> dict[str, Any]:
             f"case {case_id}: rubric has no 'sections' key — got {got}. A flat criteria list "
             "is a different grader (healthbench_rubric), not this one."
         )
-    n_criteria = sum(len(s.get("criteria") or []) for s in rubric["sections"])
-    if n_criteria == 0:
+    if sum(1 for _ in flatten_criteria(rubric)) == 0:
         raise PrepareError(f"case {case_id}: rubric flattened to 0 criteria")
     return rubric
 
@@ -160,11 +166,14 @@ def judge_criteria(rubric: Mapping[str, Any]) -> list[dict[str, Any]]:
 
     See the module INVARIANT: `official` grading shows one criterion at a time with no weight,
     so anything extra here is a protocol violation that no test downstream would catch.
+
+    INVARIANT: this PROJECTS `flatten_criteria` rather than copying its rows — that walker attaches
+    the criterion's weight and axis, and forwarding a row unchanged would put the weight in front
+    of the judge. Two keys, named explicitly, is what keeps that impossible.
     """
     return [
         {"id": criterion.get("id"), "requirement": criterion.get("requirement", "")}
-        for section in rubric.get("sections", [])
-        for criterion in section.get("criteria") or []
+        for criterion in flatten_criteria(rubric)
     ]
 
 

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/prepare.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/prepare.py
@@ -43,6 +43,35 @@ COLUMN_QUESTION = "problem"
 COLUMN_RUBRIC = "answer"
 COLUMN_DOMAIN = "domain"
 
+RETRIEVAL_POLICY_ID = "draco/official"
+
+EXCLUDED_DOMAINS = (
+    "huggingface.co/datasets/perplexity-ai/draco",
+    "openrouter.ai/blog/announcements/fusion-beats-frontier",
+    "paperswithcode.com/dataset/draco",
+    "arxiv.org/abs/2509",
+)
+"""The blocklist a DRACO candidate answers under, copied from
+`screamingface-benchmarks/benchmarks_config/draco.yaml`.
+
+DRACO is a deep-research benchmark, so a candidate that retrieves the dataset card, the
+reproduction post, or the paper is reading the answer key. That INFLATES the score, which is why
+it does not look like a bug.
+
+The SHAPE of these entries is correct: OpenRouter documents wildcards (`*.substack.com`) and
+path filtering (`openai.com/blog`) as supported values, and a live probe on 2026-07-31 drove
+blocked-host citations to zero on both the `native` and `exa` engines. An earlier note here
+claimed path prefixes could not match; that reading came from a probe run while the gateway was
+still emitting the WRONG WIRE KEY (`excluded_domains` for `exclude_domains`), so it measured the
+typo rather than the value shape. Retracted.
+
+AIDEV-NOTE — one CONTENT question is still open. `arxiv.org/abs/2509` is annotated "DRACO paper
+preprint range" upstream, but the paper is cited as arXiv:**2602.11685** throughout this repo, so
+that entry may guard the wrong range. The benchmarks repo itself calls the whole list "our best
+guess" — OpenRouter never published theirs. Because the policy is DATA, correcting it is an
+artifact edit rather than a code release.
+"""
+
 
 class PrepareError(RuntimeError):
     """The dataset could not be turned into a declared world."""
@@ -132,9 +161,44 @@ def build(rows: Sequence[dict[str, Any]], out: Path, route_prefix: str) -> dict[
             {"id": case_id, "input": question, "domain": row.get(COLUMN_DOMAIN) or "unknown"}
         )
 
+    write_policy(out)
     (out / "cases.json").write_text(json.dumps(cases), encoding="utf-8")
     (out / "url4.data.toml").write_text(render_data_table(cases, out, route_prefix), "utf-8")
     return {"cases": len(cases), "out": str(out)}
+
+
+def write_policy(out: Path) -> Path:
+    """Emit the retrieval policy an expression names with `;web_search_policy=`.
+
+    An OBJECT rather than a bare array so the policy can version itself — `id` is what a
+    published score cites — and can later carry other retrieval settings without a second route.
+
+    INVARIANT: an EMPTY blocklist is rejected HERE, at build time. The runner deliberately
+    accepts an empty policy, because a benchmark may declare unrestricted retrieval as an
+    explicit, attributable statement — but for DRACO an empty list means the generator broke, and
+    a generation bug belongs to the build rather than to a run that would score high and look
+    clean.
+    """
+    if not EXCLUDED_DOMAINS:
+        raise PrepareError("the retrieval policy is empty — a DRACO run needs its blocklist")
+    policy_dir = out / "policy"
+    policy_dir.mkdir(parents=True, exist_ok=True)
+    path = policy_dir / "retrieval.json"
+    path.write_text(
+        json.dumps(
+            {
+                "id": RETRIEVAL_POLICY_ID,
+                "excluded_domains": list(EXCLUDED_DOMAINS),
+                "note": (
+                    "Best-effort proxy for the OpenRouter post's blocklist, which was never "
+                    "published. Entries are UNVERIFIED — see prepare.EXCLUDED_DOMAINS."
+                ),
+            },
+            indent=1,
+        ),
+        encoding="utf-8",
+    )
+    return path
 
 
 def render_data_table(cases: Sequence[dict[str, Any]], out: Path, route_prefix: str) -> str:
@@ -152,6 +216,11 @@ def render_data_table(cases: Sequence[dict[str, Any]], out: Path, route_prefix: 
         "[data]",
         f'"{route_prefix}/cases" = '
         f'{{ file = "{out}/cases.json", media_type = "application/json" }}',
+        # The retrieval policy an expression names with `;web_search_policy=`. Declared like any
+        # other artifact: that is what puts the blocklist inside the recipe the scoreboard hashes,
+        # instead of in operator config where an unguarded run would hash like an honest one.
+        f'"{route_prefix}/policy/retrieval" = '
+        f'{{ file = "{out}/policy/retrieval.json", media_type = "application/json" }}',
     ]
     # Only the JUDGE-facing criteria are declared as routes. `rubrics/` is deliberately NOT
     # addressable: it carries the weights, and an expression that could fetch one could feed it

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/prepare.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/prepare.py
@@ -46,44 +46,59 @@ COLUMN_DOMAIN = "domain"
 RETRIEVAL_POLICY_ID = "draco/official"
 
 EXCLUDED_DOMAINS = (
-    "huggingface.co/datasets/perplexity-ai/draco",
-    "openrouter.ai/blog/announcements/fusion-beats-frontier",
-    "paperswithcode.com/dataset/draco",
-    # Upstream's entry, kept verbatim so our list stays comparable with the reference harness.
-    # It is a MONTH PREFIX (arXiv ids are YYMM.NNNNN), so it blocks all of September 2025.
-    "arxiv.org/abs/2509",
-    # The DRACO paper ITSELF — "DRACO: a Cross-Domain Benchmark for Deep Research Accuracy,
-    # Completeness, and Objectivity", submitted 2026-02-12 (verified against arXiv 2026-07-31).
-    # WHY this is a separate entry: the upstream prefix above covers 2025-09 and the paper is
-    # 2026-02, so upstream blocks a month that holds nothing and leaves the paper reachable. A
-    # candidate reading the benchmark's own paper is the leak this list exists to stop, and it
-    # INFLATES the score, so it never looks like a bug.
-    "arxiv.org/abs/2602.11685",
+    # INVARIANT: BARE HOSTS ONLY — no paths, no wildcards, no schemes.
+    #
+    # MEASURED 2026-08-02 (straight to OpenRouter and through the deployed gateway on kind): the
+    # provider accepts a host and REJECTS anything longer, with a 400 that kills the whole request:
+    #
+    #     ["arxiv.org"]                -> 200
+    #     ["arxiv.org/abs/2602.11685"] -> 400  "Invalid domain 'arxiv.org/abs/2602.11685'"
+    #     ["*.substack.com"]           -> 400
+    #
+    # This list was page-shaped until that measurement, which means every native answering call in
+    # a DRACO run was a hard 400 — a run that finished in five seconds, reported
+    # `terminated: succeeded`, and scored nothing. No earlier test caught it: they all used a bare
+    # host in a probe policy, and only the real expression carries the real list.
+    #
+    # OpenRouter's own docs describe wildcards and path filtering as supported values. They are not
+    # supported by the provider behind native search, and an earlier note here retracted the
+    # "paths do not match" concern on the strength of those docs. Reasoning from documentation is
+    # what cost this feature a working guard twice; measure the effect.
+    #
+    # TRADEOFF, owner decision 2026-08-02: whole SITES are blocked. `arxiv.org` and
+    # `huggingface.co` are legitimate deep-research sources, so this makes a candidate look worse
+    # at research than it is — a real distortion that belongs beside any published score. It was
+    # chosen over under-blocking, which INFLATES scores, and an inflated score is the one nobody
+    # audits.
+    "arxiv.org",
+    "huggingface.co",
+    "openrouter.ai",
+    "paperswithcode.com",
+    # Mirrors that republish the paper under their own hosts, so blocking arxiv.org alone leaves
+    # it reachable. Each was observed in a live result set while probing the entries above.
+    "alphaxiv.org",
+    "semanticscholar.org",
+    # The authors' own write-up of the DRACO evaluation — observed citing DRACO material directly
+    # in live searches. A subdomain, so `perplexity.ai` at large stays reachable.
+    "research.perplexity.ai",
 )
-"""The blocklist a DRACO candidate answers under, copied from
-`screamingface-benchmarks/benchmarks_config/draco.yaml`.
+"""The blocklist a DRACO candidate answers under, derived from
+`screamingface-benchmarks/benchmarks_config/draco.yaml` and reduced to HOSTS.
 
 DRACO is a deep-research benchmark, so a candidate that retrieves the dataset card, the
 reproduction post, or the paper is reading the answer key. That INFLATES the score, which is why
 it does not look like a bug.
 
-The SHAPE of these entries is correct: OpenRouter documents wildcards (`*.substack.com`) and
-path filtering (`openai.com/blog`) as supported values, and a live probe on 2026-07-31 drove
-blocked-host citations to zero on both the `native` and `exa` engines. An earlier note here
-claimed path prefixes could not match; that reading came from a probe run while the gateway was
-still emitting the WRONG WIRE KEY (`excluded_domains` for `exclude_domains`), so it measured the
-typo rather than the value shape. Retracted.
+Upstream's list is page-shaped (`huggingface.co/datasets/perplexity-ai/draco`,
+`arxiv.org/abs/2509`). Those values cannot ship: the provider rejects anything longer than a host
+with a 400 that fails the entire call, so a page-shaped list does not weaken the guard — it stops
+the benchmark. Ours is therefore NOT byte-comparable with the reference harness, and that is a
+deliberate divergence rather than a drift.
 
-RESOLVED 2026-07-31 — upstream's `arxiv.org/abs/2509` is annotated "DRACO paper preprint range"
-but arXiv ids are `YYMM.NNNNN`, so it covers September 2025 while the paper is **2602.11685**,
-submitted 2026-02-12 (verified against arXiv). Upstream therefore blocks a month that holds
-nothing and leaves the paper itself reachable. Both entries are kept: theirs so the list stays
-comparable with the reference harness, ours so the guard actually holds.
-
-AIDEV-NOTE: the benchmarks repo calls the whole list "our best guess" — OpenRouter never
-published theirs — so treat it as a floor, not a ceiling. Extend it from the audit logs in eval
-JSONLs (`tool_calls` in metadata) as real leak sources turn up. Because the policy is DATA,
-each addition is an artifact edit rather than a code release.
+AIDEV-NOTE: still a floor, not a ceiling — the benchmarks repo calls their list "our best guess"
+and OpenRouter never published theirs. Extend it from the audit logs in eval JSONLs (`tool_calls`
+in metadata) as real leak sources turn up. Because the policy is DATA, each addition is an
+artifact edit rather than a code release. Add HOSTS; anything longer is a 400.
 """
 
 
@@ -195,6 +210,16 @@ def write_policy(out: Path) -> Path:
     """
     if not EXCLUDED_DOMAINS:
         raise PrepareError("the retrieval policy is empty — a DRACO run needs its blocklist")
+    # INVARIANT: bare hosts only, enforced at BUILD time. A path or wildcard is a 400 from the
+    # provider on every answering call, which surfaces as a run that terminates SUCCEEDED with a
+    # zero score — so the build is the last place it can still be loud. MEASURED 2026-08-02:
+    # "Invalid domain 'arxiv.org/abs/2602.11685'".
+    malformed = sorted(d for d in EXCLUDED_DOMAINS if any(c in d for c in "/*:"))
+    if malformed:
+        raise PrepareError(
+            f"retrieval policy entries must be bare hosts, got {malformed} — a path or wildcard "
+            "is rejected by the provider with a 400 that fails every answering call"
+        )
     policy_dir = out / "policy"
     policy_dir.mkdir(parents=True, exist_ok=True)
     path = policy_dir / "retrieval.json"

--- a/apps/url4-cloud/src/url4_cloud/config.py
+++ b/apps/url4-cloud/src/url4_cloud/config.py
@@ -48,6 +48,15 @@ class Settings(BaseSettings):
     iat_window_s: int = 60
     # WHY: sync-hold cap; a run outliving it degrades to 202 async (spec §5).
     sync_max_wait_s: float = 30.0
+    # WHY: how long `DELETE /` waits for the stopped run's terminal frame before reclaiming the
+    # stream. Stopping and reclaiming are two different processes — the Runner publishes
+    # `Terminated(stopped)` while its Pod shuts down — so reclaiming immediately races that frame
+    # and wins, dropping the only evidence the cancel took effect.
+    # WHY seconds and not the sync cap: this bounds a SHUTDOWN, not an answer. It needs to cover
+    # unwinding in-flight calls plus one publish, and it holds a client's DELETE open while it
+    # runs. It must also stay under the Job's termination grace period (k8s default 30s), past
+    # which SIGKILL means no frame is coming and waiting only adds latency.
+    stop_drain_s: float = 5.0
     # WHY: idle interval between WS HeartbeatEvents for liveness (spec §6).
     ws_heartbeat_s: float = 15.0
     # INVARIANT: k8s Job activeDeadlineSeconds ceiling = 16h (spec §3).

--- a/apps/url4-cloud/src/url4_cloud/manifests.py
+++ b/apps/url4-cloud/src/url4_cloud/manifests.py
@@ -14,9 +14,29 @@ INVARIANT: every entry's registry key equals the `id:` line inside its own text.
 keyed by id, and the route serves the value for that key, so a mismatch would hand a caller a
 manifest naming a benchmark they did not ask for.
 
-AIDEV-NOTE: `routes` here must match what the benchmark image's `url4.toml` actually declares
-(`prepare.render_data_table`). Nothing enforces that yet — a pinning test in the spirit of
-`test_declared_models_match_aigateway.py` is the right home for it once a second benchmark lands.
+A manifest describes the BENCHMARK PROTOCOL — what a faithful run requires — not what any one
+deployment currently delivers. Two fields say more than the stack guarantees today, and neither
+gap is visible in a result:
+
+* `tools` names the retrieval a DRACO candidate is meant to have. Retrieval IS enabled on the
+  three routes a solo or `fable_plus_gpt` candidate answers with (`native_web_search` in the
+  image's `url4.toml`, verified live), but the four models the remaining fusions use are
+  declared with it OFF pending a live check — so those answer from weights alone. The paper
+  treats retrieval as mandatory.
+* `judge_reasoning: "low"` is pinned by arXiv:2602.11685 §4.2 and is deliberately ABSENT here
+  rather than advertised-and-unhonored: `reasoning_effort` has no OpenRouter rule, and the
+  gateway fails closed on an unknown parameter.
+
+AIDEV-NOTE: two things here are unenforced and will drift.
+
+1. `routes` must match what the benchmark image's `url4.toml` actually declares
+   (`prepare.render_data_table`).
+2. `cases` is the UPSTREAM dataset's size. The image is built with `prepare --limit`
+   (`Dockerfile.benchmark` `ARG LIMIT`), so a limited image serves fewer cases than this claims —
+   a probe image built with `LIMIT=3` still advertises 100.
+
+A pinning test in the spirit of `test_declared_models_match_aigateway.py` is the right home for
+both once a second benchmark lands. Until then the numbers here are a claim, not a guarantee.
 """
 
 from __future__ import annotations
@@ -28,6 +48,7 @@ id: draco-lite
 title: DRACO Lite
 description: Research-quality rubric evaluation.
 dataset: perplexity-ai/draco
+dataset_split: test
 cases: 100
 grading: rubric
 grading_mode: official

--- a/apps/url4-cloud/src/url4_cloud/manifests.py
+++ b/apps/url4-cloud/src/url4_cloud/manifests.py
@@ -1,0 +1,74 @@
+"""Benchmark manifests — the catalog `GET /v1/benchmarks` serves.
+
+A manifest tells a client how to RUN a benchmark: which data routes carry the cases and the
+criteria, which judge grades them, and under which protocol. It deliberately says nothing about
+where those artifacts live on disk — that is the Runner image's business, and the rubrics behind
+`criteria` must stay unreachable from any expression.
+
+WHY constants rather than files: the set is fixed at build time and changes only with a release,
+so a file would add I/O, a path to traverse, and a runtime failure mode for no gain. As constants
+they are covered by the type checker and by `tests/unit/test_benchmark_manifests.py`, and a
+malformed manifest is a build-time error rather than a 500 in front of a caller.
+
+INVARIANT: every entry's registry key equals the `id:` line inside its own text. `MANIFESTS` is
+keyed by id, and the route serves the value for that key, so a mismatch would hand a caller a
+manifest naming a benchmark they did not ask for.
+
+AIDEV-NOTE: `routes` here must match what the benchmark image's `url4.toml` actually declares
+(`prepare.render_data_table`). Nothing enforces that yet — a pinning test in the spirit of
+`test_declared_models_match_aigateway.py` is the right home for it once a second benchmark lands.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+DRACO_LITE = """\
+id: draco-lite
+title: DRACO Lite
+description: Research-quality rubric evaluation.
+dataset: perplexity-ai/draco
+cases: 100
+grading: rubric
+grading_mode: official
+judge: openrouter/google/gemini-3.1-pro-preview
+judge_runs: 3
+judge_temperature: 0.2
+routes:
+  cases: /draco/cases
+  criteria: /draco/criteria/{case_id}
+tools:
+  - web_search
+  - web_fetch
+"""
+
+MANIFESTS: dict[str, str] = {"draco-lite": DRACO_LITE}
+"""Every published manifest, keyed by its own `id`."""
+
+
+def field(text: str, name: str) -> str | None:
+    """The value of a TOP-LEVEL ``name: value`` line, or ``None``.
+
+    Deliberately not a YAML parser: the catalog needs three scalars for its summary, and pulling
+    in a parser would let a manifest's shape drift into something only a parser can explain. Lines
+    that are indented belong to a nested block (`routes:`, `tools:`) and are skipped, so
+    ``field(text, "cases")`` cannot accidentally return the `routes.cases` route.
+    """
+    for line in text.splitlines():
+        if not line[:1].strip():  # indented → nested, not a top-level key
+            continue
+        key, sep, value = line.partition(":")
+        if sep and key.strip() == name:
+            return value.strip() or None
+    return None
+
+
+def etag_of(text: str) -> str:
+    """A STRONG validator over the exact bytes served.
+
+    Strong (no ``W/``) because the response body is this string verbatim — byte-for-byte equality
+    is exactly what the validator asserts. Content-derived rather than a version counter, so two
+    manifests can never collide and a manifest edit invalidates caches without anyone remembering
+    to bump anything.
+    """
+    return '"' + hashlib.sha256(text.encode("utf-8")).hexdigest()[:32] + '"'

--- a/apps/url4-cloud/src/url4_cloud/manifests.py
+++ b/apps/url4-cloud/src/url4_cloud/manifests.py
@@ -97,11 +97,22 @@ def field(text: str, name: str) -> str | None:
 
 
 def etag_of(text: str) -> str:
-    """A STRONG validator over the exact bytes served.
+    """A STRONG validator over the exact bytes served, UNQUOTED.
 
     Strong (no ``W/``) because the response body is this string verbatim — byte-for-byte equality
     is exactly what the validator asserts. Content-derived rather than a version counter, so two
     manifests can never collide and a manifest edit invalidates caches without anyone remembering
     to bump anything.
+
+    Bare, like `catalog.port.compute_etag`: the quotes are wire syntax added at the header, so a
+    comparison never has to strip them. See `rest.conditional`.
     """
-    return '"' + hashlib.sha256(text.encode("utf-8")).hexdigest()[:32] + '"'
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:32]
+
+
+ETAGS: dict[str, str] = {key: etag_of(text) for key, text in MANIFESTS.items()}
+"""Every manifest's validator, computed ONCE at import.
+
+`MANIFESTS` is a build-time constant, so hashing a manifest per request is provably repeated work
+— including on the 304 path, where recomputing the validator is the whole cost of the response.
+"""

--- a/apps/url4-cloud/src/url4_cloud/manifests.py
+++ b/apps/url4-cloud/src/url4_cloud/manifests.py
@@ -15,28 +15,40 @@ keyed by id, and the route serves the value for that key, so a mismatch would ha
 manifest naming a benchmark they did not ask for.
 
 A manifest describes the BENCHMARK PROTOCOL — what a faithful run requires — not what any one
-deployment currently delivers. Two fields say more than the stack guarantees today, and neither
-gap is visible in a result:
+deployment currently delivers. One field still says more than the stack guarantees, and the gap
+is not visible in a result:
 
-* `tools` names the retrieval a DRACO candidate is meant to have. Retrieval IS enabled on the
-  three routes a solo or `fable_plus_gpt` candidate answers with (`native_web_search` in the
-  image's `url4.toml`, verified live), but the four models the remaining fusions use are
-  declared with it OFF pending a live check — so those answer from weights alone. The paper
-  treats retrieval as mandatory.
 * `judge_reasoning: "low"` is pinned by arXiv:2602.11685 §4.2 and is deliberately ABSENT here
   rather than advertised-and-unhonored: `reasoning_effort` has no OpenRouter rule, and the
   gateway fails closed on an unknown parameter.
 
-AIDEV-NOTE: two things here are unenforced and will drift.
+`tools` names the retrieval a DRACO candidate is meant to have, and as of 2026-08-02 EVERY
+answering route delivers it — by one of two mechanisms, per the owner's decision of that date:
+provider-side `native_web_search` where OpenRouter supports it, and the runner-driven Tavily loop
+(`web_tools`) for `kimi-k2.6`, `deepseek-v4-pro` and `qwen3.6-plus`, which answer `404` to native
+search. Both are guarded by the same declared retrieval policy. The judge declares neither, which
+is what the paper requires.
 
-1. `routes` must match what the benchmark image's `url4.toml` actually declares
-   (`prepare.render_data_table`).
-2. `cases` is the UPSTREAM dataset's size. The image is built with `prepare --limit`
-   (`Dockerfile.benchmark` `ARG LIMIT`), so a limited image serves fewer cases than this claims —
-   a probe image built with `LIMIT=3` still advertises 100.
+AIDEV-NOTE: the two mechanisms are not the same product, and a published comparison should say
+so — a native-search candidate and a Tavily candidate did not read the same web. This is a
+protocol caveat, not a defect: the alternative on the table (`exa` everywhere, uniform but
+different again) was considered and rejected.
 
-A pinning test in the spirit of `test_declared_models_match_aigateway.py` is the right home for
-both once a second benchmark lands. Until then the numbers here are a claim, not a guarantee.
+AIDEV-NOTE — what holds these honest, and the one thing still open.
+
+1. `routes`, the judge, and the retrieval declarations are pinned against the GENERATOR and
+   `url4.toml` by `tests/unit/test_manifest_matches_declared_world.py` — not against a second
+   copy of this literal, which would only prove the manifest equals itself.
+2. `cases` is the UPSTREAM dataset's size, and a benchmark image now always carries the WHOLE
+   dataset — `Dockerfile.benchmark`'s truncating build arg was removed 2026-08-02 precisely
+   because a truncated image was indistinguishable from a full one while still advertising 100
+   here. Run size is an EXPRESSION concern (`;iteration.slice=0:5`), which leaves this number
+   true by construction rather than by anyone remembering.
+
+STILL OPEN: `cases: 100` assumes the upstream dataset has 100 rows. `prepare.load_rows` calls
+`load_dataset()` with no `revision=`, so a dataset edit changes the truth of this line with no
+signal anywhere. That is the dataset-provenance gap, not a manifest gap — fixing it belongs with
+the revision pin.
 """
 
 from __future__ import annotations

--- a/apps/url4-cloud/src/url4_cloud/rest/__init__.py
+++ b/apps/url4-cloud/src/url4_cloud/rest/__init__.py
@@ -1,12 +1,14 @@
 """The url4-cloud REST surface: run lifecycle, token minting, and model catalog routes.
 
 Re-exports the FastAPI ``APIRouter``s (``router`` for run/token endpoints, ``catalog_router``
-for the model catalog) and the ``SubscriberGate`` protocol so ``app.py`` can wire them without
-reaching into the individual route modules.
+for the model catalog, ``benchmarks_router`` for the benchmark manifest catalog) and the
+``SubscriberGate`` protocol so ``app.py`` can wire them without reaching into the individual
+route modules.
 """
 
+from url4_cloud.rest.benchmarks import router as benchmarks_router
 from url4_cloud.rest.catalog import router as catalog_router
 from url4_cloud.rest.interest import DenyAllGate, SubscriberGate
 from url4_cloud.rest.routes import router
 
-__all__ = ["DenyAllGate", "SubscriberGate", "catalog_router", "router"]
+__all__ = ["DenyAllGate", "SubscriberGate", "benchmarks_router", "catalog_router", "router"]

--- a/apps/url4-cloud/src/url4_cloud/rest/benchmarks.py
+++ b/apps/url4-cloud/src/url4_cloud/rest/benchmarks.py
@@ -15,6 +15,8 @@ from fastapi import APIRouter, Header, Path
 from fastapi.responses import JSONResponse, Response
 
 from url4_cloud import manifests
+from url4_cloud.auth import PROBLEM_MEDIA_TYPE, Problem
+from url4_cloud.rest.conditional import validator_matches
 
 router = APIRouter()
 
@@ -24,8 +26,6 @@ router = APIRouter()
 # feels like it.
 _CACHE_CONTROL = "public, max-age=300, must-revalidate"
 
-_PROBLEM_JSON = "application/problem+json"
-
 _LIST_RESPONSES: dict[int | str, dict[str, object]] = {
     200: {"description": "Every published benchmark manifest, summarised."},
     304: {"description": "The catalog is unchanged since the supplied `If-None-Match`."},
@@ -33,23 +33,11 @@ _LIST_RESPONSES: dict[int | str, dict[str, object]] = {
 _MANIFEST_RESPONSES: dict[int | str, dict[str, object]] = {
     200: {"description": "The manifest, verbatim, as `text/plain`."},
     304: {"description": "The manifest is unchanged since the supplied `If-None-Match`."},
-    404: {"description": "No manifest is published under that id.", "content": {_PROBLEM_JSON: {}}},
+    404: {
+        "description": "No manifest is published under that id.",
+        "content": {PROBLEM_MEDIA_TYPE: {"schema": {"$ref": "#/components/schemas/Problem"}}},
+    },
 }
-
-
-def _matches(if_none_match: str | None, etag: str) -> bool:
-    """RFC 9110 §13.1.2 — `If-None-Match` is a LIST, and `*` matches any existing representation.
-
-    Comparison is weak per the RFC, so `W/"x"` matches `"x"`; we only ever emit strong tags, but a
-    cache is free to relay a weakened one back.
-    """
-    if not if_none_match:
-        return False
-    for candidate in if_none_match.split(","):
-        value = candidate.strip()
-        if value == "*" or value.removeprefix("W/") == etag.removeprefix("W/"):
-            return True
-    return False
 
 
 def _catalog() -> list[dict[str, str]]:
@@ -62,6 +50,13 @@ def _catalog() -> list[dict[str, str]]:
         }
         for key, text in sorted(manifests.MANIFESTS.items())
     ]
+
+
+# Both are derived from `manifests.MANIFESTS`, a build-time constant, so they are computed ONCE at
+# import rather than re-scanning every manifest and re-hashing the result per request — work that
+# a 304 would otherwise pay in full to return an empty body.
+_CATALOG = _catalog()
+_CATALOG_ETAG = manifests.etag_of(repr(_CATALOG))
 
 
 @router.get(
@@ -83,15 +78,13 @@ async def list_benchmarks(
     ] = None,
 ) -> Response:
     """Summarise every published benchmark, with a link to each full manifest."""
-    entries = _catalog()
-    # Derived from the summaries rather than the manifest bodies: this validator must change when
-    # what THIS route returns changes, and a body edit that leaves title/description alone does
-    # not alter the catalog.
-    etag = manifests.etag_of(repr(entries))
-    headers = {"ETag": etag, "Cache-Control": _CACHE_CONTROL}
-    if _matches(if_none_match, etag):
+    # The validator is derived from the SUMMARIES rather than the manifest bodies: it must change
+    # when what THIS route returns changes, and a body edit that leaves title/description alone
+    # does not alter the catalog.
+    headers = {"ETag": f'"{_CATALOG_ETAG}"', "Cache-Control": _CACHE_CONTROL}
+    if validator_matches(if_none_match, _CATALOG_ETAG):
         return Response(status_code=304, headers=headers)
-    return JSONResponse({"benchmarks": entries}, headers=headers)
+    return JSONResponse({"benchmarks": _CATALOG}, headers=headers)
 
 
 @router.get(
@@ -120,21 +113,25 @@ async def get_benchmark_manifest(
     # id is simply absent rather than dangerous — there is no filesystem behind this route.
     text = manifests.MANIFESTS.get(benchmark_id)
     if text is None:
+        # WHY the body is rendered here rather than raised as a `ProblemException`: these two
+        # routes serve build-time constants and depend on NO app state, so they are mountable on
+        # a bare router — which `tests/unit/test_benchmark_manifests.py` relies on. Raising would
+        # make the only reachable error depend on `install_problem_handlers` having run. The
+        # shared `Problem` MODEL still defines the shape, both here and in the OpenAPI entry.
         return JSONResponse(
             status_code=404,
-            media_type=_PROBLEM_JSON,
-            content={
-                "type": "about:blank",
-                "title": "Unknown benchmark",
-                "status": 404,
+            media_type=PROBLEM_MEDIA_TYPE,
+            content=Problem(
+                title="Unknown benchmark",
+                status=404,
                 # The id is echoed so a caller can tell a typo from an unpublished benchmark. It
-                # is caller-supplied, and FastAPI serialises it as a JSON string value, so it
-                # cannot break out of the field.
-                "detail": f"no manifest is published under {benchmark_id!r}",
-            },
+                # is caller-supplied, and it is serialised as a JSON string value, so it cannot
+                # break out of the field.
+                detail=f"no manifest is published under {benchmark_id!r}",
+            ).model_dump(exclude_none=True),
         )
-    etag = manifests.etag_of(text)
-    headers = {"ETag": etag, "Cache-Control": _CACHE_CONTROL}
-    if _matches(if_none_match, etag):
+    etag = manifests.ETAGS[benchmark_id]
+    headers = {"ETag": f'"{etag}"', "Cache-Control": _CACHE_CONTROL}
+    if validator_matches(if_none_match, etag):
         return Response(status_code=304, headers=headers)
     return Response(content=text, media_type="text/plain; charset=utf-8", headers=headers)

--- a/apps/url4-cloud/src/url4_cloud/rest/benchmarks.py
+++ b/apps/url4-cloud/src/url4_cloud/rest/benchmarks.py
@@ -1,0 +1,140 @@
+"""``GET /v1/benchmarks`` — the benchmark catalog, and the manifests it indexes.
+
+Unlike `/v1/models`, which proxies aigateway per caller, these two routes are identical for every
+caller: a manifest describes a benchmark, not an entitlement, and holds nothing private (the
+weighted rubrics behind `routes.criteria` are never declared as a route and never appear here).
+That is what makes the responses `public`-cacheable rather than `private`, and what makes the
+validator a plain content hash rather than something scoped to an identity.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Header, Path
+from fastapi.responses import JSONResponse, Response
+
+from url4_cloud import manifests
+
+router = APIRouter()
+
+# Manifests change only with a release, and a stale one costs a caller nothing worse than an
+# out-of-date description — but `must-revalidate` keeps a cache from serving one past its TTL, so
+# a corrected judge or route reaches callers on the next request rather than whenever a cache
+# feels like it.
+_CACHE_CONTROL = "public, max-age=300, must-revalidate"
+
+_PROBLEM_JSON = "application/problem+json"
+
+_LIST_RESPONSES: dict[int | str, dict[str, object]] = {
+    200: {"description": "Every published benchmark manifest, summarised."},
+    304: {"description": "The catalog is unchanged since the supplied `If-None-Match`."},
+}
+_MANIFEST_RESPONSES: dict[int | str, dict[str, object]] = {
+    200: {"description": "The manifest, verbatim, as `text/plain`."},
+    304: {"description": "The manifest is unchanged since the supplied `If-None-Match`."},
+    404: {"description": "No manifest is published under that id.", "content": {_PROBLEM_JSON: {}}},
+}
+
+
+def _matches(if_none_match: str | None, etag: str) -> bool:
+    """RFC 9110 §13.1.2 — `If-None-Match` is a LIST, and `*` matches any existing representation.
+
+    Comparison is weak per the RFC, so `W/"x"` matches `"x"`; we only ever emit strong tags, but a
+    cache is free to relay a weakened one back.
+    """
+    if not if_none_match:
+        return False
+    for candidate in if_none_match.split(","):
+        value = candidate.strip()
+        if value == "*" or value.removeprefix("W/") == etag.removeprefix("W/"):
+            return True
+    return False
+
+
+def _catalog() -> list[dict[str, str]]:
+    return [
+        {
+            "id": key,
+            "title": manifests.field(text, "title") or key,
+            "description": manifests.field(text, "description") or "",
+            "href": f"/v1/benchmarks/{key}",
+        }
+        for key, text in sorted(manifests.MANIFESTS.items())
+    ]
+
+
+@router.get(
+    "/v1/benchmarks",
+    tags=["Catalog"],
+    summary="List the published benchmark manifests",
+    responses=_LIST_RESPONSES,
+    description=(
+        "Summarise every benchmark this deployment publishes: its id, title, description, and a "
+        "link to the full manifest.\n\n"
+        "The response is an OBJECT, not a bare array, so a `next_cursor` can be added without "
+        "breaking clients. The set is fixed at build time and small, so it is not paginated "
+        "today."
+    ),
+)
+async def list_benchmarks(
+    if_none_match: Annotated[
+        str | None, Header(alias="If-None-Match", description="Conditional-request validator.")
+    ] = None,
+) -> Response:
+    """Summarise every published benchmark, with a link to each full manifest."""
+    entries = _catalog()
+    # Derived from the summaries rather than the manifest bodies: this validator must change when
+    # what THIS route returns changes, and a body edit that leaves title/description alone does
+    # not alter the catalog.
+    etag = manifests.etag_of(repr(entries))
+    headers = {"ETag": etag, "Cache-Control": _CACHE_CONTROL}
+    if _matches(if_none_match, etag):
+        return Response(status_code=304, headers=headers)
+    return JSONResponse({"benchmarks": entries}, headers=headers)
+
+
+@router.get(
+    "/v1/benchmarks/{benchmark_id}",
+    tags=["Catalog"],
+    summary="Fetch one benchmark manifest",
+    response_class=Response,
+    responses=_MANIFEST_RESPONSES,
+    description=(
+        "Return the manifest verbatim as `text/plain`.\n\n"
+        "The manifest IS a string — wrapping it in JSON would only make every caller unescape it "
+        "back. It names the data routes the benchmark's cases and criteria are served from, the "
+        "judge and its grading protocol, and the tools a candidate may use."
+    ),
+)
+async def get_benchmark_manifest(
+    benchmark_id: Annotated[
+        str, Path(description="The manifest's `id`, as listed by `GET /v1/benchmarks`.")
+    ],
+    if_none_match: Annotated[
+        str | None, Header(alias="If-None-Match", description="Conditional-request validator.")
+    ] = None,
+) -> Response:
+    """Return one manifest verbatim as `text/plain`, or 404 if no such benchmark is published."""
+    # INVARIANT: a registry lookup, never a path join. The id is a dict key, so a traversal-shaped
+    # id is simply absent rather than dangerous — there is no filesystem behind this route.
+    text = manifests.MANIFESTS.get(benchmark_id)
+    if text is None:
+        return JSONResponse(
+            status_code=404,
+            media_type=_PROBLEM_JSON,
+            content={
+                "type": "about:blank",
+                "title": "Unknown benchmark",
+                "status": 404,
+                # The id is echoed so a caller can tell a typo from an unpublished benchmark. It
+                # is caller-supplied, and FastAPI serialises it as a JSON string value, so it
+                # cannot break out of the field.
+                "detail": f"no manifest is published under {benchmark_id!r}",
+            },
+        )
+    etag = manifests.etag_of(text)
+    headers = {"ETag": etag, "Cache-Control": _CACHE_CONTROL}
+    if _matches(if_none_match, etag):
+        return Response(status_code=304, headers=headers)
+    return Response(content=text, media_type="text/plain; charset=utf-8", headers=headers)

--- a/apps/url4-cloud/src/url4_cloud/rest/catalog.py
+++ b/apps/url4-cloud/src/url4_cloud/rest/catalog.py
@@ -27,6 +27,7 @@ from url4_cloud import job_env
 from url4_cloud.auth import ProblemException
 from url4_cloud.catalog.cache import CatalogService
 from url4_cloud.catalog.port import CatalogError, Credential
+from url4_cloud.rest.conditional import validator_matches
 
 logger = logging.getLogger(__name__)
 
@@ -107,7 +108,7 @@ async def list_models(
         "Cache-Control": f"private, max-age={service.max_age_s(credential)}",
         "Vary": _VARY,
     }
-    if _validator_matches(if_none_match, catalog.etag):
+    if validator_matches(if_none_match, catalog.etag):
         return Response(status_code=304, headers=headers)
     return JSONResponse(content=catalog.body, headers=headers)
 
@@ -143,28 +144,6 @@ def _caller(profile: str | None, headers: Mapping[str, str]) -> Credential:
     flood protection that remains is `catalog.cache`'s entry cap and single-flight bulkhead.
     """
     return Credential.derive(profile, job_env.identity_from_headers(headers))
-
-
-def _validator_matches(if_none_match: str | None, etag: str) -> bool:
-    """RFC 9110 §13.1.2 weak comparison of an ``If-None-Match`` list against our ETag.
-
-    WHY weak: the RFC mandates weak comparison for ``If-None-Match``, so a ``W/``-prefixed tag
-    added by an intermediary must still register as a match — otherwise a client behind such a
-    proxy would re-download the catalog on every poll.
-    """
-    if if_none_match is None:
-        return False
-    return any(_tag_matches(raw, etag) for raw in if_none_match.split(","))
-
-
-def _tag_matches(raw: str, etag: str) -> bool:
-    """One entity-tag from an ``If-None-Match`` list, compared weakly."""
-    candidate = raw.strip()
-    if candidate == "*":
-        return True
-    if candidate.startswith("W/"):
-        candidate = candidate[2:]
-    return candidate.strip('"') == etag
 
 
 __all__ = ["router"]

--- a/apps/url4-cloud/src/url4_cloud/rest/conditional.py
+++ b/apps/url4-cloud/src/url4_cloud/rest/conditional.py
@@ -1,0 +1,40 @@
+"""Conditional-request handling shared by the REST catalogs (RFC 9110 §13.1.2).
+
+WHY this is one module rather than a copy per route: `If-None-Match` comparison is a spec rule,
+not a per-route preference. Two implementations of it drift — and they had already begun to,
+holding the ETag in different shapes (one bare, one pre-quoted) purely because each matcher was
+written against its own producer.
+
+INVARIANT: an ETag is stored and compared UNQUOTED, and quoted only where it is written to a
+header. The quotes are wire syntax; carrying them in the value makes every comparison site
+responsible for stripping them, which is the drift this module exists to prevent.
+"""
+
+from __future__ import annotations
+
+
+def validator_matches(if_none_match: str | None, etag: str) -> bool:
+    """RFC 9110 §13.1.2 weak comparison of an ``If-None-Match`` list against our ETag.
+
+    WHY weak: the RFC mandates weak comparison for ``If-None-Match``, so a ``W/``-prefixed tag
+    added by an intermediary must still register as a match — otherwise a client behind such a
+    proxy would re-download the representation on every poll.
+
+    ``etag`` is the bare validator, without quotes.
+    """
+    if if_none_match is None:
+        return False
+    return any(_tag_matches(raw, etag) for raw in if_none_match.split(","))
+
+
+def _tag_matches(raw: str, etag: str) -> bool:
+    """One entity-tag from an ``If-None-Match`` list, compared weakly."""
+    candidate = raw.strip()
+    if candidate == "*":
+        return True
+    if candidate.startswith("W/"):
+        candidate = candidate[2:]
+    return candidate.strip('"') == etag
+
+
+__all__ = ["validator_matches"]

--- a/apps/url4-cloud/src/url4_cloud/rest/routes.py
+++ b/apps/url4-cloud/src/url4_cloud/rest/routes.py
@@ -9,6 +9,7 @@ first.
 """
 
 import asyncio
+import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -34,6 +35,8 @@ from url4_cloud.auth import (
 from url4_cloud.config import Settings
 from url4_cloud.ports import IdentityAwareJobRunner
 from url4_cloud.rest.interest import SubscriberGate
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -424,7 +427,22 @@ async def stop_run(request: Request, claims: VerifiedClaims, topic: str | None =
         # INVARIANT: best-effort and BOUNDED. The result is discarded on purpose — a Pod that
         # died without publishing (SIGKILL past the grace period) must not strand the stream it
         # was holding, so teardown below is unconditional.
-        await _await_terminal(deps.stream, sub, deps.settings.stop_drain_s)
+        #
+        # "Unconditional" has to include a FAILED drain, not just a timed-out one. `_await_terminal`
+        # absorbs `TimeoutError` alone, while the read underneath can fail other ways — `subscribe`
+        # on a broker-backed adapter, or `_scan_terminal`'s own error when a stream ends with no
+        # terminal frame. Letting one past here skips `delete_stream` below, so the Job is gone and
+        # its stream, consumer state and filestore directory are kept forever: the very leak the
+        # `delete`-and-not-`purge` note is about. The drain is an OPTIMISATION over teardown, never
+        # a precondition for it — losing a terminal frame costs evidence, losing the reclaim costs
+        # a stream permanently, and only the second is invisible to the caller.
+        try:
+            await _await_terminal(deps.stream, sub, deps.settings.stop_drain_s)
+        except Exception:  # noqa: BLE001 - the drain's failure must never block the reclaim
+            # Logged, not swallowed: a broker that cannot be read during cancel is worth seeing,
+            # and it is not the DELETE caller's problem — the Job is stopped either way, and a 500
+            # would invite a retry with nothing left to do.
+            logger.warning("stop drain failed for topic %s; reclaiming anyway", sub, exc_info=True)
     # WHY delete and not purge: this is the run's terminal teardown, and purging a broker-backed
     # stream empties it but leaves the stream object, its consumer state and its filestore
     # directory behind — one permanent stream per run, forever. `delete_stream` defaults to

--- a/apps/url4-cloud/src/url4_cloud/rest/routes.py
+++ b/apps/url4-cloud/src/url4_cloud/rest/routes.py
@@ -297,7 +297,11 @@ _START_RESPONSES: dict[int | str, dict[str, Any]] = {
     504: _problem("The run exceeded its 16 h deadline."),
 }
 _STOP_RESPONSES: dict[int | str, dict[str, Any]] = {
-    204: {"description": "Stopped and the stream purged (idempotent)."},
+    204: {
+        "description": (
+            "Stopped, the run's terminal frame awaited, and the stream purged (idempotent)."
+        )
+    },
     403: _problem("The capability token is not authorized for that topic."),
 }
 
@@ -386,7 +390,11 @@ async def start_run(
     summary="Stop a run and purge its stream",
     responses=_STOP_RESPONSES,
     description=(
-        "Stop the Job for the token's topic and purge its stream (idempotent) → ``204`` (spec §5)."
+        "Stop the Job for the token's topic and purge its stream (idempotent) → ``204`` "
+        "(spec §5).\n\n"
+        "When a run was in flight, the response is held until its `ai.url4.terminated` frame is "
+        "observed (bounded by `stop_drain_s`) so an attached subscriber sees the run END rather "
+        "than the stream vanish under it. A frame that never arrives does not block teardown."
     ),
 )
 async def stop_run(request: Request, claims: VerifiedClaims, topic: str | None = None) -> Response:
@@ -399,7 +407,24 @@ async def stop_run(request: Request, claims: VerifiedClaims, topic: str | None =
             title="Forbidden",
             detail="the capability token is not authorized for that topic",
         )
+    # WHY `exists` is read BEFORE stopping: it is the only signal available for "was there a run
+    # to cancel", and `stop` is deliberately idempotent, so afterwards the two cases are
+    # identical. A repeat DELETE — the documented idempotent path — must not pay the drain
+    # bound waiting for a frame no process will ever publish.
+    running = await deps.job_runner.exists(sub)
     await deps.job_runner.stop(sub)
+    if running:
+        # WHY the drain: stopping and reclaiming target two different PROCESSES. `stop` returns
+        # as soon as the Job is deleted, while the Runner publishes `Terminated(stopped)` on its
+        # way down (see `runner.main.cancel_on_signal`) — so reclaiming immediately races that
+        # frame and wins, and the cancel lands as an eternally silent topic. That is the failure
+        # the Runner's signal handling exists to remove; undoing it here would be worse than not
+        # having fixed it, because the REST path is the one that looks deliberate.
+        #
+        # INVARIANT: best-effort and BOUNDED. The result is discarded on purpose — a Pod that
+        # died without publishing (SIGKILL past the grace period) must not strand the stream it
+        # was holding, so teardown below is unconditional.
+        await _await_terminal(deps.stream, sub, deps.settings.stop_drain_s)
     # WHY delete and not purge: this is the run's terminal teardown, and purging a broker-backed
     # stream empties it but leaves the stream object, its consumer state and its filestore
     # directory behind — one permanent stream per run, forever. `delete_stream` defaults to

--- a/apps/url4-cloud/src/url4_cloud/runner/config.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/config.py
@@ -42,7 +42,7 @@ DEFAULT_COMMAND_TIMEOUT_S = 120.0
 under both runtimes. Per route, not global — see :class:`CommandSpec`."""
 
 _AIGATEWAY_KEYS = frozenset({"base_url", "default_route", "models", "allow_outbound", "timeout_s"})
-_MODEL_KEYS = frozenset({"id", "web_tools"})
+_MODEL_KEYS = frozenset({"id", "web_tools", "native_web_search"})
 _COMMAND_KEYS = frozenset({"argv", "timeout_s"})
 _DATA_KEYS = frozenset({"value", "file", "command", "media_type", "timeout_s"})
 _DATA_SOURCES = ("value", "file", "command")
@@ -68,10 +68,28 @@ class ModelSpec:
     same way — so it is opted INTO per route, never inherited from the mere presence of a
     Tavily key. An operator who supplies a key but declares no `web_tools = true` route gets
     exactly the plain completions they declared.
+
+    TWO RETRIEVAL MECHANISMS, one per route, never both:
+
+    * ``web_tools`` — a CLIENT-SIDE loop. The runner declares OpenAI-shape functions, the model
+      asks, and the runner executes the search against Tavily and feeds results back. Works for
+      any provider that can call a function, which is why it stays: most providers have no
+      server-side search of their own.
+    * ``native_web_search`` — the PROVIDER runs it. The runner asks the GATEWAY for retrieval
+      with a provider-agnostic flag, and the gateway translates it into whatever that provider
+      calls it; nothing here knows one provider's spelling. No runner loop, no second search
+      backend, and the provider's own controls (notably domain exclusion) apply.
+
+    Prefer native where a provider offers it: it is the surface a published benchmark score was
+    produced on, and a client-side loop over a different search backend is a different
+    experiment. Declaring BOTH is rejected at parse — one request would then ask the provider to
+    search AND hand the model functions to search with, so the turn retrieves twice and bills
+    for both.
     """
 
     id: str
     web_tools: bool = False
+    native_web_search: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -418,12 +436,28 @@ def _model_table(table: Mapping[str, object]) -> ModelSpec:
     raw_id = table.get("id")
     if raw_id is None:
         raise RunnerConfigError("[[aigateway.models]] entry is missing its `id`")
-    web_tools = table.get("web_tools", False)
-    if not isinstance(web_tools, bool):
+    web_tools = _model_flag(table, "web_tools")
+    native_web_search = _model_flag(table, "native_web_search")
+    # INVARIANT: one route, one retrieval mechanism. Both would ask the provider to search AND
+    # hand the model functions to search with, so the turn retrieves twice and bills for both.
+    # Caught here, at parse, like every other route conflict — the alternative surfaces as a
+    # doubled bill and a doubled latency nobody attributes.
+    if web_tools and native_web_search:
         raise RunnerConfigError(
-            f"[[aigateway.models]] web_tools must be a boolean, got {web_tools!r}"
+            f"[[aigateway.models]] {raw_id!r} declares both web_tools and native_web_search — "
+            "a route serves ONE retrieval mechanism. Use native_web_search where the provider "
+            "runs the search itself, web_tools where the runner must drive it."
         )
-    return ModelSpec(id=_model_id(str(raw_id)), web_tools=web_tools)
+    return ModelSpec(
+        id=_model_id(str(raw_id)), web_tools=web_tools, native_web_search=native_web_search
+    )
+
+
+def _model_flag(table: Mapping[str, object], key: str) -> bool:
+    value = table.get(key, False)
+    if not isinstance(value, bool):
+        raise RunnerConfigError(f"[[aigateway.models]] {key} must be a boolean, got {value!r}")
+    return value
 
 
 def _model_id(model: str) -> str:

--- a/apps/url4-cloud/src/url4_cloud/runner/config.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/config.py
@@ -43,7 +43,7 @@ under both runtimes. Per route, not global — see :class:`CommandSpec`."""
 
 _AIGATEWAY_KEYS = frozenset({"base_url", "default_route", "models", "allow_outbound", "timeout_s"})
 _MODEL_KEYS = frozenset({"id", "web_tools", "native_web_search"})
-_COMMAND_KEYS = frozenset({"argv", "timeout_s"})
+_COMMAND_KEYS = frozenset({"argv", "timeout_s", "stdin"})
 _DATA_KEYS = frozenset({"value", "file", "command", "media_type", "timeout_s"})
 _DATA_SOURCES = ("value", "file", "command")
 _RESERVED_TABLES = frozenset({"holdings", "identities"})
@@ -116,11 +116,24 @@ class CommandSpec:
     genuinely different budgets — a rubric judge that calls a model outruns any bound that must
     still keep a fast data-shaping command honest. A single global value can only be wrong for
     one of them.
+
+    ``stdin`` selects which half of the request is PIPED — ``"context"`` (the default, and the
+    only behaviour before this existed) or ``"intent"``. A route whose payload is engine-supplied
+    needs the latter: a cross-row reducer receives the JSON array of every row result as its
+    intent, and a single argv token is capped by the kernel at 131,072 bytes, so argv is not a
+    channel that payload fits in. Choosing the pipe does not withdraw ``{context}`` from argv.
+
+    INVARIANT: the legal VALUES are the engine's (``_serve.COMMAND_STDIN_SOURCES``) and are NOT
+    restated here. This module may not import url4 at all — the importer set is pinned by
+    `test_only_url4_executor_module_imports_url4` — and a copy would be free to drift, so
+    `connector.register_commands` passes the string through and translates the engine's
+    `ValueError`, exactly as it already does for `node.endpoint`'s registrability rules.
     """
 
     path: str
     argv: tuple[str, ...]
     timeout_s: float = DEFAULT_COMMAND_TIMEOUT_S
+    stdin: str = "context"
 
 
 @dataclass(frozen=True, slots=True)
@@ -245,7 +258,26 @@ def _command_table(path: str, table: Mapping[str, object]) -> CommandSpec:
     if "argv" not in table:
         raise RunnerConfigError(f"[commands] {path!r} is missing its `argv`")
     timeout_s = _command_timeout(path, table.get("timeout_s"))
-    return CommandSpec(path=path, argv=_argv(path, table["argv"]), timeout_s=timeout_s)
+    return CommandSpec(
+        path=path,
+        argv=_argv(path, table["argv"]),
+        timeout_s=timeout_s,
+        stdin=_command_stdin(path, table.get("stdin")),
+    )
+
+
+def _command_stdin(path: str, value: object) -> str:
+    """The TYPE is this module's business; the VALUE SET is the engine's (see `CommandSpec`).
+
+    A non-string is caught here because it is a config-shape error like any other — `stdin = true`
+    is a plausible typo, and letting it reach the engine would surface as a confusing repr in a
+    message about allowed source names.
+    """
+    if value is None:
+        return "context"
+    if not isinstance(value, str):
+        raise RunnerConfigError(f"[commands] {path!r} stdin must be a string, got {value!r}")
+    return value
 
 
 def _command_timeout(path: str, value: object) -> float:

--- a/apps/url4-cloud/src/url4_cloud/runner/config.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/config.py
@@ -41,7 +41,16 @@ DEFAULT_COMMAND_TIMEOUT_S = 120.0
 """Matches ``url4 serve``'s ``ServeConfig.timeout``, so the same url4.toml behaves the same
 under both runtimes. Per route, not global — see :class:`CommandSpec`."""
 
-_AIGATEWAY_KEYS = frozenset({"base_url", "default_route", "models", "allow_outbound", "timeout_s"})
+_AIGATEWAY_KEYS = frozenset(
+    {
+        "base_url",
+        "default_route",
+        "models",
+        "allow_outbound",
+        "timeout_s",
+        "web_tool_max_iterations",
+    }
+)
 _MODEL_KEYS = frozenset({"id", "web_tools", "native_web_search"})
 _COMMAND_KEYS = frozenset({"argv", "timeout_s", "stdin"})
 _DATA_KEYS = frozenset({"value", "file", "command", "media_type", "timeout_s"})
@@ -101,6 +110,13 @@ class AigatewaySection:
     models: tuple[ModelSpec, ...]
     allow_outbound: bool = True
     timeout_s: float = 60.0
+    # WHY declarable rather than a constant: the runner-driven tool loop posts once per ROUND, and
+    # a research answer legitimately takes more rounds than a lookup. MEASURED 2026-08-02 —
+    # `kimi-k2.6` spent all 5 default rounds on tool calls and never returned content, for a
+    # trivial question with freely reachable sources, so on the Tavily loop the default is a hard
+    # per-case failure rather than a safety margin. It stays 5 for everyone who does not declare
+    # it: raising the default would change the cost profile of every existing tool-using world.
+    web_tool_max_iterations: int = 5
 
 
 @dataclass(frozen=True, slots=True)
@@ -387,6 +403,23 @@ def _reject_route_collisions(
             )
 
 
+def _positive_int(table: Mapping[str, object], key: str, default: int) -> int:
+    """An `[aigateway]` count that must be a whole number above zero.
+
+    INVARIANT: `bool` is rejected explicitly. It IS an `int` subclass in Python, so `true` would
+    otherwise parse as 1 — a world where every tool-using route fails on its second round,
+    configured by an operator who thought they were setting a flag.
+    """
+    value = table.get(key)
+    if value is None:
+        return default
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise RunnerConfigError(f"[aigateway] {key} must be an integer, got {value!r}")
+    if value <= 0:
+        raise RunnerConfigError(f"[aigateway] {key} must be > 0, got {value!r}")
+    return value
+
+
 def _parse_aigateway(table: Mapping[str, object], env: Mapping[str, str]) -> AigatewaySection:
     unknown = sorted(set(map(str, table)) - _AIGATEWAY_KEYS)
     if unknown:
@@ -400,6 +433,7 @@ def _parse_aigateway(table: Mapping[str, object], env: Mapping[str, str]) -> Aig
         models=models,
         allow_outbound=_bool(table, "allow_outbound", default=True),
         timeout_s=_float(table, "timeout_s", 60.0),
+        web_tool_max_iterations=_positive_int(table, "web_tool_max_iterations", 5),
     )
     section = _apply_env(section, env)
     _require_declared(section.default_model, models)

--- a/apps/url4-cloud/src/url4_cloud/runner/config.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/config.py
@@ -11,9 +11,11 @@ OpenRouter) and ``openrouter/anthropic/claude-opus-4.8`` into ``/anthropic/claud
 Aliases were also collision-dependent, so adding a model elsewhere in the catalog could
 silently REMOVE an alias an expression depended on.
 
-The file format mirrors ``url4 serve``'s (``url4.cli._serve``). ``[data]``, ``[commands]``,
-``[holdings]`` and ``[identities]`` are reserved here but not parsed yet — declaring one is a
-loud error rather than a silent no-op, so a config that looks like it works actually does.
+The file format mirrors ``url4 serve``'s (``url4.cli._serve``). ``[holdings]`` and
+``[identities]`` are reserved here but not parsed yet — declaring one is a loud error rather
+than a silent no-op, so a config that looks like it works actually does. ``[commands]`` (a local
+subprocess backend, :class:`CommandSpec`) and ``[data]`` (read-only artifacts at their own url4
+addresses, :class:`DataSpec`) ARE parsed.
 
 # AIDEV-NOTE: this loader deliberately duplicates ~120 lines of `_serve.py`'s tested parsing
 # rather than depending on it — `_serve` is a private CLI module in `packages/url4`, and the
@@ -23,6 +25,7 @@ loud error rather than a silent no-op, so a config that looks like it works actu
 
 from __future__ import annotations
 
+import shlex
 import tomllib
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
@@ -34,10 +37,17 @@ DEFAULT_CONFIG_PATH = "/etc/url4/url4.toml"
 """Where the declared world lives unless :data:`job_env.RUNNER_CONFIG` overrides it. Image-level
 wiring: the App never writes that variable — the file is baked into the image."""
 
+DEFAULT_COMMAND_TIMEOUT_S = 120.0
+"""Matches ``url4 serve``'s ``ServeConfig.timeout``, so the same url4.toml behaves the same
+under both runtimes. Per route, not global — see :class:`CommandSpec`."""
+
 _AIGATEWAY_KEYS = frozenset({"base_url", "default_route", "models", "allow_outbound", "timeout_s"})
 _MODEL_KEYS = frozenset({"id", "web_tools"})
-_RESERVED_TABLES = frozenset({"data", "commands", "holdings", "identities"})
-_TOP_LEVEL_KEYS = frozenset({"aigateway"})
+_COMMAND_KEYS = frozenset({"argv", "timeout_s"})
+_DATA_KEYS = frozenset({"value", "file", "command", "media_type", "timeout_s"})
+_DATA_SOURCES = ("value", "file", "command")
+_RESERVED_TABLES = frozenset({"holdings", "identities"})
+_TOP_LEVEL_KEYS = frozenset({"aigateway", "commands", "data"})
 
 
 class RunnerConfigError(ValueError):
@@ -76,10 +86,57 @@ class AigatewaySection:
 
 
 @dataclass(frozen=True, slots=True)
+class CommandSpec:
+    """One declared subprocess route: ``[commands]"/path" = …``.
+
+    The argv is OPERATOR config and is executed without a shell; only the token substitutions
+    (`{intent}`, `{context}`, `{param:<name>}`, `{params}`) carry caller-influenced text, and
+    they are substituted in a single pass over this template so a token-shaped string in caller
+    input stays literal. See ``url4.cli._serve.make_command_handler``.
+
+    WHY ``timeout_s`` lives HERE rather than once per config: the routes a Job declares have
+    genuinely different budgets — a rubric judge that calls a model outruns any bound that must
+    still keep a fast data-shaping command honest. A single global value can only be wrong for
+    one of them.
+    """
+
+    path: str
+    argv: tuple[str, ...]
+    timeout_s: float = DEFAULT_COMMAND_TIMEOUT_S
+
+
+@dataclass(frozen=True, slots=True)
+class DataSpec:
+    """One declared read-only artifact: ``[data]"/path" = …``.
+
+    Exactly one of ``value`` / ``file`` / ``command`` supplies the bytes. WHY exactly one and not
+    a precedence order: two sources would make the served content depend on lookup order, which
+    is a silent way to serve the wrong rubric.
+
+    ``file`` is re-read PER REQUEST, so editing an artifact takes effect without a restart —
+    the property that makes a declared world editable rather than frozen at build time.
+
+    ``media_type`` declares the route's Content-Type so a collection served here parses by its
+    declared type rather than being sniffed. Load-bearing for the case list: a one-line JSON
+    array served as text/plain collapses to a SINGLE element, which would silently benchmark
+    once against a blob instead of once per case.
+    """
+
+    path: str
+    value: str | None = None
+    file: str | None = None
+    command: tuple[str, ...] | None = None
+    media_type: str | None = None
+    timeout_s: float = DEFAULT_COMMAND_TIMEOUT_S
+
+
+@dataclass(frozen=True, slots=True)
 class RunnerConfig:
     """The whole declared world. ``aigateway is None`` is a legitimate tokenless world."""
 
     aigateway: AigatewaySection | None = None
+    commands: tuple[CommandSpec, ...] = ()
+    data: tuple[DataSpec, ...] = ()
 
 
 def routes_for(models: Sequence[ModelSpec]) -> dict[str, ModelSpec]:
@@ -108,11 +165,15 @@ def parse_config(raw: Mapping[str, object], env: Mapping[str, str]) -> RunnerCon
     """Validate a parsed TOML mapping into a :class:`RunnerConfig`. Fail-fast."""
     _reject_unsupported_tables(raw)
     table = raw.get("aigateway")
-    if table is None:
-        return RunnerConfig()
-    if not isinstance(table, Mapping):
-        raise RunnerConfigError(f"[aigateway] must be a table, got {table!r}")
-    return RunnerConfig(aigateway=_parse_aigateway(table, env))
+    section = None
+    if table is not None:
+        if not isinstance(table, Mapping):
+            raise RunnerConfigError(f"[aigateway] must be a table, got {table!r}")
+        section = _parse_aigateway(table, env)
+    commands = _commands(raw.get("commands"))
+    data = _data(raw.get("data"))
+    _reject_route_collisions(commands, data, section)
+    return RunnerConfig(aigateway=section, commands=commands, data=data)
 
 
 def _reject_unsupported_tables(raw: Mapping[str, object]) -> None:
@@ -128,6 +189,152 @@ def _reject_unsupported_tables(raw: Mapping[str, object]) -> None:
         raise RunnerConfigError(
             f"unknown top-level table(s) {unknown} (expected {sorted(_TOP_LEVEL_KEYS)})"
         )
+
+
+def _commands(value: object) -> tuple[CommandSpec, ...]:
+    """Parse ``[commands]`` — a route path per key, an argv template per value.
+
+    Absent is the normal case (a model-only world), so it yields the empty tuple rather than
+    an error. TOML forbids duplicate keys, so route uniqueness WITHIN the table is inherited
+    from the format; collisions against model routes are checked separately.
+    """
+    if value is None:
+        return ()
+    if not isinstance(value, Mapping):
+        raise RunnerConfigError(f"[commands] must be a table, got {value!r}")
+    return tuple(_command_spec(str(path), entry) for path, entry in value.items())
+
+
+def _command_spec(path: str, entry: object) -> CommandSpec:
+    """One ``[commands]`` entry — a table, or a bare argv list/string as shorthand.
+
+    The bare forms are exactly ``url4 serve``'s (``_serve._as_argv``), so a url4.toml written
+    for a standalone node keeps working here; only the table form can declare `timeout_s`.
+    """
+    if not path.startswith("/"):
+        raise RunnerConfigError(f"[commands] route {path!r} must start with '/'")
+    if isinstance(entry, Mapping):
+        return _command_table(path, entry)
+    return CommandSpec(path=path, argv=_argv(path, entry))
+
+
+def _command_table(path: str, table: Mapping[str, object]) -> CommandSpec:
+    unknown = sorted(set(map(str, table)) - _COMMAND_KEYS)
+    if unknown:
+        raise RunnerConfigError(
+            f"[commands] {path!r} has unknown key(s) {unknown} (expected {sorted(_COMMAND_KEYS)})"
+        )
+    if "argv" not in table:
+        raise RunnerConfigError(f"[commands] {path!r} is missing its `argv`")
+    timeout_s = _command_timeout(path, table.get("timeout_s"))
+    return CommandSpec(path=path, argv=_argv(path, table["argv"]), timeout_s=timeout_s)
+
+
+def _command_timeout(path: str, value: object) -> float:
+    if value is None:
+        return DEFAULT_COMMAND_TIMEOUT_S
+    try:
+        timeout_s = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        raise RunnerConfigError(
+            f"[commands] {path!r} timeout_s must be a number, got {value!r}"
+        ) from None
+    if timeout_s <= 0:
+        raise RunnerConfigError(f"[commands] {path!r} timeout_s must be > 0, got {timeout_s!r}")
+    return timeout_s
+
+
+def _argv(path: str, value: object) -> tuple[str, ...]:
+    """Coerce a declared argv: a list of tokens, or a string split like a shell would.
+
+    INVARIANT: the result is an argv LIST that is exec'd directly — never a command string
+    handed to a shell. Splitting happens HERE, at config time, on operator-owned text.
+    """
+    if isinstance(value, str):
+        argv = tuple(shlex.split(value))
+    elif isinstance(value, Sequence):
+        argv = tuple(str(item) for item in value)
+    else:
+        raise RunnerConfigError(
+            f"[commands] {path!r} must be an argv list, a string, or a table, got {value!r}"
+        )
+    if not argv:
+        raise RunnerConfigError(f"[commands] {path!r} declares an empty argv")
+    return argv
+
+
+def _data(value: object) -> tuple[DataSpec, ...]:
+    """Parse ``[data]`` — a route path per key, a provider declaration per value.
+
+    Absent is the normal case, so it yields the empty tuple. TOML forbids duplicate keys, so
+    uniqueness WITHIN the table is inherited from the format; cross-family collisions are checked
+    separately. Declaration order is preserved — a generated table diffs stably against the
+    dataset it was emitted from.
+    """
+    if value is None:
+        return ()
+    if not isinstance(value, Mapping):
+        raise RunnerConfigError(f"[data] must be a table, got {value!r}")
+    return tuple(_data_spec(str(path), entry) for path, entry in value.items())
+
+
+def _data_spec(path: str, entry: object) -> DataSpec:
+    """One ``[data]`` entry — a table, or a bare string as inline-value shorthand.
+
+    Mirrors ``url4 serve``'s ``_as_provider`` so one url4.toml dialect serves both runtimes.
+    """
+    if not path.startswith("/"):
+        raise RunnerConfigError(f"[data] route {path!r} must start with '/'")
+    if isinstance(entry, str):
+        return DataSpec(path=path, value=entry)
+    if not isinstance(entry, Mapping):
+        raise RunnerConfigError(f"[data] {path!r} must be a string or a table, got {entry!r}")
+    unknown = sorted(set(map(str, entry)) - _DATA_KEYS)
+    if unknown:
+        raise RunnerConfigError(
+            f"[data] {path!r} has unknown key(s) {unknown} (expected {sorted(_DATA_KEYS)})"
+        )
+    declared = [key for key in _DATA_SOURCES if entry.get(key) is not None]
+    if len(declared) != 1:
+        raise RunnerConfigError(
+            f"[data] {path!r} must declare exactly one of {list(_DATA_SOURCES)}, "
+            f"got {declared or 'none'}"
+        )
+    media_type = entry.get("media_type")
+    return DataSpec(
+        path=path,
+        value=str(entry["value"]) if "value" in declared else None,
+        file=str(entry["file"]) if "file" in declared else None,
+        command=_argv(path, entry["command"]) if "command" in declared else None,
+        media_type=None if media_type is None else str(media_type),
+        timeout_s=_command_timeout(path, entry.get("timeout_s")),
+    )
+
+
+def _reject_route_collisions(
+    commands: Sequence[CommandSpec],
+    data: Sequence[DataSpec],
+    section: AigatewaySection | None,
+) -> None:
+    """A route path has exactly one owner, across all three route families.
+
+    INVARIANT: registering the same path twice raises deep inside `Url4Node._check_routable` at
+    world-build time, which names the path but not the config that declared it. Catching it here
+    points the operator at the offending line instead.
+    """
+    command_paths = {cmd.path for cmd in commands}
+    overlap = sorted(command_paths & {spec.path for spec in data})
+    if overlap:
+        raise RunnerConfigError(f"[data] {overlap} already declared as [commands] route(s)")
+    if section is None:
+        return
+    model_routes = routes_for(section.models)
+    for label, paths in (("[commands]", command_paths), ("[data]", {s.path for s in data})):
+        collisions = sorted(path for path in paths if path in model_routes)
+        if collisions:
+            raise RunnerConfigError(
+                f"{label} {collisions} already declared as aigateway model route(s)"
+            )
 
 
 def _parse_aigateway(table: Mapping[str, object], env: Mapping[str, str]) -> AigatewaySection:

--- a/apps/url4-cloud/src/url4_cloud/runner/config.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/config.py
@@ -41,6 +41,19 @@ DEFAULT_COMMAND_TIMEOUT_S = 120.0
 """Matches ``url4 serve``'s ``ServeConfig.timeout``, so the same url4.toml behaves the same
 under both runtimes. Per route, not global — see :class:`CommandSpec`."""
 
+DEFAULT_WEB_TOOL_MAX_ITERATIONS = 5
+"""Rounds a runner-driven tool loop may take before it gives up, when nothing declares it.
+
+MEASURED 2026-08-02 — `kimi-k2.6` spent all 5 rounds on tool calls and never returned content,
+for a trivial question with freely reachable sources, so on the Tavily loop this is a hard
+per-case failure rather than a safety margin. It stays 5 for a world that does not declare the
+key: raising it would change the cost profile of every existing tool-using world. A benchmark
+raises it in its own `url4.toml` (DRACO declares 12).
+
+Shared with the connector's :class:`AigatewayConfig` so the parsed default and the runtime
+default cannot drift — a mismatch there is invisible, since both spellings look declared.
+"""
+
 _AIGATEWAY_KEYS = frozenset(
     {
         "base_url",
@@ -111,12 +124,9 @@ class AigatewaySection:
     allow_outbound: bool = True
     timeout_s: float = 60.0
     # WHY declarable rather than a constant: the runner-driven tool loop posts once per ROUND, and
-    # a research answer legitimately takes more rounds than a lookup. MEASURED 2026-08-02 —
-    # `kimi-k2.6` spent all 5 default rounds on tool calls and never returned content, for a
-    # trivial question with freely reachable sources, so on the Tavily loop the default is a hard
-    # per-case failure rather than a safety margin. It stays 5 for everyone who does not declare
-    # it: raising the default would change the cost profile of every existing tool-using world.
-    web_tool_max_iterations: int = 5
+    # a research answer legitimately takes more rounds than a lookup. The default and the reason
+    # it stays 5 live on :data:`DEFAULT_WEB_TOOL_MAX_ITERATIONS`.
+    web_tool_max_iterations: int = DEFAULT_WEB_TOOL_MAX_ITERATIONS
 
 
 @dataclass(frozen=True, slots=True)
@@ -433,7 +443,9 @@ def _parse_aigateway(table: Mapping[str, object], env: Mapping[str, str]) -> Aig
         models=models,
         allow_outbound=_bool(table, "allow_outbound", default=True),
         timeout_s=_float(table, "timeout_s", 60.0),
-        web_tool_max_iterations=_positive_int(table, "web_tool_max_iterations", 5),
+        web_tool_max_iterations=_positive_int(
+            table, "web_tool_max_iterations", DEFAULT_WEB_TOOL_MAX_ITERATIONS
+        ),
     )
     section = _apply_env(section, env)
     _require_declared(section.default_model, models)

--- a/apps/url4-cloud/src/url4_cloud/runner/connector.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/connector.py
@@ -85,7 +85,55 @@ weights alone, which is indistinguishable in the result.
 """
 
 
-def _native_web_search(cfg: AigatewayConfig) -> dict[str, object]:
+WEB_SEARCH_POLICY_PARAM = "web_search_policy"
+"""Names a declared `[data]` route holding this call's retrieval policy.
+
+    …!'answer';web_search_policy=/draco/policy/retrieval
+
+WHY an ADDRESS rather than the list: protocol params are parse-time CONSTANTS (the compiler
+copies `node.params` verbatim, and `$` substitution reaches only the packed context and text
+templates), so a list interpolated from scope is not expressible. A path IS a constant while its
+contents are not — which is what lets a benchmark ship its own blocklist without an engine
+change, and lets the SAME model routes serve benchmarks that disagree about what to exclude.
+
+WHY it belongs in the expression and not in operator config: the scoreboard hashes
+`url4_expression` into a recipe identity. A blocklist carried in config is invisible there, so a
+run with retrieval unguarded would hash IDENTICALLY to an honest one.
+
+``none`` selects no benchmark policy. It cannot disable the DEPLOYMENT's list, which is
+enforcement rather than default — see `_native_web_search`.
+"""
+
+WEB_SEARCH_EXCLUDE_PARAM = "web_search_exclude"
+"""Ad-hoc additional exclusions, COLON-separated: ``;web_search_exclude=a.test:b.test``.
+
+AIDEV-NOTE — the separator is `:` and a COMMA IS A TRAP. A source list splits on `,` at depth 0
+BEFORE a param value is read, so `;web_search_exclude=a.test,b.test` parses as the value
+`a.test` plus a whole extra SOURCE `b.test` — which is then packed into the model's context.
+Measured; pinned by `test_a_comma_separated_value_is_silently_truncated`. The runner cannot
+detect this: by the time it sees the params, the comma is gone. Same shape as the
+`;iteration.slice=0,5` trap. Prefer a declared policy route over a long ad-hoc chain.
+
+AIDEV-NOTE: deliberately NOT the gateway's own `web_search_excluded_domains`, which stays
+runner-owned and loudly rejected (`RUNNER_OWNED_FIELDS`, pinned by `test_model_params`). That
+field is the gateway's; an expression setting it would be overwritten by the runner's value on
+the body merge — accepted at parse, then silently discarded. This is a different thing: a
+runner-INTERPRETED request that is UNIONed with the other layers and rendered into the gateway
+field by `_native_web_search`. Same capability, no shared name, no weakened invariant.
+"""
+
+POLICY_NONE = "none"
+
+_RUNNER_INTERPRETED_PARAMS = frozenset(
+    {WEB_SEARCH_PARAM, WEB_SEARCH_POLICY_PARAM, WEB_SEARCH_EXCLUDE_PARAM}
+)
+"""Params the runner CONSUMES. Forwarded, each would be an unknown gateway field and fail closed
+on every call that carried it."""
+
+
+def _native_web_search(
+    cfg: AigatewayConfig, extra_domains: Sequence[str] = ()
+) -> dict[str, object]:
     """Ask the GATEWAY for provider-side retrieval — nothing provider-specific here.
 
     `web_search` is aigateway's provider-agnostic vocabulary: the gateway decides which
@@ -93,14 +141,24 @@ def _native_web_search(cfg: AigatewayConfig) -> dict[str, object]:
     provider's payload here instead would put OpenRouter knowledge in the runner and duplicate a
     contract the gateway already owns — the layering rule this repo states as core-defines-ports.
 
-    `web_search_excluded_domains` is UNIONed with the deployment's own list by the gateway, so
-    this can only ever tighten the guard. It is operator config, never expression-supplied: the
-    motivating case is a benchmark candidate that must not retrieve the rubric it is graded
-    against, and a blocklist a caller can rewrite is not a blocklist.
+    Three layers compose, and only ever by UNION — a caller can tighten the guard and can never
+    loosen it:
+
+    * the deployment's list (aigateway settings) — ENFORCEMENT, unreachable from an expression;
+    * this Job's `cfg` list;
+    * the expression's policy route and any ad-hoc `web_search_exclude`, both in ``extra_domains``.
+
+    INVARIANT: assembled ONCE here and rendered into the gateway field by the runner. The body is
+    merged with `extra` last, so a caller-supplied copy of the gateway's own field would be
+    overwritten — which is why that name stays runner-owned and this path exists instead.
+
+    The gateway then unions its deployment list on top, so a benchmark policy layers under a
+    leaderboard's mandatory floor rather than replacing it.
     """
     body: dict[str, object] = {"web_search": True}
-    if cfg.web_search_excluded_domains:
-        body["web_search_excluded_domains"] = list(cfg.web_search_excluded_domains)
+    domains = sorted({*cfg.web_search_excluded_domains, *extra_domains})
+    if domains:
+        body["web_search_excluded_domains"] = domains
     return body
 
 
@@ -191,6 +249,7 @@ class _ModelEndpoint:
         "_cfg",
         "_http_client",
         "_identity_headers",
+        "_policy",
         "_profile",
         "_routes",
         "_tavily_api_key",
@@ -207,6 +266,7 @@ class _ModelEndpoint:
         tavily_http: httpx.AsyncClient | None,
         tavily_api_key: str | None,
         identity_headers: Mapping[str, str] | None = None,
+        policy: RetrievalPolicyResolver | None = None,
     ) -> None:
         self._http_client = http_client
         self._cfg = cfg
@@ -215,6 +275,7 @@ class _ModelEndpoint:
         self._tavily_http = tavily_http
         self._tavily_api_key = tavily_api_key
         self._identity_headers = identity_headers
+        self._policy = policy
 
     async def __call__(self, request: Request) -> str:
         # The route resolves to its whole spec, so the id and the capabilities it was declared
@@ -232,6 +293,7 @@ class _ModelEndpoint:
             tavily_api_key=self._tavily_api_key,
             web_tools=spec.web_tools,
             identity_headers=self._identity_headers,
+            policy=self._policy,
         )
 
 
@@ -280,6 +342,85 @@ def register_data(node: Url4Node, data: Sequence[DataSpec]) -> None:
             node.data(spec.path, provider, media_type=spec.media_type)
         except ValueError as exc:
             raise RunnerConfigError(f"[data] {spec.path!r} is not registrable: {exc}") from exc
+
+
+class RetrievalPolicyResolver:
+    """Dereferences a `;web_search_policy=<path>` into that policy's excluded domains.
+
+    FEATURE: a benchmark declares its blocklist at its own url4 address, so per-benchmark
+    policies share one set of model routes.
+    STORY: as a benchmark author I need the guard that stops a candidate retrieving its own
+    rubric to travel WITH the benchmark, and to be visible in the expression that ran.
+
+    INVARIANT: resolution is bounded to declared `[data]` routes BY CONSTRUCTION. The providers
+    are built from the parsed data table, not from the node's router, so a model route, a command
+    route, or a traversal-shaped path is simply ABSENT — there is no check to forget, and the
+    runner never re-enters the node it is currently serving.
+
+    Results are memoized for the world's lifetime. A benchmark image is immutable, so staleness
+    is unreachable in production, and a DRACO run would otherwise re-read the file on every
+    answering call. TRADEOFF: a LOCAL run that edits a policy file needs a restart, which differs
+    from `[data]` routes generally (a `file` provider is re-read per request).
+    """
+
+    __slots__ = ("_cache", "_providers")
+
+    def __init__(self, data: Sequence[DataSpec] = ()) -> None:
+        self._providers = {
+            spec.path: make_data_provider(
+                ProviderSpec(
+                    value=spec.value,
+                    file=spec.file,
+                    command=spec.command,
+                    media_type=spec.media_type,
+                ),
+                spec.timeout_s,
+            )
+            for spec in data
+        }
+        self._cache: dict[str, tuple[str, ...]] = {}
+
+    async def resolve(self, path: str) -> tuple[str, ...]:
+        """The policy's excluded domains.
+
+        Raises:
+            ResolutionError: the path is not a declared `[data]` route, or what it serves is not
+                a usable policy. NEVER returns an empty tuple on failure — empty means "retrieve
+                unguarded", and the run would report success carrying an inflated score.
+        """
+        cached = self._cache.get(path)
+        if cached is not None:
+            return cached
+        provider = self._providers.get(path)
+        if provider is None:
+            raise ResolutionError(
+                f"{WEB_SEARCH_POLICY_PARAM}={path!r} is not a declared [data] route — a retrieval "
+                "policy is an artifact the benchmark image declares, like its cases and criteria"
+            )
+        domains = _parse_policy(await provider(), path)
+        self._cache[path] = domains
+        return domains
+
+
+def _parse_policy(raw: str, path: str) -> tuple[str, ...]:
+    """Read ``{"id": …, "excluded_domains": [...]}`` out of a policy artifact.
+
+    An OBJECT rather than a bare array so a policy can version itself (`id` is what a published
+    score cites) and later carry other retrieval settings without a second route.
+    """
+    try:
+        document = json.loads(raw)
+    except ValueError as exc:
+        raise ResolutionError(
+            f"{WEB_SEARCH_POLICY_PARAM}={path!r} does not serve JSON: {exc}"
+        ) from None
+    domains = document.get("excluded_domains") if isinstance(document, Mapping) else None
+    if not isinstance(domains, list) or not all(isinstance(item, str) for item in domains):
+        raise ResolutionError(
+            f"{WEB_SEARCH_POLICY_PARAM}={path!r} must declare `excluded_domains` as a list of "
+            "strings — the gateway's schema is strictly typed and would fail closed one hop later"
+        )
+    return tuple(domains)
 
 
 def build_local_world(
@@ -349,6 +490,9 @@ async def build_aigateway_world(
         tavily_http=tavily_http,
         tavily_api_key=tavily_api_key,
         identity_headers=identity_headers or None,
+        # Built from the SAME declared table `register_data` registers, so a policy can only ever
+        # name an artifact this world already serves.
+        policy=RetrievalPolicyResolver(data),
     )
 
     # WHY: `outbound=StaticIOLayer()` denies every absolute-URL fetch: an unmapped target raises
@@ -511,7 +655,7 @@ def _model_params(params: Mapping[str, str]) -> dict[str, object]:
         ResolutionError: the expression set a runner-owned field. Loud on purpose — dropping it
             silently would let the expression read as though it had pinned something it had not.
     """
-    params = {k: v for k, v in params.items() if k != WEB_SEARCH_PARAM}
+    params = {k: v for k, v in params.items() if k not in _RUNNER_INTERPRETED_PARAMS}
     owned = sorted(set(params) & RUNNER_OWNED_FIELDS)
     if owned:
         raise ResolutionError(
@@ -528,6 +672,62 @@ def _coerce_param(value: str) -> object:
         return value
 
 
+def _caller_exclusions(params: Mapping[str, str]) -> tuple[str, ...]:
+    """``;web_search_exclude=a.test:b.test`` as a tuple.
+
+    Split explicitly rather than through `_coerce_param`: `json.loads` leaves the value a STRING,
+    and the gateway's array schema would then fail closed.
+
+    COLON, not comma — see `WEB_SEARCH_EXCLUDE_PARAM`. A comma splits the enclosing source list
+    first, so it silently truncates the value AND injects the remainder as a source.
+    """
+    raw = params.get(WEB_SEARCH_EXCLUDE_PARAM)
+    if not raw:
+        return ()
+    return tuple(item.strip() for item in raw.split(":") if item.strip())
+
+
+async def _retrieval_exclusions(
+    params: Mapping[str, str], policy: RetrievalPolicyResolver | None, *, native: bool
+) -> tuple[str, ...]:
+    """The expression's contribution to this call's blocklist: its policy plus any ad-hoc adds.
+
+    Raises:
+        ResolutionError: either option was named on a call that will not run PROVIDER-side
+            retrieval. Domain exclusion is a control the searching provider honours, so on a
+            `web_tools` route (where the RUNNER searches) or a route that does not retrieve at
+            all, a declared policy would be accepted and never enforced — which is precisely the
+            failure this parameter exists to close, not an instance of it.
+    """
+    path = params.get(WEB_SEARCH_POLICY_PARAM)
+    ad_hoc = _caller_exclusions(params)
+    if not native:
+        named = [
+            name
+            for name, value in (
+                (WEB_SEARCH_POLICY_PARAM, path),
+                (WEB_SEARCH_EXCLUDE_PARAM, ad_hoc),
+            )
+            if value
+        ]
+        if named:
+            raise ResolutionError(
+                f"{', '.join(named)} needs provider-side retrieval, which this route does not "
+                "run — declare `native_web_search` on its [[aigateway.models]] entry, or drop "
+                "the option rather than letting it read as an enforced guard"
+            )
+        return ()
+    if path is None or path == POLICY_NONE:
+        # WHY `none` cannot mean "unguarded": it drops only the BENCHMARK's list. The deployment's
+        # is enforcement and is unreachable from any expression.
+        return ad_hoc
+    if policy is None:
+        raise ResolutionError(
+            f"{WEB_SEARCH_POLICY_PARAM}={path!r} but this world declares no [data] routes"
+        )
+    return (*await policy.resolve(path), *ad_hoc)
+
+
 async def _chat_completion_loop(
     *,
     http_client: httpx.AsyncClient,
@@ -541,6 +741,7 @@ async def _chat_completion_loop(
     tavily_api_key: str | None,
     web_tools: bool,
     identity_headers: Mapping[str, str] | None = None,
+    policy: RetrievalPolicyResolver | None = None,
 ) -> str:
     """Drive one `_ModelEndpoint` call: post to aigateway, execute any requested tool calls,
     and repeat until the model answers with content instead of another tool call.
@@ -562,10 +763,13 @@ async def _chat_completion_loop(
     wants_search = _wants_web_search(params, spec)
     native = wants_search and bool(spec and spec.native_web_search)
     offer_tools = wants_search and web_tools and tavily_http is not None
+    # Resolved BEFORE the loop with the sampling params: a tool-calling turn re-posts, and the
+    # blocklist must hold on every hop or a later turn retrieves what the first one was denied.
+    exclusions = await _retrieval_exclusions(params, policy, native=native)
     if native:
         # A gateway-level flag, not a tools payload: no `tool_choice` (the OpenAI selection
         # control does not govern provider-run retrieval) and no collision with function calling.
-        extra: dict[str, object] = _native_web_search(cfg)
+        extra: dict[str, object] = _native_web_search(cfg, exclusions)
     elif offer_tools:
         extra = {"tools": _WEB_TOOLS, "tool_choice": "auto"}
     else:

--- a/apps/url4-cloud/src/url4_cloud/runner/connector.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/connector.py
@@ -66,6 +66,44 @@ _WEB_TOOLS = [
 ]
 
 
+WEB_SEARCH_PARAM = "web_search"
+"""The expression-level retrieval toggle: ``…!'answer';web_search=false``.
+
+INTERPRETED by the runner, never copied through. The gateway has a `web_search` field of its
+own and the names deliberately match — but the expression's value decides WHETHER this call
+retrieves, while the gateway's field is set by `_native_web_search` only after the route's
+declared mechanism has been resolved. Forwarding the raw string would send `"false"`, which is
+a truthy JSON string, and switch retrieval ON where the expression asked for it off.
+
+It OVERRIDES the route's declaration rather than replacing it: absent means "whatever the route
+declares", so an expression that says nothing about retrieval behaves exactly as it did before
+this existed.
+
+Asking a route that declares NO mechanism to search is an error, not a silent no-op — the
+alternative is an expression that reads as though it retrieved and an answer written from
+weights alone, which is indistinguishable in the result.
+"""
+
+
+def _native_web_search(cfg: AigatewayConfig) -> dict[str, object]:
+    """Ask the GATEWAY for provider-side retrieval — nothing provider-specific here.
+
+    `web_search` is aigateway's provider-agnostic vocabulary: the gateway decides which
+    provider can retrieve and translates the flag into that provider's own spelling. Building a
+    provider's payload here instead would put OpenRouter knowledge in the runner and duplicate a
+    contract the gateway already owns — the layering rule this repo states as core-defines-ports.
+
+    `web_search_excluded_domains` is UNIONed with the deployment's own list by the gateway, so
+    this can only ever tighten the guard. It is operator config, never expression-supplied: the
+    motivating case is a benchmark candidate that must not retrieve the rubric it is graded
+    against, and a blocklist a caller can rewrite is not a blocklist.
+    """
+    body: dict[str, object] = {"web_search": True}
+    if cfg.web_search_excluded_domains:
+        body["web_search_excluded_domains"] = list(cfg.web_search_excluded_domains)
+    return body
+
+
 @dataclass(frozen=True)
 class AigatewayConfig:
     """The resolved aigateway world settings a run needs — routes, timeouts, and the optional
@@ -96,6 +134,17 @@ class AigatewayConfig:
     #   concurrently, so an unbounded fan-out is an unbounded burst of upstream requests.
     web_tool_max_result_bytes: int = 32_768
     web_tool_max_calls_per_turn: int = 8
+    # --- native (provider-side) web search, for `native_web_search = true` routes ------------
+    # INVARIANT: OPERATOR-owned, never expression-supplied. This is a leak guard — a benchmark
+    # candidate must not be able to retrieve the rubric it is graded against — and a guard a
+    # caller can rewrite is not a guard. The gateway UNIONs it with the deployment's own list,
+    # so this can only tighten. Empty omits the field entirely rather than sending an empty
+    # list, which would read as "exclude nothing" instead of "use the deployment's".
+    #
+    # WHY no engine/max_results here: those are the PROVIDER's own options, and aigateway owns
+    # them. A runner that set them would be re-specifying one provider's envelope through a
+    # flag whose whole point is that it names no provider.
+    web_search_excluded_domains: tuple[str, ...] = ()
 
 
 @dataclass
@@ -178,6 +227,7 @@ class _ModelEndpoint:
             model=spec.id,
             messages=_messages(request.context, request.intent),
             params=request.params,
+            spec=spec,
             tavily_http=self._tavily_http,
             tavily_api_key=self._tavily_api_key,
             web_tools=spec.web_tools,
@@ -392,14 +442,21 @@ def _build_tavily_client(
     return client, owns
 
 
-RUNNER_OWNED_FIELDS = frozenset({"model", "messages", "tools", "tool_choice", "stream"})
+RUNNER_OWNED_FIELDS = frozenset(
+    {"model", "messages", "tools", "tool_choice", "stream", "web_search_excluded_domains"}
+)
 """Request fields an EXPRESSION may never set — they belong to the runner, not the caller.
 
 ``model`` would let an expression address one route and run another, breaking the "a route path
-is exactly '/' + the gateway id" invariant that `url4.toml` and `routes_for` rest on. ``messages``
-is built from the resolved context and intent. ``tools``/``tool_choice`` are the per-route
-``web_tools`` opt-in, which is what keeps a configured Tavily key from silently changing every
-model's payload. ``stream`` would break `_parse_choice`.
+is exactly '/' + the gateway id" invariant that `url4.toml` and
+`test_declared_models_match_aigateway.py` exist to hold. ``tools``/``tool_choice`` would bypass
+the per-route ``web_tools`` opt-in, which is what keeps a configured Tavily key from silently
+changing every model's payload. ``stream`` would break `_parse_choice`.
+
+``web_search_excluded_domains`` is the runner's because it is set from operator config on a
+retrieving call, and the payload merge puts the runner's value last — so a caller's copy would
+be accepted at parse and then silently discarded. The gateway would union a caller list safely
+enough, but "accepted and ignored" is the failure shape this whole file exists to avoid.
 
 Everything else is forwarded: the GATEWAY is the authority on which parameters exist and which
 values are legal (`core/standard_parameters.py` plus each provider's rules), and it fails closed
@@ -407,6 +464,32 @@ on an unknown field. A second allowlist here would be a copy of that contract, f
 from it — the same reason `register_commands` translates the engine's error instead of
 restating its rules.
 """
+
+
+def _wants_web_search(params: Mapping[str, str], spec: ModelSpec | None) -> bool:
+    """Whether THIS call retrieves — the route's declaration, overridden by the expression.
+
+    The route declares what it CAN do; the expression decides whether to use it. Absent means
+    "as declared", so an expression that never mentions retrieval keeps the behavior it had
+    before this parameter existed.
+
+    Raises:
+        ResolutionError: the expression asked a route that declares no mechanism to search.
+            Loud, because the silent alternative is an answer written from weights alone that
+            reads exactly like a retrieved one.
+    """
+    declared = bool(spec and (spec.web_tools or spec.native_web_search))
+    raw = params.get(WEB_SEARCH_PARAM)
+    if raw is None:
+        return declared
+    wanted = _coerce_param(raw) is True
+    if wanted and not declared:
+        raise ResolutionError(
+            f"{WEB_SEARCH_PARAM}=true but route {'/' + spec.id if spec else '?'} declares no web "
+            "search — add `web_tools` (runner-driven) or `native_web_search` (provider-driven) "
+            "to its [[aigateway.models]] entry"
+        )
+    return wanted
 
 
 def _model_params(params: Mapping[str, str]) -> dict[str, object]:
@@ -425,6 +508,7 @@ def _model_params(params: Mapping[str, str]) -> dict[str, object]:
         ResolutionError: the expression set a runner-owned field. Loud on purpose — dropping it
             silently would let the expression read as though it had pinned something it had not.
     """
+    params = {k: v for k, v in params.items() if k != WEB_SEARCH_PARAM}
     owned = sorted(set(params) & RUNNER_OWNED_FIELDS)
     if owned:
         raise ResolutionError(
@@ -449,6 +533,7 @@ async def _chat_completion_loop(
     model: str,
     messages: list[dict],
     params: Mapping[str, str] = {},  # noqa: B006 - read-only, never mutated
+    spec: ModelSpec | None = None,
     tavily_http: httpx.AsyncClient | None,
     tavily_api_key: str | None,
     web_tools: bool,
@@ -466,8 +551,22 @@ async def _chat_completion_loop(
         ResolutionError: the loop exceeds `cfg.web_tool_max_iterations` without a final
             answer — the model keeps calling tools instead of returning content.
     """
-    offer_tools = web_tools and tavily_http is not None
-    extra = {"tools": _WEB_TOOLS, "tool_choice": "auto"} if offer_tools else {}
+    # Which mechanism serves this call. `web_tools` needs a Tavily client because the RUNNER
+    # executes the search; native needs nothing extra because the PROVIDER does. Both conditions
+    # stay load-bearing: without the route's opt-in a configured key would silently change every
+    # model's request payload, and without the client the model could call a tool nothing can
+    # execute.
+    wants_search = _wants_web_search(params, spec)
+    native = wants_search and bool(spec and spec.native_web_search)
+    offer_tools = wants_search and web_tools and tavily_http is not None
+    if native:
+        # A gateway-level flag, not a tools payload: no `tool_choice` (the OpenAI selection
+        # control does not govern provider-run retrieval) and no collision with function calling.
+        extra: dict[str, object] = _native_web_search(cfg)
+    elif offer_tools:
+        extra = {"tools": _WEB_TOOLS, "tool_choice": "auto"}
+    else:
+        extra = {}
     # Coerced ONCE, outside the loop: the value is turn-invariant, and a tool-calling turn
     # re-posts — sampling parameters must hold on every hop, or the final answer is produced
     # under different settings from the ones the expression pinned.

--- a/apps/url4-cloud/src/url4_cloud/runner/connector.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/connector.py
@@ -239,13 +239,16 @@ def register_commands(node: Url4Node, commands: Sequence[CommandSpec]) -> None:
     """Register each declared `[commands]` route as a subprocess endpoint on ``node``.
 
     INVARIANT: the ENGINE owns which paths are registrable (the eval path is dispatched by the
-    node itself; a path cannot be claimed twice). Restating those rules in `config.py` would let
-    the two drift, so the engine's `ValueError` is translated here instead — the operator gets a
-    `RunnerConfigError` naming the offending route either way.
+    node itself; a path cannot be claimed twice) AND which stdin sources exist
+    (`_serve.COMMAND_STDIN_SOURCES`). Restating either in `config.py` would let the two drift —
+    and that module may not import url4 at all — so the engine's `ValueError` is translated here
+    instead. The operator gets a `RunnerConfigError` naming the offending route either way.
     """
     for command in commands:
         try:
-            node.endpoint(command.path)(make_command_handler(command.argv, command.timeout_s))
+            node.endpoint(command.path)(
+                make_command_handler(command.argv, command.timeout_s, stdin=command.stdin)
+            )
         except ValueError as exc:
             raise RunnerConfigError(
                 f"[commands] {command.path!r} is not registrable: {exc}"

--- a/apps/url4-cloud/src/url4_cloud/runner/connector.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/connector.py
@@ -10,6 +10,7 @@ import asyncio
 import json
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from urllib.parse import urlsplit
 
 import httpx
 
@@ -688,20 +689,31 @@ def _caller_exclusions(params: Mapping[str, str]) -> tuple[str, ...]:
 
 
 async def _retrieval_exclusions(
-    params: Mapping[str, str], policy: RetrievalPolicyResolver | None, *, native: bool
+    params: Mapping[str, str], policy: RetrievalPolicyResolver | None, *, retrieves: bool
 ) -> tuple[str, ...]:
     """The expression's contribution to this call's blocklist: its policy plus any ad-hoc adds.
 
+    INVARIANT: the gate is "does this call RETRIEVE", not "which mechanism runs it". Both are
+    enforceable — a native call carries the list to the provider, and on a `web_tools` route the
+    RUNNER is the searcher and applies it itself (`_tavily_search` / `_tavily_extract`).
+
+    # AIDEV-NOTE: this used to demand PROVIDER-side retrieval and refuse a policy on a Tavily
+    # route, reasoning that domain exclusion was a control only the searching provider could
+    # honour. MEASURED 2026-08-02 against the live API, that premise is false: Tavily's `/search`
+    # accepts `exclude_domains` and honours it. The refusal then became the bug it was written to
+    # prevent — an unguardable retrieval path — once the DRACO lineup's non-native models were
+    # put on that loop. `test_naming_a_policy_on_a_tavily_route_is_loud` pinned the old rule and
+    # was retired with owner approval; `test_tavily_retrieval_guard.py` pins the new one.
+
     Raises:
-        ResolutionError: either option was named on a call that will not run PROVIDER-side
-            retrieval. Domain exclusion is a control the searching provider honours, so on a
-            `web_tools` route (where the RUNNER searches) or a route that does not retrieve at
-            all, a declared policy would be accepted and never enforced — which is precisely the
-            failure this parameter exists to close, not an instance of it.
+        ResolutionError: either option was named on a call that runs NO retrieval by either
+            mechanism. A policy there would be accepted and never enforced, reading as a guarded
+            run while no retrieval happens at all — precisely the failure this parameter exists
+            to close, not an instance of it.
     """
     path = params.get(WEB_SEARCH_POLICY_PARAM)
     ad_hoc = _caller_exclusions(params)
-    if not native:
+    if not retrieves:
         named = [
             name
             for name, value in (
@@ -712,9 +724,10 @@ async def _retrieval_exclusions(
         ]
         if named:
             raise ResolutionError(
-                f"{', '.join(named)} needs provider-side retrieval, which this route does not "
-                "run — declare `native_web_search` on its [[aigateway.models]] entry, or drop "
-                "the option rather than letting it read as an enforced guard"
+                f"{', '.join(named)} needs retrieval, which this route does not run — declare "
+                "`native_web_search` (provider-driven) or `web_tools` (runner-driven) on its "
+                "[[aigateway.models]] entry, or drop the option rather than letting it read as "
+                "an enforced guard"
             )
         return ()
     if path is None or path == POLICY_NONE:
@@ -765,7 +778,7 @@ async def _chat_completion_loop(
     offer_tools = wants_search and web_tools and tavily_http is not None
     # Resolved BEFORE the loop with the sampling params: a tool-calling turn re-posts, and the
     # blocklist must hold on every hop or a later turn retrieves what the first one was denied.
-    exclusions = await _retrieval_exclusions(params, policy, native=native)
+    exclusions = await _retrieval_exclusions(params, policy, retrieves=native or offer_tools)
     if native:
         # A gateway-level flag, not a tools payload: no `tool_choice` (the OpenAI selection
         # control does not govern provider-run retrieval) and no collision with function calling.
@@ -802,7 +815,7 @@ async def _chat_completion_loop(
         )
         messages.append({"role": "assistant", "content": content, "tool_calls": tool_calls})
         results = await asyncio.gather(
-            *(_execute_tool(tc, tavily_http, cfg, tavily_api_key) for tc in served)
+            *(_execute_tool(tc, tavily_http, cfg, tavily_api_key, exclusions) for tc in served)
         )
         for tc, result in zip(served, results, strict=True):
             messages.append(
@@ -864,20 +877,49 @@ def _tool_args(tool_call: dict) -> tuple[str, dict | None]:
     return (name, args) if isinstance(args, dict) else (name, None)
 
 
+def _is_blocked(url: str, exclusions: Sequence[str]) -> bool:
+    """Whether ``url`` matches a blocklist entry, host-wise or host+path-wise.
+
+    INVARIANT: a bare-host entry covers SUBDOMAINS (`cdn.leak.test` matches `leak.test`), or the
+    guard is walked around by the first CDN hostname the model tries. An entry carrying a path
+    matches only that path prefix, because the shipped DRACO blocklist is path-shaped
+    (`arxiv.org/abs/2602.11685`) and blocking all of `arxiv.org` would strip a major legitimate
+    source from a deep-research benchmark — distorting the score in the other direction.
+
+    # AIDEV-NOTE: MEASURED 2026-08-02 — a path-shaped entry does NOT cover the same document's
+    # other paths. Tavily returned `arxiv.org/pdf/2602.11685` while `arxiv.org/abs/2602.11685`
+    # was excluded, i.e. the DRACO paper itself. The matcher below is correct; the LIST is what
+    # has to enumerate a document's forms. See `prepare.EXCLUDED_DOMAINS`.
+    """
+    parsed = urlsplit(url if "//" in url else f"//{url}")
+    host = parsed.netloc.lower().split("@")[-1].split(":")[0]
+    path = parsed.path.lower()
+    for entry in exclusions:
+        entry_host, _, entry_path = entry.strip().lower().lstrip("*.").partition("/")
+        if not entry_host:
+            continue
+        if host != entry_host and not host.endswith(f".{entry_host}"):
+            continue
+        if not entry_path or path.startswith(f"/{entry_path}"):
+            return True
+    return False
+
+
 async def _dispatch_tool(
     name: str,
     args: dict,
     tavily_client: httpx.AsyncClient | None,
     cfg: AigatewayConfig,
     tavily_api_key: str | None,
+    exclusions: Sequence[str] = (),
 ) -> str:
     if name not in ("web_search", "web_fetch"):
         return f"unknown tool: {name}"
     if tavily_client is None or tavily_api_key is None:
         raise RuntimeError(f"{name} requested but Tavily is not configured")
     if name == "web_search":
-        return await _tavily_search(tavily_client, cfg, tavily_api_key, args)
-    return await _tavily_extract(tavily_client, cfg, tavily_api_key, args)
+        return await _tavily_search(tavily_client, cfg, tavily_api_key, args, exclusions)
+    return await _tavily_extract(tavily_client, cfg, tavily_api_key, args, exclusions)
 
 
 async def _execute_tool(
@@ -885,12 +927,13 @@ async def _execute_tool(
     tavily_client: httpx.AsyncClient | None,
     cfg: AigatewayConfig,
     tavily_api_key: str | None,
+    exclusions: Sequence[str] = (),
 ) -> str:
     name, args = _tool_args(tool_call)
     if args is None:
         return f"invalid arguments for {name}"
     try:
-        return await _dispatch_tool(name, args, tavily_client, cfg, tavily_api_key)
+        return await _dispatch_tool(name, args, tavily_client, cfg, tavily_api_key, exclusions)
     except Exception as exc:  # noqa: BLE001 — fed back to the model, not raised (dec:W2)
         return f"{name} failed: {exc}"
 
@@ -900,18 +943,32 @@ async def _tavily_search(
     cfg: AigatewayConfig,
     api_key: str,
     args: dict,
+    exclusions: Sequence[str] = (),
 ) -> str:
+    """Run one search, minus anything the run's retrieval policy excludes.
+
+    `exclude_domains` is TAVILY's spelling; ours is `excluded_domains`. The translation happens
+    HERE and only here, exactly as `_apply_web_search` is the one boundary for OpenRouter's
+    `exclude_domains`. MEASURED 2026-08-02: the key is honoured — `huggingface.co` disappears
+    from the results.
+
+    INVARIANT: omitted when empty rather than sent as `[]`, so "no benchmark policy" and "exclude
+    nothing" stay distinguishable upstream.
+    """
     query = args.get("query")
     if not isinstance(query, str) or not query:
         raise ValueError("web_search requires a non-empty 'query'")
+    payload: dict[str, object] = {
+        "query": query,
+        "search_depth": cfg.tavily_search_depth,
+        "max_results": cfg.tavily_max_results,
+    }
+    if exclusions:
+        payload["exclude_domains"] = list(exclusions)
     resp = await client.post(
         "/search",
         headers=_tavily_headers(api_key),
-        json={
-            "query": query,
-            "search_depth": cfg.tavily_search_depth,
-            "max_results": cfg.tavily_max_results,
-        },
+        json=payload,
     )
     resp.raise_for_status()
     data = resp.json()
@@ -930,25 +987,51 @@ async def _tavily_extract(
     cfg: AigatewayConfig,
     api_key: str,
     args: dict,
+    exclusions: Sequence[str] = (),
 ) -> str:
+    """Fetch one page, unless the run's retrieval policy excludes it.
+
+    INVARIANT: this is the SHARPER of the two leaks and the runner is its only guard. `/search`
+    returns ranked snippets the model may or may not use; `/extract` returns the document
+    VERBATIM, so an unguarded fetch of the DRACO paper hands over the answer key in full — and
+    Tavily's `/extract` has no exclusion parameter to delegate to.
+
+    The refusal is RETURNED, not raised: the model gets a tool message it can act on, the same
+    way every other tool failure is fed back. A silent empty result would read as "the page was
+    empty" and invite a retry through a different URL to the same document.
+    """
     url = args.get("url")
     if not isinstance(url, str) or not url:
         raise ValueError("web_fetch requires a non-empty 'url'")
+    if _is_blocked(url, exclusions):
+        return (
+            f"{url} was not fetched: the host is excluded by this run's retrieval policy. "
+            "Do not try to reach it by another URL — answer from other sources."
+        )
     resp = await client.post(
         "/extract",
         headers=_tavily_headers(api_key),
         json={"urls": url, "format": "markdown", "extract_depth": "advanced"},
     )
     resp.raise_for_status()
-    data = resp.json()
+    return _extracted_content(resp.json(), url)
+
+
+def _extracted_content(data: dict, url: str) -> str:
+    """The page text, or the reason there is none — the tail of one `/extract` call.
+
+    Split out from `_tavily_extract` so the guard clause there reads as the one early exit it is,
+    rather than one of four returns.
+    """
     results = data.get("results") or []
     if results and isinstance(results[0], dict) and results[0].get("raw_content"):
         return str(results[0]["raw_content"])
     failed = data.get("failed_results") or []
     if failed and isinstance(failed[0], dict):
-        failed_url = failed[0].get("url", url)
-        failed_err = failed[0].get("error", "unknown")
-        return f"{failed_url} could not be extracted: {failed_err}"
+        return (
+            f"{failed[0].get('url', url)} could not be extracted: "
+            f"{failed[0].get('error', 'unknown')}"
+        )
     return "no content extracted"
 
 

--- a/apps/url4-cloud/src/url4_cloud/runner/connector.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/connector.py
@@ -327,7 +327,7 @@ def _provider_of(model: str) -> str:
     return "anthropic"
 
 
-def _report_usage(model: str, usage: dict | None) -> None:
+def _report_usage(model: str, usage: dict | None, response_model: object = None) -> None:
     if usage is None:
         return
     sink = current_usage_sink()
@@ -338,6 +338,10 @@ def _report_usage(model: str, usage: dict | None) -> None:
         model=model,
         input_tokens=usage.get("prompt_tokens", 0),
         output_tokens=usage.get("completion_tokens", 0),
+        # The gateway echoes the model that actually served the call, which may be a dated
+        # snapshot behind the alias we asked for. Only a string is forwarded: this comes off an
+        # upstream JSON body, and a non-string here would otherwise reach the wire schema.
+        response_model=response_model if isinstance(response_model, str) else None,
     )
 
 
@@ -422,7 +426,7 @@ async def _chat_completion_loop(
         )
         _raise_for_status(resp)
         data = _json_or_raise(resp)
-        _report_usage(model, data.get("usage"))
+        _report_usage(model, data.get("usage"), data.get("model"))
         content, tool_calls = _parse_choice(data)
         if not tool_calls:
             return content or ""

--- a/apps/url4-cloud/src/url4_cloud/runner/connector.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/connector.py
@@ -177,6 +177,7 @@ class _ModelEndpoint:
             profile=self._profile,
             model=spec.id,
             messages=_messages(request.context, request.intent),
+            params=request.params,
             tavily_http=self._tavily_http,
             tavily_api_key=self._tavily_api_key,
             web_tools=spec.web_tools,
@@ -391,6 +392,55 @@ def _build_tavily_client(
     return client, owns
 
 
+RUNNER_OWNED_FIELDS = frozenset({"model", "messages", "tools", "tool_choice", "stream"})
+"""Request fields an EXPRESSION may never set — they belong to the runner, not the caller.
+
+``model`` would let an expression address one route and run another, breaking the "a route path
+is exactly '/' + the gateway id" invariant that `url4.toml` and `routes_for` rest on. ``messages``
+is built from the resolved context and intent. ``tools``/``tool_choice`` are the per-route
+``web_tools`` opt-in, which is what keeps a configured Tavily key from silently changing every
+model's payload. ``stream`` would break `_parse_choice`.
+
+Everything else is forwarded: the GATEWAY is the authority on which parameters exist and which
+values are legal (`core/standard_parameters.py` plus each provider's rules), and it fails closed
+on an unknown field. A second allowlist here would be a copy of that contract, free to drift
+from it — the same reason `register_commands` translates the engine's error instead of
+restating its rules.
+"""
+
+
+def _model_params(params: Mapping[str, str]) -> dict[str, object]:
+    """The caller's `;k=v` chain as a JSON-typed request fragment.
+
+    INVARIANT: values are COERCED, not passed through as text. url4 hands params over as
+    ``Mapping[str, str]``, while the gateway's schemas are strictly typed
+    (``isinstance(v, (int, float)) and not isinstance(v, bool)``), so a forwarded ``"0.2"``
+    would fail closed against ``TEMPERATURE_SCHEMA`` — no better than dropping it.
+
+    JSON is the coercion rule rather than a per-field type table, so enabling a parameter stays
+    a gateway-local edit. A value that is not JSON stays the string it was, which is what a
+    scalar ``stop`` or any enum-valued field needs.
+
+    Raises:
+        ResolutionError: the expression set a runner-owned field. Loud on purpose — dropping it
+            silently would let the expression read as though it had pinned something it had not.
+    """
+    owned = sorted(set(params) & RUNNER_OWNED_FIELDS)
+    if owned:
+        raise ResolutionError(
+            f"expression may not set {', '.join(owned)} — "
+            f"{'it is' if len(owned) == 1 else 'they are'} owned by the runner's declared world"
+        )
+    return {key: _coerce_param(value) for key, value in params.items()}
+
+
+def _coerce_param(value: str) -> object:
+    try:
+        return json.loads(value)
+    except ValueError:
+        return value
+
+
 async def _chat_completion_loop(
     *,
     http_client: httpx.AsyncClient,
@@ -398,6 +448,7 @@ async def _chat_completion_loop(
     profile: str | None,
     model: str,
     messages: list[dict],
+    params: Mapping[str, str] = {},  # noqa: B006 - read-only, never mutated
     tavily_http: httpx.AsyncClient | None,
     tavily_api_key: str | None,
     web_tools: bool,
@@ -417,12 +468,18 @@ async def _chat_completion_loop(
     """
     offer_tools = web_tools and tavily_http is not None
     extra = {"tools": _WEB_TOOLS, "tool_choice": "auto"} if offer_tools else {}
+    # Coerced ONCE, outside the loop: the value is turn-invariant, and a tool-calling turn
+    # re-posts — sampling parameters must hold on every hop, or the final answer is produced
+    # under different settings from the ones the expression pinned.
+    sampling = _model_params(params)
     headers = _headers(profile, identity_headers)
     for _ in range(cfg.web_tool_max_iterations):
         resp = await http_client.post(
             "/v1/chat/completions",
             headers=headers,
-            json={"model": model, "messages": messages, **extra},
+            # `extra` LAST: the route's declared tools are not the caller's to override.
+            # `_model_params` already rejects them, so this is defense in depth.
+            json={"model": model, "messages": messages, **sampling, **extra},
         )
         _raise_for_status(resp)
         data = _json_or_raise(resp)

--- a/apps/url4-cloud/src/url4_cloud/runner/connector.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/connector.py
@@ -8,16 +8,30 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 
 import httpx
 
+# AIDEV-NOTE: `_serve` is a PRIVATE CLI module in `packages/url4` and this reaches into it
+# deliberately. `make_command_handler` is in that module's own `__all__`, so the symbol is stable
+# even though the module path is not — and duplicating it here would fork a subprocess-exec
+# factory whose invariants (argv list never a shell string; single-pass token substitution over
+# the operator's template only) must not exist in two copies. This mirrors the note in
+# `config.py`: the Runner is the SECOND consumer of `_serve`, and the agreed threshold for
+# promoting a shared public module is a THIRD. Promote this import then, not before.
+from url4.cli._serve import ProviderSpec, make_command_handler, make_data_provider
 from url4.core.errors import ResolutionError
 from url4.io.static import StaticIOLayer
 from url4.observe import current_usage_sink
 from url4.peer.server import Request, Url4Node
-from url4_cloud.runner.config import ModelSpec, RunnerConfigError, routes_for
+from url4_cloud.runner.config import (
+    CommandSpec,
+    DataSpec,
+    ModelSpec,
+    RunnerConfigError,
+    routes_for,
+)
 
 _WEB_TOOLS = [
     {
@@ -170,6 +184,67 @@ class _ModelEndpoint:
         )
 
 
+def register_commands(node: Url4Node, commands: Sequence[CommandSpec]) -> None:
+    """Register each declared `[commands]` route as a subprocess endpoint on ``node``.
+
+    INVARIANT: the ENGINE owns which paths are registrable (the eval path is dispatched by the
+    node itself; a path cannot be claimed twice). Restating those rules in `config.py` would let
+    the two drift, so the engine's `ValueError` is translated here instead — the operator gets a
+    `RunnerConfigError` naming the offending route either way.
+    """
+    for command in commands:
+        try:
+            node.endpoint(command.path)(make_command_handler(command.argv, command.timeout_s))
+        except ValueError as exc:
+            raise RunnerConfigError(
+                f"[commands] {command.path!r} is not registrable: {exc}"
+            ) from exc
+
+
+def register_data(node: Url4Node, data: Sequence[DataSpec]) -> None:
+    """Register each declared `[data]` route as a read-only artifact on ``node``.
+
+    Provider construction reuses `_serve`'s tested factory rather than reimplementing
+    per-request file reads and subprocess handling — those behaviours are the contract
+    (`file` is live; `command` gets empty stdin), and a second copy would drift from it.
+
+    INVARIANT: registrability is the ENGINE's rule, as in `register_commands` — the eval path is
+    the node's own, and a path cannot be claimed twice. Its `ValueError` is translated so the
+    operator sees a `RunnerConfigError` naming the route.
+    """
+    for spec in data:
+        provider = make_data_provider(
+            ProviderSpec(
+                value=spec.value,
+                file=spec.file,
+                command=spec.command,
+                media_type=spec.media_type,
+            ),
+            spec.timeout_s,
+        )
+        try:
+            node.data(spec.path, provider, media_type=spec.media_type)
+        except ValueError as exc:
+            raise RunnerConfigError(f"[data] {spec.path!r} is not registrable: {exc}") from exc
+
+
+def build_local_world(
+    commands: Sequence[CommandSpec] = (), data: Sequence[DataSpec] = ()
+) -> Url4Node:
+    """A world with declared routes and nothing else — no models, no outbound fetches.
+
+    WHY this exists: a config declaring only `[commands]` and/or `[data]` is legitimate (a Job
+    that shells out or serves artifacts and never calls a model), and before those tables were
+    parsed the absence of `[aigateway]` could only mean "deny everything". `StaticIOLayer` keeps
+    the deny-by-default outbound posture, so the ONLY thing this world adds over
+    `deny_by_default_world` is the declared routes.
+    """
+    node = Url4Node("local", outbound=StaticIOLayer())
+    register_commands(node, commands)
+    register_data(node, data)
+    return node
+
+
 async def build_aigateway_world(
     cfg: AigatewayConfig,
     *,
@@ -178,6 +253,8 @@ async def build_aigateway_world(
     tavily_api_key: str | None = None,
     tavily_client: httpx.AsyncClient | None = None,
     identity_headers: Mapping[str, str] | None = None,
+    commands: Sequence[CommandSpec] = (),
+    data: Sequence[DataSpec] = (),
 ) -> AigatewayWorld:
     """Build the `Url4Node` world: one endpoint per declared model, routed to aigateway.
 
@@ -230,6 +307,11 @@ async def build_aigateway_world(
     )
     for path in routes:
         node.endpoint(path)(call_model)
+    # INVARIANT: commands are registered AFTER the model routes, so a path claimed by both is
+    # rejected by the engine here rather than silently shadowing a model. `config` already
+    # rejects that pair with a better message; this is the backstop for a world built directly.
+    register_commands(node, commands)
+    register_data(node, data)
     return AigatewayWorld(
         node=node,
         _client=http_client,

--- a/apps/url4-cloud/src/url4_cloud/runner/connector.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/connector.py
@@ -21,12 +21,18 @@ import httpx
 # the operator's template only) must not exist in two copies. This mirrors the note in
 # `config.py`: the Runner is the SECOND consumer of `_serve`, and the agreed threshold for
 # promoting a shared public module is a THIRD. Promote this import then, not before.
-from url4.cli._serve import ProviderSpec, make_command_handler, make_data_provider
+from url4.cli._serve import (
+    DataCallable,
+    ProviderSpec,
+    make_command_handler,
+    make_data_provider,
+)
 from url4.core.errors import ResolutionError
 from url4.io.static import StaticIOLayer
 from url4.observe import current_usage_sink
 from url4.peer.server import Request, Url4Node
 from url4_cloud.runner.config import (
+    DEFAULT_WEB_TOOL_MAX_ITERATIONS,
     CommandSpec,
     DataSpec,
     ModelSpec,
@@ -182,7 +188,7 @@ class AigatewayConfig:
     tavily_search_depth: str = "advanced"
     tavily_max_results: int = 5
     tavily_timeout_s: float = 30.0
-    web_tool_max_iterations: int = 5
+    web_tool_max_iterations: int = DEFAULT_WEB_TOOL_MAX_ITERATIONS
     # INVARIANT: the iteration count alone does NOT bound this loop's cost. Two other dimensions
     # have to be bounded or a single expression can run away:
     #
@@ -286,13 +292,11 @@ class _ModelEndpoint:
             http_client=self._http_client,
             cfg=self._cfg,
             profile=self._profile,
-            model=spec.id,
             messages=_messages(request.context, request.intent),
             params=request.params,
             spec=spec,
             tavily_http=self._tavily_http,
             tavily_api_key=self._tavily_api_key,
-            web_tools=spec.web_tools,
             identity_headers=self._identity_headers,
             policy=self._policy,
         )
@@ -330,19 +334,31 @@ def register_data(node: Url4Node, data: Sequence[DataSpec]) -> None:
     operator sees a `RunnerConfigError` naming the route.
     """
     for spec in data:
-        provider = make_data_provider(
-            ProviderSpec(
-                value=spec.value,
-                file=spec.file,
-                command=spec.command,
-                media_type=spec.media_type,
-            ),
-            spec.timeout_s,
-        )
+        provider = _provider_for(spec)
         try:
             node.data(spec.path, provider, media_type=spec.media_type)
         except ValueError as exc:
             raise RunnerConfigError(f"[data] {spec.path!r} is not registrable: {exc}") from exc
+
+
+def _provider_for(spec: DataSpec) -> DataCallable:
+    """Build one `[data]` route's provider from its parsed declaration.
+
+    INVARIANT: the ONLY construction site. `register_data` serves a path and
+    `RetrievalPolicyResolver` dereferences one, and the leak guard's whole argument is that the
+    policy it reads is the SAME artifact the node serves at that address. Two literals that
+    happen to match make that equality a coincidence — a field added to `DataSpec` and wired at
+    one site would silently give the two different views of one route.
+    """
+    return make_data_provider(
+        ProviderSpec(
+            value=spec.value,
+            file=spec.file,
+            command=spec.command,
+            media_type=spec.media_type,
+        ),
+        spec.timeout_s,
+    )
 
 
 class RetrievalPolicyResolver:
@@ -362,24 +378,18 @@ class RetrievalPolicyResolver:
     is unreachable in production, and a DRACO run would otherwise re-read the file on every
     answering call. TRADEOFF: a LOCAL run that edits a policy file needs a restart, which differs
     from `[data]` routes generally (a `file` provider is re-read per request).
+
+    INVARIANT: the memo holds the in-flight TASK, not just the settled value. Answering calls fan
+    out concurrently, so a value-only cache is written after the first read COMPLETES and every
+    call that starts before then misses it — the run's opening burst would each re-read the same
+    file, which is the cost this memo exists to remove.
     """
 
-    __slots__ = ("_cache", "_providers")
+    __slots__ = ("_inflight", "_specs")
 
     def __init__(self, data: Sequence[DataSpec] = ()) -> None:
-        self._providers = {
-            spec.path: make_data_provider(
-                ProviderSpec(
-                    value=spec.value,
-                    file=spec.file,
-                    command=spec.command,
-                    media_type=spec.media_type,
-                ),
-                spec.timeout_s,
-            )
-            for spec in data
-        }
-        self._cache: dict[str, tuple[str, ...]] = {}
+        self._specs = {spec.path: spec for spec in data}
+        self._inflight: dict[str, asyncio.Task[tuple[str, ...]]] = {}
 
     async def resolve(self, path: str) -> tuple[str, ...]:
         """The policy's excluded domains.
@@ -389,18 +399,28 @@ class RetrievalPolicyResolver:
                 a usable policy. NEVER returns an empty tuple on failure — empty means "retrieve
                 unguarded", and the run would report success carrying an inflated score.
         """
-        cached = self._cache.get(path)
-        if cached is not None:
-            return cached
-        provider = self._providers.get(path)
-        if provider is None:
+        spec = self._specs.get(path)
+        if spec is None:
             raise ResolutionError(
                 f"{WEB_SEARCH_POLICY_PARAM}={path!r} is not a declared [data] route — a retrieval "
                 "policy is an artifact the benchmark image declares, like its cases and criteria"
             )
-        domains = _parse_policy(await provider(), path)
-        self._cache[path] = domains
-        return domains
+        task = self._inflight.get(path)
+        if task is None:
+            task = asyncio.ensure_future(self._load(spec))
+            self._inflight[path] = task
+        try:
+            return await task
+        except BaseException:
+            # WHY the failed task is DISCARDED: a settled failure would otherwise be the answer
+            # for the world's lifetime, turning one transient read error into a permanently
+            # unguarded-or-broken policy. A deterministic failure simply fails again on the
+            # retry, which is the behaviour the value-only cache had.
+            self._inflight.pop(path, None)
+            raise
+
+    async def _load(self, spec: DataSpec) -> tuple[str, ...]:
+        return _parse_policy(await _provider_for(spec)(), spec.path)
 
 
 def _parse_policy(raw: str, path: str) -> tuple[str, ...]:
@@ -614,7 +634,7 @@ restating its rules.
 """
 
 
-def _wants_web_search(params: Mapping[str, str], spec: ModelSpec | None) -> bool:
+def _wants_web_search(params: Mapping[str, str], spec: ModelSpec) -> bool:
     """Whether THIS call retrieves — the route's declaration, overridden by the expression.
 
     The route declares what it CAN do; the expression decides whether to use it. Absent means
@@ -626,14 +646,14 @@ def _wants_web_search(params: Mapping[str, str], spec: ModelSpec | None) -> bool
             Loud, because the silent alternative is an answer written from weights alone that
             reads exactly like a retrieved one.
     """
-    declared = bool(spec and (spec.web_tools or spec.native_web_search))
+    declared = spec.web_tools or spec.native_web_search
     raw = params.get(WEB_SEARCH_PARAM)
     if raw is None:
         return declared
     wanted = _coerce_param(raw) is True
     if wanted and not declared:
         raise ResolutionError(
-            f"{WEB_SEARCH_PARAM}=true but route {'/' + spec.id if spec else '?'} declares no web "
+            f"{WEB_SEARCH_PARAM}=true but route /{spec.id} declares no web "
             "search — add `web_tools` (runner-driven) or `native_web_search` (provider-driven) "
             "to its [[aigateway.models]] entry"
         )
@@ -746,13 +766,11 @@ async def _chat_completion_loop(
     http_client: httpx.AsyncClient,
     cfg: AigatewayConfig,
     profile: str | None,
-    model: str,
     messages: list[dict],
+    spec: ModelSpec,
     params: Mapping[str, str] = {},  # noqa: B006 - read-only, never mutated
-    spec: ModelSpec | None = None,
     tavily_http: httpx.AsyncClient | None,
     tavily_api_key: str | None,
-    web_tools: bool,
     identity_headers: Mapping[str, str] | None = None,
     policy: RetrievalPolicyResolver | None = None,
 ) -> str:
@@ -774,8 +792,8 @@ async def _chat_completion_loop(
     # model's request payload, and without the client the model could call a tool nothing can
     # execute.
     wants_search = _wants_web_search(params, spec)
-    native = wants_search and bool(spec and spec.native_web_search)
-    offer_tools = wants_search and web_tools and tavily_http is not None
+    native = wants_search and spec.native_web_search
+    offer_tools = wants_search and spec.web_tools and tavily_http is not None
     # Resolved BEFORE the loop with the sampling params: a tool-calling turn re-posts, and the
     # blocklist must hold on every hop or a later turn retrieves what the first one was denied.
     exclusions = await _retrieval_exclusions(params, policy, retrieves=native or offer_tools)
@@ -798,11 +816,11 @@ async def _chat_completion_loop(
             headers=headers,
             # `extra` LAST: the route's declared tools are not the caller's to override.
             # `_model_params` already rejects them, so this is defense in depth.
-            json={"model": model, "messages": messages, **sampling, **extra},
+            json={"model": spec.id, "messages": messages, **sampling, **extra},
         )
         _raise_for_status(resp)
         data = _json_or_raise(resp)
-        _report_usage(model, data.get("usage"), data.get("model"))
+        _report_usage(spec.id, data.get("usage"), data.get("model"))
         content, tool_calls = _parse_choice(data)
         if not tool_calls:
             return content or ""
@@ -881,15 +899,20 @@ def _is_blocked(url: str, exclusions: Sequence[str]) -> bool:
     """Whether ``url`` matches a blocklist entry, host-wise or host+path-wise.
 
     INVARIANT: a bare-host entry covers SUBDOMAINS (`cdn.leak.test` matches `leak.test`), or the
-    guard is walked around by the first CDN hostname the model tries. An entry carrying a path
-    matches only that path prefix, because the shipped DRACO blocklist is path-shaped
-    (`arxiv.org/abs/2602.11685`) and blocking all of `arxiv.org` would strip a major legitimate
-    source from a deep-research benchmark — distorting the score in the other direction.
+    guard is walked around by the first CDN hostname the model tries.
+
+    An entry carrying a path matches only that path prefix. NOTE that a DECLARED policy can no
+    longer contain one: `prepare.write_policy` rejects any entry holding `/`, `*` or `:` at build
+    time, because the native-search provider 400s on anything longer than a host and that 400
+    fails every answering call. So the path branch is reachable only from an ad-hoc
+    `;web_search_exclude=`, which the runner enforces itself and no provider ever sees.
 
     # AIDEV-NOTE: MEASURED 2026-08-02 — a path-shaped entry does NOT cover the same document's
     # other paths. Tavily returned `arxiv.org/pdf/2602.11685` while `arxiv.org/abs/2602.11685`
-    # was excluded, i.e. the DRACO paper itself. The matcher below is correct; the LIST is what
-    # has to enumerate a document's forms. See `prepare.EXCLUDED_DOMAINS`.
+    # was excluded, i.e. the DRACO paper itself. That measurement is why the shipped list went to
+    # whole hosts (`prepare.EXCLUDED_DOMAINS`, owner decision the same day) rather than trying to
+    # enumerate a document's forms. The matcher keeps the path form for the ad-hoc case; anyone
+    # using it inherits that trap.
     """
     parsed = urlsplit(url if "//" in url else f"//{url}")
     host = parsed.netloc.lower().split("@")[-1].split(":")[0]

--- a/apps/url4-cloud/src/url4_cloud/runner/executor.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/executor.py
@@ -138,6 +138,10 @@ class _SpanState:
     start: datetime
     parent_span_id: str | None
     usage: tuple[str, str, int, int] | None = field(default=None)
+    # Held beside `usage` rather than widening that tuple: it is the only one of these fields
+    # that can legitimately be absent (a provider need not echo a model), so a 5th positional
+    # slot would read as "unknown" and "not reported" interchangeably.
+    response_model: str | None = field(default=None)
 
 
 class _RunState:
@@ -217,6 +221,10 @@ class _RunState:
             prior_in + event.input_tokens,
             prior_out + event.output_tokens,
         )
+        # Last writer wins, and a silent event never erases a known one: across the tool loop's
+        # round trips every response names the same model, so the only way these differ is a
+        # provider that stopped reporting mid-loop.
+        span.response_model = event.response_model or span.response_model
 
     def _finish(self, event: NodeFinished) -> list[Traced]:
         span = self.spans.pop(event.span_id, None)
@@ -234,7 +242,11 @@ class _RunState:
             operation=kind,
             provider=usage[0] if usage else None,
             request_model=usage[1] if usage else None,
-            response_model=usage[1] if usage else None,
+            # INVARIANT: left absent when the provider did not name a model. It previously
+            # repeated `request_model`, which made an alias silently resolving to a different
+            # snapshot — the one thing this field exists to reveal — indistinguishable from
+            # the provider serving exactly what was asked for.
+            response_model=span.response_model,
             input_tokens=usage[2] if usage else None,
             output_tokens=usage[3] if usage else None,
             start=start,

--- a/apps/url4-cloud/src/url4_cloud/runner/main.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/main.py
@@ -16,7 +16,12 @@ import httpx
 from url4.streaming.lifecycle import run
 from url4_cloud import job_env
 from url4_cloud.adapters.jetstream import JetStreamPublisher
-from url4_cloud.runner.config import RunnerConfig, RunnerConfigError, load_config
+from url4_cloud.runner.config import (
+    AigatewaySection,
+    RunnerConfig,
+    RunnerConfigError,
+    load_config,
+)
 from url4_cloud.runner.connector import (
     AigatewayConfig,
     build_aigateway_world,
@@ -111,13 +116,7 @@ def build_executor(
         # is anonymous. The old unconditional token requirement made every deployed run fail
         # before it issued a single request, because a deployed caller has no way to obtain one.
         world = await build_aigateway_world(
-            AigatewayConfig(
-                base_url=section.base_url,
-                default_model=section.default_model,
-                models=section.models,
-                allow_outbound=section.allow_outbound,
-                timeout_s=section.timeout_s,
-            ),
+            aigateway_config_from(section),
             profile=env.get(job_env.AIGATEWAY_PROFILE),
             identity_headers=job_env.identity_from_env(env),
             client=client,
@@ -129,6 +128,27 @@ def build_executor(
         return world.node, world.aclose
 
     return Url4Executor(world_factory=_world)
+
+
+def aigateway_config_from(section: AigatewaySection) -> AigatewayConfig:
+    """Project a parsed `[aigateway]` table onto the connector's config.
+
+    # AIDEV-NOTE: EVERY declarable field must be copied here. This was a field-by-field literal
+    # inline in `_world`, and `web_tool_max_iterations` was simply absent from it — so the
+    # connector's default of 5 was unreachable from any `url4.toml`, and MEASURED 2026-08-02 that
+    # default is a hard per-case failure on the Tavily loop. A parsed field that no projection
+    # copies is indistinguishable from one that was never declared: the config validates, the run
+    # starts, and the value silently is not the one the operator wrote. Adding a field to
+    # `AigatewaySection` without adding it here is the same bug again.
+    """
+    return AigatewayConfig(
+        base_url=section.base_url,
+        default_model=section.default_model,
+        models=section.models,
+        allow_outbound=section.allow_outbound,
+        timeout_s=section.timeout_s,
+        web_tool_max_iterations=section.web_tool_max_iterations,
+    )
 
 
 def main() -> None:  # pragma: no cover - real NATS + event loop (INFRA rule)

--- a/apps/url4-cloud/src/url4_cloud/runner/main.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/main.py
@@ -17,7 +17,11 @@ from url4.streaming.lifecycle import run
 from url4_cloud import job_env
 from url4_cloud.adapters.jetstream import JetStreamPublisher
 from url4_cloud.runner.config import RunnerConfig, RunnerConfigError, load_config
-from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+from url4_cloud.runner.connector import (
+    AigatewayConfig,
+    build_aigateway_world,
+    build_local_world,
+)
 from url4_cloud.runner.executor import Url4Executor, World, deny_by_default_world
 
 
@@ -95,8 +99,11 @@ def build_executor(
         resolved = config if config is not None else load_config(env)
         section = resolved.aigateway
         if section is None:
-            # WHY: a world with no [aigateway] table is a legitimate empty world; the node itself
-            # denies everything undeclared.
+            # WHY: a world with no [aigateway] table is a legitimate world, not necessarily an
+            # empty one — a Job may declare only `[commands]` and/or `[data]` and never call a
+            # model. With none of the three, the node denies everything undeclared, as always.
+            if resolved.commands or resolved.data:
+                return build_local_world(resolved.commands, resolved.data), None
             return deny_by_default_world(), None
         # WHY no credential check here any more: aigateway runs `cloudflare_headers` when deployed
         # and `disabled` locally, and NEITHER mode reads `Authorization` — so there is no token to
@@ -116,6 +123,8 @@ def build_executor(
             client=client,
             tavily_api_key=env.get(job_env.TAVILY_API_KEY),
             tavily_client=tavily_client,
+            commands=resolved.commands,
+            data=resolved.data,
         )
         return world.node, world.aclose
 

--- a/apps/url4-cloud/src/url4_cloud/runner/main.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/main.py
@@ -10,7 +10,7 @@ import asyncio
 import os
 import signal
 from collections.abc import Coroutine, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import Any
 
 import httpx
@@ -135,22 +135,24 @@ def build_executor(
 def aigateway_config_from(section: AigatewaySection) -> AigatewayConfig:
     """Project a parsed `[aigateway]` table onto the connector's config.
 
-    # AIDEV-NOTE: EVERY declarable field must be copied here. This was a field-by-field literal
-    # inline in `_world`, and `web_tool_max_iterations` was simply absent from it — so the
-    # connector's default of 5 was unreachable from any `url4.toml`, and MEASURED 2026-08-02 that
-    # default is a hard per-case failure on the Tavily loop. A parsed field that no projection
-    # copies is indistinguishable from one that was never declared: the config validates, the run
-    # starts, and the value silently is not the one the operator wrote. Adding a field to
-    # `AigatewaySection` without adding it here is the same bug again.
+    INVARIANT: the projection is MECHANICAL — every field `AigatewaySection` declares is copied by
+    construction, so a new `[aigateway]` key cannot be parsed and then dropped here.
+
+    # AIDEV-NOTE: this was a field-by-field literal inline in `_world`, and
+    # `web_tool_max_iterations` was simply absent from it — so the connector's default of 5 was
+    # unreachable from any `url4.toml`, and MEASURED 2026-08-02 that default is a hard per-case
+    # failure on the Tavily loop. A parsed field that no projection copies is indistinguishable
+    # from one that was never declared: the config validates, the run starts, and the value
+    # silently is not the one the operator wrote. Listing the fields again — even correctly —
+    # leaves that bug one forgotten line away, which is why the names are read off the dataclass.
+    #
+    # `fields()` rather than `asdict()`: the latter deep-converts, which would turn each
+    # `ModelSpec` into a plain dict and lose the declared route capabilities.
+    #
+    # The section is a NAME-FOR-NAME subset of `AigatewayConfig`; a field added to one and not the
+    # other is a TypeError here, at Job boot, rather than a silently defaulted value at run time.
     """
-    return AigatewayConfig(
-        base_url=section.base_url,
-        default_model=section.default_model,
-        models=section.models,
-        allow_outbound=section.allow_outbound,
-        timeout_s=section.timeout_s,
-        web_tool_max_iterations=section.web_tool_max_iterations,
-    )
+    return AigatewayConfig(**{f.name: getattr(section, f.name) for f in fields(section)})
 
 
 _CANCEL_SIGNALS: tuple[signal.Signals, ...] = (signal.SIGTERM,)

--- a/apps/url4-cloud/src/url4_cloud/runner/main.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/main.py
@@ -8,8 +8,10 @@ layering note in :mod:`url4_cloud.runner`.
 
 import asyncio
 import os
-from collections.abc import Mapping
+import signal
+from collections.abc import Coroutine, Mapping, Sequence
 from dataclasses import dataclass
+from typing import Any
 
 import httpx
 
@@ -151,18 +153,113 @@ def aigateway_config_from(section: AigatewaySection) -> AigatewayConfig:
     )
 
 
+_CANCEL_SIGNALS: tuple[signal.Signals, ...] = (signal.SIGTERM,)
+"""The signals that mean "the run is being cancelled".
+
+SIGTERM is what a Runner Job actually receives: `JobRunner.stop` deletes the Job with
+`propagation_policy="Background"`, the kubelet SIGTERMs the Pod, and SIGKILL follows once the
+termination grace period expires.
+
+INVARIANT: SIGINT is deliberately ABSENT. `asyncio.run` already installs its own SIGINT handler
+(`asyncio.runners.Runner._on_sigint`) whose first action is to cancel the main task — the exact
+cancellation this helper delivers for SIGTERM — so Ctrl-C on a local `url4-cloud run` already
+produces the terminal frame. Handling it here would REPLACE that handler and take over its
+interrupt counting, silently breaking the escalation where a second Ctrl-C force-quits a run
+that will not stop.
+"""
+
+
+async def cancel_on_signal(
+    coro: Coroutine[Any, Any, None],
+    *,
+    signals: Sequence[signal.Signals] = _CANCEL_SIGNALS,
+) -> None:
+    """Await ``coro``, turning a shutdown signal into a cancellation of it.
+
+    FEATURE: cancelling an in-flight run (OME-315).
+    STORY: as a user who cancelled a run, I need the stream to END, so my client stops waiting.
+
+    WHY this exists: `lifecycle.run` already publishes `Terminated(stopped)` from its
+    `except CancelledError` arm — but nothing ever delivered a cancellation here, so that arm
+    never ran. The topic got no terminal frame at all: a subscriber waited forever, while
+    `status()` reported the deleted Job as `not_found` — indistinguishable from a run that never
+    existed. This is the same hazard `_deadline_from_env` names for `activeDeadlineSeconds`
+    ("the substrate's deadline kills the POD, which ends the process before it can publish
+    anything"), and it gets the same answer: self-terminate first, then let the process die.
+
+    # AIDEV-NOTE: the handler is what makes the signal ARRIVE AT ALL here, not merely what makes
+    # it useful. A Runner Job sets `command:`, which overrides the image's
+    # `ENTRYPOINT ["tini", "--"]` — confirmed on a live Job, whose /proc/1/cmdline is
+    # `url4-cloud run` — so this process is PID 1 with no init supervising it, and the kernel
+    # does not apply DEFAULT signal actions to a PID-namespace init. SIGTERM was therefore
+    # DISCARDED, and the Pod ran on until SIGKILL ended the grace period.
+    #
+    # MEASURED on kind 2026-08-03, same cluster and expression, only the runner image differing:
+    #
+    #   pre-fix   no terminal frame at all; DELETE waited out its full drain bound (5.014s) and
+    #             gave up; Pod exit 137 (SIGKILL) 30s after the delete — the whole
+    #             terminationGracePeriodSeconds spent ignoring the signal
+    #   post-fix  `terminated: stopped` on the topic 27ms after the delete; Pod exit 0
+    #             ("Completed"), no grace period burned
+    #
+    # So this also removes a 30-second teardown from every cancelled run. Keep the handler, not
+    # an entrypoint change: tini would forward SIGTERM, but the default action still kills the
+    # process before `lifecycle.run` can publish anything.
+
+    # AIDEV-NOTE: `loop.add_signal_handler`, never `signal.signal`. A C-level handler runs
+    # between bytecodes on an arbitrary stack and may not touch loop state; this one is
+    # scheduled on the loop, where cancelling a task is safe. It is also why this lives in the
+    # deployable rather than in `packages/url4` — installing process-wide signal handlers is the
+    # entrypoint's call to make, never a library's.
+    """
+    loop = asyncio.get_running_loop()
+    task = asyncio.create_task(coro)
+    ours = False
+
+    def _cancel_once() -> None:
+        # INVARIANT: exactly ONE cancellation, however many signals arrive. The terminal frame is
+        # published from inside the run's `except CancelledError` arm, and that publish awaits —
+        # a second `task.cancel()` landing there raises straight through the arm's
+        # `contextlib.suppress(Exception)`, because CancelledError is a BaseException. That
+        # destroys the very frame the first signal existed to produce. Escalating a run that will
+        # not stop is the substrate's job (SIGKILL after the grace period), not a second handler.
+        nonlocal ours
+        if ours:
+            return
+        ours = True
+        task.cancel()
+
+    for sig in signals:
+        loop.add_signal_handler(sig, _cancel_once)
+    try:
+        await task
+    except asyncio.CancelledError:
+        # WHY absorbed rather than re-raised, against the usual rule: we ARE the canceller, and
+        # this is the process boundary — propagating would exit non-zero with a traceback for a
+        # shutdown that went exactly as asked. A cancellation we did NOT cause is someone else's
+        # (an enclosing TaskGroup tearing down) and must still reach them, hence the guard.
+        if not ours:
+            raise
+    finally:
+        # A handler outliving its run would cancel whatever ran next on this loop.
+        for sig in signals:
+            loop.remove_signal_handler(sig)
+
+
 def main() -> None:  # pragma: no cover - real NATS + event loop (INFRA rule)
     async def _main() -> None:
         params = params_from_env(os.environ)
         executor = build_executor(os.environ)
         traceparent = os.environ.get(job_env.TRACEPARENT)
-        await run(
-            JetStreamPublisher(params.nats_url),
-            executor,
-            params.topic,
-            params.url4,
-            traceparent=traceparent,
-            deadline_s=params.deadline_s,
+        await cancel_on_signal(
+            run(
+                JetStreamPublisher(params.nats_url),
+                executor,
+                params.topic,
+                params.url4,
+                traceparent=traceparent,
+                deadline_s=params.deadline_s,
+            )
         )
 
     asyncio.run(_main())

--- a/apps/url4-cloud/src/url4_cloud/runner/merge_config.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/merge_config.py
@@ -94,12 +94,22 @@ def _strip_data_table(base_text: str) -> str:
     """Drop the base's own ``[data]`` section — its entries are re-emitted in the merged table.
 
     Only a top-level ``[data]`` header starts the section; it ends at the next top-level header.
+
+    INVARIANT: ``[[x]]`` is a top-level header and ENDS the section. It only ever failed to start
+    one, and the guard that expressed that (`not startswith("[[")`) was applied to the whole
+    decision — so an array-of-tables header left the flag untouched and its lines were dropped.
+    The base carries no ``[data]`` today, which is exactly why this stayed invisible: add one
+    above the model list and the merged image loses every ``[[aigateway.models]]`` after it.
+    ``_validate`` cannot catch the common case, because a SHORTER model list is still a valid
+    one — the build succeeds and the missing routes surface as `endpoint_not_found` at the first
+    expression that names them.
     """
     out: list[str] = []
     skipping = False
     for line in base_text.splitlines(keepends=True):
         stripped = line.strip()
-        if stripped.startswith("[") and not stripped.startswith("[["):
+        if stripped.startswith("["):
+            # `[[data]]` is an array-of-tables, a different construct — it must not start one.
             skipping = stripped == "[data]"
         if not skipping:
             out.append(line)

--- a/apps/url4-cloud/src/url4_cloud/runner/merge_config.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/merge_config.py
@@ -1,6 +1,6 @@
 """Combine the hand-written `url4.toml` with generated `[data]` fragments, at image build.
 
-    python -m url4_cloud.benchmarks.merge_config \\
+    python -m url4_cloud.runner.merge_config \\
         --base url4.toml --fragment /opt/benchmarks/draco/url4.data.toml \\
         --out /etc/url4/url4.toml
 
@@ -108,7 +108,7 @@ def _strip_data_table(base_text: str) -> str:
 
 def _render_data(data: Mapping[str, Any]) -> str:
     lines = [
-        "# --- GENERATED — merged by url4_cloud.benchmarks.merge_config. Do not edit. ---",
+        "# --- GENERATED — merged by url4_cloud.runner.merge_config. Do not edit. ---",
         f"# {len(data)} declared artifact(s). Regenerate by rebuilding the benchmark image.",
         "[data]",
     ]

--- a/apps/url4-cloud/src/url4_cloud/runner/merge_config.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/merge_config.py
@@ -1,0 +1,178 @@
+"""Combine the hand-written `url4.toml` with generated `[data]` fragments, at image build.
+
+    python -m url4_cloud.benchmarks.merge_config \\
+        --base url4.toml --fragment /opt/benchmarks/draco/url4.data.toml \\
+        --out /etc/url4/url4.toml
+
+WHY a merge step rather than `cat`: TOML admits a table name ONCE, so two `[data]` sections
+cannot be concatenated, and a plain append cannot detect a generated route colliding with a
+declared command or model. Both failures would surface at Job BOOT — after a client has already
+minted a token and attached a WebSocket — instead of failing the build.
+
+INVARIANT: the result is validated with the RUNNER's own parser (`runner.config.parse_config`),
+not a lookalike. Anything this accepts, the Job accepts.
+
+WHY this lives in `runner/` and not beside the benchmark generators: it validates the RUN MODE's
+config, so it belongs to that half. `benchmarks/` is a shared leaf both halves may import, and a
+leaf that imports `runner` would couple every module depending on it to the run mode — the
+layering gate rejects exactly that. Nothing imports this at runtime; it is a build-step tool.
+
+The base file's text is preserved verbatim so its comments — which carry the reasoning a reviewer
+signed off on — survive into the shipped image. Only the combined `[data]` table is rendered.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tomllib
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from url4_cloud.runner.config import RunnerConfigError, parse_config
+
+
+class MergeError(ValueError):
+    """The fragments cannot be combined into a usable declared world."""
+
+
+def merge(base_text: str, fragment_texts: Sequence[str]) -> str:
+    """Return the merged TOML text. Raises :class:`MergeError` on anything unusable."""
+    if not fragment_texts:
+        return base_text
+
+    base = _parse(base_text, "base config")
+    claimed = _claimed_routes(base)
+    data: dict[str, Any] = dict(base.get("data") or {})
+    claimed |= set(data)
+
+    for index, text in enumerate(fragment_texts):
+        fragment = _parse(text, f"fragment {index}")
+        unexpected = sorted(set(fragment) - {"data"})
+        if unexpected:
+            raise MergeError(
+                f"fragment {index} declares {unexpected} — a generated fragment may declare "
+                "only [data]; executable routes stay in the reviewed base config"
+            )
+        for path, spec in (fragment.get("data") or {}).items():
+            if path in claimed:
+                raise MergeError(f"{path!r} already declared — fragment {index} would shadow it")
+            claimed.add(path)
+            data[path] = spec
+
+    merged = _strip_data_table(base_text) + "\n" + _render_data(data)
+    _validate(merged)
+    return merged
+
+
+def _parse(text: str, label: str) -> dict[str, Any]:
+    try:
+        return tomllib.loads(text)
+    except tomllib.TOMLDecodeError as exc:
+        raise MergeError(f"cannot parse {label}: {exc}") from None
+
+
+def _claimed_routes(base: Mapping[str, Any]) -> set[str]:
+    """Every path the base already owns — commands and aigateway model routes.
+
+    A generated artifact route must not shadow one: `/read` and `/benchmark` are executable, and
+    a model route is a public naming surface expressions depend on.
+    """
+    claimed = set(base.get("commands") or {})
+    section = base.get("aigateway")
+    if isinstance(section, Mapping):
+        models = section.get("models") or []
+        for entry in models:
+            model_id = entry.get("id") if isinstance(entry, Mapping) else entry
+            if model_id:
+                claimed.add("/" + str(model_id).removeprefix("/"))
+    return claimed
+
+
+def _strip_data_table(base_text: str) -> str:
+    """Drop the base's own ``[data]`` section — its entries are re-emitted in the merged table.
+
+    Only a top-level ``[data]`` header starts the section; it ends at the next top-level header.
+    """
+    out: list[str] = []
+    skipping = False
+    for line in base_text.splitlines(keepends=True):
+        stripped = line.strip()
+        if stripped.startswith("[") and not stripped.startswith("[["):
+            skipping = stripped == "[data]"
+        if not skipping:
+            out.append(line)
+    return "".join(out).rstrip() + "\n"
+
+
+def _render_data(data: Mapping[str, Any]) -> str:
+    lines = [
+        "# --- GENERATED — merged by url4_cloud.benchmarks.merge_config. Do not edit. ---",
+        f"# {len(data)} declared artifact(s). Regenerate by rebuilding the benchmark image.",
+        "[data]",
+    ]
+    lines.extend(f'"{path}" = {_render_value(spec)}' for path, spec in sorted(data.items()))
+    return "\n".join(lines) + "\n"
+
+
+def _render_value(spec: Any) -> str:
+    """Render one provider declaration back to TOML — containers here, scalars next door."""
+    if isinstance(spec, Mapping):
+        inner = ", ".join(f"{key} = {_render_value(value)}" for key, value in spec.items())
+        return f"{{ {inner} }}"
+    if isinstance(spec, (list, tuple)):
+        return "[" + ", ".join(_render_value(v) for v in spec) + "]"
+    return _render_scalar(spec)
+
+
+def _render_scalar(spec: Any) -> str:
+    # INVARIANT: bool before int — `bool` IS an `int` subclass, so the numeric branch would
+    # render True as "1" and silently change a declared flag's type.
+    if isinstance(spec, str):
+        return _quote(spec)
+    if isinstance(spec, bool):
+        return "true" if spec else "false"
+    if isinstance(spec, (int, float)):
+        return str(spec)
+    raise MergeError(f"cannot render {spec!r} as TOML")
+
+
+def _quote(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _validate(merged: str) -> None:
+    """Parse the result with the RUNNER's parser — the point of the whole step."""
+    raw = _parse(merged, "merged config")
+    try:
+        parse_config(raw, {})
+    except RunnerConfigError as exc:
+        raise MergeError(f"merged config is not a usable declared world: {exc}") from None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="merge-config", description=__doc__)
+    parser.add_argument("--base", type=Path, required=True)
+    parser.add_argument("--fragment", type=Path, action="append", default=[])
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    try:
+        merged = merge(
+            args.base.read_text(encoding="utf-8"),
+            [path.read_text(encoding="utf-8") for path in args.fragment],
+        )
+    except (MergeError, OSError) as exc:
+        print(f"merge failed: {exc}", file=sys.stderr)
+        return 1
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(merged, encoding="utf-8")
+    routes = len(tomllib.loads(merged).get("data") or {})
+    print(f"merged {len(args.fragment)} fragment(s), {routes} data route(s) → {args.out}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - build-step entrypoint
+    raise SystemExit(main())

--- a/apps/url4-cloud/tests/unit/test_benchmark_manifests.py
+++ b/apps/url4-cloud/tests/unit/test_benchmark_manifests.py
@@ -1,0 +1,152 @@
+"""``GET /v1/benchmarks`` and ``GET /v1/benchmarks/{id}`` — the benchmark catalog.
+
+FEATURE: a client picks a benchmark and learns how to run it — data routes, judge, grading
+protocol — without reading the image's url4.toml or guessing.
+
+STORY: as someone about to submit a benchmark expression, I list the available benchmarks, fetch
+one manifest, and read off the routes and judge settings it needs.
+
+The manifests are CONSTANTS, not files: there is no path to traverse and no I/O to fail, so the
+only failure a caller can provoke is an unknown id.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from url4_cloud import manifests
+from url4_cloud.rest.benchmarks import router
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def client() -> TestClient:
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+# --- the registry itself ---------------------------------------------------------
+
+
+def test_every_manifest_is_keyed_by_its_own_declared_id() -> None:
+    """INVARIANT: the registry key IS the id in the text. They are two spellings of one fact, so
+    a mismatch would make `/v1/benchmarks/{id}` serve a manifest that names a different id."""
+    for key, text in manifests.MANIFESTS.items():
+        assert manifests.field(text, "id") == key
+
+
+def test_every_manifest_carries_the_fields_a_client_needs_to_run_it() -> None:
+    required = ("id", "title", "description", "dataset", "cases", "grading", "judge")
+    for key, text in manifests.MANIFESTS.items():
+        for name in required:
+            assert manifests.field(text, name), f"{key} is missing {name!r}"
+
+
+def test_the_registry_is_not_empty() -> None:
+    assert manifests.MANIFESTS
+
+
+# --- listing ---------------------------------------------------------------------
+
+
+def test_listing_returns_an_envelope_not_a_bare_array(client: TestClient) -> None:
+    """A bare array has nowhere to grow: adding pagination later would be a breaking change."""
+    body = client.get("/v1/benchmarks").json()
+
+    assert isinstance(body, dict)
+    assert isinstance(body["benchmarks"], list)
+
+
+def test_listing_summarises_each_manifest_with_a_link_to_it(client: TestClient) -> None:
+    entries = client.get("/v1/benchmarks").json()["benchmarks"]
+
+    by_id = {e["id"]: e for e in entries}
+    assert set(by_id) == set(manifests.MANIFESTS)
+    for key, entry in by_id.items():
+        assert entry["href"] == f"/v1/benchmarks/{key}"
+        assert entry["title"]
+        assert entry["description"]
+
+
+def test_listing_is_publicly_cacheable_with_a_validator(client: TestClient) -> None:
+    r = client.get("/v1/benchmarks")
+
+    assert "public" in r.headers["cache-control"]
+    assert r.headers["etag"]
+
+
+# --- fetching one ----------------------------------------------------------------
+
+
+def test_a_manifest_is_served_verbatim_as_text(client: TestClient) -> None:
+    """The manifest IS a string. Wrapping it in JSON would make every caller unescape it back."""
+    key = next(iter(manifests.MANIFESTS))
+
+    r = client.get(f"/v1/benchmarks/{key}")
+
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/plain")
+    assert r.text == manifests.MANIFESTS[key]
+
+
+def test_a_manifest_carries_a_strong_etag_and_public_caching(client: TestClient) -> None:
+    key = next(iter(manifests.MANIFESTS))
+
+    r = client.get(f"/v1/benchmarks/{key}")
+
+    assert "public" in r.headers["cache-control"]
+    assert r.headers["etag"].startswith('"')  # strong, not W/ — we serve exact bytes
+
+
+def test_a_matching_if_none_match_gets_304_with_no_body(client: TestClient) -> None:
+    key = next(iter(manifests.MANIFESTS))
+    etag = client.get(f"/v1/benchmarks/{key}").headers["etag"]
+
+    r = client.get(f"/v1/benchmarks/{key}", headers={"If-None-Match": etag})
+
+    assert r.status_code == 304
+    assert not r.content
+
+
+def test_a_stale_if_none_match_gets_the_body(client: TestClient) -> None:
+    key = next(iter(manifests.MANIFESTS))
+
+    r = client.get(f"/v1/benchmarks/{key}", headers={"If-None-Match": '"stale"'})
+
+    assert r.status_code == 200
+    assert r.text == manifests.MANIFESTS[key]
+
+
+def test_two_manifests_never_share_an_etag() -> None:
+    """A shared validator would let a cache serve one benchmark's manifest for another."""
+    tags = {manifests.etag_of(t) for t in manifests.MANIFESTS.values()}
+    assert len(tags) == len(manifests.MANIFESTS)
+
+
+# --- the only reachable error ----------------------------------------------------
+
+
+def test_an_unknown_id_is_404_as_problem_json(client: TestClient) -> None:
+    r = client.get("/v1/benchmarks/does-not-exist")
+
+    assert r.status_code == 404
+    assert r.headers["content-type"].startswith("application/problem+json")
+    assert r.json()["status"] == 404
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    ["../../etc/passwd", "..%2f..%2fetc%2fpasswd", "draco-lite/../../secret", "%2e%2e%2f"],
+)
+def test_a_traversal_shaped_id_is_never_served(client: TestClient, hostile: str) -> None:
+    """INVARIANT: ids are dict keys, never path segments — there is nothing to traverse. This
+    pins that the registry lookup, not the filesystem, is what answers."""
+    r = client.get(f"/v1/benchmarks/{hostile}")
+
+    assert r.status_code in (404, 400)
+    assert "root:" not in r.text

--- a/apps/url4-cloud/tests/unit/test_draco_aggregate.py
+++ b/apps/url4-cloud/tests/unit/test_draco_aggregate.py
@@ -1,0 +1,345 @@
+"""DRACO aggregation — the paper's exact scoring math.
+
+FEATURE: the cross-row reducer of a Candidate benchmark run turns per-criterion judge verdicts
+into a `CandidateResult`.
+STORY: as a researcher, the score I get back is the DRACO paper's `normalized_score`, not an
+approximation, so a leaderboard number means what the paper says it means.
+
+INVARIANT: the formulas here mirror `screamingface-benchmarks/benchmarking/graders/rubric.py`
+(arXiv:2602.11685 §4.2) exactly. Every expected value below is hand-computed from the rubric in
+`_RUBRIC`, so a drift in either implementation shows up as an arithmetic failure, not a vague
+"scores moved" regression.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from url4_cloud.benchmarks.draco import aggregate as agg
+
+# Two sections, one negative criterion. Positive weights sum to 4 (a1=2, a2=1, b1=1).
+_RUBRIC = {
+    "sections": [
+        {
+            "id": "Factual Accuracy",
+            "criteria": [
+                {"id": "a1", "weight": 2, "requirement": "cites a source"},
+                {"id": "a2", "weight": 1, "requirement": "states the date"},
+                {"id": "a3", "weight": -3, "requirement": "invents a statistic"},
+            ],
+        },
+        {"id": "Presentation", "criteria": [{"id": "b1", "weight": 1, "requirement": "is terse"}]},
+    ]
+}
+
+
+def _verdicts(**kwargs: bool) -> dict[str, bool]:
+    return dict(kwargs)
+
+
+# --- normalized_score -----------------------------------------------------------
+
+
+def test_perfect_answer_scores_one() -> None:
+    # a1+a2+b1 MET (2+1+1=4), a3 UNMET → 4/4
+    v = _verdicts(a1=True, a2=True, a3=False, b1=True)
+
+    assert agg.normalized_score(_RUBRIC, v) == 1.0
+
+
+def test_a_met_negative_criterion_subtracts_from_the_numerator() -> None:
+    # 2 + 0 + (-3) + 1 = 0 over denom 4 → 0.0
+    v = _verdicts(a1=True, a2=False, a3=True, b1=True)
+
+    assert agg.normalized_score(_RUBRIC, v) == 0.0
+
+
+def test_the_score_is_clamped_at_zero_not_negative() -> None:
+    # 0 + 0 + (-3) + 0 = -3 over 4 → clamped to 0.0, never -0.75
+    v = _verdicts(a1=False, a2=False, a3=True, b1=False)
+
+    assert agg.normalized_score(_RUBRIC, v) == 0.0
+
+
+def test_partial_credit_is_weight_aware() -> None:
+    # a1 only: 2/4
+    assert agg.normalized_score(_RUBRIC, _verdicts(a1=True, a2=False, a3=False, b1=False)) == 0.5
+
+
+def test_all_negative_rubric_returns_zero_rather_than_dividing_by_zero() -> None:
+    """The paper does not define this case; returning 0.0 beats inventing a formula."""
+    rubric = {"sections": [{"id": "X", "criteria": [{"id": "n1", "weight": -1}]}]}
+
+    assert agg.normalized_score(rubric, {"n1": False}) == 0.0
+
+
+# --- pass_rate ------------------------------------------------------------------
+
+
+def test_pass_rate_counts_avoided_negatives_as_correct() -> None:
+    # a1 MET ✓, a2 MET ✓, a3 UNMET ✓ (anti-pattern avoided), b1 MET ✓ → 4/4
+    assert agg.pass_rate(_RUBRIC, _verdicts(a1=True, a2=True, a3=False, b1=True)) == 1.0
+
+
+def test_pass_rate_is_unweighted() -> None:
+    # a1 ✓, a2 ✗, a3 MET ✗ (anti-pattern triggered), b1 ✓ → 2/4, ignoring the 2 and -3 weights
+    assert agg.pass_rate(_RUBRIC, _verdicts(a1=True, a2=False, a3=True, b1=True)) == 0.5
+
+
+# --- axis_scores ----------------------------------------------------------------
+
+
+def test_axis_scores_are_per_section() -> None:
+    # Factual Accuracy: achievable 3 (2+1), achieved 2+0-3 = -1 → clamped 0.0
+    # Presentation:     achievable 1, achieved 1                → 1.0
+    axes = agg.axis_scores(_RUBRIC, _verdicts(a1=True, a2=False, a3=True, b1=True))
+
+    assert axes == {"Factual Accuracy": 0.0, "Presentation": 1.0}
+
+
+# --- unjudged criteria ----------------------------------------------------------
+
+
+def test_an_unjudged_criterion_drops_out_of_both_numerator_and_denominator() -> None:
+    """INVARIANT: a missing verdict must not be scored as UNMET.
+
+    Counting it as UNMET keeps its weight in the denominator, so a judge parse or transport
+    failure would silently deflate the score in proportion to the failure rate — a benchmark
+    that reports lower numbers when the harness is flaky.
+
+    a2 (weight 1) has no verdict: denom drops 4→3, numerator 3→3 → 1.0, not 0.75.
+    """
+    judged = {"a1": True, "a3": False, "b1": True}
+
+    assert agg.score_case(_RUBRIC, [judged])["normalized_score"] == 1.0
+
+
+def test_coverage_reports_the_judged_fraction() -> None:
+    judged = {"a1": True, "a3": False, "b1": True}  # 3 of 4
+
+    assert agg.score_case(_RUBRIC, [judged])["coverage"] == 0.75
+
+
+# --- harvesting verdicts out of the nested payload -------------------------------
+#
+# The reducer receives ONE string per case, prose-wrapped once per nesting level:
+#
+#   "case\n\ngraded: [\"criterion\\n\\ncrit: a1\\nruns: [{…}, {…}, {…}]\", …]"
+#
+# INVARIANT: the aggregator NEVER parses that scaffolding. It harvests the JSON verdict
+# objects and ignores everything between them. Prose framing is an engine formatting detail
+# that has already changed once; a regex over it would be a silent-breakage contract.
+
+
+def _verdict(cid: str, status: str, case: int = 1) -> str:
+    return json.dumps({"case_id": case, "criterion_id": cid, "criterion_status": status})
+
+
+def _case_row(case: int, *per_criterion: tuple[str, list[str]]) -> str:
+    """Rebuild the engine's real nesting: case → criteria → runs."""
+    crits = [
+        "criterion\\n\\ncrit: {}\\nruns: [{}]".format(
+            cid, ", ".join(_verdict(cid, s, case) for s in st)
+        )
+        for cid, st in per_criterion
+    ]
+    return "case\n\ngraded: [{}]".format(", ".join(json.dumps(c) for c in crits))
+
+
+def test_verdicts_are_harvested_from_the_nested_prose() -> None:
+    row = _case_row(1, ("a1", ["MET", "MET", "MET"]))
+
+    harvested = agg.harvest_verdicts(row)
+
+    assert harvested == [{"case_id": 1, "criterion_id": "a1", "criterion_status": "MET"}] * 3
+
+
+def test_harvesting_ignores_json_without_a_criterion_status() -> None:
+    """Only verdicts count — a stray object in the prose must not become one."""
+    row = 'case\n\nnote: {{"id": "not-a-verdict"}}\ngraded: [{}]'.format(
+        json.dumps("runs: [{}]".format(_verdict("a1", "MET")))
+    )
+
+    assert [v["criterion_id"] for v in agg.harvest_verdicts(row)] == ["a1"]
+
+
+def test_a_fenced_verdict_is_still_harvested() -> None:
+    row = 'runs: ["```json\\n{}\\n```"]'.format(_verdict("a1", "MET").replace('"', '\\"'))
+
+    assert len(agg.harvest_verdicts(row)) == 1
+
+
+def test_no_verdicts_at_all_yields_an_empty_list() -> None:
+    assert agg.harvest_verdicts("case\n\ngraded: I could not grade this.") == []
+
+
+# --- judge_runs: per-run scoring, then the mean ----------------------------------
+
+
+def test_runs_are_grouped_in_order_so_each_pass_scores_independently() -> None:
+    """INVARIANT: the paper scores EACH judge pass, then means the passes (§4.2).
+
+    Majority-voting the verdicts first would collapse disagreement before it reaches the score
+    and would make the reported spread meaningless — the sd IS the judge-stability signal.
+    """
+    verdicts = [
+        {"case_id": 1, "criterion_id": "a1", "criterion_status": s} for s in ("MET", "UNMET", "MET")
+    ]
+
+    per_run = agg.group_runs(verdicts)
+
+    assert per_run == [{"a1": True}, {"a1": False}, {"a1": True}]
+
+
+def test_a_criterion_with_fewer_passes_drops_out_of_the_missing_run() -> None:
+    """A dropped judge pass must not become an UNMET — it leaves that run's rubric entirely."""
+    verdicts = [
+        {"case_id": 1, "criterion_id": "a1", "criterion_status": "MET"},
+        {"case_id": 1, "criterion_id": "a1", "criterion_status": "MET"},
+        {"case_id": 1, "criterion_id": "a2", "criterion_status": "MET"},
+    ]
+
+    per_run = agg.group_runs(verdicts)
+
+    assert per_run == [{"a1": True, "a2": True}, {"a1": True}]
+
+
+def test_score_case_means_the_runs_and_reports_the_spread() -> None:
+    # run 1: a1 MET, a2 MET   → 3/4 = 0.75   (a1=2, a2=1, b1=1 positive; a3=-3)
+    # run 2: a1 MET, a2 UNMET → 2/3 … restricted to judged criteria per run
+    scored = agg.score_case(
+        _RUBRIC,
+        [
+            {"a1": True, "a2": True, "a3": False, "b1": True},
+            {"a1": True, "a2": False, "a3": False, "b1": True},
+        ],
+    )
+
+    assert scored["normalized_score"] == 0.875  # (1.0 + 0.75) / 2
+    assert scored["normalized_score_sd"] == 0.125
+    assert scored["n_runs"] == 2
+
+
+def test_a_single_run_reports_zero_spread() -> None:
+    scored = agg.score_case(_RUBRIC, [{"a1": True, "a2": True, "a3": False, "b1": True}])
+
+    assert scored["normalized_score"] == 1.0
+    assert scored["normalized_score_sd"] == 0.0
+    assert scored["n_runs"] == 1
+
+
+# --- the whole reduction ---------------------------------------------------------
+
+
+def test_aggregate_scores_the_official_nested_payload() -> None:
+    rows = json.dumps(
+        [
+            _case_row(
+                1,
+                ("a1", ["MET"] * 3),
+                ("a2", ["MET"] * 3),
+                ("a3", ["UNMET"] * 3),
+                ("b1", ["MET"] * 3),
+            ),
+            _case_row(
+                2,
+                ("a1", ["MET"] * 3),
+                ("a2", ["UNMET"] * 3),
+                ("a3", ["UNMET"] * 3),
+                ("b1", ["UNMET"] * 3),
+            ),
+        ]
+    )
+    result = agg.aggregate(rows, rubrics={1: _RUBRIC, 2: _RUBRIC}, benchmark_id="draco")
+
+    assert result["case_count"] == 2
+    assert result["score"] == 0.75  # case 1 → 1.0 · case 2 → 0.5
+    assert [c["case_id"] for c in result["case_results"]] == [1, 2]
+    assert result["metrics"]["n_runs"] == 3
+    assert result["failures"] == []
+
+
+def test_a_case_id_missing_from_the_verdicts_falls_back_to_row_position() -> None:
+    """The judge echoes the id, but an LLM can drop it — position is the benchmark's own
+    knowledge and is stable because `on_error=collect` preserves row order."""
+    row = "runs: [{}]".format(json.dumps({"criterion_id": "a1", "criterion_status": "MET"}))
+
+    result = agg.aggregate(json.dumps([row]), rubrics={1: _RUBRIC}, benchmark_id="draco")
+
+    assert result["case_results"][0]["case_id"] == 1
+
+
+def test_a_row_with_no_verdicts_is_a_failure_not_a_zero() -> None:
+    rows = json.dumps([_case_row(1, ("a1", ["MET"])), "case\n\ngraded: judge refused"])
+    result = agg.aggregate(rows, rubrics={1: _RUBRIC, 2: _RUBRIC}, benchmark_id="draco")
+
+    assert result["case_count"] == 1
+    assert len(result["failures"]) == 1
+    assert result["score"] == 1.0
+
+
+def test_no_rows_at_all_yields_a_zero_result_rather_than_an_exception() -> None:
+    result = agg.aggregate("[]", rubrics={1: _RUBRIC}, benchmark_id="draco")
+
+    assert result["case_count"] == 0
+    assert result["score"] == 0.0
+
+
+def test_a_malformed_top_level_payload_raises() -> None:
+    with pytest.raises(agg.AggregateError):
+        agg.aggregate("not json", rubrics={}, benchmark_id="draco")
+
+
+# --- where the rubrics come from -------------------------------------------------
+#
+# The [data] routes get absolute paths from `prepare --out`, so the rubrics path must come from
+# the SAME deployment rather than a literal baked into url4.toml. A live local run hit exactly
+# that: the config pinned the container path, the aggregate found no rubrics, and the run
+# returned HTTP 200 with `failures:[{"reason":"unknown case_id"}]` — a success that scored
+# nothing.
+
+
+def test_missing_rubrics_directory_raises_rather_than_scoring_nothing(tmp_path) -> None:
+    """INVARIANT: a misconfigured path is an ERROR, not an empty result.
+
+    Returning {} makes every case an `unknown case_id` failure, which surfaces as a terminated
+    run with a plausible-looking zero score. Failing here turns a silent misconfiguration into
+    a loud one.
+    """
+    with pytest.raises(agg.AggregateError, match="no rubrics"):
+        agg.load_rubrics(tmp_path / "absent")
+
+
+def test_an_empty_rubrics_directory_raises(tmp_path) -> None:
+    (tmp_path / "rubrics").mkdir()
+
+    with pytest.raises(agg.AggregateError, match="no rubrics"):
+        agg.load_rubrics(tmp_path / "rubrics")
+
+
+def test_rubrics_load_keyed_by_case_id(tmp_path) -> None:
+    (tmp_path / "7.json").write_text(json.dumps(_RUBRIC), encoding="utf-8")
+
+    assert set(agg.load_rubrics(tmp_path)) == {7}
+
+
+def test_the_rubrics_path_defaults_to_the_environment(tmp_path, monkeypatch) -> None:
+    """One source of truth per deployment: the image sets it, a local run overrides it."""
+    (tmp_path / "1.json").write_text(json.dumps(_RUBRIC), encoding="utf-8")
+    monkeypatch.setenv("URL4_BENCHMARK_RUBRICS", str(tmp_path))
+
+    assert agg.rubrics_dir(None) == tmp_path
+
+
+def test_an_explicit_path_beats_the_environment(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("URL4_BENCHMARK_RUBRICS", "/env/path")
+
+    assert agg.rubrics_dir(tmp_path) == tmp_path
+
+
+def test_without_either_it_falls_back_to_the_image_default(monkeypatch) -> None:
+    monkeypatch.delenv("URL4_BENCHMARK_RUBRICS", raising=False)
+
+    assert str(agg.rubrics_dir(None)) == agg.DEFAULT_RUBRICS_DIR

--- a/apps/url4-cloud/tests/unit/test_draco_aggregate_case_mapping.py
+++ b/apps/url4-cloud/tests/unit/test_draco_aggregate_case_mapping.py
@@ -1,0 +1,130 @@
+"""The case -> rubric mapping must be PROVABLE, never guessed from row position.
+
+FEATURE: a DRACO run scores each case's answer against that case's rubric.
+STORY: as a researcher I need a published score to be the score of the cases I ran, not of
+whichever rubrics happened to sit at the same offsets.
+
+`aggregate` learns a row's case id one of two ways: the judge ECHOES it in the verdict, or it
+falls back to the row's POSITION. Position is only defensible when the rows ARE the whole
+declared case set — `iteration.on_error=collect` preserves row order and substitutes an error
+object in place, so index N is case N+1.
+
+`;iteration.slice=10:20` breaks that, and breaks it silently. The rows are cases 11-20 while the
+positions say 1-10, so every case is scored against the WRONG rubric, no `failures` entry is
+produced, and the run reports `terminated: succeeded` with a plausible number. `iteration.slice`
+is the sanctioned way to size a run — `manifests.py` and `Dockerfile.benchmark` both advertise it,
+the latter having REMOVED a build-time case cap in its favour — so this is reachable from the
+documented path, not from misuse.
+
+INVARIANT: when a row needs the positional fallback and the row count does not match the declared
+rubric set, the mapping is unverifiable and `aggregate` RAISES. It never scores against a mapping
+it cannot prove. The honest fix is for the judge to echo `case_id`, which `case_id_of` already
+prefers whenever it is present.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from url4_cloud.benchmarks.draco import aggregate as agg
+
+
+def _rubric(criterion: str) -> dict[str, object]:
+    return {
+        "sections": [
+            {"id": "Factual Accuracy", "criteria": [{"id": criterion, "weight": 1}]},
+        ]
+    }
+
+
+# Four declared cases, each with its OWN criterion id — so a mis-pairing cannot score by luck.
+_RUBRICS: dict[int, dict[str, object]] = {n: _rubric(f"c{n}") for n in (1, 2, 3, 4)}
+
+
+def _row(criterion: str, *, case: int | None = None, status: str = "MET") -> str:
+    verdict: dict[str, object] = {"criterion_id": criterion, "criterion_status": status}
+    if case is not None:
+        verdict["case_id"] = case
+    return f"case\n\ngraded: [{json.dumps(json.dumps(verdict))}]"
+
+
+# --- the guard ------------------------------------------------------------------
+
+
+def test_a_short_row_set_without_an_echoed_case_id_raises() -> None:
+    """The `;iteration.slice=10:20` shape — two rows against four declared cases."""
+    rows = json.dumps([_row("c3"), _row("c4")])
+
+    with pytest.raises(agg.AggregateError):
+        agg.aggregate(rows, rubrics=_RUBRICS, benchmark_id="draco")
+
+
+def test_the_error_names_both_ways_out() -> None:
+    """A benchmark operator has exactly two escapes; the message must state them, because the
+    alternative it replaces produced a plausible number instead of any message at all."""
+    rows = json.dumps([_row("c3"), _row("c4")])
+
+    with pytest.raises(agg.AggregateError) as excinfo:
+        agg.aggregate(rows, rubrics=_RUBRICS, benchmark_id="draco")
+
+    message = str(excinfo.value)
+    assert "case_id" in message
+    assert "2" in message and "4" in message  # the counts that disagree
+
+
+def test_a_mixed_row_set_raises_on_the_unverifiable_row() -> None:
+    """One echoed id does not vouch for a sibling that has none."""
+    rows = json.dumps([_row("c1", case=1), _row("c2")])
+
+    with pytest.raises(agg.AggregateError):
+        agg.aggregate(rows, rubrics=_RUBRICS, benchmark_id="draco")
+
+
+# --- what the guard must NOT catch ----------------------------------------------
+
+
+def test_a_short_row_set_WITH_echoed_case_ids_scores_normally() -> None:
+    """INVARIANT: the guard targets an unprovable MAPPING, not a small run.
+
+    This is the shape a sliced run should take, and it must keep working — otherwise the fix
+    would forbid `;iteration.slice` outright rather than making it honest.
+    """
+    rows = json.dumps([_row("c3", case=3), _row("c4", case=4)])
+
+    result = agg.aggregate(rows, rubrics=_RUBRICS, benchmark_id="draco")
+
+    assert result["case_count"] == 2
+    assert [c["case_id"] for c in result["case_results"]] == [3, 4]
+    assert result["score"] == 1.0  # each row met ITS OWN case's criterion
+
+
+def test_a_full_row_set_without_echoed_ids_still_falls_back_to_position() -> None:
+    """The unchanged path: rows ARE the declared set, so position is the benchmark's own
+    knowledge and stays trustworthy."""
+    rows = json.dumps([_row(f"c{n}") for n in (1, 2, 3, 4)])
+
+    result = agg.aggregate(rows, rubrics=_RUBRICS, benchmark_id="draco")
+
+    assert result["case_count"] == 4
+    assert [c["case_id"] for c in result["case_results"]] == [1, 2, 3, 4]
+
+
+def test_no_rows_at_all_does_not_trip_the_guard() -> None:
+    """An empty payload consults no rubric, so there is no mapping to be wrong about."""
+    result = agg.aggregate("[]", rubrics=_RUBRICS, benchmark_id="draco")
+
+    assert result["case_count"] == 0
+    assert result["failures"] == []
+
+
+def test_rows_that_produced_no_verdicts_do_not_trip_the_guard() -> None:
+    """A verdict-less row becomes a `failures` entry and never reaches a rubric, so it needs no
+    mapping — counting it as unverifiable would turn a partial judge failure into a dead run."""
+    rows = json.dumps([_row("c1", case=1), "case\n\ngraded: judge refused"])
+
+    result = agg.aggregate(rows, rubrics=_RUBRICS, benchmark_id="draco")
+
+    assert result["case_count"] == 1
+    assert len(result["failures"]) == 1

--- a/apps/url4-cloud/tests/unit/test_draco_aggregate_stdin.py
+++ b/apps/url4-cloud/tests/unit/test_draco_aggregate_stdin.py
@@ -1,0 +1,131 @@
+"""The aggregate CLI reads its row array from stdin.
+
+FEATURE: the reducer payload arrives on a pipe, not in argv (gap A1).
+STORY: as a researcher running 100 DRACO cases, the ~16,000 verdicts my run produces reach the
+scorer — instead of the Job dying at exec with "Argument list too long" at roughly four cases.
+
+Its own module rather than an append to `test_draco_aggregate.py`: prior tests are append-only,
+and that module owns the scoring MATH while this one owns the CLI's input channel.
+
+`--args` is kept as an explicit override, so the script stays hand-runnable and the flag this
+repo already documented does not disappear under anyone.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from url4_cloud.benchmarks.draco import aggregate as agg
+
+_RUBRIC = {
+    "sections": [
+        {"id": "Factual Accuracy", "criteria": [{"id": "a1", "weight": 2, "requirement": "x"}]}
+    ]
+}
+
+
+@pytest.fixture
+def rubrics(tmp_path: Path) -> Path:
+    directory = tmp_path / "rubrics"
+    directory.mkdir()
+    (directory / "1.json").write_text(json.dumps(_RUBRIC), encoding="utf-8")
+    return directory
+
+
+def _row(case: int = 1, status: str = "MET") -> str:
+    return "graded: {}".format(
+        json.dumps({"case_id": case, "criterion_id": "a1", "criterion_status": status})
+    )
+
+
+def _run(monkeypatch: pytest.MonkeyPatch, argv: list[str], stdin: str | None) -> dict:
+    if stdin is not None:
+        monkeypatch.setattr("sys.stdin", io.StringIO(stdin))
+    captured: list[str] = []
+    monkeypatch.setattr("builtins.print", lambda *a, **k: captured.append(str(a[0])))
+    assert agg.main(argv) == 0
+    return json.loads(captured[-1])
+
+
+def test_payload_is_read_from_stdin(monkeypatch: pytest.MonkeyPatch, rubrics: Path) -> None:
+    result = _run(monkeypatch, ["--rubrics", str(rubrics)], json.dumps([_row()]))
+
+    assert result["case_count"] == 1
+    assert result["score"] == 1.0
+
+
+def test_explicit_args_still_overrides_stdin(
+    monkeypatch: pytest.MonkeyPatch, rubrics: Path
+) -> None:
+    """The override wins outright — a half-read of both channels would be unexplainable."""
+    result = _run(
+        monkeypatch,
+        ["--rubrics", str(rubrics), "--args", json.dumps([_row(status="MET")])],
+        json.dumps([_row(status="UNMET")]),
+    )
+
+    assert result["score"] == 1.0
+
+
+_CASES = 12
+_CRITERIA = 53  # DRACO case 1 has 53, across the paper's four axes
+_PASSES = 3  # judge_runs
+
+
+def test_a_payload_past_the_argv_ceiling_aggregates(
+    monkeypatch: pytest.MonkeyPatch, rubrics: Path
+) -> None:
+    """THE REGRESSION, at DRACO's real shape.
+
+    Sized the way a run actually is — 53 criteria × 3 passes per case — rather than by padding
+    to a number, so the ceiling this crosses is the one production crosses.
+
+    TWELVE cases clears `MAX_ARG_STRLEN` (131,072) with the MINIMAL verdict shape used here
+    (~75 bytes escaped). Real verdicts carry longer criterion ids, so production crosses it
+    sooner — somewhere in the single digits. Either way the old argv handoff died with
+    `OSError [Errno 7]` at exec, before the scorer ever started, on a 100-case run.
+    """
+    wide = {
+        "sections": [
+            {
+                "id": "Factual Accuracy",
+                "criteria": [
+                    {"id": f"c{n}", "weight": 1, "requirement": "x"} for n in range(_CRITERIA)
+                ],
+            }
+        ]
+    }
+    for case_id in range(1, _CASES + 1):
+        (rubrics / f"{case_id}.json").write_text(json.dumps(wide), encoding="utf-8")
+
+    rows = [
+        " ".join(
+            json.dumps({"case_id": case, "criterion_id": f"c{n}", "criterion_status": "MET"})
+            for _ in range(_PASSES)
+            for n in range(_CRITERIA)
+        )
+        for case in range(1, _CASES + 1)
+    ]
+    payload = json.dumps(rows)
+    assert len(payload) > 131_072, f"payload is only {len(payload)} bytes — not past the ceiling"
+
+    result = _run(monkeypatch, ["--rubrics", str(rubrics)], payload)
+
+    assert result["case_count"] == _CASES
+    assert result["failures"] == []
+    assert result["metrics"]["n_runs"] == _PASSES
+    assert result["score"] == 1.0
+
+
+def test_unreadable_stdin_payload_is_a_named_failure(
+    monkeypatch: pytest.MonkeyPatch, rubrics: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An empty pipe must not score as an empty-but-successful run."""
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))
+
+    assert agg.main(["--rubrics", str(rubrics)]) == 1
+    assert "not JSON" in capsys.readouterr().err

--- a/apps/url4-cloud/tests/unit/test_draco_blocklist_values.py
+++ b/apps/url4-cloud/tests/unit/test_draco_blocklist_values.py
@@ -1,0 +1,70 @@
+"""The blocklist VALUES — bare hosts only, because that is all a provider accepts.
+
+FEATURE: the DRACO retrieval policy keeps a candidate from reading the answer key.
+STORY: as a benchmark author, "the paper is blocked" must also mean the run still WORKS — a
+blocklist the provider rejects protects nothing, it just stops the benchmark.
+
+MEASURED 2026-08-02, straight to OpenRouter AND through the deployed gateway on a kind cluster:
+
+    exclude_domains: ["arxiv.org"]                 -> 200
+    exclude_domains: ["arxiv.org/abs/2602.11685"]  -> 400  "Invalid domain 'arxiv.org/abs/...'"
+    exclude_domains: ["*.substack.com"]            -> 400
+    exclude_domains: <the whole shipped list>      -> 400
+
+The path-shaped list this benchmark shipped therefore made EVERY native answering call a hard
+400: a run that finished in five seconds, reported `terminated: succeeded`, and scored nothing.
+It was invisible to every earlier test because those used a bare host in a PROBE policy — only
+the real expression carries the real list, and only a real Job run puts the two together.
+
+# AIDEV-NOTE: an earlier revision of this module asserted the OPPOSITE — one entry per URL form
+# (`/abs/`, `/pdf/`, `/html/`) and "never block a bare research host". That came from Tavily,
+# which does accept paths and match them partially. The provider side does not, and it is the
+# binding constraint. Both assertions were replaced the same day they were written.
+
+DECISION (owner, 2026-08-02): block whole SITES. The cost is real and belongs beside any published
+score — `arxiv.org` and `huggingface.co` are legitimate research sources, and removing them makes
+a candidate look worse at deep research than it is. The alternative under-blocks, which INFLATES
+scores, and an inflated score is the one nobody audits.
+"""
+
+from __future__ import annotations
+
+import json
+
+from url4_cloud.benchmarks.draco import prepare
+
+
+def test_every_entry_is_a_bare_host() -> None:
+    """INVARIANT: no path, no wildcard, no scheme. THE regression guard — one path-shaped entry
+    takes the whole benchmark down with a 400, and the failure presents as a successful run that
+    scored zero."""
+    for entry in prepare.EXCLUDED_DOMAINS:
+        assert "/" not in entry, f"{entry!r} has a path — the provider rejects the whole request"
+        assert "*" not in entry, f"{entry!r} is a wildcard — measured as a 400"
+        assert ":" not in entry, f"{entry!r} carries a scheme or port"
+        assert entry == entry.strip().lower(), f"{entry!r} is not normalised"
+
+
+def test_the_leak_sources_are_covered_at_host_level() -> None:
+    """Every host that actually served DRACO material in a live search."""
+    for host in ("arxiv.org", "huggingface.co", "openrouter.ai", "paperswithcode.com"):
+        assert host in prepare.EXCLUDED_DOMAINS
+
+
+def test_the_list_has_no_duplicates() -> None:
+    """Collapsing pages to hosts turns several old entries into the same host; a duplicate would
+    be sent to the provider twice and reads as sloppiness in a published artifact."""
+    entries = list(prepare.EXCLUDED_DOMAINS)
+
+    assert len(entries) == len(set(entries))
+
+
+def test_the_policy_artifact_carries_the_same_bare_hosts(tmp_path) -> None:
+    """What `prepare` WRITES is what a run sends. Asserting the constant alone would miss a
+    transform introduced between the constant and the file."""
+    prepare.write_policy(tmp_path)
+    policy = json.loads((tmp_path / "policy" / "retrieval.json").read_text(encoding="utf-8"))
+
+    assert policy["excluded_domains"]
+    for entry in policy["excluded_domains"]:
+        assert "/" not in entry and "*" not in entry

--- a/apps/url4-cloud/tests/unit/test_draco_lineup_declared.py
+++ b/apps/url4-cloud/tests/unit/test_draco_lineup_declared.py
@@ -1,0 +1,88 @@
+"""Every model the DRACO lineup answers with must have a declared route.
+
+FEATURE: a client can run any of DRACO's published configurations against this deployment.
+STORY: as a benchmark author, `budget_trio` is one of the paper's nine fusions, so its three
+panel members must be addressable — not a `ResolutionError` two minutes into a paid run.
+
+Routing is EXACT-MATCH with no wildcard form, so an undeclared model is not a degraded run: the
+expression fails to resolve. Before this guard existed, four of the eight lineup models were
+undeclared and nothing said so — the gap was invisible because the documented example expression
+only ever used the three that happened to be declared.
+
+INVARIANT: the lineup below is a HAND-COPY of
+`screamingface-benchmarks/benchmarks_config/draco.yaml`, and it duplicates that file ON PURPOSE.
+The two repos are not built together and this one cannot import the other, so a shared source is
+not available; the point of the copy is to FAIL when the lineup changes, which is exactly when a
+human needs to re-check both sides. A test that derived the list from url4.toml would assert
+nothing.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+_RUNNER_CONFIG = Path(__file__).resolve().parents[2] / "url4.toml"
+
+_GATEWAY_PREFIX = "openrouter/"
+"""DRACO runs every model through OpenRouter (`draco.yaml`: "calls go through OpenRouter,
+default for closed models"), so a route id is that prefix plus the paper's upstream slug."""
+
+# The 7 solos plus every distinct fusion panel member / synthesizer (draco.yaml §eval).
+# `qwen3.6-plus` is the one model that is NOT a solo — it appears only in `best_open_source`.
+DRACO_LINEUP = (
+    "anthropic/claude-fable-5",
+    "anthropic/claude-opus-4.8",
+    "openai/gpt-5.5",
+    "google/gemini-3.1-pro-preview",
+    "google/gemini-3-flash-preview",
+    "moonshotai/kimi-k2.6",
+    "deepseek/deepseek-v4-pro",
+    "qwen/qwen3.6-plus",
+)
+
+DRACO_JUDGE = "google/gemini-3.1-pro-preview"
+"""arXiv:2602.11685 §4.2 pins it. Also a solo candidate — see the dual-role test below."""
+
+
+def _routes() -> dict[str, dict]:
+    """Every declared model route, keyed by its gateway id."""
+    with _RUNNER_CONFIG.open("rb") as handle:
+        entries = tomllib.load(handle)["aigateway"]["models"]
+    return {e["id"]: e for e in entries if not isinstance(e, str)}
+
+
+@pytest.mark.parametrize("slug", DRACO_LINEUP)
+def test_every_lineup_model_has_a_declared_route(slug: str) -> None:
+    declared = _routes()
+    assert _GATEWAY_PREFIX + slug in declared, (
+        f"DRACO's lineup names {slug!r} but url4.toml declares no route for it. Routing is "
+        "exact-match, so every configuration using this model fails to resolve. Declare it here "
+        "AND seed it in aigateway's `_default_model_slugs()` — "
+        "`test_declared_models_match_aigateway.py` enforces the pair."
+    )
+
+
+def test_the_judge_route_never_offers_tools() -> None:
+    """INVARIANT (arXiv:2602.11685 §4.2): the judge sees only the answer and one criterion.
+
+    Offering it retrieval would let it check claims against the live web, which is a DIFFERENT
+    benchmark from the one the paper defines — and `web_tools` changes the request payload
+    (`tools`/`tool_choice`), so this is a protocol deviation even if the judge never calls one.
+    Pinned rather than left to a comment because the same model is ALSO a solo candidate, and
+    the obvious "give the candidates tools" edit would silently take the judge with it.
+    """
+    judge = _routes()[_GATEWAY_PREFIX + DRACO_JUDGE]
+
+    assert not judge.get("web_tools"), (
+        "the DRACO judge route declares web_tools — the paper's judge gets none. Note this route "
+        "is shared with the gemini-3.1-pro-preview SOLO candidate, which does want retrieval; "
+        "one id is one route, so the two roles cannot be configured apart today."
+    )
+
+
+def test_the_lineup_has_no_duplicate_entries() -> None:
+    """A duplicate would make the parametrized guard above silently weaker than it reads."""
+    assert len(set(DRACO_LINEUP)) == len(DRACO_LINEUP)

--- a/apps/url4-cloud/tests/unit/test_draco_prepare.py
+++ b/apps/url4-cloud/tests/unit/test_draco_prepare.py
@@ -1,0 +1,153 @@
+"""DRACO dataset preparation — artifacts and the generated `[data]` table.
+
+FEATURE: a benchmark's declared world is generated from its dataset at image build.
+STORY: as a benchmark author, `prepare` turns `perplexity-ai/draco` into cases, private rubrics,
+and a `[data]` table I can merge into the image's url4.toml.
+
+The HF download itself is not exercised — `build()` takes rows, so every test here runs offline.
+"""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from url4_cloud.benchmarks.draco import prepare
+
+_RUBRIC = {
+    "sections": [
+        {"id": "Factual Accuracy", "criteria": [{"id": "a1", "weight": 2, "requirement": "x"}]}
+    ]
+}
+
+
+def _row(question: str = "What is X?", rubric: object | None = None) -> dict:
+    return {
+        "problem": question,
+        "answer": json.dumps(_RUBRIC) if rubric is None else rubric,
+        "domain": "finance",
+    }
+
+
+# --- artifacts ------------------------------------------------------------------
+
+
+def test_cases_json_carries_id_and_input(tmp_path: Path) -> None:
+    prepare.build([_row("Q1"), _row("Q2")], tmp_path, "/draco")
+
+    cases = json.loads((tmp_path / "cases.json").read_text())
+    assert cases[0]["id"] == 1
+    assert cases[0]["input"] == "Q1"
+    assert [c["id"] for c in cases] == [1, 2]
+
+
+def test_cases_json_never_carries_the_rubric(tmp_path: Path) -> None:
+    """INVARIANT: the privacy boundary of the whole design.
+
+    The client receives `cases.json`; the rubric stays in the image. Leaking it here would let a
+    Candidate be tuned against the answer key while every test still passed.
+    """
+    prepare.build([_row()], tmp_path, "/draco")
+
+    body = (tmp_path / "cases.json").read_text()
+    assert "Factual Accuracy" not in body
+    assert "weight" not in body
+
+
+def test_each_rubric_is_written_to_its_own_file(tmp_path: Path) -> None:
+    prepare.build([_row(), _row()], tmp_path, "/draco")
+
+    assert json.loads((tmp_path / "rubrics" / "1.json").read_text()) == _RUBRIC
+    assert (tmp_path / "rubrics" / "2.json").exists()
+
+
+# --- the generated table --------------------------------------------------------
+
+
+def test_the_generated_table_declares_one_route_per_artifact(tmp_path: Path) -> None:
+    # WHY one per artifact: routing is exact-match, so a wildcard would not resolve.
+    prepare.build([_row(), _row(), _row()], tmp_path, "/draco")
+
+    table = tomllib.loads((tmp_path / "url4.data.toml").read_text())["data"]
+
+    assert "/draco/cases" in table
+    assert {"/draco/criteria/1", "/draco/criteria/2", "/draco/criteria/3"} <= set(table)
+
+
+def test_the_cases_route_declares_its_media_type(tmp_path: Path) -> None:
+    """Without it a one-line JSON array collapses to a single element and the run benchmarks
+    once against a blob instead of once per case."""
+    prepare.build([_row()], tmp_path, "/draco")
+
+    table = tomllib.loads((tmp_path / "url4.data.toml").read_text())["data"]
+    assert table["/draco/cases"]["media_type"] == "application/json"
+
+
+def test_the_route_prefix_is_configurable(tmp_path: Path) -> None:
+    prepare.build([_row()], tmp_path, "/bench/draco-lite")
+
+    table = tomllib.loads((tmp_path / "url4.data.toml").read_text())["data"]
+    assert "/bench/draco-lite/cases" in table
+
+
+def test_the_generated_table_is_valid_toml_for_many_cases(tmp_path: Path) -> None:
+    prepare.build([_row(f"Q{i}") for i in range(50)], tmp_path, "/draco")
+
+    table = tomllib.loads((tmp_path / "url4.data.toml").read_text())["data"]
+    assert len(table) == 51  # 50 criteria files + cases
+
+
+def test_the_weighted_rubric_is_NOT_declared_as_a_route(tmp_path: Path) -> None:
+    """INVARIANT: weights must be unreachable from an expression.
+
+    A declared `/draco/rubrics/N` could be fetched into a judge prompt, which is exactly the
+    leak `grading_mode: official` exists to prevent. Only `aggregate.py` reads them, off disk.
+    """
+    prepare.build([_row()], tmp_path, "/draco")
+
+    table = tomllib.loads((tmp_path / "url4.data.toml").read_text())["data"]
+    assert not any("rubrics" in path for path in table)
+
+
+def test_the_judge_facing_criteria_carry_no_weights(tmp_path: Path) -> None:
+    prepare.build([_row()], tmp_path, "/draco")
+
+    criteria = json.loads((tmp_path / "criteria" / "1.json").read_text())
+    assert criteria == [{"id": "a1", "requirement": "x"}]
+    assert "weight" not in json.dumps(criteria)
+
+
+# --- validation -----------------------------------------------------------------
+
+
+def test_an_empty_question_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(prepare.PrepareError, match="empty"):
+        prepare.build([_row("")], tmp_path, "/draco")
+
+
+def test_a_rubric_with_no_sections_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(prepare.PrepareError, match="sections"):
+        prepare.build([_row(rubric=json.dumps([{"id": "a1"}]))], tmp_path, "/draco")
+
+
+def test_a_rubric_that_flattens_to_zero_criteria_is_rejected(tmp_path: Path) -> None:
+    """It would score every answer 0.0 while looking like a successful run."""
+    with pytest.raises(prepare.PrepareError, match="0 criteria"):
+        prepare.build([_row(rubric=json.dumps({"sections": []}))], tmp_path, "/draco")
+
+
+# --- the round trip -------------------------------------------------------------
+
+
+def test_prepared_rubrics_load_back_into_the_aggregator(tmp_path: Path) -> None:
+    """The two halves must agree on the on-disk shape — this is the seam between them."""
+    from url4_cloud.benchmarks.draco import aggregate
+
+    prepare.build([_row(), _row()], tmp_path, "/draco")
+
+    rubrics = aggregate.load_rubrics(tmp_path / "rubrics")
+    assert set(rubrics) == {1, 2}
+    assert aggregate.normalized_score(rubrics[1], {"a1": True}) == 1.0

--- a/apps/url4-cloud/tests/unit/test_draco_prepare.py
+++ b/apps/url4-cloud/tests/unit/test_draco_prepare.py
@@ -97,7 +97,7 @@ def test_the_generated_table_is_valid_toml_for_many_cases(tmp_path: Path) -> Non
     prepare.build([_row(f"Q{i}") for i in range(50)], tmp_path, "/draco")
 
     table = tomllib.loads((tmp_path / "url4.data.toml").read_text())["data"]
-    assert len(table) == 51  # 50 criteria files + cases
+    assert len(table) == 52  # 50 criteria files + cases + the retrieval policy
 
 
 def test_the_weighted_rubric_is_NOT_declared_as_a_route(tmp_path: Path) -> None:

--- a/apps/url4-cloud/tests/unit/test_draco_prepare_policy.py
+++ b/apps/url4-cloud/tests/unit/test_draco_prepare_policy.py
@@ -1,0 +1,63 @@
+"""The retrieval policy DRACO ships as one of its declared artifacts.
+
+FEATURE: a benchmark image carries its own blocklist at its own url4 address, so benchmarks that
+disagree about what to exclude share one set of model routes.
+STORY: as a researcher I need the guard that stops a candidate reading its own answer key to
+travel with the benchmark, and to be named in the expression so the score can be attributed.
+
+INVARIANT: `rubrics/` stays undeclared. The policy is safe to address because it names PUBLIC
+leak sources and carries no weight and no requirement text; the weighted rubric is neither.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from url4_cloud.benchmarks.draco import prepare
+
+
+def test_the_policy_is_written_as_an_addressable_artifact(tmp_path: Path) -> None:
+    written = prepare.write_policy(tmp_path)
+
+    document = json.loads(written.read_text(encoding="utf-8"))
+    assert written == tmp_path / "policy" / "retrieval.json"
+    assert document["id"] == prepare.RETRIEVAL_POLICY_ID
+    assert document["excluded_domains"] == list(prepare.EXCLUDED_DOMAINS)
+
+
+def test_the_policy_carries_the_draco_leak_sources(tmp_path: Path) -> None:
+    """The dataset card, the reproduction post and the paper are where the answer key lives."""
+    document = json.loads(prepare.write_policy(tmp_path).read_text(encoding="utf-8"))
+
+    joined = " ".join(document["excluded_domains"])
+    for source in ("huggingface.co", "openrouter.ai", "arxiv.org"):
+        assert source in joined
+
+
+def test_an_empty_policy_fails_the_BUILD(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """WHY here and not in the runner: the runner deliberately ACCEPTS an empty policy, because a
+    benchmark may declare unrestricted retrieval as an explicit, attributable statement. For DRACO
+    an empty list means the generator broke — and a generation bug belongs to the build, not to a
+    run that would score high and look clean."""
+    monkeypatch.setattr(prepare, "EXCLUDED_DOMAINS", ())
+
+    with pytest.raises(prepare.PrepareError, match="policy is empty"):
+        prepare.write_policy(tmp_path)
+
+
+def test_the_data_table_declares_the_policy_route(tmp_path: Path) -> None:
+    table = prepare.render_data_table([{"id": 1}], tmp_path, "/draco")
+
+    assert '"/draco/policy/retrieval"' in table
+    assert 'media_type = "application/json"' in table
+
+
+def test_the_data_table_still_declares_no_rubric_route(tmp_path: Path) -> None:
+    """INVARIANT: an expression that could fetch a rubric could feed it to the judge."""
+    table = prepare.render_data_table([{"id": 1}, {"id": 2}], tmp_path, "/draco")
+
+    assert "/rubrics/" not in table
+    assert '"/draco/criteria/1"' in table

--- a/apps/url4-cloud/tests/unit/test_manifest_matches_declared_world.py
+++ b/apps/url4-cloud/tests/unit/test_manifest_matches_declared_world.py
@@ -177,10 +177,18 @@ def test_runner_jobs_default_to_the_benchmark_image() -> None:
     """A Runner exists to execute a benchmark, and the plain engine image declares no `[data]`
     routes — MEASURED on a real Job, the first expression fails `endpoint_not_found ... at
     '/draco/cases'`. Defaulting to the App image makes a whole deployment unable to run a single
-    case until someone remembers an override."""
-    values = _values()
+    case until someone remembers an override.
 
-    assert values["runner"]["image"]["repository"].endswith("-benchmark")
+    The default is DERIVED (`<image.repository>-benchmark`) rather than written out, so this
+    asserts on the helper that derives it. A literal path here made the override always set,
+    which left the derivation unreachable and pinned Runner Jobs to ghcr.io even when the App
+    was mirrored to a private registry — see `test_runner_image_tracks_the_app_registry.py`,
+    which pins the same invariant against a REAL `helm template` render.
+    """
+    helpers = (_CHART_VALUES.parent / "templates" / "_helpers.tpl").read_text(encoding="utf-8")
+
+    assert _values()["runner"]["image"]["repository"] == ""
+    assert '"%s-benchmark"' in helpers
 
 
 def test_the_control_plane_never_runs_the_benchmark_image() -> None:

--- a/apps/url4-cloud/tests/unit/test_manifest_matches_declared_world.py
+++ b/apps/url4-cloud/tests/unit/test_manifest_matches_declared_world.py
@@ -1,0 +1,201 @@
+"""A manifest's claims must match the world the image actually declares.
+
+FEATURE: `GET /v1/benchmarks/{id}` tells a client how to run a benchmark.
+STORY: as a client author, the routes and judge a manifest names must be the ones the Runner
+serves — or the expression I build from it fails at resolution, or worse, silently runs something
+else.
+
+WHY this module exists: `manifests.py` carried an AIDEV-NOTE saying two things were unenforced
+and "will drift" — the `routes` block against `prepare.render_data_table`, and the judge against
+`url4.toml`. An unenforced claim in a published catalog is the same shape as every other defect
+this branch has found: it reads as a guarantee and is not one.
+
+INVARIANT: these assert the manifest against the GENERATOR and the CONFIG, never against a second
+copy of the same literal — a test that restates the manifest proves only that the manifest equals
+itself.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from url4_cloud import manifests
+from url4_cloud.benchmarks.draco import prepare
+
+_RUNNER_CONFIG = Path(__file__).resolve().parents[2] / "url4.toml"
+
+
+def _declared_data_routes(case_ids: list[int]) -> set[str]:
+    """The `[data]` paths `prepare` would actually emit for these cases."""
+    cases = [{"id": case_id} for case_id in case_ids]
+    table = tomllib.loads(prepare.render_data_table(cases, Path("/opt/benchmarks/draco"), "/draco"))
+    return set(table["data"])
+
+
+def test_the_manifest_cases_route_is_one_prepare_declares() -> None:
+    route = manifests.field(manifests.DRACO_LITE, "routes")
+    # `routes:` is a nested block, so `field` returns None for it — read the leaf directly.
+    assert route is None
+    assert "cases: /draco/cases" in manifests.DRACO_LITE
+    assert "/draco/cases" in _declared_data_routes([1, 2])
+
+
+def test_the_manifest_criteria_template_matches_a_declared_route() -> None:
+    """The manifest advertises `/draco/criteria/{case_id}`; the generator emits one exact path per
+    case, because routing has no wildcard form. The TEMPLATE is only honest if substituting a real
+    id yields a route that exists."""
+    assert "criteria: /draco/criteria/{case_id}" in manifests.DRACO_LITE
+
+    declared = _declared_data_routes([1, 7])
+
+    assert {"/draco/criteria/1", "/draco/criteria/7"} <= declared
+
+
+def test_the_manifest_never_advertises_a_rubric_route() -> None:
+    """INVARIANT: the weighted rubrics are the answer key. They are deliberately NOT declared as
+    routes, so a manifest naming one would advertise a path that both leaks and does not exist."""
+    assert "rubric" not in manifests.DRACO_LITE.split("routes:")[1]
+    assert not any("/rubrics/" in route for route in _declared_data_routes([1, 2]))
+
+
+def test_the_manifest_judge_is_a_route_the_runner_declares() -> None:
+    """A judge the image cannot address is a `ResolutionError` at run time, and the paper PINS
+    this model — so a drift here silently changes what the score means."""
+    judge = manifests.field(manifests.DRACO_LITE, "judge")
+    assert judge is not None
+
+    with _RUNNER_CONFIG.open("rb") as handle:
+        entries = tomllib.load(handle)["aigateway"]["models"]
+    declared = {entry["id"] if isinstance(entry, dict) else entry for entry in entries}
+
+    assert judge in declared
+
+
+def test_the_judge_declares_no_retrieval() -> None:
+    """arXiv:2602.11685 §4.2 — the judge sees one answer and one criterion. Giving it web access
+    would let it check claims against the live web, which is a DIFFERENT benchmark."""
+    judge = manifests.field(manifests.DRACO_LITE, "judge")
+
+    with _RUNNER_CONFIG.open("rb") as handle:
+        entries = tomllib.load(handle)["aigateway"]["models"]
+    entry = next(e for e in entries if isinstance(e, dict) and e.get("id") == judge)
+
+    assert not entry.get("web_tools")
+    assert not entry.get("native_web_search")
+
+
+def test_every_answering_route_in_the_lineup_retrieves_somehow() -> None:
+    """The owner's 2026-08-02 decision: native where OpenRouter provides it, Tavily otherwise, so
+    that no DRACO candidate answers from weights alone on a DEEP-RESEARCH benchmark.
+
+    INVARIANT: this is what makes the manifest's `tools:` block honest. A route added to the
+    lineup without a retrieval mechanism would silently score below the reference chart for
+    reasons that have nothing to do with the candidate.
+    """
+    with _RUNNER_CONFIG.open("rb") as handle:
+        entries = tomllib.load(handle)["aigateway"]["models"]
+    judge = manifests.field(manifests.DRACO_LITE, "judge")
+
+    openrouter = [
+        entry
+        for entry in entries
+        if isinstance(entry, dict)
+        and str(entry.get("id", "")).startswith("openrouter/")
+        and entry.get("id") != judge
+    ]
+    assert openrouter, "no OpenRouter answering routes are declared"
+
+    silent = [
+        entry["id"]
+        for entry in openrouter
+        if not entry.get("web_tools") and not entry.get("native_web_search")
+    ]
+    assert silent == [], f"these DRACO routes would answer from weights alone: {silent}"
+
+
+def test_no_google_route_declares_native_web_search() -> None:
+    """MEASURED 2026-08-02: a Google native-search call carrying `exclude_domains` is a hard 400 —
+
+        "Domain filters (include_domains/exclude_domains) are not supported with native search on
+         Google. Use engine: 'exa' or remove domain filters"
+
+    INVARIANT: on a Google route it is retrieval OR the blocklist, never both. For a benchmark
+    whose candidates must not reach the answer key the guard is not optional, so these routes take
+    the Tavily loop instead. The trap is that the flag looks correct — the model DOES support
+    native search — and the failure only appears once a policy is attached, i.e. on the real
+    benchmark expression and not on a smoke test.
+
+    This applies to the DEPLOYMENT's blocklist too, not only an expression policy.
+    """
+    with _RUNNER_CONFIG.open("rb") as handle:
+        entries = tomllib.load(handle)["aigateway"]["models"]
+
+    offenders = [
+        entry["id"]
+        for entry in entries
+        if isinstance(entry, dict)
+        and "/google/" in str(entry.get("id", ""))
+        and entry.get("native_web_search")
+    ]
+
+    assert offenders == [], f"Google native search cannot carry a blocklist: {offenders}"
+
+
+def test_the_declared_call_timeout_fits_a_retrieving_answer() -> None:
+    """MEASURED 2026-08-02 on a real Kubernetes Job: at the 60s default the answering call raised
+    `ReadTimeout`, and because `iteration.on_error=collect` substitutes an error object in place,
+    the run reported `terminated: succeeded` with `case_count: 0`.
+
+    INVARIANT: a DRACO answer is a deep-research call WITH provider-side retrieval and does not
+    fit in the default. This pins the declaration, because the failure it prevents is silent —
+    a benchmark emptied by a network setting is indistinguishable in the result from a candidate
+    that answered badly.
+    """
+    with _RUNNER_CONFIG.open("rb") as handle:
+        section = tomllib.load(handle)["aigateway"]
+
+    assert section.get("timeout_s", 60.0) >= 180.0, (
+        "the declared aigateway timeout is at or near the 60s default — a retrieving answer "
+        "times out and the run silently scores nothing"
+    )
+
+
+_CHART_VALUES = Path(__file__).resolve().parents[2] / "deploy" / "helm" / "values.yaml"
+
+
+def _values() -> dict:
+    """Parse the chart's values without Helm — the invariants below are about DECLARED defaults,
+    and a test that needed a Helm binary would simply not run in this stack's gate."""
+    import yaml
+
+    with _CHART_VALUES.open(encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def test_runner_jobs_default_to_the_benchmark_image() -> None:
+    """A Runner exists to execute a benchmark, and the plain engine image declares no `[data]`
+    routes — MEASURED on a real Job, the first expression fails `endpoint_not_found ... at
+    '/draco/cases'`. Defaulting to the App image makes a whole deployment unable to run a single
+    case until someone remembers an override."""
+    values = _values()
+
+    assert values["runner"]["image"]["repository"].endswith("-benchmark")
+
+
+def test_the_control_plane_never_runs_the_benchmark_image() -> None:
+    """INVARIANT: the benchmark image carries the private weighted rubrics — the answer key. The
+    control plane is the process that terminates CLIENT connections, so a rubric on that pod is
+    one bug away from reaching the client it is being kept from. Two images exist for exactly this
+    asymmetry; collapsing them back to one would silently undo it."""
+    values = _values()
+
+    assert values["image"]["repository"] != values["runner"]["image"]["repository"]
+    assert not values["image"]["repository"].endswith("-benchmark")
+
+
+def test_the_runner_tag_tracks_the_app_tag() -> None:
+    """Empty => the App image's resolved tag. That is what keeps engine and dataset on ONE version,
+    so a published score can name the engine that produced it. A pinned tag here is a staged
+    rollout, not a default."""
+    assert _values()["runner"]["image"]["tag"] == ""

--- a/apps/url4-cloud/tests/unit/test_model_params.py
+++ b/apps/url4-cloud/tests/unit/test_model_params.py
@@ -126,7 +126,7 @@ async def test_no_parameters_leaves_the_body_untouched() -> None:
 
 @pytest.mark.parametrize(
     "field",
-    ["model", "messages", "tools", "tool_choice", "stream"],
+    ["model", "messages", "tools", "tool_choice", "stream", "web_search_excluded_domains"],
 )
 @pytest.mark.asyncio
 async def test_a_runner_owned_field_is_rejected(field: str) -> None:

--- a/apps/url4-cloud/tests/unit/test_model_params.py
+++ b/apps/url4-cloud/tests/unit/test_model_params.py
@@ -1,0 +1,235 @@
+"""Expression-level model parameters reaching the gateway request body.
+
+FEATURE: a url4 expression can pin a model call's sampling parameters —
+`/judge(…)!'grade';temperature=0.2;max_tokens=8192` — and they reach aigateway.
+STORY: as a benchmark author, the DRACO paper pins `judge_temperature: 0.2`
+(arXiv:2602.11685 §4.2), and a judge run at the provider's default temperature
+is a different benchmark from the one the paper defines.
+
+Before this, `_ModelEndpoint.__call__` read `path`/`context`/`intent` and never
+`params`, so every `;k=v` in an expression was parsed, carried to the endpoint, and
+silently dropped at the wire — the run still succeeded, at the wrong temperature.
+
+INVARIANT: the gateway is the AUTHORITY on which parameters exist and what values are
+legal (`core/standard_parameters.py` + each provider's rules, which fail closed on an
+unknown field). The runner keeps NO second allowlist — it rejects only the fields IT
+owns, and forwards the rest for the gateway to validate.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from url4.core.errors import ResolutionError
+from url4_cloud.runner.config import ModelSpec
+from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+
+_MODEL = "openrouter/google/gemini-3.1-pro-preview"
+
+
+# Every probe expression carries `anchor:1.0:'a'` beside the model call: with the call as the
+# body's ONLY source, the all-calls rule fires the per-row reduce and `default_route` adds a
+# gateway hop these assertions do not expect. One data sibling degrades it to a join.
+async def _evaluate(expression: str, *, web_tools: bool = False, tavily: bool = False):
+    """Run one expression against a mock gateway; return the captured request bodies."""
+    bodies: list[dict] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        bodies.append(json.loads(request.content))
+        return httpx.Response(200, json={"choices": [{"message": {"content": "OK"}}], "usage": {}})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handle), base_url="http://aigateway.test"
+    ) as client:
+        world = await build_aigateway_world(
+            AigatewayConfig(
+                default_model=_MODEL, models=(ModelSpec(id=_MODEL, web_tools=web_tools),)
+            ),
+            client=client,
+            tavily_client=client if tavily else None,
+            tavily_api_key="tv-key" if tavily else None,
+        )
+        try:
+            await world.node.evaluate(expression)
+        finally:
+            await world.aclose()
+    return bodies
+
+
+# --- the parameters reach the wire, correctly typed ------------------------------
+
+
+@pytest.mark.asyncio
+async def test_temperature_reaches_the_request_body_as_a_number() -> None:
+    """INVARIANT: coerced, not passed through as text.
+
+    url4 hands params over as `Mapping[str, str]`, but the gateway's schemas are strictly
+    typed — `isinstance(v, (int, float)) and not isinstance(v, bool)` — so the string
+    "0.2" fails closed against `TEMPERATURE_SCHEMA`. A forwarded parameter that the
+    gateway then rejects is no better than a dropped one.
+    """
+    bodies = await _evaluate(
+        f"(v:1.0:/{_MODEL}(a:1.0:'x')!'grade';temperature=0.2,anchor:1.0:'a')!'go'"
+    )
+
+    assert bodies[0]["temperature"] == 0.2
+    assert isinstance(bodies[0]["temperature"], float)
+
+
+@pytest.mark.asyncio
+async def test_max_tokens_reaches_the_request_body_as_an_integer() -> None:
+    """`max_tokens: 8192` is a hard requirement when tools are on — the DRACO anatomy doc
+    records a judge returning `content: null` because reasoning consumed the whole budget."""
+    bodies = await _evaluate(
+        f"(v:1.0:/{_MODEL}(a:1.0:'x')!'grade';max_tokens=8192,anchor:1.0:'a')!'go'"
+    )
+
+    assert bodies[0]["max_tokens"] == 8192
+    assert isinstance(bodies[0]["max_tokens"], int)
+
+
+@pytest.mark.asyncio
+async def test_an_enum_valued_parameter_stays_a_string() -> None:
+    """Coercion must not mangle a value the gateway expects as text: `stop` is a
+    `string | array[string]` union, and an enum ladder like `reasoning_effort` is a
+    plain string. Only JSON-shaped values become JSON."""
+    bodies = await _evaluate(f"(v:1.0:/{_MODEL}(a:1.0:'x')!'grade';stop=END,anchor:1.0:'a')!'go'")
+
+    assert bodies[0]["stop"] == "END"
+
+
+@pytest.mark.asyncio
+async def test_several_parameters_are_all_forwarded() -> None:
+    bodies = await _evaluate(
+        f"(v:1.0:/{_MODEL}(a:1.0:'x')!'grade';temperature=0.2;max_tokens=8192;seed=7,anchor:1.0:'a')!'go'"
+    )
+
+    assert bodies[0]["temperature"] == 0.2
+    assert bodies[0]["max_tokens"] == 8192
+    assert bodies[0]["seed"] == 7
+
+
+@pytest.mark.asyncio
+async def test_no_parameters_leaves_the_body_untouched() -> None:
+    """A call with no `;k=v` chain must send exactly what it always sent — no phantom
+    keys the gateway would then have to classify."""
+    bodies = await _evaluate(f"(v:1.0:/{_MODEL}(a:1.0:'x')!'grade',anchor:1.0:'a')!'go'")
+
+    assert set(bodies[0]) == {"model", "messages"}
+
+
+# --- the fields the RUNNER owns --------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["model", "messages", "tools", "tool_choice", "stream"],
+)
+@pytest.mark.asyncio
+async def test_a_runner_owned_field_is_rejected(field: str) -> None:
+    """INVARIANT: these are the runner's, not the caller's, and rejection is LOUD.
+
+    `model` would let an expression address one route and run another model, breaking the
+    "route path is exactly '/' + gateway id" invariant that `url4.toml` and
+    `test_declared_models_match_aigateway.py` exist to hold. `tools`/`tool_choice` would
+    bypass the per-route `web_tools` opt-in that keeps a configured Tavily key from
+    silently changing every model's payload. `stream` would break response parsing.
+
+    Dropping them silently would be worse than forwarding them: the expression would read
+    as though it had pinned something it had not.
+    """
+    with pytest.raises(ResolutionError, match=field):
+        await _evaluate(f"(v:1.0:/{_MODEL}(a:1.0:'x')!'grade';{field}=x,anchor:1.0:'a')!'go'")
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_parameter_is_forwarded_for_the_gateway_to_judge() -> None:
+    """The runner keeps no allowlist: enabling a parameter must stay a gateway-local edit.
+
+    The gateway fails closed on an unknown field ("unsupported chat parameters: …"), so a
+    typo surfaces there with a named 400 rather than being swallowed here — one authority,
+    no drift.
+    """
+    bodies = await _evaluate(
+        f"(v:1.0:/{_MODEL}(a:1.0:'x')!'grade';not_a_real_param=1,anchor:1.0:'a')!'go'"
+    )
+
+    assert bodies[0]["not_a_real_param"] == 1
+
+
+# --- interaction with the web-tool loop ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_web_tools_still_win_over_a_caller_supplied_payload() -> None:
+    """The route's declared tools must be what ships, on a route that opted in."""
+    bodies = await _evaluate(
+        f"(v:1.0:/{_MODEL}(a:1.0:'x')!'grade';temperature=0.2,anchor:1.0:'a')!'go'",
+        web_tools=True,
+        tavily=True,
+    )
+
+    assert bodies[0]["temperature"] == 0.2
+    assert bodies[0]["tool_choice"] == "auto"
+    assert isinstance(bodies[0]["tools"], list)
+
+
+@pytest.mark.asyncio
+async def test_parameters_apply_to_every_round_trip_of_the_tool_loop() -> None:
+    """A tool-calling turn re-posts; sampling parameters must hold on each hop, or the
+    answer is produced under different settings from the ones the expression pinned."""
+    calls: list[dict] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/v1/chat/completions"):
+            calls.append(json.loads(request.content))
+            if len(calls) == 1:
+                return httpx.Response(
+                    200,
+                    json={
+                        "choices": [
+                            {
+                                "message": {
+                                    "content": None,
+                                    "tool_calls": [
+                                        {
+                                            "id": "c1",
+                                            "type": "function",
+                                            "function": {
+                                                "name": "web_search",
+                                                "arguments": '{"query": "x"}',
+                                            },
+                                        }
+                                    ],
+                                }
+                            }
+                        ],
+                        "usage": {},
+                    },
+                )
+            return httpx.Response(
+                200, json={"choices": [{"message": {"content": "FINAL"}}], "usage": {}}
+            )
+        return httpx.Response(200, json={"results": []})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handle), base_url="http://aigateway.test"
+    ) as client:
+        world = await build_aigateway_world(
+            AigatewayConfig(default_model=_MODEL, models=(ModelSpec(id=_MODEL, web_tools=True),)),
+            client=client,
+            tavily_client=client,
+            tavily_api_key="tv-key",
+        )
+        try:
+            await world.node.evaluate(
+                f"(v:1.0:/{_MODEL}(a:1.0:'x')!'grade';temperature=0.2,anchor:1.0:'a')!'go'"
+            )
+        finally:
+            await world.aclose()
+
+    assert len(calls) == 2
+    assert [c["temperature"] for c in calls] == [0.2, 0.2]

--- a/apps/url4-cloud/tests/unit/test_native_web_search.py
+++ b/apps/url4-cloud/tests/unit/test_native_web_search.py
@@ -1,0 +1,211 @@
+"""Provider-side web search, and the expression-level toggle that selects it.
+
+FEATURE: a route whose provider runs search ITSELF declares `native_web_search`, and an
+expression turns retrieval on or off per call with `;web_search=`.
+STORY: as a benchmark author, a published score was produced on the provider's own server-side
+search — a client-side loop over a different backend is a different experiment, so I need the
+same surface, and I need to switch it off for the judge in the same expression.
+
+TWO MECHANISMS, one per route:
+  * `web_tools`         — the RUNNER declares OpenAI functions and executes them against Tavily.
+                          Kept for providers with no server-side search of their own.
+  * `native_web_search` — the PROVIDER executes the search and answers with it already done.
+                          The runner asks the GATEWAY for it (`web_search: true`) and never
+                          spells one provider's envelope itself.
+
+INVARIANT: never both on one route. The request would carry two tool populations and
+double-dispatch — searching twice per turn and billing for both.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from url4.core.errors import ResolutionError
+from url4_cloud.runner.config import ModelSpec, RunnerConfigError, parse_config
+from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+
+_NATIVE = "openrouter/anthropic/claude-opus-4.8"
+_TAVILY = "claude-opus-4-8"
+_PLAIN = "claude-haiku-4-5"
+
+
+async def _bodies(expression: str, *, cfg: AigatewayConfig | None = None) -> list[dict]:
+    """Evaluate against a mock gateway; return every captured chat-completions body."""
+    captured: list[dict] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content))
+        return httpx.Response(200, json={"choices": [{"message": {"content": "OK"}}], "usage": {}})
+
+    config = cfg or AigatewayConfig(
+        default_model=_PLAIN,
+        models=(
+            ModelSpec(id=_NATIVE, native_web_search=True),
+            ModelSpec(id=_TAVILY, web_tools=True),
+            ModelSpec(id=_PLAIN),
+        ),
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handle), base_url="http://aigateway.test"
+    ) as client:
+        world = await build_aigateway_world(
+            config, client=client, tavily_client=client, tavily_api_key="tv-key"
+        )
+        try:
+            await world.node.evaluate(expression)
+        finally:
+            await world.aclose()
+    return captured
+
+
+def _call(route: str, chain: str = "") -> str:
+    # `anchor` keeps the all-calls rule from firing the per-row reduce onto default_route.
+    return f"(v:1.0:/{route}(a:1.0:'x')!'answer'{chain},anchor:1.0:'a')!'go'"
+
+
+# --- the native surface ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_native_route_asks_the_gateway_for_retrieval() -> None:
+    """INVARIANT: a provider-AGNOSTIC flag, not a provider payload.
+
+    The gateway owns which provider can retrieve and how its envelope is spelled (OpenRouter's
+    is `plugins: [{"id": "web"}]`, an extensibility envelope no caller may address). Building
+    that here would put provider knowledge in the runner and fork a contract the gateway
+    already owns.
+    """
+    body = (await _bodies(_call(_NATIVE)))[0]
+
+    assert body["web_search"] is True
+    assert "plugins" not in body
+    assert "tools" not in body
+
+
+@pytest.mark.asyncio
+async def test_a_native_route_sends_no_tool_choice() -> None:
+    """`tool_choice` is the OpenAI selection control and does not govern a provider-run
+    plugin; sending it would advertise a control the provider does not honor here."""
+    body = (await _bodies(_call(_NATIVE)))[0]
+
+    assert "tool_choice" not in body
+
+
+@pytest.mark.asyncio
+async def test_a_native_route_runs_no_client_side_loop() -> None:
+    """The provider answers with retrieval already done — one request, not a tool round trip."""
+    assert len(await _bodies(_call(_NATIVE))) == 1
+
+
+@pytest.mark.asyncio
+async def test_operator_domain_exclusions_ride_on_the_native_entries() -> None:
+    """INVARIANT: the leak guard is OPERATOR-owned. A benchmark candidate must not be able to
+    retrieve the rubric it is graded against, and a blocklist the caller can rewrite is not a
+    blocklist — so it comes from config, never from the expression."""
+    cfg = AigatewayConfig(
+        default_model=_NATIVE,
+        models=(ModelSpec(id=_NATIVE, native_web_search=True),),
+        web_search_excluded_domains=("huggingface.co/datasets/perplexity-ai/draco",),
+    )
+    body = (await _bodies(_call(_NATIVE), cfg=cfg))[0]
+
+    # The gateway UNIONs this with the deployment's own list, so it can only tighten.
+    assert body["web_search_excluded_domains"] == ["huggingface.co/datasets/perplexity-ai/draco"]
+
+
+@pytest.mark.asyncio
+async def test_absent_operator_parameters_omit_the_field_entirely() -> None:
+    """An empty exclusion list must not be SENT as an empty list — that reads to the provider as
+    'exclude nothing' rather than 'use your default'."""
+    body = (await _bodies(_call(_NATIVE)))[0]
+
+    assert "web_search_excluded_domains" not in body
+
+
+# --- the expression toggle -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_toggle_switches_a_native_route_off() -> None:
+    body = (await _bodies(_call(_NATIVE, ";web_search=false")))[0]
+
+    assert "web_search" not in body
+
+
+@pytest.mark.asyncio
+async def test_the_toggle_switches_a_tavily_route_off() -> None:
+    body = (await _bodies(_call(_TAVILY, ";web_search=false")))[0]
+
+    assert "tools" not in body
+
+
+@pytest.mark.asyncio
+async def test_a_tavily_route_still_declares_openai_functions() -> None:
+    """The client-side mechanism is unchanged — it is what a provider with no server-side
+    search of its own still needs."""
+    body = (await _bodies(_call(_TAVILY)))[0]
+
+    assert [t["function"]["name"] for t in body["tools"]] == ["web_search", "web_fetch"]
+    assert body["tool_choice"] == "auto"
+
+
+@pytest.mark.asyncio
+async def test_saying_nothing_keeps_the_routes_declared_behaviour() -> None:
+    """Absent means 'as declared', so every expression written before this toggle existed
+    behaves exactly as it did."""
+    assert "web_search" in (await _bodies(_call(_NATIVE)))[0]
+    assert "tools" in (await _bodies(_call(_TAVILY)))[0]
+    assert "tools" not in (await _bodies(_call(_PLAIN)))[0]
+    assert "web_search" not in (await _bodies(_call(_PLAIN)))[0]
+
+
+@pytest.mark.asyncio
+async def test_asking_a_route_with_no_mechanism_to_search_is_loud() -> None:
+    """The silent alternative is an expression that reads as though it retrieved and an answer
+    written from weights alone — indistinguishable in the result."""
+    with pytest.raises(ResolutionError, match="declares no web search"):
+        await _bodies(_call(_PLAIN, ";web_search=true"))
+
+
+@pytest.mark.asyncio
+async def test_the_toggle_is_consumed_and_never_reaches_the_gateway() -> None:
+    """The url4 toggle is consumed by `_wants_web_search`, never forwarded as a raw param — the
+    gateway field it produces is set by the connector, not copied from the expression."""
+    body = (await _bodies(_call(_NATIVE, ";web_search=true;temperature=0.2")))[0]
+
+    assert body["web_search"] is True
+    assert body["temperature"] == 0.2
+    assert body["temperature"] == 0.2
+
+
+# --- the declared world ----------------------------------------------------------
+
+
+def test_declaring_both_mechanisms_is_a_config_error() -> None:
+    raw = {
+        "aigateway": {
+            "default_route": "/m",
+            "models": [{"id": "m", "web_tools": True, "native_web_search": True}],
+        }
+    }
+    with pytest.raises(RunnerConfigError, match="ONE retrieval mechanism"):
+        parse_config(raw, {})
+
+
+def test_native_web_search_defaults_off() -> None:
+    raw = {"aigateway": {"default_route": "/m", "models": [{"id": "m"}]}}
+
+    section = parse_config(raw, {}).aigateway
+    assert section is not None
+    assert section.models[0].native_web_search is False
+
+
+def test_native_web_search_must_be_a_boolean() -> None:
+    raw = {"aigateway": {"default_route": "/m", "models": [{"id": "m", "native_web_search": 1}]}}
+
+    with pytest.raises(RunnerConfigError, match="native_web_search must be a boolean"):
+        parse_config(raw, {})

--- a/apps/url4-cloud/tests/unit/test_response_model_provenance.py
+++ b/apps/url4-cloud/tests/unit/test_response_model_provenance.py
@@ -1,0 +1,149 @@
+"""The served model reaches the wire, end to end.
+
+FEATURE: `gen_ai.response.model` on a span must name the model that ACTUALLY served the call.
+The gateway echoes it; before this it was dropped and the field repeated the requested model,
+so a provider silently resolving an alias to a different snapshot looked identical to it
+serving exactly what was asked for.
+
+Covers both halves of the seam: the connector reporting it, and the executor putting it on the
+span frame.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from url4.dag import run as url4_run
+from url4.observe import NodeFinished, NodeStarted, ObservationEvent, RunStarted, Usage
+from url4_cloud.runner.config import ModelSpec
+from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+from url4_cloud.runner.executor import _RunState
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.events: list[ObservationEvent] = []
+
+    def on_event(self, event: ObservationEvent) -> None:
+        self.events.append(event)
+
+
+def _gateway(response_body: dict) -> httpx.AsyncClient:
+    def _handle(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/models":
+            return httpx.Response(
+                200, json={"object": "list", "data": [{"id": "google/gemini-3.1-pro-preview"}]}
+            )
+        return httpx.Response(200, json=response_body)
+
+    return httpx.AsyncClient(
+        transport=httpx.MockTransport(_handle), base_url="http://aigateway.test"
+    )
+
+
+def _body(*, model: str | None) -> dict:
+    body: dict = {
+        "choices": [{"message": {"content": "hi"}}],
+        "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+    }
+    if model is not None:
+        body["model"] = model
+    return body
+
+
+async def _run_and_get_usage(response_body: dict) -> Usage:
+    cfg = AigatewayConfig(
+        models=(ModelSpec(id="google/gemini-3.1-pro-preview"),),
+        default_model="google/gemini-3.1-pro-preview",
+    )
+    rec = _Recorder()
+    async with _gateway(response_body) as client:
+        world = await build_aigateway_world(cfg, client=client)
+        await url4_run("/google/gemini-3.1-pro-preview(ctx)!go", io=world.node, observer=rec)
+    usages = [e for e in rec.events if isinstance(e, Usage)]
+    assert len(usages) == 1
+    return usages[0]
+
+
+# --- the connector half ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_gateways_resolved_model_is_reported_not_the_requested_one() -> None:
+    usage = await _run_and_get_usage(_body(model="google/gemini-3.1-pro-preview-20260715"))
+
+    assert usage.model == "google/gemini-3.1-pro-preview"
+    assert usage.response_model == "google/gemini-3.1-pro-preview-20260715"
+
+
+@pytest.mark.asyncio
+async def test_a_gateway_that_omits_the_model_yields_none() -> None:
+    usage = await _run_and_get_usage(_body(model=None))
+
+    assert usage.model == "google/gemini-3.1-pro-preview"
+    assert usage.response_model is None
+
+
+@pytest.mark.asyncio
+async def test_a_non_string_model_is_refused_rather_than_reaching_the_wire_schema() -> None:
+    """It comes off an upstream JSON body, so its type is not ours to assume."""
+    usage = await _run_and_get_usage(_body(model=None) | {"model": {"nested": "object"}})
+
+    assert usage.response_model is None
+
+
+# --- the executor half ----------------------------------------------------------
+
+
+def _span_frames(events: list[ObservationEvent]) -> list:
+    state = _RunState()
+    frames: list = []
+    for event in events:
+        frames.extend(state.map(event))
+    return frames
+
+
+def _span_data(response_model: str | None):
+    events: list[ObservationEvent] = [
+        RunStarted(trace_id="t" * 32, root_span_id="s" * 16, expression_hash="h"),
+        NodeStarted(span_id="s" * 16, parent_span_id=None, node_kind="ModelNode", detail="d"),
+        Usage(
+            span_id="s" * 16,
+            provider="google",
+            model="gemini-3.1-pro-preview",
+            input_tokens=3,
+            output_tokens=2,
+            response_model=response_model,
+        ),
+        NodeFinished(span_id="s" * 16, status="ok", engine_seq=2),
+    ]
+    frames = _span_frames(events)
+    spans = [f.payload for f in frames if hasattr(f.payload, "request_model")]
+    assert len(spans) == 1
+    return spans[0]
+
+
+def test_the_span_carries_the_served_model_distinctly_from_the_requested_one() -> None:
+    span = _span_data("gemini-3.1-pro-preview-20260715")
+
+    assert span.request_model == "gemini-3.1-pro-preview"
+    assert span.response_model == "gemini-3.1-pro-preview-20260715"
+
+
+def test_an_unreported_served_model_leaves_the_span_field_absent() -> None:
+    """INVARIANT: absent, NOT a copy of request_model — that copy was the bug."""
+    span = _span_data(None)
+
+    assert span.request_model == "gemini-3.1-pro-preview"
+    assert span.response_model is None
+
+
+def test_the_wire_alias_serializes_the_served_model() -> None:
+    span = _span_data("gemini-3.1-pro-preview-20260715")
+
+    dumped = json.loads(span.model_dump_json(by_alias=True, exclude_none=True))
+    assert dumped["gen_ai.request.model"] == "gemini-3.1-pro-preview"
+    assert dumped["gen_ai.response.model"] == "gemini-3.1-pro-preview-20260715"

--- a/apps/url4-cloud/tests/unit/test_retrieval_policy.py
+++ b/apps/url4-cloud/tests/unit/test_retrieval_policy.py
@@ -270,14 +270,17 @@ async def test_naming_a_policy_on_a_non_retrieving_route_is_loud() -> None:
         await _bodies(_call(_PLAIN, f";web_search_policy={_POLICY_PATH}"), data=(_policy_route(),))
 
 
-@pytest.mark.asyncio
-async def test_naming_a_policy_on_a_tavily_route_is_loud() -> None:
-    """WHY the Tavily loop is not a home for this: domain exclusion is a PROVIDER-side control,
-    honoured by the provider running the search. On a `web_tools` route the RUNNER searches, so a
-    declared policy would be accepted and never enforced — which is the failure this closes, not
-    a case of it."""
-    with pytest.raises(ResolutionError):
-        await _bodies(_call(_TAVILY, f";web_search_policy={_POLICY_PATH}"), data=(_policy_route(),))
+# RETIRED 2026-08-02 (owner-approved): `test_naming_a_policy_on_a_tavily_route_is_loud`.
+#
+# It pinned the rule that a policy on a `web_tools` route must RAISE, reasoning that domain
+# exclusion was a PROVIDER-side control the runner could not enforce. MEASURED 2026-08-02 against
+# the live API, that premise is false — Tavily's `/search` accepts `exclude_domains` and honours
+# it — and once the DRACO models without native search were put on the Tavily loop, the refusal
+# became the very hole it was written to prevent: an unguardable retrieval path.
+#
+# The rule is INVERTED, not dropped. Its replacement lives in `test_tavily_retrieval_guard.py`,
+# which asserts the policy actually reaches Tavily and that a blocked `web_fetch` never leaves.
+# The two tests below are untouched: a route that retrieves by NEITHER mechanism is still loud.
 
 
 @pytest.mark.asyncio

--- a/apps/url4-cloud/tests/unit/test_retrieval_policy.py
+++ b/apps/url4-cloud/tests/unit/test_retrieval_policy.py
@@ -1,0 +1,327 @@
+"""The retrieval policy as an addressable `[data]` artifact, named by the expression.
+
+FEATURE: a benchmark declares its blocklist at its own url4 address; an expression names that
+address with `;web_search_policy=`, and the Runner dereferences it into the request.
+STORY: as a benchmark author, the blocklist that keeps a candidate from retrieving the rubric it
+is graded against must be PER BENCHMARK (the model routes are shared), tweakable for my own run,
+and visible in the expression — because the scoreboard hashes the expression into a recipe
+identity, and a blocklist hidden in operator config would let an unguarded run hash identically
+to an honest one.
+
+WHY an ADDRESS and not the list itself: protocol params are parse-time CONSTANTS (the compiler
+copies `node.params` verbatim; `$` substitution reaches only `TextNode.template` and the packed
+context), so a list interpolated from scope is not expressible. A path IS a constant, while its
+contents are not — which is the whole trick.
+
+INVARIANT: the policy never enters `context` or `intent`, so it never reaches the model. A
+source-shaped spelling could not hold this: a weight-1.0 source packs into the prompt — handing
+the candidate a pointer to the answer key — and a weight-0.0 source is excluded from the context
+and therefore invisible to the Runner too.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from url4.core.errors import ResolutionError
+from url4_cloud.runner.config import DataSpec, ModelSpec
+from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+
+_NATIVE = "openrouter/anthropic/claude-opus-4.8"
+_TAVILY = "claude-opus-4-8"
+_PLAIN = "claude-haiku-4-5"
+
+_POLICY_PATH = "/draco/policy/retrieval"
+_DOMAINS = ["answers.test", "leak.test"]
+_POLICY = json.dumps({"id": "draco/official", "excluded_domains": _DOMAINS})
+
+
+def _policy_route(body: str = _POLICY, path: str = _POLICY_PATH) -> DataSpec:
+    return DataSpec(path=path, value=body, media_type="application/json")
+
+
+async def _bodies(
+    expression: str,
+    *,
+    cfg: AigatewayConfig | None = None,
+    data: tuple[DataSpec, ...] = (),
+) -> list[dict]:
+    """Evaluate against a mock gateway; return every captured chat-completions body."""
+    captured: list[dict] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content))
+        return httpx.Response(200, json={"choices": [{"message": {"content": "OK"}}], "usage": {}})
+
+    config = cfg or AigatewayConfig(
+        default_model=_PLAIN,
+        models=(
+            ModelSpec(id=_NATIVE, native_web_search=True),
+            ModelSpec(id=_TAVILY, web_tools=True),
+            ModelSpec(id=_PLAIN),
+        ),
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handle), base_url="http://aigateway.test"
+    ) as client:
+        world = await build_aigateway_world(
+            config, client=client, data=data, tavily_client=client, tavily_api_key="tv-key"
+        )
+        try:
+            await world.node.evaluate(expression)
+        finally:
+            await world.aclose()
+    return captured
+
+
+def _call(route: str, chain: str = "") -> str:
+    # `anchor` keeps the all-calls rule from firing the per-row reduce onto default_route.
+    return f"(v:1.0:/{route}(a:1.0:'x')!'answer'{chain},anchor:1.0:'a')!'go'"
+
+
+# --- the happy path ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_named_policy_reaches_the_request_as_excluded_domains() -> None:
+    """The expression carries the ADDRESS; the Runner sends the CONTENTS."""
+    body = (
+        await _bodies(_call(_NATIVE, f";web_search_policy={_POLICY_PATH}"), data=(_policy_route(),))
+    )[0]
+
+    assert body["web_search"] is True
+    assert body["web_search_excluded_domains"] == _DOMAINS
+
+
+@pytest.mark.asyncio
+async def test_the_policy_is_consumed_and_never_forwarded_as_a_param() -> None:
+    """`web_search_policy` is the Runner's vocabulary, not the gateway's. Forwarded, it would be
+    an unknown field and the gateway fails closed — a 400 on every retrieving call."""
+    body = (
+        await _bodies(_call(_NATIVE, f";web_search_policy={_POLICY_PATH}"), data=(_policy_route(),))
+    )[0]
+
+    assert "web_search_policy" not in body
+
+
+@pytest.mark.asyncio
+async def test_the_policy_never_reaches_the_model() -> None:
+    """INVARIANT: the blocklist names the exact sources that hold the answer key. Packed into the
+    prompt it would be a POINTER to them — worse than having no blocklist at all."""
+    body = (
+        await _bodies(_call(_NATIVE, f";web_search_policy={_POLICY_PATH}"), data=(_policy_route(),))
+    )[0]
+
+    rendered = json.dumps(body["messages"])
+    for domain in _DOMAINS:
+        assert domain not in rendered
+    assert "excluded_domains" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_absent_policy_leaves_existing_behaviour_unchanged() -> None:
+    """The regression guard for every expression written before this parameter existed."""
+    body = (await _bodies(_call(_NATIVE), data=(_policy_route(),)))[0]
+
+    assert body["web_search"] is True
+    assert "web_search_excluded_domains" not in body
+
+
+# --- composition: three layers, union only ----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_none_drops_the_benchmark_list_but_keeps_the_deployment_one() -> None:
+    """WHY `none` cannot mean "retrieve unguarded": the deployment's list is ENFORCEMENT and is
+    unreachable from any expression, while the benchmark's is an attributable default. That split
+    is what lets one mechanism serve a self-service run and a hosted leaderboard."""
+    cfg = AigatewayConfig(
+        default_model=_PLAIN,
+        models=(ModelSpec(id=_NATIVE, native_web_search=True), ModelSpec(id=_PLAIN)),
+        web_search_excluded_domains=("deployment.test",),
+    )
+    body = (
+        await _bodies(_call(_NATIVE, ";web_search_policy=none"), cfg=cfg, data=(_policy_route(),))
+    )[0]
+
+    assert body["web_search_excluded_domains"] == ["deployment.test"]
+
+
+@pytest.mark.asyncio
+async def test_caller_domains_union_with_the_policy_rather_than_replacing_it() -> None:
+    """INVARIANT: a caller can only ever TIGHTEN — the Runner unions the three layers and renders
+    the gateway field itself."""
+    body = (
+        await _bodies(
+            _call(_NATIVE, f";web_search_policy={_POLICY_PATH};web_search_exclude=extra.test"),
+            data=(_policy_route(),),
+        )
+    )[0]
+
+    assert body["web_search_excluded_domains"] == sorted([*_DOMAINS, "extra.test"])
+
+
+@pytest.mark.asyncio
+async def test_caller_domains_apply_with_no_policy_named() -> None:
+    """The ad-hoc escape hatch stands alone — a run may add domains without a declared policy."""
+    body = (
+        await _bodies(_call(_NATIVE, ";web_search_exclude=a.test:b.test"), data=(_policy_route(),))
+    )[0]
+
+    assert body["web_search_excluded_domains"] == ["a.test", "b.test"]
+
+
+@pytest.mark.asyncio
+async def test_a_comma_separated_value_is_silently_truncated() -> None:
+    """AIDEV-NOTE: pins a GRAMMAR trap, not desired behaviour — the reason the separator is `:`.
+
+    A source list splits on `,` at depth 0 before a param value is read, so a comma truncates the
+    value AND turns the remainder into an extra SOURCE of the ENCLOSING group (measured at the
+    parser: the outer group gains a third source), where it reaches that group's join or reduce.
+    The runner cannot detect any of this — the comma is gone by the time it sees the params.
+
+    Only the runner-visible half is asserted here; the source injection belongs to the grammar
+    and is pinned where the grammar is tested. Recorded so the next reader finds it documented
+    rather than live.
+    """
+    body = (
+        await _bodies(_call(_NATIVE, ";web_search_exclude=a.test,b.test"), data=(_policy_route(),))
+    )[0]
+
+    assert body["web_search_excluded_domains"] == ["a.test"]
+
+
+@pytest.mark.asyncio
+async def test_the_gateway_field_name_stays_runner_owned() -> None:
+    """WHY a SEPARATE param name rather than reusing the gateway's field.
+
+    `web_search_excluded_domains` is what the GATEWAY calls it, and an expression setting it
+    would be overwritten by the Runner's own value on the body merge — accepted at parse, then
+    silently discarded. That rejection is pinned by a prior test and stays exactly as it was.
+    `web_search_exclude` is a different thing: a runner-INTERPRETED request for additional
+    exclusions, which the Runner unions and then renders into the gateway field itself.
+    """
+    with pytest.raises(ResolutionError, match="web_search_excluded_domains"):
+        await _bodies(
+            _call(_NATIVE, ";web_search_excluded_domains=sneaky.test"), data=(_policy_route(),)
+        )
+
+
+# --- resolution is bounded to declared [data] routes -------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_undeclared_policy_path_is_loud() -> None:
+    with pytest.raises(ResolutionError, match="web_search_policy"):
+        await _bodies(_call(_NATIVE, ";web_search_policy=/nope/missing"), data=(_policy_route(),))
+
+
+@pytest.mark.asyncio
+async def test_a_model_route_is_not_addressable_as_a_policy() -> None:
+    """INVARIANT: the resolver is built from the parsed `[data]` table, not from the node's
+    router — so a model or command route is ABSENT rather than defended against, and the Runner
+    never re-enters the node it is serving."""
+    with pytest.raises(ResolutionError, match="web_search_policy"):
+        await _bodies(_call(_NATIVE, f";web_search_policy=/{_NATIVE}"), data=(_policy_route(),))
+
+
+# --- a failed resolution never degrades to "no guard" ------------------------------
+
+
+@pytest.mark.asyncio
+async def test_malformed_policy_json_is_loud_never_empty() -> None:
+    """INVARIANT: an empty list is "retrieve unguarded", and the run would report success with an
+    inflated score. Every failure here raises instead."""
+    with pytest.raises(ResolutionError):
+        await _bodies(
+            _call(_NATIVE, f";web_search_policy={_POLICY_PATH}"),
+            data=(_policy_route("{not json"),),
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_policy_without_excluded_domains_is_loud() -> None:
+    with pytest.raises(ResolutionError, match="excluded_domains"):
+        await _bodies(
+            _call(_NATIVE, f";web_search_policy={_POLICY_PATH}"),
+            data=(_policy_route(json.dumps({"id": "draco/official"})),),
+        )
+
+
+@pytest.mark.asyncio
+async def test_non_string_domains_are_loud() -> None:
+    """The list reaches a strictly-typed gateway schema; a non-string would fail closed there,
+    one hop later and with a worse message."""
+    with pytest.raises(ResolutionError, match="excluded_domains"):
+        await _bodies(
+            _call(_NATIVE, f";web_search_policy={_POLICY_PATH}"),
+            data=(_policy_route(json.dumps({"excluded_domains": ["ok.test", 7]})),),
+        )
+
+
+@pytest.mark.asyncio
+async def test_naming_a_policy_on_a_non_retrieving_route_is_loud() -> None:
+    """A policy on a route that never searches reads as though retrieval were guarded when no
+    retrieval happens at all — same silent shape as `web_search=true` on such a route."""
+    with pytest.raises(ResolutionError):
+        await _bodies(_call(_PLAIN, f";web_search_policy={_POLICY_PATH}"), data=(_policy_route(),))
+
+
+@pytest.mark.asyncio
+async def test_naming_a_policy_on_a_tavily_route_is_loud() -> None:
+    """WHY the Tavily loop is not a home for this: domain exclusion is a PROVIDER-side control,
+    honoured by the provider running the search. On a `web_tools` route the RUNNER searches, so a
+    declared policy would be accepted and never enforced — which is the failure this closes, not
+    a case of it."""
+    with pytest.raises(ResolutionError):
+        await _bodies(_call(_TAVILY, f";web_search_policy={_POLICY_PATH}"), data=(_policy_route(),))
+
+
+@pytest.mark.asyncio
+async def test_ad_hoc_exclusions_on_a_non_retrieving_route_are_loud() -> None:
+    with pytest.raises(ResolutionError):
+        await _bodies(_call(_PLAIN, ";web_search_exclude=a.test"), data=(_policy_route(),))
+
+
+# --- caching --------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_policy_is_read_once_per_world(tmp_path) -> None:
+    """WHY memoized: a benchmark image is immutable, so staleness is unreachable in production,
+    and a DRACO run would otherwise re-read the file on every answering call.
+
+    TRADEOFF this pins: a LOCAL run that edits a policy file needs a restart. `file` providers
+    are otherwise re-read per request, so that difference is surprising and is asserted here
+    rather than left to be discovered.
+    """
+    path = tmp_path / "policy.json"
+    path.write_text(_POLICY, encoding="utf-8")
+    data = (DataSpec(path=_POLICY_PATH, file=str(path), media_type="application/json"),)
+
+    captured: list[dict] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content))
+        return httpx.Response(200, json={"choices": [{"message": {"content": "OK"}}], "usage": {}})
+
+    config = AigatewayConfig(
+        default_model=_PLAIN,
+        models=(ModelSpec(id=_NATIVE, native_web_search=True), ModelSpec(id=_PLAIN)),
+    )
+    call = _call(_NATIVE, f";web_search_policy={_POLICY_PATH}")
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handle), base_url="http://aigateway.test"
+    ) as client:
+        world = await build_aigateway_world(config, client=client, data=data)
+        try:
+            await world.node.evaluate(call)
+            path.write_text(json.dumps({"excluded_domains": ["changed.test"]}), encoding="utf-8")
+            await world.node.evaluate(call)
+        finally:
+            await world.aclose()
+
+    assert [body["web_search_excluded_domains"] for body in captured] == [_DOMAINS, _DOMAINS]

--- a/apps/url4-cloud/tests/unit/test_runner_command_stdin.py
+++ b/apps/url4-cloud/tests/unit/test_runner_command_stdin.py
@@ -1,0 +1,134 @@
+"""`stdin = "intent"` on a Runner `[commands]` route — parsing and registration.
+
+FEATURE: a Runner Job's command route can receive the intent on stdin (gap A1).
+STORY: as an operator I declare `/benchmark` with `stdin = "intent"`, and a 100-case reducer
+payload reaches the aggregate script instead of dying at exec with "Argument list too long".
+
+Its own module rather than an append to `test_runner_config_commands.py` or
+`test_runner_commands.py`: prior tests are append-only, and a new surface earns a new file.
+
+INVARIANT under test: the runner validates the TYPE and the ENGINE owns the VALUE SET.
+`config.py` may not import url4 (`test_only_url4_executor_module_imports_url4` pins the importer
+set), so restating the legal values there would be a second copy free to drift from
+`make_command_handler`. `register_commands` translates the engine's `ValueError` instead — the
+same move it already makes for `node.endpoint`'s registrability rules.
+"""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+
+import pytest
+
+from url4_cloud.runner.config import (
+    CommandSpec,
+    ModelSpec,
+    RunnerConfig,
+    RunnerConfigError,
+    parse_config,
+)
+from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+
+_MINIMAL = """
+[aigateway]
+base_url = "http://aigateway.test"
+default_route = "/claude-haiku-4-5"
+models = ["claude-haiku-4-5"]
+"""
+
+_ECHO_STDIN = (sys.executable, "-c", "import sys; sys.stdout.write(sys.stdin.read())")
+
+
+def _parse(toml_text: str) -> RunnerConfig:
+    return parse_config(tomllib.loads(toml_text), {})
+
+
+def _aigateway_config() -> AigatewayConfig:
+    return AigatewayConfig(
+        default_model="claude-haiku-4-5", models=(ModelSpec(id="claude-haiku-4-5"),)
+    )
+
+
+# --- parsing --------------------------------------------------------------------
+
+
+def test_stdin_intent_parses() -> None:
+    config = _parse(_MINIMAL + '\n[commands]\n"/bench" = { argv = ["cat"], stdin = "intent" }\n')
+
+    assert config.commands == (CommandSpec(path="/bench", argv=("cat",), stdin="intent"),)
+
+
+def test_stdin_defaults_to_context() -> None:
+    """The default is what every existing url4.toml relies on — notably `/read` (`cat`), whose
+    only job is echoing the piped context."""
+    config = _parse(_MINIMAL + '\n[commands]\n"/read" = ["cat"]\n')
+
+    assert config.commands[0].stdin == "context"
+
+
+def test_non_string_stdin_is_rejected_at_parse() -> None:
+    """The TYPE is the config's business, and a bare `true` is a plausible typo."""
+    with pytest.raises(RunnerConfigError, match="stdin"):
+        _parse(_MINIMAL + '\n[commands]\n"/bench" = { argv = ["cat"], stdin = true }\n')
+
+
+def test_stdin_is_an_accepted_command_key() -> None:
+    """Guards the inverse failure: an unknown-key check that never learned about `stdin` would
+    reject the very declaration this change adds."""
+    config = _parse(
+        _MINIMAL
+        + '\n[commands]\n"/bench" = { argv = ["cat"], timeout_s = 30.0, stdin = "intent" }\n'
+    )
+
+    assert config.commands[0].timeout_s == 30.0
+    assert config.commands[0].stdin == "intent"
+
+
+def test_unknown_command_key_is_still_rejected() -> None:
+    with pytest.raises(RunnerConfigError, match="unknown key"):
+        _parse(_MINIMAL + '\n[commands]\n"/bench" = { argv = ["cat"], stdinn = "intent" }\n')
+
+
+# --- registration ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_stdin_value_fails_at_world_build() -> None:
+    """Translated from the engine's ValueError, never restated in `config.py`."""
+    with pytest.raises(RunnerConfigError, match="/bench"):
+        await build_aigateway_world(
+            _aigateway_config(),
+            commands=(CommandSpec(path="/bench", argv=("cat",), stdin="params"),),
+        )
+
+
+@pytest.mark.asyncio
+async def test_declared_route_pipes_the_intent_not_the_context() -> None:
+    """END TO END on a real node, through the real subprocess handler.
+
+    The expression makes the two channels distinguishable: `aggregate` is the CONTEXT (the
+    source list) and `the-payload` is the INTENT. A route that ignored its declaration would
+    echo `aggregate` — which is exactly the live failure shape, since the reducer's context is
+    the operation token and scoring it would produce an empty run reported as a success.
+
+    The kernel-ceiling proof lives in `packages/url4/tests/unit/test_serve_command_stdin.py`,
+    where the handler is reachable directly: the limit belongs to the handler, and forcing a
+    200 KB payload through an expression here would mostly be testing the parser.
+    """
+    world = await build_aigateway_world(
+        _aigateway_config(),
+        commands=(CommandSpec(path="/bench", argv=_ECHO_STDIN, stdin="intent"),),
+    )
+    try:
+        out = await world.node.fetch("/bench?q=(aggregate)!%27the-payload%27", relative=True)
+    finally:
+        await world.aclose()
+
+    # Asserted as a discriminator rather than an equality: the intent arrives as its SURFACE
+    # literal, quotes included, because this expression writes one. The real reducer hop has no
+    # quotes — the engine REPLACES a relative-expression reducer's intent with the JSON array of
+    # row results — so pinning the exact quoted string here would encode a detail of the probe
+    # instead of the behaviour, and would fail for the wrong reason if the surface form changed.
+    assert "the-payload" in out
+    assert "aggregate" not in out

--- a/apps/url4-cloud/tests/unit/test_runner_commands.py
+++ b/apps/url4-cloud/tests/unit/test_runner_commands.py
@@ -1,0 +1,194 @@
+"""Subprocess endpoint routes on a Runner world — `[commands]` end to end.
+
+FEATURE: a Runner Job can declare a local backend (blocker B2 of the benchmark execution
+verdict). STORY: as an operator I declare `/benchmark` in url4.toml and a deployed run can
+address it, with the caller's params and context reaching the script.
+
+These drive the REAL subprocess handler (`url4.cli._serve.make_command_handler`) rather than a
+stub — the point of the unit is that the runner's config reaches the engine's registration, so
+faking the handler would test nothing.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from url4_cloud.runner.config import AigatewaySection, CommandSpec, ModelSpec, RunnerConfig
+from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+from url4_cloud.runner.main import build_executor
+
+# A script that reports what the handler handed it, so one assertion covers the whole
+# substitution surface rather than trusting the template was merely non-empty.
+_REPORT = "import sys,json;print(json.dumps({'argv': sys.argv[1:], 'stdin': sys.stdin.read()}))"
+
+
+def _report_command(path: str = "/probe", **kwargs: object) -> CommandSpec:
+    return CommandSpec(
+        path=path,
+        argv=(sys.executable, "-c", _REPORT, "{param:operation}", "{context}"),
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+def _aigateway_config() -> AigatewayConfig:
+    return AigatewayConfig(
+        default_model="claude-haiku-4-5", models=(ModelSpec(id="claude-haiku-4-5"),)
+    )
+
+
+# --- registration ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_declared_command_registers_its_route() -> None:
+    world = await build_aigateway_world(
+        _aigateway_config(), commands=(CommandSpec(path="/upper", argv=("cat",)),)
+    )
+    try:
+        routes = world.node.processor_routes()
+    finally:
+        await world.aclose()
+
+    assert "/upper" in routes
+    # INVARIANT: commands are ADDED to the model routes, never instead of them.
+    assert "/claude-haiku-4-5" in routes
+
+
+@pytest.mark.asyncio
+async def test_command_route_runs_the_subprocess_and_returns_stdout() -> None:
+    world = await build_aigateway_world(
+        _aigateway_config(),
+        commands=(CommandSpec(path="/echo", argv=(sys.executable, "-c", "print('hi')")),),
+    )
+    try:
+        result = await world.node.fetch("/echo?q=()!%27go%27", relative=True)
+    finally:
+        await world.aclose()
+
+    assert result.strip() == "hi"
+
+
+@pytest.mark.asyncio
+async def test_params_and_context_reach_the_script() -> None:
+    """`{param:…}` and `{context}` are the two channels a benchmark operation needs."""
+    import json
+
+    world = await build_aigateway_world(_aigateway_config(), commands=(_report_command(),))
+    try:
+        raw = await world.node.fetch(
+            "/probe?operation=grade&q=(the-answer)!%27go%27", relative=True
+        )
+    finally:
+        await world.aclose()
+
+    seen = json.loads(raw)
+    assert seen["argv"] == ["grade", "the-answer"]
+    # INVARIANT: the resolved context is ALSO piped to stdin — the wide channel a real payload
+    # uses, since argv cannot carry a large answer.
+    assert seen["stdin"] == "the-answer"
+
+
+@pytest.mark.asyncio
+async def test_command_colliding_with_the_eval_path_is_a_config_error() -> None:
+    # WHY here and not in `config.py`: the eval path is the ENGINE's rule. Converting its
+    # ValueError keeps the two from drifting instead of restating the rule in two places.
+    from url4_cloud.runner.config import RunnerConfigError
+
+    with pytest.raises(RunnerConfigError, match="/v1"):
+        await build_aigateway_world(
+            _aigateway_config(), commands=(CommandSpec(path="/v1", argv=("cat",)),)
+        )
+
+
+@pytest.mark.asyncio
+async def test_non_zero_exit_surfaces_as_a_resolution_error() -> None:
+    from url4.core.errors import ResolutionError
+
+    world = await build_aigateway_world(
+        _aigateway_config(),
+        commands=(CommandSpec(path="/boom", argv=(sys.executable, "-c", "raise SystemExit(3)")),),
+    )
+    try:
+        with pytest.raises(ResolutionError, match="exited 3"):
+            await world.node.fetch("/boom?q=()!%27go%27", relative=True)
+    finally:
+        await world.aclose()
+
+
+@pytest.mark.asyncio
+async def test_per_route_timeout_is_honored() -> None:
+    world = await build_aigateway_world(
+        _aigateway_config(),
+        commands=(
+            CommandSpec(
+                path="/slow",
+                argv=(sys.executable, "-c", "import time;time.sleep(5)"),
+                timeout_s=0.2,
+            ),
+        ),
+    )
+    from url4.core.errors import ResolutionError
+
+    try:
+        with pytest.raises(ResolutionError, match="timed out"):
+            await world.node.fetch("/slow?q=()!%27go%27", relative=True)
+    finally:
+        await world.aclose()
+
+
+# --- the commands-only world ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_commands_only_config_still_builds_a_serving_world() -> None:
+    """INVARIANT: no `[aigateway]` is a legitimate world, not an empty one, once commands exist.
+
+    Before commands were parsed, an absent `[aigateway]` could only mean "deny everything".
+    A config declaring only commands must reach a node that serves them.
+    """
+    executor = build_executor(
+        {},
+        config=RunnerConfig(
+            commands=(CommandSpec(path="/echo", argv=(sys.executable, "-c", "print('ok')")),)
+        ),
+    )
+    io, aclose = await executor._world_factory()  # type: ignore[misc]
+    try:
+        assert (await io.fetch("/echo?q=()!%27go%27", relative=True)).strip() == "ok"
+    finally:
+        if aclose is not None:
+            await aclose()
+
+
+@pytest.mark.asyncio
+async def test_no_aigateway_and_no_commands_still_denies_everything() -> None:
+    from url4.core.errors import Url4Error
+
+    executor = build_executor({}, config=RunnerConfig())
+    io, _ = await executor._world_factory()  # type: ignore[misc]
+
+    with pytest.raises(Url4Error):
+        await io.fetch("/anything", relative=True)
+
+
+@pytest.mark.asyncio
+async def test_commands_reach_the_world_alongside_aigateway() -> None:
+    executor = build_executor(
+        {},
+        config=RunnerConfig(
+            aigateway=AigatewaySection(
+                base_url="http://aigateway.test",
+                default_model="claude-haiku-4-5",
+                models=(ModelSpec(id="claude-haiku-4-5"),),
+            ),
+            commands=(CommandSpec(path="/echo", argv=(sys.executable, "-c", "print('ok')")),),
+        ),
+    )
+    io, aclose = await executor._world_factory()  # type: ignore[misc]
+    try:
+        assert (await io.fetch("/echo?q=()!%27go%27", relative=True)).strip() == "ok"
+    finally:
+        if aclose is not None:
+            await aclose()

--- a/apps/url4-cloud/tests/unit/test_runner_config.py
+++ b/apps/url4-cloud/tests/unit/test_runner_config.py
@@ -133,10 +133,13 @@ def test_unknown_key_in_the_aigateway_table_is_rejected() -> None:
 
 
 def test_reserved_tables_fail_loudly_rather_than_being_ignored() -> None:
-    # `[data]`/`[commands]`/`[holdings]`/`[identities]` are reserved in the format but not
-    # parsed yet — silently ignoring them would look like they worked.
+    # `[holdings]`/`[identities]` are reserved in the format but not parsed yet — silently
+    # ignoring them would look like they worked.
+    # AIDEV-NOTE: this used `[data]` as its example until `[data]` was landed; the example moved
+    # to `[holdings]` so the test keeps asserting the reserved-table RULE rather than a table
+    # that is now supported. `[commands]` and `[data]` have their own coverage.
     with pytest.raises(RunnerConfigError, match="not supported yet"):
-        _parse(_MINIMAL + '\n[data]\n"/corpus" = { value = "x" }\n')
+        _parse(_MINIMAL + '\n[holdings]\ndefault = { value = "x" }\n')
 
 
 def test_unknown_top_level_table_is_rejected() -> None:

--- a/apps/url4-cloud/tests/unit/test_runner_config_commands.py
+++ b/apps/url4-cloud/tests/unit/test_runner_config_commands.py
@@ -1,0 +1,115 @@
+"""`[commands]` parsing in the Runner's declared world.
+
+FEATURE: subprocess endpoint routes in a Runner Job (blocker B2 of the benchmark execution
+verdict). STORY: as an operator, I declare a local backend in url4.toml so a deployed run can
+address it, exactly as `url4 serve` already allows.
+
+Its own module rather than an append to `test_runner_config.py`: prior tests are append-only
+(sdlc rule 5), and a new surface earns a new file instead of editing a passing one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from url4_cloud.runner.config import CommandSpec, RunnerConfig, RunnerConfigError, parse_config
+
+_MINIMAL = """
+[aigateway]
+base_url = "http://aigateway.test"
+default_route = "/claude-haiku-4-5"
+models = ["claude-haiku-4-5", "codex/gpt-5.5"]
+"""
+
+
+def _parse(toml_text: str, env: dict[str, str] | None = None) -> RunnerConfig:
+    import tomllib
+
+    return parse_config(tomllib.loads(toml_text), env or {})
+
+
+def test_bare_list_declares_a_command_route() -> None:
+    config = _parse(_MINIMAL + '\n[commands]\n"/upper" = ["tr", "a-z", "A-Z"]\n')
+
+    assert config.commands == (
+        CommandSpec(path="/upper", argv=("tr", "a-z", "A-Z"), timeout_s=120.0),
+    )
+
+
+def test_bare_string_is_shlex_split() -> None:
+    """Parity with `url4 serve`'s `_as_argv`, so one url4.toml dialect serves both."""
+    config = _parse(_MINIMAL + '\n[commands]\n"/echo" = "bash -lc {intent}"\n')
+
+    assert config.commands[0].argv == ("bash", "-lc", "{intent}")
+
+
+def test_table_form_carries_a_per_route_timeout() -> None:
+    # WHY per route: a rubric judge with web tools outruns the 120s default that must keep
+    # bounding a fast `load`.
+    config = _parse(
+        _MINIMAL
+        + '\n[commands]\n"/benchmark" = { argv = ["python3", "run.py"], timeout_s = 300.0 }\n'
+    )
+
+    assert config.commands == (
+        CommandSpec(path="/benchmark", argv=("python3", "run.py"), timeout_s=300.0),
+    )
+
+
+def test_table_form_without_timeout_uses_the_default() -> None:
+    config = _parse(_MINIMAL + '\n[commands]\n"/b" = { argv = ["python3", "run.py"] }\n')
+
+    assert config.commands[0].timeout_s == 120.0
+
+
+def test_commands_only_config_is_valid() -> None:
+    """INVARIANT: `[aigateway]` stays optional — a tokenless, model-free world is legitimate."""
+    config = _parse('[commands]\n"/upper" = ["tr", "a-z", "A-Z"]\n')
+
+    assert config.aigateway is None
+    assert config.commands[0].path == "/upper"
+
+
+def test_no_commands_table_yields_no_commands() -> None:
+    assert _parse(_MINIMAL).commands == ()
+
+
+def test_command_path_must_start_with_a_slash() -> None:
+    with pytest.raises(RunnerConfigError, match="must start with '/'"):
+        _parse(_MINIMAL + '\n[commands]\nupper = ["tr", "a-z", "A-Z"]\n')
+
+
+def test_empty_argv_is_a_config_error() -> None:
+    with pytest.raises(RunnerConfigError, match="empty argv"):
+        _parse(_MINIMAL + '\n[commands]\n"/upper" = []\n')
+
+
+def test_non_positive_timeout_is_a_config_error() -> None:
+    with pytest.raises(RunnerConfigError, match="timeout_s"):
+        _parse(_MINIMAL + '\n[commands]\n"/b" = { argv = ["x"], timeout_s = 0 }\n')
+
+
+def test_unknown_key_in_a_command_table_is_a_config_error() -> None:
+    with pytest.raises(RunnerConfigError, match="unknown key"):
+        _parse(_MINIMAL + '\n[commands]\n"/b" = { argv = ["x"], web_tools = true }\n')
+
+
+def test_command_table_missing_argv_is_a_config_error() -> None:
+    with pytest.raises(RunnerConfigError, match="argv"):
+        _parse(_MINIMAL + '\n[commands]\n"/b" = { timeout_s = 5.0 }\n')
+
+
+def test_command_colliding_with_a_model_route_is_a_config_error() -> None:
+    # INVARIANT: a route path has exactly one owner. Registering both would raise deep in the
+    # engine at world-build time; catching it here names the offending config line instead.
+    with pytest.raises(RunnerConfigError, match="already declared"):
+        _parse(_MINIMAL + '\n[commands]\n"/claude-haiku-4-5" = ["cat"]\n')
+
+
+def test_commands_is_no_longer_reserved_but_the_others_still_are() -> None:
+    # AIDEV-NOTE: `data` was in this list until `[data]` was landed in the next cycle; it moved
+    # out because it is now supported, not because the rule weakened. `[data]`'s own reserved
+    # coverage lives in `test_runner_config_data`.
+    for table in ("holdings", "identities"):
+        with pytest.raises(RunnerConfigError, match="reserved"):
+            _parse(_MINIMAL + f'\n[{table}]\n"/x" = "y"\n')

--- a/apps/url4-cloud/tests/unit/test_runner_config_data.py
+++ b/apps/url4-cloud/tests/unit/test_runner_config_data.py
@@ -1,0 +1,130 @@
+"""`[data]` parsing in the Runner's declared world.
+
+FEATURE: every benchmark artifact is a first-class url4 address (`/draco/cases`,
+`/draco/rubrics/42`), declared one per entry and generated at image build.
+STORY: as a benchmark author, I declare my cases and rubrics in url4.toml so an expression can
+address them directly and a reader can diff the image's declared world.
+
+Its own module rather than an append to `test_runner_config.py`: prior tests are append-only
+(sdlc rule 5), and a new surface earns a new file.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from url4_cloud.runner.config import DataSpec, RunnerConfig, RunnerConfigError, parse_config
+
+_MINIMAL = """
+[aigateway]
+base_url = "http://aigateway.test"
+default_route = "/claude-haiku-4-5"
+models = ["claude-haiku-4-5", "codex/gpt-5.5"]
+"""
+
+
+def _parse(toml_text: str, env: dict[str, str] | None = None) -> RunnerConfig:
+    import tomllib
+
+    return parse_config(tomllib.loads(toml_text), env or {})
+
+
+# --- shapes ---------------------------------------------------------------------
+
+
+def test_inline_string_is_a_value_provider() -> None:
+    config = _parse(_MINIMAL + '\n[data]\n"/motd" = "hello"\n')
+
+    assert config.data == (DataSpec(path="/motd", value="hello"),)
+
+
+def test_file_provider_with_media_type() -> None:
+    config = _parse(
+        _MINIMAL
+        + '\n[data]\n"/draco/cases" = { file = "cases.json", media_type = "application/json" }\n'
+    )
+
+    assert config.data == (
+        DataSpec(path="/draco/cases", file="cases.json", media_type="application/json"),
+    )
+
+
+def test_command_provider() -> None:
+    config = _parse(_MINIMAL + '\n[data]\n"/rows" = { command = ["./rows.sh"] }\n')
+
+    assert config.data[0].command == ("./rows.sh",)
+
+
+def test_several_artifacts_keep_their_declared_order() -> None:
+    # INVARIANT: order is preserved so a generated table diffs stably against the dataset.
+    config = _parse(_MINIMAL + '\n[data]\n"/r/1" = "one"\n"/r/2" = "two"\n"/r/3" = "three"\n')
+
+    assert [spec.path for spec in config.data] == ["/r/1", "/r/2", "/r/3"]
+
+
+def test_data_only_config_is_valid() -> None:
+    """A world of pure artifacts, no models and no commands, is legitimate."""
+    config = _parse('[data]\n"/motd" = "hello"\n')
+
+    assert config.aigateway is None
+    assert config.commands == ()
+    assert config.data[0].path == "/motd"
+
+
+def test_no_data_table_yields_no_data() -> None:
+    assert _parse(_MINIMAL).data == ()
+
+
+# --- validation -----------------------------------------------------------------
+
+
+def test_path_must_start_with_a_slash() -> None:
+    with pytest.raises(RunnerConfigError, match="must start with '/'"):
+        _parse(_MINIMAL + '\n[data]\nmotd = "hello"\n')
+
+
+def test_zero_providers_is_a_config_error() -> None:
+    with pytest.raises(RunnerConfigError, match="exactly one"):
+        _parse(_MINIMAL + '\n[data]\n"/x" = { media_type = "text/plain" }\n')
+
+
+def test_two_providers_is_a_config_error() -> None:
+    # INVARIANT: exactly one source. Two would make the served bytes depend on lookup order.
+    with pytest.raises(RunnerConfigError, match="exactly one"):
+        _parse(_MINIMAL + '\n[data]\n"/x" = { value = "a", file = "b" }\n')
+
+
+def test_unknown_key_is_a_config_error() -> None:
+    with pytest.raises(RunnerConfigError, match="unknown key"):
+        _parse(_MINIMAL + '\n[data]\n"/x" = { value = "a", web_tools = true }\n')
+
+
+def test_empty_command_argv_is_a_config_error() -> None:
+    with pytest.raises(RunnerConfigError, match="empty argv"):
+        _parse(_MINIMAL + '\n[data]\n"/x" = { command = [] }\n')
+
+
+def test_non_positive_timeout_is_a_config_error() -> None:
+    with pytest.raises(RunnerConfigError, match="timeout_s"):
+        _parse(_MINIMAL + '\n[data]\n"/x" = { command = ["y"], timeout_s = 0 }\n')
+
+
+# --- collisions -----------------------------------------------------------------
+
+
+def test_data_colliding_with_a_model_route_is_a_config_error() -> None:
+    with pytest.raises(RunnerConfigError, match="already declared"):
+        _parse(_MINIMAL + '\n[data]\n"/claude-haiku-4-5" = "x"\n')
+
+
+def test_data_colliding_with_a_command_route_is_a_config_error() -> None:
+    # INVARIANT: one owner per path across ALL three route families, named at parse time rather
+    # than surfacing as a ValueError from deep inside the engine's registry.
+    with pytest.raises(RunnerConfigError, match="already declared"):
+        _parse(_MINIMAL + '\n[commands]\n"/read" = ["cat"]\n\n[data]\n"/read" = "x"\n')
+
+
+def test_holdings_and_identities_are_still_reserved() -> None:
+    for table in ("holdings", "identities"):
+        with pytest.raises(RunnerConfigError, match="reserved"):
+            _parse(_MINIMAL + f'\n[{table}]\ndefault = "y"\n')

--- a/apps/url4-cloud/tests/unit/test_runner_data_routes.py
+++ b/apps/url4-cloud/tests/unit/test_runner_data_routes.py
@@ -1,0 +1,211 @@
+"""Declared `[data]` artifacts on a Runner world — registration and serving.
+
+FEATURE: benchmark artifacts as url4 addresses (see `test_runner_config_data`).
+STORY: as a benchmark author, `/draco/cases` iterates into one row per case and
+`/draco/rubrics/42` serves that case's rubric, live, without a restart.
+
+These drive the REAL provider factory (`url4.cli._serve.make_data_provider`) rather than a stub —
+the unit under test is that the runner's config reaches the engine's registry.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+from url4_cloud.runner.config import CommandSpec, DataSpec, ModelSpec, RunnerConfig
+from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+from url4_cloud.runner.main import build_executor
+
+
+def _aigateway_config() -> AigatewayConfig:
+    return AigatewayConfig(
+        default_model="claude-haiku-4-5", models=(ModelSpec(id="claude-haiku-4-5"),)
+    )
+
+
+async def _fetch(world, target: str) -> str:
+    return await world.node.fetch(target, relative=True)
+
+
+# --- serving --------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inline_value_is_served_at_its_path() -> None:
+    world = await build_aigateway_world(
+        _aigateway_config(), data=(DataSpec(path="/draco/rubrics/42", value="RUBRIC-42"),)
+    )
+    try:
+        assert await _fetch(world, "/draco/rubrics/42") == "RUBRIC-42"
+    finally:
+        await world.aclose()
+
+
+@pytest.mark.asyncio
+async def test_file_provider_is_reread_per_request(tmp_path: Path) -> None:
+    """INVARIANT: `file` is live — editing a rubric must not need an image rebuild to take
+    effect within a running node. This is the property that makes artifacts editable at all."""
+    rubric = tmp_path / "42.md"
+    rubric.write_text("FIRST", encoding="utf-8")
+    world = await build_aigateway_world(
+        _aigateway_config(), data=(DataSpec(path="/r/42", file=str(rubric)),)
+    )
+    try:
+        assert await _fetch(world, "/r/42") == "FIRST"
+        rubric.write_text("SECOND", encoding="utf-8")
+        assert await _fetch(world, "/r/42") == "SECOND"
+    finally:
+        await world.aclose()
+
+
+@pytest.mark.asyncio
+async def test_command_provider_stdout_is_served() -> None:
+    world = await build_aigateway_world(
+        _aigateway_config(),
+        data=(DataSpec(path="/rows", command=(sys.executable, "-c", "print('ROWS')")),),
+    )
+    try:
+        assert (await _fetch(world, "/rows")).strip() == "ROWS"
+    finally:
+        await world.aclose()
+
+
+@pytest.mark.asyncio
+async def test_media_type_drives_collection_splitting() -> None:
+    """A JSON array must iterate into N rows, not collapse into one.
+
+    WHY declared rather than sniffed: a one-line JSON array served as text/plain is a single
+    element, which would silently benchmark once against a blob instead of N times.
+    """
+    cases = json.dumps([{"id": 1}, {"id": 2}, {"id": 3}])
+    world = await build_aigateway_world(
+        _aigateway_config(),
+        data=(DataSpec(path="/cases", value=cases, media_type="application/json"),),
+    )
+    try:
+        result = await world.node.evaluate("/cases*(i:1.0:$item.id)!'row'")
+    finally:
+        await world.aclose()
+
+    assert json.loads(result.text) == ["row\n\ni: 1", "row\n\ni: 2", "row\n\ni: 3"]
+
+
+# --- registration ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_models_commands_and_data_coexist_on_one_node() -> None:
+    world = await build_aigateway_world(
+        _aigateway_config(),
+        commands=(CommandSpec(path="/read", argv=("cat",)),),
+        data=(DataSpec(path="/motd", value="hi"),),
+    )
+    try:
+        routes = world.node.processor_routes()
+        assert "/claude-haiku-4-5" in routes
+        assert "/read" in routes
+        assert await _fetch(world, "/motd") == "hi"
+    finally:
+        await world.aclose()
+
+
+@pytest.mark.asyncio
+async def test_data_colliding_with_the_eval_path_is_a_config_error() -> None:
+    from url4_cloud.runner.config import RunnerConfigError
+
+    with pytest.raises(RunnerConfigError, match="/v1"):
+        await build_aigateway_world(_aigateway_config(), data=(DataSpec(path="/v1", value="x"),))
+
+
+# --- the `/read` bridge ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_bridge_resolves_a_dynamic_artifact_path() -> None:
+    """The load-bearing shape of the benchmark design.
+
+    WHY it must be written this way: a reduce dispatches to the processor only when EVERY source
+    is a call, but `$` is illegal in a CALL path and legal only in a bare data path. Wrapping the
+    dynamic fetch as a source of a static call satisfies both — `/read` is the bridge.
+
+    Asserting on what reaches the MODEL is the point: a bare `/rubrics/$item.id` source would
+    make the reduce degrade to a text join and never dispatch at all, so a per-row model request
+    carrying the right rubric is the only evidence that both halves held.
+    """
+    seen: list[httpx.Request] = []
+
+    def _handle(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(
+            200, json={"choices": [{"message": {"content": "GRADED"}}], "usage": {}}
+        )
+
+    cases = json.dumps([{"id": 42}, {"id": 43}])
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_handle), base_url="http://aigateway.test"
+    ) as client:
+        world = await build_aigateway_world(
+            _aigateway_config(),
+            client=client,
+            commands=(CommandSpec(path="/read", argv=("cat",)),),
+            data=(
+                DataSpec(path="/cases", value=cases, media_type="application/json"),
+                DataSpec(path="/rubrics/42", value="RUBRIC-42"),
+                DataSpec(path="/rubrics/43", value="RUBRIC-43"),
+            ),
+        )
+        try:
+            result = await world.node.evaluate(
+                "/cases*(rubric:1.0:/read(/rubrics/$item.id)!'get')!'grade'"
+            )
+        finally:
+            await world.aclose()
+
+    # The resolved sources land in the SYSTEM message, the intent in `[Instruction]`; assert over
+    # every message rather than a fixed index, so this does not break on prompt-shape changes.
+    prompts = ["\n".join(m["content"] for m in json.loads(r.content)["messages"]) for r in seen]
+    assert any("RUBRIC-42" in p for p in prompts)
+    assert any("RUBRIC-43" in p for p in prompts)
+    assert json.loads(result.text) == ["GRADED", "GRADED"]
+
+
+# --- the aigateway-less world ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_data_only_config_still_builds_a_serving_world() -> None:
+    executor = build_executor({}, config=RunnerConfig(data=(DataSpec(path="/motd", value="hi"),)))
+    io, aclose = await executor._world_factory()  # type: ignore[misc]
+    try:
+        assert await io.fetch("/motd", relative=True) == "hi"
+    finally:
+        if aclose is not None:
+            await aclose()
+
+
+@pytest.mark.asyncio
+async def test_data_reaches_the_world_alongside_aigateway() -> None:
+    from url4_cloud.runner.config import AigatewaySection
+
+    executor = build_executor(
+        {},
+        config=RunnerConfig(
+            aigateway=AigatewaySection(
+                base_url="http://aigateway.test",
+                default_model="claude-haiku-4-5",
+                models=(ModelSpec(id="claude-haiku-4-5"),),
+            ),
+            data=(DataSpec(path="/motd", value="hi"),),
+        ),
+    )
+    io, aclose = await executor._world_factory()  # type: ignore[misc]
+    try:
+        assert await io.fetch("/motd", relative=True) == "hi"
+    finally:
+        if aclose is not None:
+            await aclose()

--- a/apps/url4-cloud/tests/unit/test_runner_image_tracks_the_app_registry.py
+++ b/apps/url4-cloud/tests/unit/test_runner_image_tracks_the_app_registry.py
@@ -1,0 +1,103 @@
+"""A mirrored registry must carry the Runner Job image with it.
+
+FEATURE: Runner Jobs run the benchmark image while the control plane runs the plain engine image.
+STORY: as an operator mirroring this chart into a private or airgapped registry, I set my
+registry once and both images come from it.
+
+`runner.image.repository` carried the full public path as its DEFAULT, so `$override.repository`
+was always truthy and the helper's `| default .Values.image.repository` fallback was unreachable.
+Overriding `image.repository` alone therefore moved the control plane to the private registry and
+left every Runner Job pointing at ghcr.io. The control plane installs cleanly; the failure waits
+until the first submitted run and surfaces as ImagePullBackOff on a Job, one indirection away
+from the value that caused it.
+
+MEASURED before the fix, with `--set image.repository=registry.internal/url4-cloud`
+and `--set image.tag=1.2.3`:
+
+    URL4_CLOUD_RUNNER_IMAGE: "ghcr.io/openmined/screamingface-url4-cloud-benchmark:1.2.3"
+
+INVARIANT: the runner image is the app image's repository plus the `-benchmark` suffix, unless an
+operator names one explicitly. That keeps `186271ca`'s decision — a Runner defaults to a benchmark
+image, because the plain engine image declares no `[data]` routes — while making it travel with
+the registry rather than being welded to one.
+
+These render the REAL chart with `helm template` rather than reasoning about the template text: a
+lookalike of Helm's `default` semantics would prove nothing about what actually gets deployed.
+Skipped where no helm binary exists, so the stack's gate still runs without one.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_CHART = Path(__file__).resolve().parents[2] / "deploy" / "helm"
+_RUNNER_IMAGE_RE = re.compile(r'URL4_CLOUD_RUNNER_IMAGE:\s*"([^"]+)"')
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("helm") is None, reason="helm binary not available in this environment"
+)
+
+
+def _render(**overrides: str) -> str:
+    # natsUrl is required whenever the bundled NATS subchart is off, which it is by default.
+    args = ["helm", "template", "t", str(_CHART), "--set", "config.natsUrl=nats://x:4222"]
+    for key, value in overrides.items():
+        args += ["--set", f"{key.replace('__', '.')}={value}"]
+    return subprocess.run(args, capture_output=True, text=True, check=True).stdout
+
+
+def _runner_image(**overrides: str) -> str:
+    match = _RUNNER_IMAGE_RE.search(_render(**overrides))
+    assert match is not None, "the chart no longer renders URL4_CLOUD_RUNNER_IMAGE"
+    return match.group(1)
+
+
+def test_the_runner_image_follows_a_mirrored_registry() -> None:
+    """The headline: one override moves BOTH images."""
+    image = _runner_image(image__repository="registry.internal/url4-cloud", image__tag="1.2.3")
+
+    assert image == "registry.internal/url4-cloud-benchmark:1.2.3"
+
+
+def test_the_default_runner_image_is_still_the_benchmark_image() -> None:
+    """INVARIANT from `186271ca`: a Runner exists to execute a benchmark, and the plain engine
+    image declares no `[data]` routes — so the working configuration must be the one you get by
+    not thinking. Deriving the repository must not quietly undo that."""
+    repository, _, _tag = _runner_image(image__tag="9.9.9").rpartition(":")
+
+    assert repository.endswith("-benchmark")
+
+
+def test_the_control_plane_image_is_never_the_benchmark_image() -> None:
+    """INVARIANT: the benchmark image bakes in the private weighted rubrics — the answer key —
+    and the control plane is the process that terminates CLIENT connections. Deriving one
+    repository from the other must keep them two images, not collapse them into one."""
+    image = _runner_image(image__repository="registry.internal/url4-cloud", image__tag="1.2.3")
+
+    assert image != "registry.internal/url4-cloud:1.2.3"
+    assert "-benchmark" in image
+
+
+def test_an_explicit_runner_repository_still_wins() -> None:
+    """The escape hatch stays: an operator whose benchmark image is not `<app>-benchmark` names
+    it, and the derivation gets out of the way."""
+    image = _runner_image(
+        image__repository="registry.internal/url4-cloud",
+        image__tag="1.2.3",
+        runner__image__repository="elsewhere.internal/custom-bench",
+    )
+
+    assert image == "elsewhere.internal/custom-bench:1.2.3"
+
+
+def test_the_runner_tag_still_tracks_the_app_tag() -> None:
+    """Unchanged: engine and dataset stay on one version, so a published score can name the
+    engine that produced it."""
+    image = _runner_image(image__repository="registry.internal/url4-cloud", image__tag="4.5.6")
+
+    assert image.endswith(":4.5.6")

--- a/apps/url4-cloud/tests/unit/test_runner_merge_config.py
+++ b/apps/url4-cloud/tests/unit/test_runner_merge_config.py
@@ -1,0 +1,132 @@
+"""Merging generated `[data]` fragments into the hand-written `url4.toml`.
+
+FEATURE: a benchmark image ships its artifacts as declared routes.
+STORY: as a build, I combine the human-authored config with N generated fragments into the one
+file `runner/config.py` reads, and I fail HERE rather than shipping an image that fails at boot.
+
+INVARIANT: validation runs against the REAL parser (`runner.config.parse_config`), not a
+lookalike. A merged file that this accepts but the runner rejects would turn a build-time error
+into a Job that dies after the client already attached.
+"""
+
+from __future__ import annotations
+
+import tomllib
+
+import pytest
+
+from url4_cloud.runner import merge_config
+
+_BASE = """\
+# a comment the merge must preserve
+[aigateway]
+base_url = "http://aigateway.test"
+# INVARIANT: the runner's default route lives INSIDE [aigateway]; there is no top-level form.
+# It is the node's `default_processor`, i.e. the JUDGE in a benchmark image.
+default_route = "/claude-haiku-4-5"
+models = ["claude-haiku-4-5"]
+
+[commands]
+"/read" = ["cat"]
+"""
+
+_FRAGMENT = """\
+[data]
+"/draco/cases" = { file = "/opt/b/cases.json", media_type = "application/json" }
+"/draco/rubrics/1" = { file = "/opt/b/rubrics/1.json" }
+"""
+
+
+def _merged_table(*fragments: str) -> dict:
+    return tomllib.loads(merge_config.merge(_BASE, list(fragments)))
+
+
+# --- the merge ------------------------------------------------------------------
+
+
+def test_the_base_tables_survive() -> None:
+    merged = _merged_table(_FRAGMENT)
+
+    assert merged["aigateway"]["models"] == ["claude-haiku-4-5"]
+    assert merged["commands"]["/read"] == ["cat"]
+    assert merged["aigateway"]["default_route"] == "/claude-haiku-4-5"
+
+
+def test_the_fragment_routes_are_added() -> None:
+    merged = _merged_table(_FRAGMENT)
+
+    assert merged["data"]["/draco/cases"]["media_type"] == "application/json"
+    assert "/draco/rubrics/1" in merged["data"]
+
+
+def test_base_comments_are_preserved() -> None:
+    """The base is human-authored and reviewed; the merge must not strip its reasoning."""
+    assert "# a comment the merge must preserve" in merge_config.merge(_BASE, [_FRAGMENT])
+
+
+def test_several_fragments_combine_into_one_data_table() -> None:
+    """TOML allows a table name ONCE, so two `[data]` sections cannot simply be concatenated."""
+    second = '[data]\n"/mmlu/cases" = { file = "/opt/m/cases.json" }\n'
+
+    merged = _merged_table(_FRAGMENT, second)
+
+    assert {"/draco/cases", "/draco/rubrics/1", "/mmlu/cases"} <= set(merged["data"])
+
+
+def test_no_fragments_leaves_the_base_unchanged() -> None:
+    assert merge_config.merge(_BASE, []) == _BASE
+
+
+def test_a_base_that_already_declares_data_is_merged_not_duplicated() -> None:
+    base = _BASE + '\n[data]\n"/motd" = "hi"\n'
+
+    merged = tomllib.loads(merge_config.merge(base, [_FRAGMENT]))
+
+    assert merged["data"]["/motd"] == "hi"
+    assert "/draco/cases" in merged["data"]
+
+
+# --- fail at build, not at boot -------------------------------------------------
+
+
+def test_a_route_colliding_with_a_command_is_rejected() -> None:
+    """The runner rejects this at boot; catching it here fails the BUILD instead of shipping an
+    image whose Jobs die after a client has already attached."""
+    bad = '[data]\n"/read" = "x"\n'
+
+    with pytest.raises(merge_config.MergeError, match="already declared"):
+        merge_config.merge(_BASE, [bad])
+
+
+def test_a_route_colliding_with_a_model_is_rejected() -> None:
+    bad = '[data]\n"/claude-haiku-4-5" = "x"\n'
+
+    with pytest.raises(merge_config.MergeError, match="already declared"):
+        merge_config.merge(_BASE, [bad])
+
+
+def test_the_same_route_in_two_fragments_is_rejected() -> None:
+    """Silently keeping the last one would make the served rubric depend on fragment order."""
+    with pytest.raises(merge_config.MergeError, match="/draco/cases"):
+        merge_config.merge(_BASE, [_FRAGMENT, _FRAGMENT])
+
+
+def test_a_fragment_carrying_a_non_data_table_is_rejected() -> None:
+    """A generated fragment declares artifacts and nothing else — a stray `[commands]` in one
+    would let generated content redefine executable routes."""
+    with pytest.raises(merge_config.MergeError, match="only"):
+        merge_config.merge(_BASE, ['[commands]\n"/evil" = ["sh"]\n'])
+
+
+def test_malformed_toml_in_a_fragment_is_rejected() -> None:
+    with pytest.raises(merge_config.MergeError, match="cannot parse"):
+        merge_config.merge(_BASE, ["[data\n"])
+
+
+def test_the_merged_file_is_validated_by_the_real_runner_parser() -> None:
+    """A base whose `default_route` names an undeclared model is a runner error, so the merge
+    must surface it even though the fragment itself is fine."""
+    base = _BASE.replace('default_route = "/claude-haiku-4-5"', 'default_route = "/absent"')
+
+    with pytest.raises(merge_config.MergeError):
+        merge_config.merge(base, [_FRAGMENT])

--- a/apps/url4-cloud/tests/unit/test_runner_merge_config_strip.py
+++ b/apps/url4-cloud/tests/unit/test_runner_merge_config_strip.py
@@ -1,0 +1,128 @@
+"""Stripping the base's own `[data]` table must stop at the NEXT header — including `[[…]]`.
+
+FEATURE: a benchmark image merges generated artifact routes into the reviewed base config.
+STORY: as a build, the merged file I ship declares everything the base declared, minus only the
+`[data]` entries that are re-emitted from the fragments.
+
+`_strip_data_table` drops the base's `[data]` section because `merge` re-renders those entries
+alongside the generated ones. It decides where the section ENDS by watching for the next header —
+but it only re-evaluated that flag on a SINGLE-bracket header, so an array-of-tables header
+(`[[aigateway.models]]`) did not end the section and every line of it was dropped instead.
+
+The base config carries no `[data]` table today, so nothing is currently lost. That is what makes
+this worth pinning rather than leaving: the day a `[data]` entry is added above the model list,
+the merged image silently loses model routes — and `_validate` only notices if `default_route`
+happens to be among the casualties. A route that vanishes from a shipped image surfaces as
+`endpoint_not_found` at the first expression that names it, long after the build that dropped it.
+
+INVARIANT: `[[x]]` is a top-level header and ends the section, exactly as the docstring always
+claimed. Only the literal `[data]` starts one — `[[data]]` is a different construct and must not.
+"""
+
+from __future__ import annotations
+
+import tomllib
+
+from url4_cloud.runner import merge_config
+
+# `[data]` sits ABOVE the model list — legal TOML, and the shape that loses routes.
+_BASE_WITH_DATA = """\
+[aigateway]
+base_url = "http://aigateway.test"
+default_route = "/claude-haiku-4-5"
+
+[data]
+"/motd" = "hand-written, re-emitted by the merge"
+
+[[aigateway.models]]
+id = "claude-haiku-4-5"
+
+[[aigateway.models]]
+id = "claude-opus-4-8"
+web_tools = true
+
+[commands]
+"/read" = ["cat"]
+"""
+
+_FRAGMENT = """\
+[data]
+"/draco/cases" = { file = "/opt/b/cases.json", media_type = "application/json" }
+"""
+
+
+# The SILENT shape: one model is declared BEFORE `[data]`, so the survivors keep `models` a
+# non-empty list and `_validate` sees a perfectly usable world — with routes missing from it.
+_BASE_PARTIAL_LOSS = """\
+[aigateway]
+base_url = "http://aigateway.test"
+default_route = "/claude-haiku-4-5"
+
+[[aigateway.models]]
+id = "claude-haiku-4-5"
+
+[data]
+"/motd" = "hand-written"
+
+[[aigateway.models]]
+id = "openrouter/openai/gpt-5.5"
+native_web_search = true
+"""
+
+
+def test_a_partial_loss_would_pass_validation_and_must_not_happen() -> None:
+    """INVARIANT: this is why the bug is worth fixing rather than tolerating.
+
+    When only the models AFTER `[data]` are dropped, `models` stays a non-empty list, the merged
+    world parses, and the build reports success — shipping an image whose missing routes surface
+    as `endpoint_not_found` at the first expression that names one. `_validate` cannot see it:
+    a shorter list is not an invalid list.
+    """
+    merged = tomllib.loads(merge_config.merge(_BASE_PARTIAL_LOSS, [_FRAGMENT]))
+
+    assert [m["id"] for m in merged["aigateway"]["models"]] == [
+        "claude-haiku-4-5",
+        "openrouter/openai/gpt-5.5",
+    ]
+
+
+def test_an_array_of_tables_header_ends_the_stripped_section() -> None:
+    """The model routes declared after `[data]` must survive the merge."""
+    merged = tomllib.loads(merge_config.merge(_BASE_WITH_DATA, [_FRAGMENT]))
+
+    assert [m["id"] for m in merged["aigateway"]["models"]] == [
+        "claude-haiku-4-5",
+        "claude-opus-4-8",
+    ]
+
+
+def test_a_route_capability_declared_after_data_survives() -> None:
+    """Not just the id — the capability flags beside it, which decide whether a route retrieves."""
+    merged = tomllib.loads(merge_config.merge(_BASE_WITH_DATA, [_FRAGMENT]))
+    opus = next(m for m in merged["aigateway"]["models"] if m["id"] == "claude-opus-4-8")
+
+    assert opus["web_tools"] is True
+
+
+def test_a_single_bracket_table_after_data_still_survives() -> None:
+    """The case that already worked — pinned so the fix cannot regress it."""
+    merged = tomllib.loads(merge_config.merge(_BASE_WITH_DATA, [_FRAGMENT]))
+
+    assert merged["commands"]["/read"] == ["cat"]
+
+
+def test_the_base_data_entry_is_re_emitted_not_lost() -> None:
+    """Stripping is not deletion: `merge` re-renders the base's own entries with the generated
+    ones, so a hand-written artifact route survives alongside them."""
+    merged = tomllib.loads(merge_config.merge(_BASE_WITH_DATA, [_FRAGMENT]))
+
+    assert merged["data"]["/motd"] == "hand-written, re-emitted by the merge"
+    assert merged["data"]["/draco/cases"]["media_type"] == "application/json"
+
+
+def test_only_one_data_table_is_emitted() -> None:
+    """INVARIANT: the merged file has exactly one `[data]` header. Two would be a TOML redefinition
+    error at the runner, i.e. a Job that dies at boot with the build reporting success."""
+    merged_text = merge_config.merge(_BASE_WITH_DATA, [_FRAGMENT])
+
+    assert merged_text.count("\n[data]") == 1

--- a/apps/url4-cloud/tests/unit/test_runner_signal_shutdown.py
+++ b/apps/url4-cloud/tests/unit/test_runner_signal_shutdown.py
@@ -1,0 +1,196 @@
+"""A Runner Job that is SIGTERM'd still publishes its terminal frame.
+
+FEATURE: cancelling an in-flight run (OME-315).
+STORY: as a user who cancelled a run, I need the stream to END, so my client stops waiting and
+can tell "cancelled" apart from "still running".
+
+INVARIANT under test: the frame must be observed on the STREAM. Asserting that a handler was
+installed would only prove the code ran — the defect these tests pin returned a healthy-looking
+process and an eternally silent topic.
+"""
+
+import asyncio
+import os
+import signal
+from collections.abc import AsyncIterator
+
+import pytest
+from _fakes import MockExecutor
+
+from url4.streaming.interfaces import ExecStep, Executor, TraceContext
+from url4.streaming.lifecycle import run
+from url4.streaming.protocol import LogData, OutboundFrame, TerminatedEvent
+from url4_cloud.runner.main import cancel_on_signal
+from url4_cloud.testing import InMemoryEventStream
+
+TOPIC = "topic-signal"
+EXPR = "gpt()"
+_WAIT_S = 2.0
+
+
+class _BlockingExecutor(Executor):
+    """Yields one frame, then never finishes — the run can only end by cancellation."""
+
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+
+    async def execute(
+        self, url4: str, *, trace: TraceContext | None = None
+    ) -> AsyncIterator[ExecStep]:
+        yield LogData(severity_number=9, severity_text="INFO", body=f"executing {url4}")
+        # Set AFTER the yield so the flag means "the run is inside its execute loop", not merely
+        # "the task was created" — signalling too early would test a different code path.
+        self.started.set()
+        await asyncio.Event().wait()
+
+
+_LOOP_TURNS = 10
+"""Loop iterations to yield so a raised signal is actually DELIVERED.
+
+`add_signal_handler` runs its callback on a later loop iteration (the C handler only writes the
+self-pipe), so a test that raises a signal and then proceeds without yielding never lets the
+handler fire at all — it would pass whatever the code under test does.
+"""
+
+
+class _SelfSignallingStream(InMemoryEventStream):
+    """Raises a SECOND SIGTERM from inside the terminal publish, then yields the loop.
+
+    WHY the signal is raised HERE and not from the test body: the invariant is about a signal
+    arriving *while the terminal publish is suspended*. Doing it from the test would race the
+    latch release, and the await points that a delivered cancellation lands on are these ones —
+    so this reproduces the real window instead of approximating it.
+    """
+
+    async def publish(self, topic: str, event: OutboundFrame) -> None:
+        if isinstance(event, TerminatedEvent):
+            os.kill(os.getpid(), signal.SIGTERM)
+            for _ in range(_LOOP_TURNS):
+                await asyncio.sleep(0)
+        await super().publish(topic, event)
+
+
+async def _terminal_status(stream: InMemoryEventStream) -> str:
+    """The run's terminal status, read off the stream.
+
+    Scans rather than taking a fixed frame count: how much telemetry a run emits before it ends
+    is an executor detail, and pinning it here would make these tests fail for reasons that have
+    nothing to do with cancellation.
+    """
+
+    async def _scan() -> str:
+        async for event in stream.subscribe(TOPIC, None):
+            if isinstance(event, TerminatedEvent):
+                return event.data.status
+        raise AssertionError("the stream ended with no terminal frame")
+
+    return await asyncio.wait_for(_scan(), timeout=_WAIT_S)
+
+
+async def _started_run(
+    stream: InMemoryEventStream, executor: _BlockingExecutor
+) -> asyncio.Task[None]:
+    """Drive one run under `cancel_on_signal` and wait until it is genuinely in flight."""
+    task = asyncio.create_task(cancel_on_signal(run(stream, executor, TOPIC, EXPR)))
+    await asyncio.wait_for(executor.started.wait(), timeout=_WAIT_S)
+    return task
+
+
+@pytest.mark.asyncio
+async def test_sigterm_ends_the_run_with_a_stopped_terminal_frame() -> None:
+    """The headline: the Job's pod is SIGTERM'd and the topic still gets its terminal frame."""
+    stream = InMemoryEventStream()
+    executor = _BlockingExecutor()
+    task = await _started_run(stream, executor)
+
+    os.kill(os.getpid(), signal.SIGTERM)
+    await asyncio.wait_for(task, timeout=_WAIT_S)
+
+    assert await _terminal_status(stream) == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_sigint_is_left_to_asyncio_run() -> None:
+    """INVARIANT: SIGINT is NOT ours to take.
+
+    `asyncio.run` installs `Runner._on_sigint`, whose first action is to cancel the main task —
+    the same cancellation this helper delivers for SIGTERM, so Ctrl-C already ends the run with
+    a terminal frame. Claiming SIGINT here would REPLACE that handler and take over its
+    interrupt counting, silently breaking the escalation where a second Ctrl-C force-quits a run
+    that will not stop. Pinned because the loss would only ever show up under someone's fingers.
+    """
+    stream = InMemoryEventStream()
+    executor = _BlockingExecutor()
+    installed = signal.getsignal(signal.SIGINT)
+
+    task = await _started_run(stream, executor)
+    try:
+        assert signal.getsignal(signal.SIGINT) is installed
+    finally:
+        os.kill(os.getpid(), signal.SIGTERM)
+        await asyncio.wait_for(task, timeout=_WAIT_S)
+
+
+@pytest.mark.asyncio
+async def test_a_second_signal_does_not_abort_the_terminal_publish() -> None:
+    """INVARIANT: cancellation fires ONCE.
+
+    `lifecycle.run` publishes the terminal frame from inside its `except CancelledError` arm,
+    and that publish is an await. A second `task.cancel()` landing there raises straight through
+    `contextlib.suppress(Exception)` — CancelledError is a BaseException — destroying the very
+    frame the first signal existed to produce. Escalation belongs to the substrate's SIGKILL,
+    not to a second handler firing.
+
+    The stream raises the second signal itself, mid-publish — see `_SelfSignallingStream`.
+    """
+    stream = _SelfSignallingStream()
+    executor = _BlockingExecutor()
+    task = await _started_run(stream, executor)
+
+    os.kill(os.getpid(), signal.SIGTERM)
+    await asyncio.wait_for(task, timeout=_WAIT_S)
+
+    assert await _terminal_status(stream) == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_a_run_that_finishes_on_its_own_is_untouched() -> None:
+    """The regression guard: installing handlers must not change the ordinary success path."""
+    stream = InMemoryEventStream()
+
+    await asyncio.wait_for(
+        cancel_on_signal(run(stream, MockExecutor(), TOPIC, EXPR)), timeout=_WAIT_S
+    )
+
+    assert await _terminal_status(stream) == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_the_handlers_are_removed_when_the_run_ends() -> None:
+    """A handler outliving its run would cancel whatever ran next on this loop."""
+    before = {sig: signal.getsignal(sig) for sig in (signal.SIGTERM, signal.SIGINT)}
+
+    await asyncio.wait_for(
+        cancel_on_signal(run(InMemoryEventStream(), MockExecutor(), TOPIC, EXPR)), timeout=_WAIT_S
+    )
+
+    assert {sig: signal.getsignal(sig) for sig in before} == before
+
+
+@pytest.mark.asyncio
+async def test_a_cancellation_we_did_not_cause_still_propagates() -> None:
+    """Only OUR cancellation is absorbed.
+
+    Swallowing any CancelledError would make this helper a black hole for an enclosing
+    TaskGroup's shutdown — the caller asked for cancellation and must observe it.
+    """
+    stream = InMemoryEventStream()
+    executor = _BlockingExecutor()
+    task = await _started_run(stream, executor)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # The frame is still published: `lifecycle.run` terminates on its way out either way.
+    assert await _terminal_status(stream) == "stopped"

--- a/apps/url4-cloud/tests/unit/test_runner_web_tool_limits.py
+++ b/apps/url4-cloud/tests/unit/test_runner_web_tool_limits.py
@@ -1,0 +1,79 @@
+"""`web_tool_max_iterations` is declarable, because 5 is a hard failure for a research answer.
+
+FEATURE: a Runner Job declares how many tool-calling rounds an answering route may take.
+STORY: as a benchmark author, a candidate on the Tavily loop must be able to finish a
+deep-research answer instead of dying at an unreachable ceiling.
+
+WHY this exists: `AigatewayConfig.web_tool_max_iterations` defaulted to 5 and `main.py` never
+passed it, so NO Job could raise it. MEASURED 2026-08-02 against a live model and a live Tavily,
+`openrouter/moonshotai/kimi-k2.6` exhausted all 5 rounds on tool calls and never emitted content
+— for a TRIVIAL question whose sources were freely reachable (the control run: 3 searches +
+2 fetches, then `ResolutionError`). DRACO is a deep-research benchmark and the owner's 2026-08-02
+decision routes three of its models through this loop, so every one of their cases would have
+failed rather than answered.
+
+INVARIANT: the failure is LOUD (`ResolutionError`) rather than a short answer, so it degrades a
+run to fewer scored cases instead of to a wrong score. That is the honest shape — and it is still
+a failure, which is why the ceiling has to be reachable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from url4_cloud.runner.config import RunnerConfigError, parse_config
+
+_BASE = '[aigateway]\ndefault_route = "/a"\nmodels = ["a"]\n'
+
+
+def _section(text: str):
+    section = parse_config_text(text).aigateway
+    assert section is not None
+    return section
+
+
+def parse_config_text(text: str):
+    import tomllib
+
+    return parse_config(tomllib.loads(text), {})
+
+
+def test_the_iteration_cap_is_declarable() -> None:
+    assert _section(_BASE + "web_tool_max_iterations = 12\n").web_tool_max_iterations == 12
+
+
+def test_the_default_is_unchanged_when_absent() -> None:
+    """A config that never mentions the cap behaves exactly as it did before it was declarable —
+    the regression guard for every existing `url4.toml`."""
+    assert _section(_BASE).web_tool_max_iterations == 5
+
+
+@pytest.mark.parametrize("value", ["0", "-1"])
+def test_a_non_positive_cap_is_rejected(value: str) -> None:
+    """Zero rounds means the loop posts nothing and raises on the first pass — a world that can
+    never answer, accepted at parse. Same fail-fast rule as `timeout_s`."""
+    with pytest.raises(RunnerConfigError, match="web_tool_max_iterations"):
+        _section(_BASE + f"web_tool_max_iterations = {value}\n")
+
+
+def test_a_non_integer_cap_is_rejected() -> None:
+    with pytest.raises(RunnerConfigError, match="web_tool_max_iterations"):
+        _section(_BASE + 'web_tool_max_iterations = "many"\n')
+
+
+def test_a_boolean_is_not_an_integer_here() -> None:
+    """INVARIANT: `bool` IS an `int` subclass in Python, so `true` would otherwise parse as a cap
+    of 1 — a world where every tool-using route fails on its second round, configured by someone
+    who typed a flag."""
+    with pytest.raises(RunnerConfigError, match="web_tool_max_iterations"):
+        _section(_BASE + "web_tool_max_iterations = true\n")
+
+
+def test_the_declared_cap_reaches_the_connector_config() -> None:
+    """Parsing it is worth nothing if `main.py` drops it on the floor — which is exactly the bug
+    this closes. The field existed and was unreachable for the whole life of the tool loop."""
+    from url4_cloud.runner.main import aigateway_config_from
+
+    section = _section(_BASE + "web_tool_max_iterations = 9\n")
+
+    assert aigateway_config_from(section).web_tool_max_iterations == 9

--- a/apps/url4-cloud/tests/unit/test_stop_drain_survives_a_stream_error.py
+++ b/apps/url4-cloud/tests/unit/test_stop_drain_survives_a_stream_error.py
@@ -1,0 +1,158 @@
+"""A failed drain must not strand the stream it was draining (OME-315).
+
+FEATURE: cancelling an in-flight run over REST.
+STORY: as an operator, a broker hiccup while cancelling must not leave a stream behind forever.
+
+`stop_run` drains the run's terminal frame before reclaiming the stream, and states the rule it
+works to: "best-effort and BOUNDED … so teardown below is unconditional." It was not. The drain
+absorbs only `TimeoutError`, while the read underneath it can fail other ways — `subscribe` on a
+broker-backed adapter (consumer creation, a stream deleted between `exists` and the read, a NATS
+blip), or `_scan_terminal`'s own `RuntimeError` when a stream ends with no terminal frame. Any of
+those propagated out of the route BEFORE `delete_stream`, so the Job was gone and the stream, its
+consumer state and its filestore directory survived — the exact permanent-per-run leak the
+`delete`-and-not-`purge` comment two lines below exists to prevent.
+
+INVARIANT: the drain is an OPTIMISATION over teardown, never a precondition for it. A drain that
+fails costs a terminal frame; a teardown that is skipped costs a stream forever, and the caller
+cannot tell it happened.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+from _fakes import FixedGate, RecordingJobRunner
+from fastapi import FastAPI
+from httpx import ASGITransport
+
+from url4.streaming.protocol import OutboundFrame, StartedData, StartedEvent
+from url4_cloud.app import create_app
+from url4_cloud.auth import JwtCodec
+from url4_cloud.config import Settings
+from url4_cloud.testing import InMemoryEventStream
+
+SECRET = "stop-drain-error-secret"
+WINDOW_S = 60
+T0 = datetime(2026, 8, 3, 9, 0, 0, tzinfo=UTC)
+TOPIC = "topic-drain-error"
+
+
+def _cap(topic: str) -> dict[str, str]:
+    return {"URL4-Capability": JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).sign(topic, T0)}
+
+
+class _ReclaimRecordingStream(InMemoryEventStream):
+    """Records whether the reclaim ran — the whole assertion of this module."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.reclaimed = False
+
+    async def purge(self, topic: str) -> None:
+        self.reclaimed = True
+        await super().purge(topic)
+
+
+class _RaisingSubscribeStream(_ReclaimRecordingStream):
+    """`subscribe` fails outright — the broker-adapter failure mode."""
+
+    def __init__(self, error: Exception) -> None:
+        super().__init__()
+        self._error = error
+
+    def subscribe(self, topic: str, from_sequence: int | None = None):  # type: ignore[no-untyped-def]
+        raise self._error
+
+
+class _TerminalLessStream(_ReclaimRecordingStream):
+    """A stream that ends without a terminal frame — `_scan_terminal`'s own `RuntimeError`."""
+
+    def subscribe(  # type: ignore[override]
+        self, topic: str, from_sequence: int | None = None
+    ) -> AsyncIterator[OutboundFrame]:
+        async def _empty() -> AsyncIterator[OutboundFrame]:
+            return
+            yield  # pragma: no cover - makes this an async generator
+
+        return _empty()
+
+
+def _make_app(*, stream: InMemoryEventStream, job_runner: RecordingJobRunner) -> FastAPI:
+    settings = Settings(jwt_secret=SECRET, iat_window_s=WINDOW_S, stop_drain_s=5.0)
+    return create_app(
+        settings,
+        stream=stream,
+        job_runner=job_runner,
+        clock=lambda: T0,
+        interest=FixedGate(True),
+    )
+
+
+def _started(topic: str) -> OutboundFrame:
+    return StartedEvent(
+        id=f"start-{topic}",
+        source=f"/trace/{topic}/node/root",
+        subject=topic,
+        data=StartedData(url4="gpt()"),
+    )
+
+
+async def _delete(app: FastAPI) -> httpx.Response:
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        return await client.delete("/", params={"topic": TOPIC}, headers=_cap(TOPIC))
+
+
+# --- the leak -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [
+        ConnectionError("broker unreachable"),
+        RuntimeError("consumer could not be created"),
+    ],
+    ids=["connection", "runtime"],
+)
+async def test_a_failing_drain_still_reclaims_the_stream(error: Exception) -> None:
+    stream = _RaisingSubscribeStream(error)
+    await stream.publish(TOPIC, _started(TOPIC))
+    runner = RecordingJobRunner(exists=True)
+
+    resp = await _delete(_make_app(stream=stream, job_runner=runner))
+
+    assert resp.status_code == 204
+    assert stream.reclaimed
+
+
+@pytest.mark.asyncio
+async def test_a_stream_that_ends_without_a_terminal_frame_still_reclaims() -> None:
+    """`_scan_terminal` raises on this itself, so the guard has to cover more than the broker."""
+    stream = _TerminalLessStream()
+    await stream.publish(TOPIC, _started(TOPIC))
+    runner = RecordingJobRunner(exists=True)
+
+    resp = await _delete(_make_app(stream=stream, job_runner=runner))
+
+    assert resp.status_code == 204
+    assert stream.reclaimed
+
+
+@pytest.mark.asyncio
+async def test_a_failing_drain_is_not_reported_as_a_server_error() -> None:
+    """INVARIANT: DELETE stays idempotent and quiet. The drain is best-effort, so its failure is
+    not the caller's problem — the Job is stopped and the stream is reclaimed either way, and a
+    500 would invite a retry that has nothing left to do."""
+    stream = _RaisingSubscribeStream(ConnectionError("broker unreachable"))
+    await stream.publish(TOPIC, _started(TOPIC))
+    runner = RecordingJobRunner(exists=True)
+
+    resp = await _delete(_make_app(stream=stream, job_runner=runner))
+
+    assert resp.status_code == 204
+    assert runner.stopped == [TOPIC]

--- a/apps/url4-cloud/tests/unit/test_stop_drains_before_purge.py
+++ b/apps/url4-cloud/tests/unit/test_stop_drains_before_purge.py
@@ -1,0 +1,177 @@
+"""`DELETE /` gives the run's terminal frame a chance to land before reclaiming the stream.
+
+FEATURE: cancelling an in-flight run (OME-315).
+STORY: as a client that cancelled over REST, I need the run's `terminated: stopped` frame to
+survive the teardown that cancel triggered.
+
+The route stops the Job and then reclaims its stream. Those are two different processes: the
+Runner pod publishes its terminal frame while it is shutting down, so an immediate reclaim
+races it — and wins. Dropping the frame here would undo, on the REST path, exactly what the
+Runner's signal handling exists to produce.
+"""
+
+import asyncio
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+from _fakes import FixedGate, RecordingJobRunner
+from fastapi import FastAPI
+from httpx import ASGITransport
+
+from url4.streaming.protocol import (
+    OutboundFrame,
+    StartedData,
+    StartedEvent,
+    TerminatedData,
+    TerminatedEvent,
+)
+from url4_cloud.app import create_app
+from url4_cloud.auth import JwtCodec
+from url4_cloud.config import Settings
+from url4_cloud.testing import InMemoryEventStream
+
+SECRET = "stop-drain-secret"
+WINDOW_S = 60
+T0 = datetime(2026, 8, 3, 9, 0, 0, tzinfo=UTC)
+TOPIC = "topic-drain"
+
+
+def _cap(topic: str) -> dict[str, str]:
+    return {"URL4-Capability": JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).sign(topic, T0)}
+
+
+class _DrainAwareStream(InMemoryEventStream):
+    """Records how much history survived to the reclaim, and when a reader attached.
+
+    `subscribed` fires when the route opens its drain subscription — the runner below publishes
+    off that, so the test needs no sleep and no wall clock to order the two.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.subscribed = asyncio.Event()
+        self.frames_at_purge: int | None = None
+
+    def subscribe(self, topic: str, from_sequence: int | None = None):  # type: ignore[no-untyped-def]
+        self.subscribed.set()
+        return super().subscribe(topic, from_sequence)
+
+    async def purge(self, topic: str) -> None:
+        # The retained history AT the moment of reclaim is the whole assertion — read after the
+        # fact it is always empty, whether or not the drain waited.
+        self.frames_at_purge = len(self._log.get(topic, []))  # noqa: SLF001
+        await super().purge(topic)
+
+
+class _TerminatingJobRunner(RecordingJobRunner):
+    """A live run whose pod publishes `terminated: stopped` only once someone is listening.
+
+    Models the real ordering — the frame arrives AFTER `stop()` returns, from a different
+    process — without a timer. If the route never drains, nothing is ever published, which is
+    precisely the behaviour under test.
+    """
+
+    def __init__(self, stream: _DrainAwareStream) -> None:
+        super().__init__(exists=True)
+        self._stream = stream
+        self.publisher: asyncio.Task[None] | None = None
+
+    async def stop(self, topic: str) -> None:
+        await super().stop(topic)
+        self.publisher = asyncio.create_task(self._publish_terminal(topic))
+
+    async def _publish_terminal(self, topic: str) -> None:
+        await self._stream.subscribed.wait()
+        await self._stream.publish(topic, _terminated(topic))
+
+
+def _make_app(
+    *,
+    stream: InMemoryEventStream,
+    job_runner: RecordingJobRunner,
+    stop_drain_s: float = 5.0,
+) -> FastAPI:
+    settings = Settings(jwt_secret=SECRET, iat_window_s=WINDOW_S, stop_drain_s=stop_drain_s)
+    return create_app(
+        settings,
+        stream=stream,
+        job_runner=job_runner,
+        clock=lambda: T0,
+        interest=FixedGate(True),
+    )
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _started(topic: str) -> OutboundFrame:
+    return StartedEvent(
+        id=f"start-{topic}",
+        source=f"/trace/{topic}/node/root",
+        subject=topic,
+        data=StartedData(url4="gpt()"),
+    )
+
+
+def _terminated(topic: str) -> OutboundFrame:
+    return TerminatedEvent(
+        id=f"term-{topic}",
+        source=f"/trace/{topic}/node/root",
+        subject=topic,
+        data=TerminatedData(status="stopped"),
+    )
+
+
+async def _delete(app: FastAPI) -> httpx.Response:
+    async with _client(app) as client:
+        return await client.delete("/", params={"topic": TOPIC}, headers=_cap(TOPIC))
+
+
+@pytest.mark.asyncio
+async def test_the_terminal_frame_lands_before_the_stream_is_reclaimed() -> None:
+    """The headline: cancel must not delete the evidence that the cancel took effect."""
+    stream = _DrainAwareStream()
+    await stream.publish(TOPIC, _started(TOPIC))
+    runner = _TerminatingJobRunner(stream)
+
+    resp = await _delete(_make_app(stream=stream, job_runner=runner))
+
+    assert resp.status_code == 204
+    assert runner.stopped == [TOPIC]
+    # Started + Terminated: the reclaim happened downstream of the frame, not in a race with it.
+    assert stream.frames_at_purge == 2
+
+
+@pytest.mark.asyncio
+async def test_an_absent_run_is_torn_down_without_waiting() -> None:
+    """INVARIANT: DELETE stays fast and idempotent when there is nothing to stop.
+
+    Draining unconditionally would make every repeat DELETE — the documented idempotent case —
+    pay the full bound waiting for a frame no process will ever publish.
+    """
+    stream = _DrainAwareStream()
+    await stream.publish(TOPIC, _started(TOPIC))
+    runner = RecordingJobRunner(exists=False)
+
+    resp = await _delete(_make_app(stream=stream, job_runner=runner, stop_drain_s=30.0))
+
+    assert resp.status_code == 204
+    assert not stream.subscribed.is_set()
+    assert stream.frames_at_purge == 1
+
+
+@pytest.mark.asyncio
+async def test_teardown_happens_even_when_the_frame_never_arrives() -> None:
+    """INVARIANT: the drain is best-effort. A pod that dies without publishing — SIGKILL after
+    the grace period, a lost broker — must not strand the stream it was holding."""
+    stream = _DrainAwareStream()
+    await stream.publish(TOPIC, _started(TOPIC))
+    runner = RecordingJobRunner(exists=True)  # never publishes anything
+
+    resp = await _delete(_make_app(stream=stream, job_runner=runner, stop_drain_s=0.05))
+
+    assert resp.status_code == 204
+    assert stream.subscribed.is_set()
+    assert stream._log[TOPIC] == []  # noqa: SLF001 — asserting the reclaim side effect

--- a/apps/url4-cloud/tests/unit/test_tavily_retrieval_guard.py
+++ b/apps/url4-cloud/tests/unit/test_tavily_retrieval_guard.py
@@ -1,0 +1,272 @@
+"""The retrieval policy is ENFORCED on the runner-driven Tavily (`web_tools`) path.
+
+FEATURE: a declared blocklist guards every retrieving route, whichever mechanism searches.
+STORY: as a benchmark author, a candidate answering through a Tavily route must not be able to
+retrieve the rubric — or the paper — it is being graded against.
+
+WHY this module exists at all: exclusion used to be a PROVIDER-side control, so
+`_retrieval_exclusions` REFUSED a policy on a `web_tools` route on the grounds that the runner
+could not enforce one. MEASURED 2026-08-02 against the live API, that premise is false — Tavily's
+`/search` accepts `exclude_domains` and honours it. On a `web_tools` route the RUNNER is the
+searcher, so the runner is exactly who must enforce the guard.
+
+INVARIANT: `web_fetch` is the sharper of the two leaks. `/search` returns ranked snippets the
+model may or may not use; `/extract` returns the document VERBATIM, so an unguarded fetch of the
+DRACO paper hands over the answer key in full. Tavily's `/extract` has no exclusion parameter, so
+that check has no home but this one.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from url4.core.errors import ResolutionError
+from url4_cloud.runner.config import DataSpec, ModelSpec
+from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+
+_TAVILY = "claude-opus-4-8"
+_PLAIN = "claude-haiku-4-5"
+
+_POLICY_PATH = "/draco/policy/retrieval"
+_BLOCKED = "leak.test"
+_POLICY = json.dumps({"id": "draco/official", "excluded_domains": [_BLOCKED]})
+
+_SEARCH_CALL = {
+    "id": "call-1",
+    "type": "function",
+    "function": {"name": "web_search", "arguments": json.dumps({"query": "draco rubric"})},
+}
+
+
+def _fetch_call(url: str, call_id: str = "call-2") -> dict:
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": "web_fetch", "arguments": json.dumps({"url": url})},
+    }
+
+
+def _policy_route(body: str = _POLICY, path: str = _POLICY_PATH) -> DataSpec:
+    return DataSpec(path=path, value=body, media_type="application/json")
+
+
+class _Rig:
+    """A mock standing in for BOTH upstreams, routed by path.
+
+    The gateway is scripted with a queue of tool-call turns; anything left over answers with
+    content, which is what ends the loop. Tavily payloads are captured so the assertions can read
+    what the runner actually SENT rather than what it meant to send — the distinction that the
+    misspelled `excluded_domains` key made expensive.
+    """
+
+    def __init__(self, turns: list[list[dict]] | None = None) -> None:
+        self.turns = list(turns or [])
+        self.searches: list[dict] = []
+        self.extracts: list[dict] = []
+        self.tool_messages: list[dict] = []
+
+    def handle(self, request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content) if request.content else {}
+        if request.url.path.endswith("/chat/completions"):
+            return self._gateway(body)
+        if request.url.path.endswith("/search"):
+            self.searches.append(body)
+            return httpx.Response(
+                200, json={"results": [{"title": "t", "url": "https://ok.test/a", "content": "c"}]}
+            )
+        self.extracts.append(body)
+        return httpx.Response(200, json={"results": [{"raw_content": "PAGE"}]})
+
+    def _gateway(self, body: dict) -> httpx.Response:
+        # Every tool reply the runner fed back, so a refusal can be asserted as the model SAW it —
+        # not merely as the absence of an upstream call.
+        self.tool_messages.extend(
+            message for message in body.get("messages", []) if message.get("role") == "tool"
+        )
+        if not self.turns:
+            return httpx.Response(
+                200, json={"choices": [{"message": {"content": "final"}}], "usage": {}}
+            )
+        message = {"content": None, "tool_calls": self.turns.pop(0)}
+        return httpx.Response(200, json={"choices": [{"message": message}], "usage": {}})
+
+
+async def _run(
+    chain: str,
+    *,
+    turns: list[list[dict]] | None = None,
+    data: tuple[DataSpec, ...] = (),
+    route: str = _TAVILY,
+) -> _Rig:
+    rig = _Rig(turns)
+    config = AigatewayConfig(
+        default_model=_PLAIN,
+        models=(ModelSpec(id=_TAVILY, web_tools=True), ModelSpec(id=_PLAIN)),
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(rig.handle), base_url="http://aigateway.test"
+    ) as client:
+        world = await build_aigateway_world(
+            config, client=client, data=data, tavily_client=client, tavily_api_key="tv-key"
+        )
+        try:
+            # `anchor` keeps the all-calls rule from firing the per-row reduce onto default_route.
+            await world.node.evaluate(
+                f"(v:1.0:/{route}(a:1.0:'x')!'answer'{chain},anchor:1.0:'a')!'go'"
+            )
+        finally:
+            await world.aclose()
+    return rig
+
+
+# --- /search carries the blocklist -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_policy_on_a_tavily_route_reaches_the_search_as_exclude_domains() -> None:
+    """The inverse of the retired `test_naming_a_policy_on_a_tavily_route_is_loud`.
+
+    `exclude_domains` is TAVILY's spelling and is deliberately not our `excluded_domains` — the
+    translation boundary is this one call, exactly as `_apply_web_search` is for OpenRouter.
+    """
+    rig = await _run(
+        f";web_search_policy={_POLICY_PATH}", turns=[[_SEARCH_CALL]], data=(_policy_route(),)
+    )
+
+    assert rig.searches, "the tool loop never reached Tavily"
+    assert rig.searches[0]["exclude_domains"] == [_BLOCKED]
+
+
+@pytest.mark.asyncio
+async def test_no_policy_omits_the_field_rather_than_sending_an_empty_list() -> None:
+    """INVARIANT: absent and "exclude nothing" must stay distinguishable upstream — the same rule
+    `_native_web_search` follows for the gateway field."""
+    rig = await _run("", turns=[[_SEARCH_CALL]])
+
+    assert rig.searches
+    assert "exclude_domains" not in rig.searches[0]
+
+
+@pytest.mark.asyncio
+async def test_ad_hoc_exclusions_union_with_the_policy_on_the_tavily_path() -> None:
+    """A caller may TIGHTEN the guard and may never loosen it — the property the whole three-layer
+    union exists to hold, asserted here on the mechanism that had no guard at all."""
+    rig = await _run(
+        f";web_search_policy={_POLICY_PATH};web_search_exclude=extra.test",
+        turns=[[_SEARCH_CALL]],
+        data=(_policy_route(),),
+    )
+
+    assert rig.searches[0]["exclude_domains"] == [_BLOCKED, "extra.test"]
+
+
+@pytest.mark.asyncio
+async def test_the_blocklist_still_holds_on_a_later_loop_iteration() -> None:
+    """A tool-calling turn re-posts, and the guard must survive every hop.
+
+    WHY this is not paranoia: the exclusions are resolved ONCE before the loop precisely so a
+    later turn cannot escape them. A future refactor that resolved them per-iteration would pass
+    every other test in this module and fail only here.
+    """
+    rig = await _run(
+        f";web_search_policy={_POLICY_PATH}",
+        turns=[[_SEARCH_CALL], [dict(_SEARCH_CALL, id="call-3")]],
+        data=(_policy_route(),),
+    )
+
+    assert len(rig.searches) == 2
+    assert all(search["exclude_domains"] == [_BLOCKED] for search in rig.searches)
+
+
+# --- /extract is guarded by the runner, because Tavily offers no parameter ----------
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_of_a_blocked_host_never_reaches_tavily() -> None:
+    """INVARIANT: `/extract` returns the document VERBATIM, so this is the sharper leak of the
+    two. Tavily has no exclusion parameter for it, so the runner refuses before the request
+    leaves — asserted as "no upstream call", never merely as a message."""
+    rig = await _run(
+        f";web_search_policy={_POLICY_PATH}",
+        turns=[[_fetch_call(f"https://{_BLOCKED}/rubric")]],
+        data=(_policy_route(),),
+    )
+
+    assert rig.extracts == []
+
+
+@pytest.mark.asyncio
+async def test_the_refusal_is_reported_back_to_the_model() -> None:
+    """Fed back as a tool message like every other tool failure. A silent empty result would read
+    as "the page was empty" and invite a retry through a different URL."""
+    rig = await _run(
+        f";web_search_policy={_POLICY_PATH}",
+        turns=[[_fetch_call(f"https://{_BLOCKED}/rubric")]],
+        data=(_policy_route(),),
+    )
+
+    refusals = [
+        m for m in rig.tool_messages if _BLOCKED in m["content"] or "excluded" in m["content"]
+    ]
+    assert refusals, f"no refusal reached the model: {rig.tool_messages}"
+
+
+@pytest.mark.asyncio
+async def test_an_allowed_host_is_still_fetched() -> None:
+    """The guard is a blocklist, not a blanket denial — a `web_tools` route with a policy must
+    still be able to research."""
+    rig = await _run(
+        f";web_search_policy={_POLICY_PATH}",
+        turns=[[_fetch_call("https://allowed.test/page")]],
+        data=(_policy_route(),),
+    )
+
+    assert len(rig.extracts) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_path_shaped_entry_blocks_that_path_and_not_the_whole_host() -> None:
+    """MEASURED 2026-08-02: our shipped blocklist is path-shaped (`arxiv.org/abs/2602.11685`), and
+    blocking all of `arxiv.org` would strip a major legitimate source from a deep-research
+    benchmark. So the match must be precise in BOTH directions."""
+    policy = json.dumps({"id": "p", "excluded_domains": ["arxiv.org/abs/2602.11685"]})
+
+    blocked = await _run(
+        f";web_search_policy={_POLICY_PATH}",
+        turns=[[_fetch_call("https://arxiv.org/abs/2602.11685")]],
+        data=(_policy_route(policy),),
+    )
+    allowed = await _run(
+        f";web_search_policy={_POLICY_PATH}",
+        turns=[[_fetch_call("https://arxiv.org/abs/1234.56789")]],
+        data=(_policy_route(policy),),
+    )
+
+    assert blocked.extracts == []
+    assert len(allowed.extracts) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_subdomain_of_a_blocked_host_is_blocked() -> None:
+    """A bare-host entry covers subdomains, or `cdn.leak.test` walks straight around the guard."""
+    rig = await _run(
+        f";web_search_policy={_POLICY_PATH}",
+        turns=[[_fetch_call(f"https://cdn.{_BLOCKED}/rubric")]],
+        data=(_policy_route(),),
+    )
+
+    assert rig.extracts == []
+
+
+# --- the invariant that did NOT change --------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_policy_on_a_route_that_retrieves_neither_way_is_still_loud() -> None:
+    """Retiring the Tavily refusal did NOT weaken this: a policy on a route that never searches
+    still reads as a guarded run while no retrieval happens at all."""
+    with pytest.raises(ResolutionError):
+        await _run(f";web_search_policy={_POLICY_PATH}", data=(_policy_route(),), route=_PLAIN)

--- a/apps/url4-cloud/url4.toml
+++ b/apps/url4-cloud/url4.toml
@@ -14,12 +14,25 @@
 #
 # Each route is a TABLE, not a bare id, so its capabilities are declared beside it:
 #
-#   web_tools   Offer the Tavily-backed web_search/web_fetch tool loop to this model.
-#               Defaults to FALSE — a route gets tools only by declaring it. Declaring it does
-#               not by itself enable anything: the deployment must ALSO supply TAVILY_API_KEY,
-#               or the route serves plain completions (see `runner/connector.py`). Enabling it
-#               changes the request the model sees (a `tools`/`tool_choice` payload, then extra
-#               round trips feeding results back), which is why it is per-route, not global.
+#   web_tools          Offer the Tavily-backed web_search/web_fetch tool loop to this model.
+#                      The RUNNER drives it: it declares OpenAI-shape functions, the model asks,
+#                      the runner searches and feeds results back. For providers with no
+#                      server-side search of their own. Needs TAVILY_API_KEY in the deployment,
+#                      or the route serves plain completions (see `runner/connector.py`).
+#
+#   native_web_search  The PROVIDER runs the search and answers with retrieval already done.
+#                      No runner loop, no second search backend, and the provider's own controls
+#                      apply — including domain exclusion, which is how a benchmark candidate is
+#                      kept from retrieving the rubric it is graded against. Prefer this wherever
+#                      a provider offers it: it is the surface published scores were produced on.
+#
+# Both default to FALSE — a route retrieves only by declaring it, never by inheriting the mere
+# presence of a key. Declaring BOTH is rejected at parse: the request would carry two tool
+# populations and DOUBLE-DISPATCH, searching twice per turn and billing for both.
+#
+# An expression overrides per call with `;web_search=true|false`. Absent means "as declared", so
+# an expression that never mentions retrieval behaves exactly as it did before the toggle
+# existed. Asking a route that declares neither mechanism to search is a loud error.
 
 [aigateway]
 base_url = "http://127.0.0.1:9105"
@@ -30,11 +43,21 @@ default_route = "/claude-haiku-4-5"
 allow_outbound = true
 
 # --- anthropic — unprefixed ids -----------------------------------------------------------
-# web_tools OFF: the plugin dispatches OpenAI-shape tool calls through litellm, which IS the
-# shape `_WEB_TOOLS` declares, so the loop is expected to round-trip — but that has not been
-# verified end-to-end against a live Anthropic credential, and only verified routes opt in.
+# This provider has no server-side search the gateway can reach, so the runner-driven Tavily
+# loop is the ONLY retrieval available here — which is exactly why that mechanism stays.
+#
+# `claude-opus-4-8` carries it; the rest stay off. One route rather than five because the loop
+# is still UNVERIFIED against a live Anthropic credential: the plugin dispatches OpenAI-shape
+# tool calls through litellm, which IS the shape `_WEB_TOOLS` declares, so it is expected to
+# round-trip — expected is not verified, and declaring it on five routes would multiply one
+# unconfirmed claim rather than test it. Verify this route, then widen.
+#
+# It is also the config's only declared consumer of the Tavily path, which
+# `test_no_route_declares_web_tools_it_cannot_use` requires: with the OpenRouter routes moved to
+# `native_web_search`, nothing else exercises that code, and an unreachable retrieval loop rots.
 [[aigateway.models]]
 id = "claude-opus-4-8"
+web_tools = true
 
 [[aigateway.models]]
 id = "claude-opus-4-7"
@@ -94,18 +117,32 @@ id = "antigravity/gemini-3-flash"
 # CAVEAT: unlike the four static catalogs above, this list is env-overridable at deploy time
 # (AIGW_OPENROUTER_DEFAULT_MODELS), so the pinning test can only hold it to the seeds compiled
 # into the plugin — a deployment that overrides them is on its own.
-# web_tools: verified end-to-end through OpenRouter's OpenAI-shape tool calling.
+# native_web_search: the PROVIDER retrieves and answers with the search already done — no runner
+# loop and no second search backend. The runner asks the GATEWAY for this with a provider-
+# agnostic `web_search: true`; aigateway decides which providers can honor it and translates it
+# into that provider's own spelling (`prepare_chat_body`). Nothing here knows what OpenRouter
+# calls it, which is what keeps provider knowledge out of the runner.
+#
+# The Tavily loop (`web_tools`) remains for providers with no server-side search of their own.
+# It is a different mechanism, not a substitute.
+#
+# ⚠️ DO NOT "fix" this into a `tools: [{"type": "openrouter:web_search"}]` payload. That spelling
+# appears in OpenRouter's server-tool docs and in `screamingface-benchmarks`
+# (`runners/llm_client.py::build_openrouter_tool_params`), and it is INERT: measured live
+# 2026-07-31 it returns HTTP 200 with zero `annotations`, no web-search line in `cost_details`,
+# and an answer written from the model's training cutoff. A route declaring retrieval that
+# silently does not retrieve is the worst failure shape available here.
 [[aigateway.models]]
 id = "openrouter/openai/gpt-5.5"
-web_tools = true
+native_web_search = true
 
 [[aigateway.models]]
 id = "openrouter/anthropic/claude-opus-4.8"
-web_tools = true
+native_web_search = true
 
 [[aigateway.models]]
 id = "openrouter/anthropic/claude-fable-5"
-web_tools = true
+native_web_search = true
 
 # The DRACO judge. arXiv:2602.11685 §4.2 PINS this model, and a different judge materially
 # changes the scores — so a benchmark expression names it explicitly rather than inheriting
@@ -164,9 +201,10 @@ id = "openrouter/google/gemini-3.1-pro-preview"
 # case. Three nesting levels.
 #
 #   (/draco/cases*(
-#      answer:0.0:/claude-sonnet-4-5(
-#        m0:1.0:/claude-opus-4-8($item.input)!'Answer completely.'
-#      )!'Synthesize the strongest answer.',
+#      answer:0.0:/openrouter/anthropic/claude-opus-4.8(
+#        m0:1.0:/openrouter/anthropic/claude-fable-5($item.input)!'Answer completely.';max_tokens=8192,
+#        m1:1.0:/openrouter/openai/gpt-5.5($item.input)!'Answer completely.';max_tokens=8192
+#      )!'Synthesize the strongest answer.';max_tokens=8192,
 #      graded:1.0:/draco/criteria/$item.id*(
 #        cid:1.0:/read($item.id)!'get',
 #        crit:1.0:/read($item.requirement)!'get',
@@ -179,6 +217,23 @@ id = "openrouter/google/gemini-3.1-pro-preview"
 #        )!'collect'
 #      )!'criterion'
 #    )!'case')!/benchmark(aggregate)!'x'
+#
+# That fusion is the paper's `fable_plus_gpt` (panel: fable-5 + gpt-5.5, synthesizer: opus-4.8),
+# the OpenRouter post's strongest at 69.0%.
+#
+# ROUTES — why OpenRouter and not the Anthropic-native ids. DRACO's whole lineup is OpenRouter
+# slugs (`screamingface-benchmarks/benchmarks_config/draco.yaml`: "calls go through OpenRouter,
+# default for closed models"), so `/openrouter/anthropic/claude-opus-4.8` is the SAME dispatch
+# path the published numbers were produced on, while `/claude-opus-4-8` is a different provider
+# path to a same-named model. It is also the only family whose retrieval is verified: DRACO is a
+# deep-research benchmark, the paper treats retrieval as mandatory, and `native_web_search = true`
+# is declared on exactly these three routes — measured live, not assumed. Answering through the
+# Anthropic-native routes would silently produce weights-only answers and score well below the
+# reference chart.
+#
+# CAVEAT: the paper's `max_calls_per_row: 12` has no equivalent here. The cap that exists is the
+# runner's own `web_tool_max_calls_per_turn`, and it bounds a TURN rather than a row — so a
+# published score cannot claim that budget was honoured.
 #
 # Five things in that shape are load-bearing:
 #

--- a/apps/url4-cloud/url4.toml
+++ b/apps/url4-cloud/url4.toml
@@ -33,6 +33,30 @@
 # An expression overrides per call with `;web_search=true|false`. Absent means "as declared", so
 # an expression that never mentions retrieval behaves exactly as it did before the toggle
 # existed. Asking a route that declares neither mechanism to search is a loud error.
+#
+# WHAT a retrieving call may not reach — the blocklist, named by the expression:
+#
+#   ;web_search_policy=/draco/policy/retrieval   a declared [data] route holding
+#                                                {"id": …, "excluded_domains": [...]}
+#   ;web_search_policy=none                      select no benchmark policy
+#   ;web_search_exclude=a.test:b.test            ad-hoc additions, COLON-separated
+#
+# WHY the policy is DATA and named in the EXPRESSION rather than set here: the scoreboard hashes
+# `url4_expression` into a recipe identity, so a blocklist carried in operator config is invisible
+# to it — a run with retrieval unguarded would hash IDENTICALLY to an honest one. Addressing it
+# also lets benchmarks that disagree about what to exclude share these same model routes, which a
+# per-route setting could not.
+#
+# The three layers compose by UNION only — this deployment's list, the policy, and any ad-hoc
+# additions — so a caller can TIGHTEN the guard and can never loosen it. `none` therefore drops
+# only the BENCHMARK's list; the aigateway deployment's list is enforcement and is unreachable
+# from any expression. That split is what lets one mechanism serve a self-service run and a
+# hosted leaderboard.
+#
+# ⚠️ `;web_search_exclude` takes COLONS. A source list splits on `,` at depth 0 before a param
+# value is read, so a comma truncates the value AND turns the remainder into an extra SOURCE of
+# the enclosing group. The runner cannot detect it — same shape as the `;iteration.slice=0,5`
+# trap. Prefer a declared policy route over a long ad-hoc chain.
 
 [aigateway]
 base_url = "http://127.0.0.1:9105"
@@ -231,9 +255,12 @@ id = "openrouter/qwen/qwen3.6-plus"
 #
 #   (/draco/cases*(
 #      answer:0.0:/openrouter/anthropic/claude-opus-4.8(
-#        m0:1.0:/openrouter/anthropic/claude-fable-5($item.input)!'Answer completely.';max_tokens=8192,
-#        m1:1.0:/openrouter/openai/gpt-5.5($item.input)!'Answer completely.';max_tokens=8192
-#      )!'Synthesize the strongest answer.';max_tokens=8192,
+#        m0:1.0:/openrouter/anthropic/claude-fable-5($item.input)!'Answer completely.'
+#          ;max_tokens=8192;web_search_policy=/draco/policy/retrieval,
+#        m1:1.0:/openrouter/openai/gpt-5.5($item.input)!'Answer completely.'
+#          ;max_tokens=8192;web_search_policy=/draco/policy/retrieval
+#      )!'Synthesize the strongest answer.';max_tokens=8192
+#        ;web_search_policy=/draco/policy/retrieval,
 #      graded:1.0:/draco/criteria/$item.id*(
 #        cid:1.0:/read($item.id)!'get',
 #        crit:1.0:/read($item.requirement)!'get',
@@ -285,6 +312,14 @@ id = "openrouter/qwen/qwen3.6-plus"
 #
 #   answer:0.0:     instrumental — referenced as $answer, kept OUT of the row text. A 0.0 binding
 #                   is still in scope; weight 0.0 excludes from the CONTEXT, not from `$name`.
+#
+#   web_search_policy
+#                   the blocklist that keeps a candidate from retrieving the rubric it is graded
+#                   against, on the three ANSWERING calls only. It is deliberately ABSENT from
+#                   the judge call: the judge declares no retrieval, so naming it there is a loud
+#                   error rather than a no-op. Naming it in the expression is also what puts the
+#                   guard inside the recipe the scoreboard hashes — see the retrieval notes at
+#                   the top of this file.
 #
 #   (1,2,3)*        judge_runs=3. The passes are byte-identical on purpose — independence comes
 #                   from judge temperature, not from varying the prompt.

--- a/apps/url4-cloud/url4.toml
+++ b/apps/url4-cloud/url4.toml
@@ -174,7 +174,7 @@ id = "openrouter/google/gemini-3.1-pro-preview"
 #          v:1.0:/openrouter/google/gemini-3.1-pro-preview(
 #            answer:1.0:$answer, criterion_id:1.0:$cid, criterion:1.0:$crit
 #          )!'Meets this ONE criterion? Reply JSON {"criterion_id":"…","criterion_status":"MET"|"UNMET"}'
-#          ;temperature=0.2;reasoning=low,
+#          ;temperature=0.2;max_tokens=8192,
 #          pass:1.0:$item
 #        )!'collect'
 #      )!'criterion'
@@ -204,6 +204,19 @@ id = "openrouter/google/gemini-3.1-pro-preview"
 #
 #   (1,2,3)*        judge_runs=3. The passes are byte-identical on purpose — independence comes
 #                   from judge temperature, not from varying the prompt.
+#
+#   ;k=v            reaches the gateway request body (`connector._model_params`), JSON-coerced —
+#                   the gateway's schemas are strictly typed, so "0.2" as text fails closed. The
+#                   runner refuses only the fields IT owns (model / messages / tools /
+#                   tool_choice / stream); everything else is the gateway's to validate, and it
+#                   rejects an unknown field with a named 400.
+#
+# CAVEAT (judge_reasoning): arXiv:2602.11685 §4.2 also pins `judge_reasoning: "low"`, and this
+# expression does NOT carry it. `reasoning_effort` is absent from the OpenRouter plugin's rule
+# set (`plugins/openrouter_provider/parameters.py`), and unknown parameters fail closed — so
+# `;reasoning=low` would now turn every judge call into a 400 rather than being ignored. Enabling
+# it is a provider-local rule + schema in aigateway; until then this run deviates from the paper
+# on that one setting, and a published score must say so.
 #
 # `/draco/criteria/<case>` is emitted WEIGHT-FREE by `prepare.py`, and the weighted rubric is
 # deliberately NOT a declared route: `official` grading keeps the judge blind to weights.

--- a/apps/url4-cloud/url4.toml
+++ b/apps/url4-cloud/url4.toml
@@ -107,11 +107,146 @@ web_tools = true
 id = "openrouter/anthropic/claude-fable-5"
 web_tools = true
 
-# RESERVED — the format carries these (they are `url4 serve`'s tables) but the Runner does not
-# parse them yet; declaring one is a loud config error, never a silent no-op:
+# The DRACO judge. arXiv:2602.11685 §4.2 PINS this model, and a different judge materially
+# changes the scores — so a benchmark expression names it explicitly rather than inheriting
+# `default_route`. Seeded in aigateway's `_default_model_slugs()`; the two lists must agree or
+# `test_declared_models_match_aigateway.py` fails.
 #
-#   [data]        "/corpus/papers" = { file = "…", media_type = "application/json" }
-#   [commands]    "/python" = ["python3", "/opt/tools/run.py", "{intent}"]
+# web_tools stays OFF, deliberately: the judge sees only the answer and one criterion. Giving it
+# retrieval would let it check claims against the live web, which is a DIFFERENT benchmark from
+# the one the paper defines.
+[[aigateway.models]]
+id = "openrouter/google/gemini-3.1-pro-preview"
+
+# --- [commands] — local subprocess routes --------------------------------------------------
+#
+# A route path mapped to an operator-owned argv template, exec'd directly (no shell). stdout is
+# the result; a non-zero exit is a 502. The template sees the same surface a Python handler
+# would, each token substituted ONCE, in the operator's template only — token-shaped text in
+# caller input stays literal:
+#
+#   {intent}          the resolved intent
+#   {context}         the resolved context — ALSO piped to the command's stdin
+#   {param:<name>}    one decoded protocol param (`/benchmark?operation=grade`); "" if absent
+#   {params}          every param as JSON
+#
+# CAVEAT: protocol params are STATIC — they are never `$`-substituted from scope (see
+# `dag/nodes._wire_params`), so `{param:…}` can only carry run-constants. Per-item data must
+# ride in `{context}`/stdin or the intent.
+#
+# Three spellings; only the table form can declare a per-route timeout (default 120s):
+#
+#   [commands]
+#   "/upper"     = ["tr", "a-z", "A-Z"]
+#   "/echo"      = "cat -"
+#   "/benchmark" = { argv = ["python3", "/opt/bench/run.py", "--op", "{param:operation}"], timeout_s = 300.0 }
+#
+# The script must be baked into the image: a Job's rootfs is read-only apart from /tmp.
+
+[commands]
+# The all-calls bridge. A reduce dispatches to the processor only when EVERY source is a CALL,
+# and `$` is legal in a DATA path but illegal in a CALL path — so a per-item artifact cannot be
+# addressed directly and still keep the reduce dispatching. `cat` echoes the resolved context
+# (which arrives on stdin), turning a dynamic data fetch into a call:
+#
+#   rubric:1.0:/read(/draco/rubrics/$item.id)!'get'
+#
+# INVARIANT: this route reads NOTHING of its own — it has no file argument and no network. It is
+# a shim over the engine's own resolution, so it cannot widen what an expression can reach.
+"/read" = ["cat"]
+
+# The cross-row reducer. Reached as `…!/benchmark(aggregate)!'x'`, where the engine replaces the
+# intent with the JSON array of every row's judge output. `{context}` is the operation token
+# ("aggregate"); `{intent}` is that array.
+#
+# The DRACO expression it reduces — the paper's OFFICIAL protocol (arXiv:2602.11685 §4.2): one
+# judge call PER CRITERION, three independent passes each, and the ensemble answered ONCE per
+# case. Three nesting levels.
+#
+#   (/draco/cases*(
+#      answer:0.0:/claude-sonnet-4-5(
+#        m0:1.0:/claude-opus-4-8($item.input)!'Answer completely.'
+#      )!'Synthesize the strongest answer.',
+#      graded:1.0:/draco/criteria/$item.id*(
+#        cid:1.0:/read($item.id)!'get',
+#        crit:1.0:/read($item.requirement)!'get',
+#        runs:1.0:(1,2,3)*(
+#          v:1.0:/openrouter/google/gemini-3.1-pro-preview(
+#            answer:1.0:$answer, criterion_id:1.0:$cid, criterion:1.0:$crit
+#          )!'Meets this ONE criterion? Reply JSON {"criterion_id":"…","criterion_status":"MET"|"UNMET"}'
+#          ;temperature=0.2;reasoning=low,
+#          pass:1.0:$item
+#        )!'collect'
+#      )!'criterion'
+#    )!'case')!/benchmark(aggregate)!'x'
+#
+# Five things in that shape are load-bearing:
+#
+#   EXPLICIT JUDGE  the judge is a NAMED route, not `default_route`. That is what lets a
+#                   benchmark pin its own judge (the paper fixes DRACO's, and a different judge
+#                   materially changes the scores) without an image rebuild or a deploy change —
+#                   and it is the ONLY way judge parameters reach the model, since the per-row
+#                   reduce hop carries no params.
+#
+#   pass:1.0:$item  a JOIN ANCHOR, and it is not optional. With the judge call as the body's only
+#                   source, every source is a call, the all-calls rule fires the per-row reduce,
+#                   and `default_route` REPLACES all three grades with its own output — a run that
+#                   still reports success. One data sibling degrades the reduce to a text join, so
+#                   the judge's JSON survives. It also records the run index.
+#
+#   criterion_id    the judge must be TOLD which criterion it is grading or it cannot echo the id
+#                   back, and every verdict collapses onto one criterion: n_runs inflates, coverage
+#                   collapses, axes vanish — all while looking like a clean result. The id is
+#                   opaque, so this leaks no weight.
+#
+#   answer:0.0:     instrumental — referenced as $answer, kept OUT of the row text. A 0.0 binding
+#                   is still in scope; weight 0.0 excludes from the CONTEXT, not from `$name`.
+#
+#   (1,2,3)*        judge_runs=3. The passes are byte-identical on purpose — independence comes
+#                   from judge temperature, not from varying the prompt.
+#
+# `/draco/criteria/<case>` is emitted WEIGHT-FREE by `prepare.py`, and the weighted rubric is
+# deliberately NOT a declared route: `official` grading keeps the judge blind to weights.
+#
+# CAVEAT (N4): the row array reaches the script through argv, which caps near 2 MB. Keep judge
+# explanations out of the per-row payload or a 100-case run fails with E2BIG.
+# INVARIANT: no --rubrics here. The `[data]` routes get absolute paths from `prepare --out`, so
+# the rubrics path must come from the SAME deployment — it resolves from `URL4_BENCHMARK_RUBRICS`
+# (the benchmark image sets it; a local run exports it). Baking the container path into this file
+# made the two disagree the moment the runner ran outside the image, and the aggregate then found
+# no rubrics and returned a terminated-SUCCEEDED run scoring nothing. Observed live 2026-07-31.
+"/benchmark" = { argv = [
+  "python3", "-m", "url4_cloud.benchmarks.draco.aggregate",
+  "--operation", "{context}",
+  "--args", "{intent}",
+], timeout_s = 120.0 }
+
+# --- [data] — read-only artifacts at their own url4 addresses ------------------------------
+#
+# Each entry declares ONE artifact at ONE exact path. Routing is exact-match — there is no
+# prefix or wildcard form — so a benchmark with N cases declares N rubric entries. Generate
+# this table at image build from the dataset rather than hand-writing it.
+#
+#   [data]
+#   "/draco/cases"      = { file = "/opt/bench/cases.json", media_type = "application/json" }
+#   "/draco/rubrics/42" = { file = "/opt/bench/rubrics/42.md" }
+#   "/motd"             = "inline string shorthand"
+#   "/rows"             = { command = ["./rows.sh"], media_type = "application/json" }
+#
+# Exactly one of value/file/command per entry. `file` is re-read PER REQUEST, so editing an
+# artifact needs no restart. `media_type` is load-bearing for a collection: a one-line JSON
+# array served as text/plain collapses to a SINGLE element, which silently iterates once over a
+# blob instead of once per case.
+#
+# CAVEAT — the all-calls rule. A reduce dispatches to the processor only when EVERY source is a
+# CALL. A bare data source makes it degrade to a text join instead, silently. And `$` is legal
+# in a data path but ILLEGAL in a call path, so a per-item artifact needs a static call wrapping
+# a dynamic fetch:
+#
+#   rubric:1.0:/read(/draco/rubrics/$item.id)!'get'     # with [commands] "/read" = ["cat"]
+#
+# RESERVED — still carried by the format but not parsed; declaring one is a loud config error:
+#
 #   [holdings]    default = { file = "…" }
 #   [identities]
 #

--- a/apps/url4-cloud/url4.toml
+++ b/apps/url4-cloud/url4.toml
@@ -155,6 +155,35 @@ native_web_search = true
 [[aigateway.models]]
 id = "openrouter/google/gemini-3.1-pro-preview"
 
+# --- the rest of the DRACO candidate lineup -------------------------------------------------
+#
+# `budget_trio`, `pareto_cross`, `pareto_lean`, `beat_runner_up` and `best_open_source` are
+# defined over these four. Routing is exact-match, so before they were declared those five
+# fusions could not be addressed at all — a `ResolutionError`, not a degraded run.
+#
+# Retrieval stays OFF on all four pending a LIVE check, and that is a real gap, not an oversight.
+# They are OpenRouter routes, so `native_web_search = true` is the right declaration and the same
+# one the three answering routes above carry — but no one has yet confirmed that these specific
+# models accept OpenRouter's server-side tool entries. The DRACO harness ran them with retrieval,
+# so the expectation is that they do; the rule this file follows is that expectation is not
+# verification.
+#
+# Turning each on is a ONE-LINE reviewable change once checked. Until then these answer from
+# weights alone, which scores well below the reference chart for reasons unrelated to the
+# candidate — so `budget_trio`, `pareto_*` and `best_open_source` are addressable but not yet
+# publishable.
+[[aigateway.models]]
+id = "openrouter/google/gemini-3-flash-preview"
+
+[[aigateway.models]]
+id = "openrouter/moonshotai/kimi-k2.6"
+
+[[aigateway.models]]
+id = "openrouter/deepseek/deepseek-v4-pro"
+
+[[aigateway.models]]
+id = "openrouter/qwen/qwen3.6-plus"
+
 # --- [commands] — local subprocess routes --------------------------------------------------
 #
 # A route path mapped to an operator-owned argv template, exec'd directly (no shell). stdout is

--- a/apps/url4-cloud/url4.toml
+++ b/apps/url4-cloud/url4.toml
@@ -305,8 +305,13 @@ id = "openrouter/qwen/qwen3.6-plus"
 # `/draco/criteria/<case>` is emitted WEIGHT-FREE by `prepare.py`, and the weighted rubric is
 # deliberately NOT a declared route: `official` grading keeps the judge blind to weights.
 #
-# CAVEAT (N4): the row array reaches the script through argv, which caps near 2 MB. Keep judge
-# explanations out of the per-row payload or a 100-case run fails with E2BIG.
+# STDIN, not argv. `stdin = "intent"` pipes the row array in; the operation token still arrives
+# as `--operation {context}`, because the selector changes what is PIPED and withdraws no
+# substitution. Until 2026-07-31 the payload went through `--args {intent}`, and a single argv
+# token is capped by the kernel at MAX_ARG_STRLEN (131,072 bytes) — NOT the ~2 MB ARG_MAX this
+# file used to cite, which does not apply to one argument. At ~200 bytes per verdict and
+# 53 criteria × 3 passes per case, that ceiling arrived at roughly the FOURTH case, as a hard
+# `OSError [Errno 7]` at exec rather than a truncation. A pipe has no such bound.
 # INVARIANT: no --rubrics here. The `[data]` routes get absolute paths from `prepare --out`, so
 # the rubrics path must come from the SAME deployment — it resolves from `URL4_BENCHMARK_RUBRICS`
 # (the benchmark image sets it; a local run exports it). Baking the container path into this file
@@ -315,8 +320,7 @@ id = "openrouter/qwen/qwen3.6-plus"
 "/benchmark" = { argv = [
   "python3", "-m", "url4_cloud.benchmarks.draco.aggregate",
   "--operation", "{context}",
-  "--args", "{intent}",
-], timeout_s = 120.0 }
+], timeout_s = 120.0, stdin = "intent" }
 
 # --- [data] — read-only artifacts at their own url4 addresses ------------------------------
 #

--- a/apps/url4-cloud/url4.toml
+++ b/apps/url4-cloud/url4.toml
@@ -62,6 +62,37 @@
 base_url = "http://127.0.0.1:9105"
 default_route = "/claude-haiku-4-5"
 
+# How long ONE call to aigateway may take. The default is 60s, which a DRACO answer does not fit
+# in: a deep-research question answered WITH provider-side web search runs well past a minute
+# before the first token, and the judge calls are long too.
+#
+# MEASURED 2026-08-02 on a real Kubernetes Job: at 60s the answering call raised `ReadTimeout`,
+# `iteration.on_error=collect` (the default) replaced that case's row with an error object exactly
+# as designed, and the run reported `terminated: succeeded` with `case_count: 0` and
+# "no judge verdicts in row". Nothing in the result named the timeout — the row array carried
+# `{"error": {"kind": "ReadTimeout"}}` and the aggregate simply found nothing to score.
+#
+# ⚠️ THAT IS THE FAILURE SHAPE TO REMEMBER: a per-call timeout does not fail the RUN, it silently
+# empties it. A benchmark that scores zero because of a network setting looks exactly like a
+# candidate that answered badly.
+timeout_s = 300.0
+
+# How many ROUNDS a runner-driven tool loop may take before it gives up. One round is one post to
+# the gateway, and a round that comes back with tool calls costs a model turn plus its searches.
+#
+# WHY 12 and not the default 5: MEASURED 2026-08-02 against live models and live Tavily,
+# `kimi-k2.6` spent ALL 5 default rounds on tool calls and never returned content — for a trivial
+# question whose sources were freely reachable (3 searches + 2 fetches, then `ResolutionError`).
+# On a deep-research benchmark that is a hard per-case failure, not a shorter answer, and the
+# three DRACO routes without native search answer through exactly this loop.
+#
+# 12 mirrors the paper's `max_calls_per_row: 12` (arXiv:2602.11685 §4.2). CAVEAT: it is not the
+# same quantity — the paper bounds CALLS PER ROW, this bounds ROUNDS PER TURN, and one round may
+# carry up to `web_tool_max_calls_per_turn` (8) calls. So this does not implement the paper's
+# budget; it removes a ceiling that sat far below it. A published score still cannot claim that
+# budget was honoured.
+web_tool_max_iterations = 12
+
 # Absolute-URL sources (`https://…`) are a real url4 feature and a Url4Node world has always
 # been able to fetch them. Set false to hand the node a denying outbound layer instead.
 allow_outbound = true
@@ -185,28 +216,58 @@ id = "openrouter/google/gemini-3.1-pro-preview"
 # defined over these four. Routing is exact-match, so before they were declared those five
 # fusions could not be addressed at all — a `ResolutionError`, not a degraded run.
 #
-# Retrieval stays OFF on all four pending a LIVE check, and that is a real gap, not an oversight.
-# They are OpenRouter routes, so `native_web_search = true` is the right declaration and the same
-# one the three answering routes above carry — but no one has yet confirmed that these specific
-# models accept OpenRouter's server-side tool entries. The DRACO harness ran them with retrieval,
-# so the expectation is that they do; the rule this file follows is that expectation is not
-# verification.
+# RETRIEVAL MECHANISM, decided by owner 2026-08-02 and MEASURED the same day: native where
+# OpenRouter provides it, the runner-driven Tavily loop otherwise. DRACO is a deep-research
+# benchmark and the paper treats retrieval as mandatory, so every ANSWERING route retrieves by
+# one mechanism or the other; only the judge declares none.
 #
-# Turning each on is a ONE-LINE reviewable change once checked. Until then these answer from
-# weights alone, which scores well below the reference chart for reasons unrelated to the
-# candidate — so `budget_trio`, `pareto_*` and `best_open_source` are addressable but not yet
-# publishable.
+#   route                      native?           declared
+#   gemini-3-flash-preview     ⚠️ no BLOCKLIST   web_tools  (Tavily)
+#   kimi-k2.6                  ❌ 404            web_tools  (Tavily)
+#   deepseek-v4-pro            ❌ 404            web_tools  (Tavily)
+#   qwen3.6-plus               ❌ 404            web_tools  (Tavily)
+#
+# The 404 is explicit — "The requested model does not support native web search" — and
+# `engine: "auto"`, which that message recommends, is a NAMED 400 on every model (measured: the
+# validator accepts only native|exa|firecrawl|parallel|perplexity). `exa` would work on all of
+# them and was REJECTED by the owner: it is a different retrieval product, so candidates would
+# have searched differently within one benchmark.
+#
+# ⚠️ GOOGLE NATIVE SEARCH CANNOT BE GUARDED. `gemini-3-flash-preview` DOES support native search,
+# and declaring it would still be wrong: adding a blocklist to a Google native call is a hard 400
+# — measured 2026-08-02:
+#
+#     "Domain filters (include_domains/exclude_domains) are not supported with native search on
+#      Google. Use engine: \"exa\" or remove domain filters"
+#
+# So on a Google route the choice is retrieval OR the guard, never both, and for a benchmark
+# whose candidates must not read the answer key the guard is not optional. It goes on Tavily,
+# which is the same fallback the 404 routes take. This applies to the DEPLOYMENT's list too, not
+# just an expression policy — any Google native route in a deployment with a blocklist is a 400.
+#
+# A second reason to keep Google off native here: it reports every citation as a
+# `vertexaisearch.cloud.google.com` redirect, so what it retrieved cannot be audited from
+# annotations at all — a guard nobody can verify is not a guard.
+#
+# ⚠️ A `web_tools` route is guarded by the RUNNER, not the provider — `_tavily_search` sends the
+# policy as `exclude_domains` and `_tavily_extract` refuses a blocked host outright. Until
+# 2026-08-02 naming a policy on one of these was a hard error, and putting these models on the
+# Tavily loop without that fix would have made them the leak path the blocklist exists to close.
 [[aigateway.models]]
 id = "openrouter/google/gemini-3-flash-preview"
+web_tools = true
 
 [[aigateway.models]]
 id = "openrouter/moonshotai/kimi-k2.6"
+web_tools = true
 
 [[aigateway.models]]
 id = "openrouter/deepseek/deepseek-v4-pro"
+web_tools = true
 
 [[aigateway.models]]
 id = "openrouter/qwen/qwen3.6-plus"
+web_tools = true
 
 # --- [commands] — local subprocess routes --------------------------------------------------
 #

--- a/apps/url4-cloud/url4.toml
+++ b/apps/url4-cloud/url4.toml
@@ -315,6 +315,7 @@ web_tools = true
 # case. Three nesting levels.
 #
 #   (/draco/cases*(
+#      caseid:0.0:/read($item.id)!'get',
 #      answer:0.0:/openrouter/anthropic/claude-opus-4.8(
 #        m0:1.0:/openrouter/anthropic/claude-fable-5($item.input)!'Answer completely.'
 #          ;max_tokens=8192;web_search_policy=/draco/policy/retrieval,
@@ -327,8 +328,9 @@ web_tools = true
 #        crit:1.0:/read($item.requirement)!'get',
 #        runs:1.0:(1,2,3)*(
 #          v:1.0:/openrouter/google/gemini-3.1-pro-preview(
-#            answer:1.0:$answer, criterion_id:1.0:$cid, criterion:1.0:$crit
-#          )!'Meets this ONE criterion? Reply JSON {"criterion_id":"…","criterion_status":"MET"|"UNMET"}'
+#            answer:1.0:$answer, case_id:1.0:$caseid, criterion_id:1.0:$cid, criterion:1.0:$crit
+#          )!'Meets this ONE criterion? Reply JSON
+#             {"case_id":"…","criterion_id":"…","criterion_status":"MET"|"UNMET"}'
 #          ;temperature=0.2;max_tokens=8192,
 #          pass:1.0:$item
 #        )!'collect'
@@ -365,6 +367,15 @@ web_tools = true
 #                   and `default_route` REPLACES all three grades with its own output — a run that
 #                   still reports success. One data sibling degrades the reduce to a text join, so
 #                   the judge's JSON survives. It also records the run index.
+#
+#   case_id         the judge must ECHO the case id, or `aggregate` has only the row's POSITION
+#                   to identify it by. Position is correct exactly when the rows are the whole
+#                   declared set: `;iteration.slice=10:20` hands rows 1-10 that are really cases
+#                   11-20, and every one is then scored against the WRONG rubric — no failures
+#                   entry, `terminated: succeeded`, a plausible number. `aggregate` now REFUSES a
+#                   short row set that carries no echoed id rather than guessing an offset it
+#                   cannot know, so a sliced run WITHOUT this binding is a loud error. The id is
+#                   opaque, so echoing it leaks no weight — same argument as `criterion_id`.
 #
 #   criterion_id    the judge must be TOLD which criterion it is grading or it cannot echo the id
 #                   back, and every verdict collapses onto one criterion: n_runs inflates, coverage

--- a/packages/url4/src/url4/cli/_serve.py
+++ b/packages/url4/src/url4/cli/_serve.py
@@ -362,28 +362,61 @@ def _as_provider(value: object, label: str, *, allow_media_type: bool = False) -
 # --- backend handlers ------------------------------------------------------------
 
 
-def make_command_handler(argv: Sequence[str], timeout: float) -> EndpointHandler:
+COMMAND_STDIN_SOURCES = ("context", "intent")
+"""Which half of the :class:`~url4.peer.server.Request` a command route receives on stdin.
+
+The legal set lives HERE because :func:`make_command_handler` is the only thing that can honour
+it. A second consumer (the url4-cloud Runner's ``[commands]`` table) validates by passing the
+operator's string through and translating the ``ValueError``, rather than keeping a copy that is
+free to drift.
+"""
+
+
+def make_command_handler(
+    argv: Sequence[str], timeout: float, *, stdin: str = "context"
+) -> EndpointHandler:
     """An intent processor that runs a local subprocess (doctrine N4).
 
     The argv template mirrors the full :class:`~url4.peer.server.Request` surface a
-    Python endpoint handler sees (1:1): ``{intent}``, ``{context}`` (also piped
-    to stdin), ``{param:<name>}`` (one decoded protocol param, "" when absent),
+    Python endpoint handler sees (1:1): ``{intent}``, ``{context}``,
+    ``{param:<name>}`` (one decoded protocol param, "" when absent),
     and ``{params}`` (the whole mapping as JSON, for backends that want
     everything).
 
-    # AIDEV-NOTE: security — the argv is OPERATOR config; only the piped stdin
-    # (resolved context) and the token substitutions are caller-influenced.
+    ``stdin`` selects what is PIPED, independently of what is substituted — a route
+    reading its payload from the pipe still gets ``{context}`` in argv. It defaults to
+    ``"context"``, which is the only behaviour that existed before and what a bare
+    ``cat`` route relies on.
+
+    WHY the selector exists: a single argv token is capped by the kernel at
+    ``MAX_ARG_STRLEN`` (32 pages = 131,072 bytes) regardless of ``ARG_MAX``, and exec
+    fails outright with ``OSError [Errno 7]`` rather than truncating. A processor whose
+    intent is engine-supplied — a cross-row reducer receives the JSON array of every row
+    result — crosses that in ordinary use, and argv is then simply the wrong channel.
+    A pipe has no such bound.
+
+    # AIDEV-NOTE: security — the argv is OPERATOR config; only the piped stdin and the
+    # token substitutions are caller-influenced. Selecting ``intent`` does not widen
+    # that: intent is already caller-influenced and already reachable as ``{intent}``.
+    # It NARROWS exposure — an argv token is visible in /proc/<pid>/cmdline to every
+    # local reader, while a pipe is not, so a large payload belongs on stdin on those
+    # grounds alone.
     # No shell: exec an argv LIST, never a command string.
     # INVARIANT: substitution is single-pass — tokens are recognized in the
     # operator's template only, so a "{param:x}" (or "{intent}") appearing in
     # caller-supplied intent, context, or param values stays literal instead
-    # of cascading (blocks token-injection through caller input).
+    # of cascading (blocks token-injection through caller input). stdin has never
+    # been a substitution target, so the selector cannot affect that.
     """
+    if stdin not in COMMAND_STDIN_SOURCES:
+        raise ValueError(f"stdin must be one of {list(COMMAND_STDIN_SOURCES)}, got {stdin!r}")
     template = tuple(argv)
+    want_intent = stdin == "intent"
 
     async def handler(request: Request) -> str:
         command = _subst_all(template, request)
-        return await _run_command(command, request.context, timeout)
+        piped = request.intent if want_intent else request.context
+        return await _run_command(command, piped, timeout)
 
     return handler
 
@@ -613,6 +646,7 @@ async def _lifespan(receive: Callable, send: Callable, node: Url4Node) -> None:
 
 
 __all__ = [
+    "COMMAND_STDIN_SOURCES",
     "ConfigError",
     "DataCallable",
     "EndpointHandler",

--- a/packages/url4/src/url4/dag/compiler.py
+++ b/packages/url4/src/url4/dag/compiler.py
@@ -878,7 +878,7 @@ def _refs_of_ast(node: Node) -> set[str]:
             refs |= find_references(descendant.context)
         elif isinstance(descendant, StructObject):
             refs |= find_references(descendant.raw)
-        elif isinstance(descendant, VarRef) and descendant.name not in ("item", "current"):
+        elif isinstance(descendant, VarRef) and descendant.name not in _ROW_NAMES:
             refs.add(descendant.name)
     return refs
 

--- a/packages/url4/src/url4/dag/compiler.py
+++ b/packages/url4/src/url4/dag/compiler.py
@@ -288,6 +288,14 @@ def _lower_expression(node: Node, edges: Edges, registry: LoweringRegistry) -> D
     )
 
 
+_ROW_NAMES = frozenset({"item", "current"})
+"""The reserved per-row names (§5.3.4) — never wired from an enclosing binding.
+
+Mirrors the exclusion `_refs_of_ast` already applies when collecting AST references, so the
+text path and the AST path agree on which names an iteration rebinds for itself.
+"""
+
+
 def _lower_iteration(node: Node, edges: Edges, registry: LoweringRegistry) -> DagNode:
     assert isinstance(node, Iteration)
     collection = _lower_collection(node.collection, registry)
@@ -295,11 +303,36 @@ def _lower_iteration(node: Node, edges: Edges, registry: LoweringRegistry) -> Da
         body=node.body,
         intent=node.intent,
         directives=node.directives,
-        deps={"collection": collection},
+        # WHY the body's references become EDGES: the body is re-parsed per row at resolve time,
+        # so the compiler cannot see its `$name`s by walking the AST — it must read them out of
+        # the text. Without these edges the enclosing group's bindings never reach the spawned
+        # row, and a reference the grammar admits (§6.2 — `item-ref` reserves the NAME `$item`
+        # inside a body, it does not close the scope) substituted VERBATIM instead. Silently:
+        # the leaf received the literal `$ans`.
+        deps={"collection": collection, **_body_ref_edges(node.body, node.intent, edges)},
     )
     if node.reducer is not None:
         return ReduceNode(node.reducer, deps={"rows": map_node})
     return CollectNode(deps={"rows": map_node})
+
+
+def _body_ref_edges(body: str, intent: str | None, edges: Edges) -> dict[str, DagNode]:
+    """Reference edges for the `$name`s an iteration's body and per-row intent mention.
+
+    INVARIANT: ``item`` and ``current`` are excluded. They are the RESERVED row names (§5.3.4),
+    rebound per row by :class:`~url4.dag.nodes.MapNode`; wiring one to an enclosing binding of
+    the same name would let an outer value capture the row and silently iterate the wrong data.
+
+    An edge is added only for a name the enclosing group actually declares, so a body that
+    references nothing gains no dependency and keeps its previous concurrency.
+    """
+    refs = find_references(body) | (find_references(intent) if intent else set())
+    wired: dict[str, DagNode] = {}
+    for ref in sorted(refs - _ROW_NAMES):
+        key = f"pos:{ref}" if ref.isdigit() else f"bind:{ref}"
+        if key in edges:
+            wired[key] = edges[key]
+    return wired
 
 
 def _lower_collection(node: Node, registry: LoweringRegistry) -> DagNode:

--- a/packages/url4/src/url4/dag/compiler.py
+++ b/packages/url4/src/url4/dag/compiler.py
@@ -316,6 +316,18 @@ def _lower_iteration(node: Node, edges: Edges, registry: LoweringRegistry) -> Da
     return CollectNode(deps={"rows": map_node})
 
 
+def _body_intent_refs(body: str, intent: str | None) -> set[str]:
+    """The `$name`s an iteration's body and per-row intent mention, minus the reserved row names.
+
+    INVARIANT: the ONE reading of an iteration's template strings. Both compilation paths need
+    it — `_body_ref_edges` at lowering time and `_refs_of_ast` when collecting a slot's
+    references — and if they ever disagree about which names an iteration rebinds for itself,
+    the AST path silently stops wiring an outer binding while the text path keeps working. That
+    divergence is invisible: the reference substitutes VERBATIM and the run still succeeds.
+    """
+    return (find_references(body) | (find_references(intent) if intent else set())) - _ROW_NAMES
+
+
 def _body_ref_edges(body: str, intent: str | None, edges: Edges) -> dict[str, DagNode]:
     """Reference edges for the `$name`s an iteration's body and per-row intent mention.
 
@@ -326,9 +338,8 @@ def _body_ref_edges(body: str, intent: str | None, edges: Edges) -> dict[str, Da
     An edge is added only for a name the enclosing group actually declares, so a body that
     references nothing gains no dependency and keeps its previous concurrency.
     """
-    refs = find_references(body) | (find_references(intent) if intent else set())
     wired: dict[str, DagNode] = {}
-    for ref in sorted(refs - _ROW_NAMES):
+    for ref in sorted(_body_intent_refs(body, intent)):
         key = f"pos:{ref}" if ref.isdigit() else f"bind:{ref}"
         if key in edges:
             wired[key] = edges[key]
@@ -876,6 +887,19 @@ def _refs_of_ast(node: Node) -> set[str]:
             refs |= find_references(descendant.value)
         elif isinstance(descendant, (RelExpr, RemoteExpr)) and descendant.context:
             refs |= find_references(descendant.context)
+        elif isinstance(descendant, Iteration):
+            # WHY read as TEXT: an iteration's body and per-row intent are template strings,
+            # not child nodes — `children(Iteration)` yields only the collection — so the walk
+            # cannot reach their `$name`s. Without this the enclosing group's slot declared no
+            # dependency on them, `_ref_edges` emitted no `bind:` edge, and `_lower_iteration`
+            # had nothing left to wire: the AST path substituted an outer reference VERBATIM,
+            # which is the silent failure the text path already fixed (§6.2).
+            #
+            # INVARIANT: the SAME reading `_body_ref_edges` uses, shared rather than restated —
+            # a slot that declares fewer references than the lowering step wires is a wiring
+            # step with nothing to wire. The collection is deliberately not part of it: it
+            # resolves in the ENCLOSING scope and reaches this walk as an ordinary child.
+            refs |= _body_intent_refs(descendant.body, descendant.intent)
         elif isinstance(descendant, StructObject):
             refs |= find_references(descendant.raw)
         elif isinstance(descendant, VarRef) and descendant.name not in _ROW_NAMES:

--- a/packages/url4/src/url4/dag/node.py
+++ b/packages/url4/src/url4/dag/node.py
@@ -354,13 +354,30 @@ class ExecutionContext:
         return await self._execute_node_hook(self, node, scope)
 
     def report_usage(
-        self, *, provider: str, model: str, input_tokens: int, output_tokens: int
+        self,
+        *,
+        provider: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        response_model: str | None = None,
     ) -> None:
         """Report model token usage under this node's current span. A no-op
-        when no ``observer`` was passed to :func:`~url4.dag.executor.run`."""
+        when no ``observer`` was passed to :func:`~url4.dag.executor.run`.
+
+        ``model`` is the REQUESTED model; pass ``response_model`` when the provider
+        reports which model actually served the call (see :class:`~url4.observe.Usage`).
+        """
         if self._obs is not None:
             self._obs.emit(
-                Usage(self._current_span_id, provider, model, input_tokens, output_tokens)
+                Usage(
+                    self._current_span_id,
+                    provider,
+                    model,
+                    input_tokens,
+                    output_tokens,
+                    response_model,
+                )
             )
 
     def log(self, severity: str, body: str) -> None:

--- a/packages/url4/src/url4/dag/nodes.py
+++ b/packages/url4/src/url4/dag/nodes.py
@@ -881,6 +881,12 @@ class MapNode:
         items = self._items(inputs["collection"])
         if not items:
             return []
+        # WHY the frame is built ONCE here, not per row: it is row-invariant (the enclosing
+        # group's bindings), and it is what makes an outer `$name` visible inside the body —
+        # the same reference-edges-become-a-scope-frame move `LazyExprNode` makes. Without it
+        # the body's parent scope is the run scope, so a sibling binding is unreachable and
+        # substitutes verbatim.
+        frame = _frame(inputs, ctx)
         # `concurrency <= 0` (only reachable by constructing the directives
         # directly — the surface `;iteration.concurrency` syntax rejects n < 1)
         # means "use the default", not "unbounded": a falsy directive must never
@@ -894,8 +900,8 @@ class MapNode:
         # re-hashed len(items) times.
         expr = f"({self.body})!{self.intent}" if self.intent else f"({self.body})"
         if self.directives.on_error == "fail":
-            return await self._run_all(items, expr, sem, ctx)
-        rows = [self._row(item, expr, sem, ctx) for item in items]
+            return await self._run_all(items, expr, sem, ctx, frame)
+        rows = [self._row(item, expr, sem, ctx, frame) for item in items]
         raw = await asyncio.gather(*rows, return_exceptions=True)
         return self._skip(raw) if self.directives.on_error == "skip" else self._collect(raw, ctx)
 
@@ -914,22 +920,35 @@ class MapNode:
         return items
 
     async def _run_all(
-        self, items: list[str], expr: str, sem: asyncio.Semaphore, ctx: ExecutionContext
+        self,
+        items: list[str],
+        expr: str,
+        sem: asyncio.Semaphore,
+        ctx: ExecutionContext,
+        frame: Context,
     ) -> list[str]:
         # TaskGroup so the first failing row cancels its in-flight siblings.
         try:
             async with asyncio.TaskGroup() as tg:
-                tasks = [tg.create_task(self._row(item, expr, sem, ctx)) for item in items]
+                tasks = [tg.create_task(self._row(item, expr, sem, ctx, frame)) for item in items]
         except BaseExceptionGroup as group:
             reraise_first(group)
         return [task.result() for task in tasks]
 
     async def _row(
-        self, item: str, expr: str, sem: asyncio.Semaphore, ctx: ExecutionContext
+        self,
+        item: str,
+        expr: str,
+        sem: asyncio.Semaphore,
+        ctx: ExecutionContext,
+        frame: Context,
     ) -> str:
         # WHY: the body is spawned verbatim (with $item still in it) and the row is
         # bound into scope, so arbitrary row data never enters the re-parse.
-        scope = Context(bindings={_ITEM_KEY: item}, parent=ctx.scope)
+        # INVARIANT: the row shadows `frame` rather than merging into it — an enclosing binding
+        # named `item` must never capture the row, which is why the row key is NUL-prefixed and
+        # `_body_ref_edges` refuses to wire the reserved row names.
+        scope = Context(bindings={_ITEM_KEY: item}, parent=frame)
         async with sem:
             return await ctx.spawn(expr, scope)
 

--- a/packages/url4/src/url4/observe.py
+++ b/packages/url4/src/url4/observe.py
@@ -68,6 +68,14 @@ class Usage:
     model: str
     input_tokens: int
     output_tokens: int
+    # WHY a SEPARATE field rather than overwriting `model`: the GenAI semantic conventions
+    # distinguish `gen_ai.request.model` (what the caller asked for) from
+    # `gen_ai.response.model` (what actually served it), and a gateway is free to resolve an
+    # alias to a dated snapshot. `model` above stays the REQUESTED name.
+    # INVARIANT: `None` means the provider did not say — never a copy of `model`. Reporting the
+    # request as the response makes provider-side model drift undetectable, which is exactly
+    # what this field exists to expose.
+    response_model: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -101,7 +109,8 @@ class NullObserver:
 
 
 UsageSink = Callable[..., None]  # matches ExecutionContext.report_usage's kwargs:
-# (*, provider: str, model: str, input_tokens: int, output_tokens: int) -> None
+# (*, provider: str, model: str, input_tokens: int, output_tokens: int,
+#  response_model: str | None = None) -> None
 
 _usage_sink: contextvars.ContextVar[UsageSink | None] = contextvars.ContextVar(
     "url4_usage_sink", default=None

--- a/packages/url4/tests/unit/test_iteration_scope.py
+++ b/packages/url4/tests/unit/test_iteration_scope.py
@@ -1,0 +1,139 @@
+"""Outer bindings are visible inside an iteration body (spec §6.2 / §8.2).
+
+The grammar admits `$name` anywhere a `value` is admitted, including inside an iteration's
+per-row expression — `item-ref` reserves the NAME `$item` within iteration bodies, it does not
+make it the only name in scope. Before this, `_lower_iteration` discarded the enclosing group's
+edges, so a reference the grammar allows resolved to nothing and substituted VERBATIM: the
+downstream leaf received the literal characters `$ans`.
+
+That failure was silent in both field-path modes, which is what makes it worth a regression
+suite: an expression that reads correctly produced a prompt containing `$ans` and a confident,
+wrong answer.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from url4 import StaticIOLayer, evaluate_sync
+from url4.peer.server import Request, Url4Node
+
+_ROWS = json.dumps([{"id": 1}, {"id": 2}])
+
+
+def _node(**endpoints):
+    """A node whose `/echo` returns its context, so a resolved value is directly observable."""
+    node = Url4Node("scope-test", default_processor="/echo")
+    node.data("/rows", _ROWS, media_type="application/json")
+
+    @node.endpoint("/echo")
+    def echo(request: Request) -> str:
+        return request.context
+
+    @node.endpoint("/const")
+    def const(request: Request) -> str:
+        return "OUTER-VALUE"
+
+    return node
+
+
+async def _eval(expr: str) -> str:
+    node = _node()
+    try:
+        return (await node.evaluate(expr)).text
+    finally:
+        await node.aclose()
+
+
+# --- the core contract ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_outer_binding_resolves_inside_an_iteration_body() -> None:
+    result = await _eval("(ans:1.0:/const('x')!'c', r:1.0:/rows*(a:1.0:$ans)!'row')!'out'")
+
+    assert "OUTER-VALUE" in result
+    assert "$ans" not in result
+
+
+@pytest.mark.asyncio
+async def test_an_outer_binding_resolves_inside_the_per_row_intent() -> None:
+    """The intent is a substituted template, so a reference there must resolve too."""
+    result = await _eval("(ans:1.0:/const('x')!'c', r:1.0:/rows*(a:1.0:$item.id)!'saw $ans')!'o'")
+
+    assert "OUTER-VALUE" in result
+    assert "$ans" not in result
+
+
+@pytest.mark.asyncio
+async def test_an_outer_binding_resolves_inside_a_NESTED_iteration_body() -> None:
+    """Two levels deep — the shape a per-criterion benchmark protocol needs.
+
+    The answer is computed ONCE in the outer scope and read by every inner row; recomputing it
+    per inner row would multiply model cost by the inner collection's length.
+    """
+    result = await _eval(
+        "(ans:1.0:/const('x')!'c', r:1.0:/rows*(inner:1.0:/rows*(a:1.0:$ans)!'i')!'o')!'out'"
+    )
+
+    assert "OUTER-VALUE" in result
+    assert "$ans" not in result
+
+
+# --- what must NOT change -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_item_still_refers_to_the_row_not_an_outer_binding() -> None:
+    """INVARIANT: `$item` is reserved per §5.3.4 and must keep shadowing at every level.
+
+    Wiring outer references must not let an outer `item` binding capture the row — the row is
+    bound under a reserved NUL-prefixed key precisely to stay out of the `$name` namespace.
+    """
+    result = await _eval("(r:1.0:/rows*(a:1.0:$item.id)!'row')!'out'")
+
+    assert "1" in result
+    assert "2" in result
+
+
+@pytest.mark.asyncio
+async def test_the_inner_item_wins_over_the_outer_item_in_a_nested_iteration() -> None:
+    node = _node()
+    node.data("/inner", json.dumps(["X", "Y"]), media_type="application/json")
+    try:
+        result = (
+            await node.evaluate("(r:1.0:/rows*(i:1.0:/inner*(a:1.0:$item)!'in')!'out')!'o'")
+        ).text
+    finally:
+        await node.aclose()
+
+    # The innermost row values, not the outer {"id": …} objects.
+    assert "X" in result
+    assert "Y" in result
+
+
+@pytest.mark.asyncio
+async def test_an_unreferenced_binding_adds_no_edge() -> None:
+    """A body that references nothing must behave exactly as before — no new dependency, so no
+    accidental serialisation of an iteration behind an unrelated sibling."""
+    result = await _eval("(ans:1.0:/const('x')!'c', r:1.0:/rows*(a:1.0:$item.id)!'row')!'out'")
+
+    assert "1" in result
+
+
+@pytest.mark.asyncio
+async def test_a_reference_to_an_undeclared_name_still_substitutes_verbatim() -> None:
+    """Unchanged behaviour for a genuinely unbound name — this fix wires DECLARED siblings only,
+    it does not change what an unknown reference does."""
+    result = await _eval("(r:1.0:/rows*(a:1.0:$nope)!'row')!'out'")
+
+    assert "$nope" in result
+
+
+def test_a_static_world_iteration_still_resolves_offline() -> None:
+    """The engine core stays I/O-inverted: no endpoint, no network, still substitutes."""
+    io = StaticIOLayer(fetch_map={"/c": json.dumps(["a", "b"])})
+
+    assert evaluate_sync("(/c*(x:1.0:$item)!'r')!'o'", io).text is not None

--- a/packages/url4/tests/unit/test_iteration_scope_ast.py
+++ b/packages/url4/tests/unit/test_iteration_scope_ast.py
@@ -1,0 +1,137 @@
+"""Outer bindings reach an iteration body on the AST path too (spec §6.2 / §8.2).
+
+`test_iteration_scope.py` pins this contract for the TEXT path (`evaluate(text)`). This module
+pins the same contract for the PARSE-TREE path (`resolve(build(text))`), which
+:class:`~url4.core.nodes.Iteration` names as an invariant in its own docstring.
+
+The two paths collect a source's `$name` references differently. `_slot_from_text` scans the raw
+segment, so it sees a reference anywhere in the body. `_slot_from_ast` walks the parse tree — and
+`children(Iteration)` yields only ``collection``, because ``body``/``intent``/``reducer`` are
+template STRINGS rather than child nodes. So the body's references were invisible to the AST
+walk: the enclosing group's slot declared no dependency on them, `_ref_edges` emitted no
+``bind:`` edge, and `_lower_iteration` had nothing to wire.
+
+INVARIANT: both paths resolve the same expression to the same text. The failure this guards is
+the one the text-path fix already closed — an outer reference substituting VERBATIM, silently,
+so an expression that reads correctly yields a confident wrong answer.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from url4 import StaticIOLayer
+from url4.core.grammar import parse as grammar_parse
+from url4.dag import run
+
+_ROWS = json.dumps([{"id": 1}, {"id": 2}])
+_INNER = json.dumps(["X", "Y"])
+
+
+def _io() -> StaticIOLayer:
+    """A world whose `/const` route returns a fixed value, so a resolved reference is visible."""
+    return StaticIOLayer(
+        fetch_map={"/rows": _ROWS, "/inner": _INNER},
+        routes={"/const": lambda context, intent: "OUTER-VALUE"},
+    )
+
+
+async def _ast(expr: str) -> str:
+    """Resolve through the PARSE-TREE path — `compile_expression` on a parsed node."""
+    return await run(grammar_parse(expr), _io())
+
+
+async def _text(expr: str) -> str:
+    """Resolve through the TEXT path — the same expression as a string."""
+    return await run(expr, _io())
+
+
+# --- the core contract, on the AST path -----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_ast_path_resolves_an_outer_binding_inside_an_iteration_body() -> None:
+    result = await _ast("(ans:1.0:/const('x')!'c', r:1.0:/rows*(a:1.0:$ans)!'row')!'out'")
+
+    assert "OUTER-VALUE" in result
+    assert "$ans" not in result
+
+
+@pytest.mark.asyncio
+async def test_the_ast_path_resolves_an_outer_binding_inside_the_per_row_intent() -> None:
+    """The per-row intent is a substituted template, so a reference there must resolve too."""
+    result = await _ast("(ans:1.0:/const('x')!'c', r:1.0:/rows*(a:1.0:$item.id)!'saw $ans')!'o'")
+
+    assert "OUTER-VALUE" in result
+    assert "$ans" not in result
+
+
+@pytest.mark.asyncio
+async def test_the_ast_path_resolves_an_outer_binding_in_a_NESTED_iteration_body() -> None:
+    """Two levels deep — the shape a per-criterion benchmark protocol needs."""
+    result = await _ast(
+        "(ans:1.0:/const('x')!'c', r:1.0:/rows*(inner:1.0:/inner*(a:1.0:$ans)!'i')!'o')!'out'"
+    )
+
+    assert "OUTER-VALUE" in result
+    assert "$ans" not in result
+
+
+# --- the parity invariant -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "expr",
+    [
+        "(ans:1.0:/const('x')!'c', r:1.0:/rows*(a:1.0:$ans)!'row')!'out'",
+        "(ans:1.0:/const('x')!'c', r:1.0:/rows*(a:1.0:$item.id)!'saw $ans')!'o'",
+        "(r:1.0:/rows*(a:1.0:$item.id)!'row')!'out'",
+    ],
+)
+async def test_the_two_paths_agree(expr: str) -> None:
+    """INVARIANT: `evaluate(text) == resolve(build(text))` — Iteration's own docstring.
+
+    Asserted on the RESOLVED STRING rather than on graph structure: the two paths build
+    legitimately different node shapes, and it is the observable result that must not diverge.
+    """
+    assert await _text(expr) == await _ast(expr)
+
+
+# --- what must NOT change -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_ast_path_keeps_item_shadowing_the_row() -> None:
+    """INVARIANT: `$item` is reserved per §5.3.4 and keeps shadowing on this path too.
+
+    Collecting the body's references must not wire an enclosing binding NAMED `item` over the
+    row — the exclusion `_body_ref_edges` applies has to apply to the AST walk as well, or the
+    two paths disagree about which names an iteration rebinds for itself.
+    """
+    result = await _ast("(item:1.0:/const('x')!'c', r:1.0:/rows*(a:1.0:$item.id)!'row')!'out'")
+    rows = result[result.index("r: ") :]
+
+    # The rows carry the ROW's id, never the enclosing binding that happens to be named `item`.
+    assert "1" in rows
+    assert "2" in rows
+    assert "OUTER-VALUE" not in rows
+
+
+@pytest.mark.asyncio
+async def test_the_ast_path_leaves_an_undeclared_reference_verbatim() -> None:
+    """Unchanged behaviour for a genuinely unbound name — only DECLARED siblings are wired."""
+    result = await _ast("(r:1.0:/rows*(a:1.0:$nope)!'row')!'out'")
+
+    assert "$nope" in result
+
+
+@pytest.mark.asyncio
+async def test_an_unreferenced_body_gains_no_edge_on_the_ast_path() -> None:
+    """A body that references nothing keeps its previous concurrency — no new dependency."""
+    result = await _ast("(ans:1.0:/const('x')!'c', r:1.0:/rows*(a:1.0:$item.id)!'row')!'out'")
+
+    assert "1" in result
+    assert "2" in result

--- a/packages/url4/tests/unit/test_serve_command_stdin.py
+++ b/packages/url4/tests/unit/test_serve_command_stdin.py
@@ -1,0 +1,97 @@
+"""Which half of the Request a command route receives on stdin.
+
+FEATURE: a `[commands]` route can take the INTENT on stdin instead of the context.
+STORY: as a benchmark author, my cross-row reducer receives the JSON array of every row result
+as its intent — and argv cannot carry it.
+
+WHY this exists at all: a single argv token is capped at `MAX_ARG_STRLEN` (32 pages = 131,072
+bytes) by the kernel, independently of `ARG_MAX`. A reducer payload crosses that at roughly four
+DRACO cases, and the failure is `OSError [Errno 7] Argument list too long` at exec — the run dies
+rather than degrading. Stdin is a pipe and has no such bound.
+
+Its own module rather than an append to `test_serve_backends.py`: prior tests are append-only, so
+a new surface earns a new file. The default-behaviour case is RESTATED here rather than edited
+there — it is the invariant this change most needs to keep, and it must fail loudly in the module
+that introduces the selector.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from url4.cli._serve import make_command_handler
+from url4.core.errors import ResolutionError
+from url4.peer.server import Request
+
+pytestmark = pytest.mark.asyncio
+
+_ECHO_STDIN = ["python3", "-c", "import sys; sys.stdout.write(sys.stdin.read())"]
+
+# Comfortably past MAX_ARG_STRLEN (131,072). Not a round guess: the point is to sit ABOVE the
+# kernel's per-argument ceiling while staying far below `ARG_MAX`, so a failure can only be the
+# single-token limit and never the total-size one.
+_OVERSIZE = "v" * 200_000
+
+
+def _req(context: str = "the data", intent: str = "do it") -> Request:
+    return Request(path="/cmd", context=context, intent=intent, params={})
+
+
+async def test_default_still_pipes_the_context() -> None:
+    """INVARIANT: unchanged for every existing caller and every existing url4.toml.
+
+    `/read` is `["cat"]` and exists only to echo the piped context; a changed default would
+    silently turn that bridge into an intent echo.
+    """
+    handler = make_command_handler(_ECHO_STDIN, timeout=5.0)
+
+    assert await handler(_req(context="ctx", intent="int")) == "ctx"
+
+
+async def test_stdin_intent_pipes_the_intent() -> None:
+    handler = make_command_handler(_ECHO_STDIN, timeout=5.0, stdin="intent")
+
+    assert await handler(_req(context="ctx", intent="int")) == "int"
+
+
+async def test_stdin_intent_still_substitutes_context_into_argv() -> None:
+    """The two channels are independent — choosing stdin must not withdraw a substitution.
+
+    The DRACO reducer needs exactly this: the operation token arrives as `--operation {context}`
+    while the payload comes up the pipe.
+    """
+    handler = make_command_handler(
+        ["python3", "-c", "import sys; sys.stdout.write('{context}|' + sys.stdin.read())"],
+        timeout=5.0,
+        stdin="intent",
+    )
+
+    assert await handler(_req(context="aggregate", intent="[1,2]")) == "aggregate|[1,2]"
+
+
+async def test_unknown_stdin_source_is_rejected() -> None:
+    """Loud at construction. A silent fallback to the context would hand a reducer the literal
+    operation token in place of its payload, and it would score an empty run as a success."""
+    with pytest.raises(ValueError, match="stdin"):
+        make_command_handler(_ECHO_STDIN, timeout=5.0, stdin="params")
+
+
+async def test_payload_past_the_argv_ceiling_survives_on_stdin() -> None:
+    """THE REGRESSION. This is the whole point of the change."""
+    handler = make_command_handler(_ECHO_STDIN, timeout=30.0, stdin="intent")
+
+    assert await handler(_req(intent=_OVERSIZE)) == _OVERSIZE
+
+
+async def test_the_same_payload_through_argv_still_fails() -> None:
+    """The bound is the kernel's, not ours — so it is pinned rather than assumed.
+
+    If this ever starts passing, the ceiling moved and the sizing note in the spec is stale; it
+    does NOT mean the stdin path became unnecessary.
+    """
+    handler = make_command_handler(
+        ["python3", "-c", "import sys; sys.stdout.write(sys.argv[1])", "{intent}"], timeout=30.0
+    )
+
+    with pytest.raises(ResolutionError, match="failed to start"):
+        await handler(_req(intent=_OVERSIZE))

--- a/packages/url4/tests/unit/test_usage_response_model.py
+++ b/packages/url4/tests/unit/test_usage_response_model.py
@@ -1,0 +1,81 @@
+"""``Usage.response_model`` — the model that actually served a call.
+
+FEATURE: OpenTelemetry's GenAI semconv separates ``gen_ai.request.model`` (asked for) from
+``gen_ai.response.model`` (served it). A gateway may resolve an alias to a dated snapshot, so a
+consumer must be able to tell the two apart.
+
+STORY: as someone auditing a published benchmark score, I can see which model actually answered,
+not merely which one was requested — otherwise provider-side drift is invisible.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from url4.dag import run
+from url4.io.static import StaticIOLayer
+from url4.observe import ObservationEvent, Usage
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.events: list[ObservationEvent] = []
+
+    def on_event(self, event: ObservationEvent) -> None:
+        self.events.append(event)
+
+
+class _ResolvedModelNode:
+    """Reports a response model that DIFFERS from the requested one — the alias case."""
+
+    deps: dict = {}
+
+    async def resolve(self, inputs, ctx):
+        ctx.report_usage(
+            provider="google",
+            model="gemini-3.1-pro-preview",
+            input_tokens=10,
+            output_tokens=5,
+            response_model="gemini-3.1-pro-preview-20260715",
+        )
+        return "ok"
+
+
+class _SilentProviderNode:
+    """Reports no response model — a provider that does not echo one."""
+
+    deps: dict = {}
+
+    async def resolve(self, inputs, ctx):
+        ctx.report_usage(provider="anthropic", model="claude-x", input_tokens=1, output_tokens=1)
+        return "ok"
+
+
+def _usage(events: list[ObservationEvent]) -> Usage:
+    usages = [e for e in events if isinstance(e, Usage)]
+    assert len(usages) == 1
+    return usages[0]
+
+
+@pytest.mark.asyncio
+async def test_the_served_model_is_carried_separately_from_the_requested_one() -> None:
+    rec = _Recorder()
+
+    await run(_ResolvedModelNode(), StaticIOLayer(), observer=rec)
+
+    usage = _usage(rec.events)
+    assert usage.model == "gemini-3.1-pro-preview"
+    assert usage.response_model == "gemini-3.1-pro-preview-20260715"
+
+
+@pytest.mark.asyncio
+async def test_an_unreported_response_model_stays_none_rather_than_echoing_the_request() -> None:
+    """INVARIANT: the whole point of the field. Defaulting it to the requested model would make
+    "the provider served what we asked for" and "the provider never said" identical."""
+    rec = _Recorder()
+
+    await run(_SilentProviderNode(), StaticIOLayer(), observer=rec)
+
+    usage = _usage(rec.events)
+    assert usage.model == "claude-x"
+    assert usage.response_model is None


### PR DESCRIPTION
Runs the DRACO benchmark as an ordinary url4 expression on the url4-cloud Runner — no bespoke
harness. A scored `CandidateResult` has now been produced by a real Kubernetes Job.

```
terminated: succeeded
case_count: 1   score: 0.75   coverage: 0.0377   n_runs: 2   failures: []
```

## Design

Two decisions shape everything else:

1. **The judge is an ordinary url4 model call**, not script logic — so every judge call is
   observable through `url4.observe` (spans, tokens, cost) like any other call.
2. **Every benchmark artifact is a first-class url4 address** (`/draco/cases`,
   `/draco/criteria/42`, `/draco/policy/retrieval`), generated at image build. The declared world
   is a diffable manifest of exactly what an image contains.

The weighted rubrics — the answer key — are deliberately **not** addressable. The judge sees
`{id, requirement}`; `aggregate.py` reads the weights off disk after judging.

## What landed

**`packages/url4`** — outer `$name` bindings cross into an iteration body (this is what made the
paper's `official` protocol expressible at all); `make_command_handler` gains a `stdin` selector;
`Usage.response_model`.

**`apps/url4-cloud`** — `[commands]` and `[data]` tables in the runner config; `merge_config`
(validated at image build with the runner's own parser); `benchmarks/draco/{prepare,aggregate}`;
`;k=v` reaching the wire; the retrieval policy as an addressable artifact; benchmark manifests
over the REST catalog; `Dockerfile.benchmark`; the chart's Runner image split.

**`apps/aigateway`** — provider-agnostic `web_search`, the full 8-model DRACO lineup, and
`aigateway migrate`.

## The failure shape this branch keeps finding

Every real defect here presented the same way: **`terminated: succeeded`, and a score of zero — or
a score that was too high.** Both are invisible in the result. Fixed in this PR:

| Defect | How it presented |
|---|---|
| Blocklist entries were page-shaped; the provider takes bare hosts | 400 on *every* answering call — a 5-second run reporting success |
| `web_tool_max_iterations` was 5 and unreachable from any config | the model spent every round on tool calls and never answered |
| `timeout_s` defaulted to 60s | retrieving answers timed out; `on_error=collect` replaced the row, run "succeeded" |
| The Tavily path could not be guarded at all | candidates could fetch the paper they were graded against — which *raises* scores |
| `excluded_domains` vs OpenRouter's `exclude_domains` | the guard was inert from the day it shipped, and the unit tests defended the typo |

Two things that misled and are worth knowing: **provider documentation** (wildcards and path
filtering are documented and rejected in practice) and **unit tests written from the same
assumption as the code**. Only end-to-end effect measurement caught these.

## Verified

- **Kubernetes**: full stack on kind — Envoy Gateway, NATS/JetStream, aigateway in
  `cloudflare_headers` mode, url4-cloud, benchmark image. Job path, read-only rootfs,
  telemetry, and a scored result.
- **Both retrieval mechanisms in a Job**: native (gpt-5.5) and runner-driven Tavily (kimi).
- **The guard, live, with bogus-key controls** on native and Tavily.
- **Identity chain**: 401 without `X-User-Email`, 200 with, only from inside the trusted CIDR.
- Gates green on all three stacks; `helm lint` clean.

## Known gaps — deliberately not in this PR

- **Cloudflare edge never carried a real request.** Templates render; Envoy verifying an Access
  token and injecting the header is untested.
- **Scale unmeasured.** All runs were 2 of 53 criteria; a real case is ~26x.
- **`judge_reasoning: "low"`** (paper §4.2) is not carried — `reasoning_effort` has no OpenRouter
  rule and the gateway fails closed.
- **Two retrieval products** (native vs Tavily) mean candidates did not read the same web. A
  protocol caveat for any published score, not a defect.
- **No dataset revision pin**, no reproducibility fields in the result, and **no scoreboard wire**.
- The runner **discards `annotations`**, so a score cannot say what its candidates read.

## Review notes

- **This branch is behind `main` and will conflict.** `main`'s OpenRouter price/privacy routing
  commit touches the same plugin files. Rebase before merging.
- **Process deviation**: no Linear issue and no `docs/work` ledger, per the standing owner
  instruction covering this research phase. TDD, append-only tests, gates and the 95% confidence
  gate were all applied.
- **One prior test retired, owner-approved**: `test_naming_a_policy_on_a_tavily_route_is_loud`.
  Its premise ("the runner cannot enforce exclusion") is measured false; the rule is inverted, not
  dropped, and `test_tavily_retrieval_guard.py` pins the replacement.
- **Security-relevant invariant to check**: the control plane must never run the benchmark image —
  it carries the rubrics, and that pod terminates client connections. Pinned by test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
