### PR TITLE
fix(url4-cloud): move both Docker build stages to Python 3.13 together

### DIFF
--- a/apps/url4-cloud/Dockerfile
+++ b/apps/url4-cloud/Dockerfile
@@ -19,7 +19,14 @@
 # what K8sJobRunner._manifest hardens each Job Pod with: non-root uid/gid 1000 owning the venv,
 # `runAsNonRoot: true`-compatible, read-only rootfs, tini as PID 1 so activeDeadlineSeconds or a
 # stop tears a run down promptly with a clean SIGTERM.
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+# INVARIANT: the builder and runtime Python minor MUST match. The runtime copies the builder's
+# venv wholesale (see the COPY below), and a venv is version-keyed — site-packages lives under
+# lib/python<X.Y>/ and pyvenv.cfg names the interpreter that built it. A mismatch builds fine and
+# then dies at import with `ModuleNotFoundError: No module named 'url4_cloud'`.
+# AIDEV-NOTE: Dependabot CANNOT keep these two in step — they are different images
+# (ghcr.io/astral-sh/uv vs python), so no grouping setting pairs them, and it will happily bump
+# one alone. It did exactly that in #439. Base-image bumps on this file always need a human.
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS builder
 ENV UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \
     UV_PYTHON_DOWNLOADS=never
@@ -37,7 +44,8 @@ COPY apps/url4-cloud/url4.toml ./url4.toml
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev
 
-FROM python:3.12-slim-bookworm AS runtime
+# Must track the builder's Python minor exactly — see the INVARIANT above.
+FROM python:3.13-slim-bookworm AS runtime
 LABEL org.opencontainers.image.title="url4-cloud" \
       org.opencontainers.image.source="https://github.com/openmined/screamingface" \
       org.opencontainers.image.description="url4-cloud — REST + WebSocket control plane and url4 run mode"

--- a/docs/tasks/2026-08-04-ome-740-url4-cloud-docker-python.md
+++ b/docs/tasks/2026-08-04-ome-740-url4-cloud-docker-python.md
@@ -1,0 +1,56 @@
+---
+id: OME-740
+linear_url: https://linear.app/openmined/issue/OME-740/rework-the-url4-cloud-docker-python-bump-across-both-build-stages
+status: in_review
+type: task
+priority: P2
+labels: [url4-cloud, autonomous, agentic]
+created: 2026-08-04
+closed:
+---
+
+# OME-740 — move the url4-cloud image's Python across both build stages
+
+Sub-issue of `OME-733` (Dependabot compliance + alert burndown). Replaces #439 — the one PR in
+the epic's set that was **broken rather than redundant**, and therefore the only one closed.
+
+## Why #439 could not be merged
+
+`apps/url4-cloud/Dockerfile` is a two-stage build. Dependabot bumped only the runtime stage to
+3.14 and left the builder on 3.12, because the two are **different images** —
+`ghcr.io/astral-sh/uv:python3.12-bookworm-slim` versus `python:3.12-slim-bookworm` — and it only
+recognised the latter as `python`.
+
+The runtime copies the builder's venv wholesale. A venv is version-keyed: `site-packages` lives
+under `lib/python<X.Y>/` and `pyvenv.cfg` names the interpreter that built it. Drop a 3.12 venv
+into a 3.14 image and the entrypoint resolves to nothing:
+
+```
+ModuleNotFoundError: No module named 'url4_cloud'
+```
+
+That is an **import-time** fault — the image builds fine. Only CI's `Smoke both modes` step
+caught it.
+
+## Target: 3.13, not 3.14
+
+`requires-python = ">=3.12"` permits 3.14, but `url4-cloud-tests.yml` and `url4-tests.yml` run
+**3.12 and 3.13 only**. Shipping 3.14 would deploy an interpreter no test in the repo exercises.
+Moving to 3.14 must extend the CI matrix in the same change — a separate decision.
+
+## Result
+
+Both `FROM` lines on 3.13. `run_gates.py url4-cloud` all green (append-only, ruff check, ruff
+format, pyright, `check_layering.py`, pytest at the 80% floor).
+
+⚠️ No Docker daemon on the authoring machine, so the image was **not** built locally. Image-level
+proof rests on CI's `Build the image` + `Smoke both modes`.
+
+## The lasting fix is a comment, not config
+
+Added an `INVARIANT:` and an `AIDEV-NOTE:` to the Dockerfile recording that the two stages must
+move together and that **Dependabot structurally cannot do it** — no grouping setting pairs two
+different images. `OME-737`'s config rewrite does not solve this one; it is a real limit of the
+tool, mitigated by the comment plus CI's smoke step.
+
+Ledger: `docs/work/2026-08-04-OME-740-url4-cloud-docker-python.md`

--- a/docs/work/2026-08-04-OME-740-url4-cloud-docker-python.md
+++ b/docs/work/2026-08-04-OME-740-url4-cloud-docker-python.md
@@ -1,0 +1,125 @@
+---
+ticket: OME-740
+stack: url4-cloud
+status: done
+started: 2026-08-04
+finished: 2026-08-04
+---
+
+# OME-740 — move the url4-cloud image's Python across both build stages
+
+## Intent
+
+Replace Dependabot's #439, the one PR in the epic's set that is **broken rather than
+redundant**, and take the base-image bump properly.
+
+## Root cause of #439
+
+`apps/url4-cloud/Dockerfile` is a two-stage build:
+
+```
+line 22:  FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+line 40:  FROM python:3.12-slim-bookworm AS runtime
+```
+
+Dependabot's `docker` ecosystem tracks `FROM` lines independently, and it only recognised the
+runtime one as the `python` image — `ghcr.io/astral-sh/uv:python3.12-bookworm-slim` is a
+*different* image whose Python version happens to live in the tag. So it bumped the runtime to
+3.14 and left the builder on 3.12.
+
+That cannot work here. The builder runs `uv sync` to create a venv at
+`/app/apps/url4-cloud/.venv`, and the runtime stage copies that directory wholesale
+(`COPY --from=builder … /app/apps/url4-cloud`). A venv is version-keyed: its `site-packages`
+sits under `lib/python3.12/`, and its `pyvenv.cfg` and `bin/python` point at the interpreter
+that built it. Drop that into a 3.14 image and there is no 3.12 interpreter to resolve, so the
+`ENV PATH=".../.venv/bin:$PATH"` entrypoint resolves to a broken venv:
+
+```
+ModuleNotFoundError: No module named 'url4_cloud'
+```
+
+Note this is an **import-time** fault, not a build-time one. The image builds; it just cannot
+run. Only CI's `Smoke both modes` step caught it.
+
+**AIDEV-NOTE:** any future base-image bump here must move BOTH `FROM` lines together.
+Dependabot structurally cannot do this — the two images are different products, so no grouping
+setting will pair them. Treat docker bumps on this file as always needing a human.
+
+## Decision — 3.13, not Dependabot's 3.14
+
+`requires-python = ">=3.12"` permits 3.14, but the repo's Python matrices — `url4-cloud-tests.yml`
+and `url4-tests.yml` — run **3.12 and 3.13 only**. Shipping a 3.14 runtime would mean the
+deployed interpreter is a version no test in the repo has ever exercised.
+
+3.13 is the version the tests actually cover. Going to 3.14 is a separate decision that has to
+extend the CI matrix in the same change, and that is not this unit.
+
+## Planned changes
+
+- `apps/url4-cloud/Dockerfile` — builder `uv:python3.12-bookworm-slim` → `python3.13`, runtime
+  `python:3.12-slim-bookworm` → `python:3.13-slim-bookworm`, plus a comment recording why the
+  two must move together
+- Close #439 with the reason
+
+No Python source, dependency or lockfile change: `requires-python = ">=3.12"` already admits
+3.13, so `uv.lock` is unaffected.
+
+## Test plan
+
+The failing signal is #439's own CI: `Build the image` → `ModuleNotFoundError`.
+
+Verification is **CI's `Smoke both modes` step**, which is stronger than a plain build:
+
+```sh
+docker run --rm url4-cloud:ci url4-cloud --help
+docker run --rm url4-cloud:ci url4-cloud run --help
+```
+
+Both argv modes must start from the built image. That executes the entrypoint through the
+copied venv, which is precisely what the stage mismatch breaks — a green build alone would not
+prove anything.
+
+⚠️ **No Docker daemon is available on this machine**, so the image cannot be built locally. This
+unit's image verification rests entirely on CI. Stated plainly rather than implied.
+
+The Python gates (`run_gates.py url4-cloud`) still run locally and must stay green, though they
+exercise the source rather than the image.
+
+## Acceptance
+
+- Both `FROM` lines on the same Python minor.
+- CI `Build the image` green, including `Smoke both modes`.
+- `run_gates.py url4-cloud` green.
+- #439 closed with its reason recorded.
+
+## Outcome
+
+- **Actual files:** as planned — `apps/url4-cloud/Dockerfile` only, plus this ledger and its
+  `docs/tasks/` mirror. No source, dependency or lockfile change.
+
+  ```
+  FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS builder
+  FROM python:3.13-slim-bookworm AS runtime
+  ```
+
+- **Gates:** `run_gates.py url4-cloud` — **ALL GATES GREEN**. append-only check ✓ ·
+  ruff check ✓ · ruff format --check ✓ · pyright ✓ · `check_layering.py` ✓ ·
+  pytest with `--cov-fail-under=80` ✓.
+
+- **Deviations:** none from the plan.
+
+- **Verification gap, stated plainly:** no Docker daemon is available on this machine, so the
+  image was **not** built locally. The image-level proof rests entirely on CI's
+  `Build the image` job and its `Smoke both modes` step, which runs
+  `docker run --rm url4-cloud:ci url4-cloud --help` and the `run` variant. That step is what
+  caught #439's fault in the first place, so it is the right check — but it is CI's, not mine.
+
+- **Documented the trap in the Dockerfile itself.** Added an `INVARIANT:` explaining that the
+  builder and runtime Python minors must match because the venv is copied wholesale and is
+  version-keyed, and an `AIDEV-NOTE:` recording that **Dependabot structurally cannot keep the
+  two in step** — `ghcr.io/astral-sh/uv` and `python` are different images, so no grouping
+  setting will ever pair them. That is why #439 happened and why it will happen again unless the
+  next person reads it there.
+
+  This one does not get fixed by `OME-737`'s config rewrite. It is a genuine limit of the tool,
+  and the mitigation is the comment plus CI's smoke step, not configuration.


### PR DESCRIPTION
Closes `OME-740`, a sub-issue of `OME-733` (Dependabot compliance + alert burndown). Replaces #439 — the one PR in the epic's set that was **broken rather than redundant**, and therefore the only one closed instead of merged.

## Why #439 could never be merged

`apps/url4-cloud/Dockerfile` is a two-stage build. Dependabot bumped **only the runtime** stage to 3.14 and left the builder on 3.12:

```
FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder   # untouched
FROM python:3.12-slim-bookworm AS runtime                       # -> 3.14
```

It did that because the two are **different images**, and it only recognised the second as `python` — the builder's Python version merely happens to live inside a tag on an unrelated image.

The runtime copies the builder's venv wholesale (`COPY --from=builder … /app/apps/url4-cloud`). A venv is **version-keyed**: `site-packages` sits under `lib/python<X.Y>/`, and `pyvenv.cfg` / `bin/python` name the interpreter that built it. Drop a 3.12 venv into a 3.14 image and the `ENV PATH=".../.venv/bin:$PATH"` entrypoint resolves to nothing:

```
ModuleNotFoundError: No module named 'url4_cloud'
```

Note the failure mode: this is an **import-time** fault, not a build-time one. The image builds successfully. Only CI's `Smoke both modes` step — which actually runs the entrypoint — catches it. That step earns its keep here.

## Why 3.13 and not Dependabot's 3.14

`requires-python = ">=3.12"` permits 3.14, but `url4-cloud-tests.yml` and `url4-tests.yml` both run a **3.12 / 3.13** matrix. Shipping a 3.14 runtime would deploy an interpreter that no test in this repo has ever exercised.

3.13 is the newest version the tests actually cover. Going to 3.14 is a separate decision that has to extend the CI matrix in the same change.

## The lasting fix here is a comment, not configuration

This is the one finding in the epic that `OME-737`'s config rewrite does **not** solve. No `groups` setting can pair two different images, so Dependabot will keep bumping one `FROM` line alone. The mitigation is to make the trap unmissable at the site:

```dockerfile
# INVARIANT: the builder and runtime Python minor MUST match. ...
# AIDEV-NOTE: Dependabot CANNOT keep these two in step — they are different images
# (ghcr.io/astral-sh/uv vs python), so no grouping setting pairs them ...
```

## Test plan

`run_gates.py url4-cloud` — all green:

```
✓ append-only test check
✓ uv run ruff check
✓ uv run ruff format --check
✓ uv run pyright
✓ python3 ../../.claude/scripts/check_layering.py
✓ uv run pytest --cov=url4_cloud --cov=url4.streaming --cov-fail-under=80 -q
```

⚠️ **No Docker daemon was available on the authoring machine, so the image was not built locally.** The image-level proof rests entirely on this PR's CI — `Build the image` plus `Smoke both modes`:

```sh
docker run --rm url4-cloud:ci url4-cloud --help
docker run --rm url4-cloud:ci url4-cloud run --help
```

Please treat that job as the gating signal rather than my local run, since a green build alone would not prove the venv resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iy1jFtiDTBpFdk5h6x1Mu