### PR TITLE
fix(repo): add the missing `next build` gate to the aigateway-ui stack card (OME-743)

### DIFF
--- a/.claude/sdlc.local.md
+++ b/.claude/sdlc.local.md
@@ -51,10 +51,19 @@ stacks:
     gates:
       - npm ci
       - npm run lint
-      # OMDS's own enforcement gate, vendored with the tokens: no raw hex, no named color, no
+      # SFDS v2's own enforcement gate, vendored with the tokens: no raw hex, no named color, no
       # rgb()/hsl() literal on a color property. Token discipline as a merge blocker, not a nit.
       - npm run lint:css
       - npm run typecheck
+      # aigateway-ui-tests.yml runs this as a SECOND job ("Build the app"), so a card without it
+      # mirrors only half the workflow. `tsc --noEmit` does NOT cover the same ground: it never
+      # exercises Turbopack module resolution, static generation, or the `output: "standalone"`
+      # bundle the Dockerfile ships — so a build-only break (bad turbopack root, a server/client
+      # boundary violation, an unserializable prop crossing into a Server Component) passes every
+      # other gate and first surfaces in CI, or on a release tag in the image build.
+      # Ordered before test:ci deliberately: the build is ~5s against test:ci's ~60s, and the
+      # runner stops at the first red gate — so the cheap signal should come first.
+      - npm run build
       - npm run test:ci
 commit_refs: "Refs: OME-N"
 extra_anchors: []
@@ -83,13 +92,27 @@ ledger_dir: docs/work/
 - The UI holds **no** copy of the admin allowlist — `AIGATEWAY_ADMIN_EMAILS` lives in aigateway,
   which is the sole authority; the UI renders whatever the API returns (403 → not-an-admin page).
 - API keys are **write-only**: submitted, never rendered back, never logged.
-- Brand law is the **OpenMined Design System**, vendored at `src/brand/tokens/` from
-  `OpenMined/brand.openmined.org` (SHA in `src/brand/brand-version.txt`). NOT the
-  `screamingface-design` skill — this is internal operator tooling, so it wears the parent
-  OpenMined brand. The two systems genuinely conflict (radius, shadows, gradients, purple,
-  type), so do not mix them.
+- Brand law is the **`screamingface-design` skill — SFDS v2**, vendored at `src/brand/tokens/`
+  from `brand.screamingface.ai` (version string in `src/brand/README.md`). This REPLACED the
+  OpenMined Design System in `OME-716` — an owner decision reversed by an owner decision. **Do
+  not reintroduce OMDS**, and do not mix the two: they genuinely conflict on radius, shadows,
+  gradients and colour semantics.
+- **This console is the `app` register**, which is v2's default. `[data-brand="marketing"]` swaps
+  the accent family to gold; everything else takes **blue**. So `--accent-*` carries every
+  interaction, `--success-*` marks a healthy account, `--danger-*` marks destructive actions, and
+  `--brand-*`/`--gain-*` (gold) appear **nowhere** — gold is rationed to the win, and an admin
+  console has no win. `src/app/design-system.test.ts` asserts this; do not weaken it to land a
+  change.
+- **`--gain` is a trap.** The v1→v2 bridge keeps it resolving, but it now resolves to **gold**
+  where v1 had it green — a surface using it to mean "success" silently changed meaning. Use
+  `--success-*`.
 - **Never hardcode a color.** Literal palette values live only in `src/brand/tokens/tokens.css`;
-  everything else is `var(--…)`. `npm run lint:css` fails the build otherwise.
+  everything else is `var(--…)`. `npm run lint:css` fails the build otherwise. If a colour you
+  need does not exist, the fix goes **upstream into the system**, not into the vendored copy —
+  that is v2's own round-trip rule.
+- **Never hardcode a font stack either.** It is invisible to the colour gate, which is how
+  `Consolas, Monaco, "Andale Mono"…` survived two files under the previous system. Use
+  `--f-sans` / `--f-mono`; `design-system.test.ts` enforces it.
 - Re-syncing the brand means re-applying the documented font-family divergence — see
   `src/brand/README.md`.
 - `npm ci`, never `npm install`, in gates and CI: it installs from the lockfile and fails on

--- a/apps/aigateway-ui/README.md
+++ b/apps/aigateway-ui/README.md
@@ -54,10 +54,17 @@ curl -sf http://localhost:9107/healthz
 uv run .claude/scripts/run_gates.py aigateway-ui
 ```
 
-Runs `npm ci` → `npm run lint` → `npm run lint:css` → `npm run typecheck` → `npm run test:ci`,
-matching `.github/workflows/aigateway-ui-tests.yml` step for step. `npm ci` rather than
-`npm install` is deliberate: it installs from the lockfile and fails when `package.json`
-disagrees, so lockfile drift cannot pass unnoticed.
+Runs `npm ci` → `npm run lint` → `npm run lint:css` → `npm run typecheck` → `npm run build` →
+`npm run test:ci`, covering **both** jobs of `.github/workflows/aigateway-ui-tests.yml` — the
+`test` job and the separate `Build the app` job.
+
+`npm run build` earns its place: `tsc --noEmit` type-checks but never exercises Turbopack module
+resolution, static generation, or the `output: "standalone"` bundle the Dockerfile ships, so a
+build-only break passes every other gate and first appears in CI or on a release tag. It runs
+before `test:ci` because it is ~5s against ~60s and the runner stops at the first red gate.
+
+`npm ci` rather than `npm install` is deliberate: it installs from the lockfile and fails when
+`package.json` disagrees, so lockfile drift cannot pass unnoticed.
 
 ## Design system
 

--- a/docs/tasks/2026-08-04-ome-743-aigateway-ui-stack-card-repair.md
+++ b/docs/tasks/2026-08-04-ome-743-aigateway-ui-stack-card-repair.md
@@ -1,0 +1,63 @@
+---
+id: OME-743
+linear_url: https://linear.app/openmined/issue/OME-743/complete-and-correct-the-aigateway-ui-stack-card-gates
+status: planned
+type: task
+priority: P2
+labels: [repo, autonomous, agentic]
+created: 2026-08-04
+closed:
+---
+
+# OME-743 — complete and correct the `aigateway-ui` stack card
+
+Back-filled mirror. This unit was planned in a session without Linear MCP auth and carried
+`ticket: UNFILED`; the issue, ledger filename, branch and this mirror were reconciled on
+2026-08-04 from a session holding auth.
+
+**Implementation status:** both edits are already made in the working tree but **uncommitted** —
+the branch carries no commits beyond this reconciliation. They were left that way deliberately:
+they belong to the session that authored them, and the ledger's acceptance includes a negative
+test not yet run (a deliberately broken build must fail on `npm run build` specifically, and not
+on the other five gates).
+
+## Two independent problems with the `aigateway-ui` entry in `.claude/sdlc.local.md`
+
+**1 — the gate set is incomplete.** `aigateway-ui-tests.yml` has two jobs; the card mirrors one:
+
+| CI job | steps | in the card |
+|---|---|---|
+| `test` | `npm ci` · `lint` · `lint:css` · `typecheck` · `test:ci` | all five |
+| `Build the app` | `npm ci` · **`npm run build`** | **missing** |
+
+A build-only failure — bad Turbopack root, a server/client boundary violation, an unserializable
+prop crossing into a Server Component — passes every local gate and first surfaces in CI, or
+later on a release tag in the image build. `tsc --noEmit` does not cover it: it never exercises
+Turbopack module resolution, static generation, or the `output: "standalone"` bundle the
+Dockerfile depends on.
+
+Confirmed rather than theoretical: **`OME-736` ran `npm run build` by hand** and recorded it as a
+separate acceptance bullet, precisely because the gate set would not run it.
+
+**2 — the card describes the pre-`OME-716` world.** #462 (merged 2026-08-03) moved the console
+from the OpenMined Design System to SFDS v2. The card was never updated, so it contradicts
+`apps/aigateway-ui/CLAUDE.md` ("Do not reintroduce OMDS") and cites `src/brand/brand-version.txt`,
+which that unit deleted. Knock-on: `OME-736`'s PR description repeated the stale OMDS line
+straight from this card — a wrong card propagates.
+
+## Scope
+
+- `.claude/sdlc.local.md` — add `npm run build` **after `typecheck`, before `test:ci`**
+  (fail-fast: build ~5 s vs `test:ci` ~60 s, and the runner stops at the first red gate);
+  retarget the `lint:css` comment to SFDS v2; rewrite the brand-law bullet; drop the dead
+  `brand-version.txt` reference.
+- `apps/aigateway-ui/README.md` — correct the "step for step" claim.
+
+## Not in this unit
+
+The missing **a11y gate** (`OME-736`'s recorded defect, `sdlc-react` rule 7) — not a card edit,
+since `aigateway-ui` has no axe/jest-axe dependency and no `test:a11y` script. Needs its own
+ticket. Also out: the `working-in-this-repo` routing table's inverted brand-law line, and the
+"OMDS token gate" step name at `aigateway-ui-tests.yml:47`.
+
+Ledger: `docs/work/2026-08-04-OME-743-aigateway-ui-stack-card-repair.md`

--- a/docs/work/2026-08-04-OME-743-aigateway-ui-stack-card-repair.md
+++ b/docs/work/2026-08-04-OME-743-aigateway-ui-stack-card-repair.md
@@ -95,9 +95,67 @@ No RED test: this unit adds no code. The gate set **is** the test, so verificati
 - no OMDS claim and no dead file reference remains in the card
 - `grep -c OMDS .claude/sdlc.local.md` returns only historical mentions, if any
 
-## Outcome (fill at the end — required before COMMIT)
+## Outcome
 
-- **Actual files:**
-- **Commits:**
-- **Gates:**
-- **Deviations:**
+- **Actual files:** as planned — `.claude/sdlc.local.md` and `apps/aigateway-ui/README.md`. No
+  source file touched; no test touched (append-only gate clean).
+
+- **Gates:** green, with the new gate in position.
+
+  ```
+  ✓ append-only test check (vs HEAD)
+  ✓ npm ci
+  ✓ npm run lint
+  ✓ npm run lint:css
+  ✓ npm run typecheck
+  ✓ npm run build        ← this unit
+  ✓ npm run test:ci      13 files, 218 tests passed
+  ALL GATES GREEN
+  ```
+
+- **The negative test was run, and it is the real result of this unit.** A client component
+  importing the `server-only` BFF module (`src/lib/aigateway/client.ts`) — the exact violation
+  `apps/aigateway-ui/CLAUDE.md` says must "fail the build rather than ship the admin API's address
+  to the browser":
+
+  | gate | exit |
+  |---|---|
+  | `npm run lint` | 0 — does not catch it |
+  | `npm run lint:css` | 0 — does not catch it |
+  | `npm run typecheck` | 0 — does not catch it |
+  | `npm run test:ci` | 0 — does not catch it (all 218 pass) |
+  | **`npm run build`** | **1 — catches it** |
+
+  Turbopack: `Client Component Browser: ./src/lib/aigateway/client.ts ← ./src/app/probe/page.tsx`.
+
+  **So before this change the BFF invariant was enforced by CI but NOT by the local gate set.** The
+  documented guarantee held on the remote and was unverifiable on the machine writing the code.
+
+- **Acceptance:** all met. `grep` for `OMDS|OpenMined Design|brand-version.txt` in the card returns
+  only the two deliberate historical mentions ("this REPLACED the OpenMined Design System in
+  `OME-716`", "Do not reintroduce OMDS"); the dead `brand-version.txt` reference is gone.
+
+## Deviations
+
+1. **The first negative-test probe was silently inert.** It was placed at `src/app/_probe/`, and
+   Next treats a leading-underscore folder as a **private folder** excluded from routing — so it
+   was never compiled and the build passed. Only the missing `/_probe` entry in the printed route
+   table revealed it; re-run at `src/app/probe/` it failed immediately. A negative test that passes
+   for the wrong reason is worse than no negative test.
+
+2. **A stale `.next/types/validator.ts` then failed `typecheck`** after the probe was deleted — the
+   generated route validator still imported `../../src/app/probe/page.js`. `rm -rf .next` cleared
+   it. Worth knowing: **`npm run typecheck` reads build-generated types**, so it can fail on a route
+   that no longer exists. An ordering coupling between the `build` and `typecheck` gates, not a code
+   error.
+
+3. **No RED-first cycle**, by nature: the unit changes a gate list and prose, not code. The
+   behavioural verification above stands in for it.
+
+4. **Concurrent-session collision mid-unit.** The working tree was switched to another branch
+   (`OME-738-public-docs-ci-lane`) while these edits were uncommitted; git carried them across
+   because they did not conflict. Nothing was lost — the branch, the reconciliation commit and the
+   edits all survived — but the edits were briefly sitting on an unrelated unit's branch. Recovered
+   by checking out this branch again and committing immediately. **Lesson: commit early when more
+   than one session shares a checkout**; uncommitted work is the only thing a branch switch can
+   silently relocate.

--- a/docs/work/2026-08-04-OME-743-aigateway-ui-stack-card-repair.md
+++ b/docs/work/2026-08-04-OME-743-aigateway-ui-stack-card-repair.md
@@ -1,0 +1,103 @@
+---
+ticket: OME-743
+stack: aigateway-ui
+status: in_progress
+started: 2026-08-04
+finished:
+---
+
+# OME-743 — complete and correct the `aigateway-ui` stack card
+
+## PROCESS DEVIATION — RECONCILED 2026-08-04
+
+This unit was planned in a session where the Linear MCP plugin was **unauthenticated**. The card
+(`.claude/task-board.local.md`) names it the ONLY permitted transport — API tokens and raw
+GraphQL are forbidden — so the ledger was written against `ticket: UNFILED`, with the owner
+electing to proceed and record the deviation rather than authorize mid-session.
+
+**All four dangling fields have since been back-filled** from a session that does hold MCP auth:
+
+| field | correct value | status |
+|---|---|---|
+| ledger `ticket:` | `OME-743` | ✅ reconciled |
+| ledger filename | `2026-08-04-OME-743-…md` | ✅ renamed |
+| branch | `OME-743-aigateway-ui-stack-card-repair` | ✅ renamed (was `sdlc-card-aigateway-ui-gates`) |
+| `docs/tasks/` mirror | `docs/tasks/2026-08-04-ome-743-aigateway-ui-stack-card-repair.md` | ✅ created |
+
+The branch carried no commits at reconciliation time, so nothing needed rewriting — commits from
+here on **must** carry `Refs: OME-743`.
+
+**AIDEV-NOTE:** the deviation is kept on the record rather than deleted. The failure mode it
+documents is real — a session without MCP auth cannot file work, and the repo's rules leave no
+compliant alternative. See also `OME-741`, a separate instance of tooling leaving no legitimate
+path for a rule the process explicitly permits.
+
+## Intent
+
+The `aigateway-ui` entry in `.claude/sdlc.local.md` has two independent problems.
+
+**1 — the gate set is incomplete.** `aigateway-ui-tests.yml` has two jobs; the card mirrors only
+one:
+
+| CI job | steps | in the card |
+|---|---|---|
+| `test` | `npm ci` · `lint` · `lint:css` · `typecheck` · `test:ci` | all five |
+| `Build the app` | `npm ci` · **`npm run build`** | **missing** |
+
+So a build-only failure — bad Turbopack root, a server/client boundary violation, an
+unserializable prop crossing into a Server Component — passes every local gate and first appears
+in CI, or on a release tag in the image build. `tsc --noEmit` does not cover this: it never
+exercises Turbopack module resolution, static generation, or the `output: "standalone"` bundle the
+Dockerfile depends on. `apps/aigateway-ui/README.md` claims the gates match the workflow "step for
+step", which is true of one job out of two.
+
+Evidence this is real and not theoretical: `OME-736` ran `npm run build` **by hand** and recorded
+it as an acceptance bullet, because the gate set would not run it.
+
+**2 — the card still describes the pre-`OME-716` world.** `#462` merged 2026-08-03 and moved the
+console from the OpenMined Design System to SFDS v2. The card was not updated, so it now
+contradicts `apps/aigateway-ui/CLAUDE.md` — which says "Do not reintroduce OMDS" — and cites a
+file that unit deleted.
+
+## Planned changes
+
+- `.claude/sdlc.local.md`
+  - add `npm run build` to the `aigateway-ui` gates, **after `typecheck`, before `test:ci`**
+    (fail-fast: the build is ~5 s, `test:ci` ~60 s, and the runner stops at the first red gate)
+  - retarget the `lint:css` comment from OMDS to SFDS v2
+  - rewrite the brand-law bullet: SFDS v2, the app register, gold used nowhere
+  - drop the `src/brand/brand-version.txt` reference — `OME-716` deleted that file
+- `apps/aigateway-ui/README.md` — correct the "step for step" claim to name both CI jobs
+
+## Explicitly NOT in this unit
+
+- **The missing a11y gate** (`OME-736`'s recorded card defect, `sdlc-react` rule 7). Not a card
+  edit: `aigateway-ui` has no axe/jest-axe dependency and no `test:a11y` script, so it needs real
+  tooling. Stays recorded, needs its own ticket.
+- **`working-in-this-repo` skill** — its routing table carries the same inverted brand-law line.
+- **`.github/workflows/aigateway-ui-tests.yml:47`** — step still named "Lint styles (OMDS token
+  gate)".
+
+## Test plan
+
+No RED test: this unit adds no code. The gate set **is** the test, so verification is behavioural:
+
+- `run_gates.py aigateway-ui` runs `npm run build` and reports it — proving the gate is wired
+- the full set stays green (218 tests baseline)
+- a deliberately broken build is caught by the gate and **not** by the other five — proving the
+  gate closes a hole the existing ones do not
+
+## Acceptance
+
+- `npm run build` appears in the runner output between `typecheck` and `test:ci`
+- gates green end to end
+- the negative test above fails on `npm run build` specifically
+- no OMDS claim and no dead file reference remains in the card
+- `grep -c OMDS .claude/sdlc.local.md` returns only historical mentions, if any
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+- **Commits:**
+- **Gates:**
+- **Deviations:**


### PR DESCRIPTION
`Refs: OME-743`

## The gap

`aigateway-ui-tests.yml` has **two** jobs. `.claude/sdlc.local.md` mirrored only one:

| CI job | steps | in the card |
| --- | --- | --- |
| `test` | `npm ci` · `lint` · `lint:css` · `typecheck` · `test:ci` | all five |
| **`Build the app`** | `npm ci` · **`npm run build`** | **missing** |

`apps/aigateway-ui/README.md` claimed the gates matched the workflow "step for step" — true of one job out of two.

`tsc --noEmit` does not cover the same ground. It type-checks, but never exercises Turbopack module resolution, static generation, or the `output: "standalone"` bundle the Dockerfile ships. So a build-only break passes every local gate and first surfaces in CI, or on a release tag in the image build.

This is not theoretical: **`OME-736` ran `npm run build` by hand** and recorded it as an acceptance bullet, because the gate set would not run it.

## Proved, not asserted

I introduced a client component importing the `server-only` BFF module (`src/lib/aigateway/client.ts`) — the exact violation `apps/aigateway-ui/CLAUDE.md` says must *"fail the build rather than ship the admin API's address to the browser"* — and ran every gate against it:

| gate | exit |
| --- | --- |
| `npm run lint` | 0 — does not catch it |
| `npm run lint:css` | 0 — does not catch it |
| `npm run typecheck` | 0 — does not catch it |
| `npm run test:ci` | 0 — does not catch it (all 218 pass) |
| **`npm run build`** | **1 — catches it** |

Turbopack: `Client Component Browser: ./src/lib/aigateway/client.ts ← ./src/app/probe/page.tsx`

**The BFF invariant this app documents was enforced by CI but not by the local gate set** — the guarantee held on the remote and was unverifiable on the machine writing the code. The probe was removed; it is not in this diff.

## Also: the card described the pre-OME-716 world

`#462` merged yesterday and moved the console to SFDS v2. The card was not updated, so it still:

- named the **OpenMined Design System** as brand law,
- explicitly said **NOT the `screamingface-design` skill`**, and
- cited `src/brand/brand-version.txt` for the SHA — **a file OME-716 deleted**.

That directly contradicted `apps/aigateway-ui/CLAUDE.md` ("Do not reintroduce OMDS") in the very card an agent reads before touching the app. Replaced with the SFDS v2 rules: the app register, gold used nowhere, the `--gain` trap, and the round-trip rule for missing colours.

## Gates

```
✓ append-only test check (vs HEAD)
✓ npm ci
✓ npm run lint
✓ npm run lint:css
✓ npm run typecheck
✓ npm run build        ← this unit
✓ npm run test:ci      13 files, 218 tests passed
ALL GATES GREEN
```

## Two things worth knowing (in the ledger)

- **`npm run typecheck` reads build-generated types.** After deleting the probe route, `tsc` still failed on a stale `.next/types/validator.ts` importing the removed page. `rm -rf .next` clears it — an ordering coupling between the `build` and `typecheck` gates, not a code error.
- **A first probe at `src/app/_probe/` was silently inert** — Next excludes leading-underscore folders from routing, so it never compiled and the build passed. Only the missing route-table entry gave it away.

## Deliberately NOT in this PR

- **The missing a11y gate** (`OME-736`'s recorded card defect, `sdlc-react` rule 7). Not a card edit — `aigateway-ui` has no axe/jest-axe dependency and no `test:a11y` script, so it needs real tooling. Needs its own ticket.
- **`working-in-this-repo` skill** — its routing table carries the same inverted brand-law line, still pointing agents at OMDS.
- **`.github/workflows/aigateway-ui-tests.yml:47`** — step still named "Lint styles (OMDS token gate)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HAiqcmwueUjWBhsEfsQWGx