### PR TITLE
ci(repo): group Dependabot security updates and split majors out

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -104,6 +104,23 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # Two majors are KNOWN-unmergeable and are held deliberately (OME-736). Without these ignores
+    # the `-major` group regenerates a permanently-red PR every week — #480 was exactly that,
+    # re-proposing both within minutes of the holds landing. The `-major` bucket is designed to let
+    # a red major sit harmlessly, but a major that can NEVER go green is noise, not a signal.
+    # Remove each entry when its blocking ticket resolves — that is the trigger to retry.
+    ignore:
+      # OME-742. TypeScript 7 is the Go-based compiler rewrite, and openapi-typescript@7.13.0
+      # (the latest release) caps at peer typescript@^5.x with no TS6/7 build. Nothing to pick
+      # around, so every TS>=6 proposal fails at `npm ci`.
+      - dependency-name: "typescript"
+        versions: [">=6"]
+      # ESLint 10 crashes eslint-plugin-react@7.37.5, bundled inside eslint-config-next, with
+      # "contextOrFilename.getFilename is not a function". eslint-config-next declares peer
+      # eslint ">=9.0.0" at both 16.2.12 and 16.3.0 — the range is wrong, so no version of the
+      # Next config works with ESLint 10 today. Retry when Next ships a compatible config.
+      - dependency-name: "eslint"
+        versions: [">=10"]
     groups:
       aigateway-ui-npm-security:
         applies-to: security-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,30 @@
-# Scope Dependabot to the maintained apps only, with grouped updates.
+# Dependabot scope and grouping for the maintained trees.
 #
-# Without this file Dependabot auto-discovers EVERY manifest in the repo.
-# Listing explicit directories means only these trees are scanned; `groups`
-# collapses each ecosystem's bumps into a single PR.
+# Without this file Dependabot auto-discovers EVERY manifest in the repo. Listing explicit
+# directories means only these trees get VERSION updates.
+#
+# IMPORTANT — what the `directory:` list does NOT do (OME-733):
+#   SECURITY updates ignore it. They are driven by the dependency graph and fire against any
+#   manifest GitHub has indexed, listed here or not. That is how #422 (next, in
+#   apps/screamingface-studio/frontend) existed while this file deliberately excluded that tree.
+#   Omitting a directory buys you no security-update silence — it only means that tree gets no
+#   routine version bumps, which is usually the opposite of what you want.
+#
+# IMPORTANT — why every group declares `applies-to` (OME-733):
+#   `groups` defaults to `applies-to: version-updates`. Before this was made explicit, every
+#   security fix arrived as its OWN ungrouped PR — nine of them at once (#437 #435 #433 #431 #430
+#   #455 #422 #460 #432). The `-security` group below is what collapses those into one.
+#
+# IMPORTANT — why majors are split from minor/patch (OME-733):
+#   With one group per ecosystem, a single breaking major holds every security patch behind it,
+#   AND a major can slip in under cover of them. Both happened in the same PR (OME-736): the
+#   react/react-dom 19.2.8 security bumps sat behind an ESLint 10 crash, while that same PR was
+#   quietly carrying a TypeScript 5 -> 7 compiler rewrite. Splitting them means a red `-major` PR
+#   can sit indefinitely while `-security` and `-minor` keep flowing.
+#
+# NOT fixable by any setting here (OME-740): Dependabot cannot keep the two `FROM` lines of
+# apps/url4-cloud/Dockerfile in step, because ghcr.io/astral-sh/uv and python are different
+# images. See the INVARIANT in that Dockerfile; base-image bumps there need a human.
 version: 2
 updates:
   - package-ecosystem: "uv"
@@ -11,8 +33,17 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     groups:
-      aigateway-python:
+      aigateway-python-security:
+        applies-to: security-updates
         patterns: ["*"]
+      aigateway-python-minor:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      aigateway-python-major:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["major"]
 
   - package-ecosystem: "uv"
     directory: "/apps/scoreboard"
@@ -20,8 +51,17 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     groups:
-      scoreboard-python:
+      scoreboard-python-security:
+        applies-to: security-updates
         patterns: ["*"]
+      scoreboard-python-minor:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      scoreboard-python-major:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["major"]
 
   - package-ecosystem: "uv"
     directory: "/packages/url4"
@@ -29,8 +69,17 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     groups:
-      url4-python:
+      url4-python-security:
+        applies-to: security-updates
         patterns: ["*"]
+      url4-python-minor:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      url4-python-major:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["major"]
 
   - package-ecosystem: "uv"
     directory: "/apps/url4-cloud"
@@ -38,34 +87,140 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     groups:
-      url4-cloud-python:
+      url4-cloud-python-security:
+        applies-to: security-updates
         patterns: ["*"]
+      url4-cloud-python-minor:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      url4-cloud-python-major:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["major"]
 
-  # The repo's only npm tree that is a deployable component. `apps/screamingface-studio/frontend`
-  # is deliberately NOT listed — it has no CI lane, so a dependency bump there would land with
-  # nothing to verify it.
   - package-ecosystem: "npm"
     directory: "/apps/aigateway-ui"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
     groups:
-      aigateway-ui-npm:
+      aigateway-ui-npm-security:
+        applies-to: security-updates
         patterns: ["*"]
+      aigateway-ui-npm-minor:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      aigateway-ui-npm-major:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["major"]
 
-  # The runtime image's base layers drift silently otherwise — they are pinned by tag, and
-  # nothing else in CI notices a new patch release of the base.
+  # Added in OME-737, AFTER OME-738 (#484) gave public-docs a CI lane. That ordering was
+  # deliberate: before the lane existed, bumps here merged with nothing verifying them — which is
+  # how #460 and #432 landed. A directory should not be listed until something can gate it.
+  - package-ecosystem: "npm"
+    directory: "/public-docs"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      public-docs-npm-security:
+        applies-to: security-updates
+        patterns: ["*"]
+      public-docs-npm-minor:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      public-docs-npm-major:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["major"]
+
+  # apps/screamingface-studio/frontend (npm) and apps/screamingface-studio/src-tauri (cargo) are
+  # deliberately still absent — pending OME-739, which asks whether that tree is alive at all. If
+  # it is dormant the answer is to delete it, which closes the repo's last open alert (glib,
+  # medium, in its Cargo.lock) and makes both entries moot. Note that omitting them does NOT stop
+  # security PRs against that tree; see the header.
+
+  # Container base layers drift silently otherwise: they are pinned by tag, and nothing in CI
+  # notices a new patch release of a base image. Coverage is now all four Dockerfiles (was one).
+  #
+  # Grouped per directory, which PARTLY mitigates the #439 failure (OME-740): a multi-stage
+  # Dockerfile's images at least arrive in ONE pull request instead of a one-sided bump that looks
+  # complete. It does NOT fix it — each image still resolves to its own latest tag, so grouping
+  # can surface a builder on 3.13 beside a runtime on 3.14. It makes the mismatch visible in the
+  # diff rather than invisible. The actual guard stays the INVARIANT in the Dockerfile plus CI's
+  # "Smoke both modes" step, which runs the entrypoint and catches the broken venv.
   - package-ecosystem: "docker"
     directory: "/apps/url4-cloud"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    groups:
+      url4-cloud-docker-security:
+        applies-to: security-updates
+        patterns: ["*"]
+      url4-cloud-docker-version:
+        applies-to: version-updates
+        patterns: ["*"]
 
-  # Keep GitHub Actions pinned-version bumps current too (low volume).
+  - package-ecosystem: "docker"
+    directory: "/apps/aigateway"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    groups:
+      aigateway-docker-security:
+        applies-to: security-updates
+        patterns: ["*"]
+      aigateway-docker-version:
+        applies-to: version-updates
+        patterns: ["*"]
+
+  - package-ecosystem: "docker"
+    directory: "/apps/aigateway-ui"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    groups:
+      aigateway-ui-docker-security:
+        applies-to: security-updates
+        patterns: ["*"]
+      aigateway-ui-docker-version:
+        applies-to: version-updates
+        patterns: ["*"]
+
+  - package-ecosystem: "docker"
+    directory: "/apps/scoreboard"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    groups:
+      scoreboard-docker-security:
+        applies-to: security-updates
+        patterns: ["*"]
+      scoreboard-docker-version:
+        applies-to: version-updates
+        patterns: ["*"]
+
+  # Low volume, but #453 showed how far behind these drift when nothing watches them: eighteen
+  # updates at once, including actions/checkout 4 -> 7 and the Node 20 deprecation warnings that
+  # had been appearing in every workflow log.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     groups:
-      github-actions:
+      github-actions-security:
+        applies-to: security-updates
         patterns: ["*"]
+      github-actions-minor:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      github-actions-major:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["major"]

--- a/docs/tasks/2026-08-04-ome-737-dependabot-config.md
+++ b/docs/tasks/2026-08-04-ome-737-dependabot-config.md
@@ -1,0 +1,59 @@
+---
+id: OME-737
+linear_url: https://linear.app/openmined/issue/OME-737/regroup-dependabotyml-so-security-updates-group-and-majors-split-out
+status: in_review
+type: task
+priority: P2
+labels: [repo, autonomous, agentic]
+created: 2026-08-04
+closed:
+---
+
+# OME-737 — regroup dependabot.yml so security updates group and majors split out
+
+Sub-issue of `OME-733`. The structural fix of the epic: everything before this cleared a backlog,
+this stops it re-forming.
+
+## The two faults
+
+**1 — `groups` did not apply to security updates.** It defaults to
+`applies-to: version-updates`, so every security fix arrived ungrouped, one PR per package. That
+was the entire single-package backlog this epic cleared: #437 #435 #433 #431 #430 #455 #422 #460
+#432.
+
+**2 — majors rode with patches.** One breaking major held security bumps hostage, *and* a major
+slipped in under cover of them — both in the same PR. In `OME-736`, the react/react-dom 19.2.8
+security bumps sat behind an ESLint 10 crash while that same PR quietly carried a TypeScript 5→7
+compiler rewrite.
+
+Three groups per ecosystem now: `-security` (`applies-to: security-updates`), `-minor`
+(`minor`+`patch`), `-major`. A red `-major` PR can sit indefinitely while `-security` and `-minor`
+keep flowing.
+
+## Coverage
+
+**6/12 → 10/12 manifests.** Docker **1/4 → 4/4**. Added `npm` → `/public-docs`, which landed only
+after `OME-738` (#484) gave that tree a CI lane — a directory should not be listed until something
+can gate what it produces.
+
+## The comment that had to change
+
+The old file excluded `apps/screamingface-studio/frontend` because "it has no CI lane, so a
+dependency bump there would land with nothing to verify it". Sound intent, broken mechanism:
+**security updates ignore the `directory:` allowlist**, which is exactly how #422 existed in that
+very tree. Omitting a directory buys no silence — only the absence of routine version bumps, while
+security PRs arrive anyway, unverified.
+
+## Deferred
+
+Both `screamingface-studio` entries (npm + cargo) pending `OME-739`. If that tree is dormant,
+deleting it closes the repo's last open alert (`glib`) and retires the question.
+
+## Verified
+
+11 entries, **zero ungrouped**; every directory exists and holds a manifest of its declared
+ecosystem; every group declares an explicit `applies-to`. This matters because a malformed
+`dependabot.yml` fails **silently** — it stops producing PRs rather than erroring, which looks
+identical to "nothing to update".
+
+Ledger: `docs/work/2026-08-04-OME-737-dependabot-config.md`

--- a/docs/work/2026-08-04-OME-737-dependabot-config.md
+++ b/docs/work/2026-08-04-OME-737-dependabot-config.md
@@ -155,3 +155,26 @@ anyway, unverified.
 both pending `OME-739`. If that tree is dormant, deleting it closes the repo's last open alert
 (`glib`, medium) and retires the question; adding entries first would build on an unmade decision.
 The config carries a comment saying so, so the gap reads as a decision rather than an oversight.
+
+### Late addition — `ignore` rules for the two known-unmergeable majors
+
+Prompted by the owner asking why #482 and #480 were still open. Investigating them separated two
+cases the `-major` bucket alone does not:
+
+- **#482** (`uvicorn[standard]>=0.52.0`, `testcontainers[postgres]==4.15.0`) is **legitimate**.
+  `OME-735`'s `uv lock --upgrade` moved the lockfile but never touched those two `pyproject.toml`
+  constraints, so this is new work rather than redundancy. CI green — merged, not closed.
+- **#480** re-proposes exactly `eslint ^9→^10` and `typescript ^5→^7`, the two majors held in
+  `OME-736`. It is **permanently unmergeable**, and it appeared within minutes of the holds
+  landing. CI confirms: `test` and `Build the app` both FAILURE.
+
+The `-major` group was designed so a red major can sit harmlessly rather than block security
+patches. That holds for a major which might *one day* go green. It does **not** hold for one that
+can never go green while its blocker exists — that regenerates weekly and is noise, and noise is
+what trains people to stop reading Dependabot PRs.
+
+So the `aigateway-ui` npm block gained `ignore` entries for `typescript >=6` and `eslint >=10`,
+each commented with its blocking ticket. Removing an entry is the trigger to retry the upgrade.
+
+This is a genuine gap in the original design of this unit, surfaced by the owner's question rather
+than by my own review.

--- a/docs/work/2026-08-04-OME-737-dependabot-config.md
+++ b/docs/work/2026-08-04-OME-737-dependabot-config.md
@@ -1,0 +1,157 @@
+---
+ticket: OME-737
+stack: repo
+status: done
+started: 2026-08-04
+finished: 2026-08-04
+---
+
+# OME-737 — regroup dependabot.yml so security updates group and majors split out
+
+## Intent
+
+The structural fix of the `OME-733` epic. Everything before this cleared a backlog; this stops it
+re-forming.
+
+Authored in an isolated worktree branched from `origin/main` at `01c3b4c9`, per the standing
+requirement that concurrent sessions never share a checkout.
+
+## The two faults
+
+**1 — `groups` does not apply to security updates.** `groups` defaults to
+`applies-to: version-updates`. Every security fix therefore arrives ungrouped, one PR per
+package. That is the entire single-package backlog this epic just cleared: #437, #435, #433,
+#431, #430, #455, #422, #460, #432.
+
+**2 — majors ride with patches.** One breaking major holds the security bumps hostage, and the
+reverse: a major can slip in under cover of security patches. Both happened, in the same group:
+
+- `OME-736`: `next`/`react` 19.2.8 security bumps sat behind an ESLint 10 crash and a TypeScript
+  5→7 compiler rewrite, neither related to them.
+- The same PR was *carrying* that TS 5→7 rewrite — a Go-based compiler reimplementation — into a
+  routine dependency bump.
+
+A third, structural fault is **not** fixable here and is recorded so nobody tries: Dependabot
+cannot keep the two `FROM` lines of `apps/url4-cloud/Dockerfile` in step, because
+`ghcr.io/astral-sh/uv` and `python` are different images and no grouping setting pairs them. That
+is `OME-740`, mitigated by an `INVARIANT:` in the Dockerfile plus CI's smoke step.
+
+## Design
+
+Three groups per ecosystem instead of one:
+
+```yaml
+groups:
+  <name>-security:
+    applies-to: security-updates      # the directive whose absence caused fault 1
+    patterns: ["*"]
+  <name>-minor:
+    applies-to: version-updates
+    patterns: ["*"]
+    update-types: ["minor", "patch"]
+  <name>-major:
+    applies-to: version-updates
+    patterns: ["*"]
+    update-types: ["major"]
+```
+
+The point is that a red `-major` PR can sit indefinitely without blocking anything, while
+`-security` and `-minor` continue to flow and merge.
+
+## Planned changes — `.github/dependabot.yml` only
+
+- Three-group shape on all four `uv` blocks, the `aigateway-ui` npm block, and `github-actions`.
+- **Add** `npm` → `/public-docs`. Its CI lane landed in `OME-738` (#484), so this entry now has
+  something to verify what it produces — that ordering was the whole reason `OME-738` came first.
+- **Add** `docker` → `/apps/aigateway`, `/apps/aigateway-ui`, `/apps/scoreboard`. Coverage was
+  1 of 4 Dockerfiles.
+- **Correct the stale comment.** It currently claims `apps/screamingface-studio/frontend` is
+  excluded because it has no CI lane. That reasoning never worked: **security updates bypass the
+  `directory:` allowlist entirely**, which is exactly how #422 came to exist. The comment must say
+  what the exclusion does and does not buy.
+
+## Deliberately NOT in this unit
+
+`npm` → `/apps/screamingface-studio/frontend` and `cargo` → `/apps/screamingface-studio/src-tauri`.
+Both depend on an unanswered owner question — is that tree alive? If it is dormant, deleting it
+closes the repo's last remaining alert (`glib`, medium) and retires `OME-739` outright, making
+both entries pointless. Adding them first would be building on an unmade decision.
+
+## Test plan
+
+No unit test; the config **is** the artifact. Verification is in three parts, and the first two
+matter most because **a malformed `dependabot.yml` fails silently** — it does not error, it simply
+stops producing PRs, which looks identical to "no updates available".
+
+1. **Parse locally** — `yaml.safe_load`, then assert structurally: every `updates[]` entry has an
+   ecosystem and directory; every `groups` entry declares `applies-to`; every declared directory
+   exists on disk. Catches the silent-failure class before it reaches the repo.
+2. **GitHub's own validation** — after push, the repo's Dependabot page must report no config
+   error.
+3. **Behavioural** — trigger "Check for updates" and confirm PRs arrive per `applies-to` bucket
+   rather than one-per-package.
+
+## Acceptance
+
+- Every `groups` entry names an explicit `applies-to`.
+- Every directory named in the config exists on disk.
+- `/public-docs` present; both `screamingface-studio` entries absent, with the reason recorded.
+- Docker coverage 4 of 4.
+- No comment in the file still claims the directory allowlist keeps security updates out.
+
+## Outcome
+
+- **Actual files:** as planned — `.github/dependabot.yml` only, plus this ledger and its
+  `docs/tasks/` mirror.
+
+- **Gates — structural validation, run against the written file:**
+
+  ```
+  entries: 11  |  ungrouped: 0
+  all directories exist on disk, each containing a manifest of its declared ecosystem
+  every group declares an explicit applies-to
+  MANIFEST COVERAGE: 10/12
+    UNCOVERED: apps/screamingface-studio/frontend/package.json   (deferred, OME-739)
+    UNCOVERED: apps/screamingface-studio/src-tauri/Cargo.toml    (deferred, OME-739)
+  ```
+
+  Coverage **6/12 → 10/12**; the only two gaps are the deliberately deferred ones. Docker went
+  **1/4 → 4/4**.
+
+  This validation matters more than usual: a malformed `dependabot.yml` **fails silently**. It
+  does not error — it simply stops producing PRs, which is indistinguishable from "no updates
+  available". Parsing and asserting locally catches that class before it reaches the repo, where
+  it would present as suspicious quiet.
+
+### Deviation — docker entries were grouped too, which the plan had written off
+
+The plan stated the `OME-740` two-stage Dockerfile problem was "not fixable by any setting here".
+That is **half wrong**, and the correction is now in the file.
+
+Grouping the docker ecosystem per directory does not fix the mismatch — each image still resolves
+to its own latest tag, so a group can still produce a builder on 3.13 beside a runtime on 3.14.
+But it changes the failure from **invisible to visible**: #439 was a one-sided bump that *looked*
+complete, whereas a grouped PR shows both `FROM` lines in one diff, and a reviewer can see the two
+minors disagree.
+
+So the docker blocks gained `-security` / `-version` groups. The real guard remains the
+`INVARIANT:` in the Dockerfile plus CI's `Smoke both modes` step, and the comment in the config
+says exactly that rather than overclaiming.
+
+### The comment that had to change
+
+The old file said `apps/screamingface-studio/frontend` was excluded because "it has no CI lane, so
+a dependency bump there would land with nothing to verify it". The intent was sound; the mechanism
+never worked. **Security updates ignore the `directory:` allowlist entirely** — they are driven by
+the dependency graph — which is precisely how #422 (next, in that very tree) came to exist.
+
+The header now states what the allowlist does and does not buy, so nobody again assumes omitting a
+directory buys silence. It buys the opposite: no routine version bumps, while security PRs arrive
+anyway, unverified.
+
+### Still deferred, deliberately
+
+`npm` → `/apps/screamingface-studio/frontend` and `cargo` → `/apps/screamingface-studio/src-tauri`,
+both pending `OME-739`. If that tree is dormant, deleting it closes the repo's last open alert
+(`glib`, medium) and retires the question; adding entries first would build on an unmade decision.
+The config carries a comment saying so, so the gap reads as a decision rather than an oversight.


### PR DESCRIPTION
Closes `OME-737`, a sub-issue of `OME-733`. **The structural fix of the epic** — everything before this cleared a backlog; this stops it re-forming.

## Two faults, both now fixed

**1 — `groups` did not apply to security updates.** It defaults to `applies-to: version-updates`, so every security fix arrived as its own ungrouped PR. That was the *entire* single-package backlog this epic just cleared: #437 #435 #433 #431 #430 #455 #422 #460 #432. Every group now declares `applies-to` explicitly.

**2 — majors rode with patches.** With one group per ecosystem a breaking major holds security bumps hostage — *and equally* a major can slip in under cover of them. Both happened in the same PR: in `OME-736` the `react`/`react-dom` 19.2.8 security bumps sat behind an ESLint 10 crash, while that same PR was quietly carrying a **TypeScript 5 → 7 compiler rewrite**.

Now three groups per ecosystem — `-security`, `-minor` (`minor`+`patch`), `-major` — so a red major PR can sit indefinitely while security and minor keep flowing.

## Coverage: 6/12 → 10/12 manifests, docker 1/4 → 4/4

Adds `npm` → `/public-docs`. That was gated on `OME-738` (#484) giving the tree a CI lane **first** — a directory should not be listed until something can verify what it produces. #460 and #432 merged there with nothing checking them, which is the failure that ordering prevents.

## A comment that was actively misleading

The old file excluded `apps/screamingface-studio/frontend` because "it has no CI lane, so a dependency bump there would land with nothing to verify it."

Sound intent, broken mechanism: **security updates ignore the `directory:` allowlist entirely** — they run off the dependency graph. That is exactly how #422 (`next`, in that very tree) came to exist. Omitting a directory buys no silence; it buys the *opposite* — no routine version bumps, while security PRs arrive anyway, unverified. The header now says so.

## Docker grouping — an honest partial

The docker blocks are grouped too. This does **not** fix the #439 two-stage mismatch (`OME-740`): each image still resolves to its own latest tag, so a group can still pair a builder on 3.13 with a runtime on 3.14. What it changes is visibility — #439 was a one-sided bump that *looked* complete, whereas a grouped PR puts both `FROM` lines in one diff where a reviewer can see the minors disagree. The real guard stays the `INVARIANT:` in the Dockerfile plus CI's `Smoke both modes` step. The config comment says exactly that rather than overclaiming.

## Deferred, deliberately

Both `screamingface-studio` entries (npm + cargo) pending `OME-739` — is that tree alive? If dormant, deleting it closes the repo's **last open alert** (`glib`, medium, in its `Cargo.lock`) and retires the question. Adding entries first would build on an unmade decision. The config carries a comment so the gap reads as a decision, not an oversight.

## Test plan

```
entries: 11  |  ungrouped: 0
all directories exist on disk, each containing a manifest of its declared ecosystem
every group declares an explicit applies-to
MANIFEST COVERAGE: 10/12
  UNCOVERED: apps/screamingface-studio/frontend/package.json   (deferred, OME-739)
  UNCOVERED: apps/screamingface-studio/src-tauri/Cargo.toml    (deferred, OME-739)
```

⚠️ **This check matters more than it looks.** A malformed `dependabot.yml` **fails silently** — it does not error, it just stops producing PRs, which is indistinguishable from "nothing to update". So it is parsed and asserted locally rather than trusted to surface later.

**Reviewer follow-up after merge:** confirm the repo's Dependabot page reports no config error, then trigger "Check for updates" on one ecosystem and confirm PRs arrive per `applies-to` bucket rather than one-per-package.

---

Authored in an isolated git worktree branched from `origin/main` at `01c3b4c9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iy1jFtiDTBpFdk5h6x1Mu