### PR TITLE
feat(url4): add a ModelResponse observation event and its ctx-less sink

### DIFF
--- a/docs/tasks/2026-08-04-ome-744-model-response-event.md
+++ b/docs/tasks/2026-08-04-ome-744-model-response-event.md
@@ -1,0 +1,45 @@
+---
+id: OME-744
+linear_url: https://linear.app/openmined/issue/OME-744/add-a-modelresponse-observation-event-so-a-world-adapter-can-report
+status: in_progress
+type:
+priority: P2
+labels: [url4-python-sdk, autonomous, agentic]
+created: 2026-08-04
+closed:
+---
+
+# OME-744 — a ModelResponse observation event for finish_reason and refusal
+
+Sub-issue of `OME-679` (finish reason and refusal retrieved in the model response).
+
+`url4.observe` is the engine's observation seam: "a passive, pure-data event stream" carrying
+`RunStarted | NodeStarted | NodeFinished | Log | Usage | RunFinished`, plus a contextvar-bound
+`UsageSink` so a world adapter with no `ExecutionContext` of its own can still attribute a fact
+to the currently-resolving node's span.
+
+There is **no equivalent seam for response metadata**. A url4 endpoint's contract is `-> str`,
+so a model call's `finish_reason` and the provider `refusal` field have nowhere to travel and
+are discarded at the adapter — which is exactly where `OME-679` says the signal is lost.
+
+## Why a new event, not a field on `Usage`
+
+`Usage` is token accounting, and url4-cloud's executor derives `CostUsageData` from the span's
+usage tuple. Widening that tuple would push a non-cost fact into cost accounting and change what
+every existing cost consumer sees. `ObservationEvent` is a union and the module docstring frames
+the event set as the extension point, so a new member is the sanctioned move.
+
+## Scope
+
+- `src/url4/observe.py` — `ModelResponse(span_id, finish_reason, refusal)`; union + `__all__`;
+  `ResponseSink` + `_response_sink` contextvar + `current_response_sink()`.
+- `src/url4/dag/node.py` — `ExecutionContext.report_response(*, finish_reason, refusal)`.
+- `src/url4/dag/executor.py` — bind `_response_sink` in the same `try/finally` as `_usage_sink`.
+- `src/url4/streaming/protocol/signals.py` — `SpanData` gains `finish_reasons` aliased to
+  `gen_ai.response.finish_reasons` (OTel semconv) and `refusal`.
+
+## Out of scope
+
+Consuming the event — `OME-745` (`apps/url4-cloud`).
+
+Ledger: `docs/work/2026-08-04-OME-744-model-response-event.md`

--- a/docs/work/2026-08-04-OME-744-model-response-event.md
+++ b/docs/work/2026-08-04-OME-744-model-response-event.md
@@ -91,6 +91,8 @@ Failing tests first:
   | `packages/url4/uv.lock` | **no** | see Deviations |
   | `packages/url4/tests/unit/test_observe.py` | planned, **not needed** | the new file covers the event shape; nothing to append without duplicating it |
 
+- **Commits:** `604e070d` — feat(url4): add a ModelResponse observation event and its ctx-less
+  sink (this ledger line follows in a second commit so the recorded sha is the real one).
 - **Gates:** `run_gates.py url4` — **ALL GATES GREEN**. append-only check ✓ · ruff check ✓ ·
   ruff format --check ✓ · pyright ✓ (no `# type: ignore` added) · pytest `--cov=url4
   --cov-fail-under=95` ✓ — **1100 passed**, coverage **97%**, every new line covered

--- a/docs/work/2026-08-04-OME-744-model-response-event.md
+++ b/docs/work/2026-08-04-OME-744-model-response-event.md
@@ -1,0 +1,124 @@
+---
+ticket: OME-744
+stack: url4
+status: in_progress
+started: 2026-08-04
+finished:
+---
+
+# OME-744 — a ModelResponse observation event for finish_reason and refusal
+
+## Intent
+
+Sub-issue of `OME-679`. A researcher running HealthBench must be able to tell a provider
+**refusal** from a **bad answer**, or a safety-refusing model is scored as if it answered badly.
+The concrete ask is to capture `finish_reason` per model call.
+
+`url4.observe` is the engine's observation seam — a passive, pure-data event stream of
+`RunStarted | NodeStarted | NodeFinished | Log | Usage | RunFinished`, plus a contextvar-bound
+`UsageSink` that lets a world adapter with no `ExecutionContext` of its own attribute a fact to
+the currently-resolving node's span. There is **no equivalent seam for response metadata**: a
+url4 endpoint's contract is `-> str`, so a call's `finish_reason` and the provider `refusal`
+field have nowhere to travel and are dropped at the adapter. This unit adds that seam. It does
+not consume it — that is `OME-745` (`apps/url4-cloud`).
+
+**Why a new event rather than fields on `Usage`:** `Usage` is token accounting, and url4-cloud's
+executor derives `CostUsageData` from the span's usage tuple. Widening that tuple would push a
+non-cost fact into cost accounting and change what every existing cost consumer sees.
+`ObservationEvent` is a union and the module docstring frames the event set as the extension
+point, so a new member is the sanctioned move.
+
+## Planned changes
+
+- `src/url4/observe.py` — `ModelResponse(span_id, finish_reason, refusal)` frozen/slots
+  dataclass; add to the `ObservationEvent` union and `__all__`; `ResponseSink` type,
+  `_response_sink` contextvar, `current_response_sink()` — mirroring `_usage_sink` /
+  `current_usage_sink()`.
+- `src/url4/dag/node.py` — `ExecutionContext.report_response(*, finish_reason, refusal)` beside
+  `report_usage` (`:356-364`), same `if self._obs is not None: self._obs.emit(...)` shape.
+- `src/url4/dag/executor.py` — bind `_response_sink.set(node_ctx.report_response)` in the same
+  `try/finally` that already binds `_usage_sink` (`:197`, `:215`).
+- `tests/unit/test_response_sink.py` — new, mirroring `tests/unit/test_usage_sink.py`.
+- `tests/unit/test_observe.py` — append event-shape cases (append-only; no prior test touched).
+
+No schema/model change, so S1 (migrations) does not apply.
+
+### Scope moved out during DESIGN
+
+`src/url4/streaming/protocol/signals.py` (`SpanData` gaining `gen_ai.response.finish_reasons`)
+was planned here and **moved to `OME-745`**. `pyproject.toml` omits `src/url4/streaming/*` from
+this package's coverage on purpose — streaming's tests "live with its only consumers, in
+`apps/url4-cloud/tests` — that suite gates it via `--cov=url4.streaming`". A `SpanData` field
+changed here could not be driven by a failing test in this stack, so keeping it would split a
+change from its test across two PRs (TDD rule 4). It travels with its test into the url4-cloud
+unit instead. Both issue descriptions updated.
+
+## Test plan
+
+Failing tests first:
+
+- **Happy path** — a world handler reached from inside `resolve` calls
+  `current_response_sink()(finish_reason="stop", refusal=None)` and a `ModelResponse` event
+  lands on the observer, attributed to that node's span id.
+- **Invariant — no cross-talk.** Two sibling nodes resolving concurrently each see their own
+  binding; neither observes the other's sink. This is the property the contextvar-per-Task
+  design exists to protect, and the reason it is bound around `resolve` only.
+- **Boundary — outside a resolve** `current_response_sink()` is `None` (no observer attached,
+  or called outside a node), and the adapter's null-safe path is exercised.
+- **Boundary — binding does not leak** past a node's resolve, on both the success and the
+  exception path (the `finally` reset).
+- **Error path** — an observer that raises propagates, matching the documented contract that an
+  embedder bug is loud rather than swallowed.
+
+## Acceptance
+
+- `ModelResponse` is emitted through the same span-attribution path as `Usage`.
+- `current_response_sink()` is bound per `asyncio.Task` and reset in `finally`.
+- No prior test modified.
+- Gates green: `uv run .claude/scripts/run_gates.py url4` — ruff · ruff format --check ·
+  pyright · `pytest --cov=url4 --cov-fail-under=95`.
+
+## Outcome
+
+- **Actual files:**
+
+  | File | Planned? | What |
+  |---|---|---|
+  | `packages/url4/src/url4/observe.py` | yes | `ModelResponse`, union, `__all__`, `ResponseSink`, `_response_sink`, `current_response_sink()`, `_bind_node_sinks()` |
+  | `packages/url4/src/url4/dag/node.py` | yes | `ExecutionContext.report_response()` |
+  | `packages/url4/src/url4/dag/executor.py` | yes | binds both sinks via `_bind_node_sinks` |
+  | `packages/url4/tests/unit/test_response_sink.py` | yes | 9 new tests |
+  | `packages/url4/uv.lock` | **no** | see Deviations |
+  | `packages/url4/tests/unit/test_observe.py` | planned, **not needed** | the new file covers the event shape; nothing to append without duplicating it |
+
+- **Gates:** `run_gates.py url4` — **ALL GATES GREEN**. append-only check ✓ · ruff check ✓ ·
+  ruff format --check ✓ · pyright ✓ (no `# type: ignore` added) · pytest `--cov=url4
+  --cov-fail-under=95` ✓ — **1100 passed**, coverage **97%**, every new line covered
+  (`observe.py` 98%, `dag/executor.py` 98%, `dag/node.py` 93% — all misses pre-existing).
+- **Sibling stack verified:** widening `ObservationEvent` touches a public union that
+  `apps/url4-cloud` consumes, so its suite was run too — **478 passed, 5 skipped**. Safe because
+  no consumer matches the union exhaustively (`_Bridge.map` is an `isinstance` chain documented
+  as "Any other event type produces nothing"); a `assert_never` grep across both packages is
+  clean.
+
+- **Deviations:**
+  1. **`signals.py` moved to `OME-745`** (see "Scope moved out during DESIGN" above) — the
+     `SpanData` field could not be TDD'd in this stack, so it travels with its test.
+  2. **`_bind_node_sinks` landed in `observe.py`, not `executor.py`.** First written inline in
+     `_eval`, which tripped the `too-many-statements` gate (27 > 26). Rather than weaken the
+     gate, the binding was extracted — and then moved out of `executor.py` entirely, because the
+     ContextVars are `observe.py`'s private state and the executor should not reach into them to
+     scope a binding it does not own. It takes the two bound methods rather than an
+     `ExecutionContext`, keeping `observe.py` the dependency-free leaf its docstring promises.
+     Net effect: `executor.py` **shrank** 496 → 492 lines and no longer imports either private
+     ContextVar.
+  3. **`uv.lock` carries an unrelated one-line correction.** `pyproject.toml:107` pins
+     `graphviz>=0.21` but the committed lock recorded `>=0.20` — the lock was stale on `main` and
+     `uv run` regenerated the line deterministically. Kept rather than reverted: CI runs plain
+     `uv sync` (not `--frozen`), so the drift was silent rather than failing, and reverting only
+     means it returns on the next `uv run`.
+  4. **Card gap surfaced (not fixed here):** `.claude/sdlc.local.md` has body sections for
+     `aigateway`, `aigateway-ui` and `scoreboard`, but **none for `url4` or `url4-cloud`**, so
+     the skill's "read the card BODY for the active stack" step had nothing to bind. Gate
+     coverage itself is complete (format · lint · typecheck · test · coverage). Worth a
+     card-repair item alongside `OME-743`.

--- a/packages/url4/src/url4/dag/executor.py
+++ b/packages/url4/src/url4/dag/executor.py
@@ -30,7 +30,14 @@ from url4.core.context import Context
 from url4.core.errors import CycleError
 from url4.core.nodes import Node as AstNode
 from url4.io.layer import IOLayer
-from url4.observe import NodeFinished, NodeStarted, Observer, RunFinished, RunStarted, _usage_sink
+from url4.observe import (
+    NodeFinished,
+    NodeStarted,
+    Observer,
+    RunFinished,
+    RunStarted,
+    _bind_node_sinks,
+)
 
 from url4.dag.compiler import Graph, LoweringRegistry, compile_expression  # isort: skip
 from url4.dag.node import (  # isort: skip
@@ -185,34 +192,23 @@ class Executor:
             # re-attributing its code/permanent here would double-count it.
             obs.emit(NodeFinished(span_id, "cancelled", obs.next_seq()))
             raise
-        # Bind the usage-sink ContextVar to THIS node's span for the duration
-        # of its own `resolve` only — a world handler reached from inside
-        # `resolve` (e.g. an aigateway connector with no ExecutionContext of
-        # its own) can call `url4.observe.current_usage_sink()` and land a
-        # Usage event attributed to this span. ContextVar values are copied
-        # into each asyncio.Task's context at creation (`_run` -> `create_task`),
-        # so concurrent sibling nodes each see their own binding, never a
-        # sibling's — no cross-talk. Reset in `finally` so the binding never
-        # leaks past this node's resolve, success or failure.
-        _token = _usage_sink.set(node_ctx.report_usage)
-        try:
-            result = await node.resolve(dict(zip(roles, values, strict=True)), node_ctx)
-        except BaseException as exc:
-            status = "cancelled" if isinstance(exc, asyncio.CancelledError) else "error"
-            code = getattr(exc, "code", None)
-            permanent = getattr(exc, "permanent", None)
-            obs.emit(
-                NodeFinished(
-                    span_id,
-                    status,
-                    obs.next_seq(),
-                    code if isinstance(code, str) else None,
-                    permanent if isinstance(permanent, bool) else None,
+        with _bind_node_sinks(node_ctx.report_usage, node_ctx.report_response):
+            try:
+                result = await node.resolve(dict(zip(roles, values, strict=True)), node_ctx)
+            except BaseException as exc:
+                status = "cancelled" if isinstance(exc, asyncio.CancelledError) else "error"
+                code = getattr(exc, "code", None)
+                permanent = getattr(exc, "permanent", None)
+                obs.emit(
+                    NodeFinished(
+                        span_id,
+                        status,
+                        obs.next_seq(),
+                        code if isinstance(code, str) else None,
+                        permanent if isinstance(permanent, bool) else None,
+                    )
                 )
-            )
-            raise
-        finally:
-            _usage_sink.reset(_token)
+                raise
         obs.emit(NodeFinished(span_id, "ok", obs.next_seq()))
         return result
 

--- a/packages/url4/src/url4/dag/node.py
+++ b/packages/url4/src/url4/dag/node.py
@@ -47,7 +47,7 @@ from url4.io.layer import (
     SupportsHoldings,
     SupportsProcessorRoutes,
 )
-from url4.observe import Log, ObservationEvent, Observer, Usage
+from url4.observe import Log, ModelResponse, ObservationEvent, Observer, Usage
 
 
 @dataclass(frozen=True)
@@ -362,6 +362,18 @@ class ExecutionContext:
             self._obs.emit(
                 Usage(self._current_span_id, provider, model, input_tokens, output_tokens)
             )
+
+    def report_response(self, *, finish_reason: str | None, refusal: str | None) -> None:
+        """Report how one model round trip ended, under this node's current
+        span. A no-op when no ``observer`` was passed to
+        :func:`~url4.dag.executor.run`.
+
+        INVARIANT: emits one event per call — a node making several round trips
+        (a tool-calling turn) produces several events on the same span, never a
+        single collapsed one.
+        """
+        if self._obs is not None:
+            self._obs.emit(ModelResponse(self._current_span_id, finish_reason, refusal))
 
     def log(self, severity: str, body: str) -> None:
         """Emit a log line attributed to this node's current span. A no-op

--- a/packages/url4/src/url4/observe.py
+++ b/packages/url4/src/url4/observe.py
@@ -18,8 +18,9 @@ any other node failure.
 
 from __future__ import annotations
 
+import contextlib
 import contextvars
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from typing import Literal, Protocol, runtime_checkable
 
@@ -71,6 +72,27 @@ class Usage:
 
 
 @dataclass(frozen=True, slots=True)
+class ModelResponse:
+    """Emitted once per model round trip, carrying HOW that call ended.
+
+    Deliberately separate from :class:`Usage` rather than fields on it: `Usage`
+    is token accounting, and embedders derive cost frames from it, so a finish
+    reason there would put a non-cost fact into cost accounting. A node may emit
+    several of these — a tool-calling turn is several round trips against one
+    span — so consumers keep the sequence rather than overwriting.
+
+    ``finish_reason`` is the provider's own value, normalized upstream to the
+    OpenAI vocabulary (``stop`` | ``length`` | ``content_filter`` |
+    ``tool_calls``); ``refusal`` is the provider's refusal text when it sends
+    one. Both are optional because not every provider reports either.
+    """
+
+    span_id: str | None
+    finish_reason: str | None
+    refusal: str | None
+
+
+@dataclass(frozen=True, slots=True)
 class RunFinished:
     """Emitted once, after the top-level run settles (success or failure)."""
 
@@ -78,7 +100,9 @@ class RunFinished:
     engine_seq: int
 
 
-ObservationEvent = RunStarted | NodeStarted | NodeFinished | Log | Usage | RunFinished
+ObservationEvent = (
+    RunStarted | NodeStarted | NodeFinished | Log | Usage | ModelResponse | RunFinished
+)
 
 
 @runtime_checkable
@@ -121,16 +145,67 @@ def current_usage_sink() -> UsageSink | None:
     return _usage_sink.get()
 
 
+ResponseSink = Callable[..., None]  # matches ExecutionContext.report_response's kwargs:
+# (*, finish_reason: str | None, refusal: str | None) -> None
+
+_response_sink: contextvars.ContextVar[ResponseSink | None] = contextvars.ContextVar(
+    "url4_response_sink", default=None
+)
+
+
+def current_response_sink() -> ResponseSink | None:
+    """The response sink bound to the currently-resolving node's span, or
+    ``None`` when no observer is attached / outside a node resolve.
+
+    The :class:`ModelResponse` counterpart of :func:`current_usage_sink`, bound
+    by the same executor hook with the same per-:class:`asyncio.Task` scoping.
+    WHY a second sink rather than widening the usage one: a world adapter learns
+    a call's finish reason even when the provider reports no usage at all, and
+    the two facts have different lifetimes on the wire.
+    """
+    return _response_sink.get()
+
+
+@contextlib.contextmanager
+def _bind_node_sinks(usage: UsageSink, response: ResponseSink) -> Iterator[None]:
+    """Bind both ctx-less sinks to the currently-resolving node, for the duration
+    of its own ``resolve`` only.
+
+    Lives here rather than in the executor because the ContextVars are this
+    module's private state — the executor should not have to reach into them to
+    scope a binding it does not own. Takes the two bound methods rather than an
+    ``ExecutionContext`` so this module stays the dependency-free leaf its
+    docstring promises (``url4.dag.node`` imports *this*, never the reverse).
+
+    INVARIANT: no cross-talk between concurrent siblings. ContextVar values are
+    copied into each :class:`asyncio.Task`'s context at creation, so every
+    sibling node sees its own binding, never another's.
+
+    INVARIANT: neither binding outlives the node's resolve — both are reset on
+    the success path and the failure path alike.
+    """
+    usage_token = _usage_sink.set(usage)
+    response_token = _response_sink.set(response)
+    try:
+        yield
+    finally:
+        _usage_sink.reset(usage_token)
+        _response_sink.reset(response_token)
+
+
 __all__ = [
     "Log",
+    "ModelResponse",
     "NodeFinished",
     "NodeStarted",
     "NullObserver",
     "ObservationEvent",
     "Observer",
+    "ResponseSink",
     "RunFinished",
     "RunStarted",
     "Usage",
     "UsageSink",
+    "current_response_sink",
     "current_usage_sink",
 ]

--- a/packages/url4/tests/unit/test_response_sink.py
+++ b/packages/url4/tests/unit/test_response_sink.py
@@ -1,0 +1,280 @@
+"""The response-sink seam: ``url4.observe.current_response_sink()`` lets a
+ctx-less world handler (e.g. the aigateway connector in ``apps/url4-cloud``)
+report a model call's ``finish_reason`` and provider ``refusal`` tied to the
+current node's span, without holding an
+:class:`~url4.dag.node.ExecutionContext`.
+
+FEATURE: a provider refusal must be distinguishable from a bad answer, so a
+safety-refusing model is not scored as if it answered badly (OME-679).
+STORY: as a researcher running HealthBench, I can audit exactly why each model
+call ended — ``stop`` vs ``length`` vs ``content_filter``.
+
+Every test drives the real :func:`~url4.dag.run` against a
+:class:`~url4.io.static.StaticIOLayer` world with hand-built nodes — no mocking
+of the executor itself, so these exercise the actual scheduling path. Mirrors
+``test_usage_sink.py``, whose seam this one is modelled on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from url4.dag import run
+from url4.io.static import StaticIOLayer
+from url4.observe import (
+    ModelResponse,
+    NodeStarted,
+    ObservationEvent,
+    current_response_sink,
+)
+
+
+class RecordingObserver:
+    """Collects every emitted event, in emission order."""
+
+    def __init__(self) -> None:
+        self.events: list[ObservationEvent] = []
+
+    def on_event(self, event: ObservationEvent) -> None:
+        self.events.append(event)
+
+
+class _RaisingObserver:
+    """Raises on the first event — an embedder bug should be loud, not swallowed."""
+
+    def __init__(self) -> None:
+        self.error = RuntimeError("observer exploded")
+
+    def on_event(self, event: ObservationEvent) -> None:
+        raise self.error
+
+
+class _SinkReportingNode:
+    """A hand-built node reporting a finish reason through
+    ``current_response_sink()`` rather than ``ctx.report_response`` — the
+    ctx-less path a world adapter uses.
+
+    ``seen_sink`` stashes whatever the lookup returned during ``resolve`` (a
+    sentinel separates "not yet resolved" from "resolved and saw None"), so
+    tests can assert on the ctx-less lookup itself, not only its side effect.
+    """
+
+    deps: dict = {}
+
+    _UNRESOLVED = object()
+
+    def __init__(
+        self,
+        *,
+        finish_reason: str | None = "stop",
+        refusal: str | None = None,
+        delay: float = 0.0,
+    ) -> None:
+        self.finish_reason = finish_reason
+        self.refusal = refusal
+        self.delay = delay
+        self.seen_sink: object = self._UNRESOLVED
+
+    async def resolve(self, inputs, ctx):
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        sink = current_response_sink()
+        self.seen_sink = sink
+        if sink is not None:
+            sink(finish_reason=self.finish_reason, refusal=self.refusal)
+        return "ok"
+
+
+class _CtxReportingNode:
+    """Reports through ``ctx.report_response`` directly — the path an in-tree
+    node uses, proving the context method and the sink land the same event."""
+
+    deps: dict = {}
+
+    async def resolve(self, inputs, ctx):
+        ctx.report_response(finish_reason="length", refusal=None)
+        return "ok"
+
+
+class _FailingAfterReportNode:
+    """Reports, then raises — exercises the binding's reset on the error path."""
+
+    deps: dict = {}
+
+    async def resolve(self, inputs, ctx):
+        sink = current_response_sink()
+        assert sink is not None
+        sink(finish_reason="content_filter", refusal="I can't help with that")
+        raise RuntimeError("node exploded")
+
+
+class _MultiReportNode:
+    """Reports twice in one resolve — the web-tool loop's normal shape, where a
+    single node makes several model round trips."""
+
+    deps: dict = {}
+
+    async def resolve(self, inputs, ctx):
+        sink = current_response_sink()
+        assert sink is not None
+        sink(finish_reason="tool_calls", refusal=None)
+        sink(finish_reason="stop", refusal=None)
+        return "ok"
+
+
+class _JoinNode:
+    """A fan-out root joining two labeled deps, reporting nothing of its own."""
+
+    def __init__(self, deps: dict) -> None:
+        self.deps = deps
+
+    async def resolve(self, inputs, ctx):
+        return "joined"
+
+
+@pytest.mark.asyncio
+async def test_sink_reaches_a_ctx_less_caller() -> None:
+    # Behavior 1: current_response_sink() inside resolve -> a ModelResponse
+    # event carrying that node's span_id.
+    io = StaticIOLayer()
+    rec = RecordingObserver()
+    node = _SinkReportingNode(finish_reason="stop", refusal=None)
+    result = await run(node, io, observer=rec)
+    assert result == "ok"
+
+    responses = [e for e in rec.events if isinstance(e, ModelResponse)]
+    assert len(responses) == 1
+    response = responses[0]
+    assert response.finish_reason == "stop"
+    assert response.refusal is None
+
+    node_starts = [e for e in rec.events if isinstance(e, NodeStarted)]
+    assert len(node_starts) == 1
+    assert response.span_id == node_starts[0].span_id
+
+
+@pytest.mark.asyncio
+async def test_refusal_is_carried_verbatim() -> None:
+    # Behavior 2: a content_filter turn carries BOTH the finish reason and the
+    # provider's refusal text — the pair OME-679 needs to tell a refusal from a
+    # bad answer.
+    io = StaticIOLayer()
+    rec = RecordingObserver()
+    node = _SinkReportingNode(finish_reason="content_filter", refusal="I can't help with that")
+    await run(node, io, observer=rec)
+
+    (response,) = [e for e in rec.events if isinstance(e, ModelResponse)]
+    assert response.finish_reason == "content_filter"
+    assert response.refusal == "I can't help with that"
+
+
+@pytest.mark.asyncio
+async def test_ctx_report_response_emits_the_same_event() -> None:
+    # Behavior 3: ctx.report_response() during resolve -> a ModelResponse event
+    # carrying that node's span_id, identical in shape to the sink path.
+    io = StaticIOLayer()
+    rec = RecordingObserver()
+    result = await run(_CtxReportingNode(), io, observer=rec)
+    assert result == "ok"
+
+    (response,) = [e for e in rec.events if isinstance(e, ModelResponse)]
+    assert response.finish_reason == "length"
+
+    (node_start,) = [e for e in rec.events if isinstance(e, NodeStarted)]
+    assert response.span_id == node_start.span_id
+
+
+@pytest.mark.asyncio
+async def test_no_observer_means_sink_is_none() -> None:
+    # Behavior 4: no observer -> current_response_sink() is None inside resolve,
+    # and the run still succeeds (the zero-cost null path a world adapter relies
+    # on to stay observer-agnostic).
+    io = StaticIOLayer()
+    node = _SinkReportingNode()
+    result = await run(node, io)
+    assert result == "ok"
+    assert node.seen_sink is None
+
+
+@pytest.mark.asyncio
+async def test_several_reports_from_one_node_all_land_on_its_span() -> None:
+    # Behavior 5: one node, several model round trips -> one event each, in
+    # order, all attributed to the same span. INVARIANT: the seam never collapses
+    # a turn's calls into one; a tool loop's intermediate `tool_calls` and its
+    # final `stop` are both auditable.
+    io = StaticIOLayer()
+    rec = RecordingObserver()
+    await run(_MultiReportNode(), io, observer=rec)
+
+    responses = [e for e in rec.events if isinstance(e, ModelResponse)]
+    assert [r.finish_reason for r in responses] == ["tool_calls", "stop"]
+
+    (node_start,) = [e for e in rec.events if isinstance(e, NodeStarted)]
+    assert {r.span_id for r in responses} == {node_start.span_id}
+
+
+@pytest.mark.asyncio
+async def test_per_task_isolation_across_concurrent_nodes() -> None:
+    # Behavior 6: two sibling nodes reporting concurrently -> each ModelResponse
+    # carries ITS OWN node's span_id, no cross-talk.
+    # INVARIANT: this is the property the ContextVar-per-asyncio.Task binding
+    # exists to protect, and the reason it is bound around `resolve` only.
+    io = StaticIOLayer()
+    rec = RecordingObserver()
+    node_a = _SinkReportingNode(finish_reason="length", delay=0.02)
+    node_b = _SinkReportingNode(finish_reason="content_filter", refusal="nope", delay=0.0)
+    root = _JoinNode({"a": node_a, "b": node_b})
+    result = await run(root, io, observer=rec)
+    assert result == "joined"
+
+    assert node_a.seen_sink is not None
+    assert node_b.seen_sink is not None
+
+    node_starts = [e for e in rec.events if isinstance(e, NodeStarted)]
+    sink_starts = [e for e in node_starts if e.node_kind == "_SinkReportingNode"]
+    assert len(sink_starts) == 2
+
+    responses = [e for e in rec.events if isinstance(e, ModelResponse)]
+    assert len(responses) == 2
+    span_by_reason = {r.finish_reason: r.span_id for r in responses}
+    assert set(span_by_reason) == {"length", "content_filter"}
+    assert span_by_reason["length"] != span_by_reason["content_filter"]
+    assert set(span_by_reason.values()) == {e.span_id for e in sink_starts}
+
+
+@pytest.mark.asyncio
+async def test_sink_is_reset_after_resolve() -> None:
+    # Behavior 7: after a run completes, current_response_sink() at top level is
+    # None again — the ContextVar was reset, not leaked.
+    io = StaticIOLayer()
+    rec = RecordingObserver()
+    assert current_response_sink() is None
+    await run(_SinkReportingNode(), io, observer=rec)
+    assert current_response_sink() is None
+
+
+@pytest.mark.asyncio
+async def test_sink_is_reset_when_the_node_raises() -> None:
+    # Behavior 8: the binding is reset on the FAILURE path too — a node that
+    # reports and then raises must not leak its sink past its own resolve.
+    io = StaticIOLayer()
+    rec = RecordingObserver()
+    with pytest.raises(RuntimeError, match="node exploded"):
+        await run(_FailingAfterReportNode(), io, observer=rec)
+    assert current_response_sink() is None
+
+    (response,) = [e for e in rec.events if isinstance(e, ModelResponse)]
+    assert response.finish_reason == "content_filter"
+
+
+@pytest.mark.asyncio
+async def test_observer_that_raises_fails_the_run_with_that_exception() -> None:
+    # Behavior 9: an observer raising on a ModelResponse propagates out of the
+    # run — the documented contract that an embedder bug is loud, not swallowed.
+    io = StaticIOLayer()
+    observer = _RaisingObserver()
+    with pytest.raises(RuntimeError) as exc_info:
+        await run(_SinkReportingNode(), io, observer=observer)
+    assert exc_info.value is observer.error

--- a/packages/url4/uv.lock
+++ b/packages/url4/uv.lock
@@ -461,7 +461,7 @@ dev = [
     { name = "ruff", specifier = ">=0.15.13" },
     { name = "url4", extras = ["streaming"] },
 ]
-notebook = [{ name = "graphviz", specifier = ">=0.20" }]
+notebook = [{ name = "graphviz", specifier = ">=0.21" }]
 
 [[package]]
 name = "uvicorn"


### PR DESCRIPTION
Closes OME-744 · sub-issue of OME-679 · unblocks OME-745

## Why

`url4.observe` had no seam for **response metadata**. A url4 endpoint's contract is `-> str`, so a model call's `finish_reason` and the provider `refusal` field had nowhere to travel and were dropped at the world adapter — exactly where OME-679 loses the signal a researcher needs to tell a **provider refusal** from a **bad answer**. (Fable 5 refuses many medical questions; with HealthBench as the entry benchmark, a safety-refusing model is currently scored as if it answered badly.)

This adds the seam only. Consuming it is OME-745 (`apps/url4-cloud`).

## What

- `ModelResponse(span_id, finish_reason, refusal)` joins the `ObservationEvent` union.
- `ExecutionContext.report_response()` + `current_response_sink()` — the ctx-less lookup a world adapter uses, mirroring the existing `Usage` / `current_usage_sink()` pair.
- Both sinks are bound by one `_bind_node_sinks` context manager.

**Why not just a field on `Usage`:** `Usage` is token accounting, and embedders derive cost frames from the span's usage tuple — a finish reason there would push a non-cost fact into cost accounting. `ObservationEvent` is a union whose module docstring frames the event set as the extension point, so a new member is the sanctioned move.

**Where the helper lives:** written inline in `_eval` first, which tripped the `too-many-statements` gate (27 > 26). Rather than weaken the gate it was extracted — and then moved out of `executor.py` entirely, because the ContextVars are `observe.py`'s private state and the executor should not reach into them to scope a binding it does not own. It takes the two bound methods rather than an `ExecutionContext`, so `observe.py` stays the dependency-free leaf its docstring promises. Net: `executor.py` **shrank** 496 → 492 lines and no longer imports either private ContextVar.

## Test plan

`uv run .claude/scripts/run_gates.py url4` — **ALL GATES GREEN**: append-only check · ruff · ruff format --check · pyright (no `# type: ignore` added) · `pytest --cov=url4 --cov-fail-under=95`. **1100 passed**, coverage **97%**; every new line covered.

9 new tests in `packages/url4/tests/unit/test_response_sink.py`, no prior test touched:

- ctx-less sink → a `ModelResponse` on that node's span; `ctx.report_response` lands the same event
- a `content_filter` turn carries both the reason and the refusal text
- **no cross-talk** between concurrent siblings (the property the ContextVar-per-Task binding exists to protect)
- several reports from one node stay a sequence — a tool loop's `tool_calls` then `stop` are both auditable
- binding reset on **both** the success and the exception path; no observer → sink is `None`
- an observer that raises propagates (embedder bugs stay loud)

**Sibling stack verified:** this widens a public union that `apps/url4-cloud` consumes, so its suite was run too — **478 passed, 5 skipped**. Safe because no consumer matches the union exhaustively (`_Bridge.map` is an `isinstance` chain documented as "Any other event type produces nothing"); an `assert_never` grep across both packages is clean.

## Note for the reviewer

`packages/url4/uv.lock` carries one unrelated line: `pyproject.toml:107` pins `graphviz>=0.21` but the committed lock recorded `>=0.20` — the lock was stale on `main` and `uv run` regenerated it deterministically. Kept rather than reverted, since CI runs plain `uv sync` (not `--frozen`) so the drift was silent, and reverting only means it returns on the next `uv run`.

Ledger: `docs/work/2026-08-04-OME-744-model-response-event.md`