### PR TITLE
fix(aigateway): derive the Codex finish_reason instead of fabricating "stop"

### DIFF
--- a/apps/aigateway/src/aigateway/plugins/codex_provider/chat_handler.py
+++ b/apps/aigateway/src/aigateway/plugins/codex_provider/chat_handler.py
@@ -145,6 +145,28 @@ def _usage_from_response(response: dict[str, Any]) -> dict[str, int] | None:
     }
 
 
+_TERMINAL_EVENTS = frozenset({"response.completed", "response.incomplete"})
+
+# WHY: the Responses API reports truncation/filtering as `incomplete_details.reason`, whose
+# vocabulary (`max_output_tokens` | `content_filter`, per the OpenAI SDK's `IncompleteDetails`)
+# is not the OpenAI chat-completions `finish_reason` vocabulary the gateway speaks. Anything
+# unrecognized degrades to "stop" rather than leaking upstream's wording into a closed field.
+_INCOMPLETE_REASONS = {"max_output_tokens": "length", "content_filter": "content_filter"}
+
+
+def _finish_reason(response: dict[str, Any]) -> str:
+    """The chat-completions `finish_reason` for one Responses-API `Response`.
+
+    FEATURE: OME-679 — a provider refusal must be distinguishable from a bad answer, which is
+    only possible if this value is derived rather than fabricated.
+    """
+    details = response.get("incomplete_details")
+    reason = details.get("reason") if isinstance(details, dict) else None
+    if not isinstance(reason, str):
+        return "stop"
+    return _INCOMPLETE_REASONS.get(reason, "stop")
+
+
 def _consume_sse_event(data: str, state: dict[str, Any]) -> bool:
     try:
         event = json.loads(data)
@@ -161,8 +183,12 @@ def _consume_sse_event(data: str, state: dict[str, Any]) -> bool:
             state.setdefault("text_deltas", []).append(delta)
     if event_type == "response.output_item.done" and isinstance(event.get("item"), dict):
         state.setdefault("output_items", []).append(event["item"])
-    if event_type == "response.completed" and isinstance(event.get("response"), dict):
-        state["completed"] = event["response"]
+    # INVARIANT: BOTH terminal events end the stream. `response.incomplete` is how the
+    # Responses API delivers a length-truncated or content-filtered generation — treating
+    # only `response.completed` as terminal drained the stream and then raised a 502,
+    # discarding a partial answer the caller could have used (OME-746).
+    if event_type in _TERMINAL_EVENTS and isinstance(event.get("response"), dict):
+        state["final"] = event["response"]
         return True
     return False
 
@@ -186,12 +212,12 @@ async def _model_response_from_sse_stream(
 
 
 def _model_response_from_state(state: dict[str, Any], fallback_model: str) -> ModelResponse:
-    completed = state.get("completed")
+    final = state.get("final")
     error = state.get("error")
     if error is not None:
         message = error.get("message") if isinstance(error, dict) else str(error)
         raise CustomLLMError(status_code=502, message=message or "Codex upstream failed")
-    if not isinstance(completed, dict):
+    if not isinstance(final, dict):
         raise CustomLLMError(status_code=502, message="Codex upstream did not complete response")
 
     text_deltas = state.get("text_deltas")
@@ -204,19 +230,19 @@ def _model_response_from_state(state: dict[str, Any], fallback_model: str) -> Mo
         if isinstance(output_items, list):
             content = _extract_text_from_response({"output": output_items})
     if not content:
-        content = _extract_text_from_response(completed)
+        content = _extract_text_from_response(final)
     return ModelResponse(
-        id=completed.get("id"),
-        created=int(completed.get("created_at") or time.time()),
-        model=completed.get("model") or fallback_model,
+        id=final.get("id"),
+        created=int(final.get("created_at") or time.time()),
+        model=final.get("model") or fallback_model,
         choices=[
             {
                 "index": 0,
-                "finish_reason": "stop",
+                "finish_reason": _finish_reason(final),
                 "message": {"role": "assistant", "content": content},
             }
         ],
-        usage=_usage_from_response(completed),
+        usage=_usage_from_response(final),
     )
 
 

--- a/apps/aigateway/tests/unit/codex/test_finish_reason.py
+++ b/apps/aigateway/tests/unit/codex/test_finish_reason.py
@@ -1,0 +1,136 @@
+"""How a Codex response's `finish_reason` is derived.
+
+FEATURE: OME-679 — a provider refusal must be distinguishable from a bad answer, so a
+safety-refusing model is not scored as if it answered badly. That only works if this value is
+DERIVED from the upstream response; the plugin used to hardcode `"stop"` on every reply.
+
+A separate module from `test_chat_handler.py` rather than an append to it: the repo's
+append-only gate compares file status, so growing an existing test file reads as "a prior test
+was modified" even when the diff is purely additive (the line-level fix is in flight as
+OME-369). A new file keeps the guarantee unambiguous.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from litellm.llms.custom_llm import CustomLLMError
+
+from aigateway.plugins.codex_provider.chat_handler import _model_response_from_sse
+
+
+def _sse_event(payload: dict[str, Any]) -> str:
+    return f"event: {payload['type']}\ndata: {json.dumps(payload)}\n\n"
+
+
+def _terminal_sse(
+    event_type: str,
+    *,
+    status: str,
+    reason: str | None = None,
+    text: str = "partial answer",
+) -> str:
+    """One terminal Responses-API event carrying a full `Response`.
+
+    `reason=None` covers the shape where `incomplete_details` is absent entirely — it is
+    optional on the Response object, so its absence is a real case, not a contrived one.
+    """
+    response: dict[str, Any] = {
+        "id": "resp_1",
+        "created_at": 123,
+        "model": "gpt-5.4-mini",
+        "status": status,
+        "output": [
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": text}],
+            }
+        ],
+        "usage": {"input_tokens": 3, "output_tokens": 2},
+    }
+    if reason is not None:
+        response["incomplete_details"] = {"reason": reason}
+    payload = {"type": event_type, "response": response}
+    return f"event: {event_type}\ndata: {json.dumps(payload)}\n\ndata: [DONE]\n\n"
+
+
+def _incomplete_sse(reason: str | None, text: str = "partial answer") -> str:
+    return _terminal_sse("response.incomplete", status="incomplete", reason=reason, text=text)
+
+
+def _completed_sse(text: str = "hello") -> str:
+    return _terminal_sse("response.completed", status="completed", text=text)
+
+
+def test_truncated_response_reports_length_and_keeps_the_partial_content() -> None:
+    # The silently-wrong case this unit exists for. `response.incomplete` was not recognized as
+    # terminal, so the stream drained and the whole answer was discarded as a 502 — and had it
+    # survived, it would have claimed "stop".
+    # INVARIANT: a truncated answer reaches the caller, labelled as truncated.
+    response = _model_response_from_sse(_incomplete_sse("max_output_tokens"), "gpt-5.4-mini")
+
+    assert response.choices[0].finish_reason == "length"
+    assert response.choices[0].message.content == "partial answer"
+
+
+def test_filtered_response_reports_content_filter() -> None:
+    # STORY: as a researcher running HealthBench, a refused case must be visibly separate from a
+    # wrong one — OME-679 keys that on exactly this value.
+    response = _model_response_from_sse(
+        _incomplete_sse("content_filter", text="I can't help with that"),
+        "gpt-5.4-mini",
+    )
+
+    assert response.choices[0].finish_reason == "content_filter"
+    assert response.choices[0].message.content == "I can't help with that"
+
+
+def test_incomplete_without_details_falls_back_to_stop() -> None:
+    # Boundary: `incomplete_details` is optional, so its absence must degrade to "stop" rather
+    # than raise or emit None into a field with a closed vocabulary.
+    response = _model_response_from_sse(_incomplete_sse(None), "gpt-5.4-mini")
+
+    assert response.choices[0].finish_reason == "stop"
+    assert response.choices[0].message.content == "partial answer"
+
+
+def test_unknown_incomplete_reason_falls_back_to_stop() -> None:
+    # Boundary: the upstream reason enum can grow. An unrecognized value must not leak into the
+    # chat-completions `finish_reason`, whose vocabulary the gateway owns.
+    response = _model_response_from_sse(_incomplete_sse("some_future_reason"), "gpt-5.4-mini")
+
+    assert response.choices[0].finish_reason == "stop"
+
+
+def test_completed_response_still_reports_stop() -> None:
+    # Regression guard: the normal path keeps the value every existing test asserts.
+    response = _model_response_from_sse(_completed_sse("hello"), "gpt-5.4-mini")
+
+    assert response.choices[0].finish_reason == "stop"
+    assert response.choices[0].message.content == "hello"
+
+
+def test_stream_with_no_terminal_event_still_raises() -> None:
+    # Error path unchanged: recognizing a SECOND terminal event must not make the handler
+    # tolerant of a stream that terminates with neither.
+    body = _sse_event({"type": "response.output_text.delta", "delta": "Hello"})
+
+    with pytest.raises(CustomLLMError) as exc_info:
+        _model_response_from_sse(body, "gpt-5.4-mini")
+
+    assert exc_info.value.status_code == 502
+
+
+def test_failed_response_still_raises() -> None:
+    # Error path unchanged: `response.failed` is not terminal-with-content, it is an error.
+    body = _sse_event(
+        {"type": "response.failed", "error": {"message": "Codex blew up"}},
+    )
+
+    with pytest.raises(CustomLLMError) as exc_info:
+        _model_response_from_sse(body, "gpt-5.4-mini")
+
+    assert exc_info.value.status_code == 502

--- a/docs/tasks/2026-08-04-ome-746-codex-finish-reason.md
+++ b/docs/tasks/2026-08-04-ome-746-codex-finish-reason.md
@@ -1,0 +1,49 @@
+---
+id: OME-746
+linear_url: https://linear.app/openmined/issue/OME-746/stop-fabricating-the-codex-finish-reason-derive-it-from-status-and
+status: in_progress
+type:
+priority: P2
+labels: [aigateway, autonomous, agentic]
+created: 2026-08-04
+closed:
+---
+
+# OME-746 — derive the Codex finish_reason instead of fabricating "stop"
+
+Sub-issue of `OME-679`, which it blocks: `OME-679` makes a provider refusal distinguishable from
+a bad answer via `finish_reason`, and that is worthless if a provider invents the value.
+
+`plugins/codex_provider/chat_handler.py:215` hardcodes `"finish_reason": "stop"` on every
+response the plugin builds.
+
+## The finding
+
+The defect is bigger than the hardcoded value. `_consume_sse_event` treats **`response.completed`
+as the only terminal event**, but the Responses API also terminates with **`response.incomplete`**
+— exactly how a length-truncated or content-filtered answer arrives. Nothing matches it, so
+`_model_response_from_state` raises `CustomLLMError(502, "Codex upstream did not complete
+response")`.
+
+Today a truncated Codex answer is not mislabeled `stop` — **it is discarded entirely as a 502**,
+partial content and all. The `length` acceptance criterion cannot be met without handling
+`response.incomplete`, so that handling belongs to this unit.
+
+Verified from the API's own definitions rather than memory: `ResponseIncompleteEvent.type` is
+always `response.incomplete` and carries the full `Response` (OpenAI OpenAPI spec);
+`IncompleteDetails.reason` is `Literal["max_output_tokens", "content_filter"]` (installed SDK,
+`openai/types/responses/response.py`).
+
+## Scope
+
+- `src/aigateway/plugins/codex_provider/chat_handler.py` — terminate on either terminal event;
+  state key `completed` → `final`; derive the reason (`max_output_tokens` → `length`,
+  `content_filter` → `content_filter`, else `stop`), mirroring the normalizer shape at
+  `plugins/gemini_provider/message_adapter.py:103-111`.
+
+## Out of scope
+
+De-duplicating the byte-identical mapper in `gemini_provider/message_adapter.py` and
+`antigravity_provider/message_adapter.py` — real DRY debt, separate refactor.
+
+Ledger: `docs/work/2026-08-04-OME-746-codex-finish-reason.md`

--- a/docs/work/2026-08-04-OME-746-codex-finish-reason.md
+++ b/docs/work/2026-08-04-OME-746-codex-finish-reason.md
@@ -1,0 +1,134 @@
+---
+ticket: OME-746
+stack: aigateway
+status: in_progress
+started: 2026-08-04
+finished:
+---
+
+# OME-746 — derive the Codex finish_reason instead of fabricating "stop"
+
+## Intent
+
+Sub-issue of `OME-679`. `OME-679` wants a provider **refusal** to be distinguishable from a **bad
+answer**, and the mechanism is `finish_reason`. That is worthless if a provider *invents* the
+value, which is what the Codex plugin does today:
+`plugins/codex_provider/chat_handler.py:215` hardcodes `"finish_reason": "stop"` on every
+response it builds.
+
+## The finding — the defect is bigger than the hardcoded value
+
+Investigating the fix surfaced a second, worse bug underneath it.
+
+`_consume_sse_event` (`chat_handler.py:148-167`) treats **`response.completed` as the only
+terminal event**. The OpenAI Responses API also terminates a stream with **`response.incomplete`**
+— that is exactly how a length-truncated or content-filtered answer arrives. Because nothing
+matches it, `state["completed"]` is never set, the loop drains the stream, and
+`_model_response_from_state` raises `CustomLLMError(502, "Codex upstream did not complete
+response")`.
+
+So today a truncated Codex answer is not merely mislabeled `stop` — **it is discarded entirely as
+a 502, partial content and all.** The `length` acceptance criterion on this issue cannot be met
+without handling `response.incomplete` first, so that handling is part of this unit rather than
+scope creep.
+
+**Verified, not assumed** (both from the API's own definitions, not memory):
+
+- `ResponseIncompleteEvent` — `type` is always `response.incomplete`, carries the full `Response`
+  (OpenAI OpenAPI spec).
+- `Response.status` — `completed | failed | in_progress | cancelled | queued | incomplete`
+  (same spec).
+- `IncompleteDetails.reason` — `Literal["max_output_tokens", "content_filter"]`, read from the
+  installed SDK at `openai/types/responses/response.py`.
+
+## Design
+
+- Terminate on **either** terminal event, storing the `Response` under one state key (`final`)
+  rather than `completed` — the old name would be a lie for an incomplete response. No test
+  couples to the state dict, so the rename is free.
+- Derive the reason from the `Response` itself:
+  `incomplete_details.reason == "max_output_tokens"` → `length`;
+  `== "content_filter"` → `content_filter`; otherwise → `stop`.
+  Mirrors the shape of the existing normalizer at
+  `plugins/gemini_provider/message_adapter.py:103-111`.
+- `response.failed` / `error` keep raising — unchanged.
+
+## Planned changes
+
+- `src/aigateway/plugins/codex_provider/chat_handler.py` — `_consume_sse_event` also terminates
+  on `response.incomplete`; state key `completed` → `final`; new `_finish_reason(response)`;
+  `_model_response_from_state` uses it instead of the literal `"stop"`.
+- `tests/unit/codex/test_chat_handler.py` — **append only**, no prior test touched.
+
+No schema/model change, so S1 (migrations) does not apply. No credential/secret surface touched,
+so the aigateway card INVARIANTS (ORMStore-only credentials, no keychain, no litellm-enterprise)
+are unaffected.
+
+## Test plan
+
+Failing tests first:
+
+- **The silently-wrong case** — a `response.incomplete` stream with
+  `incomplete_details.reason = "max_output_tokens"` yields `finish_reason == "length"` **and
+  preserves the partial content** (today: a 502, content lost).
+- **Refusal** — `reason = "content_filter"` yields `finish_reason == "content_filter"`, the value
+  `OME-679` keys refusal detection on.
+- **Regression guard** — a normal `response.completed` still yields `stop` (the behavior every
+  existing test asserts).
+- **Boundary** — `status: "incomplete"` with `incomplete_details` absent/`null` falls back to
+  `stop` rather than raising.
+- **Error path unchanged** — `response.failed` still raises `CustomLLMError`, and a stream with
+  no terminal event at all still raises "did not complete response".
+
+## Acceptance
+
+- `incomplete_details.reason = "max_output_tokens"` surfaces as `length`, with content intact.
+- A normal completion still surfaces `stop`.
+- No prior test modified.
+- Gates green: `uv run .claude/scripts/run_gates.py aigateway`.
+
+## Outcome
+
+- **Actual files:**
+
+  | File | Planned? | What |
+  |---|---|---|
+  | `src/aigateway/plugins/codex_provider/chat_handler.py` | yes | `_TERMINAL_EVENTS`, `_INCOMPLETE_REASONS`, `_finish_reason()`; state key `completed` → `final`; the literal `"stop"` replaced |
+  | `tests/unit/codex/test_finish_reason.py` | **new file, not an append** | 7 tests — see Deviations |
+  | `tests/unit/codex/test_chat_handler.py` | planned as the test home | **not touched** — reverted, see Deviations |
+
+- **Gates:** `run_gates.py aigateway` — **ALL GATES GREEN**. append-only check ✓ · ruff check ✓ ·
+  ruff format --check ✓ · pyright ✓ (no `# type: ignore` added) · `check_no_enterprise.py` ✓ ·
+  `pytest --cov=aigateway --cov-fail-under=80` ✓. Full suite **2652 passed, 40 skipped**; the new
+  module is **7 passed**.
+- **Completeness check:** `grep '"finish_reason"'` across `codex_provider/` now returns exactly
+  one site, and it is the derived call — every response path (`_model_response_from_sse_events`,
+  `_model_response_from_sse_stream`) funnels through `_model_response_from_state`, so there is no
+  second place still fabricating a value.
+
+- **Deviations:**
+  1. **The unit is larger than filed, and had to be.** The issue described a hardcoded
+     `finish_reason`. The real defect underneath it: `_consume_sse_event` treated
+     `response.completed` as the *only* terminal event, so a `response.incomplete` stream — how a
+     truncated or filtered answer actually arrives — set no state and raised
+     `CustomLLMError(502, "Codex upstream did not complete response")`. **A truncated Codex
+     answer was being discarded outright, not mislabeled.** The filed acceptance criterion
+     ("`max_output_tokens` surfaces as `length`") is unreachable without fixing that, so it is
+     part of this unit rather than scope creep. The RED run confirmed the diagnosis: the new
+     test failed on that exact 502, not on a wrong `finish_reason`. Issue description updated.
+  2. **Tests landed in a new module instead of appended to `test_chat_handler.py`.** The append
+     was genuinely additive — `git diff --numstat` showed **86 insertions, 0 deletions**, no
+     prior test altered — but the append-only gate compares *file status*, so it read the growth
+     as a modified prior test. The line-level fix is already in flight as `OME-369` / PR #383.
+     Rather than weaken the gate or argue with it, the tests moved to
+     `tests/unit/codex/test_finish_reason.py`, which is unambiguously append-only. The module
+     docstring records why, so the split does not read as arbitrary.
+  3. **API shape verified, not recalled.** `ResponseIncompleteEvent` (`type` always
+     `response.incomplete`, carries the full `Response`) and the `Response.status` enum come from
+     the OpenAI OpenAPI spec; `IncompleteDetails.reason =
+     Literal["max_output_tokens", "content_filter"]` was read from the installed SDK at
+     `openai/types/responses/response.py`. An unrecognized reason degrades to `stop` so a future
+     upstream enum value cannot leak into the closed chat-completions vocabulary.
+  4. **Out of scope, unchanged:** the byte-identical mapper duplicated in
+     `gemini_provider/message_adapter.py` and `antigravity_provider/message_adapter.py`. Real DRY
+     debt; a separate refactor with its own blast radius.


### PR DESCRIPTION
Closes OME-746 · sub-issue of OME-679, which it blocks

## Why

OME-679 makes a provider **refusal** distinguishable from a **bad answer** via `finish_reason`. That is worthless if a provider *invents* the value — and the Codex plugin hardcoded `"finish_reason": "stop"` on every response it built.

## The bigger defect underneath

Fixing that surfaced a worse bug. `_consume_sse_event` treated **`response.completed` as the only terminal event**. The Responses API also terminates a stream with **`response.incomplete`** — which is exactly how a length-truncated or content-filtered generation arrives. Nothing matched it, so the stream drained, `state` stayed empty, and `_model_response_from_state` raised `CustomLLMError(502, "Codex upstream did not complete response")`.

**A truncated Codex answer was being discarded outright as a 502, partial content and all** — not merely mislabeled `stop`. The `length` acceptance criterion is unreachable without fixing this, so it lands here rather than as a follow-up.

The RED run confirms the diagnosis rather than assuming it: the new test failed on that exact 502, not on a wrong `finish_reason`.

## What changed

- Both terminal events end the stream (`_TERMINAL_EVENTS`).
- State key `completed` → `final` — the old name is a lie for an incomplete response. No test coupled to it.
- `_finish_reason(response)` derives the value: `max_output_tokens` → `length`, `content_filter` → `content_filter`, **anything else → `stop`**, so a future upstream enum value cannot leak into the closed chat-completions vocabulary.
- `response.failed` / `error` keep raising — unchanged.

## Shapes verified, not recalled

- `ResponseIncompleteEvent` — `type` always `response.incomplete`, carries the full `Response` (OpenAI OpenAPI spec).
- `Response.status` — `completed | failed | in_progress | cancelled | queued | incomplete` (same spec).
- `IncompleteDetails.reason` — `Literal["max_output_tokens", "content_filter"]`, read from the installed SDK at `openai/types/responses/response.py`.

## Test plan

`uv run .claude/scripts/run_gates.py aigateway` — **ALL GATES GREEN**: append-only check · ruff · ruff format --check · pyright (no `# type: ignore` added) · `check_no_enterprise.py` · `pytest --cov=aigateway --cov-fail-under=80`. Full suite **2652 passed, 40 skipped**.

7 new tests in `apps/aigateway/tests/unit/codex/test_finish_reason.py`:

- truncated → `length` **and the partial content survives** (today: 502, content lost)
- filtered → `content_filter` (the value OME-679 keys refusal detection on)
- `incomplete_details` absent → `stop`; unknown future reason → `stop`
- regression guard: a normal completion still reports `stop`
- error paths unchanged: no terminal event still raises; `response.failed` still raises

Completeness check: `grep '"finish_reason"'` across `codex_provider/` now returns exactly one site, and it is the derived call — every response path funnels through `_model_response_from_state`, so nothing else still fabricates a value.

## Note for the reviewer

The tests are a **new module** rather than an append to `test_chat_handler.py`. The append was genuinely additive — `git diff --numstat` showed **86 insertions, 0 deletions**, no prior test altered — but the append-only gate compares *file status*, so it read the growth as a modified prior test. Rather than weaken the gate, the tests moved to their own file, which is unambiguously append-only. The line-level fix for that gate is already in flight as OME-369 / #383; once it merges, this split is no longer forced.

**Out of scope:** the byte-identical mapper duplicated in `gemini_provider/message_adapter.py` and `antigravity_provider/message_adapter.py`. Real DRY debt, separate refactor.

Ledger: `docs/work/2026-08-04-OME-746-codex-finish-reason.md`