### PR TITLE
fix(repo): align aigateway and scoreboard Dockerfiles on Python 3.13

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -164,17 +164,29 @@ updates:
   # Container base layers drift silently otherwise: they are pinned by tag, and nothing in CI
   # notices a new patch release of a base image. Coverage is now all four Dockerfiles (was one).
   #
-  # Grouped per directory, which PARTLY mitigates the #439 failure (OME-740): a multi-stage
-  # Dockerfile's images at least arrive in ONE pull request instead of a one-sided bump that looks
-  # complete. It does NOT fix it — each image still resolves to its own latest tag, so grouping
-  # can surface a builder on 3.13 beside a runtime on 3.14. It makes the mismatch visible in the
-  # diff rather than invisible. The actual guard stays the INVARIANT in the Dockerfile plus CI's
-  # "Smoke both modes" step, which runs the entrypoint and catches the broken venv.
+  # CORRECTION (OME-747). An earlier version of this comment claimed grouping "partly mitigates"
+  # the #439 multi-stage failure by putting both images in one diff. It does NOT — not even
+  # partly. Dependabot does not recognise `ghcr.io/astral-sh/uv` as version-bearing at all, so the
+  # group has exactly ONE member and there is nothing to pair the runtime with. #491 proved it
+  # within minutes of this file merging: it moved `python:` alone and left the uv builder behind,
+  # exactly as #439 did. No setting in this file can fix that. The only real guards are the
+  # INVARIANT comment in each Dockerfile and a CI step that RUNS the built image (url4-cloud has
+  # one — "Smoke both modes"; aigateway and scoreboard do not).
+  #
+  # `ignore: python >=3.14` below is not about that fault — it is about test coverage. Every
+  # Python matrix in this repo runs 3.12/3.13 (aigateway-tests.yml, scoreboard-tests.yml,
+  # url4-cloud-tests.yml, url4-tests.yml), so a 3.14 base image would ship an interpreter no test
+  # here has ever exercised. LIFT THE IGNORE when those matrices gain 3.14 — that is the trigger,
+  # and removing the entry is how you retry.
   - package-ecosystem: "docker"
     directory: "/apps/url4-cloud"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    ignore:
+      # See the docker section note above: 3.14 is not covered by any CI matrix here.
+      - dependency-name: "python"
+        versions: [">=3.14"]
     groups:
       url4-cloud-docker-security:
         applies-to: security-updates
@@ -188,6 +200,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    ignore:
+      # See the docker section note above: 3.14 is not covered by any CI matrix here.
+      - dependency-name: "python"
+        versions: [">=3.14"]
     groups:
       aigateway-docker-security:
         applies-to: security-updates
@@ -214,6 +230,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    ignore:
+      # See the docker section note above: 3.14 is not covered by any CI matrix here.
+      - dependency-name: "python"
+        versions: [">=3.14"]
     groups:
       scoreboard-docker-security:
         applies-to: security-updates

--- a/apps/aigateway/Dockerfile
+++ b/apps/aigateway/Dockerfile
@@ -1,4 +1,14 @@
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+# INVARIANT: the builder and runtime Python minor MUST match. The runtime copies the builder's
+# venv wholesale (`COPY --from=builder /app /app`, entered via PATH=/app/.venv/bin), and a venv is
+# version-keyed — site-packages lives under lib/python<X.Y>/ and pyvenv.cfg names the interpreter
+# that built it. A mismatch builds fine and then dies at import with ModuleNotFoundError.
+# AIDEV-NOTE: Dependabot CANNOT keep these two in step. They are different images
+# (ghcr.io/astral-sh/uv vs python) and it does not even recognise the uv tag as version-bearing,
+# so grouping cannot pair them — proven by #491, which moved the runtime alone. It did the same to
+# url4-cloud in #439. Base-image bumps here always need a human.
+# AIDEV-NOTE: this app's CI does NOT build the image, so unlike url4-cloud there is no smoke step
+# to catch a mismatch — it would surface at deploy. Treat edits here with corresponding care.
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS builder
 
 ENV UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \
@@ -17,7 +27,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev
 
 
-FROM python:3.12-slim-bookworm AS runtime
+# Must track the builder's Python minor exactly — see the INVARIANT at the top of this file.
+FROM python:3.13-slim-bookworm AS runtime
 
 LABEL org.opencontainers.image.source="https://github.com/openmined/screamingface" \
       org.opencontainers.image.description="ScreamingFace AI Gateway" \

--- a/apps/scoreboard/Dockerfile
+++ b/apps/scoreboard/Dockerfile
@@ -1,4 +1,14 @@
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+# INVARIANT: the builder and runtime Python minor MUST match. The runtime copies the builder's
+# venv wholesale (`COPY --from=builder /app /app`, entered via PATH=/app/.venv/bin), and a venv is
+# version-keyed — site-packages lives under lib/python<X.Y>/ and pyvenv.cfg names the interpreter
+# that built it. A mismatch builds fine and then dies at import with ModuleNotFoundError.
+# AIDEV-NOTE: Dependabot CANNOT keep these two in step. They are different images
+# (ghcr.io/astral-sh/uv vs python) and it does not even recognise the uv tag as version-bearing,
+# so grouping cannot pair them — proven by #490, which moved the runtime alone. It did the same to
+# url4-cloud in #439. Base-image bumps here always need a human.
+# AIDEV-NOTE: this app's CI does NOT build the image, so unlike url4-cloud there is no smoke step
+# to catch a mismatch — it would surface at deploy. Treat edits here with corresponding care.
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS builder
 
 ENV UV_LINK_MODE=copy \
     UV_PYTHON_DOWNLOADS=never
@@ -16,7 +26,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev
 
 
-FROM python:3.12-slim-bookworm AS runtime
+# Must track the builder's Python minor exactly — see the INVARIANT at the top of this file.
+FROM python:3.13-slim-bookworm AS runtime
 
 LABEL org.opencontainers.image.source="https://github.com/openmined/screamingface" \
       org.opencontainers.image.description="ScreamingFace benchmark scoreboard" \

--- a/docs/tasks/2026-08-04-ome-747-dockerfile-python-313.md
+++ b/docs/tasks/2026-08-04-ome-747-dockerfile-python-313.md
@@ -1,0 +1,55 @@
+---
+id: OME-747
+linear_url: https://linear.app/openmined/issue/OME-747/move-aigateway-and-scoreboard-dockerfiles-to-python-313-across-both
+status: in_review
+type: task
+priority: P2
+labels: [repo, autonomous, agentic]
+created: 2026-08-04
+closed:
+---
+
+# OME-747 — aigateway + scoreboard Dockerfiles to Python 3.13, and ignore 3.14
+
+Sub-issue of `OME-733`. `OME-737`'s new docker coverage began working within minutes of merging
+and immediately opened #489, #490 and #491 — all three repeating the #439 fault `OME-740` closed.
+
+> **Label note (D9):** touches `apps/aigateway` and `apps/scoreboard`, which would normally mean
+> an epic plus a sub-issue each. Filed as one `repo` unit — a single mechanical pattern applied
+> twice plus one config edit. Flagged rather than silently deviated.
+
+## What those PRs proved
+
+**Grouping cannot pair multi-stage images.** #491 was the direct experiment and it failed: it
+moved `python:` alone and left the `ghcr.io/astral-sh/uv` builder behind. `OME-737` had claimed
+grouping would at least "make the mismatch visible in one diff" — **too generous, and corrected
+in the config**. Dependabot does not treat the uv image as version-bearing at all, so the group
+holds exactly one member. No setting can fix this.
+
+**Real drift on two apps.** Both sat on Python 3.12 in both stages with no guard comment, and both
+share url4-cloud's exact vulnerable shape — `COPY --from=builder /app /app` entered via
+`PATH=/app/.venv/bin`, where the venv is version-keyed. **Worse than url4-cloud:** neither app's
+CI builds its image, so a mismatch would surface at deploy rather than in CI.
+
+**3.14 is untested everywhere.** All Python matrices run 3.12/3.13, so merging any of the three
+would ship an interpreter no test here exercises.
+
+## Result
+
+Both Dockerfiles on **3.13 across both stages**, each carrying the `INVARIANT:` + `AIDEV-NOTE:`
+guard. `python >=3.14` ignored on the three python docker entries — **lift when the CI matrices
+gain 3.14**.
+
+Parity **asserted programmatically** (every `FROM` parsed and compared), not eyeballed — eyeballing
+is how #439 shipped. `run_gates.py` green for both stacks.
+
+⚠️ **No runtime verification exists for this change** — no Docker daemon locally and neither app's
+CI builds its image. `OME-740` had `Smoke both modes` as real proof; this has only the assertion.
+Stated plainly rather than implied.
+
+## Follow-up
+
+Neither `aigateway` nor `scoreboard` CI builds its Docker image, so nothing exercises these files.
+`url4-cloud` only gained that job because `592e4a89` broke at release time. Worth its own ticket.
+
+Ledger: `docs/work/2026-08-04-OME-747-dockerfile-python-313.md`

--- a/docs/work/2026-08-04-OME-747-dockerfile-python-313.md
+++ b/docs/work/2026-08-04-OME-747-dockerfile-python-313.md
@@ -1,0 +1,148 @@
+---
+ticket: OME-747
+stack: repo
+status: done
+started: 2026-08-04
+finished: 2026-08-04
+---
+
+# OME-747 — aigateway + scoreboard Dockerfiles to Python 3.13, both stages, and ignore 3.14
+
+Authored in an isolated worktree branched from `origin/main` at `5b43c319`.
+
+## Intent
+
+`OME-737`'s new docker coverage began working within minutes of merging and immediately opened
+#489, #490 and #491 — all three repeating the #439 fault that `OME-740` closed. Closing them
+alone would defer identical PRs to next week.
+
+## What those three PRs proved
+
+**1 — grouping cannot pair multi-stage images.** #491 was the direct experiment, and it failed:
+
+```
+-FROM python:3.13-slim-bookworm AS runtime      <- only this moved
++FROM python:3.14-slim-bookworm AS runtime
+   ghcr.io/astral-sh/uv:python3.13-...           <- builder untouched
+```
+
+`OME-737` claimed grouping would at least "make the mismatch visible in one diff". **That was too
+generous and is corrected here.** Dependabot does not recognise `ghcr.io/astral-sh/uv` as
+version-bearing at all, so the group has exactly **one** member — there is nothing to group it
+*with*. No configuration can fix this. The only guards are the `INVARIANT:` comment and a CI step
+that actually runs the built image.
+
+**2 — real drift on two apps.** Both `apps/aigateway` and `apps/scoreboard` sit on Python 3.12 in
+both stages and carry **no** guard comment. Verified they share url4-cloud's exact vulnerable
+shape:
+
+| | builder | runtime | venv copied? | PATH |
+|---|---|---|---|---|
+| `aigateway` | `uv:python3.12` | `python:3.12` | `COPY --from=builder /app /app` | `/app/.venv/bin` |
+| `scoreboard` | `uv:python3.12` | `python:3.12` | `COPY --from=builder /app /app` | `/app/.venv/bin` |
+
+A venv is version-keyed (`lib/python<X.Y>/`, and `pyvenv.cfg` names its interpreter), so a
+one-sided bump on either yields the same `ModuleNotFoundError` #439 produced.
+
+**Worse than url4-cloud:** neither app's CI builds its image at all, so there is no
+`Smoke both modes` equivalent. url4-cloud's mismatch failed loudly in CI; on these two it would
+surface at **deploy**. That gap is out of scope here but flagged below.
+
+**3 — 3.14 is untested everywhere.** Every Python matrix in the repo runs 3.12/3.13. Merging any
+of those three PRs would ship an interpreter no test in this repo has exercised.
+
+## Planned changes
+
+- `apps/aigateway/Dockerfile` — both stages 3.12 → 3.13, plus the `INVARIANT:`/`AIDEV-NOTE:` guard
+- `apps/scoreboard/Dockerfile` — same
+- `.github/dependabot.yml` — `ignore: python >=3.14` on all four docker entries, each commented
+  with the condition that lifts it (CI matrices covering 3.14)
+- Close #489, #490, #491
+
+`apps/aigateway-ui/Dockerfile` is deliberately untouched: it is node, and all three of its stages
+already share one `${NODE_VERSION}` ARG — structurally immune, and the pattern the Python files
+lack.
+
+## Test plan
+
+No RED test; these are base-image pins. Verification is structural and behavioural:
+
+1. **Both stages on the same minor** in each file — asserted programmatically by parsing every
+   `FROM` line rather than read by eye, since eyeballing is exactly how #439 shipped.
+2. `run_gates.py aigateway` and `run_gates.py scoreboard` green — the images are not built in CI,
+   so the source gates are the available signal.
+3. Config still structurally valid after the `ignore` additions: every directory exists, every
+   group declares `applies-to`.
+
+⚠️ **No Docker daemon on this machine**, and neither app's CI builds its image. So unlike
+`OME-740` — where CI's `Smoke both modes` gave real proof — this change has **no runtime
+verification available at all**. The mitigation is that both stages move together in one edit and
+an assertion enforces it, but that is a weaker guarantee and is stated plainly rather than
+implied.
+
+## Acceptance
+
+- Every `FROM` in both files on Python 3.13; asserted, not eyeballed.
+- Both files carry the guard comment.
+- `python >=3.14` ignored on the docker entries, with the lifting condition recorded.
+- #489/#490/#491 closed with the reason.
+- Gates green for both stacks.
+
+## Follow-up worth its own ticket
+
+Neither `aigateway` nor `scoreboard` CI builds its Docker image, so no test exercises these
+Dockerfiles at all. `url4-cloud` gained that only because `592e4a89` broke at release time and a
+build job was added in response. The same argument applies to these two.
+
+## Outcome
+
+- **Actual files:** as planned plus one correction — `apps/aigateway/Dockerfile`,
+  `apps/scoreboard/Dockerfile`, `.github/dependabot.yml`, this ledger, its `docs/tasks/` mirror.
+
+- **Stage parity asserted, not eyeballed** — every `FROM` line parsed and its python minor
+  compared, because eyeballing is exactly how #439 shipped:
+
+  ```
+  OK  apps/aigateway/Dockerfile    python minors=['3.13']  (2 FROM lines)
+  OK  apps/scoreboard/Dockerfile   python minors=['3.13']  (2 FROM lines)
+  OK  apps/url4-cloud/Dockerfile   python minors=['3.13']  (2 FROM lines)
+  ```
+
+- **Gates:** `run_gates.py aigateway` and `run_gates.py scoreboard` — **ALL GATES GREEN** for
+  both, including the append-only check (no test touched).
+
+- **Config:** 11 entries, zero groups missing `applies-to`, ignores now:
+
+  | ecosystem | directory | ignore |
+  |---|---|---|
+  | npm | `/apps/aigateway-ui` | `typescript >=6`, `eslint >=10` |
+  | docker | `/apps/url4-cloud` | `python >=3.14` |
+  | docker | `/apps/aigateway` | `python >=3.14` |
+  | docker | `/apps/scoreboard` | `python >=3.14` |
+
+### Deviation — dropped a dead ignore on aigateway-ui's docker entry
+
+The insertion pass added `python >=3.14` to all four docker entries mechanically.
+`apps/aigateway-ui/Dockerfile` is a **node** image (three stages, all on one `${NODE_VERSION}`
+ARG), so a python ignore there is config that can never match. Removed. Dead config is worse than
+no config — it implies a constraint that is not real, and the next reader has to work out that it
+means nothing.
+
+### Correction carried into the config
+
+`OME-737`'s docker comment claimed grouping "partly mitigates" the multi-stage failure by putting
+both images in one diff. **It does not, not even partly**, and the comment now says so. Dependabot
+does not treat `ghcr.io/astral-sh/uv` as version-bearing, so the group holds exactly one member.
+#491 demonstrated this within minutes of that config merging. The claim is replaced rather than
+softened.
+
+### Verification gap — stated plainly
+
+Neither app's CI builds its image, and there is no Docker daemon here, so **this change has no
+runtime verification at all**. `OME-740` had CI's `Smoke both modes` as real proof; this does not.
+What stands in for it: both stages move in one edit, and an assertion enforces parity. That is
+weaker, and the `AIDEV-NOTE:` in each Dockerfile now says so at the site.
+
+Follow-up worth its own ticket: neither `aigateway` nor `scoreboard` CI builds its image, so
+nothing exercises these Dockerfiles. `url4-cloud` only gained that job because `592e4a89` broke at
+release time.


### PR DESCRIPTION
Closes `OME-747`, a sub-issue of `OME-733`. Replaces #489, #490 and #491.

`OME-737`'s new docker coverage started working within minutes of merging — and immediately opened three PRs that all repeat the #439 fault `OME-740` closed. Closing them alone would defer identical PRs to next week.

## #491 was a direct experiment, and it failed

```
-FROM python:3.13-slim-bookworm AS runtime      ← only this moved
+FROM python:3.14-slim-bookworm AS runtime
   ghcr.io/astral-sh/uv:python3.13-...           ← builder untouched
```

**This corrects a claim I made in `OME-737`.** That config comment said grouping would "partly mitigate" the multi-stage failure by putting both images in one diff. It does not — *not even partly*. Dependabot does not recognise `ghcr.io/astral-sh/uv` as version-bearing at all, so the group holds exactly **one** member and there is nothing to pair the runtime with. The comment is replaced rather than softened.

## Two apps were carrying the same latent bug

`aigateway` and `scoreboard` both sat on Python 3.12 in both stages with no guard comment, and both share url4-cloud's vulnerable shape:

| | builder | runtime | venv copied? | PATH |
|---|---|---|---|---|
| `aigateway` | `uv:python3.12` | `python:3.12` | `COPY --from=builder /app /app` | `/app/.venv/bin` |
| `scoreboard` | `uv:python3.12` | `python:3.12` | `COPY --from=builder /app /app` | `/app/.venv/bin` |

A venv is version-keyed (`lib/python<X.Y>/`; `pyvenv.cfg` names its interpreter), so a one-sided bump on either produces the same `ModuleNotFoundError` #439 did.

⚠️ **Worse than url4-cloud:** neither app's CI builds its image, so there is no `Smoke both modes` equivalent. url4-cloud's mismatch failed loudly *in CI*; on these two it would surface at **deploy**. Both files now carry an `AIDEV-NOTE:` saying exactly that.

## Why 3.13, not the 3.14 the bots proposed

Every Python matrix in this repo runs **3.12/3.13** (`aigateway-tests.yml`, `scoreboard-tests.yml`, `url4-cloud-tests.yml`, `url4-tests.yml`). A 3.14 base image would ship an interpreter no test here has ever exercised.

So `python >=3.14` is now ignored on the python docker entries — **lift the ignore when those matrices gain 3.14.** Removing the entry is how you retry, same convention as the `typescript`/`eslint` ignores.

## Test plan

Stage parity **asserted programmatically**, not eyeballed — eyeballing is precisely how #439 shipped:

```
OK  apps/aigateway/Dockerfile    python minors=['3.13']  (2 FROM lines)
OK  apps/scoreboard/Dockerfile   python minors=['3.13']  (2 FROM lines)
OK  apps/url4-cloud/Dockerfile   python minors=['3.13']  (2 FROM lines)
```

`run_gates.py aigateway` and `run_gates.py scoreboard` — **ALL GATES GREEN** for both, append-only check included (no test touched). Config revalidated: 11 entries, zero groups missing `applies-to`.

⚠️ **Be aware what is NOT verified.** No Docker daemon on the authoring machine and no image build in either app's CI, so this change has **no runtime verification at all**. `OME-740` had CI's smoke step as real proof; this has only the parity assertion. Flagging rather than implying.

Also dropped a dead `ignore` the mechanical insertion pass added to `aigateway-ui`'s docker entry — that image is **node**, so a `python` ignore there can never match, and dead config is worse than none.

## Follow-up worth its own ticket

Neither `aigateway` nor `scoreboard` CI builds its Docker image, so nothing exercises these files. `url4-cloud` only gained that job because `592e4a89` broke at release time — the same argument applies here.

---

Authored in an isolated git worktree branched from `origin/main` at `5b43c319`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iy1jFtiDTBpFdk5h6x1Mu