### PR TITLE
ci(repo): audit Dependabot ignore rules so they expire

### DIFF
--- a/.claude/scripts/audit_dependabot_ignores.py
+++ b/.claude/scripts/audit_dependabot_ignores.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["pyyaml"]
+# ///
+"""Audit the `ignore:` rules in .github/dependabot.yml so they expire instead of rotting.
+
+An ignore rule is a promise that something upstream is broken. Promises rot: when the blocker
+lifts, nothing notices, and a tree stays pinned majors behind for a reason that expired. This
+re-checks every promise against live data.
+
+Two checks, with DELIBERATELY different severities:
+
+  DRIFT  -> exit 1.  An ignore with no registry entry, or an entry with no ignore, is OUR OWN
+                     inconsistency and is always fixable on the spot. Failing here is what stops
+                     an undocumented ignore ever landing.
+
+  LIFTED -> exit 0.  A blocker that has cleared only WARNS. Failing a PR because upstream shipped
+                     a release would train people to disable the check, which is strictly worse
+                     than the rot it was meant to catch. The weekly scheduled run is what makes
+                     these visible.
+
+Usage:
+    uv run .claude/scripts/audit_dependabot_ignores.py [--offline]
+
+`--offline` skips registry lookups (drift checks still run) so the audit is usable without
+network — e.g. in a pre-commit hook.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import subprocess
+import sys
+
+try:
+    import yaml
+except ImportError:
+    sys.exit(
+        "ERROR: PyYAML required. Run via `uv run .claude/scripts/audit_dependabot_ignores.py`"
+    )
+
+CONFIG = pathlib.Path(".github/dependabot.yml")
+REGISTRY = pathlib.Path(".github/dependabot-ignores.yml")
+
+GREEN, RED, WARN = "✓", "✗", "!"
+
+
+# --- version reasoning ---------------------------------------------------------------
+#
+# AIDEV-NOTE: this compares MAJORS only, not full semver. That is a deliberate limit, not an
+# oversight — every ignore we write is a major-boundary hold (">=6", ">=10", ">=3.14"), and a
+# full semver implementation would be a lot of surface area to get subtly wrong for no gain.
+# If a future ignore needs minor-level precision, this is the function to replace, and the test
+# to write first is the one that proves the old logic gets it wrong.
+
+
+def ignored_floor(spec: str) -> tuple[int, int | None] | None:
+    """The (major, minor) an ignore starts at. `">=3.14"` -> (3, 14); `">=6"` -> (6, None)."""
+    m = re.search(r"(\d+)(?:\.(\d+))?", spec)
+    if not m:
+        return None
+    return int(m.group(1)), (int(m.group(2)) if m.group(2) else None)
+
+
+def range_admits_major(npm_range: str, major: int) -> bool:
+    """Does this npm peer range admit any version of `major`?
+
+    Handles the shapes that actually occur in our blockers:
+        "^5.x"                        -> {5}
+        "^3 || ^4 || ... || ^9.7"     -> {3..9}
+        ">=4.8.4 <6.1.0"              -> {4,5,6}   (6 only because the bound is 6.1, not 6.0)
+    Anything unrecognised returns True — i.e. "assume liftable, make a human look". A false
+    warning costs a glance; a false silence costs the whole point of this script.
+    """
+    admitted: set[int] = set()
+    recognised = False
+
+    for clause in npm_range.split("||"):
+        clause = clause.strip()
+        if not clause:
+            continue
+
+        caret = re.fullmatch(r"\^\s*(\d+)(?:\.[\dx*]+)*", clause)
+        if caret:
+            admitted.add(int(caret.group(1)))
+            recognised = True
+            continue
+
+        dotx = re.fullmatch(r"(\d+)\.[x*]", clause)
+        if dotx:
+            admitted.add(int(dotx.group(1)))
+            recognised = True
+            continue
+
+        lo = re.search(r">=?\s*(\d+)(?:\.(\d+))?", clause)
+        hi = re.search(r"<=?\s*(\d+)(?:\.(\d+))?", clause)
+        if lo or hi:
+            start = int(lo.group(1)) if lo else 0
+            if hi:
+                hi_major, hi_minor = int(hi.group(1)), hi.group(2)
+                # "<6.1.0" admits some of major 6; "<6.0.0" admits none of it.
+                end = hi_major if (hi_minor and int(hi_minor) > 0) else hi_major - 1
+            else:
+                end = max(start, major)  # open upper bound
+            admitted.update(range(start, end + 1))
+            recognised = True
+            continue
+
+        exact = re.fullmatch(r"(\d+)(?:\.\d+)*", clause)
+        if exact:
+            admitted.add(int(exact.group(1)))
+            recognised = True
+
+    if not recognised:
+        return True
+    return major in admitted
+
+
+# --- blocker probes ------------------------------------------------------------------
+
+
+def probe_npm_peer(blocker: dict, floor: tuple[int, int | None]) -> tuple[bool, str]:
+    """Returns (lifted, detail). Reads the blocking package's CURRENT peer range."""
+    pkg, peer = blocker["package"], blocker["peer"]
+    r = subprocess.run(
+        ["npm", "view", pkg, "peerDependencies", "--json"],
+        capture_output=True,
+        text=True,
+        timeout=90,
+        # check=False deliberately: a registry lookup failing (network, renamed package) must
+        # NOT crash the audit. It is handled below as "treated as still blocking", which is the
+        # safe direction — a transient npm hiccup should never look like a lifted blocker.
+        check=False,
+    )
+    if r.returncode != 0 or not r.stdout.strip():
+        return (
+            False,
+            f"could not read {pkg} peerDependencies (treated as still blocking)",
+        )
+    try:
+        peers = json.loads(r.stdout) or {}
+    except json.JSONDecodeError:
+        return False, f"unparseable peerDependencies for {pkg}"
+    rng = peers.get(peer)
+    if rng is None:
+        # The blocker no longer declares this peer at all — the constraint is gone.
+        return True, f"{pkg} no longer declares a `{peer}` peer at all"
+    lifted = range_admits_major(rng, floor[0])
+    return lifted, f"{pkg} peer {peer}: {rng!r}"
+
+
+def probe_ci_matrix(blocker: dict, floor: tuple[int, int | None]) -> tuple[bool, str]:
+    """Returns (lifted, detail). Reads a workflow's version matrix from disk."""
+    wf = pathlib.Path(blocker["workflow"])
+    if not wf.exists():
+        return False, f"{wf} not found (treated as still blocking)"
+    key = blocker["matrix_key"]
+    found: set[str] = set()
+
+    def walk(node):
+        if isinstance(node, dict):
+            for k, v in node.items():
+                if k == key:
+                    # AIDEV-NOTE: both shapes occur and BOTH must be read. aigateway and
+                    # url4-cloud use a matrix list ["3.12","3.13"]; scoreboard pins a scalar
+                    # "3.12". An earlier version handled only the list and fell through to
+                    # "no matrix -> still blocking" for scoreboard — the right answer by
+                    # accident, which is the kind of thing that silently rots later.
+                    vals = v if isinstance(v, list) else [v]
+                    for x in vals:
+                        s = str(x)
+                        # `python-version: ${{ matrix.python-version }}` is the CONSUMER of the
+                        # matrix, not a version. Keeping it would clutter the report and could
+                        # never match a real version anyway.
+                        if "${{" not in s:
+                            found.add(s)
+                walk(v)
+        elif isinstance(node, list):
+            for v in node:
+                walk(v)
+
+    walk(yaml.safe_load(wf.read_text()))
+    if not found:
+        return False, f"no `{key}` found in {wf.name} (treated as still blocking)"
+    target = f"{floor[0]}.{floor[1]}" if floor[1] is not None else str(floor[0])
+    lifted = any(v == target or v.startswith(target + ".") for v in found)
+    return lifted, f"{wf.name} {key} = {sorted(found)}"
+
+
+PROBES = {"npm_peer": probe_npm_peer, "ci_matrix": probe_ci_matrix}
+
+
+# --- main ----------------------------------------------------------------------------
+
+
+def key_of(directory: str, dep: str, versions) -> tuple[str, str, str]:
+    v = versions if isinstance(versions, str) else ",".join(versions or [])
+    return (directory, dep.lower(), v)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--offline", action="store_true", help="skip registry lookups")
+    args = ap.parse_args()
+
+    for f in (CONFIG, REGISTRY):
+        if not f.exists():
+            print(f"{RED} {f} not found — run from the repo root")
+            return 1
+
+    cfg = yaml.safe_load(CONFIG.read_text())
+    reg = yaml.safe_load(REGISTRY.read_text()) or {}
+
+    actual = {}
+    for entry in cfg.get("updates", []):
+        for ig in entry.get("ignore") or []:
+            actual[
+                key_of(entry["directory"], ig["dependency-name"], ig.get("versions"))
+            ] = ig
+
+    declared = {}
+    for item in reg.get("ignores", []):
+        declared[key_of(item["directory"], item["dependency"], item["versions"])] = item
+
+    # --- drift: strict 1:1, both directions ---
+    undocumented = sorted(set(actual) - set(declared))
+    orphaned = sorted(set(declared) - set(actual))
+
+    print(f"dependabot.yml ignores : {len(actual)}")
+    print(f"registry entries       : {len(declared)}\n")
+
+    if undocumented or orphaned:
+        for d, dep, v in undocumented:
+            print(f"{RED} UNDOCUMENTED  {d}  {dep} {v}")
+            print("    every ignore needs an entry in .github/dependabot-ignores.yml")
+        for d, dep, v in orphaned:
+            print(f"{RED} ORPHANED      {d}  {dep} {v}")
+            print("    registry entry has no matching ignore in .github/dependabot.yml")
+        print("\nDRIFT — the two files disagree. This is ours to fix; failing.")
+        return 1
+    print(f"{GREEN} no drift — every ignore is documented, every entry is live\n")
+
+    if args.offline:
+        print("(--offline: blocker probes skipped)")
+        return 0
+
+    # --- are any blockers now lifted? ---
+    lifted_any = False
+    for k in sorted(actual):
+        item = declared[k]
+        directory, dep, versions = k
+        floor = ignored_floor(versions)
+        if floor is None:
+            print(f"{WARN} {directory}  {dep} {versions}: cannot parse a version floor")
+            continue
+        blocker = item["blocker"]
+        probe = PROBES.get(blocker.get("kind"))
+        if probe is None:
+            print(
+                f"{RED} unknown blocker kind {blocker.get('kind')!r} for {dep} in {directory}"
+            )
+            return 1
+        try:
+            lifted, detail = probe(blocker, floor)
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            print(
+                f"{WARN} {directory}  {dep} {versions}: probe failed ({exc}); skipping"
+            )
+            continue
+
+        ticket = item.get("ticket") or "no ticket"
+        if lifted:
+            lifted_any = True
+            print(f"{WARN} LIFTABLE   {directory}  {dep} {versions}   [{ticket}]")
+            print(f"      {detail}")
+            print("      the blocker has cleared — this ignore can probably be removed")
+        else:
+            print(f"{GREEN} blocking   {directory}  {dep} {versions}   [{ticket}]")
+            print(f"      {detail}")
+
+    if lifted_any:
+        print(
+            "\n"
+            + WARN
+            + " one or more ignores look liftable. NOT failing the build: upstream shipping a"
+            "\n  release should not break an unrelated PR. Open a ticket and remove the ignore."
+        )
+        # GitHub Actions annotation so it surfaces in the run summary.
+        print(
+            "::warning title=Dependabot ignore may be liftable::"
+            "A blocker recorded in .github/dependabot-ignores.yml has cleared — see the log."
+        )
+    else:
+        print(f"\n{GREEN} every ignore still has a live blocker")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/dependabot-ignores.yml
+++ b/.github/dependabot-ignores.yml
@@ -1,0 +1,87 @@
+# Why every `ignore:` in .github/dependabot.yml exists — in a form a machine can re-check.
+#
+# An ignore rule is a promise that something upstream is broken. Promises rot: when the blocker
+# lifts, nothing notices, and a tree stays pinned majors behind for a reason that expired months
+# ago. This file makes each promise checkable, and `.claude/scripts/audit_dependabot_ignores.py`
+# checks it.
+#
+# INVARIANT: strict 1:1 with dependabot.yml. Every ignore needs an entry here; every entry needs a
+# matching ignore. The audit FAILS on either mismatch — that is our own inconsistency and is always
+# fixable on the spot. A merely *liftable* ignore only warns, because failing a PR because upstream
+# shipped a release would train people to disable the check.
+#
+# blocker kinds:
+#   npm_peer   — read `package`'s peer range for `peer` from the npm registry. Liftable when that
+#                range admits the ignored version.
+#   ci_matrix  — read `matrix_key` from `workflow`. Liftable when the matrix covers the ignored
+#                version. Use this when WE are the blocker, not upstream — say so plainly.
+ignores:
+  - directory: /apps/aigateway-ui
+    dependency: typescript
+    versions: ">=6"
+    ticket: OME-742
+    blocker:
+      kind: npm_peer
+      package: openapi-typescript
+      peer: typescript
+    note: >-
+      openapi-typescript caps at peer typescript ^5.x and has no TS6/7 build. Note it is MANUAL
+      codegen — absent from every npm script, output committed at src/lib/aigateway/schema.d.ts —
+      so OME-742 can also lift this by dropping it from devDependencies entirely, without waiting
+      for upstream.
+
+  - directory: /apps/aigateway-ui
+    dependency: eslint
+    versions: ">=10"
+    ticket: null
+    blocker:
+      kind: npm_peer
+      package: eslint-plugin-react
+      peer: eslint
+    note: >-
+      ESLint 10 crashes eslint-plugin-react (contextOrFilename.getFilename is not a function). It
+      is bundled inside eslint-config-next, which declares peer eslint ">=9.0.0" at both 16.2.12
+      and 16.3.0 — a range it does not honor. Checking eslint-plugin-react directly rather than
+      eslint-config-next, because the config's range is wrong and would report a false lift.
+
+  # NOTE: /public-docs `typescript >=7` is NOT listed here yet — it arrives with #503 (OME-748),
+  # which is still open. That PR must add BOTH its ignore and its entry here in the same change,
+  # or this audit will fail on drift, correctly. Deliberately not stacked: this repo squash-merges
+  # and stacked PRs have caused a branch to miss main before.
+  #   blocker when added: npm_peer / typescript-eslint / peer `typescript`
+  #   (refuses TS 7 outright; bound is >=7 NOT >=6, because public-docs is already on ~6.0.0 and
+  #    is capped by a different package than aigateway-ui — do not unify the two.)
+
+  - directory: /apps/url4-cloud
+    dependency: python
+    versions: ">=3.14"
+    ticket: OME-747
+    blocker:
+      kind: ci_matrix
+      workflow: .github/workflows/url4-cloud-tests.yml
+      matrix_key: python-version
+    note: >-
+      NOT upstream-blocked. Python 3.14 works; we simply do not test against it. Lifting this is
+      our own decision — extend the matrix — not something to wait on.
+
+  - directory: /apps/aigateway
+    dependency: python
+    versions: ">=3.14"
+    ticket: OME-747
+    blocker:
+      kind: ci_matrix
+      workflow: .github/workflows/aigateway-tests.yml
+      matrix_key: python-version
+    note: >-
+      NOT upstream-blocked; see the url4-cloud entry. Extending this matrix is what lifts it.
+
+  - directory: /apps/scoreboard
+    dependency: python
+    versions: ">=3.14"
+    ticket: OME-747
+    blocker:
+      kind: ci_matrix
+      workflow: .github/workflows/scoreboard-tests.yml
+      matrix_key: python-version
+    note: >-
+      NOT upstream-blocked; see the url4-cloud entry. Extending this matrix is what lifts it.

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -1,18 +1,33 @@
 name: Repo Checks
+
+# SECURITY: every `run:` below is a static command. No event payload, ref name, PR title or
+# commit message is interpolated into a shell context, so there is no injection surface here.
 on:
   push:
     paths:
       - ".claude/skills/sdlc-**"
       - ".claude/scripts/**"
       - ".github/workflows/repo-checks.yml"
+      - ".github/dependabot.yml"
+      - ".github/dependabot-ignores.yml"
   pull_request:
     paths:
       - ".claude/skills/sdlc-**"
       - ".claude/scripts/**"
       - ".github/workflows/repo-checks.yml"
+      - ".github/dependabot.yml"
+      - ".github/dependabot-ignores.yml"
+  # WHY a schedule: the ignore audit checks state that changes when UPSTREAM ships, not when we
+  # commit. Path triggers alone would only re-check it on the rare PR that edits the config, so a
+  # blocker could clear and sit unnoticed for months — exactly the rot the audit exists to catch.
+  # Monday morning, so a liftable ignore is visible at the start of the week.
+  schedule:
+    - cron: "0 6 * * 1"
   workflow_dispatch:
+
 permissions:
   contents: read
+
 jobs:
   loop-parity:
     runs-on: ubuntu-latest
@@ -20,3 +35,20 @@ jobs:
       - uses: actions/checkout@v7
       - name: SHARED-LOOP parity
         run: python3 .claude/scripts/check_loop_parity.py
+
+  dependabot-ignores:
+    name: Dependabot ignore audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
+      # Needs `npm view` for the npm_peer probes; node is not otherwise required here.
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+      # Exit codes are deliberately asymmetric (see the script's docstring): DRIFT between
+      # dependabot.yml and the registry fails, because that is our own inconsistency and always
+      # fixable. A merely LIFTABLE ignore only warns — failing a PR because upstream published a
+      # release would train people to disable this check, which is worse than the rot it catches.
+      - name: Audit dependabot ignore rules
+        run: uv run .claude/scripts/audit_dependabot_ignores.py

--- a/docs/tasks/2026-08-04-ome-749-ignore-audit.md
+++ b/docs/tasks/2026-08-04-ome-749-ignore-audit.md
@@ -1,0 +1,64 @@
+---
+id: OME-749
+linear_url: https://linear.app/openmined/issue/OME-749/audit-dependabot-ignore-rules-so-they-expire-instead-of-silently
+status: in_review
+type: task
+priority: P2
+labels: [repo, autonomous, agentic]
+created: 2026-08-04
+closed:
+---
+
+# OME-749 — audit Dependabot ignore rules so they expire
+
+Sub-issue of `OME-733`.
+
+This epic added `ignore` rules to `dependabot.yml`. Each is justified and each names its lifting
+condition **in a comment** — which is the weakness. When `typescript-eslint` ships TS 7 support,
+nothing notices; the ignore quietly becomes permanent.
+
+Same shape as everything else this epic found: `apps/server` alerts accruing against a deleted
+tree, `public-docs` lint red for months because nothing ran it, the stack card claiming OMDS after
+the migration. **Unverified state drifting because no mechanism checks it.**
+
+## What landed
+
+- **`.github/dependabot-ignores.yml`** — a registry giving every ignore a *machine-checkable*
+  blocker. Two kinds: `npm_peer` (read the blocking package's live peer range) and `ci_matrix`
+  (read a workflow's version matrix). The second exists because `python >=3.14` is **not**
+  upstream-blocked at all — we simply declined to test 3.14, and the registry says so plainly.
+- **`.claude/scripts/audit_dependabot_ignores.py`** — the checker.
+- **`repo-checks.yml`** — runs it, plus a **weekly schedule**, since the state being checked
+  changes when upstream ships, not when we commit.
+
+## Failure semantics — the key design decision
+
+**Drift fails** (exit 1): an ignore with no registry entry, or an entry with no ignore, is our own
+inconsistency and always fixable on the spot. **A liftable ignore only warns** (exit 0): failing a
+PR because upstream published a release would train people to disable the check — strictly worse
+than the rot it catches.
+
+## Verified, including the negatives
+
+| test | expected | result |
+|---|---|---|
+| green path | exit 0, all blocking | ✅ 5/5 |
+| detects a lift | warn, exit 0 | ✅ |
+| undocumented ignore | exit 1 | ✅ |
+| orphaned registry entry | exit 1 | ✅ |
+
+**A check that has never been seen to fail is not a check.**
+
+## It found a real bug immediately — mine
+
+The `ci_matrix` probe prints what it reads, exposing `scoreboard-tests.yml python-version =
+['3.12']` against `['3.12','3.13']` for its siblings. `OME-747` moved scoreboard's Dockerfile to
+**3.13** on the claim that "every Python matrix runs 3.12/3.13" — true of two apps out of three.
+So scoreboard now ships 3.13 and tests 3.12: the exact failure `OME-747` set out to prevent,
+caused by `OME-747`. Filed as `OME-750`.
+
+Near-miss worth noting: the probe's first version read only *list* matrices and fell through to
+"no matrix → still blocking" for scoreboard — right answer, wrong reason, which would have hidden
+this permanently.
+
+Ledger: `docs/work/2026-08-04-OME-749-ignore-audit.md`

--- a/docs/work/2026-08-04-OME-749-ignore-audit.md
+++ b/docs/work/2026-08-04-OME-749-ignore-audit.md
@@ -1,0 +1,159 @@
+---
+ticket: OME-749
+stack: repo
+status: done
+started: 2026-08-04
+finished: 2026-08-04
+---
+
+# OME-749 — audit Dependabot ignore rules so they expire
+
+Authored in an isolated worktree branched from `origin/main` at `b787cf5d`.
+
+## Intent
+
+This epic added `ignore` rules to `.github/dependabot.yml`. Each is justified and each names its
+lifting condition **in a comment** — and that is precisely the weakness. When
+`typescript-eslint` ships TS 7 support, nothing in this repo notices. The ignore quietly becomes
+permanent.
+
+Same failure shape as everything else this epic surfaced: `apps/server` alerts accruing against a
+deleted tree, `public-docs` lint red for months because nothing ran it, the stack card claiming
+OMDS after the migration. **Unverified state drifting because no mechanism checks it.**
+
+An ignore is defensible only if it is *verifiable* and *expiring*. The current set is verifiable
+but does not expire.
+
+## Design
+
+Two files plus a CI hook.
+
+**`.github/dependabot-ignores.yml`** — a companion registry. Every ignore in `dependabot.yml` gets
+an entry naming a **machine-checkable** blocker, not prose. Two blocker kinds cover the current
+set:
+
+- `npm_peer` — the blocking package's peer range for some dependency. The audit reads it live from
+  the registry and asks: does it now admit the ignored range?
+- `ci_matrix` — a workflow's version matrix. Asks: does it now cover the ignored version?
+
+The second kind exists because one ignore is **not upstream-blocked at all**. `python >=3.14` is
+blocked by *our own* CI matrices only covering 3.12/3.13. Python 3.14 works fine; we declined to
+test it. The registry should say that honestly rather than dressing it as unsupported.
+
+**`.claude/scripts/audit_dependabot_ignores.py`** — the checker. `.claude/scripts/**` is already a
+`repo-checks.yml` trigger path, so it gains CI coverage without touching the workflow's filters.
+
+## Failure semantics — deliberate, and the important design decision
+
+- **Drift FAILS.** An ignore with no registry entry, or a registry entry with no ignore, is *our
+  own* inconsistency — always fixable on the spot. This is what stops an undocumented ignore ever
+  landing again.
+- **A liftable ignore WARNS only.** Failing there would break someone's unrelated PR because
+  *upstream published a release*. That trains people to disable the check, which is strictly worse
+  than the rot it was meant to catch. Visibility comes from the scheduled run, not from blocking.
+
+Getting this backwards would make the tool self-defeating, so it is stated here rather than left
+implicit in an exit code.
+
+## Ordering dependency
+
+`origin/main` carries **5** ignore entries. #503 (`OME-748`, open) adds a sixth — `typescript >=7`
+on `/public-docs`.
+
+**Revised during the unit.** The plan was to cover all six here and merge after #503. That would
+have created an ordering dependency and, in effect, a stacked pair — and this repo squash-merges,
+where a stacked PR has already caused a branch to miss main once. Instead the registry covers
+exactly the **5 on main**, so this PR is self-consistent in any merge order, and #503 carries its
+own registry entry alongside its own ignore. A comment sits at that position in the registry with
+the blocker already worked out.
+
+## Planned changes
+
+- `.github/dependabot-ignores.yml` — new registry, one entry per ignore on main (5)
+- `.claude/scripts/audit_dependabot_ignores.py` — new checker
+- `.github/workflows/repo-checks.yml` — add the audit step + a weekly `schedule:` trigger, since
+  the whole point is detecting upstream change while our repo sits still
+
+## Test plan
+
+The audit is the artifact, so verification is behavioural — and the meaningful test is the
+**negative** one:
+
+1. **Green path** — run against the real config; every blocker must report *still blocking*,
+   matching what was verified by hand on 2026-08-04.
+2. **Detects a lift** — temporarily point one entry at a condition that is already satisfied, and
+   confirm the audit reports it liftable. Without this, a check that always prints green is
+   indistinguishable from one that works.
+3. **Detects drift both ways** — remove an ignore from `dependabot.yml` (registry orphan), then
+   remove a registry entry (undocumented ignore), and confirm each fails.
+
+A check that has never been seen to fail is not a check.
+
+## Acceptance
+
+- Every ignore on main reports still-blocking against live data.
+- The audit provably detects a lift, a registry orphan, and an undocumented ignore.
+- Drift exits non-zero; a liftable ignore does not.
+- Runs in `repo-checks.yml`, including on a weekly schedule.
+
+## Outcome
+
+- **Actual files:** as planned — the registry, the checker, and the `repo-checks.yml` wiring, plus
+  this ledger and its `docs/tasks/` mirror.
+
+- **Gates — all four planned tests, including the negatives:**
+
+  | test | expected | result |
+  |---|---|---|
+  | green path against real config | exit 0, all blocking | ✅ 5/5 still blocking |
+  | detects a lift | warn, exit **0** | ✅ `LIFTABLE` + GH annotation, exit 0 |
+  | drift: undocumented ignore | exit **1** | ✅ `UNDOCUMENTED`, exit 1 |
+  | drift: orphaned registry entry | exit **1** | ✅ `ORPHANED`, exit 1 |
+
+  `check_loop_parity.py` still green (this unit touches `repo-checks.yml`). Config restored
+  byte-identical after each destructive test — `git diff` clean.
+
+  **A check that has never been seen to fail is not a check.** Tests 2–4 exist so this one has.
+
+### It found a real bug on its first run — mine
+
+The `ci_matrix` probe reads the workflow and prints what it sees, which exposed:
+
+```
+scoreboard-tests.yml python-version = ['3.12']
+aigateway-tests.yml  python-version = ['3.12', '3.13']
+url4-cloud-tests.yml python-version = ['3.12', '3.13']
+```
+
+`OME-747` moved `apps/scoreboard/Dockerfile` to Python **3.13**, justified by "every Python matrix
+in the repo runs 3.12/3.13". True of two apps out of three — `scoreboard-tests.yml` pins a
+**scalar** `"3.12"` with no matrix at all. So scoreboard now **ships 3.13 and tests 3.12**: exactly
+the failure mode `OME-747` set out to prevent, caused by `OME-747`. I generalised from two
+workflows without reading the third.
+
+Filed as `OME-750`.
+
+### The near-miss inside that finding
+
+The probe's first version handled only **list**-shaped matrices. For scoreboard it fell through to
+"no matrix found → still blocking" — the correct verdict, reached by accident, which would have
+hidden the mismatch permanently. Fixed to read scalars too, with an `AIDEV-NOTE:` recording why
+both shapes matter. A check that is right for the wrong reason is a check that will be wrong
+later.
+
+### Deliberate limits, recorded rather than hidden
+
+- **Majors only, not full semver.** Every ignore we write is a major-boundary hold (`>=6`, `>=10`,
+  `>=3.14`); a full semver implementation is a lot of surface to get subtly wrong for no gain. The
+  `AIDEV-NOTE:` names the function to replace if that ever changes.
+- **Unrecognised ranges return "liftable".** A false warning costs a glance; false silence costs
+  the entire point of the script. Fails toward noise, never toward quiet.
+- **Template expressions filtered.** `python-version: ${{ matrix.python-version }}` is the
+  *consumer* of a matrix, not a version.
+
+### Ordering
+
+`origin/main` carries 5 ignores; the registry here covers exactly those 5. #503 (`OME-748`) adds a
+sixth (`typescript >=7` on `/public-docs`) and **must add its registry entry in the same change** —
+there is a comment in the registry at that position saying so, with the blocker already worked
+out. Deliberately not stacked: this repo squash-merges and a stacked PR has missed main before.


### PR DESCRIPTION
Closes `OME-749`, a sub-issue of `OME-733`. Prompted by a fair question: *"is it OK just to ignore an issue rather than solving it?"*

## The answer, and the weakness it exposed

Mostly yes — I re-verified all three upstream blockers and there is genuinely no version to upgrade to (`openapi-typescript` caps at peer `typescript ^5.x`; `eslint-plugin-react` peer excludes ESLint 10; `typescript-eslint` peer is `<6.1.0`). The latest published release *is* the blocker.

But the real weakness isn't any individual ignore — **it's that nothing ever forces a re-check.** Each rule names its lifting condition in a comment, and comments rot. When `typescript-eslint` ships TS 7 support, nothing in this repo notices; the ignore quietly becomes permanent.

That is the same failure shape as everything else this epic uncovered: `apps/server` alerts accruing against a deleted tree, `public-docs` lint red for months because nothing ran it, the stack card claiming OMDS after the migration. **Unverified state drifting because no mechanism checks it.**

An ignore is defensible only if it is *verifiable* and *expiring*. Ours were verifiable; none expired.

## What this adds

- **`.github/dependabot-ignores.yml`** — a registry giving every ignore a **machine-checkable** blocker instead of prose. Two kinds: `npm_peer` (read the blocking package's live peer range) and `ci_matrix` (read a workflow's version matrix).
- **`.claude/scripts/audit_dependabot_ignores.py`** — the checker.
- **`repo-checks.yml`** — runs it, plus a **weekly schedule**. The state being checked changes when *upstream ships*, not when we commit, so path triggers alone would only re-check on the rare PR that edits the config.

`ci_matrix` exists because one ignore is **not upstream-blocked at all**: `python >=3.14` is blocked by *our own* matrices only covering 3.12/3.13. Python 3.14 works fine; we declined to test it. The registry says that plainly rather than dressing a choice as a constraint.

## The key design decision — asymmetric exit codes

| condition | severity | why |
|---|---|---|
| **drift** (ignore ↔ registry mismatch) | **exit 1** | our own inconsistency, always fixable on the spot |
| **liftable** blocker | **exit 0**, warn | failing a PR because *upstream published a release* would train people to disable the check — worse than the rot it catches |

Getting that backwards would make the tool self-defeating.

## Test plan — the negatives are the point

| test | expected | result |
|---|---|---|
| green path against real config | exit 0, all blocking | ✅ 5/5 |
| **detects a lift** | warn, exit 0 | ✅ `LIFTABLE` + GH annotation |
| **drift: undocumented ignore** | exit 1 | ✅ |
| **drift: orphaned registry entry** | exit 1 | ✅ |

Config restored byte-identical after each destructive test (`git diff` clean). `check_loop_parity.py` still green.

**A check that has never been seen to fail is not a check.**

## ⚠️ It found a real bug on its first run — and the bug is mine

The `ci_matrix` probe prints what it reads:

```
scoreboard-tests.yml python-version = ['3.12']
aigateway-tests.yml  python-version = ['3.12', '3.13']
url4-cloud-tests.yml python-version = ['3.12', '3.13']
```

`OME-747` (#502, merged) moved `apps/scoreboard/Dockerfile` to Python **3.13**, justified by *"every Python matrix in the repo runs 3.12/3.13"*. True of two apps out of three — `scoreboard-tests.yml` pins a **scalar** `"3.12"` with no matrix. So scoreboard now **ships 3.13 and tests 3.12**: precisely the failure `OME-747` set out to prevent, caused by `OME-747`. I generalised from two workflows without reading the third.

Filed as **`OME-750`** (High).

**Near-miss worth flagging:** the probe's first version read only *list*-shaped matrices and fell through to `no matrix → still blocking` for scoreboard — the right verdict reached by accident, which would have hidden this permanently. Fixed to read scalars too, with an `AIDEV-NOTE:` on why both shapes matter.

## Merge ordering

`origin/main` carries 5 ignores; this registry covers exactly those 5, so the PR is self-consistent in **any** merge order. #503 (`OME-748`) adds a sixth and must carry its own registry entry — there is a comment at that position with the blocker already worked out. Deliberately not stacked: this repo squash-merges, and a stacked PR has caused a branch to miss main before.

---

Authored in an isolated git worktree branched from `origin/main` at `b787cf5d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iy1jFtiDTBpFdk5h6x1Mu