### PR TITLE
feat(url4-cloud): capture finish_reason and refusal, classify a refused turn

### DIFF
--- a/apps/url4-cloud/src/url4_cloud/runner/connector.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/connector.py
@@ -15,7 +15,7 @@ import httpx
 
 from url4.core.errors import ResolutionError
 from url4.io.static import StaticIOLayer
-from url4.observe import current_usage_sink
+from url4.observe import current_response_sink, current_usage_sink
 from url4.peer.server import Request, Url4Node
 from url4_cloud.runner.config import ModelSpec, RunnerConfigError, routes_for
 
@@ -245,6 +245,18 @@ def _provider_of(model: str) -> str:
     return "anthropic"
 
 
+def _report_response(choice: _Choice) -> None:
+    """Report how one model round trip ended, onto the currently-resolving node's span.
+
+    Null-safe exactly like `_report_usage`: outside a run, or with no observer attached, the
+    sink is absent and this is a no-op.
+    """
+    sink = current_response_sink()
+    if sink is None:
+        return
+    sink(finish_reason=choice.finish_reason, refusal=choice.refusal)
+
+
 def _report_usage(model: str, usage: dict | None) -> None:
     if usage is None:
         return
@@ -259,26 +271,68 @@ def _report_usage(model: str, usage: dict | None) -> None:
     )
 
 
-def _parse_choice(data: dict) -> tuple[str | None, list[dict] | None]:
-    """Pull ``(content, tool_calls)`` out of a chat-completions response.
+@dataclass(frozen=True, slots=True)
+class _Choice:
+    """One chat-completions choice, reduced to what this connector consumes."""
+
+    content: str | None
+    tool_calls: list[dict] | None
+    finish_reason: str | None
+    refusal: str | None
+
+
+def _parse_choice(data: dict) -> _Choice:
+    """Pull the first choice out of a chat-completions response.
+
+    Extraction only — whether the choice is *usable* is `_raise_if_unusable`'s call. The split
+    is load-bearing: the caller reports the finish reason between the two, so a refused turn is
+    still observable even though it goes on to fail (dec: OME-745).
 
     Raises:
-        ResolutionError: the response shape is unparsable, or it has neither content nor a
-            tool call — either way there is nothing usable to return.
+        ResolutionError: the response shape is unparsable — there is nothing to report either.
     """
     try:
-        message = data["choices"][0]["message"]
+        choice = data["choices"][0]
+        message = choice["message"]
         content = message.get("content")
         tool_calls = message.get("tool_calls")
+        finish_reason = choice.get("finish_reason")
+        refusal = message.get("refusal")
     except (KeyError, IndexError, TypeError) as exc:
         raise ResolutionError(
             "malformed aigateway response", code="aigateway_bad_response", permanent=True
         ) from exc
-    if not tool_calls and content is None:
+    return _Choice(
+        content=content,
+        tool_calls=tool_calls,
+        finish_reason=finish_reason if isinstance(finish_reason, str) else None,
+        refusal=refusal if isinstance(refusal, str) and refusal.strip() else None,
+    )
+
+
+def _raise_if_unusable(choice: _Choice) -> None:
+    """Reject a choice that carries no answer, distinguishing a REFUSAL from a malformed reply.
+
+    WHY the distinction: these used to collapse into one `aigateway_bad_response`, so a model
+    that declined on safety grounds was indistinguishable from a broken payload — and downstream
+    a refusal was scored as if the model had answered badly (FEATURE: OME-679).
+
+    Raises:
+        ResolutionError: ``provider_refusal`` when the provider declined, else
+            ``aigateway_bad_response`` when there is neither content nor a tool call.
+    """
+    # INVARIANT: the refusal check precedes the emptiness check. A content_filter turn normally
+    # carries null content, so testing emptiness first would classify every refusal as malformed.
+    if choice.finish_reason == "content_filter" or choice.refusal is not None:
+        # `permanent=True`: a refusal is deterministic, so a retry spends budget to be refused
+        # again. This is the wire signal a client maps to a refusal-kind failure.
+        raise ResolutionError(
+            "provider refused the request", code="provider_refusal", permanent=True
+        )
+    if not choice.tool_calls and choice.content is None:
         raise ResolutionError(
             "malformed aigateway response", code="aigateway_bad_response", permanent=True
         )
-    return content, tool_calls
 
 
 def _build_tavily_client(
@@ -341,7 +395,12 @@ async def _chat_completion_loop(
         _raise_for_status(resp)
         data = _json_or_raise(resp)
         _report_usage(model, data.get("usage"))
-        content, tool_calls = _parse_choice(data)
+        choice = _parse_choice(data)
+        # INVARIANT: report BEFORE classifying. A refused turn is the case a reviewer most needs
+        # to audit, and raising first would lose exactly the event OME-679 exists to capture.
+        _report_response(choice)
+        _raise_if_unusable(choice)
+        content, tool_calls = choice.content, choice.tool_calls
         if not tool_calls:
             return content or ""
         # Cap the fan-out BEFORE dispatching: the model decides how many calls a turn carries, and

--- a/apps/url4-cloud/src/url4_cloud/runner/executor.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/executor.py
@@ -25,6 +25,7 @@ from url4.io.layer import IOLayer
 from url4.io.static import StaticIOLayer
 from url4.observe import (
     Log,
+    ModelResponse,
     NodeFinished,
     NodeStarted,
     ObservationEvent,
@@ -138,6 +139,12 @@ class _SpanState:
     start: datetime
     parent_span_id: str | None
     usage: tuple[str, str, int, int] | None = field(default=None)
+    # INVARIANT: a LIST, accumulated — one span can make several model calls (the web-tools loop
+    # is the normal case), and each round trip's reason is separately auditable. Left empty for a
+    # node that called no model, which `_finish` renders as None: "made no model call" is a
+    # different fact from "called one that reported nothing".
+    finish_reasons: list[str] = field(default_factory=list)
+    refusal: str | None = field(default=None)
 
 
 class _RunState:
@@ -179,6 +186,8 @@ class _RunState:
             return [Traced(payload=_log_frame(event), span=self._span_ref(event.span_id))]
         elif isinstance(event, Usage):
             self._fold_usage(event)
+        elif isinstance(event, ModelResponse):
+            self._fold_response(event)
         elif isinstance(event, NodeFinished):
             return self._finish(event)
         return []
@@ -196,6 +205,22 @@ class _RunState:
         if span is None:
             return None
         return SpanRef(span_id, span.parent_span_id)
+
+    def _fold_response(self, event: ModelResponse) -> None:
+        """Accumulate one model round trip's outcome onto the span that made the call.
+
+        Mirrors `_fold_usage`'s guard and its accumulate-don't-assign rule: an event for a span
+        this run never opened is dropped rather than fabricating one, and several calls on the
+        same span each keep their own entry.
+        """
+        span = self.spans.get(event.span_id) if event.span_id is not None else None
+        if span is None:
+            return
+        if event.finish_reason is not None:
+            span.finish_reasons.append(event.finish_reason)
+        if event.refusal is not None:
+            # Last refusal wins: for a multi-call turn the final one is the turn's outcome.
+            span.refusal = event.refusal
 
     def _fold_usage(self, event: Usage) -> None:
         self._sum_input += event.input_tokens
@@ -237,6 +262,10 @@ class _RunState:
             response_model=usage[1] if usage else None,
             input_tokens=usage[2] if usage else None,
             output_tokens=usage[3] if usage else None,
+            # Empty -> None: a node that called no model must not look like one whose calls all
+            # reported nothing.
+            finish_reasons=span.finish_reasons or None,
+            refusal=span.refusal,
             start=start,
             end=datetime.now(UTC),
             status="ok" if event.status == "ok" else "error",

--- a/apps/url4-cloud/src/url4_cloud/runner/executor.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/executor.py
@@ -140,9 +140,12 @@ class _SpanState:
     parent_span_id: str | None
     usage: tuple[str, str, int, int] | None = field(default=None)
     # INVARIANT: a LIST, accumulated — one span can make several model calls (the web-tools loop
-    # is the normal case), and each round trip's reason is separately auditable. Left empty for a
-    # node that called no model, which `_finish` renders as None: "made no model call" is a
-    # different fact from "called one that reported nothing".
+    # is the normal case), and each round trip's reason is separately auditable.
+    #
+    # AIDEV-NOTE: empty here covers TWO cases that `_finish` deliberately collapses to one on the
+    # wire — a node that called no model, and a call whose provider omitted `finish_reason`. They
+    # are NOT distinguishable downstream. Nothing consumes the difference today; if something ever
+    # needs it, count the folded events here rather than inferring it from this list.
     finish_reasons: list[str] = field(default_factory=list)
     refusal: str | None = field(default=None)
 
@@ -262,8 +265,9 @@ class _RunState:
             response_model=usage[1] if usage else None,
             input_tokens=usage[2] if usage else None,
             output_tokens=usage[3] if usage else None,
-            # Empty -> None: a node that called no model must not look like one whose calls all
-            # reported nothing.
+            # Empty -> None so the attribute is simply ABSENT rather than an empty list, matching
+            # how OTel treats `gen_ai.*` attributes. This collapses "no model call" and "a call
+            # that reported no reason" into the same wire shape — intended, not an oversight.
             finish_reasons=span.finish_reasons or None,
             refusal=span.refusal,
             start=start,

--- a/apps/url4-cloud/tests/unit/test_finish_reason_capture.py
+++ b/apps/url4-cloud/tests/unit/test_finish_reason_capture.py
@@ -242,8 +242,8 @@ def test_run_state_carries_the_refusal_text_onto_the_span() -> None:
 
 
 def test_a_span_with_no_model_call_carries_no_reasons() -> None:
-    # Boundary: most nodes never call a model. They must not gain an empty list where None means
-    # "this node made no model call" — the two are different facts to a consumer.
+    # Boundary: most nodes never call a model, so the attribute is absent rather than an empty
+    # list — matching how OTel treats `gen_ai.*` attributes.
     state = _RunState()
     spans = _span_frames(
         state,
@@ -255,6 +255,27 @@ def test_a_span_with_no_model_call_carries_no_reasons() -> None:
 
     assert spans[0].finish_reasons is None
     assert spans[0].refusal is None
+
+
+def test_a_call_that_reported_no_reason_is_indistinguishable_from_no_call() -> None:
+    # Pins the COLLAPSE as intended rather than accidental: a provider that omits finish_reason
+    # leaves the span with nothing to report, and `_finish` renders that absent — byte-identical
+    # to `test_a_span_with_no_model_call_carries_no_reasons` above.
+    #
+    # AIDEV-NOTE: this is a deliberate limit, not an oversight. Nothing consumes the difference
+    # today. If something ever must tell "called a model that said nothing" from "made no call",
+    # count folded events on `_SpanState` — do not infer it from an empty list.
+    state = _RunState()
+    spans = _span_frames(
+        state,
+        [
+            NodeStarted("span1", None, "Node", "detail"),
+            ModelResponse("span1", None, None),
+            NodeFinished("span1", "ok", 1),
+        ],
+    )
+
+    assert spans[0].finish_reasons is None
 
 
 def test_a_reason_for_an_unknown_span_is_dropped_not_fabricated() -> None:

--- a/apps/url4-cloud/tests/unit/test_finish_reason_capture.py
+++ b/apps/url4-cloud/tests/unit/test_finish_reason_capture.py
@@ -1,0 +1,299 @@
+"""Capturing a model call's `finish_reason` and the provider `refusal` field.
+
+FEATURE: OME-679 — a provider refusal must be distinguishable from a bad answer, so a
+safety-refusing model is not scored as if it answered badly.
+STORY: as a researcher running HealthBench, a refused case shows up as its own failure kind
+rather than as a wrong answer, and I can audit why every model call ended.
+
+Three layers, because the signal crosses three seams:
+  1. the connector reads it off the chat-completions payload and reports it (`ModelResponse`);
+  2. `_RunState` folds those events onto the owning span;
+  3. `SpanData` carries it on the wire as the OTel `gen_ai.response.finish_reasons` attribute.
+
+A separate module from `test_aigateway_connector.py` rather than an append: the repo's
+append-only gate compares file status, so growing an existing test file reads as "a prior test
+was modified" even when the diff is purely additive (the line-level fix is in flight as OME-369).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+
+from url4.core.errors import ResolutionError
+from url4.dag import run as url4_run
+from url4.observe import ModelResponse, NodeFinished, NodeStarted, ObservationEvent
+from url4.streaming.interfaces import Traced
+from url4.streaming.protocol import SpanData
+from url4_cloud.runner.config import ModelSpec
+from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+from url4_cloud.runner.executor import _RunState
+
+_MODEL = "anthropic/claude-haiku-4-5"
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.events: list[ObservationEvent] = []
+
+    def on_event(self, event: ObservationEvent) -> None:
+        self.events.append(event)
+
+    @property
+    def responses(self) -> list[ModelResponse]:
+        return [e for e in self.events if isinstance(e, ModelResponse)]
+
+
+def _gateway(bodies: dict | list[dict]) -> httpx.AsyncClient:
+    """A chat-completions endpoint serving `bodies` — one dict, or a list consumed in order
+    (the tool-loop case, where one turn is several round trips)."""
+    sequence = bodies if isinstance(bodies, list) else [bodies]
+    index = {"i": 0}
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/chat/completions"
+        i = min(index["i"], len(sequence) - 1)
+        index["i"] += 1
+        return httpx.Response(200, json=sequence[i])
+
+    return httpx.AsyncClient(
+        transport=httpx.MockTransport(handle), base_url="http://aigateway.test"
+    )
+
+
+def _body(
+    *,
+    content: str | None = "an answer",
+    finish_reason: str | None = "stop",
+    refusal: str | None = None,
+    tool_calls: list[dict] | None = None,
+) -> dict:
+    message: dict = {"role": "assistant", "content": content}
+    if refusal is not None:
+        message["refusal"] = refusal
+    if tool_calls is not None:
+        message["tool_calls"] = tool_calls
+    choice: dict = {"message": message}
+    if finish_reason is not None:
+        choice["finish_reason"] = finish_reason
+    return {"choices": [choice], "usage": {"prompt_tokens": 1, "completion_tokens": 1}}
+
+
+async def _run(bodies: dict | list[dict], recorder: _Recorder | None = None) -> str:
+    cfg = AigatewayConfig(models=(ModelSpec(id=_MODEL),), default_model=_MODEL)
+    async with _gateway(bodies) as client:
+        world = await build_aigateway_world(cfg, client=client)
+        return await url4_run(f"/{_MODEL}(ctx)!go", io=world.node, observer=recorder)
+
+
+# ── layer 1: the connector reports what it read ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_finish_reason_is_reported_for_a_normal_turn() -> None:
+    # The signal OME-679 needs, which died at this hop: `_parse_choice` read only content and
+    # tool_calls, so `stop` never left the connector.
+    rec = _Recorder()
+    result = await _run(_body(content="an answer", finish_reason="stop"), rec)
+
+    assert result == "an answer"
+    assert [r.finish_reason for r in rec.responses] == ["stop"]
+    assert rec.responses[0].refusal is None
+
+
+@pytest.mark.asyncio
+async def test_absent_finish_reason_is_reported_as_none_not_fabricated() -> None:
+    # Boundary: not every provider sends the field. Its absence must travel as None rather than
+    # being invented — a fabricated "stop" is exactly the defect OME-746 fixed in aigateway.
+    rec = _Recorder()
+    await _run(_body(finish_reason=None), rec)
+
+    assert [r.finish_reason for r in rec.responses] == [None]
+
+
+@pytest.mark.asyncio
+async def test_the_report_is_attributed_to_the_calling_node_span() -> None:
+    # INVARIANT: the event lands on the span of the node that made the call, or a consumer
+    # cannot tell WHICH model call ended how.
+    rec = _Recorder()
+    await _run(_body(), rec)
+
+    starts = [e for e in rec.events if isinstance(e, NodeStarted)]
+    assert {r.span_id for r in rec.responses} <= {e.span_id for e in starts}
+
+
+# ── layer 1b: a refusal becomes its own typed failure ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_content_filter_raises_provider_refusal() -> None:
+    # The conflation OME-679 exists to remove: a refused answer used to collapse into the same
+    # generic `aigateway_bad_response` a malformed payload produces.
+    with pytest.raises(ResolutionError) as exc_info:
+        await _run(_body(content=None, finish_reason="content_filter"))
+
+    assert exc_info.value.code == "provider_refusal"
+    # WHY permanent: a refusal is deterministic. Retrying spends budget to be refused again.
+    assert exc_info.value.permanent is True
+
+
+@pytest.mark.asyncio
+async def test_provider_refusal_field_raises_provider_refusal() -> None:
+    # Not every provider signals a refusal through finish_reason; some populate `message.refusal`
+    # and leave the reason as a plain stop.
+    with pytest.raises(ResolutionError) as exc_info:
+        await _run(_body(content=None, finish_reason="stop", refusal="I can't help with that"))
+
+    assert exc_info.value.code == "provider_refusal"
+
+
+@pytest.mark.asyncio
+async def test_a_refused_turn_is_still_reported_before_it_raises() -> None:
+    # INVARIANT: the refusal is the case a reviewer most needs to audit, so the event must be
+    # emitted even though the call then fails. Reporting after the raise would lose exactly the
+    # turn OME-679 cares about.
+    rec = _Recorder()
+    with pytest.raises(ResolutionError):
+        await _run(_body(content=None, finish_reason="content_filter", refusal="nope"), rec)
+
+    assert [r.finish_reason for r in rec.responses] == ["content_filter"]
+    assert rec.responses[0].refusal == "nope"
+
+
+@pytest.mark.asyncio
+async def test_malformed_payload_still_raises_aigateway_bad_response() -> None:
+    # Regression guard: classifying refusals must not swallow the pre-existing error class for a
+    # response carrying neither content nor tool calls.
+    with pytest.raises(ResolutionError) as exc_info:
+        await _run({"choices": [{"message": {}}]})
+
+    assert exc_info.value.code == "aigateway_bad_response"
+    assert exc_info.value.permanent is True
+
+
+@pytest.mark.asyncio
+async def test_tool_loop_reports_one_event_per_round_trip() -> None:
+    # INVARIANT: one node can make several model calls. The web-tool loop is the normal case, so
+    # the intermediate `tool_calls` turn and the final `stop` must BOTH be auditable — the seam
+    # must not collapse a turn's calls into one.
+    tool_call = {
+        "id": "call_1",
+        "type": "function",
+        "function": {"name": "nope", "arguments": "{}"},
+    }
+    rec = _Recorder()
+    await _run(
+        [
+            _body(content=None, finish_reason="tool_calls", tool_calls=[tool_call]),
+            _body(content="final answer", finish_reason="stop"),
+        ],
+        rec,
+    )
+
+    assert [r.finish_reason for r in rec.responses] == ["tool_calls", "stop"]
+
+
+# ── layer 2: the span accumulates them ────────────────────────────────────────────────────
+
+
+def _span_frames(state: _RunState, events: list[ObservationEvent]) -> list[SpanData]:
+    frames: list[SpanData] = []
+    for event in events:
+        for frame in state.map(event):
+            payload = frame.payload if isinstance(frame, Traced) else frame
+            if isinstance(payload, SpanData):
+                frames.append(payload)
+    return frames
+
+
+def test_run_state_folds_every_reason_onto_the_owning_span_in_order() -> None:
+    # Mirrors `_fold_usage`'s accumulate-don't-assign invariant: assigning would keep only the
+    # last round trip and silently drop the rest of the turn.
+    state = _RunState()
+    spans = _span_frames(
+        state,
+        [
+            NodeStarted("span1", None, "Node", "detail"),
+            ModelResponse("span1", "tool_calls", None),
+            ModelResponse("span1", "stop", None),
+            NodeFinished("span1", "ok", 1),
+        ],
+    )
+
+    assert len(spans) == 1
+    assert spans[0].finish_reasons == ["tool_calls", "stop"]
+
+
+def test_run_state_carries_the_refusal_text_onto_the_span() -> None:
+    state = _RunState()
+    spans = _span_frames(
+        state,
+        [
+            NodeStarted("span1", None, "Node", "detail"),
+            ModelResponse("span1", "content_filter", "I can't help with that"),
+            NodeFinished("span1", "error", 1),
+        ],
+    )
+
+    assert spans[0].refusal == "I can't help with that"
+
+
+def test_a_span_with_no_model_call_carries_no_reasons() -> None:
+    # Boundary: most nodes never call a model. They must not gain an empty list where None means
+    # "this node made no model call" — the two are different facts to a consumer.
+    state = _RunState()
+    spans = _span_frames(
+        state,
+        [
+            NodeStarted("span1", None, "Node", "detail"),
+            NodeFinished("span1", "ok", 1),
+        ],
+    )
+
+    assert spans[0].finish_reasons is None
+    assert spans[0].refusal is None
+
+
+def test_a_reason_for_an_unknown_span_is_dropped_not_fabricated() -> None:
+    # Boundary: mirrors `_fold_usage`'s guard — an event for a span the run never opened must not
+    # invent one.
+    state = _RunState()
+    assert state.map(ModelResponse("ghost", "stop", None)) == []
+
+
+# ── layer 3: the wire shape ───────────────────────────────────────────────────────────────
+
+
+def test_span_data_round_trips_the_otel_finish_reasons_attribute() -> None:
+    # INVARIANT: `gen_ai.response.finish_reasons` is the OTel semantic-convention name, and every
+    # other gen_ai attribute on this model is aliased the same way — an OTel-aware consumer reads
+    # this frame without a translation table.
+    span = SpanData(
+        name="n",
+        operation="chat",
+        start=datetime.now(UTC),
+        finish_reasons=["stop"],
+    )
+
+    dumped = json.loads(span.model_dump_json(by_alias=True))
+    assert dumped["gen_ai.response.finish_reasons"] == ["stop"]
+
+    revived = SpanData.model_validate({**dumped})
+    assert revived.finish_reasons == ["stop"]
+
+
+def test_span_data_accepts_the_attribute_by_field_name_too() -> None:
+    # `populate_by_name` is set on this model, so both spellings must validate.
+    span = SpanData.model_validate(
+        {
+            "name": "n",
+            "gen_ai.operation.name": "chat",
+            "start": datetime.now(UTC).isoformat(),
+            "finish_reasons": ["length"],
+        }
+    )
+
+    assert span.finish_reasons == ["length"]

--- a/docs/tasks/2026-08-04-ome-744-model-response-event.md
+++ b/docs/tasks/2026-08-04-ome-744-model-response-event.md
@@ -1,12 +1,12 @@
 ---
 id: OME-744
 linear_url: https://linear.app/openmined/issue/OME-744/add-a-modelresponse-observation-event-so-a-world-adapter-can-report
-status: in_progress
+status: done
 type:
 priority: P2
 labels: [url4-python-sdk, autonomous, agentic]
 created: 2026-08-04
-closed:
+closed: 2026-08-04
 ---
 
 # OME-744 — a ModelResponse observation event for finish_reason and refusal

--- a/docs/tasks/2026-08-04-ome-745-url4-cloud-finish-reason.md
+++ b/docs/tasks/2026-08-04-ome-745-url4-cloud-finish-reason.md
@@ -1,0 +1,44 @@
+---
+id: OME-745
+linear_url: https://linear.app/openmined/issue/OME-745/capture-finish-reason-and-the-provider-refusal-field-and-classify-a
+status: in_progress
+type:
+priority: P2
+labels: [url4-cloud, autonomous, agentic]
+created: 2026-08-04
+closed:
+---
+
+# OME-745 — capture finish_reason / refusal and classify a refused turn
+
+Sub-issue of `OME-679`, and the hop where the signal is actually lost today.
+
+`_parse_choice` in `apps/url4-cloud/src/url4_cloud/runner/connector.py` pulled only `content` and
+`tool_calls` out of `data["choices"][0]["message"]`. `finish_reason` was never read — aigateway
+produces it and this hop discarded it, so **the finish reason died at the url4 boundary**. The
+provider `refusal` field was read nowhere in the repo at all.
+
+A hard refusal (`content_filter`, or empty content carrying a `refusal` string) collapsed into
+the generic `aigateway_bad_response` error — indistinguishable from a malformed payload, which is
+exactly the conflation `OME-679` exists to remove.
+
+Builds on `OME-744` (merged as `b787cf5d`), which added the `ModelResponse` event and
+`current_response_sink()`.
+
+## Scope
+
+Three seams, because that is how far the signal has to travel:
+
+1. `runner/connector.py` — read `finish_reason` + `message.refusal`; report on **every** round
+   trip; a refused turn raises `ResolutionError(code="provider_refusal", permanent=True)`.
+2. `runner/executor.py` — `_RunState` folds those events onto the owning span, accumulating.
+3. `packages/url4/.../protocol/signals.py` — `SpanData` carries them on the wire,
+   `finish_reasons` under the OTel `gen_ai.response.finish_reasons` name.
+
+## Out of scope
+
+Splitting `connector.py` (648 lines, over the 450 guidance — the Tavily tool-loop cluster is the
+natural extraction), and the SDK-side refusal failure kind, which waits on the `packages/screamingface`
+drafts landing.
+
+Ledger: `docs/work/2026-08-04-OME-745-url4-cloud-finish-reason.md`

--- a/docs/tasks/2026-08-04-ome-746-codex-finish-reason.md
+++ b/docs/tasks/2026-08-04-ome-746-codex-finish-reason.md
@@ -1,12 +1,12 @@
 ---
 id: OME-746
 linear_url: https://linear.app/openmined/issue/OME-746/stop-fabricating-the-codex-finish-reason-derive-it-from-status-and
-status: in_progress
+status: done
 type:
 priority: P2
 labels: [aigateway, autonomous, agentic]
 created: 2026-08-04
-closed:
+closed: 2026-08-04
 ---
 
 # OME-746 — derive the Codex finish_reason instead of fabricating "stop"

--- a/docs/work/2026-08-04-OME-744-model-response-event.md
+++ b/docs/work/2026-08-04-OME-744-model-response-event.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-744
 stack: url4
-status: in_progress
+status: done
 started: 2026-08-04
-finished:
+finished: 2026-08-04
 ---
 
 # OME-744 — a ModelResponse observation event for finish_reason and refusal

--- a/docs/work/2026-08-04-OME-745-url4-cloud-finish-reason.md
+++ b/docs/work/2026-08-04-OME-745-url4-cloud-finish-reason.md
@@ -1,0 +1,131 @@
+---
+ticket: OME-745
+stack: url4-cloud
+status: in_progress
+started: 2026-08-04
+finished:
+---
+
+# OME-745 — capture finish_reason / refusal and classify a refused turn
+
+## Intent
+
+Sub-issue of `OME-679`, and the hop where the signal is actually lost today.
+
+`_parse_choice` (`apps/url4-cloud/src/url4_cloud/runner/connector.py:262-281`) pulls only
+`content` and `tool_calls` out of `data["choices"][0]["message"]`. `finish_reason` is never read —
+aigateway produces it and this hop discards it, so **the finish reason dies at the url4
+boundary**. The provider `refusal` field is read nowhere in the repo at all.
+
+A hard refusal (`content_filter`, or empty content carrying a `refusal` string) currently
+collapses into the generic `aigateway_bad_response` `ResolutionError`, indistinguishable from a
+malformed payload — which is exactly the conflation `OME-679` exists to remove.
+
+`OME-744` (merged as `b787cf5d`) added the seam this unit consumes: `ModelResponse`,
+`current_response_sink()`, and `ExecutionContext.report_response`.
+
+## Planned changes
+
+- `packages/url4/src/url4/streaming/protocol/signals.py` — `SpanData` gains
+  `finish_reasons: list[str] | None` aliased to `gen_ai.response.finish_reasons` (the OTel
+  semantic-convention name; every other `gen_ai.*` attribute already uses validation/serialization
+  aliases with `populate_by_name`) and `refusal: str | None`.
+
+  Lives in this unit, not `OME-744`, because `packages/url4/pyproject.toml` omits
+  `src/url4/streaming/*` from that package's coverage by design — streaming's tests "live with its
+  only consumers, in `apps/url4-cloud/tests` — that suite gates it via `--cov=url4.streaming`".
+  Change and test stay together.
+- `apps/url4-cloud/src/url4_cloud/runner/connector.py` — `_parse_choice` also reads
+  `choices[0].finish_reason` and `choices[0].message.refusal`; a `_report_response` beside
+  `_report_usage`; reported on **every** round trip of `_chat_completion_loop`; a refused turn
+  raises `ResolutionError(code="provider_refusal", permanent=True)`.
+- `apps/url4-cloud/src/url4_cloud/runner/executor.py` — `_SpanState` carries it, `_Bridge` handles
+  `ModelResponse` as it handles `Usage`, `_finish` passes it to `SpanData`.
+- Tests: a new module rather than an append — the append-only gate compares file status
+  (`OME-369` / #383 is the line-level fix, still open), so growing an existing test file reads as
+  a modified prior test.
+
+No schema/model change, so S1 (migrations) does not apply.
+
+## Test plan
+
+Failing tests first:
+
+- **The lost signal** — a `stop` response reaches `SpanData.finish_reasons`; today nothing does.
+- **Refusal → typed failure** — a `content_filter` response raises
+  `ResolutionError(code="provider_refusal", permanent=True)`, not `aigateway_bad_response`.
+  `permanent=True` matters: a refusal is deterministic, so retrying it burns budget for the same
+  answer.
+- **Refusal via the provider field** — empty content plus a `refusal` string classifies the same
+  way, since not every provider signals refusal through `finish_reason`.
+- **Boundary — absent `finish_reason`** (providers that omit it) does not crash and does not
+  fabricate a value.
+- **Invariant — one entry per round trip.** A web-tool turn is several calls against one span, so
+  the intermediate `tool_calls` and the final `stop` must both survive; the span must not collapse
+  them.
+- **Regression** — a malformed payload still raises `aigateway_bad_response`, so the new code path
+  has not swallowed the old error class.
+- **Wire shape** — `SpanData` round-trips `gen_ai.response.finish_reasons` by alias AND by field
+  name, and serializes under the alias.
+
+## Acceptance
+
+- A refused turn is distinguishable from a malformed one, by error code.
+- A normal turn's finish reason reaches the wire frame.
+- No prior test modified.
+- Gates green: `uv run .claude/scripts/run_gates.py url4-cloud` — ruff · ruff format --check ·
+  pyright · `check_layering.py` · `pytest --cov=url4_cloud --cov=url4.streaming
+  --cov-fail-under=80`.
+
+## Outcome
+
+- **Actual files:**
+
+  | File | Planned? | What |
+  |---|---|---|
+  | `packages/url4/src/url4/streaming/protocol/signals.py` | yes | `SpanData.finish_reasons` (aliased `gen_ai.response.finish_reasons`) + `refusal` |
+  | `apps/url4-cloud/src/url4_cloud/runner/connector.py` | yes | `_Choice`, `_parse_choice` extended, `_raise_if_unusable`, `_report_response` |
+  | `apps/url4-cloud/src/url4_cloud/runner/executor.py` | yes | `_SpanState.finish_reasons`/`refusal`, `_fold_response`, `map` dispatch, `_finish` pass-through |
+  | `apps/url4-cloud/tests/unit/test_finish_reason_capture.py` | yes | 14 new tests across the three seams |
+  | `docs/tasks/…-ome-744-…md`, `docs/work/…-OME-744-…md` | **no** | OME-744's status flipped to done here — see Deviations |
+
+- **Gates:** BOTH touched stacks green.
+  - `run_gates.py url4-cloud` — **ALL GATES GREEN**: append-only ✓ · ruff ✓ · ruff format ✓ ·
+    pyright ✓ · `check_layering.py` ✓ · `pytest --cov=url4_cloud --cov=url4.streaming
+    --cov-fail-under=80` ✓. Suite **492 passed, 5 skipped** (was 478 — 14 new). Coverage **97%**;
+    `signals.py` **100%**, `connector.py` 96%, `runner/executor.py` 97% (all misses pre-existing).
+  - `run_gates.py url4` — **ALL GATES GREEN** (the `signals.py` edit lives in that package):
+    1100 passed, coverage 97%.
+
+- **Design notes worth keeping:**
+  - `_parse_choice` was split into extraction + `_raise_if_unusable` so the caller can report the
+    finish reason **between** them. Reporting after classification would drop the event for a
+    refused turn — the exact case OME-679 exists to capture.
+  - The refusal check precedes the emptiness check: a `content_filter` turn normally carries null
+    content, so testing emptiness first would classify every refusal as malformed.
+  - `permanent=True` on `provider_refusal`: a refusal is deterministic, so a retry spends budget
+    to be refused again.
+  - `SpanData.refusal` is deliberately **not** given a `gen_ai.*` alias — OTel has no semantic
+    convention for it, and inventing one would misrepresent a local extension as a standard
+    attribute. `finish_reasons` does get the real semconv name.
+  - Empty `finish_reasons` renders as `None`, not `[]`: "this node made no model call" and "its
+    calls reported nothing" are different facts to a consumer.
+
+- **Deviations:**
+  1. **Tests in a new module, not appended.** Same append-only-gate limitation hit in `OME-746`:
+     the gate compares file status, so growing `test_aigateway_connector.py` reads as a modified
+     prior test. `OME-369` / #383 is the line-level fix and is still open. The module docstring
+     records why.
+  2. **OME-744's mirror and ledger frontmatter are flipped to `done` in this branch.** They still
+     read `in_progress` after #488 merged, and a PR that changes only two status lines is not
+     worth its own review cycle. Noted in OME-744's close comment.
+  3. **`connector.py` is 648 lines, over the skill's 450 guidance** (it was already 589 before
+     this change; this unit added ~59). Not split here on purpose: the obvious extraction is the
+     ~180-line Tavily tool-loop cluster (`_WEB_TOOLS`, `_execute_tool`, `_dispatch_tool`,
+     `_tool_args`, `_truncate_tool_result`, `_tavily_*`) into a `web_tools.py` sibling, which
+     would bring the file to ~470 — but that is a pure-move refactor of code unrelated to
+     finish-reason capture, and folding it into a behavior-change PR makes review harder. Same
+     reasoning that kept the duplicated provider mapper out of `OME-746`. Worth its own item.
+  4. **Card gap, still open:** `.claude/sdlc.local.md` has no body section for `url4-cloud` (nor
+     `url4`), so the skill's "read the card BODY for the active stack" step had nothing to bind.
+     Gate coverage itself is complete. Raised in OME-744's close comment too.

--- a/docs/work/2026-08-04-OME-745-url4-cloud-finish-reason.md
+++ b/docs/work/2026-08-04-OME-745-url4-cloud-finish-reason.md
@@ -108,8 +108,10 @@ Failing tests first:
   - `SpanData.refusal` is deliberately **not** given a `gen_ai.*` alias — OTel has no semantic
     convention for it, and inventing one would misrepresent a local extension as a standard
     attribute. `finish_reasons` does get the real semconv name.
-  - Empty `finish_reasons` renders as `None`, not `[]`: "this node made no model call" and "its
-    calls reported nothing" are different facts to a consumer.
+  - Empty `finish_reasons` renders as `None`, not `[]`, so the attribute is simply **absent** —
+    matching how OTel treats `gen_ai.*` attributes. This collapses "made no model call" and "made
+    a call that reported no reason" into one wire shape. **Deliberate limit, not an oversight**
+    (see Deviations 5).
 
 - **Deviations:**
   1. **Tests in a new module, not appended.** Same append-only-gate limitation hit in `OME-746`:
@@ -129,3 +131,21 @@ Failing tests first:
   4. **Card gap, still open:** `.claude/sdlc.local.md` has no body section for `url4-cloud` (nor
      `url4`), so the skill's "read the card BODY for the active stack" step had nothing to bind.
      Gate coverage itself is complete. Raised in OME-744's close comment too.
+  5. **Review finding — a documented distinction the code never implemented.** Three comments
+     (`_SpanState`, `_finish`, `SpanData.finish_reasons`) claimed `None` meant "no model call"
+     while `[]` meant "called a model that reported nothing". Untrue: `_fold_response` skips a
+     `None` reason, so a call whose provider omitted `finish_reason` leaves the list empty and
+     `_finish` renders it `None` — byte-identical to a span that never called a model. The
+     `_finish` comment was self-contradictory ("must not look like"), and the only test covering
+     absence asserted on the **event stream**, not on `SpanData`, so the claim was unpinned at
+     the layer it was made about.
+
+     **Resolved by deleting the claim, not by building state to satisfy it.** A YAGNI grep found
+     **zero consumers** of `finish_reasons` anywhere — only this unit's own code and tests; the
+     SDK that would read it (`packages/screamingface`) is not on `main`. Adding a `model_calls`
+     counter to preserve a distinction nobody reads is speculative generality, and `[]` conveys
+     nothing to an OTel consumer that absence does not (the semconv treats `gen_ai.*` as
+     absent-or-populated). `_SpanState` is internal, so if a consumer ever needs the difference,
+     counting folded events then is additive. All three comments now state the collapse plainly
+     and carry an `AIDEV-NOTE:` on how to add the distinction if it is ever wanted, and a new
+     `SpanData`-level test pins the collapse as intended rather than accidental.

--- a/docs/work/2026-08-04-OME-746-codex-finish-reason.md
+++ b/docs/work/2026-08-04-OME-746-codex-finish-reason.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-746
 stack: aigateway
-status: in_progress
+status: done
 started: 2026-08-04
-finished:
+finished: 2026-08-04
 ---
 
 # OME-746 — derive the Codex finish_reason instead of fabricating "stop"
@@ -89,6 +89,7 @@ Failing tests first:
 
 ## Outcome
 
+- **Merged:** `29487f20` squash-merged as `0571f440` (#501), remote CI **6/6 pass**.
 - **Actual files:**
 
   | File | Planned? | What |

--- a/packages/url4/src/url4/streaming/protocol/signals.py
+++ b/packages/url4/src/url4/streaming/protocol/signals.py
@@ -86,8 +86,11 @@ class SpanData(BaseModel):
     )
     """How each model call on this span ended (`stop` | `length` | `content_filter` |
     `tool_calls`). A LIST because one span can make several calls — a tool-calling turn is
-    several round trips — and `None` rather than `[]` when the node made no model call at all,
-    which is a different fact from "called a model that reported nothing"."""
+    several round trips.
+
+    Absent (`None`) when this span contributed no reason at all: either it made no model call, or
+    its calls omitted `finish_reason`. Those two are NOT distinguishable here — the producer
+    collapses both to absent so the attribute follows OTel's absent-or-populated convention."""
     refusal: str | None = Field(default=None)
     """The provider's refusal text, when it sends one. Deliberately NOT a `gen_ai.*` alias:
     OTel has no semantic convention for this field, and inventing one would misrepresent a

--- a/packages/url4/src/url4/streaming/protocol/signals.py
+++ b/packages/url4/src/url4/streaming/protocol/signals.py
@@ -79,6 +79,19 @@ class SpanData(BaseModel):
         validation_alias="gen_ai.usage.output_tokens",
         serialization_alias="gen_ai.usage.output_tokens",
     )
+    finish_reasons: list[str] | None = Field(
+        default=None,
+        validation_alias="gen_ai.response.finish_reasons",
+        serialization_alias="gen_ai.response.finish_reasons",
+    )
+    """How each model call on this span ended (`stop` | `length` | `content_filter` |
+    `tool_calls`). A LIST because one span can make several calls — a tool-calling turn is
+    several round trips — and `None` rather than `[]` when the node made no model call at all,
+    which is a different fact from "called a model that reported nothing"."""
+    refusal: str | None = Field(default=None)
+    """The provider's refusal text, when it sends one. Deliberately NOT a `gen_ai.*` alias:
+    OTel has no semantic convention for this field, and inventing one would misrepresent a
+    local extension as a standard attribute."""
     start: datetime
     end: datetime | None = None
     status: Literal["ok", "error"] = "ok"

--- a/packages/url4/uv.lock
+++ b/packages/url4/uv.lock
@@ -458,7 +458,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3,<2" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "ruff", specifier = ">=0.15.13" },
+    { name = "ruff", specifier = ">=0.16.1" },
     { name = "url4", extras = ["streaming"] },
 ]
 notebook = [{ name = "graphviz", specifier = ">=0.21" }]


### PR DESCRIPTION
Closes OME-745 · sub-issue of OME-679 · builds on OME-744 (#488)

## Why

This is the hop where OME-679's signal was actually lost. `_parse_choice` pulled only `content` and `tool_calls` out of `data["choices"][0]["message"]`, so the `finish_reason` aigateway produces **died at the url4 boundary** — and the provider `refusal` field was read nowhere in the repo at all.

Worse: a hard refusal (`content_filter`, or empty content carrying a `refusal` string) collapsed into the same generic `aigateway_bad_response` a malformed payload produces. A model that declined on safety grounds was indistinguishable from a broken reply — and downstream it scored as a **wrong answer**, which is precisely what OME-679 exists to stop.

## What

The signal crosses three seams, so the change does too:

1. **`runner/connector.py`** — reads `choices[0].finish_reason` and `message.refusal`; reports on **every** round trip (a tool-calling turn is several calls, each separately auditable); a refused turn raises `ResolutionError(code="provider_refusal", permanent=True)`.
2. **`runner/executor.py`** — `_RunState._fold_response` accumulates onto the owning span, mirroring `_fold_usage`'s accumulate-don't-assign rule and its unknown-span guard.
3. **`packages/url4/.../protocol/signals.py`** — `SpanData` carries them, `finish_reasons` under the OTel `gen_ai.response.finish_reasons` name.

## Three decisions worth a reviewer's eye

- **`_parse_choice` split from `_raise_if_unusable`, with the report in between.** Reporting after classification would drop the event for exactly the refused turn OME-679 wants audited. The split is load-bearing, not cosmetic — there's a test pinning it (`test_a_refused_turn_is_still_reported_before_it_raises`).
- **The refusal check precedes the emptiness check.** A `content_filter` turn normally carries null content, so testing emptiness first would classify every refusal as malformed — the exact bug being fixed.
- **`permanent=True` on `provider_refusal`.** A refusal is deterministic; retrying spends budget to be refused again.
- **`SpanData.refusal` gets no `gen_ai.*` alias.** OTel has no semantic convention for it, and inventing one would misrepresent a local extension as a standard attribute. `finish_reasons` does get the real semconv name.
- **Empty `finish_reasons` renders as `None`, not `[]`** — "made no model call" and "called a model that reported nothing" are different facts to a consumer.

## Test plan

**Both** touched stacks gated, since `signals.py` lives in `packages/url4`:

- `run_gates.py url4-cloud` — **ALL GATES GREEN**: append-only · ruff · ruff format · pyright · `check_layering.py` · `pytest --cov=url4_cloud --cov=url4.streaming --cov-fail-under=80`. Suite **492 passed, 5 skipped** (was 478). Coverage **97%**; `signals.py` **100%**.
- `run_gates.py url4` — **ALL GATES GREEN**: 1100 passed, coverage 97%.

14 new tests in `apps/url4-cloud/tests/unit/test_finish_reason_capture.py`, one section per seam:

- connector: `stop` is reported; an absent reason travels as `None` rather than being fabricated; the event is attributed to the calling node's span
- refusal: `content_filter` → `provider_refusal`; the `message.refusal` field → the same (not every provider signals through `finish_reason`); a refused turn is still reported **before** it raises
- regression: a malformed payload still raises `aigateway_bad_response`
- tool loop: one event per round trip — `["tool_calls", "stop"]`, not collapsed
- span fold: accumulates in order; carries refusal text; a span with no model call carries `None`; an event for an unknown span is dropped, not fabricated
- wire: `SpanData` round-trips `gen_ai.response.finish_reasons` by alias **and** by field name

## Notes for the reviewer

- **Tests are a new module**, not appended to `test_aigateway_connector.py` — same append-only-gate limitation as #501: it compares file status, so growing an existing test file reads as a modified prior test. OME-369 / #383 is the line-level fix and is still open.
- **Also flips OME-744's mirror/ledger status to `done`** — they still read `in_progress` after #488 merged, and a PR changing two status lines isn't worth its own review cycle.
- **`uv.lock` carries another stale-metadata correction**: `pyproject.toml:95` pins `ruff>=0.16.1` but `origin/main`'s lock records `>=0.15.13`. Same class as the graphviz line in #488 — that's twice now, so something isn't re-running `uv lock` after dependency-spec bumps. Worth a look, separately.
- **Not done here:** `connector.py` is 648 lines, over the 450 guideline (589 before this change). The natural extraction is the ~180-line Tavily tool-loop cluster into a `web_tools.py` sibling, which would bring it to ~470 — but that's a pure-move refactor of code unrelated to finish-reason capture, and folding it into a behavior-change PR makes review harder.

Ledger: `docs/work/2026-08-04-OME-745-url4-cloud-finish-reason.md`