### PR TITLE
ci(repo): publish a full-SHA ACR alias from the dev build lanes

### DIFF
--- a/.github/workflows/dev-build-aigateway-ui.yml
+++ b/.github/workflows/dev-build-aigateway-ui.yml
@@ -23,6 +23,7 @@ on:
     # a subtle inconsistency that invites someone to "fix" it back later.
     paths:
       - "apps/aigateway-ui/**"
+      - ".github/workflows/dev-build-aigateway-ui.yml"
   workflow_dispatch:
 permissions:
   contents: read
@@ -65,6 +66,11 @@ jobs:
           tags: |
             ghcr.io/openmined/screamingface-aigateway-ui:main-${{ steps.sha.outputs.short }}
             acropenmined.azurecr.io/screamingface-aigateway-ui:main-${{ steps.sha.outputs.short }}
+            acropenmined.azurecr.io/screamingface-aigateway-ui:main-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
           # Its OWN scope, not the aigateway one. The two images share no layers — uv/Python
           # against node/Next.js — so a shared scope would be pure eviction pressure with no hits.
           cache-from: type=gha,scope=dev-aigateway-ui

--- a/.github/workflows/dev-build-aigateway-ui.yml
+++ b/.github/workflows/dev-build-aigateway-ui.yml
@@ -70,7 +70,6 @@ jobs:
           labels: |
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
           # Its OWN scope, not the aigateway one. The two images share no layers — uv/Python
           # against node/Next.js — so a shared scope would be pure eviction pressure with no hits.
           cache-from: type=gha,scope=dev-aigateway-ui

--- a/.github/workflows/dev-build-aigateway.yml
+++ b/.github/workflows/dev-build-aigateway.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
     paths:
       - "apps/aigateway/**"
+      - ".github/workflows/dev-build-aigateway.yml"
   workflow_dispatch:
 permissions:
   contents: read
@@ -50,5 +51,10 @@ jobs:
           tags: |
             ghcr.io/openmined/screamingface-aigateway:main-${{ steps.sha.outputs.short }}
             acropenmined.azurecr.io/screamingface-aigateway:main-${{ steps.sha.outputs.short }}
+            acropenmined.azurecr.io/screamingface-aigateway:main-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
           cache-from: type=gha,scope=dev-aigateway
           cache-to: type=gha,scope=dev-aigateway,mode=max

--- a/.github/workflows/dev-build-aigateway.yml
+++ b/.github/workflows/dev-build-aigateway.yml
@@ -55,6 +55,5 @@ jobs:
           labels: |
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
           cache-from: type=gha,scope=dev-aigateway
           cache-to: type=gha,scope=dev-aigateway,mode=max

--- a/.github/workflows/dev-build-scoreboard.yml
+++ b/.github/workflows/dev-build-scoreboard.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
     paths:
       - "apps/scoreboard/**"
+      - ".github/workflows/dev-build-scoreboard.yml"
   workflow_dispatch:
 permissions:
   contents: read
@@ -50,5 +51,10 @@ jobs:
           tags: |
             ghcr.io/openmined/screamingface-scoreboard:main-${{ steps.sha.outputs.short }}
             acropenmined.azurecr.io/screamingface-scoreboard:main-${{ steps.sha.outputs.short }}
+            acropenmined.azurecr.io/screamingface-scoreboard:main-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
           cache-from: type=gha,scope=dev-scoreboard
           cache-to: type=gha,scope=dev-scoreboard,mode=max

--- a/.github/workflows/dev-build-scoreboard.yml
+++ b/.github/workflows/dev-build-scoreboard.yml
@@ -55,6 +55,5 @@ jobs:
           labels: |
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
           cache-from: type=gha,scope=dev-scoreboard
           cache-to: type=gha,scope=dev-scoreboard,mode=max

--- a/.github/workflows/dev-build-url4-cloud.yml
+++ b/.github/workflows/dev-build-url4-cloud.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - "apps/url4-cloud/**"
       - "packages/url4/**"
+      - ".github/workflows/dev-build-url4-cloud.yml"
   workflow_dispatch:
 permissions:
   contents: read
@@ -51,5 +52,10 @@ jobs:
           tags: |
             ghcr.io/openmined/screamingface-url4-cloud:main-${{ steps.sha.outputs.short }}
             acropenmined.azurecr.io/screamingface-url4-cloud:main-${{ steps.sha.outputs.short }}
+            acropenmined.azurecr.io/screamingface-url4-cloud:main-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
           cache-from: type=gha,scope=dev-url4-cloud
           cache-to: type=gha,scope=dev-url4-cloud,mode=max

--- a/.github/workflows/dev-build-url4-cloud.yml
+++ b/.github/workflows/dev-build-url4-cloud.yml
@@ -56,6 +56,5 @@ jobs:
           labels: |
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
           cache-from: type=gha,scope=dev-url4-cloud
           cache-to: type=gha,scope=dev-url4-cloud,mode=max


### PR DESCRIPTION
## Summary

The platform's dev promotion resolves deploys from the registry alone, and git only resolves full 40-char SHAs — so each dev build now also tags its ACR image `main-<full-sha>` (same digest; GHCR and the short tag untouched). Each workflow now lists its own file in `paths`, so lane changes (this PR included) build immediately instead of on the next app commit. OCI revision/source/created labels make build ordering and provenance explicit.

**Asana:** platform-side task (infrastructure repo)

## Components touched

`.github/workflows/dev-build-{url4-cloud,aigateway,aigateway-ui,scoreboard}.yml` — no app code.

## Test plan

- Workflow-only change; no app gates apply. All four files parse.
- First post-merge build should show the `main-<full-sha>` alias in ACR — platform verifies.

One convention note: please treat these tags as immutable — to redeploy older code, push a commit rather than re-running an old build (dev promotion orders builds by build date).

## Cross-service notes

Consumed by OpenMined/infrastructure (automatic dev deployment). No app behaviour changes.
