### PR TITLE
docs(repo): close out the OME-745 mirror and ledger

### DIFF
--- a/docs/tasks/2026-08-04-ome-745-url4-cloud-finish-reason.md
+++ b/docs/tasks/2026-08-04-ome-745-url4-cloud-finish-reason.md
@@ -1,12 +1,12 @@
 ---
 id: OME-745
 linear_url: https://linear.app/openmined/issue/OME-745/capture-finish-reason-and-the-provider-refusal-field-and-classify-a
-status: in_progress
+status: done
 type:
 priority: P2
 labels: [url4-cloud, autonomous, agentic]
 created: 2026-08-04
-closed:
+closed: 2026-08-05
 ---
 
 # OME-745 — capture finish_reason / refusal and classify a refused turn

--- a/docs/work/2026-08-04-OME-745-url4-cloud-finish-reason.md
+++ b/docs/work/2026-08-04-OME-745-url4-cloud-finish-reason.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-745
 stack: url4-cloud
-status: in_progress
+status: done
 started: 2026-08-04
-finished:
+finished: 2026-08-05
 ---
 
 # OME-745 — capture finish_reason / refusal and classify a refused turn
@@ -79,6 +79,13 @@ Failing tests first:
 
 ## Outcome
 
+- **Merged:** `3a6e4ad3` + `27b274db` + `e015be7f` squash-merged as `b594d6fc` (#506), remote CI
+  **23/23 pass**. This completes OME-679's main-landable half: `finish_reason` and the provider
+  `refusal` field now survive from aigateway through the url4 boundary onto the wire frame, and a
+  refused turn is a typed `provider_refusal` failure rather than a generic malformed-response
+  error. The remaining hop — turning that into a refusal-kind failure excluded from the scored
+  denominator, plus the refusal-rate headline — is `OME-680`, blocked on the
+  `packages/screamingface` SDK drafts landing.
 - **Actual files:**
 
   | File | Planned? | What |


### PR DESCRIPTION
Docs-only. Flips OME-745's `docs/tasks` mirror and `docs/work` ledger to `done` now that #506 is merged (`b594d6fc`), and records the merge in the ledger's Outcome.

OME-744's and OME-746's mirrors were folded into adjacent in-flight branches, but this unit has no successor branch to ride — hence a small change of its own rather than leaving the last two status lines stale.

This completes **OME-679's main-landable half**: `finish_reason` and the provider `refusal` field now survive from aigateway through the url4 boundary onto the wire frame, and a refused turn is a typed `provider_refusal` failure rather than a generic malformed-response error.

The remaining hop — turning that into a refusal-kind failure excluded from the scored denominator, plus the refusal-rate headline — is OME-680, blocked on the `packages/screamingface` SDK drafts landing.

No code, no gates affected.