### PR TITLE
ci(repo): regenerate the uv lockfiles inside the release-please job

### DIFF
--- a/.github/scripts/sync_release_locks.py
+++ b/.github/scripts/sync_release_locks.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Regenerate the uv lockfiles on release-please's open release branches.
+
+WHY THIS EXISTS
+---------------
+release-please bumps `version` in a package's `pyproject.toml` and nothing else. Every
+`uv.lock` records that same version — its own workspace's editable root entry, and for
+`apps/url4-cloud` also the editable `url4` path dependency it pins. So a release PR opens
+with a lockfile that no longer matches its `pyproject.toml`, and `url4-cloud-tests` fails
+on its first step (`uv lock --check`) before ruff, pyright or pytest ever run. `main` then
+goes red the same way once the release merges.
+
+That defect shipped three times (fixed by hand in f2b46c06 and 9061f40f, then again on
+PR #504). This script closes the loop: the release PR is re-locked in the same job that
+opens it, so it is correct from the moment it exists.
+
+Every workspace is re-locked, not just the released one, because the version churn crosses
+workspace boundaries: releasing `packages/url4` invalidates `apps/url4-cloud/uv.lock` too.
+A workspace whose lock is already current re-locks to a no-op, so the sweep is safe and it
+also heals drift that arrived by some other route.
+
+`uv lock` (no `--upgrade`) is minimal-change: it rewrites only what the `pyproject.toml`
+now requires and leaves every other pin alone. A release commit therefore never smuggles in
+a dependency bump.
+
+INPUT
+-----
+`RELEASE_PRS` — the `prs` output of googleapis/release-please-action (a JSON array of pull
+requests, each with a `headBranchName`). Read from the environment rather than interpolated
+into the workflow's `run:` block, so no branch name reaches a shell context.
+
+The caller must already have a checkout with push credentials (see
+`.github/workflows/release-please.yml`). Each branch is re-locked in its own `git worktree`
+so this script's own checkout is never switched out from under it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# release-please attributes its own commits to this identity; the lock sync is part of the
+# same release commit set and should not look like it came from a human.
+BOT_NAME = "github-actions[bot]"
+BOT_EMAIL = "41898282+github-actions[bot]@users.noreply.github.com"
+
+COMMIT_MESSAGE = "chore(release): sync the uv lockfiles with the version bump"
+
+
+def run(argv: list[str], *, cwd: Path | None = None, capture: bool = False) -> str:
+    """Run a command with no shell, failing loudly."""
+    print(f"+ {' '.join(argv)}" + (f"  (in {cwd})" if cwd else ""), flush=True)
+    result = subprocess.run(
+        argv,
+        cwd=cwd,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE if capture else None,
+    )
+    return result.stdout if capture else ""
+
+
+def workspaces(worktree: Path) -> list[Path]:
+    """Every directory in the checkout that owns a uv lockfile."""
+    tracked = run(
+        ["git", "-C", str(worktree), "ls-files", "*uv.lock"], capture=True
+    ).split()
+    return [worktree / lock for lock in tracked]
+
+
+def sync_branch(branch: str) -> None:
+    run(["git", "fetch", "origin", branch])
+
+    with tempfile.TemporaryDirectory() as tmp:
+        worktree = Path(tmp) / "release"
+        run(["git", "worktree", "add", "--detach", str(worktree), "FETCH_HEAD"])
+        try:
+            for lock in workspaces(worktree):
+                run(["uv", "lock"], cwd=lock.parent)
+
+            dirty = run(
+                ["git", "-C", str(worktree), "status", "--porcelain"], capture=True
+            ).strip()
+            if not dirty:
+                print(f"{branch}: lockfiles already current", flush=True)
+                return
+
+            print(f"{branch}: re-locked\n{dirty}", flush=True)
+            run(["git", "-C", str(worktree), "commit", "-am", COMMIT_MESSAGE])
+            # Pushing with a PAT (never GITHUB_TOKEN) is what makes this worth doing: a
+            # GITHUB_TOKEN push raises no workflow events, so the release PR would keep the
+            # red check it was opened with even though the lockfiles are now correct.
+            run(
+                [
+                    "git",
+                    "-C",
+                    str(worktree),
+                    "push",
+                    "origin",
+                    f"HEAD:refs/heads/{branch}",
+                ]
+            )
+        finally:
+            run(["git", "worktree", "remove", "--force", str(worktree)])
+
+
+def main() -> int:
+    payload = os.environ.get("RELEASE_PRS", "").strip()
+    if not payload:
+        print("RELEASE_PRS is empty — release-please opened no pull request.")
+        return 0
+
+    branches = [pr["headBranchName"] for pr in json.loads(payload)]
+    if not branches:
+        print("No release branches to sync.")
+        return 0
+
+    run(["git", "config", "user.name", BOT_NAME])
+    run(["git", "config", "user.email", BOT_EMAIL])
+
+    for branch in branches:
+        sync_branch(branch)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/aigateway-tests.yml
+++ b/.github/workflows/aigateway-tests.yml
@@ -35,6 +35,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      # WHY before `uv sync`: sync SILENTLY regenerates a stale lock, so a lockfile that no
+      # longer matches pyproject.toml is invisible to every later step — including the
+      # version bump a release PR makes and never locks.
+      - name: Check the lockfile is current
+        run: uv lock --check
+
       - name: Install dependencies
         run: uv sync
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v5
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+
+      # release-please bumps `version` in pyproject.toml and stops there, but every uv.lock
+      # records that same version — so the release PR it just opened already fails
+      # `uv lock --check`. The steps below re-lock the branch before anyone looks at it.
+      # See .github/scripts/sync_release_locks.py for the full why.
+      - uses: astral-sh/setup-uv@v7
+        if: steps.release.outputs.prs_created == 'true'
+
+      - uses: actions/checkout@v7
+        if: steps.release.outputs.prs_created == 'true'
+        with:
+          # RELEASE_PAT, not GITHUB_TOKEN: a GITHUB_TOKEN push raises no workflow events, so
+          # the release PR would keep the red check it was opened with. No `||` fallback here
+          # — a push that cannot retrigger the checks defeats the point of the step.
+          token: ${{ secrets.RELEASE_PAT }}
+          # The release branches were created moments ago by the step above; the script
+          # fetches each one, and full history keeps that fetch and the push off the
+          # shallow-clone paths.
+          fetch-depth: 0
+
+      # SECURITY: the release-please payload reaches the script through the environment,
+      # never interpolated into this shell context, and the script hands branch names to git
+      # as argv with no shell in between.
+      - name: Sync the uv lockfiles on each release branch
+        if: steps.release.outputs.prs_created == 'true'
+        env:
+          RELEASE_PRS: ${{ steps.release.outputs.prs }}
+        run: python3 .github/scripts/sync_release_locks.py

--- a/.github/workflows/scoreboard-tests.yml
+++ b/.github/workflows/scoreboard-tests.yml
@@ -32,6 +32,12 @@ jobs:
         with:
           python-version: "3.12"
 
+      # WHY before `uv sync`: sync SILENTLY regenerates a stale lock, so a lockfile that no
+      # longer matches pyproject.toml is invisible to every later step — including the
+      # version bump a release PR makes and never locks.
+      - name: Check the lockfile is current
+        run: uv lock --check
+
       - name: Install dependencies
         run: uv sync
 

--- a/.github/workflows/url4-tests.yml
+++ b/.github/workflows/url4-tests.yml
@@ -43,6 +43,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      # WHY before `uv sync`: sync SILENTLY regenerates a stale lock, so a lockfile that no
+      # longer matches pyproject.toml is invisible to every later step. Until this guard
+      # existed, url4's own drift only ever surfaced in the url4-cloud lane, which locks the
+      # same package — that is how the 1.0.0 and 1.1.0 release bumps each shipped a stale
+      # lock (f2b46c06, 9061f40f).
+      - name: Check the lockfile is current
+        run: uv lock --check
+
       - name: Install dependencies
         run: uv sync
 

--- a/docs/tasks/2026-08-05-ome-753-release-please-uv-locks.md
+++ b/docs/tasks/2026-08-05-ome-753-release-please-uv-locks.md
@@ -1,0 +1,37 @@
+---
+id: OME-753
+linear_url: https://linear.app/openmined/issue/OME-753/regenerate-uv-locks-inside-the-release-please-job
+status: in_review
+type: task
+priority: P2
+labels: [repo, autonomous, agentic, task]
+created: 2026-08-05
+closed:
+---
+
+# OME-753 — regenerate uv locks inside the release-please job
+
+release-please bumps `version` in a package's `pyproject.toml` but never regenerates the uv
+lockfiles that record that version. `url4-cloud-tests` runs `uv lock --check` first, so every
+url4 / url4-cloud release PR fails before ruff, pyright, or pytest run — and `main` goes red
+the same way once the release merges.
+
+Seen on PR #504 (`chore(main): release url4 1.2.0`):
+
+```
+Run uv lock --check
+error: The lockfile at `uv.lock` needs to be updated, but `--check` was provided.
+```
+
+`apps/url4-cloud/uv.lock` pins `url4 = 1.1.0` (editable path dependency,
+`apps/url4-cloud/pyproject.toml:58`); `packages/url4/uv.lock` pins its own root entry the
+same way. Third occurrence — the earlier two were patched by hand afterwards (`f2b46c06`,
+`9061f40f`).
+
+Fix: re-lock the affected uv workspaces inside the release-please job and push the amend
+commit with `RELEASE_PAT` (a `GITHUB_TOKEN` push does not retrigger checks), plus add the
+`uv lock --check` guard to the Python app workflows that lack it, so the drift is visible in
+its own lane instead of only through a neighbour.
+
+Rejected: relaxing or scoping off `uv lock --check` — that guard exists because a stale lock
+once shipped undetected (`.github/workflows/url4-cloud-tests.yml:41`).

--- a/docs/work/2026-08-05-OME-753-release-please-uv-locks.md
+++ b/docs/work/2026-08-05-OME-753-release-please-uv-locks.md
@@ -1,0 +1,72 @@
+---
+ticket: OME-753
+stack: repo
+status: in_review
+started: 2026-08-05
+finished:
+---
+
+# OME-753 — regenerate uv locks inside the release-please job
+
+## Intent
+
+release-please bumps `version` in a package's `pyproject.toml` but never regenerates the uv
+lockfiles that record that version. `url4-cloud-tests` runs `uv lock --check` as its first
+step, so every url4 / url4-cloud release PR fails before ruff, pyright, or pytest run, and
+`main` goes red for the same reason once the release merges. Observed on PR #504
+(`chore(main): release url4 1.2.0`); the same failure was patched by hand twice already
+(`f2b46c06`, `9061f40f`). Make the release PR correct when it is opened, and make the drift
+visible everywhere instead of only in a neighbouring app's lane.
+
+## Planned changes
+
+- `.github/workflows/release-please.yml` — after the release-please action, a step that
+  re-locks every affected uv workspace on each open release branch and pushes the amend
+  commit with `RELEASE_PAT`.
+- `.github/workflows/url4-tests.yml` — add `uv lock --check` before `uv sync`.
+- `.github/workflows/aigateway-tests.yml`, `.github/workflows/scoreboard-tests.yml` — same
+  guard.
+- `docs/tasks/2026-08-05-ome-753-release-please-uv-locks.md` — mirror.
+
+## Test plan
+
+CI-config work — no unit tests. Verification is behavioural:
+
+- `uv lock --check` fails on a version bump without a re-lock (reproduced by PR #504).
+- The re-lock step is a no-op when the locks are already current (idempotent).
+- `uv lock --check` passes in every workflow that gains the guard, on `origin/main` as-is.
+- The lock-sync step must not run for non-release pushes.
+
+## Acceptance
+
+- A release PR for `url4` / `url4-cloud` / `aigateway` / `scoreboard` opens with its uv locks
+  already regenerated, and the checks are green without human intervention.
+- The lock-sync push retriggers the branch's checks (PAT, not `GITHUB_TOKEN`).
+- Every Python app workflow verifies its lockfile is current before syncing.
+- `uv lock --check` is not relaxed or scoped off anywhere.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned, plus `.github/scripts/sync_release_locks.py` — the lock-sync
+  logic lives in a script (the `.github/scripts/verify_chart_wiring.py` convention) rather
+  than inline in the `run:` block, so branch names never reach a shell and each release
+  branch is re-locked in its own `git worktree` instead of switching the job's checkout.
+- **Commits:** see the PR.
+- **Gates:**
+  - `uv lock --check` passes in all four workspaces (`apps/aigateway`, `apps/scoreboard`,
+    `apps/url4-cloud`, `packages/url4`) on `origin/main`, so the three new guards are green
+    from the start.
+  - `ruff check` + `ruff format --check` clean on the new script.
+  - The four touched workflows parse as YAML.
+  - End-to-end rehearsal against a local bare clone acting as `origin`: a branch carrying
+    only the `packages/url4` 1.1.0 → 1.2.0 bump was re-locked to exactly the two lockfiles
+    that record that version (`packages/url4/uv.lock`, `apps/url4-cloud/uv.lock`, 3 lines),
+    committed, and pushed. `uv lock --check` then passed in all four workspaces on the
+    pushed branch. A second run reported "lockfiles already current" and pushed nothing;
+    empty and `[]` payloads exit 0 without touching the repo.
+- **Deviations:** every workspace is re-locked, not only the released one — the churn
+  crosses workspace boundaries (releasing `packages/url4` invalidates
+  `apps/url4-cloud/uv.lock`), and an unaffected workspace re-locks to a no-op.
+- **Not covered:** the step fires on `prs_created`, so an already-open release PR is only
+  healed the next time release-please updates it. PR #504 needs a one-off re-lock pushed to
+  its branch.


### PR DESCRIPTION
Refs: OME-753 — https://linear.app/openmined/issue/OME-753

## Summary

release-please bumps `version` in a package's `pyproject.toml` and stops there, but every
`uv.lock` records that same version — its own workspace's editable root entry, and for
`apps/url4-cloud` also the editable `url4` path dependency it pins. So a release PR opens
with a lockfile that `uv lock --check` rejects, `url4-cloud-tests` dies on its first step
before ruff/pyright/pytest run, and `main` goes red the same way once the release merges.

Third occurrence: patched by hand in `f2b46c06` and `9061f40f`, and live right now on #504.

- **`.github/workflows/release-please.yml` + `.github/scripts/sync_release_locks.py`** —
  after release-please opens a PR, each release branch is fetched into its own `git
  worktree`, every uv workspace is re-locked, and the result is committed and pushed. The
  push uses `RELEASE_PAT` with **no** `GITHUB_TOKEN` fallback: a `GITHUB_TOKEN` push raises
  no workflow events, so the PR would keep the red check it was opened with.
- **`url4-tests.yml`, `aigateway-tests.yml`, `scoreboard-tests.yml`** — add the
  `uv lock --check` guard they lacked. Only `url4-cloud-tests` had it, which is why url4's
  own lock drift was invisible in its own lane and only surfaced through a neighbour that
  locks the same package.

All workspaces are re-locked, not just the released one, because the churn crosses workspace
boundaries. `uv lock` (no `--upgrade`) is minimal-change, so a release commit never smuggles
in a dependency bump, and an unaffected workspace re-locks to a no-op.

Rejected: relaxing or scoping off `uv lock --check`. That guard exists precisely because a
stale lock once shipped undetected (`url4-cloud-tests.yml:41`).

## Components touched

`repo` — `.github/workflows/` and `.github/scripts/` only. No application code; the
release lanes for `packages/url4`, `apps/url4-cloud`, `apps/aigateway` and `apps/scoreboard`
all change behaviour.

## Test plan

- `uv lock --check` passes in all four workspaces on `origin/main` — the three new guards are
  green from the start.
- `ruff check` + `ruff format --check` clean on the new script; all four workflows parse.
- End-to-end rehearsal against a local bare clone acting as `origin`: a branch carrying only
  the `packages/url4` 1.1.0 → 1.2.0 bump was re-locked to exactly the two lockfiles that
  record that version (`packages/url4/uv.lock`, `apps/url4-cloud/uv.lock`, 3 lines),
  committed and pushed; `uv lock --check` then passed in all four workspaces on the pushed
  branch.
- Idempotency: a second run reported `lockfiles already current` and pushed nothing. Empty
  and `[]` payloads exit 0 without touching the repo.

## Not covered

The step fires on `prs_created`, so an already-open release PR is only healed the next time
release-please updates it. **#504 still needs a one-off re-lock pushed to its branch.**
