### PR TITLE
docs(repo): mirror the OME-754..758 follow-ups filed from the OME-679 chain

### DIFF
--- a/docs/tasks/2026-08-05-ome-754-npm-shai-hulud-hardening.md
+++ b/docs/tasks/2026-08-05-ome-754-npm-shai-hulud-hardening.md
@@ -1,0 +1,40 @@
+---
+id: OME-754
+linear_url: https://linear.app/openmined/issue/OME-754/harden-npm-installs-against-the-shai-hulud-worm-we-are-one-patch
+status: backlog
+type: task
+priority: P2
+labels: [repo, autonomous, agentic, task]
+created: 2026-08-05
+closed:
+---
+
+# OME-754 — harden npm installs against the Shai-Hulud worm
+
+**We are NOT affected.** Verified 2026-08-05 against `main` @ `b594d6fc`. This is hardening,
+not incident response.
+
+On 2026-08-04 the `jaredwray` account was compromised and used to publish malicious releases of
+the `keyv` / `cacheable` family, which then self-propagated via harvested CI tokens. A
+`preinstall` script `setup.mjs` fetches a Bun runtime and runs `Math_Symbol.js`, which exfiltrates
+npm tokens, GitHub PATs/OIDC tokens, AWS keys, Kubernetes secrets, Vault tokens, SSH keys and
+Docker credentials. 868+ packages / 1,381 versions confirmed within hours.
+
+## Scan result
+
+All three npm surfaces carry the affected family; **no poisoned version is pinned**, installed
+`node_modules` match the lockfiles exactly, and there is no `setup.mjs` preinstall hook or
+`Math_Symbol.js` on disk. But `aigateway-ui` sits **exactly one release below** the poisoned
+version on five packages — `@cacheable/memory` 2.2.0 vs 2.2.1, `@cacheable/utils` 2.5.0 vs 2.5.1,
+`cacheable` 2.5.0 vs 2.5.1, `file-entry-cache` 11.1.5 vs 11.1.6, `flat-cache` 6.1.23 vs 6.1.24.
+
+What saved us was `npm ci` in every CI lane (never `npm install`) and no open Dependabot npm PR
+touching the set during the window. Luck plus one good habit — not a control.
+
+## Proposed
+
+`npm ci --ignore-scripts` where the build tolerates it (the payload only fires via `preinstall`),
+a Dependabot cooldown so a hours-old release is not proposed immediately, and a known-bad
+`package@version` check — `npm ci` pins but does not judge.
+
+See the Linear issue for the full poisoned-version list and sources.

--- a/docs/tasks/2026-08-05-ome-755-connector-web-tools-split.md
+++ b/docs/tasks/2026-08-05-ome-755-connector-web-tools-split.md
@@ -1,0 +1,24 @@
+---
+id: OME-755
+linear_url: https://linear.app/openmined/issue/OME-755/split-the-tavily-web-tool-loop-out-of-url4-clouds-connectorpy
+status: backlog
+type: task
+priority: P4
+labels: [url4-cloud, autonomous, agentic, task]
+created: 2026-08-05
+closed:
+---
+
+# OME-755 — split the Tavily web-tool loop out of connector.py
+
+`apps/url4-cloud/src/url4_cloud/runner/connector.py` is **648 lines**, over the 450-line guidance
+in `sdlc-python`. It was 589 before `OME-745` added finish-reason capture.
+
+The file does two unrelated jobs: building the aigateway-backed `Url4Node` world, and implementing
+the Tavily web-tool loop. Moving the ~180-line tool-loop cluster (`_WEB_TOOLS`, `_execute_tool`,
+`_dispatch_tool`, `_tool_args`, `_truncate_tool_result`, `_tavily_*`, `_build_tavily_client`) into
+a `web_tools.py` sibling brings it to ~470.
+
+Pure move, no behavior change — the existing suite is the regression proof. Kept out of `OME-745`
+because folding a file split into a behavior-change PR makes review harder, the same reasoning
+that kept the duplicated provider mapper out of `OME-746`.

--- a/docs/tasks/2026-08-05-ome-756-append-only-baseline.md
+++ b/docs/tasks/2026-08-05-ome-756-append-only-baseline.md
@@ -1,0 +1,25 @@
+---
+id: OME-756
+linear_url: https://linear.app/openmined/issue/OME-756/use-originmain-as-the-append-only-baseline-for-pr-level-gate-runs
+status: backlog
+type: task
+priority: P3
+labels: [repo, autonomous, agentic, task]
+created: 2026-08-05
+closed:
+---
+
+# OME-756 — origin/main as the append-only baseline for PR-level gate runs
+
+`run_gates.py`'s append-only check compares `git diff --name-status <base>` with `--base`
+defaulting to `HEAD`. Right for a per-commit loop, wrong for a PR: it treats a test file written
+minutes earlier **in the same unit** as a "prior test", so any later edit to it fails the gate.
+
+Hit in both `OME-745` and `OME-746`. In `OME-746` the append was verifiably additive (86
+insertions, 0 deletions, no prior test altered) and still failed, because the check reads file
+*status*, not content. Both units worked around it by putting new tests in a new module rather
+than the natural one — test organisation driven by a tool artifact rather than cohesion.
+
+`--base origin/main` is the semantically correct PR-level baseline and already works. Does **not**
+duplicate `OME-369`/#383: line-level diffing and the right baseline fix different halves, and
+#383 alone would still flag a genuine edit to a test the same PR introduced.

--- a/docs/tasks/2026-08-05-ome-758-sdlc-card-url4-body.md
+++ b/docs/tasks/2026-08-05-ome-758-sdlc-card-url4-body.md
@@ -1,0 +1,26 @@
+---
+id: OME-758
+linear_url: https://linear.app/openmined/issue/OME-758/add-sdlc-card-body-sections-for-the-url4-and-url4-cloud-stacks
+status: backlog
+type: task
+priority: P3
+labels: [repo, autonomous, agentic, task]
+created: 2026-08-05
+closed:
+---
+
+# OME-758 — sdlc card body sections for url4 and url4-cloud
+
+`.claude/sdlc.local.md` declares five stacks in frontmatter but its body covers only `aigateway`,
+`aigateway-ui` and `scoreboard`. Nothing for **`url4`** or **`url4-cloud`**, so the `sdlc-python`
+skill's required "read the card BODY for the active stack" step binds nothing on either.
+
+Hit during `OME-744` and `OME-745`. Gate *lists* are complete for both — this is body prose only.
+
+Conventions worth capturing, learned the hard way: `packages/url4/pyproject.toml` omits
+`src/url4/streaming/*` from coverage on purpose (its tests live with url4-cloud, gated there via
+`--cov=url4.streaming`) — a fact that moved a file between two issues mid-flight; url4's coverage
+floor is 95% against the others' 80%; `url4.observe` is a stdlib-only leaf; and in url4-cloud only
+`runner/executor.py` and `runner/connector.py` may import the engine.
+
+Companion to `OME-743`.


### PR DESCRIPTION
Docs-only. Adds the `docs/tasks/` mirrors for four follow-up issues filed out of the OME-679 chain (OME-744 / OME-745 / OME-746).

CLAUDE.md rule 1 requires a mirror per work item, and the repo's own precedent confirms it applies to backlog items too — OME-740, 743, 747, 748, 749 and 753 all have mirrors while unstarted. I filed the Linear issues without them; this closes that gap.

| Mirror | Issue |
|---|---|
| `…-ome-754-npm-shai-hulud-hardening.md` | npm supply-chain hardening (**P2**) |
| `…-ome-755-connector-web-tools-split.md` | split the Tavily loop out of `connector.py` |
| `…-ome-756-append-only-baseline.md` | `origin/main` as the append-only baseline |
| `…-ome-758-sdlc-card-url4-body.md` | card body sections for url4 / url4-cloud |

**OME-757 is deliberately absent.** I filed it claiming no gate ran `uv lock --check`; that was wrong — it runs in all four Python lanes (`aigateway-tests.yml:42`, `scoreboard-tests.yml:39`, `url4-cloud-tests.yml:46`, `url4-tests.yml:52`). I had checked the sdlc card's `gates:` lists and grepped the workflows for `npm ci|npm install`, but never grepped CI for the lock check itself before asserting its absence. OME-753 diagnoses the same drift correctly — release-please bumping `pyproject.toml` without regenerating locks — and is already In Progress with #510. OME-757 is closed as its duplicate.

The OME-754 mirror is the one worth reading: we are **not** affected by the Shai-Hulud worm, but `aigateway-ui` pins exactly one release below the poisoned version on five packages, and what saved us was `npm ci` plus the absence of an open Dependabot npm PR during the window.

No code, no gates affected.