### PR TITLE
docs(spec): per-run cache policy for url4 — protocol spec for review

### DIFF
--- a/docs/plan/2026-08-05-url4-cache-policy.md
+++ b/docs/plan/2026-08-05-url4-cache-policy.md
@@ -1,8 +1,8 @@
 ---
 title: url4 per-run cache policy — implementation plan
-status: proposed — awaiting owner approval AND spec decisions D3, D4, D6, D11
+status: proposed — **all spec decisions locked**; awaiting approval to implement
 created: 2026-08-05
-revised: 2026-08-05 (r5 — Batch 7 prefers RFC 9211 Cache-Status; D11 reopened)
+revised: 2026-08-05 (r6 — D3/D4/D6/D11 locked; §9 removed, nothing left to flip)
 ticket: UNFILED — Linear MCP unauthenticated at authoring time
 spec: docs/spec/2026-08-05-url4-cache-policy-spec.md
 ledger: docs/work/2026-08-05-UNFILED-url4-cloud-cache-policy-spec.md
@@ -51,15 +51,14 @@ end to end — see Verification step 3.
 **Locked:** cache ON by default · protocol types in `packages/url4` · both carriers · per-run
 scope · response headers folded onto spans · no aigateway change.
 
-**Open — the plan assumes the spec's recommendation for each; §9 states what moves if you flip
-one.** The plumbing is ~90% invariant across all four.
+**All locked** (spec r7):
 
-| | decision | assumed |
+| | decision | value |
 |---|---|---|
-| **D3** | frame shape | extend `AttachData` |
-| **D4** | precedence when both carriers speak | header wins, override logged |
-| **D6** | header name | standard `Cache-Control` |
-| **D11** | `max-age` — **reopened** (spec §3.5) | opt-out now; honour it if aigateway emits `Age`/`ttl=` |
+| **D3** | frame shape | extend `AttachData` — no new inbound verb |
+| **D4** | precedence | **header wins**, override emits a `LogEvent` at `warn` |
+| **D6** | header name | standard **`Cache-Control`**; intermediaries may participate |
+| **D11** | `max-age` | **honour it** — blocked upstream today, so it degrades to opt-out (§6) |
 
 Implementation starts only on explicit approval in plain words (CLAUDE.md rule 3).
 
@@ -144,8 +143,12 @@ Every directive collapses to participate / opt-out **at this edge**; none is for
 |---|---|
 | absent | `None` — not stated |
 | `no-store`, `no-cache` | `participate=False` |
-| `max-age=<n>` | `participate=False` (D11) |
+| **`max-age=<n>`** | **`participate=True, max_age=n`** — parsed and **preserved**, not collapsed (D11, §6) |
 | `url4-use-cache` | `participate=True` |
+
+`CachePolicy` therefore carries a second field, `max_age: int | None`, which is **url4-internal
+and never sent to aigateway** — v2's closed grammar rejects it (`global_controls.py:79-83`).
+Batch 7 is where it is applied.
 
 **Tests**
 
@@ -236,6 +239,10 @@ that **hides savings**, so nobody reports it.
    member rather than the first — the test that stops an Envoy or CDN entry being misread as
    aigateway's answer.
 2b. A malformed `Cache-Status` falls back to the `X-AIGW-*` triple rather than losing the signal.
+2c. **`max_age` with no age reported → the run opts out** (`bypass`/`opted_out`), never a silent
+   stale serve. This is the D11-inert path and is the behaviour that actually ships.
+2d. **`max_age` with an age reported → honoured**: within bound is a legitimate `hit`; beyond
+   bound triggers the opt-out re-issue. Written now, dormant until aigateway reports age.
 3. **Missing headers degrade to `None`, never crash** — an older gateway, or a non-cache error
    path.
 4. `X-AIGW-Cache-Key` recorded only for hit/miss; never any prompt content.
@@ -252,6 +259,27 @@ that **hides savings**, so nobody reports it.
 - `apps/url4-cloud/README.md`; `packages/url4` docs as needed.
 
 ---
+
+## 6. D11 — honouring `max-age`, and why it is inert today
+
+The decision is to honour it. Two upstream blockers stand in the way, both verified on #507's
+branch:
+
+1. **url4 cannot ask for a bound.** `{"cache": {"max-age": 60}}` returns
+   `_refuse(BYPASS_UNSUPPORTED_CONTROL)` — v2's grammar is closed to `use-cache`.
+2. **aigateway does not report age.** No `Age`, no `Cache-Status; ttl=`.
+
+So url4 can neither request a freshness bound nor measure one, and `max-age` **degrades to
+opt-out** until one changes — observably, via `bypass` / `opted_out`.
+
+**This plan builds the degraded behaviour and keeps the value.** Batch 3 parses and preserves
+`max_age`; Batch 7 applies it when an age is available and opts out when it is not. The day
+either blocker lifts, the change is a branch in Batch 7 — not a redesign.
+
+Preferred fix is upstream (aigateway accepts a bound); raised on #507. The client-side
+alternative — participate, read `Age`, re-issue with `use-cache: false` if too old — is
+buildable by url4 alone once `Age` exists, at the cost of one extra round trip on a stale hit
+and a discarded body, multiplied across a fan-out.
 
 ## Verification
 
@@ -286,13 +314,3 @@ that **hides savings**, so nobody reports it.
 - A url4-native / Enclave GET cache.
 - Any `apps/aigateway` change — #507 owns it.
 - Extracting `url4_streaming_protocol` as its own package (spec open question 4).
-
-## 9. If a decision flips
-
-| flip | what moves |
-|---|---|
-| **D3** → `ConfigureEvent` | Batch 1 adds `ConfigureData` + a third `InboundFrame` member (`unions.py:81`); Batch 4 handles a new inbound verb and must define what a `Configure` *after* run start means (recommend: ignored + warn). Batches 2, 5-8 unchanged. |
-| **D4** → frame wins | One function in Batch 5, one matrix row. |
-| **D4** → fatal on conflict | Adds a 409 on the REST side and an `ErrorEvent` on the WS side — the only variant that grows the error surface. |
-| **D6** → `URL4-Cache` | Batch 3's constant and parser grammar; a private header can use a simple `key=value` form and needs no RFC 9111 extension token. Batches 1, 2, 4-8 unchanged. |
-| **D11** → honour `max-age` | Batch 3 keeps the parsed value instead of collapsing to opt-out, and Batch 7 reads `Age` / `Cache-Status; ttl=` to decide. Needs aigateway to emit one of them — raised on #507. |

--- a/docs/plan/2026-08-05-url4-cache-policy.md
+++ b/docs/plan/2026-08-05-url4-cache-policy.md
@@ -57,15 +57,51 @@ Both are Python → the `sdlc-python` loop: RED first, append-only tests, gates 
 Without this, everything below is inert: `config.py:127-129` defaults `request_cache_enabled` to
 `False` and the chart never sets it, so every request answers `bypass / disabled`.
 
-- `apps/aigateway/charts/aigateway/values.yaml` — add `AIGW_REQUEST_CACHE_ENABLED=true` to the
-  env block, beside the existing `AIGW_ALLOWED_NETWORKS` / `AIGW_AUTH_MODE` / `AIGW_OPENROUTER_ENABLED`.
-- **Set the TTL/size knobs explicitly too** (spec open question 5) rather than inheriting code
-  defaults — `AIGW_REQUEST_CACHE_TTL_SECONDS`, `…_MAX_TTL_SECONDS`, `…_MAX_RESPONSE_BYTES`.
-  Implicit defaults mean a future code change silently moves production behaviour.
-- `values-prod.yaml` — decide whether prod differs from the default values file.
+The chart's pattern is `values.yaml → config.<camelCase>` rendered into `templates/configmap.yaml`
+as `AIGW_*` (e.g. `AIGW_ALLOWED_NETWORKS: {{ join "," .Values.config.allowedNetworks | quote }}`).
+Follow it — do **not** introduce a raw env passthrough.
 
-**Tests:** the chart gate (`charts.yml` → `verify_chart_wiring.py`) renders and asserts on parsed
-YAML. Add an assertion that the env key is present and `"true"`.
+- `values.yaml`, new block under `config:`:
+
+  ```yaml
+  config:
+    # Response cache for deterministic chat completions. OFF in the app's own default
+    # (config.py:127) — url4 runs cache by default, so this must be on for that to mean
+    # anything. Values are pinned rather than inherited: an implicit default is a number
+    # that can move under you in a patch release.
+    requestCache:
+      enabled: true
+      ttlSeconds: 600         # per-entry freshness
+      maxTtlSeconds: 3600     # ceiling a caller's `ttl`/`s-maxage` may request
+      maxResponseBytes: 1000000
+  ```
+
+- `templates/configmap.yaml`, four new lines following the existing style:
+
+  ```yaml
+  AIGW_REQUEST_CACHE_ENABLED: {{ .Values.config.requestCache.enabled | quote }}
+  AIGW_REQUEST_CACHE_TTL_SECONDS: {{ .Values.config.requestCache.ttlSeconds | quote }}
+  AIGW_REQUEST_CACHE_MAX_TTL_SECONDS: {{ .Values.config.requestCache.maxTtlSeconds | quote }}
+  AIGW_REQUEST_CACHE_MAX_RESPONSE_BYTES: {{ .Values.config.requestCache.maxResponseBytes | quote }}
+  ```
+
+- `values-prod.yaml` — decide whether prod differs. Recommend it does **not** initially: one set
+  of numbers to reason about while hit rates are unknown.
+
+**The pinned values equal today's code defaults** (`config.py:130-138`). Pinning is not
+endorsement — it freezes behaviour so a future code-default change cannot move production
+silently, and it makes the numbers a visible dial to tune once §7 metrics show real hit rates.
+
+**Tests** — the chart gate (`charts.yml` → `verify_chart_wiring.py`) renders and asserts on parsed
+YAML:
+1. All four `AIGW_REQUEST_CACHE_*` keys are present in the rendered ConfigMap.
+2. `AIGW_REQUEST_CACHE_ENABLED` renders `"true"`.
+3. `ttlSeconds <= maxTtlSeconds` — the app has a matching validator
+   (`config.py:237-240`, `_validate_request_cache_ttls`) that **fails startup**, so a bad chart
+   value would take the gateway down rather than degrade. Catching it at render is the cheaper
+   failure.
+4. Values render **quoted** — the app reads env as strings; an unquoted `600` is a YAML int and
+   the ConfigMap would reject it.
 
 **Safe in isolation.** Turning the flag on changes nothing until a caller sends `use-cache`, which
 is Batch 6. That is what makes the ordering in Risks 1 a choice rather than a hazard.

--- a/docs/plan/2026-08-05-url4-cache-policy.md
+++ b/docs/plan/2026-08-05-url4-cache-policy.md
@@ -1,0 +1,238 @@
+---
+title: url4 per-run cache policy — implementation plan
+status: proposed — awaiting owner approval AND resolution of spec D1/D3/D4/D6
+created: 2026-08-05
+ticket: UNFILED — Linear MCP unauthenticated at authoring time
+spec: docs/spec/2026-08-05-url4-cache-policy-spec.md
+ledger: docs/work/2026-08-05-UNFILED-url4-cloud-cache-policy-spec.md
+---
+
+# Implementation plan — url4 per-run cache policy
+
+## 0. What this plan assumes
+
+The spec leaves **four decisions open**. This plan is written against the spec's
+recommendations so it is reviewable as a whole; §9 states exactly what changes if you flip
+each one. **The plumbing is ~90% identical under every combination** — only the marked steps move.
+
+| decision | assumed here | if flipped |
+|---|---|---|
+| **D1** default | **OFF** — caller opts in | §9.1 — one default value + test matrix |
+| **D3** frame shape | **extend `AttachData`** | §9.2 — Batch 1 and 4 grow a union member |
+| **D4** precedence | **header wins, override logged** | §9.3 — one function in Batch 5 |
+| **D6** header name | **`Cache-Control`** | §9.4 — one constant + parser |
+
+Implementation starts only on explicit approval in plain words (CLAUDE.md rule 3).
+
+## 0.1 Correction to spec §4.1 — surfaced while planning
+
+The spec put `as_body_field()` — the `{"cache": {...}}` mapping to aigateway's vocabulary — on the
+protocol `CachePolicy` in `packages/url4`.
+
+**That is wrong and this plan does not do it.** `packages/url4` is the protocol and engine; it must
+not know aigateway's request-body shape. CLAUDE.md's architecture rule is explicit — core defines
+ports, adapters implement them, core never imports the adapter's concerns. `apps/url4-cloud` owns
+the aigateway client (`runner/connector.py`) and is where the translation belongs.
+
+So: **the protocol carries *intent*; url4-cloud translates intent → aigateway's body vocabulary.**
+The two happen to use near-identical field names, which is convenient but must not become a
+coupling. Spec needs an r3 amendment; noted rather than silently diverged.
+
+## Stacks & gates
+
+| stack | root | gate command | note |
+|---|---|---|---|
+| `url4` | `packages/url4` | `uv run .claude/scripts/run_gates.py url4` | **`--cov-fail-under=95`** — new code needs near-total coverage |
+| `url4-cloud` | `apps/url4-cloud` | `uv run .claude/scripts/run_gates.py url4-cloud` | includes `check_layering.py` |
+
+Both are Python → the `sdlc-python` loop: RED first, append-only tests, gates before commit.
+
+---
+
+## Batch 1 — protocol types (`packages/url4`, no behaviour)
+
+**RED first.** Schema tests only; nothing consumes these yet.
+
+- `protocol/signals.py`
+  - `class CachePolicy(BaseModel)` — `use_cache`, `no_cache`, `no_store`, `s_maxage: int|None (ge=1)`.
+    **No `as_body_field()`** (see §0.1).
+  - `AttachData` gains `cache: CachePolicy | None = None`.
+  - `SpanData` gains `cache_status: Literal["hit","miss","bypass"] | None` and
+    `cache_reason: str | None`.
+- `protocol/__init__.py` — export `CachePolicy`; extend `__all__`.
+
+**Tests**
+1. An attach frame **without** `cache` still validates — backward compatibility is the whole
+   risk of touching a wire type.
+2. `cache: null` and an absent key both parse to `None`, and `None` is distinguishable from
+   `CachePolicy()`. **This distinction is load-bearing for D4** — "did not declare" must not
+   collapse into "declared off".
+3. Round-trip through `InboundFrameAdapter` preserves the policy.
+4. `s_maxage=0` and negative values are rejected (`ge=1`).
+5. `SpanData` without cache fields still validates.
+
+**Gate:** `run_gates.py url4` green at ≥95% coverage.
+
+---
+
+## Batch 2 — the aigateway mapping (`apps/url4-cloud`, pure function)
+
+- `url4_cloud/runner/cache.py` (new) — `policy_to_body_field(policy: CachePolicy | None) -> dict`.
+
+**Tests**
+1. `None` → `{}` — **the byte-identical-body guarantee**; a default run's payload must not change
+   shape at all, or aigateway's `unsupported_fields` bypass path may trigger.
+2. Each field maps to aigateway's spelling (`no_store` → `"no-store"`, `s_maxage` → `"s-maxage"`).
+3. A policy with every field `False`/`None` still yields `{}`, not `{"cache": {}}`.
+
+**Gate:** `run_gates.py url4-cloud`, including `check_layering.py` — this module must not be
+imported by anything in `packages/url4`.
+
+---
+
+## Batch 3 — HTTP ingress (`apps/url4-cloud`)
+
+- `url4_cloud/rest/cache_header.py` (new) — `parse_cache_control(raw: str|None) -> CachePolicy|None`.
+- `rest/routes.py:337` — new `Annotated[str|None, Header(alias="Cache-Control")]` param on
+  `start_run`, mirroring `x_profile` at `:347`.
+
+**Tests**
+1. `no-store` / `no-cache` / `max-age=60` / `url4-use-cache` each parse correctly.
+2. Multiple directives in one header combine.
+3. Absent header → `None` (not a default-constructed policy).
+4. **Garbage is ignored, never 4xx** — matches `parse_cache_controls`' documented posture that
+   malformed values parse as "not requested". A cache directive must never fail a run.
+5. Unknown directives are dropped without affecting known ones.
+
+---
+
+## Batch 4 — WS ingress (`apps/url4-cloud`)
+
+- `ws/bridge.py` — carry `AttachData.cache` into per-topic session state on attach.
+- **First attach wins.** A re-attach with a *different* policy does not restate it; emits a
+  `LogEvent` at `warn`.
+
+**Tests**
+1. Attach carrying a policy records it for the topic.
+2. Attach without a policy records `None`.
+3. Re-attach with a different policy leaves the recorded policy unchanged **and** logs.
+4. Re-attach with an identical policy logs nothing (no warning noise on ordinary reconnect).
+5. A run started before any attach is impossible — assert `_require_subscriber`
+   (`rest/routes.py:363`) still guards it, so the ordering the design relies on is tested, not
+   assumed.
+
+---
+
+## Batch 5 — convergence & precedence (D4)
+
+- `rest/routes.py` — resolve `(header_policy, frame_policy)` → effective policy; pass to
+  `_schedule` as one new kwarg beside `profile`/`identity`.
+
+**Tests** — the full matrix:
+
+| header | frame | effective | log |
+|---|---|---|---|
+| absent | absent | D1 default | — |
+| set | absent | header | — |
+| absent | set | frame | — |
+| set | set, same | header | — |
+| set | set, **differ** | **header** | **warn: override** |
+
+---
+
+## Batch 6 — threading & egress
+
+- `job_env` / runner — thread as a **per-run** value, exactly as `profile` travels.
+  **Not** on `AigatewayConfig`: that is world config shared by every run, and a per-run value
+  placed there would leak across runs.
+- `runner/connector.py:337` — `json={"model":…, "messages":…, **extra, **policy_to_body_field(policy)}`.
+
+**Tests**
+1. A run with no policy produces a body **byte-identical** to today's (assert on the exact dict).
+2. A `no-store` run sends `cache: {"no-store": true}`.
+3. Two concurrent runs with different policies do not contaminate each other — the regression
+   `AigatewayConfig` placement would have caused.
+4. The tool-calling loop (`connector.py:325-360`) applies the policy on **every** round trip, not
+   just the first — a turn is several calls.
+
+---
+
+## Batch 7 — reading the answer back (D7, mandatory)
+
+- `runner/connector.py` — read `X-AIGW-Cache`, `X-AIGW-Cache-Reason`, `X-AIGW-Cache-Key`; fold
+  onto the owning span beside `_report_usage`, the seam `#506` used for `finish_reason`/`refusal`.
+
+**Tests**
+1. `hit` / `miss` / `bypass` each reach `SpanData.cache_status`.
+2. The reason string is carried verbatim (`not_requested`, `disabled`, `stream`,
+   `unsupported_fields`).
+3. **Missing headers do not crash** — an older aigateway, or a non-cache error path, must degrade
+   to `None`.
+4. `X-AIGW-Cache-Key` is recorded only for hit/miss, and never any prompt content.
+
+---
+
+## Batch 8 — observability & docs
+
+- Run-level counters: hits, misses, **bypasses by reason** (the load-bearing one — it makes
+  "I asked for caching and got none" answerable). **No label may carry cache key, prompt or
+  credential**, per the catalog spec's rule.
+- `schemas/openapi.py` — document the request header.
+- `schemas/asyncapi.py` — document the attach-frame field.
+- `apps/url4-cloud/README.md` + `packages/url4` docs as needed.
+
+---
+
+## Verification
+
+1. `run_gates.py url4` and `run_gates.py url4-cloud` both green.
+2. **End-to-end against a local aigateway with `AIGATEWAY_REQUEST_CACHE_ENABLED=1`** (see Risk 1):
+   - run with no policy → `bypass` / `not_requested`
+   - opt-in run → `miss`, then an identical immediate repeat → `hit`
+   - `no-store` run after a hit → `bypass`, and the stored entry is untouched
+   - same policy via header and via frame → identical egress body
+3. A streaming turn reports `bypass` / `stream` regardless of policy.
+4. Spec §9 acceptance items 1-10 each map to a test above.
+
+## Risks
+
+1. **`request_cache_enabled` may be off in the deployed aigateway.** Then every path answers
+   `bypass / disabled` and this is inert. **Confirm before Batch 1** — it decides whether this is
+   worth building now.
+2. **Touching a wire type.** `AttachData` is live protocol. Batch 1 test 1 (old frame still
+   validates) is the guard; treat a failure there as a stop-the-line.
+3. **`packages/url4` coverage gate is 95%.** Small additions with error branches can dip it;
+   budget for exhaustive schema tests.
+4. **Ensemble determinism** (spec §8.2) — if D1 flips to ON, two nodes sampling one model for
+   variance may receive one answer twice. Not a plumbing risk; a thesis-level one.
+5. **Two ingress paths, one policy.** Batch 5's matrix is the whole defence; do not ship Batch 3
+   or 4 without it.
+
+## Out of scope
+
+- Per-node cache intent — needs url4 grammar, reopens doctrine fork **F4**.
+- A url4-native / Enclave GET cache.
+- Any `apps/aigateway` change.
+- Extracting `url4_streaming_protocol` as its own package (spec open question 6).
+
+## 9. What changes if a decision flips
+
+### 9.1 D1 → default ON
+Batch 6 supplies `use_cache=True` when no policy is declared; Batch 3/4 tests for "absent" invert
+their expected effective policy. **No structural change.** Note this makes spec §8.2's determinism
+risk live for every existing run.
+
+### 9.2 D3 → `ConfigureEvent` instead of `AttachData.cache`
+Batch 1 adds a new `ConfigureData` + `ConfigureEvent` and a third member to `InboundFrame`
+(`unions.py:81`); Batch 4 handles a new inbound verb and must define what a `Configure` arriving
+*after* run start means (recommend: ignored + warn, consistent with first-attach-wins). Batches
+2, 5, 6, 7 unchanged.
+
+### 9.3 D4 → frame wins, or fatal on conflict
+One function in Batch 5 and its matrix row. If **fatal**, add a 409 path on the REST side and an
+`ErrorEvent` on the WS side — the only variant that grows the error surface.
+
+### 9.4 D6 → `URL4-Cache` instead of `Cache-Control`
+Batch 3's header constant and parser grammar (a private header can use a simple JSON or
+key=value form rather than RFC 9111 directives, and needs no `url4-use-cache` extension token).
+Batches 1, 2, 4-8 unchanged.

--- a/docs/plan/2026-08-05-url4-cache-policy.md
+++ b/docs/plan/2026-08-05-url4-cache-policy.md
@@ -2,7 +2,7 @@
 title: url4 per-run cache policy — implementation plan
 status: proposed — awaiting owner approval AND spec decisions D3, D4, D6, D11
 created: 2026-08-05
-revised: 2026-08-05 (r4 — rewritten clean against aigateway v2 / PR #507)
+revised: 2026-08-05 (r5 — Batch 7 prefers RFC 9211 Cache-Status; D11 reopened)
 ticket: UNFILED — Linear MCP unauthenticated at authoring time
 spec: docs/spec/2026-08-05-url4-cache-policy-spec.md
 ledger: docs/work/2026-08-05-UNFILED-url4-cloud-cache-policy-spec.md
@@ -59,7 +59,7 @@ one.** The plumbing is ~90% invariant across all four.
 | **D3** | frame shape | extend `AttachData` |
 | **D4** | precedence when both carriers speak | header wins, override logged |
 | **D6** | header name | standard `Cache-Control` |
-| **D11** | `max-age` under a never-expiring cache | treat as opt-out |
+| **D11** | `max-age` — **reopened** (spec §3.5) | opt-out now; honour it if aigateway emits `Age`/`ttl=` |
 
 Implementation starts only on explicit approval in plain words (CLAUDE.md rule 3).
 
@@ -211,18 +211,31 @@ Every directive collapses to participate / opt-out **at this edge**; none is for
 
 ## Batch 7 — reading the answer back
 
-- `runner/connector.py` — read `X-AIGW-Cache`, `X-AIGW-Cache-Reason`, `X-AIGW-Cache-Key`; fold
-  onto the owning span beside `_report_usage`, the seam `#506` used for `finish_reason` /
-  `refusal`.
+- `runner/connector.py` — read the cache outcome and fold it onto the owning span beside
+  `_report_usage`, the seam `#506` used for `finish_reason` / `refusal`.
+
+**Prefer the standard, fall back to the ad hoc (spec §2.2, §7):**
+
+1. **`Cache-Status`** (RFC 9211) if present — parse as an RFC 8941 Structured Field **List** and
+   select the **aigateway member**, not blindly the first: the list may carry one entry per cache
+   that touched the response (aigateway, Envoy, a CDN), ordered origin-closest first.
+   `hit` → `hit`; `fwd=<token>` → `miss`/`bypass` with the token as reason; `key=`; `detail=`.
+2. Else the `X-AIGW-Cache` / `-Reason` / `-Key` triple, verbatim.
+
+Costs nothing now and means url4 needs no change the day aigateway adopts the standard.
 
 Without this, a hit costs nothing upstream but `_report_usage` bills it as a fresh call — an error
 that **hides savings**, so nobody reports it.
 
 **Tests**
 
-1. `hit` / `miss` / `bypass` each reach `SpanData.cache_status`.
+1. `hit` / `miss` / `bypass` each reach `SpanData.cache_status`, from **either** source.
 2. Reason carried verbatim, including v2's vocabulary: `opted_out`, `malformed_controls`,
    `unsupported_control`, `disabled`.
+2a. **`Cache-Status` wins when both are present**, and a multi-member list selects the aigateway
+   member rather than the first — the test that stops an Envoy or CDN entry being misread as
+   aigateway's answer.
+2b. A malformed `Cache-Status` falls back to the `X-AIGW-*` triple rather than losing the signal.
 3. **Missing headers degrade to `None`, never crash** — an older gateway, or a non-cache error
    path.
 4. `X-AIGW-Cache-Key` recorded only for hit/miss; never any prompt content.
@@ -282,4 +295,4 @@ that **hides savings**, so nobody reports it.
 | **D4** → frame wins | One function in Batch 5, one matrix row. |
 | **D4** → fatal on conflict | Adds a 409 on the REST side and an `ErrorEvent` on the WS side — the only variant that grows the error surface. |
 | **D6** → `URL4-Cache` | Batch 3's constant and parser grammar; a private header can use a simple `key=value` form and needs no RFC 9111 extension token. Batches 1, 2, 4-8 unchanged. |
-| **D11** → ignore `max-age` | One row in Batch 3's table and its test. |
+| **D11** → honour `max-age` | Batch 3 keeps the parsed value instead of collapsing to opt-out, and Batch 7 reads `Age` / `Cache-Status; ttl=` to decide. Needs aigateway to emit one of them — raised on #507. |

--- a/docs/plan/2026-08-05-url4-cache-policy.md
+++ b/docs/plan/2026-08-05-url4-cache-policy.md
@@ -1,7 +1,7 @@
 ---
 title: url4 per-run cache policy — implementation plan
 status: proposed — awaiting owner approval AND resolution of spec D3/D4/D6
-revised: 2026-08-05 (r2 — D1 LOCKED ON; aigateway chart batch added; AIGW_ prefix corrected)
+revised: 2026-08-05 (r3 — rebased on aigateway v2 / PR #507; Batch 0 DELETED; mapper collapses to one field)
 created: 2026-08-05
 ticket: UNFILED — Linear MCP unauthenticated at authoring time
 spec: docs/spec/2026-08-05-url4-cache-policy-spec.md
@@ -50,61 +50,16 @@ Both are Python → the `sdlc-python` loop: RED first, append-only tests, gates 
 
 ---
 
-## Batch 0 — enable the cache server-side (`apps/aigateway`, chart only)
+## Batch 0 — ~~enable the cache server-side~~ **DELETED (r3)**
 
-**Different app, different CODEOWNERS reviewer — its own sub-issue per CLAUDE.md rule 8.**
+**PR #507 does this itself.** It ships `config.requestCache.enabled` in `values.yaml` (false) and
+`values-prod.yaml` (**true**), with the data-sharing consequences documented at the decision
+point. There is no aigateway work for url4 to do, and the r2 chart batch — including r4's TTL
+pinning — is void: **v2 rows never expire**, so those knobs belong to the v1 lane.
 
-Without this, everything below is inert: `config.py:127-129` defaults `request_cache_enabled` to
-`False` and the chart never sets it, so every request answers `bypass / disabled`.
-
-The chart's pattern is `values.yaml → config.<camelCase>` rendered into `templates/configmap.yaml`
-as `AIGW_*` (e.g. `AIGW_ALLOWED_NETWORKS: {{ join "," .Values.config.allowedNetworks | quote }}`).
-Follow it — do **not** introduce a raw env passthrough.
-
-- `values.yaml`, new block under `config:`:
-
-  ```yaml
-  config:
-    # Response cache for deterministic chat completions. OFF in the app's own default
-    # (config.py:127) — url4 runs cache by default, so this must be on for that to mean
-    # anything. Values are pinned rather than inherited: an implicit default is a number
-    # that can move under you in a patch release.
-    requestCache:
-      enabled: true
-      ttlSeconds: 600         # per-entry freshness
-      maxTtlSeconds: 3600     # ceiling a caller's `ttl`/`s-maxage` may request
-      maxResponseBytes: 1000000
-  ```
-
-- `templates/configmap.yaml`, four new lines following the existing style:
-
-  ```yaml
-  AIGW_REQUEST_CACHE_ENABLED: {{ .Values.config.requestCache.enabled | quote }}
-  AIGW_REQUEST_CACHE_TTL_SECONDS: {{ .Values.config.requestCache.ttlSeconds | quote }}
-  AIGW_REQUEST_CACHE_MAX_TTL_SECONDS: {{ .Values.config.requestCache.maxTtlSeconds | quote }}
-  AIGW_REQUEST_CACHE_MAX_RESPONSE_BYTES: {{ .Values.config.requestCache.maxResponseBytes | quote }}
-  ```
-
-- `values-prod.yaml` — decide whether prod differs. Recommend it does **not** initially: one set
-  of numbers to reason about while hit rates are unknown.
-
-**The pinned values equal today's code defaults** (`config.py:130-138`). Pinning is not
-endorsement — it freezes behaviour so a future code-default change cannot move production
-silently, and it makes the numbers a visible dial to tune once §7 metrics show real hit rates.
-
-**Tests** — the chart gate (`charts.yml` → `verify_chart_wiring.py`) renders and asserts on parsed
-YAML:
-1. All four `AIGW_REQUEST_CACHE_*` keys are present in the rendered ConfigMap.
-2. `AIGW_REQUEST_CACHE_ENABLED` renders `"true"`.
-3. `ttlSeconds <= maxTtlSeconds` — the app has a matching validator
-   (`config.py:237-240`, `_validate_request_cache_ttls`) that **fails startup**, so a bad chart
-   value would take the gateway down rather than degrade. Catching it at render is the cheaper
-   failure.
-4. Values render **quoted** — the app reads env as strings; an unquoted `600` is a YAML int and
-   the ConfigMap would reject it.
-
-**Safe in isolation.** Turning the flag on changes nothing until a caller sends `use-cache`, which
-is Batch 6. That is what makes the ordering in Risks 1 a choice rather than a hazard.
+**What replaces it is a dependency, not a batch:** #507 must land before Batch 6 has any
+observable effect. Until then url4 sends the field and every request answers `bypass / disabled`,
+which is safe but proves nothing.
 
 ---
 
@@ -113,8 +68,9 @@ is Batch 6. That is what makes the ordering in Risks 1 a choice rather than a ha
 **RED first.** Schema tests only; nothing consumes these yet.
 
 - `protocol/signals.py`
-  - `class CachePolicy(BaseModel)` — **`use_cache: bool | None = None`** (tri-state, spec §4.1),
-    `no_cache`, `no_store`, `s_maxage: int|None (ge=1)`. **No `as_body_field()`** (see §0.1).
+  - `class CachePolicy(BaseModel)` — **exactly one field**, `participate: bool | None = None`
+    (tri-state, spec §4.1). **No `no_cache`, `no_store` or `s_maxage`** — v2 retired them and
+    *bypasses* on them (§1.0). **No `as_body_field()`** (see §0.1).
   - `AttachData` gains `cache: CachePolicy | None = None`.
   - `SpanData` gains `cache_status: Literal["hit","miss","bypass"] | None` and
     `cache_reason: str | None`.
@@ -130,7 +86,9 @@ is Batch 6. That is what makes the ordering in Risks 1 a choice rather than a ha
 2a. `CachePolicy()` (all-unstated) and `CachePolicy(use_cache=None)` are equivalent, and neither
    equals `CachePolicy(use_cache=False)`.
 3. Round-trip through `InboundFrameAdapter` preserves the policy.
-4. `s_maxage=0` and negative values are rejected (`ge=1`).
+4. **`CachePolicy` rejects unknown fields** (`model_config = ConfigDict(extra="forbid")`). A
+   caller who invents `no_store` must fail at the url4 edge with a clear error, rather than have
+   it forwarded and silently cost every cache hit downstream.
 5. `SpanData` without cache fields still validates.
 
 **Gate:** `run_gates.py url4` green at ≥95% coverage.
@@ -142,16 +100,16 @@ is Batch 6. That is what makes the ordering in Risks 1 a choice rather than a ha
 - `url4_cloud/runner/cache.py` (new) — `policy_to_body_field(policy: CachePolicy) -> dict`.
 
 **Takes a RESOLVED policy, never `None`.** The D1 default is applied once at convergence
-(Batch 5), so this function is a dumb translation and the policy decision lives in exactly one
-place.
+(Batch 5), so this stays a dumb translation and the policy decision lives in one place.
 
 **Tests**
-1. `CachePolicy(use_cache=True)` → `{"cache": {"use-cache": true}}` — **the D1=ON default shape**.
-2. `CachePolicy(no_store=True)` → `{"cache": {"no-store": true}}`.
-3. Each field maps to aigateway's spelling (`no_store` → `"no-store"`, `s_maxage` → `"s-maxage"`).
-4. Unstated fields are **omitted**, not sent as `false` — aigateway's `parse_cache_controls`
-   treats absent and `false` identically, but a minimal body keeps the wire honest and the
-   `unsupported_fields` surface small.
+1. `participate=True` → **`{}`** — the field is *omitted*, not sent as `{"use-cache": true}`.
+   v2 treats absent, `null` and `{}` identically as participate, and the smallest body is the
+   least likely to trip the closed-grammar bypass.
+2. `participate=False` → `{"cache": {"use-cache": false}}`.
+3. **The output `cache` object never has more than the one `use-cache` key.** Property-style:
+   whatever the input, `set(out.get("cache", {})) <= {"use-cache"}`. This is the guard that keeps
+   a future field addition from silently disabling caching for every run.
 
 **Gate:** `run_gates.py url4-cloud`, including `check_layering.py` — this module must not be
 imported by anything in `packages/url4`.
@@ -216,10 +174,9 @@ imported by anything in `packages/url4`.
 - `runner/connector.py:337` — `json={"model":…, "messages":…, **extra, **policy_to_body_field(policy)}`.
 
 **Tests**
-1. **(r2)** A run with no declared policy sends `cache: {"use-cache": true}` — the D1=ON default.
-   *(r1 asserted a byte-identical body here; that criterion died with D1. It now applies only to
-   the shape of an explicitly disabled run.)*
-2. A `no-store` run sends `cache: {"no-store": true}` and no `use-cache`.
+1. **(r3)** A run with no declared policy sends **no `cache` field** — body byte-identical to
+   today's, which under v2 *is* participation. The r1 criterion returns, for a different reason.
+2. An opted-out run sends `cache: {"use-cache": false}` and nothing else.
 3. Two concurrent runs with different policies do not contaminate each other — the regression
    `AigatewayConfig` placement would have caused.
 4. The tool-calling loop (`connector.py:325-360`) applies the policy on **every** round trip, not
@@ -266,7 +223,10 @@ imported by anything in `packages/url4`.
 
 ## Risks
 
-1. **RESOLVED — it *is* off.** `config.py:127-129` defaults `request_cache_enabled` to `False`,
+1. **RESOLVED, then superseded (r3).** #507 owns the operator gate and turns it on in
+   `values-prod.yaml`. The remaining risk is a **dependency**: this work is unobservable until
+   #507 lands, and #507 is WIP. Do not treat a green url4 test suite as evidence the cache works
+   end to end. *(Original note:* it *is* off today. `config.py:127-129` defaults `request_cache_enabled` to `False`,
    and the chart never sets it (16 env keys, none of them this). That is why Batch 0 exists. The
    risk is now one of **ordering**, not discovery: if Batch 0 lands before Batch 6, nothing
    changes; if Batch 6 lands first, nothing changes either. Both are safe — but shipping them in

--- a/docs/plan/2026-08-05-url4-cache-policy.md
+++ b/docs/plan/2026-08-05-url4-cache-policy.md
@@ -1,6 +1,7 @@
 ---
 title: url4 per-run cache policy — implementation plan
-status: proposed — awaiting owner approval AND resolution of spec D1/D3/D4/D6
+status: proposed — awaiting owner approval AND resolution of spec D3/D4/D6
+revised: 2026-08-05 (r2 — D1 LOCKED ON; aigateway chart batch added; AIGW_ prefix corrected)
 created: 2026-08-05
 ticket: UNFILED — Linear MCP unauthenticated at authoring time
 spec: docs/spec/2026-08-05-url4-cache-policy-spec.md
@@ -11,13 +12,13 @@ ledger: docs/work/2026-08-05-UNFILED-url4-cloud-cache-policy-spec.md
 
 ## 0. What this plan assumes
 
-The spec leaves **four decisions open**. This plan is written against the spec's
+The spec leaves **three decisions open** (D1 is now locked). This plan is written against the spec's
 recommendations so it is reviewable as a whole; §9 states exactly what changes if you flip
 each one. **The plumbing is ~90% identical under every combination** — only the marked steps move.
 
 | decision | assumed here | if flipped |
 |---|---|---|
-| **D1** default | **OFF** — caller opts in | §9.1 — one default value + test matrix |
+| ~~**D1** default~~ | **LOCKED ON** (owner) — caching active, only disabling explicit | n/a — decided |
 | **D3** frame shape | **extend `AttachData`** | §9.2 — Batch 1 and 4 grow a union member |
 | **D4** precedence | **header wins, override logged** | §9.3 — one function in Batch 5 |
 | **D6** header name | **`Cache-Control`** | §9.4 — one constant + parser |
@@ -36,7 +37,7 @@ the aigateway client (`runner/connector.py`) and is where the translation belong
 
 So: **the protocol carries *intent*; url4-cloud translates intent → aigateway's body vocabulary.**
 The two happen to use near-identical field names, which is convenient but must not become a
-coupling. Spec needs an r3 amendment; noted rather than silently diverged.
+coupling. **Landed in spec r3** — §4.1 now defines intent only.
 
 ## Stacks & gates
 
@@ -49,13 +50,35 @@ Both are Python → the `sdlc-python` loop: RED first, append-only tests, gates 
 
 ---
 
+## Batch 0 — enable the cache server-side (`apps/aigateway`, chart only)
+
+**Different app, different CODEOWNERS reviewer — its own sub-issue per CLAUDE.md rule 8.**
+
+Without this, everything below is inert: `config.py:127-129` defaults `request_cache_enabled` to
+`False` and the chart never sets it, so every request answers `bypass / disabled`.
+
+- `apps/aigateway/charts/aigateway/values.yaml` — add `AIGW_REQUEST_CACHE_ENABLED=true` to the
+  env block, beside the existing `AIGW_ALLOWED_NETWORKS` / `AIGW_AUTH_MODE` / `AIGW_OPENROUTER_ENABLED`.
+- **Set the TTL/size knobs explicitly too** (spec open question 5) rather than inheriting code
+  defaults — `AIGW_REQUEST_CACHE_TTL_SECONDS`, `…_MAX_TTL_SECONDS`, `…_MAX_RESPONSE_BYTES`.
+  Implicit defaults mean a future code change silently moves production behaviour.
+- `values-prod.yaml` — decide whether prod differs from the default values file.
+
+**Tests:** the chart gate (`charts.yml` → `verify_chart_wiring.py`) renders and asserts on parsed
+YAML. Add an assertion that the env key is present and `"true"`.
+
+**Safe in isolation.** Turning the flag on changes nothing until a caller sends `use-cache`, which
+is Batch 6. That is what makes the ordering in Risks 1 a choice rather than a hazard.
+
+---
+
 ## Batch 1 — protocol types (`packages/url4`, no behaviour)
 
 **RED first.** Schema tests only; nothing consumes these yet.
 
 - `protocol/signals.py`
-  - `class CachePolicy(BaseModel)` — `use_cache`, `no_cache`, `no_store`, `s_maxage: int|None (ge=1)`.
-    **No `as_body_field()`** (see §0.1).
+  - `class CachePolicy(BaseModel)` — **`use_cache: bool | None = None`** (tri-state, spec §4.1),
+    `no_cache`, `no_store`, `s_maxage: int|None (ge=1)`. **No `as_body_field()`** (see §0.1).
   - `AttachData` gains `cache: CachePolicy | None = None`.
   - `SpanData` gains `cache_status: Literal["hit","miss","bypass"] | None` and
     `cache_reason: str | None`.
@@ -65,8 +88,11 @@ Both are Python → the `sdlc-python` loop: RED first, append-only tests, gates 
 1. An attach frame **without** `cache` still validates — backward compatibility is the whole
    risk of touching a wire type.
 2. `cache: null` and an absent key both parse to `None`, and `None` is distinguishable from
-   `CachePolicy()`. **This distinction is load-bearing for D4** — "did not declare" must not
-   collapse into "declared off".
+   `CachePolicy()`. **Load-bearing twice over:** for D4 precedence ("did not declare" ≠ "declared
+   off"), and for D1=ON — with a plain `bool = False`, `cache: {}` would silently disable caching
+   for a caller who meant to express no opinion (spec §4.1).
+2a. `CachePolicy()` (all-unstated) and `CachePolicy(use_cache=None)` are equivalent, and neither
+   equals `CachePolicy(use_cache=False)`.
 3. Round-trip through `InboundFrameAdapter` preserves the policy.
 4. `s_maxage=0` and negative values are rejected (`ge=1`).
 5. `SpanData` without cache fields still validates.
@@ -77,13 +103,19 @@ Both are Python → the `sdlc-python` loop: RED first, append-only tests, gates 
 
 ## Batch 2 — the aigateway mapping (`apps/url4-cloud`, pure function)
 
-- `url4_cloud/runner/cache.py` (new) — `policy_to_body_field(policy: CachePolicy | None) -> dict`.
+- `url4_cloud/runner/cache.py` (new) — `policy_to_body_field(policy: CachePolicy) -> dict`.
+
+**Takes a RESOLVED policy, never `None`.** The D1 default is applied once at convergence
+(Batch 5), so this function is a dumb translation and the policy decision lives in exactly one
+place.
 
 **Tests**
-1. `None` → `{}` — **the byte-identical-body guarantee**; a default run's payload must not change
-   shape at all, or aigateway's `unsupported_fields` bypass path may trigger.
-2. Each field maps to aigateway's spelling (`no_store` → `"no-store"`, `s_maxage` → `"s-maxage"`).
-3. A policy with every field `False`/`None` still yields `{}`, not `{"cache": {}}`.
+1. `CachePolicy(use_cache=True)` → `{"cache": {"use-cache": true}}` — **the D1=ON default shape**.
+2. `CachePolicy(no_store=True)` → `{"cache": {"no-store": true}}`.
+3. Each field maps to aigateway's spelling (`no_store` → `"no-store"`, `s_maxage` → `"s-maxage"`).
+4. Unstated fields are **omitted**, not sent as `false` — aigateway's `parse_cache_controls`
+   treats absent and `false` identically, but a minimal body keeps the wire honest and the
+   `unsupported_fields` surface small.
 
 **Gate:** `run_gates.py url4-cloud`, including `check_layering.py` — this module must not be
 imported by anything in `packages/url4`.
@@ -132,7 +164,7 @@ imported by anything in `packages/url4`.
 
 | header | frame | effective | log |
 |---|---|---|---|
-| absent | absent | D1 default | — |
+| absent | absent | **`CachePolicy(use_cache=True)`** — the D1=ON default, applied here and nowhere else | — |
 | set | absent | header | — |
 | absent | set | frame | — |
 | set | set, same | header | — |
@@ -148,8 +180,10 @@ imported by anything in `packages/url4`.
 - `runner/connector.py:337` — `json={"model":…, "messages":…, **extra, **policy_to_body_field(policy)}`.
 
 **Tests**
-1. A run with no policy produces a body **byte-identical** to today's (assert on the exact dict).
-2. A `no-store` run sends `cache: {"no-store": true}`.
+1. **(r2)** A run with no declared policy sends `cache: {"use-cache": true}` — the D1=ON default.
+   *(r1 asserted a byte-identical body here; that criterion died with D1. It now applies only to
+   the shape of an explicitly disabled run.)*
+2. A `no-store` run sends `cache: {"no-store": true}` and no `use-cache`.
 3. Two concurrent runs with different policies do not contaminate each other — the regression
    `AigatewayConfig` placement would have caused.
 4. The tool-calling loop (`connector.py:325-360`) applies the policy on **every** round trip, not
@@ -186,7 +220,7 @@ imported by anything in `packages/url4`.
 ## Verification
 
 1. `run_gates.py url4` and `run_gates.py url4-cloud` both green.
-2. **End-to-end against a local aigateway with `AIGATEWAY_REQUEST_CACHE_ENABLED=1`** (see Risk 1):
+2. **End-to-end against a local aigateway with `AIGW_REQUEST_CACHE_ENABLED=1`** (see Risk 1):
    - run with no policy → `bypass` / `not_requested`
    - opt-in run → `miss`, then an identical immediate repeat → `hit`
    - `no-store` run after a hit → `bypass`, and the stored entry is untouched
@@ -196,15 +230,21 @@ imported by anything in `packages/url4`.
 
 ## Risks
 
-1. **`request_cache_enabled` may be off in the deployed aigateway.** Then every path answers
-   `bypass / disabled` and this is inert. **Confirm before Batch 1** — it decides whether this is
-   worth building now.
+1. **RESOLVED — it *is* off.** `config.py:127-129` defaults `request_cache_enabled` to `False`,
+   and the chart never sets it (16 env keys, none of them this). That is why Batch 0 exists. The
+   risk is now one of **ordering**, not discovery: if Batch 0 lands before Batch 6, nothing
+   changes; if Batch 6 lands first, nothing changes either. Both are safe — but shipping them in
+   the same window flips production cache behaviour at an unpredictable moment. Sequence
+   deliberately.
 2. **Touching a wire type.** `AttachData` is live protocol. Batch 1 test 1 (old frame still
    validates) is the guard; treat a failure there as a stop-the-line.
 3. **`packages/url4` coverage gate is 95%.** Small additions with error branches can dip it;
    budget for exhaustive schema tests.
-4. **Ensemble determinism** (spec §8.2) — if D1 flips to ON, two nodes sampling one model for
-   variance may receive one answer twice. Not a plumbing risk; a thesis-level one.
+4. **Ensemble determinism** (spec §8.2) — **accepted by the owner**, and with D1=ON it is the
+   default path rather than an edge case: two nodes sampling one model for variance receive one
+   answer twice and score it as agreement. Not a plumbing risk; a thesis-level one. If it needs
+   undoing later, the cheapest carve-out is a per-run nonce in prompt normalisation — no protocol
+   change.
 5. **Two ingress paths, one policy.** Batch 5's matrix is the whole defence; do not ship Batch 3
    or 4 without it.
 
@@ -216,11 +256,6 @@ imported by anything in `packages/url4`.
 - Extracting `url4_streaming_protocol` as its own package (spec open question 6).
 
 ## 9. What changes if a decision flips
-
-### 9.1 D1 → default ON
-Batch 6 supplies `use_cache=True` when no policy is declared; Batch 3/4 tests for "absent" invert
-their expected effective policy. **No structural change.** Note this makes spec §8.2's determinism
-risk live for every existing run.
 
 ### 9.2 D3 → `ConfigureEvent` instead of `AttachData.cache`
 Batch 1 adds a new `ConfigureData` + `ConfigureEvent` and a third member to `InboundFrame`

--- a/docs/plan/2026-08-05-url4-cache-policy.md
+++ b/docs/plan/2026-08-05-url4-cache-policy.md
@@ -1,8 +1,8 @@
 ---
 title: url4 per-run cache policy — implementation plan
-status: proposed — awaiting owner approval AND resolution of spec D3/D4/D6
-revised: 2026-08-05 (r3 — rebased on aigateway v2 / PR #507; Batch 0 DELETED; mapper collapses to one field)
+status: proposed — awaiting owner approval AND spec decisions D3, D4, D6, D11
 created: 2026-08-05
+revised: 2026-08-05 (r4 — rewritten clean against aigateway v2 / PR #507)
 ticket: UNFILED — Linear MCP unauthenticated at authoring time
 spec: docs/spec/2026-08-05-url4-cache-policy-spec.md
 ledger: docs/work/2026-08-05-UNFILED-url4-cloud-cache-policy-spec.md
@@ -10,124 +10,149 @@ ledger: docs/work/2026-08-05-UNFILED-url4-cloud-cache-policy-spec.md
 
 # Implementation plan — url4 per-run cache policy
 
-## 0. What this plan assumes
+> **r4 is a clean rewrite.** r1–r3 accumulated patches as the design moved (url4-cloud REST →
+> `packages/url4` protocol; cache OFF → ON; aigateway chart in scope → deleted). Those turns live
+> in the spec's revision table and the ledger; this document describes only the work as it now
+> stands.
 
-The spec leaves **three decisions open** (D1 is now locked). This plan is written against the spec's
-recommendations so it is reviewable as a whole; §9 states exactly what changes if you flip
-each one. **The plumbing is ~90% identical under every combination** — only the marked steps move.
+## 1. What this builds
 
-| decision | assumed here | if flipped |
+A caller can declare that one url4 run must **not** participate in aigateway's global response
+cache. Caching is otherwise **on**, because aigateway v2 makes it on.
+
+Two carriers, one meaning:
+
+```
+Cache-Control: no-store              (HTTP, on GET /)
+{"cache": {"participate": false}}    (WS attach frame)
+```
+
+## 2. The upstream this depends on
+
+**aigateway PR #507 (`OME-305`) — WIP, assumed landing.** It replaces the v1 per-account cache
+with one **global, never-expiring, ON-by-default** cache whose control grammar is **closed to a
+single field, `use-cache`**.
+
+Three consequences that shape every batch below:
+
+1. **url4 may send only `use-cache`.** Under v2 an unrecognised control key does not degrade to
+   "ignored" — it makes the request **bypass** (`global_controls.py`), even alongside a valid
+   `use-cache: true`. A well-meant `no-store` or `ttl` would silently cost every cache hit.
+2. **Absent, `null` and `{}` all mean participate.** So the default run sends **no `cache` field
+   at all** — the smallest body, and the least exposed to the closed-grammar bypass.
+3. **No aigateway work.** #507 ships its own chart (`requestCache.enabled` — `false` in
+   `values.yaml`, `true` in `values-prod.yaml`). url4 depends on it landing; it does not touch it.
+
+**This work is unobservable until #507 lands.** A green url4 suite is not evidence the cache works
+end to end — see Verification step 3.
+
+## 3. Decisions
+
+**Locked:** cache ON by default · protocol types in `packages/url4` · both carriers · per-run
+scope · response headers folded onto spans · no aigateway change.
+
+**Open — the plan assumes the spec's recommendation for each; §9 states what moves if you flip
+one.** The plumbing is ~90% invariant across all four.
+
+| | decision | assumed |
 |---|---|---|
-| ~~**D1** default~~ | **LOCKED ON** (owner) — caching active, only disabling explicit | n/a — decided |
-| **D3** frame shape | **extend `AttachData`** | §9.2 — Batch 1 and 4 grow a union member |
-| **D4** precedence | **header wins, override logged** | §9.3 — one function in Batch 5 |
-| **D6** header name | **`Cache-Control`** | §9.4 — one constant + parser |
+| **D3** | frame shape | extend `AttachData` |
+| **D4** | precedence when both carriers speak | header wins, override logged |
+| **D6** | header name | standard `Cache-Control` |
+| **D11** | `max-age` under a never-expiring cache | treat as opt-out |
 
 Implementation starts only on explicit approval in plain words (CLAUDE.md rule 3).
 
-## 0.1 Correction to spec §4.1 — surfaced while planning
+## 4. One architectural note
 
-The spec put `as_body_field()` — the `{"cache": {...}}` mapping to aigateway's vocabulary — on the
-protocol `CachePolicy` in `packages/url4`.
+The spec's protocol type carries **intent only** — `participate: bool | None`. The translation to
+aigateway's wire vocabulary (`{"cache": {"use-cache": false}}`) lives in `apps/url4-cloud`.
 
-**That is wrong and this plan does not do it.** `packages/url4` is the protocol and engine; it must
-not know aigateway's request-body shape. CLAUDE.md's architecture rule is explicit — core defines
-ports, adapters implement them, core never imports the adapter's concerns. `apps/url4-cloud` owns
-the aigateway client (`runner/connector.py`) and is where the translation belongs.
+`packages/url4` is the protocol and engine and must not know an adapter's request-body shape;
+CLAUDE.md's architecture rule is explicit. The two vocabularies are nearly identical, which is
+convenient and must not become a coupling — a change to aigateway's body shape must never edit a
+file that ships to SDK users.
 
-So: **the protocol carries *intent*; url4-cloud translates intent → aigateway's body vocabulary.**
-The two happen to use near-identical field names, which is convenient but must not become a
-coupling. **Landed in spec r3** — §4.1 now defines intent only.
+## 5. Stacks & gates
 
-## Stacks & gates
-
-| stack | root | gate command | note |
+| stack | root | gate | note |
 |---|---|---|---|
-| `url4` | `packages/url4` | `uv run .claude/scripts/run_gates.py url4` | **`--cov-fail-under=95`** — new code needs near-total coverage |
-| `url4-cloud` | `apps/url4-cloud` | `uv run .claude/scripts/run_gates.py url4-cloud` | includes `check_layering.py` |
+| `url4` | `packages/url4` | `run_gates.py url4` | **`--cov-fail-under=95`** |
+| `url4-cloud` | `apps/url4-cloud` | `run_gates.py url4-cloud` | includes `check_layering.py` |
 
-Both are Python → the `sdlc-python` loop: RED first, append-only tests, gates before commit.
-
----
-
-## Batch 0 — ~~enable the cache server-side~~ **DELETED (r3)**
-
-**PR #507 does this itself.** It ships `config.requestCache.enabled` in `values.yaml` (false) and
-`values-prod.yaml` (**true**), with the data-sharing consequences documented at the decision
-point. There is no aigateway work for url4 to do, and the r2 chart batch — including r4's TTL
-pinning — is void: **v2 rows never expire**, so those knobs belong to the v1 lane.
-
-**What replaces it is a dependency, not a batch:** #507 must land before Batch 6 has any
-observable effect. Until then url4 sends the field and every request answers `bypass / disabled`,
-which is safe but proves nothing.
+Both Python → the `sdlc-python` loop: RED first, append-only tests, gates before commit.
 
 ---
 
-## Batch 1 — protocol types (`packages/url4`, no behaviour)
+## Batch 1 — protocol types (`packages/url4`)
 
-**RED first.** Schema tests only; nothing consumes these yet.
+No behaviour; schema only.
 
 - `protocol/signals.py`
-  - `class CachePolicy(BaseModel)` — **exactly one field**, `participate: bool | None = None`
-    (tri-state, spec §4.1). **No `no_cache`, `no_store` or `s_maxage`** — v2 retired them and
-    *bypasses* on them (§1.0). **No `as_body_field()`** (see §0.1).
+  - `class CachePolicy(BaseModel)` — **exactly one field**, `participate: bool | None = None`,
+    with `model_config = ConfigDict(extra="forbid")`.
   - `AttachData` gains `cache: CachePolicy | None = None`.
   - `SpanData` gains `cache_status: Literal["hit","miss","bypass"] | None` and
     `cache_reason: str | None`.
-- `protocol/__init__.py` — export `CachePolicy`; extend `__all__`.
+- `protocol/__init__.py` — export `CachePolicy`, extend `__all__`.
 
 **Tests**
-1. An attach frame **without** `cache` still validates — backward compatibility is the whole
-   risk of touching a wire type.
-2. `cache: null` and an absent key both parse to `None`, and `None` is distinguishable from
-   `CachePolicy()`. **Load-bearing twice over:** for D4 precedence ("did not declare" ≠ "declared
-   off"), and for D1=ON — with a plain `bool = False`, `cache: {}` would silently disable caching
-   for a caller who meant to express no opinion (spec §4.1).
-2a. `CachePolicy()` (all-unstated) and `CachePolicy(use_cache=None)` are equivalent, and neither
-   equals `CachePolicy(use_cache=False)`.
+
+1. An attach frame **without** `cache` still validates — backward compatibility is the whole risk
+   of touching a live wire type. Treat a failure here as stop-the-line.
+2. Absent, `null` and `{}` all parse such that "not stated" is distinguishable from an explicit
+   `participate=False`. Collapsing them makes opt-out unexpressible and breaks D4.
 3. Round-trip through `InboundFrameAdapter` preserves the policy.
-4. **`CachePolicy` rejects unknown fields** (`model_config = ConfigDict(extra="forbid")`). A
-   caller who invents `no_store` must fail at the url4 edge with a clear error, rather than have
-   it forwarded and silently cost every cache hit downstream.
+4. **Unknown fields are rejected** (`extra="forbid"`). A caller inventing `no_store` fails loudly
+   at the url4 edge instead of having it forwarded to a grammar that bypasses on it.
 5. `SpanData` without cache fields still validates.
 
 **Gate:** `run_gates.py url4` green at ≥95% coverage.
 
 ---
 
-## Batch 2 — the aigateway mapping (`apps/url4-cloud`, pure function)
+## Batch 2 — the aigateway mapping (`apps/url4-cloud`)
 
 - `url4_cloud/runner/cache.py` (new) — `policy_to_body_field(policy: CachePolicy) -> dict`.
 
-**Takes a RESOLVED policy, never `None`.** The D1 default is applied once at convergence
-(Batch 5), so this stays a dumb translation and the policy decision lives in one place.
+Takes a **resolved** policy, never `None`: the default is applied once at convergence (Batch 5),
+so this stays a dumb translation and the policy decision lives in exactly one place.
 
 **Tests**
-1. `participate=True` → **`{}`** — the field is *omitted*, not sent as `{"use-cache": true}`.
-   v2 treats absent, `null` and `{}` identically as participate, and the smallest body is the
-   least likely to trip the closed-grammar bypass.
+
+1. `participate=True` → **`{}`**. The field is *omitted*, not sent as `{"use-cache": true}`.
 2. `participate=False` → `{"cache": {"use-cache": false}}`.
-3. **The output `cache` object never has more than the one `use-cache` key.** Property-style:
-   whatever the input, `set(out.get("cache", {})) <= {"use-cache"}`. This is the guard that keeps
-   a future field addition from silently disabling caching for every run.
+3. **Property: `set(out.get("cache", {})) <= {"use-cache"}` for every input.** The single most
+   important guard in this plan — any extra key silently costs every cache hit, with no error
+   anywhere.
 
 **Gate:** `run_gates.py url4-cloud`, including `check_layering.py` — this module must not be
-imported by anything in `packages/url4`.
+importable from `packages/url4`.
 
 ---
 
 ## Batch 3 — HTTP ingress (`apps/url4-cloud`)
 
-- `url4_cloud/rest/cache_header.py` (new) — `parse_cache_control(raw: str|None) -> CachePolicy|None`.
-- `rest/routes.py:337` — new `Annotated[str|None, Header(alias="Cache-Control")]` param on
+- `url4_cloud/rest/cache_header.py` (new) —
+  `parse_cache_control(raw: str | None) -> CachePolicy | None`.
+- `rest/routes.py:337` — new `Annotated[str | None, Header(alias="Cache-Control")]` on
   `start_run`, mirroring `x_profile` at `:347`.
 
+Every directive collapses to participate / opt-out **at this edge**; none is forwarded verbatim.
+
+| directive | → |
+|---|---|
+| absent | `None` — not stated |
+| `no-store`, `no-cache` | `participate=False` |
+| `max-age=<n>` | `participate=False` (D11) |
+| `url4-use-cache` | `participate=True` |
+
 **Tests**
-1. `no-store` / `no-cache` / `max-age=60` / `url4-use-cache` each parse correctly.
-2. Multiple directives in one header combine.
-3. Absent header → `None` (not a default-constructed policy).
-4. **Garbage is ignored, never 4xx** — matches `parse_cache_controls`' documented posture that
-   malformed values parse as "not requested". A cache directive must never fail a run.
+
+1. Each row above.
+2. Multiple directives in one header combine; conflicting ones resolve to opt-out (the safe side).
+3. Absent header → `None`, not a default-constructed policy.
+4. **Garbage is ignored, never 4xx.** A cache directive must never fail a run.
 5. Unknown directives are dropped without affecting known ones.
 
 ---
@@ -135,30 +160,28 @@ imported by anything in `packages/url4`.
 ## Batch 4 — WS ingress (`apps/url4-cloud`)
 
 - `ws/bridge.py` — carry `AttachData.cache` into per-topic session state on attach.
-- **First attach wins.** A re-attach with a *different* policy does not restate it; emits a
+- **First attach wins.** A re-attach with a different policy does not restate it; emits a
   `LogEvent` at `warn`.
 
 **Tests**
+
 1. Attach carrying a policy records it for the topic.
 2. Attach without a policy records `None`.
-3. Re-attach with a different policy leaves the recorded policy unchanged **and** logs.
-4. Re-attach with an identical policy logs nothing (no warning noise on ordinary reconnect).
-5. A run started before any attach is impossible — assert `_require_subscriber`
-   (`rest/routes.py:363`) still guards it, so the ordering the design relies on is tested, not
-   assumed.
+3. Re-attach with a *different* policy leaves the recorded policy unchanged **and** logs.
+4. Re-attach with an *identical* policy logs nothing — no warning noise on ordinary reconnect.
+5. `_require_subscriber` (`rest/routes.py:363`) still guards run start, so the attach-before-run
+   ordering this design relies on is tested rather than assumed.
 
 ---
 
-## Batch 5 — convergence & precedence (D4)
+## Batch 5 — convergence & precedence
 
 - `rest/routes.py` — resolve `(header_policy, frame_policy)` → effective policy; pass to
-  `_schedule` as one new kwarg beside `profile`/`identity`.
-
-**Tests** — the full matrix:
+  `_schedule` as one new kwarg beside `profile` / `identity`.
 
 | header | frame | effective | log |
 |---|---|---|---|
-| absent | absent | **`CachePolicy(use_cache=True)`** — the D1=ON default, applied here and nowhere else | — |
+| absent | absent | `participate=True` — the default, applied **here and nowhere else** | — |
 | set | absent | header | — |
 | absent | set | frame | — |
 | set | set, same | header | — |
@@ -168,102 +191,95 @@ imported by anything in `packages/url4`.
 
 ## Batch 6 — threading & egress
 
-- `job_env` / runner — thread as a **per-run** value, exactly as `profile` travels.
-  **Not** on `AigatewayConfig`: that is world config shared by every run, and a per-run value
-  placed there would leak across runs.
-- `runner/connector.py:337` — `json={"model":…, "messages":…, **extra, **policy_to_body_field(policy)}`.
+- `job_env` / runner — thread as a **per-run** value, exactly as `profile` travels. **Not** on
+  `AigatewayConfig`: that is world config shared by every run, and a per-run value there leaks
+  across runs.
+- `runner/connector.py:337` —
+  `json={"model": …, "messages": …, **extra, **policy_to_body_field(policy)}`.
 
 **Tests**
-1. **(r3)** A run with no declared policy sends **no `cache` field** — body byte-identical to
-   today's, which under v2 *is* participation. The r1 criterion returns, for a different reason.
+
+1. A default run's body is **byte-identical to today's** — no `cache` field, which under v2 *is*
+   participation.
 2. An opted-out run sends `cache: {"use-cache": false}` and nothing else.
-3. Two concurrent runs with different policies do not contaminate each other — the regression
-   `AigatewayConfig` placement would have caused.
-4. The tool-calling loop (`connector.py:325-360`) applies the policy on **every** round trip, not
-   just the first — a turn is several calls.
+3. Two concurrent runs with different policies do not contaminate each other — the regression an
+   `AigatewayConfig` placement would cause.
+4. The tool-calling loop (`connector.py:325-360`) applies the policy on **every** round trip. One
+   turn is several calls, and a policy that lapsed after the first would be worse than none.
 
 ---
 
-## Batch 7 — reading the answer back (D7, mandatory)
+## Batch 7 — reading the answer back
 
 - `runner/connector.py` — read `X-AIGW-Cache`, `X-AIGW-Cache-Reason`, `X-AIGW-Cache-Key`; fold
-  onto the owning span beside `_report_usage`, the seam `#506` used for `finish_reason`/`refusal`.
+  onto the owning span beside `_report_usage`, the seam `#506` used for `finish_reason` /
+  `refusal`.
+
+Without this, a hit costs nothing upstream but `_report_usage` bills it as a fresh call — an error
+that **hides savings**, so nobody reports it.
 
 **Tests**
+
 1. `hit` / `miss` / `bypass` each reach `SpanData.cache_status`.
-2. The reason string is carried verbatim (`not_requested`, `disabled`, `stream`,
-   `unsupported_fields`).
-3. **Missing headers do not crash** — an older aigateway, or a non-cache error path, must degrade
-   to `None`.
-4. `X-AIGW-Cache-Key` is recorded only for hit/miss, and never any prompt content.
+2. Reason carried verbatim, including v2's vocabulary: `opted_out`, `malformed_controls`,
+   `unsupported_control`, `disabled`.
+3. **Missing headers degrade to `None`, never crash** — an older gateway, or a non-cache error
+   path.
+4. `X-AIGW-Cache-Key` recorded only for hit/miss; never any prompt content.
 
 ---
 
 ## Batch 8 — observability & docs
 
-- Run-level counters: hits, misses, **bypasses by reason** (the load-bearing one — it makes
-  "I asked for caching and got none" answerable). **No label may carry cache key, prompt or
-  credential**, per the catalog spec's rule.
+- Run-level counters: hits, misses, **bypasses by reason** — the load-bearing one, since it turns
+  "I asked for no caching and something still cached" into an answerable question.
+- **No metric labelled by cache key, prompt or credential.**
 - `schemas/openapi.py` — document the request header.
 - `schemas/asyncapi.py` — document the attach-frame field.
-- `apps/url4-cloud/README.md` + `packages/url4` docs as needed.
+- `apps/url4-cloud/README.md`; `packages/url4` docs as needed.
 
 ---
 
 ## Verification
 
 1. `run_gates.py url4` and `run_gates.py url4-cloud` both green.
-2. **End-to-end against a local aigateway with `AIGW_REQUEST_CACHE_ENABLED=1`** (see Risk 1):
-   - run with no policy → `bypass` / `not_requested`
-   - opt-in run → `miss`, then an identical immediate repeat → `hit`
-   - `no-store` run after a hit → `bypass`, and the stored entry is untouched
-   - same policy via header and via frame → identical egress body
-3. A streaming turn reports `bypass` / `stream` regardless of policy.
-4. Spec §9 acceptance items 1-10 each map to a test above.
+2. Batch 2's property test passes — `cache` never carries a key other than `use-cache`.
+3. **End-to-end against a local aigateway built from #507**, with `requestCache.enabled: true`:
+   - default run → participates; `miss`, then `hit` on an identical repeat
+   - `Cache-Control: no-store` → `bypass` with reason **`opted_out`** (not `unsupported_control`
+     — that distinction is the whole point of collapsing at the url4 edge)
+   - `max-age=60` behaves as `no-store` (D11)
+   - the same policy via header and via frame produces an identical egress body
+4. A streaming turn reports `bypass` regardless of policy.
+5. Spec §9 acceptance items each map to a test above.
 
 ## Risks
 
-1. **RESOLVED, then superseded (r3).** #507 owns the operator gate and turns it on in
-   `values-prod.yaml`. The remaining risk is a **dependency**: this work is unobservable until
-   #507 lands, and #507 is WIP. Do not treat a green url4 test suite as evidence the cache works
-   end to end. *(Original note:* it *is* off today. `config.py:127-129` defaults `request_cache_enabled` to `False`,
-   and the chart never sets it (16 env keys, none of them this). That is why Batch 0 exists. The
-   risk is now one of **ordering**, not discovery: if Batch 0 lands before Batch 6, nothing
-   changes; if Batch 6 lands first, nothing changes either. Both are safe — but shipping them in
-   the same window flips production cache behaviour at an unpredictable moment. Sequence
-   deliberately.
-2. **Touching a wire type.** `AttachData` is live protocol. Batch 1 test 1 (old frame still
-   validates) is the guard; treat a failure there as a stop-the-line.
-3. **`packages/url4` coverage gate is 95%.** Small additions with error branches can dip it;
-   budget for exhaustive schema tests.
-4. **Ensemble determinism** (spec §8.2) — **accepted by the owner**, and with D1=ON it is the
-   default path rather than an edge case: two nodes sampling one model for variance receive one
-   answer twice and score it as agreement. Not a plumbing risk; a thesis-level one. If it needs
-   undoing later, the cheapest carve-out is a per-run nonce in prompt normalisation — no protocol
-   change.
-5. **Two ingress paths, one policy.** Batch 5's matrix is the whole defence; do not ship Batch 3
-   or 4 without it.
+1. **#507 is WIP.** Its control grammar could still change; this plan is written against the
+   branch as read on 2026-08-05. Re-read `global_controls.py` before Batch 2 — that file alone
+   determines the mapping.
+2. **Touching a live wire type.** `AttachData` is protocol. Batch 1 test 1 is the guard.
+3. **`packages/url4` coverage gate is 95%**; small additions with error branches can dip it.
+4. **The closed grammar is a silent failure mode.** An extra control key costs every hit and
+   raises nothing. Batch 2 test 3 exists solely for this, and it should be treated as a
+   correctness test, not a style one.
+5. **Ensemble determinism** — accepted by the owner, but v2 widens it: the collapsing repeat need
+   not share an account, a run or a day. Flagged in spec §8.2 for re-confirmation. Not a plumbing
+   risk; a thesis-level one.
 
 ## Out of scope
 
 - Per-node cache intent — needs url4 grammar, reopens doctrine fork **F4**.
 - A url4-native / Enclave GET cache.
-- Any `apps/aigateway` change.
-- Extracting `url4_streaming_protocol` as its own package (spec open question 6).
+- Any `apps/aigateway` change — #507 owns it.
+- Extracting `url4_streaming_protocol` as its own package (spec open question 4).
 
-## 9. What changes if a decision flips
+## 9. If a decision flips
 
-### 9.2 D3 → `ConfigureEvent` instead of `AttachData.cache`
-Batch 1 adds a new `ConfigureData` + `ConfigureEvent` and a third member to `InboundFrame`
-(`unions.py:81`); Batch 4 handles a new inbound verb and must define what a `Configure` arriving
-*after* run start means (recommend: ignored + warn, consistent with first-attach-wins). Batches
-2, 5, 6, 7 unchanged.
-
-### 9.3 D4 → frame wins, or fatal on conflict
-One function in Batch 5 and its matrix row. If **fatal**, add a 409 path on the REST side and an
-`ErrorEvent` on the WS side — the only variant that grows the error surface.
-
-### 9.4 D6 → `URL4-Cache` instead of `Cache-Control`
-Batch 3's header constant and parser grammar (a private header can use a simple JSON or
-key=value form rather than RFC 9111 directives, and needs no `url4-use-cache` extension token).
-Batches 1, 2, 4-8 unchanged.
+| flip | what moves |
+|---|---|
+| **D3** → `ConfigureEvent` | Batch 1 adds `ConfigureData` + a third `InboundFrame` member (`unions.py:81`); Batch 4 handles a new inbound verb and must define what a `Configure` *after* run start means (recommend: ignored + warn). Batches 2, 5-8 unchanged. |
+| **D4** → frame wins | One function in Batch 5, one matrix row. |
+| **D4** → fatal on conflict | Adds a 409 on the REST side and an `ErrorEvent` on the WS side — the only variant that grows the error surface. |
+| **D6** → `URL4-Cache` | Batch 3's constant and parser grammar; a private header can use a simple `key=value` form and needs no RFC 9111 extension token. Batches 1, 2, 4-8 unchanged. |
+| **D11** → ignore `max-age` | One row in Batch 3's table and its test. |

--- a/docs/plan/2026-08-05-url4-cache-policy.md
+++ b/docs/plan/2026-08-05-url4-cache-policy.md
@@ -29,7 +29,7 @@ Cache-Control: no-store              (HTTP, on GET /)
 
 ## 2. The upstream this depends on
 
-**aigateway PR #507 (`OME-305`) — WIP, assumed landing.** It replaces the v1 per-account cache
+**aigateway PR #507 (`OME-305`) — MERGED 2026-08-06 as `4f2a55ea`.** It replaces the v1 per-account cache
 with one **global, never-expiring, ON-by-default** cache whose control grammar is **closed to a
 single field, `use-cache`**.
 
@@ -285,7 +285,8 @@ and a discarded body, multiplied across a fan-out.
 
 1. `run_gates.py url4` and `run_gates.py url4-cloud` both green.
 2. Batch 2's property test passes — `cache` never carries a key other than `use-cache`.
-3. **End-to-end against a local aigateway built from #507**, with `requestCache.enabled: true`:
+3. **End-to-end against a local aigateway built from `origin/main`** (#507 having merged), with
+   `AIGW_REQUEST_CACHE_ENABLED=true`:
    - default run → participates; `miss`, then `hit` on an identical repeat
    - `Cache-Control: no-store` → `bypass` with reason **`opted_out`** (not `unsupported_control`
      — that distinction is the whole point of collapsing at the url4 edge)
@@ -296,9 +297,10 @@ and a discarded body, multiplied across a fan-out.
 
 ## Risks
 
-1. **#507 is WIP.** Its control grammar could still change; this plan is written against the
-   branch as read on 2026-08-05. Re-read `global_controls.py` before Batch 2 — that file alone
-   determines the mapping.
+1. ~~**#507 is WIP.** Its control grammar could still change~~ — **RETIRED 2026-08-07.** #507
+   merged as `4f2a55ea` and `global_controls.py` was re-read on `origin/main`: the grammar is
+   byte-equivalent to what this plan was written against, the sole change being a rename url4
+   never referenced (`LEGACY_CONTROL_FIELDS` → `UNSUPPORTED_CONTROL_FIELDS`). The mapping stands.
 2. **Touching a live wire type.** `AttachData` is protocol. Batch 1 test 1 is the guard.
 3. **`packages/url4` coverage gate is 95%**; small additions with error branches can dip it.
 4. **The closed grammar is a silent failure mode.** An extra control key costs every hit and

--- a/docs/spec/2026-08-05-url4-cache-policy-spec.md
+++ b/docs/spec/2026-08-05-url4-cache-policy-spec.md
@@ -2,7 +2,7 @@
 title: url4 per-run cache policy — technical specification
 status: PROPOSED — awaiting owner decisions D3, D4, D6 (§3). No code written.
 created: 2026-08-05
-revised: 2026-08-05 (r5 — rebased on aigateway v2 global cache, PR #507; r4's TTL pinning REVOKED)
+revised: 2026-08-05 (r6 — standards alignment: RFC 9211 Cache-Status + RFC 9111 Age; D11 reopened)
 author: Claude (Opus 5) + Sergey
 ticket: UNFILED — Linear MCP unauthenticated at authoring time (see the ledger)
 related:
@@ -21,6 +21,7 @@ related:
 |---|---|---|
 | r1 | 2026-08-05 | First draft — located the change in url4-cloud's REST layer. |
 | r2 | 2026-08-05 | **Superseded r1's location.** Owner: protocol belongs in `packages/url4`; both HTTP header *and* protocol frame are carriers. Adds §3 D3/D4 and §5.2. |
+| **r6** | 2026-08-05 | **Standards alignment.** Read-back prefers **`Cache-Status`** (RFC 9211) over the ad hoc `X-AIGW-Cache*`; **`Age`** (RFC 9111 §5.1) makes `max-age` honourable, so **D11 is reopened** (§3.5). Adds §2.2 with the registry evidence. |
 | **r5** | 2026-08-05 | **Rebased on aigateway v2** (`OME-305`, PR #507 — WIP, assumed landing). v2 is a **global, never-expiring, ON-by-default cache with a CLOSED one-field grammar**. This **revokes r4** (v2 rows never expire, so TTL knobs are v1's), **deletes the aigateway sub-issue** (#507 does the chart itself), and **collapses the protocol to a single opt-out signal** — §1.0. Security section rewritten: the cache is now shared across accounts. |
 | r4 | 2026-08-05 | ~~TTL/size knobs pinned explicitly in the chart~~ — **REVOKED by r5.** |
 | r3 | 2026-08-05 | **D1 LOCKED: caching is ON by default; only disabling is explicit.** That makes the aigateway **chart** part of the deliverable (D8 reversed) and makes this cross-app — see §2.1. Ensemble-determinism tradeoff (§8.2) accepted by the owner on the record. |
@@ -149,6 +150,38 @@ one sub-issue per landing**, never one ticket:
 Sub-issue 3 has a different CODEOWNERS reviewer and can land **first and independently** — it is
 a no-op until sub-issue 2 sends `use-cache`.
 
+## 2.2 Standards alignment (r6)
+
+Every claim here was verified against the RFC text and the IANA registry, not recalled.
+
+**Where a standard exists and fits exactly — use it:**
+
+| need | standard | fit |
+|---|---|---|
+| "do not cache this run" (request) | **`Cache-Control`** — RFC 9111 §5.2.1 | Exact. `no-store` is *"A cache MUST NOT store any part of either this request or any response to it"* — both directions, which is precisely v2's all-or-nothing `participate`. |
+| "was this cached, and why not" (response) | **`Cache-Status`** — RFC 9211 §2, Standards Track | Exact, including `fwd=bypass` and `fwd=miss` as **defined tokens** (§2.2). Parameters: `hit` §2.1 · `fwd` §2.2 · `stored` §2.5 · `key` §2.7 · `detail` §2.8. |
+| "how old is this answer" | **`Age`** — RFC 9111 §5.1 | *"the sender's estimate of the time since the response was generated"* — see §3.5. |
+
+**Where no standard exists — verified against the IANA HTTP Field Name Registry:**
+
+| our header | registry |
+|---|---|
+| `X-Profile` (routing/tenant selection) | **no permanent registered field** for tenant, profile or routing selection |
+| `X-User-Email` (mesh-injected identity) | **no permanent registered field** for conveying end-user identity from a proxy/gateway |
+
+Legitimately custom. The only defect is the **`X-` prefix**: RFC 6648 / **BCP 178** (June 2012)
+says *"Creators of new parameters… SHOULD NOT prefix their parameter names with 'X-'"*. A rename,
+not a redesign — and out of scope here.
+
+**Where a standard exists and was deliberately rejected — correctly:** `URL4-Capability` could
+have been `Authorization: Bearer`. Commit `79f6e9dc` explains why not — *"so an API gateway /
+mesh / SDK that owns the primary identity slot cannot strip or overwrite it"*. Sound in a
+topology where Envoy and Cloudflare Access both touch `Authorization`. It also already complies
+with BCP 178. **Unchanged.**
+
+**Consequence for this spec:** url4 reads **`Cache-Status` first**, falling back to the
+`X-AIGW-Cache*` triple. Forward-compatible whether or not #507 adopts the suggestion (§7).
+
 ## 3. Design decisions
 
 **LOCKED** where the codebase or an owner ruling settles it; **OPEN** where the owner must
@@ -164,7 +197,7 @@ choose. The OPEN items are the point of this review.
 | **D6** | Header name / intermediary participation | §3.4 | 🔴 **OPEN** |
 | D7 | Response headers read back and folded onto spans | mandatory, every variant | 🟢 LOCKED (§7) |
 | D8 | aigateway changes | **none — PR #507 does it all**, chart included. url4 depends on it landing (§1.0) | 🟢 LOCKED (r5 — reverts r3) |
-| **D11** | `Cache-Control: max-age=N` — v2 has no freshness concept | treat as **opt-out** (§3.5) | 🟡 **PROPOSED** |
+| **D11** | `Cache-Control: max-age=N` | **REOPENED (r6)** — honour it if aigateway emits `Age`, else opt-out (§3.5) | 🔴 **OPEN** |
 | D9 | Protocol location | `packages/url4/.../streaming/protocol/` | 🟢 LOCKED (owner, r2) |
 | D10 | Both carriers supported | yes | 🟢 LOCKED (owner, r2) |
 
@@ -234,18 +267,24 @@ it is what the header means. If the directive must reach *only* aigateway, the h
 header *and* aigateway-only. A standard header intermediaries are asked to ignore is the worst of
 both.
 
-### 3.5 D11 — `max-age` under a cache that never expires
+### 3.5 D11 — `max-age`, reopened (r6)
 
-v2 rows never expire, so a caller asking for `max-age=60` is asking for a guarantee the upstream
-cannot give.
+r5 proposed treating `max-age=N` as opt-out on the grounds that "v2 rows never expire, so no
+freshness bound can be honoured." **That conflated *never expiring* with *unknown age*.**
+
+`RequestCacheEntry` already carries `created_at` (`auto_now_add=True`), so an entry's age is
+computable exactly. RFC 9111 §5.1 **`Age`** is the standard field for reporting it, and RFC 9211
+carries the same fact as the `ttl` parameter inside `Cache-Status`.
 
 | option | trade |
 |---|---|
-| **(a) Treat as opt-out** *(proposed)* | Conservative and honest: they asked for bounded staleness, we cannot bound it, so we do not serve them a stored answer. Costs a cache hit they might have accepted. |
-| (b) Ignore the directive | They silently receive an arbitrarily old answer having explicitly asked not to. |
-| (c) Reject the request 4xx | Contradicts the "a cache directive must never fail a run" posture in §5.1. |
+| **(a) Honour `max-age` when `Age` is available** | Serve the stored answer if younger than *N*, forward otherwise. Turns a permanent global corpus into something with a **caller-controlled staleness bound** — "reuse yesterday's answer, not last month's" — using only standard fields. **Depends on aigateway emitting `Age` or `Cache-Status; ttl=`**, which it does not today. |
+| **(b) Treat as opt-out** *(r5's proposal)* | Conservative, works today, needs nothing from #507. Costs a hit the caller would have accepted. |
+| (c) Ignore the directive | The caller silently receives an arbitrarily old answer having explicitly asked not to. Rejected. |
 
-**Proposed (a).** Revisit if v2 ever grows an entry-age concept.
+**Recommendation: (b) now, (a) when `Age` lands** — and raise `Age` on #507 while its header
+code is open. The two are compatible: url4 honours `max-age` if it can measure age, and falls back
+to opt-out if it cannot, which is the conservative direction.
 
 ## 4. Protocol definitions — `packages/url4`
 
@@ -364,10 +403,20 @@ byte-identical to today's** — which keeps aigateway's `unsupported_fields` byp
 ## 7. Observability (D7 — mandatory)
 
 The connector currently calls `_raise_for_status` → `_json_or_raise` → `_report_usage` →
-`_parse_choice`, all body-only. It must additionally read `X-AIGW-Cache`,
-`X-AIGW-Cache-Reason`, `X-AIGW-Cache-Key` (12 hex, hit/miss only, hash-derived — never prompt
-content) and fold them onto the owning span, the same seam `#506` used for
-`finish_reason`/`refusal`.
+`_parse_choice`, all body-only. It must additionally read the cache outcome and fold it onto the
+owning span, the same seam `#506` used for `finish_reason`/`refusal`.
+
+**Read `Cache-Status` first, fall back to the `X-AIGW-Cache*` triple (r6).**
+
+| source | precedence | mapping |
+|---|---|---|
+| **`Cache-Status`** (RFC 9211) | preferred | `hit` → `hit` · `fwd=<token>` → `miss`/`bypass` with the token as reason · `key=` → key · `detail=` → reason detail · `ttl=` → entry age, feeds D11 |
+| `X-AIGW-Cache` / `-Reason` / `-Key` | fallback | today's ad hoc triple, verbatim |
+
+Preferring the standard costs nothing and means url4 needs no change on the day aigateway adopts
+it. Parse `Cache-Status` as an RFC 8941 Structured Field **List** — it may legitimately carry one
+member per cache that handled the response (aigateway, Envoy, a CDN), ordered origin-closest
+first; take the aigateway member, not blindly the first.
 
 **Without this, enabling caching makes the cost taxonomy wrong.** A hit costs nothing upstream,
 but `_report_usage` would bill it as a fresh call — an error that *hides savings*, so nobody

--- a/docs/spec/2026-08-05-url4-cache-policy-spec.md
+++ b/docs/spec/2026-08-05-url4-cache-policy-spec.md
@@ -2,7 +2,7 @@
 title: url4 per-run cache policy — technical specification
 status: PROPOSED — awaiting owner decisions D3, D4, D6 (§3). No code written.
 created: 2026-08-05
-revised: 2026-08-05 (r4 — TTL/size knobs pinned explicitly in the chart)
+revised: 2026-08-05 (r5 — rebased on aigateway v2 global cache, PR #507; r4's TTL pinning REVOKED)
 author: Claude (Opus 5) + Sergey
 ticket: UNFILED — Linear MCP unauthenticated at authoring time (see the ledger)
 related:
@@ -21,11 +21,43 @@ related:
 |---|---|---|
 | r1 | 2026-08-05 | First draft — located the change in url4-cloud's REST layer. |
 | r2 | 2026-08-05 | **Superseded r1's location.** Owner: protocol belongs in `packages/url4`; both HTTP header *and* protocol frame are carriers. Adds §3 D3/D4 and §5.2. |
-| r4 | 2026-08-05 | Owner: **TTL/size knobs pinned explicitly** in the chart rather than inherited (§10). Closes the last non-D question. |
+| **r5** | 2026-08-05 | **Rebased on aigateway v2** (`OME-305`, PR #507 — WIP, assumed landing). v2 is a **global, never-expiring, ON-by-default cache with a CLOSED one-field grammar**. This **revokes r4** (v2 rows never expire, so TTL knobs are v1's), **deletes the aigateway sub-issue** (#507 does the chart itself), and **collapses the protocol to a single opt-out signal** — §1.0. Security section rewritten: the cache is now shared across accounts. |
+| r4 | 2026-08-05 | ~~TTL/size knobs pinned explicitly in the chart~~ — **REVOKED by r5.** |
 | r3 | 2026-08-05 | **D1 LOCKED: caching is ON by default; only disabling is explicit.** That makes the aigateway **chart** part of the deliverable (D8 reversed) and makes this cross-app — see §2.1. Ensemble-determinism tradeoff (§8.2) accepted by the owner on the record. |
 
 **Nothing here is implemented.** Per CLAUDE.md rule 3, implementation starts only on explicit
 approval in plain words.
+
+## 1.0 Upstream contract — aigateway v2 (PR #507), assumed
+
+This spec is written against **`OME-305` / PR #507 `feat(aigateway): add global exact-request
+cache`** — open, non-draft, +12152/-547 at time of writing. It is **assumed to land**; url4 must
+be ready for it. Everything below consumes that contract rather than the v1 one this spec
+originally targeted.
+
+**What v2 is**, from its own source:
+
+| property | v2 | consequence for url4 |
+|---|---|---|
+| **Scope** | **ONE global cache shared by every hosted caller.** "identity is structurally absent" — no account, profile, user, auth-mode or credential anywhere in the key (`global_keys.py`) | The per-account scoping this spec's §8.1 relied on is **gone** |
+| **Default** | **ON** — "an ordinary request participates; the control object exists only to OPT OUT" (`global_controls.py`) | D1 is now aigateway's own design, not a url4 choice |
+| **Expiry** | **Rows never expire** (`values-prod.yaml`: *"rows never expire"*) | The owner's no-expiry requirement is satisfied upstream. **r4's chart TTL pinning is void** — those knobs belong to the v1 lane |
+| **Grammar** | **CLOSED. Exactly one field: `use-cache`.** Any other key — including alongside a valid `use-cache: true` — makes the request **bypass** | url4 may send **only** `use-cache`. `no-store`/`no-cache`/`ttl`/`s-maxage` are **retired** and now *cause* a bypass |
+| **Key** | the complete effective output-affecting call — prompt + every `keyed` parameter + the provider's pure projection | a run's `temperature` etc. now participate; v1 bypassed on them |
+| **Operator gate** | `request_cache_enabled` still `False` in code; `values.yaml` `requestCache.enabled: false`, **`values-prod.yaml` `true`** | **#507 does the chart work.** The aigateway sub-issue this spec added in r3 is deleted |
+
+**The exact parse (`parse_global_cache_controls`):**
+
+| body | result |
+|---|---|
+| no `cache` key · `cache: null` · `cache: {}` | **participate** — "absent, null or an empty object all state nothing" |
+| `{"use-cache": true}` | participate |
+| `{"use-cache": false}` | bypass, reason `opted_out` |
+| `{"use-cache": "yes"}` (non-bool) | bypass, `malformed_controls` |
+| **any other key**, even with a valid `use-cache` | bypass, `unsupported_control` |
+
+**So the entire protocol surface url4 needs is one signal: participate, or opt out.** Anything
+richer is not merely unnecessary — it actively causes a bypass.
 
 ## 1. Purpose & scope
 
@@ -131,7 +163,8 @@ choose. The OPEN items are the point of this review.
 | D5 | Scope | whole run — every leaf, every fan-out branch | 🟢 LOCKED (§1.2) |
 | **D6** | Header name / intermediary participation | §3.4 | 🔴 **OPEN** |
 | D7 | Response headers read back and folded onto spans | mandatory, every variant | 🟢 LOCKED (§7) |
-| D8 | aigateway changes | **chart only** — set `AIGW_REQUEST_CACHE_ENABLED=true`; no code (§2.1) | 🟢 LOCKED (owner, r3 — reverses r2's "none") |
+| D8 | aigateway changes | **none — PR #507 does it all**, chart included. url4 depends on it landing (§1.0) | 🟢 LOCKED (r5 — reverts r3) |
+| **D11** | `Cache-Control: max-age=N` — v2 has no freshness concept | treat as **opt-out** (§3.5) | 🟡 **PROPOSED** |
 | D9 | Protocol location | `packages/url4/.../streaming/protocol/` | 🟢 LOCKED (owner, r2) |
 | D10 | Both carriers supported | yes | 🟢 LOCKED (owner, r2) |
 
@@ -144,8 +177,8 @@ choose. The OPEN items are the point of this review.
 | | |
 |---|---|
 | **Default** | `use_cache = True` when neither carrier declares a policy |
-| **To disable** | `Cache-Control: no-store` (HTTP) or `{"cache": {"no_store": true}}` (frame) |
-| **Prerequisite** | `AIGW_REQUEST_CACHE_ENABLED=true` in the aigateway chart — §2.1. Without it the default is inert and every run answers `bypass / disabled`. |
+| **To disable** | `Cache-Control: no-store` (HTTP) or `{"cache": {"participate": false}}` (frame) |
+| **Prerequisite** | The operator gate, which **PR #507 already sets** — `requestCache.enabled: true` in `values-prod.yaml`. url4 does nothing here (§1.0). |
 
 **What this buys:** a fan-out with repeated sub-prompts collapses to one provider call, and the
 owner's original ask (`no-store` for a specific execution) becomes meaningful rather than a
@@ -187,8 +220,10 @@ run-scoped statement wins and says so.
 
 **Proposed: the standard `Cache-Control` request header.** RFC 9111 already defines `no-store`,
 `no-cache`, `max-age`, `only-if-cached` as *request* directives, and aigateway's control names
-(`no-cache`, `no-store`, `s-maxage`, `ttl`) are deliberately HTTP-shaped — the vocabularies
-already align and nothing is invented. It composes with doctrine N1, which justifies GET *on the
+(`no-cache`, `no-store`, `s-maxage`, `ttl`) were deliberately HTTP-shaped, so the vocabularies
+aligned and nothing had to be invented. **(r5: v2 retired all four; only `use-cache` remains, so
+the alignment is now at the level of *meaning* rather than field names — url4 collapses every
+directive to participate/opt-out at its own edge, §5.1.)** It composes with doctrine N1, which justifies GET *on the
 grounds the call is cacheable*.
 
 **Consequence:** a genuine `Cache-Control` may be honoured by Envoy or a CDN. Usually desirable —
@@ -199,39 +234,47 @@ it is what the header means. If the directive must reach *only* aigateway, the h
 header *and* aigateway-only. A standard header intermediaries are asked to ignore is the worst of
 both.
 
+### 3.5 D11 — `max-age` under a cache that never expires
+
+v2 rows never expire, so a caller asking for `max-age=60` is asking for a guarantee the upstream
+cannot give.
+
+| option | trade |
+|---|---|
+| **(a) Treat as opt-out** *(proposed)* | Conservative and honest: they asked for bounded staleness, we cannot bound it, so we do not serve them a stored answer. Costs a cache hit they might have accepted. |
+| (b) Ignore the directive | They silently receive an arbitrarily old answer having explicitly asked not to. |
+| (c) Reject the request 4xx | Contradicts the "a cache directive must never fail a run" posture in §5.1. |
+
+**Proposed (a).** Revisit if v2 ever grows an entry-age concept.
+
 ## 4. Protocol definitions — `packages/url4`
 
 ### 4.1 `protocol/signals.py` — the policy type
 
 ```python
 class CachePolicy(BaseModel):
-    """Per-run cache intent. Declared once, applied to every aigateway call in the run.
+    """Per-run cache intent. ONE field, because aigateway v2's grammar is closed to one field.
 
-    Names mirror aigateway's request-body controls (`use-cache`, `no-cache`, `no-store`,
-    `s-maxage`) so the mapping is identity, not translation — there is no second vocabulary
-    to keep in step.
+    INVARIANT: url4 must never send a control key v2 does not understand. Under v2 an
+    unrecognised key does not degrade to "ignored" — it makes the whole request BYPASS
+    (`global_controls.py`), so a well-meant `no-store` would opt the caller out for the
+    WRONG reason and a well-meant `ttl` would silently lose caching altogether.
     """
-    use_cache: bool | None = None     # None = "not stated" — resolves to the D1 default (ON)
-    no_cache: bool = False
-    no_store: bool = False
-    s_maxage: int | None = Field(default=None, ge=1)
+    participate: bool | None = None   # None = "not stated" -> D1 default (participate)
 ```
 
-**`use_cache` is tri-state, and that is a direct consequence of D1=ON (r3).** With a plain
-`bool = False` there would be two different ways to say nothing — an absent `cache` field, and a
-present-but-empty `cache: {}` — and they would resolve differently: absent → ON via D1,
-`{}` → OFF via the field default. A caller sending `{"cache": {}}` would silently disable caching
-while believing they had expressed no opinion.
+**Deliberately absent: `no_cache`, `no_store`, `s_maxage`.** r2 had all three. v2 retires them
+(`LEGACY_CONTROL_FIELDS`) and bypasses on them, so carrying them in the url4 protocol would model
+a capability the upstream does not have.
 
 Resolution table:
 
-| declared | effective |
-|---|---|
-| no `cache` field at all | **ON** (D1) |
-| `cache: {}` | **ON** — every field "not stated" |
-| `cache: {"no_store": true}` | OFF, and nothing is written |
-| `cache: {"use_cache": false}` | OFF — the explicit form |
-| `cache: {"s_maxage": 60}` | ON, entry must be younger than 60s |
+| declared | effective | sent to aigateway |
+|---|---|---|
+| no `cache` field | **participate** (D1) | field omitted |
+| `cache: {}` | **participate** — every field unstated | field omitted |
+| `cache: {"participate": false}` | **opt out** | `{"cache": {"use-cache": false}}` |
+| `cache: {"participate": true}` | participate, explicitly | `{"cache": {"use-cache": true}}` |
 
 Under **D3 (recommended)**, `AttachData` gains one optional field:
 
@@ -272,16 +315,16 @@ X-Profile: prod
 Cache-Control: no-store
 ```
 
-| directive | → aigateway `cache` | meaning |
+| directive | effective | why |
 |---|---|---|
-| `no-store` | `no-store: true` | do not read, do not write |
-| `no-cache` | `no-cache: true` | do not read a stored entry; still store the result |
-| `max-age=<n>` | `s-maxage: <n>` | accept an entry only if younger than *n* seconds |
-| `url4-use-cache` | `use-cache: true` | **(r3)** re-enable after a disabling directive earlier in the same header; rarely needed now that ON is the default. RFC 9111 §5.2.3 extension token, ignored by intermediaries. |
-| absent | field omitted | D1 default |
+| *(absent)* | **participate** | D1 |
+| `no-store` | **opt out** → `{"cache": {"use-cache": false}}` | The caller means "do not use the cache". Mapped to v2's opt-out, **not** forwarded as `no-store` — that key is retired and would bypass with reason `unsupported_control` instead of the honest `opted_out`. |
+| `no-cache` | **opt out**, same mapping | v2 has no read-only/write-only lane; "don't serve me a stored answer" can only be honoured by not participating. |
+| `max-age=<n>` | **opt out** (D11, §3.5) | v2 rows never expire, so no freshness bound can be honoured. |
+| `url4-use-cache` | participate, explicitly | RFC 9111 §5.2.3 extension token. Rarely needed now ON is the default. |
 
-RFC 9111 has no "please cache" *request* directive, hence the extension token. If that is
-unpalatable it is a further argument for `URL4-Cache` under D6.
+**Only `use-cache` ever reaches aigateway.** Every directive above collapses to participate or
+opt out at the url4 edge; none is forwarded verbatim.
 
 **`only-if-cached` is rejected** — see §8.3.
 
@@ -291,7 +334,7 @@ docstring states malformed values parse as "not requested".
 ### 5.2 WS — attach frame
 
 ```json
-{"type": "ai.url4.attach", "data": {"from_sequence": 1, "cache": {"no_store": true}}}
+{"type": "ai.url4.attach", "data": {"from_sequence": 1, "cache": {"participate": false}}}
 ```
 
 **First attach wins.** A re-attach (reconnect, or `from_sequence` resume) carrying a different
@@ -337,9 +380,23 @@ credential.**
 
 ## 8. Security & correctness consequences
 
-1. **Key scope.** `{v, account_id, profile_name, provider, model, prompt_hash}`
-   (`aigateway/core/request_cache/keys.py:124-130`) — per account *and* profile. Two runs under
-   different profiles never share an entry. url4 adds no new sharing axis.
+1. **Key scope — GLOBAL under v2, and this is the headline change.** v1 keyed
+   `{v, account_id, profile_name, provider, model, prompt_hash}`, so two accounts never shared a
+   row. **v2 removes identity entirely** — `global_keys.py`'s stated invariant is *"identity is
+   structurally absent… That is what makes one row safe to share globally."* Its own story is a
+   benchmark operator re-running a suite **from a second account** and being served the first
+   run's responses, with the second account's credential never read.
+
+   Consequences url4 inherits rather than creates, and which the owner should see stated:
+   - **Any two callers sending the identical effective call get the identical stored response.**
+   - Rows are stored as **plaintext compact JSON** in `request_cache_entries.response_ciphertext`;
+     `values-prod.yaml` states database readers, replicas, snapshots and backups can read the
+     entire corpus. Provider credentials stay encrypted in `credential_blobs` — responses do not.
+   - **Rows never expire**, so the shared corpus only grows.
+
+   url4 adds **no new sharing axis** — but it does become a major *producer* into a shared,
+   permanent, plaintext corpus, which is a different posture from v1's per-account cache. Enabling
+   it is `values-prod.yaml`'s decision, deliberately taken there.
 2. **Ensemble determinism — ACCEPTED TRADEOFF (owner, r3).** Two nodes with identical prompts but
    distinct node identities miss the engine's `_memo` (keyed on node identity,
    `dag/executor.py:109`) and hit aigateway's cache (keyed on prompt hash,
@@ -352,9 +409,17 @@ credential.**
    expecting non-identical answers.
 
    **The owner has accepted this.** Recorded here rather than buried so a future reader finds a
-   decision, not a bug. If it later needs undoing, the cheapest carve-out is engine-level — never
-   cache within one run's own fan-out — which needs no protocol change, only a per-run nonce in
-   the prompt normalisation. Not built now.
+   decision, not a bug.
+
+   **v2 makes it strictly worse and the acceptance should be re-confirmed against the new facts:**
+   the repeat no longer has to come from the same account, or the same run, or the same day — the
+   corpus is global and permanent. A variance sample repeated a month later from another account
+   still collapses. Conversely v2 keys the *complete* effective call including `keyed` parameters,
+   so anything varying `temperature`, `seed` or a routing control keys differently and is
+   unaffected — the collapse needs a genuinely byte-identical call.
+
+   If it needs undoing, the carve-out is the same and still needs no protocol change: a per-run
+   nonce in the effective request. Not built now.
 3. **`only-if-cached` rejected.** RFC 9111 requires `504` when nothing is cached. A url4 run is a
    fan-out of many calls; one uncached leaf failing the whole run is a footgun with no present
    use case.
@@ -363,16 +428,18 @@ credential.**
 
 ## 9. Acceptance
 
-1. **(r3)** A run declaring nothing sends `cache: {"use-cache": true}` and reports `miss` on
-   first execution — **not** `bypass`. *(r2's "byte-identical body" criterion is void under
-   D1=ON: the default request now carries a cache field. It survives only for a `no-store` run,
-   item 2a.)*
-2. `Cache-Control: no-store` reaches aigateway as `cache: {"no-store": true}` and reports
-   `bypass`.
-2a. A `no-store` run leaves no entry behind: an immediately following default run on the same
-   prompt reports `miss`, not `hit`.
-2b. `cache: {}` on the frame behaves **identically to declaring nothing** (§4.1) — the
-   tri-state guard.
+1. **(r5)** A run declaring nothing sends **no `cache` field at all** and reports a v2
+   participate outcome (`miss` first, `hit` on repeat). Omitting is preferred over
+   `{"use-cache": true}`: v2 treats absent, `null` and `{}` identically, and the smallest body is
+   the least likely to trip the closed-grammar bypass.
+2. `Cache-Control: no-store` sends `{"cache": {"use-cache": false}}` and aigateway reports
+   `bypass` with reason **`opted_out`** — **not** `unsupported_control`. This is the test that
+   proves url4 collapses directives at its own edge instead of forwarding retired v1 keys.
+2a. `Cache-Control: max-age=60` behaves identically to `no-store` (D11).
+2b. `cache: {}` on the frame behaves identically to declaring nothing.
+2c. **url4 never sends a key other than `use-cache`.** Assert the egress body's `cache` object
+   has at most that one key — the single most important regression guard, since any extra key
+   silently costs every hit.
 3. The same policy delivered on the attach frame produces the identical egress body.
 4. Header and frame disagreeing → header applies, and a `LogEvent` records the override.
 5. A re-attach with a different policy does **not** change the run, and warns.

--- a/docs/spec/2026-08-05-url4-cache-policy-spec.md
+++ b/docs/spec/2026-08-05-url4-cache-policy-spec.md
@@ -1,8 +1,8 @@
 ---
 title: url4 per-run cache policy — technical specification
-status: PROPOSED — awaiting owner decisions D3, D4, D6 (§3). No code written.
+status: PROPOSED — **all decisions LOCKED**. Awaiting approval to implement. No code written.
 created: 2026-08-05
-revised: 2026-08-05 (r6 — standards alignment: RFC 9211 Cache-Status + RFC 9111 Age; D11 reopened)
+revised: 2026-08-05 (r7 — D3/D4/D6/D11 all LOCKED by owner; D11's upstream blockers stated)
 author: Claude (Opus 5) + Sergey
 ticket: UNFILED — Linear MCP unauthenticated at authoring time (see the ledger)
 related:
@@ -21,6 +21,7 @@ related:
 |---|---|---|
 | r1 | 2026-08-05 | First draft — located the change in url4-cloud's REST layer. |
 | r2 | 2026-08-05 | **Superseded r1's location.** Owner: protocol belongs in `packages/url4`; both HTTP header *and* protocol frame are carriers. Adds §3 D3/D4 and §5.2. |
+| **r7** | 2026-08-05 | **Owner locked the last four**: D3 extend `AttachData` · D4 header wins · D6 standard `Cache-Control` · D11 **honour `max-age`**. D11 carries two upstream blockers — §3.5. Spec is decision-complete. |
 | **r6** | 2026-08-05 | **Standards alignment.** Read-back prefers **`Cache-Status`** (RFC 9211) over the ad hoc `X-AIGW-Cache*`; **`Age`** (RFC 9111 §5.1) makes `max-age` honourable, so **D11 is reopened** (§3.5). Adds §2.2 with the registry evidence. |
 | **r5** | 2026-08-05 | **Rebased on aigateway v2** (`OME-305`, PR #507 — WIP, assumed landing). v2 is a **global, never-expiring, ON-by-default cache with a CLOSED one-field grammar**. This **revokes r4** (v2 rows never expire, so TTL knobs are v1's), **deletes the aigateway sub-issue** (#507 does the chart itself), and **collapses the protocol to a single opt-out signal** — §1.0. Security section rewritten: the cache is now shared across accounts. |
 | r4 | 2026-08-05 | ~~TTL/size knobs pinned explicitly in the chart~~ — **REVOKED by r5.** |
@@ -191,13 +192,13 @@ choose. The OPEN items are the point of this review.
 |---|---|---|---|
 | **D1** | Default when nothing is declared | **ON** — caching active; only disabling is explicit (§3.1) | 🟢 **LOCKED** (owner, r3) |
 | D2 | HTTP carrier | header on `GET /`, mirroring `X-Profile` (`rest/routes.py:347`) | 🟢 LOCKED |
-| **D3** | Frame shape | extend `AttachData` vs new `ConfigureEvent` — §3.2 | 🔴 **OPEN** |
-| **D4** | Precedence when both carriers speak | §3.3 | 🔴 **OPEN** |
+| D3 | Frame shape | **extend `AttachData`** (§3.2) | 🟢 LOCKED (owner, r7) |
+| D4 | Precedence when both carriers speak | **header wins**, override logged (§3.3) | 🟢 LOCKED (owner, r7) |
 | D5 | Scope | whole run — every leaf, every fan-out branch | 🟢 LOCKED (§1.2) |
-| **D6** | Header name / intermediary participation | §3.4 | 🔴 **OPEN** |
+| D6 | Header name / intermediary participation | **standard `Cache-Control`**; intermediaries may participate (§3.4) | 🟢 LOCKED (owner, r7) |
 | D7 | Response headers read back and folded onto spans | mandatory, every variant | 🟢 LOCKED (§7) |
 | D8 | aigateway changes | **none — PR #507 does it all**, chart included. url4 depends on it landing (§1.0) | 🟢 LOCKED (r5 — reverts r3) |
-| **D11** | `Cache-Control: max-age=N` | **REOPENED (r6)** — honour it if aigateway emits `Age`, else opt-out (§3.5) | 🔴 **OPEN** |
+| D11 | `Cache-Control: max-age=N` | **honour it** — blocked upstream today; opt-out until then (§3.5) | 🟢 LOCKED (owner, r7) |
 | D9 | Protocol location | `packages/url4/.../streaming/protocol/` | 🟢 LOCKED (owner, r2) |
 | D10 | Both carriers supported | yes | 🟢 LOCKED (owner, r2) |
 
@@ -282,9 +283,34 @@ carries the same fact as the `ttl` parameter inside `Cache-Status`.
 | **(b) Treat as opt-out** *(r5's proposal)* | Conservative, works today, needs nothing from #507. Costs a hit the caller would have accepted. |
 | (c) Ignore the directive | The caller silently receives an arbitrarily old answer having explicitly asked not to. Rejected. |
 
-**Recommendation: (b) now, (a) when `Age` lands** — and raise `Age` on #507 while its header
-code is open. The two are compatible: url4 honours `max-age` if it can measure age, and falls back
-to opt-out if it cannot, which is the conservative direction.
+**LOCKED: (a) — honour `max-age`.** Two upstream blockers stand between that decision and a
+working implementation, both verified against #507's branch on 2026-08-05:
+
+| blocker | evidence |
+|---|---|
+| **url4 cannot ASK for a bound.** v2's grammar is closed to `use-cache`; `{"cache": {"max-age": 60}}` returns `_refuse(BYPASS_UNSUPPORTED_CONTROL)` | `global_controls.py:79-83` |
+| **aigateway does not REPORT age.** No `Age` header, no `Cache-Status; ttl=` | #507 adds `CACHE_HEADER`/`REASON_HEADER`/`WRITE_HEADER`/`KEY_HEADER` and no age field |
+
+So url4 can neither request a freshness bound nor measure one. **Until one of these changes,
+`max-age` degrades to opt-out** — the conservative direction, and observably so via
+`X-AIGW-Cache-Reason: opted_out`.
+
+**Two routes to honouring it, in preference order:**
+
+1. **Upstream — aigateway accepts a bound** (`{"cache": {"use-cache": true, "max-age": N}}`).
+   One decision, made where the cache lives, and the only version that avoids serving a response
+   the caller will discard. Requires v2 to widen its grammar by one field — deliberately, since
+   "closed" is currently an invariant. **Raised on #507.**
+2. **Client-side revalidation**, buildable by url4 alone the moment `Age` exists: participate,
+   read `Age`, and if the entry is older than `max-age`, re-issue the call with
+   `use-cache: false`. Costs one extra round trip on a too-old hit — cheap (a cache read, not a
+   provider dispatch) but it does transfer a body that is then thrown away, and it multiplies
+   across a fan-out.
+
+**Implementation posture:** Batch 3 **parses and preserves** `max-age` rather than collapsing it
+to opt-out at the edge, so the value survives to the point where it can be honoured. Batch 7
+applies it when an age is available and falls back to opt-out when it is not. That way the day
+either blocker lifts, the change is a branch, not a redesign.
 
 ## 4. Protocol definitions — `packages/url4`
 

--- a/docs/spec/2026-08-05-url4-cache-policy-spec.md
+++ b/docs/spec/2026-08-05-url4-cache-policy-spec.md
@@ -1,8 +1,8 @@
 ---
 title: url4 per-run cache policy — technical specification
-status: PROPOSED — awaiting owner decisions D1, D3, D4, D6 (§3). No code written.
+status: PROPOSED — awaiting owner decisions D3, D4, D6 (§3). No code written.
 created: 2026-08-05
-revised: 2026-08-05 (r2 — protocol moves to `packages/url4`; both carriers per owner)
+revised: 2026-08-05 (r3 — D1 LOCKED to cache-ON-by-default; aigateway chart now in scope)
 author: Claude (Opus 5) + Sergey
 ticket: UNFILED — Linear MCP unauthenticated at authoring time (see the ledger)
 related:
@@ -21,6 +21,7 @@ related:
 |---|---|---|
 | r1 | 2026-08-05 | First draft — located the change in url4-cloud's REST layer. |
 | r2 | 2026-08-05 | **Superseded r1's location.** Owner: protocol belongs in `packages/url4`; both HTTP header *and* protocol frame are carriers. Adds §3 D3/D4 and §5.2. |
+| r3 | 2026-08-05 | **D1 LOCKED: caching is ON by default; only disabling is explicit.** That makes the aigateway **chart** part of the deliverable (D8 reversed) and makes this cross-app — see §2.1. Ensemble-determinism tradeoff (§8.2) accepted by the owner on the record. |
 
 **Nothing here is implemented.** Per CLAUDE.md rule 3, implementation starts only on explicit
 approval in plain words.
@@ -56,7 +57,8 @@ a cached turn and simply cannot *ask* for one.
   (`packages/url4/src/url4/core/grammar.py` has no cache token) and reopens doctrine fork **F4**
   (`docs/spec/2026-07-15-url4-cloud-runner-spec.md:118`). Deliberately out of scope.
 - **A url4-native / Enclave GET cache.** Still deferred, same §14.
-- **Any aigateway change.** Its contract is complete and consumed as-is.
+- **Any aigateway *code* change.** Its request-cache contract is complete and consumed as-is.
+  Its **chart** does change — see §2.1.
 - **Streaming turns.** `build_cache_key` bypasses on `stream: true`
   (`aigateway/core/request_cache/keys.py:104`) — caching exists only on the transactional half,
   the same WS/GET split doctrine N1 already draws.
@@ -77,7 +79,42 @@ consumes it via the editable path dependency in its `pyproject.toml:58`.
 that talks to aigateway (`runner/connector.py:337`) and the only thing that terminates the WS
 (`ws/bridge.py:141`). It defines no protocol types.
 
-**`apps/aigateway`: no change.**
+**`apps/aigateway`: chart only, no code.** See §2.1.
+
+## 2.1 The server flag — why this is cross-app (r3)
+
+Caching is off at **two independent layers**, and D1 only addresses one of them:
+
+| layer | state | evidence |
+|---|---|---|
+| **Server flag** | `False` by default, and **the chart never sets it** | `aigateway/config.py:127-129` — `request_cache_enabled: bool = Field(default=False, validation_alias="AIGW_REQUEST_CACHE_ENABLED")`; its own comment says *"Disabled by default"*. The chart passes 16 env keys (`AIGW_ALLOWED_NETWORKS`, `AIGW_AUTH_MODE`, `AIGW_OPENROUTER_ENABLED`, …) and this is not among them. |
+| **Per-request opt-in** | `False` unless asked | `chat_dispatch.py:191` |
+
+**The deployed gateway therefore answers `bypass / disabled` today**, before per-request controls
+are consulted. D1=ON alone changes nothing observable.
+
+"Active by default" requires **both**:
+
+```
+AIGW_REQUEST_CACHE_ENABLED=true    ← apps/aigateway chart  (values.yaml)
+              AND
+cache.use-cache defaults to true   ← apps/url4-cloud       (D1)
+```
+
+Note the env prefix is **`AIGW_`**, not `AIGATEWAY_`. aigateway uses both inconsistently
+(`AIGATEWAY_ADMIN_EMAILS` vs `AIGW_AUTH_MODE`); this setting is `AIGW_`.
+
+**Consequence — CLAUDE.md rule 8.** The work now spans three components, so it is an **epic with
+one sub-issue per landing**, never one ticket:
+
+| sub-issue | landing | content |
+|---|---|---|
+| 1 | `pkg` → url4 | protocol types (§4) |
+| 2 | `app` → url4-cloud | both carriers, threading, egress, read-back (§5-§7) |
+| 3 | `app` → aigateway | chart sets `AIGW_REQUEST_CACHE_ENABLED`; TTL/size knobs reviewed |
+
+Sub-issue 3 has a different CODEOWNERS reviewer and can land **first and independently** — it is
+a no-op until sub-issue 2 sends `use-cache`.
 
 ## 3. Design decisions
 
@@ -86,29 +123,41 @@ choose. The OPEN items are the point of this review.
 
 | # | decision | value | status |
 |---|---|---|---|
-| **D1** | Default when nothing is declared | §3.1 | 🔴 **OPEN** |
+| **D1** | Default when nothing is declared | **ON** — caching active; only disabling is explicit (§3.1) | 🟢 **LOCKED** (owner, r3) |
 | D2 | HTTP carrier | header on `GET /`, mirroring `X-Profile` (`rest/routes.py:347`) | 🟢 LOCKED |
 | **D3** | Frame shape | extend `AttachData` vs new `ConfigureEvent` — §3.2 | 🔴 **OPEN** |
 | **D4** | Precedence when both carriers speak | §3.3 | 🔴 **OPEN** |
 | D5 | Scope | whole run — every leaf, every fan-out branch | 🟢 LOCKED (§1.2) |
 | **D6** | Header name / intermediary participation | §3.4 | 🔴 **OPEN** |
 | D7 | Response headers read back and folded onto spans | mandatory, every variant | 🟢 LOCKED (§7) |
-| D8 | aigateway changes | none | 🟢 LOCKED |
+| D8 | aigateway changes | **chart only** — set `AIGW_REQUEST_CACHE_ENABLED=true`; no code (§2.1) | 🟢 LOCKED (owner, r3 — reverses r2's "none") |
 | D9 | Protocol location | `packages/url4/.../streaming/protocol/` | 🟢 LOCKED (owner, r2) |
 | D10 | Both carriers supported | yes | 🟢 LOCKED (owner, r2) |
 
-### 3.1 D1 — the default (the real question)
+### 3.1 D1 — the default — **LOCKED: ON**
 
-A product decision about cost and determinism, not plumbing.
+> **Owner ruling (r3):** caching is **active by default**; only *disabling* is specified
+> explicitly. The spec had recommended the opposite; the owner overruled it, and the
+> determinism consequence in §8.2 was **explicitly accepted**.
 
-| option | consequence |
+| | |
 |---|---|
-| **(a) Default OFF, caller opts IN** | Today's behaviour preserved exactly; zero risk to existing runs. But `no-store` merely names the default — it is decorative until someone opts in. |
-| **(b) Default ON, caller opts OUT** | Makes the original ask meaningful: a fan-out with repeated sub-prompts collapses to one provider call. **Changes cost *and* determinism for every existing run, silently.** |
+| **Default** | `use_cache = True` when neither carrier declares a policy |
+| **To disable** | `Cache-Control: no-store` (HTTP) or `{"cache": {"no_store": true}}` (frame) |
+| **Prerequisite** | `AIGW_REQUEST_CACHE_ENABLED=true` in the aigateway chart — §2.1. Without it the default is inert and every run answers `bypass / disabled`. |
 
-**Recommendation: (a) for v1.** Reversible, cannot surprise a running system, and it lets the
-carriers and the observability (D7) be proven before anything depends on hits. Revisit once §7
-metrics show real hit rates. See §8.2 — the determinism argument is the strongest case for (a).
+**What this buys:** a fan-out with repeated sub-prompts collapses to one provider call, and the
+owner's original ask (`no-store` for a specific execution) becomes meaningful rather than a
+restatement of the default.
+
+**What it costs, accepted:** cost *and* determinism change for every existing run the moment the
+chart flag lands — see §8.2. The rollout order in §2.1 is the mitigation: the chart sub-issue is
+inert until url4-cloud ships the default, so the two can be sequenced deliberately rather than
+landing together by accident.
+
+**The `None` vs `CachePolicy()` distinction (§4.1) survives this decision and gets *more*
+important:** "did not declare" now resolves to ON, while an explicit `use_cache=False` resolves
+to off. Collapsing them would make `no-store` unexpressible.
 
 ### 3.2 D3 — frame shape
 
@@ -161,11 +210,27 @@ class CachePolicy(BaseModel):
     `s-maxage`) so the mapping is identity, not translation — there is no second vocabulary
     to keep in step.
     """
-    use_cache: bool = False
+    use_cache: bool | None = None     # None = "not stated" — resolves to the D1 default (ON)
     no_cache: bool = False
     no_store: bool = False
     s_maxage: int | None = Field(default=None, ge=1)
 ```
+
+**`use_cache` is tri-state, and that is a direct consequence of D1=ON (r3).** With a plain
+`bool = False` there would be two different ways to say nothing — an absent `cache` field, and a
+present-but-empty `cache: {}` — and they would resolve differently: absent → ON via D1,
+`{}` → OFF via the field default. A caller sending `{"cache": {}}` would silently disable caching
+while believing they had expressed no opinion.
+
+Resolution table:
+
+| declared | effective |
+|---|---|
+| no `cache` field at all | **ON** (D1) |
+| `cache: {}` | **ON** — every field "not stated" |
+| `cache: {"no_store": true}` | OFF, and nothing is written |
+| `cache: {"use_cache": false}` | OFF — the explicit form |
+| `cache: {"s_maxage": 60}` | ON, entry must be younger than 60s |
 
 Under **D3 (recommended)**, `AttachData` gains one optional field:
 
@@ -211,7 +276,7 @@ Cache-Control: no-store
 | `no-store` | `no-store: true` | do not read, do not write |
 | `no-cache` | `no-cache: true` | do not read a stored entry; still store the result |
 | `max-age=<n>` | `s-maxage: <n>` | accept an entry only if younger than *n* seconds |
-| `url4-use-cache` | `use-cache: true` | opt in (RFC 9111 §5.2.3 extension token; ignored by intermediaries) |
+| `url4-use-cache` | `use-cache: true` | **(r3)** re-enable after a disabling directive earlier in the same header; rarely needed now that ON is the default. RFC 9111 §5.2.3 extension token, ignored by intermediaries. |
 | absent | field omitted | D1 default |
 
 RFC 9111 has no "please cache" *request* directive, hence the extension token. If that is
@@ -274,12 +339,21 @@ credential.**
 1. **Key scope.** `{v, account_id, profile_name, provider, model, prompt_hash}`
    (`aigateway/core/request_cache/keys.py:124-130`) — per account *and* profile. Two runs under
    different profiles never share an entry. url4 adds no new sharing axis.
-2. **Ensemble determinism.** Two nodes with identical prompts but distinct node identities miss
-   the engine's `_memo` (keyed on node identity, `dag/executor.py:109`) and would hit aigateway's
-   cache (keyed on prompt hash). Usually the desired dedup — but an ensemble deliberately
-   sampling one model twice for variance would receive **one answer twice**. Narrower than it
-   sounds, since `temperature` participates in the normalised prompt, but this is a correctness
-   change to ensembling, not merely a cost optimisation. **The strongest argument for D1(a).**
+2. **Ensemble determinism — ACCEPTED TRADEOFF (owner, r3).** Two nodes with identical prompts but
+   distinct node identities miss the engine's `_memo` (keyed on node identity,
+   `dag/executor.py:109`) and hit aigateway's cache (keyed on prompt hash,
+   `keys.py:124-130`). Usually the desired dedup — but an ensemble deliberately sampling one
+   model twice for variance receives **one answer twice**, and scores it as agreement.
+
+   With **D1 = ON this is the default path, not an edge case.** Narrower than it first sounds,
+   because `temperature` participates in the normalised prompt — two samples that differ in any
+   sampling parameter key differently. It bites exactly when a run repeats an *identical* request
+   expecting non-identical answers.
+
+   **The owner has accepted this.** Recorded here rather than buried so a future reader finds a
+   decision, not a bug. If it later needs undoing, the cheapest carve-out is engine-level — never
+   cache within one run's own fan-out — which needs no protocol change, only a per-run nonce in
+   the prompt normalisation. Not built now.
 3. **`only-if-cached` rejected.** RFC 9111 requires `504` when nothing is cached. A url4 run is a
    fan-out of many calls; one uncached leaf failing the whole run is a footgun with no present
    use case.
@@ -288,13 +362,20 @@ credential.**
 
 ## 9. Acceptance
 
-1. A run declaring nothing produces a body **byte-identical** to today's, and reports
-   `bypass` / `not_requested`.
-2. `Cache-Control: no-store` reaches aigateway as `cache: {"no-store": true}`.
+1. **(r3)** A run declaring nothing sends `cache: {"use-cache": true}` and reports `miss` on
+   first execution — **not** `bypass`. *(r2's "byte-identical body" criterion is void under
+   D1=ON: the default request now carries a cache field. It survives only for a `no-store` run,
+   item 2a.)*
+2. `Cache-Control: no-store` reaches aigateway as `cache: {"no-store": true}` and reports
+   `bypass`.
+2a. A `no-store` run leaves no entry behind: an immediately following default run on the same
+   prompt reports `miss`, not `hit`.
+2b. `cache: {}` on the frame behaves **identically to declaring nothing** (§4.1) — the
+   tri-state guard.
 3. The same policy delivered on the attach frame produces the identical egress body.
 4. Header and frame disagreeing → header applies, and a `LogEvent` records the override.
 5. A re-attach with a different policy does **not** change the run, and warns.
-6. Under D1(a): opt-in run reports `miss` first, `hit` on an identical immediate repeat.
+6. A default run reports `miss` first, then `hit` on an identical immediate repeat.
 7. Two runs under different `X-Profile` never share an entry.
 8. A malformed directive is ignored; the run proceeds and is not 4xx'd.
 9. Cache status/reason appear on spans for every case above.
@@ -302,11 +383,16 @@ credential.**
 
 ## 10. Open questions for the owner
 
-1. **D1** — default OFF (recommended) or ON?
-2. **D3** — extend `AttachData` (recommended) or add `ConfigureEvent`?
-3. **D4** — header wins on conflict (recommended), frame wins, or fatal?
-4. **D6** — standard `Cache-Control` with intermediary participation, or private `URL4-Cache`?
-5. Is `request_cache_enabled` actually **on** in the deployed aigateway? If not, every path
-   answers `bypass / disabled` and this work is inert until it is switched on.
-6. Are the three empty `apps/url4-cloud/src/url4_*` directories a stale artifact to delete, or an
+1. **D3** — extend `AttachData` (recommended) or add `ConfigureEvent`?
+2. **D4** — header wins on conflict (recommended), frame wins, or fatal?
+3. **D6** — standard `Cache-Control` with intermediary participation, or private `URL4-Cache`?
+4. Are the three empty `apps/url4-cloud/src/url4_*` directories a stale artifact to delete, or an
    intended package split to file as its own epic?
+5. **TTL and size defaults**, now that the chart is in scope: the code defaults are
+   `AIGW_REQUEST_CACHE_TTL_SECONDS=600`, `…_MAX_TTL_SECONDS=3600`,
+   `…_MAX_RESPONSE_BYTES=1_000_000` (`config.py:130-138`). Accept, or set explicitly in the chart
+   alongside the enable flag? Leaving them implicit means a future code-default change silently
+   moves production behaviour.
+
+**Resolved in r3:** D1 (ON) · D8 (chart in scope) · §8.2 tradeoff (accepted) · the
+`request_cache_enabled` question (it is **off**, and turning it on is now sub-issue 3).

--- a/docs/spec/2026-08-05-url4-cache-policy-spec.md
+++ b/docs/spec/2026-08-05-url4-cache-policy-spec.md
@@ -2,7 +2,7 @@
 title: url4 per-run cache policy — technical specification
 status: PROPOSED — **all decisions LOCKED**. Awaiting approval to implement. No code written.
 created: 2026-08-05
-revised: 2026-08-05 (r7 — D3/D4/D6/D11 all LOCKED by owner; D11's upstream blockers stated)
+revised: 2026-08-06 (r8 — corrections found by the implementation's adversarial review)
 author: Claude (Opus 5) + Sergey
 ticket: UNFILED — Linear MCP unauthenticated at authoring time (see the ledger)
 related:
@@ -21,6 +21,7 @@ related:
 |---|---|---|
 | r1 | 2026-08-05 | First draft — located the change in url4-cloud's REST layer. |
 | r2 | 2026-08-05 | **Superseded r1's location.** Owner: protocol belongs in `packages/url4`; both HTTP header *and* protocol frame are carriers. Adds §3 D3/D4 and §5.2. |
+| **r8** | 2026-08-06 | **Corrections from the implementation review.** §4.1 said "exactly one field" while the type carries two (`participate`, `max_age`) — the plan superseded itself and the spec never caught up. §9.7 struck (unsatisfiable under v2). §9.10 restated as N/A. §5.2's "first attach wins" narrowed to what the code actually guarantees. |
 | **r7** | 2026-08-05 | **Owner locked the last four**: D3 extend `AttachData` · D4 header wins · D6 standard `Cache-Control` · D11 **honour `max-age`**. D11 carries two upstream blockers — §3.5. Spec is decision-complete. |
 | **r6** | 2026-08-05 | **Standards alignment.** Read-back prefers **`Cache-Status`** (RFC 9211) over the ad hoc `X-AIGW-Cache*`; **`Age`** (RFC 9111 §5.1) makes `max-age` honourable, so **D11 is reopened** (§3.5). Adds §2.2 with the registry evidence. |
 | **r5** | 2026-08-05 | **Rebased on aigateway v2** (`OME-305`, PR #507 — WIP, assumed landing). v2 is a **global, never-expiring, ON-by-default cache with a CLOSED one-field grammar**. This **revokes r4** (v2 rows never expire, so TTL knobs are v1's), **deletes the aigateway sub-issue** (#507 does the chart itself), and **collapses the protocol to a single opt-out signal** — §1.0. Security section rewritten: the cache is now shared across accounts. |
@@ -318,7 +319,7 @@ either blocker lifts, the change is a branch, not a redesign.
 
 ```python
 class CachePolicy(BaseModel):
-    """Per-run cache intent. ONE field, because aigateway v2's grammar is closed to one field.
+    """Per-run cache intent. TWO fields — one that reaches aigateway, one that never does.
 
     INVARIANT: url4 must never send a control key v2 does not understand. Under v2 an
     unrecognised key does not degrade to "ignored" — it makes the whole request BYPASS
@@ -326,7 +327,13 @@ class CachePolicy(BaseModel):
     WRONG reason and a well-meant `ttl` would silently lose caching altogether.
     """
     participate: bool | None = None   # None = "not stated" -> D1 default (participate)
+    max_age: int | None = None        # url4-INTERNAL. Never sent: v2's grammar would bypass on it.
 ```
+
+**`max_age` is url4-internal (r8).** It exists so a stated bound survives to the point where it
+could be honoured; it is never serialised into the `cache` object, because v2's closed grammar
+bypasses on any key but `use-cache`. `extra="forbid"` plus a test pinning
+`set(CachePolicy.model_fields) == {"participate", "max_age"}` keeps a third field from appearing.
 
 **Deliberately absent: `no_cache`, `no_store`, `s_maxage`.** r2 had all three. v2 retires them
 (`LEGACY_CONTROL_FIELDS`) and bypasses on them, so carrying them in the url4 protocol would model
@@ -402,8 +409,12 @@ docstring states malformed values parse as "not requested".
 {"type": "ai.url4.attach", "data": {"from_sequence": 1, "cache": {"participate": false}}}
 ```
 
-**First attach wins.** A re-attach (reconnect, or `from_sequence` resume) carrying a different
-policy does **not** restate it; the run's policy is fixed at run start. A differing re-attach
+**First attach wins, for the life of the subscription (r8).** A re-attach carrying a different
+policy does **not** restate it while a subscriber remains. Precise scope, per the implementation:
+the registry forgets the declaration when the **last** subscriber leaves, so a client that fully
+disconnects and reconnects before `GET /` can state a different policy — that is a new session,
+not a re-attach. No run in flight can change: the policy is captured into the job env at schedule
+time, and `_require_subscriber` gates run start. A differing re-attach
 emits a `LogEvent` at `warn`. Rationale: a run's aigateway calls may already have executed under
 the original policy, so a mid-run change would make the run's cache behaviour unreproducible.
 
@@ -519,10 +530,16 @@ credential.**
 4. Header and frame disagreeing → header applies, and a `LogEvent` records the override.
 5. A re-attach with a different policy does **not** change the run, and warns.
 6. A default run reports `miss` first, then `hit` on an identical immediate repeat.
-7. Two runs under different `X-Profile` never share an entry.
+7. ~~Two runs under different `X-Profile` never share an entry.~~ **STRUCK (r8)** — a v1 leftover
+   the r5 rebase missed. Under v2 identity is structurally absent from the key (§1.0), and url4
+   sends the profile as a request *header*, never in the body — so two runs differing only by
+   profile **do** share an entry. No url4-side code can satisfy this and none should try.
 8. A malformed directive is ignored; the run proceeds and is not 4xx'd.
 9. Cache status/reason appear on spans for every case above.
-10. A streaming turn reports `bypass` / `stream`, and no policy makes it cacheable.
+10. **N/A (r8)** — a streaming turn cannot reach this path. The connector only ever posts
+   transactional chat completions; there is no `stream` key in the body it builds. The criterion
+   was satisfied by absence rather than behaviour, so it is restated here instead of left as a
+   test someone will go looking for.
 
 ## 10. Open questions for the owner
 

--- a/docs/spec/2026-08-05-url4-cache-policy-spec.md
+++ b/docs/spec/2026-08-05-url4-cache-policy-spec.md
@@ -1,0 +1,312 @@
+---
+title: url4 per-run cache policy — technical specification
+status: PROPOSED — awaiting owner decisions D1, D3, D4, D6 (§3). No code written.
+created: 2026-08-05
+revised: 2026-08-05 (r2 — protocol moves to `packages/url4`; both carriers per owner)
+author: Claude (Opus 5) + Sergey
+ticket: UNFILED — Linear MCP unauthenticated at authoring time (see the ledger)
+related:
+  - packages/url4/src/url4/streaming/protocol/     # where the protocol types land
+  - docs/spec/2026-07-21-url4-cloud.md
+  - docs/spec/2026-07-26-url4-cloud-model-catalog-spec.md   # the HTTP-caching precedent
+  - docs/spec/2026-07-15-url4-cloud-runner-spec.md          # §14 doctrine fork F4
+  - apps/aigateway/src/aigateway/core/request_cache/keys.py # the upstream contract consumed
+---
+
+# url4 per-run cache policy (v1)
+
+## 0. Status & revision history
+
+| rev | date | change |
+|---|---|---|
+| r1 | 2026-08-05 | First draft — located the change in url4-cloud's REST layer. |
+| r2 | 2026-08-05 | **Superseded r1's location.** Owner: protocol belongs in `packages/url4`; both HTTP header *and* protocol frame are carriers. Adds §3 D3/D4 and §5.2. |
+
+**Nothing here is implemented.** Per CLAUDE.md rule 3, implementation starts only on explicit
+approval in plain words.
+
+## 1. Purpose & scope
+
+### 1.1 The gap
+
+aigateway has a complete response cache — keyed store, TTL, bypass reasons, response headers —
+and **url4 cannot reach any of it**.
+
+| # | fact | evidence |
+|---|---|---|
+| 1 | Caching is **opt-in**; absent opt-in the request bypasses | `aigateway/routes/chat_dispatch.py:191` — `if not controls.use_cache: return None, "bypass", "not_requested"` |
+| 2 | Opt-in arrives as a `cache` object in the **request body**, popped before provider plugins | `aigateway/core/request_cache/keys.py:71-86` |
+| 3 | url4-cloud's outgoing body is **hardcoded** | `url4_cloud/runner/connector.py:337-339` — `json={"model": model, "messages": messages, **extra}`; `extra` is only `{tools, tool_choice}` |
+| 4 | Therefore **every url4 run bypasses today**, reason `not_requested` | 1 + 3 |
+| 5 | aigateway reports outcome in headers nothing reads | `chat_dispatch.py:218-226` sets `X-AIGW-Cache`, `X-AIGW-Cache-Reason`, `X-AIGW-Cache-Key` |
+| 6 | The url4 protocol has **no** cache vocabulary inbound | `packages/url4/.../protocol/unions.py:81` — `InboundFrame = StopEvent \| AttachEvent` |
+| 7 | …but it **already has** the reporting half | `packages/url4/.../protocol/taxonomy.py:19-42` — `cache_read_tokens`, `cache_creation_tokens`, `cache_read_usd`, `cache_creation_usd` |
+
+**The inversion that shapes this spec:** the obvious request — "a switch that turns caching off"
+— is a **no-op**, because off is already the state of every path. The mechanism must carry
+policy in *both* directions or it changes nothing.
+
+Fact 7 is the argument for locating this in `packages/url4`: the protocol can already *describe*
+a cached turn and simply cannot *ask* for one.
+
+### 1.2 Non-goals
+
+- **Per-node cache intent.** A url4 expression fans out to many aigateway calls; this policy
+  covers all of them. "Node A cacheable, node B fresh" needs grammar
+  (`packages/url4/src/url4/core/grammar.py` has no cache token) and reopens doctrine fork **F4**
+  (`docs/spec/2026-07-15-url4-cloud-runner-spec.md:118`). Deliberately out of scope.
+- **A url4-native / Enclave GET cache.** Still deferred, same §14.
+- **Any aigateway change.** Its contract is complete and consumed as-is.
+- **Streaming turns.** `build_cache_key` bypasses on `stream: true`
+  (`aigateway/core/request_cache/keys.py:104`) — caching exists only on the transactional half,
+  the same WS/GET split doctrine N1 already draws.
+
+## 2. Where this lives, and why
+
+**Protocol types: `packages/url4/src/url4/streaming/protocol/`.** That is where `InboundFrame`,
+`AttachData` and the cost taxonomy already live; it ships with the SDK, and url4-cloud already
+consumes it via the editable path dependency in its `pyproject.toml:58`.
+
+> **Note for the owner.** `apps/url4-cloud/src/url4_streaming_protocol/` — along with
+> `url4_cloud_nats/` and `url4_cloud_runner/` — is an **empty, untracked, unreferenced**
+> directory (not in git, not in `pyproject.toml`'s `packages = ["src/url4_cloud"]`, imported
+> nowhere). Treated as a stale local artifact. If a package split is genuinely intended, it is
+> its own epic and this spec should not pre-empt it.
+
+**Consumption: `apps/url4-cloud`.** Unavoidable and consuming-side only — it is the only thing
+that talks to aigateway (`runner/connector.py:337`) and the only thing that terminates the WS
+(`ws/bridge.py:141`). It defines no protocol types.
+
+**`apps/aigateway`: no change.**
+
+## 3. Design decisions
+
+**LOCKED** where the codebase or an owner ruling settles it; **OPEN** where the owner must
+choose. The OPEN items are the point of this review.
+
+| # | decision | value | status |
+|---|---|---|---|
+| **D1** | Default when nothing is declared | §3.1 | 🔴 **OPEN** |
+| D2 | HTTP carrier | header on `GET /`, mirroring `X-Profile` (`rest/routes.py:347`) | 🟢 LOCKED |
+| **D3** | Frame shape | extend `AttachData` vs new `ConfigureEvent` — §3.2 | 🔴 **OPEN** |
+| **D4** | Precedence when both carriers speak | §3.3 | 🔴 **OPEN** |
+| D5 | Scope | whole run — every leaf, every fan-out branch | 🟢 LOCKED (§1.2) |
+| **D6** | Header name / intermediary participation | §3.4 | 🔴 **OPEN** |
+| D7 | Response headers read back and folded onto spans | mandatory, every variant | 🟢 LOCKED (§7) |
+| D8 | aigateway changes | none | 🟢 LOCKED |
+| D9 | Protocol location | `packages/url4/.../streaming/protocol/` | 🟢 LOCKED (owner, r2) |
+| D10 | Both carriers supported | yes | 🟢 LOCKED (owner, r2) |
+
+### 3.1 D1 — the default (the real question)
+
+A product decision about cost and determinism, not plumbing.
+
+| option | consequence |
+|---|---|
+| **(a) Default OFF, caller opts IN** | Today's behaviour preserved exactly; zero risk to existing runs. But `no-store` merely names the default — it is decorative until someone opts in. |
+| **(b) Default ON, caller opts OUT** | Makes the original ask meaningful: a fan-out with repeated sub-prompts collapses to one provider call. **Changes cost *and* determinism for every existing run, silently.** |
+
+**Recommendation: (a) for v1.** Reversible, cannot surprise a running system, and it lets the
+carriers and the observability (D7) be proven before anything depends on hits. Revisit once §7
+metrics show real hit rates. See §8.2 — the determinism argument is the strongest case for (a).
+
+### 3.2 D3 — frame shape
+
+| option | trade |
+|---|---|
+| **Extend `AttachData`** (`signals.py:141`) | No new verb, no new union member. `_require_subscriber` (`rest/routes.py:363`) already guarantees attach precedes the run, so policy is in place before any aigateway call. Cost: `AttachData` becomes two concerns (resume-from-sequence + config), and a mid-run **re-attach** could restate policy — spec must rule first-attach-wins. |
+| **New `ConfigureEvent`** | Clean separation, room to carry future run config beyond caching. Cost: a third `InboundFrame` member, a new ordering contract nothing currently enforces, and a decision about what a `Configure` after run start means. |
+
+**Recommendation: extend `AttachData`** for v1 — smallest protocol delta, and attach ordering is
+already enforced. Revisit if run configuration grows a second field unrelated to caching.
+
+### 3.3 D4 — precedence when both carriers speak
+
+Given D10, a run can be configured twice: once on WS attach, once on the `GET /` that starts it.
+
+| option | trade |
+|---|---|
+| **(a) Header wins, override is observable** | Causal order — attach happens first, the GET starts the run and is later. Last-writer-wins is the intuitive reading. A `LogEvent` records that a frame policy was overridden, so it is never silent. |
+| (b) Frame wins | The session declared intent up front; the header is per-request noise. Inverts causal order, which will surprise. |
+| (c) Conflict is fatal | Fail closed, no ambiguity. Harsh: a whole ensemble run dies over a cache directive. |
+
+**Recommendation: (a).** Explicit-beats-absent in all cases; on genuine disagreement the later,
+run-scoped statement wins and says so.
+
+### 3.4 D6 — header name and intermediaries
+
+**Proposed: the standard `Cache-Control` request header.** RFC 9111 already defines `no-store`,
+`no-cache`, `max-age`, `only-if-cached` as *request* directives, and aigateway's control names
+(`no-cache`, `no-store`, `s-maxage`, `ttl`) are deliberately HTTP-shaped — the vocabularies
+already align and nothing is invented. It composes with doctrine N1, which justifies GET *on the
+grounds the call is cacheable*.
+
+**Consequence:** a genuine `Cache-Control` may be honoured by Envoy or a CDN. Usually desirable —
+it is what the header means. If the directive must reach *only* aigateway, the header must be
+`URL4-Cache` instead, matching `URL4-Capability` as a url4-owned contract.
+
+**D6 is one decision in two parts:** standard header *and* intermediary participation, or private
+header *and* aigateway-only. A standard header intermediaries are asked to ignore is the worst of
+both.
+
+## 4. Protocol definitions — `packages/url4`
+
+### 4.1 `protocol/signals.py` — the policy type
+
+```python
+class CachePolicy(BaseModel):
+    """Per-run cache intent. Declared once, applied to every aigateway call in the run.
+
+    Names mirror aigateway's request-body controls (`use-cache`, `no-cache`, `no-store`,
+    `s-maxage`) so the mapping is identity, not translation — there is no second vocabulary
+    to keep in step.
+    """
+    use_cache: bool = False
+    no_cache: bool = False
+    no_store: bool = False
+    s_maxage: int | None = Field(default=None, ge=1)
+```
+
+Under **D3 (recommended)**, `AttachData` gains one optional field:
+
+```python
+class AttachData(BaseModel):
+    from_sequence: int | None = Field(default=None, ge=1)
+    cache: CachePolicy | None = None      # NEW — absent means "not declared", not "off"
+```
+
+`None` vs a default-constructed `CachePolicy()` is load-bearing: **absent must mean "did not
+declare"**, so D4 precedence can distinguish silence from an explicit `use_cache=False`.
+
+### 4.2 `protocol/signals.py` — reporting the outcome
+
+`SpanData` gains the cache outcome, so a hit is visible per turn:
+
+```python
+    cache_status: Literal["hit", "miss", "bypass"] | None = None
+    cache_reason: str | None = None       # aigateway's vocabulary, verbatim
+```
+
+`taxonomy.py` needs **no change** — `cache_read_tokens` / `cache_creation_tokens` /
+`cache_read_usd` / `cache_creation_usd` already exist (`:19-42`).
+
+### 4.3 `protocol/unions.py`
+
+Unchanged under D3-recommended (`AttachEvent` already a member). Under `ConfigureEvent`,
+`InboundFrame` at `:81` gains a third member and `InboundFrameAdapter` follows.
+
+## 5. The two request contracts
+
+### 5.1 HTTP — `GET /`
+
+```http
+GET /?q=(A,B)!reduce HTTP/1.1
+URL4-Capability: <jwt>
+X-Profile: prod
+Cache-Control: no-store
+```
+
+| directive | → aigateway `cache` | meaning |
+|---|---|---|
+| `no-store` | `no-store: true` | do not read, do not write |
+| `no-cache` | `no-cache: true` | do not read a stored entry; still store the result |
+| `max-age=<n>` | `s-maxage: <n>` | accept an entry only if younger than *n* seconds |
+| `url4-use-cache` | `use-cache: true` | opt in (RFC 9111 §5.2.3 extension token; ignored by intermediaries) |
+| absent | field omitted | D1 default |
+
+RFC 9111 has no "please cache" *request* directive, hence the extension token. If that is
+unpalatable it is a further argument for `URL4-Cache` under D6.
+
+**`only-if-cached` is rejected** — see §8.3.
+
+**Unparseable directives are ignored, never fatal**, matching `parse_cache_controls`, whose
+docstring states malformed values parse as "not requested".
+
+### 5.2 WS — attach frame
+
+```json
+{"type": "ai.url4.attach", "data": {"from_sequence": 1, "cache": {"no_store": true}}}
+```
+
+**First attach wins.** A re-attach (reconnect, or `from_sequence` resume) carrying a different
+policy does **not** restate it; the run's policy is fixed at run start. A differing re-attach
+emits a `LogEvent` at `warn`. Rationale: a run's aigateway calls may already have executed under
+the original policy, so a mid-run change would make the run's cache behaviour unreproducible.
+
+### 5.3 Convergence
+
+Both carriers produce a `CachePolicy | None`. Per **D4(a)**: header wins when both are present
+and differ, and the override emits a `LogEvent`. Absent on both → D1 default.
+
+## 6. url4-cloud consumption
+
+| hop | file | change |
+|---|---|---|
+| WS ingress | `ws/bridge.py:141` | `_parse_inbound` already returns the validated frame; carry `data.cache` into session state |
+| HTTP ingress | `rest/routes.py:337` | new `Header(...)` param on `start_run`; parse → `CachePolicy` |
+| converge | `rest/routes.py` `_schedule` | one new kwarg beside `profile`/`identity`; apply D4 |
+| thread | `job_env` / runner | per-**run** value, exactly as `profile` travels — **not** `AigatewayConfig`, which is world config shared by all runs |
+| egress | `runner/connector.py:337` | `json={…, **extra, **policy.as_body_field()}` |
+| ingress back | `runner/connector.py` | read `X-AIGW-Cache*`, fold onto the span beside `_report_usage` |
+
+`as_body_field()` returns `{}` when there is nothing to say, so **a default run's body stays
+byte-identical to today's** — which keeps aigateway's `unsupported_fields` bypass path untouched.
+
+## 7. Observability (D7 — mandatory)
+
+The connector currently calls `_raise_for_status` → `_json_or_raise` → `_report_usage` →
+`_parse_choice`, all body-only. It must additionally read `X-AIGW-Cache`,
+`X-AIGW-Cache-Reason`, `X-AIGW-Cache-Key` (12 hex, hit/miss only, hash-derived — never prompt
+content) and fold them onto the owning span, the same seam `#506` used for
+`finish_reason`/`refusal`.
+
+**Without this, enabling caching makes the cost taxonomy wrong.** A hit costs nothing upstream,
+but `_report_usage` would bill it as a fresh call — an error that *hides savings*, so nobody
+notices.
+
+Run-level counters follow the catalog spec's precedent (`…model-catalog-spec.md:309-311`): hits,
+misses, and **bypasses by reason** — the load-bearing one, since it turns "I asked for caching
+and got none" into an answerable question. **No metric may be labelled by cache key, prompt, or
+credential.**
+
+## 8. Security & correctness consequences
+
+1. **Key scope.** `{v, account_id, profile_name, provider, model, prompt_hash}`
+   (`aigateway/core/request_cache/keys.py:124-130`) — per account *and* profile. Two runs under
+   different profiles never share an entry. url4 adds no new sharing axis.
+2. **Ensemble determinism.** Two nodes with identical prompts but distinct node identities miss
+   the engine's `_memo` (keyed on node identity, `dag/executor.py:109`) and would hit aigateway's
+   cache (keyed on prompt hash). Usually the desired dedup — but an ensemble deliberately
+   sampling one model twice for variance would receive **one answer twice**. Narrower than it
+   sounds, since `temperature` participates in the normalised prompt, but this is a correctness
+   change to ensembling, not merely a cost optimisation. **The strongest argument for D1(a).**
+3. **`only-if-cached` rejected.** RFC 9111 requires `504` when nothing is cached. A url4 run is a
+   fan-out of many calls; one uncached leaf failing the whole run is a footgun with no present
+   use case.
+4. **No new secret material.** The policy is non-sensitive; `X-AIGW-Cache-Key` is a hash prefix
+   by construction.
+
+## 9. Acceptance
+
+1. A run declaring nothing produces a body **byte-identical** to today's, and reports
+   `bypass` / `not_requested`.
+2. `Cache-Control: no-store` reaches aigateway as `cache: {"no-store": true}`.
+3. The same policy delivered on the attach frame produces the identical egress body.
+4. Header and frame disagreeing → header applies, and a `LogEvent` records the override.
+5. A re-attach with a different policy does **not** change the run, and warns.
+6. Under D1(a): opt-in run reports `miss` first, `hit` on an identical immediate repeat.
+7. Two runs under different `X-Profile` never share an entry.
+8. A malformed directive is ignored; the run proceeds and is not 4xx'd.
+9. Cache status/reason appear on spans for every case above.
+10. A streaming turn reports `bypass` / `stream`, and no policy makes it cacheable.
+
+## 10. Open questions for the owner
+
+1. **D1** — default OFF (recommended) or ON?
+2. **D3** — extend `AttachData` (recommended) or add `ConfigureEvent`?
+3. **D4** — header wins on conflict (recommended), frame wins, or fatal?
+4. **D6** — standard `Cache-Control` with intermediary participation, or private `URL4-Cache`?
+5. Is `request_cache_enabled` actually **on** in the deployed aigateway? If not, every path
+   answers `bypass / disabled` and this work is inert until it is switched on.
+6. Are the three empty `apps/url4-cloud/src/url4_*` directories a stale artifact to delete, or an
+   intended package split to file as its own epic?

--- a/docs/spec/2026-08-05-url4-cache-policy-spec.md
+++ b/docs/spec/2026-08-05-url4-cache-policy-spec.md
@@ -2,7 +2,7 @@
 title: url4 per-run cache policy — technical specification
 status: PROPOSED — awaiting owner decisions D3, D4, D6 (§3). No code written.
 created: 2026-08-05
-revised: 2026-08-05 (r3 — D1 LOCKED to cache-ON-by-default; aigateway chart now in scope)
+revised: 2026-08-05 (r4 — TTL/size knobs pinned explicitly in the chart)
 author: Claude (Opus 5) + Sergey
 ticket: UNFILED — Linear MCP unauthenticated at authoring time (see the ledger)
 related:
@@ -21,6 +21,7 @@ related:
 |---|---|---|
 | r1 | 2026-08-05 | First draft — located the change in url4-cloud's REST layer. |
 | r2 | 2026-08-05 | **Superseded r1's location.** Owner: protocol belongs in `packages/url4`; both HTTP header *and* protocol frame are carriers. Adds §3 D3/D4 and §5.2. |
+| r4 | 2026-08-05 | Owner: **TTL/size knobs pinned explicitly** in the chart rather than inherited (§10). Closes the last non-D question. |
 | r3 | 2026-08-05 | **D1 LOCKED: caching is ON by default; only disabling is explicit.** That makes the aigateway **chart** part of the deliverable (D8 reversed) and makes this cross-app — see §2.1. Ensemble-determinism tradeoff (§8.2) accepted by the owner on the record. |
 
 **Nothing here is implemented.** Per CLAUDE.md rule 3, implementation starts only on explicit
@@ -111,7 +112,7 @@ one sub-issue per landing**, never one ticket:
 |---|---|---|
 | 1 | `pkg` → url4 | protocol types (§4) |
 | 2 | `app` → url4-cloud | both carriers, threading, egress, read-back (§5-§7) |
-| 3 | `app` → aigateway | chart sets `AIGW_REQUEST_CACHE_ENABLED`; TTL/size knobs reviewed |
+| 3 | `app` → aigateway | chart sets `AIGW_REQUEST_CACHE_ENABLED` **plus the three TTL/size knobs, pinned** (r4) |
 
 Sub-issue 3 has a different CODEOWNERS reviewer and can land **first and independently** — it is
 a no-op until sub-issue 2 sends `use-cache`.
@@ -388,11 +389,10 @@ credential.**
 3. **D6** — standard `Cache-Control` with intermediary participation, or private `URL4-Cache`?
 4. Are the three empty `apps/url4-cloud/src/url4_*` directories a stale artifact to delete, or an
    intended package split to file as its own epic?
-5. **TTL and size defaults**, now that the chart is in scope: the code defaults are
-   `AIGW_REQUEST_CACHE_TTL_SECONDS=600`, `…_MAX_TTL_SECONDS=3600`,
-   `…_MAX_RESPONSE_BYTES=1_000_000` (`config.py:130-138`). Accept, or set explicitly in the chart
-   alongside the enable flag? Leaving them implicit means a future code-default change silently
-   moves production behaviour.
-
 **Resolved in r3:** D1 (ON) · D8 (chart in scope) · §8.2 tradeoff (accepted) · the
-`request_cache_enabled` question (it is **off**, and turning it on is now sub-issue 3).
+`request_cache_enabled` question (it is **off**, and turning it on is now sub-issue 3) ·
+**TTL/size knobs pinned explicitly in the chart** (owner) — `ttlSeconds: 600`,
+`maxTtlSeconds: 3600`, `maxResponseBytes: 1000000`, equal to today's code defaults
+(`config.py:130-138`) but frozen so a patch release cannot move production behaviour. Rendered
+via `config.requestCache.*` following the chart's existing `values → configmap` pattern; see
+plan Batch 0.

--- a/docs/spec/2026-08-05-url4-cache-policy-spec.md
+++ b/docs/spec/2026-08-05-url4-cache-policy-spec.md
@@ -21,6 +21,7 @@ related:
 |---|---|---|
 | r1 | 2026-08-05 | First draft — located the change in url4-cloud's REST layer. |
 | r2 | 2026-08-05 | **Superseded r1's location.** Owner: protocol belongs in `packages/url4`; both HTTP header *and* protocol frame are carriers. Adds §3 D3/D4 and §5.2. |
+| **r9** | 2026-08-07 | **#507 landed.** The upstream contract §1.0 was written against is no longer assumed — it merged as `4f2a55ea`. §1.0 restated from *assumed* to *merged*, and re-verified against `origin/main` rather than the PR branch: the grammar is unchanged (only `LEGACY_CONTROL_FIELDS` → `UNSUPPORTED_CONTROL_FIELDS`, which url4 never referenced). §1.1's v1 citations pinned to `bc8399bc` (the pre-v2 tree) — `chat_dispatch.py:191` is unrelated code on `main` now. §7's header location corrected to `routes/chat_cache_stage.py`. |
 | **r8** | 2026-08-06 | **Corrections from the implementation review.** §4.1 said "exactly one field" while the type carries two (`participate`, `max_age`) — the plan superseded itself and the spec never caught up. §9.7 struck (unsatisfiable under v2). §9.10 restated as N/A. §5.2's "first attach wins" narrowed to what the code actually guarantees. |
 | **r7** | 2026-08-05 | **Owner locked the last four**: D3 extend `AttachData` · D4 header wins · D6 standard `Cache-Control` · D11 **honour `max-age`**. D11 carries two upstream blockers — §3.5. Spec is decision-complete. |
 | **r6** | 2026-08-05 | **Standards alignment.** Read-back prefers **`Cache-Status`** (RFC 9211) over the ad hoc `X-AIGW-Cache*`; **`Age`** (RFC 9111 §5.1) makes `max-age` honourable, so **D11 is reopened** (§3.5). Adds §2.2 with the registry evidence. |
@@ -28,15 +29,20 @@ related:
 | r4 | 2026-08-05 | ~~TTL/size knobs pinned explicitly in the chart~~ — **REVOKED by r5.** |
 | r3 | 2026-08-05 | **D1 LOCKED: caching is ON by default; only disabling is explicit.** That makes the aigateway **chart** part of the deliverable (D8 reversed) and makes this cross-app — see §2.1. Ensemble-determinism tradeoff (§8.2) accepted by the owner on the record. |
 
-**Nothing here is implemented.** Per CLAUDE.md rule 3, implementation starts only on explicit
-approval in plain words.
+**Status: implemented.** Approval was given in plain words on 2026-08-06 (CLAUDE.md rule 3) and
+the design landed as **PR #518** — `apps/url4-cloud` + `packages/url4`, gates green on both
+stacks. This spec is the design record; #518 is the implementation, and the plan's Verification
+section is the acceptance list.
 
-## 1.0 Upstream contract — aigateway v2 (PR #507), assumed
+## 1.0 Upstream contract — aigateway v2 (PR #507), MERGED
 
-This spec is written against **`OME-305` / PR #507 `feat(aigateway): add global exact-request
-cache`** — open, non-draft, +12152/-547 at time of writing. It is **assumed to land**; url4 must
-be ready for it. Everything below consumes that contract rather than the v1 one this spec
-originally targeted.
+This spec was written against **`OME-305` / PR #507 `feat(aigateway): add global exact-request
+cache`** while it was still open. **It merged on 2026-08-06 as `4f2a55ea`** — the contract below
+is no longer an assumption, and every claim in this section has been re-verified against
+`origin/main` rather than the PR branch. The one difference found is a rename url4 never
+referenced: `LEGACY_CONTROL_FIELDS` → `UNSUPPORTED_CONTROL_FIELDS`.
+
+Everything below consumes the v2 contract rather than the v1 one this spec originally targeted.
 
 **What v2 is**, from its own source:
 
@@ -69,13 +75,20 @@ richer is not merely unnecessary — it actively causes a bypass.
 aigateway has a complete response cache — keyed store, TTL, bypass reasons, response headers —
 and **url4 cannot reach any of it**.
 
-| # | fact | evidence |
+> **These are the v1 facts that motivated the spec, and their line references are pinned to
+> `bc8399bc` — the commit immediately before #507.** They are kept because they are the argument
+> for doing this work at all, not because they describe `main`. Facts 1, 2 and 5 were all
+> restructured by v2 (§1.0): caching is now ON by default rather than opt-in, and
+> `chat_dispatch.py:191` is unrelated error-handling code on `main` today. Facts 3, 4, 6 and 7 —
+> the url4 side — are unaffected and remain true.
+
+| # | fact (at `bc8399bc`, pre-v2) | evidence |
 |---|---|---|
 | 1 | Caching is **opt-in**; absent opt-in the request bypasses | `aigateway/routes/chat_dispatch.py:191` — `if not controls.use_cache: return None, "bypass", "not_requested"` |
 | 2 | Opt-in arrives as a `cache` object in the **request body**, popped before provider plugins | `aigateway/core/request_cache/keys.py:71-86` |
 | 3 | url4-cloud's outgoing body is **hardcoded** | `url4_cloud/runner/connector.py:337-339` — `json={"model": model, "messages": messages, **extra}`; `extra` is only `{tools, tool_choice}` |
 | 4 | Therefore **every url4 run bypasses today**, reason `not_requested` | 1 + 3 |
-| 5 | aigateway reports outcome in headers nothing reads | `chat_dispatch.py:218-226` sets `X-AIGW-Cache`, `X-AIGW-Cache-Reason`, `X-AIGW-Cache-Key` |
+| 5 | aigateway reports outcome in headers nothing reads | `chat_dispatch.py:218-226` sets `X-AIGW-Cache`, `X-AIGW-Cache-Reason`, `X-AIGW-Cache-Key`. **On `main` this moved to `routes/chat_cache_stage.py`** — names at `:43-46`, built by `global_cache_headers()` at `:353-375`, applied by `set_global_cache_headers()` at `:379`. `X-AIGW-Cache-Write` was added |
 | 6 | The url4 protocol has **no** cache vocabulary inbound | `packages/url4/.../protocol/unions.py:81` — `InboundFrame = StopEvent \| AttachEvent` |
 | 7 | …but it **already has** the reporting half | `packages/url4/.../protocol/taxonomy.py:19-42` — `cache_read_tokens`, `cache_creation_tokens`, `cache_read_usd`, `cache_creation_usd` |
 
@@ -198,7 +211,7 @@ choose. The OPEN items are the point of this review.
 | D5 | Scope | whole run — every leaf, every fan-out branch | 🟢 LOCKED (§1.2) |
 | D6 | Header name / intermediary participation | **standard `Cache-Control`**; intermediaries may participate (§3.4) | 🟢 LOCKED (owner, r7) |
 | D7 | Response headers read back and folded onto spans | mandatory, every variant | 🟢 LOCKED (§7) |
-| D8 | aigateway changes | **none — PR #507 does it all**, chart included. url4 depends on it landing (§1.0) | 🟢 LOCKED (r5 — reverts r3) |
+| D8 | aigateway changes | **none — PR #507 does it all**, chart included. **#507 merged 2026-08-06 (`4f2a55ea`), so this dependency is satisfied** (§1.0) | 🟢 LOCKED (r5 — reverts r3) |
 | D11 | `Cache-Control: max-age=N` | **honour it** — blocked upstream today; opt-out until then (§3.5) | 🟢 LOCKED (owner, r7) |
 | D9 | Protocol location | `packages/url4/.../streaming/protocol/` | 🟢 LOCKED (owner, r2) |
 | D10 | Both carriers supported | yes | 🟢 LOCKED (owner, r2) |
@@ -285,12 +298,13 @@ carries the same fact as the `ttl` parameter inside `Cache-Status`.
 | (c) Ignore the directive | The caller silently receives an arbitrarily old answer having explicitly asked not to. Rejected. |
 
 **LOCKED: (a) — honour `max-age`.** Two upstream blockers stand between that decision and a
-working implementation, both verified against #507's branch on 2026-08-05:
+working implementation. First verified against #507's branch on 2026-08-05; **both re-verified
+against `origin/main` on 2026-08-07, after #507 merged — both still stand:**
 
-| blocker | evidence |
+| blocker | evidence (on `main`) |
 |---|---|
-| **url4 cannot ASK for a bound.** v2's grammar is closed to `use-cache`; `{"cache": {"max-age": 60}}` returns `_refuse(BYPASS_UNSUPPORTED_CONTROL)` | `global_controls.py:79-83` |
-| **aigateway does not REPORT age.** No `Age` header, no `Cache-Status; ttl=` | #507 adds `CACHE_HEADER`/`REASON_HEADER`/`WRITE_HEADER`/`KEY_HEADER` and no age field |
+| **url4 cannot ASK for a bound.** v2's grammar is closed to `use-cache`; `{"cache": {"max-age": 60}}` returns `_refuse(BYPASS_UNSUPPORTED_CONTROL)` | `global_controls.py:72-76` — `if set(raw) - {USE_CACHE_FIELD}: … return _refuse(BYPASS_UNSUPPORTED_CONTROL)` (was `:79-83` on the PR branch) |
+| **aigateway does not REPORT age.** No `Age` header, no `Cache-Status; ttl=` | `git grep -E '"Age"\|Cache-Status' -- 'apps/aigateway/src/**/*.py'` returns **nothing**. The only cache headers are `CACHE_HEADER`/`REASON_HEADER`/`WRITE_HEADER`/`KEY_HEADER`, none carrying an age |
 
 So url4 can neither request a freshness bound nor measure one. **Until one of these changes,
 `max-age` degrades to opt-out** — the conservative direction, and observably so via

--- a/docs/work/2026-08-05-UNFILED-url4-cloud-cache-policy-spec.md
+++ b/docs/work/2026-08-05-UNFILED-url4-cloud-cache-policy-spec.md
@@ -103,6 +103,19 @@ is `packages/url4/src/url4/streaming/protocol/`. Confirmed with the owner before
    the architecture rule: the protocol must not know an adapter's wire shape. The plan places the
    translation in `apps/url4-cloud` and flags the spec for an r3 amendment rather than diverging
    silently.
-5. **The plan is written against the spec's four OPEN recommendations**, with §9 stating what
+5. **r3/r2 — owner locked D1 to cache-ON-by-default**, accepted the ensemble-determinism
+   tradeoff (spec §8.2) on the record, and brought the **aigateway chart** into scope. That
+   reverses spec D8 ("no aigateway change") and makes the work **cross-app**, so per CLAUDE.md
+   rule 8 it is now an epic + 3 sub-issues (`pkg/url4`, `app/url4-cloud`, `app/aigateway`) rather
+   than one unit. Checked and recorded: `request_cache_enabled` defaults to `False`
+   (`config.py:127-129`) and the chart never sets it, so caching is off in the deployed gateway
+   today — Batch 0 exists to fix that.
+6. **Two errors of my own, corrected in place.** (i) The plan cited
+   `AIGATEWAY_REQUEST_CACHE_ENABLED`; the real alias is **`AIGW_`** — aigateway uses both
+   prefixes inconsistently and I guessed. (ii) Flipping D1 exposed a hole in the protocol type:
+   with `use_cache: bool = False`, a caller sending `cache: {}` would silently disable caching
+   while believing they had expressed no opinion. `use_cache` is now tri-state
+   (`bool | None = None`).
+7. **The plan was written against the spec's OPEN recommendations**, with §9 stating what
    changes under each alternative. Written this way so the owner reviews spec and plan together
    rather than serialising four decisions first; the plumbing is ~90% invariant across them.

--- a/docs/work/2026-08-05-UNFILED-url4-cloud-cache-policy-spec.md
+++ b/docs/work/2026-08-05-UNFILED-url4-cloud-cache-policy-spec.md
@@ -1,0 +1,96 @@
+---
+ticket: UNFILED
+stack: url4-cloud
+status: in_progress
+started: 2026-08-05
+finished:
+---
+
+# UNFILED — spec: per-run cache policy for url4-cloud → aigateway
+
+## PROCESS DEVIATION
+
+**No Linear issue backs this unit.** The Linear MCP plugin is installed but unauthenticated;
+`.claude/task-board.local.md` names it the ONLY permitted transport. Fourth occurrence this
+session; the owner previously chose "proceed and record the deviation" for the identical
+situation (`OME-743`, reconciled after the fact).
+
+Back-fill once MCP is up: ledger `ticket:`/filename, branch name (`url4-cloud-cache-policy-spec`
+→ `OME-N-<desc>`), `docs/tasks/` mirror, commit `Refs:`.
+
+## Intent
+
+Owner asked to plan the protocol change that lets a caller declare a run must not use
+aigateway's response cache, and to produce a file to review before implementation.
+
+Per CLAUDE.md rule 3 the artifact is a **spec** in `docs/spec/`, not a plan: this changes
+url4-cloud's public REST contract. **No code in this unit.**
+
+## What the investigation established (all verified against `main`)
+
+1. **aigateway's cache is opt-in.** `routes/chat_dispatch.py:191` —
+   `if not controls.use_cache: return None, "bypass", "not_requested"`. Controls arrive as a
+   `cache` object in the request body (`core/request_cache/keys.py:71`), popped before provider
+   plugins ever see it.
+2. **url4-cloud can never send it.** `runner/connector.py:337` builds the body literally as
+   `json={"model": model, "messages": messages, **extra}`, where `extra` is only
+   `{tools, tool_choice}`. There is no `cache` field and no path to inject one.
+3. **So every url4 run already bypasses**, with reason `not_requested`. A pure "turn caching
+   off" switch would be a no-op on every code path — the inversion that reshapes the design.
+4. **The response evidence is dropped too.** aigateway sets `X-AIGW-Cache`,
+   `X-AIGW-Cache-Reason`, `X-AIGW-Cache-Key` (`chat_dispatch.py:218-226`); the connector reads
+   the body only, so a hit would bill as a fresh call.
+5. **The WS carries only `attach`/`stop` today** (`ws/bridge.py:57-67`;
+   `protocol/unions.py:81` — `InboundFrame = StopEvent | AttachEvent`), and `GET /` *requires*
+   an attached subscriber before it starts a run (`rest/routes.py:363`).
+
+   **r1 read this as "the WS is the wrong carrier"** — arguing a pre-config frame needs an
+   ordering contract and races on reconnect, with `X-Profile` (`rest/routes.py:347`) as the
+   precedent for a per-run header. **r2 overturns that.** The owner is changing the *protocol*,
+   so "inbound frames are attach/stop only" is a description of what to change, not an objection.
+   Attach-before-run is already enforced, so ordering is defined; the reconnect race is answered
+   by a first-attach-wins rule (spec §5.2) rather than by rejecting the carrier.
+
+   Both carriers are now in scope, which introduces the precedence question the spec raises as
+   **D4** — a decision r1 never had to make.
+
+## Planned changes
+
+- `docs/spec/2026-08-05-url4-cache-policy-spec.md` — the spec. Nothing else.
+
+**r2 relocation (owner, mid-unit).** r1 located the change in url4-cloud's REST layer. The owner
+directed that protocol changes belong in `packages/url4` (+ both HTTP header and protocol frame
+as carriers). The spec was rewritten; r1's file was deleted rather than left as a stale sibling.
+
+**The path the owner named does not exist.** `apps/url4-cloud/src/url4_streaming_protocol/` —
+with `url4_cloud_nats/` and `url4_cloud_runner/` — is empty, untracked, absent from
+`pyproject.toml` (`packages = ["src/url4_cloud"]`) and imported nowhere. The real protocol module
+is `packages/url4/src/url4/streaming/protocol/`. Confirmed with the owner before writing.
+
+## Explicitly NOT in this unit
+
+- Implementation (rule 3: starts only on explicit approval in plain words).
+- Per-node cache intent — needs url4 grammar, reopens doctrine fork **F4**.
+- Any aigateway change: its contract is already complete.
+
+## Acceptance
+
+- Spec follows house structure (modelled on `docs/spec/2026-07-26-url4-cloud-model-catalog-spec.md`)
+- Every claim about current behaviour carries a `file:line`
+- The genuinely open decisions are presented as owner forks, not silently resolved
+- Delivered for review before any code
+
+## Outcome
+
+- **Actual files:** `docs/spec/2026-08-05-url4-cache-policy-spec.md` only. No code, per rule 3.
+- **Owner decisions taken mid-unit:** protocol lands in `packages/url4` (D9); both carriers
+  supported (D10). Four decisions remain OPEN in the spec for review: D1 default, D3 frame shape,
+  D4 precedence, D6 header name.
+
+## Deviations
+
+1. **Process deviation** — no Linear issue; MCP unauthenticated (4th occurrence). Branch,
+   mirror and `Refs:` all dangling.
+2. **Spec rewritten mid-unit** after the owner relocated the change (r1 → r2). Recorded in the
+   spec's own revision table rather than hidden.
+3. **A named target path did not exist** — see above. Raised rather than silently substituted.

--- a/docs/work/2026-08-05-UNFILED-url4-cloud-cache-policy-spec.md
+++ b/docs/work/2026-08-05-UNFILED-url4-cloud-cache-policy-spec.md
@@ -56,7 +56,10 @@ url4-cloud's public REST contract. **No code in this unit.**
 
 ## Planned changes
 
-- `docs/spec/2026-08-05-url4-cache-policy-spec.md` — the spec. Nothing else.
+- `docs/spec/2026-08-05-url4-cache-policy-spec.md` — the spec.
+- `docs/plan/2026-08-05-url4-cache-policy.md` — the implementation plan (rule 3: spec then plan).
+
+No code.
 
 **r2 relocation (owner, mid-unit).** r1 located the change in url4-cloud's REST layer. The owner
 directed that protocol changes belong in `packages/url4` (+ both HTTP header and protocol frame
@@ -82,7 +85,8 @@ is `packages/url4/src/url4/streaming/protocol/`. Confirmed with the owner before
 
 ## Outcome
 
-- **Actual files:** `docs/spec/2026-08-05-url4-cache-policy-spec.md` only. No code, per rule 3.
+- **Actual files:** `docs/spec/2026-08-05-url4-cache-policy-spec.md` and
+  `docs/plan/2026-08-05-url4-cache-policy.md`. No code, per rule 3.
 - **Owner decisions taken mid-unit:** protocol lands in `packages/url4` (D9); both carriers
   supported (D10). Four decisions remain OPEN in the spec for review: D1 default, D3 frame shape,
   D4 precedence, D6 header name.
@@ -94,3 +98,11 @@ is `packages/url4/src/url4/streaming/protocol/`. Confirmed with the owner before
 2. **Spec rewritten mid-unit** after the owner relocated the change (r1 → r2). Recorded in the
    spec's own revision table rather than hidden.
 3. **A named target path did not exist** — see above. Raised rather than silently substituted.
+4. **The plan corrects the spec (§0.1).** Spec §4.1 put `as_body_field()` — the mapping to
+   aigateway's request-body vocabulary — on the protocol type in `packages/url4`. That violates
+   the architecture rule: the protocol must not know an adapter's wire shape. The plan places the
+   translation in `apps/url4-cloud` and flags the spec for an r3 amendment rather than diverging
+   silently.
+5. **The plan is written against the spec's four OPEN recommendations**, with §9 stating what
+   changes under each alternative. Written this way so the owner reviews spec and plan together
+   rather than serialising four decisions first; the plumbing is ~90% invariant across them.


### PR DESCRIPTION
**Spec only — no code.** Per CLAUDE.md rule 3, implementation starts only on explicit approval in plain words.

📄 **`docs/spec/2026-08-05-url4-cache-policy-spec.md`**

## The finding that shapes it

aigateway has a complete response cache — keyed store, TTL, bypass reasons, response headers — and **url4 cannot reach any of it**:

| fact | evidence |
| --- | --- |
| Caching is **opt-in**; absent opt-in the request bypasses | `chat_dispatch.py:191` — `if not controls.use_cache: return None, "bypass", "not_requested"` |
| Opt-in arrives as a `cache` object in the request **body** | `request_cache/keys.py:71-86` |
| url4-cloud's outgoing body is **hardcoded** | `connector.py:337` — `json={"model":…, "messages":…, **extra}` |
| → **every url4 run already bypasses** | |

**So the obvious design is a no-op.** A header that "turns caching off" changes nothing, because off is the state of every path. The mechanism has to carry policy in *both* directions — that inversion drives the whole spec.

## Why `packages/url4`

`protocol/taxonomy.py:19-42` already carries `cache_read_tokens`, `cache_creation_tokens`, `cache_read_usd`, `cache_creation_usd`. **The protocol can already describe a cached turn and simply cannot ask for one.** The missing half belongs next to the half that exists.

> ⚠️ **The path named in the request does not exist.** `apps/url4-cloud/src/url4_streaming_protocol/` — with `url4_cloud_nats/` and `url4_cloud_runner/` — is empty, untracked, absent from `pyproject.toml` (`packages = ["src/url4_cloud"]`) and imported nowhere. Confirmed with the owner; the real module is `packages/url4/src/url4/streaming/protocol/`. Whether those dirs are stale or an intended split is open question 6.

## Blast radius

- **`packages/url4`** — protocol types (`CachePolicy`, `AttachData.cache`, `SpanData.cache_status`)
- **`apps/url4-cloud`** — consuming side only: parse both carriers, thread per-run, merge into the egress body, read `X-AIGW-Cache*` back
- **`apps/aigateway`** — **no change**, contract complete
- Nothing else

## Four decisions left OPEN for you

1. **D1 — the default.** OFF (opt-in) or ON (opt-out)? *Recommended: OFF.* §8.2 is the reason — two ensemble nodes with identical prompts but distinct identities miss the engine's `_memo` and would hit aigateway's cache, so an ensemble deliberately sampling one model twice for variance gets **one answer twice**. That is a correctness change to ensembling, not a cost optimisation.
2. **D3 — frame shape.** Extend `AttachData` *(recommended, smallest delta)* or add a `ConfigureEvent`?
3. **D4 — precedence.** Both carriers can speak. *Recommended: header wins, override logged.*
4. **D6 — header name.** Standard `Cache-Control` with intermediary participation, or private `URL4-Cache` reaching only aigateway? One decision in two parts.

Plus: **is `request_cache_enabled` actually on in the deployed aigateway?** If not, every path answers `bypass / disabled` and this work is inert until it is switched on.

## Also mandatory regardless of the above

The connector reads the response **body only**, so a cache hit is invisible upstream — `_report_usage` would bill it as a fresh call. That is an error which *hides savings*, so nobody notices. Reading `X-AIGW-Cache*` onto the span is locked as D7.

## Process deviation

**No Linear issue backs this unit** — MCP unauthenticated (4th occurrence this session); the card names it the only permitted transport. Branch, `docs/tasks/` mirror and `Refs:` are dangling and listed in the ledger for back-fill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HAiqcmwueUjWBhsEfsQWGx