### PR TITLE
ci(scoreboard): test the Python 3.13 interpreter it already ships

### DIFF
--- a/.claude/scripts/audit_dependabot_ignores.py
+++ b/.claude/scripts/audit_dependabot_ignores.py
@@ -165,11 +165,16 @@ def probe_ci_matrix(blocker: dict, floor: tuple[int, int | None]) -> tuple[bool,
         if isinstance(node, dict):
             for k, v in node.items():
                 if k == key:
-                    # AIDEV-NOTE: both shapes occur and BOTH must be read. aigateway and
-                    # url4-cloud use a matrix list ["3.12","3.13"]; scoreboard pins a scalar
-                    # "3.12". An earlier version handled only the list and fell through to
-                    # "no matrix -> still blocking" for scoreboard — the right answer by
-                    # accident, which is the kind of thing that silently rots later.
+                    # AIDEV-NOTE: both shapes occur and BOTH must be read. The test
+                    # matrices use a list ["3.12","3.13"]; a scalar "3.12" still appears on
+                    # single-version jobs (url4-cloud's conformance job, and any workflow
+                    # that pins one interpreter deliberately). An earlier version handled
+                    # only the list and fell through to "no matrix -> still blocking",
+                    # which was the right answer by accident.
+                    #
+                    # Corrected in OME-750: this note used to cite scoreboard as THE
+                    # scalar case, and that PR is what gave scoreboard a list. The scalar
+                    # branch is still needed — just not for that reason.
                     vals = v if isinstance(v, list) else [v]
                     for x in vals:
                         s = str(x)

--- a/.github/workflows/scoreboard-tests.yml
+++ b/.github/workflows/scoreboard-tests.yml
@@ -19,6 +19,9 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
     defaults:
       run:
         working-directory: apps/scoreboard
@@ -30,7 +33,7 @@ jobs:
 
       - uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       # WHY before `uv sync`: sync SILENTLY regenerates a stale lock, so a lockfile that no
       # longer matches pyproject.toml is invisible to every later step — including the

--- a/.github/workflows/scoreboard-tests.yml
+++ b/.github/workflows/scoreboard-tests.yml
@@ -68,13 +68,20 @@ jobs:
         uses: dorny/test-reporter@v3
         if: always()
         with:
-          name: Scoreboard Test Results
+          name: Scoreboard Test Results (${{ matrix.python-version }})
           path: apps/scoreboard/results.xml
           reporter: java-junit
 
+      # ONE leg only. Without the version guard the matrix runs this twice
+      # concurrently on a PR: two coverage comments, plus a create/update race that
+      # can fail the step (it has no continue-on-error) on an otherwise-green PR.
+      # 3.12 is the shipped floor in pyproject's requires-python, so it is the leg
+      # whose number to publish.
       - name: Coverage report
         uses: orgoro/coverage@v3.3
-        if: always() && github.event_name == 'pull_request'
+        if: >-
+          always() && github.event_name == 'pull_request'
+          && matrix.python-version == '3.12'
         with:
           coverageFile: apps/scoreboard/coverage.xml
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/tasks/2026-08-04-OME-750-scoreboard-python-matrix.md
+++ b/docs/tasks/2026-08-04-OME-750-scoreboard-python-matrix.md
@@ -1,0 +1,19 @@
+---
+id: OME-750
+linear_url: https://linear.app/openmined/issue/OME-750/scoreboard-ships-python-313-but-tests-only-312
+status: in_progress
+type: task
+priority: P2
+labels: [scoreboard, agentic, autonomous, task]
+created: 2026-08-04
+closed:
+---
+
+`OME-747` moved `apps/scoreboard/Dockerfile` to Python 3.13 on both build stages, but
+`scoreboard-tests.yml` still pins a scalar `python-version: "3.12"` (no matrix) — so
+scoreboard now ships an interpreter version its CI never tests, unlike aigateway and
+url4-cloud which both run a `["3.12", "3.13"]` matrix. Found by the `OME-749` ignore
+audit's `ci_matrix` probe.
+
+Fix: extend `scoreboard-tests.yml`'s `test` job to the same `["3.12", "3.13"]` matrix
+shape as its siblings.

--- a/docs/work/2026-08-06-OME-750-scoreboard-python-matrix.md
+++ b/docs/work/2026-08-06-OME-750-scoreboard-python-matrix.md
@@ -54,7 +54,9 @@ the corrected matrix, per the ticket's own explicit Verify section.
   added `strategy.matrix.python-version: ["3.12", "3.13"]` to the `test` job and pointed
   `actions/setup-python` at `${{ matrix.python-version }}`, mirroring
   `aigateway-tests.yml`'s pattern verbatim (+4/−1 lines).
-- **Commits:** none yet — pending explicit go-ahead to commit.
+- **Commits:** `b80f73e1` ci(scoreboard): test the Python 3.13 interpreter it already ships ·
+  `e596e2c4` ci(scoreboard): name the reporter per matrix leg, publish coverage once.
+  Opened as [#516](https://github.com/OpenMined/screamingface/pull/516); CI green.
 - **Gates:** `uv run --python 3.12 .claude/scripts/run_gates.py scoreboard --base
   origin/main --skip-append-only` → ALL GATES GREEN. Re-ran the same suite under
   `--python 3.13` (fresh `.venv`, no cached 3.12 artifacts) → ALL GATES GREEN — this is

--- a/docs/work/2026-08-06-OME-750-scoreboard-python-matrix.md
+++ b/docs/work/2026-08-06-OME-750-scoreboard-python-matrix.md
@@ -1,0 +1,72 @@
+---
+ticket: OME-750
+stack: scoreboard
+status: done
+started: 2026-08-06
+finished: 2026-08-06
+---
+
+# OME-750 — scoreboard ships Python 3.13 but tests only 3.12
+
+## Intent
+
+`OME-747` moved `apps/scoreboard/Dockerfile` to Python 3.13 on both build stages,
+generalizing "every Python matrix in the repo runs 3.12/3.13" from aigateway and
+url4-cloud without checking scoreboard, whose `scoreboard-tests.yml` pins a scalar
+`python-version: "3.12"` — no matrix. Scoreboard now ships an interpreter its CI never
+tests. Fix: extend the workflow to the same `["3.12", "3.13"]` matrix shape as its
+siblings, so the shipped interpreter is actually exercised.
+
+This is a CI/workflow config change, not application code — no new product behavior,
+so there is no new `apps/scoreboard/tests/**` unit test to write (per sdlc-python's own
+TDD framing, there is no failing pytest case a YAML matrix change would "demand").
+Verification instead is: (a) the scoreboard suite actually passes when run under both
+3.12 and 3.13 locally, and (b) the `OME-749` audit script's `ci_matrix` probe reports
+the corrected matrix, per the ticket's own explicit Verify section.
+
+## Planned changes
+
+- `.github/workflows/scoreboard-tests.yml` — add `strategy: matrix: python-version:
+  ["3.12", "3.13"]` to the `test` job, and point `actions/setup-python`'s
+  `python-version` at `${{ matrix.python-version }}`, mirroring
+  `.github/workflows/aigateway-tests.yml` exactly.
+
+## Test plan
+
+- No new pytest test (declarative CI config, no new application behavior).
+- Run `uv run pytest` (+ruff+pyright, i.e. the full scoreboard gate suite) under both
+  Python 3.12 and 3.13 locally to prove the shipped interpreter is actually green, not
+  just declared.
+- Run `uv run .claude/scripts/audit_dependabot_ignores.py` and confirm its detail line
+  for the scoreboard `python >=3.14` entry now reads
+  `scoreboard-tests.yml python-version = ['3.12', '3.13']`.
+
+## Acceptance
+
+- `scoreboard-tests.yml`'s `test` job runs a `["3.12", "3.13"]` matrix.
+- The scoreboard gate suite (ruff/pyright/pytest ≥80% cov) passes under both versions.
+- The audit script's reported matrix values for the scoreboard entry include both
+  `3.12` and `3.13`.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** `.github/workflows/scoreboard-tests.yml` only, exactly as planned —
+  added `strategy.matrix.python-version: ["3.12", "3.13"]` to the `test` job and pointed
+  `actions/setup-python` at `${{ matrix.python-version }}`, mirroring
+  `aigateway-tests.yml`'s pattern verbatim (+4/−1 lines).
+- **Commits:** none yet — pending explicit go-ahead to commit.
+- **Gates:** `uv run --python 3.12 .claude/scripts/run_gates.py scoreboard --base
+  origin/main --skip-append-only` → ALL GATES GREEN. Re-ran the same suite under
+  `--python 3.13` (fresh `.venv`, no cached 3.12 artifacts) → ALL GATES GREEN — this is
+  the substantive proof the ticket asked for (the shipped interpreter is now actually
+  exercised, not just declared). `uv run .claude/scripts/audit_dependabot_ignores.py`
+  now reports `scoreboard-tests.yml python-version = ['3.12', '3.13']` for the
+  scoreboard entry, verbatim match to the ticket's own Verify section. The `python
+  >=3.14` ignore for scoreboard correctly stays "blocking" (unaffected — this fix adds
+  3.13 coverage, not 3.14, by design).
+- **Deviations:** none. No new pytest test was added — this is a declarative CI-config
+  fix with no new application behavior, so there is no failing test case it could have
+  demanded; verification is the dual-interpreter gate run + the audit probe above,
+  matching the ticket's own explicit Verify section rather than an invented unit test.
+  `--skip-append-only` used only because the flag is orthogonal to this change (no test
+  files touched at all); not a weakening of that gate.

--- a/docs/work/2026-08-06-OME-750-scoreboard-python-matrix.md
+++ b/docs/work/2026-08-06-OME-750-scoreboard-python-matrix.md
@@ -70,3 +70,27 @@ the corrected matrix, per the ticket's own explicit Verify section.
   matching the ticket's own explicit Verify section rather than an invented unit test.
   `--skip-append-only` used only because the flag is orthogonal to this change (no test
   files touched at all); not a weakening of that gate.
+
+## Review pass (2026-08-14) — three findings, all valid
+
+| Finding | Fix |
+|---|---|
+| `dorny/test-reporter` name is static while the job is a 2-leg matrix | interpolate `(${{ matrix.python-version }})` |
+| the coverage step runs once per leg, so twice concurrently on a PR | guard to the 3.12 leg |
+| the `audit_dependabot_ignores.py` AIDEV-NOTE cites scoreboard as *the* scalar case | re-pointed |
+
+**The reporter name mattered more than it looks:** both legs published identically-named check runs,
+so a 3.13-only failure was indistinguishable from the passing 3.12 report — which defeats the entire
+point of adding the 3.13 leg. Both sibling workflows the PR claims to match "exactly" already
+interpolate the version; this one didn't.
+
+**The coverage step** had no `continue-on-error`, so two concurrent runs risk a create/update race
+failing the step on an otherwise-green PR, on top of duplicate comments. Guarded to 3.12 — the
+shipped floor in `requires-python`, so it is the leg whose number to publish.
+
+**The stale note is a case of this PR invalidating its own justification.** The note explained why the
+scalar branch exists by naming scoreboard as the scalar case — and this PR is what gave scoreboard a
+list. Verified the branch is still needed before re-pointing rather than deleting: `charts.yml:59`,
+`url4-tests.yml:113` and `url4-cloud-tests.yml:102` all still pin a scalar.
+
+**Gates:** all green.


### PR DESCRIPTION
## Summary
- `apps/scoreboard/Dockerfile` (OME-747) ships Python 3.13 on both build stages, but `scoreboard-tests.yml` pinned a scalar `python-version: "3.12"` — no matrix — so the shipped interpreter was never exercised by CI.
- Extends the `test` job to a `["3.12", "3.13"]` matrix, matching `aigateway-tests.yml` and `url4-cloud-tests.yml`'s existing pattern exactly.
- Found by the `OME-749` dependabot-ignore audit's `ci_matrix` probe (itself a mistake introduced by `OME-747`, which generalized "every Python matrix runs 3.12/3.13" from aigateway/url4-cloud without checking scoreboard).

## Test plan
- [x] Full scoreboard gate suite (ruff, ruff format, pyright, pytest ≥80% cov) green under Python 3.12.
- [x] Same suite, fresh venv, green under Python 3.13 — the substantive check this ticket exists for.
- [x] `uv run .claude/scripts/audit_dependabot_ignores.py` now reports `scoreboard-tests.yml python-version = ['3.12', '3.13']` for the scoreboard entry, matching the ticket's own Verify section verbatim. The unrelated `python >=3.14` ignore correctly stays "blocking" (unaffected by this fix, by design).
- No new pytest test: this is a declarative CI-config change with no new application behavior, so there was no failing test case to write first.

Refs: OME-750