### PR TITLE
feat(url4): per-run cache policy for the aigateway global response cache

### DIFF
--- a/apps/url4-cloud/README.md
+++ b/apps/url4-cloud/README.md
@@ -147,3 +147,60 @@ caller's identity and aigateway decides, including whether an absent identity is
   `config.aigatewayBaseUrl`. Unset ⇒ the endpoint answers `503`; everything else is a code default
   (see the `models_cache_*` fields in `config.py`).
 - Cache behaviour is observable at `/metrics` (`url4_cloud_catalog_*`).
+
+## Per-run cache policy
+
+A different cache from the one above: aigateway's **response** cache, which answers an identical
+model call from a stored corpus instead of dispatching it to the provider again. Design:
+`docs/spec/2026-08-05-url4-cache-policy-spec.md`.
+
+**Caching is ON by default.** Only declining is explicit — the gateway participates unless told
+not to, so a switch that "turns caching off" is the only switch there is. Two carriers, one
+meaning, scoped to the **whole run** (every leaf, every fan-out branch — per-node intent would
+need url4 grammar and is out of scope):
+
+```sh
+# HTTP — the standard RFC 9111 request field on GET /
+curl -H 'URL4-Capability: <jwt>' -H 'Cache-Control: no-store' 'http://localhost:9108/?q=...'
+```
+
+```json
+{"type": "ai.url4.attach", "data": {"from_sequence": 1, "cache": {"participate": false}}}
+```
+
+| directive | effect |
+| --- | --- |
+| *(absent)* | participate — the default |
+| `no-store`, `no-cache` | do not participate |
+| `max-age=<seconds>` | participate under a freshness bound (see **Known-inert** below) |
+| `url4-use-cache` | participate, explicitly — the token that lets the header override a frame opt-out |
+
+Conflicting directives resolve to **not** participating: the worst case of declining is a missed
+hit, while the worst case of participating against a caller who refused is a shared answer they
+explicitly declined. Unknown and malformed directives are **ignored, never 4xx** — a cache
+directive is a hint about cost, not a term of the request.
+
+**Precedence: the header wins**, and the overridden declaration is announced as a `warn`
+`ai.url4.log` on the stream. **First attach wins** on the frame side: a re-attach with a different
+policy leaves the run's policy alone (calls may already have run under it) and warns.
+
+> **INVARIANT — url4 never sends a cache control key other than `use-cache`.** aigateway's cache
+> grammar is CLOSED to that one field, and any other key inside the request body's `cache` object
+> makes the whole request **bypass** the cache — silently, with nothing raised anywhere, even
+> alongside a valid `use-cache: true`. So every directive above collapses to participate/opt-out
+> at url4's own edge (`rest/cache_header.py` → intent, `runner/cache.py` → the wire), and a run
+> that participates sends **no `cache` field at all**. `tests/unit/test_runner_cache_body_field.py`
+> pins it as a property over every input.
+
+**Observability.** Each span carries `cache_status` (`hit`/`miss`/`bypass`) and `cache_reason` —
+the gateway's vocabulary verbatim, so `opted_out` stays distinct from `unsupported_control`. The
+run publishes one summary `ai.url4.log` with its hit, miss and **bypass-by-reason** totals
+(`runner/cache_counters.py`). Not Prometheus: a run is a one-shot Job with no scrape endpoint, and
+the layering gate keeps `url4_cloud.runner.*` out of `url4_cloud.metrics` anyway. **No counter is
+labelled by cache key, prompt or credential** — the gateway's entry key is parsed and stops at
+`runner/cache_readback.py`.
+
+**Known-inert: `max-age`.** The bound is parsed and preserved end to end, but the gateway today
+neither accepts a freshness bound nor reports an entry's `Age`, so a bounded run cannot prove a
+hit fresh and declines instead — observably, as `bypass` / `opted_out`. The honouring path is
+written and dormant; when either upstream half lands, the change is a branch, not a redesign.

--- a/apps/url4-cloud/src/url4_cloud/adapters/inprocess.py
+++ b/apps/url4-cloud/src/url4_cloud/adapters/inprocess.py
@@ -23,6 +23,7 @@ from url4.streaming.interfaces import (
     job_name,
 )
 from url4.streaming.lifecycle import run as lifecycle_run
+from url4.streaming.protocol import CachePolicy
 from url4.streaming.trace import valid_traceparent
 from url4_cloud import job_env
 from url4_cloud.ports import IdentityAwareJobRunner
@@ -128,6 +129,7 @@ class InProcessJobRunner(IdentityAwareJobRunner):
         traceparent: str | None,
         profile: str | None,
         identity: Mapping[str, str] | None = None,
+        cache: CachePolicy | None = None,
     ) -> dict[str, str]:
         """The environment this run's `Executor` is built from.
 
@@ -156,6 +158,13 @@ class InProcessJobRunner(IdentityAwareJobRunner):
         for name in job_env.IDENTITY_HEADER_ENV.values():
             env.pop(name, None)
         env.update(job_env.identity_to_env(identity or {}))
+        # INVARIANT: same reset, and the sharpest case for it. `_base_env` is one dict shared by
+        # every local run, so a leftover `participate=true` would let a run that explicitly opted
+        # out be served a stored answer it refused — the exact silent, chargeable failure this
+        # whole design exists to prevent. Cleared unconditionally, then re-stated from THIS run.
+        for name in (job_env.CACHE_PARTICIPATE, job_env.CACHE_MAX_AGE_S):
+            env.pop(name, None)
+        env.update(job_env.cache_policy_to_env(cache))
         return env
 
     # --- the JobRunner port -----------------------------------------------------------------
@@ -170,6 +179,7 @@ class InProcessJobRunner(IdentityAwareJobRunner):
         credential: str | None = None,
         profile: str | None = None,
         identity: Mapping[str, str] | None = None,
+        cache: CachePolicy | None = None,
     ) -> str:
         """Spawn the run as a task and return its job name.
 
@@ -183,7 +193,7 @@ class InProcessJobRunner(IdentityAwareJobRunner):
         existing = self._tasks.get(name)
         if existing is not None and not existing.done():
             raise JobAlreadyExists(name)
-        env = self._env(topic, url4, deadline_s, traceparent, profile, identity)
+        env = self._env(topic, url4, deadline_s, traceparent, profile, identity, cache)
         # WHY build the Executor here but resolve its world lazily (inside `execute`): a factory
         # that raised now would take down the caller's request with nothing on the stream, where a
         # failure inside the run terminates the topic properly. See `Url4Executor._resolve_world`.

--- a/apps/url4-cloud/src/url4_cloud/adapters/k8s.py
+++ b/apps/url4-cloud/src/url4_cloud/adapters/k8s.py
@@ -15,6 +15,7 @@ from typing import Protocol
 from kubernetes.client import ApiException
 
 from url4.streaming.interfaces import JobAlreadyExists, JobStatus, job_name
+from url4.streaming.protocol import CachePolicy
 from url4.streaming.trace import valid_traceparent
 from url4_cloud import job_env
 from url4_cloud.ports import IdentityAwareJobRunner
@@ -143,6 +144,7 @@ class K8sJobRunner(IdentityAwareJobRunner):
         credential: str | None = None,
         profile: str | None = None,
         identity: Mapping[str, str] | None = None,
+        cache: CachePolicy | None = None,
     ) -> str:
         """Creates the Job.
 
@@ -161,6 +163,7 @@ class K8sJobRunner(IdentityAwareJobRunner):
             traceparent=traceparent,
             profile=profile,
             identity=identity,
+            cache=cache,
         )
 
     def _schedule_blocking(
@@ -172,12 +175,15 @@ class K8sJobRunner(IdentityAwareJobRunner):
         traceparent: str | None = None,
         profile: str | None = None,
         identity: Mapping[str, str] | None = None,
+        cache: CachePolicy | None = None,
     ) -> str:
         name = job_name(topic)
         try:
             self._client.create_namespaced_job(
                 self._namespace,
-                self._manifest(name, topic, url4, deadline_s, traceparent, profile, identity),
+                self._manifest(
+                    name, topic, url4, deadline_s, traceparent, profile, identity, cache
+                ),
                 _request_timeout=self._request_timeout_s,
             )
         except ApiException as exc:
@@ -240,6 +246,7 @@ class K8sJobRunner(IdentityAwareJobRunner):
         traceparent: str | None,
         profile: str | None = None,
         identity: Mapping[str, str] | None = None,
+        cache: CachePolicy | None = None,
     ) -> list[dict[str, object]]:
         # INVARIANT: PER-RUN values only. Everything constant for a deployment (the NATS URL, the
         # aigateway base URL and model, the Tavily key) arrives through `envFrom` — Helm owns both
@@ -265,6 +272,14 @@ class K8sJobRunner(IdentityAwareJobRunner):
             {"name": name, "value": value}
             for name, value in job_env.identity_to_env(identity or {}).items()
         )
+        # Plain `value` again, and for a plainer reason: a cache directive names nothing about the
+        # caller and authorizes nothing — it says only whether this run may reuse a stored answer.
+        # A run that declared nothing writes nothing, so a Job spec still shows exactly what was
+        # decided rather than the default restated.
+        env.extend(
+            {"name": name, "value": value}
+            for name, value in job_env.cache_policy_to_env(cache).items()
+        )
         return env
 
     def _env_from(self) -> list[dict[str, object]]:
@@ -289,6 +304,7 @@ class K8sJobRunner(IdentityAwareJobRunner):
         traceparent: str | None = None,
         profile: str | None = None,
         identity: Mapping[str, str] | None = None,
+        cache: CachePolicy | None = None,
     ) -> dict[str, object]:
         """Builds the Job manifest: a hardened, single-attempt Pod (no restarts, no privilege
         escalation, non-root, read-only rootfs) running `self._command` with per-run env layered
@@ -297,7 +313,7 @@ class K8sJobRunner(IdentityAwareJobRunner):
             "name": "runner",
             "image": self._image,
             "command": self._command,
-            "env": self._env(topic, url4, deadline_s, traceparent, profile, identity),
+            "env": self._env(topic, url4, deadline_s, traceparent, profile, identity, cache),
             "securityContext": {
                 "allowPrivilegeEscalation": False,
                 "capabilities": {"drop": ["ALL"]},

--- a/apps/url4-cloud/src/url4_cloud/job_env.py
+++ b/apps/url4-cloud/src/url4_cloud/job_env.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 from collections.abc import Mapping
 from types import MappingProxyType
 
+from url4.streaming.protocol import CachePolicy
+
 # --- per-run: written by the App onto the Job spec -------------------------------------------
 TOPIC = "URL4_CLOUD_TOPIC"
 EXPRESSION = "URL4_CLOUD_EXPRESSION"
@@ -99,6 +101,74 @@ def identity_from_env(env: Mapping[str, str]) -> dict[str, str]:
     }
 
 
+CACHE_PARTICIPATE = "URL4_CLOUD_CACHE_PARTICIPATE"
+"""Whether this run may participate in the gateway's response cache — `"true"` / `"false"`.
+
+Per-run for the same reason ``AIGATEWAY_PROFILE`` is: it does not exist until a caller states it,
+so Helm cannot supply it and the App must. INVARIANT: it is written per RUN and never onto shared
+world configuration — the run mode's ``AigatewayConfig`` describes the gateway for every run in the
+process, and a per-run value parked there is one caller's directive another caller's run can read.
+
+Absent means the App stated nothing, which the run mode carries through as "not stated" rather
+than resolving: the D1 default belongs to convergence (:mod:`url4_cloud.rest.cache_policy`) and is
+decided exactly once, there.
+"""
+
+CACHE_MAX_AGE_S = "URL4_CLOUD_CACHE_MAX_AGE_S"
+"""The caller's freshness bound in whole seconds, when they stated one.
+
+url4-INTERNAL: it is never sent to the gateway, whose cache-control grammar is closed to a single
+key and BYPASSES on any other. It travels only so the value survives to read-back, where an entry's
+age can be compared against it.
+"""
+
+_TRUE, _FALSE = "true", "false"
+
+
+def cache_policy_to_env(policy: CachePolicy | None) -> dict[str, str]:
+    """Render a run's cache policy as the Job env keys that carry it.
+
+    Args:
+        policy: The run's RESOLVED policy, or ``None`` when this hop was told nothing — a Job
+            scheduled directly rather than through the REST edge. ``None`` renders NOTHING, so an
+            unstated policy stays distinguishable from a stated one all the way down.
+
+    Returns:
+        Only the fields the policy actually states. A `None` field is silence, and rendering it as
+        a literal would turn "nobody said" into "somebody said the default".
+    """
+    if policy is None:
+        return {}
+    env: dict[str, str] = {}
+    if policy.participate is not None:
+        env[CACHE_PARTICIPATE] = _TRUE if policy.participate else _FALSE
+    if policy.max_age is not None:
+        env[CACHE_MAX_AGE_S] = str(policy.max_age)
+    return env
+
+
+def cache_policy_from_env(env: Mapping[str, str]) -> CachePolicy:
+    """Read a run's cache policy back out of its environment. Total — it never raises.
+
+    Returns a policy rather than ``CachePolicy | None`` because an all-unstated policy already IS
+    "nothing declared": :func:`url4_cloud.runner.cache.policy_to_body_field` renders it as an absent
+    `cache` field, which the gateway reads as participation. So a Job whose env carries no policy
+    behaves like every other one WITHOUT the run mode re-deciding what silence means.
+
+    An unreadable ``CACHE_PARTICIPATE`` resolves to **opt out**, not to silence. This env is
+    App-written, so an unrecognised value is a bug rather than caller input, and of the two wrong
+    answers the cheap one — a missed hit — is the one to take: the expensive one serves a run a
+    shared, permanent answer it may have explicitly refused. An unreadable bound is simply dropped;
+    it is advisory and cannot be got wrong in a direction that costs anything.
+    """
+    raw_participate = env.get(CACHE_PARTICIPATE)
+    raw_max_age = env.get(CACHE_MAX_AGE_S)
+    return CachePolicy(
+        participate=None if raw_participate is None else raw_participate.strip().lower() == _TRUE,
+        max_age=int(raw_max_age) if raw_max_age is not None and raw_max_age.isdigit() else None,
+    )
+
+
 # --- per-deploy: named by the chart, injected via envFrom ------------------------------------
 NATS_URL = "URL4_CLOUD_NATS_URL"
 AIGATEWAY_BASE_URL = "AIGATEWAY_BASE_URL"
@@ -142,6 +212,8 @@ WRITTEN_BY_APP = frozenset(
         JOB_DEADLINE_S,
         TRACEPARENT,
         AIGATEWAY_PROFILE,
+        CACHE_PARTICIPATE,
+        CACHE_MAX_AGE_S,
         *IDENTITY_HEADER_ENV.values(),
     }
 )
@@ -157,6 +229,8 @@ __all__ = [
     "AIGATEWAY_BASE_URL",
     "AIGATEWAY_MODEL",
     "AIGATEWAY_PROFILE",
+    "CACHE_MAX_AGE_S",
+    "CACHE_PARTICIPATE",
     "DEFAULT_NATS_URL",
     "DEPLOY_TIME",
     "EXPRESSION",
@@ -170,6 +244,8 @@ __all__ = [
     "TOPIC",
     "TRACEPARENT",
     "WRITTEN_BY_APP",
+    "cache_policy_from_env",
+    "cache_policy_to_env",
     "identity_from_env",
     "identity_from_headers",
     "identity_to_env",

--- a/apps/url4-cloud/src/url4_cloud/notices.py
+++ b/apps/url4-cloud/src/url4_cloud/notices.py
@@ -1,0 +1,59 @@
+"""Advisory frames the control plane says to an attached client about its own run.
+
+A notice is not a nack and not an error: the request it comments on was accepted and is being
+honoured. It exists because something the caller stated was DROPPED — a re-attach's cache policy
+that first-attach-wins ignored, a frame declaration that the request header overrode — and a
+dropped declaration nobody is told about is indistinguishable from a bug in the gateway.
+
+TWO EMITTERS, ONE VOICE. The WS bridge raises the first case and the REST route the second, and
+they are asking the client to answer the same question — *what did I ask for, and what actually
+applies?* — so the frame and its attribute names are built here rather than twice. A client that
+had to learn two spellings of "cache.effective" depending on which carrier lost would be reading
+the noise, not the signal.
+
+WHY THIS IS A SHARED LEAF (`.claude/scripts/check_layering.py`): it names the wire protocol and
+nothing else — no FastAPI, no broker, no engine — so it belongs to neither half of the
+distribution and couples nothing to either. Its importers today are both control-plane modules;
+that is a fact about who needs it, not about what it depends on.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime
+from uuid import uuid4
+
+from url4.streaming.protocol import CachePolicy, LogData, LogEvent, source_for
+
+Clock = Callable[[], datetime]
+
+LogAttributes = dict[str, str | int | float | bool | None]
+
+NOT_STATED = "not stated"
+"""How an absent policy renders as a log attribute.
+
+Its own token rather than an empty object, because "did not declare" and "declared an all-unset
+policy" are different statements — and a notice that collapsed them could not answer why a
+declaration was refused."""
+
+
+def warn(topic: str, clock: Clock, message: str, attributes: LogAttributes) -> LogEvent:
+    """Build a ``warn`` ``LogEvent`` for ``topic``'s attached client — advisory, never a nack.
+
+    ``LogData.at`` derives the OTel SeverityNumber from the level, so the pair cannot disagree.
+    """
+    return LogEvent(
+        id=uuid4().hex,
+        source=source_for(topic),
+        subject=topic,
+        time=clock(),
+        data=LogData.at("WARN", message, attributes),
+    )
+
+
+def rendered(policy: CachePolicy | None) -> str:
+    """A cache intent as a log-attribute value; :data:`NOT_STATED` when there is none."""
+    return NOT_STATED if policy is None else policy.model_dump_json(exclude_none=True)
+
+
+__all__ = ["NOT_STATED", "Clock", "LogAttributes", "rendered", "warn"]

--- a/apps/url4-cloud/src/url4_cloud/ports.py
+++ b/apps/url4-cloud/src/url4_cloud/ports.py
@@ -20,10 +20,12 @@ from abc import abstractmethod
 from collections.abc import Mapping
 
 from url4.streaming.interfaces import JobRunner
+from url4.streaming.protocol import CachePolicy
 
 
 class IdentityAwareJobRunner(JobRunner):
-    """A :class:`JobRunner` whose ``schedule`` also carries the caller's verified identity.
+    """A :class:`JobRunner` whose ``schedule`` also carries the caller's verified identity and the
+    run's cache policy.
 
     ``identity`` is canonical header name → value, exactly as
     :func:`url4_cloud.job_env.identity_from_headers` produces it. An adapter serializes it onto the
@@ -34,6 +36,17 @@ class IdentityAwareJobRunner(JobRunner):
     calls aigateway are different processes, and the outgoing request does not exist yet when the
     headers arrive. Identity has to be captured, serialized, and re-rendered — the same path
     ``credential`` and ``profile`` already take.
+
+    ``cache`` takes that same path for the same reason, and is declared HERE rather than on the
+    engine's port for the same one again: whether a run participates in some GATEWAY's response
+    cache is this app's deployment concern, not a term of the url4 language. It is the run's
+    RESOLVED policy — both carriers have already been reconciled
+    (:mod:`url4_cloud.rest.cache_policy`) — or ``None`` when the caller of this port stated
+    nothing at all, which stays distinguishable from an explicit opt-out all the way down.
+
+    INVARIANT: per RUN. It must never be folded into world configuration shared by every run in a
+    process — in local mode those runs share one event loop, so a policy parked there is one
+    caller's directive that another caller's run reads.
     """
 
     @abstractmethod
@@ -47,4 +60,5 @@ class IdentityAwareJobRunner(JobRunner):
         credential: str | None = None,
         profile: str | None = None,
         identity: Mapping[str, str] | None = None,
+        cache: CachePolicy | None = None,
     ) -> str: ...

--- a/apps/url4-cloud/src/url4_cloud/rest/cache_header.py
+++ b/apps/url4-cloud/src/url4_cloud/rest/cache_header.py
@@ -1,0 +1,156 @@
+"""Parse the request ``Cache-Control`` field into a run's cache INTENT (spec §5.1, D6).
+
+`Cache-Control` is the standard field and it was chosen deliberately over a private
+`URL4-Cache`: RFC 9111 already defines `no-store` / `no-cache` / `max-age` as *request*
+directives with exactly the meaning wanted here, and D6 accepts the consequence that an
+intermediary — Envoy, a CDN, a browser's hard-refresh — may both read it and add to it. That is
+what the field means; a standard header intermediaries are asked to ignore would be the worst of
+both.
+
+**Every directive collapses to participate / opt-out AT THIS EDGE. None is forwarded verbatim.**
+That is not a convenience, it is the correctness boundary: aigateway v2's cache-control grammar
+is CLOSED to a single key, `use-cache`, and any other key inside the request body's `cache`
+object makes the whole request BYPASS the cache — silently, with nothing raised anywhere (spec
+§1.0). Forwarding `no-store` as itself would opt the caller out for the *wrong* reason
+(`unsupported_control` rather than the honest `opted_out`), and forwarding `max-age` would lose
+caching altogether. So this module speaks HTTP and returns intent; `runner/cache.py` is the only
+place that speaks the gateway's wire vocabulary.
+
+TWO GUARANTEES this module owes every caller:
+
+1. **It never raises.** The field is caller- and proxy-controlled; a cache directive is a hint
+   about cost, not a term of the request, so failing a whole ensemble run over a malformed one
+   trades a free missed hit for a dead run. Garbage is ignored.
+2. **It never invents intent.** Undecipherable input returns ``None`` — *not stated* — which
+   resolves to the ON default at convergence. Returning a default-constructed policy instead
+   would let a malformed header shadow a perfectly good declaration on the WS attach frame.
+
+``max-age`` is the one directive **preserved rather than collapsed** (D11, spec §3.5): url4 can
+today neither ask the gateway for a freshness bound nor read an entry's age, so the directive
+degrades to an opt-out at read-back — but the value survives this edge, so the day either
+upstream blocker lifts the change is a branch, not a redesign.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from url4.streaming.protocol import CachePolicy
+
+_OPT_OUT_DIRECTIVES = frozenset({"no-store", "no-cache"})
+"""Both mean "do not use the cache" once they reach v2, which has no read-only/write-only lane:
+`no-cache` ("don't serve me a stored answer") can only be honoured by not participating at all.
+Mapping it to anything else would be a promise the upstream cannot keep."""
+
+_OPT_IN_DIRECTIVE = "url4-use-cache"
+"""An extension token, url4-owned — RFC 9111 provides no *request* directive meaning "you may
+serve me a stored answer", because that is HTTP's default and it is ours too (D1). It exists so a
+caller can state participation rather than merely fail to forbid it, which is what lets the header
+carrier override an opt-out declared on the attach frame."""
+
+_MAX_AGE_DIRECTIVE = "max-age"
+
+
+@dataclass(frozen=True)
+class _Declared:
+    """What one field-value actually said, before it is turned into a policy."""
+
+    opt_out: bool
+    opt_in: bool
+    max_age: int | None
+
+    @property
+    def states_participation(self) -> bool:
+        """Whether anything asked to participate. `is not None` and not truthiness: `max-age=0`
+        is the strictest bound a caller can state, and dropping it for being falsy would turn the
+        strictest request into silence — and silence into the ON default."""
+        return self.opt_in or self.max_age is not None
+
+
+def parse_cache_control(raw: str | None) -> CachePolicy | None:
+    """The run's declared cache intent, or ``None`` when the field stated nothing.
+
+    Args:
+        raw: The inbound ``Cache-Control`` field value, or ``None`` when the header is absent.
+
+    Returns:
+        ``CachePolicy(participate=False)`` when any opt-out directive appears — conflicts resolve
+        to the safe side, because the worst case of opting out is a missed hit while the worst
+        case of participating against a caller who refused is a stale or shared answer they
+        explicitly declined. ``CachePolicy(participate=True, max_age=…)`` when something asked to
+        participate. ``None`` when nothing decipherable was said, so the default applies.
+
+        A returned policy carries ``max_age`` only alongside ``participate=True``: a freshness
+        bound on a run that does not participate is meaningless, and carrying it would invent an
+        "opted out, but only for 60s" state nothing downstream can act on.
+    """
+    if not raw:
+        return None
+    declared = _scan(raw)
+    # Checked FIRST, so an opt-out anywhere in the list wins over anything else in it and the
+    # outcome cannot depend on the order an intermediary happened to concatenate members in.
+    if declared.opt_out:
+        return CachePolicy(participate=False)
+    return (
+        CachePolicy(participate=True, max_age=declared.max_age)
+        if declared.states_participation
+        else None
+    )
+
+
+def _scan(raw: str) -> _Declared:
+    """Fold the field's list members into what they collectively declared.
+
+    Unknown members are dropped without disturbing known ones — `Cache-Control` is an open
+    vocabulary that intermediaries legitimately add to, so an unrecognised member is ordinary
+    traffic rather than an error. `only-if-cached` lands here on purpose (spec §8.3): honouring
+    it would require a 504 when nothing is cached, and a url4 run fans out to many gateway calls,
+    so one uncached leaf would kill an entire ensemble.
+    """
+    opt_out = False
+    opt_in = False
+    max_age: int | None = None
+    for member in raw.split(","):
+        name, _, value = member.partition("=")
+        # Lower-cased because directive names are case-insensitive — the same normalisation
+        # `_parse_prefer` already applies. A client that upper-cases would otherwise have its
+        # opt-out silently dropped, which is the exact failure mode this design exists to avoid.
+        key = name.strip().lower()
+        if key in _OPT_OUT_DIRECTIVES:
+            opt_out = True
+        elif key == _OPT_IN_DIRECTIVE:
+            opt_in = True
+        elif key == _MAX_AGE_DIRECTIVE:
+            max_age = _tighter(max_age, _delta_seconds(value))
+    return _Declared(opt_out=opt_out, opt_in=opt_in, max_age=max_age)
+
+
+def _delta_seconds(value: str) -> int | None:
+    """A directive's argument as non-negative whole seconds, or ``None`` if it is not one.
+
+    The argument may be written as a quoted-string, so the quotes are stripped before parsing.
+    Anything else — empty, fractional, negative, non-numeric — makes the *directive* unusable
+    rather than the field, so it is dropped and its neighbours are honoured unchanged.
+    """
+    try:
+        seconds = int(value.strip().strip('"'))
+    except ValueError:
+        return None
+    return seconds if seconds >= 0 else None
+
+
+def _tighter(current: int | None, candidate: int | None) -> int | None:
+    """The stricter of two bounds, treating ``None`` as "no bound stated".
+
+    A repeated `max-age` is a conflict like any other and resolves conservatively: the smaller
+    bound admits fewer stale answers. First-wins or last-wins would let a duplicate appended by
+    an intermediary LOOSEN what the caller asked for.
+    """
+    if candidate is None:
+        return current
+    if current is None:
+        return candidate
+    return min(current, candidate)
+
+
+__all__ = ["parse_cache_control"]

--- a/apps/url4-cloud/src/url4_cloud/rest/cache_policy.py
+++ b/apps/url4-cloud/src/url4_cloud/rest/cache_policy.py
@@ -1,0 +1,109 @@
+"""Converge the run's two cache carriers into ONE effective policy (spec §5.3, D4).
+
+A run can be configured twice — on the WS attach frame, and on the ``GET /`` that starts it — and
+the gateway must be told exactly one thing. Everything downstream of this module takes a RESOLVED
+policy, which is what lets ``runner/cache.py`` stay a dumb translation: "what does saying nothing
+mean?" is answered here, once, and nowhere else.
+
+THE PRECEDENCE RULE — the header wins a genuine disagreement (D4(a)). Attach necessarily happens
+first (``_require_subscriber`` refuses to start a run with nothing attached), so the GET is the
+LATER, run-scoped statement and last-writer-wins matches causal order. The alternatives were
+weighed and rejected: frame-wins inverts that order and will surprise, and treating a conflict as
+fatal kills an entire ensemble run over a directive about cost.
+
+**A disagreement is never silent.** The loser is carried out of here on the resolution so the
+caller can name it in a warning — a client that stated two things must be able to learn WHICH one
+lost, and a resolution that only flagged "there was a conflict" could not tell it.
+
+THE DEFAULT LIVES HERE — silence on both carriers is participation (D1). Deliberately not spread
+across the parsers: both of them return ``None`` for "not stated" precisely so that the one place
+that turns silence into a decision is this one. Were the header parser to default instead, a
+malformed header would shadow a perfectly good frame declaration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from url4.streaming.protocol import CachePolicy
+
+
+def default_policy() -> CachePolicy:
+    """The D1 default: a run nobody spoke for participates in the gateway's response cache.
+
+    Built fresh per call rather than shared as a module constant. A pydantic model is mutable, so
+    one shared instance handed to every run is state two concurrent runs could contaminate each
+    other through — at the one seam where a wrong value costs money silently.
+    """
+    return CachePolicy(participate=True)
+
+
+@dataclass(frozen=True)
+class Resolution:
+    """The run's one policy, plus whatever stating it displaced."""
+
+    effective: CachePolicy
+    """What the run actually executes under. Never ``None`` — convergence always decides."""
+    overridden: CachePolicy | None = None
+    """The frame's declaration, when the header disagreed with it and won; ``None`` otherwise.
+
+    Present so the override can be REPORTED with both halves of the disagreement. It is not an
+    error and nothing acts on it beyond saying so."""
+
+
+def resolve(header: CachePolicy | None, frame: CachePolicy | None) -> Resolution:
+    """Reconcile the two carriers' declarations into the run's effective cache policy.
+
+    Args:
+        header: What ``Cache-Control`` on the ``GET /`` stated, or ``None`` for "not stated".
+        frame: What the WS attach frame declared, or ``None`` for "not stated".
+
+    Returns:
+        A :class:`Resolution` whose ``effective`` policy is the header's when it spoke, the
+        frame's when only it did, and :func:`default_policy` when neither did. ``overridden``
+        names the frame policy the header displaced, and only in that case — one carrier speaking
+        into the other's silence is not a disagreement, and reporting it as one would make an
+        ordinary per-request directive warn on every run that ever attached quietly.
+    """
+    if header is None:
+        stated = frame if frame is not None else default_policy()
+        return Resolution(effective=_degrade_unhonourable_bound(stated))
+    # Equality, not identity, and over the WHOLE policy: two carriers that agree on participation
+    # while disagreeing on the freshness bound are still two different statements, and the one
+    # that applies must be the one the caller is told about.
+    overridden = frame if frame is not None and frame != header else None
+    return Resolution(effective=_degrade_unhonourable_bound(header), overridden=overridden)
+
+
+# Whether the gateway can tell url4 how old a cached answer is. FALSE today: aigateway emits no
+# `Age` (RFC 9111 §5.1) and no `Cache-Status; ttl=` (RFC 9211 §2.4), and its control grammar is
+# closed to `use-cache`, so url4 can neither ask for a bound nor measure one. Raised on PR #507.
+#
+# FLIPPING THIS TO TRUE is the whole of D11's honouring half: `requires_revalidation` and its
+# tests already exist and are correct, they are simply unreachable while this is False.
+GATEWAY_REPORTS_AGE = False
+
+
+def _degrade_unhonourable_bound(policy: CachePolicy) -> CachePolicy:
+    """Collapse a freshness bound the gateway cannot honour into an opt-out (spec §3.5).
+
+    WHY collapse here rather than revalidate on the response: with no age reported, EVERY hit
+    under a bound is unprovable, so honouring it after the fact means a second gateway call and a
+    discarded body on every one — inside `for _ in range(web_tool_max_iterations)`, so a
+    four-iteration tool turn becomes eight calls, multiplied again across a fan-out.
+
+    The accidental case is what settles it. D6 chose the standard `Cache-Control` header
+    specifically so intermediaries may participate, and `max-age=0` is what a browser reload
+    sends. A caller who never thought about caching could otherwise double every gateway call in
+    their run by pressing refresh through a forwarding proxy.
+
+    Opting out costs one call and stores nothing, which is the conservative reading of a caller
+    who asked for bounded staleness and cannot be given it. It is also observable rather than
+    silent: aigateway answers `bypass` with reason `opted_out`.
+    """
+    if policy.max_age is None or GATEWAY_REPORTS_AGE:
+        return policy
+    return policy.model_copy(update={"participate": False})
+
+
+__all__ = ["Resolution", "default_policy", "resolve"]

--- a/apps/url4-cloud/src/url4_cloud/rest/routes.py
+++ b/apps/url4-cloud/src/url4_cloud/rest/routes.py
@@ -9,7 +9,7 @@ first.
 """
 
 import asyncio
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Annotated, Any
@@ -21,9 +21,9 @@ from url4.streaming.interfaces import (
     JobAlreadyExists,
     JobRunnerAtCapacity,
 )
-from url4.streaming.protocol import ResultEvent, TerminatedEvent
+from url4.streaming.protocol import CachePolicy, ResultEvent, TerminatedEvent
 from url4.streaming.trace import valid_traceparent
-from url4_cloud import job_env
+from url4_cloud import job_env, notices
 from url4_cloud.auth import (
     PROBLEM_MEDIA_TYPE,
     JwtCodec,
@@ -33,7 +33,10 @@ from url4_cloud.auth import (
 )
 from url4_cloud.config import Settings
 from url4_cloud.ports import IdentityAwareJobRunner
+from url4_cloud.rest.cache_header import parse_cache_control
+from url4_cloud.rest.cache_policy import resolve
 from url4_cloud.rest.interest import SubscriberGate
+from url4_cloud.rest.sessions import RunSessions
 
 router = APIRouter()
 
@@ -55,6 +58,7 @@ class _Deps:
     stream: EventConsumer
     job_runner: IdentityAwareJobRunner
     interest: SubscriberGate
+    sessions: RunSessions
     settings: Settings
 
 
@@ -72,6 +76,11 @@ def _deps(request: Request) -> _Deps:
         stream=state.stream,
         job_runner=job_runner,
         interest=state.interest,
+        # `registry` and not `interest`: the subscriber gate is a DI seam tests replace with a
+        # fixed answer, while the session state is the real registry the WS transport writes an
+        # attach frame's declaration into. Reading the declaration off a substituted gate would
+        # make the frame carrier disappear the moment a test pinned the 428 behaviour.
+        sessions=state.registry,
         settings=state.settings,
     )
 
@@ -141,11 +150,18 @@ async def _schedule(
     traceparent: str | None = None,
     profile: str | None = None,
     identity: Mapping[str, str] | None = None,
+    cache: CachePolicy,
 ) -> None:
     """Schedule the run on the job runner, or raise 409 if one already exists for ``topic``.
 
     Topics are single-shot: both the pre-check and the runner's own ``JobAlreadyExists`` guard
     against a race collapse into the same 409 problem.
+
+    ``cache`` is the run's RESOLVED cache policy — the one thing both carriers converged on, and
+    required rather than optional so that "nobody decided" cannot reach this hop. It travels
+    beside ``profile`` and ``identity`` because it is the same kind of value: per-RUN, captured at
+    the REST edge, re-rendered onto the aigateway call by the Runner. It is deliberately NOT world
+    config; a per-run value parked on the shared aigateway configuration would leak across runs.
     """
     if await deps.job_runner.exists(topic):
         raise ProblemException(status=409, title="Conflict", detail="a run already exists")
@@ -157,6 +173,7 @@ async def _schedule(
             traceparent=traceparent,
             profile=profile,
             identity=identity,
+            cache=cache,
         )
     except JobAlreadyExists as exc:
         raise ProblemException(status=409, title="Conflict", detail="a run already exists") from exc
@@ -241,6 +258,41 @@ def _terminal_response(terminated: TerminatedEvent, result: ResultEvent | None) 
     raise ProblemException(status=http_status, title=title, detail=detail)
 
 
+_OVERRIDE_WARNING = (
+    "this request's Cache-Control header overrode the cache policy declared on the attach frame"
+)
+
+
+def _converge_cache(
+    deps: _Deps, topic: str, cache_control: str | None, clock: Callable[[], datetime]
+) -> CachePolicy:
+    """The run's one cache policy, and a word to the client when stating it cost them theirs.
+
+    Convergence happens BEFORE the run is scheduled, so the notice is queued ahead of any frame
+    the run itself produces: a client reads "your declaration was overridden" and only then the
+    run that ran under the other policy, rather than having to reinterpret what it already saw.
+
+    The warning names both halves of the disagreement, in the same attribute vocabulary the
+    re-attach warning uses, because the client's question is the same one either way — *what did I
+    ask for, and what actually applies?*
+    """
+    resolution = resolve(parse_cache_control(cache_control), deps.sessions.cache_policy_for(topic))
+    if resolution.overridden is not None:
+        deps.sessions.notify(
+            topic,
+            notices.warn(
+                topic,
+                clock,
+                _OVERRIDE_WARNING,
+                {
+                    "cache.declared": notices.rendered(resolution.overridden),
+                    "cache.effective": notices.rendered(resolution.effective),
+                },
+            ),
+        )
+    return resolution.effective
+
+
 async def _run_sync(deps: _Deps, topic: str, wait_s: float | None) -> Response:
     """Hold the request until the run's terminal frame, or 202-fall-back once the bound elapses.
 
@@ -309,6 +361,16 @@ _PREFER_DESC = (
 )
 
 
+_CACHE_CONTROL_DESC = (
+    "RFC 9111 request cache directives, scoped to this whole run — every leaf and every fan-out "
+    "branch. Omit → the run participates in the gateway's response cache (the default). "
+    "`no-store` / `no-cache` → it does not. `max-age=<seconds>` → participate under a freshness "
+    "bound. `url4-use-cache` → participate, explicitly. Conflicting directives resolve to "
+    "not participating; unknown or malformed ones are ignored — a cache directive never fails a "
+    "run."
+)
+
+
 _START_DESC = (
     "Start the run for the token's topic (spec §5).\n\n"
     "Synchronous (default): hold until the terminal frame (bounded by ``SYNC_MAX_WAIT``) and "
@@ -323,7 +385,11 @@ _START_DESC = (
     "The caller's verified identity header (``X-User-Email``) is read off the inbound request and "
     "carried to the run, which renders it onto its aigateway calls. Envoy strips and re-injects it "
     "after re-verifying Cloudflare Access's assertion, so a client cannot forge it. Absent, the "
-    "run carries no identity and an aigateway in header mode rejects it."
+    "run carries no identity and an aigateway in header mode rejects it.\n\n"
+    "The optional ``Cache-Control`` header declares whether this run may participate in the "
+    "gateway's response cache. It is the standard field, so an intermediary may read and add to "
+    "it; a malformed or unknown directive is ignored rather than refused, because a cache "
+    "directive is a hint about cost and must never fail a run."
 )
 
 
@@ -347,6 +413,16 @@ async def start_run(
         str | None,
         Header(alias="X-Profile", description="Optional aigateway routing profile label."),
     ] = None,
+    # DECLARED HERE, RESOLVED IN `_converge_cache`. The run's cache intent has two carriers — this
+    # header and the WS attach frame — and the header wins when both speak. Reading it into a
+    # policy is therefore not this handler's business alone: `cache_header.parse_cache_control`
+    # turns the field into intent, and convergence reconciles it with the frame's declaration
+    # before the run is scheduled. The parameter lands here so the ingress contract and its
+    # OpenAPI documentation are one thing, not two.
+    cache_control: Annotated[
+        str | None,
+        Header(alias="Cache-Control", description=_CACHE_CONTROL_DESC),
+    ] = None,
 ) -> Response:
     """Require an attached subscriber, then schedule the run for the token's topic, forwarding
     the adopted traceparent and the caller's verified identity; hold for the terminal frame by
@@ -366,6 +442,7 @@ async def start_run(
     # document. `or None`: absent identity is None, the same "nothing to forward" every other
     # optional forwarded value uses — one representation rather than an empty mapping meaning it.
     identity = job_env.identity_from_headers(request.headers) or None
+    clock = getattr(request.app.state, "clock", _default_clock)
     await _schedule(
         deps,
         topic,
@@ -373,6 +450,7 @@ async def start_run(
         traceparent=inbound_traceparent,
         profile=x_profile,
         identity=identity,
+        cache=_converge_cache(deps, topic, cache_control, clock),
     )
     pref = _parse_prefer(prefer or "")
     if pref.respond_async:

--- a/apps/url4-cloud/src/url4_cloud/rest/sessions.py
+++ b/apps/url4-cloud/src/url4_cloud/rest/sessions.py
@@ -1,0 +1,32 @@
+"""The port ``routes.py`` uses to reach a topic's WebSocket session — its declaration, and its ear.
+
+``start_run`` has to reconcile the cache policy declared on the attach frame with the one on its
+own ``Cache-Control`` header (spec §5.3), and then say so when the header overrode the frame. Both
+halves are questions about a session the WebSocket transport owns, so they arrive here as a port
+rather than as an import of ``ws.registry`` — the same shape, and for the same reason, as
+``SubscriberGate`` next door.
+
+The 428 gate is what makes the second half deliverable rather than best-effort: a run cannot be
+scheduled unless a subscriber is already attached, so at the moment an override happens there IS a
+live connection for the topic in this process. The App never publishes to the broker, so this is
+the only route a notice has.
+"""
+
+from typing import Protocol
+
+from url4.streaming.protocol import CachePolicy, OutboundFrame
+
+
+class RunSessions(Protocol):
+    """Port for reading a topic's declared cache intent and reaching whoever declared it."""
+
+    def cache_policy_for(self, topic: str) -> CachePolicy | None:
+        """The intent standing for ``topic``, or ``None`` when no attach frame declared one."""
+        ...
+
+    def notify(self, topic: str, frame: OutboundFrame) -> None:
+        """Offer ``frame`` to every connection attached to ``topic``; a silent no-op if none is."""
+        ...
+
+
+__all__ = ["RunSessions"]

--- a/apps/url4-cloud/src/url4_cloud/runner/cache.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/cache.py
@@ -1,0 +1,59 @@
+"""Translate a run's cache INTENT into aigateway's request-body vocabulary.
+
+This module is the ONLY place in url4 that knows the string `use-cache`, and that is the whole
+point of it existing. `packages/url4`'s :class:`~url4.streaming.protocol.CachePolicy` speaks
+intent — "does this run participate?" — because it ships to SDK users and must not encode some
+server's body shape (plan §4). The adapter that talks to that server owns the wire words.
+
+INVARIANT — aigateway v2's cache-control grammar is CLOSED to exactly one field, `use-cache`
+(spec §1.0). An unrecognised key inside the `cache` object does NOT degrade to "ignored": it
+makes the whole request **bypass** the cache, silently, with nothing raised anywhere, and even
+alongside an otherwise valid `use-cache: true`. The only symptom is a cache that never hits. So:
+
+    NOTHING but `use-cache` may ever appear in the object this module builds.
+
+`CachePolicy.max_age` is therefore url4-INTERNAL and is deliberately not read here. v2 refuses a
+freshness bound (`global_controls.py:79-83`), so forwarding it would buy `unsupported_control`
+instead of a bound; it is applied at read-back (plan Batch 7), where an entry's age can be
+compared against it, and degrades to an opt-out until the gateway reports one.
+"""
+
+from __future__ import annotations
+
+from url4.streaming.protocol import CachePolicy
+
+_USE_CACHE = "use-cache"
+"""aigateway v2's one and only cache-control key. Named once so the invariant above has a single
+place to be violated, rather than a literal repeated at each branch."""
+
+
+def policy_to_body_field(policy: CachePolicy) -> dict[str, dict[str, bool]]:
+    """The `cache` field to merge into an aigateway chat-completions body, or nothing.
+
+    A dumb translation on purpose. It takes a RESOLVED policy — the D1 default is applied once,
+    at convergence (plan Batch 5), so the decision "what does silence mean?" lives in exactly one
+    place and this function never has to re-derive it.
+
+    Args:
+        policy: The run's resolved cache intent. Never ``None``; a run that declared nothing
+            arrives here as a policy, not as an absence.
+
+    Returns:
+        ``{"cache": {"use-cache": False}}`` when the run opted out, and an EMPTY dict otherwise
+        — participation is expressed by saying nothing. v2 reads absent, ``null`` and ``{}``
+        identically (spec §1.0), so the omission is not a shortcut: it keeps a default run's
+        egress body byte-identical to today's (spec §9.1) and keeps the smallest possible surface
+        exposed to the closed-grammar bypass. Merge with ``**`` at the call site.
+    """
+    # `participate is False` rather than `not policy.participate`: `None` means NOT STATED, and
+    # under D1 an unstated policy participates — same wire answer as an explicit True. Only an
+    # explicit opt-out earns a field on the wire.
+    if policy.participate is False:
+        # Built fresh per call. A module-level literal would be shared mutable state that two
+        # concurrent runs could contaminate each other through, at the one seam where a wrong
+        # value costs money silently.
+        return {"cache": {_USE_CACHE: False}}
+    return {}
+
+
+__all__ = ["policy_to_body_field"]

--- a/apps/url4-cloud/src/url4_cloud/runner/cache_counters.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/cache_counters.py
@@ -1,0 +1,169 @@
+"""What the gateway's response cache did across ONE run — hits, misses, and bypasses by reason
+(spec §7 / D7, plan Batch 8).
+
+**WHY counting is not optional.** Caching fails silently in both directions. A hit costs nothing
+upstream, so nobody notices the savings; a bypass costs a hit, and the request that caused it
+succeeded, so nobody notices the loss either. Per-span `cache_status` answers "what happened to
+this call"; only a run-level total answers the question an operator actually asks — *did this run
+use the cache, and if not, why not?* — without correlating every span by hand.
+
+**Bypasses BY REASON is the load-bearing one.** The gateway's vocabulary distinguishes
+`opted_out` (url4 asked for no cache, and got none — working as designed) from
+`unsupported_control` (url4 sent a control key the gateway's closed grammar does not know, and
+silently lost EVERY hit — a defect that raises nothing anywhere). Collapsing them into one
+"bypasses" number would erase exactly the distinction this telemetry exists to surface.
+
+WHY THIS IS NOT PROMETHEUS. Two reasons, and either alone would settle it:
+
+1. The run mode is a one-shot Job. It has no scrape endpoint and exits when the run does, so a
+   counter incremented there is a counter nobody ever reads.
+2. `.claude/scripts/check_layering.py` forbids `url4_cloud.runner.*` from importing
+   `url4_cloud.metrics` at all — the run mode must not load the serving half.
+
+The run's own telemetry stream is the only channel that exists, and it is also the right one: the
+question is about one run, and the answer arrives beside the spans it explains.
+
+INVARIANT — **no counter is labelled by cache key, prompt or credential** (spec §7). Enforced
+structurally rather than by review: :meth:`RunCacheCounters.record` accepts a status and a reason
+and nothing else, so there is no slot a key could occupy. The gateway's entry key IS parsed, one
+seam upstream (:class:`url4_cloud.runner.cache_readback.CacheOutcome`), and deliberately stops
+there.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+from url4_cloud.runner.cache_readback import CacheStatus
+
+CACHE_HITS = "cache.hits"
+CACHE_MISSES = "cache.misses"
+CACHE_BYPASSES = "cache.bypasses"
+BYPASS_REASON_PREFIX = "cache.bypass."
+"""Namespace for the per-reason breakdown, so `cache.bypasses` and its parts read as one family
+and a consumer can find the breakdown by prefix without knowing the gateway's vocabulary."""
+
+UNSTATED_REASON = "unstated"
+"""The bucket for a bypass that named no reason.
+
+Its own bucket rather than being dropped: the breakdown must always sum to `cache.bypasses`, and
+a reader who finds it does not — because some counts silently went nowhere — cannot trust either
+number. Spelled without a space so it is usable as an attribute-key suffix; the equivalent notion
+for a POLICY renders as :data:`url4_cloud.notices.NOT_STATED`, which is prose, not a key.
+"""
+
+OVERFLOW_REASON = "other"
+REASON_BUCKET_CAP = 16
+"""Ceiling on distinct reason buckets, past which reasons collapse into
+:data:`OVERFLOW_REASON` — at most ``REASON_BUCKET_CAP + 1`` buckets in all.
+
+The same cardinality doctrine `url4_cloud.metrics._route_label` applies to a Prometheus label,
+for the same reason: the reason is an UPSTREAM FREE STRING, carried verbatim on purpose, and a
+gateway that ever embeds a request id in one would otherwise mint a new attribute per call. The
+cap costs nothing in practice — the gateway's actual vocabulary is a handful of tokens — and it
+collapses rather than drops, so the breakdown still sums to the total it belongs to.
+"""
+
+_COUNTED_BYPASS: CacheStatus = "bypass"
+
+
+@dataclass(slots=True)
+class RunCacheCounters:
+    """One run's cache tallies. Plain integers, lifted onto the wire by the executor.
+
+    Not a `prometheus_client` object for the layering reason in the module docstring, and not one
+    even in spirit: a counter here is scoped to a run and dies with it, which is what makes it
+    answerable without any label identifying WHICH run.
+    """
+
+    hits: int = 0
+    misses: int = 0
+    bypasses: int = 0
+    _bypass_reasons: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def observed(self) -> bool:
+        """Whether this run saw any cache outcome at all.
+
+        The gate the executor publishes on. Most runs call no gateway — a static expression, a
+        reduce over already-fetched leaves — and an older gateway reports nothing even when one
+        is called. Emitting "0 hit, 0 miss, 0 bypass" for those would put a line on every run's
+        stream that says only that the feature exists, which trains a reader to skip the line on
+        the runs where it says something.
+        """
+        return bool(self.hits or self.misses or self.bypasses)
+
+    @property
+    def bypass_reasons(self) -> Mapping[str, int]:
+        """The per-reason breakdown, read-only. Always sums to :attr:`bypasses`."""
+        return self._bypass_reasons
+
+    def record(self, status: CacheStatus | None, reason: str | None) -> None:
+        """Tally one gateway round trip's reported outcome.
+
+        Args:
+            status: What the gateway said, or ``None`` when it said nothing — an older gateway,
+                or a path that never reached the cache. ``None`` counts as NOTHING rather than as
+                a miss: "not reported" is not "the cache was consulted and had nothing", and
+                inventing the second from the first would report a cache interaction that never
+                happened.
+            reason: The gateway's own word for that status, verbatim. Only a bypass's reason is
+                broken out — a miss means the entry simply was not there, which answers nothing a
+                reader would ask, while a bypass means the cache was never consulted at all,
+                which is precisely the case that needs a why.
+        """
+        if status == "hit":
+            self.hits += 1
+        elif status == "miss":
+            self.misses += 1
+        elif status == _COUNTED_BYPASS:
+            self.bypasses += 1
+            self._count_reason((reason or "").strip() or UNSTATED_REASON)
+
+    def attributes(self) -> dict[str, str | int | float | bool | None]:
+        """The counters as `LogData` attributes: the three totals, plus one entry per reason.
+
+        INVARIANT: every value is an integer count and every key is under `cache.`. That is the
+        whole enforcement of spec §7's "no metric labelled by cache key, prompt or credential" —
+        the shape admits no other kind of value.
+        """
+        attributes: dict[str, str | int | float | bool | None] = {
+            CACHE_HITS: self.hits,
+            CACHE_MISSES: self.misses,
+            CACHE_BYPASSES: self.bypasses,
+        }
+        for reason, count in self._bypass_reasons.items():
+            attributes[f"{BYPASS_REASON_PREFIX}{reason}"] = count
+        return attributes
+
+    def summary_body(self) -> str:
+        """The human-readable half of the summary line.
+
+        The totals are stated here as well as in the attributes on purpose: a reader scanning a
+        run's log sees the answer without expanding a structured payload, and the reasons — which
+        are the part worth expanding for — stay in the attributes where they can be aggregated.
+        """
+        return (
+            f"gateway response cache: {self.hits} hit, {self.misses} miss, {self.bypasses} bypass"
+        )
+
+    def _count_reason(self, reason: str) -> None:
+        """Increment ``reason``'s bucket, collapsing into :data:`OVERFLOW_REASON` once the cap is
+        reached. An already-known reason always keeps its own bucket, so the cap can never move a
+        count that was already being reported separately."""
+        if reason not in self._bypass_reasons and len(self._bypass_reasons) >= REASON_BUCKET_CAP:
+            reason = OVERFLOW_REASON
+        self._bypass_reasons[reason] = self._bypass_reasons.get(reason, 0) + 1
+
+
+__all__ = [
+    "BYPASS_REASON_PREFIX",
+    "CACHE_BYPASSES",
+    "CACHE_HITS",
+    "CACHE_MISSES",
+    "OVERFLOW_REASON",
+    "REASON_BUCKET_CAP",
+    "UNSTATED_REASON",
+    "RunCacheCounters",
+]

--- a/apps/url4-cloud/src/url4_cloud/runner/cache_readback.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/cache_readback.py
@@ -1,0 +1,329 @@
+"""Read the gateway's cache answer off a chat-completions response, and decide what to do with
+it (spec §7 / D7, plan Batch 7).
+
+The mirror image of :mod:`url4_cloud.runner.cache`, and a separate module from it on purpose:
+that one is four lines guarding ONE invariant — nothing but `use-cache` ever goes out — and
+burying a structured-field parser beside it would hide the single most expensive rule in this
+feature. Egress out, ingress here.
+
+**WHY reading it back is mandatory rather than nice-to-have.** A cache hit costs nothing
+upstream, yet `_report_usage` bills it exactly like a fresh call. Turning caching on without
+this makes the run's cost taxonomy wrong in the direction that HIDES savings — so nobody ever
+reports the bug.
+
+TWO SOURCES, IN PREFERENCE ORDER (spec §2.2):
+
+1. **`Cache-Status`** — RFC 9211, Standards Track, and an exact fit: `hit`, `fwd=bypass` and
+   `fwd=miss` are its own defined tokens. Read FIRST even though aigateway does not emit it yet,
+   because doing so costs nothing today and means url4 needs no change on the day it does.
+2. **`X-AIGW-Cache` / `-Reason` / `-Key`** — the ad hoc triple aigateway emits today, verbatim.
+
+`Cache-Status` is an RFC 8941 Structured Field **List**: one member per cache that handled the
+response — aigateway, an Envoy sidecar, a CDN — ordered origin-closest first. url4 selects the
+**aigateway member**, never blindly the first. Reading a CDN's `hit` as aigateway's answer would
+report a saving that never happened and mark a real provider dispatch as free.
+
+THREE GUARANTEES this module owes its caller:
+
+1. **It never raises.** Every function here runs on the response path of every gateway call. A
+   cache outcome is an observation ABOUT a call, never a term OF it; failing a run over a
+   malformed header would trade a missing telemetry field for a dead ensemble.
+2. **It never invents.** Anything undecipherable degrades to ``None`` — an absent status, not a
+   guessed one. A fabricated `bypass` reads as "the cache refused this", a claim nobody made.
+3. **It carries the gateway's vocabulary verbatim.** Normalising `opted_out` and
+   `unsupported_control` into one word would erase the difference between "url4 asked for no
+   cache and got none" and "url4 sent a key the gateway does not know and silently lost every
+   hit" — which is the question this telemetry exists to answer.
+
+**`Age`, and D11.** Freshness is read from the standard `Age` field (RFC 9111 §5.1) — "the
+sender's estimate of the time since the response was generated", which is precisely the fact a
+`max-age` bound is compared against. `Cache-Status`'s `ttl` parameter is deliberately NOT read as
+an age: RFC 9211 §2.4 defines it as the *remaining freshness lifetime*, the inverse quantity, and
+against a corpus whose rows never expire it has no meaning at all. Until the gateway reports an
+age, a bounded hit cannot be proven fresh — see :func:`requires_revalidation`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Literal
+
+from url4.streaming.protocol import CachePolicy
+
+CacheStatus = Literal["hit", "miss", "bypass"]
+"""The protocol's closed outcome vocabulary, restated for the parse.
+
+AIDEV-NOTE: the same literal is spelled on `url4.streaming.protocol.SpanData` and on
+`url4.observe.ModelResponse` — the wire end and the engine end of the same fact. Change all
+three together; a value that parses here but does not validate there is a run-time 500 on the
+publishing path, not a type error.
+"""
+
+_CACHE_STATUS_FIELD = "Cache-Status"
+_AGE_FIELD = "Age"
+_LEGACY_STATUS_FIELD = "X-AIGW-Cache"
+_LEGACY_REASON_FIELD = "X-AIGW-Cache-Reason"
+_LEGACY_KEY_FIELD = "X-AIGW-Cache-Key"
+
+_AIGATEWAY_MEMBER = "aigateway"
+"""The cache identity url4 believes in a `Cache-Status` list. Every other member belongs to some
+intermediary and says nothing about whether the GATEWAY served this call from its corpus."""
+
+_HIT_PARAM, _FWD_PARAM, _DETAIL_PARAM, _KEY_PARAM = "hit", "fwd", "detail", "key"
+_FWD_BYPASS = "bypass"
+"""RFC 9211 §2.2's one token meaning the cache was not consulted at all. Every other `fwd` token
+(`miss`, `uri-miss`, `vary-miss`, `stale`, …) means it WAS consulted and had nothing to serve —
+the difference between "you opted out" and "we looked and it wasn't there"."""
+
+_SF_TRUE = "?1"
+"""RFC 8941 §3.3.6's Boolean true. A bare parameter (`; hit`) is true by definition (§3.1.2), so
+only an explicit `hit=?0` can turn it off."""
+
+_LEGACY_STATUSES: dict[str, CacheStatus] = {"hit": "hit", "miss": "miss", "bypass": "bypass"}
+"""A LOOKUP rather than a membership test, so the closed vocabulary and the type that carries it
+cannot drift apart: a value the protocol would reject is one this mapping simply does not have."""
+
+_KEYED_STATUSES = frozenset({"hit", "miss"})
+"""A bypassed request has no entry, so a key on it identifies nothing. aigateway already sets its
+header only for these two; url4 re-states the rule rather than trusting the sender."""
+
+
+@dataclass(frozen=True, slots=True)
+class CacheOutcome:
+    """What one gateway round trip reported about the cache. Every field is optional because
+    every one of them can be legitimately absent — an older gateway, a non-cache error path, or
+    a response that never reached the cache at all."""
+
+    status: CacheStatus | None
+    reason: str | None
+    key: str | None
+    """The entry's identity — a hash PREFIX by construction (the gateway truncates it), never
+    prompt or response content, which is what makes it safe to carry.
+
+    AIDEV-NOTE: parsed but not published. `SpanData` carries no key field, and inventing one to
+    hold this would put a per-entry identifier on a wire type nothing consumes. It is read here
+    so the "hit/miss only" rule is enforced at the seam that would otherwise leak it, and so a
+    future consumer has it without re-deriving the parse. Never label a metric with it (spec §7).
+    """
+    age_s: int | None
+
+
+def read_cache_outcome(headers: Mapping[str, str]) -> CacheOutcome:
+    """The cache outcome a chat-completions response reported. Total — it never raises.
+
+    Args:
+        headers: The response's fields. Matched case-insensitively (RFC 9110 §5.1), so an
+            `httpx.Headers` and a plain dict behave the same.
+
+    Returns:
+        The parsed outcome, preferring `Cache-Status` and falling back to the `X-AIGW-Cache*`
+        triple. An unusable preferred field falls THROUGH to the fallback rather than shadowing
+        it: the signal exists in the other field, and dropping it because the standard one was
+        garbage would lose the outcome for no reason.
+    """
+    reported = _from_cache_status(headers) or _from_legacy_triple(headers)
+    age_s = _non_negative_int(_field(headers, _AGE_FIELD))
+    if reported is None:
+        return CacheOutcome(status=None, reason=None, key=None, age_s=age_s)
+    keyed = reported.status in _KEYED_STATUSES
+    return CacheOutcome(
+        status=reported.status,
+        reason=reported.reason or None,
+        key=(reported.key or None) if keyed else None,
+        age_s=age_s,
+    )
+
+
+def requires_revalidation(policy: CachePolicy, outcome: CacheOutcome) -> bool:
+    """Whether this answer must be refused and the call re-issued with an explicit opt-out.
+
+    D11 (spec §3.5) says a `max-age` bound is HONOURED. Two upstream halves are missing: the
+    gateway's control grammar accepts no bound, and it reports no age. So url4 honours the bound
+    at the only place left to it — the response — by refusing what it cannot prove fresh.
+
+    Args:
+        policy: The run's resolved policy. ``max_age`` is url4-internal and never left this
+            process; it exists precisely so this decision can be made.
+        outcome: What the gateway just reported.
+
+    Returns:
+        ``True`` only for a HIT whose age is unknown or beyond the bound.
+
+        The three ``False`` cases each matter. **No bound stated** — the D1 default asks for
+        nothing, so the overwhelming majority of runs pay nothing for D11 existing. **A miss or a
+        bypass** — that answer was just generated, so its age is zero and every bound already
+        holds; re-issuing there would double the cost of every call a bounded run makes. **A hit
+        within the bound** — the honoured path, dormant until the gateway reports `Age`.
+
+        Cost of the ``True`` case: one extra round trip, and a body read then discarded. Cheap
+        against the alternative, which is silently serving an answer of unknown age out of a
+        corpus that never expires to a caller who explicitly bounded it.
+    """
+    if policy.max_age is None or outcome.status != "hit":
+        return False
+    if outcome.age_s is None:
+        return True
+    # `>` not `>=`: RFC 9111 §5.2.1.1 asks for an age "less than or equal to" the bound, so an
+    # entry exactly at it is still acceptable.
+    return outcome.age_s > policy.max_age
+
+
+@dataclass(frozen=True, slots=True)
+class _Reported:
+    """One source's raw reading, before the key rule and the age are applied to it."""
+
+    status: CacheStatus
+    reason: str | None
+    key: str | None
+
+
+def _from_cache_status(headers: Mapping[str, str]) -> _Reported | None:
+    """The aigateway member of an RFC 9211 `Cache-Status` list, or ``None`` when the field is
+    absent, names no aigateway member, or names one that states neither a hit nor a forward."""
+    raw = _field(headers, _CACHE_STATUS_FIELD)
+    if not raw:
+        return None
+    for member in _split_top_level(raw, ","):
+        name, params = _parse_member(member)
+        # A member that names us but says nothing usable does not stop the scan: a second one
+        # that does is worth more than an early return of nothing.
+        if name.lower() == _AIGATEWAY_MEMBER and (reported := _reported_from(params)) is not None:
+            return reported
+    return None
+
+
+def _reported_from(params: dict[str, str | None]) -> _Reported | None:
+    """Read one member's parameters as an outcome, or ``None`` when it states none.
+
+    `detail` outranks the `fwd` token as the reason: `fwd` says only THAT the request was
+    forwarded, while `detail` is where a cache puts its own word for WHY — which under aigateway
+    is the vocabulary (`opted_out`, `unsupported_control`, …) this whole field exists to surface.
+    """
+    detail, key = params.get(_DETAIL_PARAM), params.get(_KEY_PARAM)
+    if _HIT_PARAM in params and _is_true(params[_HIT_PARAM]):
+        return _Reported("hit", detail, key)
+    fwd = params.get(_FWD_PARAM)
+    if not fwd:
+        return None
+    status: CacheStatus = "bypass" if fwd.strip().lower() == _FWD_BYPASS else "miss"
+    return _Reported(status, detail or fwd, key)
+
+
+def _from_legacy_triple(headers: Mapping[str, str]) -> _Reported | None:
+    """The `X-AIGW-Cache*` triple aigateway emits today, verbatim.
+
+    A status outside the closed vocabulary yields ``None`` rather than a guess: the field is a
+    free string on the wire, and no rule could recover which of the three an unknown word meant.
+    """
+    status = _LEGACY_STATUSES.get((_field(headers, _LEGACY_STATUS_FIELD) or "").strip().lower())
+    if status is None:
+        return None
+    return _Reported(
+        status,
+        (_field(headers, _LEGACY_REASON_FIELD) or "").strip() or None,
+        (_field(headers, _LEGACY_KEY_FIELD) or "").strip() or None,
+    )
+
+
+def _field(headers: Mapping[str, str], name: str) -> str | None:
+    """One field's value, matched case-insensitively.
+
+    `httpx.Headers` already is case-insensitive; a plain mapping a caller hands in is not, and
+    RFC 9110 §5.1 makes field names case-insensitive regardless of which one arrived.
+    """
+    value = headers.get(name)
+    if value is not None:
+        return value
+    lowered = name.lower()
+    return next((v for k, v in headers.items() if k.lower() == lowered), None)
+
+
+def _split_top_level(raw: str, sep: str) -> list[str]:
+    """Split on `sep` OUTSIDE quoted strings.
+
+    INVARIANT: quote-aware, because an RFC 8941 String may contain the separator — a cache named
+    `"CDN, Inc."` splits into two bogus members under a naive `split(",")`, and the real
+    aigateway member is then never found. Characters are kept verbatim; unescaping is
+    :func:`_unquote`'s job. An unterminated quote simply swallows the rest of the field, which
+    leaves an undecipherable member rather than an exception.
+    """
+    parts: list[str] = []
+    current = ""
+    in_quotes = False
+    escaped = False
+    for char in raw:
+        if escaped:
+            escaped = False
+        elif char == "\\" and in_quotes:
+            escaped = True
+        elif char == '"':
+            in_quotes = not in_quotes
+        elif char == sep and not in_quotes:
+            parts.append(current)
+            current = ""
+            continue
+        current += char
+    parts.append(current)
+    return parts
+
+
+def _parse_member(raw: str) -> tuple[str, dict[str, str | None]]:
+    """One list member as `(cache name, parameters)`.
+
+    A parameter with no `=` is a Boolean true by RFC 8941 §3.1.2 and is recorded as ``None`` —
+    distinguishable from `hit=?0`, which is an explicit false. Unnamed parameters are dropped;
+    a later repeat of a name wins, matching §3.1.2's "the last instance".
+    """
+    parts = _split_top_level(raw, ";")
+    name = _unquote(parts[0].strip())
+    params: dict[str, str | None] = {}
+    for part in parts[1:]:
+        key, assigned, value = part.partition("=")
+        key = key.strip().lower()
+        if key:
+            params[key] = _unquote(value.strip()) if assigned else None
+    return name, params
+
+
+def _unquote(raw: str) -> str:
+    """An RFC 8941 String with its delimiters removed and its escapes resolved.
+
+    Anything not delimited — a Token, an Integer, a fragment left by an unterminated quote — is
+    returned unchanged, so a bare `aigateway` and a quoted `"aigateway"` read identically.
+    """
+    if len(raw) < 2 or not raw.startswith('"') or not raw.endswith('"'):
+        return raw
+    out = ""
+    escaped = False
+    for char in raw[1:-1]:
+        if not escaped and char == "\\":
+            escaped = True
+            continue
+        out += char
+        escaped = False
+    return out
+
+
+def _is_true(value: str | None) -> bool:
+    """RFC 8941 Boolean semantics: a bare parameter is true; only `?1` is true when written out."""
+    return value is None or value.strip() == _SF_TRUE
+
+
+def _non_negative_int(raw: str | None) -> int | None:
+    """`raw` as whole non-negative seconds, or ``None`` when it is not that.
+
+    RFC 9111 §5.1 defines `Age` as a non-negative integer. Anything else is unusable, and an
+    unusable age must read as UNKNOWN — the conservative direction, since it is exactly an
+    unknown age that makes a caller's freshness bound unenforceable.
+    """
+    if raw is None:
+        return None
+    try:
+        seconds = int(raw.strip())
+    except ValueError:
+        return None
+    return seconds if seconds >= 0 else None
+
+
+__all__ = ["CacheOutcome", "CacheStatus", "read_cache_outcome", "requires_revalidation"]

--- a/apps/url4-cloud/src/url4_cloud/runner/connector.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/connector.py
@@ -17,7 +17,12 @@ from url4.core.errors import ResolutionError
 from url4.io.static import StaticIOLayer
 from url4.observe import current_response_sink, current_usage_sink
 from url4.peer.server import Request, Url4Node
+from url4.streaming.protocol import CachePolicy
+from url4_cloud.runner.cache import policy_to_body_field
+from url4_cloud.runner.cache_readback import CacheOutcome, read_cache_outcome, requires_revalidation
 from url4_cloud.runner.config import ModelSpec, RunnerConfigError, routes_for
+
+_COMPLETIONS_PATH = "/v1/chat/completions"
 
 _WEB_TOOLS = [
     {
@@ -125,6 +130,7 @@ class _ModelEndpoint:
     """
 
     __slots__ = (
+        "_cache",
         "_cfg",
         "_http_client",
         "_identity_headers",
@@ -144,6 +150,7 @@ class _ModelEndpoint:
         tavily_http: httpx.AsyncClient | None,
         tavily_api_key: str | None,
         identity_headers: Mapping[str, str] | None = None,
+        cache: CachePolicy,
     ) -> None:
         self._http_client = http_client
         self._cfg = cfg
@@ -152,6 +159,10 @@ class _ModelEndpoint:
         self._tavily_http = tavily_http
         self._tavily_api_key = tavily_api_key
         self._identity_headers = identity_headers
+        # INVARIANT: held HERE and not on `cfg`. This object is built once per RUN, while `cfg` is
+        # the world every run in the process shares — and in local mode those runs share an event
+        # loop, so a policy parked on `cfg` is the previous caller's answer applied to this one.
+        self._cache = cache
 
     async def __call__(self, request: Request) -> str:
         # The route resolves to its whole spec, so the id and the capabilities it was declared
@@ -167,6 +178,7 @@ class _ModelEndpoint:
             tavily_api_key=self._tavily_api_key,
             web_tools=spec.web_tools,
             identity_headers=self._identity_headers,
+            cache=self._cache,
         )
 
 
@@ -178,6 +190,7 @@ async def build_aigateway_world(
     tavily_api_key: str | None = None,
     tavily_client: httpx.AsyncClient | None = None,
     identity_headers: Mapping[str, str] | None = None,
+    cache: CachePolicy | None = None,
 ) -> AigatewayWorld:
     """Build the `Url4Node` world: one endpoint per declared model, routed to aigateway.
 
@@ -185,6 +198,12 @@ async def build_aigateway_world(
     `url4_cloud.job_env.IDENTITY_HEADER_ENV`), rendered onto every chat-completions request this
     world makes. It is per-RUN rather than per-call: one run has exactly one caller, so the
     endpoint holds it for the run's duration exactly as it holds `profile`.
+
+    ``cache`` is that run's cache policy, and it is a PARAMETER of this call rather than a field of
+    `cfg` for exactly one reason: `cfg` is the world, one description of the gateway shared by
+    every run in the process, and a per-run value there is a value one run reads out of another's.
+    ``None`` means nothing was stated, which reaches the wire as no `cache` field at all — the
+    gateway's own default — so this half never has to re-decide what silence means.
 
     Raises:
         RunnerConfigError: no models are declared, or `default_model` is not among them.
@@ -218,6 +237,9 @@ async def build_aigateway_world(
         tavily_http=tavily_http,
         tavily_api_key=tavily_api_key,
         identity_headers=identity_headers or None,
+        # `is not None`, not `or`: a policy is a pydantic model and always truthy, but spelling the
+        # fallback explicitly says what it is — an unstated policy, not a stated default.
+        cache=cache if cache is not None else CachePolicy(),
     )
 
     # WHY: `outbound=StaticIOLayer()` denies every absolute-URL fetch: an unmapped target raises
@@ -245,16 +267,27 @@ def _provider_of(model: str) -> str:
     return "anthropic"
 
 
-def _report_response(choice: _Choice) -> None:
-    """Report how one model round trip ended, onto the currently-resolving node's span.
+def _report_response(choice: _Choice, cache: CacheOutcome) -> None:
+    """Report how one model round trip ended — and whether the gateway served it from its
+    response cache — onto the currently-resolving node's span.
 
     Null-safe exactly like `_report_usage`: outside a run, or with no observer attached, the
     sink is absent and this is a no-op.
+
+    INVARIANT: reported BESIDE `_report_usage`, for the same call, or the two disagree. A hit
+    costs nothing upstream while `_report_usage` bills it as a fresh call, so a span that
+    carries the tokens without the outcome states a cost that was never paid — an error in the
+    direction that hides savings, and therefore one nobody reports.
     """
     sink = current_response_sink()
     if sink is None:
         return
-    sink(finish_reason=choice.finish_reason, refusal=choice.refusal)
+    sink(
+        finish_reason=choice.finish_reason,
+        refusal=choice.refusal,
+        cache_status=cache.status,
+        cache_reason=cache.reason,
+    )
 
 
 def _report_usage(model: str, usage: dict | None) -> None:
@@ -359,6 +392,55 @@ def _build_tavily_client(
     return client, owns
 
 
+async def _fetch_completion(
+    http_client: httpx.AsyncClient,
+    *,
+    headers: dict[str, str],
+    body: dict,
+    cache: CachePolicy,
+) -> tuple[httpx.Response, CacheOutcome]:
+    """One chat-completions round trip under this run's cache policy, plus what the gateway
+    reported about the cache — re-issued without the cache when the answer cannot be served.
+
+    The re-issue is D11's honouring half (spec §3.5). A caller that stated `max-age` gets an
+    answer it can trust: a hit whose age the gateway cannot establish is refused rather than
+    served, since the corpus is global and never expires, so "how old is this" has no bound at
+    all. It costs one extra round trip and a discarded body, and ONLY on a hit — a miss or a
+    bypass was generated just now and satisfies every bound already (`requires_revalidation`).
+
+    INVARIANT: the discarded response is read for its headers and nothing else. Its usage is
+    never reported, or the turn would be billed twice — the exact error class this read-back
+    exists to prevent.
+
+    Returns:
+        The response to consume, and the cache outcome of the round trip that produced IT — not
+        of the one that was discarded, whose only remaining trace is that it happened.
+    """
+    resp = await http_client.post(
+        _COMPLETIONS_PATH,
+        headers=headers,
+        # `policy_to_body_field` yields an EMPTY dict for a run that participates, so an ordinary
+        # run's body is byte-identical to the one this connector has always sent — which is also
+        # the smallest surface exposed to the gateway's closed cache grammar, where one
+        # unrecognised key silently costs every hit (spec §1.0).
+        json={**body, **policy_to_body_field(cache)},
+    )
+    _raise_for_status(resp)
+    outcome = read_cache_outcome(resp.headers)
+    if not requires_revalidation(cache, outcome):
+        return resp, outcome
+    # An explicit opt-out, built here rather than derived from `cache`: the run's own policy
+    # PARTICIPATES (a bound is not a refusal), and the re-issue must state the one thing the
+    # closed grammar understands — `use-cache: false` — and nothing else.
+    resp = await http_client.post(
+        _COMPLETIONS_PATH,
+        headers=headers,
+        json={**body, **policy_to_body_field(CachePolicy(participate=False))},
+    )
+    _raise_for_status(resp)
+    return resp, read_cache_outcome(resp.headers)
+
+
 async def _chat_completion_loop(
     *,
     http_client: httpx.AsyncClient,
@@ -370,6 +452,7 @@ async def _chat_completion_loop(
     tavily_api_key: str | None,
     web_tools: bool,
     identity_headers: Mapping[str, str] | None = None,
+    cache: CachePolicy,
 ) -> str:
     """Drive one `_ModelEndpoint` call: post to aigateway, execute any requested tool calls,
     and repeat until the model answers with content instead of another tool call.
@@ -379,6 +462,11 @@ async def _chat_completion_loop(
     configured key would silently change every model's request payload, and without the client
     the model could call a tool nothing can execute.
 
+    INVARIANT: the cache policy is re-applied on EVERY round trip, not merged once before the
+    loop. One turn is several independently-keyed gateway calls, and a policy that lapsed after
+    the first would serve the tool-augmented continuation — the most context-specific call of the
+    turn — from a shared corpus the caller had just refused.
+
     Raises:
         ResolutionError: the loop exceeds `cfg.web_tool_max_iterations` without a final
             answer — the model keeps calling tools instead of returning content.
@@ -387,18 +475,16 @@ async def _chat_completion_loop(
     extra = {"tools": _WEB_TOOLS, "tool_choice": "auto"} if offer_tools else {}
     headers = _headers(profile, identity_headers)
     for _ in range(cfg.web_tool_max_iterations):
-        resp = await http_client.post(
-            "/v1/chat/completions",
-            headers=headers,
-            json={"model": model, "messages": messages, **extra},
+        body = {"model": model, "messages": messages, **extra}
+        resp, outcome = await _fetch_completion(
+            http_client, headers=headers, body=body, cache=cache
         )
-        _raise_for_status(resp)
         data = _json_or_raise(resp)
         _report_usage(model, data.get("usage"))
         choice = _parse_choice(data)
         # INVARIANT: report BEFORE classifying. A refused turn is the case a reviewer most needs
         # to audit, and raising first would lose exactly the event OME-679 exists to capture.
-        _report_response(choice)
+        _report_response(choice, outcome)
         _raise_if_unusable(choice)
         content, tool_calls = choice.content, choice.tool_calls
         if not tool_calls:

--- a/apps/url4-cloud/src/url4_cloud/runner/executor.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/executor.py
@@ -18,7 +18,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import cast
+from typing import Literal, cast
 
 from url4.dag import run as url4_run
 from url4.io.layer import IOLayer
@@ -43,6 +43,7 @@ from url4.streaming.protocol import (
     TokenUsage,
 )
 from url4.streaming.protocol.taxonomy import CostBreakdown
+from url4_cloud.runner.cache_counters import RunCacheCounters
 
 _logger = logging.getLogger(__name__)
 
@@ -148,6 +149,11 @@ class _SpanState:
     # needs it, count the folded events here rather than inferring it from this list.
     finish_reasons: list[str] = field(default_factory=list)
     refusal: str | None = field(default=None)
+    # A span carries ONE cache outcome while a turn may be several gateway calls, so last-wins
+    # (see `_fold_response`). Held as a pair and written as a pair: a status from one round trip
+    # beside a reason from another would describe a call that never happened.
+    cache_status: Literal["hit", "miss", "bypass"] | None = field(default=None)
+    cache_reason: str | None = field(default=None)
 
 
 class _RunState:
@@ -162,6 +168,10 @@ class _RunState:
         self.trace_id: str | None = None
         self.root_span_id: str | None = None
         self.spans: dict[str, _SpanState] = {}
+        # Run-level, exactly like the subtree token sums beside it, and for the same reason: the
+        # per-span outcome answers "what happened to this call", while the question an operator
+        # asks is about the run. Published once at the end — see `Url4Executor.execute`.
+        self.cache_counters = RunCacheCounters()
         self._sum_input = 0
         self._sum_output = 0
         self._providers_models: set[tuple[str, str]] = set()
@@ -216,6 +226,11 @@ class _RunState:
         this run never opened is dropped rather than fabricating one, and several calls on the
         same span each keep their own entry.
         """
+        # Counted BEFORE the span guard, and that difference is deliberate. A span frame must not
+        # be fabricated for an id this run never opened — a consumer cannot tell an invented span
+        # from a real one. A run TOTAL has no such problem: the round trip happened and it either
+        # cost or saved money, so dropping it would under-report the run's own summary.
+        self.cache_counters.record(event.cache_status, event.cache_reason)
         span = self.spans.get(event.span_id) if event.span_id is not None else None
         if span is None:
             return
@@ -224,6 +239,13 @@ class _RunState:
         if event.refusal is not None:
             # Last refusal wins: for a multi-call turn the final one is the turn's outcome.
             span.refusal = event.refusal
+        if event.cache_status is not None:
+            # Same rule, and guarded on the STATUS rather than on the event: a later round trip
+            # that reported no outcome at all — an older gateway, a non-cache error path — must
+            # leave the earlier one standing rather than blanking it, because "nothing reported"
+            # is not "no cache involved".
+            span.cache_status = event.cache_status
+            span.cache_reason = event.cache_reason
 
     def _fold_usage(self, event: Usage) -> None:
         self._sum_input += event.input_tokens
@@ -270,6 +292,10 @@ class _RunState:
             # that reported no reason" into the same wire shape — intended, not an oversight.
             finish_reasons=span.finish_reasons or None,
             refusal=span.refusal,
+            # Absent for the many nodes that call no gateway at all. A default of "bypass" would
+            # read as "the cache refused this call" — a claim nobody made.
+            cache_status=span.cache_status,
+            cache_reason=span.cache_reason,
             start=start,
             end=datetime.now(UTC),
             status="ok" if event.status == "ok" else "error",
@@ -334,6 +360,43 @@ class _RunState:
         if len(self._providers_models) == 1:
             return next(iter(self._providers_models))
         return "mixed", "mixed"
+
+
+def _closing_logs(dropped: int, counters: RunCacheCounters) -> list[Traced]:
+    """The log frames a run emits about ITSELF, after its last span and before `Completed`.
+
+    Both are statements about the whole run rather than about any node, so both carry
+    ``span=None`` and neither can be made until every event has been folded. Extracted from
+    `Url4Executor.execute` so the generator stays a straight line — the run loop's shape is what
+    a reader checks for correctness, and a growing tail of end-of-run bookkeeping obscures it.
+
+    Args:
+        dropped: Log events the bridge discarded under backpressure.
+        counters: The run's cache tallies.
+
+    Returns:
+        Only the frames that have something to say. A run that dropped nothing and touched no
+        cache — the overwhelming majority, since most expressions call no gateway at all —
+        produces neither, rather than two lines reporting that nothing happened.
+    """
+    frames: list[Traced] = []
+    if dropped:
+        frames.append(
+            Traced(
+                payload=LogData.at("WARN", f"dropped {dropped} log event(s) (telemetry overflow)"),
+                span=None,
+            )
+        )
+    if counters.observed:
+        # The run's cache summary (spec §7): hits, misses and bypasses BY REASON, which is what
+        # turns "I asked for no caching and something still cached" into an answerable question.
+        frames.append(
+            Traced(
+                payload=LogData.at("INFO", counters.summary_body(), counters.attributes()),
+                span=None,
+            )
+        )
+    return frames
 
 
 def _log_frame(event: Log) -> LogData:
@@ -418,13 +481,8 @@ class Url4Executor(Executor):
                 for frame in state.map(ev):
                     yield frame
             result_str = await task
-            if bridge.dropped:
-                yield Traced(
-                    payload=LogData.at(
-                        "WARN", f"dropped {bridge.dropped} log event(s) (telemetry overflow)"
-                    ),
-                    span=None,
-                )
+            for frame in _closing_logs(bridge.dropped, state.cache_counters):
+                yield frame
             yield Completed(
                 result=state.build_result(result_str, self._result_cap),
                 subtree_cost=state.build_subtree(),

--- a/apps/url4-cloud/src/url4_cloud/runner/main.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/main.py
@@ -113,6 +113,12 @@ def build_executor(
             ),
             profile=env.get(job_env.AIGATEWAY_PROFILE),
             identity_headers=job_env.identity_from_env(env),
+            # Read back per RUN, from this run's own environment — never folded into the
+            # `AigatewayConfig` above, which describes the WORLD and is shared by every run the
+            # process serves. `cache_policy_from_env` is total, so an env that states nothing
+            # yields a policy that states nothing, which the connector sends as no `cache` field
+            # at all — participation, without this half re-deciding what silence means.
+            cache=job_env.cache_policy_from_env(env),
             client=client,
             tavily_api_key=env.get(job_env.TAVILY_API_KEY),
             tavily_client=tavily_client,

--- a/apps/url4-cloud/src/url4_cloud/schemas/asyncapi.py
+++ b/apps/url4-cloud/src/url4_cloud/schemas/asyncapi.py
@@ -19,6 +19,23 @@ INFO_DESCRIPTION = """\
 The url4-cloud telemetry stream. One **CloudEvents 1.0** event per WebSocket message
 (subprotocol `cloudevents.json`, docs/protocol.md §8). The client *receives* lifecycle/log/span/
 cost/heartbeat/result/terminated events and *sends* stop/attach commands.
+
+`ai.url4.attach` carries more than a resume point: its optional **`cache`** object declares
+whether the run may participate in the gateway's response cache, which it otherwise does by
+default. `{"cache": {"participate": false}}` declines for the whole run — every leaf, every
+fan-out branch. Omitting the object, sending `null`, or sending `{}` all state *nothing*, which
+is not the same as declining and stays distinguishable from it.
+
+Two rules govern it, and both are announced rather than silent:
+
+- **The first attach wins.** A re-attach carrying a different policy does not restate it — the
+  run's gateway calls may already have executed under the original one, so a mid-run change would
+  make the run's cache behaviour unreproducible. The client is told with a `warn` `ai.url4.log`.
+- **A `Cache-Control` header on the `GET /` that starts the run overrides this frame**, since it
+  is the later, run-scoped statement. That override is announced the same way.
+
+The outcome comes back on `ai.url4.span` as `cache_status` / `cache_reason`, plus one run summary
+`ai.url4.log` carrying the hit, miss and bypass-by-reason totals.
 """
 
 

--- a/apps/url4-cloud/src/url4_cloud/schemas/openapi.py
+++ b/apps/url4-cloud/src/url4_cloud/schemas/openapi.py
@@ -33,6 +33,31 @@ Result arrives on the WebSocket stream:
 replay via `ai.url4.attach`, or cancel via `ai.url4.stop`:
 
 ![Streaming, resume and cancel](/diagrams/url4-cloud-execution-stream.svg)
+
+## Response caching
+
+A run **participates in the gateway's response cache by default**: an identical call is answered
+from the stored corpus instead of being dispatched to the provider again. Only *declining* is
+explicit, and there are two carriers for it — one per execution flow above:
+
+- **`Cache-Control` on this `GET /`** — `no-store` / `no-cache` decline, `max-age=<seconds>`
+  states a freshness bound, `url4-use-cache` opts in explicitly. It is the standard RFC 9111
+  field, deliberately, so an intermediary may read it and add to it; conflicting directives
+  resolve to declining, and an unknown or malformed one is ignored. A cache directive is a hint
+  about cost, never a term of the request, so it never fails a run.
+- **`cache` on the `ai.url4.attach` frame** — the same intent stated when the WebSocket attaches,
+  for a client that has no other request to hang a header on. Described in the companion
+  **AsyncAPI** doc at `/asyncapi.json`.
+
+**The header wins** when both carriers speak, and the overridden declaration is announced on the
+stream as a `warn` `ai.url4.log` rather than dropped silently. The policy covers the **whole
+run** — every leaf and every fan-out branch — because one url4 expression is many gateway calls
+and a per-node intent is not expressible in the grammar.
+
+The outcome comes back: every span carries `cache_status` (`hit` / `miss` / `bypass`) and
+`cache_reason` in the gateway's own vocabulary, and the run publishes one summary `ai.url4.log`
+with its hit, miss and bypass-by-reason totals. Nothing in that telemetry is labelled by cache
+key, prompt or credential.
 """
 
 TAGS: list[dict[str, str]] = [

--- a/apps/url4-cloud/src/url4_cloud/ws/bridge.py
+++ b/apps/url4-cloud/src/url4_cloud/ws/bridge.py
@@ -10,6 +10,7 @@ import asyncio
 import contextlib
 from collections.abc import Callable
 from datetime import datetime
+from typing import Protocol
 from uuid import uuid4
 
 from fastapi import WebSocket, WebSocketDisconnect
@@ -19,6 +20,7 @@ from url4.streaming.codec import encode
 from url4.streaming.interfaces import EventConsumer, JobRunner
 from url4.streaming.protocol import (
     AttachEvent,
+    CachePolicy,
     ErrorData,
     ErrorEvent,
     HeartbeatEvent,
@@ -27,10 +29,36 @@ from url4.streaming.protocol import (
     StopEvent,
     source_for,
 )
+from url4_cloud import notices
 
 Clock = Callable[[], datetime]
 
 _InboundEvent = AttachEvent | StopEvent
+
+
+class TopicSession(Protocol):
+    """The per-topic session state a bridge reads, writes and registers itself with.
+
+    A port, not an import of the concrete registry: what a bridge needs is somewhere that outlives
+    ONE connection — first-attach-wins has to hold across a reconnect and across two sockets on the
+    same topic, which a per-connection object cannot express — and nothing more specific than that.
+    """
+
+    def declare_cache_policy(self, topic: str, policy: CachePolicy | None) -> bool:
+        """Record ``policy`` for ``topic`` if nothing is recorded yet; ``False`` if it conflicts."""
+        ...
+
+    def cache_policy_for(self, topic: str) -> CachePolicy | None:
+        """The intent standing for ``topic``, or ``None`` when none was declared."""
+        ...
+
+    def add_notifier(self, topic: str, notify: Callable[[OutboundFrame], None]) -> None:
+        """Register this connection as a destination for out-of-band frames on ``topic``."""
+        ...
+
+    def remove_notifier(self, topic: str, notify: Callable[[OutboundFrame], None]) -> None:
+        """Withdraw a destination registered by :meth:`add_notifier`."""
+        ...
 
 
 async def _send(ws: WebSocket, event: OutboundFrame) -> None:
@@ -87,6 +115,7 @@ class Bridge:
         topic: str,
         *,
         job_runner: JobRunner | None,
+        sessions: TopicSession,
         clock: Clock,
         heartbeat_s: float,
     ) -> None:
@@ -94,6 +123,7 @@ class Bridge:
         self._stream = stream
         self._topic = topic
         self._job_runner = job_runner
+        self._sessions = sessions
         self._clock = clock
         self._heartbeat_s = heartbeat_s
         # INVARIANT: bounded. `_pump` awaits `put`, so a full queue is BACKPRESSURE — the pump
@@ -125,12 +155,20 @@ class Bridge:
         Blocks for the connection's whole lifetime: either the inbound task
         observes a disconnect or the writer fails to send, and both paths set
         `_stop`, which is the only way this coroutine returns.
+
+        The connection is registered as a notice destination for its topic for exactly this
+        window, and withdrawn in `finally`. That is what lets a REST handler — which has no socket
+        of its own and, in a deployed App, no publisher either — tell an attached client that
+        something it declared was overridden. `_offer` is the sink because it is already the
+        non-blocking, drop-if-behind path every other advisory frame takes.
         """
+        self._sessions.add_notifier(self._topic, self._offer)
         inbound = asyncio.ensure_future(self._inbound())
         writer = asyncio.ensure_future(self._writer())
         try:
             await self._stop.wait()
         finally:
+            self._sessions.remove_notifier(self._topic, self._offer)
             await self._teardown(inbound, writer)
 
     async def _inbound(self) -> None:
@@ -162,6 +200,10 @@ class Bridge:
         else queues an `unsupported` error frame.
         """
         if isinstance(event, AttachEvent):
+            # ORDER MATTERS, and only in this direction: the declaration is recorded before the
+            # subscription is (re)started, so a run cannot be scheduled — nor a replayed frame
+            # delivered — under a policy the session state has not seen yet.
+            self._declare_cache(event.data.cache)
             self._resubscribe(event.data.from_sequence)
         elif isinstance(event, StopEvent):
             if self._job_runner is not None:
@@ -176,6 +218,36 @@ class Bridge:
                         event.id,
                     )
                 )
+
+    def _declare_cache(self, policy: CachePolicy | None) -> None:
+        """Carry the attach frame's cache intent into the topic's session state.
+
+        FIRST ATTACH WINS (spec §5.2). A re-attach — a reconnect, a `from_sequence` resume, or a
+        second socket on the same topic — does NOT restate the policy: the run's aigateway calls
+        may already have executed under the standing one, so accepting a change mid-run would make
+        the run's cache behaviour unreproducible after the fact.
+
+        WHY it warns rather than nacks: the frame is otherwise perfectly valid and its
+        resubscription is honoured in full, so refusing it would cost the client its replay over a
+        directive about cost. `warn` says the intent was dropped, loudly enough to debug "I asked
+        for no caching and something still cached" and quietly enough not to break the resume.
+        """
+        if self._sessions.declare_cache_policy(self._topic, policy):
+            return
+        self._offer(
+            notices.warn(
+                self._topic,
+                self._clock,
+                "the run's cache policy is fixed by its first attach; this re-attach declared a "
+                "different one and it was ignored",
+                {
+                    "cache.declared": notices.rendered(policy),
+                    "cache.effective": notices.rendered(
+                        self._sessions.cache_policy_for(self._topic)
+                    ),
+                },
+            )
+        )
 
     def _resubscribe(self, cursor: int | None) -> None:
         # WHY: an attach mid-connection (e.g. client resuming after a gap) replaces
@@ -254,6 +326,7 @@ async def run_bridge(
     topic: str,
     *,
     job_runner: JobRunner | None,
+    sessions: TopicSession,
     clock: Clock,
     heartbeat_s: float,
 ) -> None:
@@ -263,5 +336,11 @@ async def run_bridge(
     (client disconnect or an unrecoverable send failure).
     """
     await Bridge(
-        ws, stream, topic, job_runner=job_runner, clock=clock, heartbeat_s=heartbeat_s
+        ws,
+        stream,
+        topic,
+        job_runner=job_runner,
+        sessions=sessions,
+        clock=clock,
+        heartbeat_s=heartbeat_s,
     ).run()

--- a/apps/url4-cloud/src/url4_cloud/ws/endpoint.py
+++ b/apps/url4-cloud/src/url4_cloud/ws/endpoint.py
@@ -76,8 +76,18 @@ async def ws_endpoint(websocket: WebSocket, ticket: str | None = None) -> None:
     registry.add(topic)
     try:
         await _accept(websocket)
+        # `registry` is passed twice over, as the subscriber count AND as the session state the
+        # attach frame's cache intent lands in: both are per-topic bookkeeping with the same
+        # lifetime, and the `add` above is what guarantees the session exists before any frame
+        # arrives.
         await run_bridge(
-            websocket, stream, topic, job_runner=job_runner, clock=clock, heartbeat_s=heartbeat_s
+            websocket,
+            stream,
+            topic,
+            job_runner=job_runner,
+            sessions=registry,
+            clock=clock,
+            heartbeat_s=heartbeat_s,
         )
     finally:
         # INVARIANT: the registry count is decremented exactly once per successful

--- a/apps/url4-cloud/src/url4_cloud/ws/registry.py
+++ b/apps/url4-cloud/src/url4_cloud/ws/registry.py
@@ -1,25 +1,132 @@
-"""In-process bookkeeping of active WebSocket subscribers per topic."""
+"""In-process, per-topic WebSocket session state: how many connections are attached, what cache
+policy the first of them declared, and where to reach them with a notice.
+
+All three live on one record deliberately. A declaration is only load-bearing between the first
+attach and the moment the run is scheduled — ``_require_subscriber`` refuses to schedule a run
+with nothing attached, so that window is entirely contained inside "this topic has a subscriber",
+and the runner captures the policy at schedule time. Binding the declaration's lifetime to the
+subscriber count therefore costs nothing that can affect a run, and buys a store bounded by live
+connections instead of one that grows by a row per topic the process has ever seen.
+
+The same invariant is what makes the notice channel deliverable rather than best-effort: the REST
+route can only override a frame's declaration on a request that already passed the 428 gate, so a
+socket for the topic is attached, in THIS process, at exactly that moment. The App never publishes
+to the broker — it schedules runs and reads their log — so routing a notice through the attached
+connection is the only path that does not change that posture.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from url4.streaming.protocol import CachePolicy, OutboundFrame
+
+Notify = Callable[[OutboundFrame], None]
+"""How one live connection accepts an out-of-band frame. Synchronous and non-blocking by
+contract: it is called from a request handler, so it hands the frame to that connection's own
+outbound queue and returns — it must never await the socket."""
+
+
+@dataclass
+class _Session:
+    """One topic's WS session: live connections, the cache intent they declared, and their sinks."""
+
+    subscribers: int = 0
+    cache: CachePolicy | None = None
+    cache_declared: bool = False
+    """Whether ANY attach has spoken yet. Distinct from ``cache is None`` on purpose: an attach
+    frame carrying no policy still declares — it fixes the run under the default — so without this
+    flag a later attach could retroactively opt out a run that had already started."""
+    notifiers: list[Notify] = field(default_factory=list)
+    """One sink per live connection on this topic. A list and not a single slot because two
+    sockets may legitimately observe one run, and a notice about the run belongs to both."""
 
 
 class ConnectionRegistry:
-    """Tracks how many live WS connections are attached to each topic.
+    """Tracks each topic's live WS connections and its first-attach cache declaration.
 
-    Counts, rather than sets of connection ids, so concurrent connections on the
-    same topic are supported without the endpoint having to hand back a token.
+    Counts, rather than sets of connection ids, so concurrent connections on the same topic are
+    supported without the endpoint having to hand back a token.
     """
 
     def __init__(self) -> None:
-        self._counts: dict[str, int] = {}
+        self._sessions: dict[str, _Session] = {}
 
     def add(self, topic: str) -> None:
-        self._counts[topic] = self._counts.get(topic, 0) + 1
+        self._sessions.setdefault(topic, _Session()).subscribers += 1
 
     def remove(self, topic: str) -> None:
-        remaining = self._counts.get(topic, 0) - 1
-        if remaining > 0:
-            self._counts[topic] = remaining
-        else:
-            self._counts.pop(topic, None)
+        session = self._sessions.get(topic)
+        if session is None:
+            return
+        session.subscribers -= 1
+        if session.subscribers <= 0:
+            del self._sessions[topic]
 
     async def has_subscriber(self, topic: str) -> bool:
-        return self._counts.get(topic, 0) > 0
+        session = self._sessions.get(topic)
+        return session is not None and session.subscribers > 0
+
+    def declare_cache_policy(self, topic: str, policy: CachePolicy | None) -> bool:
+        """Record ``policy`` as ``topic``'s cache intent — FIRST ATTACH WINS (spec §5.2).
+
+        Args:
+            topic: The run's topic.
+            policy: What this attach frame declared; ``None`` when it declared nothing.
+
+        Returns:
+            ``True`` when the topic's standing intent now equals ``policy`` — either because this
+            call recorded it, or because the call merely restated what was already recorded (an
+            ordinary reconnect re-sending its frame, which must not be reported as anything).
+            ``False`` when an intent was already recorded and this one DIFFERS: the standing one
+            is left untouched and the caller is expected to say so.
+
+        A run's aigateway calls may already have executed under the recorded intent, so letting a
+        re-attach change it would make the run's cache behaviour unreproducible — the reason the
+        answer is "ignored and reported" rather than "last writer wins".
+        """
+        session = self._sessions.setdefault(topic, _Session())
+        if session.cache_declared:
+            return session.cache == policy
+        session.cache_declared = True
+        session.cache = policy
+        return True
+
+    def cache_policy_for(self, topic: str) -> CachePolicy | None:
+        """``topic``'s declared cache intent, or ``None`` if nothing was declared for it.
+
+        ``None`` is deliberately the answer to both "no attach has spoken" and "an attach declared
+        nothing": neither states an intent, and both resolve to the default at convergence. What
+        the two must NOT be confused with is an explicit opt-out, and that is a policy, not
+        ``None``.
+        """
+        session = self._sessions.get(topic)
+        return session.cache if session is not None else None
+
+    def add_notifier(self, topic: str, notify: Notify) -> None:
+        """Register one connection's sink for out-of-band frames on ``topic``."""
+        self._sessions.setdefault(topic, _Session()).notifiers.append(notify)
+
+    def remove_notifier(self, topic: str, notify: Notify) -> None:
+        """Drop a sink registered by :meth:`add_notifier`; a stale one is not an error.
+
+        Idempotent on purpose: the connection that registered it unregisters in a ``finally``,
+        which also runs on the path where the last ``remove`` already discarded the whole session.
+        """
+        session = self._sessions.get(topic)
+        if session is not None and notify in session.notifiers:
+            session.notifiers.remove(notify)
+
+    def notify(self, topic: str, frame: OutboundFrame) -> None:
+        """Offer ``frame`` to every connection attached to ``topic``.
+
+        Best-effort by design, and silent about a topic nobody is listening to: a notice explains
+        something about a request that has ALREADY been accepted, so failing the request because
+        the explanation could not be delivered would trade a real answer for a footnote. The sinks
+        are copied before iterating — a sink is free to drop the frame, and nothing here should
+        depend on the list surviving the call.
+        """
+        session = self._sessions.get(topic)
+        if session is None:
+            return
+        for notify in list(session.notifiers):
+            notify(frame)

--- a/apps/url4-cloud/tests/integration/test_e2e_compose_flow.py
+++ b/apps/url4-cloud/tests/integration/test_e2e_compose_flow.py
@@ -11,6 +11,7 @@ from url4.streaming.interfaces import JobStatus, job_name
 from url4.streaming.protocol import (
     AttachData,
     AttachEvent,
+    CachePolicy,
     CostUsageEvent,
     OutboundFrame,
     OutboundFrameAdapter,
@@ -49,6 +50,9 @@ class MockRunnerJobRunner(IdentityAwareJobRunner):
         credential: str | None = None,
         profile: str | None = None,
         identity: Mapping[str, str] | None = None,
+        # Accepted so this fake still satisfies the port; the mock run it publishes never reaches
+        # a gateway, so there is nothing here for a cache policy to change.
+        cache: CachePolicy | None = None,
     ) -> str:
         self.scheduled.append((topic, url4, deadline_s))
         self._tasks.append(asyncio.ensure_future(publish_mock_run(self._stream, topic, url4)))

--- a/apps/url4-cloud/tests/unit/_fakes.py
+++ b/apps/url4-cloud/tests/unit/_fakes.py
@@ -20,6 +20,7 @@ from url4.streaming.interfaces import (
     job_name,
 )
 from url4.streaming.protocol import (
+    CachePolicy,
     CostUsageData,
     LogData,
     OutboundFrame,
@@ -137,6 +138,11 @@ class RecordingJobRunner(IdentityAwareJobRunner):
         credential: str | None = None,
         profile: str | None = None,
         identity: Mapping[str, str] | None = None,
+        # Accepted so this fake still satisfies the port, and deliberately NOT recorded onto
+        # `ScheduledRun`: that tuple is compared whole by an existing test, so widening it would
+        # change what an already-written assertion means. A test that needs to observe the policy
+        # subclasses this and records it there.
+        cache: CachePolicy | None = None,
     ) -> str:
         if self._conflict:
             raise JobAlreadyExists(topic)

--- a/apps/url4-cloud/tests/unit/test_cache_docs_surface.py
+++ b/apps/url4-cloud/tests/unit/test_cache_docs_surface.py
@@ -1,0 +1,77 @@
+"""The cache policy's two published contracts describe themselves (plan Batch 8).
+
+FEATURE: a run's cache intent has two carriers — the `Cache-Control` request header on `GET /`
+and the `cache` field on the `ai.url4.attach` frame — and a client discovers each from a
+different document. A carrier nobody can find is a carrier nobody uses, which leaves the whole
+feature to be discovered by reading url4-cloud's source.
+
+STORY: as an SDK author I can read `/openapi.json` and `/asyncapi.json` and learn that caching is
+ON by default, how to turn it off on either carrier, and which one wins when both speak.
+
+These are served artifacts, not prose: `/openapi.json` and `/asyncapi.json` are endpoints, so the
+documents are part of the app's behaviour and testable as such. `apps/url4-cloud/README.md` is
+prose and is deliberately NOT asserted here — pinning wording would make an editorial improvement
+a red build.
+"""
+
+from __future__ import annotations
+
+from url4_cloud.app import create_app
+from url4_cloud.schemas.asyncapi import build_asyncapi
+
+
+def _get_root_header(name: str) -> dict:
+    parameters = create_app().openapi()["paths"]["/"]["get"]["parameters"]
+    return next(p for p in parameters if p["in"] == "header" and p["name"] == name)
+
+
+# ── the HTTP carrier ──────────────────────────────────────────────────────────────────────
+
+
+def test_the_cache_control_header_is_a_documented_parameter_of_the_run_start() -> None:
+    # Regression pin on the ingress contract itself: the parameter is what a generated client
+    # turns into a callable argument, so losing it silently removes the carrier from every SDK.
+    parameter = _get_root_header("Cache-Control")
+
+    assert parameter["required"] is False
+    assert parameter["description"]
+
+
+def test_the_cache_control_parameter_names_every_directive_it_honours() -> None:
+    # Each of these maps to a DIFFERENT outcome at the url4 edge, and a caller guessing between
+    # them pays for the guess in cache hits.
+    description = _get_root_header("Cache-Control")["description"]
+
+    for directive in ("no-store", "no-cache", "max-age", "url4-use-cache"):
+        assert directive in description, f"undocumented directive: {directive}"
+
+
+def test_the_api_description_explains_response_caching() -> None:
+    # The parameter description says what the directives do; the API description is where a
+    # reader learns the two facts that are NOT visible from one parameter — that caching is on by
+    # default, and that a second carrier exists on the WebSocket.
+    description = create_app().openapi()["info"]["description"]
+
+    assert "Cache-Control" in description
+    assert "ai.url4.attach" in description
+
+
+# ── the WebSocket carrier ─────────────────────────────────────────────────────────────────
+
+
+def test_the_attach_frame_schema_carries_the_cache_field() -> None:
+    schemas = build_asyncapi()["components"]["schemas"]
+
+    assert "cache" in schemas["AttachData"]["properties"]
+    assert schemas["AttachData"]["properties"]["cache"]["description"]
+    assert schemas["CachePolicy"]["properties"].keys() == {"participate", "max_age"}
+
+
+def test_the_asyncapi_description_explains_the_attach_frames_cache_field() -> None:
+    # The schema says the field EXISTS; nothing in it can say that the first attach wins, or that
+    # the HTTP header overrides this frame — both are properties of the exchange, which is what
+    # this document's description is for.
+    description = build_asyncapi()["info"]["description"]
+
+    assert "cache" in description
+    assert "Cache-Control" in description

--- a/apps/url4-cloud/tests/unit/test_cache_policy_threading.py
+++ b/apps/url4-cloud/tests/unit/test_cache_policy_threading.py
@@ -1,0 +1,523 @@
+"""Batch 6 — the resolved cache policy travels from the REST edge onto the aigateway request.
+
+Convergence (Batch 5) ends with ONE policy per run and hands it to `_schedule`. This is the rest
+of the journey, and it is the same journey `profile` and the caller's identity already make:
+
+    GET / ──► _schedule ──► JobRunner.schedule(cache=…) ──► the run's ENV ──► build_executor
+                                                                                   │
+                        the aigateway chat-completions body ◄── the connector ◄─────┘
+
+**PER-RUN, and that is the whole design constraint.** The obvious shortcut — parking the policy on
+`AigatewayConfig` — is wrong for a reason no test would otherwise catch: that dataclass is WORLD
+config, one instance describing the gateway for every run in the process, so a per-run value on it
+is a value one caller's run can read out of another's. In local mode (`InProcessJobRunner`) those
+runs share an event loop, so the contamination is not hypothetical. Hence
+`test_two_concurrent_runs_with_different_policies_do_not_contaminate_each_other`, which builds both
+worlds from ONE `AigatewayConfig` instance on purpose.
+
+**The egress assertions are correctness tests, not style ones (spec §1.0).** aigateway v2's cache
+grammar is CLOSED to exactly one key, `use-cache`; any other key inside the `cache` object makes
+the whole request BYPASS the cache — silently, with nothing raised anywhere, even alongside a
+valid `use-cache: true`. So "the body carries at most that one key" is the guard that stops a cache
+which never hits and never says why, and `max_age` — url4-internal, applied at read-back — must be
+proven NOT to reach the wire.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator, Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import pytest
+from _fakes import FixedGate, RecordingJobRunner
+from _k8s_fakes import FakeCreatedJob, fake_created_job
+from fastapi import FastAPI
+from httpx import ASGITransport
+
+from url4.dag import run as url4_run
+from url4.streaming.interfaces import ExecStep, Executor, TraceContext
+from url4.streaming.protocol import CachePolicy
+from url4_cloud import job_env
+from url4_cloud.adapters.inprocess import InProcessJobRunner
+from url4_cloud.adapters.k8s import K8sJobRunner
+from url4_cloud.app import create_app
+from url4_cloud.auth import JwtCodec
+from url4_cloud.config import Settings
+from url4_cloud.runner.cache import policy_to_body_field
+from url4_cloud.runner.config import AigatewaySection, ModelSpec, RunnerConfig
+from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+from url4_cloud.runner.main import build_executor
+from url4_cloud.testing import InMemoryEventStream
+
+SECRET = "cache-threading-secret"
+WINDOW_S = 60
+T0 = datetime(2026, 8, 5, 9, 0, 0, tzinfo=UTC)
+MODEL = "anthropic/claude-haiku-4-5"
+TAVILY_TOKEN = "tvly-threading"  # noqa: S105 - not a real credential
+
+OPT_OUT = CachePolicy(participate=False)
+OPT_IN = CachePolicy(participate=True)
+BOUNDED = CachePolicy(participate=True, max_age=60)
+
+
+# --- the contract sets: the policy is per-RUN, and it is not a secret --------------------------
+
+
+def test_the_cache_env_names_are_per_run_and_never_deploy_time() -> None:
+    """Helm cannot know a policy that does not exist until a caller states one.
+
+    The membership is not decoration: `WRITTEN_BY_APP` is what
+    `test_job_env_contract.test_every_variable_the_app_writes_is_one_the_runner_reads` checks the
+    App's writes against, so a name missing here is a variable written into a Job that nothing
+    reads — the failure direction that breaks silently.
+    """
+    names = {job_env.CACHE_PARTICIPATE, job_env.CACHE_MAX_AGE_S}
+
+    assert names <= job_env.WRITTEN_BY_APP
+    assert not (names & job_env.DEPLOY_TIME)
+    assert not (names & job_env.SECRET), (
+        "a cache directive authorizes nothing and reveals nothing — declaring it SECRET would "
+        "force it through valueFrom.secretKeyRef and imply a confidentiality it does not have"
+    )
+
+
+# --- the env round trip: one contract, rendered by the App and read by the run mode ------------
+
+
+def test_an_opted_out_policy_round_trips_through_the_env() -> None:
+    env = job_env.cache_policy_to_env(OPT_OUT)
+
+    assert job_env.cache_policy_from_env(env) == OPT_OUT
+
+
+def test_a_freshness_bound_survives_the_env_round_trip() -> None:
+    """`max_age` is url4-internal and applied at read-back, so it has to REACH the run mode."""
+    env = job_env.cache_policy_to_env(BOUNDED)
+
+    assert job_env.cache_policy_from_env(env) == BOUNDED
+
+
+def test_a_run_that_declared_nothing_writes_no_cache_variables_at_all() -> None:
+    """`None` is "this hop was told nothing" — it must not render as a stated policy."""
+    assert job_env.cache_policy_to_env(None) == {}
+
+
+def test_an_env_with_no_cache_declaration_reads_back_as_nothing_stated() -> None:
+    """And "nothing stated" must reach the wire as participation WITHOUT re-deciding D1 here.
+
+    The default belongs to convergence and nowhere else. The run mode gets that answer for free:
+    an unstated policy translates to an absent `cache` field, which v2 reads as participate — so
+    a Job scheduled by an older App, or by hand, behaves like every other one.
+    """
+    policy = job_env.cache_policy_from_env({})
+
+    assert policy.participate is None
+    assert policy.max_age is None
+    assert policy_to_body_field(policy) == {}
+
+
+def test_an_unreadable_participation_value_is_read_as_an_opt_out() -> None:
+    """Conservative on purpose: the expensive silent failure is caching a run that refused.
+
+    This env is App-written, so a value that is neither `true` nor `false` is a bug rather than
+    caller input — and the cheap wrong answer (a missed hit) is the one to take.
+    """
+    policy = job_env.cache_policy_from_env({job_env.CACHE_PARTICIPATE: "yes"})
+
+    assert policy.participate is False
+
+
+def test_an_unreadable_freshness_bound_is_dropped_rather_than_failing_the_run() -> None:
+    policy = job_env.cache_policy_from_env(
+        {job_env.CACHE_PARTICIPATE: "true", job_env.CACHE_MAX_AGE_S: "soon"}
+    )
+
+    assert policy == OPT_IN
+
+
+# --- the two adapters: two renderings of ONE contract ------------------------------------------
+
+
+class _RecordingBatchApi:
+    def __init__(self) -> None:
+        self.created: list[dict[str, Any]] = []
+
+    def create_namespaced_job(
+        self, namespace: str, body: Any, *, _request_timeout: float | None = None
+    ) -> FakeCreatedJob:
+        self.created.append(dict(body))
+        return fake_created_job(f"uid-{body['metadata']['name']}")
+
+    def read_namespaced_job(
+        self, name: str, namespace: str, *, _request_timeout: float | None = None
+    ) -> Any:  # pragma: no cover
+        raise NotImplementedError
+
+    def delete_namespaced_job(
+        self,
+        name: str,
+        namespace: str,
+        *,
+        propagation_policy: str = "",
+        _request_timeout: float | None = None,
+    ) -> object:  # pragma: no cover
+        raise NotImplementedError
+
+
+def _job_env_of(api: _RecordingBatchApi) -> dict[str, str]:
+    container = api.created[0]["spec"]["template"]["spec"]["containers"][0]
+    return {e["name"]: e["value"] for e in container["env"] if "value" in e}
+
+
+@pytest.mark.asyncio
+async def test_the_k8s_adapter_writes_the_policy_as_plain_env_and_the_run_reads_it_back() -> None:
+    api = _RecordingBatchApi()
+
+    await K8sJobRunner(api, image="runner:test").schedule("t", "gpt(hi)", 60, cache=BOUNDED)
+
+    assert job_env.cache_policy_from_env(_job_env_of(api)) == BOUNDED
+
+
+class _NeverExecutor(Executor):
+    """Never executed — these tests assert the env the runner BUILDS, not what it then runs."""
+
+    async def execute(  # type: ignore[override]
+        self, url4: str, *, trace: TraceContext | None = None
+    ) -> AsyncIterator[ExecStep]:  # pragma: no cover - the run is never started
+        raise NotImplementedError
+        yield  # pragma: no cover - unreachable; makes this an async generator
+
+
+def _local_runner(base_env: dict[str, str] | None = None) -> InProcessJobRunner:
+    return InProcessJobRunner(
+        stream=InMemoryEventStream(),
+        executor_factory=lambda env: _NeverExecutor(),
+        base_env=base_env,
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_inprocess_adapter_renders_the_same_env_as_the_k8s_one() -> None:
+    """Local mode must not diverge: `build_executor` cannot tell a local run from a Job's."""
+    api = _RecordingBatchApi()
+    await K8sJobRunner(api, image="runner:test").schedule("t", "gpt(hi)", 60, cache=OPT_OUT)
+
+    local = _local_runner()._env("t", "gpt(hi)", 60, None, None, None, OPT_OUT)  # noqa: SLF001
+
+    assert job_env.cache_policy_to_env(OPT_OUT).items() <= local.items()
+    assert job_env.cache_policy_from_env(local) == job_env.cache_policy_from_env(_job_env_of(api))
+
+
+def test_this_runs_policy_replaces_any_ambient_one() -> None:
+    """`_base_env` is the App's OWN environment, shared by every local run.
+
+    A leftover there would apply one caller's opt-out to the next caller's run — or, worse in the
+    other direction, let a run that opted out inherit `participate=true` and be served a shared
+    answer it explicitly refused.
+    """
+    stale = {job_env.CACHE_PARTICIPATE: "true", job_env.CACHE_MAX_AGE_S: "900"}
+
+    env = _local_runner(stale)._env("t", "gpt(hi)", 60, None, None, None, OPT_OUT)  # noqa: SLF001
+
+    assert job_env.cache_policy_from_env(env) == OPT_OUT
+
+
+def test_a_run_with_no_policy_clears_any_ambient_one() -> None:
+    stale = {job_env.CACHE_PARTICIPATE: "false"}
+
+    env = _local_runner(stale)._env("t", "gpt(hi)", 60, None, None, None, None)  # noqa: SLF001
+
+    assert job_env.cache_policy_from_env(env).participate is None
+
+
+# --- the REST edge: the resolved policy reaches the job runner ---------------------------------
+
+
+class _CacheRecordingRunner(RecordingJobRunner):
+    """`RecordingJobRunner`, plus the one argument this batch adds to the port.
+
+    Recorded here rather than in the shared fake's `ScheduledRun` on purpose: that tuple is
+    compared whole by an earlier test, so widening it would change what a committed assertion
+    means. A subclass adds the observation without touching anything already asserted.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.cache_policies: list[CachePolicy | None] = []
+
+    async def schedule(
+        self,
+        topic: str,
+        url4: str,
+        deadline_s: int,
+        *,
+        traceparent: str | None = None,
+        credential: str | None = None,
+        profile: str | None = None,
+        identity: Mapping[str, str] | None = None,
+        cache: CachePolicy | None = None,
+    ) -> str:
+        self.cache_policies.append(cache)
+        return await super().schedule(
+            topic,
+            url4,
+            deadline_s,
+            traceparent=traceparent,
+            credential=credential,
+            profile=profile,
+            identity=identity,
+        )
+
+
+async def _start(runner: _CacheRecordingRunner, topic: str, **headers: str) -> httpx.Response:
+    app: FastAPI = create_app(
+        Settings(jwt_secret=SECRET, iat_window_s=WINDOW_S),
+        stream=InMemoryEventStream(),
+        job_runner=runner,
+        clock=lambda: T0,
+        interest=FixedGate(),
+    )
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        return await client.get(
+            "/",
+            params={"q": "gpt(hi)"},
+            headers={
+                "URL4-Capability": JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).sign(topic, T0),
+                "Prefer": "respond-async",
+                **headers,
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_headers_opt_out_reaches_the_job_runner() -> None:
+    runner = _CacheRecordingRunner()
+
+    resp = await _start(runner, "thread-no-store", **{"Cache-Control": "no-store"})
+
+    assert resp.status_code == 202
+    assert runner.cache_policies == [OPT_OUT]
+
+
+@pytest.mark.asyncio
+async def test_a_run_declaring_nothing_reaches_the_job_runner_already_resolved() -> None:
+    """Never `None` past convergence — the runner must not be left to guess what silence meant."""
+    runner = _CacheRecordingRunner()
+
+    await _start(runner, "thread-default")
+
+    assert runner.cache_policies == [OPT_IN]
+
+
+# --- the run mode: the env reaches the connector ------------------------------------------------
+
+
+def _declared() -> RunnerConfig:
+    return RunnerConfig(
+        aigateway=AigatewaySection(
+            base_url="http://aigateway.test",
+            default_model=MODEL,
+            models=(ModelSpec(id=MODEL),),
+        )
+    )
+
+
+class _MockAigateway:
+    """Records every chat-completions body, and can answer a scripted sequence per model."""
+
+    def __init__(self, script: list[dict[str, Any] | str] | None = None) -> None:
+        self.bodies: list[dict[str, Any]] = []
+        self.contents: list[bytes] = []
+        self._script = script or []
+        self._index = 0
+
+    def _handle(self, request: httpx.Request) -> httpx.Response:
+        self.contents.append(request.content)
+        self.bodies.append(json.loads(request.content))
+        if self._index < len(self._script):
+            scripted = self._script[self._index]
+            self._index += 1
+            if isinstance(scripted, dict):
+                return httpx.Response(200, json=scripted)
+        return httpx.Response(
+            200,
+            json={
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            },
+        )
+
+    def client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            transport=httpx.MockTransport(self._handle), base_url="http://aigateway.test"
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_runs_env_reaches_the_connectors_request_body() -> None:
+    """The one hop no unit below this can prove: `build_executor` reading the policy back."""
+    gw = _MockAigateway()
+    env = job_env.cache_policy_to_env(OPT_OUT)
+
+    async with gw.client() as client:
+        executor = build_executor(env, _declared(), client=client)
+        async for _ in executor.execute(f"/{MODEL}(ctx)!go"):
+            pass
+
+    assert gw.bodies[0]["cache"] == {"use-cache": False}
+
+
+@pytest.mark.asyncio
+async def test_an_env_that_declares_no_policy_sends_no_cache_field() -> None:
+    gw = _MockAigateway()
+
+    async with gw.client() as client:
+        executor = build_executor({}, _declared(), client=client)
+        async for _ in executor.execute(f"/{MODEL}(ctx)!go"):
+            pass
+
+    assert "cache" not in gw.bodies[0]
+
+
+# --- egress: what the gateway actually receives -------------------------------------------------
+
+
+async def _bodies(cache: CachePolicy | None, *, expression: str = f"/{MODEL}('ctx')!'go'") -> Any:
+    gw = _MockAigateway()
+    cfg = AigatewayConfig(models=(ModelSpec(id=MODEL),), default_model=MODEL)
+    async with gw.client() as client:
+        world = await build_aigateway_world(cfg, client=client, cache=cache)
+        await url4_run(expression, io=world.node)
+    return gw
+
+
+@pytest.mark.asyncio
+async def test_a_default_runs_body_is_byte_identical_to_one_that_states_no_policy() -> None:
+    """v2 reads absent, `null` and `{}` identically, so participation is expressed by SILENCE.
+
+    Byte-compared rather than key-compared: the acceptance criterion is that turning this feature
+    on changes nothing about an ordinary run's request, and `{"cache": {"use-cache": true}}` would
+    satisfy a key-set assertion while enlarging the surface exposed to the closed-grammar bypass
+    for no gain at all.
+    """
+    unstated = await _bodies(None)
+    participating = await _bodies(OPT_IN)
+
+    assert participating.contents == unstated.contents
+    assert set(unstated.bodies[0]) == {"model", "messages"}
+
+
+@pytest.mark.asyncio
+async def test_an_opted_out_run_sends_use_cache_false_and_nothing_else() -> None:
+    gw = await _bodies(OPT_OUT)
+
+    body = gw.bodies[0]
+    assert body["cache"] == {"use-cache": False}
+    assert set(body) == {"model", "messages", "cache"}
+
+
+@pytest.mark.asyncio
+async def test_a_freshness_bound_never_reaches_the_wire() -> None:
+    """D11 is applied at read-back. Sent as a control key it would BYPASS, which is the opposite.
+
+    `max-age` is not in v2's grammar, and v2 does not ignore what it does not know — an extra key
+    costs the caller every hit, for a bound the gateway was never going to honour anyway.
+    """
+    gw = await _bodies(BOUNDED)
+
+    assert "cache" not in gw.bodies[0]
+    assert set(gw.bodies[0]) == {"model", "messages"}
+
+
+@pytest.mark.asyncio
+async def test_no_policy_ever_puts_a_key_other_than_use_cache_on_the_wire() -> None:
+    """The single most important regression guard here: an extra key is a silent, permanent cost."""
+    for policy in (None, OPT_IN, OPT_OUT, BOUNDED, CachePolicy(), CachePolicy(max_age=0)):
+        gw = await _bodies(policy)
+
+        assert set(gw.bodies[0].get("cache", {})) <= {"use-cache"}, policy
+
+
+@pytest.mark.asyncio
+async def test_two_concurrent_runs_with_different_policies_do_not_contaminate_each_other() -> None:
+    """Both worlds are built from ONE `AigatewayConfig` — the placement the plan forbids.
+
+    Parked there, the second `build_aigateway_world` would rewrite the first run's policy, and in
+    local mode the two runs share an event loop, so the winner would be whichever ran last.
+    """
+    gw = _MockAigateway()
+    shared_cfg = AigatewayConfig(models=(ModelSpec(id=MODEL),), default_model=MODEL)
+
+    async with gw.client() as client:
+        opted_out = await build_aigateway_world(shared_cfg, client=client, cache=OPT_OUT)
+        participating = await build_aigateway_world(shared_cfg, client=client, cache=OPT_IN)
+
+        await asyncio.gather(
+            url4_run(f"/{MODEL}('run-a')!'go'", io=opted_out.node),
+            url4_run(f"/{MODEL}('run-b')!'go'", io=participating.node),
+        )
+
+    by_context = {body["messages"][-1]["content"]: body for body in gw.bodies}
+    assert by_context["run-a"]["cache"] == {"use-cache": False}
+    assert "cache" not in by_context["run-b"]
+
+
+def _tool_call_turn() -> dict[str, Any]:
+    return {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "web_search",
+                                "arguments": json.dumps({"query": "who is leo"}),
+                            },
+                        }
+                    ],
+                }
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+
+
+@pytest.mark.asyncio
+async def test_the_tool_calling_loop_applies_the_policy_on_every_round_trip() -> None:
+    """One url4 turn is several gateway calls, and each is keyed and cached independently.
+
+    A policy that lapsed after the first would be worse than none: the caller who asked for a
+    fresh answer would get one, then have the tool-augmented continuation — the expensive, most
+    context-specific call of the turn — served from a shared corpus anyway.
+    """
+    gw = _MockAigateway(script=[_tool_call_turn()])
+    tavily = httpx.AsyncClient(
+        transport=httpx.MockTransport(
+            lambda _r: httpx.Response(200, json={"results": [{"title": "t", "url": "u"}]})
+        ),
+        base_url="https://api.tavily.com",
+    )
+    cfg = AigatewayConfig(models=(ModelSpec(id=MODEL, web_tools=True),), default_model=MODEL)
+
+    async with gw.client() as client, tavily:
+        world = await build_aigateway_world(
+            cfg,
+            client=client,
+            cache=OPT_OUT,
+            tavily_api_key=TAVILY_TOKEN,
+            tavily_client=tavily,
+        )
+        await url4_run(f"/{MODEL}('ctx')!'go'", io=world.node)
+
+    assert len(gw.bodies) == 2, "the tool loop must have made a second round trip"
+    assert all(body["cache"] == {"use-cache": False} for body in gw.bodies)

--- a/apps/url4-cloud/tests/unit/test_cache_readback.py
+++ b/apps/url4-cloud/tests/unit/test_cache_readback.py
@@ -1,0 +1,633 @@
+"""Batch 7 — reading the gateway's cache answer back onto the run's spans.
+
+FEATURE: url4 per-run cache policy (spec §7, D7 — mandatory observability).
+STORY: as an operator who turned caching on, every span tells me whether that call hit, missed
+or bypassed the cache and — when it did not hit — the gateway's own word for why, so "I asked
+for no caching and something still cached" is an answerable question.
+
+**Why it is mandatory rather than nice-to-have.** A hit costs nothing upstream, but
+`_report_usage` bills it exactly like a fresh call. Without the outcome beside it, enabling the
+cache makes the cost taxonomy wrong in the direction that HIDES savings — so nobody reports it.
+
+Three layers, because the signal crosses three seams — the same shape
+`test_finish_reason_capture.py` uses, and for the same reason:
+
+  0. `runner/cache_readback.py` parses the response headers into a `CacheOutcome`;
+  1. the connector reports it beside `_report_usage` (`ModelResponse`);
+  2. `_RunState` folds it onto the owning span, which carries it on the wire as
+     `SpanData.cache_status` / `cache_reason` (the wire shape itself is pinned by
+     `test_protocol_cache.py`).
+
+**Two sources, in preference order (spec §2.2, §7).** `Cache-Status` (RFC 9211) is the Standards
+Track field for exactly this fact and is read FIRST; the ad hoc `X-AIGW-Cache*` triple aigateway
+emits today is the fallback. Preferring the standard costs nothing now and means url4 needs no
+change the day the gateway adopts it. The list may carry one member per cache that touched the
+response — aigateway, an Envoy sidecar, a CDN — so selecting the AIGATEWAY member rather than
+blindly the first is a correctness test, not a style one: reading a CDN's `hit` as aigateway's
+answer would report a cache saving that never happened.
+
+**The D11 branches (spec §3.5).** `max-age` is honoured, but the two upstream halves that would
+make it work are missing: the gateway accepts no freshness bound and reports no age. So a hit
+whose age cannot be established is re-issued with an explicit opt-out — never served stale — and
+the honoured path is written here, dormant, against a gateway that reports `Age`.
+
+A separate module rather than an append to `test_aigateway_connector.py`: the repo's append-only
+gate compares file status, so growing an existing test file reads as "a prior test was modified"
+even when the diff is purely additive.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from url4.dag import run as url4_run
+from url4.observe import ModelResponse, NodeFinished, NodeStarted, ObservationEvent
+from url4.streaming.interfaces import Traced
+from url4.streaming.protocol import CachePolicy, SpanData
+from url4_cloud.runner.cache_readback import (
+    CacheOutcome,
+    CacheStatus,
+    read_cache_outcome,
+    requires_revalidation,
+)
+from url4_cloud.runner.config import ModelSpec
+from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+from url4_cloud.runner.executor import _RunState
+
+_MODEL = "anthropic/claude-haiku-4-5"
+
+# The four reasons aigateway v2 can give for not using the cache. They are ITS vocabulary and the
+# whole point of carrying the field verbatim: `opted_out` means url4 asked for no cache and got
+# none, while `unsupported_control` means url4 sent a key v2 does not know and silently lost every
+# hit. Collapsing them would hide the second behind the first.
+_V2_REASONS = ["opted_out", "malformed_controls", "unsupported_control", "disabled"]
+
+
+# ── layer 0: the header parse ─────────────────────────────────────────────────────────────
+
+
+def test_cache_status_reports_a_hit() -> None:
+    outcome = read_cache_outcome({"Cache-Status": "aigateway; hit"})
+
+    assert outcome.status == "hit"
+
+
+@pytest.mark.parametrize(
+    ("fwd", "status"),
+    [
+        # RFC 9211 §2.2's defined tokens. `bypass` is the only one that means "the cache was not
+        # consulted at all"; every other forward reason means it was consulted and had nothing.
+        ("bypass", "bypass"),
+        ("miss", "miss"),
+        ("uri-miss", "miss"),
+        ("vary-miss", "miss"),
+        ("stale", "miss"),
+        ("request", "miss"),
+        ("method", "miss"),
+        ("partial", "miss"),
+    ],
+)
+def test_a_forwarded_request_maps_its_token_to_a_status_and_keeps_it_as_the_reason(
+    fwd: str, status: str
+) -> None:
+    outcome = read_cache_outcome({"Cache-Status": f"aigateway; fwd={fwd}"})
+
+    assert (outcome.status, outcome.reason) == (status, fwd)
+
+
+@pytest.mark.parametrize("reason", _V2_REASONS)
+def test_detail_supplies_the_reason_verbatim_when_present(reason: str) -> None:
+    # INVARIANT: `detail` is where a cache puts its OWN word for the outcome, so it outranks the
+    # generic `fwd` token — which says only that the request was forwarded, never why.
+    outcome = read_cache_outcome({"Cache-Status": f'aigateway; fwd=bypass; detail="{reason}"'})
+
+    assert (outcome.status, outcome.reason) == ("bypass", reason)
+
+
+def test_the_aigateway_member_is_selected_not_the_first_one() -> None:
+    # INVARIANT: the field is a LIST — one member per cache that handled the response. Taking the
+    # first would read a CDN's hit as aigateway's answer and report a saving that never happened.
+    outcome = read_cache_outcome(
+        {"Cache-Status": 'ExampleCDN; hit; ttl=376, aigateway; fwd=bypass; detail="opted_out"'}
+    )
+
+    assert (outcome.status, outcome.reason) == ("bypass", "opted_out")
+
+
+def test_the_aigateway_member_is_found_wherever_it_sits_in_the_list() -> None:
+    # RFC 9211 orders the list origin-closest first, so aigateway normally leads — but the rule is
+    # a SHOULD, and an intermediary that prepends must not change what url4 reads.
+    outcome = read_cache_outcome({"Cache-Status": "aigateway; hit, ExampleCDN; fwd=miss"})
+
+    assert outcome.status == "hit"
+
+
+def test_a_quoted_member_name_containing_a_comma_does_not_split_the_list() -> None:
+    # Boundary: RFC 8941 String members may contain the list separator. A naive `split(",")` reads
+    # `"CDN, Inc."` as two members and then finds no aigateway member at all.
+    outcome = read_cache_outcome({"Cache-Status": '"CDN, Inc."; fwd=miss, "aigateway"; hit'})
+
+    assert outcome.status == "hit"
+
+
+def test_an_escaped_quote_inside_a_string_does_not_end_it() -> None:
+    # Boundary: RFC 8941 §3.3.3 allows `\"` and `\\` inside a String. A parser that ends the
+    # string at the escaped quote leaves the rest of the field looking unquoted — and then the
+    # comma inside it splits the list, and the aigateway member is never found.
+    outcome = read_cache_outcome({"Cache-Status": '"CDN \\", Inc."; hit, aigateway; fwd=miss'})
+
+    assert (outcome.status, outcome.reason) == ("miss", "miss")
+
+
+def test_escapes_inside_a_reason_are_resolved_not_carried() -> None:
+    # The reason is published verbatim onto a span, so it must be the string the cache MEANT —
+    # transport escaping is the wire's business, not the reader's.
+    outcome = read_cache_outcome(
+        {"Cache-Status": '"aigateway"; fwd=bypass; detail="say \\"no\\" \\\\ twice"'}
+    )
+
+    assert outcome.reason == 'say "no" \\ twice'
+
+
+def test_a_list_naming_only_other_caches_reports_nothing_for_aigateway() -> None:
+    # Boundary: an Envoy hit is not a gateway hit. Reporting it as one would attribute a saving to
+    # the wrong cache and, worse, mark a real provider dispatch as free.
+    outcome = read_cache_outcome({"Cache-Status": "ExampleCDN; hit, Envoy; fwd=miss"})
+
+    assert outcome.status is None
+
+
+def test_cache_status_wins_over_the_legacy_triple_when_both_are_present() -> None:
+    # The forward-compatibility guarantee: on the day aigateway emits both, the standard field is
+    # what url4 believes, so adopting it upstream needs no change here.
+    outcome = read_cache_outcome(
+        {
+            "Cache-Status": "aigateway; hit",
+            "X-AIGW-Cache": "bypass",
+            "X-AIGW-Cache-Reason": "disabled",
+        }
+    )
+
+    assert (outcome.status, outcome.reason) == ("hit", None)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "   ",
+        ",,,",
+        ";;;",
+        "aigateway",  # a member that states neither hit nor fwd says nothing at all
+        '"unterminated; hit',
+        "aigateway; hit=?0",  # an explicit NOT-a-hit, with no forward reason to fall back on
+        "=;=,=",
+    ],
+)
+def test_an_unusable_cache_status_falls_back_to_the_legacy_triple(raw: str) -> None:
+    # INVARIANT: falling back rather than failing. The signal exists in the other field; dropping
+    # it because the preferred one was garbage would lose the outcome for no reason.
+    outcome = read_cache_outcome(
+        {"Cache-Status": raw, "X-AIGW-Cache": "miss", "X-AIGW-Cache-Reason": "not_requested"}
+    )
+
+    assert (outcome.status, outcome.reason) == ("miss", "not_requested")
+
+
+@pytest.mark.parametrize("status", ["hit", "miss", "bypass"])
+def test_the_legacy_triple_reports_every_status(status: str) -> None:
+    outcome = read_cache_outcome({"X-AIGW-Cache": status})
+
+    assert outcome.status == status
+
+
+@pytest.mark.parametrize("reason", _V2_REASONS)
+def test_the_legacy_triples_reason_is_carried_verbatim(reason: str) -> None:
+    outcome = read_cache_outcome({"X-AIGW-Cache": "bypass", "X-AIGW-Cache-Reason": reason})
+
+    assert outcome.reason == reason
+
+
+def test_an_unrecognised_legacy_status_is_dropped_rather_than_invented() -> None:
+    # Boundary: the wire field is a free string. A value outside the protocol's closed vocabulary
+    # cannot be put on a span, and guessing which of the three it meant would be a fabrication.
+    outcome = read_cache_outcome({"X-AIGW-Cache": "warmed"})
+
+    assert outcome.status is None
+
+
+@pytest.mark.parametrize("status", ["hit", "miss"])
+def test_the_cache_key_is_recorded_for_a_hit_or_a_miss(status: str) -> None:
+    # The key is a hash PREFIX by construction (aigateway truncates to 12 chars) — never prompt or
+    # response content, which is what makes it safe to carry at all (spec §8.4).
+    outcome = read_cache_outcome({"X-AIGW-Cache": status, "X-AIGW-Cache-Key": "a1b2c3d4e5f6"})
+
+    assert outcome.key == "a1b2c3d4e5f6"
+
+
+def test_a_key_arriving_with_a_bypass_is_dropped() -> None:
+    # INVARIANT: a bypassed request has no entry, so a key on it identifies nothing. aigateway sets
+    # the header only for hit/miss; url4 re-states the rule rather than trusting the sender.
+    outcome = read_cache_outcome({"X-AIGW-Cache": "bypass", "X-AIGW-Cache-Key": "a1b2c3d4e5f6"})
+
+    assert outcome.key is None
+
+
+def test_the_key_is_read_from_cache_status_too() -> None:
+    outcome = read_cache_outcome({"Cache-Status": 'aigateway; hit; key="a1b2c3d4e5f6"'})
+
+    assert outcome.key == "a1b2c3d4e5f6"
+
+
+def test_no_cache_headers_at_all_degrade_to_nothing_reported() -> None:
+    # The ordinary case for an older gateway, and for every non-cache error path. It must produce
+    # an absence, not a crash and not a fabricated status.
+    assert read_cache_outcome({}) == CacheOutcome(status=None, reason=None, key=None, age_s=None)
+
+
+def test_header_names_are_matched_case_insensitively() -> None:
+    # RFC 9110 §5.1: field names are case-insensitive. `httpx.Headers` already honours that; a
+    # plain mapping handed in by a caller does not, and the parse must not depend on which it got.
+    outcome = read_cache_outcome({"cache-status": "aigateway; hit"})
+
+    assert outcome.status == "hit"
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {"Cache-Status": "aigateway; hit; key="},
+        {"Cache-Status": "aigateway; ttl=; fwd="},
+        {"Cache-Status": "aigateway;;; hit"},
+        {"Cache-Status": "aigateway; hit; detail=\\"},
+        {"Cache-Status": "аigateway; hit"},  # Cyrillic а — a lookalike, not our member
+        {"Cache-Status": "aigateway; hit" * 500},
+        {"X-AIGW-Cache": ""},
+        {"X-AIGW-Cache": "hit", "X-AIGW-Cache-Reason": ""},
+        {"Age": "not-a-number"},
+    ],
+)
+def test_hostile_or_malformed_headers_never_raise(headers: dict[str, str]) -> None:
+    # INVARIANT: this parse runs on the response path of every gateway call. A cache outcome is an
+    # observation about a call, never a term of it — failing a run over one would trade a missing
+    # telemetry field for a dead ensemble.
+    read_cache_outcome(headers)
+
+
+def test_the_age_header_is_read_as_whole_seconds() -> None:
+    outcome = read_cache_outcome({"X-AIGW-Cache": "hit", "Age": "42"})
+
+    assert outcome.age_s == 42
+
+
+@pytest.mark.parametrize("raw", ["", "-1", "1.5", "abc", "9 9"])
+def test_an_unusable_age_is_no_age_at_all(raw: str) -> None:
+    # Boundary: RFC 9111 §5.1 defines `Age` as a non-negative integer. Anything else is unusable,
+    # and an unusable age must read as "unknown" — which is the conservative direction, since an
+    # unknown age is exactly what makes a freshness bound unenforceable.
+    outcome = read_cache_outcome({"X-AIGW-Cache": "hit", "Age": raw})
+
+    assert outcome.age_s is None
+
+
+# ── layer 0b: the D11 freshness decision ──────────────────────────────────────────────────
+
+
+def _outcome(status: CacheStatus | None, *, age_s: int | None = None) -> CacheOutcome:
+    return CacheOutcome(status=status, reason=None, key=None, age_s=age_s)
+
+
+@pytest.mark.parametrize("status", ["hit", "miss", "bypass", None])
+def test_a_run_that_stated_no_bound_never_revalidates(status: CacheStatus | None) -> None:
+    # INVARIANT: the D1 default participates and asks for nothing, so the overwhelming majority of
+    # runs must pay nothing for D11 existing.
+    assert requires_revalidation(CachePolicy(participate=True), _outcome(status)) is False
+
+
+def test_a_hit_of_unknown_age_is_refused_because_the_bound_cannot_be_honoured() -> None:
+    # THE PATH THAT ACTUALLY SHIPS (plan §6). aigateway reports no age, so a stored answer cannot
+    # be proven within the caller's bound — and serving it anyway would be a silent stale serve of
+    # a corpus that never expires.
+    assert requires_revalidation(CachePolicy(max_age=60), _outcome("hit")) is True
+
+
+@pytest.mark.parametrize("status", ["miss", "bypass"])
+def test_a_freshly_generated_answer_is_never_revalidated(status: CacheStatus) -> None:
+    # INVARIANT: a miss or a bypass IS the fresh answer — age zero, within every bound. Re-issuing
+    # there would double the cost of a bound that was already honoured, on every call of the run.
+    assert requires_revalidation(CachePolicy(max_age=60), _outcome(status)) is False
+
+
+def test_a_hit_within_the_bound_is_a_legitimate_hit() -> None:
+    # DORMANT until aigateway reports `Age` — written now so the day it does, D11 is a branch that
+    # already works rather than a redesign.
+    assert requires_revalidation(CachePolicy(max_age=60), _outcome("hit", age_s=10)) is False
+
+
+def test_a_hit_exactly_at_the_bound_is_still_within_it() -> None:
+    # RFC 9111 §5.2.1.1: max-age asks for an age "less than or equal to" N.
+    assert requires_revalidation(CachePolicy(max_age=60), _outcome("hit", age_s=60)) is False
+
+
+def test_a_hit_beyond_the_bound_is_refused() -> None:
+    assert requires_revalidation(CachePolicy(max_age=60), _outcome("hit", age_s=61)) is True
+
+
+def test_a_zero_bound_refuses_every_stored_answer() -> None:
+    # Boundary: `max-age=0` is the strictest bound a caller can state, and it must not be confused
+    # with having stated nothing — the parse edge preserves it for exactly this reason.
+    assert requires_revalidation(CachePolicy(max_age=0), _outcome("hit", age_s=1)) is True
+
+
+# ── layer 1: the connector reports what it read ───────────────────────────────────────────
+
+
+class _Gateway:
+    """A chat-completions endpoint serving `(json, headers)` pairs in order, recording every
+    request body so a re-issue is provable rather than inferred."""
+
+    def __init__(self, turns: list[tuple[dict, dict[str, str]]]) -> None:
+        self._turns = turns
+        self._index = 0
+        self.bodies: list[dict] = []
+
+    def client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            transport=httpx.MockTransport(self._handle), base_url="http://aigateway.test"
+        )
+
+    def _handle(self, request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/chat/completions"
+        self.bodies.append(json.loads(request.content))
+        body, headers = self._turns[min(self._index, len(self._turns) - 1)]
+        self._index += 1
+        return httpx.Response(200, json=body, headers=headers)
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.events: list[ObservationEvent] = []
+
+    def on_event(self, event: ObservationEvent) -> None:
+        self.events.append(event)
+
+    @property
+    def responses(self) -> list[ModelResponse]:
+        return [e for e in self.events if isinstance(e, ModelResponse)]
+
+
+def _completion(content: str = "an answer", **extra: object) -> dict:
+    message: dict = {"role": "assistant", "content": content, **extra}
+    return {
+        "choices": [{"message": message, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+    }
+
+
+async def _run_against(
+    gateway: _Gateway, *, cache: CachePolicy | None = None
+) -> tuple[str, _Recorder]:
+    cfg = AigatewayConfig(models=(ModelSpec(id=_MODEL),), default_model=_MODEL)
+    rec = _Recorder()
+    async with gateway.client() as client:
+        world = await build_aigateway_world(cfg, client=client, cache=cache)
+        result = await url4_run(f"/{_MODEL}(ctx)!go", io=world.node, observer=rec)
+    return result, rec
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["hit", "miss", "bypass"])
+async def test_the_connector_reports_the_legacy_triples_status(status: str) -> None:
+    gateway = _Gateway([(_completion(), {"X-AIGW-Cache": status, "X-AIGW-Cache-Reason": "r"})])
+
+    _, rec = await _run_against(gateway)
+
+    assert [(r.cache_status, r.cache_reason) for r in rec.responses] == [(status, "r")]
+
+
+@pytest.mark.asyncio
+async def test_the_connector_prefers_cache_status_over_the_triple() -> None:
+    gateway = _Gateway(
+        [(_completion(), {"Cache-Status": "aigateway; hit", "X-AIGW-Cache": "miss"})]
+    )
+
+    _, rec = await _run_against(gateway)
+
+    assert rec.responses[0].cache_status == "hit"
+
+
+@pytest.mark.asyncio
+async def test_a_gateway_that_reports_no_cache_headers_still_completes_the_run() -> None:
+    # INVARIANT: degrade to None, never crash — an older gateway, or any path that answered
+    # without reaching the cache at all.
+    gateway = _Gateway([(_completion(), {})])
+
+    result, rec = await _run_against(gateway)
+
+    assert result == "an answer"
+    assert (rec.responses[0].cache_status, rec.responses[0].cache_reason) == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_a_hit_of_unknown_age_under_a_bound_is_re_issued_as_an_opt_out() -> None:
+    # THE D11-INERT PATH, end to end (plan test 2c). The caller asked for a freshness bound; the
+    # gateway can neither accept one nor report an age, so the stored answer is refused and the
+    # call is re-issued with an explicit opt-out. The run's outcome is the SECOND answer.
+    gateway = _Gateway(
+        [
+            (_completion("stale answer"), {"X-AIGW-Cache": "hit"}),
+            (
+                _completion("fresh answer"),
+                {"X-AIGW-Cache": "bypass", "X-AIGW-Cache-Reason": "opted_out"},
+            ),
+        ]
+    )
+
+    result, rec = await _run_against(gateway, cache=CachePolicy(max_age=60))
+
+    assert result == "fresh answer"
+    assert len(gateway.bodies) == 2
+    # INVARIANT (spec §1.0): the re-issue is still bound by the closed grammar — `use-cache` and
+    # nothing else, or the request would bypass for the wrong reason.
+    assert gateway.bodies[0].get("cache") is None
+    assert gateway.bodies[1]["cache"] == {"use-cache": False}
+    assert [(r.cache_status, r.cache_reason) for r in rec.responses] == [("bypass", "opted_out")]
+
+
+@pytest.mark.asyncio
+async def test_the_discarded_answer_is_never_billed() -> None:
+    # INVARIANT: the refused response is read for its headers and thrown away. Reporting its usage
+    # too would bill one turn twice — the precise error class this whole batch exists to prevent.
+    gateway = _Gateway(
+        [
+            (_completion("stale answer"), {"X-AIGW-Cache": "hit"}),
+            (_completion("fresh answer"), {"X-AIGW-Cache": "bypass"}),
+        ]
+    )
+
+    _, rec = await _run_against(gateway, cache=CachePolicy(max_age=60))
+
+    assert len(rec.responses) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_hit_within_the_bound_is_served_without_a_second_call() -> None:
+    # DORMANT until aigateway reports `Age` (plan test 2d) — the honoured half of D11.
+    gateway = _Gateway([(_completion(), {"X-AIGW-Cache": "hit", "Age": "10"})])
+
+    _, rec = await _run_against(gateway, cache=CachePolicy(max_age=60))
+
+    assert len(gateway.bodies) == 1
+    assert rec.responses[0].cache_status == "hit"
+
+
+@pytest.mark.asyncio
+async def test_a_hit_beyond_the_bound_is_re_issued() -> None:
+    gateway = _Gateway(
+        [
+            (_completion("month-old answer"), {"X-AIGW-Cache": "hit", "Age": "600"}),
+            (_completion("fresh answer"), {"X-AIGW-Cache": "bypass"}),
+        ]
+    )
+
+    result, _ = await _run_against(gateway, cache=CachePolicy(max_age=60))
+
+    assert result == "fresh answer"
+
+
+@pytest.mark.asyncio
+async def test_a_miss_under_a_bound_costs_no_second_call() -> None:
+    # INVARIANT: a miss IS the fresh answer. Re-issuing it would double the cost of every call a
+    # bounded run makes, for an answer that already satisfied the bound.
+    gateway = _Gateway([(_completion(), {"X-AIGW-Cache": "miss"})])
+
+    _, _ = await _run_against(gateway, cache=CachePolicy(max_age=60))
+
+    assert len(gateway.bodies) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_run_without_a_bound_never_makes_a_second_call_on_a_hit() -> None:
+    # Regression guard for the default path: D11 must be invisible to the run that states nothing.
+    gateway = _Gateway([(_completion(), {"X-AIGW-Cache": "hit"})])
+
+    _, rec = await _run_against(gateway)
+
+    assert len(gateway.bodies) == 1
+    assert rec.responses[0].cache_status == "hit"
+
+
+@pytest.mark.asyncio
+async def test_every_round_trip_of_a_tool_turn_reports_its_own_outcome() -> None:
+    # One turn is several independently-keyed gateway calls; a continuation that missed after a
+    # first call that hit is two facts, and collapsing them would misreport the turn's cost.
+    tool_call = {"id": "c1", "type": "function", "function": {"name": "nope", "arguments": "{}"}}
+    gateway = _Gateway(
+        [
+            (
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": None,
+                                "tool_calls": [tool_call],
+                            },
+                            "finish_reason": "tool_calls",
+                        }
+                    ]
+                },
+                {"X-AIGW-Cache": "hit"},
+            ),
+            (_completion("final answer"), {"X-AIGW-Cache": "miss"}),
+        ]
+    )
+    cfg = AigatewayConfig(models=(ModelSpec(id=_MODEL, web_tools=True),), default_model=_MODEL)
+    rec = _Recorder()
+    async with gateway.client() as client, httpx.AsyncClient() as tavily:
+        world = await build_aigateway_world(
+            cfg, client=client, tavily_api_key="tvly-test", tavily_client=tavily
+        )
+        result = await url4_run(f"/{_MODEL}(ctx)!go", io=world.node, observer=rec)
+
+    assert result == "final answer"
+    assert [r.cache_status for r in rec.responses] == ["hit", "miss"]
+
+
+# ── layer 2: the span carries it ──────────────────────────────────────────────────────────
+
+
+def _span_frames(state: _RunState, events: list[ObservationEvent]) -> list[SpanData]:
+    frames: list[SpanData] = []
+    for event in events:
+        for frame in state.map(event):
+            payload = frame.payload if isinstance(frame, Traced) else frame
+            if isinstance(payload, SpanData):
+                frames.append(payload)
+    return frames
+
+
+@pytest.mark.parametrize("status", ["hit", "miss", "bypass"])
+def test_the_outcome_reaches_the_span_frame(status: CacheStatus) -> None:
+    spans = _span_frames(
+        _RunState(),
+        [
+            NodeStarted("span1", None, "Node", "detail"),
+            ModelResponse("span1", "stop", None, status, "opted_out"),
+            NodeFinished("span1", "ok", 1),
+        ],
+    )
+
+    assert (spans[0].cache_status, spans[0].cache_reason) == (status, "opted_out")
+
+
+def test_a_span_that_called_no_model_reports_no_cache_outcome() -> None:
+    # Boundary: most nodes never call a gateway, so the attribute must be ABSENT rather than a
+    # fabricated "bypass" — which would read as "the cache refused this", a claim nobody made.
+    spans = _span_frames(
+        _RunState(),
+        [NodeStarted("span1", None, "Node", "detail"), NodeFinished("span1", "ok", 1)],
+    )
+
+    assert (spans[0].cache_status, spans[0].cache_reason) == (None, None)
+
+
+def test_the_last_round_trips_outcome_is_the_spans_outcome() -> None:
+    # The span carries ONE status while a turn may be several calls, so a rule is unavoidable.
+    # Last-wins, matching `refusal` on this same fold: the final round trip is the one that
+    # produced the answer the span returns.
+    spans = _span_frames(
+        _RunState(),
+        [
+            NodeStarted("span1", None, "Node", "detail"),
+            ModelResponse("span1", "tool_calls", None, "hit", None),
+            ModelResponse("span1", "stop", None, "miss", "not_requested"),
+            NodeFinished("span1", "ok", 1),
+        ],
+    )
+
+    assert (spans[0].cache_status, spans[0].cache_reason) == ("miss", "not_requested")
+
+
+def test_a_round_trip_reporting_no_outcome_does_not_erase_an_earlier_one() -> None:
+    # Boundary: "nothing reported" is not "no cache involved". A second call whose headers were
+    # missing must leave the first call's answer standing rather than blanking it.
+    spans = _span_frames(
+        _RunState(),
+        [
+            NodeStarted("span1", None, "Node", "detail"),
+            ModelResponse("span1", "tool_calls", None, "hit", None),
+            ModelResponse("span1", "stop", None, None, None),
+            NodeFinished("span1", "ok", 1),
+        ],
+    )
+
+    assert spans[0].cache_status == "hit"
+
+
+def test_an_outcome_for_an_unknown_span_is_dropped_not_fabricated() -> None:
+    # Mirrors `_fold_usage`'s guard: an event for a span this run never opened must not invent one.
+    assert _RunState().map(ModelResponse("ghost", "stop", None, "hit", None)) == []

--- a/apps/url4-cloud/tests/unit/test_cache_run_counters.py
+++ b/apps/url4-cloud/tests/unit/test_cache_run_counters.py
@@ -1,0 +1,277 @@
+"""Run-level cache counters: hits, misses, and bypasses BY REASON (spec §7 / D7, plan Batch 8).
+
+FEATURE: turning the gateway's response cache on is unobservable without these. A hit costs
+nothing upstream, so the failure mode of caching is *silent* in both directions — nobody notices
+the savings, and nobody notices when a run that asked for no caching got some anyway.
+STORY: as an operator I can answer "did this run actually use the cache, and if not, why not?"
+from the run's own telemetry, without correlating spans by hand.
+
+WHY the counters are RUN-level and ride the telemetry stream rather than `/metrics`: the run mode
+is a one-shot Job with no scrape endpoint, and `.claude/scripts/check_layering.py` forbids
+`url4_cloud.runner.*` from importing `url4_cloud.metrics` at all. The run's own log frame is the
+only channel that exists — and it is the right one, since the question is about ONE run.
+
+**The load-bearing rule this file guards (spec §7): no metric may be labelled by cache key,
+prompt or credential.** `test_the_summary_carries_counts_and_nothing_else` and
+`test_a_cache_key_on_the_wire_never_reaches_the_summary` are that guard, at the unit and the
+end-to-end seam respectively.
+
+A separate module rather than an append to `test_url4_executor.py` / `test_cache_readback.py`:
+the repo's append-only gate compares file status, so growing an existing test file reads as "a
+prior test was modified" even when the diff is purely additive (OME-369).
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import httpx
+import pytest
+
+from url4.observe import ModelResponse, NodeFinished, NodeStarted, ObservationEvent
+from url4.streaming.interfaces import Completed, Traced
+from url4.streaming.protocol import LogData
+from url4_cloud.runner.cache_counters import (
+    BYPASS_REASON_PREFIX,
+    CACHE_BYPASSES,
+    CACHE_HITS,
+    CACHE_MISSES,
+    OVERFLOW_REASON,
+    REASON_BUCKET_CAP,
+    UNSTATED_REASON,
+    RunCacheCounters,
+)
+from url4_cloud.runner.config import ModelSpec
+from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+from url4_cloud.runner.executor import Url4Executor, _RunState
+
+_MODEL = "anthropic/claude-haiku-4-5"
+
+
+# ── layer 1: the counter itself ───────────────────────────────────────────────────────────
+
+
+def test_a_run_that_saw_no_outcome_has_nothing_to_report() -> None:
+    # The gate the executor uses. Most runs call no gateway at all, and a summary reading
+    # "0 hit, 0 miss, 0 bypass" on every static expression would be noise that trains readers to
+    # ignore the line that matters.
+    assert RunCacheCounters().observed is False
+
+
+def test_an_unreported_outcome_counts_as_nothing_rather_than_a_miss() -> None:
+    # Boundary: an older gateway, or a non-cache error path, reports no status at all. "Nothing
+    # reported" is not "the cache was not used" — counting it as a miss would invent a cache
+    # interaction that never happened.
+    counters = RunCacheCounters()
+    counters.record(None, None)
+
+    assert counters.observed is False
+    assert (counters.hits, counters.misses, counters.bypasses) == (0, 0, 0)
+
+
+def test_hits_misses_and_bypasses_each_land_in_their_own_total() -> None:
+    counters = RunCacheCounters()
+    counters.record("hit", None)
+    counters.record("hit", None)
+    counters.record("miss", "not_found")
+    counters.record("bypass", "opted_out")
+
+    assert (counters.hits, counters.misses, counters.bypasses) == (2, 1, 1)
+    assert counters.observed is True
+
+
+def test_bypasses_are_broken_down_by_reason() -> None:
+    # THE load-bearing counter (spec §7). "I asked for caching and got none" is only answerable
+    # if `opted_out` (url4 asked for no cache) stays distinct from `unsupported_control` (url4
+    # sent a key the gateway does not know and silently lost every hit).
+    counters = RunCacheCounters()
+    counters.record("bypass", "opted_out")
+    counters.record("bypass", "unsupported_control")
+    counters.record("bypass", "opted_out")
+
+    assert counters.bypass_reasons == {"opted_out": 2, "unsupported_control": 1}
+    assert counters.bypasses == 3
+
+
+def test_only_bypasses_are_broken_down_by_reason() -> None:
+    # A miss carries a reason too, but it answers nothing: the entry simply was not there. Only
+    # a bypass means the cache was never consulted, which is the case that needs a why.
+    counters = RunCacheCounters()
+    counters.record("miss", "not_found")
+    counters.record("hit", "fresh")
+
+    assert counters.bypass_reasons == {}
+
+
+def test_a_bypass_with_no_stated_reason_gets_its_own_bucket() -> None:
+    # Boundary: the reason field is optional on both sources. Dropping the count would make the
+    # per-reason breakdown fail to sum to the total, which is worse than an honest "unstated".
+    counters = RunCacheCounters()
+    counters.record("bypass", None)
+    counters.record("bypass", "")
+
+    assert counters.bypass_reasons == {UNSTATED_REASON: 2}
+    assert counters.bypasses == 2
+
+
+def test_reason_buckets_are_bounded_and_the_surplus_still_sums() -> None:
+    # INVARIANT: the reason is an upstream free string, so the bucket set must be bounded — the
+    # same cardinality doctrine `metrics._route_label` applies to a Prometheus label. Overflow
+    # collapses into one bucket rather than being dropped, so the breakdown never under-reports
+    # the total it belongs to.
+    counters = RunCacheCounters()
+    surplus = REASON_BUCKET_CAP + 5
+    for i in range(surplus):
+        counters.record("bypass", f"reason_{i}")
+
+    reasons = counters.bypass_reasons
+    assert len(reasons) <= REASON_BUCKET_CAP + 1
+    assert reasons[OVERFLOW_REASON] == surplus - REASON_BUCKET_CAP
+    assert sum(reasons.values()) == counters.bypasses == surplus
+
+
+def test_the_summary_carries_counts_and_nothing_else() -> None:
+    # SPEC §7: "No metric may be labelled by cache key, prompt, or credential." The guard is
+    # structural — every attribute is an integer count under `cache.`, so there is no slot a key
+    # or a prompt could occupy even if one reached this far.
+    counters = RunCacheCounters()
+    counters.record("hit", None)
+    counters.record("bypass", "opted_out")
+
+    attributes = counters.attributes()
+
+    assert attributes[CACHE_HITS] == 1
+    assert attributes[CACHE_MISSES] == 0
+    assert attributes[CACHE_BYPASSES] == 1
+    assert attributes[f"{BYPASS_REASON_PREFIX}opted_out"] == 1
+    assert all(isinstance(v, int) for v in attributes.values())
+    assert all(k.startswith("cache.") for k in attributes)
+
+
+def test_the_summary_body_states_the_three_totals() -> None:
+    # The attributes are for machines; a human reading the log line must not have to open them.
+    counters = RunCacheCounters()
+    counters.record("hit", None)
+    counters.record("miss", None)
+    counters.record("bypass", "disabled")
+
+    body = counters.summary_body()
+
+    assert "1" in body and "hit" in body and "miss" in body and "bypass" in body
+
+
+# ── layer 2: the run state accumulates them ───────────────────────────────────────────────
+
+
+def _drive(state: _RunState, events: list[ObservationEvent]) -> None:
+    for event in events:
+        state.map(event)
+
+
+def test_run_state_counts_every_round_trips_outcome() -> None:
+    state = _RunState()
+    _drive(
+        state,
+        [
+            NodeStarted("span1", None, "Node", "detail"),
+            ModelResponse("span1", "tool_calls", None, "miss", None),
+            ModelResponse("span1", "stop", None, "hit", None),
+            NodeFinished("span1", "ok", 1),
+        ],
+    )
+
+    assert (state.cache_counters.hits, state.cache_counters.misses) == (1, 1)
+
+
+def test_run_state_counts_an_outcome_whose_span_it_never_opened() -> None:
+    # DIFFERENT rule from `_fold_response`'s span guard, deliberately: a span frame must not be
+    # fabricated for an id this run never opened, but the round trip still happened and still
+    # cost (or saved) money. A run-level total that dropped it would under-report.
+    state = _RunState()
+
+    assert state.map(ModelResponse("ghost", "stop", None, "bypass", "opted_out")) == []
+    assert state.cache_counters.bypass_reasons == {"opted_out": 1}
+
+
+# ── layer 3: the run publishes the summary ────────────────────────────────────────────────
+
+
+def _gateway(headers: dict[str, str]) -> httpx.AsyncClient:
+    """A chat-completions endpoint that answers once, with `headers` on the response."""
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/chat/completions"
+        return httpx.Response(
+            200,
+            headers=headers,
+            json={
+                "choices": [{"message": {"role": "assistant", "content": "an answer"}}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+            },
+        )
+
+    return httpx.AsyncClient(
+        transport=httpx.MockTransport(handle), base_url="http://aigateway.test"
+    )
+
+
+async def _run_frames(headers: dict[str, str]) -> list[object]:
+    cfg = AigatewayConfig(models=(ModelSpec(id=_MODEL),), default_model=_MODEL)
+    async with _gateway(headers) as client:
+        world = await build_aigateway_world(cfg, client=client)
+        executor = Url4Executor(world.node)
+        return [frame async for frame in executor.execute(f"/{_MODEL}(ctx)!go")]
+
+
+def _logs(frames: list[object]) -> list[LogData]:
+    payloads = [f.payload if isinstance(f, Traced) else f for f in frames]
+    return [p for p in payloads if isinstance(p, LogData)]
+
+
+@pytest.mark.asyncio
+async def test_a_run_that_touched_the_cache_publishes_one_summary_log() -> None:
+    frames = await _run_frames({"X-AIGW-Cache": "hit", "X-AIGW-Cache-Reason": "fresh"})
+
+    assert isinstance(frames[-1], Completed)
+    summaries = [log for log in _logs(frames) if CACHE_HITS in log.attributes]
+    assert len(summaries) == 1
+    assert summaries[0].severity_text == "INFO"
+    assert summaries[0].attributes[CACHE_HITS] == 1
+
+
+@pytest.mark.asyncio
+async def test_a_run_that_never_reached_a_cache_publishes_no_summary() -> None:
+    # Boundary: an older gateway reports nothing, and a run made entirely of static nodes calls
+    # no gateway at all. Neither should emit a line saying the cache did nothing.
+    frames = await _run_frames({})
+
+    assert [log for log in _logs(frames) if CACHE_HITS in log.attributes] == []
+
+
+@pytest.mark.asyncio
+async def test_a_cache_key_on_the_wire_never_reaches_the_summary() -> None:
+    # SPEC §7, end to end. The gateway sends its entry key on every hit; it is read (so the
+    # hit/miss-only rule is enforced at the seam that would otherwise leak it) and it must go no
+    # further. A key on a run-level counter is a per-entry identifier in telemetry.
+    secret = "e3b0c44298fc1c14"
+    frames = await _run_frames(
+        {"X-AIGW-Cache": "hit", "X-AIGW-Cache-Key": secret, "X-AIGW-Cache-Reason": "fresh"}
+    )
+
+    summary = next(log for log in _logs(frames) if CACHE_HITS in log.attributes)
+    rendered = summary.model_dump_json()
+    assert secret not in rendered
+    assert all(isinstance(v, int) for v in cast("dict", summary.attributes).values())
+
+
+@pytest.mark.asyncio
+async def test_the_summary_names_the_bypass_reason_the_gateway_gave() -> None:
+    # The whole point of Batch 8: "I asked for caching and got none" becomes answerable from the
+    # run's own stream, in the gateway's vocabulary rather than a normalised one.
+    frames = await _run_frames(
+        {"X-AIGW-Cache": "bypass", "X-AIGW-Cache-Reason": "unsupported_control"}
+    )
+
+    summary = next(log for log in _logs(frames) if CACHE_HITS in log.attributes)
+    assert summary.attributes[CACHE_BYPASSES] == 1
+    assert summary.attributes[f"{BYPASS_REASON_PREFIX}unsupported_control"] == 1

--- a/apps/url4-cloud/tests/unit/test_protocol_cache.py
+++ b/apps/url4-cloud/tests/unit/test_protocol_cache.py
@@ -1,0 +1,266 @@
+"""`CachePolicy` — per-run cache intent on the wire (plan Batch 1, spec §4.1/§4.2).
+
+INVARIANT (spec §1.0): aigateway v2's cache-control grammar is **CLOSED to exactly one field**,
+`use-cache`. Any other key inside a request body's `cache` object makes the WHOLE request
+**bypass** — silently, with no error anywhere, even alongside a valid `use-cache: true`. So this
+protocol type is `extra="forbid"`: a caller inventing `no_store` fails loudly HERE, at the url4
+edge, instead of having it forwarded to a grammar whose only answer is to quietly cost every hit.
+
+The type carries **intent only** (`participate`); the translation into aigateway's wire vocabulary
+lives in `apps/url4-cloud` (plan §4), because `packages/url4` ships to SDK users and must not know
+an adapter's request-body shape. `max_age` is url4-internal and is **never** sent upstream — v2
+refuses it (`global_controls.py:79-83`).
+
+WHY these tests live here and not in `packages/url4/tests`: `url4.streaming` ships from the url4
+distribution but is gated by its only consumer — see the `[tool.coverage.run] omit` note in
+`packages/url4/pyproject.toml`. Every other protocol test is in this directory.
+"""
+
+from datetime import datetime
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+import url4.streaming.protocol
+from url4.streaming.protocol import (
+    AttachData,
+    AttachEvent,
+    CachePolicy,
+    InboundFrameAdapter,
+    SpanData,
+)
+
+
+def _attach_frame(data: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "specversion": "1.0",
+        "type": "ai.url4.attach",
+        "id": "att",
+        "source": "/client",
+        "subject": "t",
+        "data": data,
+    }
+
+
+# --- backward compatibility: STOP-THE-LINE -------------------------------------------
+
+
+def test_attach_frame_without_cache_still_validates() -> None:
+    """**Stop-the-line** (plan Batch 1 test 1). `AttachData` is a LIVE wire type — every client
+    already in flight sends an attach frame with no `cache` key. If this fails, the field was
+    made required and every existing client is broken; do not "fix" the test.
+    """
+    frame = InboundFrameAdapter.validate_python(_attach_frame({"from_sequence": 1}))
+
+    assert isinstance(frame, AttachEvent)
+    assert frame.data.from_sequence == 1
+    assert frame.data.cache is None
+
+
+def test_attach_frame_with_empty_data_still_validates() -> None:
+    """The other half of the live-wire guard: an attach frame that states nothing at all."""
+    frame = InboundFrameAdapter.validate_python(_attach_frame({}))
+
+    assert isinstance(frame, AttachEvent)
+    assert frame.data.from_sequence is None
+    assert frame.data.cache is None
+
+
+# --- "not stated" must stay distinguishable from an explicit opt-out ------------------
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param({}, id="cache-absent"),
+        pytest.param({"cache": None}, id="cache-null"),
+        pytest.param({"cache": {}}, id="cache-empty-object"),
+    ],
+)
+def test_absent_null_and_empty_object_all_read_as_not_stated(data: dict[str, Any]) -> None:
+    """Plan Batch 1 test 2. v2 treats absent / `null` / `{}` identically — all three mean
+    "participate" — so all three must land on "not stated" rather than on a stated value.
+    """
+    attach = AttachData.model_validate(data)
+
+    assert attach.cache is None or attach.cache.participate is None
+
+
+def test_explicit_opt_out_is_distinguishable_from_not_stated() -> None:
+    """The `None` vs `CachePolicy()` distinction is load-bearing (spec §3.1): collapsing them
+    makes opt-out unexpressible and breaks D4's header-wins precedence, which can only fire when
+    silence is distinguishable from a stated `False`.
+    """
+    stated = AttachData.model_validate({"cache": {"participate": False}})
+    unstated = AttachData.model_validate({"cache": {}})
+
+    assert stated.cache is not None
+    assert stated.cache.participate is False
+    assert unstated.cache is not None
+    assert unstated.cache.participate is None
+
+
+def test_explicit_participate_true_is_also_stated() -> None:
+    """`participate=True` is a statement, not the default — D4 must be able to see it."""
+    policy = CachePolicy.model_validate({"participate": True})
+
+    assert policy.participate is True
+
+
+# --- round trip ----------------------------------------------------------------------
+
+
+def test_inbound_adapter_round_trip_preserves_the_policy() -> None:
+    """Plan Batch 1 test 3. The policy has to survive serialize → transport → parse, or the WS
+    carrier delivers nothing.
+    """
+    original = InboundFrameAdapter.validate_python(
+        _attach_frame({"from_sequence": 2, "cache": {"participate": False}})
+    )
+    revived = InboundFrameAdapter.validate_python(
+        original.model_dump(mode="json", by_alias=True)  # type: ignore[union-attr]
+    )
+
+    assert isinstance(revived, AttachEvent)
+    assert revived.data.cache is not None
+    assert revived.data.cache.participate is False
+    assert revived.data.from_sequence == 2
+
+
+def test_round_trip_preserves_max_age() -> None:
+    """`max_age` is parsed at the HTTP edge (Batch 3) and applied at read-back (Batch 7); it has
+    to survive the frame carrier too, or the two carriers stop being equivalent.
+    """
+    frame = InboundFrameAdapter.validate_python(
+        _attach_frame({"cache": {"participate": True, "max_age": 60}})
+    )
+    revived = InboundFrameAdapter.validate_python(
+        frame.model_dump(mode="json", by_alias=True)  # type: ignore[union-attr]
+    )
+
+    assert isinstance(revived, AttachEvent)
+    assert revived.data.cache is not None
+    assert revived.data.cache.max_age == 60
+
+
+def test_max_age_defaults_to_not_stated() -> None:
+    """A policy that says nothing about freshness must not invent a bound."""
+    assert CachePolicy().max_age is None
+
+
+# --- the closed grammar: unknown keys fail HERE, not upstream -------------------------
+
+
+@pytest.mark.parametrize(
+    "unknown",
+    [
+        pytest.param({"no_store": True}, id="v1-no-store"),
+        pytest.param({"no_cache": True}, id="v1-no-cache"),
+        pytest.param({"s_maxage": 60}, id="v1-s-maxage"),
+        pytest.param({"ttl": 60}, id="v1-ttl"),
+        pytest.param({"use-cache": False}, id="aigateway-wire-vocabulary"),
+        pytest.param({"participate": False, "no_store": True}, id="valid-plus-unknown"),
+    ],
+)
+def test_cache_policy_rejects_unknown_fields(unknown: dict[str, Any]) -> None:
+    """Plan Batch 1 test 4 — the correctness test, not a style one.
+
+    Under v2 an unrecognised control key does not degrade to "ignored": it makes the request
+    BYPASS, even next to a valid `use-cache: true`. A well-meant `no_store` would therefore opt
+    the caller out for the WRONG reason and a well-meant `ttl` would lose caching altogether,
+    with nothing raised anywhere. `extra="forbid"` moves that failure to the url4 edge, loudly.
+
+    `use-cache` is in this list deliberately: it is *aigateway's* vocabulary. The protocol type
+    speaks intent, and the translation belongs in the adapter (plan §4).
+    """
+    with pytest.raises(ValidationError):
+        CachePolicy.model_validate(unknown)
+
+
+def test_attach_frame_with_unknown_cache_key_is_rejected() -> None:
+    """The guard has to hold through the frame, which is how a real caller reaches it."""
+    with pytest.raises(ValidationError):
+        InboundFrameAdapter.validate_python(_attach_frame({"cache": {"no_store": True}}))
+
+
+def test_cache_policy_has_exactly_the_two_designed_fields() -> None:
+    """Pin the field set. A third field added without a design decision is how the closed
+    grammar gets violated — and `max_age` is only safe because Batch 2 never forwards it.
+    """
+    assert set(CachePolicy.model_fields) == {"participate", "max_age"}
+
+
+# --- the reporting half: SpanData ----------------------------------------------------
+
+
+def test_span_data_without_cache_fields_still_validates() -> None:
+    """Plan Batch 1 test 5. `SpanData` is emitted by every run today; the new fields must be
+    optional or every existing producer breaks.
+    """
+    span = SpanData(name="chat", operation="chat", start=datetime(2026, 8, 5, 9, 0, 0))
+
+    assert span.cache_status is None
+    assert span.cache_reason is None
+
+
+@pytest.mark.parametrize("status", ["hit", "miss", "bypass"])
+def test_span_data_carries_cache_status_and_reason(status: str) -> None:
+    """The three outcomes aigateway can report, plus its reason verbatim (spec §4.2)."""
+    span = SpanData.model_validate(
+        {
+            "name": "chat",
+            "gen_ai.operation.name": "chat",
+            "start": datetime(2026, 8, 5, 9, 0, 0),
+            "cache_status": status,
+            "cache_reason": "opted_out",
+        }
+    )
+
+    assert span.cache_status == status
+    assert span.cache_reason == "opted_out"
+
+
+def test_span_data_rejects_an_unknown_cache_status() -> None:
+    """The status vocabulary is closed to what aigateway actually reports; a typo must not
+    reach a dashboard as a fourth silent category.
+    """
+    with pytest.raises(ValidationError):
+        SpanData.model_validate(
+            {
+                "name": "chat",
+                "gen_ai.operation.name": "chat",
+                "start": datetime(2026, 8, 5, 9, 0, 0),
+                "cache_status": "stale",
+            }
+        )
+
+
+def test_span_data_cache_fields_survive_the_wire() -> None:
+    """`SpanData` dumps by alias; the cache fields carry no `gen_ai.*` alias (OTel has no
+    semantic convention for them), so assert they still appear under their own names.
+    """
+    span = SpanData(
+        name="chat",
+        operation="chat",
+        start=datetime(2026, 8, 5, 9, 0, 0),
+        cache_status="hit",
+        cache_reason="opted_out",
+    )
+    dumped = span.model_dump(mode="json", by_alias=True)
+    revived = SpanData.model_validate(dumped)
+
+    assert dumped["cache_status"] == "hit"
+    assert revived.cache_status == "hit"
+    assert revived.cache_reason == "opted_out"
+
+
+# --- the export surface --------------------------------------------------------------
+
+
+def test_cache_policy_is_exported_from_the_protocol_package() -> None:
+    """url4-cloud imports the protocol as a package; a type reachable only by module path is
+    not part of the contract.
+    """
+    assert url4.streaming.protocol.CachePolicy is CachePolicy
+    assert "CachePolicy" in url4.streaming.protocol.__all__

--- a/apps/url4-cloud/tests/unit/test_rest_cache_convergence.py
+++ b/apps/url4-cloud/tests/unit/test_rest_cache_convergence.py
@@ -1,0 +1,467 @@
+"""Batch 5 — convergence: two carriers, ONE effective cache policy.
+
+A run can be configured twice — once on the WS attach frame, once on the ``GET /`` that starts it
+— and the gateway must be told exactly one thing. This is where the two become one (spec §5.3, D4):
+
+* **The header wins a genuine disagreement.** Attach happens first; the GET is the later,
+  run-scoped statement, so last-writer-wins matches causal order. The override is never silent — a
+  ``warn`` ``LogEvent`` reaches the attached client saying what it declared and what actually
+  applies. Losing a declaration quietly is the failure mode this whole design exists to avoid.
+* **Explicit beats absent, both ways.** One carrier speaking while the other is silent is not a
+  disagreement and warns about nothing.
+* **Silence on both resolves to the ON default HERE, and nowhere else.** Everything downstream
+  takes a RESOLVED policy, so "what does saying nothing mean?" is answered exactly once —
+  which is the only reason ``policy_to_body_field`` gets to stay a dumb translation.
+
+The route-level tests spy on ``_schedule`` rather than on the job runner. That is deliberate and
+not laziness: threading the policy past ``_schedule`` onto the runner is the NEXT batch, so the
+kwarg it is handed is genuinely the last observable point in this one. Asserting further down
+would either pass vacuously or pin work that does not exist yet.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import pytest
+from _fakes import FixedGate, RecordingJobRunner
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from httpx import ASGITransport
+
+from url4.streaming.protocol import (
+    AttachData,
+    AttachEvent,
+    CachePolicy,
+    OutboundFrame,
+    StartedData,
+    StartedEvent,
+    TerminatedData,
+    TerminatedEvent,
+)
+from url4_cloud.app import create_app
+from url4_cloud.auth import JwtCodec
+from url4_cloud.config import Settings
+from url4_cloud.rest import cache_policy, routes
+from url4_cloud.rest.cache_policy import default_policy, resolve
+from url4_cloud.testing import InMemoryEventStream
+from url4_cloud.ws import ConnectionRegistry
+
+SECRET = "rest-cache-convergence-secret"
+WINDOW_S = 60
+T0 = datetime(2026, 8, 5, 9, 0, 0, tzinfo=UTC)
+
+OPT_OUT = CachePolicy(participate=False)
+OPT_IN = CachePolicy(participate=True)
+BOUNDED = CachePolicy(participate=True, max_age=60)
+
+
+# --- the resolver, on its own ------------------------------------------------------------------
+
+
+def test_silence_on_both_carriers_resolves_to_the_on_default() -> None:
+    resolution = resolve(None, None)
+
+    assert resolution.effective == CachePolicy(participate=True)
+    assert resolution.overridden is None
+
+
+def test_the_default_is_participation_and_carries_no_freshness_bound() -> None:
+    """D1: caching is active unless a caller says otherwise, and silence states no bound."""
+    assert default_policy().participate is True
+    assert default_policy().max_age is None
+
+
+def test_each_default_is_its_own_object() -> None:
+    """A shared module-level instance would be mutable state two concurrent runs could edit."""
+    first, second = default_policy(), default_policy()
+
+    assert first == second
+    assert first is not second
+
+
+def test_the_header_alone_is_the_effective_policy() -> None:
+    resolution = resolve(OPT_OUT, None)
+
+    assert resolution.effective == OPT_OUT
+    assert resolution.overridden is None
+
+
+def test_the_frame_alone_is_the_effective_policy() -> None:
+    """Explicit beats absent in BOTH directions — the header does not win by merely existing."""
+    resolution = resolve(None, OPT_OUT)
+
+    assert resolution.effective == OPT_OUT
+    assert resolution.overridden is None
+
+
+def test_carriers_that_agree_override_nothing() -> None:
+    """A client that states the same intent twice is not in conflict with itself."""
+    resolution = resolve(CachePolicy(participate=False), CachePolicy(participate=False))
+
+    assert resolution.effective == OPT_OUT
+    assert resolution.overridden is None
+
+
+def test_the_header_overrides_a_disagreeing_frame_and_the_loser_is_reported() -> None:
+    resolution = resolve(OPT_IN, OPT_OUT)
+
+    assert resolution.effective == OPT_IN
+    # The displaced policy is carried out of the resolver rather than merely flagged: the warning
+    # has to be able to name what was dropped, or a client cannot tell WHICH of its two statements
+    # lost.
+    assert resolution.overridden == OPT_OUT
+
+
+def test_a_freshness_bound_the_gateway_cannot_honour_degrades_to_opt_out() -> None:
+    """Owner decision 2026-08-06 (spec §3.5): while `GATEWAY_REPORTS_AGE` is False, a stated
+    `max-age` opts the run out at convergence rather than participating and revalidating.
+
+    Honouring it after the fact would cost a second gateway call and a discarded body on EVERY
+    bounded hit — inside the tool loop, so a four-iteration turn becomes eight calls. And D6
+    invites intermediaries to inject the header, so `max-age=0` from a browser reload would
+    trigger it accidentally.
+    """
+    resolution = resolve(BOUNDED, None)
+
+    assert resolution.effective.participate is False
+    assert resolution.effective.max_age == 60, "the bound is preserved, only participation flips"
+
+
+def test_the_bound_is_honoured_the_day_the_gateway_reports_age(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """D11's honouring half, dormant behind one flag. `requires_revalidation` and its tests are
+    already written and correct; this pins that flipping the flag is all that reaches them."""
+    monkeypatch.setattr(cache_policy, "GATEWAY_REPORTS_AGE", True)
+
+    resolution = resolve(BOUNDED, None)
+
+    assert resolution.effective.participate is True
+    assert resolution.effective.max_age == 60
+
+
+def test_carriers_agreeing_on_participation_but_not_on_the_bound_still_conflict() -> None:
+    """Participate, and participate-but-nothing-older-than-60s, are different statements."""
+    resolution = resolve(BOUNDED, OPT_IN)
+
+    # The header still WINS and the frame is still reported as overridden — the disagreement is
+    # judged on what the carriers STATED, before the gateway-capability degrade rewrites it.
+    assert resolution.effective.max_age == 60
+    assert resolution.effective.participate is False, "degraded: no age source (spec §3.5)"
+    assert resolution.overridden == OPT_IN
+
+
+# --- the route: the resolved policy reaches `_schedule` -----------------------------------------
+
+
+def _token(topic: str) -> str:
+    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).sign(topic, T0)
+
+
+@pytest.fixture
+def scheduled(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Capture the keyword arguments `start_run` hands `_schedule` (see the module docstring)."""
+    calls: list[dict[str, Any]] = []
+
+    async def _spy(deps: object, topic: str, url4: str, **kwargs: Any) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(routes, "_schedule", _spy)
+    return calls
+
+
+def _gated_app() -> FastAPI:
+    """An app whose subscriber gate always passes — no socket, so no frame carrier either."""
+    return create_app(
+        Settings(jwt_secret=SECRET, iat_window_s=WINDOW_S),
+        stream=InMemoryEventStream(),
+        job_runner=RecordingJobRunner(),
+        clock=lambda: T0,
+        interest=FixedGate(),
+    )
+
+
+async def _start(app: FastAPI, topic: str, **headers: str) -> httpx.Response:
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        return await client.get(
+            "/",
+            params={"q": "gpt(hi)"},
+            headers={
+                "URL4-Capability": _token(topic),
+                "Prefer": "respond-async",
+                **headers,
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_run_declaring_nothing_is_scheduled_participating(
+    scheduled: list[dict[str, Any]],
+) -> None:
+    """The ON default is applied at convergence, so nothing downstream sees `None` and guesses."""
+    resp = await _start(_gated_app(), "conv-default")
+
+    assert resp.status_code == 202
+    assert scheduled[0]["cache"] == CachePolicy(participate=True)
+
+
+@pytest.mark.asyncio
+async def test_the_headers_opt_out_reaches_the_scheduled_run(
+    scheduled: list[dict[str, Any]],
+) -> None:
+    await _start(_gated_app(), "conv-no-store", **{"Cache-Control": "no-store"})
+
+    assert scheduled[0]["cache"] == CachePolicy(participate=False)
+
+
+@pytest.mark.asyncio
+async def test_a_headers_freshness_bound_reaches_the_scheduled_run(
+    scheduled: list[dict[str, Any]],
+) -> None:
+    await _start(_gated_app(), "conv-max-age", **{"Cache-Control": "max-age=60"})
+
+    # Degraded at convergence, so what reaches the run — and therefore the gateway — is an
+    # opt-out. The bound rides along unused until `GATEWAY_REPORTS_AGE` flips.
+    assert scheduled[0]["cache"] == CachePolicy(participate=False, max_age=60)
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_header_falls_back_to_the_default_rather_than_failing_the_run(
+    scheduled: list[dict[str, Any]],
+) -> None:
+    """A cache directive is a hint about cost; it must never be the reason an ensemble run dies."""
+    resp = await _start(_gated_app(), "conv-garbage", **{"Cache-Control": "%%% not a directive"})
+
+    assert resp.status_code == 202
+    assert scheduled[0]["cache"] == CachePolicy(participate=True)
+
+
+@pytest.mark.asyncio
+async def test_the_cache_policy_travels_beside_profile_and_identity_not_instead_of_them(
+    scheduled: list[dict[str, Any]],
+) -> None:
+    """One more per-run value on the same hop — it must not displace the ones already there."""
+    await _start(
+        _gated_app(),
+        "conv-beside",
+        **{"Cache-Control": "no-store", "X-Profile": "prod", "X-User-Email": "a@b.c"},
+    )
+
+    call = scheduled[0]
+    assert call["profile"] == "prod"
+    assert call["identity"] == {"X-User-Email": "a@b.c"}
+    assert call["cache"] == CachePolicy(participate=False)
+
+
+# --- the route + the socket: the frame carrier, and the override warning ------------------------
+
+
+def _socket_app(stream: InMemoryEventStream) -> FastAPI:
+    """No injected gate: the real registry is BOTH the subscriber gate and the frame's session."""
+    return create_app(
+        Settings(jwt_secret=SECRET, iat_window_s=WINDOW_S),
+        stream=stream,
+        job_runner=RecordingJobRunner(),
+        clock=lambda: T0,
+    )
+
+
+def _seed(
+    client: TestClient, stream: InMemoryEventStream, topic: str, events: list[OutboundFrame]
+) -> None:
+    portal = client.portal
+    assert portal is not None
+    for event in events:
+        portal.call(stream.publish, topic, event)
+
+
+def _started(topic: str) -> StartedEvent:
+    return StartedEvent(
+        id=f"s-{topic}",
+        source=f"/trace/{topic}/node/root",
+        subject=topic,
+        data=StartedData(url4="gpt()"),
+    )
+
+
+def _terminated(topic: str) -> TerminatedEvent:
+    return TerminatedEvent(
+        id=f"t-{topic}",
+        source=f"/trace/{topic}/node/root",
+        subject=topic,
+        data=TerminatedData(status="succeeded"),
+    )
+
+
+def _attach(cache: CachePolicy | None) -> dict[str, Any]:
+    event = AttachEvent(
+        id="att",
+        source="/client",
+        subject="t",
+        data=AttachData(from_sequence=None, cache=cache),
+    )
+    return event.model_dump(mode="json", by_alias=True)
+
+
+def _get(client: TestClient, topic: str, **headers: str) -> httpx.Response:
+    return client.get(
+        "/",
+        params={"q": "gpt()"},
+        headers={"URL4-Capability": _token(topic), "Prefer": "respond-async", **headers},
+    )
+
+
+def test_the_frames_declaration_reaches_the_scheduled_run(
+    scheduled: list[dict[str, Any]],
+) -> None:
+    topic = "conv-frame-only"
+    stream = InMemoryEventStream()
+    app = _socket_app(stream)
+    with TestClient(app) as client:
+        _seed(client, stream, topic, [_started(topic)])
+        with client.websocket_connect(f"/ws?ticket={_token(topic)}") as ws:
+            ws.send_json(_attach(OPT_OUT))
+            assert ws.receive_json()["type"] == "ai.url4.started"
+            assert _get(client, topic).status_code == 202
+
+    assert scheduled[0]["cache"] == OPT_OUT
+
+
+def test_a_conflicting_header_wins_and_the_attached_client_is_told(
+    scheduled: list[dict[str, Any]],
+) -> None:
+    topic = "conv-conflict"
+    stream = InMemoryEventStream()
+    app = _socket_app(stream)
+    with TestClient(app) as client:
+        _seed(client, stream, topic, [_started(topic)])
+        with client.websocket_connect(f"/ws?ticket={_token(topic)}") as ws:
+            ws.send_json(_attach(OPT_OUT))
+            assert ws.receive_json()["type"] == "ai.url4.started"
+            assert _get(client, topic, **{"Cache-Control": "url4-use-cache"}).status_code == 202
+            warned = ws.receive_json()
+
+    assert scheduled[0]["cache"] == OPT_IN
+    assert warned["type"] == "ai.url4.log"
+    assert warned["data"]["severity_text"] == "WARN"
+    assert warned["subject"] == topic
+    attributes = warned["data"]["attributes"]
+    # The same two attribute names the re-attach warning uses. One vocabulary for one question —
+    # "what did I ask for, and what actually applies?" — regardless of which carrier lost.
+    assert attributes["cache.declared"] == '{"participate":false}'
+    assert attributes["cache.effective"] == '{"participate":true}'
+
+
+def test_carriers_that_agree_warn_about_nothing(scheduled: list[dict[str, Any]]) -> None:
+    """A warning would have been queued BEFORE this seeded frame, so the frame arriving first is
+    proof none was emitted — an assertion about ORDER, which cannot flake, rather than about time.
+    """
+    topic = "conv-agree"
+    stream = InMemoryEventStream()
+    app = _socket_app(stream)
+    with TestClient(app) as client:
+        _seed(client, stream, topic, [_started(topic)])
+        with client.websocket_connect(f"/ws?ticket={_token(topic)}") as ws:
+            ws.send_json(_attach(OPT_OUT))
+            assert ws.receive_json()["type"] == "ai.url4.started"
+            assert _get(client, topic, **{"Cache-Control": "no-store"}).status_code == 202
+            _seed(client, stream, topic, [_terminated(topic)])
+            assert ws.receive_json()["type"] == "ai.url4.terminated"
+
+    assert scheduled[0]["cache"] == OPT_OUT
+
+
+def test_a_silent_header_does_not_override_the_frame_and_warns_about_nothing(
+    scheduled: list[dict[str, Any]],
+) -> None:
+    """Absent is not a statement. If it were, no frame declaration could ever survive a GET."""
+    topic = "conv-silent-header"
+    stream = InMemoryEventStream()
+    app = _socket_app(stream)
+    with TestClient(app) as client:
+        _seed(client, stream, topic, [_started(topic)])
+        with client.websocket_connect(f"/ws?ticket={_token(topic)}") as ws:
+            ws.send_json(_attach(OPT_OUT))
+            assert ws.receive_json()["type"] == "ai.url4.started"
+            assert _get(client, topic).status_code == 202
+            _seed(client, stream, topic, [_terminated(topic)])
+            assert ws.receive_json()["type"] == "ai.url4.terminated"
+
+    assert scheduled[0]["cache"] == OPT_OUT
+
+
+def test_a_malformed_header_leaves_the_frames_declaration_standing(
+    scheduled: list[dict[str, Any]],
+) -> None:
+    """Garbage parses to "not stated", so it must not shadow a perfectly good frame declaration."""
+    topic = "conv-garbage-header"
+    stream = InMemoryEventStream()
+    app = _socket_app(stream)
+    with TestClient(app) as client:
+        _seed(client, stream, topic, [_started(topic)])
+        with client.websocket_connect(f"/ws?ticket={_token(topic)}") as ws:
+            ws.send_json(_attach(OPT_OUT))
+            assert ws.receive_json()["type"] == "ai.url4.started"
+            assert _get(client, topic, **{"Cache-Control": "=,=,="}).status_code == 202
+            _seed(client, stream, topic, [_terminated(topic)])
+            assert ws.receive_json()["type"] == "ai.url4.terminated"
+
+    assert scheduled[0]["cache"] == OPT_OUT
+
+
+# --- the notice channel the override warning travels down --------------------------------------
+
+
+def _notice() -> StartedEvent:
+    """Any frame will do — the channel is about DELIVERY, not about what is delivered."""
+    return _started("notice")
+
+
+def test_a_notice_reaches_every_connection_attached_to_the_topic() -> None:
+    """Two sockets may legitimately observe one run, and a notice about it belongs to both."""
+    registry = ConnectionRegistry()
+    first: list[OutboundFrame] = []
+    second: list[OutboundFrame] = []
+    registry.add_notifier("t", first.append)
+    registry.add_notifier("t", second.append)
+
+    frame = _notice()
+    registry.notify("t", frame)
+
+    assert first == [frame]
+    assert second == [frame]
+
+
+def test_a_withdrawn_sink_stops_receiving() -> None:
+    """A disconnected connection must not keep collecting frames nobody will ever read."""
+    registry = ConnectionRegistry()
+    received: list[OutboundFrame] = []
+    registry.add_notifier("t", received.append)
+    registry.remove_notifier("t", received.append)
+
+    registry.notify("t", _notice())
+
+    assert received == []
+
+
+def test_withdrawing_a_sink_from_a_topic_that_is_already_gone_is_not_an_error() -> None:
+    """A connection withdraws in `finally`, which also runs after the session was discarded."""
+    registry = ConnectionRegistry()
+    received: list[OutboundFrame] = []
+
+    registry.remove_notifier("never-seen", received.append)
+
+
+def test_notifying_a_topic_nobody_is_attached_to_is_a_silent_no_op() -> None:
+    """A notice explains a request that was ALREADY accepted.
+
+    Failing — or raising — because the explanation had nowhere to land would trade the answer for
+    its footnote. The 428 gate means this cannot happen on the override path; it must still not be
+    an exception waiting for the first caller that reaches it another way.
+    """
+    ConnectionRegistry().notify("never-seen", _notice())

--- a/apps/url4-cloud/tests/unit/test_rest_cache_header.py
+++ b/apps/url4-cloud/tests/unit/test_rest_cache_header.py
@@ -1,0 +1,416 @@
+"""`parse_cache_control` — the HTTP carrier for a run's cache intent (plan Batch 3, spec §5.1).
+
+Every directive collapses to participate / opt-out **at this edge**; none is forwarded verbatim.
+That is the point of the module and the reason these tests are correctness tests rather than
+parser trivia: aigateway v2's cache-control grammar is CLOSED to one key, `use-cache`, and any
+other key inside the `cache` object makes the whole request BYPASS silently (spec §1.0). A
+`no-store` forwarded as itself would opt the caller out for the WRONG reason
+(`unsupported_control` instead of `opted_out`); a forwarded `max-age` would lose caching
+altogether with nothing raised anywhere.
+
+`max-age` is the one directive that is **preserved rather than collapsed** (spec §3.5, plan §6):
+url4 can neither ask the gateway for a freshness bound nor read an entry's age today, so the
+directive degrades to an opt-out at read-back — but the VALUE survives this edge, so the day
+either upstream blocker lifts the change is a branch, not a redesign.
+
+TWO NEVERS this module owes its callers:
+
+- **never 4xx.** A cache directive is an optimisation hint. Failing a whole ensemble run over a
+  malformed one would trade a cheap missed hit for a dead run.
+- **never invent intent.** Garbage and unknown directives return `None` — "not stated" — which
+  converges to the D1 default, not to some parser-chosen policy.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+from _fakes import FixedGate, RecordingJobRunner
+from fastapi import FastAPI
+from httpx import ASGITransport
+
+from url4.streaming.protocol import CachePolicy
+from url4_cloud.app import create_app
+from url4_cloud.auth import JwtCodec
+from url4_cloud.config import Settings
+from url4_cloud.rest.cache_header import parse_cache_control
+from url4_cloud.testing import InMemoryEventStream
+
+# --- the plan's Batch 3 table, row by row --------------------------------------------
+
+
+def test_absent_header_states_nothing() -> None:
+    """Plan Batch 3 test 3 — `None`, NOT a default-constructed policy.
+
+    The distinction is load-bearing rather than stylistic: precedence between the HTTP and frame
+    carriers can only prefer a stated policy over silence if silence has its own value, and a
+    `CachePolicy()` here would read as "the header spoke" and shadow the frame's declaration.
+    """
+    assert parse_cache_control(None) is None
+
+
+def test_a_present_but_empty_header_states_nothing() -> None:
+    """An empty field-value carries no directive, so it declares nothing — the same as absent.
+    Distinguishing them would give an empty header a meaning no caller intended by sending it.
+    """
+    assert parse_cache_control("") is None
+
+
+def test_no_store_opts_out() -> None:
+    """Spec §5.1. The caller means "do not use the cache"; url4 maps it to v2's ONLY opt-out."""
+    assert parse_cache_control("no-store") == CachePolicy(participate=False)
+
+
+def test_no_cache_opts_out_identically() -> None:
+    """v2 has no read-only/write-only lane (spec §5.1), so "don't serve me a stored answer" can
+    only be honoured by not participating at all. Mapping it to anything else would be a promise
+    the upstream cannot keep.
+    """
+    assert parse_cache_control("no-cache") == CachePolicy(participate=False)
+
+
+def test_max_age_participates_and_preserves_the_bound() -> None:
+    """Plan Batch 3 table + §6 — the directive is **preserved, not collapsed**.
+
+    r5 proposed collapsing `max-age` to an opt-out here. The owner locked the opposite (D11): the
+    run participates and carries the bound, so read-back can honour it the moment the gateway
+    reports an age. Collapsing at this edge would destroy the number before anything could use it.
+    """
+    assert parse_cache_control("max-age=60") == CachePolicy(participate=True, max_age=60)
+
+
+def test_max_age_zero_is_a_bound_not_an_absence() -> None:
+    """`0` is falsy and a truthiness test would silently drop it — turning "only a brand-new
+    answer will do" into "said nothing", which resolves to the ON default and serves an
+    arbitrarily old one. The strictest possible request would become the loosest outcome.
+    """
+    assert parse_cache_control("max-age=0") == CachePolicy(participate=True, max_age=0)
+
+
+def test_url4_use_cache_participates_explicitly() -> None:
+    """Spec §5.1 — the extension token. Rarely needed now that ON is the default, but it is how a
+    caller states participation rather than merely failing to forbid it, which matters when the
+    frame carrier declared an opt-out and the header must be able to override it.
+    """
+    assert parse_cache_control("url4-use-cache") == CachePolicy(participate=True)
+
+
+# --- combining, and the safe side of a conflict --------------------------------------
+
+
+def test_directives_that_agree_combine() -> None:
+    """Plan Batch 3 test 2. Both say participate, and the bound survives alongside the token."""
+    assert parse_cache_control("url4-use-cache, max-age=60") == CachePolicy(
+        participate=True, max_age=60
+    )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "max-age=60, no-store",
+        "no-store, max-age=60",
+        "url4-use-cache, no-cache",
+        "no-cache, url4-use-cache",
+        "no-store, url4-use-cache, max-age=5",
+    ],
+    ids=repr,
+)
+def test_conflicting_directives_resolve_to_opt_out(raw: str) -> None:
+    """Plan Batch 3 test 2 — conflicts resolve to the SAFE side, regardless of order.
+
+    Opting out is safe because its worst case is a missed cache hit; participating against a
+    caller who asked not to is unsafe because its worst case is a stale or shared answer they
+    explicitly refused. Order-independence is asserted deliberately: last-wins would make the
+    outcome depend on how an intermediary happened to concatenate the field.
+    """
+    assert parse_cache_control(raw) == CachePolicy(participate=False)
+
+
+def test_opting_out_drops_the_freshness_bound() -> None:
+    """A bound on a run that does not participate is meaningless, and carrying it would invent a
+    fourth state — "opted out, but only for 60s" — that nothing downstream can act on. Keeping
+    `max_age` set only alongside `participate=True` is what makes the read-back branch total.
+    """
+    policy = parse_cache_control("no-store, max-age=60")
+
+    assert policy is not None
+    assert policy.max_age is None
+
+
+def test_the_tighter_of_two_bounds_wins() -> None:
+    """A repeated directive is a conflict like any other, so it resolves conservatively: the
+    smaller bound is the one that admits fewer stale answers. First-wins or last-wins would let
+    a duplicate appended by an intermediary LOOSEN what the caller asked for.
+    """
+    assert parse_cache_control("max-age=600, max-age=60") == CachePolicy(
+        participate=True, max_age=60
+    )
+    assert parse_cache_control("max-age=60, max-age=600") == CachePolicy(
+        participate=True, max_age=60
+    )
+
+
+# --- tolerance: garbage in, silence out ----------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "   ",
+        ",,,",
+        "=",
+        "===",
+        "no-store=",  # a valueless directive spelled with a stray `=`
+        "\x00\x01",
+        "max-age",  # no argument at all
+        "max-age=",
+        "max-age=abc",
+        "max-age=6 0",
+        "max-age=1e3",
+        "max-age=-5",
+        "max-age=1.5",
+        "max-age=" + "9" * 400,  # absurd but numeric — must not be special-cased into a crash
+        "totally unrelated text",
+        "private, s-maxage=30, stale-while-revalidate=10",
+    ],
+    ids=repr,
+)
+def test_garbage_never_raises(raw: str) -> None:
+    """Plan Batch 3 test 4, at the parser. This function is called on a header a caller — or any
+    proxy between them — controls, so every input must produce a value rather than an exception.
+    The route-level half of this guarantee is asserted further down.
+    """
+    parse_cache_control(raw)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "   ",
+        ",,,",
+        "=",
+        "max-age",
+        "max-age=",
+        "max-age=abc",
+        "max-age=-5",
+        "max-age=1.5",
+        "totally unrelated text",
+        "private, s-maxage=30",
+    ],
+    ids=repr,
+)
+def test_undecipherable_input_states_nothing_rather_than_guessing(raw: str) -> None:
+    """Garbage must resolve to "not stated" — `None` — so the run falls through to the D1
+    default. Any other choice invents an intent the caller never expressed: guessing opt-out
+    would silently cost every hit for a typo, and guessing a default-constructed policy would
+    let a malformed header shadow a perfectly good one on the frame carrier.
+    """
+    assert parse_cache_control(raw) is None
+
+
+def test_a_malformed_max_age_drops_only_itself() -> None:
+    """Plan Batch 3 test 5. One unusable directive must not take a valid neighbour down with it —
+    the caller still said `url4-use-cache`, and honouring it costs nothing.
+    """
+    assert parse_cache_control("max-age=abc, url4-use-cache") == CachePolicy(participate=True)
+
+
+def test_unknown_directives_are_dropped_without_disturbing_known_ones() -> None:
+    """Plan Batch 3 test 5. `Cache-Control` is an open vocabulary that intermediaries add to
+    (D6 accepts intermediary participation), so an unrecognised member is ordinary traffic, not
+    an error.
+    """
+    assert parse_cache_control("private, immutable, max-age=60, no-transform") == CachePolicy(
+        participate=True, max_age=60
+    )
+
+
+def test_only_if_cached_is_rejected_by_being_ignored() -> None:
+    """Spec §8.3 — rejected, and "rejected" means IGNORED, never enforced and never fatal.
+
+    RFC 9111 requires `504` when nothing is cached. A url4 run fans out to many gateway calls, so
+    honouring it would let one uncached leaf kill an entire ensemble; there is no present use
+    case worth that. It therefore lands as an unknown directive and states nothing on its own.
+    """
+    assert parse_cache_control("only-if-cached") is None
+    assert parse_cache_control("only-if-cached, max-age=60") == CachePolicy(
+        participate=True, max_age=60
+    )
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("NO-STORE", CachePolicy(participate=False)),
+        ("No-Cache", CachePolicy(participate=False)),
+        ("MAX-AGE=60", CachePolicy(participate=True, max_age=60)),
+        ("URL4-Use-Cache", CachePolicy(participate=True)),
+    ],
+    ids=repr,
+)
+def test_directive_names_are_case_insensitive(raw: str, expected: CachePolicy) -> None:
+    """Field-value directive names are case-insensitive, and the codebase already normalises this
+    way in `_parse_prefer`. A caller whose HTTP client upper-cases would otherwise have their
+    opt-out silently dropped — the failure mode this whole design exists to prevent.
+    """
+    assert parse_cache_control(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["  no-store  ", "\tno-store", "no-store ,", ", no-store", "no-store,,"],
+    ids=repr,
+)
+def test_surrounding_whitespace_and_empty_members_are_tolerated(raw: str) -> None:
+    """Whitespace around list members and stray separators are how real clients and proxies
+    serialise this field; none of it changes what was said.
+    """
+    assert parse_cache_control(raw) == CachePolicy(participate=False)
+
+
+def test_a_quoted_argument_is_accepted() -> None:
+    """The argument of a directive may be given as a quoted-string, so `max-age="60"` is the same
+    request as `max-age=60`. Rejecting it would discard a well-formed bound.
+    """
+    assert parse_cache_control('max-age="60"') == CachePolicy(participate=True, max_age=60)
+
+
+# --- the invariant the whole batch is here to keep -----------------------------------
+
+_CORPUS = [
+    None,
+    "",
+    "no-store",
+    "no-cache",
+    "max-age=0",
+    "max-age=60",
+    "url4-use-cache",
+    "url4-use-cache, max-age=60",
+    "no-store, max-age=60",
+    "max-age=abc",
+    "only-if-cached",
+    "private, immutable",
+    ",,,",
+    "\x00",
+]
+
+
+@pytest.mark.parametrize("raw", _CORPUS, ids=repr)
+def test_a_bound_is_only_ever_carried_by_a_participating_policy(raw: str | None) -> None:
+    """The structural invariant every consumer of this parser may rely on: `max_age` is set only
+    when `participate` is `True`. It keeps the read-back branch total — there is no "opted out
+    with a bound" case to reason about — and it is asserted over a corpus rather than at the two
+    happy paths, because the way it breaks is a new directive setting one field and not the other.
+    """
+    policy = parse_cache_control(raw)
+
+    assert policy is None or policy.max_age is None or policy.participate is True
+
+
+@pytest.mark.parametrize("raw", _CORPUS, ids=repr)
+def test_the_parser_only_ever_yields_a_policy_or_silence(raw: str | None) -> None:
+    """`CachePolicy` is `extra="forbid"`, so a parser that tried to smuggle a directive through as
+    an extra field would raise here rather than reach the gateway. This asserts the return type is
+    exactly that closed model — the type on which the "only `use-cache` ever ships" guarantee in
+    `runner/cache.py` depends.
+    """
+    policy = parse_cache_control(raw)
+
+    assert policy is None or isinstance(policy, CachePolicy)
+
+
+# --- the route carrier ---------------------------------------------------------------
+
+SECRET = "cache-header-unit-secret"
+WINDOW_S = 60
+T0 = datetime(2026, 8, 5, 9, 0, 0, tzinfo=UTC)
+
+
+def _app(runner: RecordingJobRunner) -> FastAPI:
+    return create_app(
+        Settings(jwt_secret=SECRET, iat_window_s=WINDOW_S, sync_max_wait_s=5.0),
+        stream=InMemoryEventStream(),
+        job_runner=runner,
+        clock=lambda: T0,
+        interest=FixedGate(True),
+    )
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _cap(topic: str) -> dict[str, str]:
+    return {"URL4-Capability": JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).sign(topic, T0)}
+
+
+@pytest.mark.parametrize(
+    "cache_control",
+    ["no-store", "no-cache", "max-age=60", "url4-use-cache", "private, immutable"],
+    ids=repr,
+)
+@pytest.mark.asyncio
+async def test_a_cache_control_header_never_stops_the_run_from_starting(
+    cache_control: str,
+) -> None:
+    """The header is declared on `start_run`, so FastAPI extracts it — and extracting it must
+    change nothing about whether the run is scheduled. `no-cache` is the load-bearing case: a
+    browser hard-refresh sends it unprompted, and D6 deliberately accepts the standard field, so
+    ordinary traffic carries it whether or not the caller meant anything by it.
+    """
+    runner = RecordingJobRunner()
+    async with _client(_app(runner)) as client:
+        resp = await client.get(
+            "/",
+            params={"q": "gpt(hi)"},
+            headers={**_cap("topic-cc"), "Prefer": "respond-async", "Cache-Control": cache_control},
+        )
+
+    assert resp.status_code == 202
+    assert [run[0] for run in runner.scheduled] == ["topic-cc"]
+
+
+@pytest.mark.parametrize(
+    "cache_control",
+    ["max-age=abc", ",,,", "=", "totally unrelated text", "max-age=-5"],
+    ids=repr,
+)
+@pytest.mark.asyncio
+async def test_a_malformed_cache_control_header_is_never_4xx(cache_control: str) -> None:
+    """Plan Batch 3 test 4, at the route — the half that the parser alone cannot prove.
+
+    A cache directive is a hint about cost, not a term of the request. Rejecting a run because a
+    proxy appended something unparseable would convert a free missed hit into a failed ensemble.
+    """
+    runner = RecordingJobRunner()
+    async with _client(_app(runner)) as client:
+        resp = await client.get(
+            "/",
+            params={"q": "gpt(hi)"},
+            headers={
+                **_cap("topic-cc-bad"),
+                "Prefer": "respond-async",
+                "Cache-Control": cache_control,
+            },
+        )
+
+    assert resp.status_code == 202
+    assert runner.scheduled
+
+
+def test_the_start_route_documents_the_cache_control_header() -> None:
+    """The header is a public contract, so it belongs in the generated OpenAPI beside `X-Profile`
+    and `Prefer` — a caller cannot opt a run out of a shared, permanent, global cache using a
+    knob nothing tells them exists.
+    """
+    schema = _app(RecordingJobRunner()).openapi()
+
+    params = schema["paths"]["/"]["get"]["parameters"]
+    declared = {p["name"]: p for p in params if p["in"] == "header"}
+
+    assert "Cache-Control" in declared
+    assert declared["Cache-Control"]["required"] is False
+    assert declared["Cache-Control"]["description"]

--- a/apps/url4-cloud/tests/unit/test_runner_cache_body_field.py
+++ b/apps/url4-cloud/tests/unit/test_runner_cache_body_field.py
@@ -1,0 +1,158 @@
+"""`policy_to_body_field` — url4's cache INTENT translated into aigateway's wire vocabulary
+(plan Batch 2, spec §4.1 resolution table / §5.1 / §9.2c).
+
+THE INVARIANT THIS MODULE EXISTS TO PROTECT (spec §1.0). aigateway v2's cache-control grammar is
+**CLOSED to exactly one field**, `use-cache`. Any other key inside the request body's `cache`
+object makes the WHOLE request bypass the cache — silently, with no error raised anywhere, and
+even alongside an otherwise valid `use-cache: true`. So an extra key here is not a style defect:
+it costs every cache hit forever and nothing reports it. `test_no_input_ever_produces_a_key_other
+_than_use_cache` is that guard, and it is a CORRECTNESS test.
+
+WHY the translation lives in `url4_cloud` and not in the protocol type: `packages/url4` ships to
+SDK users and must not know an adapter's request-body shape (plan §4). `CachePolicy` speaks
+intent (`participate`); this module — and only this module — speaks `use-cache`.
+
+`max_age` is url4-INTERNAL. v2 refuses it (`global_controls.py:79-83`), so it must never reach
+the body; it is applied at read-back (Batch 7), where an entry's age can be compared against it.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Any
+
+import pytest
+
+from url4.streaming.protocol import CachePolicy
+from url4_cloud.runner.cache import policy_to_body_field
+
+# The full input space, one tuple per `CachePolicy` field. `_AXES` is asserted against
+# `model_fields` below, so a THIRD field added to the policy fails this module loudly instead of
+# quietly escaping the property test's coverage.
+_AXES: dict[str, tuple[Any, ...]] = {
+    "participate": (None, True, False),
+    "max_age": (None, 0, 1, 60, 86_400),
+}
+
+
+def _every_policy() -> list[CachePolicy]:
+    names = list(_AXES)
+    return [
+        CachePolicy(**dict(zip(names, values, strict=True)))
+        for values in itertools.product(*(_AXES[name] for name in names))
+    ]
+
+
+# --- the two mapped outcomes ---------------------------------------------------------
+
+
+def test_participate_true_omits_the_field_entirely() -> None:
+    """Plan Batch 2 test 1. Participation is expressed by saying NOTHING.
+
+    v2 treats absent, `null` and `{}` identically — all three participate (spec §1.0) — so the
+    smallest body is both sufficient and the least exposed to the closed-grammar bypass. Sending
+    `{"use-cache": true}` would be equivalent upstream but is deliberately NOT what we emit: it
+    would also change a default run's egress body, which spec §9.1 requires stay byte-identical.
+    """
+    assert policy_to_body_field(CachePolicy(participate=True)) == {}
+
+
+def test_participate_false_sends_the_opt_out() -> None:
+    """Plan Batch 2 test 2. The one thing url4 ever puts on the wire."""
+    body = policy_to_body_field(CachePolicy(participate=False))
+
+    assert body == {"cache": {"use-cache": False}}
+
+
+def test_opt_out_value_is_a_real_bool_not_a_string() -> None:
+    """v2 bypasses a non-bool `use-cache` with reason `malformed_controls` rather than honouring
+    it (spec §1.0 parse table). `"false"` would opt the caller out for the WRONG reason, and the
+    acceptance test that distinguishes `opted_out` from every other bypass would pass by accident.
+    """
+    body = policy_to_body_field(CachePolicy(participate=False))
+
+    assert body["cache"]["use-cache"] is False
+
+
+def test_not_stated_is_treated_as_participate() -> None:
+    """A resolved policy always states `participate` (convergence, Batch 5) — but `None` must
+    still mean participate, not "unknown, so fail". D1's default is ON, so "not stated" and
+    "stated True" have the SAME wire answer; making this raise would turn a harmless convergence
+    slip into a dead run for no gain.
+    """
+    assert policy_to_body_field(CachePolicy()) == {}
+
+
+# --- max_age is url4-internal and never leaves ---------------------------------------
+
+
+@pytest.mark.parametrize("max_age", _AXES["max_age"])
+@pytest.mark.parametrize("participate", _AXES["participate"])
+def test_max_age_never_reaches_the_body(participate: bool | None, max_age: int | None) -> None:
+    """Spec §3.5 / plan §6. `max_age` is a url4-internal freshness bound: v2's grammar refuses
+    it, so forwarding it would bypass the cache with `unsupported_control` — the exact silent
+    cost this design exists to avoid. It changes nothing about what is emitted here.
+    """
+    body = policy_to_body_field(CachePolicy(participate=participate, max_age=max_age))
+    without_max_age = policy_to_body_field(CachePolicy(participate=participate))
+
+    assert "max-age" not in body.get("cache", {})
+    assert "max_age" not in body.get("cache", {})
+    assert body == without_max_age
+
+
+# --- THE property: the closed grammar, over the whole input space --------------------
+
+
+def test_the_axes_cover_every_policy_field() -> None:
+    """Guards the guard. The property test below is only exhaustive if `_AXES` enumerates every
+    field `CachePolicy` has; a field added without extending it would leave the closed-grammar
+    invariant untested while the suite stayed green.
+    """
+    assert set(_AXES) == set(CachePolicy.model_fields)
+
+
+@pytest.mark.parametrize("policy", _every_policy(), ids=repr)
+def test_no_input_ever_produces_a_key_other_than_use_cache(policy: CachePolicy) -> None:
+    """Plan Batch 2 test 3 — **the single most important guard in this plan.**
+
+    Under v2 an unrecognised control key does not degrade to "ignored": the request BYPASSES,
+    silently, even next to a valid `use-cache: true` (`global_controls.py`). So there is no
+    error, no log and no metric to notice — the only symptom is a cache that never hits. This
+    asserts the containment over the FULL cartesian product of the policy's fields, not over the
+    two happy paths, because the way this breaks is a new field being spread into the object.
+    """
+    out = policy_to_body_field(policy)
+
+    assert set(out.get("cache", {})) <= {"use-cache"}
+
+
+@pytest.mark.parametrize("policy", _every_policy(), ids=repr)
+def test_the_body_field_is_spreadable_and_carries_at_most_cache(policy: CachePolicy) -> None:
+    """The call site is `json={"model": …, "messages": …, **extra, **policy_to_body_field(p)}`
+    (Batch 6), so the return value must be a mapping that contributes AT MOST the `cache` key —
+    a stray top-level key would land in the chat-completions body, where aigateway's own
+    unsupported-fields path would reject or bypass it.
+    """
+    out = policy_to_body_field(policy)
+    merged = {"model": "m", "messages": [], **out}
+
+    assert set(out) <= {"cache"}
+    assert set(merged) <= {"model", "messages", "cache"}
+
+
+def test_each_call_returns_an_independent_object() -> None:
+    """No shared module-level literal. Two runs in one process must not be able to contaminate
+    each other's egress body — the same isolation Batch 6 test 3 asserts one layer up, enforced
+    here at the source so a cached constant can never become the vehicle.
+    """
+    first = policy_to_body_field(CachePolicy(participate=False))
+    second = policy_to_body_field(CachePolicy(participate=False))
+
+    assert first == second
+    assert first is not second
+    assert first["cache"] is not second["cache"]
+
+    first["cache"]["use-cache"] = True
+
+    assert second == {"cache": {"use-cache": False}}

--- a/apps/url4-cloud/tests/unit/test_ws_cache_policy.py
+++ b/apps/url4-cloud/tests/unit/test_ws_cache_policy.py
@@ -1,0 +1,272 @@
+"""Batch 4 — the WS carrier: an attach frame's cache intent becomes the topic's session state.
+
+FIRST ATTACH WINS (spec §5.2). The run's aigateway calls may already have executed under the
+policy the first attach declared, so a later re-attach that says something different cannot be
+allowed to restate it — the run's cache behaviour would stop being reproducible. It is ignored and
+said out loud, at `warn`, on the socket that sent it.
+
+The barrier every socket test here uses is a SEEDED STREAM EVENT rather than a heartbeat: the
+declaration is recorded before the subscription is (re)started, so receiving a pumped frame proves
+the declaration already landed, and a warning — queued before that same subscription — would
+always arrive first. That makes "no warning was emitted" an assertion about frame ORDER rather
+than about elapsed time, so it cannot flake.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from _fakes import RecordingJobRunner
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from url4.streaming.protocol import (
+    AttachData,
+    AttachEvent,
+    CachePolicy,
+    OutboundFrame,
+    StartedData,
+    StartedEvent,
+)
+from url4_cloud.app import create_app
+from url4_cloud.auth import JwtCodec
+from url4_cloud.config import Settings
+from url4_cloud.testing import InMemoryEventStream
+from url4_cloud.ws import ConnectionRegistry
+
+SECRET = "ws-cache-policy-secret"
+WINDOW_S = 60
+T0 = datetime(2026, 8, 5, 9, 0, 0, tzinfo=UTC)
+
+OPT_OUT = CachePolicy(participate=False)
+OPT_IN = CachePolicy(participate=True)
+
+
+def _token(topic: str) -> str:
+    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).sign(topic, T0)
+
+
+def _make_app(*, stream: InMemoryEventStream) -> FastAPI:
+    settings = Settings(jwt_secret=SECRET, iat_window_s=WINDOW_S)
+    return create_app(settings, stream=stream, job_runner=RecordingJobRunner(), clock=lambda: T0)
+
+
+def _seed(
+    client: TestClient, stream: InMemoryEventStream, topic: str, events: list[OutboundFrame]
+) -> None:
+    portal = client.portal
+    assert portal is not None
+    for event in events:
+        portal.call(stream.publish, topic, event)
+
+
+def _started(topic: str) -> StartedEvent:
+    return StartedEvent(
+        id=f"s-{topic}",
+        source=f"/trace/{topic}/node/root",
+        subject=topic,
+        data=StartedData(url4="gpt()"),
+    )
+
+
+def _attach(
+    *, cache: CachePolicy | None = None, from_sequence: int | None = None
+) -> dict[str, Any]:
+    event = AttachEvent(
+        id="att",
+        source="/client",
+        subject="t",
+        data=AttachData(from_sequence=from_sequence, cache=cache),
+    )
+    return event.model_dump(mode="json", by_alias=True)
+
+
+def _attach_without_cache_key(from_sequence: int | None = None) -> dict[str, Any]:
+    """An attach frame with no `cache` key AT ALL — what every client in flight already sends."""
+    frame = _attach(from_sequence=from_sequence)
+    del frame["data"]["cache"]
+    return frame
+
+
+# --- the registry, directly -------------------------------------------------------------------
+
+
+def test_registry_records_the_first_declaration_and_ignores_a_later_conflicting_one() -> None:
+    registry = ConnectionRegistry()
+    registry.add("t")
+    assert registry.declare_cache_policy("t", OPT_OUT) is True
+    assert registry.cache_policy_for("t") == OPT_OUT
+    assert registry.declare_cache_policy("t", OPT_IN) is False
+    assert registry.cache_policy_for("t") == OPT_OUT
+
+
+def test_registry_accepts_a_restatement_of_the_standing_policy() -> None:
+    registry = ConnectionRegistry()
+    registry.add("t")
+    registry.declare_cache_policy("t", OPT_OUT)
+    # A reconnecting client re-sends the frame it sent the first time. That is not a conflict, and
+    # reporting it as one would make every ordinary reconnect emit a warning nobody can act on.
+    assert registry.declare_cache_policy("t", CachePolicy(participate=False)) is True
+    assert registry.cache_policy_for("t") == OPT_OUT
+
+
+def test_registry_treats_declaring_nothing_as_the_first_declaration() -> None:
+    registry = ConnectionRegistry()
+    registry.add("t")
+    # "Did not declare" IS a declaration for first-attach-wins purposes: the run starts under the
+    # ON default, and a later attach cannot retroactively opt that run out.
+    assert registry.declare_cache_policy("t", None) is True
+    assert registry.declare_cache_policy("t", OPT_OUT) is False
+    assert registry.cache_policy_for("t") is None
+
+
+def test_registry_forgets_the_declaration_when_the_last_subscriber_leaves() -> None:
+    registry = ConnectionRegistry()
+    registry.add("t")
+    registry.add("t")
+    registry.declare_cache_policy("t", OPT_OUT)
+    registry.remove("t")
+    assert registry.cache_policy_for("t") == OPT_OUT
+    registry.remove("t")
+    assert registry.cache_policy_for("t") is None
+
+
+def test_registry_reports_no_policy_for_an_unknown_topic() -> None:
+    assert ConnectionRegistry().cache_policy_for("never-seen") is None
+
+
+def test_registry_declaration_without_a_subscriber_does_not_outlive_a_remove() -> None:
+    registry = ConnectionRegistry()
+    assert registry.declare_cache_policy("t", OPT_OUT) is True
+    registry.remove("t")
+    assert registry.cache_policy_for("t") is None
+
+
+@pytest.mark.asyncio
+async def test_registry_declaration_does_not_make_a_topic_look_subscribed() -> None:
+    registry = ConnectionRegistry()
+    registry.declare_cache_policy("t", OPT_OUT)
+    # The 428 precondition asks about SUBSCRIBERS. A declaration is not one, and letting it pass
+    # for one would start a run with nothing attached to observe its terminal frame.
+    assert await registry.has_subscriber("t") is False
+
+
+# --- the socket -------------------------------------------------------------------------------
+
+
+def test_attach_carrying_a_policy_records_it_for_the_topic() -> None:
+    topic = "ws-cache-declared"
+    stream = InMemoryEventStream()
+    app = _make_app(stream=stream)
+    with TestClient(app) as client:
+        _seed(client, stream, topic, [_started(topic)])
+        with client.websocket_connect(f"/ws?ticket={_token(topic)}") as ws:
+            ws.send_json(_attach(cache=OPT_OUT))
+            assert ws.receive_json()["type"] == "ai.url4.started"
+            assert app.state.registry.cache_policy_for(topic) == OPT_OUT
+
+
+def test_attach_without_a_cache_field_records_no_policy() -> None:
+    topic = "ws-cache-absent"
+    stream = InMemoryEventStream()
+    app = _make_app(stream=stream)
+    with TestClient(app) as client:
+        _seed(client, stream, topic, [_started(topic)])
+        with client.websocket_connect(f"/ws?ticket={_token(topic)}") as ws:
+            ws.send_json(_attach_without_cache_key())
+            assert ws.receive_json()["type"] == "ai.url4.started"
+            # `None`, not a default-constructed policy: the header carrier must still be able to
+            # tell silence from a stated intent when the two are reconciled.
+            assert app.state.registry.cache_policy_for(topic) is None
+
+
+def test_reattach_with_a_different_policy_leaves_it_unchanged_and_warns() -> None:
+    topic = "ws-cache-conflict"
+    stream = InMemoryEventStream()
+    app = _make_app(stream=stream)
+    with TestClient(app) as client:
+        _seed(client, stream, topic, [_started(topic)])
+        with client.websocket_connect(f"/ws?ticket={_token(topic)}") as ws:
+            ws.send_json(_attach(cache=OPT_OUT))
+            assert ws.receive_json()["type"] == "ai.url4.started"
+            ws.send_json(_attach(cache=OPT_IN, from_sequence=1))
+            warned = ws.receive_json()
+            assert app.state.registry.cache_policy_for(topic) == OPT_OUT
+            # The re-attach still resubscribes — the policy is ignored, the frame is not.
+            assert ws.receive_json()["type"] == "ai.url4.started"
+    assert warned["type"] == "ai.url4.log"
+    assert warned["data"]["severity_text"] == "WARN"
+    assert warned["subject"] == topic
+    attributes = warned["data"]["attributes"]
+    assert attributes["cache.declared"] == '{"participate":true}'
+    assert attributes["cache.effective"] == '{"participate":false}'
+
+
+def test_reattach_with_an_identical_policy_warns_about_nothing() -> None:
+    topic = "ws-cache-restated"
+    stream = InMemoryEventStream()
+    app = _make_app(stream=stream)
+    with TestClient(app) as client:
+        _seed(client, stream, topic, [_started(topic)])
+        with client.websocket_connect(f"/ws?ticket={_token(topic)}") as ws:
+            ws.send_json(_attach(cache=OPT_OUT))
+            assert ws.receive_json()["type"] == "ai.url4.started"
+            ws.send_json(_attach(cache=CachePolicy(participate=False), from_sequence=1))
+            # A warning would have been queued BEFORE this replay, so the replay arriving first is
+            # proof none was emitted.
+            assert ws.receive_json()["type"] == "ai.url4.started"
+
+
+def test_reattach_declaring_a_policy_after_declaring_none_is_ignored_and_warns() -> None:
+    topic = "ws-cache-late-declaration"
+    stream = InMemoryEventStream()
+    app = _make_app(stream=stream)
+    with TestClient(app) as client:
+        _seed(client, stream, topic, [_started(topic)])
+        with client.websocket_connect(f"/ws?ticket={_token(topic)}") as ws:
+            ws.send_json(_attach_without_cache_key())
+            assert ws.receive_json()["type"] == "ai.url4.started"
+            ws.send_json(_attach(cache=OPT_OUT, from_sequence=1))
+            warned = ws.receive_json()
+            assert app.state.registry.cache_policy_for(topic) is None
+    assert warned["type"] == "ai.url4.log"
+    assert warned["data"]["severity_text"] == "WARN"
+    assert warned["data"]["attributes"]["cache.effective"] == "not stated"
+
+
+def test_a_second_connection_cannot_restate_the_first_connections_policy() -> None:
+    topic = "ws-cache-two-connections"
+    stream = InMemoryEventStream()
+    app = _make_app(stream=stream)
+    with TestClient(app) as client:
+        _seed(client, stream, topic, [_started(topic)])
+        url = f"/ws?ticket={_token(topic)}"
+        with client.websocket_connect(url) as first:
+            first.send_json(_attach(cache=OPT_OUT))
+            assert first.receive_json()["type"] == "ai.url4.started"
+            with client.websocket_connect(url) as second:
+                second.send_json(_attach(cache=OPT_IN))
+                warned = second.receive_json()
+                assert app.state.registry.cache_policy_for(topic) == OPT_OUT
+    assert warned["type"] == "ai.url4.log"
+    assert warned["data"]["severity_text"] == "WARN"
+
+
+def test_run_start_stays_gated_on_an_attached_subscriber() -> None:
+    """The whole design rests on attach preceding run start; assert it rather than assume it."""
+    topic = "ws-cache-gate"
+    stream = InMemoryEventStream()
+    app = _make_app(stream=stream)
+    headers = {"URL4-Capability": _token(topic)}
+    with TestClient(app) as client:
+        _seed(client, stream, topic, [_started(topic)])
+        assert client.get("/", params={"q": "gpt()"}, headers=headers).status_code == 428
+        with client.websocket_connect(f"/ws?ticket={_token(topic)}") as ws:
+            ws.send_json(_attach(cache=OPT_OUT))
+            assert ws.receive_json()["type"] == "ai.url4.started"
+            started = client.get(
+                "/", params={"q": "gpt()"}, headers={**headers, "Prefer": "respond-async"}
+            )
+            # By the time a run CAN be scheduled, the frame's declaration is already recorded.
+            assert app.state.registry.cache_policy_for(topic) == OPT_OUT
+    assert started.status_code == 202

--- a/docs/work/2026-08-05-UNFILED-url4-cache-policy-impl.md
+++ b/docs/work/2026-08-05-UNFILED-url4-cache-policy-impl.md
@@ -1,0 +1,176 @@
+---
+ticket: UNFILED
+stack: url4-cloud
+status: in_progress
+started: 2026-08-05
+finished:
+---
+
+# UNFILED — implement the url4 per-run cache policy
+
+## PROCESS DEVIATION
+
+**No Linear issue backs this unit.** Linear MCP unauthenticated; `.claude/task-board.local.md`
+names it the only permitted transport. Fifth occurrence this session; the owner has consistently
+chosen "proceed and record the deviation".
+
+**This one is worse than the previous four**: the work spans `packages/url4` **and**
+`apps/url4-cloud`, so CLAUDE.md rule 8 requires an **epic + one sub-issue per landing**. It is
+being executed as a single unit because there is no way to file the epic. Back-fill on MCP:
+epic + 2 sub-issues, branch rename, `docs/tasks/` mirrors, `Refs:` on commits.
+
+## Intent
+
+Implement the design approved in plain words by the owner on 2026-08-05.
+
+- **Spec:** `docs/spec/2026-08-05-url4-cache-policy-spec.md` (r7 — decision-complete)
+- **Plan:** `docs/plan/2026-08-05-url4-cache-policy.md` (r6 — 8 batches)
+
+Both live on branch `url4-cloud-cache-policy-spec` (PR #515), **not yet on `main`**. This branch
+is cut from `main` and carries code only, so the two PRs stay independent rather than stacked
+(the repo squash-merges; stacking has bitten before — see `feedback_no_stacked_prs_squash`).
+
+## Locked design
+
+| | |
+|---|---|
+| Default | caching **ON**; only disabling is explicit |
+| Carriers | `Cache-Control` header on `GET /` **and** `AttachData.cache` on the WS attach frame |
+| Precedence | **header wins**; override emits a `LogEvent` at `warn` |
+| Frame shape | extend `AttachData` — no new inbound verb |
+| `max-age` | **honour it** — inert today (§6 of the plan), value preserved rather than collapsed |
+| Read-back | prefer `Cache-Status` (RFC 9211), fall back to the `X-AIGW-*` triple |
+| aigateway | **no change** — PR #507 owns the upstream |
+
+## Method
+
+Executed as a **sequential agent pipeline** (one agent per plan batch, `/workflows`), each
+running its stack's gates and stopping the chain on red. Sequential rather than parallel because
+the batches form a dependency chain and share `rest/routes.py`; the value here is bounded
+context per batch and a deterministic stop-on-red, not concurrency.
+
+## APPEND-ONLY EXCEPTION — owner-approved 2026-08-06
+
+Batch 6 widened the `IdentityAwareJobRunner` port with `cache: CachePolicy | None = None`. Two
+test **doubles** had to accept the new parameter or stop implementing the port, which tripped
+`run_gates.py`'s append-only check and stopped the pipeline — correctly, since sdlc rule 5 makes
+that a Confidence-Gate decision.
+
+**What changed — +10 lines, two files, zero assertions:**
+
+| file | change |
+|---|---|
+| `tests/unit/_fakes.py` | import `CachePolicy`; `RecordingJobRunner.schedule` accepts `cache=None` |
+| `tests/integration/test_e2e_compose_flow.py` | import `CachePolicy`; `MockRunnerJobRunner.schedule` accepts `cache=None` |
+
+No assertion was altered, nothing was deleted, and no test's meaning changed. The implementing
+agent explicitly declined the one change that *would* have crossed the line, and said so in the
+code:
+
+> *"deliberately NOT recorded onto `ScheduledRun`: that tuple is compared whole by an existing
+> test, so widening it would change what an already-written assertion means."*
+
+**Owner ruling:** accepted as port conformance rather than an assertion change.
+
+**Why the gate could not decide this itself:** it is a `git diff --name-status` over the test
+globs, so it cannot distinguish "changed what a test asserts" from "kept a double compiling
+against a widened interface". Only the first is what rule 5 protects. Escalating rather than
+guessing is the right behaviour for the gate; the cost is that port-widening work always stops
+here.
+
+**Everything else was green at the stop point** — `ruff`, `ruff format`, `pyright`,
+`check_layering.py`, and the full suite with coverage.
+
+## Acceptance
+
+Plan §Verification, items 1-5. Notably:
+- the Batch 2 property test — `cache` never carries a key other than `use-cache`
+- a default run's egress body is byte-identical to today's
+- `no-store` produces `opted_out`, **not** `unsupported_control`
+
+## Known-inert
+
+`max-age` degrades to opt-out until aigateway either accepts a bound or reports `Age`. Both
+blockers verified on #507's branch; the honoured path is written and dormant.
+
+## Batch 7 — two design notes the owner should see
+
+**1. The read-back seam widened `packages/url4`, which the plan's Batch 7 bullet did not name.**
+The connector holds an HTTP response; `SpanData` is built in `runner/executor.py` from
+`url4.observe` events. The only channel between them is the observation stream, so the outcome
+had to ride one. It was added to the EXISTING `ModelResponse` (`cache_status` / `cache_reason`,
+both defaulted) rather than as a new event kind: the fact is per-round-trip exactly as
+`finish_reason` is, both are read off the same response, and a second event would force a
+consumer to correlate two streams to answer one question about one call. `ctx.report_response`
+and the `ResponseSink` contract gained the same two optional kwargs — every existing caller
+compiles and behaves unchanged (pinned by
+`test_a_caller_that_reports_no_cache_outcome_still_works`).
+
+**2. Age is read from `Age`, NOT from `Cache-Status; ttl=`.** Spec §7's mapping table says
+`ttl=` → entry age; RFC 9211 §2.4 defines `ttl` as the *remaining freshness lifetime*, which is
+the inverse quantity — and against a corpus whose rows never expire it has no meaning at all.
+Reading it as an age would make a `max-age` decision on a number that means the opposite, the
+day the gateway starts emitting it. `Age` (RFC 9111 §5.1) is "the sender's estimate of the time
+since the response was generated", which is exactly what a bound is compared against, and is
+already what spec §2.2 and §3.5's blocker table name. Written down here rather than silently.
+
+**D11's shape, concretely.** `requires_revalidation` re-issues with an explicit opt-out ONLY for
+a hit whose age is unknown or beyond the bound. A miss or a bypass was generated just now, so
+its age is zero and every bound already holds — re-issuing there would double the cost of every
+call a bounded run makes, for an answer that was never stale. The discarded response is read for
+its headers and nothing else; its usage is never reported, or the turn would be billed twice.
+
+## Outcome
+
+- **Gates:** green on both stacks.
+
+  ```
+  url4        ✓ append-only ✓ ruff ✓ format ✓ pyright ✓ pytest --cov (97.45%, 1100 passed)
+  url4-cloud  ✓ ruff ✓ format ✓ pyright ✓ check_layering ✓ pytest --cov (>80%)
+              append-only: the owner-approved exception above
+  ```
+
+- **8 batches, 9 agents.** The pipeline stopped once (batch 6, append-only) exactly as designed;
+  resumed after the owner ruling with batches 1-6 replayed from cache.
+
+- **Agents overruled the plan twice, both correctly.**
+  1. Batch 1 found the plan self-contradictory — Batch 1's bullet said `CachePolicy` has "exactly
+     one field", Batch 3 said it carries a second (`max_age`). Batch 3 must win, since it lives in
+     `apps/url4-cloud` and cannot add a field to a `packages/url4` model. Spec r8 corrected.
+  2. Batch 1 placed protocol tests in `apps/url4-cloud/tests/` rather than `packages/url4/tests/`,
+     because `packages/url4/pyproject.toml` omits `src/url4/streaming/*` from its own coverage with
+     the comment *"its tests live with its only consumers"*. Repo convention over plan text; both
+     gates run either way.
+
+## The adversarial review changed the shipped behaviour
+
+The 9th agent reviewed against the spec's acceptance criteria and returned 10 findings. Two were
+substantive; the rest were doc staleness, fixed in spec r8.
+
+**The one that mattered:** batch 7 implemented D11 as *participate-then-revalidate* — send the
+request participating, and if the answer is a hit whose age cannot be proven, re-issue with an
+explicit opt-out and discard the first body. Spec §3.5 said the shipped behaviour is *degrade to
+opt-out*.
+
+Since aigateway reports no age today, **every hit under a bound cost two gateway calls** — inside
+`for _ in range(cfg.web_tool_max_iterations)`, so a four-iteration tool turn became eight calls,
+multiplied again across a fan-out. And D6 deliberately invites intermediaries to inject
+`Cache-Control`, making `max-age=0` from a browser reload an accidental trigger.
+
+**Owner ruling: opt out upfront, per the spec.** Implemented in `rest/cache_policy.py` as
+`_degrade_unhonourable_bound`, gated on a single `GATEWAY_REPORTS_AGE = False` constant.
+`requires_revalidation` and its tests are kept, correct and unreachable — flipping that one flag
+is the whole of D11's honouring half. Three batch-5 tests encoding the old behaviour were updated
+(new files from this same unit, not prior tests).
+
+## Deviations
+
+1. **Process** — `UNFILED`, no Linear issue, no `docs/tasks/` mirror, no `Refs:` on commits.
+   **Also a rule 8 breach**: this spans `packages/url4` + `apps/url4-cloud` and should be an epic
+   with one sub-issue per landing. Executed as one unit only because MCP is unauthenticated.
+2. **Append-only exception** — owner-approved, documented above.
+3. **D11 shipped inert.** `max-age` degrades to opt-out; the honoured path is written and dormant.
+4. **End-to-end verification not run.** Plan Verification step 3 needs a local aigateway built
+   from #507. Every test here asserts against a mock transport, so the aigateway half of the
+   contract is verified by reading `global_controls.py`, not by execution. **Green gates are not
+   evidence this works end to end** — the plan says so and it remains true.

--- a/docs/work/2026-08-05-UNFILED-url4-cache-policy-impl.md
+++ b/docs/work/2026-08-05-UNFILED-url4-cache-policy-impl.md
@@ -1,9 +1,9 @@
 ---
 ticket: UNFILED
 stack: url4-cloud
-status: in_progress
+status: done
 started: 2026-08-05
-finished:
+finished: 2026-08-07
 ---
 
 # UNFILED — implement the url4 per-run cache policy
@@ -26,9 +26,10 @@ Implement the design approved in plain words by the owner on 2026-08-05.
 - **Spec:** `docs/spec/2026-08-05-url4-cache-policy-spec.md` (r7 — decision-complete)
 - **Plan:** `docs/plan/2026-08-05-url4-cache-policy.md` (r6 — 8 batches)
 
-Both live on branch `url4-cloud-cache-policy-spec` (PR #515), **not yet on `main`**. This branch
-is cut from `main` and carries code only, so the two PRs stay independent rather than stacked
-(the repo squash-merges; stacking has bitten before — see `feedback_no_stacked_prs_squash`).
+Both shipped as **PR #515, merged 2026-08-07 as `b113f41c`** (spec r9 / plan r7 — re-synced to
+the merged #507). This branch was cut from `main` and carries code only, so the two PRs stayed
+independent rather than stacked (the repo squash-merges; stacking has bitten before — see
+`feedback_no_stacked_prs_squash`). The file sets were disjoint, so neither blocked the other.
 
 ## Locked design
 
@@ -91,7 +92,8 @@ Plan §Verification, items 1-5. Notably:
 ## Known-inert
 
 `max-age` degrades to opt-out until aigateway either accepts a bound or reports `Age`. Both
-blockers verified on #507's branch; the honoured path is written and dormant.
+blockers verified on #507's branch, and **re-verified on merged `main` 2026-08-07 — both still
+stand**; the honoured path is written and dormant.
 
 ## Batch 7 — two design notes the owner should see
 
@@ -170,7 +172,70 @@ is the whole of D11's honouring half. Three batch-5 tests encoding the old behav
    with one sub-issue per landing. Executed as one unit only because MCP is unauthenticated.
 2. **Append-only exception** — owner-approved, documented above.
 3. **D11 shipped inert.** `max-age` degrades to opt-out; the honoured path is written and dormant.
-4. **End-to-end verification not run.** Plan Verification step 3 needs a local aigateway built
-   from #507. Every test here asserts against a mock transport, so the aigateway half of the
-   contract is verified by reading `global_controls.py`, not by execution. **Green gates are not
-   evidence this works end to end** — the plan says so and it remains true.
+4. ~~**End-to-end verification not run.**~~ — **RUN 2026-08-07, ALL CHECKS PASSED.** See below.
+
+## End-to-end verification — 2026-08-07, after #507 merged
+
+The gap this ledger flagged is closed. #507 merged as `4f2a55ea`, which made the run possible
+for the first time.
+
+**What made it an E2E rather than a restatement of the same belief.** The request bodies were
+not hand-written. They came out of url4-cloud's own production chain —
+`parse_cache_control()` → `resolve()` → `policy_to_body_field()` — and were POSTed over real
+HTTP to a real aigateway process running merged `main`. Had the reading of `global_controls.py`
+been wrong, these assertions fail; the mock suite would not have moved.
+
+**Harness** (scratchpad only, nothing tracked): a stub Ollama on `:11499` counting its own
+calls, and aigateway on `:9155` with `AIGW_REQUEST_CACHE_ENABLED=true`,
+`AIGATEWAY_AUTH_ENABLED=false`, `AIGW_OLLAMA_HOST` pointed at the stub, and an isolated sqlite
+(a shared DB would let a previous run's rows decide this run's hit/miss). Schema built the way
+`tests/conftest.py:184` does — `main.py` never creates tables; aerich does that out of band.
+
+| # | check | result |
+|---|---|---|
+| 1 | default body clears the control gate (`provider_projection`, **not** a caller-attributed reason) | ✅ |
+| 2 | `Cache-Control: no-store` → `bypass` / **`opted_out`** | ✅ |
+| 2 | `Cache-Control: no-cache` → `bypass` / **`opted_out`** | ✅ |
+| 3 | `max-age=60` and `max-age=0` → `bypass` / `opted_out` (D11 degrade) | ✅ |
+| 4 | **negative control** — raw `{"no-store":true}`, `{"ttl":60}`, `{"use-cache":true,"s-maxage":30}` → `unsupported_control` | ✅ |
+| 5 | a default run's egress body carries no `cache` key (spec §9.1) | ✅ |
+
+**Check 4 is what makes check 2 mean anything.** If the gateway answered `opted_out` for
+everything, check 2 would pass for the wrong reason. Sending the v1 vocabulary url4 deliberately
+no longer emits, and getting a *different* reason back, proves the distinction is real and that
+collapsing at the url4 edge buys something.
+
+### The one thing still not proven end to end, and why
+
+**`default → miss → hit` was not driven through url4.** Not a defect and not skipped for
+convenience — it is unreachable locally:
+
+- ollama inherits `CacheBypass(provider_projection)` from `ProviderPluginBase` and can never
+  produce a hit. Its `parameters.py:83-90` states this and names the conformance test enforcing it.
+- **anthropic and openrouter are the only providers implementing `global_cache_projection`**, and
+  both PIN their `api_base` deliberately (openrouter D7, "request-local api_base beats every
+  LiteLLM global/env fallback"). Neither is stubbable; a real miss needs a paid credential.
+
+**Why the residual risk is small.** url4's default egress body is byte-identical to a pre-#518
+body — it carries no `cache` field at all (check 5). So miss→hit is aigateway's own contract on a
+body url4 does not touch, and aigateway's suite covers it directly. Verified passing on merged
+`main` alongside this run:
+
+```
+test_repeated_bare_request_still_hits                        ← a BARE request repeated,
+test_a_second_account_hits_the_first_accounts_stored_response   the exact shape url4 sends
+test_a_different_profile_hits_the_same_global_entry
+test_a_profile_that_cannot_authenticate_still_gets_a_hit
+tests/unit/test_chat_global_cache_route.py                   ← 25 passed
+```
+
+### An ordering fact worth recording
+
+`global_plan.build_global_cache_plan` evaluates: `cache_enabled` → `participates_in_global_cache`
+→ **`controls.participate`** → projection. url4's opt-out is adjudicated at the third step, which
+is why the *same* provider returns `opted_out` for an opt-out and `provider_projection` for a
+default. Two different reasons from one provider is the evidence the control gate saw
+participation — the E2E leans on that rather than on a header taken at face value.
+
+`GATEWAY_REPORTS_AGE = False` re-verified on `main`: `git grep -E '"Age"|Cache-Status' --
+'apps/aigateway/src/**/*.py'` returns nothing. D11's honouring half stays correctly dormant.

--- a/packages/url4/src/url4/dag/node.py
+++ b/packages/url4/src/url4/dag/node.py
@@ -35,7 +35,7 @@ import asyncio
 import secrets
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import NoReturn, Protocol, runtime_checkable
+from typing import Literal, NoReturn, Protocol, runtime_checkable
 
 from url4.core.context import Context
 from url4.io.layer import (
@@ -380,7 +380,14 @@ class ExecutionContext:
                 )
             )
 
-    def report_response(self, *, finish_reason: str | None, refusal: str | None) -> None:
+    def report_response(
+        self,
+        *,
+        finish_reason: str | None,
+        refusal: str | None,
+        cache_status: Literal["hit", "miss", "bypass"] | None = None,
+        cache_reason: str | None = None,
+    ) -> None:
         """Report how one model round trip ended, under this node's current
         span. A no-op when no ``observer`` was passed to
         :func:`~url4.dag.executor.run`.
@@ -388,9 +395,18 @@ class ExecutionContext:
         INVARIANT: emits one event per call — a node making several round trips
         (a tool-calling turn) produces several events on the same span, never a
         single collapsed one.
+
+        ``cache_status`` / ``cache_reason`` describe whether the answering
+        gateway served this trip from its response cache. They DEFAULT to
+        nothing on purpose: not every world talks to a cache, and this is a
+        live seam whose existing callers must keep compiling unchanged.
         """
         if self._obs is not None:
-            self._obs.emit(ModelResponse(self._current_span_id, finish_reason, refusal))
+            self._obs.emit(
+                ModelResponse(
+                    self._current_span_id, finish_reason, refusal, cache_status, cache_reason
+                )
+            )
 
     def log(self, severity: str, body: str) -> None:
         """Emit a log line attributed to this node's current span. A no-op

--- a/packages/url4/src/url4/observe.py
+++ b/packages/url4/src/url4/observe.py
@@ -93,11 +93,28 @@ class ModelResponse:
     OpenAI vocabulary (``stop`` | ``length`` | ``content_filter`` |
     ``tool_calls``); ``refusal`` is the provider's refusal text when it sends
     one. Both are optional because not every provider reports either.
+
+    ``cache_status`` / ``cache_reason`` say whether the gateway that answered
+    served this round trip from its response cache, and — when it did not —
+    its own word for why. They ride HERE rather than on a seam of their own
+    because the fact is per-round-trip exactly as ``finish_reason`` is, and an
+    adapter reads both off the same response. WHY it must be reported at all: a
+    hit costs nothing upstream, so a run that cannot report one bills it as a
+    fresh call — an error that HIDES savings and is therefore never noticed.
+    ``cache_reason`` is the reporting cache's vocabulary VERBATIM; normalizing
+    it here would erase the distinction that makes "I asked for no caching and
+    something still cached" an answerable question.
     """
 
     span_id: str | None
     finish_reason: str | None
     refusal: str | None
+    # AIDEV-NOTE: this literal is spelled again on `url4.streaming.protocol.SpanData`, which is
+    # where it reaches the wire. Deliberately duplicated rather than shared: this module is the
+    # engine's dependency-free observation leaf and the protocol package is the wire contract,
+    # and coupling the two to save three tokens would be the worse trade. Change both together.
+    cache_status: Literal["hit", "miss", "bypass"] | None = None
+    cache_reason: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -155,7 +172,12 @@ def current_usage_sink() -> UsageSink | None:
 
 
 ResponseSink = Callable[..., None]  # matches ExecutionContext.report_response's kwargs:
-# (*, finish_reason: str | None, refusal: str | None) -> None
+# (*, finish_reason: str | None, refusal: str | None,
+#     cache_status: Literal["hit", "miss", "bypass"] | None = None,
+#     cache_reason: str | None = None) -> None
+# INVARIANT: the two cache kwargs are OPTIONAL. This is a live seam with callers already written
+# against it, and an adapter that learns no cache outcome must be able to say nothing rather
+# than be forced to invent one.
 
 _response_sink: contextvars.ContextVar[ResponseSink | None] = contextvars.ContextVar(
     "url4_response_sink", default=None

--- a/packages/url4/src/url4/streaming/protocol/__init__.py
+++ b/packages/url4/src/url4/streaming/protocol/__init__.py
@@ -2,6 +2,7 @@ from url4.streaming.protocol.envelope import CloudEvent, source_for
 from url4.streaming.protocol.signals import (
     SEVERITY_NUMBER,
     AttachData,
+    CachePolicy,
     CostUsageData,
     ErrorData,
     HeartbeatData,
@@ -37,6 +38,7 @@ __all__ = [
     "SEVERITY_NUMBER",
     "AttachData",
     "AttachEvent",
+    "CachePolicy",
     "CloudEvent",
     "CostBreakdown",
     "CostUsageData",

--- a/packages/url4/src/url4/streaming/protocol/signals.py
+++ b/packages/url4/src/url4/streaming/protocol/signals.py
@@ -95,6 +95,18 @@ class SpanData(BaseModel):
     """The provider's refusal text, when it sends one. Deliberately NOT a `gen_ai.*` alias:
     OTel has no semantic convention for this field, and inventing one would misrepresent a
     local extension as a standard attribute."""
+    cache_status: Literal["hit", "miss", "bypass"] | None = Field(default=None)
+    """Whether the gateway served this span's call from its response cache.
+
+    Absent when nothing reported one — an older gateway, or a path that never reached the cache.
+    Without it a hit that cost nothing upstream is still billed as a fresh call, an error that
+    HIDES savings and so goes unreported. Not a `gen_ai.*` alias, for the same reason as
+    `refusal`: OTel defines no convention for it."""
+    cache_reason: str | None = Field(default=None)
+    """The gateway's reason for that status, VERBATIM — its vocabulary, not ours.
+
+    Recorded rather than mapped so "I asked for no caching and something still cached" stays an
+    answerable question; normalising it here would erase exactly the distinction that answers it."""
     start: datetime
     end: datetime | None = None
     status: Literal["ok", "error"] = "ok"
@@ -138,8 +150,44 @@ class StopData(BaseModel):
     reason: str | None = None
 
 
+class CachePolicy(BaseModel):
+    """Per-run cache intent — whether this run may participate in the gateway's response cache.
+
+    INTENT ONLY. The translation into any gateway's request vocabulary lives in the adapter that
+    talks to it, never here: this module ships to SDK users, so a change to some server's body
+    shape must not edit a file they install.
+
+    INVARIANT — the field set is CLOSED, and `extra="forbid"` is what closes it. The gateway this
+    protocol is consumed against accepts exactly one cache-control key; an unrecognised one there
+    does not degrade to "ignored", it makes the whole request BYPASS the cache, silently and even
+    alongside an otherwise valid opt-in. So a caller inventing `no_store` must fail HERE, loudly,
+    rather than have it forwarded and pay for it on every call with nothing raised anywhere.
+    """
+
+    model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
+
+    participate: bool | None = None
+    """`None` means NOT STATED, which is not the same as `False`.
+
+    Absent must stay distinguishable from an explicit opt-out: the precedence rule between the
+    HTTP and frame carriers can only prefer a stated policy over silence if silence has its own
+    value, and collapsing the two would make opting out unexpressible."""
+    max_age: int | None = None
+    """Caller's freshness bound in seconds, parsed from `Cache-Control: max-age=<n>`.
+
+    url4-INTERNAL — never sent upstream. It is preserved rather than collapsed at the parsing
+    edge so the value survives to the point where an entry's age can be compared against it; the
+    gateway neither accepts a bound nor reports an age today, so it degrades to an opt-out."""
+
+
 class AttachData(BaseModel):
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
     from_sequence: int | None = Field(default=None, ge=1)
+    cache: CachePolicy | None = None
+    """Cache intent for the run this attach opens. `None` means the frame DID NOT DECLARE one —
+    not "off". Optional because this is a live wire type: every client already in flight sends an
+    attach frame without it."""
 
 
 class ErrorData(BaseModel):

--- a/packages/url4/tests/unit/test_cache_outcome_reporting.py
+++ b/packages/url4/tests/unit/test_cache_outcome_reporting.py
@@ -1,0 +1,162 @@
+"""The response seam carries a call's CACHE outcome alongside how it ended.
+
+FEATURE: url4 per-run cache policy (spec §7, D7) — a turn served from a gateway's response
+cache costs nothing upstream, so a run that cannot report the outcome bills a hit as a fresh
+call. That error HIDES savings, which is why nobody ever reports it.
+STORY: as an operator who turned caching on, I can see per span whether the call hit, missed or
+bypassed the cache, and — when it did not hit — the gateway's own reason for it.
+
+WHY this rides the EXISTING `ModelResponse` seam rather than a new event kind: the fact is
+per-round-trip, exactly like `finish_reason`, and a world adapter learns both from the same
+response. A second event would double the seam and force consumers to correlate two streams to
+answer one question about one call.
+
+A separate module from `test_response_sink.py` rather than an append: the repo's append-only
+gate compares file status, so growing an existing test file reads as "a prior test was
+modified" even when the diff is purely additive (same reason `test_finish_reason_capture.py`
+exists next to `test_aigateway_connector.py` in url4-cloud).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from url4.dag import run
+from url4.io.static import StaticIOLayer
+from url4.observe import ModelResponse, NodeStarted, ObservationEvent, current_response_sink
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.events: list[ObservationEvent] = []
+
+    def on_event(self, event: ObservationEvent) -> None:
+        self.events.append(event)
+
+
+class _CacheReportingNode:
+    """Reports a cache outcome through the ctx-less sink — the path the aigateway connector
+    takes, since it holds an HTTP response and no `ExecutionContext`."""
+
+    deps: dict = {}
+
+    def __init__(self, *, cache_status: str | None, cache_reason: str | None) -> None:
+        self.cache_status = cache_status
+        self.cache_reason = cache_reason
+
+    async def resolve(self, inputs, ctx):
+        sink = current_response_sink()
+        assert sink is not None
+        sink(
+            finish_reason="stop",
+            refusal=None,
+            cache_status=self.cache_status,
+            cache_reason=self.cache_reason,
+        )
+        return "ok"
+
+
+class _LegacyReportingNode:
+    """Reports the two ORIGINAL fields only — every caller written before the cache outcome
+    existed, which must keep working unchanged."""
+
+    deps: dict = {}
+
+    async def resolve(self, inputs, ctx):
+        sink = current_response_sink()
+        assert sink is not None
+        sink(finish_reason="stop", refusal=None)
+        return "ok"
+
+
+class _CtxCacheReportingNode:
+    """Reports through `ctx.report_response` — the in-tree path, which must land the same
+    event as the ctx-less sink."""
+
+    deps: dict = {}
+
+    async def resolve(self, inputs, ctx):
+        ctx.report_response(
+            finish_reason="stop", refusal=None, cache_status="bypass", cache_reason="opted_out"
+        )
+        return "ok"
+
+
+class _MultiCacheReportNode:
+    """Two round trips in one resolve — the web-tool loop's normal shape. Each carries its own
+    cache outcome, because each is an independently-keyed gateway call."""
+
+    deps: dict = {}
+
+    async def resolve(self, inputs, ctx):
+        sink = current_response_sink()
+        assert sink is not None
+        sink(finish_reason="tool_calls", refusal=None, cache_status="hit", cache_reason=None)
+        sink(finish_reason="stop", refusal=None, cache_status="miss", cache_reason=None)
+        return "ok"
+
+
+def _responses(rec: _Recorder) -> list[ModelResponse]:
+    return [e for e in rec.events if isinstance(e, ModelResponse)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["hit", "miss", "bypass"])
+async def test_every_cache_status_reaches_the_observer(status: str) -> None:
+    rec = _Recorder()
+    node = _CacheReportingNode(cache_status=status, cache_reason=None)
+    await run(node, StaticIOLayer(), observer=rec)
+
+    (response,) = _responses(rec)
+    assert response.cache_status == status
+
+
+@pytest.mark.asyncio
+async def test_the_gateways_reason_is_carried_verbatim() -> None:
+    # INVARIANT: the gateway's vocabulary, not ours. Normalising it here would erase exactly the
+    # distinction that answers "I asked for no caching and something still cached".
+    rec = _Recorder()
+    await run(
+        _CacheReportingNode(cache_status="bypass", cache_reason="unsupported_control"),
+        StaticIOLayer(),
+        observer=rec,
+    )
+
+    (response,) = _responses(rec)
+    assert response.cache_reason == "unsupported_control"
+
+
+@pytest.mark.asyncio
+async def test_a_caller_that_reports_no_cache_outcome_still_works() -> None:
+    # INVARIANT: this seam is a live contract with callers already written against it (and the
+    # engine's own `ctx.report_response`). Widening it must not require any of them to change,
+    # and an absent outcome must read as "nothing reported" rather than a fabricated status.
+    rec = _Recorder()
+    await run(_LegacyReportingNode(), StaticIOLayer(), observer=rec)
+
+    (response,) = _responses(rec)
+    assert response.finish_reason == "stop"
+    assert response.cache_status is None
+    assert response.cache_reason is None
+
+
+@pytest.mark.asyncio
+async def test_ctx_report_response_carries_the_outcome_too() -> None:
+    rec = _Recorder()
+    await run(_CtxCacheReportingNode(), StaticIOLayer(), observer=rec)
+
+    (response,) = _responses(rec)
+    assert (response.cache_status, response.cache_reason) == ("bypass", "opted_out")
+
+    (node_start,) = [e for e in rec.events if isinstance(e, NodeStarted)]
+    assert response.span_id == node_start.span_id
+
+
+@pytest.mark.asyncio
+async def test_each_round_trip_reports_its_own_outcome() -> None:
+    # INVARIANT: one node can make several gateway calls, and they are keyed independently — a
+    # turn whose first call hit and whose continuation missed is two facts, not one.
+    rec = _Recorder()
+    await run(_MultiCacheReportNode(), StaticIOLayer(), observer=rec)
+
+    assert [r.cache_status for r in _responses(rec)] == ["hit", "miss"]


### PR DESCRIPTION
Implements the design approved in **#515** (spec r8 / plan r6). A caller can declare that one url4 run must **not** participate in aigateway's global response cache; caching is otherwise on, because aigateway v2 makes it on.

```
Cache-Control: no-store              (HTTP, on GET /)
{"cache": {"participate": false}}    (WS attach frame)
```

Depends on **#507** (`OME-305`) for the upstream half. `apps/aigateway` is untouched.

## The constraint everything is shaped by

v2's control grammar is **closed to exactly one field**. An unrecognised key does not degrade to "ignored" — `global_controls.py:79-83` makes the whole request **bypass**, even alongside a valid `use-cache: true`. A well-meant `no-store` or `ttl` would silently cost every cache hit, with nothing raised anywhere.

So url4 collapses every directive to participate/opt-out **at its own edge** and never forwards a name v2 retired. Guarded three ways, the load-bearing one being a property test:

```python
set(out.get("cache", {})) <= {"use-cache"}   # for every input
```

That is a correctness test, not a style one — the failure mode it prevents is *absence of an effect*, which a green suite would otherwise hide.

## What ships

| batch | |
| --- | --- |
| 1 | `CachePolicy` + `AttachData.cache` + `SpanData.cache_status/reason` in `packages/url4` |
| 2 | the aigateway mapping — the only place in url4 that knows the string `use-cache` |
| 3 | `Cache-Control` on `GET /`, mirroring `X-Profile` |
| 4 | WS attach ingress, first-attach-wins |
| 5 | convergence — header wins, override logged |
| 6 | per-run threading (**not** on `AigatewayConfig`) + egress |
| 7 | read-back preferring RFC 9211 `Cache-Status` |
| 8 | counters by bypass reason, OpenAPI/AsyncAPI docs |

**Read-back matters more than it looks.** Without it a cache hit bills as a fresh call — an error that *hides savings*, so nobody reports it. `Cache-Status` is parsed as an RFC 8941 List selecting the **aigateway member**, not the first: the list may legitimately carry Envoy or CDN entries, and reading a CDN's hit as ours would report a saving that never happened.

## `max-age` ships inert, deliberately

url4 can neither ask for a freshness bound (closed grammar) nor measure one (no `Age` header). So a stated bound **degrades to opt-out**, behind a single `GATEWAY_REPORTS_AGE = False`. The honouring path — `requires_revalidation` and its tests — is written, correct and unreachable; flipping that one flag is all of D11's second half.

This changed during review. The first implementation did *participate-then-revalidate*, which with no `Age` meant **two gateway calls on every bounded hit** — inside `for _ in range(cfg.web_tool_max_iterations)`, so a four-iteration tool turn became eight calls, multiplied across a fan-out. And since D6 deliberately invites intermediaries to inject `Cache-Control`, `max-age=0` from a browser reload was an accidental trigger. Owner ruled for opt-out.

## Gates

```
url4        ✓ append-only ✓ ruff ✓ format ✓ pyright ✓ pytest --cov  (97.45%, 1100 passed)
url4-cloud  ✓ ruff ✓ format ✓ pyright ✓ check_layering ✓ pytest --cov (>80%)
```

**One accepted exception.** Widening the `IdentityAwareJobRunner` port meant two test **doubles** had to accept the new parameter (+10 lines, imports plus one optional arg). The append-only gate stopped the run — correctly, since rule 5 makes that a Confidence-Gate decision — and the owner accepted it as port conformance: no assertion altered, nothing deleted. The implementing agent explicitly declined to widen `ScheduledRun` because an existing test compares that tuple whole. Full diff quoted in the ledger.

## How it was built, and what that caught

Eight sequential agents (one per batch, each running its stack's gates, stop-on-red), then a ninth reviewing adversarially against the spec's acceptance criteria. It returned 10 findings; two were substantive — the `max-age` cost above, and a spec/code disagreement about whether `max-age` equals `no-store` on a miss (it doesn't, per RFC 9111 — `max-age` bounds *reading*, `no-store` prohibits *storing*; my spec conflated them). The other eight were doc staleness, fixed in spec r8 on #515.

Agents also overruled the plan twice, both correctly: it was internally inconsistent about whether `CachePolicy` has one field or two, and it named a test location that contradicts `packages/url4/pyproject.toml`'s own documented convention.

## Not verified

**Green gates are not evidence this works end to end.** Every test asserts against a mock transport, so the aigateway half of the contract is verified by *reading* `global_controls.py`, not by executing it. Plan Verification step 3 needs a local gateway built from #507 and has not been run.

## Process deviation

**No Linear issue** — MCP unauthenticated; the card names it the only permitted transport. This also breaches **rule 8**: the work spans `packages/url4` + `apps/url4-cloud` and should be an epic with one sub-issue per landing. Executed as one `UNFILED` unit because the epic cannot be created. Branch name, `docs/tasks/` mirror and `Refs:` all need back-filling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HAiqcmwueUjWBhsEfsQWGx