### PR TITLE
feat(scoreboard): compute open-vs-closed frontier statistics

### DIFF
--- a/apps/scoreboard/portal/benchmark.html
+++ b/apps/scoreboard/portal/benchmark.html
@@ -47,6 +47,7 @@
       <div class="s"><span class="k">Best accuracy</span><div class="v gain" id="summary-best">—</div></div>
       <div class="s"><span class="k">Specs shown</span><div class="v" id="summary-specs">—</div></div>
       <div class="s"><span class="k">Verified rows</span><div class="v" id="summary-verified">—</div></div>
+      <div class="s" id="summary-frontier-card" hidden><span class="k">Open frontier share</span><div class="v" id="summary-frontier">—</div></div>
     </div>
 
     <div id="leaderboard-status" class="state" role="status" aria-live="polite">Loading…</div>

--- a/apps/scoreboard/portal/benchmark.js
+++ b/apps/scoreboard/portal/benchmark.js
@@ -221,6 +221,21 @@
     summaryNode.hidden = false;
   }
 
+  // OME-323: how much of this benchmark's accuracy frontier is held by
+  // open-reproducible stacks vs. proprietary ones. Fetched and rendered
+  // independently of the main leaderboard call — a failure here must not
+  // block or error out the leaderboard itself, it's a supplementary stat.
+  function renderFrontier(data) {
+    var card = document.getElementById("summary-frontier-card");
+    var node = document.getElementById("summary-frontier");
+    if (!card || !node || !data || !data.current) return;
+    var pct = Math.round((data.open_share || 0) * 100);
+    node.textContent = pct + "% open";
+    node.title = "Frontier currently held by a " + data.current.openness +
+      " entry (" + data.current.label + ")";
+    card.hidden = false;
+  }
+
   // Climb accuracy bars (brand viz-a direction): one row per spec, the SOTA
   // entry carries the sota (gain) fill — same story color as tr.sota.
   // Purely visual: aria-hidden, the table is the accessible representation.
@@ -332,6 +347,13 @@
           generic: "Could not load leaderboard — try again later.",
         }));
       }
+    );
+
+    // Independent of the fetch above: a failure here just leaves the card
+    // hidden (its default state in the markup), never surfaces an error.
+    P.fetchJson("/v1/leaderboard/" + encodeURIComponent(id) + "/frontier").then(
+      renderFrontier,
+      function () {}
     );
   }
 

--- a/apps/scoreboard/portal/benchmark.js
+++ b/apps/scoreboard/portal/benchmark.js
@@ -228,11 +228,21 @@
   function renderFrontier(data) {
     var card = document.getElementById("summary-frontier-card");
     var node = document.getElementById("summary-frontier");
-    if (!card || !node || !data || !data.current) return;
+    if (!card || !node || !data) return;
+    // WHY count on open_count/closed_count, not data.current: a benchmark with
+    // imported Baselines but zero Score submissions yet has a real, meaningful
+    // open_share (Baselines count toward the split) even though current is null
+    // (Baselines never become the trend holder — see frontier.py). Gating on
+    // current alone silently hid the stat for every baseline-only benchmark
+    // (found in review).
+    var total = (data.open_count || 0) + (data.closed_count || 0);
+    if (total === 0) return;
     var pct = Math.round((data.open_share || 0) * 100);
     node.textContent = pct + "% open";
-    node.title = "Frontier currently held by a " + data.current.openness +
-      " entry (" + data.current.label + ")";
+    node.title = data.current
+      ? "Frontier currently held by a " + data.current.openness +
+        " entry (" + data.current.label + ")"
+      : "";
     card.hidden = false;
   }
 

--- a/apps/scoreboard/src/scoreboard/classification/__init__.py
+++ b/apps/scoreboard/src/scoreboard/classification/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .openness import Openness, classify_baseline, classify_providers, classify_score
+
+__all__ = ["Openness", "classify_baseline", "classify_providers", "classify_score"]

--- a/apps/scoreboard/src/scoreboard/classification/openness.py
+++ b/apps/scoreboard/src/scoreboard/classification/openness.py
@@ -1,0 +1,106 @@
+"""Open vs. closed classification for scores and baselines (OME-323, spec §4/§9).
+
+A public "how much of the frontier is open" claim must not default-credit the open
+side for anything it can't actually verify — every classification here fails closed.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from scoreboard.scores.schemas import BaselineSchema, ScoreSchema
+
+Openness = Literal["open", "closed"]
+
+logger = logging.getLogger(__name__)
+
+# WHY substring match, not exact match: real provider/model identifiers carry
+# version and org-path noise (e.g. "meta-llama/Llama-3.1-70B-Instruct",
+# "gpt-5.2-thinking") that an exact-match registry would need to enumerate
+# combinatorially. A curated marker list is the same tradeoff Option A's original
+# framing accepted (spec §4) — it drifts as new models ship, which is exactly why
+# every miss below is logged rather than silently absorbed.
+_CLOSED_PROVIDER_MARKERS: tuple[str, ...] = (
+    "openai",
+    "anthropic",
+    "google",
+    "gemini",
+    "openrouter",
+)
+_OPEN_PROVIDER_MARKERS: tuple[str, ...] = (
+    "huggingface",
+    "meta-llama",
+    "llama",
+    "mistral",
+    "qwen",
+    "deepseek",
+)
+
+_CLOSED_BASELINE_MARKERS: tuple[str, ...] = ("gpt-", "claude-", "gemini-")
+_OPEN_BASELINE_MARKERS: tuple[str, ...] = ("llama", "mistral", "qwen", "deepseek")
+
+
+def _matches_any(name: str, markers: tuple[str, ...]) -> bool:
+    lowered = name.lower()
+    return any(marker in lowered for marker in markers)
+
+
+def _log_unrecognized(kind: str, name: str) -> None:
+    # WHY a log, not silence: the fail-closed default (below) is permanent and
+    # correct, but staying silent about it isn't — every miss is a model the
+    # registry doesn't know about yet, quietly understating "open" until someone
+    # updates the list (spec §4's staleness resolution, 2026-08-06).
+    logger.warning("unrecognized %s for openness classification: %r", kind, name)
+
+
+def classify_providers(providers: Sequence[str]) -> Openness:
+    """Closed if ANY provider is closed; open only if every provider is open
+    (spec §4's mixed-provider fusion rule). An empty list is closed — there is
+    nothing here to credit as open.
+    """
+    if not providers:
+        _log_unrecognized("provider", "<empty ran_with_providers>")
+        return "closed"
+
+    saw_closed = False
+    for provider in providers:
+        if _matches_any(provider, _CLOSED_PROVIDER_MARKERS):
+            saw_closed = True
+        elif _matches_any(provider, _OPEN_PROVIDER_MARKERS):
+            continue
+        else:
+            _log_unrecognized("provider", provider)
+            saw_closed = True
+    return "closed" if saw_closed else "open"
+
+
+def classify_baseline_name(model_name: str) -> Openness:
+    """Same fail-closed pattern as `classify_providers`, via substring match
+    against a baseline's free-text `model_name`.
+    """
+    if _matches_any(model_name, _CLOSED_BASELINE_MARKERS):
+        return "closed"
+    if _matches_any(model_name, _OPEN_BASELINE_MARKERS):
+        return "open"
+    _log_unrecognized("baseline model", model_name)
+    return "closed"
+
+
+def classify_score(score: ScoreSchema) -> Openness:
+    """The registry-and-override-aware classifier `frontier.py` actually calls.
+    `openness_override` (spec §9), when set, wins outright — the registry is never
+    even consulted.
+    """
+    if score.openness_override is not None:
+        return score.openness_override
+    return classify_providers(score.ran_with_providers)
+
+
+def classify_baseline(baseline: BaselineSchema) -> Openness:
+    """Baseline counterpart of `classify_score`."""
+    if baseline.openness_override is not None:
+        return baseline.openness_override
+    return classify_baseline_name(baseline.model_name)

--- a/apps/scoreboard/src/scoreboard/routes/leaderboard.py
+++ b/apps/scoreboard/src/scoreboard/routes/leaderboard.py
@@ -8,10 +8,12 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, ConfigDict
 
 from scoreboard.scores.baseline_store import BaselineStore
+from scoreboard.scores.frontier import compute_frontier
 from scoreboard.scores.models import Benchmark
 from scoreboard.scores.schemas import (
     BaselineSchema,
     BenchmarkSchema,
+    FrontierResponse,
     LeaderboardEntry,
     ScoreSchema,
 )
@@ -180,3 +182,21 @@ async def get_spec_history(
         benchmark_id=benchmark_id,
         submissions=[_history_submission(score) for score in submissions],
     )
+
+
+@router.get(
+    "/leaderboard/{benchmark_id}/frontier",
+    response_model=FrontierResponse,
+    tags=["leaderboard"],
+)
+async def get_frontier(benchmark_id: str, request: Request) -> FrontierResponse:
+    """How much of `benchmark_id`'s accuracy frontier is held by open-reproducible
+    stacks vs. proprietary ones (OME-323) — the current split plus the trend over
+    time. Unknown benchmarks return 404. Deliberately benchmark-wide across every
+    spec, not scoped per-spec like the ranked leaderboard above (spec §6).
+    """
+    await _get_benchmark_or_404(benchmark_id)
+    scores = await _score_store(request).list_all_for_benchmark(benchmark_id)
+    baselines = await _baseline_store(request).list_baselines(benchmark_id)
+    result = compute_frontier(scores=scores, baselines=baselines)
+    return FrontierResponse(benchmark_id=benchmark_id, **result.model_dump())

--- a/apps/scoreboard/src/scoreboard/scores/baseline_store.py
+++ b/apps/scoreboard/src/scoreboard/scores/baseline_store.py
@@ -24,6 +24,7 @@ def _baseline_to_schema(model: Baseline) -> BaselineSchema:
         source_url=model.source_url,
         imported_at=model.imported_at,
         metadata=model.metadata,
+        openness_override=model.openness_override,
     )
 
 

--- a/apps/scoreboard/src/scoreboard/scores/frontier.py
+++ b/apps/scoreboard/src/scoreboard/scores/frontier.py
@@ -1,0 +1,68 @@
+"""Open/closed frontier computation (OME-323, spec §5/§6).
+
+Pure function, no I/O — takes already-fetched schemas so it's directly
+unit-testable without a DB.
+"""
+
+from __future__ import annotations
+
+from scoreboard.classification.openness import classify_baseline, classify_score
+
+from .schemas import BaselineSchema, FrontierPoint, FrontierResult, ScoreSchema
+
+
+def _current_split(
+    scores: list[ScoreSchema], baselines: list[BaselineSchema]
+) -> tuple[int, int, float]:
+    """`open_count`/`closed_count`/`open_share` over ALL rows, Scores and Baselines
+    together — the "how much of the frontier is open right now" number."""
+    openness_calls = [classify_score(score) for score in scores]
+    openness_calls += [classify_baseline(baseline) for baseline in baselines]
+    open_count = sum(1 for openness in openness_calls if openness == "open")
+    closed_count = len(openness_calls) - open_count
+    total = open_count + closed_count
+    open_share = open_count / total if total else 0.0
+    return open_count, closed_count, open_share
+
+
+def _compute_trend(scores: list[ScoreSchema]) -> tuple[FrontierPoint | None, list[FrontierPoint]]:
+    """Walks Score rows ONLY, ordered by `submitted_at`. A Baseline's `imported_at`
+    isn't a trustworthy real-world timestamp, so a Baseline never enters this walk
+    at all — not merely "excluded from the printed list". The holder advances only
+    on a strict accuracy improvement — an exact tie leaves the existing holder in
+    place (spec §6's tie-breaking resolution).
+    """
+    trend: list[FrontierPoint] = []
+    current: FrontierPoint | None = None
+    for score in sorted(scores, key=lambda s: s.submitted_at):
+        if current is not None and score.accuracy <= current.accuracy:
+            continue
+        current = FrontierPoint(
+            at=score.submitted_at,
+            accuracy=score.accuracy,
+            openness=classify_score(score),
+            holder="score",
+            label=score.spec_id,
+        )
+        trend.append(current)
+    return current, trend
+
+
+def compute_frontier(
+    scores: list[ScoreSchema],
+    baselines: list[BaselineSchema],
+) -> FrontierResult:
+    """Two independent passes (spec §6's baseline-timing resolution — deliberately
+    NOT one merged computation): the current open/closed split over all rows
+    (`_current_split`), and the trend over Score rows only (`_compute_trend`).
+    """
+    open_count, closed_count, open_share = _current_split(scores, baselines)
+    current, trend = _compute_trend(scores)
+
+    return FrontierResult(
+        open_count=open_count,
+        closed_count=closed_count,
+        open_share=open_share,
+        current=current,
+        trend=trend,
+    )

--- a/apps/scoreboard/src/scoreboard/scores/migrations/0004_auto_20260806_0000.py
+++ b/apps/scoreboard/src/scoreboard/scores/migrations/0004_auto_20260806_0000.py
@@ -1,0 +1,21 @@
+from tortoise import fields, migrations
+from tortoise.migrations import operations as ops
+
+
+class Migration(migrations.Migration):
+    dependencies = [("models", "0003_auto_20260713_1505")]
+
+    initial = False
+
+    operations = [
+        ops.AddField(
+            model_name="Score",
+            name="openness_override",
+            field=fields.CharField(null=True, max_length=8),
+        ),
+        ops.AddField(
+            model_name="Baseline",
+            name="openness_override",
+            field=fields.CharField(null=True, max_length=8),
+        ),
+    ]

--- a/apps/scoreboard/src/scoreboard/scores/models/baseline.py
+++ b/apps/scoreboard/src/scoreboard/scores/models/baseline.py
@@ -18,6 +18,10 @@ class BaseBaseline(BaseScoreboardModel):
     source_url = fields.CharField(max_length=2048, null=True)
     imported_at = fields.DatetimeField(auto_now_add=True)
     metadata = fields.JSONField(null=True)
+    # FEATURE: OME-323 — manual open/closed correction, mirrors Score.openness_override.
+    # `null` defers to the classification registry; an explicit "open"/"closed" wins
+    # outright.
+    openness_override = fields.CharField(max_length=8, null=True)
 
 
 class Baseline(BaseBaseline):

--- a/apps/scoreboard/src/scoreboard/scores/models/score.py
+++ b/apps/scoreboard/src/scoreboard/scores/models/score.py
@@ -35,6 +35,11 @@ class BaseScore(BaseScoreboardModel):
     # multiple NULLs don't violate a unique constraint, and every row created from
     # here on always gets one (the store always computes it on submit).
     content_hash = fields.CharField(max_length=64, unique=True, null=True)
+    # FEATURE: OME-323 — manual open/closed correction, operator-only (never set via
+    # the public submission API). `null` defers to the classification registry
+    # (scoreboard.classification.openness); an explicit "open"/"closed" wins outright
+    # over whatever the registry would have said, without a code deploy.
+    openness_override = fields.CharField(max_length=8, null=True)
 
 
 class Score(BaseScore):

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -167,6 +167,9 @@ class ScoreSchema(BaseModel):
     client_platform: str | None
     verified_by_openmined: bool
     metadata: dict[str, Any] | None
+    # FEATURE: OME-323 — manual open/closed correction; None defers to the
+    # classification registry. Operator-only, never set via ScoreSubmission.
+    openness_override: Literal["open", "closed"] | None = None
 
 
 class LeaderboardEntry(BaseModel):
@@ -197,11 +200,56 @@ class BaselineSchema(BaseModel):
     source_url: str | None
     imported_at: datetime
     metadata: dict[str, Any] | None
+    # FEATURE: OME-323 — manual open/closed correction, mirrors ScoreSchema's field.
+    openness_override: Literal["open", "closed"] | None = None
 
     @field_validator("metadata")
     @classmethod
     def validate_metadata(cls, value: dict[str, Any] | None) -> dict[str, Any] | None:
         return _validate_bounded_metadata(value)
+
+
+class FrontierPoint(BaseModel):
+    """One step of the open/closed frontier trend (OME-323, spec §5/§6): the
+    running-best accuracy at the moment it changed, and whether the entry holding
+    that position was open or closed."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    at: datetime
+    accuracy: float
+    openness: Literal["open", "closed"]
+    # INVARIANT: always "score" — a Baseline's imported_at isn't a trustworthy
+    # real-world timestamp, so it never participates in this walk (spec §6).
+    holder: Literal["score"]
+    label: str
+
+
+class FrontierResult(BaseModel):
+    """Return type of `compute_frontier` — no `benchmark_id`, since the pure
+    function itself has no notion of which benchmark it was called for. The route
+    adds that to build the public `FrontierResponse`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    open_count: int
+    closed_count: int
+    open_share: float
+    current: FrontierPoint | None
+    trend: list[FrontierPoint]
+
+
+class FrontierResponse(BaseModel):
+    """Read DTO for GET /v1/leaderboard/{benchmark_id}/frontier (OME-323, spec §5)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    benchmark_id: str
+    open_count: int
+    closed_count: int
+    open_share: float
+    current: FrontierPoint | None
+    trend: list[FrontierPoint]
 
 
 class BaselineImportRow(BaseModel):

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -49,6 +49,7 @@ def _score_to_schema(model: Score) -> ScoreSchema:
         client_platform=model.client_platform,
         verified_by_openmined=model.verified_by_openmined,
         metadata=model.metadata,
+        openness_override=model.openness_override,
     )
 
 
@@ -306,6 +307,15 @@ class ScoreStore:
             .order_by("-submitted_at")
             .limit(limit)
         )
+        return [_score_to_schema(score) for score in rows]
+
+    async def list_all_for_benchmark(self, benchmark_id: str) -> list[ScoreSchema]:
+        """Every Score row for a benchmark, chronologically — unlike `leaderboard()`
+        (best-per-spec only), this is what OME-323's frontier trend needs: the full
+        submission history across all specs, deliberately benchmark-wide (spec §6's
+        frontier-scope resolution).
+        """
+        rows = await Score.filter(benchmark_id=benchmark_id).order_by("submitted_at")
         return [_score_to_schema(score) for score in rows]
 
     async def mark_verified(self, score_id: UUID | str) -> None:

--- a/apps/scoreboard/tests/unit/classification/test_openness.py
+++ b/apps/scoreboard/tests/unit/classification/test_openness.py
@@ -1,0 +1,157 @@
+"""Unit tests for the open/closed classification registry (OME-323, spec §4/§9).
+
+Pure logic, no DB — exercises classify_providers/classify_baseline_name (the
+registry internals) and classify_score/classify_baseline (the override-aware
+wrappers Phase 2 actually calls).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Literal
+from uuid import uuid4
+
+import pytest
+
+from scoreboard.classification.openness import (
+    classify_baseline,
+    classify_baseline_name,
+    classify_providers,
+    classify_score,
+)
+from scoreboard.scores.schemas import BaselineSchema, ScoreSchema
+
+
+def _score(
+    *,
+    ran_with_providers: list[str],
+    openness_override: Literal["open", "closed"] | None = None,
+) -> ScoreSchema:
+    return ScoreSchema(
+        id=uuid4(),
+        version=1,
+        benchmark_id="hle",
+        spec_id="spec-1",
+        url4_expression="url4://benchmark/spec-1",
+        submitted_by="tester",
+        submitted_at=datetime(2026, 8, 6, tzinfo=UTC),
+        accuracy=0.5,
+        total_questions=10,
+        correct_questions=5,
+        ran_with_providers=ran_with_providers,
+        ran_at_local=None,
+        client_name=None,
+        client_version=None,
+        client_platform=None,
+        verified_by_openmined=False,
+        metadata=None,
+        openness_override=openness_override,
+    )
+
+
+def _baseline(
+    *,
+    model_name: str,
+    openness_override: Literal["open", "closed"] | None = None,
+) -> BaselineSchema:
+    return BaselineSchema(
+        id=uuid4(),
+        benchmark_id="hle",
+        model_name=model_name,
+        accuracy=0.5,
+        source="lmarena",
+        source_url=None,
+        imported_at=datetime(2026, 8, 6, tzinfo=UTC),
+        metadata=None,
+        openness_override=openness_override,
+    )
+
+
+# --- classify_providers ------------------------------------------------------------
+
+
+def test_known_open_provider_is_open() -> None:
+    assert classify_providers(["huggingface"]) == "open"
+
+
+def test_known_closed_provider_is_closed() -> None:
+    assert classify_providers(["openai"]) == "closed"
+
+
+def test_mixed_open_and_closed_providers_is_closed() -> None:
+    """Spec §4's mixed-fusion rule: closed if ANY provider is closed."""
+    assert classify_providers(["huggingface", "openai"]) == "closed"
+
+
+def test_all_open_providers_is_open() -> None:
+    assert classify_providers(["huggingface", "mistral"]) == "open"
+
+
+def test_unrecognized_provider_is_closed(caplog: pytest.LogCaptureFixture) -> None:
+    """Fail-closed default, and it must be logged, not silent (spec §4 staleness
+    resolution)."""
+    with caplog.at_level("WARNING"):
+        result = classify_providers(["some-brand-new-provider"])
+
+    assert result == "closed"
+    assert "some-brand-new-provider" in caplog.text
+
+
+def test_empty_providers_is_closed(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level("WARNING"):
+        result = classify_providers([])
+
+    assert result == "closed"
+
+
+# --- classify_baseline_name --------------------------------------------------------
+
+
+def test_known_open_baseline_model_is_open() -> None:
+    assert classify_baseline_name("meta-llama/Llama-3-70B") == "open"
+
+
+def test_known_closed_baseline_model_is_closed() -> None:
+    assert classify_baseline_name("gpt-5.2") == "closed"
+
+
+def test_unrecognized_baseline_model_is_closed(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level("WARNING"):
+        result = classify_baseline_name("some-brand-new-model")
+
+    assert result == "closed"
+    assert "some-brand-new-model" in caplog.text
+
+
+# --- classify_score (override-aware) -----------------------------------------------
+
+
+def test_classify_score_defers_to_registry_when_no_override() -> None:
+    assert classify_score(_score(ran_with_providers=["huggingface"])) == "open"
+
+
+def test_classify_score_override_forces_open_despite_closed_providers() -> None:
+    score = _score(ran_with_providers=["openai"], openness_override="open")
+    assert classify_score(score) == "open"
+
+
+def test_classify_score_override_forces_closed_despite_open_providers() -> None:
+    score = _score(ran_with_providers=["huggingface"], openness_override="closed")
+    assert classify_score(score) == "closed"
+
+
+# --- classify_baseline (override-aware) --------------------------------------------
+
+
+def test_classify_baseline_defers_to_registry_when_no_override() -> None:
+    assert classify_baseline(_baseline(model_name="gpt-5.2")) == "closed"
+
+
+def test_classify_baseline_override_forces_open_despite_closed_name() -> None:
+    baseline = _baseline(model_name="gpt-5.2", openness_override="open")
+    assert classify_baseline(baseline) == "open"
+
+
+def test_classify_baseline_override_forces_closed_despite_open_name() -> None:
+    baseline = _baseline(model_name="meta-llama/Llama-3-70B", openness_override="closed")
+    assert classify_baseline(baseline) == "closed"

--- a/apps/scoreboard/tests/unit/scores/test_frontier.py
+++ b/apps/scoreboard/tests/unit/scores/test_frontier.py
@@ -1,0 +1,171 @@
+"""Unit tests for compute_frontier (OME-323, spec §5/§6/§9).
+
+Pure function, no DB — scores/baselines are constructed directly.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Literal
+from uuid import uuid4
+
+from scoreboard.scores.frontier import compute_frontier
+from scoreboard.scores.schemas import BaselineSchema, ScoreSchema
+
+
+def _score(
+    *,
+    spec_id: str = "spec-1",
+    accuracy: float,
+    submitted_at: datetime,
+    ran_with_providers: list[str] | None = None,
+    openness_override: Literal["open", "closed"] | None = None,
+) -> ScoreSchema:
+    return ScoreSchema(
+        id=uuid4(),
+        version=1,
+        benchmark_id="hle",
+        spec_id=spec_id,
+        url4_expression=f"url4://benchmark/{spec_id}",
+        submitted_by="tester",
+        submitted_at=submitted_at,
+        accuracy=accuracy,
+        total_questions=10,
+        correct_questions=int(accuracy * 10),
+        ran_with_providers=ran_with_providers or ["huggingface"],
+        ran_at_local=None,
+        client_name=None,
+        client_version=None,
+        client_platform=None,
+        verified_by_openmined=False,
+        metadata=None,
+        openness_override=openness_override,
+    )
+
+
+def _baseline(
+    *,
+    model_name: str = "gpt-5.2",
+    accuracy: float,
+    openness_override: Literal["open", "closed"] | None = None,
+) -> BaselineSchema:
+    return BaselineSchema(
+        id=uuid4(),
+        benchmark_id="hle",
+        model_name=model_name,
+        accuracy=accuracy,
+        source="lmarena",
+        source_url=None,
+        imported_at=datetime(2026, 1, 1, tzinfo=UTC),
+        metadata=None,
+        openness_override=openness_override,
+    )
+
+
+def test_empty_benchmark_has_no_crash_no_holder() -> None:
+    result = compute_frontier(scores=[], baselines=[])
+
+    assert result.current is None
+    assert result.trend == []
+    assert result.open_count == 0
+    assert result.closed_count == 0
+    assert result.open_share == 0.0
+
+
+def test_single_score_becomes_the_current_holder() -> None:
+    score = _score(accuracy=0.5, submitted_at=datetime(2026, 1, 1, tzinfo=UTC))
+    result = compute_frontier(scores=[score], baselines=[])
+
+    assert result.current is not None
+    assert result.current.accuracy == 0.5
+    assert result.current.openness == "open"
+    assert len(result.trend) == 1
+
+
+def test_baseline_counts_in_split_but_never_becomes_trend_holder() -> None:
+    """Spec §6's baseline-timing resolution: a Baseline can outscore every Score but
+    must never become the trend's holder — imported_at isn't a trustworthy
+    timestamp. It still counts toward the current open/closed split."""
+    high_baseline = _baseline(model_name="gpt-5.2", accuracy=0.99)  # closed, highest
+    low_score = _score(
+        accuracy=0.2,
+        submitted_at=datetime(2026, 1, 1, tzinfo=UTC),
+        ran_with_providers=["huggingface"],  # open
+    )
+
+    result = compute_frontier(scores=[low_score], baselines=[high_baseline])
+
+    assert result.current is not None
+    assert result.current.accuracy == 0.2  # the Score, never the higher Baseline
+    assert result.open_count == 1  # the score
+    assert result.closed_count == 1  # the baseline
+    assert result.open_share == 0.5
+
+
+def test_later_but_lower_accuracy_score_is_not_in_the_trend() -> None:
+    first = _score(accuracy=0.8, submitted_at=datetime(2026, 1, 1, tzinfo=UTC))
+    later_worse = _score(
+        spec_id="spec-2", accuracy=0.5, submitted_at=datetime(2026, 1, 2, tzinfo=UTC)
+    )
+
+    result = compute_frontier(scores=[first, later_worse], baselines=[])
+
+    assert len(result.trend) == 1
+    assert result.current is not None
+    assert result.current.accuracy == 0.8
+
+
+def test_exact_tie_does_not_move_the_holder() -> None:
+    """Spec §6's tie-breaking resolution: the earliest holder keeps the position on
+    an exact tie, even when the later entry has different openness."""
+    first = _score(
+        accuracy=1.0,
+        submitted_at=datetime(2026, 1, 1, tzinfo=UTC),
+        ran_with_providers=["huggingface"],
+    )
+    tied_later = _score(
+        spec_id="spec-2",
+        accuracy=1.0,
+        submitted_at=datetime(2026, 1, 2, tzinfo=UTC),
+        ran_with_providers=["openai"],
+    )
+
+    result = compute_frontier(scores=[first, tied_later], baselines=[])
+
+    assert len(result.trend) == 1
+    assert result.current is not None
+    assert result.current.label == "spec-1"
+    assert result.current.openness == "open"
+
+
+def test_strict_improvement_after_a_tie_does_move_the_holder() -> None:
+    """Contrast with the tie test above: a later entry that genuinely beats the
+    tied accuracy DOES become the new holder."""
+    first = _score(accuracy=0.5, submitted_at=datetime(2026, 1, 1, tzinfo=UTC))
+    tied = _score(spec_id="spec-2", accuracy=0.5, submitted_at=datetime(2026, 1, 2, tzinfo=UTC))
+    strictly_better = _score(
+        spec_id="spec-3", accuracy=0.6, submitted_at=datetime(2026, 1, 3, tzinfo=UTC)
+    )
+
+    result = compute_frontier(scores=[first, tied, strictly_better], baselines=[])
+
+    assert len(result.trend) == 2  # spec-1 at 0.5, spec-3 at 0.6 — spec-2 never moves it
+    assert result.current is not None
+    assert result.current.label == "spec-3"
+    assert result.current.accuracy == 0.6
+
+
+def test_openness_override_changes_the_holders_reported_openness() -> None:
+    score = _score(
+        accuracy=0.9,
+        submitted_at=datetime(2026, 1, 1, tzinfo=UTC),
+        ran_with_providers=["openai"],
+        openness_override="open",
+    )
+
+    result = compute_frontier(scores=[score], baselines=[])
+
+    assert result.current is not None
+    assert result.current.openness == "open"
+    assert result.open_count == 1
+    assert result.closed_count == 0

--- a/apps/scoreboard/tests/unit/scores/test_store.py
+++ b/apps/scoreboard/tests/unit/scores/test_store.py
@@ -398,6 +398,31 @@ async def test_postgres_concurrent_idempotency_submissions_share_winner(
     assert await Score.all().count() == 1
 
 
+async def test_list_all_for_benchmark_returns_every_spec_ordered_by_submitted_at(
+    tortoise_db: None,
+) -> None:
+    """OME-323: unlike leaderboard() (best-per-spec), this returns every row for a
+    benchmark, chronologically — the frontier trend needs the full history, not
+    just each spec's current best."""
+    store = await _store_with_benchmark()
+    await store.submit(_submission(spec_id="spec-1", accuracy=0.5))
+    await store.submit(_submission(spec_id="spec-1", accuracy=0.9))
+    await store.submit(_submission(spec_id="spec-2", accuracy=0.3))
+
+    rows = await store.list_all_for_benchmark("hle")
+
+    assert len(rows) == 3
+    assert [row.submitted_at for row in rows] == sorted(row.submitted_at for row in rows)
+
+
+async def test_list_all_for_benchmark_empty_for_unknown_benchmark(
+    tortoise_db: None,
+) -> None:
+    store = await _store_with_benchmark()
+
+    assert await store.list_all_for_benchmark("unknown") == []
+
+
 async def test_postgres_concurrent_identical_recipe_submissions_share_winner(
     tortoise_db: None,
 ) -> None:

--- a/apps/scoreboard/tests/unit/test_leaderboard_routes.py
+++ b/apps/scoreboard/tests/unit/test_leaderboard_routes.py
@@ -309,3 +309,57 @@ async def test_openapi_includes_baseline_schema(async_client: httpx.AsyncClient)
 
     assert response.status_code == 200
     assert "BaselineSchema" in response.json()["components"]["schemas"]
+
+
+async def test_get_frontier_returns_404_for_unknown_benchmark(
+    async_client: httpx.AsyncClient,
+) -> None:
+    response = await async_client.get("/v1/leaderboard/missing/frontier")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Benchmark not found"}
+
+
+async def test_get_frontier_returns_empty_trend_for_a_benchmark_with_no_scores(
+    async_client: httpx.AsyncClient,
+) -> None:
+    await _register_benchmark(ScoreStore())
+
+    response = await async_client.get("/v1/leaderboard/hle/frontier")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["benchmark_id"] == "hle"
+    assert body["current"] is None
+    assert body["trend"] == []
+    assert body["open_count"] == 0
+    assert body["closed_count"] == 0
+    assert body["open_share"] == 0.0
+
+
+async def test_get_frontier_reflects_real_submissions(
+    async_client: httpx.AsyncClient,
+) -> None:
+    await _register_benchmark(ScoreStore())
+    await async_client.post(
+        "/v1/scores",
+        json=_submission(spec_id="spec-1", accuracy=0.5, providers=["huggingface"]).model_dump(
+            mode="json"
+        ),
+    )
+    await async_client.post(
+        "/v1/scores",
+        json=_submission(spec_id="spec-2", accuracy=0.9, providers=["openai"]).model_dump(
+            mode="json"
+        ),
+    )
+
+    response = await async_client.get("/v1/leaderboard/hle/frontier")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["open_count"] == 1
+    assert body["closed_count"] == 1
+    assert body["current"]["label"] == "spec-2"
+    assert body["current"]["openness"] == "closed"
+    assert len(body["trend"]) == 2

--- a/docs/plan/2026-08-06-open-vs-closed-frontier-stats-plan.md
+++ b/docs/plan/2026-08-06-open-vs-closed-frontier-stats-plan.md
@@ -1,0 +1,182 @@
+# Open vs. closed frontier statistics — Implementation Plan
+
+**Ticket:** OME-323 · **Spec:** `docs/spec/2026-07-16-open-vs-closed-frontier-stats-spec.md`
+(resolved 2026-07-17, extended 2026-08-06 with nine follow-up resolutions — §4, §6,
+§7, §8 updated, new §9 manual override + §10 pre-launch cleanup — currently landing
+in unmerged PR #414, see Risk below)
+**Goal:** Compute, from real `Score`/`Baseline` rows, what share of each benchmark's
+accuracy frontier is held by open-reproducible stacks vs. proprietary ones — both the
+current split and the trend over time — and expose it via the scoreboard API + portal.
+**Architecture:** A classification registry (`scoreboard/classification/openness.py`)
+classifies each `Score` (by `ran_with_providers`, closed-if-any-provider-closed) and
+`Baseline` (by `model_name`), fail-closed for anything unrecognized and logging every
+time that fail-closed default actually fires. A per-row `openness_override` column
+lets an operator correct a specific row without a code deploy. A pure
+frontier-computation function runs two independent passes: the *current* open/closed
+split over all rows, and a *trend* walk over Score rows only (never Baselines, whose
+`imported_at` isn't a trustworthy timestamp), advancing the holder only on a strict
+accuracy improvement (a tie never moves it). Exposed as a new read endpoint, rendered
+as one additional stat card on the existing benchmark portal page. Marketing-site
+(`screamingface-web`) integration, real score verification, and the rich 2D/3D trend
+chart (OME-324) are explicitly out of scope (spec §7).
+**Tech stack:** Same as the rest of scoreboard — Python 3.12, FastAPI, Tortoise ORM,
+pytest + ruff + pyright.
+
+## Phase 0 — Manual classification override (spec §9, new)
+
+- [ ] Migration: add `openness_override: str | None` (`"open"` | `"closed"` | `null`)
+  to both `Score` and `Baseline` models (`scores/models/score.py`, `baseline.py`),
+  plus the corresponding Tortoise migration — created and committed in this same
+  iteration per Stack rule S1. This is the **one** place this feature needs a
+  migration; the registry/classification logic itself stays a pure code-side lookup
+  (spec §7 non-goal, unchanged).
+- [ ] Add `openness_override` to `ScoreSchema`/`BaselineSchema` (`schemas.py`),
+  nullable. **Not** added to `ScoreSubmission` — this is an operator-only correction
+  (set directly against the DB, or a future admin surface), never client-supplied at
+  submission time.
+
+## Phase 1 — Classification registry (spec §4)
+
+- [ ] `apps/scoreboard/src/scoreboard/classification/__init__.py` + `openness.py`:
+  - `Openness = Literal["open", "closed"]`.
+  - `classify_providers(providers: list[str]) -> Openness` — **closed if any provider
+    is closed; open only if every provider is open** (spec §4's mixed-provider rule,
+    confirmed 2026-08-06 — not an implementation assumption anymore, an actual
+    decision).
+  - `classify_baseline_name(model_name: str) -> Openness` — same fail-closed pattern
+    via substring match.
+  - **Staleness logging (spec §4, new):** both functions log (e.g.
+    `logger.warning("unrecognized provider/model for openness classification: %r",
+    name)`) every time the fail-closed default actually fires for a name the
+    registry doesn't recognize — a visible signal instead of silent, permanent
+    undercounting as new models ship.
+  - `classify_score(score: ScoreSchema) -> Openness` / `classify_baseline(baseline:
+    BaselineSchema) -> Openness`: check `openness_override` (Phase 0) first — if set,
+    return it outright, registry never consulted; else defer to
+    `classify_providers`/`classify_baseline_name`. These two are what Phase 2 and the
+    tests actually call — `classify_providers`/`classify_baseline_name` are the
+    registry's internals.
+  - Registry stays a plain module-level tuple/set of markers.
+- [ ] Unit tests (`tests/unit/classification/test_openness.py`): known-open,
+  known-closed, mixed-provider (one open + one closed → closed), unrecognized →
+  closed **and logged** (assert the log record fires, not just the return value), an
+  `openness_override` set on a row wins outright over what the registry alone would
+  have said (both directions — forcing open, forcing closed).
+
+## Phase 2 — Frontier trend computation (spec §5, §6)
+
+- [ ] `apps/scoreboard/src/scoreboard/scores/frontier.py`:
+  - `FrontierPoint`: `{at: datetime, accuracy: float, openness: Openness, holder:
+    "score", label: str}` (`label` = `spec_id`; `holder` is always `"score"` now —
+    see below).
+  - `compute_frontier(scores: list[ScoreSchema], baselines: list[BaselineSchema]) ->
+    FrontierResult`, where `FrontierResult = {current: FrontierPoint | None, trend:
+    list[FrontierPoint], open_count: int, closed_count: int, open_share: float}`.
+    **Two independent passes, not one merged timeline:**
+    1. **Current split** — `open_count`/`closed_count`/`open_share` computed over
+       **all** rows, Scores (via `classify_score`) *and* Baselines (via
+       `classify_baseline`) together. This is the "how much of the frontier is open
+       right now" number the ticket asks for.
+    2. **Trend** — walks **Score rows only**, ordered by `submitted_at`. Baselines
+       never enter this walk at all (spec's baseline-timing resolution:
+       `imported_at` isn't a real-world timestamp, so a Baseline must never become
+       "the current holder" via the trend — not merely "excluded from the printed
+       list"). Emits a new `FrontierPoint` only on a **strict** improvement
+       (`accuracy > running_best`) — an exact tie leaves the existing holder in
+       place (spec's tie-breaking resolution; matters on real data today: the live
+       board already has two submissions tied at 100%).
+  - Pure function, no I/O — directly unit-testable without a DB.
+- [ ] `ScoreStore.list_all_for_benchmark(benchmark_id: str) -> list[ScoreSchema]` —
+  new query alongside the existing best-per-spec `leaderboard()`, reusing
+  `_score_to_schema`. Deliberately **benchmark-wide across all `spec_id`s** (spec's
+  frontier-scope resolution, confirmed 2026-08-06) — this is not an oversight
+  relative to the leaderboard's own per-spec ranking, it's the spec's literal scope.
+- [ ] Unit tests (`tests/unit/scores/test_frontier.py`): empty benchmark (no
+  scores/baselines → empty trend, `current=None`, no crash); single score; a Baseline
+  with higher accuracy than any Score still counts in the current split but never
+  becomes `current`'s holder; a later-but-lower-accuracy Score row absent from the
+  trend; **exact-tie regression test** — two Scores, identical accuracy, different
+  openness, holder does not change on the second one; `openness_override` on a Score
+  changes both which bucket it counts in AND, if it's the frontier holder, the
+  `openness` reported at that trend point.
+
+## Phase 3 — Read endpoint (spec §5)
+
+- [ ] New response schema in `schemas.py`: `FrontierResponse` (`benchmark_id`,
+  `open_count`, `closed_count`, `open_share`, `current: FrontierPoint | None`,
+  `trend: list[FrontierPoint]`), following the file's existing `extra="forbid"`
+  convention.
+- [ ] `GET /v1/leaderboard/{benchmark_id}/frontier` in `routes/leaderboard.py`,
+  reusing `_get_benchmark_or_404`; calls `ScoreStore.list_all_for_benchmark` +
+  `BaselineStore.list_baselines` + `compute_frontier`.
+- [ ] Tests (`tests/unit/test_leaderboard_routes.py`): 404 for unknown benchmark,
+  empty-benchmark 200 with an empty trend and `current: null`, response-shape
+  stability.
+
+## Phase 4 — Portal stat card (spec §5 "render it somewhere")
+
+- [ ] Extend the existing `#leaderboard-summary` stats row (`portal/benchmark.html`)
+  with one more `.s` card — "Open frontier share" (e.g. "73% open") — sourced from
+  the new endpoint in `benchmark.js`. No new charting library; a stat tile, not the
+  trend chart (OME-324's job per spec §7).
+- [ ] No portal unit tests exist today for this page (untested vanilla JS) — matches
+  existing practice; not introducing a JS test harness in this unit.
+
+## Non-goals (spec §7)
+
+- Rendering on the `screamingface.ai` marketing site (separate `screamingface-web`
+  repo).
+- Backfill/migration for the registry's own classification logic (still true — the
+  registry is a code-side lookup evaluated at read time; only Phase 0's
+  `openness_override` column needs a migration, and that's additive, not a backfill).
+- Syncing the registry with AI Gateway's own `hosted_shared` classification
+  (OME-428/OME-394) — resolved as "ship now, cross-link the dependency" (see
+  Follow-ups below), not implemented in this unit.
+- Real score/claim verification for the public claim — ship as-is; unverified and
+  even anonymous submissions affect this stat exactly as they already affect the rest
+  of the leaderboard today. A separate, much larger, already-unowned effort.
+- OME-324's 2D/3D frontier charts.
+
+## Acceptance (spec §8)
+
+- Split + trend computed from real `Score`/`Baseline` rows only, no mock data in the
+  code path.
+- Registry is deterministic and unit-tested, including the fail-closed default and
+  its logging.
+- A mixed-provider `Score` is classified closed-if-any-provider-closed.
+- The frontier trend never moves the holder on an exact accuracy tie.
+- Baselines are included in the current split, excluded from the trend walk.
+- `openness_override` is respected by the classification path and ships with its
+  migration in this same unit.
+- Exposed via the scoreboard API/portal; marketing-site integration explicitly
+  deferred.
+
+## Follow-ups (owner-driven, not part of this PR's code)
+
+- **Linear cross-link (spec §4):** post a comment on OME-428 and OME-394 pointing at
+  scoreboard's registry and this ticket, so whoever eventually builds AI Gateway's
+  own classification sees the dependency in their own ticket rather than a
+  scoreboard doc they'd have no reason to read. Can happen anytime — not blocking
+  this unit's implementation.
+- **Production data cleanup (spec §10):** delete the known smoke-test row
+  (`spec_id: score-007-smoke`, confirmed live on `scoreboard.screamingface.ai`) and
+  any other junk data from production **before** this feature computes its first
+  real public number. A direct write against live production data — its own
+  explicitly-confirmed action, separate from this code PR, not something this unit
+  does automatically.
+
+## Risk / dependency
+
+- **PR #414 (the spec itself) is still unmerged.** Implementation should wait for it
+  to merge so `docs/spec/` on `main` matches what the code claims to implement. #414
+  now carries nine additional resolved decisions (this plan is built against all of
+  them) and is pending review — Irina Bejan (product/policy content: the
+  classification rules and the accepted verification/gaming-risk tradeoffs) plus
+  CODEOWNERS (sergio-bershadsky/HupBaHa, auto-requested).
+
+## Ticket
+
+No new sub-issues — single unit, same ticket (`OME-323`), same
+branch/worktree used for this plan doc (`OME-323-open-vs-closed-landing-page`).
+Phases 0–4 ship as one PR, not a cascade — the scope is one app, one cohesive
+feature, unlike the url4-cloud-runner epic's multi-app spread.

--- a/docs/work/2026-08-06-OME-323-implement-frontier-stats.md
+++ b/docs/work/2026-08-06-OME-323-implement-frontier-stats.md
@@ -133,3 +133,24 @@ OME-404's security-critical auth-boundary work that warranted 4 rounds.
   happened yet, so this feature's first real computation on production will
   currently include that junk row until that separate, explicitly-confirmed cleanup
   action happens.
+
+## Review round 1 (2026-08-06) — PR #519 feedback
+
+External review found a real gap `renderFrontier` (`benchmark.js`) gated on
+`data.current` being set, but a benchmark with imported `Baseline` rows and zero
+`Score` submissions yet has a real, meaningful `open_share` — Baselines count
+toward the current split (`_current_split`) independent of the trend walk
+(`_compute_trend`, which only ever produces a `current` holder from Score rows).
+Verified empirically before fixing: `compute_frontier(scores=[], baselines=[one
+open baseline])` returns `current=None` but `open_share=1.0`. The old guard
+silently hid the stat card for every baseline-only benchmark — plausible in
+practice, since that's the normal state right after `import_baselines` runs and
+before anyone's submitted a Score.
+
+**Fixed:** gate on `open_count + closed_count > 0` (is there anything to show at
+all) instead of `data.current` truthiness; `current` is now used only for the
+optional hover title, which is simply empty when there's no Score holder yet.
+
+**Gates:** re-ran the full suite (`ruff check`/`format`, `pyright`, `pytest`) —
+all green, unchanged pass count (this fix touches only untested portal JS, per
+the plan's own decision not to introduce a JS test harness in this unit).

--- a/docs/work/2026-08-06-OME-323-implement-frontier-stats.md
+++ b/docs/work/2026-08-06-OME-323-implement-frontier-stats.md
@@ -1,0 +1,135 @@
+---
+ticket: OME-323
+stack: scoreboard
+status: in_progress
+started: 2026-08-06
+finished:
+---
+
+# OME-323 — implement open-vs-closed frontier statistics
+
+## Intent
+
+Implements `docs/plan/2026-08-06-open-vs-closed-frontier-stats-plan.md` (built against
+`docs/spec/2026-07-16-open-vs-closed-frontier-stats-spec.md`, resolved 2026-07-17,
+extended 2026-08-06 with nine follow-up resolutions, currently on unmerged PR #414).
+Compute, from real `Score`/`Baseline` rows, what share of a benchmark's accuracy
+frontier is held by open-reproducible stacks vs. proprietary ones — both the current
+split and the trend over time — and expose it via a new scoreboard API endpoint +
+portal stat card.
+
+Starting on Irina Bejan's informal huddle agreement to the nine spec resolutions
+(2026-08-06; formal huddle notes pending, PR #414 review still outstanding) — owner
+call to proceed with implementation now rather than wait for the formal record.
+
+## Planned changes
+
+- `apps/scoreboard/src/scoreboard/scores/models/score.py`,
+  `baseline.py`: `openness_override` column (Phase 0).
+- New migration `0004_*.py` (Phase 0).
+- `apps/scoreboard/src/scoreboard/scores/schemas.py`: `openness_override` on
+  `ScoreSchema`/`BaselineSchema` (Phase 0).
+- New `apps/scoreboard/src/scoreboard/classification/{__init__.py,openness.py}`
+  (Phase 1).
+- New `apps/scoreboard/src/scoreboard/scores/frontier.py` (Phase 2).
+- `apps/scoreboard/src/scoreboard/scores/store.py`: `list_all_for_benchmark` (Phase 2).
+- `apps/scoreboard/src/scoreboard/scores/schemas.py`: `FrontierResponse` (Phase 3).
+- `apps/scoreboard/src/scoreboard/routes/leaderboard.py`: new frontier route (Phase 3).
+- `apps/scoreboard/portal/benchmark.html`, `benchmark.js` (Phase 4).
+
+## Test plan
+
+- Phase 0+1 tests written together (Phase 0 is pure additive schema with no
+  standalone behavior to test in isolation — Phase 1's override-respecting tests are
+  what actually exercise the new column, avoiding a synthetic "column exists"
+  assertion): known-open/closed, mixed-provider closed-if-any-closed, unrecognized →
+  closed + logged, override wins over the registry in both directions.
+- Phase 2: empty benchmark, single score, baseline-in-split-never-in-trend, later-but-
+  lower-accuracy not in trend, exact-tie regression, override changes bucket/holder.
+- Phase 3: 404 unknown benchmark, empty-benchmark 200, response-shape stability.
+- Phase 4: no test harness for the untested vanilla-JS portal page (matches existing
+  practice).
+
+## Acceptance
+
+Per plan's Acceptance section (mirrors spec §8, extended).
+
+## Wisdom + confidence review (2026-08-06)
+
+Self-review pass against the complete diff before commit:
+
+- **Empty-providers edge case:** `classify_providers([])` — without the explicit
+  early-return, an empty list would fall through the loop with `saw_closed=False`
+  and incorrectly return `"open"`. The early return (logged) is load-bearing, not
+  redundant; covered by `test_empty_providers_is_closed`.
+- **Tie-boundary correctness:** `_compute_trend`'s `score.accuracy <= current.accuracy`
+  skip condition uses `<=`, not `<` — confirmed this is what makes an exact tie
+  leave the holder unmoved while a strict improvement still advances it. Covered by
+  both `test_exact_tie_does_not_move_the_holder` and
+  `test_strict_improvement_after_a_tie_does_move_the_holder`.
+- **Write-path protection:** `openness_override` is deliberately absent from
+  `ScoreSubmission`/`BaselineImportRow` — confirmed a client can't smuggle it in via
+  `POST /v1/scores` either, since `ScoreSubmission` keeps `extra="forbid"` and
+  `_submission_to_kwargs` lists every kwarg explicitly (no `**payload`
+  pass-through). The override is genuinely operator-only, as designed.
+- **Route collision check:** `/leaderboard/{benchmark_id}/frontier` (2 path
+  segments) vs. the existing `/leaderboard/{benchmark_id}/{spec_id}/history` (3
+  segments, literal `history` tail) — confirmed no ambiguity, and the new route's
+  own passing tests are empirical proof, not just theoretical.
+- **Schema/model change safety:** `openness_override` is nullable with no explicit
+  default, matching the existing `content_hash` field's own pattern in this exact
+  model — confirmed safe for `Score.create()` calls that don't mention it.
+
+No findings. One round was sufficient — the surface area here (an additive column,
+a pure function, one new route, one supplementary portal stat) is much smaller than
+OME-404's security-critical auth-boundary work that warranted 4 rounds.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+  - `scores/models/{score,baseline}.py` — `openness_override` column (Phase 0).
+  - `scores/migrations/0004_auto_20260806_0000.py` — new migration (Phase 0),
+    verified to apply cleanly and idempotently against a throwaway sqlite DB.
+  - `scores/schemas.py` — `openness_override` on `ScoreSchema`/`BaselineSchema`;
+    new `FrontierPoint`, `FrontierResult`, `FrontierResponse` (Phase 0/2/3).
+  - `scores/store.py`, `scores/baseline_store.py` — `openness_override` passthrough
+    in `_score_to_schema`/`_baseline_to_schema`; new
+    `ScoreStore.list_all_for_benchmark` (Phase 0/2).
+  - `classification/{__init__.py,openness.py}` — new (Phase 1).
+  - `scores/frontier.py` — new; `compute_frontier` refactored into
+    `_current_split`/`_compute_trend` helpers to satisfy `pyright`'s
+    too-many-branches lint (Phase 2).
+  - `routes/leaderboard.py` — new `GET /v1/leaderboard/{benchmark_id}/frontier`
+    (Phase 3).
+  - `portal/benchmark.html`, `benchmark.js` — new stat card, fetched independently
+    of the main leaderboard call so a failure here never blocks/errors the page
+    (Phase 4).
+  - Tests: `tests/unit/classification/test_openness.py` (new, 15 cases),
+    `tests/unit/scores/test_frontier.py` (new, 7 cases), plus append-only additions
+    to `tests/unit/scores/test_store.py` (2 cases) and
+    `tests/unit/test_leaderboard_routes.py` (3 cases).
+- **Commits:** pending — landing with this ledger update.
+- **Gates:** `uv run .claude/scripts/run_gates.py scoreboard --base origin/main
+  --skip-append-only` → ruff check ✓, ruff format ✓, pyright (0 errors) ✓, pytest
+  155 passed / 2 skipped, coverage ≥80% ✓. Re-run identically under `--python 3.13`
+  (fresh venv) → same result.
+- **Deviations:**
+  1. `--skip-append-only` used, justified: `test_store.py` and
+     `test_leaderboard_routes.py` show as git status `M` against `origin/main`
+     purely because new tests were appended — confirmed via `git diff | grep '^-'`
+     showing zero removed lines in either file. `origin/main` doesn't yet have
+     OME-369's line-level append-only fix (still an unmerged PR), so the coarser
+     current gate flags any file-level `M` regardless of whether the change is a
+     pure addition.
+  2. `compute_frontier` was split into `_current_split`/`_compute_trend` helpers,
+     not in the original plan text, to satisfy pyright's `PLR0912`
+     too-many-branches rule — a mechanical refactor, no behavior change (both
+     helpers are exercised by the same tests, which stayed green throughout).
+  3. Started on Irina Bejan's informal huddle agreement to the spec's nine
+     resolutions (2026-08-06) rather than waiting for the formal huddle notes or
+     PR #414's GitHub review — owner's explicit call.
+- **Owner-verify:** none beyond the plan's own risk note — PR #414 (the spec) is
+  still unmerged, and §10's production data cleanup (the smoke-test row) hasn't
+  happened yet, so this feature's first real computation on production will
+  currently include that junk row until that separate, explicitly-confirmed cleanup
+  action happens.

--- a/docs/work/2026-08-06-OME-323-open-vs-closed-frontier-stats-plan.md
+++ b/docs/work/2026-08-06-OME-323-open-vs-closed-frontier-stats-plan.md
@@ -1,0 +1,68 @@
+---
+ticket: OME-323
+stack: scoreboard
+status: in_progress
+started: 2026-08-06
+finished:
+---
+
+# OME-323 — plan the open-vs-closed frontier stats implementation
+
+## Intent
+
+`docs/spec/2026-07-16-open-vs-closed-frontier-stats-spec.md` (resolved 2026-07-17,
+currently landing in unmerged PR #414) settled both open questions: classification is
+a static, fail-closed provider/model registry seeded from the OME-428 HF-vs-OpenRouter
+precedent (§4), and "the frontier" means a trend over time, not a point-in-time
+snapshot (§6). This unit produces the `docs/plan/` artifact translating that spec into
+concrete scoreboard changes — a classification registry, a frontier-trend computation
+over `Score`+`Baseline` rows, a read endpoint, and a minimal portal stat placement — so
+implementation can start on explicit approval. No product code in this unit.
+
+## Planned changes
+
+- `docs/plan/2026-08-06-open-vs-closed-frontier-stats-plan.md` (new)
+
+## Test plan
+
+N/A — plan-only artifact, no code path in this unit.
+
+## Acceptance
+
+- Plan doc translates every spec section (§4 registry, §5 scope, §6 trend, §7
+  non-goals, §8 acceptance) into concrete file-level changes grounded in the current
+  `apps/scoreboard` codebase (models, store, routes, portal).
+- Plan is presented to Filip for explicit approval before any implementation commit.
+
+## Revision (2026-08-06, same day) — updated against nine spec follow-up resolutions
+
+Before implementation started, a deeper review of the resolved spec against real
+production data surfaced nine dilemmas the original §4/§6 text hadn't actually
+covered (see `docs/work/2026-07-17-OME-323-resolve-classification-spec.md`'s Round 2
+and the amended spec on PR #414). Updated this plan to match all nine:
+
+- Added **Phase 0** (new): an `openness_override` column on `Score`/`Baseline` +
+  migration — the one place this feature now needs a schema change.
+- **Phase 1:** confirmed (not assumed) the closed-if-any-provider-closed mixed-fusion
+  rule; added staleness logging for the fail-closed default; added override-aware
+  `classify_score`/`classify_baseline` wrapping the registry internals.
+- **Phase 2:** split `compute_frontier` into two independent passes — current split
+  over all rows, trend walk over Score rows only (Baselines never become the trend
+  holder); trend now advances only on a strict accuracy improvement, not a tie.
+- **Non-goals/Acceptance:** added the verification/anonymous-submission risk as an
+  explicit accepted non-goal; added acceptance criteria for the tie rule, the
+  baseline/trend split, and the override field.
+- **New Follow-ups section:** the OME-428/OME-394 Linear cross-link and the
+  production data cleanup (§10) — both owner-driven, neither part of this PR's code.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** `docs/plan/2026-08-06-open-vs-closed-frontier-stats-plan.md`
+  (substantially revised, see above).
+- **Commits:** none yet — pending explicit approval to proceed to implementation.
+  The plan doc itself stays uncommitted until implementation starts, same as before
+  this revision — it lands together with Phase 0–4's code in one PR, mirroring how
+  the spec (unlike this plan) got its own dedicated PR (#414) only because it was
+  asked for explicitly.
+- **Gates:** N/A (no code path touched).
+- **Deviations:** none.


### PR DESCRIPTION
## Summary
- Implements OME-323: how much of a benchmark's accuracy frontier is held by open-reproducible stacks vs. proprietary ones, backed by real `Score`/`Baseline` rows, plus the trend over time.
- `classification/openness.py`: fail-closed provider/model registry — closed if any provider in a fusion is closed, open only if every provider is open. Unrecognized names are logged, not silently absorbed.
- An `openness_override` column on `Score`/`Baseline` lets an operator correct a specific row's classification without a code deploy — the one schema change this needs, migration included (verified to apply cleanly and idempotently).
- `scores/frontier.py`: `compute_frontier` runs two independent passes — current split over all rows, trend walk over Score rows only (Baselines never become the trend holder — `imported_at` isn't a trustworthy real-world timestamp). Holder advances only on a strict accuracy improvement; an exact tie leaves it in place.
- `GET /v1/leaderboard/{benchmark_id}/frontier`, deliberately benchmark-wide across all specs.
- A stat card on the benchmark portal page, fetched independently of the main leaderboard call so a failure there can't block it.

Built against `docs/spec/2026-07-16-open-vs-closed-frontier-stats-spec.md` (resolved 2026-07-17, extended 2026-08-06 with nine follow-up resolutions — see PR #414, still open) and `docs/plan/2026-08-06-open-vs-closed-frontier-stats-plan.md`.

**Known follow-ups, tracked, not blocking this PR:**
- PR #414 (the spec itself) is still unmerged.
- Spec §10's production data cleanup (a pre-existing smoke-test row) hasn't happened yet — separate, explicitly-confirmed action.
- A Linear cross-link to OME-428/OME-394 flagging the drift risk with AI Gateway's future classification — owner-driven, not code.

## Test plan
- [x] `classification/test_openness.py` — 15 cases: known open/closed, mixed-provider fusion rule, fail-closed + logged for unrecognized names, override wins in both directions.
- [x] `scores/test_frontier.py` — 7 cases: empty benchmark, single score, baseline-in-split-never-in-trend, later-but-lower-accuracy excluded, exact-tie regression, strict-improvement-after-tie, override changes reported openness.
- [x] `scores/test_store.py` — `list_all_for_benchmark` returns every spec chronologically, empty for unknown benchmark.
- [x] `test_leaderboard_routes.py` — 404 for unknown benchmark, empty-trend 200, real-submission response shape.
- [x] Full gate suite (ruff/pyright/pytest ≥80% cov) green under Python 3.12 and 3.13.
- [x] Migration applies cleanly and idempotently against a throwaway sqlite DB.

Refs: OME-323