### PR TITLE
feat(aigateway): expose model, provider, and search contracts

### DIFF
--- a/apps/aigateway/src/aigateway/core/plugin_base/_provider.py
+++ b/apps/aigateway/src/aigateway/core/plugin_base/_provider.py
@@ -49,6 +49,7 @@ class ProviderPluginCore[TSettings: PluginSettings](ABC):
     """
 
     custom_llm_provider: str
+    provider_display_name: str
     settings_cls: ClassVar[type[PluginSettings]] = PluginSettings
 
     def __init__(self, settings: TSettings | None = None) -> None:

--- a/apps/aigateway/src/aigateway/core/standard_parameters.py
+++ b/apps/aigateway/src/aigateway/core/standard_parameters.py
@@ -69,6 +69,26 @@ LOGPROBS_SCHEMA = ParameterSchema(type="boolean")
 # its log probability. OpenAI's documented range is an integer 0..20 INCLUSIVE; a value
 # outside it, a boolean, or a non-integer fails closed at classification.
 TOP_LOGPROBS_SCHEMA = ParameterSchema(type="integer", minimum=0, maximum=20)
+# ``web_search``: ask the PROVIDER to retrieve before answering. A plain boolean on purpose.
+#
+# Providers spell server-side retrieval differently and each spelling is an extensibility
+# ENVELOPE — OpenRouter's is `plugins: [...]`, a list of arbitrary provider extensions. An
+# envelope cannot be meaningfully bounded, because carrying anything is the point of it, so a
+# rule enabling one authorizes a path and forwards nested JSON verbatim: exactly what OME-646
+# removed. A boolean is bounded COMPLETELY, and the provider translates it into its own
+# spelling in `prepare_chat_body`, where a gateway-owned value is assigned rather than merged.
+#
+# This is the shared vocabulary, so the word is provider-agnostic: any provider that can
+# retrieve enables the same field, and one that cannot simply does not — a caller asking then
+# gets a named 400 from the authority on capability, rather than silence.
+WEB_SEARCH_SCHEMA = ParameterSchema(type="boolean")
+# ``web_search_excluded_domains``: domains the caller asks the provider to exclude.
+#
+# INVARIANT: this can only ever ADD to the deployment's own requested exclusions — a provider
+# composes the two as a UNION (see the OpenRouter plugin). Whether the upstream engine enforces
+# exclusions is model-specific, so a protocol requiring a hard block must choose a compatible
+# Engine route rather than treating this wire field as universal enforcement.
+WEB_SEARCH_EXCLUDED_DOMAINS_SCHEMA = ParameterSchema(type="array", item_type="string")
 
 
 def direct_rule(

--- a/apps/aigateway/src/aigateway/main.py
+++ b/apps/aigateway/src/aigateway/main.py
@@ -48,6 +48,7 @@ from .routes import (
     model_parameters,
     models,
     oauth_connections,
+    providers,
 )
 
 logger = logging.getLogger(__name__)
@@ -341,6 +342,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(oauth_connections.router)
     app.include_router(health.router)
     app.include_router(models.router)
+    app.include_router(providers.router)
     app.include_router(model_parameters.router)
     app.include_router(chat.router)
 

--- a/apps/aigateway/src/aigateway/plugins/anthropic_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/anthropic_provider/plugin.py
@@ -63,6 +63,7 @@ def _api_key_headers(api_key: str) -> dict[str, str]:
 
 class AnthropicProviderPlugin(ProviderPluginBase[AnthropicPluginSettings]):
     custom_llm_provider = "anthropic"
+    provider_display_name = "Anthropic"
     settings_cls = AnthropicPluginSettings
 
     def register_models(self) -> list[ModelEntry]:

--- a/apps/aigateway/src/aigateway/plugins/antigravity_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/antigravity_provider/plugin.py
@@ -77,6 +77,7 @@ def _detail_for_error(exc: CustomLLMError) -> dict[str, str]:
 
 class AntigravityProviderPlugin(ProviderPluginBase[AntigravityPluginSettings]):
     custom_llm_provider = "antigravity"
+    provider_display_name = "Antigravity"
     settings_cls = AntigravityPluginSettings
 
     def credential_service_provider(self) -> str:

--- a/apps/aigateway/src/aigateway/plugins/codex_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/codex_provider/plugin.py
@@ -49,6 +49,7 @@ class CodexProviderPlugin(ProviderPluginBase):
     # api_key_not_supported for codex. Routing API-key profiles to the OpenAI
     # platform API instead is a possible follow-up.
     custom_llm_provider = "codex"
+    provider_display_name = "Codex"
 
     def register_models(self) -> list[ModelEntry]:
         return list(MODELS)

--- a/apps/aigateway/src/aigateway/plugins/gemini_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/gemini_provider/plugin.py
@@ -98,6 +98,7 @@ def _detail_for_error(exc: CustomLLMError) -> dict[str, str]:
 
 class GeminiProviderPlugin(ProviderPluginBase[GeminiPluginSettings]):
     custom_llm_provider = "gemini-cli"
+    provider_display_name = "Gemini CLI"
     settings_cls = GeminiPluginSettings
 
     def credential_service_provider(self) -> str:

--- a/apps/aigateway/src/aigateway/plugins/huggingface_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/huggingface_provider/plugin.py
@@ -71,6 +71,7 @@ def _credential_service_for(profile_name: str) -> str:
 
 class HuggingFaceProviderPlugin(ProviderPluginBase[HuggingFacePluginSettings]):
     custom_llm_provider = "huggingface"
+    provider_display_name = "Hugging Face"
     settings_cls = HuggingFacePluginSettings
 
     def register_models(self) -> list[ModelEntry]:

--- a/apps/aigateway/src/aigateway/plugins/ollama_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/ollama_provider/plugin.py
@@ -24,6 +24,7 @@ _CLIENT_AUTH_HEADER_NAMES = {"authorization", "x-api-key", "proxy-authorization"
 
 class OllamaProviderPlugin(ProviderPluginBase):
     custom_llm_provider = "ollama"
+    provider_display_name = "Ollama"
 
     def register_models(self) -> list[ModelEntry]:
         host = resolve_ollama_host()

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/dispatch_errors.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/dispatch_errors.py
@@ -31,6 +31,23 @@ def _invalid_model_error() -> HTTPException:
     )
 
 
+def _online_model_suffix_error() -> HTTPException:
+    """Refuse OpenRouter's implicit-search model variant.
+
+    Search is a provider-neutral Gateway parameter. Allowing ``:online`` would create a second,
+    provider-specific route around parameter validation and deployment domain exclusions.
+    """
+
+    return HTTPException(
+        status_code=400,
+        detail={
+            "code": "unsupported_model_variant",
+            "provider": "openrouter",
+            "message": "OpenRouter ':online' is not supported; use web_search=true",
+        },
+    )
+
+
 class _UnsafeLiteLLMStateError(HTTPException):
     """A pre-dispatch global-state conflict that the retry loop must not repeat."""
 

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/global_cache.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/global_cache.py
@@ -25,7 +25,12 @@ from aigateway.core.parameter_projection import WRAPPER_KEY
 from .dispatch_errors import _UnexpectedRoutingPolicyError
 from .parameters import EXTRA_BODY_OBJECT, TOP_K_LEAF
 from .routing_policy import PROVIDER_OBJECT, build_provider_policy, project_routing_controls
-from .settings import GATEWAY_MODEL_PREFIX, OFFICIAL_API_BASE, is_valid_upstream_model_id
+from .settings import (
+    GATEWAY_MODEL_PREFIX,
+    OFFICIAL_API_BASE,
+    is_online_variant,
+    is_valid_upstream_model_id,
+)
 
 # OME-305: the revision of THIS plugin's output-affecting preparation, as reported
 # by ``global_cache_projection``.
@@ -40,7 +45,11 @@ from .settings import GATEWAY_MODEL_PREFIX, OFFICIAL_API_BASE, is_valid_upstream
 # what a caller may say and where each value lands; this one versions what the
 # boundary adds on its own. A change to either must invalidate, and collapsing them
 # into one constant would make every rule edit look like a dispatch change.
-GLOBAL_CACHE_ADAPTER_REVISION = "openrouter-global-cache-2026-08"
+#
+# OME-712 (`...-08` -> `...-08b`): `:online` ids USED to dispatch and fill entries, and are
+# now refused. The projection below bypasses them, but a bypass only stops NEW rows — rows
+# written before this landed stay readable under their old key. Bumping abandons them.
+GLOBAL_CACHE_ADAPTER_REVISION = "openrouter-global-cache-2026-08b"
 
 
 def project_global_cache_request(body: dict[str, Any]) -> dict[str, Any] | CacheBypass:
@@ -80,6 +89,14 @@ def project_global_cache_request(body: dict[str, Any]) -> dict[str, Any] | Cache
         return CacheBypass(reason=PROJECTION_BYPASS_REASON)
     upstream = model[len(GATEWAY_MODEL_PREFIX) :]
     if not is_valid_upstream_model_id(upstream):
+        return CacheBypass(reason=PROJECTION_BYPASS_REASON)
+    if is_online_variant(upstream):
+        # OME-712: ``prepare_chat_body`` REFUSES this id with a 400 — the `:online` suffix is
+        # OpenRouter's implicit search, a second route around the provider-neutral `web_search`
+        # parameter and the deployment exclusions it carries. The refusal alone is not enough,
+        # because the cache is read BEFORE preparation: without this, a stored entry would
+        # answer 200 for a request the gateway must refuse. Same class as the routing-policy
+        # bypass below, and the same predicate as the dispatch guard so the two cannot drift.
         return CacheBypass(reason=PROJECTION_BYPASS_REASON)
     wrapper = body.get(WRAPPER_KEY)
     try:

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/parameters.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/parameters.py
@@ -101,6 +101,37 @@ _TOOL_CAPABILITIES: tuple[ToolCapability, ...] = (
 # `plugin.prepare_chat_body` ASSIGNS the `plugins` payload from gateway-owned policy, the same
 # two-layer shape `provider` already uses: the classifier refuses the native field, the provider
 # sets it. The caller can never reach the envelope.
+#
+# AIDEV-NOTE (OME-712, owner decision — READ BEFORE PROMOTING THESE TO ``keyed``). Both search
+# rules declare ``cache_behavior="bypass"``, alone among the output-affecting rules in this file.
+# Two independent reasons, either sufficient:
+#
+# 1. The dispatched envelope's `exclude_domains` is the UNION of the caller's list and the
+#    DEPLOYMENT setting ``AIGW_OPENROUTER_WEB_SEARCH_EXCLUDED_DOMAINS``. That setting is not in
+#    the request body, and ``global_cache_projection`` is contractually forbidden from reading
+#    ``self.settings`` (the purity INVARIANT on the port, with
+#    ``test_no_projection_reads_operator_configuration`` as the tripwire), so it can never reach
+#    the key. That is exactly the shape ruling 34 names: identical bodies, one key, two different
+#    upstream calls. Ruling 34 allows two answers — bypass, or accept the collision in writing —
+#    and the colliding input here is a BLOCKLIST, so accepting the collision would mean serving
+#    an answer retrieved without an operator's exclusions to a deployment that requires them.
+# 2. Retrieval is time-varying by definition. An EXACT-REQUEST cache answers "the same call was
+#    made before"; for a search-backed call that is precisely the wrong question.
+#
+# INVARIANT this rests on: the `plugins` envelope is emitted ONLY when `web_search is True`
+# (``web_search.apply_web_search`` returns early otherwise), and any request carrying that field
+# bypasses here. So no CACHEABLE request can be dispatched with a `plugins` block, which is what
+# keeps ``global_cache``'s `prepared` a complete description of what this boundary sends. Emit
+# the envelope on any other condition and that projection silently becomes incomplete.
+#
+# ACCEPTED CONSEQUENCE: a benchmark re-run that uses `web_search` re-pays OpenRouter every time,
+# and `web_search: false` bypasses too — ``_accept`` reads ``cache_behavior`` before it looks at
+# the value. Do not add a falsy-value exemption; the saving is not worth a second code path.
+#
+# The route out, if this ever needs to be `keyed`: fold the deployment policy into the request
+# BODY before the key is built — the pattern OME-638 already uses for profile defaults — so the
+# projection has nothing unobservable left to read. That needs a new plugin port; it is not a
+# change to this file alone.
 
 _RULES: tuple[ParameterProjectionRule, ...] = (
     direct_rule(

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/parameters.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/parameters.py
@@ -238,12 +238,17 @@ _RULES: tuple[ParameterProjectionRule, ...] = (
     # emitted `plugins` retrieves: same prompt, with it a current cited answer, without it the
     # model's training cutoff.
     direct_rule(
-        "web_search", auth_modes=_AUTH, schema=WEB_SEARCH_SCHEMA, projection_revision=_REVISION
+        "web_search",
+        auth_modes=_AUTH,
+        schema=WEB_SEARCH_SCHEMA,
+        cache_behavior="bypass",
+        projection_revision=_REVISION,
     ),
     direct_rule(
         "web_search_excluded_domains",
         auth_modes=_AUTH,
         schema=WEB_SEARCH_EXCLUDED_DOMAINS_SCHEMA,
+        cache_behavior="bypass",
         projection_revision=_REVISION,
     ),
 )

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/parameters.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/parameters.py
@@ -30,6 +30,8 @@ from aigateway.core.standard_parameters import (
     TEMPERATURE_SCHEMA,
     TOP_LOGPROBS_SCHEMA,
     TOP_P_SCHEMA,
+    WEB_SEARCH_EXCLUDED_DOMAINS_SCHEMA,
+    WEB_SEARCH_SCHEMA,
     direct_rule,
     function_calling_rules,
     provider_native_rule,
@@ -80,7 +82,25 @@ TOP_K_LEAF = "top_k"
 # WITH tool_choice.
 _TOOL_CAPABILITIES: tuple[ToolCapability, ...] = (
     ToolCapability(tool_type="function", provider_support="supported", gateway_status="enabled"),
+    # AIDEV-NOTE: `openrouter:web_search` / `openrouter:web_fetch` are deliberately ABSENT.
+    # OpenRouter documents that server-tool surface, but the 2026-07-31 conformance probe through
+    # this Gateway's pinned LiteLLM/provider path returned HTTP 200 without search evidence.
+    # Server-side web search in this landing uses the separately proven `web_search` rule below.
+    # Advertising another surface requires fresh end-to-end evidence; it is not a compatibility
+    # fallback for the proven plugin projection.
 )
+
+# --- server-side web search --------------------------------------------------
+# OpenRouter retrieves through `plugins: [{"id": "web", ...}]`, and `plugins` stays REFUSED as a
+# caller path (OME-646, pinned by `test_openrouter_security`). That is not an obstacle worked
+# around here — it is correct, and the reason is worth stating: `plugins` is an extensibility
+# ENVELOPE. Carrying arbitrary provider extensions is its entire purpose, so no schema can bound
+# it without defeating it, and a rule enabling it forwards nested JSON verbatim.
+#
+# The caller instead says `web_search: true` — bounded completely, because it is a boolean — and
+# `plugin.prepare_chat_body` ASSIGNS the `plugins` payload from gateway-owned policy, the same
+# two-layer shape `provider` already uses: the classifier refuses the native field, the provider
+# sets it. The caller can never reach the envelope.
 
 _RULES: tuple[ParameterProjectionRule, ...] = (
     direct_rule(
@@ -212,6 +232,20 @@ _RULES: tuple[ParameterProjectionRule, ...] = (
     *routing_policy_rules(auth_modes=_AUTH, projection_revision=_REVISION),
     # OME-583: tools + tool_choice (OpenAI-native, §9 proof).
     *function_calling_rules(_TOOL_CAPABILITIES, auth_modes=_AUTH, projection_revision=_REVISION),
+    # Server-side web search — the caller-facing half. `direct` is the ADDRESSING kind, not the
+    # wire shape: `prepare_chat_body` consumes both fields and emits `plugins` in their place,
+    # so neither name reaches OpenRouter. Verified live 2026-07-31 (litellm 1.87.0) that the
+    # emitted `plugins` retrieves: same prompt, with it a current cited answer, without it the
+    # model's training cutoff.
+    direct_rule(
+        "web_search", auth_modes=_AUTH, schema=WEB_SEARCH_SCHEMA, projection_revision=_REVISION
+    ),
+    direct_rule(
+        "web_search_excluded_domains",
+        auth_modes=_AUTH,
+        schema=WEB_SEARCH_EXCLUDED_DOMAINS_SCHEMA,
+        projection_revision=_REVISION,
+    ),
 )
 
 

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/plugin.py
@@ -50,6 +50,7 @@ from .discovery import (
 from .dispatch_errors import (
     _embedded_error_exception,
     _invalid_model_error,
+    _online_model_suffix_error,
     _unsafe_litellm_state_error,
 )
 
@@ -337,6 +338,8 @@ class OpenRouterProviderPlugin(ProviderPluginBase[OpenRouterPluginSettings]):
         model = out.get("model")
         if not isinstance(model, str) or not model.startswith(GATEWAY_MODEL_PREFIX):
             raise _invalid_model_error()
+        if model.endswith(":online"):
+            raise _online_model_suffix_error()
         if not is_valid_upstream_model_id(model[len(GATEWAY_MODEL_PREFIX) :]):
             raise _invalid_model_error()
         # Keep the model unchanged: the gateway prefix IS LiteLLM's provider

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/plugin.py
@@ -159,6 +159,7 @@ _STRIPPED_CALLER_HEADERS = frozenset(
 
 class OpenRouterProviderPlugin(ProviderPluginBase[OpenRouterPluginSettings]):
     custom_llm_provider = "openrouter"
+    provider_display_name = "OpenRouter"
     settings_cls = OpenRouterPluginSettings
 
     def register_models(self) -> list[ModelEntry]:

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/plugin.py
@@ -81,6 +81,7 @@ from .routing_policy import build_provider_policy
 from .settings import (
     GATEWAY_MODEL_PREFIX,
     OpenRouterPluginSettings,
+    is_online_variant,
     is_valid_upstream_model_id,
 )
 from .settings import OFFICIAL_API_BASE as OFFICIAL_API_BASE
@@ -338,7 +339,10 @@ class OpenRouterProviderPlugin(ProviderPluginBase[OpenRouterPluginSettings]):
         model = out.get("model")
         if not isinstance(model, str) or not model.startswith(GATEWAY_MODEL_PREFIX):
             raise _invalid_model_error()
-        if model.endswith(":online"):
+        # OME-712: BEFORE the validity check, so a `:online` id reports the specific
+        # `unsupported_model_variant` rather than a generic invalid-model error. The
+        # cache projection refuses the same ids via the same predicate.
+        if is_online_variant(model):
             raise _online_model_suffix_error()
         if not is_valid_upstream_model_id(model[len(GATEWAY_MODEL_PREFIX) :]):
             raise _invalid_model_error()

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/plugin.py
@@ -83,6 +83,11 @@ from .settings import (
     is_valid_upstream_model_id,
 )
 from .settings import OFFICIAL_API_BASE as OFFICIAL_API_BASE
+from .web_search import (
+    WEB_SEARCH_EXCLUDED_DOMAINS_PARAM,
+    WEB_SEARCH_PARAM,
+    apply_web_search,
+)
 
 if TYPE_CHECKING:
     from aigateway.core.chat_parameters import (
@@ -222,6 +227,11 @@ class OpenRouterProviderPlugin(ProviderPluginBase[OpenRouterPluginSettings]):
                 ("logprobs", "top_logprobs"),
                 reason="top_logprobs_requires_logprobs_true",
             )
+        if WEB_SEARCH_EXCLUDED_DOMAINS_PARAM in body and body.get(WEB_SEARCH_PARAM) is not True:
+            raise IncompatibleParametersError(
+                (WEB_SEARCH_PARAM, WEB_SEARCH_EXCLUDED_DOMAINS_PARAM),
+                reason="web_search_excluded_domains_requires_web_search_true",
+            )
 
     def chat_parameter_tools(
         self, *, model: str, auth_type: AuthMode | None = None
@@ -258,7 +268,15 @@ class OpenRouterProviderPlugin(ProviderPluginBase[OpenRouterPluginSettings]):
                 source=LOCAL_SOURCE,
             )
             + direct_parameter_observations(
-                ("response_format", "n", "logprobs", "top_logprobs"), source=LOCAL_SOURCE
+                (
+                    "response_format",
+                    "n",
+                    "logprobs",
+                    "top_logprobs",
+                    "web_search",
+                    "web_search_excluded_domains",
+                ),
+                source=LOCAL_SOURCE,
             )
         )
 
@@ -347,6 +365,7 @@ class OpenRouterProviderPlugin(ProviderPluginBase[OpenRouterPluginSettings]):
         # discard an accepted price ceiling or data policy. A fresh dict per request
         # keeps one caller from mutating the policy the next one gets.
         out["provider"] = build_provider_policy(out.pop("provider", None))
+        apply_web_search(out, self.settings)
         return out
 
     def global_cache_projection(self, body: dict[str, Any]) -> dict[str, Any] | CacheBypass:

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/settings.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/settings.py
@@ -48,6 +48,27 @@ def is_valid_upstream_model_id(value: object) -> bool:
     return isinstance(value, str) and _UPSTREAM_MODEL_ID_RE.fullmatch(value) is not None
 
 
+# OME-712: OpenRouter's implicit-search model variant. It is a syntactically VALID
+# ``:variant`` (D8 accepts it), so nothing else in this module refuses it — it needs its
+# own predicate.
+ONLINE_VARIANT_SUFFIX = ":online"
+
+
+def is_online_variant(model: str) -> bool:
+    """True for OpenRouter's implicit web-search model variant.
+
+    ONE predicate for two call sites that must never disagree: ``prepare_chat_body``
+    REFUSES such a model (search is a provider-neutral Gateway parameter, and this suffix
+    is a second route around it), and the global-cache projection BYPASSES it. Both are
+    required, because the cache is consulted before dispatch — a guard only on the
+    dispatch path would still let a stored entry answer 200 for a refused request.
+
+    Suffix-only, so it answers for a gateway id and its upstream remainder alike:
+    ``prepare_chat_body`` holds the former and the projection the latter.
+    """
+    return model.endswith(ONLINE_VARIANT_SUFFIX)
+
+
 def _default_model_slugs() -> list[str]:
     """URL4 leaf seeds in gateway form — recommended bootstrap metadata (D8).
 

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/settings.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/settings.py
@@ -51,13 +51,32 @@ def is_valid_upstream_model_id(value: object) -> bool:
 def _default_model_slugs() -> list[str]:
     """URL4 leaf seeds in gateway form — recommended bootstrap metadata (D8).
 
-    All three were present in the live OpenRouter catalog on 2026-07-15;
-    re-check at release. Never treat this list as an authorization boundary.
+    All were present in the live OpenRouter catalog on 2026-08-05; re-check at release. Never
+    treat this list as an authorization boundary.
+
+    Validation here is purely SYNTACTIC (`is_valid_upstream_model_id`, D8) — nothing checks a
+    slug against the live catalog, so a typo in one of these surfaces as a dispatch failure
+    inside a user's expression, not at boot. Re-checking at release is the only guard.
     """
     return [
         "openrouter/anthropic/claude-fable-5",
+        "openrouter/anthropic/claude-haiku-4.5",
         "openrouter/openai/gpt-5.5",
         "openrouter/anthropic/claude-opus-4.8",
+        # AIDEV-NOTE: the DRACO benchmark judge. arXiv:2602.11685 §4.2 PINS it, and the
+        # benchmarks repo warns that a different judge materially changes the scores — so it is
+        # seeded here rather than left to a deployment. `apps/url4-cloud/url4.toml` declares the
+        # matching route; `test_declared_models_match_aigateway.py` fails if the two drift.
+        "openrouter/google/gemini-3.1-pro-preview",
+        # The remaining DRACO candidate lineup, also used by the Fusion and
+        # CorrectiveEnsemble examples. These must be real gateway seeds: merely adding them to
+        # a dev environment makes catalog checks pass while execution still fails elsewhere.
+        # All were present in the live OpenRouter catalog on 2026-08-05; re-check at release.
+        "openrouter/google/gemini-3-flash-preview",
+        "openrouter/moonshotai/kimi-k2.6",
+        "openrouter/moonshotai/kimi-k3",
+        "openrouter/deepseek/deepseek-v4-pro",
+        "openrouter/qwen/qwen3.6-plus",
     ]
 
 

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/settings.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/settings.py
@@ -108,6 +108,11 @@ class OpenRouterPluginSettings(PluginSettings):
     enabled: bool = False
     default_models: list[str] = Field(default_factory=_default_model_slugs)
     validation_model: str = "openrouter/openrouter/free"
+    # Domains this deployment asks OpenRouter search to exclude for every caller. A caller's own
+    # list is UNIONed with this and can never remove an operator entry. Actual support varies by
+    # upstream model/engine; protocols needing hard exclusion must select a compatible route.
+    # Empty by default: inventing policy here would silently shape everyone's retrieval.
+    web_search_excluded_domains: list[str] = Field(default_factory=list)
 
     @field_validator("default_models")
     @classmethod

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/web_search.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/web_search.py
@@ -1,0 +1,54 @@
+"""Translate Gateway web-search intent into OpenRouter's owned plugin envelope.
+
+Callers never submit OpenRouter's extensible ``plugins`` object. They submit bounded standard
+parameters, and this module assigns the native request shape documented at
+https://openrouter.ai/docs/guides/features/plugins/web-search.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+WEB_SEARCH_PARAM = "web_search"
+WEB_SEARCH_EXCLUDED_DOMAINS_PARAM = "web_search_excluded_domains"
+
+EXCLUDE_DOMAINS_KEY = "exclude_domains"
+"""OpenRouter web-plugin spelling; its server-tool surface uses a different field name."""
+
+_WEB_SEARCH_POLICY: dict[str, object] = {"id": "web", "engine": "native"}
+
+
+class WebSearchSettings(Protocol):
+    """The deployment policy needed to prepare an OpenRouter request."""
+
+    web_search_excluded_domains: list[str]
+
+
+def apply_web_search(body: dict[str, Any], settings: WebSearchSettings) -> None:
+    """Consume standard fields and assign OpenRouter's web-plugin envelope.
+
+    Deployment and caller exclusions are unioned, so a caller cannot remove an operator's
+    requested exclusions. Upstream support remains model/engine-specific; a benchmark requiring
+    hard exclusion must choose a compatible Engine route.
+    """
+    wanted = body.pop(WEB_SEARCH_PARAM, None)
+    caller_excluded = body.pop(WEB_SEARCH_EXCLUDED_DOMAINS_PARAM, None) or []
+    if wanted is not True:
+        return
+
+    excluded = sorted({*settings.web_search_excluded_domains, *caller_excluded})
+    plugin = dict(_WEB_SEARCH_POLICY)
+    if excluded:
+        plugin[EXCLUDE_DOMAINS_KEY] = excluded
+
+    # Assignment, never merge: caller-supplied plugin envelopes are refused by classification.
+    body["plugins"] = [plugin]
+
+
+__all__ = [
+    "EXCLUDE_DOMAINS_KEY",
+    "WEB_SEARCH_EXCLUDED_DOMAINS_PARAM",
+    "WEB_SEARCH_PARAM",
+    "WebSearchSettings",
+    "apply_web_search",
+]

--- a/apps/aigateway/src/aigateway/routes/providers.py
+++ b/apps/aigateway/src/aigateway/routes/providers.py
@@ -1,0 +1,33 @@
+"""Credential-provider discovery derived from the loaded plugin registry."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+
+from ..core.auth.middleware import CurrentAccount
+
+router = APIRouter()
+
+
+@router.get("/v1/providers")
+async def list_providers(request: Request, _current: CurrentAccount) -> dict[str, object]:
+    """List enabled model providers whose credentials a caller can manage."""
+
+    rows: list[dict[str, object]] = []
+    for plugin in request.app.state.providers.all():
+        auth_methods = tuple(method for method in plugin.available_auth_modes() if method != "none")
+        if not auth_methods or not plugin.register_models():
+            continue
+        rows.append(
+            {
+                "object": "provider",
+                "id": plugin.custom_llm_provider,
+                "display_name": plugin.provider_display_name,
+                "auth_methods": list(auth_methods),
+            }
+        )
+    rows.sort(key=lambda row: str(row["id"]))
+    return {"object": "list", "data": rows}
+
+
+__all__ = ["router"]

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_dispatch.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_dispatch.py
@@ -19,12 +19,6 @@ from aigateway.plugins.openrouter_provider import plugin as openrouter_plugin_mo
 from aigateway.plugins.openrouter_provider.plugin import OpenRouterProviderPlugin
 from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSettings
 
-_SEEDS = [
-    "openrouter/anthropic/claude-fable-5",
-    "openrouter/openai/gpt-5.5",
-    "openrouter/anthropic/claude-opus-4.8",
-]
-
 
 def _plugin(*, enabled: bool) -> OpenRouterProviderPlugin:
     return OpenRouterProviderPlugin(OpenRouterPluginSettings(enabled=enabled))
@@ -46,7 +40,7 @@ def test_register_models_empty_when_disabled() -> None:
 
 def test_register_models_seeds_when_enabled() -> None:
     entries = _plugin(enabled=True).register_models()
-    assert [entry.model_name for entry in entries] == _SEEDS
+    assert [entry.model_name for entry in entries] == OpenRouterPluginSettings().default_models
     for entry in entries:
         assert entry.litellm_params == {"model": entry.model_name}
 

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_settings.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_settings.py
@@ -14,10 +14,21 @@ from aigateway.plugins.openrouter_provider.settings import (
     is_valid_upstream_model_id,
 )
 
+# Independent protocol pin: this is the single source in the test suite that fails when the
+# canonical benchmark seed set changes. Dispatch tests consume the configured defaults so every
+# newly pinned seed is exercised without copying this list again.
 _SEEDS = [
     "openrouter/anthropic/claude-fable-5",
+    "openrouter/anthropic/claude-haiku-4.5",
     "openrouter/openai/gpt-5.5",
     "openrouter/anthropic/claude-opus-4.8",
+    "openrouter/google/gemini-3.1-pro-preview",
+    # The remaining DRACO / IFEval small-model candidate lineup.
+    "openrouter/google/gemini-3-flash-preview",
+    "openrouter/moonshotai/kimi-k2.6",
+    "openrouter/moonshotai/kimi-k3",
+    "openrouter/deepseek/deepseek-v4-pro",
+    "openrouter/qwen/qwen3.6-plus",
 ]
 
 
@@ -25,7 +36,7 @@ def test_enabled_defaults_false() -> None:
     assert OpenRouterPluginSettings().enabled is False
 
 
-def test_default_models_are_the_three_seeds() -> None:
+def test_default_models_are_exactly_the_declared_seeds() -> None:
     assert OpenRouterPluginSettings().default_models == _SEEDS
 
 

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_web_plugin.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_web_plugin.py
@@ -20,11 +20,14 @@ Gateway's pinned LiteLLM/provider path; it is not a compatibility fallback for t
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
 from aigateway.core.parameter_projection import IncompatibleParametersError
+from aigateway.plugins.openrouter_provider import plugin as openrouter_plugin_module
 from aigateway.plugins.openrouter_provider.parameters import (
     openrouter_chat_parameter_rules,
     openrouter_chat_parameter_tools,
@@ -37,6 +40,57 @@ from aigateway.plugins.openrouter_provider.web_search import (
 )
 
 _MODEL = "openrouter/google/gemini-3-flash-preview"
+_KEY = "sk-or-v1-test"
+
+
+@pytest.fixture(autouse=True)
+def _api_key_validation_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    from aigateway.core.api_key_validation import (
+        ApiKeyValidationResult,
+        ApiKeyValidationStage,
+        ApiKeyValidationState,
+    )
+    from aigateway.core.api_key_validation_service import ApiKeyValidationService
+
+    async def _valid(_self, _plugin, _provider, _api_key) -> ApiKeyValidationResult:
+        return ApiKeyValidationResult(
+            state=ApiKeyValidationState.VALID,
+            stage=ApiKeyValidationStage.READINESS,
+        )
+
+    monkeypatch.setattr(ApiKeyValidationService, "validate", _valid)
+
+
+@pytest.fixture()
+def enabled_openrouter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        openrouter_plugin_module.PLUGIN,
+        "settings",
+        OpenRouterPluginSettings(enabled=True),
+    )
+
+
+def _create_connection(client) -> None:
+    response = client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "openrouter", "label": "work-openrouter", "api_key": _KEY},
+    )
+    assert response.status_code == 201, response.text
+
+
+def _fake_acompletion(captured: dict):
+    async def fake_acompletion(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            model_dump=lambda: {"id": "or-1", "choices": [{"message": {"content": "ok"}}]}
+        )
+
+    return fake_acompletion
+
+
+def _post_chat(client, body: dict):
+    payload = {"model": _MODEL, "messages": [{"role": "user", "content": "hi"}], **body}
+    return client.post("/v1/chat/completions", json=payload)
 
 
 class _Settings:
@@ -119,9 +173,51 @@ def test_the_caller_facing_keys_never_reach_the_wire() -> None:
     assert "web_search_excluded_domains" not in out
 
 
+def test_web_search_reaches_dispatch_through_the_real_route_pipeline(
+    enabled_openrouter, credential_blobs, authenticated_client
+) -> None:
+    """Classifier, projection, provider preparation and dispatch preserve one guarded intent."""
+
+    _create_connection(authenticated_client)
+    captured: dict = {}
+    with patch("litellm.acompletion", _fake_acompletion(captured)):
+        response = _post_chat(
+            authenticated_client,
+            {
+                "web_search": True,
+                "web_search_excluded_domains": ["rubric.test"],
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    assert "web_search" not in captured
+    assert "web_search_excluded_domains" not in captured
+    assert captured["plugins"] == [
+        {"id": "web", "engine": "native", "exclude_domains": ["rubric.test"]}
+    ]
+
+
 def test_false_and_absent_both_send_no_plugin() -> None:
     assert "plugins" not in _prepared({"web_search": False})
     assert "plugins" not in _prepared({})
+
+
+def test_online_model_suffix_is_rejected_in_favour_of_the_neutral_parameter(
+    enabled_openrouter, credential_blobs, authenticated_client
+) -> None:
+    _create_connection(authenticated_client)
+
+    response = _post_chat(
+        authenticated_client,
+        {"model": "openrouter/google/gemini-3-flash-preview:online"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == {
+        "code": "unsupported_model_variant",
+        "provider": "openrouter",
+        "message": "OpenRouter ':online' is not supported; use web_search=true",
+    }
 
 
 def test_exclusions_without_web_search_fail_instead_of_becoming_a_silent_noop() -> None:

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_web_plugin.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_web_plugin.py
@@ -1,0 +1,203 @@
+"""Server-side web search: caller intent in, the provider's native envelope out.
+
+FEATURE: a caller asks OpenRouter to retrieve before answering with `web_search: true`.
+STORY: as a benchmark author, a published retrieval-bearing score was produced on the provider's
+own search; a client-side loop over a different backend is a different experiment.
+
+WHY the caller does NOT send `plugins` — OpenRouter's own spelling. `plugins` is an
+extensibility ENVELOPE: carrying arbitrary provider extensions is its whole purpose, so no
+schema can bound it without defeating it, and OME-646 removed it for exactly that reason. It
+stays refused (`test_openrouter_security`). The caller sends a BOOLEAN, which is bounded
+completely, and `prepare_chat_body` assigns the envelope from gateway-owned policy — the same
+two-layer shape `provider` already uses.
+
+WHY this landing does not advertise `tools: [{"type": "openrouter:web_search"}]` — in its
+2026-07-31 compatibility probe, that spelling returned HTTP 200 without search evidence, while
+the emitted `plugins` envelope retrieved successfully. OpenRouter now documents both surfaces,
+so enabling the server-tool form later requires fresh conformance evidence through this
+Gateway's pinned LiteLLM/provider path; it is not a compatibility fallback for this contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from aigateway.core.parameter_projection import IncompatibleParametersError
+from aigateway.plugins.openrouter_provider.parameters import (
+    openrouter_chat_parameter_rules,
+    openrouter_chat_parameter_tools,
+)
+from aigateway.plugins.openrouter_provider.plugin import OpenRouterProviderPlugin
+from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSettings
+from aigateway.plugins.openrouter_provider.web_search import (
+    EXCLUDE_DOMAINS_KEY,
+    apply_web_search,
+)
+
+_MODEL = "openrouter/google/gemini-3-flash-preview"
+
+
+class _Settings:
+    def __init__(self, excluded: list[str] | None = None) -> None:
+        self.web_search_excluded_domains = excluded or []
+
+
+def _rule(path: str):
+    for rule in openrouter_chat_parameter_rules(model=_MODEL, auth_type="api_key"):
+        if rule.request_path == path:
+            return rule
+    return None
+
+
+def _prepared(body: dict[str, Any], settings: _Settings | None = None) -> dict[str, Any]:
+    out = dict(body)
+    apply_web_search(out, settings or _Settings())
+    return out
+
+
+# --- the caller-facing contract --------------------------------------------------
+
+
+def test_web_search_is_enabled_as_a_plain_boolean() -> None:
+    """A boolean is bounded COMPLETELY — there is no nested JSON for a caller to smuggle."""
+    rule = _rule("web_search")
+
+    assert rule is not None
+    assert rule.parameter_schema is not None
+    assert rule.parameter_schema.type == "boolean"
+
+
+def test_caller_exclusions_are_a_bounded_string_array() -> None:
+    rule = _rule("web_search_excluded_domains")
+
+    assert rule is not None
+    assert rule.parameter_schema is not None
+    assert rule.parameter_schema.type == "array"
+    assert rule.parameter_schema.item_type == "string"
+
+
+def test_the_native_envelope_stays_refused_as_a_caller_path() -> None:
+    """INVARIANT: enabling web search must not re-open `plugins`. If this ever passes with a
+    rule present, a caller can hand OpenRouter arbitrary extensions again."""
+    assert _rule("plugins") is None
+
+
+def test_the_routing_controls_ome_646_removed_stay_removed() -> None:
+    for path in ("provider", "route", "models"):
+        assert _rule(path) is None, path
+
+
+def test_unproven_server_tool_types_stay_unadvertised() -> None:
+    """`tools_schema` gates each item's `type`, so leaving these out is what makes a caller
+    fail closed until this Gateway path has current conformance evidence for them."""
+    enabled = {
+        tool.tool_type
+        for tool in openrouter_chat_parameter_tools(model=_MODEL, auth_type="api_key")
+    }
+
+    assert "openrouter:web_search" not in enabled
+    assert "openrouter:web_fetch" not in enabled
+    assert "function" in enabled
+
+
+# --- the translation -------------------------------------------------------------
+
+
+def test_true_becomes_the_providers_web_plugin() -> None:
+    out = _prepared({"web_search": True})
+
+    assert out["plugins"] == [{"id": "web", "engine": "native"}]
+
+
+def test_the_caller_facing_keys_never_reach_the_wire() -> None:
+    """Neither is an OpenRouter field; leaving one on the body sends an unknown parameter."""
+    out = _prepared({"web_search": True, "web_search_excluded_domains": ["a.test"]})
+
+    assert "web_search" not in out
+    assert "web_search_excluded_domains" not in out
+
+
+def test_false_and_absent_both_send_no_plugin() -> None:
+    assert "plugins" not in _prepared({"web_search": False})
+    assert "plugins" not in _prepared({})
+
+
+def test_exclusions_without_web_search_fail_instead_of_becoming_a_silent_noop() -> None:
+    """An accepted parameter must have an effect or fail closed; silently dropping a valid
+    exclusion list would make a caller believe its retrieval policy was active when no search
+    was requested at all."""
+    plugin = OpenRouterProviderPlugin(OpenRouterPluginSettings(enabled=True))
+
+    with pytest.raises(
+        IncompatibleParametersError,
+        match="web_search_excluded_domains_requires_web_search_true",
+    ):
+        plugin.validate_chat_parameter_combination(
+            {"web_search_excluded_domains": ["a.test"]},
+            model=_MODEL,
+            auth_mode="api_key",
+        )
+
+
+# --- the exclusion union ---------------------------------------------------------
+
+
+def test_deployment_exclusions_apply_without_the_caller_asking() -> None:
+    out = _prepared({"web_search": True}, _Settings(["rubric.test"]))
+
+    assert out["plugins"][0]["exclude_domains"] == ["rubric.test"]
+
+
+def test_caller_exclusions_are_added_to_the_deployments() -> None:
+    out = _prepared(
+        {"web_search": True, "web_search_excluded_domains": ["extra.test"]},
+        _Settings(["rubric.test"]),
+    )
+
+    assert out["plugins"][0]["exclude_domains"] == ["extra.test", "rubric.test"]
+
+
+def test_a_caller_cannot_drop_a_deployment_exclusion() -> None:
+    """INVARIANT: UNION, never substitution. The motivating case is a benchmark candidate that
+    must not retrieve the rubric it is graded against — a guard a caller can shorten is not a
+    guard, and the caller supplying its own list is exactly when it would try."""
+    out = _prepared(
+        {"web_search": True, "web_search_excluded_domains": ["unrelated.test"]},
+        _Settings(["rubric.test"]),
+    )
+
+    assert "rubric.test" in out["plugins"][0]["exclude_domains"]
+
+
+def test_no_exclusions_omits_the_field_rather_than_sending_an_empty_list() -> None:
+    """An empty list reads to the provider as 'exclude nothing' rather than 'use your default'."""
+    out = _prepared({"web_search": True})
+
+    # Both spellings: the emitted one must be absent, and the historical typo must never return.
+    assert EXCLUDE_DOMAINS_KEY not in out["plugins"][0]
+    assert "excluded_domains" not in out["plugins"][0]
+
+
+def test_the_wire_key_is_openrouters_spelling() -> None:
+    """INVARIANT: the blocklist rides `exclude_domains`. `excluded_domains` is IGNORED.
+
+    This is pinned by name because no status code can catch it. OpenRouter does not validate the
+    `plugins` envelope — an invented key returns HTTP 200 exactly like a real one — so the wrong
+    spelling produced a normal answer, a normal bill, and no exclusion at all, from `26858fc1`
+    until 2026-07-31.
+
+    MEASURED live on both engines: `exclude_domains` drove blocked-host citations to zero, while
+    `excluded_domains` left them identical to baseline. Excluding a single host removed exactly
+    that host, which is what rules out search noise as the explanation.
+
+    A benchmark candidate that can reach its own rubric scores HIGHER, so this failure never looks
+    like a bug from the outside. If a future change renames this key, this test fails loudly
+    instead of the guard going quiet again.
+    """
+    out = _prepared({"web_search": True}, _Settings(["rubric.test"]))
+
+    assert EXCLUDE_DOMAINS_KEY == "exclude_domains"
+    assert out["plugins"][0]["exclude_domains"] == ["rubric.test"]
+    assert "excluded_domains" not in out["plugins"][0]

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_web_plugin.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_web_plugin.py
@@ -119,6 +119,7 @@ def test_web_search_is_enabled_as_a_plain_boolean() -> None:
     rule = _rule("web_search")
 
     assert rule is not None
+    assert rule.cache_behavior == "bypass"
     assert rule.parameter_schema is not None
     assert rule.parameter_schema.type == "boolean"
 
@@ -127,6 +128,7 @@ def test_caller_exclusions_are_a_bounded_string_array() -> None:
     rule = _rule("web_search_excluded_domains")
 
     assert rule is not None
+    assert rule.cache_behavior == "bypass"
     assert rule.parameter_schema is not None
     assert rule.parameter_schema.type == "array"
     assert rule.parameter_schema.item_type == "string"

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_web_search_cache.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_web_search_cache.py
@@ -1,0 +1,372 @@
+"""OME-712 — server-side web search meets the OME-305 global exact-request cache.
+
+FEATURE: provider-neutral `web_search`, and one globally shared exact-request cache.
+The two landed independently and interact in exactly two places, both of which are
+wrong-hit risks rather than performance ones.
+
+STORY: as a benchmark operator I set a deployment blocklist so no run retrieves from
+the domains under test. No caller, and no stored cache row, may hand me an answer that
+was retrieved without it.
+
+INVARIANT under test (1): a request carrying either search parameter is UNCACHEABLE.
+The dispatched envelope's `exclude_domains` is the union of the caller's list and a
+DEPLOYMENT setting, and the cache projection is contractually forbidden from reading
+settings — so that union can never reach the key. Ruling 34 calls this out by name:
+identical bodies, one key, two different upstream calls. Both rules therefore declare
+`cache_behavior="bypass"`, and these tests prove the declaration actually fires.
+
+INVARIANT under test (2): the `plugins` envelope is emitted ONLY when
+`web_search is True`. That is what keeps invariant (1) sufficient — if the envelope
+could appear on any other condition, a CACHEABLE request would carry an unprojected
+output-affecting field and `global_cache`'s `prepared` would silently stop describing
+what this boundary sends.
+
+INVARIANT under test (3): `:online` — OpenRouter's implicit-search model variant — is
+refused at dispatch AND bypassed at projection. The refusal alone is not enough: the
+cache is read before `prepare_chat_body` runs, so a stored row would answer 200 for a
+request the gateway must refuse. This is the same class as the routing-policy bypass
+and is pinned the same way.
+
+AIDEV-NOTE: these are deliberately NOT key-difference tests. A key-difference test is
+what plan §10 owes a KEYED parameter; the obligation for a BYPASS parameter is the
+opposite — prove no key is produced at all — plus a non-vacuity proof that the same
+helper does produce one for a bare request, so a blanket bypass cannot pass by
+accident.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Literal, cast
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from aigateway.core.cache_ports import PROJECTION_BYPASS_REASON, CacheBypass
+from aigateway.core.request_cache import RequestCacheWrite
+from aigateway.core.request_cache.global_keys import BYPASS_DECLARED, build_global_cache_key
+from aigateway.plugins.openrouter_provider import plugin as openrouter_plugin_module
+from aigateway.plugins.openrouter_provider.plugin import OpenRouterProviderPlugin
+from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSettings
+
+_MODEL = "openrouter/anthropic/claude-fable-5"
+_ONLINE_MODEL = f"{_MODEL}:online"
+_MESSAGES: list[Any] = [{"role": "user", "content": "what happened today?"}]
+_KEY = "sk-or-v1-test"
+
+_WriteStatus = Literal["stored", "race_lost", "not_stored"]
+
+
+def _plugin(**settings: Any) -> OpenRouterProviderPlugin:
+    return OpenRouterProviderPlugin(OpenRouterPluginSettings(enabled=True, **settings))
+
+
+def _body(**overrides: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {"model": _MODEL, "messages": [dict(m) for m in _MESSAGES]}
+    body.update(overrides)
+    return body
+
+
+def _built(plugin: OpenRouterProviderPlugin | None = None, **overrides: Any) -> Any:
+    """The real key builder, wired exactly as the route wires it."""
+    plugin = plugin or _plugin()
+    return build_global_cache_key(
+        provider="openrouter",
+        body=_body(**overrides),
+        rules=plugin.chat_parameter_rules(model=_MODEL, auth_type=None),
+        projection=plugin.global_cache_projection,
+        provider_auth_modes=plugin.available_auth_modes(),
+    )
+
+
+def _bypass_reason(**overrides: Any) -> str:
+    built = _built(**overrides)
+    assert isinstance(built, CacheBypass), built
+    return built.reason
+
+
+# --- R1: a search request never reaches the key -----------------------------------
+
+
+def test_a_web_search_request_is_never_keyed() -> None:
+    """THE test for the bypass decision.
+
+    If this ever returns a key, the deployment blocklist — which shapes the dispatched
+    request and cannot reach that key — becomes a wrong-hit class: an answer retrieved
+    WITHOUT an operator's exclusions served to a deployment that requires them.
+    """
+    assert _bypass_reason(web_search=True) == BYPASS_DECLARED
+
+
+def test_caller_exclusions_alone_are_never_keyed() -> None:
+    """The second field must bypass on its own, not by leaning on the first.
+
+    ``validate_chat_parameter_combination`` refuses exclusions without
+    ``web_search: true`` — but that hook runs on the MISS path only, well after the
+    lookup. The cache stage never consults it, so this field has to carry its own
+    disposition.
+    """
+    assert _bypass_reason(web_search_excluded_domains=["example.test"]) == BYPASS_DECLARED
+
+
+def test_both_fields_together_bypass_for_the_declared_reason() -> None:
+    # Not the projection failing, not an unknown parameter — the reviewed declaration.
+    assert _bypass_reason(web_search=True, web_search_excluded_domains=["a.test"]) == (
+        BYPASS_DECLARED
+    )
+
+
+def test_the_deployment_blocklist_cannot_smuggle_itself_into_a_key() -> None:
+    """Two deployments, same body, different operator policy: neither may be keyed.
+
+    This is the concrete shape of ruling 34's hazard. Were these keyed, both plugins
+    would produce the SAME hash while dispatching different `exclude_domains` — so one
+    deployment would be served the other's retrieval.
+    """
+    for plugin in (_plugin(), _plugin(web_search_excluded_domains=["rubric.test"])):
+        built = _built(plugin, web_search=True)
+        assert isinstance(built, CacheBypass), built
+        assert built.reason == BYPASS_DECLARED
+
+
+# --- R4: the bypass is scoped to search traffic -----------------------------------
+
+
+def test_a_request_without_search_still_gets_a_key() -> None:
+    """Non-vacuity for every bypass assertion above, and the blast-radius proof.
+
+    A blanket bypass would satisfy all of R1 while quietly destroying the cache this
+    provider just gained.
+    """
+    built = _built()
+    assert not isinstance(built, CacheBypass), built
+    assert built.key_hash
+
+
+def test_an_ordinary_keyed_parameter_is_unaffected() -> None:
+    built = _built(temperature=0.4)
+    assert not isinstance(built, CacheBypass), built
+
+
+# --- R3: the invariant the bypass decision rests on -------------------------------
+
+
+@pytest.mark.parametrize("value", [False, None, 0, "true", "True", [], {}])
+def test_only_a_literal_true_emits_the_provider_envelope(value: Any) -> None:
+    """No cacheable request may carry a `plugins` block.
+
+    INVARIANT: the envelope is emitted on `web_search is True` and nothing else. Every
+    body that produces one bypasses the cache, so `global_cache`'s `prepared` stays a
+    COMPLETE description of what this boundary sends. Widen this condition — an
+    is-truthy test, a deployment default that turns search on — and the projection
+    silently becomes incomplete while every test above still passes.
+    """
+    prepared = _plugin(web_search_excluded_domains=["rubric.test"]).prepare_chat_body(
+        _body(web_search=value)
+    )
+    assert "plugins" not in prepared
+
+
+def test_a_literal_true_does_emit_the_envelope() -> None:
+    # The other half: the parametrized test above must not be passing because the
+    # envelope is never emitted at all.
+    prepared = _plugin().prepare_chat_body(_body(web_search=True))
+    assert prepared["plugins"] == [{"id": "web", "engine": "native"}]
+
+
+def test_a_request_with_no_search_field_projects_without_an_envelope() -> None:
+    produced = _plugin(web_search_excluded_domains=["rubric.test"]).global_cache_projection(_body())
+    assert not isinstance(produced, CacheBypass), produced
+    assert "plugins" not in produced["prepared"]
+
+
+# --- R2: the :online variant is refused ahead of the cache ------------------------
+
+
+def test_an_online_model_is_bypassed_by_the_projection() -> None:
+    """The guard that has to sit AHEAD of the cache read.
+
+    ``prepare_chat_body`` refuses `:online` (see the dual-path pin below), but it runs
+    long after the lookup. Without this bypass a row stored before that refusal landed
+    would answer 200 for a request the gateway now refuses — retrieval with neither the
+    neutral parameter nor the deployment exclusions.
+    """
+    produced = _plugin().global_cache_projection(_body(model=_ONLINE_MODEL))
+    assert isinstance(produced, CacheBypass), produced
+    assert produced.reason == PROJECTION_BYPASS_REASON
+
+
+def test_an_online_model_is_refused_at_dispatch() -> None:
+    # The dual-path pin: the projection BYPASSES where dispatch RAISES. One predicate
+    # answers both, so the two cannot drift into disagreeing.
+    with pytest.raises(HTTPException) as excinfo:
+        _plugin().prepare_chat_body(_body(model=_ONLINE_MODEL))
+    assert excinfo.value.status_code == 400
+    assert cast(dict, excinfo.value.detail)["code"] == "unsupported_model_variant"
+
+
+def test_an_online_model_produces_no_key() -> None:
+    built = _built(model=_ONLINE_MODEL)
+    assert isinstance(built, CacheBypass), built
+
+
+# --- R5: the published contract states the disposition ----------------------------
+
+
+def test_both_search_paths_publish_a_bypass_disposition() -> None:
+    """A caller reading the parameter contract must see that search is not cached."""
+    behaviors = {
+        rule.request_path: rule.cache_behavior
+        for rule in _plugin().chat_parameter_rules(model=_MODEL, auth_type="api_key")
+    }
+    assert behaviors["web_search"] == "bypass"
+    assert behaviors["web_search_excluded_domains"] == "bypass"
+
+
+def test_neither_search_path_appears_in_the_keyed_set() -> None:
+    # Guards against a future promotion to ``keyed`` landing without the design work
+    # ruling 34 requires — see the AIDEV-NOTE in ``parameters.py``.
+    keyed = {
+        rule.request_path
+        for rule in _plugin().chat_parameter_rules(model=_MODEL, auth_type="api_key")
+        if rule.cache_behavior == "keyed"
+    }
+    assert "web_search" not in keyed
+    assert "web_search_excluded_domains" not in keyed
+
+
+# --- R6: the same behaviour through the real route --------------------------------
+
+
+class _Store:
+    """Records every probe, read and write so a bypass can be proven non-vacuous."""
+
+    def __init__(self) -> None:
+        self.probes = 0
+        self.reads: list[str] = []
+        self.rows: dict[str, dict[str, Any]] = {}
+
+    def cache_available(self) -> bool:
+        self.probes += 1
+        return True
+
+    async def get(self, key_hash: str) -> dict[str, Any] | None:
+        self.reads.append(key_hash)
+        return self.rows.get(key_hash)
+
+    async def set_if_absent(self, entry: RequestCacheWrite) -> _WriteStatus:
+        self.rows[entry.key_hash] = entry.response
+        return "stored"
+
+
+@pytest.fixture(autouse=True)
+def _api_key_validation_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    from aigateway.core.api_key_validation import (
+        ApiKeyValidationResult,
+        ApiKeyValidationStage,
+        ApiKeyValidationState,
+    )
+    from aigateway.core.api_key_validation_service import ApiKeyValidationService
+
+    async def _valid(_self, _plugin, _provider, _api_key) -> ApiKeyValidationResult:
+        return ApiKeyValidationResult(
+            state=ApiKeyValidationState.VALID,
+            stage=ApiKeyValidationStage.READINESS,
+        )
+
+    monkeypatch.setattr(ApiKeyValidationService, "validate", _valid)
+
+
+@pytest.fixture
+def _cache_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AIGW_REQUEST_CACHE_ENABLED", "true")
+
+
+@pytest.fixture
+def cached_client(_cache_env, authenticated_client: TestClient) -> TestClient:
+    return authenticated_client
+
+
+def _enable_openrouter(monkeypatch: pytest.MonkeyPatch, **settings: Any) -> None:
+    monkeypatch.setattr(
+        openrouter_plugin_module.PLUGIN,
+        "settings",
+        OpenRouterPluginSettings(enabled=True, **settings),
+    )
+
+
+def _create_connection(client: TestClient) -> None:
+    response = client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "openrouter", "label": "work-openrouter", "api_key": _KEY},
+    )
+    assert response.status_code == 201, response.text
+
+
+def _fake_acompletion(calls: list[dict[str, Any]]):
+    async def fake_acompletion(**kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(
+            model_dump=lambda: {"id": "or-1", "choices": [{"message": {"content": "ok"}}]}
+        )
+
+    return fake_acompletion
+
+
+def test_a_web_search_request_bypasses_the_cache_through_the_real_route(
+    monkeypatch: pytest.MonkeyPatch, credential_blobs, cached_client: TestClient
+) -> None:
+    """End to end: the disposition is wired, not merely declared.
+
+    Asserts store ACTIVITY as well as the published headers — a correct header with a
+    stage that never ran would be a vacuous pass, and the probe count is what
+    distinguishes the two.
+    """
+    _enable_openrouter(monkeypatch, web_search_excluded_domains=["rubric.test"])
+    _create_connection(cached_client)
+    store = _Store()
+    cast(Any, cached_client.app).state.request_cache_store = store
+    calls: list[dict[str, Any]] = []
+
+    with patch("litellm.acompletion", _fake_acompletion(calls)):
+        response = cached_client.post(
+            "/v1/chat/completions",
+            json={"model": _MODEL, "messages": _MESSAGES, "web_search": True},
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.headers["X-AIGW-Cache"] == "bypass"
+    assert response.headers["X-AIGW-Cache-Reason"] == BYPASS_DECLARED
+    # The stage RAN (so the assertions below are not vacuous) and still read nothing.
+    assert store.probes >= 1
+    assert store.reads == []
+    assert store.rows == {}
+    # The request was really dispatched, carrying the union of both exclusion lists.
+    assert len(calls) == 1
+    assert calls[0]["plugins"] == [
+        {"id": "web", "engine": "native", "exclude_domains": ["rubric.test"]}
+    ]
+
+
+def test_a_bare_request_still_uses_the_cache_through_the_real_route(
+    monkeypatch: pytest.MonkeyPatch, credential_blobs, cached_client: TestClient
+) -> None:
+    # Blast-radius proof at the route level: the bypass above is about the search
+    # fields, not about OpenRouter losing the cache it just gained.
+    _enable_openrouter(monkeypatch, web_search_excluded_domains=["rubric.test"])
+    _create_connection(cached_client)
+    store = _Store()
+    cast(Any, cached_client.app).state.request_cache_store = store
+    calls: list[dict[str, Any]] = []
+
+    with patch("litellm.acompletion", _fake_acompletion(calls)):
+        response = cached_client.post(
+            "/v1/chat/completions",
+            json={"model": _MODEL, "messages": _MESSAGES},
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.headers["X-AIGW-Cache"] == "miss"
+    assert store.reads != []

--- a/apps/aigateway/tests/unit/test_providers_route.py
+++ b/apps/aigateway/tests/unit/test_providers_route.py
@@ -1,0 +1,37 @@
+"""Credential-provider discovery derived from the loaded plugin registry."""
+
+from __future__ import annotations
+
+
+def test_providers_lists_loaded_credential_capabilities(authenticated_client) -> None:
+    resp = authenticated_client.get("/v1/providers")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["object"] == "list"
+    providers = {row["id"]: row for row in body["data"]}
+    assert providers["anthropic"] == {
+        "object": "provider",
+        "id": "anthropic",
+        "display_name": "Anthropic",
+        "auth_methods": ["api_key", "oauth"],
+    }
+    assert providers["codex"]["auth_methods"] == ["oauth"]
+    assert providers["gemini-cli"]["display_name"] == "Gemini CLI"
+    assert "ollama" not in providers
+    assert "openrouter" not in providers
+
+
+def test_providers_requires_auth(client) -> None:
+    resp = client.get("/v1/providers")
+
+    assert resp.status_code == 401
+
+
+def test_providers_is_available_when_local_auth_is_explicitly_disabled(client) -> None:
+    client.app.state.settings.auth_mode = "disabled"
+
+    resp = client.get("/v1/providers")
+
+    assert resp.status_code == 200
+    assert resp.json()["object"] == "list"


### PR DESCRIPTION
## Summary

- register the OpenRouter model seeds required by the current benchmark and notebook flows
- expose enabled credential providers from the loaded plugin registry
- accept bounded provider-neutral web-search intent and apply Gateway-owned OpenRouter policy
- reject the unadvertised `:online` variant so it cannot bypass deployment domain exclusions

## Architecture

The caller supplies `web_search` and optional excluded domains, never OpenRouter's extensible plugin envelope. The OpenRouter adapter owns the private wire representation and unions caller exclusions with deployment policy.

This deliberately preserves the existing Engine routing decision: verified provider-side retrieval remains provider-side, while routes that cannot enforce DRACO's blocklist continue to use the Runner-owned Tavily loop. This PR does not change benchmark grading or retrieval routing.

## Verification

- `pytest -q`: 2671 passed, 40 skipped
- OpenRouter provider suite: 743 passed
- `pyright`: 0 errors
- Ruff check and format verification passed

Refs: OME-712
