### PR TITLE
feat(url4-cloud): proxy model parameter contracts

### DIFF
--- a/apps/url4-cloud/src/url4_cloud/app.py
+++ b/apps/url4-cloud/src/url4_cloud/app.py
@@ -1,8 +1,8 @@
 """The FastAPI composition root for the url4-cloud App.
 
-Builds the App instance: wires the REST, catalog, WS, and ops routers, installs auth/problem
-handlers and the metrics middleware, and assembles the injectable adapters (event stream, job
-runner, catalog service) that tests substitute for the production ones built here from `Settings`.
+Builds the App instance: wires the REST, model discovery, WS, and ops routers, installs
+auth/problem handlers and the metrics middleware, and assembles the injectable adapters that
+tests substitute for the production ones built here from `Settings`.
 """
 
 from __future__ import annotations
@@ -18,6 +18,7 @@ from url4_cloud.adapters.factory import build_job_runner
 from url4_cloud.auth import Clock, install_problem_handlers
 from url4_cloud.catalog import build_catalog_service
 from url4_cloud.catalog.cache import CatalogService
+from url4_cloud.catalog.port import ModelParameterSource
 from url4_cloud.config import INSECURE_DEFAULT_JWT_SECRET, Settings
 from url4_cloud.metrics import MetricsMiddleware, build_metrics, register_catalog_metrics
 from url4_cloud.ops import router as ops_router
@@ -45,6 +46,7 @@ def create_app(
     clock: Clock | None = None,
     interest: SubscriberGate | None = None,
     catalog: CatalogService | None = None,
+    model_parameters: ModelParameterSource | None = None,
 ) -> FastAPI:
     """Build the App instance.
 
@@ -57,6 +59,7 @@ def create_app(
     app.state.stream = stream
     app.state.job_runner = job_runner
     app.state.catalog = catalog
+    app.state.model_parameters = model_parameters
     app.state.metrics = build_metrics()
     # WHY: pass a getter, not `catalog` directly — the collector re-reads app.state.catalog on
     # every /metrics scrape rather than capturing the value built here.
@@ -118,7 +121,13 @@ def create_app_from_env() -> FastAPI:  # pragma: no cover - env/NATS wiring (INF
             "URL4_CLOUD_RUNNER is 'none' — this App bridges NATS but cannot schedule runs"
         )
     catalog = build_catalog_service(settings)
-    app = create_app(settings, stream=stream, job_runner=job_runner, catalog=catalog)
+    app = create_app(
+        settings,
+        stream=stream,
+        job_runner=job_runner,
+        catalog=catalog,
+        model_parameters=catalog.model_parameter_source if catalog is not None else None,
+    )
     app.router.on_shutdown.append(stream.close)
     if catalog is not None:
         app.router.on_shutdown.append(catalog.aclose)

--- a/apps/url4-cloud/src/url4_cloud/catalog/__init__.py
+++ b/apps/url4-cloud/src/url4_cloud/catalog/__init__.py
@@ -1,9 +1,10 @@
-"""Public surface of the model-catalog subsystem.
+"""Public surface and production wiring for Engine model discovery.
 
 Re-exports the hexagonal port (``catalog/port.py``), the aigateway adapter
 (``catalog/aigateway.py``), and the caching layer (``catalog/cache.py``), and
-provides ``build_catalog_service`` — the composition root that wires an
-``AigatewayCatalogSource`` behind a ``CachedCatalog`` from ``Settings``.
+provides ``build_catalog_service`` — the composition root that wires one
+``AigatewayCatalogSource`` behind a ``CachedCatalog`` for model lists while retaining uncached
+model-detail delegation through the same client.
 """
 
 from __future__ import annotations
@@ -22,6 +23,9 @@ from url4_cloud.catalog.port import (
     CatalogUnavailable,
     Credential,
     ModelCatalog,
+    ModelParameterBadResponse,
+    ModelParameterResponse,
+    ModelParameterSource,
     compute_etag,
 )
 from url4_cloud.config import Settings
@@ -47,8 +51,10 @@ def build_catalog_service(
     if not base_url:
         return None
     client = client_factory(base_url)
+    source = AigatewayCatalogSource(client)
     return CachedCatalog(
-        AigatewayCatalogSource(client),
+        source,
+        parameter_source=source,
         ttl_s=settings.models_cache_ttl_s,
         stale_max_s=settings.models_cache_stale_max_s,
         error_backoff_s=settings.models_cache_error_backoff_s,
@@ -70,6 +76,9 @@ __all__ = [
     "CatalogUnavailable",
     "Credential",
     "ModelCatalog",
+    "ModelParameterBadResponse",
+    "ModelParameterResponse",
+    "ModelParameterSource",
     "build_catalog_service",
     "compute_etag",
 ]

--- a/apps/url4-cloud/src/url4_cloud/catalog/aigateway.py
+++ b/apps/url4-cloud/src/url4_cloud/catalog/aigateway.py
@@ -1,14 +1,14 @@
-"""Concrete ``CatalogSource`` adapter for aigateway's ``/v1/models`` endpoint.
+"""AI Gateway adapter for model-list and profile-bound model-detail discovery.
 
-Implements the ``CatalogSource`` port (see ``catalog/port.py``) by forwarding a
-caller's credential to aigateway's model-listing endpoint and translating transport
-and validation failures into the ``CatalogError`` hierarchy.
+Implements both discovery ports in ``catalog/port.py`` with one HTTP client and one identity
+boundary. The model list is cached by its decorator; detailed parameter contracts deliberately
+pass through uncached.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Never
 
 import httpx
 
@@ -18,12 +18,18 @@ from url4_cloud.catalog.port import (
     CatalogUnavailable,
     Credential,
     ModelCatalog,
+    ModelParameterBadResponse,
+    ModelParameterResponse,
     compute_etag,
 )
 
 logger = logging.getLogger(__name__)
 
 _CATALOG_PATH = "/v1/models"
+_MODEL_PARAMETERS_PATH = "/v1/model-parameters"
+# WHY: these statuses describe caller-correctable identity, profile, or model choices. Preserve
+# their JSON verbatim; mask every server/transport failure behind the Engine's stable 502/504.
+_CALLER_CORRECTABLE_STATUSES = frozenset({400, 401, 403, 404, 409})
 
 # WHY: aigateway may refuse a credential with either 401 or 403; both are treated as
 # a bad credential (CatalogRejected, always surfaced as 401) rather than CatalogBadResponse.
@@ -31,7 +37,7 @@ _REJECTION_STATUSES = frozenset({401, 403})
 
 
 class AigatewayCatalogSource:
-    """Fetches and validates the model catalog from aigateway, per credential."""
+    """Fetch and minimally validate AI Gateway model discovery for one caller."""
 
     def __init__(self, client: httpx.AsyncClient) -> None:
         self._client = client
@@ -43,38 +49,104 @@ class AigatewayCatalogSource:
         and malformed payloads map to ``CatalogBadResponse``; a timeout maps to
         ``CatalogUnavailable``.
         """
-        response = await self._get(credential)
+        response = await self._request(
+            _CATALOG_PATH,
+            credential,
+            label="catalog",
+            bad_response=CatalogBadResponse,
+        )
         if response.status_code in _REJECTION_STATUSES:
             logger.info("aigateway refused the catalog request (status=%d)", response.status_code)
             raise CatalogRejected(CatalogRejected.detail)
         if response.status_code >= 300:
             logger.warning("aigateway catalog returned status=%d", response.status_code)
             raise CatalogBadResponse(CatalogBadResponse.detail)
-        body = self._decode(response)
+        body = self._decode_object(response)
         _validate(body)
         return ModelCatalog(body=body, etag=compute_etag(body))
 
-    async def _get(self, credential: Credential) -> httpx.Response:
-        """Issue the upstream GET, translating transport failures to ``CatalogError``."""
+    async def fetch_model_parameters(
+        self,
+        credential: Credential,
+        model: str,
+    ) -> ModelParameterResponse:
+        """Fetch one detailed model contract for the caller's profile."""
+
+        response = await self._request(
+            _MODEL_PARAMETERS_PATH,
+            credential,
+            params={"model": model},
+            label="model-parameter",
+            bad_response=ModelParameterBadResponse,
+        )
+        body = self._decode_json(
+            response,
+            bad_response=ModelParameterBadResponse,
+            label="model-parameter",
+        )
+        if response.status_code in _CALLER_CORRECTABLE_STATUSES:
+            return ModelParameterResponse(status=response.status_code, content=response.content)
+        if response.status_code >= 300:
+            raise ModelParameterBadResponse(ModelParameterBadResponse.detail)
+        _validate_model_parameters(body, model)
+        return ModelParameterResponse(status=response.status_code, content=response.content)
+
+    async def _request(
+        self,
+        path: str,
+        credential: Credential,
+        *,
+        label: str,
+        bad_response: type[CatalogBadResponse],
+        params: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        """Issue one upstream GET and translate transport failures at the adapter boundary."""
+
         try:
-            return await self._client.get(_CATALOG_PATH, headers=_headers(credential))
+            return await self._client.get(path, params=params, headers=_headers(credential))
         except httpx.TimeoutException as exc:
-            logger.warning("aigateway catalog request timed out")
+            logger.warning("aigateway %s request timed out", label)
             raise CatalogUnavailable(CatalogUnavailable.detail) from exc
         except httpx.HTTPError as exc:
-            logger.warning("aigateway catalog request failed at the transport layer: %s", exc)
-            raise CatalogBadResponse(CatalogBadResponse.detail) from exc
+            logger.warning("aigateway %s request failed at the transport layer", label)
+            raise bad_response(bad_response.detail) from exc
 
-    def _decode(self, response: httpx.Response) -> dict[str, Any]:
-        """Parse the response body as a JSON object, raising ``CatalogBadResponse`` otherwise."""
+    def _decode_json(
+        self,
+        response: httpx.Response,
+        *,
+        bad_response: type[CatalogBadResponse] = CatalogBadResponse,
+        label: str = "catalog",
+    ) -> Any:
+        """Validate one upstream body as JSON without changing the bytes returned downstream."""
+
+        # INVARIANT: decoding is inspection only. The proxy returns ``response.content`` so
+        # unknown fields and valid numbers outside Python's finite float range survive unchanged.
         try:
-            body = response.json()
+            return response.json(parse_constant=_reject_non_json_constant)
         except ValueError as exc:
-            logger.warning("aigateway catalog response was not JSON")
-            raise CatalogBadResponse(CatalogBadResponse.detail) from exc
+            logger.warning("aigateway %s response was not JSON", label)
+            raise bad_response(bad_response.detail) from exc
+
+    def _decode_object(
+        self,
+        response: httpx.Response,
+        *,
+        bad_response: type[CatalogBadResponse] = CatalogBadResponse,
+        label: str = "catalog",
+    ) -> dict[str, Any]:
+        """Parse one upstream response as a JSON object, or raise its typed failure."""
+
+        body = self._decode_json(response, bad_response=bad_response, label=label)
         if not isinstance(body, dict):
-            raise CatalogBadResponse(CatalogBadResponse.detail)
+            raise bad_response(bad_response.detail)
         return body
+
+
+def _reject_non_json_constant(value: str) -> Never:
+    """Reject JavaScript constants that Python's permissive decoder otherwise accepts."""
+
+    raise ValueError(f"{value} is not valid JSON")
 
 
 def _headers(credential: Credential) -> dict[str, str]:
@@ -103,6 +175,25 @@ def _validate(body: dict[str, Any]) -> None:
     for entry in data:
         if not isinstance(entry, dict) or not isinstance(entry.get("id"), str):
             raise CatalogBadResponse(CatalogBadResponse.detail)
+
+
+def _validate_model_parameters(body: object, model: str) -> None:
+    """Reject a success document that cannot describe the requested model."""
+
+    # INVARIANT: success must identify the exact requested model and contain every envelope the
+    # Client needs to preflight; unknown fields remain owned by AI Gateway and pass through.
+    selected = body.get("model") if isinstance(body, dict) else None
+    if (
+        not isinstance(body, dict)
+        or isinstance(body.get("schema_version"), bool)
+        or not isinstance(body.get("schema_version"), int)
+        or not isinstance(selected, dict)
+        or selected.get("id") != model
+        or not isinstance(body.get("parameters"), dict)
+        or not isinstance(body.get("tools"), dict)
+        or not isinstance(body.get("transport"), dict)
+    ):
+        raise ModelParameterBadResponse(ModelParameterBadResponse.detail)
 
 
 __all__ = ["AigatewayCatalogSource"]

--- a/apps/url4-cloud/src/url4_cloud/catalog/cache.py
+++ b/apps/url4-cloud/src/url4_cloud/catalog/cache.py
@@ -18,6 +18,8 @@ Five behaviours compose here, each closing a specific failure:
 
 AIDEV-NOTE: the stale-on-error discipline is deliberate — serve what is cached, refuse when cold,
 never fail open. A refresh failure must not degrade into "this credential can address no models".
+Detailed model-parameter contracts are profile-stateful and explicitly no-store, so this service
+only retains their source for composition; those reads never enter this cache.
 """
 
 from __future__ import annotations
@@ -30,7 +32,13 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
-from url4_cloud.catalog.port import CatalogError, CatalogSource, Credential, ModelCatalog
+from url4_cloud.catalog.port import (
+    CatalogError,
+    CatalogSource,
+    Credential,
+    ModelCatalog,
+    ModelParameterSource,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +102,7 @@ class CachedCatalog:
         self,
         source: CatalogSource,
         *,
+        parameter_source: ModelParameterSource | None = None,
         ttl_s: float = 300.0,
         stale_max_s: float = 3600.0,
         error_backoff_s: float = 30.0,
@@ -104,6 +113,7 @@ class CachedCatalog:
         source_aclose: Callable[[], Awaitable[None]] | None = None,
     ) -> None:
         self._source = source
+        self._parameter_source = parameter_source
         # WHY teardown lives here rather than on the source: the app holds the CACHE, so the cache
         # is what its ASGI shutdown hook can reach. Mirrors `Url4Executor(world_aclose=...)`.
         self._source_aclose = source_aclose
@@ -135,6 +145,12 @@ class CachedCatalog:
         aclose, self._source_aclose = self._source_aclose, None
         if aclose is not None:
             await aclose()
+
+    @property
+    def model_parameter_source(self) -> ModelParameterSource | None:
+        """The uncached detail source sharing this service's owned client lifecycle."""
+
+        return self._parameter_source
 
     def max_age_s(self, credential: Credential) -> int:
         """Seconds this credential's entry may still be considered fresh, floored at 0.

--- a/apps/url4-cloud/src/url4_cloud/catalog/port.py
+++ b/apps/url4-cloud/src/url4_cloud/catalog/port.py
@@ -1,4 +1,4 @@
-"""The model-catalog port — the contract the cache and the aigateway adapter share (spec §6.2).
+"""Model-discovery ports shared by the cache, REST boundary, and AI Gateway adapter.
 
 FEATURE: model-catalog discovery. ``GET /v1/models`` on url4-cloud answers "which models can I
 address?" by forwarding the caller's own verified identity upstream and caching the result per
@@ -7,10 +7,10 @@ caller.
 STORY: as a client composing a url4 expression, I ask url4-cloud which model paths exist before I
 reference one, instead of guessing and failing at run time.
 
-Defines the domain value types (``Credential``, ``ModelCatalog``), the RFC 9457-style error
-hierarchy the aigateway adapter and the REST layer share, and the ``CatalogSource`` Protocol — the
-port that concrete catalog adapters (e.g. ``AigatewayCatalogSource`` in ``catalog/aigateway.py``)
-implement.
+Defines the shared identity, the cached model-list contract, the uncached profile-bound parameter
+contract, and the RFC 9457-style error hierarchy. ``CatalogSource`` and
+``ModelParameterSource`` stay separate so a catalog-only adapter is not forced to pretend it can
+serve details.
 
 AIDEV-NOTE: this module is a dependency-free leaf on purpose — no httpx, no FastAPI. Both the
 adapter (which speaks HTTP) and the cache (which speaks to nothing) import it, and the route maps
@@ -94,6 +94,14 @@ class ModelCatalog:
     etag: str
 
 
+@dataclass(frozen=True, slots=True)
+class ModelParameterResponse:
+    """One validated JSON response from AI Gateway, retaining its wire representation."""
+
+    status: int
+    content: bytes
+
+
 def compute_etag(body: dict[str, object]) -> str:
     """A strong ETag over the catalog's content (spec §5.2).
 
@@ -138,6 +146,12 @@ class CatalogBadResponse(CatalogError):
     detail = "aigateway returned an unusable model catalog"
 
 
+class ModelParameterBadResponse(CatalogBadResponse):
+    """The detailed parameter response was not safe to proxy."""
+
+    detail = "aigateway returned an unusable model-parameter contract"
+
+
 class CatalogUnavailable(CatalogError):
     """The upstream request timed out."""
 
@@ -158,6 +172,17 @@ class CatalogSource(Protocol):
     async def fetch(self, credential: Credential) -> ModelCatalog: ...
 
 
+@runtime_checkable
+class ModelParameterSource(Protocol):
+    """Anything that can fetch one profile-bound model-parameter contract."""
+
+    async def fetch_model_parameters(
+        self,
+        credential: Credential,
+        model: str,
+    ) -> ModelParameterResponse: ...
+
+
 __all__ = [
     "CatalogBadResponse",
     "CatalogError",
@@ -166,5 +191,8 @@ __all__ = [
     "CatalogUnavailable",
     "Credential",
     "ModelCatalog",
+    "ModelParameterBadResponse",
+    "ModelParameterResponse",
+    "ModelParameterSource",
     "compute_etag",
 ]

--- a/apps/url4-cloud/src/url4_cloud/local.py
+++ b/apps/url4-cloud/src/url4_cloud/local.py
@@ -114,7 +114,13 @@ def create_local_app(
         max_history=settings.local_max_run_history,
     )
     catalog = build_catalog_service(settings)
-    app = create_app(settings, stream=stream, job_runner=job_runner, catalog=catalog)
+    app = create_app(
+        settings,
+        stream=stream,
+        job_runner=job_runner,
+        catalog=catalog,
+        model_parameters=catalog.model_parameter_source if catalog is not None else None,
+    )
     app.router.on_shutdown.append(job_runner.aclose)
     if catalog is not None:
         app.router.on_shutdown.append(catalog.aclose)

--- a/apps/url4-cloud/src/url4_cloud/rest/catalog.py
+++ b/apps/url4-cloud/src/url4_cloud/rest/catalog.py
@@ -1,4 +1,4 @@
-"""``GET /v1/models`` — the cached, credential-scoped model catalog (spec §5).
+"""Credential-scoped Engine model discovery.
 
 FEATURE: model-catalog discovery.
 
@@ -10,8 +10,9 @@ Owns request-side concerns only (credential resolution, conditional-request/ETag
 ``CatalogError`` to RFC 9457 problems); the actual upstream fetch and per-credential caching live
 in ``url4_cloud.catalog.cache.CatalogService``.
 
-Every response is tied to the caller's credential, which is why ``Cache-Control`` is unconditionally
-``private`` and ``Vary`` names all three credential headers.
+``GET /v1/models`` is the cached summary. ``GET /v1/model-parameters`` is an uncached,
+profile-bound detail proxy. Every response is private and varies by the identity inputs that can
+change it.
 """
 
 from __future__ import annotations
@@ -26,7 +27,7 @@ from fastapi.responses import JSONResponse
 from url4_cloud import job_env
 from url4_cloud.auth import ProblemException
 from url4_cloud.catalog.cache import CatalogService
-from url4_cloud.catalog.port import CatalogError, Credential
+from url4_cloud.catalog.port import CatalogError, Credential, ModelParameterSource
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +42,21 @@ _VARY = "X-Profile, X-User-Email"
 # would name this deployment's identity provider to an unauthenticated caller. Only used to relay
 # an upstream refusal now; this route no longer refuses anyone itself.
 _CHALLENGE = {"WWW-Authenticate": "Bearer"}
+_MODEL_PARAMETER_HEADERS = {
+    "Cache-Control": "private, no-store",
+    "Vary": _VARY,
+}
+_MODEL_PARAMETER_OPENAPI = {
+    "parameters": [
+        {
+            "name": "model",
+            "in": "query",
+            "required": True,
+            "description": "Canonical provider-prefixed model id.",
+            "schema": {"type": "string"},
+        }
+    ]
+}
 
 _MODELS_RESPONSES: dict[int | str, dict[str, object]] = {
     200: {"description": "The models this caller can address."},
@@ -49,6 +65,18 @@ _MODELS_RESPONSES: dict[int | str, dict[str, object]] = {
     502: {"description": "aigateway returned an unusable catalog."},
     503: {"description": "The catalog is not configured on this deployment."},
     504: {"description": "aigateway did not respond in time."},
+}
+
+_MODEL_PARAMETER_RESPONSES: dict[int | str, dict[str, object]] = {
+    200: {"description": "AI Gateway's model-parameter contract."},
+    400: {"description": "The canonical model id is invalid."},
+    401: {"description": "The selected profile requires authentication."},
+    403: {"description": "The caller cannot access the selected profile."},
+    404: {"description": "The model or profile does not exist."},
+    409: {"description": "The selected profile is not ready."},
+    502: {"description": "AI Gateway returned an unusable contract."},
+    503: {"description": "AI Gateway is not configured."},
+    504: {"description": "AI Gateway did not respond in time."},
 }
 
 
@@ -112,6 +140,55 @@ async def list_models(
     return JSONResponse(content=catalog.body, headers=headers)
 
 
+@router.get(
+    "/v1/model-parameters",
+    tags=["Catalog"],
+    summary="Get one model's parameter contract",
+    responses=_MODEL_PARAMETER_RESPONSES,
+    openapi_extra=_MODEL_PARAMETER_OPENAPI,
+    description=(
+        "Proxy AI Gateway's profile-bound parameter contract for one canonical model. "
+        "The body is AI Gateway's, verbatim, and is never cached by URL4 Cloud."
+    ),
+)
+async def model_parameters(
+    request: Request,
+    x_profile: Annotated[
+        str | None, Header(alias="X-Profile", description="Optional AI Gateway profile.")
+    ] = None,
+) -> Response:
+    """Return one caller/profile-specific AI Gateway model contract."""
+
+    model = request.query_params.get("model")
+    if model is None:
+        raise ProblemException(
+            status=400,
+            title="Bad Request",
+            detail="model is required",
+            headers=_MODEL_PARAMETER_HEADERS,
+        )
+    source = _require_model_parameter_source(request)
+    try:
+        result = await source.fetch_model_parameters(
+            _caller(x_profile, request.headers),
+            model,
+        )
+    except CatalogError as exc:
+        logger.info("model-parameter request failed: %s", type(exc).__name__)
+        raise ProblemException(
+            status=exc.status,
+            title=exc.title,
+            detail=exc.detail,
+            headers=_MODEL_PARAMETER_HEADERS,
+        ) from exc
+    return Response(
+        status_code=result.status,
+        content=result.content,
+        media_type="application/json",
+        headers=_model_parameter_headers(result.status),
+    )
+
+
 def _require_service(request: Request) -> CatalogService:
     """The wired catalog service, or a 503.
 
@@ -127,6 +204,26 @@ def _require_service(request: Request) -> CatalogService:
             detail="the model catalog is not configured (URL4_CLOUD_AIGATEWAY_BASE_URL)",
         )
     return service
+
+
+def _require_model_parameter_source(request: Request) -> ModelParameterSource:
+    source = getattr(request.app.state, "model_parameters", None)
+    if source is None:
+        raise ProblemException(
+            status=503,
+            title="Service Unavailable",
+            detail="model details are not configured (URL4_CLOUD_AIGATEWAY_BASE_URL)",
+            headers=_MODEL_PARAMETER_HEADERS,
+        )
+    return source
+
+
+def _model_parameter_headers(status: int) -> dict[str, str]:
+    """Privacy headers for every result, plus the challenge RFC 9110 requires on 401."""
+
+    if status == 401:
+        return {**_MODEL_PARAMETER_HEADERS, **_CHALLENGE}
+    return _MODEL_PARAMETER_HEADERS
 
 
 def _caller(profile: str | None, headers: Mapping[str, str]) -> Credential:

--- a/apps/url4-cloud/tests/unit/test_model_parameters_proxy.py
+++ b/apps/url4-cloud/tests/unit/test_model_parameters_proxy.py
@@ -1,0 +1,449 @@
+"""OME-480: the Engine exposes AI Gateway's profile-bound model-parameter contract."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from httpx import ASGITransport
+
+from url4_cloud.app import create_app
+from url4_cloud.catalog import build_catalog_service
+from url4_cloud.catalog.aigateway import AigatewayCatalogSource
+from url4_cloud.catalog.port import (
+    CatalogBadResponse,
+    CatalogUnavailable,
+    Credential,
+    ModelParameterBadResponse,
+    ModelParameterResponse,
+)
+from url4_cloud.config import Settings
+from url4_cloud.local import create_local_app
+from url4_cloud.testing import InMemoryEventStream
+
+pytestmark = pytest.mark.asyncio
+
+# FEATURE: profile-bound model-parameter discovery through the Engine.
+# INVARIANT: valid Gateway JSON crosses this proxy byte-for-byte, under private/no-store headers.
+_MODEL = "openrouter/openai/gpt-5.5"
+_IDENTITY = {"X-User-Email": "alice@example.com"}
+_CONTRACT = {
+    "schema_version": 1,
+    "contract_id": "pc_fixture",
+    "model": {
+        "id": _MODEL,
+        "gateway_provider": "openrouter",
+        "upstream_id": "openai/gpt-5.5",
+    },
+    "context": {"scope": "account_profile", "auth_mode": "api_key"},
+    "parameters": {
+        "temperature": {
+            "request_path": "temperature",
+            "schema": {"type": "number", "minimum": 0, "maximum": 2},
+            "gateway": {"status": "enabled", "projection": "direct"},
+        }
+    },
+    "tools": {},
+    "transport": {},
+    "freshness": {"stale": False, "degraded": False},
+    "future_field": {"preserved": True},
+}
+
+
+def _json_content(value: object) -> bytes:
+    return json.dumps(value, separators=(",", ":")).encode()
+
+
+async def test_adapter_returns_model_details_verbatim_for_the_callers_scope() -> None:
+    seen: list[httpx.Request] = []
+    content = _json_content(_CONTRACT)
+
+    def upstream(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, content=content, headers={"content-type": "application/json"})
+
+    client = httpx.AsyncClient(
+        base_url="http://aigateway.test",
+        transport=httpx.MockTransport(upstream),
+    )
+    source = AigatewayCatalogSource(client)
+    response = await source.fetch_model_parameters(
+        Credential.derive("research", _IDENTITY),
+        _MODEL,
+    )
+    assert response.status == 200
+    assert response.content == content
+    assert seen[0].url.path == "/v1/model-parameters"
+    assert dict(seen[0].url.params) == {"model": _MODEL}
+    assert seen[0].headers["X-User-Email"] == "alice@example.com"
+    assert seen[0].headers["X-Profile"] == "research"
+    assert "authorization" not in seen[0].headers
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404, 409])
+async def test_adapter_preserves_caller_correctable_gateway_responses(status: int) -> None:
+    body = {"detail": {"code": "profile_not_ready", "name": "research"}}
+    content = _json_content(body)
+    client = httpx.AsyncClient(
+        base_url="http://aigateway.test",
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(
+                status,
+                content=content,
+                headers={"content-type": "application/json"},
+            )
+        ),
+    )
+
+    response = await AigatewayCatalogSource(client).fetch_model_parameters(
+        Credential.derive(),
+        _MODEL,
+    )
+
+    assert response.status == status
+    assert response.content == content
+
+
+@pytest.mark.parametrize("content", [b'["not ready"]', b'"not ready"', b"17", b"null"])
+async def test_adapter_preserves_any_caller_correctable_json_document(content: bytes) -> None:
+    client = httpx.AsyncClient(
+        base_url="http://aigateway.test",
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(
+                400,
+                content=content,
+                headers={"content-type": "application/json"},
+            )
+        ),
+    )
+
+    response = await AigatewayCatalogSource(client).fetch_model_parameters(
+        Credential.derive(),
+        _MODEL,
+    )
+
+    assert response.status == 400
+    assert response.content == content
+
+
+async def test_adapter_translates_a_model_details_timeout() -> None:
+    def timeout(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("slow upstream", request=request)
+
+    client = httpx.AsyncClient(
+        base_url="http://aigateway.test",
+        transport=httpx.MockTransport(timeout),
+    )
+
+    with pytest.raises(CatalogUnavailable):
+        await AigatewayCatalogSource(client).fetch_model_parameters(
+            Credential.derive(),
+            _MODEL,
+        )
+
+
+@pytest.mark.parametrize(
+    ("status", "content"),
+    [
+        (200, b"not json"),
+        (200, b"[]"),
+        (400, b"NaN"),
+        (500, b'{"detail":"internal"}'),
+    ],
+)
+async def test_adapter_rejects_unusable_gateway_responses(
+    status: int,
+    content: bytes,
+) -> None:
+    client = httpx.AsyncClient(
+        base_url="http://aigateway.test",
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(
+                status,
+                content=content,
+                headers={"content-type": "application/json"},
+            )
+        ),
+    )
+
+    with pytest.raises(ModelParameterBadResponse):
+        await AigatewayCatalogSource(client).fetch_model_parameters(
+            Credential.derive(),
+            _MODEL,
+        )
+
+
+async def test_adapter_translates_a_gateway_connection_failure() -> None:
+    def disconnected(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("gateway unavailable", request=request)
+
+    client = httpx.AsyncClient(
+        base_url="http://aigateway.test",
+        transport=httpx.MockTransport(disconnected),
+    )
+
+    with pytest.raises(ModelParameterBadResponse):
+        await AigatewayCatalogSource(client).fetch_model_parameters(
+            Credential.derive(),
+            _MODEL,
+        )
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {**_CONTRACT, "schema_version": True},
+        {**_CONTRACT, "model": {**_CONTRACT["model"], "id": "openrouter/other"}},
+        {**_CONTRACT, "parameters": []},
+        {**_CONTRACT, "tools": []},
+        {**_CONTRACT, "transport": []},
+    ],
+)
+async def test_adapter_rejects_an_unusable_success_document(body: object) -> None:
+    client = httpx.AsyncClient(
+        base_url="http://aigateway.test",
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, json=body)),
+    )
+
+    with pytest.raises(CatalogBadResponse):
+        await AigatewayCatalogSource(client).fetch_model_parameters(
+            Credential.derive(),
+            _MODEL,
+        )
+
+
+async def test_adapter_names_an_unusable_model_parameter_response() -> None:
+    client = httpx.AsyncClient(
+        base_url="http://aigateway.test",
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(500, json={"detail": "internal"})
+        ),
+    )
+
+    with pytest.raises(ModelParameterBadResponse) as caught:
+        await AigatewayCatalogSource(client).fetch_model_parameters(
+            Credential.derive(),
+            _MODEL,
+        )
+
+    assert caught.value.detail == "aigateway returned an unusable model-parameter contract"
+
+
+class _ParameterSource:
+    def __init__(self, response: ModelParameterResponse) -> None:
+        self.response = response
+        self.seen: list[tuple[Credential, str]] = []
+
+    async def fetch_model_parameters(
+        self,
+        credential: Credential,
+        model: str,
+    ) -> ModelParameterResponse:
+        self.seen.append((credential, model))
+        return self.response
+
+
+class _FailingParameterSource:
+    async def fetch_model_parameters(
+        self,
+        credential: Credential,
+        model: str,
+    ) -> ModelParameterResponse:
+        raise CatalogBadResponse("upstream included a secret-shaped detail")
+
+
+async def test_engine_returns_model_details_for_the_verified_identity_and_profile() -> None:
+    source = _ParameterSource(ModelParameterResponse(status=200, content=_json_content(_CONTRACT)))
+    app = create_app(
+        Settings(jwt_secret="model-details-test"),
+        stream=InMemoryEventStream(),
+        model_parameters=source,
+    )
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            "/v1/model-parameters",
+            params={"model": _MODEL},
+            headers={"X-User-Email": "alice@example.com", "X-Profile": "research"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == _CONTRACT
+    assert response.headers["Cache-Control"] == "private, no-store"
+    assert response.headers["Vary"] == "X-Profile, X-User-Email"
+    credential, model = source.seen[0]
+    assert model == _MODEL
+    assert credential.profile == "research"
+    assert credential.identity == _IDENTITY
+
+
+async def test_production_catalog_wiring_exposes_model_details_without_a_second_client() -> None:
+    clients: list[httpx.AsyncClient] = []
+
+    def client_factory(base_url: str) -> httpx.AsyncClient:
+        client = httpx.AsyncClient(
+            base_url=base_url,
+            transport=httpx.MockTransport(lambda request: httpx.Response(200, json=_CONTRACT)),
+        )
+        clients.append(client)
+        return client
+
+    settings = Settings(
+        jwt_secret="model-details-test",
+        aigateway_base_url="http://aigateway.test",
+    )
+    service = build_catalog_service(settings, client_factory=client_factory)
+    assert service is not None
+    app = create_app(
+        settings,
+        stream=InMemoryEventStream(),
+        catalog=service,
+        model_parameters=service.model_parameter_source,
+    )
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/v1/model-parameters", params={"model": _MODEL})
+
+    assert response.status_code == 200
+    assert response.json() == _CONTRACT
+    assert len(clients) == 1
+    await service.aclose()
+
+
+async def test_engine_hides_unusable_upstream_details_behind_a_private_problem() -> None:
+    app = create_app(
+        Settings(jwt_secret="model-details-test"),
+        stream=InMemoryEventStream(),
+        model_parameters=_FailingParameterSource(),
+    )
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/v1/model-parameters", params={"model": _MODEL})
+
+    assert response.status_code == 502
+    assert response.headers["content-type"].startswith("application/problem+json")
+    assert response.headers["Cache-Control"] == "private, no-store"
+    assert response.headers["Vary"] == "X-Profile, X-User-Email"
+    assert "secret-shaped" not in response.text
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404, 409])
+async def test_engine_preserves_caller_correctable_model_detail_responses(status: int) -> None:
+    body: dict[str, object] = {"detail": {"code": "profile_not_ready", "name": "research"}}
+    source = _ParameterSource(ModelParameterResponse(status=status, content=_json_content(body)))
+    app = create_app(
+        Settings(jwt_secret="model-details-test"),
+        stream=InMemoryEventStream(),
+        model_parameters=source,
+    )
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/v1/model-parameters", params={"model": _MODEL})
+
+    assert response.status_code == status
+    assert response.json() == body
+    assert response.headers["Cache-Control"] == "private, no-store"
+    assert response.headers["Vary"] == "X-Profile, X-User-Email"
+    if status == 401:
+        assert response.headers["WWW-Authenticate"] == "Bearer"
+
+
+async def test_unconfigured_model_details_are_a_private_503_problem() -> None:
+    app = create_app(Settings(jwt_secret="model-details-test"), stream=InMemoryEventStream())
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/v1/model-parameters", params={"model": _MODEL})
+
+    assert response.status_code == 503
+    assert response.headers["content-type"].startswith("application/problem+json")
+    assert response.headers["Cache-Control"] == "private, no-store"
+    assert response.headers["Vary"] == "X-Profile, X-User-Email"
+
+
+async def test_missing_model_is_a_private_400_problem() -> None:
+    source = _ParameterSource(ModelParameterResponse(status=200, content=_json_content(_CONTRACT)))
+    app = create_app(
+        Settings(jwt_secret="model-details-test"),
+        stream=InMemoryEventStream(),
+        model_parameters=source,
+    )
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/v1/model-parameters")
+
+    assert response.status_code == 400
+    assert response.headers["content-type"].startswith("application/problem+json")
+    assert response.headers["Cache-Control"] == "private, no-store"
+    assert response.headers["Vary"] == "X-Profile, X-User-Email"
+    assert source.seen == []
+
+
+async def test_engine_maps_a_model_details_timeout_to_a_private_504_problem() -> None:
+    class _TimedOut:
+        async def fetch_model_parameters(
+            self,
+            credential: Credential,
+            model: str,
+        ) -> ModelParameterResponse:
+            raise CatalogUnavailable(CatalogUnavailable.detail)
+
+    app = create_app(
+        Settings(jwt_secret="model-details-test"),
+        stream=InMemoryEventStream(),
+        model_parameters=_TimedOut(),
+    )
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/v1/model-parameters", params={"model": _MODEL})
+
+    assert response.status_code == 504
+    assert response.headers["Cache-Control"] == "private, no-store"
+    assert response.headers["Vary"] == "X-Profile, X-User-Email"
+
+
+async def test_model_details_are_published_in_openapi_under_catalog() -> None:
+    app = create_app(Settings(jwt_secret="model-details-test"), stream=InMemoryEventStream())
+    operation = app.openapi()["paths"]["/v1/model-parameters"]["get"]
+    assert operation["tags"] == ["Catalog"]
+    parameters = {parameter["name"]: parameter for parameter in operation["parameters"]}
+    assert parameters["model"]["required"] is True
+
+
+async def test_engine_relays_valid_contract_bytes_without_reserializing() -> None:
+    content = _json_content(_CONTRACT)[:-1] + b',"future_number":1e999}'
+    source = _ParameterSource(ModelParameterResponse(status=200, content=content))
+    app = create_app(
+        Settings(jwt_secret="model-details-test"),
+        stream=InMemoryEventStream(),
+        model_parameters=source,
+    )
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/v1/model-parameters", params={"model": _MODEL})
+    assert response.status_code == 200
+    assert response.content == content
+    assert response.headers["Cache-Control"] == "private, no-store"
+    assert response.headers["Vary"] == "X-Profile, X-User-Email"
+
+
+async def test_local_composition_exposes_the_uncached_model_parameter_source() -> None:
+    app = create_local_app(
+        Settings(
+            jwt_secret="model-details-test",
+            aigateway_base_url="http://aigateway.test",
+        ),
+        env={},
+    )
+    assert app.state.catalog is not None
+    assert app.state.model_parameters is app.state.catalog.model_parameter_source
+    await app.state.catalog.aclose()
+    await app.state.job_runner.aclose()

--- a/docs/plan/2026-08-05-OME-480-model-parameters.md
+++ b/docs/plan/2026-08-05-OME-480-model-parameters.md
@@ -1,0 +1,35 @@
+---
+title: OME-480 URL4 Cloud model-parameter proxy — implementation plan
+status: approved
+created: 2026-08-05
+ticket: OME-480
+spec: docs/spec/2026-08-05-OME-480-model-parameters.md
+ledger: docs/work/2026-08-05-OME-480-model-parameters.md
+---
+
+# OME-480 implementation plan
+
+Branch `OME-480-engine-model-parameters`, stack `url4-cloud`, based directly on `origin/main`.
+
+## Slice 1 — upstream adapter
+
+- Add a model-parameter source port without widening the catalog source contract.
+- Fetch the canonical model query using the existing verified identity/profile headers.
+- Preserve valid v1 documents and caller-correctable `4xx`; reject unsafe upstream failures and
+  malformed/mismatched success documents.
+- RED first through an `httpx.MockTransport` public adapter seam.
+
+## Slice 2 — Engine route
+
+- Delegate uncached detail reads through the existing production service/client lifecycle.
+- Add an injectable model-parameter dependency and public route.
+- Apply private/no-store and identity/profile `Vary` to every result.
+- RED first through the ASGI endpoint seam, including OpenAPI and unconfigured/failure paths.
+
+## Verification
+
+- Focused new test module while iterating; existing test files remain unchanged.
+- `python3 .claude/scripts/run_gates.py url4-cloud` from the repository root.
+- Final `origin/main...HEAD` scope and secret-leak review.
+
+No SDK, AI Gateway, URL4, Benchmark, cache-setting, or provider-policy change belongs here.

--- a/docs/plan/2026-08-05-OME-480-model-parameters.md
+++ b/docs/plan/2026-08-05-OME-480-model-parameters.md
@@ -29,7 +29,7 @@ Branch `OME-480-engine-model-parameters`, stack `url4-cloud`, based directly on 
 ## Verification
 
 - Focused new test module while iterating; existing test files remain unchanged.
-- `python3 .claude/scripts/run_gates.py url4-cloud` from the repository root.
+- `uv run .claude/scripts/run_gates.py url4-cloud` from the repository root.
 - Final `origin/main...HEAD` scope and secret-leak review.
 
 No SDK, AI Gateway, URL4, Benchmark, cache-setting, or provider-policy change belongs here.

--- a/docs/spec/2026-08-05-OME-480-model-parameters.md
+++ b/docs/spec/2026-08-05-OME-480-model-parameters.md
@@ -1,0 +1,68 @@
+---
+title: URL4 Cloud model-parameter contract proxy
+status: approved
+created: 2026-08-05
+ticket: OME-480
+upstream: OME-479
+downstream: OME-481
+---
+
+# URL4 Cloud model-parameter contract proxy
+
+## Public contract
+
+```http
+GET /v1/model-parameters?model=openrouter%2Fopenai%2Fgpt-5.5
+X-User-Email: alice@example.com
+X-Profile: research
+```
+
+On success, URL4 Cloud returns AI Gateway's JSON document verbatim. URL4 Cloud checks only the
+minimum envelope needed to avoid serving an unusable or mismatched contract:
+
+- the body is a JSON object;
+- `schema_version` is an integer;
+- `model.id` equals the requested canonical model id;
+- `parameters`, `tools`, and `transport` are objects.
+
+Every response from this route carries:
+
+```http
+Cache-Control: private, no-store
+Vary: X-Profile, X-User-Email
+```
+
+The route uses the existing mesh-verified identity and optional profile. AI Gateway remains the
+sole owner of account/profile resolution, provider evidence, parameter schemas, and dispatch
+validation. URL4 Cloud adds no cache: this document varies with account, profile, connection
+state, and observed provider evidence.
+
+## Failures
+
+- Caller-correctable AI Gateway responses (`400`, `401`, `403`, `404`, `409`) retain their status
+  and JSON body, with the private/no-store policy applied.
+- An unconfigured upstream returns RFC 9457 `503`.
+- A timeout returns RFC 9457 `504`.
+- A transport failure, upstream `5xx`, non-JSON body, or malformed successful document returns
+  RFC 9457 `502`; upstream details are not exposed.
+
+No path returns a plausible empty parameter set after a failed lookup.
+
+## Internal boundary
+
+`ModelParameterSource` is a small port beside `CatalogSource`; widening `CatalogSource` would
+break existing catalog-only adapters and fakes. The same `AigatewayCatalogSource` implements both
+operations because they share one upstream and identity boundary. `CachedCatalog` exposes a
+reference to that uncached detail source for composition, but never implements or caches the
+detail operation itself. The two routes therefore preserve one HTTP client and shutdown lifecycle
+without confusing cached and uncached behavior.
+
+## Acceptance
+
+1. `/v1/model-parameters` is present in the Engine OpenAPI document.
+2. The requested model, verified identity, and optional profile reach AI Gateway.
+3. A valid v1 contract passes through without field loss, including unknown fields.
+4. A mismatched or malformed success fails as `502`.
+5. Caller-correctable upstream responses retain their status and body.
+6. Every outcome is `private, no-store` and varies by identity/profile.
+7. `/v1/models`, execution, AI Gateway, URL4, and SDK behavior remain unchanged.

--- a/docs/tasks/2026-08-05-ome-480-model-parameters.md
+++ b/docs/tasks/2026-08-05-ome-480-model-parameters.md
@@ -4,7 +4,7 @@ linear_url: https://linear.app/openmined/issue/OME-480/the-sf-engine-should-expo
 status: in_progress
 type: feature
 priority:
-labels: [screamingface-engine, app/url4-cloud, autonomous, agentic]
+labels: [screamingface-engine, url4-cloud, autonomous, agentic]
 created: 2026-08-05
 closed:
 ---

--- a/docs/tasks/2026-08-05-ome-480-model-parameters.md
+++ b/docs/tasks/2026-08-05-ome-480-model-parameters.md
@@ -1,0 +1,35 @@
+---
+id: OME-480
+linear_url: https://linear.app/openmined/issue/OME-480/the-sf-engine-should-expose-all-the-params-offered-by-the-model
+status: in_progress
+type: feature
+priority:
+labels: [screamingface-engine, app/url4-cloud, autonomous, agentic]
+created: 2026-08-05
+closed:
+---
+
+# OME-480 — expose AI Gateway model details through the Engine
+
+The Client talks to the Engine, not directly to AI Gateway. AI Gateway already owns the
+profile-bound `GET /v1/model-parameters?model=...` contract; this unit exposes that document
+through URL4 Cloud for the same verified identity and profile used by execution.
+
+## Scope
+
+- Add `GET /v1/model-parameters?model=...` to URL4 Cloud.
+- Forward `X-User-Email` and `X-Profile` through the existing identity boundary.
+- Preserve AI Gateway's successful v1 document without defining another parameter schema.
+- Keep success and caller-facing errors private and uncacheable.
+- Fail loudly when AI Gateway is unconfigured, unavailable, or returns an unusable contract.
+
+## Out of scope
+
+- SDK model details and preflight (`OME-481`).
+- Any AI Gateway, provider-policy, URL4, or Benchmark change.
+
+Spec: `docs/spec/2026-08-05-OME-480-model-parameters.md`
+
+Plan: `docs/plan/2026-08-05-OME-480-model-parameters.md`
+
+Ledger: `docs/work/2026-08-05-OME-480-model-parameters.md`

--- a/docs/work/2026-08-05-OME-480-model-parameters.md
+++ b/docs/work/2026-08-05-OME-480-model-parameters.md
@@ -43,7 +43,7 @@ No schema/model migration applies.
 
 ## Outcome
 
-- **Actual files:** six URL4 Cloud modules, one new focused test module, and this task's
+- **Actual files:** seven URL4 Cloud modules, one new focused test module, and this task's
   task/spec/plan/work artifacts. No runner, connector, Benchmark, AI Gateway, URL4, SDK, Helm, or
   dependency file changed.
 - **Behavior:** URL4 Cloud exposes uncached `GET /v1/model-parameters`, forwards the existing
@@ -53,9 +53,11 @@ No schema/model migration applies.
   skipped**, and **96.74%** coverage.
 - **Gates:** `uv run .claude/scripts/run_gates.py url4-cloud` — append-only, Ruff, formatting,
   Pyright, layering, and pytest/coverage all green.
-- **Commit:** `feat(url4-cloud): proxy model parameter contracts` (`Refs: OME-480`), based
-  directly on `origin/main`.
+- **Implementation commit:** `d9db1e6c` — `feat(url4-cloud): proxy model parameter contracts`
+  (`Refs: OME-480`), based directly on `origin/main`.
 - **Deviations:** `CachedCatalog` retains a reference to the detail source for composition rather
   than implementing `ModelParameterSource`; this keeps the cache boundary honest while preserving
-  one owned HTTP client and shutdown hook. Linear remains unchanged until the full stack is ready
-  for review, as requested.
+  one owned HTTP client and shutdown hook. `local.py` also wires that source into local mode; it
+  was omitted from Planned changes, but without it the production entrypoint would work while the
+  supported local composition returned `503`. Linear remains unchanged until the full stack is
+  ready for review, as requested.

--- a/docs/work/2026-08-05-OME-480-model-parameters.md
+++ b/docs/work/2026-08-05-OME-480-model-parameters.md
@@ -1,0 +1,61 @@
+---
+ticket: OME-480
+stack: url4-cloud
+status: done
+started: 2026-08-05
+finished: 2026-08-06
+---
+
+# OME-480 — expose AI Gateway model details through the Engine
+
+## Intent
+
+Expose AI Gateway's authoritative, profile-bound model-parameter contract through URL4 Cloud so
+the Client can discover and preflight model parameters without bypassing the Engine or creating
+a second parameter language.
+
+## Planned changes
+
+- `catalog/port.py` — model-detail response and source port.
+- `catalog/aigateway.py` — identity-aware, uncached upstream request and envelope validation.
+- `catalog/cache.py` — retain the uncached detail source in the existing client lifecycle.
+- `app.py` — injectable model-parameter source.
+- `rest/catalog.py` — public endpoint and private/no-store policy.
+- `tests/unit/test_model_parameters_proxy.py` — new behavioral tests only.
+- OME-480 task/spec/plan/work artifacts.
+
+No schema/model migration applies.
+
+## Test plan
+
+- Verbatim successful v1 document, unknown fields, model query, identity/profile forwarding.
+- Anonymous local request and no invented bearer token.
+- Caller-correctable `4xx` pass-through.
+- Mismatched/malformed success, `5xx`, timeout, transport, and non-JSON failures.
+- ASGI success/error cache policy, RFC 9457 `502`/`503`/`504`, and OpenAPI visibility.
+- Existing `/v1/models` tests remain unchanged and green.
+
+## Acceptance
+
+- All spec acceptance points hold.
+- Existing tests are not edited.
+- Full `url4-cloud` gates are green.
+
+## Outcome
+
+- **Actual files:** six URL4 Cloud modules, one new focused test module, and this task's
+  task/spec/plan/work artifacts. No runner, connector, Benchmark, AI Gateway, URL4, SDK, Helm, or
+  dependency file changed.
+- **Behavior:** URL4 Cloud exposes uncached `GET /v1/model-parameters`, forwards the existing
+  verified identity/profile, preserves valid v1 documents and caller-correctable JSON `4xx`, and
+  fails closed for malformed or unavailable upstream responses.
+- **Tests:** 36 focused contract tests; the complete URL4 Cloud suite passes with **529 passed, 5
+  skipped**, and **96.74%** coverage.
+- **Gates:** `uv run .claude/scripts/run_gates.py url4-cloud` — append-only, Ruff, formatting,
+  Pyright, layering, and pytest/coverage all green.
+- **Commit:** `feat(url4-cloud): proxy model parameter contracts` (`Refs: OME-480`), based
+  directly on `origin/main`.
+- **Deviations:** `CachedCatalog` retains a reference to the detail source for composition rather
+  than implementing `ModelParameterSource`; this keeps the cache boundary honest while preserving
+  one owned HTTP client and shutdown hook. Linear remains unchanged until the full stack is ready
+  for review, as requested.


### PR DESCRIPTION
## Summary

Expose AI Gateway's authoritative, profile-bound model-parameter contract through the Engine at `GET /v1/model-parameters`. The Engine forwards the caller's verified identity and optional profile, returns valid Gateway documents verbatim, keeps the route uncached, and fails closed on malformed or unavailable upstream responses.

**Linear:** https://linear.app/openmined/issue/OME-480/the-sf-engine-should-expose-all-the-params-offered-by-the-model

## Components touched

- `apps/url4-cloud`: model-parameter source port, AI Gateway adapter, production wiring, and REST route
- `docs`: focused OME-480 spec, plan, task, and work ledger

## Test plan

- [x] Ran `python3 .claude/scripts/run_gates.py url4-cloud`
  - Ruff and format checks
  - Pyright
  - layering check
  - full pytest suite with coverage gate
- [x] Added 36 focused adapter, ASGI, OpenAPI, and local-composition contract cases
- [x] Confirmed `git diff --check` and reviewed the complete `origin/main...HEAD` diff

## Cross-service notes

- AI Gateway remains the sole owner of parameter schemas, profile resolution, provider evidence, and dispatch validation; its OME-479 endpoint is already on `main`.
- This PR is based directly on `main` and does not include AI Gateway, URL4, benchmark, SDK, Helm, or dependency changes.
- OME-481 can consume this Engine endpoint in the later Client PR.
