### PR TITLE
feat(url4-cloud): expose provider connections

### DIFF
--- a/.claude/scripts/check_layering.py
+++ b/.claude/scripts/check_layering.py
@@ -9,7 +9,7 @@ One image ships two modes, and the whole point of that shape is a rule about wha
     control plane   run mode                    Every concrete implementation, in the half that
     (serve)         (run)                       runs it — and the two halves stay disjoint.
 
-  Control plane: app · rest · ws · auth · catalog · config · metrics · ops · schemas
+  Control plane: app · rest · ws · auth · catalog · connections · config · metrics · ops · schemas
                  adapters.k8s · adapters.factory    (FastAPI, uvicorn, the kubernetes client)
   Run mode:      runner.executor (the url4 engine) · runner.connector · runner.config
 
@@ -50,6 +50,7 @@ CONTROL_PLANE = {
     "auth",
     "catalog",
     "cli",
+    "connections",
     "config",
     "local",
     "metrics",

--- a/apps/url4-cloud/README.md
+++ b/apps/url4-cloud/README.md
@@ -204,3 +204,39 @@ labelled by cache key, prompt or credential** — the gateway's entry key is par
 neither accepts a freshness bound nor reports an entry's `Age`, so a bounded run cannot prove a
 hit fresh and declines instead — observably, as `bypass` / `opted_out`. The honouring path is
 written and dormant; when either upstream half lands, the change is a branch, not a redesign.
+
+## Provider connections — `/v1/connections`
+
+The ScreamingFace Client connects provider credentials through the Engine:
+
+```text
+GET    /v1/connections
+PUT    /v1/connections/{provider}
+POST   /v1/connections/{provider}/oauth
+DELETE /v1/connections/{provider}
+```
+
+The list is derived from AI Gateway's enabled provider plugins and advertises each provider's
+supported authentication methods. `PUT` accepts `{"api_key": "..."}` for a provider that
+supports API-key authentication; the Engine forwards the key and never persists or echoes it.
+`POST .../oauth` starts OAuth only when the provider advertises that method and returns a
+sanitized authorization URL and bounded lifetime. Provider-specific URLs, scopes, callback paths,
+and token exchange remain owned by AI Gateway.
+
+The label `screamingface` is the explicit inter-service designation for the row this Engine
+manages. A row assigned that label through another Gateway surface is intentionally opted into
+Engine management; creator identity is not inferred. Rows under every other label are never
+adopted, replaced, reported, or deleted. API-key `PUT` creates the designated row when absent and
+replaces its key only when it already uses API-key authentication. Changing authentication methods
+requires an explicit disconnect, so setup never destroys a working connection as a side effect.
+
+In a deployed App these routes return `503` when `URL4_CLOUD_AIGATEWAY_BASE_URL` is unset. Local
+mode uses `http://127.0.0.1:9105` for connection operations unless explicitly overridden; this does
+not change the existing local model-catalog configuration.
+
+Responses contain only the public provider name, supported methods, status, authentication method,
+and optional account label. AI Gateway account identifiers, credential locators, OAuth state, and
+upstream error bodies never cross this boundary. The Engine forwards only the verified
+`X-User-Email` identity; it does not forward `Authorization`. OAuth state is returned only as part
+of the provider-generated authorization URL, never as a separate response field. All successful
+connection responses are private and non-cacheable and vary by the verified identity header.

--- a/apps/url4-cloud/README.md
+++ b/apps/url4-cloud/README.md
@@ -231,8 +231,10 @@ replaces its key only when it already uses API-key authentication. Changing auth
 requires an explicit disconnect, so setup never destroys a working connection as a side effect.
 
 In a deployed App these routes return `503` when `URL4_CLOUD_AIGATEWAY_BASE_URL` is unset. Local
-mode uses `http://127.0.0.1:9105` for connection operations unless explicitly overridden; this does
-not change the existing local model-catalog configuration.
+mode falls back to `URL4_CLOUD_LOCAL_AIGATEWAY_BASE_URL` (default `http://127.0.0.1:9105`) for
+connection operations; an explicit `URL4_CLOUD_AIGATEWAY_BASE_URL` still outranks it and points
+catalog and connections at one gateway. Neither changes the existing local model-catalog
+configuration — the catalog stays off until the shared field is set.
 
 Responses contain only the public provider name, supported methods, status, authentication method,
 and optional account label. AI Gateway account identifiers, credential locators, OAuth state, and

--- a/apps/url4-cloud/src/url4_cloud/app.py
+++ b/apps/url4-cloud/src/url4_cloud/app.py
@@ -20,9 +20,11 @@ from url4_cloud.catalog import build_catalog_service
 from url4_cloud.catalog.cache import CatalogService
 from url4_cloud.catalog.port import ModelParameterSource
 from url4_cloud.config import INSECURE_DEFAULT_JWT_SECRET, Settings
+from url4_cloud.connections import build_connections
+from url4_cloud.connections.port import Connections
 from url4_cloud.metrics import MetricsMiddleware, build_metrics, register_catalog_metrics
 from url4_cloud.ops import router as ops_router
-from url4_cloud.rest import SubscriberGate, catalog_router
+from url4_cloud.rest import SubscriberGate, catalog_router, connection_router
 from url4_cloud.rest import router as rest_router
 from url4_cloud.schemas import customize_openapi
 from url4_cloud.ws import ConnectionRegistry
@@ -47,6 +49,7 @@ def create_app(
     interest: SubscriberGate | None = None,
     catalog: CatalogService | None = None,
     model_parameters: ModelParameterSource | None = None,
+    connections: Connections | None = None,
 ) -> FastAPI:
     """Build the App instance.
 
@@ -60,6 +63,7 @@ def create_app(
     app.state.job_runner = job_runner
     app.state.catalog = catalog
     app.state.model_parameters = model_parameters
+    app.state.connections = connections
     app.state.metrics = build_metrics()
     # WHY: pass a getter, not `catalog` directly — the collector re-reads app.state.catalog on
     # every /metrics scrape rather than capturing the value built here.
@@ -74,6 +78,7 @@ def create_app(
     app.include_router(router)
     app.include_router(rest_router)
     app.include_router(catalog_router)
+    app.include_router(connection_router)
     app.include_router(ws_router)
     app.include_router(ops_router)
     app.mount("/diagrams", StaticFiles(directory=_DIAGRAMS_DIR), name="diagrams")
@@ -121,14 +126,18 @@ def create_app_from_env() -> FastAPI:  # pragma: no cover - env/NATS wiring (INF
             "URL4_CLOUD_RUNNER is 'none' — this App bridges NATS but cannot schedule runs"
         )
     catalog = build_catalog_service(settings)
+    connections = build_connections(settings)
     app = create_app(
         settings,
         stream=stream,
         job_runner=job_runner,
         catalog=catalog,
         model_parameters=catalog.model_parameter_source if catalog is not None else None,
+        connections=connections,
     )
     app.router.on_shutdown.append(stream.close)
     if catalog is not None:
         app.router.on_shutdown.append(catalog.aclose)
+    if connections is not None:
+        app.router.on_shutdown.append(connections.aclose)
     return app

--- a/apps/url4-cloud/src/url4_cloud/config.py
+++ b/apps/url4-cloud/src/url4_cloud/config.py
@@ -26,17 +26,10 @@ and bridges NATS but schedules nothing.
 # secret.
 INSECURE_DEFAULT_JWT_SECRET = "dev-insecure-change-me"
 
+# WHY a named module constant (not a bare literal) for the local gateway address: it is the
+# DEFAULT of `local_aigateway_base_url` below, and naming it lets a test pin the loopback value
+# without restating the literal — the same shape as INSECURE_DEFAULT_JWT_SECRET above.
 LOCAL_AIGATEWAY_BASE_URL = "http://127.0.0.1:9105"
-"""The AI Gateway address local-mode connection operations fall back to.
-
-WHY it lives beside `aigateway_base_url` rather than in `local.py`: it is a DEFAULT for that
-setting, not a property of how local mode is assembled, and stating it here keeps the field and
-its local fallback from drifting apart. An explicit `URL4_CLOUD_AIGATEWAY_BASE_URL` still wins —
-`create_local_app` only substitutes this when the setting is unset.
-
-INVARIANT: loopback, like `LOCAL_HOST`. Local mode is a single-process developer deployment, and
-the gateway it manages credentials through is the one running beside it.
-"""
 
 
 class Settings(BaseSettings):
@@ -140,6 +133,19 @@ class Settings(BaseSettings):
     # WHY bounded run history: `status()` answers from finished tasks, so they are retained past
     # completion — this caps how many, the way `ttlSecondsAfterFinished` caps retained Jobs.
     local_max_run_history: int = 1000
+    # WHY a SECOND gateway address rather than defaulting `aigateway_base_url` itself: that field
+    # is read by the model catalog too, where `None` is a meaningful state (the endpoint answers
+    # 503 "not configured"). Defaulting it to loopback would silently switch the local catalog on
+    # and point it at a gateway that may not be running. This field says the narrower thing —
+    # where local-mode CONNECTION operations go when nothing else was stated.
+    #
+    # INVARIANT: `aigateway_base_url` still wins. `create_local_app` substitutes this only when
+    # that field is unset, so one explicit `URL4_CLOUD_AIGATEWAY_BASE_URL` continues to point the
+    # whole App — catalog and connections alike — at one gateway.
+    #
+    # WHY loopback, like `LOCAL_HOST`: local mode is a single-process developer deployment, and
+    # the gateway it manages credentials through is the one running beside it.
+    local_aigateway_base_url: str = LOCAL_AIGATEWAY_BASE_URL
 
     # INVARIANT: a finished Job's NAME is the stateless single-use replay guard, so reclaiming
     # it re-opens replay for that topic — but only for as long as the token is still usable.

--- a/apps/url4-cloud/src/url4_cloud/config.py
+++ b/apps/url4-cloud/src/url4_cloud/config.py
@@ -26,6 +26,18 @@ and bridges NATS but schedules nothing.
 # secret.
 INSECURE_DEFAULT_JWT_SECRET = "dev-insecure-change-me"
 
+LOCAL_AIGATEWAY_BASE_URL = "http://127.0.0.1:9105"
+"""The AI Gateway address local-mode connection operations fall back to.
+
+WHY it lives beside `aigateway_base_url` rather than in `local.py`: it is a DEFAULT for that
+setting, not a property of how local mode is assembled, and stating it here keeps the field and
+its local fallback from drifting apart. An explicit `URL4_CLOUD_AIGATEWAY_BASE_URL` still wins —
+`create_local_app` only substitutes this when the setting is unset.
+
+INVARIANT: loopback, like `LOCAL_HOST`. Local mode is a single-process developer deployment, and
+the gateway it manages credentials through is the one running beside it.
+"""
+
 
 class Settings(BaseSettings):
     """Environment-backed configuration for the App: auth, NATS, job-runner backend selection,

--- a/apps/url4-cloud/src/url4_cloud/connections/__init__.py
+++ b/apps/url4-cloud/src/url4_cloud/connections/__init__.py
@@ -1,0 +1,65 @@
+"""Provider-connection subsystem and production composition helper."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Protocol
+
+import httpx
+
+from url4_cloud.connections.aigateway import AigatewayConnections
+from url4_cloud.connections.port import (
+    Caller,
+    Connection,
+    ConnectionAlreadyConnected,
+    ConnectionBadResponse,
+    ConnectionConflict,
+    ConnectionError,
+    ConnectionMethodUnsupported,
+    ConnectionNotFound,
+    ConnectionRateLimited,
+    ConnectionRejected,
+    Connections,
+    ConnectionTimeout,
+    ConnectionUnavailable,
+)
+
+_UPSTREAM_TIMEOUT_S = 10.0
+
+
+class _ConnectionSettings(Protocol):
+    aigateway_base_url: str | None
+
+
+def _default_client(base_url: str) -> httpx.AsyncClient:
+    return httpx.AsyncClient(base_url=base_url, timeout=_UPSTREAM_TIMEOUT_S)
+
+
+def build_connections(
+    settings: _ConnectionSettings,
+    *,
+    client_factory: Callable[[str], httpx.AsyncClient] = _default_client,
+) -> Connections | None:
+    """Build the AI Gateway adapter, or disable the endpoints when no upstream is configured."""
+
+    if not settings.aigateway_base_url:
+        return None
+    return AigatewayConnections(client_factory(settings.aigateway_base_url))
+
+
+__all__ = [
+    "Caller",
+    "Connection",
+    "ConnectionAlreadyConnected",
+    "ConnectionBadResponse",
+    "ConnectionConflict",
+    "ConnectionError",
+    "ConnectionMethodUnsupported",
+    "ConnectionNotFound",
+    "ConnectionRateLimited",
+    "ConnectionRejected",
+    "ConnectionTimeout",
+    "ConnectionUnavailable",
+    "Connections",
+    "build_connections",
+]

--- a/apps/url4-cloud/src/url4_cloud/connections/aigateway.py
+++ b/apps/url4-cloud/src/url4_cloud/connections/aigateway.py
@@ -1,0 +1,432 @@
+"""AI Gateway adapter for the SF Engine provider-connection port."""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Literal, cast
+from urllib.parse import urlsplit
+from uuid import UUID
+
+import httpx
+
+from url4_cloud.connections.port import (
+    AuthMethod,
+    Caller,
+    Connection,
+    ConnectionAlreadyConnected,
+    ConnectionBadResponse,
+    ConnectionConflict,
+    ConnectionMethodUnsupported,
+    ConnectionNotFound,
+    ConnectionRateLimited,
+    ConnectionRejected,
+    ConnectionStatus,
+    ConnectionTimeout,
+    ConnectionUnavailable,
+    OAuthAuthorization,
+)
+
+logger = logging.getLogger(__name__)
+
+_PROVIDERS_PATH = "/v1/providers"
+_CONNECTIONS_PATH = "/v1/oauth/connections"
+_API_KEY_PATH = f"{_CONNECTIONS_PATH}/api-key"
+# Inter-service contract: assigning this label explicitly designates a row for ScreamingFace
+# management. Rows under every other label remain outside this adapter's public projection.
+_MANAGED_LABEL = "screamingface"
+_MAX_OAUTH_EXPIRES_IN_SECONDS = 30 * 60
+_PROVIDER_ID = re.compile(r"[a-z0-9][a-z0-9_-]*\Z", re.ASCII)
+
+
+@dataclass(frozen=True, slots=True)
+class _Provider:
+    id: str
+    display_name: str
+    auth_methods: tuple[AuthMethod, ...]
+
+
+_UpstreamConnectionStatus = Literal["pending", "active", "expired", "revoked", "error"]
+
+
+@dataclass(frozen=True, slots=True)
+class _ConnectionRow:
+    id: UUID
+    provider: str
+    label: str
+    status: _UpstreamConnectionStatus
+    auth_type: AuthMethod
+    account_label: str | None
+
+
+class AigatewayConnections:
+    """Combine AI Gateway provider capabilities with caller-scoped connection state."""
+
+    def __init__(self, client: httpx.AsyncClient) -> None:
+        self._client = client
+
+    async def list(self, caller: Caller) -> tuple[Connection, ...]:
+        providers = await self._providers(caller)
+        rows = await self._rows(caller)
+        return tuple(
+            _disconnected(provider)
+            if (selected := _select(rows, provider.id)) is None
+            else _public(selected, provider)
+            for provider in providers
+        )
+
+    async def connect(self, caller: Caller, provider: str, api_key: str) -> Connection:
+        selected_provider = _provider(await self._providers(caller), provider)
+        if "api_key" not in selected_provider.auth_methods:
+            raise ConnectionMethodUnsupported()
+        rows = await self._rows(caller, provider=provider)
+        selected = _select(rows, provider)
+        if selected is None:
+            response = await self._request(
+                "POST",
+                _API_KEY_PATH,
+                caller,
+                json={"provider": provider, "label": _MANAGED_LABEL, "api_key": api_key},
+            )
+            expected_status = 201
+        else:
+            if selected.auth_type != "api_key":
+                raise ConnectionAlreadyConnected()
+            response = await self._request(
+                "PUT",
+                f"{_CONNECTIONS_PATH}/{selected.id}/api-key",
+                caller,
+                json={"api_key": api_key},
+            )
+            expected_status = 200
+        row = _decode_row(response)
+        if (
+            response.status_code != expected_status
+            or row.label != _MANAGED_LABEL
+            or row.auth_type != "api_key"
+            or row.status != "active"
+        ):
+            raise ConnectionBadResponse()
+        return _public(row, selected_provider)
+
+    async def start_oauth(self, caller: Caller, provider: str) -> OAuthAuthorization:
+        selected_provider = _provider(await self._providers(caller), provider)
+        if "oauth" not in selected_provider.auth_methods:
+            raise ConnectionMethodUnsupported()
+        rows = await self._rows(caller, provider=provider)
+        selected = _select(rows, provider)
+        if selected is not None:
+            raise ConnectionAlreadyConnected()
+        response = await self._request(
+            "POST",
+            _CONNECTIONS_PATH,
+            caller,
+            json={"provider": provider, "label": _MANAGED_LABEL},
+        )
+        return _decode_oauth_authorization(response, provider)
+
+    async def disconnect(self, caller: Caller, provider: str) -> Connection:
+        selected_provider = _provider(await self._providers(caller), provider)
+        rows = await self._rows(caller, provider=provider)
+        selected = _select(rows, provider)
+        if selected is None:
+            return _disconnected(selected_provider)
+        try:
+            response = await self._request(
+                "DELETE",
+                f"{_CONNECTIONS_PATH}/{selected.id}",
+                caller,
+            )
+        except ConnectionNotFound:
+            # The caller-visible operation is idempotent. A concurrent disconnect may revoke the
+            # row after our list but before our delete; that already achieved the requested state.
+            return _disconnected(selected_provider)
+        if response.status_code != 204:
+            raise ConnectionBadResponse()
+        return _disconnected(selected_provider)
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    async def _providers(self, caller: Caller) -> tuple[_Provider, ...]:
+        response = await self._request("GET", _PROVIDERS_PATH, caller)
+        if response.status_code != 200:
+            raise ConnectionBadResponse()
+        body = _decode_object(response)
+        if body.get("object") != "list" or not isinstance(body.get("data"), list):
+            raise ConnectionBadResponse()
+        providers = tuple(_validate_provider(row) for row in body["data"])
+        ids = tuple(provider.id for provider in providers)
+        if len(ids) != len(set(ids)):
+            raise ConnectionBadResponse()
+        return providers
+
+    async def _rows(
+        self,
+        caller: Caller,
+        *,
+        provider: str | None = None,
+    ) -> list[_ConnectionRow]:
+        response = await self._request(
+            "GET",
+            _CONNECTIONS_PATH,
+            caller,
+            params={"provider": provider} if provider is not None else None,
+        )
+        if response.status_code != 200:
+            raise ConnectionBadResponse()
+        body = _decode_object(response)
+        rows = body.get("connections")
+        if not isinstance(rows, list):
+            raise ConnectionBadResponse()
+        return [_validate_row(row) for row in rows]
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        caller: Caller,
+        *,
+        params: Mapping[str, str] | None = None,
+        json: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        try:
+            response = await self._client.request(
+                method,
+                path,
+                headers=dict(caller.identity),
+                params=params,
+                json=json,
+            )
+        except httpx.TimeoutException as exc:
+            logger.warning("AI Gateway provider-connection request timed out")
+            raise ConnectionTimeout() from exc
+        except httpx.HTTPError as exc:
+            logger.warning(
+                "AI Gateway provider-connection transport failure (%s)", type(exc).__name__
+            )
+            raise ConnectionUnavailable() from exc
+        _raise_for_status(response)
+        return response
+
+
+def _provider(providers: tuple[_Provider, ...], provider: str) -> _Provider:
+    selected = next((item for item in providers if item.id == provider), None)
+    if selected is None:
+        raise ConnectionNotFound()
+    return selected
+
+
+def _select(rows: list[_ConnectionRow], provider: str) -> _ConnectionRow | None:
+    managed = [row for row in rows if row.provider == provider and row.label == _MANAGED_LABEL]
+    if len(managed) == 1:
+        return managed[0]
+    if len(managed) > 1:
+        raise ConnectionConflict()
+    return None
+
+
+def _disconnected(provider: _Provider) -> Connection:
+    return Connection(
+        provider=provider.id,
+        display_name=provider.display_name,
+        auth_methods=provider.auth_methods,
+        status="not_connected",
+    )
+
+
+def _public(row: _ConnectionRow, provider: _Provider) -> Connection:
+    if row.provider != provider.id:
+        raise ConnectionBadResponse()
+    status = {
+        "active": "connected",
+        "pending": "pending",
+        "expired": "needs_reauth",
+        "revoked": "needs_reauth",
+        "error": "error",
+    }.get(row.status)
+    if status is None:
+        raise ConnectionBadResponse()
+    auth_method = row.auth_type
+    if auth_method not in provider.auth_methods:
+        raise ConnectionBadResponse()
+    return Connection(
+        provider=provider.id,
+        display_name=provider.display_name,
+        auth_methods=provider.auth_methods,
+        status=cast(ConnectionStatus, status),
+        auth_method=auth_method,
+        account_label=row.account_label if auth_method == "oauth" else None,
+    )
+
+
+def _validate_provider(value: object) -> _Provider:
+    if not isinstance(value, dict) or set(value) != {
+        "object",
+        "id",
+        "display_name",
+        "auth_methods",
+    }:
+        raise ConnectionBadResponse()
+    methods = value.get("auth_methods")
+    if (
+        value.get("object") != "provider"
+        or not isinstance(value.get("id"), str)
+        or _PROVIDER_ID.fullmatch(value["id"]) is None
+        or not isinstance(value.get("display_name"), str)
+        or not value["display_name"].strip()
+        or not isinstance(methods, list)
+        or not methods
+        or any(not isinstance(method, str) for method in methods)
+    ):
+        raise ConnectionBadResponse()
+    if any(method not in {"api_key", "oauth"} for method in methods) or len(methods) != len(
+        set(methods)
+    ):
+        raise ConnectionBadResponse()
+    return _Provider(
+        id=value["id"],
+        display_name=value["display_name"],
+        auth_methods=cast(tuple[AuthMethod, ...], tuple(methods)),
+    )
+
+
+def _decode_row(response: httpx.Response) -> _ConnectionRow:
+    return _validate_row(_decode_object(response))
+
+
+def _decode_oauth_authorization(
+    response: httpx.Response,
+    provider: str,
+) -> OAuthAuthorization:
+    body = _decode_object(response)
+    if response.status_code != 201 or set(body) != {
+        "connection_id",
+        "authorize_url",
+        "state",
+        "expires_in",
+    }:
+        raise ConnectionBadResponse()
+    authorize_url = body.get("authorize_url")
+    expires_in = body.get("expires_in")
+    connection_id = body.get("connection_id")
+    state = body.get("state")
+    if (
+        not _is_uuid(connection_id)
+        or not isinstance(state, str)
+        or not state.strip()
+        or not isinstance(authorize_url, str)
+        or not _is_https_url(authorize_url)
+        or isinstance(expires_in, bool)
+        or not isinstance(expires_in, int)
+        or not 1 <= expires_in <= _MAX_OAUTH_EXPIRES_IN_SECONDS
+    ):
+        raise ConnectionBadResponse()
+    return OAuthAuthorization(provider, authorize_url, expires_in)
+
+
+def _is_https_url(value: str) -> bool:
+    try:
+        parts = urlsplit(value)
+        _ = parts.port
+    except ValueError:
+        return False
+    return (
+        parts.scheme == "https"
+        and bool(parts.hostname)
+        and parts.username is None
+        and parts.password is None
+    )
+
+
+def _is_uuid(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    try:
+        UUID(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _decode_object(response: httpx.Response) -> dict[str, Any]:
+    try:
+        body = response.json()
+    except ValueError as exc:
+        raise ConnectionBadResponse() from exc
+    if not isinstance(body, dict):
+        raise ConnectionBadResponse()
+    return body
+
+
+def _validate_row(value: object) -> _ConnectionRow:
+    if not isinstance(value, dict):
+        raise ConnectionBadResponse()
+    connection_id = value.get("id")
+    provider = value.get("provider")
+    label = value.get("label")
+    status = value.get("status")
+    auth_type = value.get("auth_type")
+    if (
+        not isinstance(connection_id, str)
+        or not _is_uuid(connection_id)
+        or not isinstance(provider, str)
+        or _PROVIDER_ID.fullmatch(provider) is None
+        or not isinstance(label, str)
+        or not label.strip()
+        or not isinstance(status, str)
+        or status not in {"pending", "active", "expired", "revoked", "error"}
+        or not isinstance(auth_type, str)
+        or auth_type not in {"api_key", "oauth"}
+    ):
+        raise ConnectionBadResponse()
+    return _ConnectionRow(
+        id=UUID(connection_id),
+        provider=provider,
+        label=label,
+        status=cast(_UpstreamConnectionStatus, status),
+        auth_type=cast(AuthMethod, auth_type),
+        account_label=_account_label(value.get("account")),
+    )
+
+
+def _account_label(value: object) -> str | None:
+    """Extract AI Gateway's safe display label without retaining raw account metadata."""
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ConnectionBadResponse()
+    for field in ("email", "name", "sub"):
+        candidate = value.get(field)
+        if candidate is None:
+            continue
+        if not isinstance(candidate, str) or not candidate.strip():
+            raise ConnectionBadResponse()
+        return candidate.strip()
+    return None
+
+
+def _raise_for_status(response: httpx.Response) -> None:
+    status = response.status_code
+    if status < 300:
+        return
+    error = {
+        # Provider capability is checked locally before a credential leaves the Engine.
+        # AI Gateway also uses 400 for malformed credentials, so an upstream 400 is a
+        # rejection—not evidence that the advertised method is unsupported.
+        400: ConnectionRejected,
+        401: ConnectionRejected,
+        403: ConnectionRejected,
+        404: ConnectionNotFound,
+        409: ConnectionConflict,
+        422: ConnectionRejected,
+        429: ConnectionRateLimited,
+        503: ConnectionUnavailable,
+        504: ConnectionTimeout,
+    }.get(status, ConnectionBadResponse)
+    raise error()
+
+
+__all__ = ["AigatewayConnections"]

--- a/apps/url4-cloud/src/url4_cloud/connections/port.py
+++ b/apps/url4-cloud/src/url4_cloud/connections/port.py
@@ -1,0 +1,170 @@
+"""Provider-connection domain types and the Engine-facing port.
+
+The control plane exposes connection state without exposing aigateway's account IDs,
+credential locators, or provider response bodies. Concrete adapters translate their
+upstream into these deliberately small values.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Literal, Protocol, runtime_checkable
+
+AuthMethod = Literal["api_key", "oauth"]
+ConnectionStatus = Literal[
+    "not_connected",
+    "pending",
+    "connected",
+    "needs_reauth",
+    "error",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class Caller:
+    """Verified identity headers associated with one Engine request."""
+
+    identity: Mapping[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class Connection:
+    """The safe, public status of one provider connection."""
+
+    provider: str
+    display_name: str
+    auth_methods: tuple[AuthMethod, ...]
+    status: ConnectionStatus
+    auth_method: AuthMethod | None = None
+    account_label: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class OAuthAuthorization:
+    """A bounded browser authorization created by AI Gateway."""
+
+    provider: str
+    authorize_url: str
+    expires_in: int
+
+
+class ConnectionError(Exception):
+    """A safe connection failure with its public HTTP mapping."""
+
+    status = 502
+    title = "Bad Gateway"
+    detail = "the provider connection could not be updated"
+
+    def __init__(self, detail: str | None = None) -> None:
+        # Accepting a caller message is useful for logs/tests, but public routes always use
+        # the class-level safe detail. This prevents an upstream body or API key from leaking.
+        self.internal_detail = detail
+        super().__init__(self.detail)
+
+
+class ConnectionRejected(ConnectionError):
+    """The caller identity or provider credential was rejected."""
+
+    status = 401
+    title = "Unauthorized"
+    detail = "the provider connection was rejected"
+
+
+class ConnectionNotFound(ConnectionError):
+    """The requested provider is not exposed by this Engine."""
+
+    status = 404
+    title = "Not Found"
+    detail = "the requested provider is not available"
+
+
+class ConnectionMethodUnsupported(ConnectionError):
+    """The provider exists but cannot accept the requested credential method."""
+
+    status = 400
+    title = "Bad Request"
+    detail = "the provider does not support the requested connection method"
+
+
+class ConnectionConflict(ConnectionError):
+    """AI Gateway connection state conflicts with the requested operation."""
+
+    status = 409
+    title = "Conflict"
+    detail = "provider connection state conflicts with this operation"
+
+
+class ConnectionAlreadyConnected(ConnectionError):
+    """Changing authentication methods requires an explicit disconnect."""
+
+    status = 409
+    title = "Conflict"
+    detail = "the provider is already connected; disconnect it before changing authentication"
+
+
+class ConnectionRateLimited(ConnectionError):
+    """AI Gateway refused the operation because it was rate limited."""
+
+    status = 429
+    title = "Too Many Requests"
+    detail = "provider connection requests are temporarily rate limited"
+
+
+class ConnectionBadResponse(ConnectionError):
+    """AI Gateway returned a malformed or otherwise unusable response."""
+
+    status = 502
+    title = "Bad Gateway"
+    detail = "AI Gateway returned an unusable provider connection response"
+
+
+class ConnectionUnavailable(ConnectionError):
+    """AI Gateway could not be reached."""
+
+    status = 503
+    title = "Service Unavailable"
+    detail = "AI Gateway is unavailable"
+
+
+class ConnectionTimeout(ConnectionError):
+    """AI Gateway did not respond before the Engine timeout."""
+
+    status = 504
+    title = "Gateway Timeout"
+    detail = "AI Gateway did not respond in time"
+
+
+@runtime_checkable
+class Connections(Protocol):
+    """Provider-connection operations required by the Engine REST surface."""
+
+    async def list(self, caller: Caller) -> tuple[Connection, ...]: ...
+
+    async def connect(self, caller: Caller, provider: str, api_key: str) -> Connection: ...
+
+    async def start_oauth(self, caller: Caller, provider: str) -> OAuthAuthorization: ...
+
+    async def disconnect(self, caller: Caller, provider: str) -> Connection: ...
+
+    async def aclose(self) -> None: ...
+
+
+__all__ = [
+    "AuthMethod",
+    "Caller",
+    "Connection",
+    "ConnectionAlreadyConnected",
+    "ConnectionBadResponse",
+    "ConnectionConflict",
+    "ConnectionError",
+    "ConnectionMethodUnsupported",
+    "ConnectionNotFound",
+    "ConnectionRateLimited",
+    "ConnectionRejected",
+    "ConnectionStatus",
+    "ConnectionTimeout",
+    "ConnectionUnavailable",
+    "Connections",
+    "OAuthAuthorization",
+]

--- a/apps/url4-cloud/src/url4_cloud/local.py
+++ b/apps/url4-cloud/src/url4_cloud/local.py
@@ -33,7 +33,12 @@ from url4_cloud.adapters.inprocess import InProcessJobRunner
 from url4_cloud.adapters.memory import InMemoryEventStream
 from url4_cloud.app import create_app
 from url4_cloud.catalog import build_catalog_service
-from url4_cloud.config import INSECURE_DEFAULT_JWT_SECRET, Settings
+from url4_cloud.config import (
+    INSECURE_DEFAULT_JWT_SECRET,
+    LOCAL_AIGATEWAY_BASE_URL,
+    Settings,
+)
+from url4_cloud.connections import build_connections
 
 _logger = logging.getLogger(__name__)
 
@@ -114,16 +119,25 @@ def create_local_app(
         max_history=settings.local_max_run_history,
     )
     catalog = build_catalog_service(settings)
+    connection_settings = settings
+    if connection_settings.aigateway_base_url is None:
+        connection_settings = connection_settings.model_copy(
+            update={"aigateway_base_url": LOCAL_AIGATEWAY_BASE_URL}
+        )
+    connections = build_connections(connection_settings)
     app = create_app(
         settings,
         stream=stream,
         job_runner=job_runner,
         catalog=catalog,
         model_parameters=catalog.model_parameter_source if catalog is not None else None,
+        connections=connections,
     )
     app.router.on_shutdown.append(job_runner.aclose)
     if catalog is not None:
         app.router.on_shutdown.append(catalog.aclose)
+    if connections is not None:
+        app.router.on_shutdown.append(connections.aclose)
     return app
 
 

--- a/apps/url4-cloud/src/url4_cloud/local.py
+++ b/apps/url4-cloud/src/url4_cloud/local.py
@@ -33,11 +33,7 @@ from url4_cloud.adapters.inprocess import InProcessJobRunner
 from url4_cloud.adapters.memory import InMemoryEventStream
 from url4_cloud.app import create_app
 from url4_cloud.catalog import build_catalog_service
-from url4_cloud.config import (
-    INSECURE_DEFAULT_JWT_SECRET,
-    LOCAL_AIGATEWAY_BASE_URL,
-    Settings,
-)
+from url4_cloud.config import INSECURE_DEFAULT_JWT_SECRET, Settings
 from url4_cloud.connections import build_connections
 
 _logger = logging.getLogger(__name__)
@@ -122,7 +118,7 @@ def create_local_app(
     connection_settings = settings
     if connection_settings.aigateway_base_url is None:
         connection_settings = connection_settings.model_copy(
-            update={"aigateway_base_url": LOCAL_AIGATEWAY_BASE_URL}
+            update={"aigateway_base_url": settings.local_aigateway_base_url}
         )
     connections = build_connections(connection_settings)
     app = create_app(

--- a/apps/url4-cloud/src/url4_cloud/rest/__init__.py
+++ b/apps/url4-cloud/src/url4_cloud/rest/__init__.py
@@ -6,7 +6,14 @@ reaching into the individual route modules.
 """
 
 from url4_cloud.rest.catalog import router as catalog_router
+from url4_cloud.rest.connections import router as connection_router
 from url4_cloud.rest.interest import DenyAllGate, SubscriberGate
 from url4_cloud.rest.routes import router
 
-__all__ = ["DenyAllGate", "SubscriberGate", "catalog_router", "router"]
+__all__ = [
+    "DenyAllGate",
+    "SubscriberGate",
+    "catalog_router",
+    "connection_router",
+    "router",
+]

--- a/apps/url4-cloud/src/url4_cloud/rest/connections.py
+++ b/apps/url4-cloud/src/url4_cloud/rest/connections.py
@@ -1,0 +1,247 @@
+"""SF Engine provider-connection routes backed by AI Gateway."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Coroutine
+from typing import Annotated, Any, Literal
+
+from fastapi import APIRouter, Path, Request, Response
+from fastapi.exceptions import RequestValidationError
+from fastapi.routing import APIRoute
+from pydantic import BaseModel, ConfigDict, SecretStr
+
+from url4_cloud import job_env
+from url4_cloud.auth import PROBLEM_MEDIA_TYPE, ProblemException
+from url4_cloud.connections.port import (
+    AuthMethod,
+    Caller,
+    Connection,
+    ConnectionError,
+    Connections,
+    ConnectionStatus,
+    OAuthAuthorization,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class _SecretSafeRoute(APIRoute):
+    """Replace FastAPI's input-bearing validation errors at the credential boundary."""
+
+    def get_route_handler(
+        self,
+    ) -> Callable[[Request], Coroutine[Any, Any, Response]]:
+        route_handler = super().get_route_handler()
+
+        async def secret_safe_route_handler(request: Request) -> Response:
+            try:
+                return await route_handler(request)
+            except RequestValidationError:
+                logger.info("provider connection request validation failed")
+                raise ProblemException(
+                    status=422,
+                    title="Unprocessable Content",
+                    detail="the provider connection request is invalid",
+                ) from None
+
+        return secret_safe_route_handler
+
+
+router = APIRouter(tags=["Connections"], route_class=_SecretSafeRoute)
+
+
+class ApiKeyRequest(BaseModel):
+    """A provider credential accepted only long enough to forward it to AI Gateway."""
+
+    model_config = ConfigDict(extra="forbid", hide_input_in_errors=True)
+
+    api_key: SecretStr
+
+
+class ConnectionResponse(BaseModel):
+    """The complete secret-free connection projection exposed by the Engine."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    object: Literal["connection"] = "connection"
+    provider: str
+    display_name: str
+    auth_methods: tuple[AuthMethod, ...]
+    status: ConnectionStatus
+    auth_method: AuthMethod | None = None
+    account_label: str | None = None
+
+
+class ConnectionListResponse(BaseModel):
+    """Caller-scoped provider connections."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    object: Literal["list"] = "list"
+    data: tuple[ConnectionResponse, ...]
+
+
+class OAuthAuthorizationResponse(BaseModel):
+    """The public browser authorization fields returned to the Client."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    object: Literal["oauth_authorization"] = "oauth_authorization"
+    provider: str
+    authorize_url: str
+    expires_in: int
+
+
+_ERROR_DESCRIPTIONS = {
+    400: "The provider does not support the requested authentication method.",
+    401: "The caller or provider credential was rejected.",
+    404: "The provider is not available.",
+    409: "The Engine-managed connection state conflicts with this operation.",
+    422: "The request body is invalid.",
+    429: "Provider connection requests are rate limited.",
+    502: "AI Gateway returned an unusable response.",
+    503: "Provider connections or AI Gateway are unavailable.",
+    504: "AI Gateway did not respond in time.",
+}
+
+
+def _error_responses() -> dict[int | str, dict[str, Any]]:
+    return {
+        status: {
+            "description": description,
+            "content": {PROBLEM_MEDIA_TYPE: {"schema": {"$ref": "#/components/schemas/Problem"}}},
+        }
+        for status, description in _ERROR_DESCRIPTIONS.items()
+    }
+
+
+def _serialize(connection: Connection) -> ConnectionResponse:
+    return ConnectionResponse(
+        provider=connection.provider,
+        display_name=connection.display_name,
+        auth_methods=connection.auth_methods,
+        status=connection.status,
+        auth_method=connection.auth_method,
+        account_label=connection.account_label,
+    )
+
+
+def _serialize_oauth(authorization: OAuthAuthorization) -> OAuthAuthorizationResponse:
+    return OAuthAuthorizationResponse(
+        provider=authorization.provider,
+        authorize_url=authorization.authorize_url,
+        expires_in=authorization.expires_in,
+    )
+
+
+def _caller(request: Request) -> Caller:
+    return Caller(job_env.identity_from_headers(request.headers))
+
+
+def _service(request: Request) -> Connections:
+    service = getattr(request.app.state, "connections", None)
+    if service is None:
+        raise ProblemException(
+            status=503,
+            title="Service Unavailable",
+            detail="provider connections are not configured on this Engine",
+        )
+    return service
+
+
+def _problem(exc: ConnectionError) -> ProblemException:
+    logger.info("provider connection request failed: %s", type(exc).__name__)
+    return ProblemException(status=exc.status, title=exc.title, detail=exc.detail)
+
+
+def _mark_private(response: Response) -> None:
+    response.headers["Cache-Control"] = "private, no-store"
+    response.headers["Vary"] = "X-User-Email"
+
+
+@router.get(
+    "/v1/connections",
+    summary="List provider connections",
+    description="Return the safe connection state exposed to the ScreamingFace Client.",
+    response_model=ConnectionListResponse,
+    responses=_error_responses(),
+)
+async def list_connections(request: Request, response: Response) -> ConnectionListResponse:
+    try:
+        rows = await _service(request).list(_caller(request))
+    except ConnectionError as exc:
+        raise _problem(exc) from exc
+    _mark_private(response)
+    return ConnectionListResponse(data=tuple(_serialize(row) for row in rows))
+
+
+@router.put(
+    "/v1/connections/{provider}",
+    summary="Connect or replace a provider API key",
+    response_model=ConnectionResponse,
+    responses=_error_responses(),
+)
+async def connect_provider(
+    request: Request,
+    body: ApiKeyRequest,
+    response: Response,
+    provider: Annotated[str, Path(min_length=1)],
+) -> ConnectionResponse:
+    try:
+        connection = await _service(request).connect(
+            _caller(request),
+            provider,
+            body.api_key.get_secret_value(),
+        )
+    except ConnectionError as exc:
+        raise _problem(exc) from exc
+    _mark_private(response)
+    return _serialize(connection)
+
+
+@router.post(
+    "/v1/connections/{provider}/oauth",
+    status_code=201,
+    summary="Start provider OAuth authorization",
+    response_model=OAuthAuthorizationResponse,
+    responses=_error_responses(),
+)
+async def start_provider_oauth(
+    request: Request,
+    response: Response,
+    provider: Annotated[str, Path(min_length=1)],
+) -> OAuthAuthorizationResponse:
+    try:
+        authorization = await _service(request).start_oauth(_caller(request), provider)
+    except ConnectionError as exc:
+        raise _problem(exc) from exc
+    _mark_private(response)
+    return _serialize_oauth(authorization)
+
+
+@router.delete(
+    "/v1/connections/{provider}",
+    summary="Disconnect a provider",
+    response_model=ConnectionResponse,
+    responses=_error_responses(),
+)
+async def disconnect_provider(
+    request: Request,
+    response: Response,
+    provider: Annotated[str, Path(min_length=1)],
+) -> ConnectionResponse:
+    try:
+        connection = await _service(request).disconnect(_caller(request), provider)
+    except ConnectionError as exc:
+        raise _problem(exc) from exc
+    _mark_private(response)
+    return _serialize(connection)
+
+
+__all__ = [
+    "ConnectionListResponse",
+    "ConnectionResponse",
+    "OAuthAuthorizationResponse",
+    "router",
+]

--- a/apps/url4-cloud/src/url4_cloud/schemas/openapi.py
+++ b/apps/url4-cloud/src/url4_cloud/schemas/openapi.py
@@ -64,6 +64,10 @@ TAGS: list[dict[str, str]] = [
     {"name": "Token", "description": "Mint a topic-capability JWT (spec §4)."},
     {"name": "Execution", "description": "Start (sync/async) and stop a url4 run (spec §5)."},
     {"name": "Catalog", "description": "Discover the models a credential can address (OME-625)."},
+    {
+        "name": "Connections",
+        "description": "Connect provider credentials through the ScreamingFace Engine.",
+    },
 ]
 
 

--- a/apps/url4-cloud/tests/unit/test_connections_aigateway.py
+++ b/apps/url4-cloud/tests/unit/test_connections_aigateway.py
@@ -1,0 +1,613 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from url4_cloud.connections.aigateway import AigatewayConnections
+from url4_cloud.connections.port import (
+    Caller,
+    Connection,
+    ConnectionAlreadyConnected,
+    ConnectionBadResponse,
+    ConnectionConflict,
+    ConnectionMethodUnsupported,
+    ConnectionRejected,
+    Connections,
+    ConnectionTimeout,
+    ConnectionUnavailable,
+    OAuthAuthorization,
+)
+
+pytestmark = pytest.mark.asyncio
+
+IDENTITY = {"X-User-Email": "alice@example.com"}
+SECRET = "sk-or-v1-unit-secret"
+
+
+def _adapter(
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> tuple[AigatewayConnections, list[httpx.Request]]:
+    seen: list[httpx.Request] = []
+
+    def capture(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return handler(request)
+
+    client = httpx.AsyncClient(
+        base_url="http://aigateway.test",
+        transport=httpx.MockTransport(capture),
+    )
+    return AigatewayConnections(client), seen
+
+
+def _list(*rows: dict[str, object]) -> dict[str, object]:
+    return {"connections": list(rows)}
+
+
+def _providers(*rows: dict[str, object]) -> dict[str, object]:
+    return {"object": "list", "data": list(rows) if rows else [_provider()]}
+
+
+def _provider(
+    provider: str = "openrouter",
+    display_name: str = "OpenRouter",
+    auth_methods: tuple[str, ...] = ("api_key",),
+) -> dict[str, object]:
+    return {
+        "object": "provider",
+        "id": provider,
+        "display_name": display_name,
+        "auth_methods": list(auth_methods),
+    }
+
+
+def _get(request: httpx.Request, *rows: dict[str, object]) -> httpx.Response:
+    payload = _providers() if request.url.path == "/v1/providers" else _list(*rows)
+    return httpx.Response(200, json=payload)
+
+
+def _disconnected(provider: str = "openrouter", display_name: str = "OpenRouter") -> Connection:
+    return Connection(provider, display_name, ("api_key",), "not_connected")
+
+
+def _row(
+    *,
+    connection_id: str = "00000000-0000-0000-0000-000000000001",
+    status: str = "active",
+    auth_type: str = "api_key",
+    label: str = "screamingface",
+    provider: str = "openrouter",
+    account: object = None,
+) -> dict[str, object]:
+    return {
+        "id": connection_id,
+        "account_id": "00000000-0000-0000-0000-000000000099",
+        "provider": provider,
+        "label": label,
+        "status": status,
+        "auth_type": auth_type,
+        "account": account,
+        "credential_locator": {"service": "must-not-leak", "account": "default"},
+        "created_at": "2026-07-31T00:00:00Z",
+        "last_used_at": None,
+        "last_refreshed_at": None,
+        "error_message": None,
+        "is_duplicate": False,
+    }
+
+
+async def test_adapter_satisfies_the_connection_port_and_advertises_openrouter() -> None:
+    adapter, _ = _adapter(_get)
+
+    assert isinstance(adapter, Connections)
+    assert await adapter.list(Caller(IDENTITY)) == (_disconnected(),)
+
+
+@pytest.mark.parametrize("provider", ["../../token", "openrouter/keys", "OpenRouter"])
+async def test_provider_catalog_rejects_ids_that_are_not_one_path_segment(
+    provider: str,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/providers":
+            return httpx.Response(200, json=_providers(_provider(provider)))
+        raise AssertionError("invalid provider catalogue reached the connection store")
+
+    adapter, _ = _adapter(handler)
+
+    with pytest.raises(ConnectionBadResponse):
+        await adapter.list(Caller())
+
+
+async def test_connected_state_is_sanitized_and_identity_is_forwarded() -> None:
+    adapter, seen = _adapter(lambda request: _get(request, _row()))
+
+    (connection,) = await adapter.list(Caller(IDENTITY))
+
+    assert connection.provider == "openrouter"
+    assert connection.status == "connected"
+    assert connection.auth_method == "api_key"
+    assert connection.account_label is None
+    assert seen[0].headers["X-User-Email"] == "alice@example.com"
+    assert "authorization" not in seen[0].headers
+    assert "credential_locator" not in repr(connection)
+
+
+async def test_oauth_account_exposes_only_the_safe_display_label() -> None:
+    provider = _provider("anthropic", "Anthropic", ("oauth",))
+    row = _row(
+        provider="anthropic",
+        auth_type="oauth",
+        account={
+            "sub": "provider-account-id",
+            "email": " alice@example.com ",
+            "name": "Alice",
+            "raw": {"access_token": "must-not-leak"},
+        },
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = _providers(provider) if request.url.path == "/v1/providers" else _list(row)
+        return httpx.Response(200, json=payload)
+
+    adapter, _ = _adapter(handler)
+
+    (connection,) = await adapter.list(Caller(IDENTITY))
+
+    assert connection.account_label == "alice@example.com"
+    assert "provider-account-id" not in repr(connection)
+    assert "must-not-leak" not in repr(connection)
+
+
+@pytest.mark.parametrize("account", ["alice@example.com", {"email": 7}, {"name": " "}])
+async def test_malformed_oauth_account_is_rejected(account: object) -> None:
+    provider = _provider("anthropic", "Anthropic", ("oauth",))
+    row = _row(provider="anthropic", auth_type="oauth", account=account)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = _providers(provider) if request.url.path == "/v1/providers" else _list(row)
+        return httpx.Response(200, json=payload)
+
+    adapter, _ = _adapter(handler)
+
+    with pytest.raises(ConnectionBadResponse):
+        await adapter.list(Caller())
+
+
+async def test_connect_creates_a_validated_connection_without_leaking_the_key() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:  # noqa: PLR0911
+        if request.method == "GET":
+            return _get(request)
+        assert request.url.path == "/v1/oauth/connections/api-key"
+        assert json.loads(request.content) == {
+            "provider": "openrouter",
+            "label": "screamingface",
+            "api_key": SECRET,
+        }
+        return httpx.Response(201, json=_row())
+
+    adapter, seen = _adapter(handler)
+
+    connection = await adapter.connect(Caller(IDENTITY), "openrouter", SECRET)
+
+    assert connection.status == "connected"
+    assert SECRET not in repr(connection)
+    assert SECRET not in str(seen[-1].url)
+
+
+async def test_start_oauth_creates_a_sanitized_authorization() -> None:
+    provider = _provider("anthropic", "Anthropic", ("api_key", "oauth"))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/providers":
+            return httpx.Response(200, json=_providers(provider))
+        if request.method == "GET":
+            return httpx.Response(200, json=_list())
+        assert request.method == "POST"
+        assert request.url.path == "/v1/oauth/connections"
+        assert json.loads(request.content) == {
+            "provider": "anthropic",
+            "label": "screamingface",
+        }
+        return httpx.Response(
+            201,
+            json={
+                "connection_id": "00000000-0000-0000-0000-000000000001",
+                "authorize_url": "https://claude.example/authorize?state=private",
+                "state": "must-not-leak",
+                "expires_in": 600,
+            },
+        )
+
+    adapter, _ = _adapter(handler)
+
+    authorization = await adapter.start_oauth(Caller(IDENTITY), "anthropic")
+
+    assert authorization == OAuthAuthorization(
+        provider="anthropic",
+        authorize_url="https://claude.example/authorize?state=private",
+        expires_in=600,
+    )
+    assert "must-not-leak" not in repr(authorization)
+
+
+async def test_start_oauth_rejects_an_unbounded_authorization_lifetime() -> None:
+    provider = _provider("anthropic", "Anthropic", ("oauth",))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/providers":
+            return httpx.Response(200, json=_providers(provider))
+        if request.method == "GET":
+            return httpx.Response(200, json=_list())
+        return httpx.Response(
+            201,
+            json={
+                "connection_id": "00000000-0000-0000-0000-000000000001",
+                "authorize_url": "https://claude.example/authorize",
+                "state": "private",
+                "expires_in": 1801,
+            },
+        )
+
+    adapter, _ = _adapter(handler)
+
+    with pytest.raises(ConnectionBadResponse):
+        await adapter.start_oauth(Caller(), "anthropic")
+
+
+async def test_start_oauth_rejects_a_malformed_authorization_url() -> None:
+    provider = _provider("anthropic", "Anthropic", ("oauth",))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/providers":
+            return httpx.Response(200, json=_providers(provider))
+        if request.method == "GET":
+            return httpx.Response(200, json=_list())
+        return httpx.Response(
+            201,
+            json={
+                "connection_id": "00000000-0000-0000-0000-000000000001",
+                "authorize_url": "https://[malformed",
+                "state": "private",
+                "expires_in": 600,
+            },
+        )
+
+    adapter, _ = _adapter(handler)
+
+    with pytest.raises(ConnectionBadResponse):
+        await adapter.start_oauth(Caller(), "anthropic")
+
+
+@pytest.mark.parametrize(
+    "authorize_url",
+    ["https://provider.example:bad/authorize", "https://provider.example:99999/authorize"],
+)
+async def test_start_oauth_rejects_an_invalid_authorization_port(
+    authorize_url: str,
+) -> None:
+    provider = _provider("anthropic", "Anthropic", ("oauth",))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/providers":
+            return httpx.Response(200, json=_providers(provider))
+        if request.method == "GET":
+            return httpx.Response(200, json=_list())
+        return httpx.Response(
+            201,
+            json={
+                "connection_id": "00000000-0000-0000-0000-000000000001",
+                "authorize_url": authorize_url,
+                "state": "private",
+                "expires_in": 600,
+            },
+        )
+
+    adapter, _ = _adapter(handler)
+
+    with pytest.raises(ConnectionBadResponse):
+        await adapter.start_oauth(Caller(), "anthropic")
+
+
+async def test_start_oauth_requires_explicit_disconnect_of_a_managed_connection() -> None:
+    provider = _provider("anthropic", "Anthropic", ("oauth",))
+    existing = _row(provider="anthropic", auth_type="oauth")
+    methods: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/providers":
+            return httpx.Response(200, json=_providers(provider))
+        if request.method == "GET":
+            return httpx.Response(200, json=_list(existing))
+        methods.append(request.method)
+        raise AssertionError("OAuth replacement must not mutate a connected provider")
+
+    adapter, _ = _adapter(handler)
+
+    with pytest.raises(ConnectionAlreadyConnected):
+        await adapter.start_oauth(Caller(), "anthropic")
+
+    assert methods == []
+
+
+async def test_connect_does_not_adopt_a_single_unmanaged_api_key_connection() -> None:
+    existing = _row(label="research")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return _get(request, existing)
+        assert request.method == "POST"
+        assert request.url.path == "/v1/oauth/connections/api-key"
+        assert json.loads(request.content) == {
+            "provider": "openrouter",
+            "label": "screamingface",
+            "api_key": SECRET,
+        }
+        return httpx.Response(201, json=_row())
+
+    adapter, _ = _adapter(handler)
+
+    assert (await adapter.connect(Caller(), "openrouter", SECRET)).status == "connected"
+
+
+async def test_connect_replaces_only_the_existing_managed_api_key_connection() -> None:
+    existing = _row()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return _get(request, existing)
+        assert request.method == "PUT"
+        assert request.url.path.endswith("/00000000-0000-0000-0000-000000000001/api-key")
+        assert json.loads(request.content) == {"api_key": SECRET}
+        return httpx.Response(200, json=existing)
+
+    adapter, _ = _adapter(handler)
+
+    assert (await adapter.connect(Caller(), "openrouter", SECRET)).status == "connected"
+
+
+async def test_connect_requires_disconnect_before_replacing_oauth_with_an_api_key() -> None:
+    provider = _provider("openrouter", "OpenRouter", ("api_key", "oauth"))
+    existing = _row(auth_type="oauth")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/providers":
+            return httpx.Response(200, json=_providers(provider))
+        if request.method == "GET":
+            return httpx.Response(200, json=_list(existing))
+        raise AssertionError("the API key must not leave the Engine before explicit disconnect")
+
+    adapter, seen = _adapter(handler)
+
+    with pytest.raises(ConnectionAlreadyConnected):
+        await adapter.connect(Caller(), "openrouter", SECRET)
+
+    assert all(SECRET not in request.content.decode(errors="ignore") for request in seen)
+
+
+@pytest.mark.parametrize(
+    ("status_code", "status", "auth_type"),
+    [(202, "active", "api_key"), (201, "pending", "api_key"), (201, "active", "oauth")],
+)
+async def test_connect_rejects_an_incorrect_success_response(
+    status_code: int,
+    status: str,
+    auth_type: str,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return _get(request)
+        return httpx.Response(
+            status_code,
+            json=_row(status=status, auth_type=auth_type),
+        )
+
+    adapter, _ = _adapter(handler)
+
+    with pytest.raises(ConnectionBadResponse):
+        await adapter.connect(Caller(), "openrouter", SECRET)
+
+
+async def test_multiple_unmanaged_rows_leave_the_automatic_row_disconnected() -> None:
+    rows = [
+        _row(connection_id="00000000-0000-0000-0000-000000000001", label="one"),
+        _row(connection_id="00000000-0000-0000-0000-000000000002", label="two"),
+    ]
+
+    adapter, _ = _adapter(lambda request: _get(request, *rows))
+
+    assert await adapter.list(Caller()) == (_disconnected(),)
+
+
+async def test_managed_row_is_selected_without_mutating_unmanaged_rows() -> None:
+    rows = [
+        _row(connection_id="00000000-0000-0000-0000-000000000001", label="research"),
+        _row(connection_id="00000000-0000-0000-0000-000000000002"),
+    ]
+
+    adapter, _ = _adapter(lambda request: _get(request, *rows))
+
+    (connection,) = await adapter.list(Caller())
+    assert connection.status == "connected"
+
+
+async def test_multiple_managed_rows_are_a_conflict() -> None:
+    rows = [
+        _row(connection_id="00000000-0000-0000-0000-000000000001"),
+        _row(connection_id="00000000-0000-0000-0000-000000000002"),
+    ]
+    adapter, _ = _adapter(lambda request: _get(request, *rows))
+
+    with pytest.raises(ConnectionConflict):
+        await adapter.list(Caller())
+
+
+async def test_disconnect_never_deletes_an_unmanaged_connection() -> None:
+    existing = _row(label="research")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method != "GET":
+            raise AssertionError("disconnect must not mutate an unmanaged Gateway row")
+        return _get(request, existing)
+
+    adapter, seen = _adapter(handler)
+
+    assert (await adapter.disconnect(Caller(), "openrouter")).status == "not_connected"
+    assert all(request.method == "GET" for request in seen)
+
+
+async def test_disconnect_is_idempotent_and_removes_the_selected_connection() -> None:
+    rows = [_row()]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return _get(request, *rows)
+        assert request.method == "DELETE"
+        rows.clear()
+        return httpx.Response(204)
+
+    adapter, seen = _adapter(handler)
+
+    assert (await adapter.disconnect(Caller(), "openrouter")).status == "not_connected"
+    assert (await adapter.disconnect(Caller(), "openrouter")).status == "not_connected"
+    assert [request.method for request in seen].count("DELETE") == 1
+
+
+async def test_disconnect_is_idempotent_when_a_concurrent_delete_wins() -> None:
+    existing = _row()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return _get(request, existing)
+        return httpx.Response(404, json={"detail": {"code": "connection_not_found"}})
+
+    adapter, _ = _adapter(handler)
+
+    connection = await adapter.disconnect(Caller(), "openrouter")
+    assert connection.status == "not_connected"
+
+
+@pytest.mark.parametrize("status", [401, 403])
+async def test_caller_authentication_rejection_is_typed(status: int) -> None:
+    adapter, _ = _adapter(lambda _: httpx.Response(status, json={"detail": "private"}))
+
+    with pytest.raises(ConnectionRejected):
+        await adapter.list(Caller(IDENTITY))
+
+
+@pytest.mark.parametrize("status", [400, 422])
+async def test_invalid_key_failure_is_sanitized(status: int) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return _get(request)
+        return httpx.Response(
+            status,
+            json={"detail": {"code": "invalid_api_key", "message": SECRET}},
+        )
+
+    adapter, _ = _adapter(handler)
+
+    with pytest.raises(ConnectionRejected) as failure:
+        await adapter.connect(Caller(), "openrouter", SECRET)
+
+    assert SECRET not in str(failure.value)
+
+
+async def test_malformed_upstream_response_is_typed() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/providers":
+            return httpx.Response(200, json=_providers())
+        return httpx.Response(200, json={"connections": [_row(status="x")]})
+
+    adapter, _ = _adapter(handler)
+
+    with pytest.raises(ConnectionBadResponse):
+        await adapter.list(Caller())
+
+
+async def test_non_string_provider_auth_method_is_typed() -> None:
+    malformed = _provider()
+    malformed["auth_methods"] = [{}]
+    adapter, _ = _adapter(lambda request: httpx.Response(200, json=_providers(malformed)))
+
+    with pytest.raises(ConnectionBadResponse):
+        await adapter.list(Caller())
+
+
+async def test_unhashable_connection_status_is_typed() -> None:
+    adapter, _ = _adapter(lambda request: _get(request, _row(status=[])))  # type: ignore[arg-type]
+
+    with pytest.raises(ConnectionBadResponse):
+        await adapter.list(Caller())
+
+
+async def test_non_uuid_connection_id_is_rejected_before_it_can_enter_a_request_path() -> None:
+    adapter, _ = _adapter(lambda request: _get(request, _row(connection_id="../token")))
+
+    with pytest.raises(ConnectionBadResponse):
+        await adapter.disconnect(Caller(), "openrouter")
+
+
+async def test_timeout_is_typed_and_secret_safe() -> None:
+    def timeout(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout(SECRET, request=request)
+
+    adapter, _ = _adapter(timeout)
+
+    with pytest.raises(ConnectionTimeout) as failure:
+        await adapter.connect(Caller(), "openrouter", SECRET)
+
+    assert SECRET not in str(failure.value)
+
+
+async def test_lists_every_provider_and_keeps_credentials_provider_scoped() -> None:
+    providers = _providers(
+        _provider(),
+        _provider("anthropic", "Anthropic", ("api_key", "oauth")),
+        _provider("codex", "Codex", ("oauth",)),
+    )
+    rows = [_row(provider="anthropic", auth_type="oauth")]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = providers if request.url.path == "/v1/providers" else _list(*rows)
+        return httpx.Response(200, json=payload)
+
+    adapter, _ = _adapter(handler)
+    connections = await adapter.list(Caller())
+
+    assert [(item.provider, item.status) for item in connections] == [
+        ("openrouter", "not_connected"),
+        ("anthropic", "connected"),
+        ("codex", "not_connected"),
+    ]
+    assert connections[1].auth_methods == ("api_key", "oauth")
+
+
+async def test_api_key_connect_rejects_an_oauth_only_provider_before_sending_a_secret() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json=_providers(_provider("codex", "Codex", ("oauth",))))
+
+    adapter, _ = _adapter(handler)
+    with pytest.raises(ConnectionMethodUnsupported):
+        await adapter.connect(Caller(), "codex", SECRET)
+
+    assert [request.url.path for request in seen] == ["/v1/providers"]
+
+
+async def test_connection_refusal_is_reported_as_gateway_unavailable() -> None:
+    def refused(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError(SECRET, request=request)
+
+    adapter, _ = _adapter(refused)
+
+    with pytest.raises(ConnectionUnavailable) as failure:
+        await adapter.list(Caller())
+
+    assert failure.value.status == 503
+    assert failure.value.detail == "AI Gateway is unavailable"
+    assert SECRET not in str(failure.value)

--- a/apps/url4-cloud/tests/unit/test_local_aigateway_connection.py
+++ b/apps/url4-cloud/tests/unit/test_local_aigateway_connection.py
@@ -37,3 +37,31 @@ async def test_local_app_closes_its_connection_client_on_shutdown() -> None:
         assert not client.is_closed
 
     assert client.is_closed
+
+
+def test_the_local_gateway_address_is_configurable() -> None:
+    app = _app(local_aigateway_base_url="http://sidecar.test:9105")
+
+    assert isinstance(app.state.connections, AigatewayConnections)
+    assert str(app.state.connections._client.base_url) == "http://sidecar.test:9105"  # noqa: SLF001
+
+
+def test_an_explicit_aigateway_url_outranks_the_local_default() -> None:
+    """INVARIANT: one `URL4_CLOUD_AIGATEWAY_BASE_URL` still points the whole App at one gateway.
+
+    The local default is a fallback, not an override — a developer who states the shared field
+    must not have connections quietly diverge from the catalog onto a different address.
+    """
+    app = _app(
+        aigateway_base_url="http://gateway.test:9876",
+        local_aigateway_base_url="http://sidecar.test:9105",
+    )
+
+    assert isinstance(app.state.connections, AigatewayConnections)
+    assert str(app.state.connections._client.base_url) == "http://gateway.test:9876"  # noqa: SLF001
+
+
+def test_the_local_gateway_address_defaults_to_loopback() -> None:
+    """INVARIANT: loopback, like `LOCAL_HOST` — pinned against the literal, not the constant."""
+    assert Settings(jwt_secret="s" * 32).local_aigateway_base_url == "http://127.0.0.1:9105"
+    assert LOCAL_AIGATEWAY_BASE_URL == "http://127.0.0.1:9105"

--- a/apps/url4-cloud/tests/unit/test_local_aigateway_connection.py
+++ b/apps/url4-cloud/tests/unit/test_local_aigateway_connection.py
@@ -1,0 +1,39 @@
+"""Local mode owns one explicit loopback AI Gateway connection."""
+
+import pytest
+from fastapi import FastAPI
+
+from url4_cloud.config import LOCAL_AIGATEWAY_BASE_URL, Settings
+from url4_cloud.connections.aigateway import AigatewayConnections
+from url4_cloud.local import create_local_app
+
+
+def _app(**kwargs: object) -> FastAPI:
+    return create_local_app(Settings(jwt_secret="s" * 32, **kwargs), env={})  # type: ignore[arg-type]
+
+
+def test_local_app_automatically_wires_the_loopback_aigateway() -> None:
+    app = _app()
+
+    assert isinstance(app.state.connections, AigatewayConnections)
+    assert str(app.state.connections._client.base_url) == LOCAL_AIGATEWAY_BASE_URL  # noqa: SLF001
+    assert app.state.catalog is None
+
+
+def test_local_app_preserves_an_explicit_aigateway_url() -> None:
+    app = _app(aigateway_base_url="http://gateway.test:9876")
+
+    assert isinstance(app.state.connections, AigatewayConnections)
+    assert str(app.state.connections._client.base_url) == "http://gateway.test:9876"  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_local_app_closes_its_connection_client_on_shutdown() -> None:
+    app = _app()
+    assert isinstance(app.state.connections, AigatewayConnections)
+    client = app.state.connections._client  # noqa: SLF001
+
+    async with app.router.lifespan_context(app):
+        assert not client.is_closed
+
+    assert client.is_closed

--- a/apps/url4-cloud/tests/unit/test_rest_connections.py
+++ b/apps/url4-cloud/tests/unit/test_rest_connections.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport
+
+from url4_cloud.app import create_app
+from url4_cloud.config import Settings
+from url4_cloud.connections.port import (
+    AuthMethod,
+    Caller,
+    Connection,
+    ConnectionAlreadyConnected,
+    ConnectionRejected,
+    ConnectionStatus,
+    OAuthAuthorization,
+)
+from url4_cloud.testing import InMemoryEventStream
+
+pytestmark = pytest.mark.asyncio
+
+SECRET = "sk-or-v1-route-secret"
+EMAIL = "researcher@example.com"
+
+
+class FakeConnections:
+    def __init__(self) -> None:
+        self.connection = self._connection()
+        self.calls: list[tuple[str, Caller, str | None]] = []
+        self.error: Exception | None = None
+
+    async def list(self, caller: Caller) -> tuple[Connection, ...]:
+        self.calls.append(("list", caller, None))
+        self._raise()
+        return (self.connection,)
+
+    async def connect(self, caller: Caller, provider: str, api_key: str) -> Connection:
+        self.calls.append(("connect", caller, api_key))
+        self._raise()
+        self.connection = self._connection(
+            status="connected",
+            auth_method="api_key",
+        )
+        return self.connection
+
+    async def disconnect(self, caller: Caller, provider: str) -> Connection:
+        self.calls.append(("disconnect", caller, provider))
+        self._raise()
+        self.connection = self._connection()
+        return self.connection
+
+    async def start_oauth(self, caller: Caller, provider: str) -> OAuthAuthorization:
+        self.calls.append(("start_oauth", caller, provider))
+        self._raise()
+        return OAuthAuthorization(
+            provider=provider,
+            authorize_url="https://provider.example/authorize?state=private",
+            expires_in=600,
+        )
+
+    async def aclose(self) -> None:
+        return None
+
+    @staticmethod
+    def _connection(
+        *,
+        status: ConnectionStatus = "not_connected",
+        auth_method: AuthMethod | None = None,
+    ) -> Connection:
+        return Connection(
+            provider="openrouter",
+            display_name="OpenRouter",
+            auth_methods=("api_key",),
+            status=status,
+            auth_method=auth_method,
+        )
+
+    def _raise(self) -> None:
+        if self.error is not None:
+            raise self.error
+
+
+def _app(connections: FakeConnections | None) -> FastAPI:
+    return create_app(
+        Settings(jwt_secret="route-secret"),
+        stream=InMemoryEventStream(),
+        connections=connections,
+    )
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def test_list_returns_one_automatic_openrouter_row() -> None:
+    service = FakeConnections()
+
+    async with _client(_app(service)) as client:
+        response = await client.get("/v1/connections", headers={"X-User-Email": EMAIL})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "object": "list",
+        "data": [
+            {
+                "object": "connection",
+                "provider": "openrouter",
+                "display_name": "OpenRouter",
+                "auth_methods": ["api_key"],
+                "status": "not_connected",
+                "auth_method": None,
+                "account_label": None,
+            }
+        ],
+    }
+    assert response.headers["cache-control"] == "private, no-store"
+    assert response.headers["vary"] == "X-User-Email"
+    assert service.calls[0][1].identity == {"X-User-Email": EMAIL}
+
+
+async def test_put_connects_without_returning_the_secret() -> None:
+    service = FakeConnections()
+
+    async with _client(_app(service)) as client:
+        response = await client.put(
+            "/v1/connections/openrouter",
+            headers={"X-User-Email": EMAIL},
+            json={"api_key": SECRET},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "connected"
+    assert SECRET not in response.text
+    assert service.calls[-1][2] == SECRET
+
+
+async def test_delete_returns_the_disconnected_row_and_is_idempotent() -> None:
+    service = FakeConnections()
+
+    async with _client(_app(service)) as client:
+        first = await client.delete("/v1/connections/openrouter")
+        second = await client.delete("/v1/connections/openrouter")
+
+    assert first.status_code == second.status_code == 200
+    assert first.json()["status"] == second.json()["status"] == "not_connected"
+
+
+async def test_post_oauth_returns_only_the_public_authorization_fields() -> None:
+    service = FakeConnections()
+
+    async with _client(_app(service)) as client:
+        response = await client.post(
+            "/v1/connections/anthropic/oauth",
+            headers={"X-User-Email": EMAIL},
+        )
+
+    assert response.status_code == 201
+    assert response.json() == {
+        "object": "oauth_authorization",
+        "provider": "anthropic",
+        "authorize_url": "https://provider.example/authorize?state=private",
+        "expires_in": 600,
+    }
+    assert service.calls[-1] == (
+        "start_oauth",
+        Caller({"X-User-Email": EMAIL}),
+        "anthropic",
+    )
+
+
+async def test_invalid_keys_become_safe_rfc9457_problems() -> None:
+    service = FakeConnections()
+    service.error = ConnectionRejected("upstream body containing " + SECRET)
+
+    async with _client(_app(service)) as client:
+        response = await client.put(
+            "/v1/connections/openrouter",
+            json={"api_key": SECRET},
+        )
+
+    assert response.status_code == 401
+    assert response.headers["content-type"].startswith("application/problem+json")
+    assert SECRET not in response.text
+
+
+async def test_malformed_key_body_cannot_echo_the_secret() -> None:
+    service = FakeConnections()
+
+    async with _client(_app(service)) as client:
+        response = await client.put(
+            "/v1/connections/openrouter",
+            json={"api_key": [SECRET]},
+        )
+
+    assert response.status_code == 422
+    assert response.headers["content-type"].startswith("application/problem+json")
+    assert response.json() == {
+        "type": "about:blank",
+        "title": "Unprocessable Content",
+        "status": 422,
+        "detail": "the provider connection request is invalid",
+    }
+    assert SECRET not in response.text
+    assert service.calls == []
+
+
+async def test_existing_connection_conflict_is_a_safe_problem() -> None:
+    service = FakeConnections()
+    service.error = ConnectionAlreadyConnected()
+
+    async with _client(_app(service)) as client:
+        response = await client.post("/v1/connections/openrouter/oauth")
+
+    assert response.status_code == 409
+    assert response.headers["content-type"].startswith("application/problem+json")
+    assert response.json()["detail"] == (
+        "the provider is already connected; disconnect it before changing authentication"
+    )
+
+
+async def test_oauth_authorization_is_private_and_not_cacheable() -> None:
+    async with _client(_app(FakeConnections())) as client:
+        response = await client.post("/v1/connections/anthropic/oauth")
+
+    assert response.headers["cache-control"] == "private, no-store"
+    assert response.headers["vary"] == "X-User-Email"
+
+
+async def test_unconfigured_connections_are_a_503() -> None:
+    async with _client(_app(None)) as client:
+        response = await client.get("/v1/connections")
+
+    assert response.status_code == 503
+
+
+async def test_connection_routes_are_published_in_openapi() -> None:
+    schema = _app(FakeConnections()).openapi()
+    paths = schema["paths"]
+
+    assert "/v1/connections" in paths
+    assert "/v1/connections/{provider}" in paths
+    assert set(paths["/v1/connections/{provider}"]) >= {"put", "delete"}
+    assert "post" in paths["/v1/connections/{provider}/oauth"]
+    assert paths["/v1/connections"]["get"]["responses"]["200"]["content"]["application/json"][
+        "schema"
+    ] == {"$ref": "#/components/schemas/ConnectionListResponse"}
+    assert paths["/v1/connections/{provider}"]["put"]["responses"]["200"]["content"][
+        "application/json"
+    ]["schema"] == {"$ref": "#/components/schemas/ConnectionResponse"}
+    assert paths["/v1/connections/{provider}"]["put"]["responses"]["422"]["content"][
+        "application/problem+json"
+    ]["schema"] == {"$ref": "#/components/schemas/Problem"}

--- a/docs/plan/2026-08-06-OME-766-engine-provider-connections.md
+++ b/docs/plan/2026-08-06-OME-766-engine-provider-connections.md
@@ -1,0 +1,23 @@
+---
+title: Implement ScreamingFace Engine provider connections
+ticket: OME-766
+status: approved
+date: 2026-08-06
+spec: ../spec/2026-08-06-OME-766-engine-provider-connections.md
+---
+
+# Implement ScreamingFace Engine provider connections
+
+1. Add an Engine-facing provider-connection port with secret-free public values and typed errors.
+2. Add an AI Gateway adapter that combines provider capabilities with the caller-scoped,
+   `screamingface`-designated row and validates every value that may enter a request path.
+3. Add REST routes for list, API-key connect/replace, OAuth start, and idempotent disconnect.
+4. Forward only the verified identity headers selected by the existing Engine identity contract.
+5. Wire the adapter into production and local composition, including deterministic shutdown.
+6. Publish concrete connection response schemas, errors, routes, and tag in OpenAPI.
+7. Add focused adapter, route, local-composition, identity, malformed-response, timeout, and
+   secret-safety tests.
+8. Run `python3 .claude/scripts/run_gates.py url4-cloud` and review the direct
+   `origin/main...HEAD` diff.
+
+No external Linear mutation is part of this implementation pass.

--- a/docs/spec/2026-08-06-OME-766-engine-provider-connections.md
+++ b/docs/spec/2026-08-06-OME-766-engine-provider-connections.md
@@ -1,0 +1,75 @@
+---
+title: ScreamingFace Engine provider connections
+ticket: OME-766
+status: approved
+date: 2026-08-06
+---
+
+# ScreamingFace Engine provider connections
+
+## Outcome
+
+The ScreamingFace Client can inspect and manage the caller's enabled AI-provider connections
+through the Engine without learning AI Gateway account identifiers, credential locators, OAuth
+state as a standalone value, or provider response bodies.
+
+The Engine exposes:
+
+- `GET /v1/connections`
+- `PUT /v1/connections/{provider}`
+- `POST /v1/connections/{provider}/oauth`
+- `DELETE /v1/connections/{provider}`
+
+## Ownership
+
+AI Gateway remains authoritative for enabled providers, supported authentication methods, and
+stored connection state. The Engine owns a small public projection and forwards only the verified
+caller identity installed by the deployment boundary.
+
+Within AI Gateway, `screamingface` is the explicit designation for the row managed by the Engine.
+The label is an opt-in inter-service marker, not proof of creator identity: assigning it through
+another Gateway surface intentionally opts that row into Engine management. Rows under every other
+label are neither projected nor mutated. A missing designated row is `not_connected`, even when
+unrelated rows exist for the same provider.
+
+The Client never calls AI Gateway directly. Provider API keys are write-only: the Engine accepts
+one long enough to forward it and never returns it.
+
+## Contract
+
+Each public connection contains only:
+
+- provider identifier and display name;
+- supported authentication methods;
+- public connection status;
+- the selected authentication method, when connected; and
+- an optional non-secret account label for OAuth connections.
+
+Provider identifiers must be one lowercase URL path segment. Connection identifiers received from
+AI Gateway must be UUIDs before they can enter an upstream request path. OAuth authorization URLs
+must be HTTPS and their lifetime is bounded to 30 minutes.
+
+API-key connect creates the designated row or replaces its key only when it already uses API-key
+authentication. Changing authentication methods never deletes a working connection implicitly:
+when the designated row already uses another method, the Engine returns a secret-free 409 and
+requires an explicit disconnect first. Disconnect is idempotent, including concurrent retries, and
+never deletes a row under another label.
+
+AI Gateway failures are translated to stable, secret-free RFC 9457 problems. Transport timeouts and
+unavailability remain distinguishable. Upstream payloads, credentials, and exception text never
+become public error details. Request validation at these routes is likewise replaced with a
+secret-free problem, because FastAPI's default validation body can include the rejected API-key
+input. Successful connection responses use `Cache-Control: private, no-store` and
+`Vary: X-User-Email`; this also prevents caching an OAuth URL containing one-time state.
+
+## Composition
+
+When `URL4_CLOUD_AIGATEWAY_BASE_URL` is absent in production, the connection service is disabled
+and the routes return 503. Local mode uses the existing loopback AI Gateway at
+`http://127.0.0.1:9105` unless explicitly overridden.
+
+## Dependencies and exclusions
+
+The adapter consumes AI Gateway's provider-discovery contract from the separate Gateway PR. This
+unit does not change AI Gateway, model-parameter contracts, executable model filtering, benchmark
+execution, DRACO, IFEval, deployment charts, or the Client implementation.

--- a/docs/tasks/2026-08-06-OME-766-engine-provider-connections.md
+++ b/docs/tasks/2026-08-06-OME-766-engine-provider-connections.md
@@ -1,0 +1,24 @@
+---
+id: OME-766
+linear_url: https://linear.app/openmined/issue/OME-766/expose-provider-connection-management-through-the-screamingface-engine
+status: Pick Immediately
+type: Feature
+priority: P1
+labels: [url4-cloud, agentic, autonomous]
+created: 2026-08-06
+closed:
+---
+
+# Expose provider connection management through the ScreamingFace Engine
+
+Publish one Engine-owned connection surface for listing caller-scoped provider state, connecting
+or replacing an API key, starting provider OAuth, and disconnecting. AI Gateway remains
+authoritative for provider capabilities and credential storage; the Engine exposes only validated,
+secret-free public values and forwards only the identity already verified by the deployment edge.
+
+Dependencies: OME-497 provides AI Gateway provider discovery; this implementation also satisfies
+OME-498's narrower Engine discovery requirement and unblocks the Client work in OME-496.
+
+Spec: `docs/spec/2026-08-06-OME-766-engine-provider-connections.md`
+Plan: `docs/plan/2026-08-06-OME-766-engine-provider-connections.md`
+Ledger: `docs/work/2026-08-06-OME-766-engine-provider-connections.md`

--- a/docs/work/2026-08-06-OME-766-engine-provider-connections.md
+++ b/docs/work/2026-08-06-OME-766-engine-provider-connections.md
@@ -1,0 +1,56 @@
+---
+ticket: OME-766
+stack: url4-cloud
+status: in_progress
+started: 2026-08-06
+finished:
+---
+
+# OME-766 — expose provider connections through the ScreamingFace Engine
+
+## Intent
+
+Extract the Engine half of the first Client's provider-connection flow into one direct-from-main,
+security-focused review unit.
+
+## Planned changes
+
+- `apps/url4-cloud/src/url4_cloud/connections/`
+- `apps/url4-cloud/src/url4_cloud/rest/connections.py`
+- the production/local composition roots and OpenAPI tag
+- focused URL4 Cloud tests
+- this unit's specification and plan
+
+## Test plan
+
+- Provider discovery and disconnected/connected projections.
+- API-key create/replace and explicit OAuth authentication-method changes.
+- Idempotent disconnect.
+- Verified identity forwarding without Authorization forwarding.
+- Provider-path and connection-id validation.
+- Malformed payload, caller rejection, timeout, and unavailable-upstream mappings.
+- Secret absence from public values and RFC 9457 responses.
+- Local loopback and explicit-upstream composition.
+
+## Acceptance
+
+- All four public connection operations are available through the Engine.
+- The Client-visible schema contains no AI Gateway-private or credential fields.
+- Invalid path material is rejected before it can enter an upstream path.
+- Only the `screamingface`-designated row is projected or mutated; other labels stay private.
+- Validation and upstream failures remain typed and cannot echo a submitted key.
+- Production and local composition close their connection clients cleanly.
+- The complete URL4 Cloud gate is green.
+
+## Outcome
+
+- **Actual files:** the planned connection port, AI Gateway adapter, REST surface, composition,
+  OpenAPI, focused tests, README contract, and the required task/spec/plan/work artifacts.
+- **Commits:** one conventional feature commit on `OME-766-engine-provider-connections`.
+- **Gates:** 53 focused tests passed; complete `url4-cloud` gate green.
+- **Deviations:** OAuth account identity arrives as an object rather than a label string, so the
+  adapter explicitly derives `email → name → sub` and discards raw provider metadata. Local
+  connection operations use the loopback Gateway by default without changing the existing local
+  model-catalog behavior.
+- **External state:** OME-766 was owner-approved and created in `Pick Immediately`; no comment or
+  status advancement was made.


### PR DESCRIPTION
## Summary

Expose caller-scoped provider connection management through the ScreamingFace Engine. The Engine now publishes validated, secret-free list, API-key connect/replace, OAuth-start, and idempotent disconnect operations while keeping AI Gateway authoritative for provider capabilities and credential storage.

**Linear:** https://linear.app/openmined/issue/OME-766/expose-provider-connection-management-through-the-screamingface-engine

## Components touched

- `apps/url4-cloud`
- Engine REST/OpenAPI composition and local wiring
- Focused connection adapter and route tests
- OME-766 spec, plan, task, and work ledger

## Test plan

- [x] Append-only test check against `origin/main`
- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run pyright`
- [x] `python3 ../../.claude/scripts/check_layering.py`
- [x] `uv run pytest --cov=url4_cloud --cov=url4.streaming --cov-fail-under=80 -q`
- [ ] Gateway live tests (no Gateway implementation changed)
- [ ] Screenshots / recording (no UI changes)

## Cross-service notes

This PR consumes the Gateway-owned provider catalogue and credential operations but does not alter Gateway code or schemas. It satisfies the Engine portion required by OME-498 and unblocks the ScreamingFace Client work in OME-496.

## Scope boundary

No ScreamingFace Client, benchmark runtime, model catalogue, model-parameter contract, or deployment changes are included.
