### PR TITLE
feat(url4-cloud): add Engine benchmark foundation

### DIFF
--- a/apps/url4-cloud/src/url4_cloud/app.py
+++ b/apps/url4-cloud/src/url4_cloud/app.py
@@ -16,6 +16,7 @@ from fastapi.staticfiles import StaticFiles
 from url4.streaming.interfaces import EventConsumer, JobRunner
 from url4_cloud.adapters.factory import build_job_runner
 from url4_cloud.auth import Clock, install_problem_handlers
+from url4_cloud.benchmarks import EMPTY_BENCHMARKS, BenchmarkRegistry
 from url4_cloud.catalog import build_catalog_service
 from url4_cloud.catalog.cache import CatalogService
 from url4_cloud.catalog.port import ModelParameterSource
@@ -24,7 +25,12 @@ from url4_cloud.connections import build_connections
 from url4_cloud.connections.port import Connections
 from url4_cloud.metrics import MetricsMiddleware, build_metrics, register_catalog_metrics
 from url4_cloud.ops import router as ops_router
-from url4_cloud.rest import SubscriberGate, catalog_router, connection_router
+from url4_cloud.rest import (
+    SubscriberGate,
+    benchmark_router,
+    catalog_router,
+    connection_router,
+)
 from url4_cloud.rest import router as rest_router
 from url4_cloud.schemas import customize_openapi
 from url4_cloud.ws import ConnectionRegistry
@@ -33,6 +39,18 @@ from url4_cloud.ws import router as ws_router
 router = APIRouter()
 
 _DIAGRAMS_DIR = Path(__file__).parent / "assets" / "diagrams"
+
+# Mounted in this order by `create_app`. A tuple rather than seven calls: the wiring is data, and
+# every new surface (benchmarks, connections, …) would otherwise grow the builder itself.
+_ROUTERS = (
+    router,
+    rest_router,
+    benchmark_router,
+    catalog_router,
+    connection_router,
+    ws_router,
+    ops_router,
+)
 
 
 @router.get("/healthz", include_in_schema=False)
@@ -50,6 +68,7 @@ def create_app(
     catalog: CatalogService | None = None,
     model_parameters: ModelParameterSource | None = None,
     connections: Connections | None = None,
+    benchmarks: BenchmarkRegistry = EMPTY_BENCHMARKS,
 ) -> FastAPI:
     """Build the App instance.
 
@@ -64,6 +83,7 @@ def create_app(
     app.state.catalog = catalog
     app.state.model_parameters = model_parameters
     app.state.connections = connections
+    app.state.benchmarks = benchmarks
     app.state.metrics = build_metrics()
     # WHY: pass a getter, not `catalog` directly — the collector re-reads app.state.catalog on
     # every /metrics scrape rather than capturing the value built here.
@@ -75,12 +95,8 @@ def create_app(
     if clock is not None:
         app.state.clock = clock
     install_problem_handlers(app)
-    app.include_router(router)
-    app.include_router(rest_router)
-    app.include_router(catalog_router)
-    app.include_router(connection_router)
-    app.include_router(ws_router)
-    app.include_router(ops_router)
+    for api_router in _ROUTERS:
+        app.include_router(api_router)
     app.mount("/diagrams", StaticFiles(directory=_DIAGRAMS_DIR), name="diagrams")
     customize_openapi(app)
     return app

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/__init__.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/__init__.py
@@ -1,6 +1,12 @@
 """Public definition and installation surface for Engine-owned Benchmarks."""
 
-from url4_cloud.benchmarks.definition import Benchmark, BenchmarkInstaller, candidate
+from url4_cloud.benchmarks.definition import (
+    CANDIDATE_REF,
+    Benchmark,
+    BenchmarkInstaller,
+    candidate,
+    link_candidate,
+)
 from url4_cloud.benchmarks.registry import (
     BENCHMARK_ASSETS_ENV,
     DEFAULT_BENCHMARK_ASSETS_ROOT,
@@ -11,6 +17,7 @@ from url4_cloud.benchmarks.registry import (
 
 __all__ = [
     "BENCHMARK_ASSETS_ENV",
+    "CANDIDATE_REF",
     "DEFAULT_BENCHMARK_ASSETS_ROOT",
     "Benchmark",
     "BenchmarkInstaller",
@@ -18,4 +25,5 @@ __all__ = [
     "EMPTY_BENCHMARKS",
     "assets_root",
     "candidate",
+    "link_candidate",
 ]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/__init__.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/__init__.py
@@ -1,0 +1,21 @@
+"""Public definition and installation surface for Engine-owned Benchmarks."""
+
+from url4_cloud.benchmarks.definition import Benchmark, BenchmarkInstaller, candidate
+from url4_cloud.benchmarks.registry import (
+    BENCHMARK_ASSETS_ENV,
+    DEFAULT_BENCHMARK_ASSETS_ROOT,
+    EMPTY_BENCHMARKS,
+    BenchmarkRegistry,
+    assets_root,
+)
+
+__all__ = [
+    "BENCHMARK_ASSETS_ENV",
+    "DEFAULT_BENCHMARK_ASSETS_ROOT",
+    "Benchmark",
+    "BenchmarkInstaller",
+    "BenchmarkRegistry",
+    "EMPTY_BENCHMARKS",
+    "assets_root",
+    "candidate",
+]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/candidate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/candidate.py
@@ -1,0 +1,139 @@
+"""Candidate Invocation adapter installed into the shared Runner URL4 world."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from url4.core.errors import ResolutionError
+from url4.peer.server import Request, Url4Node
+from url4_cloud.benchmarks.contract import (
+    CANDIDATE_ROUTE,
+    encode_candidate_invocation,
+)
+from url4_cloud.model_outcomes import (
+    ModelOutcome,
+    capture_model_outcomes,
+    model_outcome_from_error,
+)
+from url4_cloud.retrieval_policy import (
+    RetrievalPolicy,
+    RetrievalPolicyError,
+    normalize_excluded_domains,
+    retrieval_scope,
+)
+
+_POLICY_PARAMS = frozenset({"web_search", "web_search_exclude"})
+
+
+class _CandidateInvocation:
+    """Evaluate linked Candidate URL4 in the same world under a narrower ambient policy."""
+
+    __slots__ = ("_node",)
+
+    def __init__(self, node: Url4Node) -> None:
+        self._node = node
+
+    async def __call__(self, request: Request) -> str:
+        if not request.intent.strip():
+            raise ResolutionError(
+                "Candidate Invocation expression must be non-empty",
+                code="candidate_contract_error",
+                permanent=True,
+            )
+        policy = _candidate_policy(request.params)
+        outcomes: list[ModelOutcome]
+        try:
+            with retrieval_scope(policy), capture_model_outcomes() as outcomes:
+                try:
+                    result = await self._node.evaluate(
+                        request.intent,
+                        env={"input": request.context or ""},
+                    )
+                except ResolutionError as exc:
+                    if exc.code != "provider_refusal":
+                        raise
+                    outcome = model_outcome_from_error(exc)
+                    if outcome is None:
+                        raise ResolutionError(
+                            "provider refusal carried no terminal outcome",
+                            code="candidate_contract_error",
+                            permanent=True,
+                        ) from exc
+                    return _encode_candidate_invocation("", outcome)
+        except RetrievalPolicyError as exc:
+            raise ResolutionError(
+                str(exc),
+                code="candidate_policy_escalation",
+                permanent=True,
+            ) from exc
+
+        outcome = outcomes[-1] if outcomes else ModelOutcome(None, None)
+        return _encode_candidate_invocation(result.text, outcome)
+
+
+def install_candidate_invocation(node: Url4Node) -> None:
+    """Install the one Engine-owned Candidate adapter on ``node``."""
+
+    node.endpoint(CANDIDATE_ROUTE)(_CandidateInvocation(node))
+
+
+def _encode_candidate_invocation(output: str, outcome: ModelOutcome) -> str:
+    try:
+        return encode_candidate_invocation(
+            output,
+            outcome.finish_reason,
+            outcome.refusal,
+        )
+    except ValueError as exc:
+        raise ResolutionError(
+            str(exc),
+            code="candidate_contract_error",
+            permanent=True,
+        ) from exc
+
+
+def _candidate_policy(params: Mapping[str, str]) -> RetrievalPolicy:
+    unknown = sorted(set(params) - _POLICY_PARAMS)
+    if unknown:
+        raise ResolutionError(
+            f"unsupported Candidate policy parameter(s) {unknown}",
+            code="candidate_policy_invalid",
+            permanent=True,
+        )
+    raw_search = params.get("web_search")
+    if raw_search not in {"true", "false"}:
+        raise ResolutionError(
+            "Candidate policy requires web_search=true or web_search=false",
+            code="candidate_policy_invalid",
+            permanent=True,
+        )
+    excluded = _excluded_domains(params.get("web_search_exclude"))
+    if raw_search == "false" and excluded:
+        raise ResolutionError(
+            "web_search_exclude requires web_search=true",
+            code="candidate_policy_invalid",
+            permanent=True,
+        )
+    return RetrievalPolicy(web_search=raw_search == "true", excluded_domains=excluded)
+
+
+def _excluded_domains(value: str | None) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, str):
+        raise ResolutionError(
+            "web_search_exclude must be a colon-separated list of bare domains",
+            code="candidate_policy_invalid",
+            permanent=True,
+        )
+    try:
+        return normalize_excluded_domains(value.split(":"))
+    except ValueError as exc:
+        raise ResolutionError(
+            "web_search_exclude must be a colon-separated list of bare domains",
+            code="candidate_policy_invalid",
+            permanent=True,
+        ) from exc
+
+
+__all__ = ["install_candidate_invocation"]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/candidate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/candidate.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 
 from url4.core.errors import ResolutionError
 from url4.peer.server import Request, Url4Node
@@ -67,8 +67,22 @@ class _CandidateInvocation:
                 permanent=True,
             ) from exc
 
-        outcome = outcomes[-1] if outcomes else ModelOutcome(None, None)
-        return _encode_candidate_invocation(result.text, outcome)
+        return _encode_candidate_invocation(result.text, _terminal_outcome(outcomes))
+
+
+def _terminal_outcome(outcomes: Sequence[ModelOutcome]) -> ModelOutcome:
+    """Return the outcome that describes the returned answer, or state that none is known.
+
+    A Candidate composes ordinary URL4, so one scope may record several terminal outcomes while
+    the recorder cannot say which branch produced the text that came back. Taking the most recent
+    one attributes a sibling's fields to an unrelated answer, and can pair a non-empty output with
+    a refusal — a shape the contract does not admit. Unanimity is not ambiguity, so agreeing
+    branches still describe the answer; disagreeing ones report null, which the contract allows.
+    A benchmark that needs per-call fidelity must invoke one Candidate per model call.
+    """
+
+    distinct = set(outcomes)
+    return distinct.pop() if len(distinct) == 1 else ModelOutcome(None, None)
 
 
 def install_candidate_invocation(node: Url4Node) -> None:

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/contract.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/contract.py
@@ -1,0 +1,74 @@
+"""Wire names shared by Engine-owned Benchmarks and Candidate Invocation."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+
+CANDIDATE_ROUTE = "/benchmarks/candidate"
+CANDIDATE_INVOCATION_SCHEMA = "screamingface.candidate-invocation.v1"
+FINISH_REASONS = frozenset({"stop", "length", "tool_calls", "content_filter"})
+
+
+def encode_candidate_invocation(
+    output: str,
+    finish_reason: str | None,
+    refusal: str | None,
+) -> str:
+    """Encode one Candidate answer without discarding its provider-originated outcome."""
+
+    _validate_candidate_invocation(output, finish_reason, refusal)
+    return json.dumps(
+        {
+            "schema": CANDIDATE_INVOCATION_SCHEMA,
+            "output": output,
+            "finish_reason": finish_reason,
+            "refusal": refusal,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def decode_candidate_invocation(value: str) -> tuple[str, str | None, str | None]:
+    """Decode and validate the internal value returned by the Candidate adapter."""
+
+    try:
+        decoded = json.loads(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Candidate Invocation result is not JSON: {exc}") from None
+    if not isinstance(decoded, Mapping) or decoded.get("schema") != CANDIDATE_INVOCATION_SCHEMA:
+        raise ValueError("Candidate Invocation result has an unsupported schema")
+    if set(decoded) != {"schema", "output", "finish_reason", "refusal"}:
+        raise ValueError("Candidate Invocation result has an invalid shape")
+    output = decoded["output"]
+    finish_reason = decoded["finish_reason"]
+    refusal = decoded["refusal"]
+    _validate_candidate_invocation(output, finish_reason, refusal)
+    return output, finish_reason, refusal
+
+
+def _validate_candidate_invocation(
+    output: object,
+    finish_reason: object,
+    refusal: object,
+) -> None:
+    if not isinstance(output, str):
+        raise ValueError("Candidate Invocation output must be text")
+    if finish_reason is not None and (
+        not isinstance(finish_reason, str) or finish_reason not in FINISH_REASONS
+    ):
+        raise ValueError(
+            "Candidate Invocation finish_reason must be a supported provider value or null"
+        )
+    if refusal is not None and (not isinstance(refusal, str) or not refusal.strip()):
+        raise ValueError("Candidate Invocation refusal must be non-empty text or null")
+
+
+__all__ = [
+    "CANDIDATE_INVOCATION_SCHEMA",
+    "CANDIDATE_ROUTE",
+    "FINISH_REASONS",
+    "decode_candidate_invocation",
+    "encode_candidate_invocation",
+]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/contract.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/contract.py
@@ -6,6 +6,9 @@ import json
 from collections.abc import Mapping
 
 CANDIDATE_ROUTE = "/benchmarks/candidate"
+# The source name a client binds its Candidate expression under, so the protocol's `$candidate`
+# resolves. Published in every Benchmark resource: a client cannot be expected to infer it.
+CANDIDATE_BINDING = "candidate"
 CANDIDATE_INVOCATION_SCHEMA = "screamingface.candidate-invocation.v1"
 FINISH_REASONS = frozenset({"stop", "length", "tool_calls", "content_filter"})
 
@@ -66,6 +69,7 @@ def _validate_candidate_invocation(
 
 
 __all__ = [
+    "CANDIDATE_BINDING",
     "CANDIDATE_INVOCATION_SCHEMA",
     "CANDIDATE_ROUTE",
     "FINISH_REASONS",

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/definition.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/definition.py
@@ -1,0 +1,144 @@
+"""Shared definitions and authoring helpers for Engine-owned Benchmarks."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from url4 import Node, RelExpr, expr, render, src, text
+from url4.peer.server import Url4Node
+from url4_cloud.benchmarks.contract import CANDIDATE_ROUTE
+from url4_cloud.retrieval_policy import normalize_excluded_domains
+
+type BenchmarkInstaller = Callable[[Url4Node, Path], None]
+
+_BENCHMARK_ID = re.compile(r"[a-z0-9][a-z0-9._-]*(?:/[a-z0-9][a-z0-9._-]*)*")
+_VARIANT = re.compile(r"[a-z0-9][a-z0-9._-]*")
+
+
+def _no_routes(_node: Url4Node, _assets_root: Path) -> None:
+    """Default installer for a protocol that needs no private routes or assets."""
+
+
+@dataclass(frozen=True, slots=True)
+class Benchmark:
+    """Immutable metadata plus one complete URL4 protocol builder.
+
+    ``build`` is pure: it specializes the protocol to an exact selected case count and returns a
+    structured URL4 node. ``install`` owns any private routes and validates immutable assets
+    against the explicitly injected root before a run can spend money.
+    """
+
+    id: str
+    variant: str
+    title: str
+    description: str
+    revision: str
+    case_count: int
+    build: Callable[[int], Node]
+    install: BenchmarkInstaller = _no_routes
+
+    def __post_init__(self) -> None:
+        for name in ("title", "description", "revision"):
+            value = getattr(self, name)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"Benchmark {name} must be non-empty text")
+        if not isinstance(self.id, str) or _BENCHMARK_ID.fullmatch(self.id) is None:
+            raise ValueError("Benchmark id must contain lowercase slash-qualified path segments")
+        if not isinstance(self.variant, str) or _VARIANT.fullmatch(self.variant) is None:
+            raise ValueError("Benchmark variant must be one lowercase path segment")
+        if (
+            isinstance(self.case_count, bool)
+            or not isinstance(self.case_count, int)
+            or self.case_count < 1
+        ):
+            raise ValueError("Benchmark case_count must be a positive integer")
+
+    def catalog_entry(self) -> dict[str, object]:
+        """Return metadata sufficient for one-request Benchmark discovery."""
+
+        return {
+            "object": "benchmark",
+            **self._metadata(),
+            "href": f"/v1/benchmarks/{self.id}",
+        }
+
+    def _metadata(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "variant": self.variant,
+            "title": self.title,
+            "description": self.description,
+            "revision": self.revision,
+            "case_count": self.case_count,
+        }
+
+    def protocol(self, selected_case_count: int) -> Node:
+        """Build and type-check one exact selection without rendering it prematurely."""
+
+        if (
+            isinstance(selected_case_count, bool)
+            or not isinstance(selected_case_count, int)
+            or selected_case_count < 1
+            or selected_case_count > self.case_count
+        ):
+            raise ValueError(
+                f"Benchmark limit must be between 1 and {self.case_count}, "
+                f"got {selected_case_count!r}"
+            )
+        protocol = self.build(selected_case_count)
+        if not isinstance(protocol, Node):
+            raise TypeError("Benchmark build must return a URL4 Node")
+        return protocol
+
+    def resource(self, limit: int | None = None) -> dict[str, object]:
+        """Build one flat, independently executable public resource."""
+
+        selected = self.case_count if limit is None else limit
+        protocol = self.protocol(selected)
+        return {
+            "schema": "screamingface.benchmark.v1",
+            **self._metadata(),
+            "selected_case_count": selected,
+            "url4": render(protocol),
+        }
+
+
+def candidate(
+    input: str,
+    *,
+    binding: str = "$candidate",
+    web_search: bool,
+    web_search_exclude: Sequence[str] = (),
+) -> Node:
+    """Invoke a structurally linked Candidate under explicit Benchmark retrieval policy."""
+
+    if not isinstance(input, str) or not input:
+        raise ValueError("Candidate Invocation input must be non-empty URL4 context")
+    if not isinstance(binding, str) or not binding.startswith("$"):
+        raise ValueError("Candidate binding must be a URL4 structural reference")
+    if not isinstance(web_search, bool):
+        raise TypeError("web_search must be a boolean")
+    excluded = normalize_excluded_domains(web_search_exclude)
+    if not web_search and excluded:
+        raise ValueError("web_search_exclude requires web_search=true")
+
+    params: list[tuple[str, str]] = [("web_search", "true" if web_search else "false")]
+    if excluded:
+        params.append(("web_search_exclude", ":".join(excluded)))
+    call = RelExpr(
+        path=CANDIDATE_ROUTE,
+        context=input,
+        intent=text(binding),
+        params=tuple(params),
+    )
+    # A parameterized relative call needs an expression boundary to round-trip canonically.
+    return expr(
+        src(call, name="candidate_invocation", weight=0.0),
+        intent=text("$candidate_invocation"),
+    )
+
+
+__all__ = ["Benchmark", "BenchmarkInstaller", "candidate"]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/definition.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/definition.py
@@ -7,10 +7,12 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
-from url4 import Node, RelExpr, expr, render, src, text
+from url4 import Node, RelExpr, build, expr, render, src, text
 from url4.peer.server import Url4Node
-from url4_cloud.benchmarks.contract import CANDIDATE_ROUTE
+from url4_cloud.benchmarks.contract import CANDIDATE_BINDING, CANDIDATE_ROUTE
 from url4_cloud.retrieval_policy import normalize_excluded_domains
+
+CANDIDATE_REF = f"${CANDIDATE_BINDING}"
 
 type BenchmarkInstaller = Callable[[Url4Node, Path], None]
 
@@ -102,6 +104,7 @@ class Benchmark:
             "schema": "screamingface.benchmark.v1",
             **self._metadata(),
             "selected_case_count": selected,
+            "candidate_binding": CANDIDATE_BINDING,
             "url4": render(protocol),
         }
 
@@ -109,7 +112,7 @@ class Benchmark:
 def candidate(
     input: str,
     *,
-    binding: str = "$candidate",
+    binding: str = CANDIDATE_REF,
     web_search: bool,
     web_search_exclude: Sequence[str] = (),
 ) -> Node:
@@ -141,4 +144,30 @@ def candidate(
     )
 
 
-__all__ = ["Benchmark", "BenchmarkInstaller", "candidate"]
+def link_candidate(candidate_expression: Node | str, protocol: Node | str) -> str:
+    """Bind one Candidate expression to a fetched Benchmark protocol, ready to execute.
+
+    This is the executable half of the resource contract `candidate_binding` names: the Candidate
+    is carried as an inert text source under that name, which is what makes the protocol's
+    `$candidate` resolve. It weighs 0.0 because it contributes no content of its own — the
+    protocol decides where and how often the Candidate is invoked.
+    """
+
+    return render(
+        expr(
+            src(
+                text(_as_text(candidate_expression)),
+                name=CANDIDATE_BINDING,
+                weight=0.0,
+            ),
+            protocol if isinstance(protocol, Node) else build(protocol),
+            intent=text(""),
+        )
+    )
+
+
+def _as_text(value: Node | str) -> str:
+    return value if isinstance(value, str) else render(value)
+
+
+__all__ = ["CANDIDATE_REF", "Benchmark", "BenchmarkInstaller", "candidate", "link_candidate"]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/registry.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/registry.py
@@ -1,0 +1,92 @@
+"""Validated registry shared by Benchmark discovery and Runner installation."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable, Iterator, Mapping
+from pathlib import Path
+from types import MappingProxyType
+
+from url4 import Iteration, Node, RelExpr, build, render
+from url4.core.nodes import walk
+from url4.peer.server import Url4Node
+from url4_cloud.benchmarks.definition import Benchmark
+
+BENCHMARK_ASSETS_ENV = "URL4_BENCHMARK_ASSETS"
+DEFAULT_BENCHMARK_ASSETS_ROOT = Path("/opt/benchmarks")
+
+
+def assets_root(env: Mapping[str, str] | None = None) -> Path:
+    """Resolve the immutable asset root once at the Runner composition boundary."""
+
+    selected = os.environ if env is None else env
+    return Path(selected.get(BENCHMARK_ASSETS_ENV) or DEFAULT_BENCHMARK_ASSETS_ROOT)
+
+
+class BenchmarkRegistry:
+    """One immutable set of Benchmarks installed on an Engine deployment."""
+
+    __slots__ = ("_benchmarks",)
+
+    def __init__(self, benchmarks: Iterable[Benchmark] = ()) -> None:
+        selected: dict[str, Benchmark] = {}
+        for benchmark in benchmarks:
+            if benchmark.id in selected:
+                raise ValueError(f"duplicate Benchmark id {benchmark.id!r}")
+            selected[benchmark.id] = benchmark
+        self._benchmarks: Mapping[str, Benchmark] = MappingProxyType(selected)
+
+    def __len__(self) -> int:
+        return len(self._benchmarks)
+
+    def __iter__(self) -> Iterator[Benchmark]:
+        for benchmark_id in sorted(self._benchmarks):
+            yield self._benchmarks[benchmark_id]
+
+    def get(self, benchmark_id: str) -> Benchmark | None:
+        return self._benchmarks.get(benchmark_id)
+
+    def install(self, node: Url4Node, *, assets_root: Path) -> None:
+        """Install and validate every concrete protocol before its first paid request."""
+
+        for benchmark in self:
+            benchmark.install(node, assets_root)
+        declared = frozenset(node.processor_routes())
+        for benchmark in self:
+            protocol = benchmark.protocol(benchmark.case_count)
+            # Rendering at installation catches malformed hand-built ASTs before discovery can
+            # publish an expression that the Runner cannot execute.
+            render(protocol)
+            missing = sorted(_relative_endpoint_paths(protocol) - declared)
+            if missing:
+                raise ValueError(
+                    f"Benchmark {benchmark.id!r} references uninstalled endpoint(s) {missing}"
+                )
+
+
+def _relative_endpoint_paths(protocol: Node) -> set[str]:
+    """Collect literal endpoint paths, including those inside iteration templates."""
+
+    found: set[str] = set()
+    pending = [protocol]
+    while pending:
+        selected = pending.pop()
+        for child in walk(selected):
+            if isinstance(child, RelExpr):
+                found.add(child.path)
+            if isinstance(child, Iteration):
+                for template in (child.body, child.intent, child.reducer):
+                    if template:
+                        pending.append(build(template))
+    return found
+
+
+EMPTY_BENCHMARKS = BenchmarkRegistry()
+
+__all__ = [
+    "BENCHMARK_ASSETS_ENV",
+    "DEFAULT_BENCHMARK_ASSETS_ROOT",
+    "BenchmarkRegistry",
+    "EMPTY_BENCHMARKS",
+    "assets_root",
+]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/registry.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/registry.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import os
+import re
 from collections.abc import Iterable, Iterator, Mapping
 from pathlib import Path
 from types import MappingProxyType
 
-from url4 import Iteration, Node, RelExpr, build, render
+from url4 import Iteration, Node, RelExpr, RelUrl, build, render
+from url4.core.errors import ParseError
 from url4.core.nodes import walk
 from url4.peer.server import Url4Node
 from url4_cloud.benchmarks.definition import Benchmark
@@ -51,7 +53,7 @@ class BenchmarkRegistry:
 
         for benchmark in self:
             benchmark.install(node, assets_root)
-        declared = frozenset(node.processor_routes())
+        declared = frozenset(node.processor_routes()) | _data_routes(node)
         for benchmark in self:
             protocol = benchmark.protocol(benchmark.case_count)
             # Rendering at installation catches malformed hand-built ASTs before discovery can
@@ -64,20 +66,65 @@ class BenchmarkRegistry:
                 )
 
 
+def _data_routes(node: Url4Node) -> frozenset[str]:
+    """The node's data paths, which are servable relative targets too.
+
+    WHY read privately: `processor_routes()` lists endpoints only, and `Url4Node` publishes no
+    accessor for its data table — widening the engine's API is outside this landing's boundary.
+    Degrades to the endpoint-only check rather than rejecting a valid Benchmark.
+    """
+
+    return frozenset(getattr(node, "_data", {}))
+
+
+# A path is only a route name while every segment is literal. url4's segment charset is
+# ALPHA / DIGIT / "-" / "_" / "." / "~" (spec §8), and a reference may carry a call, a query or
+# parameters after it — `!/reduce()` and `(/cases?limit=2)` both name the route before that tail.
+_LITERAL_PATH = re.compile(r"/[A-Za-z0-9\-_.~]+(?:/[A-Za-z0-9\-_.~]+)*")
+_PATH_TAILS = frozenset({"", "(", ")", "?", "#", ";", "!", ","})
+
+
+def _literal_path(reference: str) -> str | None:
+    """The route a relative reference names, or None when it names none until substitution."""
+
+    match = _LITERAL_PATH.match(reference.strip())
+    if match is None:
+        return None
+    # `/judge/$item` matches only as far as `/judge`, and `/judge` is not the route it will
+    # resolve to. A reference whose tail continues the path is unvalidatable, not broken.
+    return match.group() if reference.strip()[match.end() :][:1] in _PATH_TAILS else None
+
+
 def _relative_endpoint_paths(protocol: Node) -> set[str]:
-    """Collect literal endpoint paths, including those inside iteration templates."""
+    """Collect literal relative routes, including those inside iteration templates."""
 
     found: set[str] = set()
     pending = [protocol]
     while pending:
         selected = pending.pop()
         for child in walk(selected):
-            if isinstance(child, RelExpr):
-                found.add(child.path)
+            # A `/path!intent` call and a bare `(/path)` data reference both resolve against the
+            # routes installed on this node, so both have to be checked.
+            reference = (
+                child.path
+                if isinstance(child, RelExpr)
+                else child.value
+                if isinstance(child, RelUrl)
+                else None
+            )
+            if reference is not None and (path := _literal_path(reference)) is not None:
+                found.add(path)
             if isinstance(child, Iteration):
                 for template in (child.body, child.intent, child.reducer):
-                    if template:
+                    if not template:
+                        continue
+                    try:
                         pending.append(build(template))
+                    except ParseError:
+                        # A row template is URL4 only once `$item` is substituted, so one that
+                        # cannot be parsed here carries no route to check. Skipping narrows the
+                        # check; raising would fail the world for a legal Benchmark.
+                        continue
     return found
 
 

--- a/apps/url4-cloud/src/url4_cloud/local.py
+++ b/apps/url4-cloud/src/url4_cloud/local.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import logging
 import os
 from collections.abc import Mapping
+from functools import partial
 from pathlib import Path
 
 from fastapi import FastAPI
@@ -32,6 +33,7 @@ from url4_cloud import job_env
 from url4_cloud.adapters.inprocess import InProcessJobRunner
 from url4_cloud.adapters.memory import InMemoryEventStream
 from url4_cloud.app import create_app
+from url4_cloud.benchmarks import EMPTY_BENCHMARKS, BenchmarkRegistry
 from url4_cloud.catalog import build_catalog_service
 from url4_cloud.config import INSECURE_DEFAULT_JWT_SECRET, Settings
 from url4_cloud.connections import build_connections
@@ -85,7 +87,10 @@ def _with_runner_config(env: Mapping[str, str]) -> Mapping[str, str]:
 
 
 def create_local_app(
-    settings: Settings | None = None, *, env: Mapping[str, str] | None = None
+    settings: Settings | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+    benchmarks: BenchmarkRegistry = EMPTY_BENCHMARKS,
 ) -> FastAPI:
     """Build the local-mode App: in-process runner, in-memory stream, real everything else.
 
@@ -109,7 +114,7 @@ def create_local_app(
 
     job_runner = InProcessJobRunner(
         stream,
-        build_executor,
+        partial(build_executor, benchmarks=benchmarks),
         base_env=_with_runner_config(env if env is not None else os.environ),
         max_concurrent_runs=settings.local_max_concurrent_runs,
         max_history=settings.local_max_run_history,
@@ -128,6 +133,7 @@ def create_local_app(
         catalog=catalog,
         model_parameters=catalog.model_parameter_source if catalog is not None else None,
         connections=connections,
+        benchmarks=benchmarks,
     )
     app.router.on_shutdown.append(job_runner.aclose)
     if catalog is not None:

--- a/apps/url4-cloud/src/url4_cloud/model_outcomes.py
+++ b/apps/url4-cloud/src/url4_cloud/model_outcomes.py
@@ -1,0 +1,67 @@
+"""Task-local model outcomes shared by connectors and orchestration adapters."""
+
+from __future__ import annotations
+
+import contextvars
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ModelOutcome:
+    """Literal terminal fields reported by one provider round trip."""
+
+    finish_reason: str | None
+    refusal: str | None
+
+
+type OutcomeRecorder = list[ModelOutcome]
+
+_recorders: contextvars.ContextVar[tuple[OutcomeRecorder, ...]] = contextvars.ContextVar(
+    "url4_cloud_model_outcome_recorders", default=()
+)
+_ERROR_OUTCOME_ATTRIBUTE = "_url4_cloud_model_outcome"
+
+
+@contextmanager
+def capture_model_outcomes() -> Iterator[OutcomeRecorder]:
+    """Capture outcomes in this scope without hiding them from an enclosing scope."""
+
+    recorder: OutcomeRecorder = []
+    token = _recorders.set((*_recorders.get(), recorder))
+    try:
+        yield recorder
+    finally:
+        _recorders.reset(token)
+
+
+def record_model_outcome(finish_reason: str | None, refusal: str | None) -> None:
+    """Publish one already-observed provider outcome to every active scope."""
+
+    outcome = ModelOutcome(finish_reason=finish_reason, refusal=refusal)
+    for recorder in _recorders.get():
+        recorder.append(outcome)
+
+
+def bind_model_outcome(error: BaseException, outcome: ModelOutcome) -> BaseException:
+    """Attach the exact provider outcome to the error raised for that round trip."""
+
+    setattr(error, _ERROR_OUTCOME_ATTRIBUTE, outcome)
+    return error
+
+
+def model_outcome_from_error(error: BaseException) -> ModelOutcome | None:
+    """Return an outcome bound by the Connector, without depending on its error type."""
+
+    outcome = getattr(error, _ERROR_OUTCOME_ATTRIBUTE, None)
+    return outcome if isinstance(outcome, ModelOutcome) else None
+
+
+__all__ = [
+    "ModelOutcome",
+    "bind_model_outcome",
+    "capture_model_outcomes",
+    "model_outcome_from_error",
+    "record_model_outcome",
+]

--- a/apps/url4-cloud/src/url4_cloud/rest/__init__.py
+++ b/apps/url4-cloud/src/url4_cloud/rest/__init__.py
@@ -5,6 +5,7 @@ for the model catalog) and the ``SubscriberGate`` protocol so ``app.py`` can wir
 reaching into the individual route modules.
 """
 
+from url4_cloud.rest.benchmarks import router as benchmark_router
 from url4_cloud.rest.catalog import router as catalog_router
 from url4_cloud.rest.connections import router as connection_router
 from url4_cloud.rest.interest import DenyAllGate, SubscriberGate
@@ -13,6 +14,7 @@ from url4_cloud.rest.routes import router
 __all__ = [
     "DenyAllGate",
     "SubscriberGate",
+    "benchmark_router",
     "catalog_router",
     "connection_router",
     "router",

--- a/apps/url4-cloud/src/url4_cloud/rest/benchmarks.py
+++ b/apps/url4-cloud/src/url4_cloud/rest/benchmarks.py
@@ -1,0 +1,85 @@
+"""Discovery for flat, Engine-owned executable Benchmark resources."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Annotated
+
+from fastapi import APIRouter, Header, Path, Query, Request
+from fastapi.responses import Response
+
+from url4_cloud.auth import ProblemException
+from url4_cloud.benchmarks import BenchmarkRegistry
+from url4_cloud.rest.conditional import validator_matches
+
+router = APIRouter()
+
+_CACHE_CONTROL = "public, max-age=300, must-revalidate"
+
+
+def _registry(request: Request) -> BenchmarkRegistry:
+    return request.app.state.benchmarks
+
+
+def _json_bytes(value: object) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+    ).encode()
+
+
+def _response(value: object, if_none_match: str | None) -> Response:
+    body = _json_bytes(value)
+    etag = hashlib.sha256(body).hexdigest()[:32]
+    headers = {"ETag": f'"{etag}"', "Cache-Control": _CACHE_CONTROL}
+    if validator_matches(if_none_match, etag):
+        return Response(status_code=304, headers=headers)
+    return Response(content=body, media_type="application/json", headers=headers)
+
+
+@router.get("/v1/benchmarks", tags=["Catalog"], summary="List the installed Benchmarks")
+async def list_benchmarks(
+    request: Request,
+    if_none_match: Annotated[str | None, Header(alias="If-None-Match")] = None,
+) -> Response:
+    registry = _registry(request)
+    return _response(
+        {
+            "object": "list",
+            "data": [benchmark.catalog_entry() for benchmark in registry],
+        },
+        if_none_match,
+    )
+
+
+@router.get(
+    "/v1/benchmarks/{benchmark_id:path}",
+    tags=["Catalog"],
+    summary="Fetch one Engine-owned Benchmark expression",
+)
+async def get_benchmark(
+    request: Request,
+    benchmark_id: Annotated[str, Path(description="An explicit installed Benchmark id.")],
+    limit: Annotated[int | None, Query(ge=1, description="Exact selected case count.")] = None,
+    if_none_match: Annotated[str | None, Header(alias="If-None-Match")] = None,
+) -> Response:
+    benchmark = _registry(request).get(benchmark_id)
+    if benchmark is None:
+        raise ProblemException(
+            status=404,
+            title="Unknown benchmark",
+            detail=f"no Benchmark is installed under {benchmark_id!r}",
+        )
+    if limit is not None and limit > benchmark.case_count:
+        raise ProblemException(
+            status=422,
+            title="Invalid benchmark selection",
+            detail=f"limit must be between 1 and {benchmark.case_count} for {benchmark.id!r}",
+        )
+    return _response(benchmark.resource(limit), if_none_match)
+
+
+__all__ = ["router"]

--- a/apps/url4-cloud/src/url4_cloud/rest/catalog.py
+++ b/apps/url4-cloud/src/url4_cloud/rest/catalog.py
@@ -28,6 +28,7 @@ from url4_cloud import job_env
 from url4_cloud.auth import ProblemException
 from url4_cloud.catalog.cache import CatalogService
 from url4_cloud.catalog.port import CatalogError, Credential, ModelParameterSource
+from url4_cloud.rest.conditional import validator_matches
 
 logger = logging.getLogger(__name__)
 
@@ -135,7 +136,7 @@ async def list_models(
         "Cache-Control": f"private, max-age={service.max_age_s(credential)}",
         "Vary": _VARY,
     }
-    if _validator_matches(if_none_match, catalog.etag):
+    if validator_matches(if_none_match, catalog.etag):
         return Response(status_code=304, headers=headers)
     return JSONResponse(content=catalog.body, headers=headers)
 
@@ -240,28 +241,6 @@ def _caller(profile: str | None, headers: Mapping[str, str]) -> Credential:
     flood protection that remains is `catalog.cache`'s entry cap and single-flight bulkhead.
     """
     return Credential.derive(profile, job_env.identity_from_headers(headers))
-
-
-def _validator_matches(if_none_match: str | None, etag: str) -> bool:
-    """RFC 9110 §13.1.2 weak comparison of an ``If-None-Match`` list against our ETag.
-
-    WHY weak: the RFC mandates weak comparison for ``If-None-Match``, so a ``W/``-prefixed tag
-    added by an intermediary must still register as a match — otherwise a client behind such a
-    proxy would re-download the catalog on every poll.
-    """
-    if if_none_match is None:
-        return False
-    return any(_tag_matches(raw, etag) for raw in if_none_match.split(","))
-
-
-def _tag_matches(raw: str, etag: str) -> bool:
-    """One entity-tag from an ``If-None-Match`` list, compared weakly."""
-    candidate = raw.strip()
-    if candidate == "*":
-        return True
-    if candidate.startswith("W/"):
-        candidate = candidate[2:]
-    return candidate.strip('"') == etag
 
 
 __all__ = ["router"]

--- a/apps/url4-cloud/src/url4_cloud/rest/conditional.py
+++ b/apps/url4-cloud/src/url4_cloud/rest/conditional.py
@@ -1,0 +1,23 @@
+"""Shared RFC 9110 conditional-request helpers."""
+
+from __future__ import annotations
+
+
+def validator_matches(if_none_match: str | None, etag: str) -> bool:
+    """Weakly compare an ``If-None-Match`` list with one unquoted entity tag."""
+
+    if if_none_match is None:
+        return False
+    return any(_tag_matches(raw, etag) for raw in if_none_match.split(","))
+
+
+def _tag_matches(raw: str, etag: str) -> bool:
+    candidate = raw.strip()
+    if candidate == "*":
+        return True
+    if candidate.startswith("W/"):
+        candidate = candidate[2:]
+    return candidate.strip('"') == etag
+
+
+__all__ = ["validator_matches"]

--- a/apps/url4-cloud/src/url4_cloud/retrieval_policy.py
+++ b/apps/url4-cloud/src/url4_cloud/retrieval_policy.py
@@ -1,0 +1,98 @@
+"""Task-local retrieval ceilings shared by Engine orchestration components."""
+
+from __future__ import annotations
+
+import contextvars
+import re
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalPolicy:
+    """Whether retrieval is available and the domains it must never reach."""
+
+    web_search: bool
+    excluded_domains: tuple[str, ...] = ()
+
+
+class RetrievalPolicyError(ValueError):
+    """A nested invocation attempted to broaden its ambient retrieval ceiling."""
+
+
+_DOMAIN_LABEL = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?")
+
+
+def normalize_excluded_domains(values: Sequence[str]) -> tuple[str, ...]:
+    """Validate and canonicalize bare domains carried by retrieval policy."""
+
+    if isinstance(values, (str, bytes)):
+        raise ValueError("web_search_exclude must contain bare domains")
+    normalized: list[str] = []
+    for value in values:
+        if not isinstance(value, str):
+            raise ValueError("web_search_exclude must contain bare domains")
+        domain = value.strip().lower().removesuffix(".")
+        try:
+            ascii_domain = domain.encode("ascii").decode("ascii")
+        except UnicodeEncodeError:
+            raise ValueError("web_search_exclude must contain bare domains") from None
+        labels = ascii_domain.split(".")
+        if (
+            not ascii_domain
+            or len(ascii_domain) > 253
+            or any(_DOMAIN_LABEL.fullmatch(label) is None for label in labels)
+        ):
+            raise ValueError("web_search_exclude must contain bare domains")
+        normalized.append(ascii_domain)
+    return tuple(sorted(set(normalized)))
+
+
+_policy: contextvars.ContextVar[RetrievalPolicy | None] = contextvars.ContextVar(
+    "url4_cloud_retrieval_policy", default=None
+)
+
+
+def current_retrieval_policy() -> RetrievalPolicy | None:
+    """Return the effective policy for this task, or ``None`` outside orchestration."""
+
+    return _policy.get()
+
+
+@contextmanager
+def retrieval_scope(requested: RetrievalPolicy) -> Iterator[RetrievalPolicy]:
+    """Apply ``requested`` beneath the ambient ceiling and restore it on exit."""
+
+    parent = _policy.get()
+    if parent is not None and requested.web_search and not parent.web_search:
+        raise RetrievalPolicyError(
+            "nested Candidate Invocation cannot enable retrieval disabled by its parent"
+        )
+    effective = RetrievalPolicy(
+        web_search=(
+            requested.web_search if parent is None else parent.web_search and requested.web_search
+        ),
+        excluded_domains=tuple(
+            sorted(
+                {
+                    *(parent.excluded_domains if parent is not None else ()),
+                    *requested.excluded_domains,
+                }
+            )
+        ),
+    )
+    token = _policy.set(effective)
+    try:
+        yield effective
+    finally:
+        _policy.reset(token)
+
+
+__all__ = [
+    "RetrievalPolicy",
+    "RetrievalPolicyError",
+    "current_retrieval_policy",
+    "normalize_excluded_domains",
+    "retrieval_scope",
+]

--- a/apps/url4-cloud/src/url4_cloud/runner/connector.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/connector.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 
 import httpx
@@ -18,6 +18,11 @@ from url4.io.static import StaticIOLayer
 from url4.observe import current_response_sink, current_usage_sink
 from url4.peer.server import Request, Url4Node
 from url4.streaming.protocol import CachePolicy
+from url4_cloud.model_outcomes import ModelOutcome, bind_model_outcome, record_model_outcome
+from url4_cloud.retrieval_policy import (
+    RetrievalPolicy,
+    current_retrieval_policy,
+)
 from url4_cloud.runner.cache import policy_to_body_field
 from url4_cloud.runner.cache_readback import CacheOutcome, read_cache_outcome, requires_revalidation
 from url4_cloud.runner.config import ModelSpec, RunnerConfigError, routes_for
@@ -177,6 +182,7 @@ class _ModelEndpoint:
             tavily_http=self._tavily_http,
             tavily_api_key=self._tavily_api_key,
             web_tools=spec.web_tools,
+            retrieval_policy=current_retrieval_policy(),
             identity_headers=self._identity_headers,
             cache=self._cache,
         )
@@ -227,7 +233,13 @@ async def build_aigateway_world(
     )
     routes = routes_for(cfg.models)
 
-    tavily_http, owns_tavily_client = _build_tavily_client(cfg, tavily_api_key, tavily_client)
+    normalized_tavily_key = tavily_api_key.strip() if tavily_api_key else None
+    normalized_tavily_key = normalized_tavily_key or None
+    tavily_http, owns_tavily_client = _build_tavily_client(
+        cfg,
+        normalized_tavily_key,
+        tavily_client,
+    )
 
     call_model = _ModelEndpoint(
         http_client=http_client,
@@ -235,7 +247,7 @@ async def build_aigateway_world(
         profile=profile,
         routes=routes,
         tavily_http=tavily_http,
-        tavily_api_key=tavily_api_key,
+        tavily_api_key=normalized_tavily_key,
         identity_headers=identity_headers or None,
         # `is not None`, not `or`: a policy is a pydantic model and always truthy, but spelling the
         # fallback explicitly says what it is — an unstated policy, not a stated default.
@@ -279,6 +291,7 @@ def _report_response(choice: _Choice, cache: CacheOutcome) -> None:
     carries the tokens without the outcome states a cost that was never paid — an error in the
     direction that hides savings, and therefore one nobody reports.
     """
+    record_model_outcome(choice.finish_reason, choice.refusal)
     sink = current_response_sink()
     if sink is None:
         return
@@ -359,8 +372,13 @@ def _raise_if_unusable(choice: _Choice) -> None:
     if choice.finish_reason == "content_filter" or choice.refusal is not None:
         # `permanent=True`: a refusal is deterministic, so a retry spends budget to be refused
         # again. This is the wire signal a client maps to a refusal-kind failure.
-        raise ResolutionError(
-            "provider refused the request", code="provider_refusal", permanent=True
+        raise bind_model_outcome(
+            ResolutionError(
+                "provider refused the request",
+                code="provider_refusal",
+                permanent=True,
+            ),
+            ModelOutcome(choice.finish_reason, choice.refusal),
         )
     if not choice.tool_calls and choice.content is None:
         raise ResolutionError(
@@ -441,6 +459,48 @@ async def _fetch_completion(
     return resp, read_cache_outcome(resp.headers)
 
 
+@dataclass(frozen=True, slots=True)
+class _WebToolRuntime:
+    client: httpx.AsyncClient
+    config: AigatewayConfig
+    api_key: str
+    excluded_domains: tuple[str, ...]
+
+
+def _web_tool_runtime(
+    *,
+    model: str,
+    route_supports_tools: bool,
+    tavily_http: httpx.AsyncClient | None,
+    tavily_api_key: str | None,
+    config: AigatewayConfig,
+    policy: RetrievalPolicy | None,
+) -> _WebToolRuntime | None:
+    """Resolve tool availability before the first paid model request."""
+
+    if policy is None:
+        return (
+            _WebToolRuntime(tavily_http, config, tavily_api_key, ())
+            if route_supports_tools and tavily_http is not None and tavily_api_key is not None
+            else None
+        )
+    if not policy.web_search:
+        return None
+    if not route_supports_tools:
+        raise ResolutionError(
+            f"model route {model!r} does not declare runner-driven web tools",
+            code="benchmark_retrieval_unavailable",
+            permanent=True,
+        )
+    if tavily_http is None or tavily_api_key is None:
+        raise ResolutionError(
+            "Benchmark requires web retrieval but Tavily is not configured",
+            code="benchmark_retrieval_unavailable",
+            permanent=True,
+        )
+    return _WebToolRuntime(tavily_http, config, tavily_api_key, policy.excluded_domains)
+
+
 async def _chat_completion_loop(
     *,
     http_client: httpx.AsyncClient,
@@ -451,6 +511,7 @@ async def _chat_completion_loop(
     tavily_http: httpx.AsyncClient | None,
     tavily_api_key: str | None,
     web_tools: bool,
+    retrieval_policy: RetrievalPolicy | None = None,
     identity_headers: Mapping[str, str] | None = None,
     cache: CachePolicy,
 ) -> str:
@@ -471,8 +532,15 @@ async def _chat_completion_loop(
         ResolutionError: the loop exceeds `cfg.web_tool_max_iterations` without a final
             answer — the model keeps calling tools instead of returning content.
     """
-    offer_tools = web_tools and tavily_http is not None
-    extra = {"tools": _WEB_TOOLS, "tool_choice": "auto"} if offer_tools else {}
+    tools = _web_tool_runtime(
+        model=model,
+        route_supports_tools=web_tools,
+        tavily_http=tavily_http,
+        tavily_api_key=tavily_api_key,
+        config=cfg,
+        policy=retrieval_policy,
+    )
+    extra = {"tools": _WEB_TOOLS, "tool_choice": "auto"} if tools is not None else {}
     headers = _headers(profile, identity_headers)
     for _ in range(cfg.web_tool_max_iterations):
         body = {"model": model, "messages": messages, **extra}
@@ -497,9 +565,7 @@ async def _chat_completion_loop(
             tool_calls[cfg.web_tool_max_calls_per_turn :],
         )
         messages.append({"role": "assistant", "content": content, "tool_calls": tool_calls})
-        results = await asyncio.gather(
-            *(_execute_tool(tc, tavily_http, cfg, tavily_api_key) for tc in served)
-        )
+        results = await asyncio.gather(*(_execute_tool(tc, tools) for tc in served))
         for tc, result in zip(served, results, strict=True):
             messages.append(
                 {
@@ -563,55 +629,56 @@ def _tool_args(tool_call: dict) -> tuple[str, dict | None]:
 async def _dispatch_tool(
     name: str,
     args: dict,
-    tavily_client: httpx.AsyncClient | None,
-    cfg: AigatewayConfig,
-    tavily_api_key: str | None,
+    runtime: _WebToolRuntime | None,
 ) -> str:
     if name not in ("web_search", "web_fetch"):
         return f"unknown tool: {name}"
-    if tavily_client is None or tavily_api_key is None:
+    if runtime is None:
         raise RuntimeError(f"{name} requested but Tavily is not configured")
     if name == "web_search":
-        return await _tavily_search(tavily_client, cfg, tavily_api_key, args)
-    return await _tavily_extract(tavily_client, cfg, tavily_api_key, args)
+        return await _tavily_search(runtime, args)
+    return await _tavily_extract(runtime, args)
 
 
 async def _execute_tool(
     tool_call: dict,
-    tavily_client: httpx.AsyncClient | None,
-    cfg: AigatewayConfig,
-    tavily_api_key: str | None,
+    runtime: _WebToolRuntime | None,
 ) -> str:
     name, args = _tool_args(tool_call)
     if args is None:
         return f"invalid arguments for {name}"
     try:
-        return await _dispatch_tool(name, args, tavily_client, cfg, tavily_api_key)
+        return await _dispatch_tool(name, args, runtime)
     except Exception as exc:  # noqa: BLE001 — fed back to the model, not raised (dec:W2)
         return f"{name} failed: {exc}"
 
 
 async def _tavily_search(
-    client: httpx.AsyncClient,
-    cfg: AigatewayConfig,
-    api_key: str,
+    runtime: _WebToolRuntime,
     args: dict,
 ) -> str:
     query = args.get("query")
     if not isinstance(query, str) or not query:
         raise ValueError("web_search requires a non-empty 'query'")
-    resp = await client.post(
+    payload: dict[str, object] = {
+        "query": query,
+        "search_depth": runtime.config.tavily_search_depth,
+        "max_results": runtime.config.tavily_max_results,
+    }
+    if runtime.excluded_domains:
+        payload["exclude_domains"] = list(runtime.excluded_domains)
+    resp = await runtime.client.post(
         "/search",
-        headers=_tavily_headers(api_key),
-        json={
-            "query": query,
-            "search_depth": cfg.tavily_search_depth,
-            "max_results": cfg.tavily_max_results,
-        },
+        headers=_tavily_headers(runtime.api_key),
+        json=payload,
     )
     resp.raise_for_status()
     data = resp.json()
-    results = data.get("results") or []
+    results = [
+        result
+        for result in (data.get("results") or [])
+        if isinstance(result, dict) and _search_result_allowed(result, runtime.excluded_domains)
+    ]
     if not results:
         return "no results"
     return "\n\n".join(
@@ -622,17 +689,17 @@ async def _tavily_search(
 
 
 async def _tavily_extract(
-    client: httpx.AsyncClient,
-    cfg: AigatewayConfig,
-    api_key: str,
+    runtime: _WebToolRuntime,
     args: dict,
 ) -> str:
     url = args.get("url")
     if not isinstance(url, str) or not url:
         raise ValueError("web_fetch requires a non-empty 'url'")
-    resp = await client.post(
+    if _is_blocked(url, runtime.excluded_domains):
+        raise ValueError("web_fetch URL is blocked by Benchmark retrieval policy")
+    resp = await runtime.client.post(
         "/extract",
-        headers=_tavily_headers(api_key),
+        headers=_tavily_headers(runtime.api_key),
         json={"urls": url, "format": "markdown", "extract_depth": "advanced"},
     )
     resp.raise_for_status()
@@ -646,6 +713,31 @@ async def _tavily_extract(
         failed_err = failed[0].get("error", "unknown")
         return f"{failed_url} could not be extracted: {failed_err}"
     return "no content extracted"
+
+
+def _search_result_allowed(result: Mapping[str, object], exclusions: Sequence[str]) -> bool:
+    if not exclusions:
+        return True
+    url = result.get("url")
+    return isinstance(url, str) and not _is_blocked(url, exclusions)
+
+
+def _is_blocked(url: str, exclusions: Sequence[str]) -> bool:
+    """Match a bare-domain exclusion against its host and every subdomain."""
+
+    if not exclusions:
+        return False
+    normalized_host: str | None = None
+    try:
+        parsed = httpx.URL(url if "://" in url else f"https://{url}")
+        normalized_host = parsed.raw_host.decode("ascii").lower().rstrip(".")
+    except (httpx.InvalidURL, UnicodeDecodeError):
+        pass
+    if not normalized_host:
+        return True
+    return any(
+        normalized_host == domain or normalized_host.endswith(f".{domain}") for domain in exclusions
+    )
 
 
 def _tavily_headers(api_key: str) -> dict[str, str]:

--- a/apps/url4-cloud/src/url4_cloud/runner/connector.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/connector.py
@@ -291,7 +291,6 @@ def _report_response(choice: _Choice, cache: CacheOutcome) -> None:
     carries the tokens without the outcome states a cost that was never paid — an error in the
     direction that hides savings, and therefore one nobody reports.
     """
-    record_model_outcome(choice.finish_reason, choice.refusal)
     sink = current_response_sink()
     if sink is None:
         return
@@ -556,6 +555,11 @@ async def _chat_completion_loop(
         _raise_if_unusable(choice)
         content, tool_calls = choice.content, choice.tool_calls
         if not tool_calls:
+            # Recorded HERE, not per round trip: a tool loop is several round trips serving ONE
+            # logical model call, and only this one is terminal. Publishing the intermediate
+            # `tool_calls` rounds too would leave a consumer unable to tell a call that progressed
+            # from two calls that disagreed (`_terminal_outcome` in `benchmarks/candidate.py`).
+            record_model_outcome(choice.finish_reason, choice.refusal)
             return content or ""
         # Cap the fan-out BEFORE dispatching: the model decides how many calls a turn carries, and
         # they all run concurrently. The dropped ones still get a tool message, because the API
@@ -733,7 +737,11 @@ def _is_blocked(url: str, exclusions: Sequence[str]) -> bool:
         normalized_host = parsed.raw_host.decode("ascii").lower().rstrip(".")
     except (httpx.InvalidURL, UnicodeDecodeError):
         pass
-    if not normalized_host:
+    # Fail closed on a host this comparison cannot decide. An unparsed host is the obvious case;
+    # a percent-encoded one is the subtle one — httpx leaves the authority encoded, so `ev%69l.com`
+    # would not match `evil.com` here and would then be handed to a fetcher that decodes it. A
+    # real host never carries a literal `%`, so refusing one costs nothing.
+    if not normalized_host or "%" in normalized_host:
         return True
     return any(
         normalized_host == domain or normalized_host.endswith(f".{domain}") for domain in exclusions

--- a/apps/url4-cloud/src/url4_cloud/runner/main.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/main.py
@@ -10,12 +10,15 @@ import asyncio
 import os
 from collections.abc import Mapping
 from dataclasses import dataclass
+from pathlib import Path
 
 import httpx
 
 from url4.streaming.lifecycle import run
 from url4_cloud import job_env
 from url4_cloud.adapters.jetstream import JetStreamPublisher
+from url4_cloud.benchmarks import EMPTY_BENCHMARKS, BenchmarkRegistry, assets_root
+from url4_cloud.benchmarks.candidate import install_candidate_invocation
 from url4_cloud.runner.config import RunnerConfig, RunnerConfigError, load_config
 from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
 from url4_cloud.runner.executor import Url4Executor, World, deny_by_default_world
@@ -73,6 +76,8 @@ def build_executor(
     *,
     client: httpx.AsyncClient | None = None,
     tavily_client: httpx.AsyncClient | None = None,
+    benchmarks: BenchmarkRegistry = EMPTY_BENCHMARKS,
+    benchmark_assets_root: Path | None = None,
 ) -> Url4Executor:
     """Wire an executor over the DECLARED world — without building it yet.
 
@@ -95,6 +100,10 @@ def build_executor(
         resolved = config if config is not None else load_config(env)
         section = resolved.aigateway
         if section is None:
+            if len(benchmarks):
+                raise RunnerConfigError(
+                    "installed Benchmarks require a declared aigateway model world"
+                )
             # WHY: a world with no [aigateway] table is a legitimate empty world; the node itself
             # denies everything undeclared.
             return deny_by_default_world(), None
@@ -123,6 +132,20 @@ def build_executor(
             tavily_api_key=env.get(job_env.TAVILY_API_KEY),
             tavily_client=tavily_client,
         )
+        if len(benchmarks):
+            try:
+                install_candidate_invocation(world.node)
+                benchmarks.install(
+                    world.node,
+                    assets_root=(
+                        benchmark_assets_root
+                        if benchmark_assets_root is not None
+                        else assets_root(env)
+                    ),
+                )
+            except Exception:
+                await world.aclose()
+                raise
         return world.node, world.aclose
 
     return Url4Executor(world_factory=_world)

--- a/apps/url4-cloud/tests/unit/test_benchmark_foundation.py
+++ b/apps/url4-cloud/tests/unit/test_benchmark_foundation.py
@@ -27,7 +27,7 @@ from url4_cloud.model_outcomes import (
     record_model_outcome,
 )
 from url4_cloud.runner.config import AigatewaySection, ModelSpec, RunnerConfig
-from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+from url4_cloud.runner.connector import AigatewayConfig, _is_blocked, build_aigateway_world
 from url4_cloud.runner.main import build_executor
 from url4_cloud.testing import InMemoryEventStream
 
@@ -775,3 +775,101 @@ async def test_runner_composition_installs_benchmarks_with_the_injected_asset_ro
         "stop",
         None,
     )
+
+
+async def _two_branch_candidate(
+    fast_outcome: ModelOutcome,
+    slow_outcome: ModelOutcome,
+) -> tuple[str, str | None, str | None]:
+    """Run one Candidate whose scope records two outcomes, returning the FAST branch's text."""
+
+    # An explicit default processor: without one the node falls back to the FIRST registered
+    # endpoint, which would make the Candidate adapter itself reduce the group.
+    node = Url4Node("test", default_processor="/provider/fast")
+    install_candidate_invocation(node)
+
+    async def fast(_request: Request) -> str:
+        record_model_outcome(fast_outcome.finish_reason, fast_outcome.refusal)
+        return "fast answer"
+
+    async def slow(_request: Request) -> str:
+        # Finishes LAST, so a "most recent outcome" rule would attribute this branch's
+        # terminal fields to the answer produced by `fast`.
+        await asyncio.sleep(0.01)
+        record_model_outcome(slow_outcome.finish_reason, slow_outcome.refusal)
+        return "slow answer"
+
+    node.endpoint("/provider/fast")(fast)
+    node.endpoint("/provider/slow")(slow)
+
+    branches = expr(
+        src(
+            RelExpr(path="/provider/fast", context="$input", intent=text("a")),
+            name="a",
+            weight=0.0,
+        ),
+        src(
+            RelExpr(path="/provider/slow", context="$input", intent=text("b")),
+            name="b",
+            weight=0.0,
+        ),
+        # A pure structural reference: the answer is `fast`'s text and no further model call
+        # is made to produce it.
+        intent=text("$a"),
+    )
+
+    result = await node.evaluate(_candidate_call(branches, web_search=False))
+    return decode_candidate_invocation(result.text)
+
+
+async def test_divergent_sibling_outcomes_are_reported_as_unknown() -> None:
+    """A sibling's terminal fields are never attributed to another branch's answer."""
+
+    output, finish_reason, refusal = await _two_branch_candidate(
+        ModelOutcome("stop", None),
+        ModelOutcome("length", None),
+    )
+
+    assert output == "fast answer"
+    assert finish_reason is None
+    assert refusal is None
+
+
+async def test_a_tolerated_sibling_refusal_never_accompanies_an_answer() -> None:
+    """The contract has no shape for a non-empty output carrying a provider refusal."""
+
+    output, finish_reason, refusal = await _two_branch_candidate(
+        ModelOutcome("stop", None),
+        ModelOutcome("content_filter", "safety policy"),
+    )
+
+    assert output == "fast answer"
+    assert refusal is None
+    assert finish_reason is None
+
+
+async def test_agreeing_sibling_outcomes_are_still_reported() -> None:
+    """Unanimity is not ambiguity — an agreed outcome still describes the answer."""
+
+    output, finish_reason, refusal = await _two_branch_candidate(
+        ModelOutcome("stop", None),
+        ModelOutcome("stop", None),
+    )
+
+    assert output == "fast answer"
+    assert finish_reason == "stop"
+    assert refusal is None
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://ev%69l.com/page",
+        "https://evil%2ecom/page",
+        "https://sub.ev%69l.com/page",
+    ],
+)
+async def test_percent_encoded_hosts_cannot_evade_an_exclusion(url: str) -> None:
+    """httpx leaves the authority percent-encoded; a fetcher downstream may not."""
+
+    assert _is_blocked(url, ("evil.com",)) is True

--- a/apps/url4-cloud/tests/unit/test_benchmark_foundation.py
+++ b/apps/url4-cloud/tests/unit/test_benchmark_foundation.py
@@ -11,14 +11,24 @@ import httpx
 import pytest
 from fastapi import FastAPI
 
-from url4 import Node, RelExpr, build, expr, render, src, text
+from url4 import Node, RelExpr, RelUrl, build, expr, iterate, render, src, text
 from url4.core.errors import ResolutionError
 from url4.peer.server import Request, Url4Node
 from url4.streaming.interfaces import Completed
 from url4_cloud.app import create_app
-from url4_cloud.benchmarks import Benchmark, BenchmarkInstaller, BenchmarkRegistry, candidate
+from url4_cloud.benchmarks import (
+    Benchmark,
+    BenchmarkInstaller,
+    BenchmarkRegistry,
+    candidate,
+    link_candidate,
+)
 from url4_cloud.benchmarks.candidate import install_candidate_invocation
-from url4_cloud.benchmarks.contract import CANDIDATE_ROUTE, decode_candidate_invocation
+from url4_cloud.benchmarks.contract import (
+    CANDIDATE_BINDING,
+    CANDIDATE_ROUTE,
+    decode_candidate_invocation,
+)
 from url4_cloud.config import Settings
 from url4_cloud.model_outcomes import (
     ModelOutcome,
@@ -60,13 +70,9 @@ def _benchmark(
 
 
 def _link(candidate_expression: Node, benchmark_expression: Node) -> str:
-    return render(
-        expr(
-            src(text(render(candidate_expression)), name="candidate", weight=0.0),
-            benchmark_expression,
-            intent=text(""),
-        )
-    )
+    # The linking convention is published, not re-stated here — a client cannot import a helper
+    # that lives in a test file.
+    return link_candidate(candidate_expression, benchmark_expression)
 
 
 async def _get(
@@ -873,3 +879,95 @@ async def test_percent_encoded_hosts_cannot_evade_an_exclusion(url: str) -> None
     """httpx leaves the authority percent-encoded; a fetcher downstream may not."""
 
     assert _is_blocked(url, ("evil.com",)) is True
+
+
+async def test_missing_relative_source_route_fails_before_execution() -> None:
+    """A `(/cases)` data reference names a route just as a `/path!intent` call does."""
+
+    benchmark = _benchmark(
+        build_protocol=lambda _selected: expr(
+            src(RelUrl("/cases/missing"), name="cases", weight=0.0),
+            intent=text("summarize"),
+        )
+    )
+    node = Url4Node("test")
+    install_candidate_invocation(node)
+
+    with pytest.raises(ValueError, match="/cases/missing"):
+        BenchmarkRegistry((benchmark,)).install(node, assets_root=Path("/assets"))
+
+
+async def test_a_benchmark_may_serve_its_cases_from_a_data_route() -> None:
+    """`data()` routes are servable relative targets, so referencing one is not a missing route."""
+
+    def install(node: Url4Node, _root: Path) -> None:
+        node.data("/cases/example", '[{"id": "c1"}]', media_type="application/json")
+
+    benchmark = _benchmark(
+        install=install,
+        build_protocol=lambda _selected: expr(
+            src(RelUrl("/cases/example"), name="cases", weight=0.0),
+            intent=text("summarize"),
+        ),
+    )
+    node = Url4Node("test")
+    install_candidate_invocation(node)
+
+    BenchmarkRegistry((benchmark,)).install(node, assets_root=Path("/assets"))
+
+
+async def test_iteration_templates_do_not_invent_routes_from_placeholders() -> None:
+    """A row template names no route until `$item` is substituted, so it cannot be validated."""
+
+    def build_protocol(_selected: int) -> Node:
+        return iterate(
+            RelUrl("/cases/example"),
+            "(/judge/$item)!'grade'",
+            intent="'grade'",
+        )
+
+    def install(node: Url4Node, _root: Path) -> None:
+        node.data("/cases/example", '[{"id": "c1"}]', media_type="application/json")
+
+    node = Url4Node("test")
+    install_candidate_invocation(node)
+
+    BenchmarkRegistry((_benchmark(install=install, build_protocol=build_protocol),)).install(
+        node, assets_root=Path("/assets")
+    )
+
+
+async def test_detail_resource_publishes_the_candidate_binding() -> None:
+    """A client cannot link a Candidate it must learn the name of from a test helper."""
+
+    app = create_app(
+        Settings(jwt_secret="s"),
+        stream=InMemoryEventStream(),
+        benchmarks=BenchmarkRegistry((_benchmark(),)),
+    )
+
+    detail = (await _get(app, "/v1/benchmarks/example/smoke")).json()
+
+    assert detail["candidate_binding"] == CANDIDATE_BINDING
+    assert f"${CANDIDATE_BINDING}" in detail["url4"]
+
+
+async def test_the_published_linking_helper_executes_a_fetched_resource() -> None:
+    """`link_candidate` is the one definition of how a Candidate is bound to a protocol."""
+
+    requests: list[dict[str, object]] = []
+    benchmark = _benchmark()
+    client, world = await _world(BenchmarkRegistry((benchmark,)), requests)
+    candidate_expression = RelExpr(path="/provider/model", context="$input", intent=text("answer"))
+
+    protocol = benchmark.resource()["url4"]
+    assert isinstance(protocol, str)
+
+    try:
+        # Exactly what a client holds after a fetch: the resource's URL4 text, nothing else.
+        result = await world.node.evaluate(link_candidate(candidate_expression, protocol))
+    finally:
+        await world.aclose()
+        await client.aclose()
+
+    assert "Rayleigh scattering." in result.text

--- a/apps/url4-cloud/tests/unit/test_benchmark_foundation.py
+++ b/apps/url4-cloud/tests/unit/test_benchmark_foundation.py
@@ -1,0 +1,777 @@
+"""Generic Engine Benchmark discovery and shared-world Candidate Invocation."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable, Mapping
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from url4 import Node, RelExpr, build, expr, render, src, text
+from url4.core.errors import ResolutionError
+from url4.peer.server import Request, Url4Node
+from url4.streaming.interfaces import Completed
+from url4_cloud.app import create_app
+from url4_cloud.benchmarks import Benchmark, BenchmarkInstaller, BenchmarkRegistry, candidate
+from url4_cloud.benchmarks.candidate import install_candidate_invocation
+from url4_cloud.benchmarks.contract import CANDIDATE_ROUTE, decode_candidate_invocation
+from url4_cloud.config import Settings
+from url4_cloud.model_outcomes import (
+    ModelOutcome,
+    bind_model_outcome,
+    capture_model_outcomes,
+    record_model_outcome,
+)
+from url4_cloud.runner.config import AigatewaySection, ModelSpec, RunnerConfig
+from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+from url4_cloud.runner.main import build_executor
+from url4_cloud.testing import InMemoryEventStream
+
+pytestmark = pytest.mark.asyncio
+
+
+def _benchmark(
+    *,
+    benchmark_id: str = "example/smoke",
+    variant: str = "smoke",
+    install: BenchmarkInstaller | None = None,
+    build_protocol: Callable[[int], Node] | None = None,
+) -> Benchmark:
+    values = {
+        "id": benchmark_id,
+        "variant": variant,
+        "title": "Example Smoke",
+        "description": "One non-comparable structural probe.",
+        "revision": "example-smoke-v1",
+        "case_count": 3,
+        "build": build_protocol
+        or (
+            lambda selected: candidate(
+                f"Explain why the sky looks blue. Selected cases: {selected}.",
+                web_search=False,
+            )
+        ),
+    }
+    return Benchmark(**values) if install is None else Benchmark(**values, install=install)
+
+
+def _link(candidate_expression: Node, benchmark_expression: Node) -> str:
+    return render(
+        expr(
+            src(text(render(candidate_expression)), name="candidate", weight=0.0),
+            benchmark_expression,
+            intent=text(""),
+        )
+    )
+
+
+async def _get(
+    app: FastAPI,
+    path: str,
+    *,
+    headers: Mapping[str, str] | None = None,
+) -> httpx.Response:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://engine.test",
+    ) as client:
+        return await client.get(path, headers=headers)
+
+
+async def test_empty_installation_has_an_honest_empty_catalog() -> None:
+    app = create_app(Settings(jwt_secret="s"), stream=InMemoryEventStream())
+    response = await _get(app, "/v1/benchmarks")
+
+    assert response.status_code == 200
+    assert response.json() == {"object": "list", "data": []}
+
+
+async def test_list_is_complete_metadata_and_detail_is_an_exact_selection() -> None:
+    registry = BenchmarkRegistry((_benchmark(),))
+    app = create_app(
+        Settings(jwt_secret="s"),
+        stream=InMemoryEventStream(),
+        benchmarks=registry,
+    )
+
+    catalog = (await _get(app, "/v1/benchmarks")).json()
+    detail = (await _get(app, "/v1/benchmarks/example/smoke?limit=1")).json()
+
+    assert catalog == {
+        "object": "list",
+        "data": [
+            {
+                "object": "benchmark",
+                "id": "example/smoke",
+                "variant": "smoke",
+                "title": "Example Smoke",
+                "description": "One non-comparable structural probe.",
+                "revision": "example-smoke-v1",
+                "case_count": 3,
+                "href": "/v1/benchmarks/example/smoke",
+            }
+        ],
+    }
+    assert detail["schema"] == "screamingface.benchmark.v1"
+    assert detail["id"] == "example/smoke"
+    assert detail["case_count"] == 3
+    assert detail["selected_case_count"] == 1
+    assert CANDIDATE_ROUTE in detail["url4"]
+    assert "Selected cases: 1" in detail["url4"]
+
+
+async def test_default_alias_does_not_exist() -> None:
+    app = create_app(
+        Settings(jwt_secret="s"),
+        stream=InMemoryEventStream(),
+        benchmarks=BenchmarkRegistry((_benchmark(),)),
+    )
+
+    response = await _get(app, "/v1/benchmarks/default")
+
+    assert response.status_code == 404
+
+
+async def test_detail_rejects_clamping_and_invalid_limits() -> None:
+    benchmark = _benchmark()
+    app = create_app(
+        Settings(jwt_secret="s"),
+        stream=InMemoryEventStream(),
+        benchmarks=BenchmarkRegistry((benchmark,)),
+    )
+
+    too_large = await _get(app, "/v1/benchmarks/example/smoke?limit=4")
+    empty = await _get(app, "/v1/benchmarks/example/smoke?limit=0")
+
+    assert too_large.status_code == 422
+    assert too_large.headers["content-type"].startswith("application/problem+json")
+    assert empty.status_code == 422
+    for invalid in (True, 0, -1, 4):
+        with pytest.raises(ValueError, match="between 1 and 3"):
+            benchmark.resource(invalid)  # type: ignore[arg-type]
+
+
+async def test_detail_supports_entity_specific_conditional_reads() -> None:
+    registry = BenchmarkRegistry((_benchmark(),))
+    app = create_app(
+        Settings(jwt_secret="s"),
+        stream=InMemoryEventStream(),
+        benchmarks=registry,
+    )
+    full = await _get(app, "/v1/benchmarks/example/smoke")
+    limited = await _get(app, "/v1/benchmarks/example/smoke?limit=1")
+    repeated = await _get(
+        app,
+        "/v1/benchmarks/example/smoke?limit=1",
+        headers={"If-None-Match": limited.headers["etag"]},
+    )
+
+    assert full.headers["etag"] != limited.headers["etag"]
+    assert repeated.status_code == 304
+    assert repeated.content == b""
+
+
+@pytest.mark.parametrize(
+    "benchmark_id",
+    ("draco:smoke", "/draco/smoke", "draco//smoke", "draco/smoke/", "DRACO/smoke"),
+)
+async def test_benchmark_ids_reject_noncanonical_variant_spellings(benchmark_id: str) -> None:
+    with pytest.raises(ValueError, match="slash-qualified"):
+        _benchmark(benchmark_id=benchmark_id)
+
+
+async def test_candidate_authoring_canonicalizes_bare_domain_exclusions() -> None:
+    protocol = candidate(
+        "question",
+        web_search=True,
+        web_search_exclude=("B.TEST.", "a.test", "b.test"),
+    )
+
+    assert "web_search_exclude=a.test:b.test" in render(protocol)
+    with pytest.raises(ValueError, match="bare domains"):
+        candidate(
+            "question",
+            web_search=True,
+            web_search_exclude="blocked.test",  # type: ignore[arg-type]
+        )
+    for malformed in (
+        ".example.com",
+        "bad..example",
+        "-bad.example",
+        "bad_domain.example",
+        "bücher.example",
+    ):
+        with pytest.raises(ValueError, match="bare domains"):
+            candidate("question", web_search=True, web_search_exclude=(malformed,))
+
+
+async def test_registry_installs_every_concrete_definition_even_with_one_installer() -> None:
+    installed: list[Path] = []
+
+    def install(_node: Url4Node, root: Path) -> None:
+        installed.append(root)
+
+    registry = BenchmarkRegistry(
+        (
+            _benchmark(benchmark_id="example/a", variant="a", install=install),
+            _benchmark(benchmark_id="example/b", variant="b", install=install),
+        )
+    )
+    node = Url4Node("test")
+    install_candidate_invocation(node)
+
+    registry.install(node, assets_root=Path("/immutable/assets"))
+
+    assert installed == [Path("/immutable/assets"), Path("/immutable/assets")]
+
+
+async def test_duplicate_benchmark_routes_fail_installation() -> None:
+    def install(node: Url4Node, _root: Path) -> None:
+        node.endpoint("/benchmarks/example/private")(lambda _request: "private")
+
+    registry = BenchmarkRegistry(
+        (
+            _benchmark(benchmark_id="example/a", variant="a", install=install),
+            _benchmark(benchmark_id="example/b", variant="b", install=install),
+        )
+    )
+    node = Url4Node("test")
+    install_candidate_invocation(node)
+
+    with pytest.raises(ValueError, match="already registered"):
+        registry.install(node, assets_root=Path("/assets"))
+
+
+async def test_missing_literal_model_route_fails_before_execution() -> None:
+    benchmark = _benchmark(
+        build_protocol=lambda _selected: RelExpr(
+            path="/judge/missing",
+            context="grade",
+            intent=text("judge"),
+        )
+    )
+    node = Url4Node("test")
+    install_candidate_invocation(node)
+
+    with pytest.raises(ValueError, match="/judge/missing"):
+        BenchmarkRegistry((benchmark,)).install(node, assets_root=Path("/assets"))
+
+
+def _response(requests: list[dict[str, object]]) -> Callable[[httpx.Request], httpx.Response]:
+    def respond(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "message": {"content": "Rayleigh scattering."},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 4, "completion_tokens": 2},
+            },
+        )
+
+    return respond
+
+
+async def _world(
+    registry: BenchmarkRegistry,
+    requests: list[dict[str, object]],
+    *,
+    models: tuple[ModelSpec, ...] = (ModelSpec(id="provider/model"),),
+    response: Callable[[httpx.Request], httpx.Response] | None = None,
+    tavily_client: httpx.AsyncClient | None = None,
+):
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(response or _response(requests)),
+        base_url="http://aigateway.test",
+    )
+    world = await build_aigateway_world(
+        AigatewayConfig(default_model="provider/model", models=models),
+        client=client,
+        tavily_api_key="tvly-test" if tavily_client is not None else None,
+        tavily_client=tavily_client,
+    )
+    install_candidate_invocation(world.node)
+    registry.install(world.node, assets_root=Path("/assets"))
+    return client, world
+
+
+async def test_fetched_resource_links_and_executes_through_candidate_route() -> None:
+    requests: list[dict[str, object]] = []
+    benchmark = _benchmark()
+    client, world = await _world(BenchmarkRegistry((benchmark,)), requests)
+    candidate_expression = RelExpr(
+        path="/provider/model",
+        context="$input",
+        intent=text("Answer accurately."),
+    )
+
+    try:
+        result = await world.node.evaluate(
+            _link(candidate_expression, build(str(benchmark.resource(1)["url4"])))
+        )
+    finally:
+        await world.aclose()
+        await client.aclose()
+
+    assert decode_candidate_invocation(result.text) == (
+        "Rayleigh scattering.",
+        "stop",
+        None,
+    )
+    assert requests == [
+        {
+            "model": "provider/model",
+            "messages": [
+                {"role": "system", "content": "Answer accurately."},
+                {"role": "user", "content": "Explain why the sky looks blue. Selected cases: 1."},
+            ],
+        }
+    ]
+
+
+async def test_candidate_uses_the_shared_world_including_benchmark_routes() -> None:
+    async def private(_request: Request) -> str:
+        return "benchmark-owned value"
+
+    def install(node: Url4Node, _root: Path) -> None:
+        node.endpoint("/benchmarks/example/private")(private)
+
+    benchmark = _benchmark(install=install)
+    client, world = await _world(BenchmarkRegistry((benchmark,)), [])
+    linked = _link(
+        RelExpr(
+            path="/benchmarks/example/private",
+            context="ignored",
+            intent=text("read"),
+        ),
+        benchmark.protocol(1),
+    )
+
+    try:
+        result = await world.node.evaluate(linked)
+    finally:
+        await world.aclose()
+        await client.aclose()
+
+    assert decode_candidate_invocation(result.text) == ("benchmark-owned value", None, None)
+
+
+async def test_candidate_preserves_a_successful_empty_output() -> None:
+    async def empty(_request: Request) -> str:
+        return ""
+
+    def install(node: Url4Node, _root: Path) -> None:
+        node.endpoint("/benchmarks/example/empty")(empty)
+
+    benchmark = _benchmark(install=install)
+    client, world = await _world(BenchmarkRegistry((benchmark,)), [])
+    linked = _link(
+        RelExpr(
+            path="/benchmarks/example/empty",
+            context="ignored",
+            intent=text("read"),
+        ),
+        benchmark.protocol(1),
+    )
+
+    try:
+        result = await world.node.evaluate(linked)
+    finally:
+        await world.aclose()
+        await client.aclose()
+
+    assert decode_candidate_invocation(result.text) == ("", None, None)
+
+
+def _candidate_call(
+    expression: Node,
+    *,
+    web_search: bool,
+    exclusions: tuple[str, ...] = (),
+) -> Node:
+    params = [("web_search", "true" if web_search else "false")]
+    if exclusions:
+        params.append(("web_search_exclude", ":".join(exclusions)))
+    call = RelExpr(
+        path=CANDIDATE_ROUTE,
+        context="question",
+        intent=text(render(expression)),
+        params=tuple(params),
+    )
+    return expr(src(call, name="invocation", weight=0.0), intent=text("$invocation"))
+
+
+async def test_nested_candidate_invocation_is_valid_composition() -> None:
+    requests: list[dict[str, object]] = []
+    benchmark = _benchmark()
+    client, world = await _world(BenchmarkRegistry((benchmark,)), requests)
+    model = RelExpr(path="/provider/model", context="$input", intent=text("answer"))
+    nested = _candidate_call(_candidate_call(model, web_search=False), web_search=False)
+
+    try:
+        outer = await world.node.evaluate(nested)
+    finally:
+        await world.aclose()
+        await client.aclose()
+
+    inner_json, outer_finish, outer_refusal = decode_candidate_invocation(outer.text)
+    assert (outer_finish, outer_refusal) == ("stop", None)
+    assert decode_candidate_invocation(inner_json) == ("Rayleigh scattering.", "stop", None)
+    assert len(requests) == 1
+
+
+async def test_nested_candidate_cannot_broaden_retrieval_policy() -> None:
+    benchmark = _benchmark()
+    client, world = await _world(BenchmarkRegistry((benchmark,)), [])
+    model = RelExpr(path="/provider/model", context="$input", intent=text("answer"))
+    nested = _candidate_call(_candidate_call(model, web_search=True), web_search=False)
+
+    try:
+        with pytest.raises(ResolutionError, match="cannot enable retrieval") as caught:
+            await world.node.evaluate(nested)
+    finally:
+        await world.aclose()
+        await client.aclose()
+
+    assert caught.value.code == "candidate_policy_escalation"
+
+
+@pytest.mark.parametrize(
+    "params",
+    (
+        (),
+        (("web_search", "yes"),),
+        (("web_search", "false"), ("web_search_exclude", "blocked.test")),
+        (("web_search", "true"), ("unknown", "value")),
+    ),
+)
+async def test_candidate_policy_is_explicit_and_fail_closed(
+    params: tuple[tuple[str, str], ...],
+) -> None:
+    benchmark = _benchmark()
+    client, world = await _world(BenchmarkRegistry((benchmark,)), [])
+    call = RelExpr(
+        path=CANDIDATE_ROUTE,
+        context="question",
+        intent=text("literal answer"),
+        params=params,
+    )
+    request = expr(src(call, name="invocation", weight=0.0), intent=text("$invocation"))
+
+    try:
+        with pytest.raises(ResolutionError) as caught:
+            await world.node.evaluate(request)
+    finally:
+        await world.aclose()
+        await client.aclose()
+
+    assert caught.value.code == "candidate_policy_invalid"
+
+
+async def test_required_retrieval_fails_before_model_spend_when_route_cannot_serve_it() -> None:
+    requests: list[dict[str, object]] = []
+    benchmark = _benchmark()
+    client, world = await _world(BenchmarkRegistry((benchmark,)), requests)
+    model = RelExpr(path="/provider/model", context="$input", intent=text("answer"))
+
+    try:
+        with pytest.raises(ResolutionError) as caught:
+            await world.node.evaluate(_candidate_call(model, web_search=True))
+    finally:
+        await world.aclose()
+        await client.aclose()
+
+    assert caught.value.code == "benchmark_retrieval_unavailable"
+    assert requests == []
+
+
+async def test_required_retrieval_treats_a_blank_tavily_key_as_unconfigured() -> None:
+    requests: list[dict[str, object]] = []
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(_response(requests)),
+        base_url="http://aigateway.test",
+    )
+    tavily = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _request: httpx.Response(500)),
+        base_url="https://api.tavily.com",
+    )
+    world = await build_aigateway_world(
+        AigatewayConfig(
+            default_model="provider/model",
+            models=(ModelSpec(id="provider/model", web_tools=True),),
+        ),
+        client=client,
+        tavily_api_key="   ",
+        tavily_client=tavily,
+    )
+    install_candidate_invocation(world.node)
+    model = RelExpr(path="/provider/model", context="$input", intent=text("answer"))
+
+    try:
+        with pytest.raises(ResolutionError) as caught:
+            await world.node.evaluate(_candidate_call(model, web_search=True))
+    finally:
+        await world.aclose()
+        await client.aclose()
+        await tavily.aclose()
+
+    assert caught.value.code == "benchmark_retrieval_unavailable"
+    assert requests == []
+
+
+async def test_retrieval_policy_protects_search_results_and_direct_fetches() -> None:
+    model_requests: list[dict] = []
+
+    def model_response(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        model_requests.append(body)
+        if len(model_requests) == 1:
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [
+                        {
+                            "message": {
+                                "content": None,
+                                "tool_calls": [
+                                    {
+                                        "id": "search",
+                                        "function": {
+                                            "name": "web_search",
+                                            "arguments": '{"query":"evidence"}',
+                                        },
+                                    },
+                                    {
+                                        "id": "fetch",
+                                        "function": {
+                                            "name": "web_fetch",
+                                            "arguments": '{"url":"https://blocked.test/secret"}',
+                                        },
+                                    },
+                                ],
+                            },
+                            "finish_reason": "tool_calls",
+                        }
+                    ]
+                },
+            )
+        return httpx.Response(
+            200,
+            json={
+                "choices": [{"message": {"content": "researched answer"}, "finish_reason": "stop"}]
+            },
+        )
+
+    tavily_requests: list[dict] = []
+
+    def tavily_response(request: httpx.Request) -> httpx.Response:
+        tavily_requests.append(json.loads(request.content))
+        assert request.url.path == "/search"
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {
+                        "title": "blocked",
+                        "url": "https://sub.blocked.test/leak",
+                        "content": "secret",
+                    },
+                    {
+                        "title": "idna blocked",
+                        "url": "https://bücher.example/leak",
+                        "content": "secret",
+                    },
+                    {
+                        "title": "idna-2008 blocked",
+                        "url": "https://faß.de/leak",
+                        "content": "secret",
+                    },
+                    {
+                        "title": "allowed",
+                        "url": "https://allowed.test/source",
+                        "content": "public",
+                    },
+                    {
+                        "title": "idna allowed",
+                        "url": "https://münchen.example/source",
+                        "content": "public idna",
+                    },
+                ]
+            },
+        )
+
+    tavily = httpx.AsyncClient(
+        transport=httpx.MockTransport(tavily_response),
+        base_url="https://api.tavily.com",
+    )
+    benchmark = _benchmark()
+    client, world = await _world(
+        BenchmarkRegistry((benchmark,)),
+        [],
+        models=(ModelSpec(id="provider/model", web_tools=True),),
+        response=model_response,
+        tavily_client=tavily,
+    )
+    model = RelExpr(path="/provider/model", context="$input", intent=text("answer"))
+
+    try:
+        result = await world.node.evaluate(
+            _candidate_call(
+                model,
+                web_search=True,
+                exclusions=("blocked.test", "xn--bcher-kva.example", "xn--fa-hia.de"),
+            )
+        )
+    finally:
+        await world.aclose()
+        await client.aclose()
+        await tavily.aclose()
+
+    assert decode_candidate_invocation(result.text) == ("researched answer", "stop", None)
+    assert tavily_requests == [
+        {
+            "query": "evidence",
+            "search_depth": "advanced",
+            "max_results": 5,
+            "exclude_domains": ["blocked.test", "xn--bcher-kva.example", "xn--fa-hia.de"],
+        }
+    ]
+    tool_messages = [
+        message for message in model_requests[1]["messages"] if message["role"] == "tool"
+    ]
+    assert tool_messages[0]["content"] == (
+        "Title: allowed\nURL: https://allowed.test/source\nContent: public\n\n"
+        "Title: idna allowed\nURL: https://münchen.example/source\nContent: public idna"
+    )
+    assert "blocked by Benchmark retrieval policy" in tool_messages[1]["content"]
+
+
+async def test_provider_refusal_is_a_normal_candidate_envelope() -> None:
+    def refusal(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "message": {"content": None, "refusal": "safety policy"},
+                        "finish_reason": "content_filter",
+                    }
+                ]
+            },
+        )
+
+    benchmark = _benchmark()
+    client, world = await _world(BenchmarkRegistry((benchmark,)), [], response=refusal)
+    model = RelExpr(path="/provider/model", context="$input", intent=text("answer"))
+
+    try:
+        result = await world.node.evaluate(_candidate_call(model, web_search=False))
+    finally:
+        await world.aclose()
+        await client.aclose()
+
+    assert decode_candidate_invocation(result.text) == (
+        "",
+        "content_filter",
+        "safety policy",
+    )
+
+
+async def test_provider_refusal_uses_its_own_outcome_when_a_sibling_finishes_later() -> None:
+    node = Url4Node("test")
+    install_candidate_invocation(node)
+
+    async def refuse(_request: Request) -> str:
+        record_model_outcome("content_filter", "safety policy")
+        record_model_outcome("content_filter", "different sibling policy")
+        raise bind_model_outcome(
+            ResolutionError(
+                "provider refused the request",
+                code="provider_refusal",
+                permanent=True,
+            ),
+            ModelOutcome("content_filter", "safety policy"),
+        )
+
+    node.endpoint("/provider/refuse")(refuse)
+    expression = RelExpr(path="/provider/refuse", context="$input", intent=text("answer"))
+
+    result = await node.evaluate(_candidate_call(expression, web_search=False))
+
+    assert decode_candidate_invocation(result.text) == (
+        "",
+        "content_filter",
+        "safety policy",
+    )
+
+
+async def test_model_outcome_capture_is_task_local_and_nested() -> None:
+    both_started = asyncio.Event()
+    started = 0
+
+    async def capture(reason: str) -> tuple[str | None, list[str | None]]:
+        nonlocal started
+        with capture_model_outcomes() as outer:
+            with capture_model_outcomes() as inner:
+                record_model_outcome(reason, None)
+                started += 1
+                if started == 2:
+                    both_started.set()
+                await asyncio.wait_for(both_started.wait(), timeout=1)
+            return inner[-1].finish_reason, [item.finish_reason for item in outer]
+
+    first, second = await asyncio.gather(capture("stop"), capture("length"))
+
+    assert first == ("stop", ["stop"])
+    assert second == ("length", ["length"])
+
+
+async def test_runner_composition_installs_benchmarks_with_the_injected_asset_root() -> None:
+    roots: list[Path] = []
+
+    def install(_node: Url4Node, root: Path) -> None:
+        roots.append(root)
+
+    benchmark = _benchmark(install=install)
+    registry = BenchmarkRegistry((benchmark,))
+    requests: list[dict[str, object]] = []
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(_response(requests)),
+        base_url="http://aigateway.test",
+    )
+    config = RunnerConfig(
+        aigateway=AigatewaySection(
+            base_url="http://aigateway.test",
+            default_model="provider/model",
+            models=(ModelSpec(id="provider/model"),),
+        )
+    )
+    model = RelExpr(path="/provider/model", context="$input", intent=text("answer"))
+    executor = build_executor(
+        {},
+        config,
+        client=client,
+        benchmarks=registry,
+        benchmark_assets_root=Path("/immutable/assets"),
+    )
+
+    try:
+        frames = [frame async for frame in executor.execute(_link(model, benchmark.protocol(1)))]
+    finally:
+        await client.aclose()
+
+    assert roots == [Path("/immutable/assets")]
+    assert isinstance(frames[-1], Completed)
+    assert decode_candidate_invocation(frames[-1].result.body) == (
+        "Rayleigh scattering.",
+        "stop",
+        None,
+    )

--- a/apps/url4-cloud/tests/unit/test_url4_executor.py
+++ b/apps/url4-cloud/tests/unit/test_url4_executor.py
@@ -500,30 +500,45 @@ def _imports_url4_engine(py_file: Path) -> bool:
     return False
 
 
-_ALLOWED_URL4_IMPORTERS = frozenset({"executor.py", "connector.py"})
+_ALLOWED_RUNNER_IMPORTERS = frozenset(
+    {
+        Path("url4_cloud/runner/executor.py"),
+        Path("url4_cloud/runner/connector.py"),
+    }
+)
 
 
-def test_only_url4_executor_module_imports_url4() -> None:
-    """The ENGINE (`url4.dag`, `url4.peer`, …) has exactly two importers in the whole app.
+def _may_import_url4_engine(py_file: Path) -> bool:
+    """Engine adapters and Engine-owned Benchmark extensions may speak URL4 directly."""
+
+    relative = py_file.relative_to(_SRC_ROOT)
+    return relative in _ALLOWED_RUNNER_IMPORTERS or relative.parts[:2] == (
+        "url4_cloud",
+        "benchmarks",
+    )
+
+
+def test_only_engine_extensions_import_url4() -> None:
+    """The URL4 ENGINE is confined to Runner adapters and Benchmark extensions.
 
     `url4.streaming` is exempt — it is the wire contract, which both halves speak. This scans
-    the whole distribution now rather than a separate runner tree: merging the two packages
-    means the control-plane modules are in scope too, so the guard covers strictly more code
-    than it did when it could only see the separate runner source tree.
+    the whole distribution. Benchmark definitions deliberately build structured URL4 and install
+    routes on the shared Runner node; no other control-plane or shared module may import it.
     """
     offenders = [
         py_file
         for py_file in _SRC_ROOT.rglob("*.py")
-        if _imports_url4_engine(py_file) and py_file.name not in _ALLOWED_URL4_IMPORTERS
+        if _imports_url4_engine(py_file) and not _may_import_url4_engine(py_file)
     ]
     assert offenders == []
 
     allowed = {
-        py_file.name
+        py_file.relative_to(_SRC_ROOT)
         for py_file in _SRC_ROOT.rglob("*.py")
-        if py_file.name in _ALLOWED_URL4_IMPORTERS and _imports_url4_engine(py_file)
+        if py_file.relative_to(_SRC_ROOT) in _ALLOWED_RUNNER_IMPORTERS
+        and _imports_url4_engine(py_file)
     }
-    assert allowed == _ALLOWED_URL4_IMPORTERS
+    assert allowed == _ALLOWED_RUNNER_IMPORTERS
 
 
 # --- per-span usage accumulation ---------------------------------------------------------

--- a/docs/plan/2026-08-06-OME-712-engine-benchmark-foundation.md
+++ b/docs/plan/2026-08-06-OME-712-engine-benchmark-foundation.md
@@ -1,0 +1,46 @@
+---
+title: OME-712 — Engine benchmark foundation implementation plan
+status: completed
+created: 2026-08-06
+ticket: OME-712
+spec: docs/spec/2026-08-06-OME-712-engine-benchmark-foundation.md
+---
+
+# Engine benchmark foundation implementation plan
+
+## Goal
+
+Land the generic Engine extension seam required by future DRACO and IFEval runtimes without
+installing a scored Benchmark or moving Benchmark semantics into URL4 or AI Gateway.
+
+## Sequence
+
+1. Define immutable Benchmark metadata, structured protocol builders, strict selection, and a
+   static registry with explicit installer and asset-root injection.
+2. Expose metadata-only list discovery and complete executable detail resources with deterministic
+   conditional HTTP responses.
+3. Install one Candidate Invocation adapter into the shared Runner `Url4Node`, carrying exact
+   output, finish reason, and provider refusal fields.
+4. Add task-local retrieval ceilings and terminal model-outcome recording without coupling the
+   Connector to Benchmark definitions.
+5. Enforce nested retrieval narrowing, pre-spend capability checks, Tavily exclusions,
+   post-filtering, and direct-fetch blocking.
+6. Validate every full Benchmark protocol and installed literal endpoint before the Runner world
+   becomes executable.
+7. Prove discovery, installation, composition, concurrency isolation, retrieval enforcement, and
+   outcome preservation with focused tests, then run all URL4 Cloud quality gates.
+
+## Landing boundary
+
+- Modify only URL4 Cloud Engine code, its tests, and OME-712 artifacts.
+- Defer scored protocols, case browsing, SDK/report behavior, deployment, authentication, budgets,
+  and notebook behavior to their owning PRs.
+- Update the inherited URL4 importer boundary test explicitly because Benchmarks are now an owned
+  Engine extension that builds structured URL4. Disclose that deliberate append-only exception in
+  the PR test plan.
+
+## Verification
+
+- Focused Benchmark foundation tests.
+- URL4 Engine importer boundary and Engine/control-plane layering checks.
+- Ruff lint and formatting, Pyright, and the complete URL4 Cloud test suite with coverage.

--- a/docs/spec/2026-08-06-OME-712-engine-benchmark-foundation.md
+++ b/docs/spec/2026-08-06-OME-712-engine-benchmark-foundation.md
@@ -1,0 +1,135 @@
+---
+title: OME-712 — Engine benchmark foundation
+status: accepted
+created: 2026-08-06
+ticket: OME-712
+---
+
+# Engine benchmark foundation
+
+## Purpose
+
+The Engine needs one small extension seam for discovering and executing Engine-owned Benchmarks
+before scored protocols such as DRACO or IFEval are installed. This landing defines that seam,
+including Candidate Invocation, retrieval ceilings, and terminal provider outcomes. It installs no
+scored Benchmark and owns no rubric or scoring rule.
+
+## Benchmark definition and installation
+
+Each immutable `Benchmark` has explicit metadata, a total `case_count`, a pure
+`build(selected_case_count) -> Node`, and an installer that receives the shared `Url4Node` plus an
+explicit immutable asset root.
+
+- Definitions build structured URL4; rendering happens only at the public resource boundary.
+- Every concrete definition installs independently. Installer identity is not an aliasing or
+  deduplication mechanism.
+- `Url4Node.endpoint()` and `Url4Node.data()` remain authoritative for path validity and collisions.
+- Installation validates every definition at its full selection, renders it, and checks every
+  literal relative endpoint against the routes actually installed in the shared world.
+- Assets and routes are validated before the first model request. A broken definition fails the
+  Runner world atomically; it is never omitted from discovery and never discovered half-working.
+- A non-empty registry requires a declared AI Gateway model world.
+
+The registry is static and immutable for a process. There is no dynamic Python loading and no
+compatibility behavior for unreleased contracts.
+
+## Public resource contract
+
+- `GET /v1/benchmarks` returns metadata only. Each item includes `id`, `variant`, `revision`, total
+  `case_count`, and `href`; URL4 text is not duplicated into the list.
+- `GET /v1/benchmarks/{id}` returns one `screamingface.benchmark.v1` resource containing metadata,
+  total `case_count`, authoritative `selected_case_count`, and complete executable URL4 text.
+- IDs are explicit and slash-qualified (`draco`, `draco/lite`, `draco/smoke`). There is no
+  `default` alias.
+- An omitted `limit` selects all cases. A supplied limit is exact and valid only when
+  `1 <= limit <= case_count`; it is never clamped.
+- Selection changes the rendered protocol and HTTP entity tag, but not the installed Benchmark
+  revision.
+- List and detail responses are deterministic and support `If-None-Match`.
+- An Engine with no installed Benchmarks returns an honest empty list.
+
+Benchmark-specific reducers must bind and validate the exact ordered selection in their own
+protocol. The shared foundation publishes the authoritative count; DRACO and IFEval add their
+case-ID checks in their respective runtime PRs.
+
+## Candidate Invocation
+
+When Benchmarks are installed, the Runner adds `/benchmarks/candidate` to the same `Url4Node` as
+model and Benchmark routes. Candidate URL4 therefore uses ordinary URL4 composition: nested
+Candidate calls and calls to other installed routes are valid. The adapter is not a new URL4 node
+kind and does not create a second execution world.
+
+Each invocation requires an explicit policy:
+
+- `web_search=true|false` is mandatory.
+- optional `web_search_exclude` is a non-empty colon-separated list of bare domains and is valid
+  only when retrieval is enabled.
+- unknown or malformed policy parameters fail closed.
+- a nested invocation may disable retrieval or add exclusions, but cannot enable retrieval that
+  its parent disabled.
+- exclusions are inherited by union, so a nested call cannot remove its parent's guard.
+- `web_search=true` grants both Runner-driven `web_search` and `web_fetch`; it does not force a
+  model to call either tool.
+- a route that cannot provide the required capability fails before its first paid model request.
+- exclusions are sent to Tavily, re-applied to returned search rows, and checked before direct
+  fetches.
+
+General URL4 deadlines and cancellation bound execution. Candidate Invocation has no global,
+cross-run counter and no special recursion rule.
+
+## Candidate outcome contract
+
+The adapter returns exactly:
+
+```json
+{
+  "schema": "screamingface.candidate-invocation.v1",
+  "output": "...",
+  "finish_reason": "stop",
+  "refusal": null
+}
+```
+
+All four fields are required. `finish_reason` is a literal supported provider value or null;
+`refusal` is literal non-empty provider text or null. No benchmark synthesizes a refusal and no
+soft-refusal classifier is applied.
+
+The Connector reports every model round trip through the existing observation stream and a small
+task-local outcome recorder. A typed `provider_refusal` is converted only at the Candidate seam
+into a normal envelope with an empty output plus its exact finish/refusal fields. Timeouts,
+transport errors, malformed responses, and all other failures still fail normally. Each scored
+Benchmark decides how a refusal affects its denominator and score.
+
+## Ownership
+
+- `url4_cloud.benchmarks` owns definitions, registry validation, Candidate adaptation, and wire
+  envelopes.
+- `url4_cloud.rest.benchmarks` owns discovery and conditional HTTP responses.
+- `url4_cloud.model_outcomes` and `url4_cloud.retrieval_policy` are task-local shared leaves used by
+  the Connector and Candidate adapter; neither depends on the serving or Runner half.
+- `url4_cloud.runner.connector` builds only AI Gateway model routes and reports model outcomes. It
+  does not install or import Benchmark protocols.
+- `url4_cloud.runner.main` is the composition boundary: it builds the model world, installs the
+  Candidate adapter, injects the asset root, and installs the registry.
+- the App, local mode, and Runner receive the same registry through dependency injection.
+
+## Deferred deliberately
+
+- DRACO/IFEval cases, prompts, judges, reducers, exact case-ID validation, and scoring.
+- public paginated case browsing (`{id,input}` only), which needs the first real benchmark-owned
+  case-source interface.
+- SDK linking, decoding, report construction, and defensive selected-count verification.
+- benchmark image, Helm, and workflow changes.
+- run budgets and paid notebook gates.
+
+## Acceptance
+
+- A fetched exact-selection resource structurally links to a Candidate and executes.
+- list discovery is one request and carries revision/count metadata.
+- missing routes, duplicate routes, invalid limits, invalid policies, and unavailable retrieval
+  fail before model spend.
+- nested Candidate calls inherit retrieval policy without task leakage.
+- Tavily search and fetch honor exclusions defensively.
+- output, `finish_reason`, and `refusal` survive Candidate Invocation.
+- the whole URL4 Cloud gate passes with the URL4 Engine importer guard expanded only to the
+  explicitly owned `benchmarks/` extension subtree.

--- a/docs/spec/2026-08-06-OME-712-engine-benchmark-foundation.md
+++ b/docs/spec/2026-08-06-OME-712-engine-benchmark-foundation.md
@@ -2,7 +2,12 @@
 title: OME-712 — Engine benchmark foundation
 status: accepted
 created: 2026-08-06
+revised: 2026-08-07 (r2 — contract decisions forced by the branch review of the implementation)
 ticket: OME-712
+related:
+  - docs/plan/2026-08-06-OME-712-engine-benchmark-foundation.md
+  - docs/work/2026-08-06-OME-712-engine-benchmark-foundation.md
+  - docs/spec/2026-08-04-OME-712-url4-runtime-foundations.md
 ---
 
 # Engine benchmark foundation
@@ -25,7 +30,12 @@ explicit immutable asset root.
   deduplication mechanism.
 - `Url4Node.endpoint()` and `Url4Node.data()` remain authoritative for path validity and collisions.
 - Installation validates every definition at its full selection, renders it, and checks every
-  literal relative endpoint against the routes actually installed in the shared world.
+  literal relative reference against the routes actually installed in the shared world. A call and
+  a data reference both name a route, and the routes come from `endpoint()` and from `data()`.
+- A reference names a route only while each segment is literal. `/judge/$item` names no route
+  before the Runner substitutes the row, and installation does not check it. Installation also
+  does not fail on an iteration template that it cannot parse before substitution. These
+  references stay unchecked; installation must not reject a legal Benchmark.
 - Assets and routes are validated before the first model request. A broken definition fails the
   Runner world atomically; it is never omitted from discovery and never discovered half-working.
 - A non-empty registry requires a declared AI Gateway model world.
@@ -38,7 +48,11 @@ compatibility behavior for unreleased contracts.
 - `GET /v1/benchmarks` returns metadata only. Each item includes `id`, `variant`, `revision`, total
   `case_count`, and `href`; URL4 text is not duplicated into the list.
 - `GET /v1/benchmarks/{id}` returns one `screamingface.benchmark.v1` resource containing metadata,
-  total `case_count`, authoritative `selected_case_count`, and complete executable URL4 text.
+  total `case_count`, authoritative `selected_case_count`, `candidate_binding`, and complete
+  executable URL4 text.
+- `candidate_binding` names the source the client binds its Candidate expression under. The
+  protocol reads that name back as `$candidate`. A client must not infer the name, and the Engine
+  publishes one helper that builds the linked expression.
 - IDs are explicit and slash-qualified (`draco`, `draco/lite`, `draco/smoke`). There is no
   `default` alias.
 - An omitted `limit` selects all cases. A supplied limit is exact and valid only when
@@ -94,11 +108,27 @@ All four fields are required. `finish_reason` is a literal supported provider va
 `refusal` is literal non-empty provider text or null. No benchmark synthesizes a refusal and no
 soft-refusal classifier is applied.
 
-The Connector reports every model round trip through the existing observation stream and a small
-task-local outcome recorder. A typed `provider_refusal` is converted only at the Candidate seam
-into a normal envelope with an empty output plus its exact finish/refusal fields. Timeouts,
-transport errors, malformed responses, and all other failures still fail normally. Each scored
-Benchmark decides how a refusal affects its denominator and score.
+The Connector reports every model round trip through the existing observation stream. It reports
+one terminal outcome per model call to a small task-local recorder. A tool loop makes more than
+one round trip for one call, but only the round trip that returns content is terminal. A typed
+`provider_refusal` is converted only at the Candidate seam into a normal envelope with an empty
+output plus its exact finish/refusal fields. Timeouts, transport errors, malformed responses, and
+all other failures still fail normally. Each scored Benchmark decides how a refusal affects its
+denominator and score.
+
+Candidate URL4 composes freely, so one Candidate scope can record more than one terminal outcome.
+The recorder does not know which model call produced the returned text. Therefore the adapter
+applies this rule:
+
+- One recorded outcome describes the answer. The adapter reports it.
+- Two or more recorded outcomes that agree also describe the answer. The adapter reports them.
+- Two or more recorded outcomes that disagree describe different branches. The adapter reports
+  null for `finish_reason` and null for `refusal`, which this contract permits.
+
+The adapter must not report the most recent outcome. That rule gives one branch's fields to
+another branch's answer. It can also put a refusal beside a non-empty output, and this contract
+has no such shape. A Benchmark that needs the exact fields of each model call must invoke one
+Candidate for each model call.
 
 ## Ownership
 
@@ -118,7 +148,8 @@ Benchmark decides how a refusal affects its denominator and score.
 - DRACO/IFEval cases, prompts, judges, reducers, exact case-ID validation, and scoring.
 - public paginated case browsing (`{id,input}` only), which needs the first real benchmark-owned
   case-source interface.
-- SDK linking, decoding, report construction, and defensive selected-count verification.
+- SDK linking, decoding, report construction, and defensive selected-count verification. The
+  Engine publishes the binding name and one linking helper; the SDK that consumes them is deferred.
 - benchmark image, Helm, and workflow changes.
 - run budgets and paid notebook gates.
 
@@ -130,6 +161,9 @@ Benchmark decides how a refusal affects its denominator and score.
   fail before model spend.
 - nested Candidate calls inherit retrieval policy without task leakage.
 - Tavily search and fetch honor exclusions defensively.
-- output, `finish_reason`, and `refusal` survive Candidate Invocation.
+- output, `finish_reason`, and `refusal` survive Candidate Invocation for one model call, and a
+  tool loop stays one model call.
+- a Candidate never gives one branch's `finish_reason` or `refusal` to another branch's answer,
+  and never reports a refusal beside a non-empty output.
 - the whole URL4 Cloud gate passes with the URL4 Engine importer guard expanded only to the
   explicitly owned `benchmarks/` extension subtree.

--- a/docs/work/2026-08-06-OME-712-engine-benchmark-foundation.md
+++ b/docs/work/2026-08-06-OME-712-engine-benchmark-foundation.md
@@ -32,6 +32,11 @@ or generic command/data changes.
 - Runner composition owns Candidate/Benchmark installation and immutable asset-root injection;
   Connector owns model routes only.
 - Startup validation for duplicate/missing routes and malformed full-selection protocols.
+- One terminal outcome per logical model call: the Connector records when its tool loop returns
+  content, not on each round trip, so a consumer can tell a call that progressed from two calls
+  that disagreed. The Candidate reports an agreed outcome and reports null when branches differ.
+- Retrieval exclusions fail closed on any host this comparison cannot decide, including a
+  percent-encoded one.
 
 ## Test plan
 
@@ -55,12 +60,16 @@ or generic command/data changes.
 
 ## Verification
 
-- Focused Benchmark foundation tests: 30 passed.
-- Affected Connector, finish-reason, REST, and Benchmark tests: 108 passed.
-- Full URL4 Cloud suite: 523 passed, 5 skipped, 95.85% coverage.
+- Focused Benchmark foundation tests: 36 passed.
+- Full URL4 Cloud suite: 956 passed, 5 skipped, 96% coverage. Counts are measured after the
+  rebase onto `main`, so they include the cache-policy and connections work that landed there.
 - Ruff lint/format, Pyright, and Engine/control-plane layering: passed.
 - Two-axis branch review: Standards findings resolved in code; accepted spec passes with no
   missing, partial, incorrect, or out-of-scope behavior.
+- Open follow-ups from branch review, deliberately not fixed here: `_relative_endpoint_paths`
+  collects `RelExpr` paths only, so a relative source such as `(/cases)` escapes install-time
+  route validation, and `processor_routes()` excludes `data()` routes; the `$candidate` binding
+  convention is defined only by a test helper rather than by the published resource.
 - Deliberate test-history exception: the inherited URL4 importer boundary test was updated because
   the accepted architecture explicitly makes `url4_cloud.benchmarks` an Engine-owned structured
   URL4 extension. No behavioral assertion was weakened; the boundary became path-specific.

--- a/docs/work/2026-08-06-OME-712-engine-benchmark-foundation.md
+++ b/docs/work/2026-08-06-OME-712-engine-benchmark-foundation.md
@@ -1,0 +1,66 @@
+---
+ticket: OME-712
+stack: url4-cloud
+status: completed
+started: 2026-08-06
+---
+
+# OME-712 — Engine benchmark foundation
+
+## Intent
+
+Reconstruct the generic Engine-owned Benchmark and Candidate Invocation foundation from current
+`main`, without carrying forward DRACO, IFEval, connections, deployment, SDK, AI Gateway, URL4,
+or generic command/data changes.
+
+## Artifacts
+
+- Spec: `docs/spec/2026-08-06-OME-712-engine-benchmark-foundation.md`
+- Plan: `docs/plan/2026-08-06-OME-712-engine-benchmark-foundation.md`
+- Task mirror: `docs/tasks/2026-07-31-ome-712-run-draco-url4.md`
+
+## Implemented shape
+
+- Immutable explicit Benchmark registry; no default alias or installer deduplication.
+- Structured `Node` builders and strict exact `limit` specialization.
+- Metadata-complete list plus selection-complete detail resources with body-derived ETags.
+- Shared-world `/benchmarks/candidate` adapter rather than a second restricted node.
+- Explicit task-local retrieval ceilings with nested intersection and exclusion union.
+- Search-result post-filtering and direct-fetch blocking in addition to Tavily request filters.
+- Generic task-local terminal outcome recording; refusal remains provider data at the Candidate
+  boundary.
+- Runner composition owns Candidate/Benchmark installation and immutable asset-root injection;
+  Connector owns model routes only.
+- Startup validation for duplicate/missing routes and malformed full-selection protocols.
+
+## Test plan
+
+- Catalog: empty/list/detail, slash IDs, no alias, strict limits, selected count, per-entity ETags.
+- Installation: every concrete definition, duplicate paths, missing literal model routes, injected
+  asset root.
+- Execution: fetched resource linking, same-world Benchmark routes, nested Candidate composition.
+- Policy: required values, unknown values, no parent-policy escalation, capability preflight,
+  concurrent task isolation.
+- Retrieval: Tavily exclusions, search post-filter, blocked direct fetch.
+- Outcomes: normal completion, provider refusal envelope, nested and concurrent recorder scopes.
+- Full URL4 Cloud lint, format, type, layering, and coverage gates.
+
+## Boundaries
+
+- No scored Benchmark is installed here.
+- Benchmark reducers must add exact ordered case-ID enforcement in their own PRs.
+- Client selection/preflight/report changes remain in the Client PR.
+- Case browsing waits for the first benchmark-owned case-source implementation.
+- No deployment or authentication behavior changes.
+
+## Verification
+
+- Focused Benchmark foundation tests: 30 passed.
+- Affected Connector, finish-reason, REST, and Benchmark tests: 108 passed.
+- Full URL4 Cloud suite: 523 passed, 5 skipped, 95.85% coverage.
+- Ruff lint/format, Pyright, and Engine/control-plane layering: passed.
+- Two-axis branch review: Standards findings resolved in code; accepted spec passes with no
+  missing, partial, incorrect, or out-of-scope behavior.
+- Deliberate test-history exception: the inherited URL4 importer boundary test was updated because
+  the accepted architecture explicitly makes `url4_cloud.benchmarks` an Engine-owned structured
+  URL4 extension. No behavioral assertion was weakened; the boundary became path-specific.

--- a/docs/work/2026-08-06-OME-712-engine-benchmark-foundation.md
+++ b/docs/work/2026-08-06-OME-712-engine-benchmark-foundation.md
@@ -37,6 +37,11 @@ or generic command/data changes.
   that disagreed. The Candidate reports an agreed outcome and reports null when branches differ.
 - Retrieval exclusions fail closed on any host this comparison cannot decide, including a
   percent-encoded one.
+- Install-time route validation covers relative data references and `data()` routes, not only
+  `RelExpr` calls against endpoints, and treats an iteration row template as unvalidatable rather
+  than as a route named `/judge` when it reads `/judge/$item`.
+- The Candidate binding is published: `candidate_binding` in every detail resource, plus
+  `link_candidate` as the one definition of how a client binds its Candidate to a protocol.
 
 ## Test plan
 
@@ -60,16 +65,17 @@ or generic command/data changes.
 
 ## Verification
 
-- Focused Benchmark foundation tests: 36 passed.
-- Full URL4 Cloud suite: 956 passed, 5 skipped, 96% coverage. Counts are measured after the
+- Focused Benchmark foundation tests: 41 passed.
+- Full URL4 Cloud suite: 961 passed, 5 skipped, 96% coverage. Counts are measured after the
   rebase onto `main`, so they include the cache-policy and connections work that landed there.
 - Ruff lint/format, Pyright, and Engine/control-plane layering: passed.
 - Two-axis branch review: Standards findings resolved in code; accepted spec passes with no
   missing, partial, incorrect, or out-of-scope behavior.
-- Open follow-ups from branch review, deliberately not fixed here: `_relative_endpoint_paths`
-  collects `RelExpr` paths only, so a relative source such as `(/cases)` escapes install-time
-  route validation, and `processor_routes()` excludes `data()` routes; the `$candidate` binding
-  convention is defined only by a test helper rather than by the published resource.
+- Open follow-up: `Url4Node` publishes no accessor for its data routes, so the registry reads the
+  table privately. An accessor belongs upstream in the URL4 engine, which is outside this
+  landing's boundary.
+- Open follow-up: installation does not verify that a protocol's free reference is the declared
+  Candidate binding, so a misspelled `$candiate` still fails at run time rather than at install.
 - Deliberate test-history exception: the inherited URL4 importer boundary test was updated because
   the accepted architecture explicitly makes `url4_cloud.benchmarks` an Engine-owned structured
   URL4 extension. No behavioral assertion was weakened; the boundary became path-specific.


### PR DESCRIPTION
## Summary

Add the generic Engine-owned Benchmark foundation without installing a scored protocol. URL4
Cloud now exposes an immutable Benchmark registry through `GET /v1/benchmarks` and
`GET /v1/benchmarks/{id}`, specializes each protocol to an exact selected case count, and installs
Benchmark routes plus Candidate Invocation into one shared Runner `Url4Node`.

Candidate Invocation carries explicit retrieval policy and preserves the provider's exact terminal
outcome in the four-field `screamingface.candidate-invocation.v1` envelope: `output`,
`finish_reason`, and `refusal` plus the schema identifier.

Benchmark variants use explicit slash-qualified IDs such as `draco/smoke` and `draco/lite`;
`variant` remains separate metadata. An Engine with no installed Benchmarks returns an honest empty
catalogue.

**Linear:** https://linear.app/openmined/issue/OME-712/run-draco-end-to-end-as-a-url4-expression-on-the-runner-path

## Components touched

- `apps/url4-cloud`: Benchmark definition/registry, discovery resources, Candidate adapter,
  retrieval ceilings, terminal model-outcome capture, and Runner composition
- `tests`: discovery, installation, shared-world execution, nested policy, retrieval enforcement,
  refusal correlation, concurrency isolation, and importer-boundary coverage
- `docs`: accepted OME-712 foundation spec, implementation plan, and completed work ledger

## Test plan

- [x] `python3 .claude/scripts/run_gates.py url4-cloud --skip-append-only`
  - Ruff and format checks
  - Pyright
  - Engine/control-plane layering check
  - full pytest suite with coverage gate
- [x] Full URL4 Cloud suite: 523 passed, 5 skipped, 95.85% coverage
- [x] Focused Benchmark foundation suite: 30 passed
- [x] Affected Connector, finish-reason, REST, and Benchmark suites: 108 passed
- [x] `git diff --check origin/main...HEAD`
- [x] Independent Standards and accepted-spec reviews
- [ ] Screenshots / recording (no UI changes)

The append-only test check is skipped deliberately: this PR updates the inherited URL4 importer
boundary test because `url4_cloud.benchmarks` is now an explicitly owned Engine extension that
builds structured URL4. The assertion is not weakened; it remains path-specific and continues to
reject URL4 Engine imports everywhere else.

## Contract

- Benchmark builders return structured URL4 `Node` values; rendering occurs only at the resource
  boundary.
- `limit` is exact: omitted selects all cases; supplied values must satisfy
  `1 <= limit <= case_count` and are never clamped.
- List discovery is metadata-only; detail resources carry total and selected counts plus complete
  executable URL4. Entity tags are body-derived.
- Every concrete Benchmark installs independently with the shared `Url4Node` and an explicit
  immutable asset root. Missing literal routes and route collisions fail during world creation.
- `/benchmarks/candidate` evaluates linked Candidate URL4 in that same world. Nested Candidate
  composition is valid; there is no second node kind or isolated execution world.
- Every Candidate invocation declares `web_search=true|false`. Nested calls may narrow retrieval or
  add exclusions, but cannot broaden their parent's policy.
- Retrieval capability is checked before the first model request. Tavily exclusions are forwarded,
  reapplied to search results, and enforced before direct fetches.
- General URL4 deadlines and cancellation bound execution; there is no Candidate-specific global
  invocation counter.
- A typed provider refusal becomes a normal Candidate envelope only at the Candidate seam. Other
  transport, timeout, protocol, and provider errors still fail normally.

## Scope boundary

This PR deliberately installs no DRACO or IFEval protocol and contains no Judge, rubric, grading,
aggregation, public cases endpoint, Benchmark image/Helm/workflow, run-budget, notebook,
provider-connection, Cloudflare authentication, model-parameter, ScreamingFace Client, AI Gateway,
or URL4 package changes. Those remain independently reviewable follow-up landings.
