### PR TITLE
feat(public-docs): six SF Client user guides against the live SDK

### DIFF
--- a/docs/tasks/2026-08-06-user-guides-v1.md
+++ b/docs/tasks/2026-08-06-user-guides-v1.md
@@ -1,0 +1,46 @@
+---
+id: OME-668
+linear_url: https://linear.app/openmined/issue/OME-668
+parent: OME-666
+status: In Progress
+type: Task
+priority: P2
+labels: [repo, autonomous, agentic, task]
+created: 2026-08-06
+closed:
+---
+
+# User guides v1 for connections, compose (models, fusions), benchmarks (first only), running an evaluation
+
+Second of six sub-issues under `OME-666` (Documentation for ScreamingFace Client V1). Adds six of
+the parent's ten user-guide pages; `OME-669` covers the remaining four.
+
+Pages, in sidebar order:
+
+```
+USER GUIDES
+  Connections
+  ▸ Compose
+      Models
+      Fusions
+  Benchmarks
+  Running an evaluation
+  Reproduce & share (URL4)
+```
+
+Every guide follows the parent's five-part shape — what it is · what you can do with it · main
+APIs · how to · links — and ends with `Based on state at commit e387aefd`.
+
+Written against `OME-605-screamingface-client-v1` @ `e387aefd`. The client moved off the
+`OME-400` branch, so the parent's spec and the merged Overview and Quickstart name API that no
+longer exists (`sf.config`, `StudyReport`, reducers, `draco-lite`). Every sample here is verified
+against `e387aefd` and executed against a local Engine, using `ifeval` — its grading is
+deterministic and costs nothing.
+
+Branch `callis/ome-668-user-guides-v1-for-connections-compose-models-fusions` is cut from the epic
+branch `callis/ome-666-documentation-for-screamingface-client-v1`; its PR targets that branch, not
+`main`.
+
+Milestone: Week 3.
+
+Ledger: `docs/work/2026-08-06-OME-668-user-guides-v1.md`

--- a/docs/tasks/2026-08-06-user-guides-v1.md
+++ b/docs/tasks/2026-08-06-user-guides-v1.md
@@ -2,12 +2,12 @@
 id: OME-668
 linear_url: https://linear.app/openmined/issue/OME-668
 parent: OME-666
-status: In Progress
+status: Done
 type: Task
 priority: P2
 labels: [repo, autonomous, agentic, task]
 created: 2026-08-06
-closed:
+closed: 2026-08-06
 ---
 
 # User guides v1 for connections, compose (models, fusions), benchmarks (first only), running an evaluation

--- a/docs/work/2026-08-06-OME-668-user-guides-v1.md
+++ b/docs/work/2026-08-06-OME-668-user-guides-v1.md
@@ -1,0 +1,84 @@
+---
+ticket: OME-668
+stack: repo
+status: in_progress
+started: 2026-08-06
+finished:
+---
+
+# OME-668 — User guides v1: connections, models, fusions, benchmarks, evaluation, URL4
+
+## Intent
+
+Second sub-issue of `OME-666`. `public-docs/` has an Overview and a Quickstart but no user guides,
+so a reader who finishes the Quickstart has nowhere to go to understand connections, composition,
+benchmarks, or reports. This unit adds six of the parent's ten guide pages; `OME-669` covers the
+rest.
+
+Written against `OME-605-screamingface-client-v1` @ `e387aefd`. That matters: the client moved
+branches, and the parent's spec plus the merged Overview and Quickstart describe the older
+`OME-400` API. Every code sample here is verified against `e387aefd` and executed against a local
+Engine.
+
+## Planned changes
+
+- `public-docs/src/pages/sf-client/guides/ConnectionsPage.vue`
+- `public-docs/src/pages/sf-client/guides/ModelsPage.vue`
+- `public-docs/src/pages/sf-client/guides/FusionsPage.vue`
+- `public-docs/src/pages/sf-client/guides/BenchmarksPage.vue`
+- `public-docs/src/pages/sf-client/guides/EvaluationPage.vue`
+- `public-docs/src/pages/sf-client/guides/Url4Page.vue`
+- `public-docs/src/composables/useDocNavigation.ts` — replace `NavSection`/`NavItem` with one
+  recursive `NavEntry` union: a group (title + children) or a link (title + path + optional
+  children). `flatNav` walks recursively and collects links only
+- `public-docs/src/components/layout/NavTree.vue` — new; renders one level and recurses, so a group
+  renders as a label and a link as a `RouterLink`
+- `public-docs/src/components/layout/DocLayout.vue` — replace the hand-rolled sidebar loop with
+  `<NavTree>`
+- `public-docs/src/navigation/sf-client.ts` — `User Guides` group with a nested `Compose` group;
+  Overview becomes a plain top-level link, retiring the empty-title-section convention
+- `public-docs/src/navigation/sdk.ts` — migrate to `NavEntry`
+- `public-docs/src/router/index.ts` — six routes under `/sf-client/guides/`
+- `public-docs/CLAUDE.md` — routes, navigation tables, and the navigation model
+- this ledger and `docs/tasks/2026-08-06-user-guides-v1.md`
+
+## Test plan
+
+`public-docs` has no test suite and is not a registered stack in `.claude/sdlc.local.md`, so there
+is no RED→GREEN loop. Verification is the gates CI runs, plus live execution and manual checks:
+
+- `npx oxlint .` · `npx eslint .` — bare, as CI runs them
+- `npm run build` (type-check + vite build)
+- `npx prettier --check` on the touched files
+- Every snippet executed against a local Engine on `:9108` with AI Gateway on `:9105`; real output
+  goes on the page. `ifeval` only — deterministic grading, no judge spend
+- Every API name checked against `e387aefd`
+- Sidebar shows `User Guides` with the `Compose` child group; active state correct
+- Prev/next traverses Overview → Quickstart → Installation → the six guides
+- Six pages in light and dark theme, and at mobile width with no horizontal page scroll
+
+## Acceptance
+
+- Six guide pages exist and are reachable from the sidebar
+- Sidebar renders `User Guides` with `Compose` as a non-clickable label and Models/Fusions indented
+  beneath it
+- Navigation entries are either a link (has a path) or a group (label + children); groups are never
+  clickable and never appear in prev/next
+- Prev/next traverses only pages: Overview → Quickstart → Installation → Connections → Models →
+  Fusions → Benchmarks → Running an evaluation → Reproduce & share
+- Each follows the parent's five-part shape: What it is · What you can do · Main APIs · How to ·
+  Links
+- Each ends with `Based on state at commit e387aefd`
+- Every code sample uses only API present in `e387aefd`; no `StudyReport`, no reducers, no
+  `benchmark.evaluate(...)`, no `draco-lite`
+- Displayed output is real, from an executed run
+- Pages compose from the existing `components/nb/` and `components/ui/` primitives; headings `h2`
+  under `DocLayout`'s `h1`
+- Gates green: lint, build, format on touched files
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+- **Commits:**
+- **Gates:**
+- **Deviations:**

--- a/docs/work/2026-08-06-OME-668-user-guides-v1.md
+++ b/docs/work/2026-08-06-OME-668-user-guides-v1.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-668
 stack: repo
-status: in_progress
+status: done
 started: 2026-08-06
-finished:
+finished: 2026-08-06
 ---
 
 # OME-668 — User guides v1: connections, models, fusions, benchmarks, evaluation, URL4
@@ -78,7 +78,23 @@ is no RED→GREEN loop. Verification is the gates CI runs, plus live execution a
 
 ## Outcome (fill at the end — required before COMMIT)
 
-- **Actual files:**
+- **Actual files:** 21 changed, +1751 / −163. More than planned: the navigation refactor and the
+  mobile navigation were added during the unit.
+  - six guide pages under `public-docs/src/pages/sf-client/guides/`
+  - `useDocNavigation.ts` (NavEntry union), `NavTree.vue` (new), `DocLayout.vue`,
+    `TheNavbar.vue`, both `navigation/` files, `router/index.ts`
+  - `components/nb/NbTextOut.vue` (new) and `nb/index.ts`
+  - `Index.vue`, `InstallationPage.vue`, `QuickstartPage.vue` — version prop; the Overview also
+    lost its "Where next" section
+  - `public-docs/CLAUDE.md`, plus this ledger and the `docs/tasks` mirror
 - **Commits:**
-- **Gates:**
-- **Deviations:**
+  - `0a4dab36` — feat(public-docs): model navigation as groups and links, add the User Guides tree
+  - `a7ed90ba` — feat(public-docs): six SF Client user guides against the live SDK
+  - `0c0161b3` — feat(public-docs): make the sidebar and product nav reachable on mobile
+- **Gates:** `oxlint` and `eslint` clean (run bare, as CI does) · `build` succeeds ·
+  `prettier --check` clean on every file this unit touched. `public-docs` has no test suite, so
+  there is no RED→GREEN loop.
+- **Deviations:** the navigation model was refactored (groups vs links) rather than patched;
+  mobile navigation was added — a drawer plus a navbar product switcher — which was not in the AC
+  and touches `TheNavbar`; the commit stamp renders once in the sidebar footer rather than at the
+  foot of each guide; the Overview's "Where next" section was removed as duplicating the sidebar.

--- a/public-docs/CLAUDE.md
+++ b/public-docs/CLAUDE.md
@@ -34,8 +34,10 @@ There is no automated test setup in this project.
 
 - `src/App.vue` — shell: `<TheNavbar />` + `<RouterView />`
 - `src/components/layout/TheNavbar.vue` — sticky top nav (brand, product links [Home / SF Client / SDK], theme toggle, GitHub)
-- `src/components/layout/DocLayout.vue` — sidebar + optional page header + content slot + prev/next buttons (`title` is optional; the header is skipped when omitted). A navigation section whose `title` is an empty string renders no group heading, so an item can sit ungrouped above the labelled sections.
+- `src/components/layout/DocLayout.vue` — sidebar (`NavTree`) + optional page header + content slot + prev/next buttons + an optional sidebar version footer (`version` prop). `title` is optional; the header is skipped when omitted.
+- `src/components/layout/NavTree.vue` — renders one level of a navigation tree and recurses for children. A group renders as a label (uppercase at depth 0, muted below), a link as a `RouterLink`. Depth drives styling only, so nesting is unbounded.
 - `src/components/ui/` — reusable content components: `CodeBlock`, `TabbedCodeBlock`, `ApiBlock`, `Collapsible`, `ImageCarousel`, `NotebookViewer`
+- `src/components/nb/` — notebook-cell primitives for docs pages: `NbCell` (input + output chrome), `NbTextOut` (plain repr output), `NbStateCarousel`, plus the panel kit (`NbPanel`, `NbRowList`, `NbProgress`, `NbStatGrid`, `NbCheckList`, `NbScoreList`, `ProviderConnections`, `EvaluationReport`, `CandidateScores`) and `tokens.css`. A page wraps each cell in `<div class="not-prose">`.
 - `src/composables/` — reusable logic: `useCopy` (clipboard + "Copied!" feedback), `useHighlight` (central Prism setup + `highlight()`), `useDocNavigation` (sidebar active-state + prev/next from a nav tree), `useCarousel` (index + auto-advance)
 - `src/stores/` — Pinia stores for shared reactive state: `theme` (`isDark` state, `theme` getter, dark/light + localStorage persistence) and `codeLang` (shared code-tab language across `TabbedCodeBlock`s)
 - `src/lib/` — framework-agnostic helpers: `utils.ts` (`cn` class merge) and `notebook.ts` (nbformat types + pure helpers for `NotebookViewer`)
@@ -51,6 +53,12 @@ There is no automated test setup in this project.
 | `/sf-client` | `src/pages/sf-client/Index.vue` |
 | `/sf-client/installation` | `src/pages/sf-client/InstallationPage.vue` |
 | `/sf-client/quickstartPage` | `src/pages/sf-client/QuickstartPage.vue` |
+| `/sf-client/guides/connections` | `src/pages/sf-client/guides/ConnectionsPage.vue` |
+| `/sf-client/guides/models` | `src/pages/sf-client/guides/ModelsPage.vue` |
+| `/sf-client/guides/fusions` | `src/pages/sf-client/guides/FusionsPage.vue` |
+| `/sf-client/guides/benchmarks` | `src/pages/sf-client/guides/BenchmarksPage.vue` |
+| `/sf-client/guides/running-an-evaluation` | `src/pages/sf-client/guides/EvaluationPage.vue` |
+| `/sf-client/guides/reproduce-and-share` | `src/pages/sf-client/guides/Url4Page.vue` |
 | `/sdk` | `src/pages/sdk/Index.vue` |
 
 ### NotebookViewer
@@ -66,37 +74,68 @@ It supports a `showTitle` toggle and rewrites inter-notebook links via
 The sidebar and prev/next buttons are driven by shared data files in
 `src/navigation/`, one file per documentation section.
 
+A tree is built from two node kinds, distinguished by whether the node has a
+destination (`isLink()` narrows on `'path' in entry`):
+
+- a **group** (`{ title, children }`) labels its children and is never clickable
+- a **link** (`{ title, path, children? }`) points at a page
+
+Depth is not fixed — a group nested in a group is the same construct as a
+top-level one, so `NavTree` renders any number of levels. `flatNav` collects
+links only, so prev/next steps over group labels.
+
+```ts
+export const sfClientNavigation: NavEntry[] = [
+  { title: 'Overview', path: '/sf-client' },
+  { title: 'Get Started', children: [{ title: 'Quickstart', path: '…' }] },
+  {
+    title: 'User Guides',
+    children: [
+      { title: 'Connections', path: '…' },
+      { title: 'Compose', children: [{ title: 'Models', path: '…' }] },
+    ],
+  },
+]
+```
+
 | File | Export | Used by | Entries |
 |---|---|---|---|
-| `src/navigation/sf-client.ts` | `sfClientNavigation` | All `/sf-client/*` pages | Overview (ungrouped), then **Get Started**: Quickstart, Installation |
-| `src/navigation/sdk.ts` | `sdkNavigation` | All `/sdk/*` pages | Overview |
+| `src/navigation/sf-client.ts` | `sfClientNavigation`, `sfClientVersion` | All `/sf-client/*` pages | Overview, then **Get Started** and **User Guides** (with a nested **Compose** group) |
+| `src/navigation/sdk.ts` | `sdkNavigation` | All `/sdk/*` pages | **Getting Started**: Overview |
+
+**Versioning.** `sf-client.ts` also exports `sfClientVersion`
+(`{ prefix, label, url }`), rendered once in the sidebar footer rather than on
+each page. It is a commit while `screamingface` is unpublished; when the package
+ships to PyPI only that object changes.
 
 **How pages consume it:**
 
 ```ts
-import { sfClientNavigation as navigation } from '@/navigation/sf-client'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
 ```
 
-The `as navigation` alias keeps templates uniform — every page passes
-`:navigation="navigation"` to `DocLayout`.
+Every page passes `:navigation="navigation"` and `:version="version"` to
+`DocLayout`.
 
-**How prev/next works:** `DocLayout` flattens the navigation tree
-(sections → items → children) into a sequential list and computes the previous
-and next page from the current route. Adding a page to a nav file automatically
-gives it prev/next buttons — no per-page configuration.
+**How prev/next works:** `useDocNavigation` walks the tree recursively, collects
+every link in sidebar order, and computes the previous and next page from the
+current route. Adding a link to a nav file automatically gives it prev/next
+buttons — no per-page configuration.
 
 **Adding a new page:**
 
 1. Create the Vue page under `src/pages/<section>/`, rendering it inside `DocLayout`.
 2. Add a route in `src/router/index.ts`.
-3. Add the page entry to the relevant `src/navigation/<section>.ts` file
-   (top-level item or child of an existing item).
-4. Import the shared navigation in the new page:
-   `import { <export> as navigation } from '@/navigation/<section>'`.
+3. Add a link entry to the relevant `src/navigation/<section>.ts` file — at the
+   top level, or in a group's `children`.
+4. Import the shared navigation (and version, if the section has one) in the page.
 
 **Adding a new section:**
 
-1. Create `src/navigation/<section>.ts` exporting a `<section>Navigation` array.
+1. Create `src/navigation/<section>.ts` exporting a `<section>Navigation: NavEntry[]`.
 2. Add the section's routes in `src/router/index.ts`.
 3. Add a top-level link to the section in `src/components/layout/TheNavbar.vue`
    (`products` array + `currentProduct` computed).

--- a/public-docs/src/components/layout/DocLayout.vue
+++ b/public-docs/src/components/layout/DocLayout.vue
@@ -1,16 +1,16 @@
 <script setup lang="ts">
 import { RouterLink, useRoute } from 'vue-router'
 import { watch } from 'vue'
-import { ChevronDown, ChevronUp } from 'lucide-vue-next'
 import { useCodeLangStore } from '@/stores/codelangStore'
-import { useDocNavigation, type NavSection } from '@/composables/useDocNavigation'
+import { useDocNavigation, type NavEntry } from '@/composables/useDocNavigation'
+import NavTree from './NavTree.vue'
 
 interface Props {
   // Optional: when omitted, the page header is skipped entirely (e.g. a notebook
   // page whose NotebookViewer renders the notebook's own title as content).
   title?: string
   description?: string
-  navigation: NavSection[]
+  navigation: NavEntry[]
 }
 
 const props = defineProps<Props>()
@@ -18,7 +18,9 @@ const route = useRoute()
 const { reset: resetCodeLang } = useCodeLangStore()
 watch(() => route.path, resetCodeLang)
 
-const { isActive, isActiveOrChild, prevPage, nextPage } = useDocNavigation(() => props.navigation)
+// Active state and the sidebar tree belong to NavTree; this layout only needs
+// the prev/next pair.
+const { prevPage, nextPage } = useDocNavigation(() => props.navigation)
 </script>
 
 <template>
@@ -26,48 +28,8 @@ const { isActive, isActiveOrChild, prevPage, nextPage } = useDocNavigation(() =>
     <!-- Sidebar -->
     <aside class="hidden lg:flex w-64 flex-col border-r border-border/50 bg-sidebar sticky top-16 h-[calc(100vh-4rem)]">
       <div class="flex-1 overflow-y-auto py-6 px-4">
-        <nav class="space-y-6">
-          <div v-for="section in navigation" :key="section.title">
-            <!-- An empty section title renders no heading, letting an item sit ungrouped. -->
-            <h3 v-if="section.title" class="px-3 text-xs font-semibold tracking-widest text-muted-foreground/70 uppercase mb-3">
-              {{ section.title }}
-            </h3>
-            <ul class="space-y-1">
-              <li v-for="item in section.items" :key="item.path">
-                <RouterLink
-                  :to="item.path"
-                  :class="[
-                    'flex items-center gap-2 px-3 py-2 text-sm rounded-md transition-all duration-200',
-                    isActive(item.path)
-                      ? 'text-sidebar-primary bg-sidebar-accent border-l-2 border-sidebar-primary'
-                      : 'text-sidebar-foreground hover:text-sidebar-primary hover:bg-sidebar-accent/50'
-                  ]"
-                >
-                  {{ item.title }}
-                  <template v-if="item.children">
-                    <ChevronUp v-if="isActiveOrChild(item)" class="ml-auto w-3.5 h-3.5 text-muted-foreground shrink-0" />
-                    <ChevronDown v-else class="ml-auto w-3.5 h-3.5 text-muted-foreground shrink-0" />
-                  </template>
-                </RouterLink>
-                <!-- Nested children -->
-                <ul v-if="item.children && isActiveOrChild(item)" class="ml-4 mt-1 space-y-1 border-l border-border/50 pl-2">
-                  <li v-for="child in item.children" :key="child.path">
-                    <RouterLink
-                      :to="child.path"
-                      :class="[
-                        'flex items-center gap-2 px-3 py-1.5 text-sm rounded-md transition-all duration-200',
-                        isActive(child.path)
-                          ? 'text-sidebar-primary bg-sidebar-accent/50'
-                          : 'text-muted-foreground hover:text-sidebar-primary hover:bg-sidebar-accent/30'
-                      ]"
-                    >
-                      {{ child.title }}
-                    </RouterLink>
-                  </li>
-                </ul>
-              </li>
-            </ul>
-          </div>
+        <nav>
+          <NavTree :entries="navigation" />
         </nav>
       </div>
     </aside>

--- a/public-docs/src/components/layout/DocLayout.vue
+++ b/public-docs/src/components/layout/DocLayout.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { RouterLink, useRoute } from 'vue-router'
-import { watch } from 'vue'
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { Menu, X } from 'lucide-vue-next'
 import { useCodeLangStore } from '@/stores/codelangStore'
 import { useDocNavigation, type NavEntry } from '@/composables/useDocNavigation'
 import NavTree from './NavTree.vue'
@@ -19,7 +20,24 @@ interface Props {
 const props = defineProps<Props>()
 const route = useRoute()
 const { reset: resetCodeLang } = useCodeLangStore()
-watch(() => route.path, resetCodeLang)
+
+// Below lg the sidebar is off-canvas. Above it this stays false and is inert,
+// because the drawer classes are all lg:-overridden.
+const navOpen = ref(false)
+
+watch(
+  () => route.path,
+  () => {
+    resetCodeLang()
+    navOpen.value = false
+  },
+)
+
+const onKeydown = (event: KeyboardEvent) => {
+  if (event.key === 'Escape') navOpen.value = false
+}
+onMounted(() => document.addEventListener('keydown', onKeydown))
+onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
 
 // Active state and the sidebar tree belong to NavTree; this layout only needs
 // the prev/next pair.
@@ -28,10 +46,32 @@ const { prevPage, nextPage } = useDocNavigation(() => props.navigation)
 
 <template>
   <div class="flex min-h-[calc(100vh-4rem)]">
-    <!-- Sidebar -->
+    <!-- Backdrop, drawer only -->
+    <div
+      v-if="navOpen"
+      class="lg:hidden fixed inset-0 z-30 bg-background/80 backdrop-blur-sm"
+      @click="navOpen = false"
+    />
+
+    <!-- Sidebar: one element, two layouts. Off-canvas below lg, a static
+         column above it — so the drawer reuses NavTree rather than copying it. -->
     <aside
-      class="hidden lg:flex w-64 flex-col border-r border-border/50 bg-sidebar sticky top-16 h-[calc(100vh-4rem)]"
+      :class="[
+        'w-64 flex flex-col border-r border-border/50 bg-sidebar',
+        'fixed inset-y-0 left-0 z-40 pt-16 transition-transform duration-200',
+        'lg:sticky lg:inset-y-auto lg:top-16 lg:z-auto lg:h-[calc(100vh-4rem)] lg:pt-0 lg:translate-x-0',
+        navOpen ? 'translate-x-0' : '-translate-x-full',
+      ]"
     >
+      <button
+        type="button"
+        class="lg:hidden self-end m-3 p-1 text-muted-foreground hover:text-foreground"
+        aria-label="Close navigation"
+        @click="navOpen = false"
+      >
+        <X class="w-5 h-5" />
+      </button>
+
       <div class="flex-1 overflow-y-auto py-6 px-4">
         <nav>
           <NavTree :entries="navigation" />
@@ -58,6 +98,15 @@ const { prevPage, nextPage } = useDocNavigation(() => props.navigation)
     <!-- Main content -->
     <div class="flex-1 overflow-y-auto">
       <div class="max-w-4xl mx-auto px-6 py-10">
+        <button
+          type="button"
+          class="lg:hidden mb-8 flex items-center gap-2 px-3 py-2 text-sm rounded-md border border-border/50 text-muted-foreground hover:text-foreground hover:border-primary/40"
+          @click="navOpen = true"
+        >
+          <Menu class="w-4 h-4" />
+          Menu
+        </button>
+
         <!-- Page header (skipped when no title/description — e.g. notebook pages) -->
         <header v-if="title || description" class="mb-12 pb-8 border-b border-border/50">
           <h1

--- a/public-docs/src/components/layout/DocLayout.vue
+++ b/public-docs/src/components/layout/DocLayout.vue
@@ -11,6 +11,9 @@ interface Props {
   title?: string
   description?: string
   navigation: NavEntry[]
+  // Which version of the documented thing these pages describe. Optional because
+  // DocLayout also serves sections that have no version to claim.
+  version?: { prefix: string; label: string; url: string }
 }
 
 const props = defineProps<Props>()
@@ -26,11 +29,29 @@ const { prevPage, nextPage } = useDocNavigation(() => props.navigation)
 <template>
   <div class="flex min-h-[calc(100vh-4rem)]">
     <!-- Sidebar -->
-    <aside class="hidden lg:flex w-64 flex-col border-r border-border/50 bg-sidebar sticky top-16 h-[calc(100vh-4rem)]">
+    <aside
+      class="hidden lg:flex w-64 flex-col border-r border-border/50 bg-sidebar sticky top-16 h-[calc(100vh-4rem)]"
+    >
       <div class="flex-1 overflow-y-auto py-6 px-4">
         <nav>
           <NavTree :entries="navigation" />
         </nav>
+      </div>
+
+      <!-- Version footer: the nav above is flex-1, so this sits on the bottom edge. -->
+      <div v-if="version" class="border-t border-border/50 px-4 py-3">
+        <p class="text-xs text-muted-foreground">
+          {{ version.prefix }}
+          <!-- Underlined at rest: the sidebar sits outside .prose-content, so it
+               inherits none of the layout's link styling. -->
+          <a
+            :href="version.url"
+            target="_blank"
+            rel="noopener"
+            class="font-mono text-primary underline underline-offset-2 hover:text-accent"
+            >{{ version.label }}</a
+          >
+        </p>
       </div>
     </aside>
 
@@ -39,10 +60,16 @@ const { prevPage, nextPage } = useDocNavigation(() => props.navigation)
       <div class="max-w-4xl mx-auto px-6 py-10">
         <!-- Page header (skipped when no title/description — e.g. notebook pages) -->
         <header v-if="title || description" class="mb-12 pb-8 border-b border-border/50">
-          <h1 v-if="title" class="text-4xl sm:text-5xl font-normal tracking-tight text-foreground mb-4 bg-linear-to-r from-foreground via-foreground to-muted-foreground bg-clip-text">
+          <h1
+            v-if="title"
+            class="text-4xl sm:text-5xl font-normal tracking-tight text-foreground mb-4 bg-linear-to-r from-foreground via-foreground to-muted-foreground bg-clip-text"
+          >
             {{ title }}
           </h1>
-          <p v-if="description" class="text-lg sm:text-xl text-muted-foreground leading-relaxed max-w-3xl">
+          <p
+            v-if="description"
+            class="text-lg sm:text-xl text-muted-foreground leading-relaxed max-w-3xl"
+          >
             {{ description }}
           </p>
         </header>
@@ -53,7 +80,10 @@ const { prevPage, nextPage } = useDocNavigation(() => props.navigation)
         </div>
 
         <!-- Prev / Next navigation -->
-        <div v-if="prevPage || nextPage" class="flex justify-between items-center mt-16 pt-8 border-t border-border/50 gap-4">
+        <div
+          v-if="prevPage || nextPage"
+          class="flex justify-between items-center mt-16 pt-8 border-t border-border/50 gap-4"
+        >
           <RouterLink
             v-if="prevPage"
             :to="prevPage.path"
@@ -62,7 +92,11 @@ const { prevPage, nextPage } = useDocNavigation(() => props.navigation)
             <span class="text-muted-foreground group-hover:text-primary transition-colors">←</span>
             <div class="text-right min-w-0">
               <div class="text-xs text-muted-foreground mb-0.5">Previous</div>
-              <div class="text-sm font-medium text-foreground group-hover:text-primary transition-colors truncate">{{ prevPage.title }}</div>
+              <div
+                class="text-sm font-medium text-foreground group-hover:text-primary transition-colors truncate"
+              >
+                {{ prevPage.title }}
+              </div>
             </div>
           </RouterLink>
           <div v-else />
@@ -74,7 +108,11 @@ const { prevPage, nextPage } = useDocNavigation(() => props.navigation)
           >
             <div class="text-left min-w-0">
               <div class="text-xs text-muted-foreground mb-0.5">Next</div>
-              <div class="text-sm font-medium text-foreground group-hover:text-primary transition-colors truncate">{{ nextPage.title }}</div>
+              <div
+                class="text-sm font-medium text-foreground group-hover:text-primary transition-colors truncate"
+              >
+                {{ nextPage.title }}
+              </div>
             </div>
             <span class="text-muted-foreground group-hover:text-primary transition-colors">→</span>
           </RouterLink>
@@ -231,7 +269,7 @@ const { prevPage, nextPage } = useDocNavigation(() => props.navigation)
 }
 
 /* Reset prose link styles inside .not-prose, but preserve explicit text-color classes */
-.prose-content :deep(.not-prose a:not([class*="text-"])) {
+.prose-content :deep(.not-prose a:not([class*='text-'])) {
   color: inherit;
   text-decoration: none;
 }

--- a/public-docs/src/components/layout/NavTree.vue
+++ b/public-docs/src/components/layout/NavTree.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import { isLink, useDocNavigation, type NavEntry } from '@/composables/useDocNavigation'
+
+// Renders one level of a navigation tree and recurses for children, so a group
+// nested in a group needs no special case. `depth` drives styling only.
+const props = withDefaults(defineProps<{ entries: NavEntry[]; depth?: number }>(), { depth: 0 })
+
+const { isActive } = useDocNavigation(() => props.entries)
+</script>
+
+<template>
+  <ul :class="depth === 0 ? 'space-y-6' : 'space-y-1'">
+    <li v-for="entry in entries" :key="entry.title">
+      <!-- A group labels its children and is never clickable. -->
+      <template v-if="!isLink(entry)">
+        <h3
+          v-if="depth === 0"
+          class="px-3 text-xs font-semibold tracking-widest text-muted-foreground/70 uppercase mb-3"
+        >
+          {{ entry.title }}
+        </h3>
+        <div v-else class="px-3 py-2 text-sm font-medium text-sidebar-foreground/60">
+          {{ entry.title }}
+        </div>
+        <NavTree
+          :entries="entry.children"
+          :depth="depth + 1"
+          :class="depth === 0 ? '' : 'ml-4 mt-1 border-l border-border/50 pl-2'"
+        />
+      </template>
+
+      <!-- A link points at a page. -->
+      <template v-else>
+        <RouterLink
+          :to="entry.path"
+          :class="[
+            'flex items-center gap-2 px-3 py-2 text-sm rounded-md transition-all duration-200',
+            isActive(entry.path)
+              ? 'text-sidebar-primary bg-sidebar-accent border-l-2 border-sidebar-primary'
+              : 'text-sidebar-foreground hover:text-sidebar-primary hover:bg-sidebar-accent/50',
+          ]"
+        >
+          {{ entry.title }}
+        </RouterLink>
+        <NavTree
+          v-if="entry.children"
+          :entries="entry.children"
+          :depth="depth + 1"
+          class="ml-4 mt-1 border-l border-border/50 pl-2"
+        />
+      </template>
+    </li>
+  </ul>
+</template>

--- a/public-docs/src/components/layout/TheNavbar.vue
+++ b/public-docs/src/components/layout/TheNavbar.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
+import { ChevronDown } from 'lucide-vue-next'
 import { storeToRefs } from 'pinia'
 import { useThemeStore } from '@/stores/themeStore'
 
@@ -28,6 +29,22 @@ const isActive = (productPath: string) => {
   if (productPath === '/') return route.path === '/'
   return route.path.startsWith(productPath)
 }
+
+// The product link row collapses below md, so the current-product label becomes
+// the only way to reach another section — it has to be a control, not text.
+const productsOpen = ref(false)
+watch(
+  () => route.path,
+  () => {
+    productsOpen.value = false
+  },
+)
+
+const onKeydown = (event: KeyboardEvent) => {
+  if (event.key === 'Escape') productsOpen.value = false
+}
+onMounted(() => document.addEventListener('keydown', onKeydown))
+onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
 </script>
 
 <template>
@@ -36,37 +53,69 @@ const isActive = (productPath: string) => {
       <nav class="flex items-center justify-between h-16">
         <!-- Logo -->
         <RouterLink to="/" class="flex items-center gap-3 group">
-          <div class="w-10 h-10 flex items-center justify-center transition-all duration-300 group-hover:scale-105">
+          <div
+            class="w-10 h-10 flex items-center justify-center transition-all duration-300 group-hover:scale-105"
+          >
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 311 360" class="w-8 h-8">
               <g clip-path="url(#clip0_navbar)">
-                <path d="M311.414 89.7878L155.518 179.998L-0.378906 89.7878L155.518 -0.422485L311.414 89.7878Z" fill="url(#paint0_navbar)"/>
-                <path d="M311.414 89.7878V270.208L155.518 360.423V179.998L311.414 89.7878Z" fill="url(#paint1_navbar)"/>
-                <path d="M155.518 179.998V360.423L-0.378906 270.208V89.7878L155.518 179.998Z" fill="url(#paint2_navbar)"/>
+                <path
+                  d="M311.414 89.7878L155.518 179.998L-0.378906 89.7878L155.518 -0.422485L311.414 89.7878Z"
+                  fill="url(#paint0_navbar)"
+                />
+                <path
+                  d="M311.414 89.7878V270.208L155.518 360.423V179.998L311.414 89.7878Z"
+                  fill="url(#paint1_navbar)"
+                />
+                <path
+                  d="M155.518 179.998V360.423L-0.378906 270.208V89.7878L155.518 179.998Z"
+                  fill="url(#paint2_navbar)"
+                />
               </g>
               <defs>
-                <linearGradient id="paint0_navbar" x1="-0.378904" y1="89.7878" x2="311.414" y2="89.7878" gradientUnits="userSpaceOnUse">
-                  <stop stop-color="#DC7A6E"/>
-                  <stop offset="0.251496" stop-color="#F6A464"/>
-                  <stop offset="0.501247" stop-color="#FDC577"/>
-                  <stop offset="0.753655" stop-color="#EFC381"/>
-                  <stop offset="1" stop-color="#B9D599"/>
+                <linearGradient
+                  id="paint0_navbar"
+                  x1="-0.378904"
+                  y1="89.7878"
+                  x2="311.414"
+                  y2="89.7878"
+                  gradientUnits="userSpaceOnUse"
+                >
+                  <stop stop-color="#DC7A6E" />
+                  <stop offset="0.251496" stop-color="#F6A464" />
+                  <stop offset="0.501247" stop-color="#FDC577" />
+                  <stop offset="0.753655" stop-color="#EFC381" />
+                  <stop offset="1" stop-color="#B9D599" />
                 </linearGradient>
-                <linearGradient id="paint1_navbar" x1="309.51" y1="89.7878" x2="155.275" y2="360.285" gradientUnits="userSpaceOnUse">
-                  <stop stop-color="#BFCD94"/>
-                  <stop offset="0.245025" stop-color="#B2D69E"/>
-                  <stop offset="0.504453" stop-color="#8DCCA6"/>
-                  <stop offset="0.745734" stop-color="#5CB8B7"/>
-                  <stop offset="1" stop-color="#4CA5B8"/>
+                <linearGradient
+                  id="paint1_navbar"
+                  x1="309.51"
+                  y1="89.7878"
+                  x2="155.275"
+                  y2="360.285"
+                  gradientUnits="userSpaceOnUse"
+                >
+                  <stop stop-color="#BFCD94" />
+                  <stop offset="0.245025" stop-color="#B2D69E" />
+                  <stop offset="0.504453" stop-color="#8DCCA6" />
+                  <stop offset="0.745734" stop-color="#5CB8B7" />
+                  <stop offset="1" stop-color="#4CA5B8" />
                 </linearGradient>
-                <linearGradient id="paint2_navbar" x1="-0.378906" y1="89.7878" x2="155.761" y2="360.282" gradientUnits="userSpaceOnUse">
-                  <stop stop-color="#D7686D"/>
-                  <stop offset="0.225" stop-color="#C64B77"/>
-                  <stop offset="0.485" stop-color="#A2638E"/>
-                  <stop offset="0.703194" stop-color="#758AA8"/>
-                  <stop offset="1" stop-color="#639EAF"/>
+                <linearGradient
+                  id="paint2_navbar"
+                  x1="-0.378906"
+                  y1="89.7878"
+                  x2="155.761"
+                  y2="360.282"
+                  gradientUnits="userSpaceOnUse"
+                >
+                  <stop stop-color="#D7686D" />
+                  <stop offset="0.225" stop-color="#C64B77" />
+                  <stop offset="0.485" stop-color="#A2638E" />
+                  <stop offset="0.703194" stop-color="#758AA8" />
+                  <stop offset="1" stop-color="#639EAF" />
                 </linearGradient>
                 <clipPath id="clip0_navbar">
-                  <rect width="311" height="360" fill="white"/>
+                  <rect width="311" height="360" fill="white" />
                 </clipPath>
               </defs>
             </svg>
@@ -87,7 +136,7 @@ const isActive = (productPath: string) => {
               'px-3 py-2 text-sm font-normal rounded-md transition-all duration-200',
               isActive(product.path)
                 ? 'text-sidebar-primary bg-sidebar-primary/10 border border-sidebar-primary/30'
-                : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
+                : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
             ]"
           >
             {{ product.name }}
@@ -96,8 +145,51 @@ const isActive = (productPath: string) => {
 
         <!-- Mobile menu + actions -->
         <div class="flex items-center gap-2">
-          <!-- Mobile current product -->
-          <span class="md:hidden text-sm font-normal text-sidebar-primary">{{ currentProduct }}</span>
+          <!-- Mobile product switcher -->
+          <div class="md:hidden relative">
+            <div v-if="productsOpen" class="fixed inset-0 z-40" @click="productsOpen = false" />
+
+            <button
+              type="button"
+              class="relative z-50 flex items-center gap-1 px-2 py-1.5 text-sm font-normal text-sidebar-primary rounded-md hover:bg-muted/50"
+              :aria-expanded="productsOpen"
+              aria-haspopup="true"
+              @click="productsOpen = !productsOpen"
+            >
+              {{ currentProduct }}
+              <ChevronDown
+                class="w-3.5 h-3.5 transition-transform"
+                :class="productsOpen && 'rotate-180'"
+              />
+            </button>
+
+            <div
+              v-if="productsOpen"
+              class="absolute right-0 z-50 mt-2 w-40 rounded-md border border-border bg-background shadow-lg overflow-hidden"
+            >
+              <RouterLink
+                v-for="product in products"
+                :key="product.path"
+                :to="product.path"
+                :class="[
+                  'block px-3 py-2 text-sm',
+                  isActive(product.path)
+                    ? 'text-sidebar-primary bg-sidebar-primary/10'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+                ]"
+              >
+                {{ product.name }}
+              </RouterLink>
+              <a
+                href="https://github.com/OpenMined"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="sm:hidden block px-3 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50 border-t border-border"
+              >
+                GitHub
+              </a>
+            </div>
+          </div>
 
           <!-- Theme Toggle -->
           <button
@@ -106,12 +198,28 @@ const isActive = (productPath: string) => {
             :aria-label="isDark ? 'Switch to light mode' : 'Switch to dark mode'"
           >
             <!-- Sun icon (shown in dark mode) -->
-            <svg v-if="isDark" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+            <svg
+              v-if="isDark"
+              class="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
+              />
             </svg>
             <!-- Moon icon (shown in light mode) -->
             <svg v-else class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
+              />
             </svg>
           </button>
 
@@ -134,7 +242,11 @@ const isActive = (productPath: string) => {
             class="hidden sm:flex items-center gap-2 px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground border border-border rounded-md hover:border-sidebar-primary/50 transition-all duration-200"
           >
             <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-              <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+              <path
+                fill-rule="evenodd"
+                d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+                clip-rule="evenodd"
+              />
             </svg>
             GitHub
           </a>

--- a/public-docs/src/components/nb/NbTextOut.vue
+++ b/public-docs/src/components/nb/NbTextOut.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+/**
+ * Plain text notebook output — a repr, a printed line, a dict. Most SDK calls
+ * return a value whose repr IS the output, so this is the default shape inside
+ * an NbCell slot; the panels in this folder cover the richer cases.
+ */
+defineProps<{ text: string }>()
+</script>
+
+<template>
+  <pre class="nbo">{{ text }}</pre>
+</template>
+
+<style scoped>
+.nbo {
+  margin: 0;
+  padding: 0;
+  background: none;
+  border: 0;
+  font-family: var(--nb-mono);
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--nb-ink);
+  /* Reprs run long — a 1400-character URL4 must wrap rather than scroll the page. */
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+</style>

--- a/public-docs/src/components/nb/index.ts
+++ b/public-docs/src/components/nb/index.ts
@@ -1,4 +1,5 @@
 export { default as NbCell } from './NbCell.vue'
+export { default as NbTextOut } from './NbTextOut.vue'
 export { default as NbPanel } from './NbPanel.vue'
 export { default as NbStateCarousel } from './NbStateCarousel.vue'
 export { default as NbRowList } from './NbRowList.vue'

--- a/public-docs/src/composables/useDocNavigation.ts
+++ b/public-docs/src/composables/useDocNavigation.ts
@@ -1,45 +1,54 @@
 import { computed, toValue, type MaybeRefOrGetter } from 'vue'
 import { useRoute } from 'vue-router'
 
-export interface NavItem {
+// A navigation tree is built from two node kinds, distinguished by whether the
+// node has a destination:
+//
+//   - a GROUP labels its children and is never clickable ("USER GUIDES", "Compose")
+//   - a LINK points at a page, and may itself have children
+//
+// Depth is not fixed: a group nested in a group is the same construct as a
+// top-level one, so the sidebar renders any number of levels.
+export interface NavGroup {
   title: string
-  path: string
-  children?: NavItem[]
+  children: NavEntry[]
 }
 
-export interface NavSection {
+export interface NavLink {
   title: string
-  items: NavItem[]
+  path: string
+  children?: NavEntry[]
+}
+
+export type NavEntry = NavGroup | NavLink
+
+/** Narrow a node to the kind that has a destination. */
+export const isLink = (entry: NavEntry): entry is NavLink => 'path' in entry
+
+/** Every link in the tree, depth-first, in sidebar order. Groups are skipped. */
+function links(entries: NavEntry[]): NavLink[] {
+  return entries.flatMap((entry) => [
+    ...(isLink(entry) ? [entry] : []),
+    ...links(entry.children ?? []),
+  ])
 }
 
 // Derives everything a doc layout needs from a section's navigation tree and
 // the current route: active-link state and the flattened prev/next sequence.
 // Adding a page to the navigation data automatically gives it prev/next links.
-export function useDocNavigation(navigation: MaybeRefOrGetter<NavSection[]>) {
+export function useDocNavigation(navigation: MaybeRefOrGetter<NavEntry[]>) {
   const route = useRoute()
 
   const isActive = (path: string) => route.path === path
 
-  const isActiveOrChild = (item: NavItem): boolean => {
-    if (isActive(item.path)) return true
-    if (item.children) return item.children.some((child) => isActive(child.path))
-    return false
-  }
+  const isActiveOrChild = (entry: NavEntry): boolean =>
+    (isLink(entry) && isActive(entry.path)) ||
+    (entry.children ?? []).some((child) => isActiveOrChild(child))
 
-  const flatNav = computed(() => {
-    const pages: { title: string; path: string }[] = []
-    for (const section of toValue(navigation)) {
-      for (const item of section.items) {
-        pages.push({ title: item.title, path: item.path })
-        if (item.children) {
-          for (const child of item.children) {
-            pages.push({ title: child.title, path: child.path })
-          }
-        }
-      }
-    }
-    return pages
-  })
+  // Only links are navigable, so prev/next steps over group labels.
+  const flatNav = computed(() =>
+    links(toValue(navigation)).map((link) => ({ title: link.title, path: link.path })),
+  )
 
   const currentIndex = computed(() => flatNav.value.findIndex((p) => p.path === route.path))
   const prevPage = computed(() =>

--- a/public-docs/src/navigation/sdk.ts
+++ b/public-docs/src/navigation/sdk.ts
@@ -1,8 +1,9 @@
-export const sdkNavigation = [
+import type { NavEntry } from '@/composables/useDocNavigation'
+
+// SDK sidebar. Typed like sf-client so the shared NavTree renders it.
+export const sdkNavigation: NavEntry[] = [
   {
     title: 'Getting Started',
-    items: [
-      { title: 'Overview', path: '/sdk' },
-    ],
+    children: [{ title: 'Overview', path: '/sdk' }],
   },
 ]

--- a/public-docs/src/navigation/sf-client.ts
+++ b/public-docs/src/navigation/sf-client.ts
@@ -1,5 +1,15 @@
 import type { NavEntry } from '@/composables/useDocNavigation'
 
+// The SDK version these pages were written and verified against, shown once in the
+// sidebar footer. A commit for now because screamingface is not on PyPI yet; when it
+// ships this becomes { prefix: 'Version', label: '1.0.0', url: <PyPI release> } and
+// nothing else changes.
+export const sfClientVersion = {
+  prefix: 'Based on state at commit',
+  label: 'e387aefd',
+  url: 'https://github.com/OpenMined/screamingface/commit/e387aefd311b1f4f057a0858fdf4c363f145bddb',
+}
+
 // ScreamingFace Client sidebar (OME-666). A group labels its children and is
 // never clickable; a link points at a page. Overview is a plain top-level link,
 // so it sits above the labelled groups without needing a group of its own.

--- a/public-docs/src/navigation/sf-client.ts
+++ b/public-docs/src/navigation/sf-client.ts
@@ -1,18 +1,32 @@
-import type { NavSection } from '@/composables/useDocNavigation'
+import type { NavEntry } from '@/composables/useDocNavigation'
 
-// ScreamingFace Client sidebar (OME-666). Overview sits ungrouped above the
-// labelled sections — a section with an empty title renders no group heading.
-// User Guides and API Reference are added by the tickets that own their pages.
-export const sfClientNavigation: NavSection[] = [
-  {
-    title: '',
-    items: [{ title: 'Overview', path: '/sf-client' }],
-  },
+// ScreamingFace Client sidebar (OME-666). A group labels its children and is
+// never clickable; a link points at a page. Overview is a plain top-level link,
+// so it sits above the labelled groups without needing a group of its own.
+// API Reference is added by the tickets that own those pages.
+export const sfClientNavigation: NavEntry[] = [
+  { title: 'Overview', path: '/sf-client' },
   {
     title: 'Get Started',
-    items: [
+    children: [
       { title: 'Quickstart', path: '/sf-client/quickstartPage' },
       { title: 'Installation', path: '/sf-client/installation' },
+    ],
+  },
+  {
+    title: 'User Guides',
+    children: [
+      { title: 'Connections', path: '/sf-client/guides/connections' },
+      {
+        title: 'Compose',
+        children: [
+          { title: 'Models', path: '/sf-client/guides/models' },
+          { title: 'Fusions', path: '/sf-client/guides/fusions' },
+        ],
+      },
+      { title: 'Benchmarks', path: '/sf-client/guides/benchmarks' },
+      { title: 'Running an evaluation', path: '/sf-client/guides/running-an-evaluation' },
+      { title: 'Reproduce & share (URL4)', path: '/sf-client/guides/reproduce-and-share' },
     ],
   },
 ]

--- a/public-docs/src/pages/sf-client/Index.vue
+++ b/public-docs/src/pages/sf-client/Index.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
-import { RouterLink } from 'vue-router'
 import DocLayout from '@/components/layout/DocLayout.vue'
 import CodeBlock from '@/components/ui/CodeBlock.vue'
-import { sfClientNavigation as navigation } from '@/navigation/sf-client'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
 
 // The smallest complete run: configure an engine, compose a Fusion, evaluate it,
 // read the comparison. Every name here is part of the shipped public API.
@@ -20,6 +22,7 @@ print(report.score, report.baseline, report.gain)`
     title="Overview"
     description="Compose an ensemble of frontier models, evaluate it against a benchmark, and see whether it beat its own best member."
     :navigation="navigation"
+    :version="version"
   >
     <p>
       ScreamingFace is an open-source client for building <strong>model ensembles</strong> — several
@@ -74,22 +77,5 @@ print(report.score, report.baseline, report.gain)`
       expression is the contract between them: the engine resolves it, and anyone holding it can
       reproduce the run.
     </p>
-
-    <h2>Where next</h2>
-
-    <ul>
-      <li>
-        <RouterLink to="/sf-client/quickstartPage">Quickstart</RouterLink> — run a benchmark end to
-        end and read the comparison.
-      </li>
-      <li>
-        <RouterLink to="/sf-client/installation">Installation</RouterLink> — install the library and
-        start the engine.
-      </li>
-      <li>
-        <strong>User guides</strong> — connections, composing models and fusions, benchmarks, and
-        reports. Coming soon.
-      </li>
-    </ul>
   </DocLayout>
 </template>

--- a/public-docs/src/pages/sf-client/InstallationPage.vue
+++ b/public-docs/src/pages/sf-client/InstallationPage.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import DocLayout from '@/components/layout/DocLayout.vue'
-import { sfClientNavigation as navigation } from '@/navigation/sf-client'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
 </script>
 
 <template>
@@ -8,6 +11,7 @@ import { sfClientNavigation as navigation } from '@/navigation/sf-client'
     title="Installation"
     description="Stub page — replace with real content."
     :navigation="navigation"
+    :version="version"
   >
     <p>Stub content for this page. Route: <code>/sf-client/installation</code>.</p>
   </DocLayout>

--- a/public-docs/src/pages/sf-client/QuickstartPage.vue
+++ b/public-docs/src/pages/sf-client/QuickstartPage.vue
@@ -10,7 +10,10 @@ import type { Provider } from '@/components/nb/ProviderConnections.vue'
 import EvaluationReport from '@/components/nb/EvaluationReport.vue'
 import CandidateScores from '@/components/nb/CandidateScores.vue'
 import type { NbCheckItem, NbRowForm, NbStat } from '@/components/nb/types'
-import { sfClientNavigation as navigation } from '@/navigation/sf-client'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
 
 // Every provider the development engine advertises, read from its registry.
 const providers: Provider[] = [
@@ -269,6 +272,7 @@ const evaluate = `report = draco.evaluate(candidates)`
     title="Quickstart"
     description="Run DRACO-Lite end to end and compare seven solo models against nine ensembles built from them."
     :navigation="navigation"
+    :version="version"
   >
     <p>
       By the end you will have a scored comparison of <strong>16 candidates</strong> — seven single

--- a/public-docs/src/pages/sf-client/guides/BenchmarksPage.vue
+++ b/public-docs/src/pages/sf-client/guides/BenchmarksPage.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import DocLayout from '@/components/layout/DocLayout.vue'
+import { sfClientNavigation as navigation } from '@/navigation/sf-client'
+</script>
+
+<template>
+  <DocLayout
+    title="Benchmarks"
+    description="Discover Engine-owned benchmarks and read their cases before spending."
+    :navigation="navigation"
+  >
+    <p>Stub page — replace with real content.</p>
+  </DocLayout>
+</template>

--- a/public-docs/src/pages/sf-client/guides/BenchmarksPage.vue
+++ b/public-docs/src/pages/sf-client/guides/BenchmarksPage.vue
@@ -1,6 +1,39 @@
 <script setup lang="ts">
+import { RouterLink } from 'vue-router'
 import DocLayout from '@/components/layout/DocLayout.vue'
-import { sfClientNavigation as navigation } from '@/navigation/sf-client'
+import NbCell from '@/components/nb/NbCell.vue'
+import NbTextOut from '@/components/nb/NbTextOut.vue'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const listing = `import screamingface as sf
+
+for b in sf.benchmarks.list():
+    print(b.id, "|", b.title, "|", b.case_count, "cases |", b.revision)`
+const listingOut = `draco | DRACO | 100 cases | defbb6efdae69211
+ifeval | IFEval | 541 cases | 22ca96fe77b0f7de`
+
+const card = `ifeval = sf.benchmarks.get("ifeval")
+ifeval`
+const cardOut = `Benchmark(id='ifeval', title='IFEval', description="The 541-prompt
+instruction-following benchmark (https://arxiv.org/abs/2311.07911) with
+deterministic verification. Default method 'corrective' reproduces the protocol
+of 'Beyond Leaderboards: Tokenomics of Agentic Small Language Model Ensembles'
+(Skurikhin et al., Los Alamos National Laboratory) — a bounded 3-attempt retry
+chain fed by the checker's violations (3x candidate calls; scores are NOT
+comparable to published single-pass IFEval numbers). Select method 'single_pass'
+for the paper-comparable protocol.", revision='22ca96fe77b0f7de',
+case_count=541)`
+
+const methods = `sf.benchmarks.get("ifeval").revision, sf.benchmarks.get("ifeval", method="single_pass").revision`
+const methodsOut = `('22ca96fe77b0f7de', '047f1de449639c61')`
+
+const cases = `for c in ifeval.cases(limit=2):
+    print(c.id, "|", c.input[:120])`
+const casesOut = `1 | Write a 300+ word summary of the wikipedia page "https://en.wikipedia.org/wiki/Raymond_III,_Count_of_Tripoli". Do not us …
+2 | I am planning a trip to Japan, and I would like thee to write an itinerary for my journey in a Shakespearean style. You  …`
 </script>
 
 <template>
@@ -8,7 +41,131 @@ import { sfClientNavigation as navigation } from '@/navigation/sf-client'
     title="Benchmarks"
     description="Discover Engine-owned benchmarks and read their cases before spending."
     :navigation="navigation"
+    :version="version"
   >
-    <p>Stub page — replace with real content.</p>
+    <p>
+      A <strong>benchmark</strong> is the exam. It is owned entirely by the engine and it owns
+      everything about how candidates are judged: which cases exist, in what order they are asked,
+      which judge model grades them, how grades become a score. Your candidate answers; it does not
+      get a say in any of that.
+    </p>
+
+    <p>
+      That split is the point. Because the exam is fixed and pinned, a solo Model and a
+      <RouterLink to="/sf-client/guides/fusions">Fusion</RouterLink> evaluated against it are
+      genuinely comparable.
+    </p>
+
+    <h2>What you can do with it</h2>
+
+    <ul>
+      <li>List the benchmarks this engine publishes.</li>
+      <li>Read one's identity card — size, revision, and what it actually measures.</li>
+      <li>Page its real prompts before spending anything.</li>
+      <li>Select a protocol variant with <code>method</code>.</li>
+    </ul>
+
+    <h2>Main APIs</h2>
+
+    <ul>
+      <li><code>sf.benchmarks.list()</code> — every benchmark this engine publishes</li>
+      <li>
+        <code>sf.benchmarks.get(id, *, method=None)</code> — one benchmark's identity card, for a
+        chosen protocol
+      </li>
+      <li>
+        <code>sf.Benchmark</code> — that card: <code>.id</code> <code>.title</code>
+        <code>.description</code> <code>.revision</code> <code>.case_count</code>
+        <code>.cases(limit, offset)</code>
+      </li>
+      <li><code>sf.BenchmarkInfo</code> — the pinned subset a report carries</li>
+      <li><code>sf.CaseInfo</code> — one case's <code>id</code> and <code>input</code></li>
+    </ul>
+
+    <p>
+      <strong>All of this is free.</strong> Discovery and case browsing are plain engine requests;
+      no model is called and nothing is charged. Only
+      <RouterLink to="/sf-client/guides/running-an-evaluation">evaluation</RouterLink> spends.
+    </p>
+
+    <h2>How to</h2>
+
+    <h3>See what this engine publishes</h3>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="listing"><NbTextOut :text="listingOut" /></NbCell>
+    </div>
+
+    <p>
+      Two benchmarks, and they differ in what grading costs. <strong>DRACO</strong> is 100
+      deep-research tasks graded by a judge model
+      (<code>openrouter/google/gemini-3.1-pro-preview</code>) with five independent passes per
+      criterion — the grading itself is the expensive part. <strong>IFEval</strong> is 541
+      instruction-following prompts checked by a deterministic verifier, so its grading is
+      <strong>free</strong>: only the answers cost anything.
+    </p>
+
+    <h3>Read the identity card</h3>
+
+    <div class="not-prose">
+      <NbCell :count="2" :code="card"><NbTextOut :text="cardOut" /></NbCell>
+    </div>
+
+    <p>
+      The <code>revision</code> is an opaque hash of the pinned protocol, and it is stamped into
+      every report produced against it. That is what keeps old results attributable: if the public
+      name later points at a newer snapshot, your report still names the revision it actually ran.
+    </p>
+
+    <h3>Select a method</h3>
+
+    <p>
+      Some benchmarks publish more than one protocol. IFEval's default is <code>corrective</code> —
+      a bounded three-attempt retry chain fed by the verifier's complaints.
+      <code>single_pass</code> is one answer, one check, and it is the only variant comparable to
+      published IFEval numbers.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="3" :code="methods"><NbTextOut :text="methodsOut" /></NbCell>
+    </div>
+
+    <p>
+      Notice the revisions differ. A method is not a flag on one exam — it is a
+      <strong>different pinned protocol</strong>, with a different cost and a score that means
+      something different. Comparing a corrective score against a single-pass one is a mistake the
+      revisions let you catch.
+    </p>
+
+    <h3>Read the cases before you spend</h3>
+
+    <p>
+      <code>cases()</code> pages the real prompts, 50 at a time by default. For IFEval this is worth
+      doing: each prompt carries its own constraints in its text — "300+ words", "no commas",
+      "highlight three sections" — which is exactly what makes it machine-checkable.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="4" :code="cases"><NbTextOut :text="casesOut" /></NbCell>
+    </div>
+
+    <p>
+      A <code>CaseInfo</code> carries only its <code>id</code> and <code>input</code>. Grading
+      criteria, rubrics and answer keys never cross the engine boundary — you can read the exam
+      questions, not the marking scheme.
+    </p>
+
+    <h2>Links</h2>
+
+    <ul>
+      <li>
+        <a
+          href="https://github.com/OpenMined/screamingface/blob/OME-605-screamingface-client-v1/packages/screamingface/examples/07_ifeval_e2e.ipynb"
+          target="_blank"
+          rel="noopener"
+          >Companion notebook — <code>07_ifeval_e2e.ipynb</code></a
+        >
+      </li>
+    </ul>
   </DocLayout>
 </template>

--- a/public-docs/src/pages/sf-client/guides/ConnectionsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/ConnectionsPage.vue
@@ -1,6 +1,35 @@
 <script setup lang="ts">
+import { RouterLink } from 'vue-router'
 import DocLayout from '@/components/layout/DocLayout.vue'
-import { sfClientNavigation as navigation } from '@/navigation/sf-client'
+import NbCell from '@/components/nb/NbCell.vue'
+import NbTextOut from '@/components/nb/NbTextOut.vue'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const panel = `import screamingface as sf
+
+sf.connect()`
+
+const script = `sf.connect("openrouter", api_key="sk-or-v1-…")`
+
+const readState = `sf.connections.list()`
+const readStateOut = `(Connection(provider='openrouter', display_name='OpenRouter',
+            auth_methods=('api_key',), status='connected',
+            auth_method='api_key', account_label=None),)`
+
+const readOne = `sf.connections.get("openrouter")`
+const readOneOut = `Connection(provider='openrouter', display_name='OpenRouter',
+           auth_methods=('api_key',), status='connected',
+           auth_method='api_key', account_label=None)`
+
+const remove = `sf.disconnect("openrouter")`
+
+const hosted = `client = sf.Client(engine_url="https://engine.example.com")
+client.login()          # opens Cloudflare Access in your browser
+client.authenticated    # True once the token arrives
+client.logout()`
 </script>
 
 <template>
@@ -8,7 +37,171 @@ import { sfClientNavigation as navigation } from '@/navigation/sf-client'
     title="Connections"
     description="Connect a model provider through the SF Engine, and log in to a hosted engine."
     :navigation="navigation"
+    :version="version"
   >
-    <p>Stub page — replace with real content.</p>
+    <p>
+      A <strong>connection</strong> is a provider credential the engine holds on your behalf. The
+      client never talks to OpenRouter, Anthropic or any other provider directly — it sends your key
+      to the engine once, the engine passes it to AI Gateway to validate and store encrypted, and
+      every later model call is dispatched there. Your notebook keeps no copy.
+    </p>
+
+    <p>
+      This is the first thing to do in a new environment. Without a connection the engine can list
+      benchmarks and models, but any evaluation fails: there is no credential to call a model with.
+    </p>
+
+    <h2>What you can do with it</h2>
+
+    <ul>
+      <li>
+        Connect a provider interactively from a notebook, or with an explicit key from a script.
+      </li>
+      <li>Read which providers this engine advertises, and the state of each.</li>
+      <li>Remove a credential.</li>
+      <li>Log in to a hosted engine that sits behind Cloudflare Access.</li>
+    </ul>
+
+    <h2>Main APIs</h2>
+
+    <ul>
+      <li><code>sf.connect()</code> — open the interactive provider panel</li>
+      <li><code>sf.connect(provider, api_key=…)</code> — connect one provider directly</li>
+      <li><code>sf.connections.list()</code> — every provider this engine advertises</li>
+      <li><code>sf.connections.get(provider)</code> — one provider's current state</li>
+      <li><code>sf.disconnect(provider)</code> — remove a stored credential</li>
+      <li><code>sf.Connection</code> — the sanitised provider-state value</li>
+      <li><code>sf.ConnectionPanel</code> — the widget <code>sf.connect()</code> returns</li>
+      <li>
+        <code>sf.Client.login()</code> · <code>sf.Client.logout()</code> — Cloudflare Access on a
+        hosted engine
+      </li>
+    </ul>
+
+    <h2>How to</h2>
+
+    <h3>Connect from a notebook</h3>
+
+    <p>
+      Called with no arguments, <code>sf.connect()</code> returns a <code>ConnectionPanel</code> — a
+      live widget listing every provider the engine advertises, with a field for each one's
+      supported auth method. The
+      <RouterLink to="/sf-client/quickstartPage">Quickstart</RouterLink> steps through the whole
+      flow state by state.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="panel" />
+    </div>
+
+    <h3>Connect from a script</h3>
+
+    <p>
+      With a provider and a key, the same function connects directly and returns the resulting
+      <code>Connection</code> instead of a widget.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="2" :code="script" />
+    </div>
+
+    <p>
+      The two arguments go together. <code>sf.connect("openrouter")</code> without a key raises
+      <code>ValueError</code>, and passing <code>api_key=</code> without a provider raises
+      <code>TypeError</code> — there is no partial form that silently does nothing.
+    </p>
+
+    <h3>Read the current state</h3>
+
+    <div class="not-prose">
+      <NbCell :count="3" :code="readState">
+        <NbTextOut :text="readStateOut" />
+      </NbCell>
+    </div>
+
+    <p>
+      Note the trailing comma — <code>list()</code> returns a <strong>tuple</strong>, not a list,
+      and this engine advertises exactly one provider. Fetch a single one by name when you only care
+      about its state:
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="4" :code="readOne">
+        <NbTextOut :text="readOneOut" />
+      </NbCell>
+    </div>
+
+    <h3>Disconnect</h3>
+
+    <div class="not-prose">
+      <NbCell :count="5" :code="remove" />
+    </div>
+
+    <p>
+      Repeated calls are harmless. The returned <code>Connection</code> shows the provider back in
+      its <code>not_connected</code> state.
+    </p>
+
+    <h3>A hosted engine</h3>
+
+    <p>
+      A remote engine may sit behind <strong>Cloudflare Access</strong>. There is no token to paste:
+      <code>login()</code> prints a URL and opens it in your browser, then polls an encrypted
+      transfer service and decrypts the returned token locally. The token lives only in process
+      memory and is sent as <code>Cf-Access-Token</code>.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="6" :code="hosted" />
+    </div>
+
+    <p>
+      In a notebook the panel handles this for you: a protected engine shows a login row first and
+      only loads provider rows once login succeeds. A local engine never shows the row at all.
+    </p>
+
+    <h2>What a connection carries</h2>
+
+    <p>
+      Every <code>Connection</code> is sanitised — the public provider name, its supported methods,
+      and its state. AI Gateway account IDs, credential locators and upstream error bodies never
+      cross this boundary.
+    </p>
+
+    <ul>
+      <li>
+        <code>status</code> — one of <code>not_connected</code>, <code>pending</code>,
+        <code>connected</code>, <code>needs_reauth</code>, <code>error</code>
+      </li>
+      <li>
+        <code>auth_methods</code> — what the provider supports. The current engine advertises
+        <code>('api_key',)</code> for OpenRouter
+      </li>
+      <li><code>auth_method</code> — which one is in use, or <code>None</code></li>
+      <li><code>account_label</code> — an optional display label</li>
+    </ul>
+
+    <h2>When it fails</h2>
+
+    <p>
+      Credential problems raise <code>ProviderConnectionError</code>, which carries a stable
+      <code>code</code> and a <code>hint</code>. One rule is worth knowing before you deploy: an API
+      key sent to a non-loopback <code>http://</code> engine is
+      <strong>refused outright</strong> with <code>secure_transport_required</code>. A remote engine
+      must be HTTPS.
+    </p>
+
+    <h2>Links</h2>
+
+    <ul>
+      <li>
+        <a
+          href="https://github.com/OpenMined/screamingface/blob/OME-605-screamingface-client-v1/packages/screamingface/examples/00_quickstart.ipynb"
+          target="_blank"
+          rel="noopener"
+          >Companion notebook — <code>00_quickstart.ipynb</code></a
+        >
+      </li>
+    </ul>
   </DocLayout>
 </template>

--- a/public-docs/src/pages/sf-client/guides/ConnectionsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/ConnectionsPage.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import DocLayout from '@/components/layout/DocLayout.vue'
+import { sfClientNavigation as navigation } from '@/navigation/sf-client'
+</script>
+
+<template>
+  <DocLayout
+    title="Connections"
+    description="Connect a model provider through the SF Engine, and log in to a hosted engine."
+    :navigation="navigation"
+  >
+    <p>Stub page — replace with real content.</p>
+  </DocLayout>
+</template>

--- a/public-docs/src/pages/sf-client/guides/EvaluationPage.vue
+++ b/public-docs/src/pages/sf-client/guides/EvaluationPage.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import DocLayout from '@/components/layout/DocLayout.vue'
+import { sfClientNavigation as navigation } from '@/navigation/sf-client'
+</script>
+
+<template>
+  <DocLayout
+    title="Running an evaluation"
+    description="Evaluate one or many candidates against a benchmark and get one Report."
+    :navigation="navigation"
+  >
+    <p>Stub page — replace with real content.</p>
+  </DocLayout>
+</template>

--- a/public-docs/src/pages/sf-client/guides/EvaluationPage.vue
+++ b/public-docs/src/pages/sf-client/guides/EvaluationPage.vue
@@ -1,6 +1,63 @@
 <script setup lang="ts">
 import DocLayout from '@/components/layout/DocLayout.vue'
-import { sfClientNavigation as navigation } from '@/navigation/sf-client'
+import NbCell from '@/components/nb/NbCell.vue'
+import NbTextOut from '@/components/nb/NbTextOut.vue'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const run = `import screamingface as sf
+
+haiku = sf.Model("openrouter/anthropic/claude-haiku-4.5")
+report = sf.evaluate(haiku, benchmark="ifeval", limit=3)
+report`
+const runOut = `Report(benchmark='ifeval', candidates=['claude-haiku-4.5'], ok=True)`
+
+const score = `c = report.candidates.only
+c.name, c.score, report.case_count, report.benchmark`
+const scoreOut = `('claude-haiku-4.5', 1.0, 3, BenchmarkInfo(id='ifeval', revision='22ca96fe77b0f7de', case_count=541))`
+
+const metrics = `dict(c.metrics)`
+const metricsOut = `{'inst_level_strict_accuracy': 1.0,
+ 'prompt_level_loose_accuracy': 1.0,
+ 'inst_level_loose_accuracy': 1.0,
+ 'pass_at_1': 1.0,
+ 'pass_at_2': 1.0,
+ 'pass_at_3': 1.0,
+ 'corrected_cases': 0.0,
+ 'cases_checked': 3.0,
+ 'cases_fallback': 0.0}`
+
+const many = `opus = sf.Model("openrouter/anthropic/claude-opus-4.8")
+gpt = sf.Model("openrouter/openai/gpt-5.5")
+
+sf.evaluate([opus, gpt, sf.Fusion([opus, gpt])], benchmark="draco", limit=1)`
+
+const compare = `corr = sf.evaluate(haiku, benchmark="ifeval", limit=3)
+base = sf.evaluate(haiku, benchmark="ifeval", limit=3, method="single_pass")
+
+{"corrective":  {"score": corr.candidates.only.score, "tokens": corr.usage.output_tokens},
+ "single_pass": {"score": base.candidates.only.score, "tokens": base.usage.output_tokens}}`
+const compareOut = `{'corrective': {'score': 1.0, 'tokens': 3686},
+ 'single_pass': {'score': 1.0, 'tokens': 1167}}`
+
+const usage = `report.usage`
+const usageOut = `Usage(input_tokens=3691, output_tokens=3686, cache_read_tokens=0,
+      cache_creation_tokens=0, reasoning_tokens=0, cost_usd=Decimal('0'))`
+
+const watch = `def observe(event: sf.Event) -> None:
+    print(event.kind)
+
+sf.evaluate(haiku, benchmark="ifeval", limit=1, on_event=observe, progress=False)`
+
+const clients = `client = sf.Client(engine_url="https://engine.example.com")
+report = client.evaluate(haiku, benchmark="ifeval", limit=3)
+client.close()
+
+# or module-level, once, for every later call
+sf.configure(engine_url="https://engine.example.com")
+sf.close()`
 </script>
 
 <template>
@@ -8,7 +65,186 @@ import { sfClientNavigation as navigation } from '@/navigation/sf-client'
     title="Running an evaluation"
     description="Evaluate one or many candidates against a benchmark and get one Report."
     :navigation="navigation"
+    :version="version"
   >
-    <p>Stub page — replace with real content.</p>
+    <p>
+      <code>sf.evaluate()</code> is the one call that spends money. You hand it candidates and a
+      benchmark id; it compiles each candidate against that benchmark's pinned protocol, runs them
+      concurrently on the engine, and returns a single <code>Report</code>.
+    </p>
+
+    <p>
+      Everything expensive is on the far side of this call. Validation happens first and entirely —
+      an unknown benchmark, an unreachable route, a malformed candidate all fail
+      <strong>before the first paid request</strong>.
+    </p>
+
+    <h2>What you can do with it</h2>
+
+    <ul>
+      <li>Evaluate one candidate, or several in one run.</li>
+      <li>Cap how many cases run with <code>limit</code>.</li>
+      <li>Choose a protocol variant with <code>method</code>.</li>
+      <li>Watch the run as it happens, or silence the progress display.</li>
+      <li>Run against an explicit client, synchronously or with <code>await</code>.</li>
+    </ul>
+
+    <h2>Main APIs</h2>
+
+    <ul>
+      <li>
+        <code
+          >sf.evaluate(candidates, *, benchmark, limit=None, method=None, on_event=None,
+          progress=None)</code
+        >
+        — run candidates against a benchmark, returns <code>sf.Report</code>
+      </li>
+      <li>
+        <code>sf.Client.evaluate(...)</code> · <code>await sf.AsyncClient.evaluate(...)</code> — the
+        same call on an explicit client
+      </li>
+      <li><code>sf.configure(engine_url=…)</code> — repoint the shared client</li>
+      <li><code>sf.close()</code> — release the shared client</li>
+    </ul>
+
+    <h2>How to</h2>
+
+    <h3>Evaluate one candidate</h3>
+
+    <p>
+      The benchmark id is <strong>required</strong> — there is no default and no implicit choice.
+      <code>limit</code> caps the case count, and it is your main cost control.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="run"><NbTextOut :text="runOut" /></NbCell>
+    </div>
+
+    <p>
+      The repr is a summary: which benchmark, which candidates, and whether anything failed.
+      <code>ok</code> is <code>True</code> only when no candidate and no member recorded a failure.
+    </p>
+
+    <h3>Read the score</h3>
+
+    <p>
+      Scores live on candidates, not on the report — a report may hold several. With one candidate,
+      <code>.only</code> is the direct way to it.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="2" :code="score"><NbTextOut :text="scoreOut" /></NbCell>
+    </div>
+
+    <p>
+      Note the two case counts. <code>report.case_count</code> is how many cases <em>ran</em>;
+      <code>report.benchmark.case_count</code> is how many the benchmark has. Running 3 of 541 is a
+      smoke test, and the report says so rather than letting you forget.
+    </p>
+
+    <p>
+      <code>score</code> is always higher-is-better and may be <code>None</code> if a candidate
+      failed. Benchmark-specific diagnostics live under <code>metrics</code>:
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="3" :code="metrics"><NbTextOut :text="metricsOut" /></NbCell>
+    </div>
+
+    <h3>Evaluate several at once</h3>
+
+    <p>
+      Pass a list. Every candidate runs against the same pinned exam in the same call, which is what
+      makes the comparison fair — and it is the only way to compare, because a report has no
+      "baseline" or "gain" field. You put the solo model and the ensemble in one run and read both
+      scores.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="4" :code="many" />
+    </div>
+
+    <p>
+      Results come back in declared order. Mind the cost here: this is DRACO, where every criterion
+      is graded by five judge passes, so even <code>limit=1</code> is a real spend.
+    </p>
+
+    <h3>Compare two protocols</h3>
+
+    <p>
+      Because a <code>method</code> is a different pinned protocol, comparing them is two runs. This
+      is IFEval's retry chain against its single-pass baseline, on the same three cases:
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="5" :code="compare"><NbTextOut :text="compareOut" /></NbCell>
+    </div>
+
+    <p>
+      An honest result: identical scores, <strong>3.2× the output tokens</strong>. On this slice the
+      retry loop bought nothing — <code>corrected_cases</code> above is <code>0.0</code>, meaning no
+      case failed first and passed later. That is what a three-case sample of a capable model looks
+      like, and it is the reason to run more cases before concluding anything.
+    </p>
+
+    <h3>Read what it cost</h3>
+
+    <div class="not-prose">
+      <NbCell :count="6" :code="usage"><NbTextOut :text="usageOut" /></NbCell>
+    </div>
+
+    <p>
+      <code>cost_usd</code> is <code>Decimal('0')</code> here because this engine has no pricing
+      data — a zero means "not reported", not "free". Token counts are the reliable measure. Any
+      field is <code>None</code> if even one candidate run failed to report it, rather than being
+      silently summed as a partial total.
+    </p>
+
+    <h3>Watch a run</h3>
+
+    <p>
+      <code>on_event</code> receives typed events in sequence as the run executes, and
+      <code>progress=False</code> silences the default display. If your callback raises, the client
+      cancels every active run and re-raises your exception.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="7" :code="watch" />
+    </div>
+
+    <h3>Use an explicit client</h3>
+
+    <p>
+      The module-level functions share one lazily built client pointed at
+      <code>http://127.0.0.1:9108</code>. Construct your own to talk to a different engine, or call
+      <code>sf.configure()</code> once to repoint the shared one. <code>sf.AsyncClient</code> has
+      the same interface with <code>await</code>.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="8" :code="clients" />
+    </div>
+
+    <h2>When it fails</h2>
+
+    <p>
+      <code>PlanningError</code> means the run never started — change the candidate, benchmark or
+      configuration. <code>ExecutionError</code> means it reached the engine and ended without a
+      valid report. <code>EngineUnavailableError</code> means the engine was not reachable at all.
+      Each carries a stable <code>code</code> and a <code>hint</code>.
+    </p>
+
+    <h2>Links</h2>
+
+    <ul>
+      <li>
+        <a
+          href="https://github.com/OpenMined/screamingface/blob/OME-605-screamingface-client-v1/packages/screamingface/examples/05_draco_e2e.ipynb"
+          target="_blank"
+          rel="noopener"
+          >Companion notebook — <code>05_draco_e2e.ipynb</code></a
+        >
+      </li>
+    </ul>
   </DocLayout>
 </template>

--- a/public-docs/src/pages/sf-client/guides/FusionsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/FusionsPage.vue
@@ -1,6 +1,36 @@
 <script setup lang="ts">
+import { RouterLink } from 'vue-router'
 import DocLayout from '@/components/layout/DocLayout.vue'
-import { sfClientNavigation as navigation } from '@/navigation/sf-client'
+import NbCell from '@/components/nb/NbCell.vue'
+import NbTextOut from '@/components/nb/NbTextOut.vue'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const basic = `import screamingface as sf
+
+opus = sf.Model("openrouter/anthropic/claude-opus-4.8")
+gpt = sf.Model("openrouter/openai/gpt-5.5")
+
+pair = sf.Fusion([opus, gpt])
+pair`
+const basicOut = `Fusion(['claude-opus-4.8', 'gpt-5.5'])`
+
+const inspect = `pair.name, [m.name for m in pair.members]`
+const inspectOut = `('claude-opus-4.8+gpt-5.5', ['claude-opus-4.8', 'gpt-5.5'])`
+
+const synth = `sf.Fusion(
+    [opus, gpt],
+    name="pair-gpt-synth",
+    synthesizer="openrouter/openai/gpt-5.5",
+)`
+const synthOut = `Fusion(['claude-opus-4.8', 'gpt-5.5'], name='pair-gpt-synth', synthesizer='openrouter/openai/gpt-5.5')`
+
+const nested = `haiku = sf.Model("openrouter/anthropic/claude-haiku-4.5")
+
+sf.Fusion([pair, haiku], name="nested")`
+const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name='nested')`
 </script>
 
 <template>
@@ -8,7 +38,122 @@ import { sfClientNavigation as navigation } from '@/navigation/sf-client'
     title="Fusions"
     description="Combine two or more members into one answer through a synthesizer."
     :navigation="navigation"
+    :version="version"
   >
-    <p>Stub page — replace with real content.</p>
+    <p>
+      A <strong>Fusion</strong> asks several members the same question and then has one more model —
+      the <strong>synthesizer</strong> — read their answers and produce a single final one. That
+      final answer is what the benchmark grades, so a Fusion competes in exactly the same column as
+      a solo <RouterLink to="/sf-client/guides/models">Model</RouterLink>.
+    </p>
+
+    <p>
+      This is the ensemble in ScreamingFace. It is worth stating plainly what it is <em>not</em>:
+      there is no vote, no averaging, no score-merging. Members produce candidate answers, and a
+      model decides.
+    </p>
+
+    <p>Like a Model, a Fusion is immutable and network-free — building one makes no request.</p>
+
+    <h2>What you can do with it</h2>
+
+    <ul>
+      <li>Combine two or more Models into one candidate.</li>
+      <li>Choose which model does the synthesising, and how it is prompted.</li>
+      <li>Nest a Fusion inside another Fusion.</li>
+      <li>Read back the members and the resolved name.</li>
+    </ul>
+
+    <h2>Main APIs</h2>
+
+    <ul>
+      <li>
+        <code>sf.Fusion(members, *, name=None, synthesizer=None, prompt=None, params=None)</code> —
+        combine members behind a synthesizer
+      </li>
+      <li>
+        <code>.name</code> · <code>.members</code> · <code>.synthesizer</code> ·
+        <code>.prompt</code> · <code>.params</code> — read back the resolved shape
+      </li>
+      <li><code>sf.Recipe</code> — the shared base type of every candidate kind</li>
+    </ul>
+
+    <h2>How to</h2>
+
+    <h3>Combine two models</h3>
+
+    <p>
+      Members come first and positionally. Nothing else is required: the engine declares a default
+      synthesizer (<code>openrouter/anthropic/claude-haiku-4.5</code>) and the SDK supplies a
+      constraint-aware synthesis prompt, so a two-line Fusion is complete.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="basic"><NbTextOut :text="basicOut" /></NbCell>
+    </div>
+
+    <p>
+      A Fusion needs <strong>at least two</strong> members and their names must be unique — one
+      member is not an ensemble, and two identically named ones could not be told apart in a report.
+      Both raise immediately, at construction.
+    </p>
+
+    <h3>Read the resolved name</h3>
+
+    <p>
+      Without an explicit <code>name</code>, the Fusion's name is its members' names joined with
+      <code>+</code>. That is the label a report will show.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="2" :code="inspect"><NbTextOut :text="inspectOut" /></NbCell>
+    </div>
+
+    <h3>Choose the synthesizer</h3>
+
+    <p>
+      The synthesizer is a <strong>model route string</strong>, not a Model object — it is the
+      engine that resolves it. Swapping it is the main lever a Fusion has: the same members with a
+      stronger synthesizer is a different candidate, and worth measuring as one.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="3" :code="synth"><NbTextOut :text="synthOut" /></NbCell>
+    </div>
+
+    <p>
+      <code>prompt</code> and <code>params</code> work the same way here as on a Model, but they
+      apply to the <em>synthesis</em> step — how the final answer is written, not how members
+      answer. Give a member its own prompt by setting it on that Model.
+    </p>
+
+    <h3>Nest a fusion</h3>
+
+    <p>
+      A member may itself be a Fusion, so a pair can become a member of a larger ensemble. The inner
+      Fusion appears under its own resolved name.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="4" :code="nested"><NbTextOut :text="nestedOut" /></NbCell>
+    </div>
+
+    <p>
+      Members must be Models or Fusions. A corrective ensemble cannot be a member — it grades its
+      own members' raw drafts, which a surrounding synthesizer would have already replaced.
+    </p>
+
+    <h2>Links</h2>
+
+    <ul>
+      <li>
+        <a
+          href="https://github.com/OpenMined/screamingface/blob/OME-605-screamingface-client-v1/packages/screamingface/examples/00_quickstart.ipynb"
+          target="_blank"
+          rel="noopener"
+          >Companion notebook — <code>00_quickstart.ipynb</code></a
+        >
+      </li>
+    </ul>
   </DocLayout>
 </template>

--- a/public-docs/src/pages/sf-client/guides/FusionsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/FusionsPage.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import DocLayout from '@/components/layout/DocLayout.vue'
+import { sfClientNavigation as navigation } from '@/navigation/sf-client'
+</script>
+
+<template>
+  <DocLayout
+    title="Fusions"
+    description="Combine two or more members into one answer through a synthesizer."
+    :navigation="navigation"
+  >
+    <p>Stub page — replace with real content.</p>
+  </DocLayout>
+</template>

--- a/public-docs/src/pages/sf-client/guides/ModelsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/ModelsPage.vue
@@ -1,6 +1,39 @@
 <script setup lang="ts">
+import { RouterLink } from 'vue-router'
 import DocLayout from '@/components/layout/DocLayout.vue'
-import { sfClientNavigation as navigation } from '@/navigation/sf-client'
+import NbCell from '@/components/nb/NbCell.vue'
+import NbTextOut from '@/components/nb/NbTextOut.vue'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const basic = `import screamingface as sf
+
+opus = sf.Model("openrouter/anthropic/claude-opus-4.8")
+opus`
+const basicOut = `Model('openrouter/anthropic/claude-opus-4.8')`
+
+const named = `sf.Model("openrouter/openai/gpt-5.5", name="gpt-run-2")`
+const namedOut = `Model('openrouter/openai/gpt-5.5', name='gpt-run-2')`
+
+const policy = `sf.Model(
+    "openrouter/openai/gpt-5.5",
+    prompt="Answer concisely.",
+    params={"reasoning": "high"},
+)`
+const policyOut = `Model('openrouter/openai/gpt-5.5', prompt='Answer concisely.', params={'reasoning': 'high'})`
+
+const listing = `sf.models.list()`
+const listingOut = `ModelInfo(id='anthropic/claude-opus-4-8', provider='anthropic')
+ModelInfo(id='anthropic/claude-haiku-4-5', provider='anthropic')
+ModelInfo(id='codex/gpt-5.5', provider='codex')
+ModelInfo(id='gemini-cli/gemini-2.5-pro', provider='gemini-cli')
+ModelInfo(id='huggingface/deepseek-ai/DeepSeek-R1:novita', provider='huggingface')
+ModelInfo(id='openrouter/anthropic/claude-opus-4.8', provider='openrouter')
+ModelInfo(id='openrouter/openai/gpt-5.5', provider='openrouter')
+ModelInfo(id='openrouter/google/gemini-3.1-pro-preview', provider='openrouter')
+…   # 29 entries across 6 providers on this engine`
 </script>
 
 <template>
@@ -8,7 +41,113 @@ import { sfClientNavigation as navigation } from '@/navigation/sf-client'
     title="Models"
     description="Select a model route and set the answer policy a candidate owns."
     :navigation="navigation"
+    :version="version"
   >
-    <p>Stub page — replace with real content.</p>
+    <p>
+      A <strong>Model</strong> names one model route and, optionally, the answer policy that route
+      should use. It is the smallest thing you can evaluate, and the building block every
+      <RouterLink to="/sf-client/guides/fusions">Fusion</RouterLink> is made of.
+    </p>
+
+    <p>
+      A Model is <strong>immutable and network-free</strong>. Constructing one makes no request and
+      needs no connection — it is a value describing what to ask for. Nothing happens until you pass
+      it to an evaluation.
+    </p>
+
+    <h2>What you can do with it</h2>
+
+    <ul>
+      <li>Select a route to evaluate.</li>
+      <li>Name a Model so two samples of the same route stay distinguishable.</li>
+      <li>Override the answer prompt and generation parameters.</li>
+      <li>List the routes this engine can actually reach.</li>
+    </ul>
+
+    <h2>Main APIs</h2>
+
+    <ul>
+      <li>
+        <code>sf.Model(model, *, name=None, prompt=None, params=None)</code> — select a route,
+        optionally with answer policy
+      </li>
+      <li>
+        <code>sf.models.list()</code> — routes this engine can reach, as <code>sf.ModelInfo</code>
+      </li>
+      <li>
+        <code>.name</code> · <code>.model</code> · <code>.prompt</code> · <code>.params</code> —
+        read back what a Model resolved to
+      </li>
+    </ul>
+
+    <h2>How to</h2>
+
+    <h3>Select a route</h3>
+
+    <p>
+      The route is the only required argument. The Model's <code>name</code> is inferred from its
+      last segment, which is what appears in a report.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="basic"><NbTextOut :text="basicOut" /></NbCell>
+    </div>
+
+    <h3>Name an independent sample</h3>
+
+    <p>
+      Two Models on the same route with the same policy are the <em>same</em> candidate — the engine
+      deduplicates them by content inside one compiled graph. An explicit <code>name</code> is how
+      you say you meant two independent samples, and it is the name the report uses.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="2" :code="named"><NbTextOut :text="namedOut" /></NbCell>
+    </div>
+
+    <h3>Override the answer policy</h3>
+
+    <p>
+      The SDK supplies a general answer prompt, so a bare Model works. When an experiment needs
+      something specific, <code>prompt</code> and <code>params</code> replace it.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="3" :code="policy"><NbTextOut :text="policyOut" /></NbCell>
+    </div>
+
+    <p>
+      These are <strong>candidate-owned</strong> settings: they change how your candidate answers,
+      and they can never touch benchmark-owned cases, judge models, grading or aggregation. That
+      separation is what keeps two candidates comparable on the same benchmark. Whatever you set is
+      resolved and embedded in the run's URL4, so a report records the policy that actually ran.
+    </p>
+
+    <h3>See what the engine can reach</h3>
+
+    <div class="not-prose">
+      <NbCell :count="4" :code="listing"><NbTextOut :text="listingOut" /></NbCell>
+    </div>
+
+    <p>
+      Two things to note. The catalogue spans <strong>every provider the engine knows</strong>, not
+      only the ones you have connected — a route you have no credential for will fail at evaluation,
+      not here. And ID shapes differ per provider: <code>anthropic/claude-opus-4-8</code> against
+      <code>openrouter/anthropic/claude-opus-4.8</code>. Copy the <code>id</code> rather than
+      retyping it.
+    </p>
+
+    <h2>Links</h2>
+
+    <ul>
+      <li>
+        <a
+          href="https://github.com/OpenMined/screamingface/blob/OME-605-screamingface-client-v1/packages/screamingface/examples/00_quickstart.ipynb"
+          target="_blank"
+          rel="noopener"
+          >Companion notebook — <code>00_quickstart.ipynb</code></a
+        >
+      </li>
+    </ul>
   </DocLayout>
 </template>

--- a/public-docs/src/pages/sf-client/guides/ModelsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/ModelsPage.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import DocLayout from '@/components/layout/DocLayout.vue'
+import { sfClientNavigation as navigation } from '@/navigation/sf-client'
+</script>
+
+<template>
+  <DocLayout
+    title="Models"
+    description="Select a model route and set the answer policy a candidate owns."
+    :navigation="navigation"
+  >
+    <p>Stub page — replace with real content.</p>
+  </DocLayout>
+</template>

--- a/public-docs/src/pages/sf-client/guides/Url4Page.vue
+++ b/public-docs/src/pages/sf-client/guides/Url4Page.vue
@@ -1,6 +1,33 @@
 <script setup lang="ts">
+import { RouterLink } from 'vue-router'
 import DocLayout from '@/components/layout/DocLayout.vue'
-import { sfClientNavigation as navigation } from '@/navigation/sf-client'
+import NbCell from '@/components/nb/NbCell.vue'
+import NbTextOut from '@/components/nb/NbTextOut.vue'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const get = `plan = report.candidates.only.url4
+len(plan)`
+const getOut = `1402`
+
+const audit = `print("candidate slots :", plan.count("/candidate("))
+print("checker calls   :", plan.count("/check("))
+print("revision pinned :", report.benchmark.revision in plan)`
+const auditOut = `candidate slots : 3
+checker calls   : 3
+revision pinned : True`
+
+const ops = `c = report.candidates.only
+len(c.operations), [o.kind for o in c.operations]`
+const opsOut = `(1, ['model'])`
+
+const runId = `c.run_id`
+const runIdOut = `'z4DrOL5qGcURcfEVB6evxPDlHyg0T2Cwjso10dJ1p5O4TocWXK5FLcYgdbPcnSnQ'`
+
+const share = `report.to_dict()   # schema: screamingface.report.v1
+report.to_json()   # the same, as one string`
 </script>
 
 <template>
@@ -8,7 +35,142 @@ import { sfClientNavigation as navigation } from '@/navigation/sf-client'
     title="Reproduce &amp; share (URL4)"
     description="Read the exact plan a run executed, and hand it to someone else."
     :navigation="navigation"
+    :version="version"
   >
-    <p>Stub page — replace with real content.</p>
+    <p>
+      Every candidate result carries a <code>url4</code> string: the complete expression the engine
+      executed. Not a summary of it, not a log of it — the plan itself, the thing that ran. Your
+      candidate, the benchmark's routes, the retry prompts, and the pinned protocol revision, all in
+      one line of text you can read, diff, and send to someone.
+    </p>
+
+    <p>
+      This is what makes a result auditable. A score on its own is a claim; a score with its URL4
+      shows exactly what produced it.
+    </p>
+
+    <h2>What you can do with it</h2>
+
+    <ul>
+      <li>Read what actually executed, including defaults you never set.</li>
+      <li>Confirm which benchmark revision the run was pinned to.</li>
+      <li>Inspect the operation graph a candidate compiled to.</li>
+      <li>Serialise a whole report and hand it over.</li>
+    </ul>
+
+    <h2>Main APIs</h2>
+
+    <ul>
+      <li><code>CandidateResult.url4</code> — the expression that executed</li>
+      <li>
+        <code>CandidateResult.operations</code> — the same plan as an
+        <code>sf.OperationInfo</code> DAG
+      </li>
+      <li><code>CandidateResult.run_id</code> — the engine's identifier for this run</li>
+      <li><code>Report.benchmark.revision</code> — the pinned protocol the run used</li>
+      <li>
+        <code>Report.to_dict()</code> · <code>Report.to_json()</code> — the whole report, serialised
+      </li>
+    </ul>
+
+    <h2>How to</h2>
+
+    <h3>Get the plan</h3>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="get"><NbTextOut :text="getOut" /></NbCell>
+    </div>
+
+    <p>
+      Fourteen hundred characters for a three-case run of one model. That length is the point: it
+      spells out the resolved answer prompt, the generation parameters, every benchmark route, and
+      the retry chain — including everything the SDK filled in on your behalf.
+    </p>
+
+    <h3>Audit it without reading all of it</h3>
+
+    <p>It is a string, so plain string operations answer real questions about what ran.</p>
+
+    <div class="not-prose">
+      <NbCell :count="2" :code="audit"><NbTextOut :text="auditOut" /></NbCell>
+    </div>
+
+    <p>
+      Three candidate slots and three checker calls, from a run over three cases with IFEval's
+      corrective method — the retry chain is <em>unrolled</em> into the expression rather than being
+      a loop the engine hides. Every attempt is visible before anything executes, which is also why
+      every attempt is paid for even when the first one passes.
+    </p>
+
+    <p>
+      <code>revision pinned : True</code> is the important one. The benchmark's protocol revision
+      appears inside the routes, so the expression cannot silently execute against a newer version
+      of the exam.
+    </p>
+
+    <h3>Inspect the operation graph</h3>
+
+    <p>
+      <code>operations</code> is the same plan as structured data — a directed acyclic graph of
+      <code>OperationInfo</code> values, each with an <code>id</code>, a <code>kind</code>, a
+      <code>label</code> and its <code>depends_on</code> edges.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="3" :code="ops"><NbTextOut :text="opsOut" /></NbCell>
+    </div>
+
+    <p>
+      A solo model is one operation. A
+      <RouterLink to="/sf-client/guides/fusions">Fusion</RouterLink>
+      contributes one per member plus the synthesis step, so this is where you read an ensemble's
+      shape rather than inferring it from its name.
+    </p>
+
+    <h3>Identify the run</h3>
+
+    <div class="not-prose">
+      <NbCell :count="4" :code="runId"><NbTextOut :text="runIdOut" /></NbCell>
+    </div>
+
+    <h3>Share the whole report</h3>
+
+    <div class="not-prose">
+      <NbCell :count="5" :code="share" />
+    </div>
+
+    <p>
+      The dict carries a <code>schema</code> field — <code>screamingface.report.v1</code> — so a
+      consumer can tell what shape it is reading. Every candidate's <code>url4</code>, scores,
+      metrics, usage and the pinned benchmark revision travel with it.
+    </p>
+
+    <h2>What "reproduce" means here</h2>
+
+    <p>
+      A URL4 pins the run's <strong>definition</strong>, not its outputs. Re-executing the same
+      expression asks the same models the same questions under the same protocol — and models are
+      not deterministic, so the scores will move. What is reproducible is the experiment, not the
+      number.
+    </p>
+
+    <p>
+      That is the useful guarantee. When two results differ, the URL4 tells you whether the
+      <em>setup</em> differed, which is the question you actually need answered before comparing
+      them.
+    </p>
+
+    <h2>Links</h2>
+
+    <ul>
+      <li>
+        <a
+          href="https://github.com/OpenMined/screamingface/blob/OME-605-screamingface-client-v1/packages/screamingface/examples/07_ifeval_e2e.ipynb"
+          target="_blank"
+          rel="noopener"
+          >Companion notebook — <code>07_ifeval_e2e.ipynb</code></a
+        >, which prints a full expression
+      </li>
+    </ul>
   </DocLayout>
 </template>

--- a/public-docs/src/pages/sf-client/guides/Url4Page.vue
+++ b/public-docs/src/pages/sf-client/guides/Url4Page.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import DocLayout from '@/components/layout/DocLayout.vue'
+import { sfClientNavigation as navigation } from '@/navigation/sf-client'
+</script>
+
+<template>
+  <DocLayout
+    title="Reproduce &amp; share (URL4)"
+    description="Read the exact plan a run executed, and hand it to someone else."
+    :navigation="navigation"
+  >
+    <p>Stub page — replace with real content.</p>
+  </DocLayout>
+</template>

--- a/public-docs/src/router/index.ts
+++ b/public-docs/src/router/index.ts
@@ -24,6 +24,36 @@ const router = createRouter({
       component: () => import('@/pages/sf-client/QuickstartPage.vue'),
     },
     {
+      path: '/sf-client/guides/connections',
+      name: 'sf-client-guides-connections',
+      component: () => import('@/pages/sf-client/guides/ConnectionsPage.vue'),
+    },
+    {
+      path: '/sf-client/guides/models',
+      name: 'sf-client-guides-models',
+      component: () => import('@/pages/sf-client/guides/ModelsPage.vue'),
+    },
+    {
+      path: '/sf-client/guides/fusions',
+      name: 'sf-client-guides-fusions',
+      component: () => import('@/pages/sf-client/guides/FusionsPage.vue'),
+    },
+    {
+      path: '/sf-client/guides/benchmarks',
+      name: 'sf-client-guides-benchmarks',
+      component: () => import('@/pages/sf-client/guides/BenchmarksPage.vue'),
+    },
+    {
+      path: '/sf-client/guides/running-an-evaluation',
+      name: 'sf-client-guides-evaluation',
+      component: () => import('@/pages/sf-client/guides/EvaluationPage.vue'),
+    },
+    {
+      path: '/sf-client/guides/reproduce-and-share',
+      name: 'sf-client-guides-url4',
+      component: () => import('@/pages/sf-client/guides/Url4Page.vue'),
+    },
+    {
       path: '/sdk',
       name: 'sdk',
       component: () => import('@/pages/sdk/Index.vue'),


### PR DESCRIPTION
Second sub-issue of `OME-666`. Adds six of the parent's ten user-guide pages;
`OME-669` covers the remaining four.

## What's here

```
USER GUIDES
  Connections
  ▸ Compose
      Models
      Fusions
  Benchmarks
  Running an evaluation
  Reproduce & share (URL4)
```

Every API name is checked against `OME-605-screamingface-client-v1` @ `e387aefd`,
and every displayed output comes from a real run against a local engine —
discovery for the first four pages, an `ifeval` evaluation for the last two.
No figure is invented; cells with no captured output show code only.

## The SDK moved

These document a different API than `OME-666` describes, because the client moved
off the abandoned `OME-400` branch: `sf.evaluate()` rather than
`benchmark.evaluate()`, one `Report` rather than `Report` + `StudyReport`, Fusion
synthesizers rather than reducers, `sf.configure()` rather than `sf.config()`, and
no `draco-lite`.

## Beyond the AC

- **Navigation is modelled as groups and links.** `Compose` is a label with no page,
  which the old tree could not express — every entry had to be a link. Now a group
  labels children and a link points at a page, rendered by one recursive `NavTree`.
- **Mobile navigation.** Below 1024px there was no sidebar and the navbar's product
  row collapsed to plain text, so a phone reader could only move by prev/next. The
  sidebar is now off-canvas below `lg` and the product label is a switcher.
- **The commit stamp renders once in the sidebar footer**, not at the foot of each
  guide as the ticket asks. It becomes a semver label when the package ships to PyPI.
- **The Overview lost "Where next"**, which duplicated the sidebar and still said the
  guides were coming.

## Test plan

`public-docs` has no test suite. Gates: `oxlint` and `eslint` clean run bare as CI
does, `build` succeeds, `prettier --check` clean on every touched file. Verified in
light and dark theme, and at 400px / 800px / 1200px.

Refs: OME-668