### PR TITLE
fix(aigateway): enable OpenRouter in prod chart values

### DIFF
--- a/apps/aigateway/charts/aigateway/values-prod.yaml
+++ b/apps/aigateway/charts/aigateway/values-prod.yaml
@@ -22,6 +22,11 @@ config:
   # for a file that cannot know who the operators are — the console will report "admin API
   # disabled" rather than silently letting anyone in.
   adminEmails: []
+  # Production serves OpenRouter models when callers have provisioned per-account credentials. This
+  # is only the plugin availability gate; provider API keys remain in `credential_blobs`, not chart
+  # values.
+  openrouter:
+    enabled: true
   # Re-state the chart's default-on global response cache explicitly for production. Read the five
   # consequences documented on `config.requestCache` in `values.yaml`; the load-bearing ones are
   # that any two callers sending the identical request get the identical stored response, and that


### PR DESCRIPTION
Linear issue: OME-428

Summary:
- Explicitly enables the OpenRouter provider gate in AIGateway production Helm values.
- Keeps provider API keys out of chart values; credentials remain per-account in credential_blobs.

Test plan:
- helm template aigw apps/aigateway/charts/aigateway --namespace aigw --show-only templates/configmap.yaml
- helm template aigw apps/aigateway/charts/aigateway --namespace aigw --values apps/aigateway/charts/aigateway/values-prod.yaml --show-only templates/configmap.yaml
- /Users/dmitry/.claude/skills/storing-memories/venv/bin/python .github/scripts/verify_chart_wiring.py
- helm lint apps/aigateway/charts/db && helm lint apps/aigateway/charts/aigateway && helm template aigw-db apps/aigateway/charts/db --namespace aigw --values apps/aigateway/charts/db-aigateway.values.yaml >/tmp/aigw-db.yaml && helm template aigw apps/aigateway/charts/aigateway --namespace aigw >/tmp/aigw.yaml && helm template aigw apps/aigateway/charts/aigateway --namespace aigw --values apps/aigateway/charts/aigateway/values-prod.yaml >/tmp/aigw-prod.yaml
- git diff --check -- apps/aigateway/charts/aigateway/values-prod.yaml

Refs: OME-428