### PR TITLE
feat(url4-cloud): expose only executable models

### DIFF
--- a/.claude/scripts/check_layering.py
+++ b/.claude/scripts/check_layering.py
@@ -11,9 +11,9 @@ One image ships two modes, and the whole point of that shape is a rule about wha
 
   Control plane: app · rest · ws · auth · catalog · connections · config · metrics · ops · schemas
                  adapters.k8s · adapters.factory    (FastAPI, uvicorn, the kubernetes client)
-  Run mode:      runner.executor (the url4 engine) · runner.connector · runner.config
+  Run mode:      runner.executor (the url4 engine) · runner.connector · runner.main
 
-  Shared leaves, importable by BOTH: job_env · subjects · adapters.jetstream
+  Shared leaves, importable by BOTH: job_env · subjects · adapters.jetstream · world_config
 
 WHY this rule outlived the package split it was born in: it used to be proved structurally — the
 two halves were separate distributions with separate images, so a cross-import could not even be

--- a/apps/url4-cloud/Dockerfile
+++ b/apps/url4-cloud/Dockerfile
@@ -56,10 +56,10 @@ WORKDIR /app/apps/url4-cloud
 # INVARIANT: same absolute layout as the builder — editable installs resolve through these paths.
 COPY --from=builder --chown=1000:1000 /app/packages/url4 /app/packages/url4
 COPY --from=builder --chown=1000:1000 /app/apps/url4-cloud /app/apps/url4-cloud
-# The DECLARED world the run mode evaluates against (`url4_cloud.runner.config`,
+# The DECLARED world both serving discovery and run mode consume (`url4_cloud.world_config`,
 # DEFAULT_CONFIG_PATH). Endpoints are declared here, never discovered from the gateway catalog —
 # the image decides what CAN exist. URL4_RUNNER_CONFIG overrides the path; a read-only rootfs is
-# fine, it is read once at boot. Unused by the serving mode.
+# fine, it is read once per process at boot.
 COPY --from=builder --chown=1000:1000 /app/apps/url4-cloud/url4.toml /etc/url4/url4.toml
 ENV PATH="/app/apps/url4-cloud/.venv/bin:$PATH" \
     PYTHONUNBUFFERED=1 \

--- a/apps/url4-cloud/README.md
+++ b/apps/url4-cloud/README.md
@@ -124,9 +124,12 @@ installed by the wheel, so in a checkout local mode falls back to the checkout's
 
 ## Model catalog — `GET /v1/models`
 
-Discover which models an expression can address, proxied from aigateway's own `/v1/models` and
-served from a per-caller cache. Design: `docs/spec/2026-07-26-url4-cloud-model-catalog-spec.md`
-· OME-625.
+Discover which models an expression can address: aigateway's own `/v1/models` for this caller,
+**intersected with the model routes this Engine declares** in `url4.toml`, served from a
+per-caller cache. Every id it returns is a route the Runner can actually execute — a model
+aigateway could serve directly but the Engine has not declared is omitted rather than advertised
+and then failing at render time. Retained model documents are aigateway's, unchanged.
+Design: `docs/spec/2026-07-26-url4-cloud-model-catalog-spec.md` · OME-625.
 
 The caller is the verified `X-User-Email` the mesh gateway injects. Deployed, Envoy always supplies
 it. Locally, aigateway runs with auth disabled and none is needed:
@@ -146,6 +149,13 @@ caller's identity and aigateway decides, including whether an absent identity is
 - **Enabled by `URL4_CLOUD_AIGATEWAY_BASE_URL`** — the same value the chart already sets as
   `config.aigatewayBaseUrl`. Unset ⇒ the endpoint answers `503`; everything else is a code default
   (see the `models_cache_*` fields in `config.py`).
+- **Also needs a readable declared world.** With a base URL set, the App reads `url4.toml` at boot
+  (the same file the Runner uses — see above; baked into the image, `URL4_RUNNER_CONFIG` overrides
+  the path). If it is missing or invalid, both catalog routes answer `503` and an `ERROR` is
+  logged naming the cause; runs, streaming and health are unaffected. Discovery never guesses,
+  and never advertises a route it cannot execute.
+- **`GET /v1/model-parameters` is bounded by the same set** — an undeclared model answers `404`
+  without contacting aigateway, so the listing and the detail cannot disagree.
 - Cache behaviour is observable at `/metrics` (`url4_cloud_catalog_*`).
 
 ## Per-run cache policy

--- a/apps/url4-cloud/deploy/helm/templates/configmap.yaml
+++ b/apps/url4-cloud/deploy/helm/templates/configmap.yaml
@@ -39,9 +39,13 @@ data:
   {{- with .Values.config.aigatewayBaseUrl }}
   # Forwarded into every Runner Job as AIGATEWAY_BASE_URL. The Runner's own fallback is loopback,
   # which inside a Job Pod is that Pod — so this must name the aigateway Service to reach it.
-  # ALSO enables the App's own `GET /v1/models` catalog endpoint (OME-625), which proxies
-  # aigateway using the CALLER's forwarded credential — it needs no credential of its own, so this
-  # URL is the only thing that switches the endpoint on. Unset => `/v1/models` answers 503.
+  # ALSO enables the App's own `GET /v1/models` catalog endpoint (OME-625), which reads aigateway
+  # using the CALLER's forwarded credential — it needs no credential of its own. Unset =>
+  # `/v1/models` answers 503.
+  # NOT sufficient on its own: the endpoint returns aigateway's catalog INTERSECTED with the
+  # models declared in this image's `url4.toml` (/etc/url4/url4.toml), so the App reads that file
+  # at boot too. An unusable declared world disables both catalog routes (503) and logs an ERROR;
+  # it does NOT stop the App — runs, streaming and health are unaffected.
   URL4_CLOUD_AIGATEWAY_BASE_URL: {{ . | quote }}
   {{- end }}
   # The ConfigMap of DEPLOY-TIME Runner env (configmap-runner-env.yaml). The App only references

--- a/apps/url4-cloud/docs/execution-flow-diagrams.md
+++ b/apps/url4-cloud/docs/execution-flow-diagrams.md
@@ -43,7 +43,7 @@ narrative) and `docs/protocol.md` (the wire contract).
 │                                                                               │
 │  runner/main.py  ◄── entrypoint (url4-cloud run)                              │
 │   ├─ params_from_env   ──► RunnerParams(topic,url4,nats)                      │
-│   └─ build_executor    ──► runner/config.py load_config (url4.toml)           │
+│   └─ build_executor    ──► world_config.py load_config (url4.toml)            │
 │         ├─ [aigateway] ► runner/connector.build_aigateway_world ─► Url4Executor│
 │         └─ no table    ► runner/executor.deny_by_default_world  ─► Url4Executor│
 │                                                                               │
@@ -131,9 +131,10 @@ narrative) and `docs/protocol.md` (the wire contract).
    └─────────────────────────────────────────────────────────────┘
 ```
 
-The run mode's own reading of `runner/config.py` is the only place the DECLARED model world
-enters: `url4.toml` ships in the image at `/etc/url4/url4.toml`, baked from
-`apps/url4-cloud/url4.toml` (it moved there with the merge — there is no `runner/` tree any more).
+`world_config.py` is the single parser for the DECLARED model world. The control plane uses it to
+project discovery and the run mode uses it to build routes, so the two cannot disagree.
+`url4.toml` ships in the image at `/etc/url4/url4.toml`, baked from
+`apps/url4-cloud/url4.toml`.
 
 ### Run-mode call sequence (one run)
 
@@ -194,7 +195,7 @@ runner/main.py::main()
 │ runner/connector.py   declared routes + credential → Url4Node │
 │                       (+ optional Tavily web tools)           │
 ├─ declared world ──────────────────────────────────────────────┤
-│ runner/config.py   parses url4.toml (/etc/url4/url4.toml)     │
+│ world_config.py    parses url4.toml (/etc/url4/url4.toml)     │
 ├─ boundary doc ────────────────────────────────────────────────┤
 │ runner/__init__.py   states the layering rule the gate proves │
 └───────────────────────────────────────────────────────────────┘
@@ -205,7 +206,7 @@ runner/main.py::main()
 | `runner/main.py` | `url4-cloud run` entrypoint: read env (names from `url4_cloud/job_env.py`) → wire `JetStreamPublisher` + executor → call `lifecycle.run` |
 | `runner/executor.py` | The **only** url4-engine adapter (`_Bridge` sync→async, `_RunState`, `Url4Executor`) |
 | `runner/connector.py` | Builds the `Url4Node` "world" of declared routes → aigateway chat (+ optional Tavily tools) |
-| `runner/config.py` | Parses `url4.toml` — the DECLARED model world, baked into the image at `/etc/url4/url4.toml` from the repo's `url4.toml` |
+| `world_config.py` | Parses `url4.toml` once for both control-plane discovery and Runner execution |
 | `runner/__init__.py` | No re-exports — it carries the layering rule (what this half may and may not import) |
 
 ### Control plane (`src/url4_cloud/`)

--- a/apps/url4-cloud/docs/request-workflow.md
+++ b/apps/url4-cloud/docs/request-workflow.md
@@ -268,7 +268,7 @@ swallow — leaving the client staring at heartbeats forever.
 | mode dispatch | `url4_cloud/cli.py::main` — `serve` (default) / `run`, each imported lazily |
 | Runner lifecycle | `url4_cloud/runner/main.py::main`, `url4/streaming/lifecycle.py::run` |
 | url4 engine bridge | `url4_cloud/runner/executor.py::{Url4Executor,_Bridge,_RunState}` |
-| aigateway connector | `url4_cloud/runner/connector.py::{build_aigateway_world,_chat_completion_loop}`, `url4_cloud/runner/config.py::{load_config,routes_for}` |
+| aigateway connector | `url4_cloud/runner/connector.py::{build_aigateway_world,_chat_completion_loop}`, `url4_cloud/world_config.py::{load_config,routes_for}` |
 | aigateway chat | `aigateway/routes/chat.py::chat_completions` (+ `chat_dispatch.py`) |
 | stream ports + implementations | `url4/streaming/interfaces/stream.py` (the abstractions), `url4_cloud/adapters/jetstream.py::{JetStreamPublisher,JetStreamConsumer}` (JetStream, shared leaf), `url4_cloud/testing/memory_stream.py` (test double) |
 | the layering rule | `.claude/scripts/check_layering.py`, `url4_cloud/runner/__init__.py` |

--- a/apps/url4-cloud/src/url4_cloud/app.py
+++ b/apps/url4-cloud/src/url4_cloud/app.py
@@ -8,6 +8,7 @@ tests substitute for the production ones built here from `Settings`.
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 
 from fastapi import APIRouter, FastAPI
@@ -17,7 +18,7 @@ from url4.streaming.interfaces import EventConsumer, JobRunner
 from url4_cloud.adapters.factory import build_job_runner
 from url4_cloud.auth import Clock, install_problem_handlers
 from url4_cloud.benchmarks import EMPTY_BENCHMARKS, BenchmarkRegistry
-from url4_cloud.catalog import build_catalog_service
+from url4_cloud.catalog import build_executable_catalog_service
 from url4_cloud.catalog.cache import CatalogService
 from url4_cloud.catalog.port import ModelParameterSource
 from url4_cloud.config import INSECURE_DEFAULT_JWT_SECRET, Settings
@@ -141,7 +142,7 @@ def create_app_from_env() -> FastAPI:  # pragma: no cover - env/NATS wiring (INF
         logging.warning(
             "URL4_CLOUD_RUNNER is 'none' — this App bridges NATS but cannot schedule runs"
         )
-    catalog = build_catalog_service(settings)
+    catalog = build_executable_catalog_service(settings, os.environ)
     connections = build_connections(settings)
     app = create_app(
         settings,

--- a/apps/url4-cloud/src/url4_cloud/catalog/__init__.py
+++ b/apps/url4-cloud/src/url4_cloud/catalog/__init__.py
@@ -2,19 +2,19 @@
 
 Re-exports the hexagonal port (``catalog/port.py``), the aigateway adapter
 (``catalog/aigateway.py``), and the caching layer (``catalog/cache.py``), and
-provides ``build_catalog_service`` — the composition root that wires one
-``AigatewayCatalogSource`` behind a ``CachedCatalog`` for model lists while retaining uncached
-model-detail delegation through the same client.
+provides composition builders that retain one Gateway client while projecting model discovery
+and profile-bound details onto the Engine's declared executable routes.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 
 import httpx
 
 from url4_cloud.catalog.aigateway import AigatewayCatalogSource
 from url4_cloud.catalog.cache import CacheCounters, CachedCatalog, CatalogService
+from url4_cloud.catalog.executable import ExecutableCatalog, ExecutableModelParameterSource
 from url4_cloud.catalog.port import (
     CatalogBadResponse,
     CatalogError,
@@ -23,12 +23,14 @@ from url4_cloud.catalog.port import (
     CatalogUnavailable,
     Credential,
     ModelCatalog,
+    ModelNotInstalled,
     ModelParameterBadResponse,
     ModelParameterResponse,
     ModelParameterSource,
     compute_etag,
 )
 from url4_cloud.config import Settings
+from url4_cloud.world_config import declared_model_ids
 
 _UPSTREAM_TIMEOUT_S = 10.0
 
@@ -64,6 +66,22 @@ def build_catalog_service(
     )
 
 
+def build_executable_catalog_service(
+    settings: Settings,
+    env: Mapping[str, str],
+    *,
+    client_factory: Callable[[str], httpx.AsyncClient] = _default_client,
+) -> ExecutableCatalog | None:
+    """Wire Gateway discovery through the Engine routes, validating them when configured."""
+
+    if not settings.aigateway_base_url:
+        return None
+    model_ids = declared_model_ids(env)
+    source = build_catalog_service(settings, client_factory=client_factory)
+    assert source is not None
+    return ExecutableCatalog(source, model_ids)
+
+
 __all__ = [
     "AigatewayCatalogSource",
     "CacheCounters",
@@ -75,10 +93,14 @@ __all__ = [
     "CatalogSource",
     "CatalogUnavailable",
     "Credential",
+    "ExecutableCatalog",
+    "ExecutableModelParameterSource",
     "ModelCatalog",
+    "ModelNotInstalled",
     "ModelParameterBadResponse",
     "ModelParameterResponse",
     "ModelParameterSource",
     "build_catalog_service",
+    "build_executable_catalog_service",
     "compute_etag",
 ]

--- a/apps/url4-cloud/src/url4_cloud/catalog/__init__.py
+++ b/apps/url4-cloud/src/url4_cloud/catalog/__init__.py
@@ -8,6 +8,7 @@ and profile-bound details onto the Engine's declared executable routes.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Mapping
 
 import httpx
@@ -30,7 +31,9 @@ from url4_cloud.catalog.port import (
     compute_etag,
 )
 from url4_cloud.config import Settings
-from url4_cloud.world_config import declared_model_ids
+from url4_cloud.world_config import WorldConfigError, declared_model_ids
+
+logger = logging.getLogger(__name__)
 
 _UPSTREAM_TIMEOUT_S = 10.0
 
@@ -72,14 +75,37 @@ def build_executable_catalog_service(
     *,
     client_factory: Callable[[str], httpx.AsyncClient] = _default_client,
 ) -> ExecutableCatalog | None:
-    """Wire Gateway discovery through the Engine routes, validating them when configured."""
+    """Wire Gateway discovery through the Engine routes, validating them when configured.
+
+    Returns None — the same "not configured" signal :func:`build_catalog_service` gives, which
+    ``rest/catalog.py`` answers with 503 — when there is no Gateway base URL, or when the
+    declared world is unusable.
+
+    WHY an unusable world DEGRADES rather than raising: this runs inside the App's composition
+    root, so a raise here takes down run submission, streaming, connections and health along
+    with discovery — for a file whose only reader used to be the Runner. The failure is still
+    loud (an ERROR log naming the cause, and 503 on both catalog routes, never a silently empty
+    catalog), and it is still fail-FAST for execution: the Runner validates the same world at
+    Job start, where a bad route actually changes what runs. This mirrors the reasoning at
+    ``runner/main.py``'s ``_world`` — a bad config surfaces as a scoped failure, not as a
+    process that dies before it can report anything.
+    """
 
     if not settings.aigateway_base_url:
         return None
-    model_ids = declared_model_ids(env)
+    try:
+        model_ids = declared_model_ids(env)
+    except WorldConfigError:
+        # The cause is logged, not raised: `rest/catalog.py` turns None into the generic 503, so
+        # an unauthenticated caller never learns why this deployment's world is unusable.
+        logger.error("model discovery disabled: the declared world is unusable", exc_info=True)
+        return None
+    logger.info("model discovery projects onto %d declared route(s)", len(model_ids))
     source = build_catalog_service(settings, client_factory=client_factory)
-    assert source is not None
-    return ExecutableCatalog(source, model_ids)
+    # `source is None` cannot happen — it guards on the same base URL checked above — but the
+    # narrowing is expressed rather than asserted, so the two guards drifting apart degrades
+    # exactly like an unconfigured deployment instead of raising at import time under `-O`.
+    return None if source is None else ExecutableCatalog(source, model_ids)
 
 
 __all__ = [

--- a/apps/url4-cloud/src/url4_cloud/catalog/executable.py
+++ b/apps/url4-cloud/src/url4_cloud/catalog/executable.py
@@ -62,14 +62,24 @@ class ExecutableCatalog:
     async def fetch(self, credential: Credential) -> ModelCatalog:
         catalog = await self._source.fetch(credential)
         data = catalog.body.get("data")
+        # WHY this one raises but a bad ENTRY does not: a `data` that is not a list cannot be
+        # projected at all, so there is no honest answer to give. A single malformed entry has
+        # one — omit it. Raising there would let one odd upstream document turn discovery into a
+        # 502 for every caller, and `CachedCatalog` serves stale-on-error, so a PERSISTENT
+        # oddity would degrade into an outage once `stale_max_s` elapsed.
         if not isinstance(data, list):
             raise CatalogBadResponse("catalog data is not a list")
-        for item in data:
-            if not isinstance(item, Mapping) or not isinstance(item.get("id"), str):
-                raise CatalogBadResponse("catalog model is missing a string id")
+        # INVARIANT: membership is the whole filter. An entry that is not a mapping, or whose id
+        # is absent or not a string, cannot equal a declared id — so the acceptance contract
+        # ("every id returned is a declared route") holds without a separate shape check, and an
+        # unknown future field on a RETAINED document still passes through untouched.
         body = {
             **catalog.body,
-            "data": [item for item in data if item.get("id") in self._model_ids],
+            "data": [
+                item
+                for item in data
+                if isinstance(item, Mapping) and item.get("id") in self._model_ids
+            ],
         }
         return ModelCatalog(body=body, etag=compute_etag(body))
 

--- a/apps/url4-cloud/src/url4_cloud/catalog/executable.py
+++ b/apps/url4-cloud/src/url4_cloud/catalog/executable.py
@@ -1,0 +1,106 @@
+"""Project AI Gateway discovery onto the Engine's declared execution world."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Protocol
+
+from url4_cloud.catalog.cache import CacheCounters, CatalogService
+from url4_cloud.catalog.port import (
+    CatalogBadResponse,
+    Credential,
+    ModelCatalog,
+    ModelNotInstalled,
+    ModelParameterResponse,
+    ModelParameterSource,
+    compute_etag,
+)
+
+
+class ExecutableCatalogSource(CatalogService, Protocol):
+    """The managed catalog surface preserved by the executable-world decorator."""
+
+    @property
+    def counters(self) -> CacheCounters | None: ...
+
+    @property
+    def entry_count(self) -> int: ...
+
+    @property
+    def model_parameter_source(self) -> ModelParameterSource | None: ...
+
+    async def aclose(self) -> None: ...
+
+
+class ExecutableCatalog:
+    """A catalog decorator that keeps only model documents installed on this Engine.
+
+    The wrapped cache remains caller-scoped and stores AI Gateway's authoritative response.
+    Projection happens after that fetch so one deployment-level route set cannot leak into the
+    Gateway adapter's provider/profile contract. Retained model documents and unknown top-level
+    fields pass through unchanged.
+    """
+
+    def __init__(self, source: ExecutableCatalogSource, model_ids: frozenset[str]) -> None:
+        self._source = source
+        self._model_ids = model_ids
+        parameter_source = source.model_parameter_source
+        self._model_parameter_source = (
+            None
+            if parameter_source is None
+            else ExecutableModelParameterSource(parameter_source, model_ids)
+        )
+
+    @property
+    def counters(self) -> CacheCounters | None:
+        return self._source.counters
+
+    @property
+    def entry_count(self) -> int:
+        return self._source.entry_count
+
+    async def fetch(self, credential: Credential) -> ModelCatalog:
+        catalog = await self._source.fetch(credential)
+        data = catalog.body.get("data")
+        if not isinstance(data, list):
+            raise CatalogBadResponse("catalog data is not a list")
+        for item in data:
+            if not isinstance(item, Mapping) or not isinstance(item.get("id"), str):
+                raise CatalogBadResponse("catalog model is missing a string id")
+        body = {
+            **catalog.body,
+            "data": [item for item in data if item.get("id") in self._model_ids],
+        }
+        return ModelCatalog(body=body, etag=compute_etag(body))
+
+    def max_age_s(self, credential: Credential) -> int:
+        return self._source.max_age_s(credential)
+
+    async def aclose(self) -> None:
+        await self._source.aclose()
+
+    @property
+    def model_parameter_source(self) -> ModelParameterSource | None:
+        """The uncached Gateway detail source, guarded by this same executable route set."""
+
+        return self._model_parameter_source
+
+
+class ExecutableModelParameterSource:
+    """Reject model-parameter lookups outside the same declared execution world."""
+
+    def __init__(self, source: ModelParameterSource, model_ids: frozenset[str]) -> None:
+        self._source = source
+        self._model_ids = model_ids
+
+    async def fetch_model_parameters(
+        self,
+        credential: Credential,
+        model: str,
+    ) -> ModelParameterResponse:
+        if model not in self._model_ids:
+            raise ModelNotInstalled(model)
+        return await self._source.fetch_model_parameters(credential, model)
+
+
+__all__ = ["ExecutableCatalog", "ExecutableCatalogSource", "ExecutableModelParameterSource"]

--- a/apps/url4-cloud/src/url4_cloud/catalog/port.py
+++ b/apps/url4-cloud/src/url4_cloud/catalog/port.py
@@ -84,10 +84,10 @@ class Credential:
 
 @dataclass(frozen=True, slots=True)
 class ModelCatalog:
-    """One fetched catalog: aigateway's response body verbatim, plus its derived ETag.
+    """One fetched catalog document plus its derived ETag.
 
-    WHY verbatim: url4-cloud proxies, it does not reshape. Passing the body through unchanged keeps
-    the response OpenAI-tool-compatible and means a new upstream field needs no change here.
+    The AI Gateway adapter fills this with the upstream body verbatim. The Engine projection
+    later replaces only ``data`` with the declared-route intersection and derives a new ETag.
     """
 
     body: dict[str, object]
@@ -152,6 +152,14 @@ class ModelParameterBadResponse(CatalogBadResponse):
     detail = "aigateway returned an unusable model-parameter contract"
 
 
+class ModelNotInstalled(CatalogError):
+    """The requested model is absent from this Engine's declared execution world."""
+
+    status = 404
+    title = "Not Found"
+    detail = "the model is not installed on this Engine"
+
+
 class CatalogUnavailable(CatalogError):
     """The upstream request timed out."""
 
@@ -191,6 +199,7 @@ __all__ = [
     "CatalogUnavailable",
     "Credential",
     "ModelCatalog",
+    "ModelNotInstalled",
     "ModelParameterBadResponse",
     "ModelParameterResponse",
     "ModelParameterSource",

--- a/apps/url4-cloud/src/url4_cloud/job_env.py
+++ b/apps/url4-cloud/src/url4_cloud/job_env.py
@@ -181,7 +181,7 @@ TAVILY_API_KEY = "TAVILY_API_KEY"
 Absent => web tools stay off."""
 
 RUNNER_CONFIG = "URL4_RUNNER_CONFIG"
-"""Path to the declared world (:mod:`url4_cloud.runner.config`). Baked into the image; the App
+"""Path to the declared world (:mod:`url4_cloud.world_config`). Baked into the image; the App
 never writes it."""
 
 DEFAULT_NATS_URL = "nats://localhost:4222"

--- a/apps/url4-cloud/src/url4_cloud/job_env.py
+++ b/apps/url4-cloud/src/url4_cloud/job_env.py
@@ -203,7 +203,8 @@ holding — re-adding a per-run secret must go through it rather than around it.
 """
 
 REQUIRED = frozenset({TOPIC, EXPRESSION})
-"""Absent ⇒ run mode raises ``RunnerConfigError`` at boot. Every adapter must write these."""
+"""Absent ⇒ run mode raises ``runner.main.RunnerConfigError`` at boot (the PER-RUN env error; a
+bad declared world is ``world_config.WorldConfigError``). Every adapter must write these."""
 
 WRITTEN_BY_APP = frozenset(
     {

--- a/apps/url4-cloud/src/url4_cloud/local.py
+++ b/apps/url4-cloud/src/url4_cloud/local.py
@@ -34,7 +34,7 @@ from url4_cloud.adapters.inprocess import InProcessJobRunner
 from url4_cloud.adapters.memory import InMemoryEventStream
 from url4_cloud.app import create_app
 from url4_cloud.benchmarks import EMPTY_BENCHMARKS, BenchmarkRegistry
-from url4_cloud.catalog import build_catalog_service
+from url4_cloud.catalog import build_executable_catalog_service
 from url4_cloud.config import INSECURE_DEFAULT_JWT_SECRET, Settings
 from url4_cloud.connections import build_connections
 
@@ -75,7 +75,7 @@ def _with_runner_config(env: Mapping[str, str]) -> Mapping[str, str]:
     Deliberately narrow: an explicit ``URL4_RUNNER_CONFIG`` always wins, and so does a real
     ``/etc/url4/url4.toml`` — this only fills a gap that exists nowhere but a source checkout.
     """
-    from url4_cloud.runner.config import DEFAULT_CONFIG_PATH
+    from url4_cloud.world_config import DEFAULT_CONFIG_PATH
 
     if job_env.RUNNER_CONFIG in env or Path(DEFAULT_CONFIG_PATH).is_file():
         return env
@@ -112,14 +112,15 @@ def create_local_app(
     # import (see the SCOPE NOTE in `check_layering.py`).
     from url4_cloud.runner.main import build_executor
 
+    run_env = _with_runner_config(env if env is not None else os.environ)
     job_runner = InProcessJobRunner(
         stream,
         partial(build_executor, benchmarks=benchmarks),
-        base_env=_with_runner_config(env if env is not None else os.environ),
+        base_env=run_env,
         max_concurrent_runs=settings.local_max_concurrent_runs,
         max_history=settings.local_max_run_history,
     )
-    catalog = build_catalog_service(settings)
+    catalog = build_executable_catalog_service(settings, run_env)
     connection_settings = settings
     if connection_settings.aigateway_base_url is None:
         connection_settings = connection_settings.model_copy(

--- a/apps/url4-cloud/src/url4_cloud/rest/catalog.py
+++ b/apps/url4-cloud/src/url4_cloud/rest/catalog.py
@@ -3,8 +3,7 @@
 FEATURE: model-catalog discovery.
 
 STORY: as a client about to compose a url4 expression, I ask url4-cloud which models I can address
-— and get back exactly what aigateway would have told me directly, without url4-cloud holding a
-credential of its own.
+and receive the caller-visible AI Gateway models installed in this Engine's declared world.
 
 Owns request-side concerns only (credential resolution, conditional-request/ETag handling, mapping
 ``CatalogError`` to RFC 9457 problems); the actual upstream fetch and per-credential caching live
@@ -87,13 +86,15 @@ _MODEL_PARAMETER_RESPONSES: dict[int | str, dict[str, object]] = {
     summary="List the models this caller can address",
     responses=_MODELS_RESPONSES,
     description=(
-        "Proxy aigateway's model listing for the caller's own identity, from a per-caller cache."
+        "List the caller-visible aigateway models installed as routes on this Engine, from a "
+        "per-caller cache."
         "\n\n"
         "The caller is the verified ``X-User-Email`` the mesh gateway injects, matching "
         "``GET /?q=``. url4-cloud verifies nothing and holds no credential of its own — aigateway "
         "decides, and refuses the request itself when its mode requires an identity that is "
         "absent. Locally, where aigateway runs with auth disabled, no identity is needed.\n\n"
-        "The body is aigateway's, verbatim. Responses are cached per caller, so "
+        "Retained model documents are aigateway's verbatim; models outside this Engine's "
+        "declared execution world are omitted. Responses are cached per caller, so "
         "``Cache-Control`` is ``private`` and ``ETag``/``If-None-Match`` are scoped to that "
         "caller's catalog."
     ),
@@ -107,13 +108,13 @@ async def list_models(
         str | None, Header(alias="If-None-Match", description="Conditional-request validator.")
     ] = None,
 ) -> Response:
-    """Proxy aigateway's model listing for the caller's own identity, from a per-caller cache.
+    """List caller-visible AI Gateway models installed in this Engine's execution world.
 
     The caller is the verified ``X-User-Email`` the mesh gateway injects, matching ``GET /?q=``.
     url4-cloud verifies nothing and holds no credential of its own — aigateway does.
 
-    The body is aigateway's, verbatim. Responses are cached per caller, so ``Cache-Control`` is
-    ``private`` and ``ETag``/``If-None-Match`` are scoped to that caller's catalog.
+    Retained documents are passed through unchanged. Responses are cached per caller, so
+    ``Cache-Control`` is ``private`` and ``ETag``/``If-None-Match`` are scoped to that caller.
     """
     service = _require_service(request)
     credential = _caller(x_profile, request.headers)

--- a/apps/url4-cloud/src/url4_cloud/rest/catalog.py
+++ b/apps/url4-cloud/src/url4_cloud/rest/catalog.py
@@ -9,9 +9,14 @@ Owns request-side concerns only (credential resolution, conditional-request/ETag
 ``CatalogError`` to RFC 9457 problems); the actual upstream fetch and per-credential caching live
 in ``url4_cloud.catalog.cache.CatalogService``.
 
-``GET /v1/models`` is the cached summary. ``GET /v1/model-parameters`` is an uncached,
-profile-bound detail proxy. Every response is private and varies by the identity inputs that can
+``GET /v1/models`` is the cached summary. ``GET /v1/model-parameters`` is the uncached,
+profile-bound detail. Every response is private and varies by the identity inputs that can
 change it.
+
+BOTH surfaces are bounded by the same declared execution world (``url4_cloud.world_config``):
+the summary omits models this Engine has not declared, and the detail refuses them with 404
+before any upstream request. Neither reshapes what it does return. When the declared world is
+unusable the composition root wires no service at all, and both answer 503.
 """
 
 from __future__ import annotations
@@ -72,10 +77,15 @@ _MODEL_PARAMETER_RESPONSES: dict[int | str, dict[str, object]] = {
     400: {"description": "The canonical model id is invalid."},
     401: {"description": "The selected profile requires authentication."},
     403: {"description": "The caller cannot access the selected profile."},
-    404: {"description": "The model or profile does not exist."},
+    404: {
+        "description": (
+            "The model is not installed on this Engine, or AI Gateway does not know the "
+            "model or profile."
+        )
+    },
     409: {"description": "The selected profile is not ready."},
     502: {"description": "AI Gateway returned an unusable contract."},
-    503: {"description": "AI Gateway is not configured."},
+    503: {"description": "AI Gateway is not configured, or the declared world is unusable."},
     504: {"description": "AI Gateway did not respond in time."},
 }
 
@@ -149,8 +159,11 @@ async def list_models(
     responses=_MODEL_PARAMETER_RESPONSES,
     openapi_extra=_MODEL_PARAMETER_OPENAPI,
     description=(
-        "Proxy AI Gateway's profile-bound parameter contract for one canonical model. "
-        "The body is AI Gateway's, verbatim, and is never cached by URL4 Cloud."
+        "Return AI Gateway's profile-bound parameter contract for one canonical model. "
+        "The body is AI Gateway's, verbatim, and is never cached by URL4 Cloud.\n\n"
+        "Bounded by the same declared execution world as ``GET /v1/models``: a model this "
+        "Engine has not declared answers 404 without contacting AI Gateway, so this surface "
+        "and the listing can never describe different execution capabilities."
     ),
 )
 async def model_parameters(

--- a/apps/url4-cloud/src/url4_cloud/runner/__init__.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/__init__.py
@@ -6,8 +6,13 @@ the App's own image with that command). It reads its whole world from the Job's 
 
 LAYERING: this subpackage and the control plane (`app`, `rest`, `ws`, `auth`, `catalog`,
 `config`, `metrics`, `ops`, `schemas`, `adapters.k8s`, `adapters.factory`) MUST NOT import each
-other. They share exactly three leaves — :mod:`url4_cloud.job_env`, :mod:`url4_cloud.subjects`
-and :mod:`url4_cloud.adapters.jetstream` — and `.claude/scripts/check_layering.py` proves it.
+other. They share exactly four leaves — :mod:`url4_cloud.job_env`, :mod:`url4_cloud.subjects`,
+:mod:`url4_cloud.adapters.jetstream` and :mod:`url4_cloud.world_config` — and
+`.claude/scripts/check_layering.py` proves it.
+
+WHY `world_config` is shared (OME-625): discovery must answer for the SAME declared world the
+run mode executes. A second, partial reader of `url4.toml` on the control-plane side would let
+the two disagree — which is the bug that made the Engine advertise a model it could not run.
 
 WHY the rule outlived the package split it was born in: the two modes ship in one image and one
 venv now, so nothing at runtime stops the run path from importing FastAPI or the kubernetes

--- a/apps/url4-cloud/src/url4_cloud/runner/connector.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/connector.py
@@ -25,7 +25,7 @@ from url4_cloud.retrieval_policy import (
 )
 from url4_cloud.runner.cache import policy_to_body_field
 from url4_cloud.runner.cache_readback import CacheOutcome, read_cache_outcome, requires_revalidation
-from url4_cloud.runner.config import ModelSpec, RunnerConfigError, routes_for
+from url4_cloud.world_config import ModelSpec, WorldConfigError, routes_for
 
 _COMPLETIONS_PATH = "/v1/chat/completions"
 
@@ -212,16 +212,16 @@ async def build_aigateway_world(
     gateway's own default — so this half never has to re-decide what silence means.
 
     Raises:
-        RunnerConfigError: no models are declared, or `default_model` is not among them.
+        WorldConfigError: no models are declared, or `default_model` is not among them.
     """
     if not cfg.models:
-        raise RunnerConfigError(
+        raise WorldConfigError(
             "aigateway declares no models — the runner's endpoints are declared in url4.toml, "
             "not discovered from the gateway catalog"
         )
     declared_ids = [model.id for model in cfg.models]
     if cfg.default_model not in declared_ids:
-        raise RunnerConfigError(
+        raise WorldConfigError(
             f"default_model {cfg.default_model!r} is not a declared model {declared_ids!r}"
         )
 

--- a/apps/url4-cloud/src/url4_cloud/runner/main.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/main.py
@@ -19,9 +19,13 @@ from url4_cloud import job_env
 from url4_cloud.adapters.jetstream import JetStreamPublisher
 from url4_cloud.benchmarks import EMPTY_BENCHMARKS, BenchmarkRegistry, assets_root
 from url4_cloud.benchmarks.candidate import install_candidate_invocation
-from url4_cloud.runner.config import RunnerConfig, RunnerConfigError, load_config
 from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
 from url4_cloud.runner.executor import Url4Executor, World, deny_by_default_world
+from url4_cloud.world_config import WorldConfig, WorldConfigError, load_config
+
+
+class RunnerConfigError(ValueError):
+    """The per-run Job environment is missing or malformed."""
 
 
 @dataclass(frozen=True)
@@ -56,7 +60,7 @@ def _deadline_from_env(environ: Mapping[str, str]) -> float | None:
 
 
 def params_from_env(environ: Mapping[str, str]) -> RunnerParams:
-    """Read the required per-run env vars, turning a missing one into ``RunnerConfigError``."""
+    """Read required per-run env vars, turning a missing one into ``RunnerConfigError``."""
     try:
         topic = environ[job_env.TOPIC]
         url4 = environ[job_env.EXPRESSION]
@@ -72,7 +76,7 @@ def params_from_env(environ: Mapping[str, str]) -> RunnerParams:
 
 def build_executor(
     env: Mapping[str, str],
-    config: RunnerConfig | None = None,
+    config: WorldConfig | None = None,
     *,
     client: httpx.AsyncClient | None = None,
     tavily_client: httpx.AsyncClient | None = None,
@@ -101,7 +105,7 @@ def build_executor(
         section = resolved.aigateway
         if section is None:
             if len(benchmarks):
-                raise RunnerConfigError(
+                raise WorldConfigError(
                     "installed Benchmarks require a declared aigateway model world"
                 )
             # WHY: a world with no [aigateway] table is a legitimate empty world; the node itself

--- a/apps/url4-cloud/src/url4_cloud/world_config.py
+++ b/apps/url4-cloud/src/url4_cloud/world_config.py
@@ -1,4 +1,7 @@
-"""The run mode's declared world — `url4.toml`, read once at startup.
+"""The Engine's declared world — ``url4.toml``, read once at startup.
+
+Both the control plane and Runner consume this module. Discovery must project onto the exact
+configuration the Runner executes; a second partial TOML reader would let the two disagree.
 
 Endpoints are DECLARED, never discovered. A route path is exactly
 ``"/" + gateway_id``: no renaming and no synthesized aliases. Gateway ids are unique by
@@ -15,14 +18,14 @@ The file format mirrors ``url4 serve``'s (``url4.cli._serve``). ``[data]``, ``[c
 ``[holdings]`` and ``[identities]`` are reserved here but not parsed yet — declaring one is a
 loud error rather than a silent no-op, so a config that looks like it works actually does.
 
-# AIDEV-NOTE: this loader deliberately duplicates ~120 lines of `_serve.py`'s tested parsing
-# rather than depending on it — `_serve` is a private CLI module in `packages/url4`, and the
-# Runner is the only other consumer today. Extract a shared public module when a THIRD
-# consumer appears; until then the duplication is cheaper than the coupling.
+# AIDEV-NOTE: this loader deliberately duplicates `_serve.py`'s tested parsing rather than
+# depending on it — `_serve` is a private CLI module in another package. Within URL4 Cloud this
+# module is the single authority shared by the App and Runner.
 """
 
 from __future__ import annotations
 
+import re
 import tomllib
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
@@ -31,6 +34,7 @@ from pathlib import Path
 from url4_cloud import job_env
 
 DEFAULT_CONFIG_PATH = "/etc/url4/url4.toml"
+
 """Where the declared world lives unless :data:`job_env.RUNNER_CONFIG` overrides it. Image-level
 wiring: the App never writes that variable — the file is baked into the image."""
 
@@ -38,9 +42,10 @@ _AIGATEWAY_KEYS = frozenset({"base_url", "default_route", "models", "allow_outbo
 _MODEL_KEYS = frozenset({"id", "web_tools"})
 _RESERVED_TABLES = frozenset({"data", "commands", "holdings", "identities"})
 _TOP_LEVEL_KEYS = frozenset({"aigateway"})
+_MODEL_ID_RE = re.compile(r"[A-Za-z0-9\-_.~]+(?:/[A-Za-z0-9\-_.~]+)*", re.ASCII)
 
 
-class RunnerConfigError(ValueError):
+class WorldConfigError(ValueError):
     """The Runner's configuration is unusable — raised at startup, before any run."""
 
 
@@ -76,7 +81,7 @@ class AigatewaySection:
 
 
 @dataclass(frozen=True, slots=True)
-class RunnerConfig:
+class WorldConfig:
     """The whole declared world. ``aigateway is None`` is a legitimate tokenless world."""
 
     aigateway: AigatewaySection | None = None
@@ -93,39 +98,48 @@ def routes_for(models: Sequence[ModelSpec]) -> dict[str, ModelSpec]:
     return {"/" + model.id: model for model in models}
 
 
-def load_config(env: Mapping[str, str]) -> RunnerConfig:
+def declared_model_ids(env: Mapping[str, str]) -> frozenset[str]:
+    """Return the model ids from the same fully validated world the Runner consumes."""
+
+    section = load_config(env).aigateway
+    if section is None:
+        return frozenset()
+    return frozenset(model.id for model in section.models)
+
+
+def load_config(env: Mapping[str, str]) -> WorldConfig:
     """Read and validate the declared world from ``env``'s config path."""
     path = Path(env.get(job_env.RUNNER_CONFIG, DEFAULT_CONFIG_PATH))
     try:
         with path.open("rb") as handle:
             raw = tomllib.load(handle)
     except (OSError, tomllib.TOMLDecodeError) as exc:
-        raise RunnerConfigError(f"cannot read runner config {str(path)!r}: {exc}") from exc
+        raise WorldConfigError(f"cannot read world config {str(path)!r}: {exc}") from exc
     return parse_config(raw, env)
 
 
-def parse_config(raw: Mapping[str, object], env: Mapping[str, str]) -> RunnerConfig:
-    """Validate a parsed TOML mapping into a :class:`RunnerConfig`. Fail-fast."""
+def parse_config(raw: Mapping[str, object], env: Mapping[str, str]) -> WorldConfig:
+    """Validate a parsed TOML mapping into a :class:`WorldConfig`. Fail-fast."""
     _reject_unsupported_tables(raw)
     table = raw.get("aigateway")
     if table is None:
-        return RunnerConfig()
+        return WorldConfig()
     if not isinstance(table, Mapping):
-        raise RunnerConfigError(f"[aigateway] must be a table, got {table!r}")
-    return RunnerConfig(aigateway=_parse_aigateway(table, env))
+        raise WorldConfigError(f"[aigateway] must be a table, got {table!r}")
+    return WorldConfig(aigateway=_parse_aigateway(table, env))
 
 
 def _reject_unsupported_tables(raw: Mapping[str, object]) -> None:
     declared = set(map(str, raw))
     reserved = sorted(declared & _RESERVED_TABLES)
     if reserved:
-        raise RunnerConfigError(
-            f"{reserved} is reserved in the runner config format but not supported yet — "
+        raise WorldConfigError(
+            f"{reserved} is reserved in the world config format but not supported yet — "
             "remove it, or land the endpoint kind that reads it"
         )
     unknown = sorted(declared - _TOP_LEVEL_KEYS - _RESERVED_TABLES)
     if unknown:
-        raise RunnerConfigError(
+        raise WorldConfigError(
             f"unknown top-level table(s) {unknown} (expected {sorted(_TOP_LEVEL_KEYS)})"
         )
 
@@ -133,7 +147,7 @@ def _reject_unsupported_tables(raw: Mapping[str, object]) -> None:
 def _parse_aigateway(table: Mapping[str, object], env: Mapping[str, str]) -> AigatewaySection:
     unknown = sorted(set(map(str, table)) - _AIGATEWAY_KEYS)
     if unknown:
-        raise RunnerConfigError(
+        raise WorldConfigError(
             f"[aigateway] has unknown key(s) {unknown} (expected {sorted(_AIGATEWAY_KEYS)})"
         )
     models = _models(table.get("models"))
@@ -164,7 +178,7 @@ def _apply_env(section: AigatewaySection, env: Mapping[str, str]) -> AigatewaySe
 def _require_declared(default_model: str, models: tuple[ModelSpec, ...]) -> None:
     ids = [model.id for model in models]
     if default_model not in ids:
-        raise RunnerConfigError(
+        raise WorldConfigError(
             f"default_route {'/' + default_model!r} is not a declared model — "
             f"declared: {sorted(ids)}"
         )
@@ -172,15 +186,15 @@ def _require_declared(default_model: str, models: tuple[ModelSpec, ...]) -> None
 
 def _models(value: object) -> tuple[ModelSpec, ...]:
     if not isinstance(value, list):
-        raise RunnerConfigError(f"[aigateway] models must be a list, got {value!r}")
+        raise WorldConfigError(f"[aigateway] models must be a list, got {value!r}")
     if not value:
-        raise RunnerConfigError("[aigateway] must declare at least one model")
+        raise WorldConfigError("[aigateway] must declare at least one model")
     models: list[ModelSpec] = []
     seen: set[str] = set()
     for entry in value:
         spec = _model_spec(entry)
         if spec.id in seen:
-            raise RunnerConfigError(f"[aigateway] declares duplicate model id {spec.id!r}")
+            raise WorldConfigError(f"[aigateway] declares duplicate model id {spec.id!r}")
         seen.add(spec.id)
         models.append(spec)
     return tuple(models)
@@ -197,7 +211,7 @@ def _model_spec(entry: object) -> ModelSpec:
         return _model_table(entry)
     if isinstance(entry, str):
         return ModelSpec(id=_model_id(entry))
-    raise RunnerConfigError(
+    raise WorldConfigError(
         f"[aigateway] model entry must be a table or an id string, got {entry!r}"
     )
 
@@ -205,15 +219,15 @@ def _model_spec(entry: object) -> ModelSpec:
 def _model_table(table: Mapping[str, object]) -> ModelSpec:
     unknown = sorted(set(map(str, table)) - _MODEL_KEYS)
     if unknown:
-        raise RunnerConfigError(
+        raise WorldConfigError(
             f"[[aigateway.models]] has unknown key(s) {unknown} (expected {sorted(_MODEL_KEYS)})"
         )
     raw_id = table.get("id")
     if raw_id is None:
-        raise RunnerConfigError("[[aigateway.models]] entry is missing its `id`")
+        raise WorldConfigError("[[aigateway.models]] entry is missing its `id`")
     web_tools = table.get("web_tools", False)
     if not isinstance(web_tools, bool):
-        raise RunnerConfigError(
+        raise WorldConfigError(
             f"[[aigateway.models]] web_tools must be a boolean, got {web_tools!r}"
         )
     return ModelSpec(id=_model_id(str(raw_id)), web_tools=web_tools)
@@ -221,10 +235,15 @@ def _model_table(table: Mapping[str, object]) -> ModelSpec:
 
 def _model_id(model: str) -> str:
     if not model:
-        raise RunnerConfigError("[aigateway] declares an empty model id")
+        raise WorldConfigError("[aigateway] declares an empty model id")
     if model.startswith("/"):
-        raise RunnerConfigError(
+        raise WorldConfigError(
             f"model id {model!r} must not start with '/' — the route path is derived as '/' + id"
+        )
+    if _MODEL_ID_RE.fullmatch(model) is None:
+        raise WorldConfigError(
+            f"model id {model!r} is not a valid URL4 expression path — each segment may contain "
+            "only ASCII letters, digits, '-', '_', '.', or '~'"
         )
     return model
 
@@ -244,7 +263,7 @@ def _bool(table: Mapping[str, object], key: str, *, default: bool) -> bool:
     if value is None:
         return default
     if not isinstance(value, bool):
-        raise RunnerConfigError(f"[aigateway] {key} must be a boolean, got {value!r}")
+        raise WorldConfigError(f"[aigateway] {key} must be a boolean, got {value!r}")
     return value
 
 
@@ -255,14 +274,15 @@ def _float(table: Mapping[str, object], key: str, default: float) -> float:
     try:
         return float(value)  # type: ignore[arg-type]
     except (TypeError, ValueError):
-        raise RunnerConfigError(f"[aigateway] {key} must be a number, got {value!r}") from None
+        raise WorldConfigError(f"[aigateway] {key} must be a number, got {value!r}") from None
 
 
 __all__ = [
     "DEFAULT_CONFIG_PATH",
     "AigatewaySection",
-    "RunnerConfig",
-    "RunnerConfigError",
+    "WorldConfig",
+    "WorldConfigError",
+    "declared_model_ids",
     "load_config",
     "parse_config",
     "routes_for",

--- a/apps/url4-cloud/src/url4_cloud/world_config.py
+++ b/apps/url4-cloud/src/url4_cloud/world_config.py
@@ -14,7 +14,10 @@ OpenRouter) and ``openrouter/anthropic/claude-opus-4.8`` into ``/anthropic/claud
 Aliases were also collision-dependent, so adding a model elsewhere in the catalog could
 silently REMOVE an alias an expression depended on.
 
-The file format mirrors ``url4 serve``'s (``url4.cli._serve``). ``[data]``, ``[commands]``,
+The file format mirrors ``url4 serve``'s (``url4.cli._serve``), one way stricter: a model id here
+must also be renderable as a URL4 expression path (see ``_MODEL_ID_RE``).
+
+``[data]``, ``[commands]``,
 ``[holdings]`` and ``[identities]`` are reserved here but not parsed yet — declaring one is a
 loud error rather than a silent no-op, so a config that looks like it works actually does.
 

--- a/apps/url4-cloud/tests/unit/test_aigateway_connector.py
+++ b/apps/url4-cloud/tests/unit/test_aigateway_connector.py
@@ -9,8 +9,8 @@ import pytest
 from url4.core.errors import ResolutionError
 from url4.dag import run as url4_run
 from url4.observe import ObservationEvent, Usage
-from url4_cloud.runner.config import ModelSpec, RunnerConfigError
 from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+from url4_cloud.world_config import ModelSpec, WorldConfigError
 
 pytestmark = pytest.mark.asyncio
 
@@ -368,7 +368,7 @@ async def test_default_model_must_be_one_of_the_declared_models() -> None:
         default_model="anthropic/claude-haiku-4-5", models=(ModelSpec(id="openrouter/gpt-4o"),)
     )
     async with gw.client() as client:
-        with pytest.raises(RunnerConfigError, match="anthropic/claude-haiku-4-5"):
+        with pytest.raises(WorldConfigError, match="anthropic/claude-haiku-4-5"):
             await build_aigateway_world(cfg, client=client)
 
 
@@ -416,7 +416,7 @@ async def test_a_bad_default_model_is_rejected_before_any_client_is_created() ->
 
     with (
         mock.patch.object(httpx.AsyncClient, "__init__", _spy_init),
-        pytest.raises(RunnerConfigError, match="not/in-catalog"),
+        pytest.raises(WorldConfigError, match="not/in-catalog"),
     ):
         await build_aigateway_world(cfg)
 
@@ -424,7 +424,7 @@ async def test_a_bad_default_model_is_rejected_before_any_client_is_created() ->
 
 
 async def test_declaring_no_models_is_a_config_error() -> None:
-    with pytest.raises(RunnerConfigError, match="declares no models"):
+    with pytest.raises(WorldConfigError, match="declares no models"):
         await build_aigateway_world(AigatewayConfig(models=()))
 
 

--- a/apps/url4-cloud/tests/unit/test_aigateway_connector_redirect.py
+++ b/apps/url4-cloud/tests/unit/test_aigateway_connector_redirect.py
@@ -10,8 +10,8 @@ import pytest
 
 from url4.core.errors import ResolutionError
 from url4.dag import run as url4_run
-from url4_cloud.runner.config import ModelSpec
 from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+from url4_cloud.world_config import ModelSpec
 
 _TOKEN = "tok"  # noqa: S105 - not a real credential
 _MODEL = "claude-haiku-4-5"

--- a/apps/url4-cloud/tests/unit/test_benchmark_foundation.py
+++ b/apps/url4-cloud/tests/unit/test_benchmark_foundation.py
@@ -36,10 +36,10 @@ from url4_cloud.model_outcomes import (
     capture_model_outcomes,
     record_model_outcome,
 )
-from url4_cloud.runner.config import AigatewaySection, ModelSpec, RunnerConfig
 from url4_cloud.runner.connector import AigatewayConfig, _is_blocked, build_aigateway_world
 from url4_cloud.runner.main import build_executor
 from url4_cloud.testing import InMemoryEventStream
+from url4_cloud.world_config import AigatewaySection, ModelSpec, WorldConfig
 
 pytestmark = pytest.mark.asyncio
 
@@ -753,7 +753,7 @@ async def test_runner_composition_installs_benchmarks_with_the_injected_asset_ro
         transport=httpx.MockTransport(_response(requests)),
         base_url="http://aigateway.test",
     )
-    config = RunnerConfig(
+    config = WorldConfig(
         aigateway=AigatewaySection(
             base_url="http://aigateway.test",
             default_model="provider/model",

--- a/apps/url4-cloud/tests/unit/test_cache_policy_threading.py
+++ b/apps/url4-cloud/tests/unit/test_cache_policy_threading.py
@@ -48,10 +48,10 @@ from url4_cloud.app import create_app
 from url4_cloud.auth import JwtCodec
 from url4_cloud.config import Settings
 from url4_cloud.runner.cache import policy_to_body_field
-from url4_cloud.runner.config import AigatewaySection, ModelSpec, RunnerConfig
 from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
 from url4_cloud.runner.main import build_executor
 from url4_cloud.testing import InMemoryEventStream
+from url4_cloud.world_config import AigatewaySection, ModelSpec, WorldConfig
 
 SECRET = "cache-threading-secret"
 WINDOW_S = 60
@@ -318,8 +318,8 @@ async def test_a_run_declaring_nothing_reaches_the_job_runner_already_resolved()
 # --- the run mode: the env reaches the connector ------------------------------------------------
 
 
-def _declared() -> RunnerConfig:
-    return RunnerConfig(
+def _declared() -> WorldConfig:
+    return WorldConfig(
         aigateway=AigatewaySection(
             base_url="http://aigateway.test",
             default_model=MODEL,

--- a/apps/url4-cloud/tests/unit/test_cache_readback.py
+++ b/apps/url4-cloud/tests/unit/test_cache_readback.py
@@ -53,9 +53,9 @@ from url4_cloud.runner.cache_readback import (
     read_cache_outcome,
     requires_revalidation,
 )
-from url4_cloud.runner.config import ModelSpec
 from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
 from url4_cloud.runner.executor import _RunState
+from url4_cloud.world_config import ModelSpec
 
 _MODEL = "anthropic/claude-haiku-4-5"
 

--- a/apps/url4-cloud/tests/unit/test_cache_run_counters.py
+++ b/apps/url4-cloud/tests/unit/test_cache_run_counters.py
@@ -41,9 +41,9 @@ from url4_cloud.runner.cache_counters import (
     UNSTATED_REASON,
     RunCacheCounters,
 )
-from url4_cloud.runner.config import ModelSpec
 from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
 from url4_cloud.runner.executor import Url4Executor, _RunState
+from url4_cloud.world_config import ModelSpec
 
 _MODEL = "anthropic/claude-haiku-4-5"
 

--- a/apps/url4-cloud/tests/unit/test_executable_model_catalog.py
+++ b/apps/url4-cloud/tests/unit/test_executable_model_catalog.py
@@ -8,6 +8,7 @@ at render time that the route is absent or cannot be expressed as URL4.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import httpx
@@ -27,7 +28,7 @@ from url4_cloud.catalog.port import (
 )
 from url4_cloud.config import Settings
 from url4_cloud.testing import InMemoryEventStream
-from url4_cloud.world_config import WorldConfigError
+from url4_cloud.world_config import WorldConfigError, declared_model_ids
 
 pytestmark = pytest.mark.asyncio
 
@@ -193,12 +194,39 @@ async def test_unconfigured_builder_stays_unconfigured() -> None:
     assert service is None
 
 
-async def test_configured_builder_fails_when_declared_routes_cannot_be_read() -> None:
-    with pytest.raises(WorldConfigError, match="cannot read world config"):
-        build_executable_catalog_service(
+async def test_unreadable_declared_world_disables_discovery_without_killing_the_app(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.ERROR, logger="url4_cloud.catalog"):
+        service = build_executable_catalog_service(
             Settings(aigateway_base_url="http://aigateway.test"),
             {job_env.RUNNER_CONFIG: "/missing/url4.toml"},
         )
+
+    # Scoped, not fatal: the App composes, and only the catalog routes report unavailable. The
+    # Runner still refuses the same world at Job start, where a bad route changes what runs.
+    assert service is None
+    assert "declared world is unusable" in caplog.text
+
+
+async def test_unusable_declared_world_serves_503_and_leaves_the_app_running() -> None:
+    app = create_app(
+        Settings(jwt_secret="executable-catalog-secret"),
+        stream=InMemoryEventStream(),
+        catalog=build_executable_catalog_service(
+            Settings(aigateway_base_url="http://aigateway.test"),
+            {job_env.RUNNER_CONFIG: "/missing/url4.toml"},
+        ),
+    )
+
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://engine.test"
+    ) as client:
+        models = await client.get("/v1/models")
+        health = await client.get("/healthz")
+
+    assert models.status_code == 503
+    assert health.status_code == 200
 
 
 async def test_configured_builder_accepts_the_valid_empty_engine_world(tmp_path: Path) -> None:
@@ -225,7 +253,7 @@ async def test_configured_builder_accepts_the_valid_empty_engine_world(tmp_path:
     await service.aclose()
 
 
-async def test_configured_builder_rejects_a_runner_invalid_model_capability(
+async def test_runner_invalid_model_capability_disables_discovery_and_still_fails_the_runner(
     tmp_path: Path,
 ) -> None:
     config = tmp_path / "url4.toml"
@@ -233,12 +261,18 @@ async def test_configured_builder_rejects_a_runner_invalid_model_capability(
         '[aigateway]\ndefault_route = "model"\n'
         '[[aigateway.models]]\nid = "model"\nweb_tools = "yes"\n'
     )
+    env = {job_env.RUNNER_CONFIG: str(config)}
 
+    service = build_executable_catalog_service(
+        Settings(aigateway_base_url="http://aigateway.test"),
+        env,
+    )
+
+    # One world, two consequences: discovery advertises nothing rather than something it cannot
+    # execute, and the Runner — the authority on what a run may address — still refuses outright.
+    assert service is None
     with pytest.raises(WorldConfigError, match="web_tools must be a boolean"):
-        build_executable_catalog_service(
-            Settings(aigateway_base_url="http://aigateway.test"),
-            {job_env.RUNNER_CONFIG: str(config)},
-        )
+        declared_model_ids(env)
 
 
 async def test_malformed_gateway_catalog_cannot_bypass_the_projection() -> None:
@@ -248,16 +282,27 @@ async def test_malformed_gateway_catalog_cannot_bypass_the_projection() -> None:
         await catalog.fetch(Credential.derive())
 
 
-async def test_malformed_gateway_model_cannot_bypass_the_projection() -> None:
+async def test_malformed_gateway_model_is_omitted_without_failing_the_catalog() -> None:
     class _MalformedGatewayModel(_GatewayCatalog):
         async def fetch(self, credential: Credential) -> ModelCatalog:
-            body: dict[str, object] = {"object": "list", "data": [{"object": "model"}]}
+            body: dict[str, object] = {
+                "object": "list",
+                "data": [
+                    {"object": "model"},
+                    {"id": 7},
+                    "not-a-mapping",
+                    {"id": _DECLARED, "object": "model"},
+                ],
+            }
             return ModelCatalog(body=body, etag=compute_etag(body))
 
     catalog = ExecutableCatalog(_MalformedGatewayModel(), frozenset({_DECLARED}))
 
-    with pytest.raises(CatalogBadResponse, match="missing a string id"):
-        await catalog.fetch(Credential.derive())
+    result = await catalog.fetch(Credential.derive())
+
+    # An entry that cannot state a declared id cannot BE one — it is dropped, and one odd
+    # upstream document never denies every caller the models that are executable.
+    assert result.body["data"] == [{"id": _DECLARED, "object": "model"}]
 
 
 async def test_undeclared_model_details_fail_without_contacting_gateway() -> None:

--- a/apps/url4-cloud/tests/unit/test_executable_model_catalog.py
+++ b/apps/url4-cloud/tests/unit/test_executable_model_catalog.py
@@ -1,0 +1,285 @@
+"""The Engine advertises only Gateway models its declared world can execute.
+
+FEATURE: OME-625 — model discovery is an Engine capability contract, not a raw copy of every
+route AI Gateway could serve directly.
+STORY: an SDK user can select any id returned by Engine ``GET /v1/models`` without discovering
+at render time that the route is absent or cannot be expressed as URL4.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+from httpx import ASGITransport
+
+from url4_cloud import job_env
+from url4_cloud.app import create_app
+from url4_cloud.catalog import build_executable_catalog_service
+from url4_cloud.catalog.executable import ExecutableCatalog, ExecutableModelParameterSource
+from url4_cloud.catalog.port import (
+    CatalogBadResponse,
+    Credential,
+    ModelCatalog,
+    ModelParameterResponse,
+    compute_etag,
+)
+from url4_cloud.config import Settings
+from url4_cloud.testing import InMemoryEventStream
+from url4_cloud.world_config import WorldConfigError
+
+pytestmark = pytest.mark.asyncio
+
+_DECLARED = "openrouter/openai/gpt-5.5"
+_GATEWAY_ONLY = "huggingface/google/gemma-2-2b-it:featherless-ai"
+
+
+class _GatewayCatalog:
+    counters = None
+    entry_count = 0
+    model_parameter_source = None
+
+    async def fetch(self, credential: Credential) -> ModelCatalog:
+        body: dict[str, object] = {
+            "object": "list",
+            "gateway_extension": {"kept": True},
+            "data": [
+                {"id": _DECLARED, "object": "model", "future_field": 7},
+                {"id": _GATEWAY_ONLY, "object": "model"},
+            ],
+        }
+        return ModelCatalog(body=body, etag=compute_etag(body))
+
+    def max_age_s(self, credential: Credential) -> int:
+        return 60
+
+    async def aclose(self) -> None:
+        pass
+
+
+class _MalformedGatewayCatalog(_GatewayCatalog):
+    async def fetch(self, credential: Credential) -> ModelCatalog:
+        body: dict[str, object] = {"object": "list", "data": "not-a-list"}
+        return ModelCatalog(body=body, etag=compute_etag(body))
+
+
+class _GatewayDetails:
+    def __init__(self) -> None:
+        self.seen: list[str] = []
+
+    async def fetch_model_parameters(
+        self,
+        credential: Credential,
+        model: str,
+    ) -> ModelParameterResponse:
+        self.seen.append(model)
+        content = f'{{"model":{{"id":"{model}"}}}}'.encode()
+        return ModelParameterResponse(status=200, content=content)
+
+    async def aclose(self) -> None:
+        pass
+
+
+def _app(details: _GatewayDetails | None = None):
+    return create_app(
+        Settings(jwt_secret="executable-catalog-secret"),
+        stream=InMemoryEventStream(),
+        catalog=ExecutableCatalog(_GatewayCatalog(), frozenset({_DECLARED})),
+        model_parameters=(
+            ExecutableModelParameterSource(details, frozenset({_DECLARED}))
+            if details is not None
+            else None
+        ),
+    )
+
+
+async def test_catalog_contains_only_declared_executable_models_without_reshaping_them() -> None:
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=_app()), base_url="http://test"
+    ) as client:
+        response = await client.get("/v1/models")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "object": "list",
+        "gateway_extension": {"kept": True},
+        "data": [{"id": _DECLARED, "object": "model", "future_field": 7}],
+    }
+    assert response.headers["ETag"] == f'"{compute_etag(response.json())}"'
+
+
+async def test_empty_executable_intersection_is_a_valid_catalog() -> None:
+    catalog = ExecutableCatalog(_GatewayCatalog(), frozenset())
+
+    result = await catalog.fetch(Credential.derive())
+
+    assert result.body == {
+        "object": "list",
+        "gateway_extension": {"kept": True},
+        "data": [],
+    }
+    assert result.etag == compute_etag(result.body)
+
+
+async def test_production_builder_wraps_the_gateway_source_with_the_declared_routes(
+    tmp_path: Path,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/models"
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [
+                    {"id": _DECLARED, "object": "model"},
+                    {"id": _GATEWAY_ONLY, "object": "model"},
+                ],
+            },
+        )
+
+    config = tmp_path / "url4.toml"
+    config.write_text(
+        '[aigateway]\ndefault_route = "openrouter/openai/gpt-5.5"\n'
+        'models = ["openrouter/openai/gpt-5.5"]\n'
+    )
+    service = build_executable_catalog_service(
+        Settings(aigateway_base_url="http://aigateway.test"),
+        {job_env.RUNNER_CONFIG: str(config)},
+        client_factory=lambda base_url: httpx.AsyncClient(
+            base_url=base_url,
+            transport=httpx.MockTransport(handler),
+        ),
+    )
+
+    assert service is not None
+    catalog = await service.fetch(Credential.derive())
+    assert catalog.body["data"] == [{"id": _DECLARED, "object": "model"}]
+    await service.aclose()
+
+
+async def test_production_builder_snapshots_declared_routes_at_startup(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"object": "list", "data": [{"id": _DECLARED, "object": "model"}]},
+        )
+
+    config = tmp_path / "url4.toml"
+    config.write_text(f'[aigateway]\ndefault_route = "{_DECLARED}"\nmodels = ["{_DECLARED}"]\n')
+    service = build_executable_catalog_service(
+        Settings(aigateway_base_url="http://aigateway.test"),
+        {job_env.RUNNER_CONFIG: str(config)},
+        client_factory=lambda base_url: httpx.AsyncClient(
+            base_url=base_url,
+            transport=httpx.MockTransport(handler),
+        ),
+    )
+    assert service is not None
+
+    config.write_text('[aigateway]\nmodels = ["openrouter/other/model"]\n')
+    catalog = await service.fetch(Credential.derive())
+
+    assert catalog.body["data"] == [{"id": _DECLARED, "object": "model"}]
+    await service.aclose()
+
+
+async def test_unconfigured_builder_stays_unconfigured() -> None:
+    service = build_executable_catalog_service(
+        Settings(aigateway_base_url=None),
+        {job_env.RUNNER_CONFIG: "/missing/url4.toml"},
+    )
+
+    assert service is None
+
+
+async def test_configured_builder_fails_when_declared_routes_cannot_be_read() -> None:
+    with pytest.raises(WorldConfigError, match="cannot read world config"):
+        build_executable_catalog_service(
+            Settings(aigateway_base_url="http://aigateway.test"),
+            {job_env.RUNNER_CONFIG: "/missing/url4.toml"},
+        )
+
+
+async def test_configured_builder_accepts_the_valid_empty_engine_world(tmp_path: Path) -> None:
+    config = tmp_path / "url4.toml"
+    config.write_text("")
+    service = build_executable_catalog_service(
+        Settings(aigateway_base_url="http://aigateway.test"),
+        {job_env.RUNNER_CONFIG: str(config)},
+        client_factory=lambda base_url: httpx.AsyncClient(
+            base_url=base_url,
+            transport=httpx.MockTransport(
+                lambda request: httpx.Response(
+                    200,
+                    json={"object": "list", "data": [{"id": _DECLARED}]},
+                )
+            ),
+        ),
+    )
+    assert service is not None
+
+    catalog = await service.fetch(Credential.derive())
+
+    assert catalog.body["data"] == []
+    await service.aclose()
+
+
+async def test_configured_builder_rejects_a_runner_invalid_model_capability(
+    tmp_path: Path,
+) -> None:
+    config = tmp_path / "url4.toml"
+    config.write_text(
+        '[aigateway]\ndefault_route = "model"\n'
+        '[[aigateway.models]]\nid = "model"\nweb_tools = "yes"\n'
+    )
+
+    with pytest.raises(WorldConfigError, match="web_tools must be a boolean"):
+        build_executable_catalog_service(
+            Settings(aigateway_base_url="http://aigateway.test"),
+            {job_env.RUNNER_CONFIG: str(config)},
+        )
+
+
+async def test_malformed_gateway_catalog_cannot_bypass_the_projection() -> None:
+    catalog = ExecutableCatalog(_MalformedGatewayCatalog(), frozenset({_DECLARED}))
+
+    with pytest.raises(CatalogBadResponse, match="not a list"):
+        await catalog.fetch(Credential.derive())
+
+
+async def test_malformed_gateway_model_cannot_bypass_the_projection() -> None:
+    class _MalformedGatewayModel(_GatewayCatalog):
+        async def fetch(self, credential: Credential) -> ModelCatalog:
+            body: dict[str, object] = {"object": "list", "data": [{"object": "model"}]}
+            return ModelCatalog(body=body, etag=compute_etag(body))
+
+    catalog = ExecutableCatalog(_MalformedGatewayModel(), frozenset({_DECLARED}))
+
+    with pytest.raises(CatalogBadResponse, match="missing a string id"):
+        await catalog.fetch(Credential.derive())
+
+
+async def test_undeclared_model_details_fail_without_contacting_gateway() -> None:
+    details = _GatewayDetails()
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=_app(details)), base_url="http://test"
+    ) as client:
+        response = await client.get("/v1/model-parameters", params={"model": _GATEWAY_ONLY})
+
+    assert response.status_code == 404
+    assert response.headers["content-type"].startswith("application/problem+json")
+    assert response.json()["detail"] == "the model is not installed on this Engine"
+    assert details.seen == []
+
+
+async def test_declared_model_details_keep_the_gateway_contract() -> None:
+    details = _GatewayDetails()
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=_app(details)), base_url="http://test"
+    ) as client:
+        response = await client.get("/v1/model-parameters", params={"model": _DECLARED})
+
+    assert response.status_code == 200
+    assert response.json() == {"model": {"id": _DECLARED}}
+    assert details.seen == [_DECLARED]

--- a/apps/url4-cloud/tests/unit/test_executable_model_routes.py
+++ b/apps/url4-cloud/tests/unit/test_executable_model_routes.py
@@ -1,0 +1,45 @@
+"""Declared model ids must be valid URL4 expression paths before the world starts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from url4_cloud import job_env
+from url4_cloud.world_config import WorldConfigError, declared_model_ids, load_config, parse_config
+
+
+def _config(model: str) -> dict[str, object]:
+    return {
+        "aigateway": {
+            "default_route": model,
+            "models": [{"id": model}],
+        }
+    }
+
+
+def test_colon_qualified_model_id_is_rejected_at_config_parse() -> None:
+    model = "huggingface/google/gemma-2-2b-it:featherless-ai"
+
+    with pytest.raises(WorldConfigError, match="URL4 expression path"):
+        parse_config(_config(model), {})
+
+
+def test_expression_path_compatible_model_id_remains_declared() -> None:
+    model = "openrouter/openai/gpt-5.5"
+
+    section = parse_config(_config(model), {}).aigateway
+
+    assert section is not None
+    assert [item.id for item in section.models] == [model]
+
+
+def test_control_plane_and_runner_read_the_same_declared_ids() -> None:
+    config_path = Path(__file__).resolve().parents[2] / "url4.toml"
+    env = {job_env.RUNNER_CONFIG: str(config_path)}
+
+    section = load_config(env).aigateway
+
+    assert section is not None
+    assert declared_model_ids(env) == frozenset(item.id for item in section.models)

--- a/apps/url4-cloud/tests/unit/test_finish_reason_capture.py
+++ b/apps/url4-cloud/tests/unit/test_finish_reason_capture.py
@@ -28,9 +28,9 @@ from url4.dag import run as url4_run
 from url4.observe import ModelResponse, NodeFinished, NodeStarted, ObservationEvent
 from url4.streaming.interfaces import Traced
 from url4.streaming.protocol import SpanData
-from url4_cloud.runner.config import ModelSpec
 from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
 from url4_cloud.runner.executor import _RunState
+from url4_cloud.world_config import ModelSpec
 
 _MODEL = "anthropic/claude-haiku-4-5"
 

--- a/apps/url4-cloud/tests/unit/test_identity_header_propagation.py
+++ b/apps/url4-cloud/tests/unit/test_identity_header_propagation.py
@@ -33,9 +33,9 @@ from url4_cloud.adapters.k8s import K8sJobRunner
 from url4_cloud.app import create_app
 from url4_cloud.auth import JwtCodec
 from url4_cloud.config import Settings
-from url4_cloud.runner.config import ModelSpec
 from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
 from url4_cloud.testing import InMemoryEventStream
+from url4_cloud.world_config import ModelSpec
 
 pytestmark = pytest.mark.asyncio
 

--- a/apps/url4-cloud/tests/unit/test_runner.py
+++ b/apps/url4-cloud/tests/unit/test_runner.py
@@ -28,10 +28,10 @@ from url4.streaming.protocol import (
 )
 from url4.streaming.protocol.taxonomy import CostBreakdown
 from url4_cloud import job_env
-from url4_cloud.runner.config import AigatewaySection, ModelSpec, RunnerConfig
 from url4_cloud.runner.executor import Url4Executor
 from url4_cloud.runner.main import RunnerConfigError, build_executor, params_from_env
 from url4_cloud.testing import InMemoryEventStream
+from url4_cloud.world_config import AigatewaySection, ModelSpec, WorldConfig
 
 TOPIC = "cap-topic"
 EXPR = "(@)!'hi'"
@@ -259,14 +259,14 @@ def test_params_from_env_missing_required_raises() -> None:
 _MODEL = "claude-haiku-4-5"
 
 
-def _declared(*models: str, web_tools: bool = False) -> RunnerConfig:
+def _declared(*models: str, web_tools: bool = False) -> WorldConfig:
     """A config declaring `models`, defaulting to the first — the Runner never discovers.
 
     `web_tools` is the per-route opt-in every declared route here shares; it defaults off,
     matching the shipped default, so a test that wants the tool loop must ask for it.
     """
     declared = models or (_MODEL,)
-    return RunnerConfig(
+    return WorldConfig(
         aigateway=AigatewaySection(
             base_url="http://aigateway.test",
             default_model=declared[0],
@@ -308,7 +308,7 @@ async def test_build_executor_returns_an_executor_over_the_aigateway_world() -> 
 
 @pytest.mark.asyncio
 async def test_a_config_with_no_aigateway_table_is_deny_by_default() -> None:
-    executor = build_executor({}, RunnerConfig())
+    executor = build_executor({}, WorldConfig())
 
     assert isinstance(executor, Url4Executor)
     with pytest.raises(ResolutionError):

--- a/apps/url4-cloud/tests/unit/test_runner_config.py
+++ b/apps/url4-cloud/tests/unit/test_runner_config.py
@@ -5,11 +5,11 @@ from pathlib import Path
 import pytest
 
 from url4_cloud import job_env
-from url4_cloud.runner.config import (
+from url4_cloud.world_config import (
     AigatewaySection,
     ModelSpec,
-    RunnerConfig,
-    RunnerConfigError,
+    WorldConfig,
+    WorldConfigError,
     load_config,
     parse_config,
     routes_for,
@@ -23,7 +23,7 @@ models = ["claude-haiku-4-5", "codex/gpt-5.5"]
 """
 
 
-def _parse(toml_text: str, env: dict[str, str] | None = None) -> RunnerConfig:
+def _parse(toml_text: str, env: dict[str, str] | None = None) -> WorldConfig:
     return parse_config(_toml(toml_text), env or {})
 
 
@@ -103,49 +103,49 @@ def test_absent_aigateway_table_is_a_valid_tokenless_world() -> None:
 
 
 def test_default_route_must_be_a_declared_model() -> None:
-    with pytest.raises(RunnerConfigError, match="not a declared model"):
+    with pytest.raises(WorldConfigError, match="not a declared model"):
         _parse(_MINIMAL.replace('"/claude-haiku-4-5"', '"/claude-opus-4-8"'))
 
 
 def test_empty_models_list_is_rejected() -> None:
-    with pytest.raises(RunnerConfigError, match="at least one model"):
+    with pytest.raises(WorldConfigError, match="at least one model"):
         _parse('[aigateway]\ndefault_route = "/x"\nmodels = []\n')
 
 
 def test_model_id_may_not_start_with_a_slash() -> None:
-    with pytest.raises(RunnerConfigError, match="must not start with"):
+    with pytest.raises(WorldConfigError, match="must not start with"):
         _parse('[aigateway]\ndefault_route = "/x"\nmodels = ["/x"]\n')
 
 
 def test_empty_model_id_is_rejected() -> None:
-    with pytest.raises(RunnerConfigError, match="empty"):
+    with pytest.raises(WorldConfigError, match="empty"):
         _parse('[aigateway]\ndefault_route = "/x"\nmodels = ["x", ""]\n')
 
 
 def test_duplicate_model_ids_are_rejected() -> None:
-    with pytest.raises(RunnerConfigError, match="duplicate"):
+    with pytest.raises(WorldConfigError, match="duplicate"):
         _parse('[aigateway]\ndefault_route = "/x"\nmodels = ["x", "x"]\n')
 
 
 def test_unknown_key_in_the_aigateway_table_is_rejected() -> None:
-    with pytest.raises(RunnerConfigError, match="unknown"):
+    with pytest.raises(WorldConfigError, match="unknown"):
         _parse(_MINIMAL + "modles = []\n")
 
 
 def test_reserved_tables_fail_loudly_rather_than_being_ignored() -> None:
     # `[data]`/`[commands]`/`[holdings]`/`[identities]` are reserved in the format but not
     # parsed yet — silently ignoring them would look like they worked.
-    with pytest.raises(RunnerConfigError, match="not supported yet"):
+    with pytest.raises(WorldConfigError, match="not supported yet"):
         _parse(_MINIMAL + '\n[data]\n"/corpus" = { value = "x" }\n')
 
 
 def test_unknown_top_level_table_is_rejected() -> None:
-    with pytest.raises(RunnerConfigError, match="unknown"):
+    with pytest.raises(WorldConfigError, match="unknown"):
         _parse(_MINIMAL + "\n[nonsense]\nx = 1\n")
 
 
 def test_models_must_be_a_list() -> None:
-    with pytest.raises(RunnerConfigError, match="list"):
+    with pytest.raises(WorldConfigError, match="list"):
         _parse('[aigateway]\ndefault_route = "/x"\nmodels = "x"\n')
 
 
@@ -190,28 +190,28 @@ def test_the_two_spellings_may_be_mixed() -> None:
 
 
 def test_a_route_table_without_an_id_is_rejected() -> None:
-    with pytest.raises(RunnerConfigError, match="missing its `id`"):
+    with pytest.raises(WorldConfigError, match="missing its `id`"):
         _parse('[aigateway]\ndefault_route = "/a"\nmodels = [{ web_tools = true }]\n')
 
 
 def test_unknown_key_on_a_route_table_is_rejected() -> None:
     # A typo'd capability must fail loudly, not read as "declared nothing".
-    with pytest.raises(RunnerConfigError, match="unknown key"):
+    with pytest.raises(WorldConfigError, match="unknown key"):
         _parse('[aigateway]\ndefault_route = "/a"\nmodels = [{ id = "a", web_tool = true }]\n')
 
 
 def test_non_boolean_web_tools_is_rejected() -> None:
-    with pytest.raises(RunnerConfigError, match="web_tools must be a boolean"):
+    with pytest.raises(WorldConfigError, match="web_tools must be a boolean"):
         _parse('[aigateway]\ndefault_route = "/a"\nmodels = [{ id = "a", web_tools = "yes" }]\n')
 
 
 def test_a_route_entry_of_the_wrong_type_is_rejected() -> None:
-    with pytest.raises(RunnerConfigError, match="table or an id string"):
+    with pytest.raises(WorldConfigError, match="table or an id string"):
         _parse('[aigateway]\ndefault_route = "/a"\nmodels = [1]\n')
 
 
 def test_duplicate_ids_are_rejected_across_both_spellings() -> None:
-    with pytest.raises(RunnerConfigError, match="duplicate"):
+    with pytest.raises(WorldConfigError, match="duplicate"):
         _parse('[aigateway]\ndefault_route = "/a"\nmodels = ["a", { id = "a" }]\n')
 
 
@@ -231,7 +231,7 @@ def test_env_overrides_the_default_model_when_it_is_declared() -> None:
 
 
 def test_env_default_model_must_still_be_declared() -> None:
-    with pytest.raises(RunnerConfigError, match="not a declared model"):
+    with pytest.raises(WorldConfigError, match="not a declared model"):
         _parse(_MINIMAL, {job_env.AIGATEWAY_MODEL: "not-declared"})
 
 
@@ -249,7 +249,7 @@ def test_load_config_reads_the_declared_path(tmp_path: Path) -> None:
 
 
 def test_missing_config_file_is_a_config_error(tmp_path: Path) -> None:
-    with pytest.raises(RunnerConfigError, match="cannot read"):
+    with pytest.raises(WorldConfigError, match="cannot read"):
         load_config({"URL4_RUNNER_CONFIG": str(tmp_path / "absent.toml")})
 
 
@@ -257,5 +257,5 @@ def test_malformed_toml_is_a_config_error(tmp_path: Path) -> None:
     path = tmp_path / "url4.toml"
     path.write_text("[aigateway\n", encoding="utf-8")
 
-    with pytest.raises(RunnerConfigError, match="cannot read"):
+    with pytest.raises(WorldConfigError, match="cannot read"):
         load_config({"URL4_RUNNER_CONFIG": str(path)})

--- a/apps/url4-cloud/url4.toml
+++ b/apps/url4-cloud/url4.toml
@@ -1,4 +1,5 @@
-# url4-cloud RUNNER — the declared world.
+# url4-cloud — the declared world, read by BOTH the Runner (what a run may address) and the App
+# (what `GET /v1/models` advertises). One file, so discovery cannot promise what execution refuses.
 #
 # Baked into the image at /etc/url4/url4.toml (see Dockerfile). The image decides what CAN
 # exist; env supplies only per-Job values (the token, and optional base_url / model overrides).

--- a/docs/plan/2026-07-26-url4-cloud-model-catalog.md
+++ b/docs/plan/2026-07-26-url4-cloud-model-catalog.md
@@ -1,17 +1,36 @@
 ---
 title: url4-cloud model catalog endpoint — implementation plan
-status: proposed — awaiting owner approval
+status: approved
 created: 2026-07-26
-revised: 2026-07-26 (r3 — credential required; no service secret)
+revised: 2026-08-07 (r4 — executable Engine catalog)
 ticket: OME-625
 spec: docs/spec/2026-07-26-url4-cloud-model-catalog-spec.md
-ledger: docs/work/2026-07-26-OME-625-url4-cloud-model-catalog.md
+ledger: docs/work/2026-08-05-OME-625-executable-model-catalog.md
 ---
 
-# Implementation plan — OME-625 (r3)
+# Implementation plan — OME-625
 
-Branch `OME-625-url4-cloud-model-catalog`. Stack `url4-cloud` (`sdlc-python`), TDD RED→GREEN per
-batch, `run_gates.py` between batches. Conventional commits, body `Refs: OME-625`.
+Branch `OME-625-engine-executable-model-catalog`. Stack `url4-cloud` (`sdlc-python`).
+
+## r4 executable-world correction — approved 2026-08-07
+
+The original catalog and cache are already implemented. This correction makes discovery answer
+which models the Engine can execute rather than which models AI Gateway can serve directly:
+
+1. Move the declared-world parser to a neutral URL4 Cloud module shared by the App and Runner.
+   Both consumers must validate the complete same configuration; no partial second TOML reader.
+2. Reject model ids that cannot form URL4 expression paths while parsing the declared world.
+3. Decorate the caller-visible Gateway catalog with the declared model-id intersection, preserving
+   retained model documents and unknown top-level fields and recomputing the ETag.
+4. Guard model-parameter lookup with the same declared set and reject undeclared ids before an
+   upstream request.
+5. Wire production and local composition, add focused parity/HTTP/startup tests, and run the full
+   URL4 Cloud gate.
+
+No AI Gateway, URL4 grammar, Benchmark, authentication, deployment, or Client changes belong in
+this correction.
+
+## Historical r3 implementation plan
 
 **r3 vs r2:** the anonymous path and the `aigateway_token` setting are gone (spec D1/D2), so
 Batch 5 shrinks, `Cache-Control` stops being conditional, and Batch 6 loses the chart Secret

--- a/docs/spec/2026-07-26-url4-cloud-model-catalog-spec.md
+++ b/docs/spec/2026-07-26-url4-cloud-model-catalog-spec.md
@@ -48,6 +48,21 @@ segments containing only ASCII letters, digits, `-`, `_`, `.`, or `~`. Invalid i
 the Runner configuration is parsed. There is deliberately no aliasing, percent-encoding escape,
 or URL4 grammar extension.
 
+An unusable declared world — unreadable file, or any validation failure including an invalid id —
+**disables discovery; it does not stop the Engine.** The composition root wires no catalog
+service, both catalog routes answer the existing 503, and the cause is logged at ERROR. Run
+submission, streaming, connections and health are unaffected, and the Runner still refuses the
+same world at Job start.
+
+WHY not fail the process: the declared world reaches the control plane only to answer *what can
+this Engine execute*. Raising in the App's composition root would convert a discovery-scoped
+misconfiguration into a total outage of a control plane that was serving runs correctly — and it
+would do so for a file whose only reader, before r4, was the Runner. Degrading is also never
+contract-violating: the acceptance invariant is that every advertised id is executable, and
+advertising nothing satisfies it. Fail-fast is retained where it decides correctness — the
+Runner, at Job start, before a run can address a route that does not exist. A silently EMPTY
+catalog is separately prevented: an unusable world is 503 and an ERROR, never `data: []`.
+
 The raw AI Gateway adapter and its caller-keyed cache remain broad and unchanged. Projection is
 an Engine composition decorator after the cache, so provider/profile semantics stay in AI
 Gateway and deployment route policy stays in URL4 Cloud.

--- a/docs/spec/2026-07-26-url4-cloud-model-catalog-spec.md
+++ b/docs/spec/2026-07-26-url4-cloud-model-catalog-spec.md
@@ -1,8 +1,8 @@
 ---
 title: url4-cloud model catalog endpoint — technical specification
-status: implemented — shipped in `92fdf233`; live at `apps/url4-cloud/src/url4_cloud/rest/catalog.py`
+status: r4 implemented
 created: 2026-07-26
-revised: 2026-07-26 (r3 — credential required; no service secret; mode-agnostic by construction)
+revised: 2026-08-05 (r4 — Engine catalog projected onto declared executable routes)
 author: Claude (Opus 5) + Ionesio
 ticket: OME-625
 related:
@@ -16,13 +16,46 @@ related:
 
 ## 0. Status & revision history
 
-Proposed. Implementation starts only on explicit approval.
+r4 is the current normative contract. The r1–r3 material after §0.1 is retained as design
+history only; where it disagrees with r4 or the current identity-header flow it is superseded.
 
 | Rev | Change | Why |
 |---|---|---|
 | r1 | Unauthenticated · one shared cache entry · service credential | Initial owner forks. |
 | r2 | Credential-optional · identity-keyed cache | Owner required correctness under aigateway `byok` **and** `shared`. |
 | **r3** | **Credential required · no service credential · no new secret** | Owner confirmed callers are already authenticated when they reach url4-cloud, so the anonymous path bought nothing and cost a standing privileged secret. |
+| **r4** | **Caller-visible Gateway catalog ∩ Engine-declared model routes** | A live quickstart selected a colon-qualified Hugging Face id returned by the Engine, but URL4 expression paths cannot represent that id and the Runner had no such declared route. Discovery must describe the Engine, not the Gateway in isolation. |
+
+### 0.1 Current normative contract (r4)
+
+`GET /v1/models` answers: **which model routes can this caller execute through this Engine?**
+The answer is the intersection of:
+
+1. the caller/profile-visible AI Gateway catalog; and
+2. the model ids declared in the Engine's configured `url4.toml`.
+
+AI Gateway remains the authority for model metadata and caller visibility. The Engine remains
+the authority for its executable world. Retained model documents and unknown top-level fields
+are preserved; only undeclared model entries are omitted. The ETag is recomputed over that
+projected response.
+
+The same declared set guards `GET /v1/model-parameters?model=…`. An undeclared model returns a
+404 problem without contacting AI Gateway. This prevents the list and details surfaces from
+describing different execution capabilities.
+
+The declared model id must be a valid URL4 expression-path id: one or more non-empty `/`-separated
+segments containing only ASCII letters, digits, `-`, `_`, `.`, or `~`. Invalid ids fail while
+the Runner configuration is parsed. There is deliberately no aliasing, percent-encoding escape,
+or URL4 grammar extension.
+
+The raw AI Gateway adapter and its caller-keyed cache remain broad and unchanged. Projection is
+an Engine composition decorator after the cache, so provider/profile semantics stay in AI
+Gateway and deployment route policy stays in URL4 Cloud.
+
+The caller identity contract is the verified `X-User-Email` header plus optional `X-Profile`;
+anonymous local mode remains valid and AI Gateway decides whether the identity is sufficient.
+
+### Historical r1–r3 design (superseded where inconsistent with §0.1)
 
 ## 1. Purpose & scope
 

--- a/docs/tasks/2026-07-26-ome-625-url4-cloud-model-catalog.md
+++ b/docs/tasks/2026-07-26-ome-625-url4-cloud-model-catalog.md
@@ -9,13 +9,13 @@ created: 2026-07-26
 closed:
 ---
 
-# Add a cached aigateway model-catalog endpoint to url4-cloud
+# Expose only executable models from the Engine catalog
 
-Read-only `GET /v1/models` on the url4-cloud backend, proxied from aigateway's own
-`GET /v1/models` and served from a process-wide TTL cache with single-flight and
-stale-on-error. Unauthenticated by owner decision (ingress is the trust boundary); the
-Runner's `_list_models` is out of scope.
+Project the existing caller-visible AI Gateway catalog onto the model routes declared by this
+Engine's `url4.toml`. The App and Runner consume one shared declared-world parser, so discovery
+cannot advertise a route whose complete execution configuration is invalid. Apply the same set to
+model-parameter lookup and reject undeclared models without contacting AI Gateway.
 
 Spec: `docs/spec/2026-07-26-url4-cloud-model-catalog-spec.md`
 Plan: `docs/plan/2026-07-26-url4-cloud-model-catalog.md`
-Ledger: `docs/work/2026-07-26-OME-625-url4-cloud-model-catalog.md`
+Ledger: `docs/work/2026-08-05-OME-625-executable-model-catalog.md`

--- a/docs/work/2026-08-05-OME-625-executable-model-catalog.md
+++ b/docs/work/2026-08-05-OME-625-executable-model-catalog.md
@@ -62,3 +62,37 @@ seam and does not weaken normal discovery: an invalid id is never advertised by 
 - **Deviations:** The SDK planning-error portion is intentionally assigned to the later Client
   candidate-authoring PR. No Gateway, URL4 package, Benchmark, authentication, deployment, or
   Client code is included here.
+
+## Post-review corrections (2026-08-07)
+
+Rebased onto `main` after the Benchmark foundation landed in the same composition roots, then
+reviewed. Three corrections, all inside the r4 contract:
+
+1. **An unusable declared world degrades discovery instead of stopping the Engine.**
+   `build_executable_catalog_service` catches `WorldConfigError`, logs it at ERROR, and returns
+   `None` — so both catalog routes answer the existing 503 while runs, streaming, connections and
+   health keep serving. Raising in the App's composition root would have turned a
+   discovery-scoped misconfiguration into a total control-plane outage, for a file whose only
+   reader before r4 was the Runner. Reachable in practice: `url4.toml` instructs operators that
+   ids must match AI Gateway's EXACTLY, and the Hugging Face provider seeds colon-qualified slugs
+   that r4 now rejects. Fail-fast is kept where it decides correctness — the Runner, at Job start.
+   Recorded in the spec §0.1; the two tests that pinned the raise now pin the degrade, plus a new
+   HTTP-level test that `/v1/models` is 503 while `/healthz` is 200.
+2. **One malformed Gateway model entry no longer fails the whole catalog.** Membership in the
+   declared set is the entire filter: an entry that cannot state a declared id cannot be one, so
+   it is omitted. Raising there let a single odd upstream document 502 every caller — and with
+   stale-on-error, a persistent one would have become an outage after `stale_max_s`. The
+   `data`-is-not-a-list check still raises: that shape cannot be projected at all.
+3. **Documentation truthfulness at the seams this work moved.** The app README, the Helm
+   ConfigMap operator comment, the `/v1/model-parameters` OpenAPI description and its 404/503
+   texts, `rest/catalog.py`'s module docstring, `runner/__init__.py`'s layering statement (three
+   shared leaves → four, with the reason), `check_layering.py`'s own module list, `job_env.py`'s
+   error-name note, `url4.toml`'s header, and `world_config.py`'s format-mirror claim all still
+   described the pre-r4 verbatim-proxy world.
+
+The `assert source is not None` flagged in review was verified unreachable (`build_catalog_service`
+guards on the same base URL) — replaced with expressed narrowing rather than an assertion, so a
+future drift between the two guards degrades like an unconfigured deployment instead of raising.
+
+- **Gates after corrections:** complete URL4 Cloud suite (977 passed, 5 skipped, 95.21% coverage);
+  Ruff; format; Pyright; and the Engine/Runner layering check all pass.

--- a/docs/work/2026-08-05-OME-625-executable-model-catalog.md
+++ b/docs/work/2026-08-05-OME-625-executable-model-catalog.md
@@ -1,0 +1,64 @@
+---
+ticket: OME-625
+stack: url4-cloud
+status: done
+started: 2026-08-05
+finished: 2026-08-07
+---
+
+# OME-625 — make the Engine model catalog executable
+
+## Intent
+
+Correct the Engine catalog contract after a live quickstart exposed a model that AI Gateway
+advertised but the Engine could not express or resolve as URL4. `GET /v1/models` must describe
+the caller-visible subset of the Engine's declared model routes, not every model the downstream
+Gateway can serve directly. The Gateway catalog remains unchanged and broad.
+
+## Planned changes
+
+- `apps/url4-cloud/src/url4_cloud/catalog/` — project the caller-visible Gateway catalog onto
+  the Engine's declared model ids and guard model-detail requests with the same set.
+- `apps/url4-cloud/src/url4_cloud/local.py` and composition roots — inject the declared model
+  set rather than letting discovery drift from the execution world.
+- `apps/url4-cloud/src/url4_cloud/world_config.py` — share the complete declared-world parser
+  across discovery and execution, rejecting ids that URL4 cannot render as expression paths.
+- `apps/url4-cloud/tests/unit/` — add public HTTP/startup tests for the executable-catalog
+  invariant, undeclared detail rejection, and invalid route configuration.
+- `docs/spec/2026-07-26-url4-cloud-model-catalog-spec.md` — supersede the obsolete verbatim-proxy
+  claim with the executable Engine catalog contract.
+
+## Test plan
+
+- RED: a Gateway-only, colon-qualified Hugging Face model is absent from Engine `/v1/models`.
+- RED: Engine `/v1/model-parameters` rejects a model absent from the declared execution world
+  without contacting AI Gateway.
+- RED: runner configuration rejects an expression-path-incompatible declared model at startup.
+- Preserve caller/profile catalog behavior for declared models and run the complete URL4 Cloud
+  gate.
+
+## Acceptance
+
+- Every id returned by Engine `/v1/models` is a declared, URL4-executable model route.
+- Gateway discovery remains unchanged; no alias, escaping fallback, or URL4 grammar change exists.
+- Undeclared detail lookup fails before model spend with a clear Engine error.
+- URL4 Cloud gates are green.
+
+The separate Client candidate-authoring PR owns translating a manually supplied invalid Model id
+into a typed planning error. Keeping that SDK behavior out of this Engine PR preserves the app
+seam and does not weaken normal discovery: an invalid id is never advertised by the Engine.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** Engine catalog projection and error port, shared declared-route reader,
+  production/local composition, Runner route-id validation, focused tests, and the existing model
+  catalog specification.
+- **Commits:** one local commit rebased directly onto `main`; it is not a stacked change.
+- **Gates:** 47 focused executable-catalog/world-config tests; complete URL4 Cloud suite
+  (879 passed, 5 skipped, 97.18% coverage); Ruff; format; Pyright; and the Engine/Runner layering
+  check all pass. The full gate used its documented append-only override because moving and
+  renaming the shared configuration types necessarily updates imports and type names in existing
+  tests; their behavioral assertions are unchanged.
+- **Deviations:** The SDK planning-error portion is intentionally assigned to the later Client
+  candidate-authoring PR. No Gateway, URL4 package, Benchmark, authentication, deployment, or
+  Client code is included here.


### PR DESCRIPTION
## Summary

- project the caller-visible AI Gateway catalog onto the model routes declared by this Engine
- guard model-parameter lookup with the same declared set, rejecting undeclared models before an upstream request
- share one fully validated `url4.toml` world between control-plane discovery and Runner execution
- preserve retained Gateway model documents and caller-scoped cache behavior while recomputing the projected ETag

## Design

URL4 Cloud remains the deployable URL4 host. AI Gateway integration is wired explicitly at the composition edges through the existing catalog and execution interfaces; this PR does not introduce a plugin framework. It changes no URL4 grammar, AI Gateway implementation, benchmark protocol, authentication flow, or Client code.

The catalog answers:

> caller-visible AI Gateway models ∩ Engine-declared executable routes

An empty declared world returns a valid empty catalog. Invalid declared-world configuration fails startup when catalog integration is enabled. Configuration is snapshotted until restart so discovery and execution cannot drift.

## Verification

- 47 focused executable-catalog/world-configuration tests
- complete URL4 Cloud suite: 879 passed, 5 skipped, 97.18% coverage
- Ruff check and format
- Pyright
- control-plane/Runner layering gate

The full gate used `--skip-append-only` because moving and renaming the shared configuration types necessarily updates imports and type names in existing tests. Their behavioral assertions are unchanged.

Refs: OME-625
