### PR TITLE
fix(aigateway): roll Pods when the ConfigMap changes

### DIFF
--- a/apps/aigateway/charts/aigateway/templates/deployment.yaml
+++ b/apps/aigateway/charts/aigateway/templates/deployment.yaml
@@ -16,10 +16,15 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
       annotations:
+        # Roll the Pods when the ConfigMap changes. Without this a `helm upgrade` that flips
+        # AIGW_OPENROUTER_ENABLED (or any other key) updates the ConfigMap and changes nothing
+        # else — envFrom is read once at container start, so every Pod keeps the old value and
+        # the upgrade reports success. Same guard aigateway-ui already carries.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "aigateway.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}


### PR DESCRIPTION
## Summary

A `helm upgrade` that only changes a config value updates the ConfigMap and nothing else, so the running Pods keep serving the old value and the upgrade still reports success. This adds the same `checksum/config` guard `aigateway-ui` already has, so a config change rolls the Pods.

We hit this today on our dev deploy: the release that flipped `AIGW_OPENROUTER_ENABLED` to `true` landed, the ConfigMap said `true`, and the running gateway still had `false` until we manually restarted it. The same thing happened twice before with `AIGATEWAY_ADMIN_EMAILS` — the deploy is green, the manifests are right, and only the process is stale, which makes it a slow one to spot.

**Asana:** n/a — reporting from the platform side; happy to have this filed under whichever task you prefer.

## Components touched

`apps/aigateway` — chart template only. No app code, no values schema change, no new inputs.

## What the change is

`apps/aigateway/charts/aigateway/templates/deployment.yaml` — the Pod template's `annotations` block always renders now, carrying a hash of the rendered ConfigMap, with `podAnnotations` merged in after it as before:

```yaml
      annotations:
        # Roll the Pods when the ConfigMap changes. Without this a `helm upgrade` that flips
        # AIGW_OPENROUTER_ENABLED (or any other key) updates the ConfigMap and changes nothing
        # else — envFrom is read once at container start, so every Pod keeps the old value and
        # the upgrade reports success. Same guard aigateway-ui already carries.
        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
        {{- with .Values.podAnnotations }}
        {{- toYaml . | nindent 8 }}
        {{- end }}
```

This is copied from `apps/aigateway-ui/charts/aigateway-ui/templates/deployment.yaml`, where the same guard (and a comment saying why) has been in place since the console shipped.

Note it also restructures the block slightly: previously `annotations:` was wrapped in `{{- with .Values.podAnnotations }}`, so with no custom annotations nothing rendered at all. Now the block always renders and `podAnnotations` merges after the checksum — same shape as the `aigateway-ui` chart.

## Test plan

- [x] `helm template` with `config.openrouter.enabled=false` vs `true` → the checksum differs, so a config-only change now produces a new Pod template and a rollout
- [x] `helm template --set podAnnotations.foo=bar` → custom annotations still merge; nothing that previously worked stops working
- [x] Chart renders clean with default values; no other object changes

## Cross-service notes

Nothing changes for callers or for `helm install`. The only visible difference is that a config-only upgrade now restarts the Pods instead of silently leaving them on the old config — which is the intent.

If you would rather not always render the annotations block, the alternative is to leave the chart as is and have every consumer restart the Deployment by hand after any config change; we would rather not rely on remembering that, and `aigateway-ui` already set the precedent.