### PR TITLE
feat(url4-cloud): deploy DRACO benchmark protocol

### DIFF
--- a/.github/scripts/verify_chart_wiring.py
+++ b/.github/scripts/verify_chart_wiring.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Assert what the aigateway and aigateway-ui charts actually RENDER (OME-710).
+"""Assert what the aigateway, aigateway-ui, and url4-cloud charts actually render.
 
 WHY this exists rather than a `helm lint` step: `helm lint` reports "0 chart(s) failed" on a chart
 that cannot render at all — it reads the templates without executing them, so every `fail` guard
@@ -30,12 +30,14 @@ import yaml
 REPO = Path(__file__).resolve().parents[2]
 GATEWAY_CHART = REPO / "apps/aigateway/charts/aigateway"
 CONSOLE_CHART = REPO / "apps/aigateway-ui/charts/aigateway-ui"
+URL4_CLOUD_CHART = REPO / "apps/url4-cloud/deploy/helm"
 
 # The release name this repo uses for the gateway everywhere (release-aigateway.yml renders with
 # it, and the console chart's `aigateway.serviceName` default is derived from it). The pair check
 # below is what keeps that default honest.
 GATEWAY_RELEASE = "aigw"
 CONSOLE_RELEASE = "aigw-ui"
+URL4_CLOUD_RELEASE = "url4-cloud"
 
 failures: list[str] = []
 checks = 0
@@ -83,6 +85,14 @@ def find(docs: list[dict], kind: str) -> dict:
     raise AssertionError(f"no {kind} in the rendered chart")
 
 
+def find_data_owner(docs: list[dict], key: str) -> dict:
+    """Return the single rendered object whose data contains ``key``."""
+    matches = [doc for doc in docs if key in doc.get("data", {})]
+    if len(matches) != 1:
+        raise AssertionError(f"expected one rendered object carrying {key!r}, found {len(matches)}")
+    return matches[0]
+
+
 def peer_names(policy: dict, direction: str) -> set[str]:
     """Pod names admitted by a policy, counting ONLY properly-paired selectors.
 
@@ -96,9 +106,7 @@ def peer_names(policy: dict, direction: str) -> set[str]:
         for element in rule.get("from", []) + rule.get("to", []):
             pod = element.get("podSelector", {}).get("matchLabels", {})
             ns = element.get("namespaceSelector", {}).get("matchLabels", {})
-            if pod.get("app.kubernetes.io/name") and ns.get(
-                "kubernetes.io/metadata.name"
-            ):
+            if pod.get("app.kubernetes.io/name") and ns.get("kubernetes.io/metadata.name"):
                 names.add(pod["app.kubernetes.io/name"])
     return names
 
@@ -141,9 +149,9 @@ check(
     "joins the allowlist with commas — the app parses a comma list, not JSON (NoDecode)",
 )
 check(
-    find(gw_with_admins, "Deployment")["spec"]["template"]["spec"]["containers"][0][
-        "envFrom"
-    ][0]["configMapRef"]["name"]
+    find(gw_with_admins, "Deployment")["spec"]["template"]["spec"]["containers"][0]["envFrom"][0][
+        "configMapRef"
+    ]["name"]
     == gw_config["metadata"]["name"],
     "the gateway container actually reads that ConfigMap",
 )
@@ -214,8 +222,7 @@ check(
     "allows DNS — without it the gateway's Service name never resolves",
 )
 check(
-    dns_rule is not None
-    and {p["protocol"] for p in dns_rule["ports"]} == {"UDP", "TCP"},
+    dns_rule is not None and {p["protocol"] for p in dns_rule["ports"]} == {"UDP", "TCP"},
     "allows DNS over BOTH UDP and TCP — resolvers retry over TCP past 512 bytes",
 )
 check(
@@ -248,16 +255,12 @@ check(
     == gw_service["metadata"]["name"],
     "the console's configured host IS the Service name the gateway chart renders",
 )
-gw_pod_name = gw_deployment["spec"]["template"]["metadata"]["labels"][
-    "app.kubernetes.io/name"
-]
+gw_pod_name = gw_deployment["spec"]["template"]["metadata"]["labels"]["app.kubernetes.io/name"]
 check(
     gw_pod_name in peer_names(c_policy, "egress"),
     "the console's egress names the label the gateway's Pods actually carry",
 )
-console_pod_name = c_deployment["spec"]["template"]["metadata"]["labels"][
-    "app.kubernetes.io/name"
-]
+console_pod_name = c_deployment["spec"]["template"]["metadata"]["labels"]["app.kubernetes.io/name"]
 check(
     console_pod_name in peer_names(gw_policy, "ingress"),
     "the gateway's ingress names the label the console's Pods actually carry",
@@ -267,6 +270,28 @@ check(
         f":{gw_service['spec']['ports'][0]['port']}"
     ),
     "the console's port IS the port the gateway's Service listens on",
+)
+
+print("\nurl4-cloud chart")
+url4_cloud = render(
+    URL4_CLOUD_CHART,
+    URL4_CLOUD_RELEASE,
+    "--set-string",
+    "config.natsUrl=nats://nats.example:4222",
+)
+url4_deployment = find(url4_cloud, "Deployment")
+url4_config = find_data_owner(url4_cloud, "URL4_CLOUD_RUNNER_IMAGE")
+url4_app_image = url4_deployment["spec"]["template"]["spec"]["containers"][0]["image"]
+url4_runner_image = url4_config["data"]["URL4_CLOUD_RUNNER_IMAGE"]
+url4_app_repository, url4_app_tag = url4_app_image.rsplit(":", 1)
+url4_runner_repository, url4_runner_tag = url4_runner_image.rsplit(":", 1)
+check(
+    url4_runner_repository == f"{url4_app_repository}-benchmark",
+    "derives the Runner repository from the control-plane repository",
+)
+check(
+    url4_runner_tag == url4_app_tag,
+    "pins the Runner and control-plane images to the same tag",
 )
 
 print("\nthe publishing lanes")
@@ -286,9 +311,7 @@ check(
 # image.repository/tag. What must hold is that the GHCR name is the same repository the chart and
 # the release lane already agree on — a dev image under a different name is one the chart can never
 # be pointed at without editing values.
-dev_lane = yaml.safe_load(
-    (REPO / ".github/workflows/dev-build-aigateway-ui.yml").read_text()
-)
+dev_lane = yaml.safe_load((REPO / ".github/workflows/dev-build-aigateway-ui.yml").read_text())
 dev_tags = [
     t.strip()
     for t in dev_lane["jobs"]["image"]["steps"][-1]["with"]["tags"].split("\n")
@@ -299,9 +322,43 @@ check(
     "the dev lane pushes the SAME image repository the chart and release lane name",
 )
 check(
-    all(":main-" in t for t in dev_tags)
-    and not any(t.endswith(":latest") for t in dev_tags),
+    all(":main-" in t for t in dev_tags) and not any(t.endswith(":latest") for t in dev_tags),
     "the dev lane publishes only immutable main-<sha> tags — never :latest",
+)
+
+url4_dev_lane = yaml.safe_load((REPO / ".github/workflows/dev-build-url4-cloud.yml").read_text())
+url4_benchmark_tags = {
+    tag.strip()
+    for tag in url4_dev_lane["jobs"]["benchmark-image"]["steps"][-1]["with"]["tags"].split("\n")
+    if tag.strip()
+}
+check(
+    {
+        "ghcr.io/openmined/screamingface-url4-cloud-benchmark:"
+        "main-${{ needs.image.outputs.short }}",
+        "acropenmined.azurecr.io/screamingface-url4-cloud-benchmark:"
+        "main-${{ needs.image.outputs.short }}",
+        "acropenmined.azurecr.io/screamingface-url4-cloud-benchmark:main-${{ github.sha }}",
+    }
+    <= url4_benchmark_tags,
+    "the dev lane publishes the paired benchmark image to GHCR and ACR",
+)
+
+url4_release_lane = yaml.safe_load((REPO / ".github/workflows/release-url4-cloud.yml").read_text())
+release_benchmark_job = url4_release_lane["jobs"]["benchmark-image"]
+release_benchmark_repo = release_benchmark_job["env"]["REPO"]
+release_benchmark_tags = {
+    tag.strip().replace("${{ env.REPO }}", release_benchmark_repo)
+    for tag in release_benchmark_job["steps"][-1]["with"]["tags"].split("\n")
+    if tag.strip()
+}
+check(
+    {tag.rsplit(":", 1)[0] for tag in release_benchmark_tags} == {url4_runner_repository},
+    "the release lane publishes the Runner repository rendered by the chart",
+)
+check(
+    release_benchmark_tags and not any(tag.endswith(":latest") for tag in release_benchmark_tags),
+    "the benchmark image is published only under immutable version tags",
 )
 
 # A shared GHA cache scope between images with disjoint layer sets (uv/Python vs node/Next.js) is
@@ -314,7 +371,8 @@ for wf in sorted((REPO / ".github/workflows").glob("dev-build-*.yml")):
     scopes[wf.name] = step.get("cache-to", "")
 check(
     len(set(scopes.values())) == len(scopes),
-    f"every dev-build lane has its OWN cache scope ({len(scopes)} lanes, {len(set(scopes.values()))} distinct)",
+    f"every dev-build lane has its OWN cache scope "
+    f"({len(scopes)} lanes, {len(set(scopes.values()))} distinct)",
 )
 # `helm package --app-version "$VERSION"` sets appVersion from the tag, and the chart's image
 # helper falls back to appVersion when image.tag is empty — so a released chart pins the exact

--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -17,6 +17,7 @@ on:
       - "apps/aigateway/charts/**"
       - "apps/aigateway-ui/charts/**"
       - "apps/aigateway-ui/Dockerfile"
+      - "apps/url4-cloud/deploy/helm/**"
       - ".github/scripts/verify_chart_wiring.py"
       - ".github/workflows/charts.yml"
       # The verifier compares the chart's image against the images these lanes publish, and checks
@@ -24,12 +25,14 @@ on:
       # installable and permanently ImagePullBackOff, so editing either lane has to re-run the
       # comparison. `dev-build-*` is a glob because the cache-scope check spans all of them.
       - ".github/workflows/release-aigateway-ui.yml"
+      - ".github/workflows/release-url4-cloud.yml"
       - ".github/workflows/dev-build-*.yml"
   pull_request:
     paths:
       - "apps/aigateway/charts/**"
       - "apps/aigateway-ui/charts/**"
       - "apps/aigateway-ui/Dockerfile"
+      - "apps/url4-cloud/deploy/helm/**"
       - ".github/scripts/verify_chart_wiring.py"
       - ".github/workflows/charts.yml"
       # The verifier compares the chart's image against the images these lanes publish, and checks
@@ -37,6 +40,7 @@ on:
       # installable and permanently ImagePullBackOff, so editing either lane has to re-run the
       # comparison. `dev-build-*` is a glob because the cache-scope check spans all of them.
       - ".github/workflows/release-aigateway-ui.yml"
+      - ".github/workflows/release-url4-cloud.yml"
       - ".github/workflows/dev-build-*.yml"
   workflow_dispatch:
 
@@ -67,10 +71,10 @@ jobs:
           helm lint apps/aigateway/charts/aigateway
           helm lint apps/aigateway/charts/db
           helm lint apps/aigateway-ui/charts/aigateway-ui
+          helm lint apps/url4-cloud/deploy/helm
 
-      # Renders both charts and asserts on the parsed output — including the cross-chart
-      # properties neither chart can check alone: the console points at the Service the gateway
-      # renders, and the gateway admits the label the console's Pods carry.
+      # Renders the charts and asserts on parsed output, including the cross-chart console/gateway
+      # contract and url4-cloud's paired Runner image.
       - name: Verify chart wiring
         run: python3 .github/scripts/verify_chart_wiring.py
 

--- a/.github/workflows/dev-build-url4-cloud.yml
+++ b/.github/workflows/dev-build-url4-cloud.yml
@@ -21,6 +21,8 @@ concurrency:
 jobs:
   image:
     runs-on: ubuntu-latest
+    outputs:
+      short: ${{ steps.sha.outputs.short }}
     steps:
       - uses: actions/checkout@v7
       - id: sha
@@ -58,3 +60,35 @@ jobs:
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           cache-from: type=gha,scope=dev-url4-cloud
           cache-to: type=gha,scope=dev-url4-cloud,mode=max
+
+  benchmark-image:
+    needs: image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: azure/login@v3
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      - run: az acr login --name acropenmined
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: apps/url4-cloud/Dockerfile.benchmark
+          platforms: linux/amd64
+          push: true
+          build-args: |
+            BASE=ghcr.io/openmined/screamingface-url4-cloud:main-${{ needs.image.outputs.short }}
+          tags: |
+            ghcr.io/openmined/screamingface-url4-cloud-benchmark:main-${{ needs.image.outputs.short }}
+            acropenmined.azurecr.io/screamingface-url4-cloud-benchmark:main-${{ needs.image.outputs.short }}
+            acropenmined.azurecr.io/screamingface-url4-cloud-benchmark:main-${{ github.sha }}
+          cache-from: type=gha,scope=dev-url4-cloud-benchmark
+          cache-to: type=gha,scope=dev-url4-cloud-benchmark,mode=max

--- a/.github/workflows/release-url4-cloud.yml
+++ b/.github/workflows/release-url4-cloud.yml
@@ -79,6 +79,37 @@ jobs:
             org.opencontainers.image.version=${{ needs.verify.outputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}
 
+  benchmark-image:
+    needs: [verify, image]
+    runs-on: ubuntu-latest
+    env:
+      REPO: ghcr.io/openmined/screamingface-url4-cloud-benchmark
+      BASE: ghcr.io/openmined/screamingface-url4-cloud
+    steps:
+      - uses: actions/checkout@v7
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: apps/url4-cloud/Dockerfile.benchmark
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            BASE=${{ env.BASE }}:${{ needs.verify.outputs.version }}
+          tags: ${{ env.REPO }}:${{ needs.verify.outputs.version }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ needs.verify.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
   chart:
     # NOTE: the chart is LINTED only. OCI Helm publishing is DEFERRED until the NATS dependency in
     # apps/url4-cloud/deploy/helm/Chart.yaml is pinned + vendored — it is a placeholder today
@@ -94,7 +125,7 @@ jobs:
         run: helm lint apps/url4-cloud/deploy/helm
 
   release:
-    needs: [verify, image, chart]
+    needs: [verify, image, benchmark-image, chart]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -105,10 +136,14 @@ jobs:
           name: ScreamingFace url4-cloud ${{ needs.verify.outputs.version }}
           draft: true
           body: |
-            Container image (one artifact, two modes — `url4-cloud serve` and `url4-cloud run`;
-            the separate runner image is merged in as of this release):
+            Control-plane image:
             ```
             docker pull ghcr.io/openmined/screamingface-url4-cloud:${{ needs.verify.outputs.version }}
+            ```
+
+            DRACO benchmark Runner image:
+            ```
+            docker pull ghcr.io/openmined/screamingface-url4-cloud-benchmark:${{ needs.verify.outputs.version }}
             ```
 
             Helm chart: OCI publish deferred until the NATS dependency is pinned (see OME-567).

--- a/.github/workflows/url4-cloud-tests.yml
+++ b/.github/workflows/url4-cloud-tests.yml
@@ -131,7 +131,7 @@ jobs:
           fi
 
   image:
-    name: Build the image
+    name: Build the deployable images
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -139,6 +139,9 @@ jobs:
       # context, mirrored /app layout, editable path-dep resolution at runtime) and nothing built
       # it until a release tag — so a break surfaced at release time, on the release path.
       - uses: docker/setup-buildx-action@v4
+        with:
+          # Let the benchmark build consume the PR-built base without publishing it.
+          driver: docker
       - uses: docker/build-push-action@v7
         with:
           context: .
@@ -146,14 +149,25 @@ jobs:
           push: false
           load: true
           tags: url4-cloud:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Build the DRACO benchmark image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: apps/url4-cloud/Dockerfile.benchmark
+          build-contexts: |
+            url4-cloud-ci=docker-image://url4-cloud:ci
+          build-args: |
+            BASE=url4-cloud-ci
+          push: false
+          load: true
+          tags: url4-cloud-benchmark:ci
       # Both argv modes must at least start from the built image: the entrypoint is the mode
       # switch, so a broken one is a deployment that cannot run either half.
       - name: Smoke both modes
         run: |
           docker run --rm url4-cloud:ci url4-cloud --help
           docker run --rm url4-cloud:ci url4-cloud run --help
+          docker run --rm url4-cloud-benchmark:ci url4-cloud run --help
 
   chart:
     name: Render the Helm chart

--- a/apps/url4-cloud/Dockerfile.benchmark
+++ b/apps/url4-cloud/Dockerfile.benchmark
@@ -21,10 +21,16 @@
 #
 # WHY: use a SEPARATE image layered on the base rather than a stage in the main Dockerfile:
 #
-#   - the default url4-cloud image stays dataset-free. Baking DRACO into it would put ~40
-#     rubrics per case into every deployment, including ones that never benchmark;
-#   - dataset revisions rebuild THIS image only, so benchmark releases do not force an
-#     engine release (and cannot silently change the engine a published score was produced by);
+#   - ISOLATION OF CONCERNS: benchmark assets grow as benchmarks are added, and they change for
+#     reasons that have nothing to do with the engine. Keeping them in their own artifact keeps
+#     the client-facing control-plane image lean and gives grading assets their own build inputs.
+#     NOTE: this does NOT keep assets out of deployments that never benchmark — the chart makes
+#     this image the ONLY Runner image, so every deployment pulls it;
+#   - dataset revisions rebuild THIS image only. CAVEAT: they do not yet ship independently —
+#     `_helpers.tpl` derives this image's tag from the control plane's, and the release lane
+#     builds it only inside a version-gated `url4-cloud-v*` release, so a benchmark-only change
+#     still rides an engine version bump. Independent benchmark versioning needs an explicit tag
+#     plus a control-plane/Runner compatibility check;
 #   - `datasets` (and its pyarrow tail) is installed in a build stage that is thrown away — the
 #     runtime image never carries it. `prepare.py` imports it through `importlib` for exactly
 #     this reason.
@@ -32,8 +38,10 @@
 # INVARIANT: build context is the REPO ROOT, like the base image — `prepare` runs from the
 # installed package, which path-depends on `packages/url4`.
 #
-# AIDEV-NOTE: datasets are welded to an image, so adding a benchmark means a
-# rebuild and anyone who can pull the image has the rubrics. The alternative is a mounted volume
+# AIDEV-NOTE: datasets are welded to an image, so adding a benchmark means a rebuild. Anyone who
+# can pull the image has the rubrics — accepted: DRACO's rubrics are PUBLIC (the upstream
+# `perplexity-ai/draco` dataset downloads without credentials, and each Case Result publishes its
+# graded criteria), so this image needs no registry secrecy. The alternative is a mounted volume
 # plus `URL4_RUNNER_CONFIG` pointing beside it — which needs a volume the Job spec does not have
 # today (read-only rootfs, one emptyDir at /tmp). Decide before this leaves experimentation.
 

--- a/apps/url4-cloud/Dockerfile.benchmark
+++ b/apps/url4-cloud/Dockerfile.benchmark
@@ -1,0 +1,73 @@
+# syntax=docker/dockerfile:1.7
+# The BENCHMARK image — the url4-cloud Runner plus every registered benchmark's assets.
+#
+#   docker build -f apps/url4-cloud/Dockerfile -t url4-cloud:dev .
+#   docker build -f apps/url4-cloud/Dockerfile.benchmark \
+#       --build-arg BASE=url4-cloud:dev \
+#       -t url4-cloud-benchmark:dev .
+#
+# INVARIANT: the benchmark image carries every registered Benchmark's WHOLE dataset. There is
+# deliberately no build arg to truncate any of them.
+#
+# WHY: run size is an EXPRESSION concern — `…!'case';iteration.slice=0:5`
+# picks how many declared cases a run touches, needs no rebuild, and lives inside the recipe
+# identity the scoreboard hashes. A build-time cap addressed the same need one layer down and
+# produced a DIFFERENT ARTIFACT THAT LOOKS IDENTICAL: same tags, a manifest still advertising
+# `cases: 100`, and nothing in the result recording the truncation — so a partial run was
+# indistinguishable from a full one, in the flattering direction. It also bought almost nothing,
+# because `load_dataset` downloads the full split regardless and only the file writes were
+# skipped. `prepare --limit` still exists for a local generator run; it just cannot shape a
+# deployable image any more.
+#
+# WHY: use a SEPARATE image layered on the base rather than a stage in the main Dockerfile:
+#
+#   - the default url4-cloud image stays dataset-free. Baking DRACO into it would put ~40
+#     rubrics per case into every deployment, including ones that never benchmark;
+#   - dataset revisions rebuild THIS image only, so benchmark releases do not force an
+#     engine release (and cannot silently change the engine a published score was produced by);
+#   - `datasets` (and its pyarrow tail) is installed in a build stage that is thrown away — the
+#     runtime image never carries it. `prepare.py` imports it through `importlib` for exactly
+#     this reason.
+#
+# INVARIANT: build context is the REPO ROOT, like the base image — `prepare` runs from the
+# installed package, which path-depends on `packages/url4`.
+#
+# AIDEV-NOTE: datasets are welded to an image, so adding a benchmark means a
+# rebuild and anyone who can pull the image has the rubrics. The alternative is a mounted volume
+# plus `URL4_RUNNER_CONFIG` pointing beside it — which needs a volume the Job spec does not have
+# today (read-only rootfs, one emptyDir at /tmp). Decide before this leaves experimentation.
+
+ARG BASE=url4-cloud:dev
+
+# --- build stage: download the dataset, emit the declared world -----------------------------
+FROM ${BASE} AS prepare
+# root only for the build stage; the runtime image below drops back to uid 1000.
+USER 0
+WORKDIR /app/apps/url4-cloud
+# WHY: `uv` is copied in because the base image's uv-created venv has no pip and its runtime
+# stage does not install uv. Reusing the base image's package manager keeps one installer across
+# both Dockerfiles.
+# Keep this digest and the exact datasets version synchronized with DRACO's preparer revision.
+# Changing either changes the bytes that may be baked into an image.
+COPY --from=ghcr.io/astral-sh/uv:python3.12-bookworm-slim@sha256:e5b65587bce7de595f299855d7385fe7fca39b8a74baa261ba1b7147afa78e58 /usr/local/bin/uv /usr/local/bin/uv
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --python /app/apps/url4-cloud/.venv/bin/python --quiet "datasets==5.0.0"
+RUN mkdir -p /opt/benchmarks/draco \
+ && /app/apps/url4-cloud/.venv/bin/python -m url4_cloud.benchmarks.draco.prepare \
+      --out /opt/benchmarks/draco
+
+# --- runtime: the base image + the prepared assets -------------------------------------------
+FROM ${BASE} AS runtime
+LABEL org.opencontainers.image.title="url4-cloud-benchmark" \
+      org.opencontainers.image.description="url4-cloud Runner with registered Benchmark assets"
+USER 0
+# `rubrics/` ships too — DRACO's installed runtime reads it off disk. It is deliberately NOT a
+# data route: the weights must be unreachable from an expression, or a judge prompt could be
+# handed the thing it is being kept blind to.
+COPY --from=prepare --chown=1000:1000 /opt/benchmarks /opt/benchmarks
+# The Benchmark definition installs its own namespaced routes. This one root points those routes
+# at the immutable assets baked into this image; the shared url4.toml remains model-only.
+ENV URL4_BENCHMARK_ASSETS=/opt/benchmarks
+USER 1000
+# Unchanged from the base: `url4-cloud` (serve) by default, `["url4-cloud","run"]` for a Job.
+CMD ["url4-cloud"]

--- a/apps/url4-cloud/deploy/helm/README.md
+++ b/apps/url4-cloud/deploy/helm/README.md
@@ -6,11 +6,14 @@ the App **Deployment · Service · ConfigMap · Secret**, one of two edge object
 (**ServiceAccount · Role · RoleBinding**) that lets the App schedule Runner Jobs in its own
 namespace.
 
-**One image, two modes.** The Deployment runs `url4-cloud` (which defaults to `serve`); every
-Runner Job runs the **same** image with `command: ["url4-cloud", "run"]`. There is no second
-`runner.image` block and no separate template helper for it any more — `URL4_CLOUD_RUNNER_IMAGE`
-renders from the App's own `image:` block via `url4-cloud.image`, so the two can no longer drift
-out of version alignment.
+**Two paired images.** The Deployment runs the dataset-free control-plane image. Runner Jobs run
+the matching `-benchmark` image with `command: ["url4-cloud", "run"]`; that image layers private
+grading assets onto the same engine release. `runner.image.tag` defaults to the control-plane
+tag, so upgrades remain paired while rubrics stay off the client-facing pod.
+
+By default a control-plane repository such as `registry.example/url4-cloud` yields Runner image
+`registry.example/url4-cloud-benchmark`. Override `runner.image.repository` only when a registry
+uses another name.
 
 ## Install
 
@@ -114,11 +117,11 @@ maintained as a second definition.)
 
 What the App schedules:
 
-- the App's **own image** in run mode — `command: ["url4-cloud", "run"]`, pinned in
+- the paired benchmark image in run mode — `command: ["url4-cloud", "run"]`, pinned in
   `url4_cloud.adapters.k8s` rather than in values: the command is the mode switch and nothing
   else, so a chart override could only ever name a mode the image does not have. The image
-  reference itself stays a value (`URL4_CLOUD_RUNNER_IMAGE`, rendered from `image:`) so a staged
-  rollout can still pin Jobs to a different tag than the Deployment
+  reference itself stays a value (`URL4_CLOUD_RUNNER_IMAGE`, rendered from `runner.image`) so a
+  staged rollout can still pin Jobs to a different tag than the Deployment
 - run-once — `backoffLimit: 0`, `restartPolicy: Never` (retry = new token, new job; spec §2.3)
 - `activeDeadlineSeconds` = `config.jobDeadlineS`, surfacing as `timed_out`
 - `enableServiceLinks: false` — kubelet's legacy Docker-link vars would export

--- a/apps/url4-cloud/deploy/helm/templates/_helpers.tpl
+++ b/apps/url4-cloud/deploy/helm/templates/_helpers.tpl
@@ -47,6 +47,17 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/*
+Runner Jobs use the benchmark image, which layers private grading assets onto the matching
+control-plane release. Deriving both repository and tag keeps mirrors and upgrades paired; an
+operator may override either value when their registry uses a different naming convention.
+*/}}
+{{- define "url4-cloud.runnerImage" -}}
+{{- $repo := .Values.runner.image.repository | default (printf "%s-benchmark" .Values.image.repository) -}}
+{{- $tag := .Values.runner.image.tag | default (default .Chart.AppVersion .Values.image.tag) -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+
+{{/*
 Where the App reaches NATS.
 
 WHY a helper and not a plain value: the previous default hardcoded `nats://url4-cloud-nats:4222`,

--- a/apps/url4-cloud/deploy/helm/templates/configmap.yaml
+++ b/apps/url4-cloud/deploy/helm/templates/configmap.yaml
@@ -17,12 +17,12 @@ data:
   # INVARIANT: Jobs are created in the release namespace only — this must match the namespace the
   # Role/RoleBinding bind, or the App's ServiceAccount is not authorized to create them.
   URL4_CLOUD_NAMESPACE: {{ .Release.Namespace | quote }}
-  # The Job runs THIS SAME image in its run mode (`url4-cloud run`) — one artifact, two modes.
-  # WHY the App is told its own image rather than discovering it: a process cannot reliably read
+  # The image every Runner Job runs, in its run mode (`url4-cloud run`).
+  # WHY: the App is told the image because a process cannot reliably read
   # back the image reference it was started from (that lives in the pod spec, needs RBAC on pods,
-  # and the Downward API does not expose it). Rendering the same `image:` the Deployment gets is
-  # what keeps the Job and the App on one version through an upgrade.
-  URL4_CLOUD_RUNNER_IMAGE: {{ include "url4-cloud.image" . | quote }}
+  # and the Downward API does not expose it). The derived image carries private benchmark assets
+  # while retaining the control plane's resolved tag.
+  URL4_CLOUD_RUNNER_IMAGE: {{ include "url4-cloud.runnerImage" . | quote }}
   {{- with .Values.runner.resources }}
   # The Runner's own requests/limits. Carried as JSON because a ConfigMap value is a string and
   # pydantic-settings parses complex fields as JSON — so the k8s `resources` block travels
@@ -53,7 +53,7 @@ data:
   # no App change and no restart.
   URL4_CLOUD_RUNNER_ENV_CONFIGMAP: {{ include "url4-cloud.fullname" . }}-runner-env
   {{- if .Values.tavily.enabled }}
-  # WHY only the Secret's NAME travels: the App attaches it to each Job with `envFrom.secretRef`
+  # WHY: only the Secret's NAME travels; the App attaches it to each Job with `envFrom.secretRef`
   # and never reads the credential, so nothing secret belongs in this ConfigMap. The Secret's KEY
   # must be `TAVILY_API_KEY` — `envFrom` injects keys under their own names and does no renaming.
   # Absent => the Runner never sees TAVILY_API_KEY and web tools stay off (dec:W5).

--- a/apps/url4-cloud/deploy/helm/values.schema.json
+++ b/apps/url4-cloud/deploy/helm/values.schema.json
@@ -78,6 +78,20 @@
           ],
           "description": "Mirrors url4_cloud.config.RunnerBackend. `none` deploys an App that cannot schedule and answers 503 to every run."
         },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "description": "Empty derives `<image.repository>-benchmark`; override when the benchmark image uses another repository."
+            },
+            "tag": {
+              "type": "string",
+              "description": "Empty uses the control-plane image's resolved tag; override only for a staged rollout."
+            }
+          },
+          "additionalProperties": false
+        },
         "resources": {
           "type": "object"
         },

--- a/apps/url4-cloud/deploy/helm/values.yaml
+++ b/apps/url4-cloud/deploy/helm/values.yaml
@@ -20,11 +20,9 @@
 # size one against.
 replicaCount: 1
 
-# ONE image, used two ways: the Deployment runs it as the control plane (`url4-cloud serve`),
-# and every Runner Job runs the SAME image in run mode (`url4-cloud run`) — see
-# `URL4_CLOUD_RUNNER_IMAGE` in configmap.yaml. There is no second `runner.image` block any more;
-# the two artifacts were merged, so they cannot drift out of version alignment. Build-time OCI
-# labels the image should carry are listed in README.md (org.opencontainers.image.*).
+# The control-plane image. Runner Jobs use the matching benchmark image configured under
+# `runner.image`; private grading assets therefore never reach the client-facing process.
+# Build-time OCI labels are listed in README.md (org.opencontainers.image.*).
 image:
   repository: ghcr.io/openmined/screamingface-url4-cloud
   tag: ""            # defaults to .Chart.AppVersion
@@ -260,9 +258,12 @@ runner:
   # Which JobRunner substrate the App schedules on (url4_cloud.config.RunnerBackend). `k8s` is the
   # point of this chart; `none` degrades the App to a token-minting NATS bridge that cannot run.
   backend: k8s
-  # NOTE: there is deliberately no `image` here any more. A Runner Job runs the App's OWN image
-  # (the `image:` block at the top of this file) in its run mode, so there is nothing left to
-  # configure separately — and nothing that can drift out of version alignment during an upgrade.
+  # Runner Jobs need benchmark datasets and private grading assets that the control plane must
+  # not carry. Empty values derive `<image.repository>-benchmark` with the control plane's
+  # resolved tag, keeping the two artifacts paired across mirrors and upgrades.
+  image:
+    repository: ""
+    tag: ""
   #
   # NOTE: there is deliberately no `command` here either. The Job's command is the mode switch
   # `["url4-cloud", "run"]`, pinned in code beside the Job spec that uses it

--- a/apps/url4-cloud/src/url4_cloud/app.py
+++ b/apps/url4-cloud/src/url4_cloud/app.py
@@ -17,7 +17,7 @@ from fastapi.staticfiles import StaticFiles
 from url4.streaming.interfaces import EventConsumer, JobRunner
 from url4_cloud.adapters.factory import build_job_runner
 from url4_cloud.auth import Clock, install_problem_handlers
-from url4_cloud.benchmarks import EMPTY_BENCHMARKS, BenchmarkRegistry
+from url4_cloud.benchmarks import BENCHMARKS, EMPTY_BENCHMARKS, BenchmarkRegistry
 from url4_cloud.catalog import build_executable_catalog_service
 from url4_cloud.catalog.cache import CatalogService
 from url4_cloud.catalog.port import ModelParameterSource
@@ -151,6 +151,7 @@ def create_app_from_env() -> FastAPI:  # pragma: no cover - env/NATS wiring (INF
         catalog=catalog,
         model_parameters=catalog.model_parameter_source if catalog is not None else None,
         connections=connections,
+        benchmarks=BENCHMARKS,
     )
     app.router.on_shutdown.append(stream.close)
     if catalog is not None:

--- a/apps/url4-cloud/src/url4_cloud/app.py
+++ b/apps/url4-cloud/src/url4_cloud/app.py
@@ -17,7 +17,8 @@ from fastapi.staticfiles import StaticFiles
 from url4.streaming.interfaces import EventConsumer, JobRunner
 from url4_cloud.adapters.factory import build_job_runner
 from url4_cloud.auth import Clock, install_problem_handlers
-from url4_cloud.benchmarks import BENCHMARKS, EMPTY_BENCHMARKS, BenchmarkRegistry
+from url4_cloud.benchmarks import EMPTY_BENCHMARKS, BenchmarkRegistry
+from url4_cloud.benchmarks.builtins import BUILTIN_BENCHMARKS
 from url4_cloud.catalog import build_executable_catalog_service
 from url4_cloud.catalog.cache import CatalogService
 from url4_cloud.catalog.port import ModelParameterSource
@@ -151,7 +152,7 @@ def create_app_from_env() -> FastAPI:  # pragma: no cover - env/NATS wiring (INF
         catalog=catalog,
         model_parameters=catalog.model_parameter_source if catalog is not None else None,
         connections=connections,
-        benchmarks=BENCHMARKS,
+        benchmarks=BUILTIN_BENCHMARKS,
     )
     app.router.on_shutdown.append(stream.close)
     if catalog is not None:

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/__init__.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/__init__.py
@@ -7,6 +7,7 @@ from url4_cloud.benchmarks.definition import (
     candidate,
     link_candidate,
 )
+from url4_cloud.benchmarks.draco.definition import DRACO, DRACO_LITE, DRACO_SMOKE
 from url4_cloud.benchmarks.registry import (
     BENCHMARK_ASSETS_ENV,
     DEFAULT_BENCHMARK_ASSETS_ROOT,
@@ -15,9 +16,12 @@ from url4_cloud.benchmarks.registry import (
     assets_root,
 )
 
+BENCHMARKS = BenchmarkRegistry((DRACO, DRACO_LITE, DRACO_SMOKE))
+
 __all__ = [
     "BENCHMARK_ASSETS_ENV",
     "CANDIDATE_REF",
+    "BENCHMARKS",
     "DEFAULT_BENCHMARK_ASSETS_ROOT",
     "Benchmark",
     "BenchmarkInstaller",

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/__init__.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/__init__.py
@@ -7,7 +7,6 @@ from url4_cloud.benchmarks.definition import (
     candidate,
     link_candidate,
 )
-from url4_cloud.benchmarks.draco.definition import DRACO, DRACO_LITE, DRACO_SMOKE
 from url4_cloud.benchmarks.registry import (
     BENCHMARK_ASSETS_ENV,
     DEFAULT_BENCHMARK_ASSETS_ROOT,
@@ -16,12 +15,9 @@ from url4_cloud.benchmarks.registry import (
     assets_root,
 )
 
-BENCHMARKS = BenchmarkRegistry((DRACO, DRACO_LITE, DRACO_SMOKE))
-
 __all__ = [
     "BENCHMARK_ASSETS_ENV",
     "CANDIDATE_REF",
-    "BENCHMARKS",
     "DEFAULT_BENCHMARK_ASSETS_ROOT",
     "Benchmark",
     "BenchmarkInstaller",

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/builtins.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/builtins.py
@@ -1,0 +1,10 @@
+"""Concrete Benchmarks selected by the URL4 Cloud deployment."""
+
+from url4_cloud.benchmarks.draco.definition import DRACO, DRACO_LITE, DRACO_SMOKE
+from url4_cloud.benchmarks.registry import BenchmarkRegistry
+
+# WHY: protocol-neutral registry machinery does not import concrete protocols. This composition
+# module is the single place where this deployment chooses which Benchmark adapters to install.
+BUILTIN_BENCHMARKS = BenchmarkRegistry((DRACO, DRACO_LITE, DRACO_SMOKE))
+
+__all__ = ["BUILTIN_BENCHMARKS"]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/contract.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/contract.py
@@ -10,6 +10,7 @@ CANDIDATE_ROUTE = "/benchmarks/candidate"
 # resolves. Published in every Benchmark resource: a client cannot be expected to infer it.
 CANDIDATE_BINDING = "candidate"
 CANDIDATE_INVOCATION_SCHEMA = "screamingface.candidate-invocation.v1"
+CANDIDATE_RESULT_SCHEMA = "screamingface.candidate-result.v1"
 FINISH_REASONS = frozenset({"stop", "length", "tool_calls", "content_filter"})
 
 
@@ -71,6 +72,7 @@ def _validate_candidate_invocation(
 __all__ = [
     "CANDIDATE_BINDING",
     "CANDIDATE_INVOCATION_SCHEMA",
+    "CANDIDATE_RESULT_SCHEMA",
     "CANDIDATE_ROUTE",
     "FINISH_REASONS",
     "decode_candidate_invocation",

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/__init__.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/__init__.py
@@ -1,0 +1,8 @@
+"""DRACO — Perplexity's research-quality rubric benchmark (`perplexity-ai/draco`).
+
+Ground truth is a WEIGHTED RUBRIC, not a reference answer: ~40 criteria grouped into sections,
+where a NEGATIVE weight marks behaviour the answer must not show. Text-similarity metrics are
+meaningless here; only a judge reading the rubric can produce a score.
+
+Reference: arXiv:2602.11685 §4.2 · `screamingface-benchmarks/docs/draco-benchmark-anatomy.md`
+"""

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/aggregate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/aggregate.py
@@ -54,6 +54,7 @@ from url4_cloud.benchmarks.draco.case_evaluation import decode_case_evaluation
 from url4_cloud.benchmarks.draco.definition import JUDGE_PASSES, REVISION
 from url4_cloud.benchmarks.draco.errors import AggregateError as AggregateError
 from url4_cloud.benchmarks.draco.scoring import flatten_criteria as flatten_criteria
+from url4_cloud.benchmarks.draco.validation import optional_integer
 
 COVERAGE_TARGET = case_results_module.COVERAGE_TARGET
 VERDICT_SCHEMA = case_results_module.VERDICT_SCHEMA
@@ -217,7 +218,7 @@ def _aggregate_rows(
             )
             continue
         case_record = row.case_records[0]
-        case_id = _as_int(case_record.get("case_id"))
+        case_id = optional_integer(case_record.get("case_id"))
         if case_id is None:  # pragma: no cover - sealed by _require_verifiable_mapping
             raise AssertionError("a scored DRACO row must carry its Engine-bound case_id")
         rubric = rubrics.get(case_id)
@@ -338,7 +339,8 @@ def _require_verifiable_mapping(rows: Sequence[_DecodedRow]) -> None:
                 f"found {len(case_records)}"
             )
         ids = [
-            _as_int(record.get("case_id")) for record in (*case_records, *check_records, *verdicts)
+            optional_integer(record.get("case_id"))
+            for record in (*case_records, *check_records, *verdicts)
         ]
         if any(case_id is None for case_id in ids):
             raise AggregateError(
@@ -376,7 +378,7 @@ def _validate_selected_cases(
     expected = list(selected_cases)
     ids: set[int] = set()
     for index, case in enumerate(expected):
-        case_id = _as_int(case.get("id")) if isinstance(case, Mapping) else None
+        case_id = optional_integer(case.get("id")) if isinstance(case, Mapping) else None
         input_value = case.get("input") if isinstance(case, Mapping) else None
         if case_id is None or case_id < 1 or not isinstance(input_value, str) or not input_value:
             raise AggregateError(f"selected Case {index} must carry a positive id and input text")
@@ -384,13 +386,6 @@ def _validate_selected_cases(
             raise AggregateError(f"selected Case sequence repeats case_id {case_id}")
         ids.add(case_id)
     return expected
-
-
-def _as_int(value: Any) -> int | None:
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
 
 
 def _grade(case: Mapping[str, Any]) -> Mapping[str, Any]:

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/aggregate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/aggregate.py
@@ -1,0 +1,430 @@
+"""The DRACO cross-row reducer — per-criterion verdicts in, Candidate Result out.
+
+FEATURE: one url4 expression per Candidate ends in a cross-row reduce that turns every case's
+judge verdicts into one scored result.
+STORY: as a researcher, the number I publish is the DRACO paper's `normalized_score`.
+
+Installed directly into each Runner world in the reducer position::
+
+    (…iteration…)!/benchmarks/draco/<revision>/aggregate($rows)!'aggregate'
+
+    context (row array)  →  the JSON array of every row's judge output
+    intent ("aggregate") →  the fixed reduction operation
+
+INVARIANT: the scoring formulas mirror `screamingface-benchmarks/benchmarking/graders/rubric.py`
+(arXiv:2602.11685 §4.2) EXACTLY. Do not "improve" them. A different formula is a different
+benchmark, and a leaderboard number computed here must mean what the paper says it means.
+
+The expression this reducer serves runs the paper's `official` grading mode: ONE judge call per
+CRITERION, five independent passes, and the judge blind to the weights and to the sibling
+criteria. The Engine-owned Benchmark definition constructs that fan-out and this in-process
+handler reduces the complete row collection without crossing an operating-system argv boundary.
+
+AIDEV-NOTE: protocol caveats, the two ways a run here still differs from the paper:
+
+* `judge_reasoning: "low"` (arXiv:2602.11685 §4.2) is NOT carried until the gateway supports it.
+  `reasoning_effort` is absent from the OpenRouter plugin's rule set, and the gateway fails
+  closed on an unknown parameter, so
+  sending it would turn every judge call into a 400 rather than a deviation. `judge_temperature`
+  and `max_tokens` DO reach the model.
+* Retrieval reaches EVERY answering route as of 2026-08-02, but by TWO different mechanisms
+  (owner decision, same date): provider-side `native_web_search` on the OpenRouter routes that
+  support it, and the runner-driven Tavily loop on `gemini-3.1-pro-preview`,
+  `gemini-3-flash-preview`, `kimi-k2.6`, `deepseek-v4-pro`, and `qwen3.6-plus`. Both honour the
+  same declared blocklist—verified live on both paths—but they are not the same search product,
+  so a candidate that answered through Tavily and one that answered natively did not read the
+  same web. A comparison ACROSS those two groups carries that caveat; the reference chart used
+  neither exactly.
+
+Neither is visible in the numbers this module emits. A score published as "DRACO-reproduced"
+has to state both.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from url4_cloud.benchmarks.contract import CANDIDATE_RESULT_SCHEMA
+from url4_cloud.benchmarks.draco import assets
+from url4_cloud.benchmarks.draco import case_results as case_results_module
+from url4_cloud.benchmarks.draco.case_evaluation import decode_case_evaluation
+from url4_cloud.benchmarks.draco.definition import JUDGE_PASSES, REVISION
+from url4_cloud.benchmarks.draco.errors import AggregateError as AggregateError
+from url4_cloud.benchmarks.draco.scoring import flatten_criteria as flatten_criteria
+
+COVERAGE_TARGET = case_results_module.COVERAGE_TARGET
+VERDICT_SCHEMA = case_results_module.VERDICT_SCHEMA
+group_runs = case_results_module.group_runs
+valid_verdicts = case_results_module.valid_verdicts
+load_rubrics = assets.load_rubrics
+
+
+@dataclass(frozen=True)
+class _DecodedRow:
+    """One selected Case and its exact decoded evaluation, kept together."""
+
+    raw: Any
+    expected_case: Mapping[str, Any]
+    evaluation: Mapping[str, Any] | None
+    decode_error: str | None
+
+    @property
+    def case_records(self) -> Sequence[Mapping[str, Any]]:
+        return [self.evaluation["case"]] if self.evaluation is not None else []
+
+    @property
+    def checks(self) -> Sequence[Mapping[str, Any]]:
+        return self.evaluation["checks"] if self.evaluation is not None else []
+
+    @property
+    def evidence(self) -> Sequence[Mapping[str, Any]]:
+        return self.evaluation["evidence"] if self.evaluation is not None else []
+
+
+# --- the reduction ---------------------------------------------------------------
+
+
+def aggregate(
+    rows_json: str,
+    rubrics: Mapping[int, Mapping[str, Any]],
+    benchmark_id: str,
+    *,
+    selected_cases: Sequence[Mapping[str, Any]],
+    judge_passes: int = JUDGE_PASSES,
+    benchmark_revision: str = REVISION,
+    criterion_count: int | None = None,
+) -> dict[str, Any]:
+    """Reduce the row array into a Candidate Result — one row per Case.
+
+    INVARIANT: a case that produced no verdicts is EXCLUDED from the mean and named in
+    ``failures`` — never scored 0.0. Scoring it zero would penalise the Candidate for a harness
+    failure, the same class of error as counting an unjudged criterion as UNMET.
+    """
+    try:
+        rows = json.loads(rows_json)
+    except (TypeError, ValueError) as exc:
+        raise AggregateError(f"reducer payload is not JSON: {exc}") from None
+    if not isinstance(rows, list):
+        raise AggregateError(f"reducer payload must be a JSON array, got {type(rows).__name__}")
+    if isinstance(judge_passes, bool) or not isinstance(judge_passes, int) or judge_passes < 1:
+        raise AggregateError("judge_passes must be a positive integer")
+    if criterion_count is not None and (
+        isinstance(criterion_count, bool)
+        or not isinstance(criterion_count, int)
+        or criterion_count < 1
+    ):
+        raise AggregateError("criterion_count must be a positive integer or None")
+    # INVARIANT: absence of evaluated Cases is an execution failure, not Candidate score zero.
+    if not rows:
+        raise AggregateError("no DRACO Case results were collected; the Candidate cannot be scored")
+    expected_cases = _validate_selected_cases(selected_cases, len(rows))
+
+    decoded_rows = _decode_rows(rows, expected_cases, judge_passes)
+    _require_verifiable_mapping(decoded_rows)
+    case_results = _aggregate_rows(decoded_rows, rubrics, judge_passes, criterion_count)
+    scored = [
+        case
+        for case in case_results
+        if isinstance((grade := case.get("grade")), Mapping)
+        and isinstance(grade.get("score"), int | float)
+        and not isinstance(grade.get("score"), bool)
+    ]
+    if len(scored) != len(case_results):
+        return {
+            "schema": CANDIDATE_RESULT_SCHEMA,
+            "benchmark_id": benchmark_id,
+            "benchmark_revision": benchmark_revision,
+            "case_count": len(case_results),
+            "score": None,
+            "metrics": {},
+            "cases": case_results,
+            "failures": [],
+        }
+
+    return {
+        "schema": CANDIDATE_RESULT_SCHEMA,
+        "benchmark_id": benchmark_id,
+        "benchmark_revision": benchmark_revision,
+        "case_count": len(case_results),
+        "score": _mean_grades(scored, "score"),
+        "metrics": {
+            "normalized_score_sd": _mean_grade_metrics(scored, "normalized_score_sd"),
+            "pass_rate": _mean_grade_metrics(scored, "pass_rate"),
+            "pass_rate_sd": _mean_grade_metrics(scored, "pass_rate_sd"),
+            "accuracy": _mean_grade_metrics(scored, "accuracy"),
+            "accuracy_pass_rate": _mean_grade_metrics(scored, "accuracy_pass_rate"),
+            "axis_scores": _mean_grade_metric_maps(scored, "axis_scores"),
+            "axis_pass_rates": _mean_grade_metric_maps(scored, "axis_pass_rates"),
+            "coverage": _mean_grade_metrics(scored, "coverage"),
+            "coverage_sd": _mean_grade_metrics(scored, "coverage_sd"),
+            "coverage_target": COVERAGE_TARGET,
+            "n_runs": max((_grade_metric(case, "n_runs") for case in scored), default=0),
+            "verdicts_expected": _sum_grade_metrics(scored, "verdicts_expected"),
+            "verdicts_accepted": _sum_grade_metrics(scored, "verdicts_accepted"),
+            "verdicts_rejected": _sum_grade_metrics(scored, "verdicts_rejected"),
+            "verdicts_invalid": _sum_grade_metrics(scored, "verdicts_invalid"),
+            "verdicts_missing": _sum_grade_metrics(scored, "verdicts_missing"),
+        },
+        "cases": case_results,
+        # Case-scoped failures live on their Case Result. Candidate-level failures are reserved
+        # for failures that cannot be attributed to a selected Case.
+        "failures": [],
+    }
+
+
+def _decode_rows(
+    rows: Sequence[Any],
+    expected_cases: Sequence[Mapping[str, Any]],
+    judge_passes: int,
+) -> list[_DecodedRow]:
+    decoded: list[_DecodedRow] = []
+    for raw, expected_case in zip(rows, expected_cases, strict=True):
+        try:
+            evaluation = decode_case_evaluation(
+                raw,
+                int(expected_case["id"]),
+                judge_passes=judge_passes,
+            )
+        except (TypeError, ValueError) as exc:
+            evaluation = None
+            error = str(exc)
+        else:
+            error = None
+        decoded.append(_DecodedRow(raw, expected_case, evaluation, error))
+    return decoded
+
+
+def _aggregate_rows(
+    decoded_rows: Sequence[_DecodedRow],
+    rubrics: Mapping[int, Mapping[str, Any]],
+    judge_passes: int,
+    criterion_count: int | None,
+) -> list[dict[str, Any]]:
+    case_results: list[dict[str, Any]] = []
+    for index, row in enumerate(decoded_rows):
+        if not row.case_records:
+            failure = _row_failure(
+                row.raw,
+                index,
+                row.expected_case,
+                row.decode_error,
+            )
+            case_results.append(
+                case_results_module.failed_selected_case_result(row.expected_case, failure)
+            )
+            continue
+        case_record = row.case_records[0]
+        case_id = _as_int(case_record.get("case_id"))
+        if case_id is None:  # pragma: no cover - sealed by _require_verifiable_mapping
+            raise AssertionError("a scored DRACO row must carry its Engine-bound case_id")
+        rubric = rubrics.get(case_id)
+        if rubric is None:
+            failure = {
+                "stage": "grading",
+                "code": "missing_case_rubric",
+                "message": "the selected Case has no installed DRACO rubric",
+                "retryable": None,
+                "case_id": case_id,
+                "metadata": {"row_index": index},
+            }
+            case_results.append(case_results_module.ungraded_case_result(case_record, failure))
+            continue
+        verdicts = case_results_module.valid_verdicts(rubric, row.evidence, case_id)
+        if not verdicts:
+            failure = {
+                "stage": "grading",
+                "code": "no_valid_judge_verdict",
+                "message": "no valid Judge verdict was produced for this Case",
+                "retryable": None,
+                "case_id": case_id,
+                "metadata": {"row_index": index},
+            }
+            case_results.append(
+                case_results_module.incomplete_case_result(
+                    case_record,
+                    rubric,
+                    row.checks,
+                    row.evidence,
+                    judge_passes,
+                    criterion_count,
+                    failure,
+                )
+            )
+            continue
+        case_results.append(
+            case_results_module.scored_case_result(
+                case_record,
+                rubric,
+                row.checks,
+                row.evidence,
+                verdicts,
+                judge_passes,
+                criterion_count,
+            )
+        )
+    return case_results
+
+
+def _row_failure(
+    row: Any,
+    index: int,
+    expected_case: Mapping[str, Any],
+    decode_error: str | None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "row_index": index,
+        **({"reason": " ".join(decode_error.split())[:200]} if decode_error else {}),
+    }
+    failure: dict[str, Any] = {
+        "stage": "grading",
+        "code": "invalid_case_evaluation",
+        "message": "the Case produced no valid DRACO Case Evaluation",
+        "retryable": None,
+        "case_id": int(expected_case["id"]),
+        "metadata": metadata,
+    }
+    error = row.get("error") if isinstance(row, Mapping) else None
+    if not isinstance(error, Mapping):
+        return failure
+    metadata.clear()
+    metadata["row_index"] = index
+    selected = _bounded_error(error)
+    failure.update(
+        {
+            "stage": "candidate",
+            "code": selected.get("code", "case_execution_failed"),
+            "message": selected.get("message", "Candidate Case execution failed"),
+            "retryable": _retryable(error),
+        }
+    )
+    if kind := selected.get("kind"):
+        metadata["error_kind"] = kind
+    return failure
+
+
+def _bounded_error(error: Mapping[str, Any]) -> dict[str, str]:
+    limits = {"kind": 80, "code": 80, "message": 200}
+    return {
+        field: " ".join(value.split())[:limit]
+        for field, limit in limits.items()
+        if isinstance((value := error.get(field)), str) and value.strip()
+    }
+
+
+def _retryable(error: Mapping[str, Any]) -> bool | None:
+    if isinstance(value := error.get("retryable"), bool):
+        return value
+    if isinstance(permanent := error.get("permanent"), bool):
+        return not permanent
+    return None
+
+
+def _require_verifiable_mapping(rows: Sequence[_DecodedRow]) -> None:
+    """Require one unique Engine-bound Case identity for every scoreable row."""
+
+    claimed: dict[int, int] = {}
+    for index, row in enumerate(rows):
+        case_records = row.case_records
+        check_records = row.checks
+        verdicts = row.evidence
+        if not case_records and not verdicts:
+            continue
+        if len(case_records) != 1:
+            raise AggregateError(
+                f"Case result at position {index} must carry exactly one Engine-bound Case record; "
+                f"found {len(case_records)}"
+            )
+        ids = [
+            _as_int(record.get("case_id")) for record in (*case_records, *check_records, *verdicts)
+        ]
+        if any(case_id is None for case_id in ids):
+            raise AggregateError(
+                f"Case result at position {index} has a verdict without an Engine-bound case_id"
+            )
+        unique = {case_id for case_id in ids if case_id is not None}
+        if len(unique) != 1:
+            raise AggregateError(
+                f"Case result at position {index} carries multiple case_id values {sorted(unique)}"
+            )
+        case_id = unique.pop()
+        previous = claimed.get(case_id)
+        if previous is not None:
+            raise AggregateError(
+                f"duplicate case_id {case_id} appears at Case result positions "
+                f"{previous} and {index}"
+            )
+        expected_id = int(row.expected_case["id"])
+        if case_id != expected_id:
+            raise AggregateError(
+                f"Case result at position {index} claims case_id {case_id}, "
+                f"but the selected Case is {expected_id}"
+            )
+        claimed[case_id] = index
+
+
+def _validate_selected_cases(
+    selected_cases: Sequence[Mapping[str, Any]], row_count: int
+) -> list[Mapping[str, Any]]:
+    if len(selected_cases) != row_count:
+        raise AggregateError(
+            f"selected Case sequence must exactly match the {row_count} collected Case results; "
+            f"got {len(selected_cases)} selections"
+        )
+    expected = list(selected_cases)
+    ids: set[int] = set()
+    for index, case in enumerate(expected):
+        case_id = _as_int(case.get("id")) if isinstance(case, Mapping) else None
+        input_value = case.get("input") if isinstance(case, Mapping) else None
+        if case_id is None or case_id < 1 or not isinstance(input_value, str) or not input_value:
+            raise AggregateError(f"selected Case {index} must carry a positive id and input text")
+        if case_id in ids:
+            raise AggregateError(f"selected Case sequence repeats case_id {case_id}")
+        ids.add(case_id)
+    return expected
+
+
+def _as_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _grade(case: Mapping[str, Any]) -> Mapping[str, Any]:
+    grade = case.get("grade")
+    if not isinstance(grade, Mapping):  # pragma: no cover - selected by caller
+        raise AssertionError("scored Case must carry a Case Grade")
+    return grade
+
+
+def _grade_metric(case: Mapping[str, Any], key: str) -> Any:
+    metrics = _grade(case).get("metrics")
+    if not isinstance(metrics, Mapping):  # pragma: no cover - constructed locally
+        raise AssertionError("Case Grade must carry metrics")
+    return metrics[key]
+
+
+def _mean_grades(cases: Sequence[Mapping[str, Any]], key: str) -> float:
+    return round(sum(float(_grade(case)[key]) for case in cases) / len(cases), 4)
+
+
+def _mean_grade_metrics(cases: Sequence[Mapping[str, Any]], key: str) -> float:
+    return round(sum(float(_grade_metric(case, key)) for case in cases) / len(cases), 4)
+
+
+def _sum_grade_metrics(cases: Sequence[Mapping[str, Any]], key: str) -> int:
+    return sum(int(_grade_metric(case, key)) for case in cases)
+
+
+def _mean_grade_metric_maps(cases: Sequence[Mapping[str, Any]], key: str) -> dict[str, float]:
+    values: dict[str, list[float]] = {}
+    for case in cases:
+        metric = _grade_metric(case, key)
+        if not isinstance(metric, Mapping):  # pragma: no cover - constructed locally
+            raise AssertionError(f"Case Grade metric {key!r} must be an object")
+        for name, value in metric.items():
+            values.setdefault(str(name), []).append(float(value))
+    return {name: round(sum(items) / len(items), 4) for name, items in sorted(values.items())}

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/aggregate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/aggregate.py
@@ -100,9 +100,14 @@ def aggregate(
 ) -> dict[str, Any]:
     """Reduce the row array into a Candidate Result — one row per Case.
 
-    INVARIANT: a case that produced no verdicts is EXCLUDED from the mean and named in
-    ``failures`` — never scored 0.0. Scoring it zero would penalise the Candidate for a harness
-    failure, the same class of error as counting an unjudged criterion as UNMET.
+    INVARIANT: a case that produced no verdicts is never scored 0.0. Scoring it zero would
+    penalise the Candidate for a harness failure, the same class of error as counting an unjudged
+    criterion as UNMET. Instead the whole Candidate goes unscored: if ANY Case Result lacks a
+    numeric grade, the result carries ``score: None`` and empty ``metrics``, so a partial run can
+    never be mistaken for a complete one.
+
+    The Case-scoped failure is attached to its own Case Result. Candidate-level ``failures`` stays
+    empty by design — it is reserved for failures that cannot be attributed to a selected Case.
     """
     try:
         rows = json.loads(rows_json)
@@ -155,8 +160,8 @@ def aggregate(
             "normalized_score_sd": _mean_grade_metrics(scored, "normalized_score_sd"),
             "pass_rate": _mean_grade_metrics(scored, "pass_rate"),
             "pass_rate_sd": _mean_grade_metrics(scored, "pass_rate_sd"),
-            "accuracy": _mean_grade_metrics(scored, "accuracy"),
-            "accuracy_pass_rate": _mean_grade_metrics(scored, "accuracy_pass_rate"),
+            "accuracy": _mean_optional_grade_metrics(scored, "accuracy"),
+            "accuracy_pass_rate": _mean_optional_grade_metrics(scored, "accuracy_pass_rate"),
             "axis_scores": _mean_grade_metric_maps(scored, "axis_scores"),
             "axis_pass_rates": _mean_grade_metric_maps(scored, "axis_pass_rates"),
             "coverage": _mean_grade_metrics(scored, "coverage"),
@@ -408,6 +413,23 @@ def _mean_grades(cases: Sequence[Mapping[str, Any]], key: str) -> float:
 
 def _mean_grade_metrics(cases: Sequence[Mapping[str, Any]], key: str) -> float:
     return round(sum(float(_grade_metric(case, key)) for case in cases) / len(cases), 4)
+
+
+def _mean_optional_grade_metrics(cases: Sequence[Mapping[str, Any]], key: str) -> float | None:
+    """Mean over the Cases that reported ``key``, or ``None`` when none of them did.
+
+    A Case whose rubric has no Factual Accuracy axis reports ``None`` rather than 0.0, so it must
+    be skipped instead of dragging the Candidate mean toward zero. This mirrors how
+    :func:`_mean_grade_metric_maps` averages each axis over the Cases that carry it.
+    """
+    values = [
+        float(value)
+        for case in cases
+        if (value := _grade_metric(case, key)) is not None and not isinstance(value, bool)
+    ]
+    if not values:
+        return None
+    return round(sum(values) / len(values), 4)
 
 
 def _sum_grade_metrics(cases: Sequence[Mapping[str, Any]], key: str) -> int:

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/assets.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/assets.py
@@ -13,8 +13,10 @@ from url4_cloud.benchmarks.draco.errors import AggregateError
 def load_rubrics(directory: Path) -> dict[int, dict[str, Any]]:
     """Load ``<directory>/<case_id>.json`` for every rubric on disk.
 
-    The rubrics are private: they live only in the benchmark image and are never returned to a
-    client. Only the case id crosses the wire.
+    The rubrics ship in the benchmark image rather than the control plane so that grading assets
+    have their own build lifecycle — NOT because they are secret. The upstream dataset is public,
+    and each Case Result publishes the requirement text, weight, and axis of every graded
+    criterion (see ``case_results._checks``). Do not add a secrecy guarantee on top of this.
 
     INVARIANT: an absent or empty directory raises. Returning ``{}`` makes every case an
     "unknown case_id" failure, which reaches the client as a terminated-succeeded run carrying a

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/assets.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/assets.py
@@ -1,0 +1,93 @@
+"""Load DRACO's private grading assets."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from url4_cloud.benchmarks.draco import scoring, tasks
+from url4_cloud.benchmarks.draco.errors import AggregateError
+
+
+def load_rubrics(directory: Path) -> dict[int, dict[str, Any]]:
+    """Load ``<directory>/<case_id>.json`` for every rubric on disk.
+
+    The rubrics are private: they live only in the benchmark image and are never returned to a
+    client. Only the case id crosses the wire.
+
+    INVARIANT: an absent or empty directory raises. Returning ``{}`` makes every case an
+    "unknown case_id" failure, which reaches the client as a terminated-succeeded run carrying a
+    plausible zero score. A misconfigured path must be loud.
+    """
+    rubrics: dict[int, dict[str, Any]] = {}
+    for path in sorted(directory.glob("*.json")) if directory.is_dir() else []:
+        try:
+            case_id = int(path.stem)
+        except ValueError:
+            continue
+        rubrics[case_id] = json.loads(path.read_text(encoding="utf-8"))
+    if not rubrics:
+        raise AggregateError(
+            f"no rubrics under {str(directory)!r}; the installed DRACO assets are incomplete"
+        )
+    return rubrics
+
+
+def validate_protocol_assets(
+    root: Path,
+    cases: list[dict[str, object]],
+    criterion_count: int | None,
+    criterion_selection: scoring.CriterionSelection,
+) -> dict[int, dict[str, Any]]:
+    """Validate complete Case/criteria/rubric alignment before installing any route."""
+    rubrics = load_rubrics(root / "rubrics")
+    seen_case_ids: set[int] = set()
+    for index, case in enumerate(cases):
+        case_id = tasks.positive_case_id(case.get("id"))
+        if case_id in seen_case_ids:
+            raise ValueError(f"DRACO Case sequence repeats case_id {case_id}")
+        seen_case_ids.add(case_id)
+        _validate_case_assets(
+            root,
+            rubrics,
+            case,
+            index,
+            case_id,
+            criterion_count,
+            criterion_selection,
+        )
+    return rubrics
+
+
+def _validate_case_assets(
+    root: Path,
+    rubrics: dict[int, dict[str, Any]],
+    case: dict[str, object],
+    index: int,
+    case_id: int,
+    criterion_count: int | None,
+    criterion_selection: scoring.CriterionSelection,
+) -> None:
+    question = case.get("input")
+    if not isinstance(question, str) or not question.strip():
+        raise ValueError(f"DRACO Case {index} must carry non-empty input text")
+    rubric = rubrics.get(case_id)
+    if rubric is None:
+        raise ValueError(f"Case {case_id} has no installed DRACO rubric")
+    rubric_ids = [str(criterion.get("id")) for criterion in scoring.flatten_criteria(rubric)]
+    if not rubric_ids:
+        raise ValueError(f"Case {case_id} has no DRACO rubric criteria")
+    if len(set(rubric_ids)) != len(rubric_ids):
+        raise ValueError(f"Case {case_id} DRACO rubric repeats a criterion id")
+    criteria = tasks.load_criteria(root / "criteria", case_id)
+    validated_tasks = tasks.build_tasks(case_id, question, "asset validation", criteria)
+    criteria_ids = [task["criterion_id"] for task in validated_tasks]
+    if criteria_ids != rubric_ids:
+        raise ValueError(f"Case {case_id} criterion assets do not match its installed DRACO rubric")
+    if criterion_count is not None and criterion_count > len(rubric_ids):
+        raise ValueError(
+            f"criterion_count {criterion_count} exceeds Case {case_id} rubric size "
+            f"{len(rubric_ids)}"
+        )
+    scoring.select_criteria(rubric, criterion_count, criterion_selection)

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/case_evaluation.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/case_evaluation.py
@@ -1,4 +1,8 @@
-"""Exact DRACO framing between URL4 execution and benchmark Aggregation."""
+"""Exact DRACO framing between URL4 execution and benchmark Aggregation.
+
+INVARIANT: decoding accepts only the declared envelope and direct fields. It never searches
+recursively for plausible grading records because that could bind unrelated nested output.
+"""
 
 from __future__ import annotations
 
@@ -7,6 +11,11 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 from url4_cloud.benchmarks.draco.records import CASE_SCHEMA, CHECK_SCHEMA
+from url4_cloud.benchmarks.draco.validation import (
+    has_text,
+    optional_integer,
+    require_positive_integer,
+)
 from url4_cloud.benchmarks.draco.verdict import SCHEMA as VERDICT_SCHEMA
 
 CRITERION_EVALUATION_SCHEMA = "screamingface.draco-criterion-evaluation.v1"
@@ -23,7 +32,7 @@ def bind_criterion_evaluation(
 ) -> dict[str, Any]:
     """Bind one Check and its ordered Judge Evidence to an Engine-known Case."""
 
-    selected_id = _positive_int(case_id)
+    selected_id = require_positive_integer(case_id, "DRACO Case id")
     case = dict(case_record) if case_record else None
     if case is not None and not _valid_case(case, selected_id):
         raise ValueError("DRACO Criterion evaluation carries an invalid Case record")
@@ -51,7 +60,7 @@ def bind_case_evaluation(
 ) -> dict[str, Any]:
     """Flatten ordered Criterion Evaluations into one authoritative Case Evaluation."""
 
-    selected_id = _positive_int(case_id)
+    selected_id = require_positive_integer(case_id, "DRACO Case id")
     selected = _mapping_sequence(criteria, "DRACO Criterion evaluations")
     cases: list[dict[str, Any]] = []
     checks: list[dict[str, Any]] = []
@@ -194,10 +203,10 @@ def _valid_case(value: Mapping[str, Any], case_id: int) -> bool:
     finish_reason = value.get("finish_reason")
     return (
         value.get("schema") == CASE_SCHEMA
-        and _optional_int(value.get("case_id")) == case_id
-        and _text(value.get("input"))
-        and _text(value.get("output"))
-        and (finish_reason is None or _text(finish_reason))
+        and optional_integer(value.get("case_id")) == case_id
+        and has_text(value.get("input"))
+        and has_text(value.get("output"))
+        and (finish_reason is None or has_text(finish_reason))
         and isinstance(value.get("metadata"), Mapping)
     )
 
@@ -205,10 +214,10 @@ def _valid_case(value: Mapping[str, Any], case_id: int) -> bool:
 def _valid_check(value: Mapping[str, Any], case_id: int) -> bool:
     return (
         value.get("schema") == CHECK_SCHEMA
-        and _optional_int(value.get("case_id")) == case_id
-        and _text(value.get("criterion_id"))
+        and optional_integer(value.get("case_id")) == case_id
+        and has_text(value.get("criterion_id"))
         and value.get("criterion_type") in {"positive", "negative"}
-        and _text(value.get("requirement"))
+        and has_text(value.get("requirement"))
     )
 
 
@@ -220,11 +229,11 @@ def _valid_evidence(
 ) -> bool:
     if not (
         value.get("schema") == VERDICT_SCHEMA
-        and _optional_int(value.get("case_id")) == case_id
+        and optional_integer(value.get("case_id")) == case_id
         and value.get("criterion_id") == criterion_id
-        and _optional_int(value.get("sequence")) == sequence
+        and optional_integer(value.get("sequence")) == sequence
         and value.get("producer_type") == "model"
-        and _text(value.get("producer_id"))
+        and has_text(value.get("producer_id"))
         and isinstance(value.get("raw_output"), str)
         and type(value.get("valid")) is bool
     ):
@@ -233,7 +242,7 @@ def _valid_evidence(
         return value.get("criterion_status") in {"MET", "UNMET"} and isinstance(
             value.get("explanation"), str
         )
-    return _text(value.get("reason"))
+    return has_text(value.get("reason"))
 
 
 def _root_object(value: Any) -> dict[str, Any] | None:
@@ -244,26 +253,6 @@ def _root_object(value: Any) -> dict[str, Any] | None:
         except ValueError:
             return None
     return dict(decoded) if isinstance(decoded, Mapping) else None
-
-
-def _positive_int(value: object) -> int:
-    selected = _optional_int(value)
-    if selected is None or selected < 1:
-        raise ValueError("DRACO Case id must be a positive integer")
-    return selected
-
-
-def _optional_int(value: object) -> int | None:
-    if isinstance(value, bool) or not isinstance(value, int | str):
-        return None
-    try:
-        return int(value)
-    except ValueError:
-        return None
-
-
-def _text(value: object) -> bool:
-    return isinstance(value, str) and bool(value.strip())
 
 
 __all__ = [

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/case_evaluation.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/case_evaluation.py
@@ -1,0 +1,275 @@
+"""Exact DRACO framing between URL4 execution and benchmark Aggregation."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from url4_cloud.benchmarks.draco.records import CASE_SCHEMA, CHECK_SCHEMA
+from url4_cloud.benchmarks.draco.verdict import SCHEMA as VERDICT_SCHEMA
+
+CRITERION_EVALUATION_SCHEMA = "screamingface.draco-criterion-evaluation.v1"
+CASE_EVALUATION_SCHEMA = "screamingface.draco-case-evaluation.v1"
+_CRITERION_FIELDS = frozenset({"schema", "case", "check", "evidence"})
+_CASE_FIELDS = frozenset({"schema", "case", "checks", "evidence"})
+
+
+def bind_criterion_evaluation(
+    case_id: int,
+    case_record: Mapping[str, Any] | None,
+    check_record: Mapping[str, Any],
+    evidence: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Bind one Check and its ordered Judge Evidence to an Engine-known Case."""
+
+    selected_id = _positive_int(case_id)
+    case = dict(case_record) if case_record else None
+    if case is not None and not _valid_case(case, selected_id):
+        raise ValueError("DRACO Criterion evaluation carries an invalid Case record")
+    check = dict(check_record)
+    if not _valid_check(check, selected_id):
+        raise ValueError("DRACO Criterion evaluation carries an invalid Check record")
+    selected_evidence = [dict(item) for item in evidence]
+    if not selected_evidence:
+        raise ValueError("DRACO Criterion evaluation must contain Judge Evidence")
+    criterion_id = str(check["criterion_id"])
+    for sequence, item in enumerate(selected_evidence, start=1):
+        if not _valid_evidence(item, selected_id, criterion_id, sequence):
+            raise ValueError("DRACO Criterion evaluation carries invalid Judge Evidence")
+    return {
+        "schema": CRITERION_EVALUATION_SCHEMA,
+        "case": case,
+        "check": check,
+        "evidence": selected_evidence,
+    }
+
+
+def bind_case_evaluation(
+    case_id: int,
+    criteria: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Flatten ordered Criterion Evaluations into one authoritative Case Evaluation."""
+
+    selected_id = _positive_int(case_id)
+    selected = _mapping_sequence(criteria, "DRACO Criterion evaluations")
+    cases: list[dict[str, Any]] = []
+    checks: list[dict[str, Any]] = []
+    evidence: list[dict[str, Any]] = []
+    criterion_ids: set[str] = set()
+    for item in selected:
+        case, check, items = _criterion_parts(item, selected_id)
+        if case is not None:
+            cases.append(case)
+        criterion_id = str(check["criterion_id"])
+        _require(
+            criterion_id not in criterion_ids,
+            f"DRACO Case evaluation repeats Check {criterion_id!r}",
+        )
+        criterion_ids.add(criterion_id)
+        checks.append(check)
+        evidence.extend(items)
+    _require(
+        len(cases) == 1,
+        f"DRACO Case evaluation must carry exactly one Case record; found {len(cases)}",
+    )
+    return _case_envelope(cases[0], checks, evidence)
+
+
+def decode_case_evaluation(
+    value: Any,
+    expected_case_id: int,
+    *,
+    judge_passes: int,
+) -> dict[str, Any]:
+    """Decode one exact Case Evaluation without searching nested text or values."""
+
+    decoded = _root_object(value)
+    _require(
+        decoded is not None
+        and set(decoded) == _CASE_FIELDS
+        and decoded.get("schema") == CASE_EVALUATION_SCHEMA,
+        "invalid DRACO Case Evaluation envelope",
+    )
+    assert decoded is not None
+    case = _mapping(decoded.get("case"), "DRACO Case record")
+    _require(_valid_case(case, expected_case_id), "invalid DRACO Case record")
+    checks = _mapping_sequence(decoded.get("checks"), "DRACO Checks")
+    evidence = _mapping_sequence(decoded.get("evidence"), "DRACO Judge Evidence")
+    _validate_final_records(expected_case_id, checks, evidence, judge_passes)
+    return _case_envelope(case, checks, evidence)
+
+
+def _criterion_parts(
+    item: Mapping[str, Any], case_id: int
+) -> tuple[dict[str, Any] | None, dict[str, Any], list[dict[str, Any]]]:
+    _require(
+        set(item) == _CRITERION_FIELDS and item.get("schema") == CRITERION_EVALUATION_SCHEMA,
+        "DRACO Case evaluation contains an invalid Criterion envelope",
+    )
+    raw_case = item.get("case")
+    _require(
+        raw_case is None or isinstance(raw_case, Mapping) and _valid_case(raw_case, case_id),
+        "DRACO Case evaluation contains an invalid Case record",
+    )
+    case = dict(raw_case) if isinstance(raw_case, Mapping) else None
+    check = _mapping(item.get("check"), "DRACO Check record")
+    _require(_valid_check(check, case_id), "DRACO Case evaluation contains an invalid Check record")
+    criterion_id = str(check["criterion_id"])
+    evidence = _mapping_sequence(item.get("evidence"), "DRACO Judge Evidence")
+    for sequence, value in enumerate(evidence, start=1):
+        _require(
+            _valid_evidence(value, case_id, criterion_id, sequence),
+            "DRACO Case evaluation contains invalid Judge Evidence",
+        )
+    return case, check, evidence
+
+
+def _validate_final_records(
+    case_id: int,
+    checks: Sequence[Mapping[str, Any]],
+    evidence: Sequence[Mapping[str, Any]],
+    judge_passes: int,
+) -> None:
+    _require(judge_passes > 0, "judge_passes must be positive")
+    criterion_ids = [str(item.get("criterion_id")) for item in checks]
+    _require(
+        len(set(criterion_ids)) == len(criterion_ids)
+        and all(_valid_check(item, case_id) for item in checks),
+        "invalid DRACO Checks",
+    )
+    known = set(criterion_ids)
+    sequences: dict[str, int] = {criterion_id: 0 for criterion_id in known}
+    for item in evidence:
+        criterion_id = str(item.get("criterion_id"))
+        _require(criterion_id in known, "Judge Evidence names an unknown DRACO Check")
+        sequences[criterion_id] += 1
+        _require(
+            _valid_evidence(item, case_id, criterion_id, sequences[criterion_id]),
+            "invalid DRACO Judge Evidence",
+        )
+    _require(all(sequences.values()), "a DRACO Check carries no Judge Evidence")
+    _require(
+        all(count <= judge_passes for count in sequences.values()),
+        f"a DRACO Check cannot carry more than {judge_passes} Judge Evidence records",
+    )
+
+
+def _case_envelope(
+    case: Mapping[str, Any],
+    checks: Sequence[Mapping[str, Any]],
+    evidence: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "schema": CASE_EVALUATION_SCHEMA,
+        "case": dict(case),
+        "checks": [dict(item) for item in checks],
+        "evidence": [dict(item) for item in evidence],
+    }
+
+
+def _mapping(value: object, label: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be an object")
+    return dict(value)
+
+
+def _mapping_sequence(value: object, label: str) -> list[dict[str, Any]]:
+    if (
+        isinstance(value, str | bytes)
+        or not isinstance(value, Sequence)
+        or not value
+        or not all(isinstance(item, Mapping) for item in value)
+    ):
+        raise ValueError(f"{label} must be a non-empty array of objects")
+    return [dict(item) for item in value]
+
+
+def _require(condition: object, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _valid_case(value: Mapping[str, Any], case_id: int) -> bool:
+    finish_reason = value.get("finish_reason")
+    return (
+        value.get("schema") == CASE_SCHEMA
+        and _optional_int(value.get("case_id")) == case_id
+        and _text(value.get("input"))
+        and _text(value.get("output"))
+        and (finish_reason is None or _text(finish_reason))
+        and isinstance(value.get("metadata"), Mapping)
+    )
+
+
+def _valid_check(value: Mapping[str, Any], case_id: int) -> bool:
+    return (
+        value.get("schema") == CHECK_SCHEMA
+        and _optional_int(value.get("case_id")) == case_id
+        and _text(value.get("criterion_id"))
+        and value.get("criterion_type") in {"positive", "negative"}
+        and _text(value.get("requirement"))
+    )
+
+
+def _valid_evidence(
+    value: Mapping[str, Any],
+    case_id: int,
+    criterion_id: str,
+    sequence: int,
+) -> bool:
+    if not (
+        value.get("schema") == VERDICT_SCHEMA
+        and _optional_int(value.get("case_id")) == case_id
+        and value.get("criterion_id") == criterion_id
+        and _optional_int(value.get("sequence")) == sequence
+        and value.get("producer_type") == "model"
+        and _text(value.get("producer_id"))
+        and isinstance(value.get("raw_output"), str)
+        and type(value.get("valid")) is bool
+    ):
+        return False
+    if value["valid"] is True:
+        return value.get("criterion_status") in {"MET", "UNMET"} and isinstance(
+            value.get("explanation"), str
+        )
+    return _text(value.get("reason"))
+
+
+def _root_object(value: Any) -> dict[str, Any] | None:
+    decoded = value
+    if isinstance(decoded, str):
+        try:
+            decoded = json.loads(decoded)
+        except ValueError:
+            return None
+    return dict(decoded) if isinstance(decoded, Mapping) else None
+
+
+def _positive_int(value: object) -> int:
+    selected = _optional_int(value)
+    if selected is None or selected < 1:
+        raise ValueError("DRACO Case id must be a positive integer")
+    return selected
+
+
+def _optional_int(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int | str):
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def _text(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+__all__ = [
+    "CASE_EVALUATION_SCHEMA",
+    "CRITERION_EVALUATION_SCHEMA",
+    "bind_case_evaluation",
+    "bind_criterion_evaluation",
+    "decode_case_evaluation",
+]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/case_results.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/case_results.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from url4_cloud.benchmarks.draco.errors import AggregateError
 from url4_cloud.benchmarks.draco.scoring import flatten_criteria, score_case
+from url4_cloud.benchmarks.draco.validation import optional_integer
 from url4_cloud.benchmarks.draco.verdict import SCHEMA as VERDICT_SCHEMA
 
 COVERAGE_TARGET = 0.95
@@ -22,7 +23,7 @@ def group_runs(verdicts: Sequence[Mapping[str, Any]]) -> list[dict[str, bool]]:
     runs: list[dict[str, bool]] = []
     for verdict in verdicts:
         criterion_id = verdict.get("criterion_id") or verdict.get("id")
-        sequence = _as_int(verdict.get("sequence"))
+        sequence = optional_integer(verdict.get("sequence"))
         if criterion_id is None or sequence is None or sequence < 1:
             continue
         index = sequence - 1
@@ -44,10 +45,10 @@ def valid_verdicts(
         if (
             verdict.get("schema") != VERDICT_SCHEMA
             or verdict.get("valid") is not True
-            or _as_int(verdict.get("case_id")) != case_id
+            or optional_integer(verdict.get("case_id")) != case_id
             or str(criterion_id) not in expected
             or status not in {"MET", "UNMET"}
-            or (_as_int(verdict.get("sequence")) or 0) < 1
+            or (optional_integer(verdict.get("sequence")) or 0) < 1
             or verdict.get("producer_type") != "model"
             or not isinstance(verdict.get("producer_id"), str)
             or not isinstance(verdict.get("raw_output"), str)
@@ -250,7 +251,7 @@ def _checks(
     for criterion in selected:
         criterion_id = str(criterion["id"])
         record = by_id.get(criterion_id)
-        if record is None or _as_int(record.get("case_id")) != case_id:
+        if record is None or optional_integer(record.get("case_id")) != case_id:
             raise AggregateError(f"Case {case_id} has no Engine-bound Check {criterion_id!r}")
         checks.append(
             {
@@ -292,10 +293,3 @@ def _evidence(record: Mapping[str, Any]) -> dict[str, Any]:
     else:
         value["metadata"] = {"rejection_reason": record.get("reason", "invalid")}
     return value
-
-
-def _as_int(value: Any) -> int | None:
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/case_results.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/case_results.py
@@ -1,0 +1,301 @@
+"""Build auditable DRACO Case Results from Engine-bound checks and evidence."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from url4_cloud.benchmarks.draco.errors import AggregateError
+from url4_cloud.benchmarks.draco.scoring import flatten_criteria, score_case
+from url4_cloud.benchmarks.draco.verdict import SCHEMA as VERDICT_SCHEMA
+
+COVERAGE_TARGET = 0.95
+
+
+def group_runs(verdicts: Sequence[Mapping[str, Any]]) -> list[dict[str, bool]]:
+    """Split flat verdicts into one dict per judge pass, in sequence order.
+
+    INVARIANT: the paper scores each pass independently and then means the passes. Majority-voting
+    first would erase the judge-disagreement signal. A criterion with fewer verdicts has no entry
+    in the later runs, so it drops out rather than becoming an UNMET.
+    """
+    runs: list[dict[str, bool]] = []
+    for verdict in verdicts:
+        criterion_id = verdict.get("criterion_id") or verdict.get("id")
+        sequence = _as_int(verdict.get("sequence"))
+        if criterion_id is None or sequence is None or sequence < 1:
+            continue
+        index = sequence - 1
+        while len(runs) <= index:
+            runs.append({})
+        runs[index][str(criterion_id)] = str(verdict.get("criterion_status", "")).upper() == "MET"
+    return runs
+
+
+def valid_verdicts(
+    rubric: Mapping[str, Any], verdicts: Sequence[Mapping[str, Any]], case_id: int
+) -> list[dict[str, Any]]:
+    """Keep strict verdicts for criterion ids owned by this case's rubric."""
+    expected = {str(criterion["id"]) for criterion in flatten_criteria(rubric)}
+    accepted: list[dict[str, Any]] = []
+    for verdict in verdicts:
+        criterion_id = verdict.get("criterion_id") or verdict.get("id")
+        status = str(verdict.get("criterion_status", "")).upper()
+        if (
+            verdict.get("schema") != VERDICT_SCHEMA
+            or verdict.get("valid") is not True
+            or _as_int(verdict.get("case_id")) != case_id
+            or str(criterion_id) not in expected
+            or status not in {"MET", "UNMET"}
+            or (_as_int(verdict.get("sequence")) or 0) < 1
+            or verdict.get("producer_type") != "model"
+            or not isinstance(verdict.get("producer_id"), str)
+            or not isinstance(verdict.get("raw_output"), str)
+        ):
+            continue
+        accepted.append({**verdict, "criterion_id": str(criterion_id), "criterion_status": status})
+    return accepted
+
+
+def scored_case_result(
+    case_record: Mapping[str, Any],
+    rubric: Mapping[str, Any],
+    check_records: Sequence[Mapping[str, Any]],
+    records: Sequence[Mapping[str, Any]],
+    verdicts: Sequence[Mapping[str, Any]],
+    judge_passes: int,
+    criterion_count: int | None,
+) -> dict[str, Any]:
+    """Build one scored or coverage-failed Case Result."""
+    case_id, criteria_expected = _expected_criteria(case_record, rubric, criterion_count)
+    expected = criteria_expected * judge_passes
+    accepted = len(verdicts)
+    scored = score_case(rubric, group_runs(verdicts), criteria_expected=criteria_expected)
+    coverage = (accepted / expected) if expected else 0.0
+    metrics = {
+        "normalized_score_sd": scored["normalized_score_sd"],
+        "pass_rate": scored["pass_rate"],
+        "pass_rate_sd": scored["pass_rate_sd"],
+        "accuracy": scored["accuracy"],
+        "accuracy_pass_rate": scored["accuracy_pass_rate"],
+        "axis_scores": scored["axis_scores"],
+        "axis_pass_rates": scored["axis_pass_rates"],
+        "coverage": round(coverage, 4),
+        "coverage_sd": scored["coverage_sd"],
+        "n_runs": scored["n_runs"],
+        "verdicts_expected": expected,
+        "verdicts_accepted": accepted,
+        "verdicts_rejected": max(expected - accepted, 0),
+        "verdicts_invalid": max(len(records) - accepted, 0),
+        "verdicts_missing": max(expected - len(records), 0),
+    }
+    failures: list[dict[str, Any]] = []
+    score: float | None = scored["normalized_score"]
+    if coverage < COVERAGE_TARGET:
+        score = None
+        failures.append(
+            {
+                "stage": "grading",
+                "code": "insufficient_judge_coverage",
+                "message": (
+                    f"Judge coverage {coverage:.1%} is below the required {COVERAGE_TARGET:.0%}"
+                ),
+                "retryable": None,
+                "case_id": case_id,
+                "metadata": {
+                    "coverage": round(coverage, 4),
+                    "coverage_target": COVERAGE_TARGET,
+                },
+            }
+        )
+    return _case_result(
+        case_record,
+        score=score,
+        metrics=metrics,
+        checks=_checks(case_id, rubric, check_records, records, criteria_expected),
+        failures=failures,
+    )
+
+
+def incomplete_case_result(
+    case_record: Mapping[str, Any],
+    rubric: Mapping[str, Any],
+    check_records: Sequence[Mapping[str, Any]],
+    evidence: Sequence[Mapping[str, Any]],
+    judge_passes: int,
+    criterion_count: int | None,
+    failure: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Retain auditable grading material when no Judge Evidence was scoreable."""
+    case_id, criteria_expected = _expected_criteria(case_record, rubric, criterion_count)
+    verdicts_expected = criteria_expected * judge_passes
+    metrics = {
+        "normalized_score_sd": 0.0,
+        "pass_rate": 0.0,
+        "pass_rate_sd": 0.0,
+        "accuracy": 0.0,
+        "accuracy_pass_rate": 0.0,
+        "axis_scores": {},
+        "axis_pass_rates": {},
+        "coverage": 0.0,
+        "coverage_sd": 0.0,
+        "n_runs": 0,
+        "verdicts_expected": verdicts_expected,
+        "verdicts_accepted": 0,
+        "verdicts_rejected": verdicts_expected,
+        "verdicts_invalid": len(evidence),
+        "verdicts_missing": max(verdicts_expected - len(evidence), 0),
+    }
+    return _case_result(
+        case_record,
+        score=None,
+        metrics=metrics,
+        checks=_checks(case_id, rubric, check_records, evidence, criteria_expected),
+        failures=[dict(failure)],
+    )
+
+
+def failed_selected_case_result(
+    selected_case: Mapping[str, Any], failure: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Represent a selected Case that never produced a Candidate answer."""
+    return {
+        "case_id": int(selected_case["id"]),
+        "input": selected_case["input"],
+        "output": None,
+        "finish_reason": None,
+        "grade": None,
+        "failures": [dict(failure)],
+        "metadata": {
+            key: value for key, value in selected_case.items() if key not in {"id", "input"}
+        },
+    }
+
+
+def ungraded_case_result(
+    case_record: Mapping[str, Any], failure: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Retain an observed Candidate answer when private grading material is unavailable."""
+    return {
+        "case_id": int(case_record["case_id"]),
+        "input": case_record["input"],
+        "output": case_record["output"],
+        "finish_reason": case_record["finish_reason"],
+        "grade": None,
+        "failures": [dict(failure)],
+        "metadata": case_record.get("metadata", {}),
+    }
+
+
+def _expected_criteria(
+    case_record: Mapping[str, Any],
+    rubric: Mapping[str, Any],
+    criterion_count: int | None,
+) -> tuple[int, int]:
+    case_id = int(case_record["case_id"])
+    rubric_count = sum(1 for _ in flatten_criteria(rubric))
+    if criterion_count is not None and criterion_count > rubric_count:
+        raise AggregateError(
+            f"criterion_count {criterion_count} exceeds Case {case_id} rubric size {rubric_count}"
+        )
+    return case_id, criterion_count if criterion_count is not None else rubric_count
+
+
+def _case_result(
+    case_record: Mapping[str, Any],
+    *,
+    score: float | None,
+    metrics: Mapping[str, Any],
+    checks: Sequence[Mapping[str, Any]],
+    failures: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Assemble the shared Case Result envelope once."""
+    return {
+        "case_id": int(case_record["case_id"]),
+        "input": case_record["input"],
+        "output": case_record["output"],
+        "finish_reason": case_record["finish_reason"],
+        "grade": {
+            "method": "rubric",
+            "score": score,
+            "metrics": dict(metrics),
+            "checks": [dict(check) for check in checks],
+        },
+        "failures": [dict(failure) for failure in failures],
+        "metadata": case_record.get("metadata", {}),
+    }
+
+
+def _checks(
+    case_id: int,
+    rubric: Mapping[str, Any],
+    records: Sequence[Mapping[str, Any]],
+    evidence: Sequence[Mapping[str, Any]],
+    criteria_expected: int,
+) -> list[dict[str, Any]]:
+    rubric_by_id = {str(criterion["id"]): criterion for criterion in flatten_criteria(rubric)}
+    selected_ids = [str(record.get("criterion_id")) for record in records]
+    if len(selected_ids) != criteria_expected or len(set(selected_ids)) != criteria_expected:
+        raise AggregateError(
+            f"Case {case_id} must carry exactly {criteria_expected} unique Engine-bound Checks"
+        )
+    try:
+        selected = [rubric_by_id[criterion_id] for criterion_id in selected_ids]
+    except KeyError as exc:
+        raise AggregateError(
+            f"Case {case_id} has an Engine-bound Check for unknown criterion {exc.args[0]!r}"
+        ) from None
+    by_id = {str(record.get("criterion_id")): record for record in records}
+    checks: list[dict[str, Any]] = []
+    for criterion in selected:
+        criterion_id = str(criterion["id"])
+        record = by_id.get(criterion_id)
+        if record is None or _as_int(record.get("case_id")) != case_id:
+            raise AggregateError(f"Case {case_id} has no Engine-bound Check {criterion_id!r}")
+        checks.append(
+            {
+                "type": "criterion",
+                "id": criterion_id,
+                "label": record["requirement"],
+                "evidence": [
+                    _evidence(item)
+                    for item in sorted(
+                        (
+                            item
+                            for item in evidence
+                            if str(item.get("criterion_id")) == criterion_id
+                        ),
+                        key=lambda item: int(item["sequence"]),
+                    )
+                ],
+                "metadata": {
+                    "criterion_type": record["criterion_type"],
+                    "weight": criterion["weight"],
+                    "axis": criterion["axis"],
+                },
+            }
+        )
+    return checks
+
+
+def _evidence(record: Mapping[str, Any]) -> dict[str, Any]:
+    value: dict[str, Any] = {
+        "sequence": int(record["sequence"]),
+        "producer": {"type": record["producer_type"], "id": record["producer_id"]},
+        "valid": record.get("valid") is True,
+        "raw_output": record["raw_output"],
+        "metadata": {},
+    }
+    if value["valid"]:
+        value["outcome"] = record["criterion_status"]
+        value["explanation"] = record["explanation"]
+    else:
+        value["metadata"] = {"rejection_reason": record.get("reason", "invalid")}
+    return value
+
+
+def _as_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/case_results.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/case_results.py
@@ -134,8 +134,9 @@ def incomplete_case_result(
         "normalized_score_sd": 0.0,
         "pass_rate": 0.0,
         "pass_rate_sd": 0.0,
-        "accuracy": 0.0,
-        "accuracy_pass_rate": 0.0,
+        # Nothing was judged, so the Factual Accuracy axis was never observed — unknown, not zero.
+        "accuracy": None,
+        "accuracy_pass_rate": None,
         "axis_scores": {},
         "axis_pass_rates": {},
         "coverage": 0.0,

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/definition.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/definition.py
@@ -1,0 +1,391 @@
+"""DRACO as one Engine-owned Benchmark definition."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from url4 import Node, RelExpr, Text, expr, iterate, render, src, struct
+from url4.peer.server import Url4Node
+from url4_cloud.benchmarks.definition import Benchmark, candidate
+from url4_cloud.benchmarks.draco.prompts import JUDGE_INSTRUCTIONS
+from url4_cloud.benchmarks.draco.verdict import call as criterion_verdict
+
+BENCHMARK_ID = "draco"
+CASE_COUNT = 100
+LITE_BENCHMARK_ID = "draco/lite"
+# Two most represented pinned-data domains; within each, choose the Case nearest the global
+# median rubric size (38 criteria), breaking ties by Case id. Order follows domain prevalence.
+LITE_CASE_IDS = (2, 15)
+LITE_CASE_COUNT = len(LITE_CASE_IDS)
+LITE_CRITERION_COUNT = 10
+LITE_CRITERION_SELECTION = "axis-balanced"
+SMOKE_BENCHMARK_ID = "draco/smoke"
+SMOKE_CASE_COUNT = 1
+DATASET = "perplexity-ai/draco"
+DATASET_REVISION = "ce076749809027649ebd331bcb70f42bf720d387"
+DATASET_PREPARER_REVISION = "datasets-5.0.0"
+PROTOCOL_REVISION = "five-pass-reproduction-v1"
+LITE_PROTOCOL_REVISION = "balanced-lite-v1"
+SMOKE_PROTOCOL_REVISION = "structural-smoke-v1"
+# The paper pins Gemini-3-Pro Preview, which Google shut down on 2026-03-09. Google designated
+# Gemini-3.1-Pro Preview as its replacement, so this reproduction uses that successor model.
+JUDGE_MODEL = "openrouter/google/gemini-3.1-pro-preview"
+JUDGE_PASSES = 5
+JUDGE_SEEDS = tuple(range(1, JUDGE_PASSES + 1))
+LITE_JUDGE_PASSES = 1
+SMOKE_JUDGE_PASSES = 1
+SMOKE_CRITERION_COUNT = 1
+RETRIEVAL_POLICY_ID = "draco/reproduction"
+EXCLUDED_DOMAINS = (
+    "arxiv.org",
+    "huggingface.co",
+    "openrouter.ai",
+    "paperswithcode.com",
+    "alphaxiv.org",
+    "semanticscholar.org",
+    "research.perplexity.ai",
+)
+JUDGE_PARAMS = (
+    # The same model is also a DRACO Candidate. Its route can retrieve, but Grading cannot. The
+    # Runner consumes this control and sends no search field or tools to AI Gateway, so the Judge
+    # request remains eligible for the exact-response cache.
+    ("web_search", "false"),
+    ("temperature", "0.2"),
+    # The official low-reasoning setting is added once AI Gateway exposes a validated
+    # OpenRouter parameter for it. Unknown fields fail closed, so guessing here breaks every
+    # judge call rather than producing a documented protocol deviation.
+    ("max_tokens", "4096"),
+)
+REVISION = hashlib.sha256(
+    "\n".join(
+        (
+            DATASET,
+            DATASET_REVISION,
+            DATASET_PREPARER_REVISION,
+            PROTOCOL_REVISION,
+            RETRIEVAL_POLICY_ID,
+            repr(EXCLUDED_DOMAINS),
+            JUDGE_MODEL,
+            str(JUDGE_PASSES),
+            repr(JUDGE_SEEDS),
+            repr(JUDGE_PARAMS),
+            JUDGE_INSTRUCTIONS,
+        )
+    ).encode()
+).hexdigest()[:16]
+LITE_REVISION = hashlib.sha256(
+    "\n".join(
+        (
+            REVISION,
+            LITE_PROTOCOL_REVISION,
+            repr(LITE_CASE_IDS),
+            str(LITE_CRITERION_COUNT),
+            LITE_CRITERION_SELECTION,
+            str(LITE_JUDGE_PASSES),
+        )
+    ).encode()
+).hexdigest()[:16]
+SMOKE_REVISION = hashlib.sha256(
+    "\n".join(
+        (
+            REVISION,
+            SMOKE_PROTOCOL_REVISION,
+            str(SMOKE_CASE_COUNT),
+            str(SMOKE_CRITERION_COUNT),
+            str(SMOKE_JUDGE_PASSES),
+        )
+    ).encode()
+).hexdigest()[:16]
+ROUTE_PREFIX = f"/benchmarks/{BENCHMARK_ID}/{REVISION}"
+CASES_ROUTE = f"{ROUTE_PREFIX}/cases"
+TASKS_ROUTE = f"{ROUTE_PREFIX}/tasks"
+VERDICT_ROUTE = f"{ROUTE_PREFIX}/criterion-verdict"
+CRITERION_EVALUATION_ROUTE = f"{ROUTE_PREFIX}/criterion-evaluation"
+CASE_EVALUATION_ROUTE = f"{ROUTE_PREFIX}/case-evaluation"
+AGGREGATE_ROUTE = f"{ROUTE_PREFIX}/aggregate"
+LITE_ROUTE_PREFIX = f"/benchmarks/{LITE_BENCHMARK_ID}/{LITE_REVISION}"
+LITE_CASES_ROUTE = f"{LITE_ROUTE_PREFIX}/cases"
+LITE_TASKS_ROUTE = f"{LITE_ROUTE_PREFIX}/tasks"
+LITE_VERDICT_ROUTE = f"{LITE_ROUTE_PREFIX}/criterion-verdict"
+LITE_CRITERION_EVALUATION_ROUTE = f"{LITE_ROUTE_PREFIX}/criterion-evaluation"
+LITE_CASE_EVALUATION_ROUTE = f"{LITE_ROUTE_PREFIX}/case-evaluation"
+LITE_AGGREGATE_ROUTE = f"{LITE_ROUTE_PREFIX}/aggregate"
+SMOKE_ROUTE_PREFIX = f"/benchmarks/{SMOKE_BENCHMARK_ID}/{SMOKE_REVISION}"
+SMOKE_CASES_ROUTE = f"{SMOKE_ROUTE_PREFIX}/cases"
+SMOKE_TASKS_ROUTE = f"{SMOKE_ROUTE_PREFIX}/tasks"
+SMOKE_VERDICT_ROUTE = f"{SMOKE_ROUTE_PREFIX}/criterion-verdict"
+SMOKE_CRITERION_EVALUATION_ROUTE = f"{SMOKE_ROUTE_PREFIX}/criterion-evaluation"
+SMOKE_CASE_EVALUATION_ROUTE = f"{SMOKE_ROUTE_PREFIX}/case-evaluation"
+SMOKE_AGGREGATE_ROUTE = f"{SMOKE_ROUTE_PREFIX}/aggregate"
+
+
+def _build(case_count: int) -> Node:
+    return _build_protocol(
+        case_count,
+        cases_route=CASES_ROUTE,
+        tasks_route=TASKS_ROUTE,
+        verdict_route=VERDICT_ROUTE,
+        criterion_evaluation_route=CRITERION_EVALUATION_ROUTE,
+        case_evaluation_route=CASE_EVALUATION_ROUTE,
+        aggregate_route=AGGREGATE_ROUTE,
+        judge_passes=JUDGE_PASSES,
+        criterion_count=None,
+    )
+
+
+def _build_lite(case_count: int) -> Node:
+    return _build_protocol(
+        case_count,
+        cases_route=LITE_CASES_ROUTE,
+        tasks_route=LITE_TASKS_ROUTE,
+        verdict_route=LITE_VERDICT_ROUTE,
+        criterion_evaluation_route=LITE_CRITERION_EVALUATION_ROUTE,
+        case_evaluation_route=LITE_CASE_EVALUATION_ROUTE,
+        aggregate_route=LITE_AGGREGATE_ROUTE,
+        judge_passes=LITE_JUDGE_PASSES,
+        criterion_count=LITE_CRITERION_COUNT,
+    )
+
+
+def _build_smoke(case_count: int) -> Node:
+    return _build_protocol(
+        case_count,
+        cases_route=SMOKE_CASES_ROUTE,
+        tasks_route=SMOKE_TASKS_ROUTE,
+        verdict_route=SMOKE_VERDICT_ROUTE,
+        criterion_evaluation_route=SMOKE_CRITERION_EVALUATION_ROUTE,
+        case_evaluation_route=SMOKE_CASE_EVALUATION_ROUTE,
+        aggregate_route=SMOKE_AGGREGATE_ROUTE,
+        judge_passes=SMOKE_JUDGE_PASSES,
+        criterion_count=SMOKE_CRITERION_COUNT,
+    )
+
+
+def _build_protocol(
+    case_count: int,
+    *,
+    cases_route: str,
+    tasks_route: str,
+    verdict_route: str,
+    criterion_evaluation_route: str,
+    case_evaluation_route: str,
+    aggregate_route: str,
+    judge_passes: int,
+    criterion_count: int | None,
+) -> Node:
+    judge_calls = tuple(
+        src(
+            criterion_verdict(
+                RelExpr(
+                    path=_model_route(JUDGE_MODEL),
+                    # Every dynamic value is local to this iteration item. The model sees only
+                    # the official prompt fields; the Engine binds the known criterion id after
+                    # the reply, so grading never trusts a model-generated identifier.
+                    context=_judge_context(),
+                    intent=Text(_url4_text(JUDGE_INSTRUCTIONS)),
+                    # Stable pass seeds create five independent cache slots. Repeated benchmark
+                    # runs may reuse those slots, but one run can never collapse five Judge
+                    # passes into one cached response.
+                    params=(*JUDGE_PARAMS, ("seed", str(run))),
+                ),
+                "$item.criterion_id",
+                case_id="$item.case_id",
+                sequence=run,
+                route=verdict_route,
+            ),
+            name=f"verdict_{run}",
+            weight=0.0,
+        )
+        for run in range(1, judge_passes + 1)
+    )
+    criterion_evaluation = expr(
+        src("$item.case_record", name="case_record", weight=0.0),
+        src("$item.check_record", name="check_record", weight=0.0),
+        *judge_calls,
+        src(
+            RelExpr(
+                path=criterion_evaluation_route,
+                context=render(
+                    struct(
+                        {
+                            "case": "$case_record",
+                            "check": "$check_record",
+                            **{
+                                f"evidence_{run}": f"$verdict_{run}"
+                                for run in range(1, judge_passes + 1)
+                            },
+                        }
+                    )
+                ),
+                intent=Text("$item.case_id"),
+            ),
+            name="criterion_evaluation",
+            weight=0.0,
+        ),
+        intent=Text("$criterion_evaluation"),
+    )
+    criteria = iterate(
+        RelExpr(
+            path=tasks_route,
+            # This collection boundary invokes the Candidate exactly once, then returns the
+            # criterion tasks plus Engine-bound Case/Check records for lossless aggregation.
+            context=render(
+                candidate(
+                    "$item.input",
+                    web_search=True,
+                    web_search_exclude=EXCLUDED_DOMAINS,
+                )
+            ),
+            intent=Text("$item.id"),
+        ),
+        body=(src(criterion_evaluation, name="evaluated", weight=0.0),),
+        intent=Text("$evaluated"),
+        slice=None if criterion_count is None else (0, criterion_count),
+    )
+    case_evaluation = expr(
+        src(criteria, name="criteria", weight=0.0),
+        src(
+            RelExpr(
+                path=case_evaluation_route,
+                context="$criteria",
+                intent=Text("$item.id"),
+            ),
+            name="case_evaluation",
+            weight=0.0,
+        ),
+        intent=Text("$case_evaluation"),
+    )
+    rows = iterate(
+        cases_route,
+        body=(src(case_evaluation, name="graded", weight=0.0),),
+        intent=Text("$graded"),
+        slice=None if case_count == CASE_COUNT else (0, case_count),
+        on_error="collect",
+    )
+    row_set = expr(
+        src(rows, name="selected_rows", weight=0.0),
+        intent=Text("$selected_rows"),
+    )
+    node = expr(
+        src(row_set, name="rows", weight=0.0),
+        src(
+            RelExpr(
+                path=aggregate_route,
+                # The complete row collection is the wide channel. Keeping it in context means
+                # an in-process handler receives it directly and a subprocess adapter would pipe
+                # it over stdin; it can never hit the operating system's argv size limit.
+                context="$rows",
+                # INVARIANT: the reducer receives the selection bound authored into this exact
+                # protocol. It must not infer intent from however many rows happened to survive.
+                intent=Text(f"aggregate:{case_count}"),
+            ),
+            name="result",
+            weight=0.0,
+        ),
+        intent=Text("$result"),
+    )
+    return node
+
+
+def _install_canonical(node: Url4Node, assets: Path) -> None:
+    # Lazy import keeps the resource-only control-plane path from loading filesystem runtime code.
+    from url4_cloud.benchmarks.draco.runtime import install_canonical
+
+    install_canonical(node, assets / BENCHMARK_ID)
+
+
+def _install_lite(node: Url4Node, assets: Path) -> None:
+    from url4_cloud.benchmarks.draco.runtime import install_lite
+
+    install_lite(node, assets / BENCHMARK_ID)
+
+
+def _install_smoke(node: Url4Node, assets: Path) -> None:
+    from url4_cloud.benchmarks.draco.runtime import install_smoke
+
+    install_smoke(node, assets / BENCHMARK_ID)
+
+
+DRACO = Benchmark(
+    id=BENCHMARK_ID,
+    variant="canonical",
+    title="DRACO",
+    description=(
+        "A 100-task DRACO reproduction with official score arithmetic. It uses the successor "
+        "Judge model, provider-default reasoning, mixed native/Tavily retrieval, and a host-only "
+        "approximation of the reference blocklist, so its scores are not paper-identical."
+    ),
+    revision=REVISION,
+    case_count=CASE_COUNT,
+    build=_build,
+    install=_install_canonical,
+)
+
+DRACO_LITE = Benchmark(
+    id=LITE_BENCHMARK_ID,
+    variant="lite",
+    title="DRACO Lite",
+    description=(
+        "A two-Case directional preview using an axis-balanced selection of ten criteria per "
+        "Case and one Judge pass per criterion. Its score is not comparable to canonical DRACO."
+    ),
+    revision=LITE_REVISION,
+    case_count=LITE_CASE_COUNT,
+    build=_build_lite,
+    install=_install_lite,
+)
+
+DRACO_SMOKE = Benchmark(
+    id=SMOKE_BENCHMARK_ID,
+    variant="smoke",
+    title="DRACO Structural Smoke",
+    description=(
+        "A one-Case, one-criterion, one-Judge-pass structural probe. Its score is diagnostic "
+        "and not comparable to canonical DRACO."
+    ),
+    revision=SMOKE_REVISION,
+    case_count=SMOKE_CASE_COUNT,
+    build=_build_smoke,
+    install=_install_smoke,
+)
+
+
+def _model_route(model: str) -> str:
+    return "/" + model.removeprefix("/")
+
+
+def _judge_context() -> str:
+    return " ".join(
+        (
+            "<criterion_type>",
+            "$item.criterion_type",
+            "</criterion_type>",
+            "<criterion>",
+            "$item.criterion",
+            "</criterion>",
+            "<query>",
+            "$item.question",
+            "</query>",
+            "<response>",
+            "$item.answer",
+            "</response>",
+        )
+    )
+
+
+def _url4_text(value: str) -> str:
+    normalized = value.replace("\r\n", "\n").replace("\r", "\n")
+    normalized = normalized.replace("\n", "\u2028").replace("\t", " ")
+    unsupported = next(
+        (character for character in normalized if character < " " or character == "\x7f"),
+        None,
+    )
+    if unsupported is not None:
+        raise ValueError(
+            f"Benchmark prompt contains unsupported control character U+{ord(unsupported):04X}"
+        )
+    return normalized.replace("$", "$$")
+
+
+__all__ = ["DRACO", "DRACO_LITE", "DRACO_SMOKE"]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/errors.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/errors.py
@@ -1,0 +1,5 @@
+"""Errors raised by DRACO's deterministic grading pipeline."""
+
+
+class AggregateError(ValueError):
+    """The reducer's input is unusable and cannot be scored."""

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/prepare.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/prepare.py
@@ -16,9 +16,10 @@ judges one criterion at a time, blind to its weight and to its siblings; a judge
 weight can infer how much a criterion is worth and bias toward the expensive ones. The weights
 therefore live ONLY in `rubrics/`, which `aggregate.py` reads after the judging is done.
 
-INVARIANT: `cases.json` carries NO rubric. The whole privacy boundary of the design is that the
-client receives case ids and inputs while the rubric stays in the image, so a Candidate cannot be
-tuned against the answer key. Adding the rubric column here would silently defeat it.
+INVARIANT: `cases.json` carries NO rubric. It is the Candidate-facing input, and a rubric column
+here would put the grading criteria straight into the prompt the Candidate answers. This is a
+protocol boundary, not a secrecy one: `perplexity-ai/draco` is a public dataset and each Case
+Result publishes its graded criteria, so nothing here is an undisclosed answer key.
 
 Dataset: `perplexity-ai/draco` (arXiv:2602.11685). Column mapping mirrors
 `screamingface-benchmarks/benchmarks_config/draco.yaml`:

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/prepare.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/prepare.py
@@ -1,0 +1,246 @@
+"""Download the pinned DRACO dataset and emit its private runtime assets.
+
+Run at IMAGE BUILD time, never at run time: a Job's rootfs is read-only apart from `/tmp` and it
+holds no HuggingFace credential, so every benchmark artifact must exist before the Job starts.
+
+    uv run python -m url4_cloud.benchmarks.draco.prepare --out /opt/benchmarks/draco --limit 5
+
+Emits::
+
+    <out>/cases.json           [{"id": …, "input": …}]  — the ONLY thing a client ever sees
+    <out>/criteria/<id>.json   [{id, requirement, criterion_type}] — private task-builder input
+    <out>/rubrics/<id>.json    the weighted rubric      — private, read by `aggregate.py`
+
+INVARIANT: the judge NEVER sees weights. `grading_mode: "official"` (arXiv:2602.11685 §4.2)
+judges one criterion at a time, blind to its weight and to its siblings; a judge that can see a
+weight can infer how much a criterion is worth and bias toward the expensive ones. The weights
+therefore live ONLY in `rubrics/`, which `aggregate.py` reads after the judging is done.
+
+INVARIANT: `cases.json` carries NO rubric. The whole privacy boundary of the design is that the
+client receives case ids and inputs while the rubric stays in the image, so a Candidate cannot be
+tuned against the answer key. Adding the rubric column here would silently defeat it.
+
+Dataset: `perplexity-ai/draco` (arXiv:2602.11685). Column mapping mirrors
+`screamingface-benchmarks/benchmarks_config/draco.yaml`:
+
+    problem → the research prompt   ·   answer → the weighted rubric JSON   ·   domain → metadata
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from url4_cloud.benchmarks.draco.definition import (
+    CASE_COUNT,
+    DATASET,
+    DATASET_REVISION,
+    EXCLUDED_DOMAINS,
+    RETRIEVAL_POLICY_ID,
+)
+from url4_cloud.benchmarks.draco.scoring import flatten_criteria
+
+COLUMN_QUESTION = "problem"
+COLUMN_RUBRIC = "answer"
+COLUMN_DOMAIN = "domain"
+
+"""The blocklist a DRACO candidate answers under, derived from
+`screamingface-benchmarks/benchmarks_config/draco.yaml` and reduced to HOSTS.
+
+DRACO is a deep-research benchmark, so a candidate that retrieves the dataset card, the
+reproduction post, or the paper is reading the answer key. That INFLATES the score, which is why
+it does not look like a bug.
+
+Upstream's list is page-shaped (`huggingface.co/datasets/perplexity-ai/draco`,
+`arxiv.org/abs/2509`). Those values cannot ship: the provider rejects anything longer than a host
+with a 400 that fails the entire call, so a page-shaped list does not weaken the guard — it stops
+the benchmark. Ours is therefore NOT byte-comparable with the reference harness, and that is a
+deliberate divergence rather than a drift.
+
+AIDEV-NOTE: still a floor, not a ceiling — the benchmarks repo calls their list "our best guess"
+and OpenRouter never published theirs. Extend it from the audit logs in eval JSONLs (`tool_calls`
+in metadata) as real leak sources turn up. The Engine embeds this list in the Benchmark's
+``/candidate`` call and hashes it into the Benchmark revision; this file is the matching audit
+copy baked into the image. Add HOSTS; anything longer is a 400.
+"""
+
+
+class PrepareError(RuntimeError):
+    """The dataset could not be turned into a declared world."""
+
+
+def load_rows(limit: int | None = None) -> list[dict[str, Any]]:
+    """Download the dataset and return its rows.
+
+    `datasets` is NOT a dependency of url4-cloud. This module runs at image BUILD time on a
+    machine that has it; the Job that later serves the artifacts needs only the emitted files.
+
+    # WHY: `importlib` rather than a plain import; the same pattern `url4.peer.server` uses for
+    # its optional uvicorn extra. A static import would make an optional build-time package look
+    # like a hard dependency to every reader and to the type checker, for a module that a
+    # deployed Job never imports at all.
+    """
+    try:
+        datasets_mod = importlib.import_module("datasets")
+    except ModuleNotFoundError as exc:
+        raise PrepareError(
+            "the `datasets` package is required to prepare a benchmark — "
+            "`uv pip install datasets` in the build environment"
+        ) from exc
+
+    loaded = datasets_mod.load_dataset(DATASET, revision=DATASET_REVISION)
+    rows: list[dict[str, Any]] = []
+    for split in loaded:  # null split in draco.yaml means "all splits"
+        for row in loaded[split]:
+            rows.append(dict(row))
+            if limit is not None and len(rows) >= limit:
+                return rows
+    return rows
+
+
+def parse_rubric(raw: Any, case_id: int) -> dict[str, Any]:
+    """Decode the `answer` column into the rubric object the grader walks.
+
+    The column is a JSON STRING holding ``{"sections": [{"criteria": [...]}]}``. A rubric that
+    flattens to zero criteria is rejected loudly: it would score every answer 0.0 while looking
+    like a successful run.
+    """
+    rubric = json.loads(raw) if isinstance(raw, str) else raw
+    if not isinstance(rubric, dict) or "sections" not in rubric:
+        got = list(rubric)[:5] if isinstance(rubric, dict) else type(rubric).__name__
+        raise PrepareError(
+            f"case {case_id}: rubric has no 'sections' key — got {got}. A flat criteria list "
+            "is a different grader (healthbench_rubric), not this one."
+        )
+    if sum(1 for _ in flatten_criteria(rubric)) == 0:
+        raise PrepareError(f"case {case_id}: rubric flattened to 0 criteria")
+    return rubric
+
+
+def judge_criteria(rubric: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """The criteria as the JUDGE sees them — id, requirement, and sign-derived type.
+
+    The official protocol hides the numeric weight but explicitly supplies whether a criterion
+    is positive or negative. Deriving that label here preserves both requirements: the judge can
+    interpret MET correctly without learning how strongly the criterion affects the score.
+
+    INVARIANT: this projects the scorer's shared ``flatten_criteria`` walk rather than maintaining
+    a second traversal. It names the three safe fields explicitly so the attached numeric weight
+    can never cross the judge boundary.
+    """
+    return [
+        {
+            "id": criterion.get("id"),
+            "requirement": criterion.get("requirement", ""),
+            "criterion_type": ("negative" if float(criterion.get("weight", 0)) < 0 else "positive"),
+        }
+        for criterion in flatten_criteria(rubric)
+    ]
+
+
+def build(
+    rows: Sequence[dict[str, Any]],
+    out: Path,
+    *,
+    expected_count: int | None = None,
+) -> dict[str, Any]:
+    """Write the cases and private criterion/rubric files read by DRACO's runtime."""
+    if expected_count is not None and len(rows) != expected_count:
+        raise PrepareError(
+            f"expected {expected_count} DRACO cases, but the pinned dataset produced {len(rows)}"
+        )
+    rubric_dir = out / "rubrics"
+    criteria_dir = out / "criteria"
+    rubric_dir.mkdir(parents=True, exist_ok=True)
+    criteria_dir.mkdir(parents=True, exist_ok=True)
+
+    cases: list[dict[str, Any]] = []
+    for index, row in enumerate(rows):
+        case_id = index + 1  # 1-based and stable for a given dataset order
+        question = row.get(COLUMN_QUESTION)
+        if not question:
+            raise PrepareError(f"case {case_id}: empty {COLUMN_QUESTION!r} column")
+        rubric = parse_rubric(row.get(COLUMN_RUBRIC), case_id)
+        (rubric_dir / f"{case_id}.json").write_text(json.dumps(rubric, indent=1), encoding="utf-8")
+        (criteria_dir / f"{case_id}.json").write_text(
+            json.dumps(judge_criteria(rubric)), encoding="utf-8"
+        )
+        cases.append(
+            {"id": case_id, "input": question, "domain": row.get(COLUMN_DOMAIN) or "unknown"}
+        )
+
+    write_policy(out)
+    (out / "cases.json").write_text(json.dumps(cases), encoding="utf-8")
+    return {"cases": len(cases), "out": str(out)}
+
+
+def write_policy(out: Path) -> Path:
+    """Emit the retrieval policy an expression names with `;web_search_policy=`.
+
+    An OBJECT rather than a bare array so the policy can version itself — `id` is what a
+    published score cites — and can later carry other retrieval settings without a second route.
+
+    INVARIANT: an EMPTY blocklist is rejected HERE, at build time. The runner deliberately
+    accepts an empty policy, because a benchmark may declare unrestricted retrieval as an
+    explicit, attributable statement — but for DRACO an empty list means the generator broke, and
+    a generation bug belongs to the build rather than to a run that would score high and look
+    clean.
+    """
+    if not EXCLUDED_DOMAINS:
+        raise PrepareError("the retrieval policy is empty — a DRACO run needs its blocklist")
+    # INVARIANT: bare hosts only, enforced at BUILD time. A path or wildcard is a 400 from the
+    # provider on every answering call, which surfaces as a run that terminates SUCCEEDED with a
+    # zero score — so the build is the last place it can still be loud. MEASURED 2026-08-02:
+    # "Invalid domain 'arxiv.org/abs/2602.11685'".
+    malformed = sorted(d for d in EXCLUDED_DOMAINS if any(c in d for c in "/*:"))
+    if malformed:
+        raise PrepareError(
+            f"retrieval policy entries must be bare hosts, got {malformed} — a path or wildcard "
+            "is rejected by the provider with a 400 that fails every answering call"
+        )
+    policy_dir = out / "policy"
+    policy_dir.mkdir(parents=True, exist_ok=True)
+    path = policy_dir / "retrieval.json"
+    path.write_text(
+        json.dumps(
+            {
+                "id": RETRIEVAL_POLICY_ID,
+                "excluded_domains": list(EXCLUDED_DOMAINS),
+                "note": (
+                    "Best-effort proxy for the OpenRouter post's blocklist, which was never "
+                    "published. Entries are UNVERIFIED — see prepare.EXCLUDED_DOMAINS."
+                ),
+            },
+            indent=1,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="draco-prepare", description=__doc__)
+    parser.add_argument("--out", type=Path, default=Path("/opt/benchmarks/draco"))
+    parser.add_argument("--limit", type=int, default=None, help="cap the case count (probes)")
+    args = parser.parse_args(argv)
+
+    try:
+        summary = build(
+            load_rows(args.limit),
+            args.out,
+            expected_count=CASE_COUNT if args.limit is None else args.limit,
+        )
+    except PrepareError as exc:
+        print(f"prepare failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(summary))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - process entrypoint
+    raise SystemExit(main())

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/prompts.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/prompts.py
@@ -1,0 +1,113 @@
+"""The pinned DRACO Judge instructions; Candidate policy belongs to the SDK user."""
+
+# Appendix C.5, byte-for-byte aligned with the reference DRACO harness. Identifier association is
+# deliberately absent: the Engine already knows the criterion and binds it after the Judge call.
+JUDGE_INSTRUCTIONS = """You are evaluating a response for a given query against a single \
+criterion.
+
+You will receive the response to evaluate, a single criterion to check, and a \
+<criterion_type> field indicating if the criterion is positive or negative.
+
+CRITERION TYPES:
+The <criterion_type> field tells you whether this criterion describes something desirable \
+(positive) or undesirable (negative). Your job is THE SAME for both types: determine if the thing \
+described in the criterion is actually present in the response.
+
+POSITIVE CRITERIA:
+Positive criteria describe desired traits, requirements, or content that should be present.
+- MET (criterion_status: "MET"): The response contains/satisfies the requirement
+- UNMET (criterion_status: "UNMET"): The response does not contain/satisfy the requirement
+
+NEGATIVE CRITERIA:
+Negative criteria describe active errors or mistakes that the response is making.
+- MET (criterion_status: "MET"): The response advocates, states, or recommends the problematic thing
+- UNMET (criterion_status: "UNMET"): The response does NOT make this error, OR it mentions \
+the thing only to warn against it or mention why it's wrong
+
+Examples of what does NOT count as MET for negative criteria:
+- "This is often misdiagnosed as X, but it's actually Y" → NOT stating it's X (UNMET)
+- "Avoid doing X because..." → NOT recommending X (UNMET)
+- "Unlike X, the correct approach is Y" → NOT advocating for X (UNMET)
+- "A common mistake is thinking X" → NOT claiming X is correct (UNMET)
+
+EVALUATION RULES:
+- For numerical values: Check if they fall within specified ranges or match exactly as required.
+- For factual claims: Verify the information is present and accurate, regardless of exact phrasing.
+- For required elements: Confirm presence, counting precisely when numbers are specified.
+- For exclusion requirements: Confirm that restricted content is absent.
+- For length requirements: Carefully measure the number of words, characters, items, etc.
+- Be strict about factual accuracy but flexible about wording.
+- Accept semantically equivalent statements or implications where appropriate.
+- Pay careful attention to negation, warnings, and contrasts.
+
+CONDITIONAL VS UNCONDITIONAL ACTIONS (CRITICAL):
+When a criterion requires an action to be done "immediately", "now", "as soon as possible", or \
+unconditionally, you must distinguish:
+- UNCONDITIONAL: "Give epinephrine now" or "Administer X immediately" → action IS being taken
+- CONDITIONAL: "If Y occurs, give epinephrine" or "Start X if condition Z" → action is NOT being \
+taken immediately; it's contingent on a future condition
+
+If the criterion says something should happen "immediately" or without conditions, a conditional \
+statement does NOT satisfy the criterion. Mark as UNMET.
+
+Example:
+- Criterion: "Administers alteplase immediately for acute ischemic stroke"
+- Output: "If CT confirms no hemorrhage, consider alteplase" → UNMET (conditional, not immediate)
+- Output: "Give alteplase now per acute stroke protocol" → MET (immediate, unconditional)
+
+IMPLICIT VS EXPLICIT SATISFACTION:
+Consider whether a criterion can be satisfied implicitly through context, tone, or logical \
+implication, not just explicit statements:
+- "States there is no location in China" can be MET by "Locations are only in United States and \
+Canada"—if locations are ONLY in US and Canada, China is excluded; no need to mention China
+- "Confirms the user is logged out" can be MET by "Session expired at 3:42 PM"—an expired session \
+means the user is logged out, even without stating it directly
+
+CRITERION STATUS:
+"criterion_status" has *nothing* to do with quality or correctness. It only means:
+- "MET": The thing described in the criterion IS present/occurring in the response
+- "UNMET": The thing described in the criterion IS NOT present/occurring in the response
+
+Your response must be valid JSON with this exact format:
+
+{
+"explanation": "Brief explanation of why the criterion is MET.",
+"criterion_status": "MET"
+}
+
+Examples:
+
+Positive criterion: "States Q4 2023 base margin as 17.2%"
+Response: "The Q4 2023 base margin was 17.2% before adjustments."
+{
+"explanation": "The response states Q4 2023 base margin as 17.2%, as required.",
+"criterion_status": "MET"
+}
+
+Negative criterion: "States that the patient has celiac disease"
+Response: "This patient does not have celiac disease."
+{
+"explanation": "The response explicitly states the patient does NOT have celiac disease, so \
+this error is not present.",
+"criterion_status": "UNMET"
+}
+
+Positive criterion: "Administers epinephrine immediately for anaphylaxis"
+Response: "If symptoms worsen, give epinephrine and call for help."
+{
+"explanation": "Epinephrine is mentioned only as a conditional action contingent on symptom \
+worsening, not as an immediate intervention.",
+"criterion_status": "UNMET"
+}
+
+Positive criterion: "States there is no location in China"
+Response: "Locations are only in United States and Canada."
+{
+"explanation": "If locations are only in US and Canada, China is excluded. The response logically \
+entails no China location without mentioning China.",
+"criterion_status": "MET"
+}
+
+Return only raw JSON starting with {, no back-ticks, no 'json' prefix."""
+
+__all__ = ["JUDGE_INSTRUCTIONS"]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/records.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/records.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping
 
+from url4_cloud.benchmarks.draco.validation import (
+    optional_integer,
+    require_positive_integer,
+    require_text,
+)
+
 CASE_SCHEMA = "screamingface.draco-case-record.v1"
 CHECK_SCHEMA = "screamingface.draco-check-record.v1"
 _CRITERION_TYPES = frozenset({"positive", "negative"})
@@ -15,7 +21,7 @@ def bind_case(
 ) -> dict[str, object]:
     """Bind one Candidate output to the Engine-owned Case selected by ``case_id``."""
 
-    selected_id = _case_id(case_id)
+    selected_id = require_positive_integer(case_id, "case_id")
     if not isinstance(output, str) or not output.strip():
         raise ValueError("DRACO Candidate output must be non-empty text")
     try:
@@ -25,7 +31,7 @@ def bind_case(
     if not isinstance(cases, list):
         raise ValueError("DRACO cases must be a JSON array")
     for row in cases:
-        if not isinstance(row, Mapping) or _optional_case_id(row.get("id")) != selected_id:
+        if not isinstance(row, Mapping) or optional_integer(row.get("id")) != selected_id:
             continue
         input_value = row.get("input")
         if not isinstance(input_value, str) or not input_value.strip():
@@ -50,38 +56,16 @@ def bind_check(
 ) -> dict[str, object]:
     """Bind one public criterion description to Engine-known Case identity."""
 
-    selected_type = _text(criterion_type, "criterion_type")
+    selected_type = require_text(criterion_type, "criterion_type")
     if selected_type not in _CRITERION_TYPES:
         raise ValueError(f"unsupported DRACO criterion_type {selected_type!r}")
     return {
         "schema": CHECK_SCHEMA,
-        "case_id": _case_id(case_id),
-        "criterion_id": _text(criterion_id, "criterion_id"),
+        "case_id": require_positive_integer(case_id, "case_id"),
+        "criterion_id": require_text(criterion_id, "criterion_id"),
         "criterion_type": selected_type,
-        "requirement": _text(requirement, "criterion requirement"),
+        "requirement": require_text(requirement, "criterion requirement"),
     }
-
-
-def _case_id(value: object) -> int:
-    selected = _optional_case_id(value)
-    if selected is None or selected < 1:
-        raise ValueError("case_id must be a positive integer")
-    return selected
-
-
-def _optional_case_id(value: object) -> int | None:
-    if isinstance(value, bool) or not isinstance(value, (int, str)):
-        return None
-    try:
-        return int(value)
-    except ValueError:
-        return None
-
-
-def _text(value: object, label: str) -> str:
-    if not isinstance(value, str) or not value.strip():
-        raise ValueError(f"{label} must be non-empty text")
-    return value
 
 
 __all__ = ["CASE_SCHEMA", "CHECK_SCHEMA", "bind_case", "bind_check"]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/records.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/records.py
@@ -1,0 +1,87 @@
+"""Engine-bound DRACO Case and Check records carried through ordinary URL4 output."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+
+CASE_SCHEMA = "screamingface.draco-case-record.v1"
+CHECK_SCHEMA = "screamingface.draco-check-record.v1"
+_CRITERION_TYPES = frozenset({"positive", "negative"})
+
+
+def bind_case(
+    raw_cases: str, *, case_id: int, output: str, finish_reason: str | None
+) -> dict[str, object]:
+    """Bind one Candidate output to the Engine-owned Case selected by ``case_id``."""
+
+    selected_id = _case_id(case_id)
+    if not isinstance(output, str) or not output.strip():
+        raise ValueError("DRACO Candidate output must be non-empty text")
+    try:
+        cases = json.loads(raw_cases)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"DRACO cases are not JSON: {exc}") from None
+    if not isinstance(cases, list):
+        raise ValueError("DRACO cases must be a JSON array")
+    for row in cases:
+        if not isinstance(row, Mapping) or _optional_case_id(row.get("id")) != selected_id:
+            continue
+        input_value = row.get("input")
+        if not isinstance(input_value, str) or not input_value.strip():
+            raise ValueError(f"DRACO Case {selected_id} input must be non-empty text")
+        return {
+            "schema": CASE_SCHEMA,
+            "case_id": selected_id,
+            "input": input_value,
+            "output": output,
+            "finish_reason": finish_reason,
+            "metadata": {key: value for key, value in row.items() if key not in {"id", "input"}},
+        }
+    raise ValueError(f"unknown DRACO Case {selected_id}")
+
+
+def bind_check(
+    requirement: str,
+    *,
+    case_id: int,
+    criterion_id: str,
+    criterion_type: str,
+) -> dict[str, object]:
+    """Bind one public criterion description to Engine-known Case identity."""
+
+    selected_type = _text(criterion_type, "criterion_type")
+    if selected_type not in _CRITERION_TYPES:
+        raise ValueError(f"unsupported DRACO criterion_type {selected_type!r}")
+    return {
+        "schema": CHECK_SCHEMA,
+        "case_id": _case_id(case_id),
+        "criterion_id": _text(criterion_id, "criterion_id"),
+        "criterion_type": selected_type,
+        "requirement": _text(requirement, "criterion requirement"),
+    }
+
+
+def _case_id(value: object) -> int:
+    selected = _optional_case_id(value)
+    if selected is None or selected < 1:
+        raise ValueError("case_id must be a positive integer")
+    return selected
+
+
+def _optional_case_id(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, (int, str)):
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def _text(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be non-empty text")
+    return value
+
+
+__all__ = ["CASE_SCHEMA", "CHECK_SCHEMA", "bind_case", "bind_check"]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/runtime.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/runtime.py
@@ -1,4 +1,8 @@
-"""Install DRACO's private assets and deterministic functions into one Runner world."""
+"""Install DRACO's private assets and deterministic functions into one Runner world.
+
+INVARIANT: a profile validates its complete selected Case/criteria/rubric set before any of its
+routes are registered, so an executable world can never expose a half-installed DRACO protocol.
+"""
 
 from __future__ import annotations
 

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/runtime.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/runtime.py
@@ -1,0 +1,411 @@
+"""Install DRACO's private assets and deterministic functions into one Runner world."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from url4.core.errors import ResolutionError
+from url4.peer.server import Request, Url4Node
+from url4_cloud.benchmarks.contract import decode_candidate_invocation
+from url4_cloud.benchmarks.draco import aggregate as scoring
+from url4_cloud.benchmarks.draco import assets as protocol_assets
+from url4_cloud.benchmarks.draco import records, tasks
+from url4_cloud.benchmarks.draco import scoring as rubric_scoring
+from url4_cloud.benchmarks.draco.case_evaluation import (
+    bind_case_evaluation,
+    bind_criterion_evaluation,
+)
+from url4_cloud.benchmarks.draco.definition import (
+    AGGREGATE_ROUTE,
+    BENCHMARK_ID,
+    CASE_COUNT,
+    CASE_EVALUATION_ROUTE,
+    CASES_ROUTE,
+    CRITERION_EVALUATION_ROUTE,
+    JUDGE_MODEL,
+    JUDGE_PASSES,
+    LITE_AGGREGATE_ROUTE,
+    LITE_BENCHMARK_ID,
+    LITE_CASE_COUNT,
+    LITE_CASE_EVALUATION_ROUTE,
+    LITE_CASE_IDS,
+    LITE_CASES_ROUTE,
+    LITE_CRITERION_COUNT,
+    LITE_CRITERION_EVALUATION_ROUTE,
+    LITE_CRITERION_SELECTION,
+    LITE_JUDGE_PASSES,
+    LITE_REVISION,
+    LITE_TASKS_ROUTE,
+    LITE_VERDICT_ROUTE,
+    REVISION,
+    SMOKE_AGGREGATE_ROUTE,
+    SMOKE_BENCHMARK_ID,
+    SMOKE_CASE_COUNT,
+    SMOKE_CASE_EVALUATION_ROUTE,
+    SMOKE_CASES_ROUTE,
+    SMOKE_CRITERION_COUNT,
+    SMOKE_CRITERION_EVALUATION_ROUTE,
+    SMOKE_JUDGE_PASSES,
+    SMOKE_REVISION,
+    SMOKE_TASKS_ROUTE,
+    SMOKE_VERDICT_ROUTE,
+    TASKS_ROUTE,
+    VERDICT_ROUTE,
+)
+from url4_cloud.benchmarks.draco.verdict import bind, binding_key
+
+
+def install_canonical(node: Url4Node, root: Path) -> None:
+    """Register the routes referenced by canonical DRACO."""
+    _install_protocol(
+        node,
+        root,
+        cases_route=CASES_ROUTE,
+        tasks_route=TASKS_ROUTE,
+        verdict_route=VERDICT_ROUTE,
+        criterion_evaluation_route=CRITERION_EVALUATION_ROUTE,
+        case_evaluation_route=CASE_EVALUATION_ROUTE,
+        aggregate_route=AGGREGATE_ROUTE,
+        benchmark_id=BENCHMARK_ID,
+        benchmark_revision=REVISION,
+        declared_case_count=CASE_COUNT,
+        judge_passes=JUDGE_PASSES,
+        criterion_count=None,
+        criterion_selection="all",
+        case_ids=None,
+    )
+
+
+def install_lite(node: Url4Node, root: Path) -> None:
+    """Register the routes referenced by DRACO Lite."""
+    _install_protocol(
+        node,
+        root,
+        cases_route=LITE_CASES_ROUTE,
+        tasks_route=LITE_TASKS_ROUTE,
+        verdict_route=LITE_VERDICT_ROUTE,
+        criterion_evaluation_route=LITE_CRITERION_EVALUATION_ROUTE,
+        case_evaluation_route=LITE_CASE_EVALUATION_ROUTE,
+        aggregate_route=LITE_AGGREGATE_ROUTE,
+        benchmark_id=LITE_BENCHMARK_ID,
+        benchmark_revision=LITE_REVISION,
+        declared_case_count=LITE_CASE_COUNT,
+        judge_passes=LITE_JUDGE_PASSES,
+        criterion_count=LITE_CRITERION_COUNT,
+        criterion_selection=LITE_CRITERION_SELECTION,
+        case_ids=LITE_CASE_IDS,
+    )
+
+
+def install_smoke(node: Url4Node, root: Path) -> None:
+    """Register the routes referenced by DRACO Smoke."""
+    _install_protocol(
+        node,
+        root,
+        cases_route=SMOKE_CASES_ROUTE,
+        tasks_route=SMOKE_TASKS_ROUTE,
+        verdict_route=SMOKE_VERDICT_ROUTE,
+        criterion_evaluation_route=SMOKE_CRITERION_EVALUATION_ROUTE,
+        case_evaluation_route=SMOKE_CASE_EVALUATION_ROUTE,
+        aggregate_route=SMOKE_AGGREGATE_ROUTE,
+        benchmark_id=SMOKE_BENCHMARK_ID,
+        benchmark_revision=SMOKE_REVISION,
+        declared_case_count=SMOKE_CASE_COUNT,
+        judge_passes=SMOKE_JUDGE_PASSES,
+        criterion_count=SMOKE_CRITERION_COUNT,
+        criterion_selection="prefix",
+        case_ids=(1,),
+    )
+
+
+def _install_protocol(
+    node: Url4Node,
+    root: Path,
+    *,
+    cases_route: str,
+    tasks_route: str,
+    verdict_route: str,
+    criterion_evaluation_route: str,
+    case_evaluation_route: str,
+    aggregate_route: str,
+    benchmark_id: str,
+    benchmark_revision: str,
+    declared_case_count: int,
+    judge_passes: int,
+    criterion_count: int | None,
+    criterion_selection: rubric_scoring.CriterionSelection,
+    case_ids: tuple[int, ...] | None,
+) -> None:
+    """Register one DRACO multiplicity profile over the shared pinned assets."""
+
+    cases_json, selected_cases, rubrics = _protocol_assets(
+        root,
+        case_ids,
+        declared_case_count,
+        criterion_count,
+        criterion_selection,
+    )
+    node.data(cases_route, cases_json, media_type="application/json")
+    node.endpoint(tasks_route)(_task_rows(root, criterion_count, criterion_selection))
+    node.endpoint(verdict_route)(_criterion_verdict)
+    node.endpoint(criterion_evaluation_route)(_criterion_evaluation(judge_passes))
+    node.endpoint(case_evaluation_route)(_case_evaluation)
+    node.endpoint(aggregate_route)(
+        _aggregate(
+            benchmark_id,
+            benchmark_revision,
+            judge_passes,
+            criterion_count,
+            selected_cases,
+            rubrics,
+        )
+    )
+
+
+def _protocol_assets(
+    root: Path,
+    case_ids: tuple[int, ...] | None,
+    declared_case_count: int,
+    criterion_count: int | None,
+    criterion_selection: rubric_scoring.CriterionSelection,
+) -> tuple[str, list[dict[str, object]], dict[int, dict[str, Any]]]:
+    """Load and validate one complete profile before registering any route."""
+
+    raw = _read(root / "cases.json", "DRACO cases")
+    selected = _select_cases(raw, case_ids)
+    if len(selected) != declared_case_count:
+        raise _unavailable(
+            f"expected {declared_case_count} DRACO cases for this profile, got {len(selected)}"
+        )
+    try:
+        rubrics = protocol_assets.validate_protocol_assets(
+            root, selected, criterion_count, criterion_selection
+        )
+    except (OSError, ValueError) as exc:
+        raise _unavailable(str(exc)) from exc
+    return (
+        json.dumps(selected, ensure_ascii=False, separators=(",", ":")),
+        selected,
+        rubrics,
+    )
+
+
+def _task_rows(
+    root: Path,
+    criterion_count: int | None,
+    criterion_selection: rubric_scoring.CriterionSelection,
+):
+    def task_rows(request: Request) -> str:
+        try:
+            case_id = tasks.positive_case_id(request.intent)
+            output, finish_reason, refusal = decode_candidate_invocation(request.context)
+            if refusal is not None:
+                raise ResolutionError(
+                    "Candidate refused the DRACO Case",
+                    code="provider_refusal",
+                    permanent=True,
+                )
+            raw_cases = _read(root / "cases.json", "DRACO cases")
+            criteria = tasks.load_criteria(root / "criteria", case_id)
+            rubric = _object(
+                _read(root / "rubrics" / f"{case_id}.json", f"DRACO Case {case_id} rubric"),
+                f"DRACO Case {case_id} rubric",
+            )
+            selected = rubric_scoring.select_criteria(
+                rubric,
+                criterion_count,
+                criterion_selection,
+            )
+            criteria_by_id = {str(criterion.get("id")): criterion for criterion in criteria}
+            selected_criteria = [criteria_by_id[str(criterion["id"])] for criterion in selected]
+            result = tasks.build_tasks(
+                case_id,
+                tasks.load_question(root / "criteria", case_id),
+                output,
+                selected_criteria,
+            )
+            case_record = records.bind_case(
+                raw_cases,
+                case_id=case_id,
+                output=output,
+                finish_reason=finish_reason,
+            )
+            for index, row in enumerate(result):
+                row["case_record"] = (
+                    json.dumps(case_record, ensure_ascii=False, separators=(",", ":"))
+                    if index == 0
+                    else "{}"
+                )
+                row["check_record"] = json.dumps(
+                    records.bind_check(
+                        row["criterion"],
+                        case_id=case_id,
+                        criterion_id=row["criterion_id"],
+                        criterion_type=row["criterion_type"],
+                    ),
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                )
+        except (OSError, ValueError) as exc:
+            raise _unavailable(str(exc)) from exc
+        return json.dumps(result, ensure_ascii=False, separators=(",", ":"))
+
+    return task_rows
+
+
+def _criterion_verdict(request: Request) -> str:
+    try:
+        case_id, sequence, criterion_id = binding_key(request.intent)
+        record = bind(
+            request.context,
+            case_id=case_id,
+            criterion_id=criterion_id,
+            sequence=sequence,
+            producer_id=JUDGE_MODEL,
+        )
+    except ValueError as exc:
+        raise _unavailable(str(exc)) from exc
+    return json.dumps(record, ensure_ascii=False, separators=(",", ":"))
+
+
+def _criterion_evaluation(judge_passes: int):
+    def criterion_evaluation(request: Request) -> str:
+        try:
+            case_id = tasks.positive_case_id(request.intent)
+            payload = _object(request.context, "DRACO Criterion evaluation")
+            expected = (
+                "case",
+                "check",
+                *(f"evidence_{sequence}" for sequence in range(1, judge_passes + 1)),
+            )
+            if tuple(payload) != expected:
+                raise ValueError(
+                    "DRACO Criterion evaluation fields must be case, check, and consecutive "
+                    "evidence_1..evidence_N"
+                )
+            raw_case = _embedded_object(payload["case"], "Case record")
+            case_record = raw_case or None
+            check_record = _embedded_object(payload["check"], "Check record")
+            evidence = [
+                _embedded_object(payload[field], field)
+                for field in expected
+                if field.startswith("evidence_")
+            ]
+            result = bind_criterion_evaluation(
+                case_id,
+                case_record,
+                check_record,
+                evidence,
+            )
+        except (TypeError, ValueError) as exc:
+            raise _unavailable(str(exc)) from exc
+        return json.dumps(result, ensure_ascii=False, separators=(",", ":"))
+
+    return criterion_evaluation
+
+
+def _case_evaluation(request: Request) -> str:
+    try:
+        case_id = tasks.positive_case_id(request.intent)
+        raw = json.loads(request.context)
+        if not isinstance(raw, list) or not raw:
+            raise ValueError("DRACO Case evaluation must be a non-empty JSON array")
+        criteria = [
+            _embedded_object(item, f"Criterion evaluation {index}")
+            for index, item in enumerate(raw, start=1)
+        ]
+        result = bind_case_evaluation(case_id, criteria)
+    except (TypeError, ValueError) as exc:
+        raise _unavailable(str(exc)) from exc
+    return json.dumps(result, ensure_ascii=False, separators=(",", ":"))
+
+
+def _object(value: str, label: str) -> dict[str, object]:
+    decoded = json.loads(value)
+    if not isinstance(decoded, dict):
+        raise ValueError(f"{label} must be a JSON object")
+    return decoded
+
+
+def _embedded_object(value: object, label: str) -> dict[str, object]:
+    decoded = json.loads(value) if isinstance(value, str) else value
+    if not isinstance(decoded, dict):
+        raise ValueError(f"{label} must decode to an object")
+    return decoded
+
+
+def _aggregate(
+    benchmark_id: str,
+    benchmark_revision: str,
+    judge_passes: int,
+    criterion_count: int | None,
+    selected_cases: list[dict[str, object]],
+    rubrics: dict[int, dict[str, Any]],
+):
+    def aggregate(request: Request) -> str:
+        if not request.intent.startswith("aggregate:"):
+            raise ResolutionError(
+                f"unsupported DRACO operation {request.intent!r}",
+                code="benchmark_operation_unsupported",
+                permanent=True,
+            )
+        try:
+            selected_count = _selected_count(request.intent, len(selected_cases))
+            result = scoring.aggregate(
+                request.context,
+                rubrics,
+                benchmark_id,
+                selected_cases=selected_cases[:selected_count],
+                judge_passes=judge_passes,
+                benchmark_revision=benchmark_revision,
+                criterion_count=criterion_count,
+            )
+        except (OSError, ValueError) as exc:
+            raise _unavailable(str(exc)) from exc
+        return json.dumps(result, ensure_ascii=False, separators=(",", ":"))
+
+    return aggregate
+
+
+def _selected_count(intent: str, available: int) -> int:
+    raw = intent.removeprefix("aggregate:")
+    try:
+        selected = int(raw)
+    except ValueError:
+        raise ValueError("DRACO aggregate selection must be a positive integer") from None
+    if selected < 1 or selected > available:
+        raise ValueError(f"DRACO aggregate selection must be between 1 and {available}")
+    return selected
+
+
+def _select_cases(raw: str, case_ids: tuple[int, ...] | None) -> list[dict[str, object]]:
+    try:
+        rows = json.loads(raw)
+        if not isinstance(rows, list) or not all(isinstance(row, dict) for row in rows):
+            raise ValueError("expected a JSON array of objects")
+        if case_ids is None:
+            return rows
+        by_id = {row["id"]: row for row in rows}
+        return [by_id[case_id] for case_id in case_ids]
+    except (KeyError, TypeError, ValueError) as exc:
+        raise _unavailable(f"could not select DRACO cases {case_ids}: {exc}") from exc
+
+
+def _read(path: Path, label: str) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise _unavailable(f"could not read {label} at {str(path)!r}: {exc}") from exc
+
+
+def _unavailable(detail: str) -> ResolutionError:
+    return ResolutionError(
+        detail,
+        code="benchmark_unavailable",
+        permanent=True,
+    )
+
+
+__all__ = ["install_canonical", "install_lite", "install_smoke"]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/scoring.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/scoring.py
@@ -4,6 +4,9 @@ These formulas mirror ``screamingface-benchmarks/benchmarking/graders/rubric.py`
 (arXiv:2602.11685 §4.2). They are deliberately isolated from execution framing and
 aggregation so protocol math can be reviewed and tested without the URL4 payload
 machinery.
+
+INVARIANT: changes that make these formulas more intuitive but diverge from the pinned reference
+create a different benchmark and must not land as DRACO.
 """
 
 from __future__ import annotations

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/scoring.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/scoring.py
@@ -146,12 +146,23 @@ def axis_pass_rates(rubric: Mapping[str, Any], verdicts: Mapping[str, bool]) -> 
     return {axis: (correct / total) if total else 0.0 for axis, (correct, total) in by_axis.items()}
 
 
-def _factual_axis_value(axes: Mapping[str, float]) -> float:
+def _factual_axis_value(axes: Mapping[str, float]) -> float | None:
+    """The Factual Accuracy axis value, or ``None`` when this rubric has no such axis.
+
+    INVARIANT: absence is NOT zero. A rubric without a Factual Accuracy section (lite and smoke
+    selections routinely have none) would otherwise publish ``accuracy: 0.0`` for a Candidate that
+    scored 1.0, which reads as "0% factually accurate" — the same absence-renders-as-zero error
+    this module refuses for ``score``.
+    """
     for axis, value in axes.items():
         normalized = str(axis).lower().replace("_", "-").replace(" ", "-")
         if normalized in {"factual-accuracy", "factualaccuracy"}:
             return float(value)
-    return 0.0
+    return None
+
+
+def _round_optional(value: float | None) -> float | None:
+    return None if value is None else round(value, 4)
 
 
 def _restrict(rubric: Mapping[str, Any], judged_ids: Sequence[str]) -> dict[str, Any]:
@@ -187,8 +198,9 @@ def score_case(
             "normalized_score_sd": 0.0,
             "pass_rate": 0.0,
             "pass_rate_sd": 0.0,
-            "accuracy": 0.0,
-            "accuracy_pass_rate": 0.0,
+            # No run was scored, so no axis was observed — unknown, not zero.
+            "accuracy": None,
+            "accuracy_pass_rate": None,
             "axis_scores": {},
             "axis_pass_rates": {},
             "coverage": 0.0,
@@ -212,8 +224,8 @@ def score_case(
         "normalized_score_sd": round(_stdev(norms), 4),
         "pass_rate": round(_avg(pass_rates), 4),
         "pass_rate_sd": round(_stdev(pass_rates), 4),
-        "accuracy": round(_factual_axis_value(axis_means), 4),
-        "accuracy_pass_rate": round(_factual_axis_value(axis_pass_means), 4),
+        "accuracy": _round_optional(_factual_axis_value(axis_means)),
+        "accuracy_pass_rate": _round_optional(_factual_axis_value(axis_pass_means)),
         "axis_scores": axis_means,
         "axis_pass_rates": axis_pass_means,
         "coverage": round(_avg(coverages), 4),

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/scoring.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/scoring.py
@@ -1,0 +1,242 @@
+"""Pure DRACO rubric scoring primitives.
+
+These formulas mirror ``screamingface-benchmarks/benchmarking/graders/rubric.py``
+(arXiv:2602.11685 §4.2). They are deliberately isolated from execution framing and
+aggregation so protocol math can be reviewed and tested without the URL4 payload
+machinery.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterator, Mapping, Sequence
+from statistics import stdev
+from typing import Any, Literal
+
+CriterionSelection = Literal["all", "prefix", "axis-balanced"]
+
+
+def flatten_criteria(rubric: Mapping[str, Any]) -> Iterator[dict[str, Any]]:
+    """Walk rubric sections into criteria with their scoring axis attached."""
+    for section in rubric.get("sections", []):
+        axis = section.get("id") or section.get("title") or "unknown"
+        for criterion in section.get("criteria") or []:
+            row = dict(criterion)
+            row.setdefault("weight", 0)
+            row["axis"] = axis
+            yield row
+
+
+def select_criteria(
+    rubric: Mapping[str, Any],
+    count: int | None,
+    selection: CriterionSelection,
+) -> list[dict[str, Any]]:
+    """Select the exact rubric subset one protocol will send to its Judge."""
+
+    criteria = list(flatten_criteria(rubric))
+    selected_count = _selection_count(criteria, count, selection)
+    if selection == "all":
+        return criteria
+    assert selected_count is not None
+    if selection == "prefix":
+        return criteria[:selected_count]
+    return _axis_balanced(criteria, selected_count)
+
+
+def _selection_count(
+    criteria: Sequence[Mapping[str, Any]],
+    count: int | None,
+    selection: str,
+) -> int | None:
+    if selection not in {"all", "prefix", "axis-balanced"}:
+        raise ValueError(f"unknown DRACO criterion selection {selection!r}")
+    if selection == "all":
+        if count is not None:
+            raise ValueError("all-criteria selection cannot declare a criterion count")
+        return None
+    if isinstance(count, bool) or not isinstance(count, int) or count < 1:
+        raise ValueError(f"{selection} selection requires a positive criterion count")
+    if count > len(criteria):
+        raise ValueError(f"criterion count {count} exceeds rubric size {len(criteria)}")
+    return count
+
+
+def _axis_balanced(
+    criteria: Sequence[dict[str, Any]],
+    count: int,
+) -> list[dict[str, Any]]:
+    by_axis: dict[str, list[dict[str, Any]]] = {}
+    for criterion in criteria:
+        by_axis.setdefault(str(criterion["axis"]), []).append(criterion)
+    ordered = [
+        axis_criteria[offset]
+        for offset in range(max(map(len, by_axis.values())))
+        for axis_criteria in by_axis.values()
+        if offset < len(axis_criteria)
+    ]
+    return ordered[:count]
+
+
+def normalized_score(rubric: Mapping[str, Any], verdicts: Mapping[str, bool]) -> float:
+    """Weight-aware score in [0, 1] — ``clamp(Σ MET·w / Σ w⁺)``."""
+    weighted_sum = 0.0
+    denom_pos = 0.0
+    for criterion in flatten_criteria(rubric):
+        weight = float(criterion.get("weight", 0))
+        met = bool(verdicts.get(criterion["id"], False))
+        if weight > 0:
+            denom_pos += weight
+            if met:
+                weighted_sum += weight
+        elif weight < 0 and met:
+            weighted_sum += weight
+    if denom_pos <= 0:
+        return 0.0
+    return max(0.0, min(1.0, weighted_sum / denom_pos))
+
+
+def pass_rate(rubric: Mapping[str, Any], verdicts: Mapping[str, bool]) -> float:
+    """Unweighted fraction of positive criteria met and negative criteria avoided."""
+    n_correct = 0
+    n_total = 0
+    for criterion in flatten_criteria(rubric):
+        weight = float(criterion.get("weight", 0))
+        met = bool(verdicts.get(criterion["id"], False))
+        if (weight >= 0 and met) or (weight < 0 and not met):
+            n_correct += 1
+        n_total += 1
+    return (n_correct / n_total) if n_total else 0.0
+
+
+def axis_scores(rubric: Mapping[str, Any], verdicts: Mapping[str, bool]) -> dict[str, float]:
+    """Recompute :func:`normalized_score` independently for each rubric section."""
+    by_axis: dict[str, list[float]] = defaultdict(lambda: [0.0, 0.0])
+    for criterion in flatten_criteria(rubric):
+        weight = float(criterion.get("weight", 0))
+        met = bool(verdicts.get(criterion["id"], False))
+        achieved, achievable = by_axis[criterion["axis"]]
+        if weight >= 0:
+            achievable += weight
+            if met:
+                achieved += weight
+        elif met:
+            achieved += weight
+        by_axis[criterion["axis"]] = [achieved, achievable]
+    return {
+        axis: (max(0.0, min(1.0, achieved / achievable)) if achievable > 0 else 0.0)
+        for axis, (achieved, achievable) in by_axis.items()
+    }
+
+
+def axis_pass_rates(rubric: Mapping[str, Any], verdicts: Mapping[str, bool]) -> dict[str, float]:
+    """Recompute the unweighted :func:`pass_rate` independently for each axis."""
+
+    by_axis: dict[str, list[int]] = defaultdict(lambda: [0, 0])
+    for criterion in flatten_criteria(rubric):
+        weight = float(criterion.get("weight", 0))
+        met = bool(verdicts.get(criterion["id"], False))
+        correct, total = by_axis[criterion["axis"]]
+        if (weight >= 0 and met) or (weight < 0 and not met):
+            correct += 1
+        by_axis[criterion["axis"]] = [correct, total + 1]
+    return {axis: (correct / total) if total else 0.0 for axis, (correct, total) in by_axis.items()}
+
+
+def _factual_axis_value(axes: Mapping[str, float]) -> float:
+    for axis, value in axes.items():
+        normalized = str(axis).lower().replace("_", "-").replace(" ", "-")
+        if normalized in {"factual-accuracy", "factualaccuracy"}:
+            return float(value)
+    return 0.0
+
+
+def _restrict(rubric: Mapping[str, Any], judged_ids: Sequence[str]) -> dict[str, Any]:
+    """Remove unjudged criteria from both the scoring numerator and denominator."""
+    keep = set(judged_ids)
+    return {
+        "sections": [
+            {
+                **section,
+                "criteria": [c for c in (section.get("criteria") or []) if c.get("id") in keep],
+            }
+            for section in rubric.get("sections", [])
+        ]
+    }
+
+
+def score_case(
+    rubric: Mapping[str, Any],
+    runs: Sequence[Mapping[str, bool]],
+    *,
+    criteria_expected: int | None = None,
+) -> dict[str, Any]:
+    """Score each judge pass independently, then report its mean and sample spread."""
+    total = (
+        criteria_expected
+        if criteria_expected is not None
+        else sum(1 for _ in flatten_criteria(rubric))
+    )
+    scored = [_score_one_run(rubric, verdicts, total) for verdicts in runs]
+    if not scored:
+        return {
+            "normalized_score": 0.0,
+            "normalized_score_sd": 0.0,
+            "pass_rate": 0.0,
+            "pass_rate_sd": 0.0,
+            "accuracy": 0.0,
+            "accuracy_pass_rate": 0.0,
+            "axis_scores": {},
+            "axis_pass_rates": {},
+            "coverage": 0.0,
+            "coverage_sd": 0.0,
+            "n_runs": 0,
+        }
+    axes: dict[str, list[float]] = defaultdict(list)
+    axis_passes: dict[str, list[float]] = defaultdict(list)
+    for run in scored:
+        for axis, value in run["axis_scores"].items():
+            axes[axis].append(value)
+        for axis, value in run["axis_pass_rates"].items():
+            axis_passes[axis].append(value)
+    norms = [run["normalized_score"] for run in scored]
+    pass_rates = [run["pass_rate"] for run in scored]
+    coverages = [run["coverage"] for run in scored]
+    axis_means = {axis: round(_avg(values), 4) for axis, values in axes.items()}
+    axis_pass_means = {axis: round(_avg(values), 4) for axis, values in axis_passes.items()}
+    return {
+        "normalized_score": round(_avg(norms), 4),
+        "normalized_score_sd": round(_stdev(norms), 4),
+        "pass_rate": round(_avg(pass_rates), 4),
+        "pass_rate_sd": round(_stdev(pass_rates), 4),
+        "accuracy": round(_factual_axis_value(axis_means), 4),
+        "accuracy_pass_rate": round(_factual_axis_value(axis_pass_means), 4),
+        "axis_scores": axis_means,
+        "axis_pass_rates": axis_pass_means,
+        "coverage": round(_avg(coverages), 4),
+        "coverage_sd": round(_stdev(coverages), 4),
+        "n_runs": len(scored),
+    }
+
+
+def _score_one_run(
+    rubric: Mapping[str, Any], verdicts: Mapping[str, bool], total: int
+) -> dict[str, Any]:
+    restricted = _restrict(rubric, list(verdicts))
+    return {
+        "normalized_score": normalized_score(restricted, verdicts),
+        "pass_rate": pass_rate(restricted, verdicts),
+        "axis_scores": axis_scores(restricted, verdicts),
+        "axis_pass_rates": axis_pass_rates(restricted, verdicts),
+        "coverage": (len(verdicts) / total) if total else 0.0,
+    }
+
+
+def _avg(values: Sequence[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _stdev(values: Sequence[float]) -> float:
+    if len(values) < 2:
+        return 0.0
+    return stdev(values)

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/tasks.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/tasks.py
@@ -1,0 +1,112 @@
+"""Prepare weight-free DRACO judge tasks at the case-to-criterion scope boundary."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+
+class TasksError(ValueError):
+    """The case payload or prepared criterion data is unusable."""
+
+
+def build_tasks(
+    case_id: int,
+    question: str,
+    answer: str,
+    criteria: Sequence[Mapping[str, Any]],
+) -> list[dict[str, str]]:
+    """Join one dynamic Candidate answer to Engine-owned, weight-free judge inputs."""
+    selected_case_id = positive_case_id(case_id)
+    selected_question = _text(question, "question")
+    selected_answer = _text(answer, "answer")
+
+    tasks: list[dict[str, str]] = []
+    for index, criterion in enumerate(criteria):
+        if not isinstance(criterion, Mapping):
+            raise TasksError(f"criterion {index} must be a JSON object")
+        criterion_type = _text(criterion.get("criterion_type"), "criterion_type")
+        if criterion_type not in {"positive", "negative"}:
+            raise TasksError(f"criterion {index} has invalid criterion_type {criterion_type!r}")
+        tasks.append(
+            {
+                "case_id": str(selected_case_id),
+                "question": selected_question,
+                "answer": selected_answer,
+                "criterion_id": _text(criterion.get("id"), "criterion id"),
+                "criterion": _text(criterion.get("requirement"), "criterion requirement"),
+                "criterion_type": criterion_type,
+            }
+        )
+    if not tasks:
+        raise TasksError(f"case {selected_case_id} has no judge criteria")
+    return tasks
+
+
+def load_criteria(directory: Path, case_id: int) -> list[dict[str, Any]]:
+    path = directory / f"{case_id}.json"
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise TasksError(f"could not read criteria for case {case_id}: {exc}") from None
+    except ValueError as exc:
+        raise TasksError(f"criteria for case {case_id} are not JSON: {exc}") from None
+    if not isinstance(value, list):
+        raise TasksError(f"criteria for case {case_id} must be a JSON array")
+    return value
+
+
+def load_question(directory: Path, case_id: int) -> str:
+    path = directory.parent / "cases.json"
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise TasksError(f"could not read DRACO cases: {exc}") from None
+    except ValueError as exc:
+        raise TasksError(f"DRACO cases are not JSON: {exc}") from None
+    if not isinstance(value, list):
+        raise TasksError("DRACO cases must be a JSON array")
+    for row in value:
+        if isinstance(row, Mapping) and _case_id(row.get("id")) == case_id:
+            return _text(row.get("input"), "question")
+    raise TasksError(f"unknown DRACO case {case_id}")
+
+
+def positive_case_id(value: object) -> int:
+    """Decode the case id carried in a Benchmark route intent."""
+    label = "case_id"
+    if isinstance(value, bool) or not isinstance(value, (int, str)):
+        raise TasksError(f"{label} must be a positive integer")
+    try:
+        selected = int(value)
+    except ValueError:
+        raise TasksError(f"{label} must be a positive integer") from None
+    if selected < 1:
+        raise TasksError(f"{label} must be a positive integer")
+    return selected
+
+
+def _case_id(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, (int, str)):
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def _text(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise TasksError(f"{label} must be non-empty text")
+    return value
+
+
+__all__ = [
+    "TasksError",
+    "build_tasks",
+    "load_criteria",
+    "load_question",
+    "positive_case_id",
+]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/tasks.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/tasks.py
@@ -1,4 +1,8 @@
-"""Prepare weight-free DRACO judge tasks at the case-to-criterion scope boundary."""
+"""Prepare weight-free DRACO judge tasks at the case-to-criterion scope boundary.
+
+INVARIANT: Judge inputs contain one criterion's public requirement and type, never its weight,
+axis score, sibling criteria, or private rubric structure.
+"""
 
 from __future__ import annotations
 
@@ -6,6 +10,12 @@ import json
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
+
+from url4_cloud.benchmarks.draco.validation import (
+    optional_integer,
+    require_positive_integer,
+    require_text,
+)
 
 
 class TasksError(ValueError):
@@ -76,31 +86,21 @@ def load_question(directory: Path, case_id: int) -> str:
 
 def positive_case_id(value: object) -> int:
     """Decode the case id carried in a Benchmark route intent."""
-    label = "case_id"
-    if isinstance(value, bool) or not isinstance(value, (int, str)):
-        raise TasksError(f"{label} must be a positive integer")
     try:
-        selected = int(value)
-    except ValueError:
-        raise TasksError(f"{label} must be a positive integer") from None
-    if selected < 1:
-        raise TasksError(f"{label} must be a positive integer")
-    return selected
+        return require_positive_integer(value, "case_id")
+    except ValueError as exc:
+        raise TasksError(str(exc)) from None
 
 
 def _case_id(value: object) -> int | None:
-    if isinstance(value, bool) or not isinstance(value, (int, str)):
-        return None
-    try:
-        return int(value)
-    except ValueError:
-        return None
+    return optional_integer(value)
 
 
 def _text(value: object, label: str) -> str:
-    if not isinstance(value, str) or not value.strip():
-        raise TasksError(f"{label} must be non-empty text")
-    return value
+    try:
+        return require_text(value, label)
+    except ValueError as exc:
+        raise TasksError(str(exc)) from None
 
 
 __all__ = [

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/validation.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/validation.py
@@ -1,0 +1,41 @@
+"""Shared scalar validation for DRACO wire and asset records."""
+
+from __future__ import annotations
+
+
+def optional_integer(value: object) -> int | None:
+    """Return an integer carried as JSON integer/text, excluding booleans and other coercions."""
+
+    if isinstance(value, bool) or not isinstance(value, int | str):
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def require_positive_integer(value: object, label: str) -> int:
+    """Decode one positive integer or raise a field-specific validation error."""
+
+    selected = optional_integer(value)
+    if selected is None or selected < 1:
+        raise ValueError(f"{label} must be a positive integer")
+    return selected
+
+
+def require_text(value: object, label: str) -> str:
+    """Decode one non-empty text field without normalizing its contents."""
+
+    if not has_text(value):
+        raise ValueError(f"{label} must be non-empty text")
+    assert isinstance(value, str)
+    return value
+
+
+def has_text(value: object) -> bool:
+    """Return whether a wire value is non-empty text."""
+
+    return isinstance(value, str) and bool(value.strip())
+
+
+__all__ = ["has_text", "optional_integer", "require_positive_integer", "require_text"]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/verdict.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/verdict.py
@@ -1,0 +1,180 @@
+"""DRACO's deterministic binding of a Judge reply to an Engine-known criterion."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from url4 import Node, RelExpr, Text, render
+
+SCHEMA = "screamingface.criterion-verdict.v1"
+
+
+def call(
+    judge: Node,
+    criterion_id: str,
+    *,
+    case_id: str,
+    sequence: int,
+    route: str,
+) -> RelExpr:
+    """Wrap a Judge call with the case and criterion identities already known by the Engine."""
+
+    if not isinstance(criterion_id, str) or not criterion_id:
+        raise ValueError("criterion_id must be non-empty URL4 text")
+    if not isinstance(case_id, str) or not case_id:
+        raise ValueError("case_id must be non-empty URL4 text")
+    if isinstance(sequence, bool) or not isinstance(sequence, int) or sequence < 1:
+        raise ValueError("sequence must be a positive integer")
+    if not isinstance(route, str) or not route.startswith("/"):
+        raise ValueError("criterion verdict route must be an absolute URL4 path")
+    return RelExpr(
+        path=route,
+        context=render(judge, check=False),
+        # The case id is numeric, so the first colon is an unambiguous boundary even when an
+        # opaque criterion id itself contains colons. The model never sees or supplies either id.
+        intent=Text(f"{case_id}:{sequence}:{criterion_id}"),
+    )
+
+
+def binding_key(value: str) -> tuple[int, int, str]:
+    """Decode ``case_id:sequence:criterion_id`` while preserving criterion-id colons."""
+
+    case_text, first, remainder = value.partition(":")
+    sequence_text, second, criterion_id = remainder.partition(":")
+    if not first or not second:
+        raise ValueError("criterion verdict binding must contain case_id:sequence:criterion_id")
+    try:
+        case_id = int(case_text)
+        sequence = int(sequence_text)
+    except ValueError as exc:
+        raise ValueError(
+            "criterion verdict case_id and sequence must be positive integers"
+        ) from exc
+    if case_id < 1:
+        raise ValueError("criterion verdict case_id must be a positive integer")
+    if sequence < 1:
+        raise ValueError("criterion verdict sequence must be a positive integer")
+    return case_id, sequence, _text(criterion_id, "criterion_id")
+
+
+def bind(
+    raw: str,
+    *,
+    case_id: int,
+    criterion_id: str,
+    sequence: int,
+    producer_id: str,
+) -> dict[str, object]:
+    """Validate ``raw`` and attach Engine-known case and criterion identifiers."""
+
+    if isinstance(case_id, bool) or not isinstance(case_id, int) or case_id < 1:
+        raise ValueError("case_id must be a positive integer")
+    if isinstance(sequence, bool) or not isinstance(sequence, int) or sequence < 1:
+        raise ValueError("sequence must be a positive integer")
+    selected_id = _text(criterion_id, "criterion_id")
+    selected_producer = _text(producer_id, "producer_id")
+    decoded = _decode_object(raw)
+    reason = _invalid_reason(raw, decoded)
+    if reason is not None:
+        return _invalid(
+            raw,
+            case_id=case_id,
+            criterion_id=selected_id,
+            sequence=sequence,
+            producer_id=selected_producer,
+            reason=reason,
+        )
+    assert isinstance(decoded, Mapping)
+    explanation = decoded.get("explanation")
+    status = decoded.get("criterion_status")
+    assert isinstance(explanation, str) and status in ("MET", "UNMET")
+    return {
+        "schema": SCHEMA,
+        "case_id": case_id,
+        "criterion_id": selected_id,
+        "sequence": sequence,
+        "producer_type": "model",
+        "producer_id": selected_producer,
+        "valid": True,
+        "explanation": explanation,
+        "criterion_status": status,
+        "raw_output": raw,
+    }
+
+
+def _invalid_reason(raw: object, decoded: object) -> str | None:
+    if not isinstance(raw, str) or not raw.strip():
+        reason = "empty"
+    elif decoded is None:
+        reason = "invalid_json"
+    elif not isinstance(decoded, Mapping):
+        reason = "invalid_shape"
+    elif not isinstance(decoded.get("explanation"), str) or "criterion_status" not in decoded:
+        reason = "invalid_shape"
+    elif decoded.get("criterion_status") not in ("MET", "UNMET"):
+        reason = "invalid_status"
+    else:
+        reason = None
+    return reason
+
+
+def _decode_object(raw: object) -> Any:
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    text = _without_fences(raw.strip())
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return _first_json_value(text)
+
+
+def _without_fences(text: str) -> str:
+    if "```" not in text:
+        return text
+    return "\n".join(
+        line for line in text.splitlines() if not line.strip().startswith("```")
+    ).strip()
+
+
+def _first_json_value(text: str) -> Any:
+    start = text.find("{")
+    if start < 0:
+        return None
+    try:
+        value, _ = json.JSONDecoder().raw_decode(text[start:])
+    except json.JSONDecodeError:
+        return None
+    return value
+
+
+def _invalid(
+    raw: str,
+    *,
+    case_id: int,
+    criterion_id: str,
+    sequence: int,
+    producer_id: str,
+    reason: str,
+) -> dict[str, object]:
+    return {
+        "schema": SCHEMA,
+        "case_id": case_id,
+        "criterion_id": criterion_id,
+        "sequence": sequence,
+        "producer_type": "model",
+        "producer_id": producer_id,
+        "valid": False,
+        "reason": reason,
+        "raw_output": raw,
+    }
+
+
+def _text(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be non-empty text")
+    return value
+
+
+__all__ = ["SCHEMA", "bind", "binding_key", "call"]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/verdict.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/verdict.py
@@ -1,4 +1,8 @@
-"""DRACO's deterministic binding of a Judge reply to an Engine-known criterion."""
+"""DRACO's deterministic binding of a Judge reply to an Engine-known criterion.
+
+INVARIANT: Case, criterion, sequence, and producer identity come from Engine-owned URL4 bindings;
+the Judge supplies only the verdict payload and cannot relabel its Evidence.
+"""
 
 from __future__ import annotations
 
@@ -7,6 +11,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from url4 import Node, RelExpr, Text, render
+from url4_cloud.benchmarks.draco.validation import require_text
 
 SCHEMA = "screamingface.criterion-verdict.v1"
 
@@ -56,7 +61,7 @@ def binding_key(value: str) -> tuple[int, int, str]:
         raise ValueError("criterion verdict case_id must be a positive integer")
     if sequence < 1:
         raise ValueError("criterion verdict sequence must be a positive integer")
-    return case_id, sequence, _text(criterion_id, "criterion_id")
+    return case_id, sequence, require_text(criterion_id, "criterion_id")
 
 
 def bind(
@@ -73,8 +78,8 @@ def bind(
         raise ValueError("case_id must be a positive integer")
     if isinstance(sequence, bool) or not isinstance(sequence, int) or sequence < 1:
         raise ValueError("sequence must be a positive integer")
-    selected_id = _text(criterion_id, "criterion_id")
-    selected_producer = _text(producer_id, "producer_id")
+    selected_id = require_text(criterion_id, "criterion_id")
+    selected_producer = require_text(producer_id, "producer_id")
     decoded = _decode_object(raw)
     reason = _invalid_reason(raw, decoded)
     if reason is not None:
@@ -169,12 +174,6 @@ def _invalid(
         "reason": reason,
         "raw_output": raw,
     }
-
-
-def _text(value: object, label: str) -> str:
-    if not isinstance(value, str) or not value.strip():
-        raise ValueError(f"{label} must be non-empty text")
-    return value
 
 
 __all__ = ["SCHEMA", "bind", "binding_key", "call"]

--- a/apps/url4-cloud/src/url4_cloud/local.py
+++ b/apps/url4-cloud/src/url4_cloud/local.py
@@ -33,7 +33,8 @@ from url4_cloud import job_env
 from url4_cloud.adapters.inprocess import InProcessJobRunner
 from url4_cloud.adapters.memory import InMemoryEventStream
 from url4_cloud.app import create_app
-from url4_cloud.benchmarks import BENCHMARKS, BenchmarkRegistry
+from url4_cloud.benchmarks import BenchmarkRegistry
+from url4_cloud.benchmarks.builtins import BUILTIN_BENCHMARKS
 from url4_cloud.catalog import build_executable_catalog_service
 from url4_cloud.config import INSECURE_DEFAULT_JWT_SECRET, Settings
 from url4_cloud.connections import build_connections
@@ -90,7 +91,7 @@ def create_local_app(
     settings: Settings | None = None,
     *,
     env: Mapping[str, str] | None = None,
-    benchmarks: BenchmarkRegistry = BENCHMARKS,
+    benchmarks: BenchmarkRegistry = BUILTIN_BENCHMARKS,
 ) -> FastAPI:
     """Build the local-mode App: in-process runner, in-memory stream, real everything else.
 

--- a/apps/url4-cloud/src/url4_cloud/local.py
+++ b/apps/url4-cloud/src/url4_cloud/local.py
@@ -33,7 +33,7 @@ from url4_cloud import job_env
 from url4_cloud.adapters.inprocess import InProcessJobRunner
 from url4_cloud.adapters.memory import InMemoryEventStream
 from url4_cloud.app import create_app
-from url4_cloud.benchmarks import EMPTY_BENCHMARKS, BenchmarkRegistry
+from url4_cloud.benchmarks import BENCHMARKS, BenchmarkRegistry
 from url4_cloud.catalog import build_executable_catalog_service
 from url4_cloud.config import INSECURE_DEFAULT_JWT_SECRET, Settings
 from url4_cloud.connections import build_connections
@@ -90,7 +90,7 @@ def create_local_app(
     settings: Settings | None = None,
     *,
     env: Mapping[str, str] | None = None,
-    benchmarks: BenchmarkRegistry = EMPTY_BENCHMARKS,
+    benchmarks: BenchmarkRegistry = BENCHMARKS,
 ) -> FastAPI:
     """Build the local-mode App: in-process runner, in-memory stream, real everything else.
 

--- a/apps/url4-cloud/src/url4_cloud/rest/benchmarks.py
+++ b/apps/url4-cloud/src/url4_cloud/rest/benchmarks.py
@@ -18,17 +18,13 @@ router = APIRouter()
 _CACHE_CONTROL = "public, max-age=300, must-revalidate"
 
 
-def _registry(request: Request) -> BenchmarkRegistry:
-    return request.app.state.benchmarks
-
-
 def _json_bytes(value: object) -> bytes:
     return json.dumps(
         value,
         ensure_ascii=False,
         allow_nan=False,
         separators=(",", ":"),
-    ).encode()
+    ).encode("utf-8")
 
 
 def _response(value: object, if_none_match: str | None) -> Response:
@@ -40,17 +36,21 @@ def _response(value: object, if_none_match: str | None) -> Response:
     return Response(content=body, media_type="application/json", headers=headers)
 
 
-@router.get("/v1/benchmarks", tags=["Catalog"], summary="List the installed Benchmarks")
+def _registry(request: Request) -> BenchmarkRegistry:
+    return request.app.state.benchmarks
+
+
+@router.get(
+    "/v1/benchmarks",
+    tags=["Catalog"],
+    summary="List the installed Benchmarks",
+)
 async def list_benchmarks(
     request: Request,
     if_none_match: Annotated[str | None, Header(alias="If-None-Match")] = None,
 ) -> Response:
-    registry = _registry(request)
     return _response(
-        {
-            "object": "list",
-            "data": [benchmark.catalog_entry() for benchmark in registry],
-        },
+        {"object": "list", "data": [benchmark.catalog_entry() for benchmark in _registry(request)]},
         if_none_match,
     )
 

--- a/apps/url4-cloud/src/url4_cloud/runner/connector.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/connector.py
@@ -23,7 +23,6 @@ from url4_cloud.retrieval_policy import (
 )
 from url4_cloud.runner.cache import policy_to_body_field
 from url4_cloud.runner.cache_readback import CacheOutcome, read_cache_outcome, requires_revalidation
-from url4_cloud.world_config import ModelSpec, WorldConfigError, routes_for
 from url4_cloud.runner.errors import RunnerRequestError
 from url4_cloud.runner.model_response import (
     Choice,
@@ -45,6 +44,7 @@ from url4_cloud.runner.web_tools import (
     build_runtime,
     truncate_tool_result,
 )
+from url4_cloud.world_config import ModelSpec, WorldConfigError, routes_for
 
 _COMPLETIONS_PATH = "/v1/chat/completions"
 _truncate_tool_result = truncate_tool_result

--- a/apps/url4-cloud/src/url4_cloud/runner/connector.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/connector.py
@@ -6,9 +6,7 @@ resolves and runs an expression against.
 
 from __future__ import annotations
 
-import asyncio
-import json
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from dataclasses import dataclass
 
 import httpx
@@ -18,7 +16,7 @@ from url4.io.static import StaticIOLayer
 from url4.observe import current_response_sink, current_usage_sink
 from url4.peer.server import Request, Url4Node
 from url4.streaming.protocol import CachePolicy
-from url4_cloud.model_outcomes import ModelOutcome, bind_model_outcome, record_model_outcome
+from url4_cloud.model_outcomes import bind_model_outcome, record_model_outcome
 from url4_cloud.retrieval_policy import (
     RetrievalPolicy,
     current_retrieval_policy,
@@ -26,40 +24,30 @@ from url4_cloud.retrieval_policy import (
 from url4_cloud.runner.cache import policy_to_body_field
 from url4_cloud.runner.cache_readback import CacheOutcome, read_cache_outcome, requires_revalidation
 from url4_cloud.world_config import ModelSpec, WorldConfigError, routes_for
+from url4_cloud.runner.errors import RunnerRequestError
+from url4_cloud.runner.model_response import (
+    Choice,
+    parse_choice,
+    raise_if_unusable,
+)
+from url4_cloud.runner.request_parameters import (
+    WEB_SEARCH_PARAM,
+    apply_retrieval_policy,
+    caller_exclusions,
+    model_params,
+    wants_web_search,
+)
+from url4_cloud.runner.web_tools import (
+    WEB_TOOLS,
+    WebToolRuntime,
+    append_tool_results,
+    build_client,
+    build_runtime,
+    truncate_tool_result,
+)
 
 _COMPLETIONS_PATH = "/v1/chat/completions"
-
-_WEB_TOOLS = [
-    {
-        "type": "function",
-        "function": {
-            "name": "web_search",
-            "description": (
-                "Search the web for current or real-time information. Use when the answer "
-                "needs up-to-date data not in your training."
-            ),
-            "parameters": {
-                "type": "object",
-                "properties": {"query": {"type": "string", "description": "The search query."}},
-                "required": ["query"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "web_fetch",
-            "description": "Fetch and extract the main content of a web page from a known URL.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "url": {"type": "string", "description": "The absolute URL to fetch."}
-                },
-                "required": ["url"],
-            },
-        },
-    },
-]
+_truncate_tool_result = truncate_tool_result
 
 
 @dataclass(frozen=True)
@@ -172,20 +160,28 @@ class _ModelEndpoint:
     async def __call__(self, request: Request) -> str:
         # The route resolves to its whole spec, so the id and the capabilities it was declared
         # with travel together — the call can never run one route's model under another's flags.
-        spec = self._routes[request.path]
-        return await _chat_completion_loop(
-            http_client=self._http_client,
-            cfg=self._cfg,
-            profile=self._profile,
-            model=spec.id,
-            messages=_messages(request.context, request.intent),
-            tavily_http=self._tavily_http,
-            tavily_api_key=self._tavily_api_key,
-            web_tools=spec.web_tools,
-            retrieval_policy=current_retrieval_policy(),
-            identity_headers=self._identity_headers,
-            cache=self._cache,
-        )
+        try:
+            spec = self._routes[request.path]
+            retrieval_policy = current_retrieval_policy()
+            params = apply_retrieval_policy(request.params, retrieval_policy)
+            return await _chat_completion_loop(
+                http_client=self._http_client,
+                cfg=self._cfg,
+                profile=self._profile,
+                messages=_messages(request.context, request.intent),
+                params=params,
+                spec=spec,
+                tavily_http=self._tavily_http,
+                tavily_api_key=self._tavily_api_key,
+                retrieval_policy=retrieval_policy,
+                identity_headers=self._identity_headers,
+                cache=self._cache,
+            )
+        except RunnerRequestError as exc:
+            error = ResolutionError(str(exc), code=exc.code, permanent=exc.permanent)
+            if exc.outcome is not None:
+                bind_model_outcome(error, exc.outcome)
+            raise error from exc
 
 
 async def build_aigateway_world(
@@ -235,7 +231,7 @@ async def build_aigateway_world(
 
     normalized_tavily_key = tavily_api_key.strip() if tavily_api_key else None
     normalized_tavily_key = normalized_tavily_key or None
-    tavily_http, owns_tavily_client = _build_tavily_client(
+    tavily_http, owns_tavily_client = build_client(
         cfg,
         normalized_tavily_key,
         tavily_client,
@@ -273,13 +269,7 @@ async def build_aigateway_world(
     )
 
 
-def _provider_of(model: str) -> str:
-    if "/" in model:
-        return model.split("/", 1)[0]
-    return "anthropic"
-
-
-def _report_response(choice: _Choice, cache: CacheOutcome) -> None:
+def _report_response(choice: Choice, cache: CacheOutcome) -> None:
     """Report how one model round trip ended — and whether the gateway served it from its
     response cache — onto the currently-resolving node's span.
 
@@ -303,110 +293,14 @@ def _report_response(choice: _Choice, cache: CacheOutcome) -> None:
 
 
 def _report_usage(model: str, usage: dict | None) -> None:
-    if usage is None:
-        return
-    sink = current_usage_sink()
-    if sink is None:
+    if usage is None or (sink := current_usage_sink()) is None:
         return
     sink(
-        provider=_provider_of(model),
+        provider=model.split("/", 1)[0] if "/" in model else "anthropic",
         model=model,
         input_tokens=usage.get("prompt_tokens", 0),
         output_tokens=usage.get("completion_tokens", 0),
     )
-
-
-@dataclass(frozen=True, slots=True)
-class _Choice:
-    """One chat-completions choice, reduced to what this connector consumes."""
-
-    content: str | None
-    tool_calls: list[dict] | None
-    finish_reason: str | None
-    refusal: str | None
-
-
-def _parse_choice(data: dict) -> _Choice:
-    """Pull the first choice out of a chat-completions response.
-
-    Extraction only — whether the choice is *usable* is `_raise_if_unusable`'s call. The split
-    is load-bearing: the caller reports the finish reason between the two, so a refused turn is
-    still observable even though it goes on to fail (dec: OME-745).
-
-    Raises:
-        ResolutionError: the response shape is unparsable — there is nothing to report either.
-    """
-    try:
-        choice = data["choices"][0]
-        message = choice["message"]
-        content = message.get("content")
-        tool_calls = message.get("tool_calls")
-        finish_reason = choice.get("finish_reason")
-        refusal = message.get("refusal")
-    except (KeyError, IndexError, TypeError) as exc:
-        raise ResolutionError(
-            "malformed aigateway response", code="aigateway_bad_response", permanent=True
-        ) from exc
-    return _Choice(
-        content=content,
-        tool_calls=tool_calls,
-        finish_reason=finish_reason if isinstance(finish_reason, str) else None,
-        refusal=refusal if isinstance(refusal, str) and refusal.strip() else None,
-    )
-
-
-def _raise_if_unusable(choice: _Choice) -> None:
-    """Reject a choice that carries no answer, distinguishing a REFUSAL from a malformed reply.
-
-    WHY the distinction: these used to collapse into one `aigateway_bad_response`, so a model
-    that declined on safety grounds was indistinguishable from a broken payload — and downstream
-    a refusal was scored as if the model had answered badly (FEATURE: OME-679).
-
-    Raises:
-        ResolutionError: ``provider_refusal`` when the provider declined, else
-            ``aigateway_bad_response`` when there is neither content nor a tool call.
-    """
-    # INVARIANT: the refusal check precedes the emptiness check. A content_filter turn normally
-    # carries null content, so testing emptiness first would classify every refusal as malformed.
-    if choice.finish_reason == "content_filter" or choice.refusal is not None:
-        # `permanent=True`: a refusal is deterministic, so a retry spends budget to be refused
-        # again. This is the wire signal a client maps to a refusal-kind failure.
-        raise bind_model_outcome(
-            ResolutionError(
-                "provider refused the request",
-                code="provider_refusal",
-                permanent=True,
-            ),
-            ModelOutcome(choice.finish_reason, choice.refusal),
-        )
-    if not choice.tool_calls and choice.content is None:
-        raise ResolutionError(
-            "malformed aigateway response", code="aigateway_bad_response", permanent=True
-        )
-
-
-def _build_tavily_client(
-    cfg: AigatewayConfig,
-    tavily_api_key: str | None,
-    tavily_client: httpx.AsyncClient | None,
-) -> tuple[httpx.AsyncClient | None, bool]:
-    """Resolve the optional Tavily client.
-
-    Returns:
-        ``(client, owns_client)`` — ``client`` is ``None`` when no API key is configured, which
-        IS the "web tools are off" signal (see `AigatewayWorld.web_tools_enabled`);
-        ``owns_client`` says whether the caller must close it (``False`` when an existing client
-        was passed in).
-    """
-    if tavily_api_key is None:
-        return None, False
-    owns = tavily_client is None
-    client = (
-        tavily_client
-        if tavily_client is not None
-        else httpx.AsyncClient(base_url=cfg.tavily_base_url, timeout=cfg.tavily_timeout_s)
-    )
-    return client, owns
 
 
 async def _fetch_completion(
@@ -458,58 +352,16 @@ async def _fetch_completion(
     return resp, read_cache_outcome(resp.headers)
 
 
-@dataclass(frozen=True, slots=True)
-class _WebToolRuntime:
-    client: httpx.AsyncClient
-    config: AigatewayConfig
-    api_key: str
-    excluded_domains: tuple[str, ...]
-
-
-def _web_tool_runtime(
-    *,
-    model: str,
-    route_supports_tools: bool,
-    tavily_http: httpx.AsyncClient | None,
-    tavily_api_key: str | None,
-    config: AigatewayConfig,
-    policy: RetrievalPolicy | None,
-) -> _WebToolRuntime | None:
-    """Resolve tool availability before the first paid model request."""
-
-    if policy is None:
-        return (
-            _WebToolRuntime(tavily_http, config, tavily_api_key, ())
-            if route_supports_tools and tavily_http is not None and tavily_api_key is not None
-            else None
-        )
-    if not policy.web_search:
-        return None
-    if not route_supports_tools:
-        raise ResolutionError(
-            f"model route {model!r} does not declare runner-driven web tools",
-            code="benchmark_retrieval_unavailable",
-            permanent=True,
-        )
-    if tavily_http is None or tavily_api_key is None:
-        raise ResolutionError(
-            "Benchmark requires web retrieval but Tavily is not configured",
-            code="benchmark_retrieval_unavailable",
-            permanent=True,
-        )
-    return _WebToolRuntime(tavily_http, config, tavily_api_key, policy.excluded_domains)
-
-
 async def _chat_completion_loop(
     *,
     http_client: httpx.AsyncClient,
     cfg: AigatewayConfig,
     profile: str | None,
-    model: str,
     messages: list[dict],
+    spec: ModelSpec,
+    params: Mapping[str, str],
     tavily_http: httpx.AsyncClient | None,
     tavily_api_key: str | None,
-    web_tools: bool,
     retrieval_policy: RetrievalPolicy | None = None,
     identity_headers: Mapping[str, str] | None = None,
     cache: CachePolicy,
@@ -517,10 +369,10 @@ async def _chat_completion_loop(
     """Drive one `_ModelEndpoint` call: post to aigateway, execute any requested tool calls,
     and repeat until the model answers with content instead of another tool call.
 
-    Tools are offered only when the ROUTE opted in (`web_tools`) AND the world can serve them
-    (a Tavily client exists). Both conditions are load-bearing: without the route's opt-in a
-    configured key would silently change every model's request payload, and without the client
-    the model could call a tool nothing can execute.
+    Tools are offered only when the route declares `web_tools` and the world can serve them
+    through Tavily. A configured key alone must never change a model request, an explicit
+    ``web_search=false`` disables retrieval, and benchmark-required search fails closed when
+    Tavily is unavailable.
 
     INVARIANT: the cache policy is re-applied on EVERY round trip, not merged once before the
     loop. One turn is several independently-keyed gateway calls, and a policy that lapsed after
@@ -531,28 +383,28 @@ async def _chat_completion_loop(
         ResolutionError: the loop exceeds `cfg.web_tool_max_iterations` without a final
             answer — the model keeps calling tools instead of returning content.
     """
-    tools = _web_tool_runtime(
-        model=model,
-        route_supports_tools=web_tools,
+    tools, extra = _retrieval_request(
+        cfg=cfg,
+        spec=spec,
+        params=params,
         tavily_http=tavily_http,
         tavily_api_key=tavily_api_key,
-        config=cfg,
-        policy=retrieval_policy,
+        retrieval_policy=retrieval_policy,
     )
-    extra = {"tools": _WEB_TOOLS, "tool_choice": "auto"} if tools is not None else {}
+    sampling = model_params(params)
     headers = _headers(profile, identity_headers)
     for _ in range(cfg.web_tool_max_iterations):
-        body = {"model": model, "messages": messages, **extra}
+        body = {"model": spec.id, "messages": messages, **sampling, **extra}
         resp, outcome = await _fetch_completion(
             http_client, headers=headers, body=body, cache=cache
         )
         data = _json_or_raise(resp)
-        _report_usage(model, data.get("usage"))
-        choice = _parse_choice(data)
+        _report_usage(spec.id, data.get("usage"))
+        choice = parse_choice(data)
         # INVARIANT: report BEFORE classifying. A refused turn is the case a reviewer most needs
         # to audit, and raising first would lose exactly the event OME-679 exists to capture.
         _report_response(choice, outcome)
-        _raise_if_unusable(choice)
+        raise_if_unusable(choice)
         content, tool_calls = choice.content, choice.tool_calls
         if not tool_calls:
             # Recorded HERE, not per round trip: a tool loop is several round trips serving ONE
@@ -561,36 +413,8 @@ async def _chat_completion_loop(
             # from two calls that disagreed (`_terminal_outcome` in `benchmarks/candidate.py`).
             record_model_outcome(choice.finish_reason, choice.refusal)
             return content or ""
-        # Cap the fan-out BEFORE dispatching: the model decides how many calls a turn carries, and
-        # they all run concurrently. The dropped ones still get a tool message, because the API
-        # requires one reply per tool_call_id — omitting them makes the next request malformed.
-        served, dropped = (
-            tool_calls[: cfg.web_tool_max_calls_per_turn],
-            tool_calls[cfg.web_tool_max_calls_per_turn :],
-        )
         messages.append({"role": "assistant", "content": content, "tool_calls": tool_calls})
-        results = await asyncio.gather(*(_execute_tool(tc, tools) for tc in served))
-        for tc, result in zip(served, results, strict=True):
-            messages.append(
-                {
-                    "role": "tool",
-                    "tool_call_id": tc["id"],
-                    "name": tc["function"]["name"],
-                    "content": _truncate_tool_result(result, cfg.web_tool_max_result_bytes),
-                }
-            )
-        for tc in dropped:
-            messages.append(
-                {
-                    "role": "tool",
-                    "tool_call_id": tc["id"],
-                    "name": tc.get("function", {}).get("name", ""),
-                    "content": (
-                        f"error: not executed — at most {cfg.web_tool_max_calls_per_turn} tool "
-                        f"calls are served per turn; request fewer"
-                    ),
-                }
-            )
+        await append_tool_results(messages, tool_calls, tools, cfg)
     raise ResolutionError(
         f"web tool loop exceeded {cfg.web_tool_max_iterations} iterations",
         code="web_tool_loop_limit",
@@ -598,158 +422,44 @@ async def _chat_completion_loop(
     )
 
 
-_TOOL_TRUNCATION_MARKER = "\n…[truncated]"
-
-
-def _truncate_tool_result(result: str, cap: int) -> str:
-    """Bound one tool result to `cap` UTF-8 bytes, marking that it was cut.
-
-    Cuts on a byte boundary (`errors="ignore"` drops a partial trailing character rather than
-    raising), mirroring `_RunState.build_result`. The marker matters: a silently truncated web
-    page reads to the model as a complete one, and it will answer confidently from the fragment.
-    """
-    encoded = result.encode("utf-8")
-    if len(encoded) <= cap:
-        return result
-    marker = _TOOL_TRUNCATION_MARKER.encode("utf-8")
-    if len(marker) >= cap:
-        return marker[:cap].decode("utf-8", errors="ignore")
-    kept = encoded[: cap - len(marker)]
-    return kept.decode("utf-8", errors="ignore") + _TOOL_TRUNCATION_MARKER
-
-
-def _tool_args(tool_call: dict) -> tuple[str, dict | None]:
-    """The call's tool name plus its parsed arguments, or ``None`` args when they are unusable —
-    the caller renders the one error message both failure modes produce."""
-    name = tool_call.get("function", {}).get("name", "")
-    raw = tool_call.get("function", {}).get("arguments")
-    try:
-        args = json.loads(raw) if isinstance(raw, str) else (raw or {})
-    except (TypeError, json.JSONDecodeError):
-        return name, None
-    return (name, args) if isinstance(args, dict) else (name, None)
-
-
-async def _dispatch_tool(
-    name: str,
-    args: dict,
-    runtime: _WebToolRuntime | None,
-) -> str:
-    if name not in ("web_search", "web_fetch"):
-        return f"unknown tool: {name}"
-    if runtime is None:
-        raise RuntimeError(f"{name} requested but Tavily is not configured")
-    if name == "web_search":
-        return await _tavily_search(runtime, args)
-    return await _tavily_extract(runtime, args)
-
-
-async def _execute_tool(
-    tool_call: dict,
-    runtime: _WebToolRuntime | None,
-) -> str:
-    name, args = _tool_args(tool_call)
-    if args is None:
-        return f"invalid arguments for {name}"
-    try:
-        return await _dispatch_tool(name, args, runtime)
-    except Exception as exc:  # noqa: BLE001 — fed back to the model, not raised (dec:W2)
-        return f"{name} failed: {exc}"
-
-
-async def _tavily_search(
-    runtime: _WebToolRuntime,
-    args: dict,
-) -> str:
-    query = args.get("query")
-    if not isinstance(query, str) or not query:
-        raise ValueError("web_search requires a non-empty 'query'")
-    payload: dict[str, object] = {
-        "query": query,
-        "search_depth": runtime.config.tavily_search_depth,
-        "max_results": runtime.config.tavily_max_results,
-    }
-    if runtime.excluded_domains:
-        payload["exclude_domains"] = list(runtime.excluded_domains)
-    resp = await runtime.client.post(
-        "/search",
-        headers=_tavily_headers(runtime.api_key),
-        json=payload,
+def _retrieval_request(
+    *,
+    cfg: AigatewayConfig,
+    spec: ModelSpec,
+    params: Mapping[str, str],
+    tavily_http: httpx.AsyncClient | None,
+    tavily_api_key: str | None,
+    retrieval_policy: RetrievalPolicy | None,
+) -> tuple[WebToolRuntime | None, dict[str, object]]:
+    if (
+        retrieval_policy is not None
+        and params.get(WEB_SEARCH_PARAM) == "true"
+        and not (spec.web_tools or spec.native_web_search)
+    ):
+        raise ResolutionError(
+            f"model route {spec.id!r} does not declare a web search mechanism",
+            code="benchmark_retrieval_unavailable",
+            permanent=True,
+        )
+    wants_search = wants_web_search(params, spec)
+    tools = build_runtime(
+        spec=spec,
+        wants_search=wants_search,
+        tavily_http=tavily_http,
+        tavily_api_key=tavily_api_key,
+        config=cfg,
+        policy=retrieval_policy,
+        params=params,
     )
-    resp.raise_for_status()
-    data = resp.json()
-    results = [
-        result
-        for result in (data.get("results") or [])
-        if isinstance(result, dict) and _search_result_allowed(result, runtime.excluded_domains)
-    ]
-    if not results:
-        return "no results"
-    return "\n\n".join(
-        f"Title: {r.get('title', '')}\nURL: {r.get('url', '')}\nContent: {r.get('content', '')}"
-        for r in results
-        if isinstance(r, dict)
-    )
-
-
-async def _tavily_extract(
-    runtime: _WebToolRuntime,
-    args: dict,
-) -> str:
-    url = args.get("url")
-    if not isinstance(url, str) or not url:
-        raise ValueError("web_fetch requires a non-empty 'url'")
-    if _is_blocked(url, runtime.excluded_domains):
-        raise ValueError("web_fetch URL is blocked by Benchmark retrieval policy")
-    resp = await runtime.client.post(
-        "/extract",
-        headers=_tavily_headers(runtime.api_key),
-        json={"urls": url, "format": "markdown", "extract_depth": "advanced"},
-    )
-    resp.raise_for_status()
-    data = resp.json()
-    results = data.get("results") or []
-    if results and isinstance(results[0], dict) and results[0].get("raw_content"):
-        return str(results[0]["raw_content"])
-    failed = data.get("failed_results") or []
-    if failed and isinstance(failed[0], dict):
-        failed_url = failed[0].get("url", url)
-        failed_err = failed[0].get("error", "unknown")
-        return f"{failed_url} could not be extracted: {failed_err}"
-    return "no content extracted"
-
-
-def _search_result_allowed(result: Mapping[str, object], exclusions: Sequence[str]) -> bool:
-    if not exclusions:
-        return True
-    url = result.get("url")
-    return isinstance(url, str) and not _is_blocked(url, exclusions)
-
-
-def _is_blocked(url: str, exclusions: Sequence[str]) -> bool:
-    """Match a bare-domain exclusion against its host and every subdomain."""
-
-    if not exclusions:
-        return False
-    normalized_host: str | None = None
-    try:
-        parsed = httpx.URL(url if "://" in url else f"https://{url}")
-        normalized_host = parsed.raw_host.decode("ascii").lower().rstrip(".")
-    except (httpx.InvalidURL, UnicodeDecodeError):
-        pass
-    # Fail closed on a host this comparison cannot decide. An unparsed host is the obvious case;
-    # a percent-encoded one is the subtle one — httpx leaves the authority encoded, so `ev%69l.com`
-    # would not match `evil.com` here and would then be handed to a fetcher that decodes it. A
-    # real host never carries a literal `%`, so refusing one costs nothing.
-    if not normalized_host or "%" in normalized_host:
-        return True
-    return any(
-        normalized_host == domain or normalized_host.endswith(f".{domain}") for domain in exclusions
-    )
-
-
-def _tavily_headers(api_key: str) -> dict[str, str]:
-    return {"Authorization": f"Bearer {api_key}"}
+    if wants_search and spec.native_web_search:
+        extra: dict[str, object] = {"web_search": True}
+        exclusions = caller_exclusions(params)
+        if exclusions:
+            extra["web_search_excluded_domains"] = list(exclusions)
+        return tools, extra
+    if tools is not None:
+        return tools, {"tools": WEB_TOOLS, "tool_choice": "auto"}
+    return tools, {}
 
 
 def _messages(context: str | None, intent: str | None) -> list[dict[str, str]]:

--- a/apps/url4-cloud/src/url4_cloud/runner/errors.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/errors.py
@@ -1,0 +1,22 @@
+"""Runner-local failures translated by the URL4 connector boundary."""
+
+from __future__ import annotations
+
+from url4_cloud.model_outcomes import ModelOutcome
+
+
+class RunnerRequestError(ValueError):
+    """A model-request failure with stable wire semantics but no URL4 dependency."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str,
+        permanent: bool,
+        outcome: ModelOutcome | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.permanent = permanent
+        self.outcome = outcome

--- a/apps/url4-cloud/src/url4_cloud/runner/main.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/main.py
@@ -17,7 +17,7 @@ import httpx
 from url4.streaming.lifecycle import run
 from url4_cloud import job_env
 from url4_cloud.adapters.jetstream import JetStreamPublisher
-from url4_cloud.benchmarks import EMPTY_BENCHMARKS, BenchmarkRegistry, assets_root
+from url4_cloud.benchmarks import BENCHMARKS, EMPTY_BENCHMARKS, BenchmarkRegistry, assets_root
 from url4_cloud.benchmarks.candidate import install_candidate_invocation
 from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
 from url4_cloud.runner.executor import Url4Executor, World, deny_by_default_world
@@ -97,7 +97,7 @@ def build_executor(
     ``AIGATEWAY_SECRET_KEY`` — never logged. It is read here and forwarded to
     ``build_aigateway_world`` as ``tavily_api_key``; when it is unset, the built world disables
     the web-search/web-fetch tool loop entirely (deny-by-default — see
-    ``connector._build_tavily_client``), rather than leaving it half-configured.
+    ``web_tools.build_client``), rather than leaving it half-configured.
     """
 
     async def _world() -> World:
@@ -111,7 +111,7 @@ def build_executor(
             # WHY: a world with no [aigateway] table is a legitimate empty world; the node itself
             # denies everything undeclared.
             return deny_by_default_world(), None
-        # WHY no credential check here any more: aigateway runs `cloudflare_headers` when deployed
+        # WHY: no credential check here; aigateway runs `cloudflare_headers` when deployed
         # and `disabled` locally, and NEITHER mode reads `Authorization` — so there is no token to
         # demand. Identity is forwarded when present and simply absent locally, where every caller
         # is anonymous. The old unconditional token requirement made every deployed run fail
@@ -123,6 +123,7 @@ def build_executor(
                 models=section.models,
                 allow_outbound=section.allow_outbound,
                 timeout_s=section.timeout_s,
+                web_tool_max_iterations=section.web_tool_max_iterations,
             ),
             profile=env.get(job_env.AIGATEWAY_PROFILE),
             identity_headers=job_env.identity_from_env(env),
@@ -158,7 +159,7 @@ def build_executor(
 def main() -> None:  # pragma: no cover - real NATS + event loop (INFRA rule)
     async def _main() -> None:
         params = params_from_env(os.environ)
-        executor = build_executor(os.environ)
+        executor = build_executor(os.environ, benchmarks=BENCHMARKS)
         traceparent = os.environ.get(job_env.TRACEPARENT)
         await run(
             JetStreamPublisher(params.nats_url),

--- a/apps/url4-cloud/src/url4_cloud/runner/main.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/main.py
@@ -9,6 +9,7 @@ layering note in :mod:`url4_cloud.runner`.
 import asyncio
 import os
 from collections.abc import Mapping
+from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -17,7 +18,8 @@ import httpx
 from url4.streaming.lifecycle import run
 from url4_cloud import job_env
 from url4_cloud.adapters.jetstream import JetStreamPublisher
-from url4_cloud.benchmarks import BENCHMARKS, EMPTY_BENCHMARKS, BenchmarkRegistry, assets_root
+from url4_cloud.benchmarks import EMPTY_BENCHMARKS, BenchmarkRegistry, assets_root
+from url4_cloud.benchmarks.builtins import BUILTIN_BENCHMARKS
 from url4_cloud.benchmarks.candidate import install_candidate_invocation
 from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
 from url4_cloud.runner.executor import Url4Executor, World, deny_by_default_world
@@ -138,7 +140,10 @@ def build_executor(
             tavily_client=tavily_client,
         )
         if len(benchmarks):
-            try:
+            # WHY: installation can fail through any concrete Benchmark adapter. AsyncExitStack
+            # guarantees the already-open model world closes without a catch-all exception clause.
+            async with AsyncExitStack() as cleanup:
+                cleanup.push_async_callback(world.aclose)
                 install_candidate_invocation(world.node)
                 benchmarks.install(
                     world.node,
@@ -148,9 +153,7 @@ def build_executor(
                         else assets_root(env)
                     ),
                 )
-            except Exception:
-                await world.aclose()
-                raise
+                cleanup.pop_all()
         return world.node, world.aclose
 
     return Url4Executor(world_factory=_world)
@@ -159,7 +162,7 @@ def build_executor(
 def main() -> None:  # pragma: no cover - real NATS + event loop (INFRA rule)
     async def _main() -> None:
         params = params_from_env(os.environ)
-        executor = build_executor(os.environ, benchmarks=BENCHMARKS)
+        executor = build_executor(os.environ, benchmarks=BUILTIN_BENCHMARKS)
         traceparent = os.environ.get(job_env.TRACEPARENT)
         await run(
             JetStreamPublisher(params.nats_url),

--- a/apps/url4-cloud/src/url4_cloud/runner/model_response.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/model_response.py
@@ -1,0 +1,55 @@
+"""Decode and classify one AI Gateway chat-completions choice."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from url4_cloud.model_outcomes import ModelOutcome
+from url4_cloud.runner.errors import RunnerRequestError
+
+
+@dataclass(frozen=True, slots=True)
+class Choice:
+    """One chat-completions choice reduced to what the Runner consumes."""
+
+    content: str | None
+    tool_calls: list[dict] | None
+    finish_reason: str | None
+    refusal: str | None
+
+
+def parse_choice(data: dict) -> Choice:
+    """Pull the first choice out of a chat-completions response."""
+    try:
+        choice = data["choices"][0]
+        message = choice["message"]
+        content = message.get("content")
+        tool_calls = message.get("tool_calls")
+        finish_reason = choice.get("finish_reason")
+        refusal = message.get("refusal")
+    except (KeyError, IndexError, TypeError) as exc:
+        raise RunnerRequestError(
+            "malformed aigateway response", code="aigateway_bad_response", permanent=True
+        ) from exc
+    return Choice(
+        content=content,
+        tool_calls=tool_calls,
+        finish_reason=finish_reason if isinstance(finish_reason, str) else None,
+        refusal=refusal if isinstance(refusal, str) and refusal.strip() else None,
+    )
+
+
+def raise_if_unusable(choice: Choice) -> None:
+    """Reject a refusal or a choice carrying neither answer nor tool call."""
+    # INVARIANT: refusal precedes emptiness because content-filter turns normally carry null text.
+    if choice.finish_reason == "content_filter" or choice.refusal is not None:
+        raise RunnerRequestError(
+            "provider refused the request",
+            code="provider_refusal",
+            permanent=True,
+            outcome=ModelOutcome(choice.finish_reason, choice.refusal),
+        )
+    if not choice.tool_calls and choice.content is None:
+        raise RunnerRequestError(
+            "malformed aigateway response", code="aigateway_bad_response", permanent=True
+        )

--- a/apps/url4-cloud/src/url4_cloud/runner/request_parameters.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/request_parameters.py
@@ -1,0 +1,94 @@
+"""Validate URL4 model-call parameters and apply an active retrieval ceiling."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+
+from url4_cloud.retrieval_policy import RetrievalPolicy, normalize_excluded_domains
+from url4_cloud.runner.errors import RunnerRequestError
+from url4_cloud.world_config import ModelSpec
+
+WEB_SEARCH_PARAM = "web_search"
+WEB_SEARCH_EXCLUDE_PARAM = "web_search_exclude"
+_INTERPRETED_PARAMS = frozenset({WEB_SEARCH_PARAM, WEB_SEARCH_EXCLUDE_PARAM})
+_RUNNER_OWNED_FIELDS = frozenset(
+    {"model", "messages", "tools", "tool_choice", "stream", "web_search_excluded_domains"}
+)
+
+
+def apply_retrieval_policy(
+    params: Mapping[str, str],
+    policy: RetrievalPolicy | None,
+) -> dict[str, str]:
+    """Apply the active Benchmark ceiling while allowing a nested call to narrow it."""
+    selected = dict(params)
+    if policy is None:
+        return selected
+    if not policy.web_search:
+        selected[WEB_SEARCH_PARAM] = "false"
+        selected.pop(WEB_SEARCH_EXCLUDE_PARAM, None)
+        return selected
+    if selected.get(WEB_SEARCH_PARAM) != "false":
+        selected[WEB_SEARCH_PARAM] = "true"
+        excluded = {*policy.excluded_domains, *caller_exclusions(selected)}
+        if excluded:
+            selected[WEB_SEARCH_EXCLUDE_PARAM] = ":".join(sorted(excluded))
+    return selected
+
+
+def wants_web_search(params: Mapping[str, str], spec: ModelSpec) -> bool:
+    """Resolve an optional URL4 search toggle against the declared route capabilities."""
+    declared = spec.web_tools or spec.native_web_search
+    raw = params.get(WEB_SEARCH_PARAM)
+    if raw is None:
+        return declared
+    if raw not in {"true", "false"}:
+        raise RunnerRequestError(
+            "web_search must be true or false",
+            code="web_retrieval_invalid",
+            permanent=True,
+        )
+    wanted = raw == "true"
+    if wanted and not declared:
+        raise RunnerRequestError(
+            f"web_search=true but route /{spec.id} declares no web search mechanism",
+            code="web_retrieval_unavailable",
+            permanent=True,
+        )
+    return wanted
+
+
+def caller_exclusions(params: Mapping[str, str]) -> tuple[str, ...]:
+    """Decode and normalize the URL4 form of the caller's exclusion list."""
+    raw = params.get(WEB_SEARCH_EXCLUDE_PARAM)
+    if not raw:
+        return ()
+    try:
+        return normalize_excluded_domains(raw.split(":"))
+    except ValueError as exc:
+        raise RunnerRequestError(
+            "web_search_exclude must be a colon-separated list of bare domains",
+            code="web_retrieval_invalid",
+            permanent=True,
+        ) from exc
+
+
+def model_params(params: Mapping[str, str]) -> dict[str, object]:
+    """Project URL4 parameters into the model request without Runner-owned fields."""
+    selected = {key: value for key, value in params.items() if key not in _INTERPRETED_PARAMS}
+    owned = sorted(set(selected) & _RUNNER_OWNED_FIELDS)
+    if owned:
+        raise RunnerRequestError(
+            f"expression may not set {', '.join(owned)} — owned by the Runner's declared world",
+            code="model_parameter_invalid",
+            permanent=True,
+        )
+    return {key: _coerce_param(value) for key, value in selected.items()}
+
+
+def _coerce_param(value: str) -> object:
+    try:
+        return json.loads(value)
+    except ValueError:
+        return value

--- a/apps/url4-cloud/src/url4_cloud/runner/request_parameters.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/request_parameters.py
@@ -1,4 +1,8 @@
-"""Validate URL4 model-call parameters and apply an active retrieval ceiling."""
+"""Validate URL4 model-call parameters and apply an active retrieval ceiling.
+
+INVARIANT: a nested call may narrow its active retrieval policy, but it cannot enable retrieval
+or remove excluded domains forbidden by its parent invocation.
+"""
 
 from __future__ import annotations
 

--- a/apps/url4-cloud/src/url4_cloud/runner/web_tools.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/web_tools.py
@@ -1,4 +1,8 @@
-"""Bounded Tavily-backed web tools for model routes that declare them."""
+"""Bounded Tavily-backed web tools for model routes that declare them.
+
+INVARIANT: exclusions are sent to Tavily and enforced again on returned search rows and direct
+fetch URLs; provider-side filtering is never the sole privacy guard.
+"""
 
 from __future__ import annotations
 
@@ -282,7 +286,11 @@ def _is_blocked(url: str, exclusions: Sequence[str]) -> bool:
         normalized_host = parsed.raw_host.decode("ascii").lower().rstrip(".")
     except (httpx.InvalidURL, UnicodeDecodeError):
         pass
-    if not normalized_host:
+    # Fail closed on a host this comparison cannot decide. An unparsed host is the obvious case;
+    # a percent-encoded one is the subtle one — httpx leaves the authority encoded, so `ev%69l.com`
+    # would not match `evil.com` here and would then be handed to a fetcher that decodes it. A
+    # real host never carries a literal `%`, so refusing one costs nothing.
+    if not normalized_host or "%" in normalized_host:
         return True
     return any(
         normalized_host == domain or normalized_host.endswith(f".{domain}") for domain in exclusions

--- a/apps/url4-cloud/src/url4_cloud/runner/web_tools.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/web_tools.py
@@ -113,8 +113,11 @@ def build_runtime(
         return None
     required = params.get(WEB_SEARCH_PARAM) == "true"
     if not required and policy is None:
+        # A route that declares web_tools searches by default, so the caller reaches here without
+        # writing `web_search=true`. Their exclusions still bind: an ignored exclusion list is the
+        # worst failure mode for a privacy control, because it looks like it was honoured.
         return (
-            WebToolRuntime(tavily_http, config, tavily_api_key, ())
+            WebToolRuntime(tavily_http, config, tavily_api_key, caller_exclusions(params))
             if tavily_http is not None and tavily_api_key is not None
             else None
         )

--- a/apps/url4-cloud/src/url4_cloud/runner/web_tools.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/web_tools.py
@@ -1,0 +1,293 @@
+"""Bounded Tavily-backed web tools for model routes that declare them."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+import httpx
+
+from url4_cloud.retrieval_policy import RetrievalPolicy
+from url4_cloud.runner.errors import RunnerRequestError
+from url4_cloud.runner.request_parameters import WEB_SEARCH_PARAM, caller_exclusions
+from url4_cloud.world_config import ModelSpec
+
+WEB_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "web_search",
+            "description": (
+                "Search the web for current or real-time information. Use when the answer "
+                "needs up-to-date data not in your training."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string", "description": "The search query."}},
+                "required": ["query"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "web_fetch",
+            "description": "Fetch and extract the main content of a web page from a known URL.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "url": {"type": "string", "description": "The absolute URL to fetch."}
+                },
+                "required": ["url"],
+            },
+        },
+    },
+]
+
+
+class WebToolConfig(Protocol):
+    """Configuration fields consumed by the tool runtime."""
+
+    @property
+    def tavily_search_depth(self) -> str: ...
+
+    @property
+    def tavily_base_url(self) -> str: ...
+
+    @property
+    def tavily_timeout_s(self) -> float: ...
+
+    @property
+    def tavily_max_results(self) -> int: ...
+
+    @property
+    def web_tool_max_calls_per_turn(self) -> int: ...
+
+    @property
+    def web_tool_max_result_bytes(self) -> int: ...
+
+
+@dataclass(frozen=True, slots=True)
+class WebToolRuntime:
+    client: httpx.AsyncClient
+    config: WebToolConfig
+    api_key: str
+    excluded_domains: tuple[str, ...]
+
+
+def build_client(
+    config: WebToolConfig,
+    api_key: str | None,
+    client: httpx.AsyncClient | None,
+) -> tuple[httpx.AsyncClient | None, bool]:
+    """Resolve the optional Tavily client and whether the world owns it."""
+    if api_key is None:
+        return None, False
+    owns_client = client is None
+    resolved = client or httpx.AsyncClient(
+        base_url=config.tavily_base_url,
+        timeout=config.tavily_timeout_s,
+    )
+    return resolved, owns_client
+
+
+def build_runtime(
+    *,
+    spec: ModelSpec,
+    wants_search: bool,
+    tavily_http: httpx.AsyncClient | None,
+    tavily_api_key: str | None,
+    config: WebToolConfig,
+    policy: RetrievalPolicy | None,
+    params: Mapping[str, str],
+) -> WebToolRuntime | None:
+    """Resolve tool availability before the first paid model request."""
+    if not wants_search or not spec.web_tools:
+        return None
+    required = params.get(WEB_SEARCH_PARAM) == "true"
+    if not required and policy is None:
+        return (
+            WebToolRuntime(tavily_http, config, tavily_api_key, ())
+            if tavily_http is not None and tavily_api_key is not None
+            else None
+        )
+    if tavily_http is None or tavily_api_key is None:
+        raise RunnerRequestError(
+            f"web_search=true on /{spec.id} requires a configured Tavily connection",
+            code=(
+                "benchmark_retrieval_unavailable"
+                if policy is not None
+                else "web_retrieval_unavailable"
+            ),
+            permanent=True,
+        )
+    return WebToolRuntime(tavily_http, config, tavily_api_key, caller_exclusions(params))
+
+
+async def append_tool_results(
+    messages: list[dict],
+    tool_calls: list[dict],
+    runtime: WebToolRuntime | None,
+    config: WebToolConfig,
+) -> None:
+    """Execute a bounded tool fan-out and append one reply for every requested call."""
+    served = tool_calls[: config.web_tool_max_calls_per_turn]
+    dropped = tool_calls[config.web_tool_max_calls_per_turn :]
+    results = await asyncio.gather(*(_execute_tool(call, runtime) for call in served))
+    for call, result in zip(served, results, strict=True):
+        messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": call["id"],
+                "name": call["function"]["name"],
+                "content": truncate_tool_result(result, config.web_tool_max_result_bytes),
+            }
+        )
+    for call in dropped:
+        messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": call["id"],
+                "name": call.get("function", {}).get("name", ""),
+                "content": (
+                    f"error: not executed — at most {config.web_tool_max_calls_per_turn} tool "
+                    "calls are served per turn; request fewer"
+                ),
+            }
+        )
+
+
+_TOOL_TRUNCATION_MARKER = "\n…[truncated]"
+
+
+def truncate_tool_result(result: str, cap: int) -> str:
+    """Bound one tool result to `cap` UTF-8 bytes and mark truncation."""
+    encoded = result.encode("utf-8")
+    if len(encoded) <= cap:
+        return result
+    marker = _TOOL_TRUNCATION_MARKER.encode("utf-8")
+    if len(marker) >= cap:
+        return marker[:cap].decode("utf-8", errors="ignore")
+    kept = encoded[: cap - len(marker)]
+    return kept.decode("utf-8", errors="ignore") + _TOOL_TRUNCATION_MARKER
+
+
+def _tool_args(tool_call: dict) -> tuple[str, dict | None]:
+    name = tool_call.get("function", {}).get("name", "")
+    raw = tool_call.get("function", {}).get("arguments")
+    try:
+        args = json.loads(raw) if isinstance(raw, str) else (raw or {})
+    except (TypeError, json.JSONDecodeError):
+        return name, None
+    return (name, args) if isinstance(args, dict) else (name, None)
+
+
+async def _dispatch_tool(
+    name: str,
+    args: dict,
+    runtime: WebToolRuntime | None,
+) -> str:
+    if name not in ("web_search", "web_fetch"):
+        return f"unknown tool: {name}"
+    if runtime is None:
+        raise RuntimeError(f"{name} requested but Tavily is not configured")
+    if name == "web_search":
+        return await _tavily_search(runtime, args)
+    return await _tavily_extract(runtime, args)
+
+
+async def _execute_tool(tool_call: dict, runtime: WebToolRuntime | None) -> str:
+    name, args = _tool_args(tool_call)
+    if args is None:
+        return f"invalid arguments for {name}"
+    try:
+        return await _dispatch_tool(name, args, runtime)
+    except (RuntimeError, ValueError, httpx.HTTPError) as exc:
+        return f"{name} failed: {exc}"
+
+
+async def _tavily_search(runtime: WebToolRuntime, args: dict) -> str:
+    query = args.get("query")
+    if not isinstance(query, str) or not query:
+        raise ValueError("web_search requires a non-empty 'query'")
+    payload: dict[str, object] = {
+        "query": query,
+        "search_depth": runtime.config.tavily_search_depth,
+        "max_results": runtime.config.tavily_max_results,
+    }
+    if runtime.excluded_domains:
+        payload["exclude_domains"] = list(runtime.excluded_domains)
+    response = await runtime.client.post(
+        "/search",
+        headers=_tavily_headers(runtime.api_key),
+        json=payload,
+    )
+    response.raise_for_status()
+    data = response.json()
+    results = [
+        result
+        for result in (data.get("results") or [])
+        if isinstance(result, dict) and _search_result_allowed(result, runtime.excluded_domains)
+    ]
+    if not results:
+        return "no results"
+    return "\n\n".join(
+        f"Title: {r.get('title', '')}\nURL: {r.get('url', '')}\nContent: {r.get('content', '')}"
+        for r in results
+        if isinstance(r, dict)
+    )
+
+
+async def _tavily_extract(runtime: WebToolRuntime, args: dict) -> str:
+    url = args.get("url")
+    if not isinstance(url, str) or not url:
+        raise ValueError("web_fetch requires a non-empty 'url'")
+    if _is_blocked(url, runtime.excluded_domains):
+        raise ValueError("web_fetch URL is blocked by Benchmark retrieval policy")
+    response = await runtime.client.post(
+        "/extract",
+        headers=_tavily_headers(runtime.api_key),
+        json={"urls": url, "format": "markdown", "extract_depth": "advanced"},
+    )
+    response.raise_for_status()
+    data = response.json()
+    results = data.get("results") or []
+    if results and isinstance(results[0], dict) and results[0].get("raw_content"):
+        return str(results[0]["raw_content"])
+    failed = data.get("failed_results") or []
+    if failed and isinstance(failed[0], dict):
+        failed_url = failed[0].get("url", url)
+        failed_error = failed[0].get("error", "unknown")
+        return f"{failed_url} could not be extracted: {failed_error}"
+    return "no content extracted"
+
+
+def _search_result_allowed(result: Mapping[str, object], exclusions: Sequence[str]) -> bool:
+    if not exclusions:
+        return True
+    url = result.get("url")
+    return isinstance(url, str) and not _is_blocked(url, exclusions)
+
+
+def _is_blocked(url: str, exclusions: Sequence[str]) -> bool:
+    """Match a bare-domain exclusion against its host and every subdomain."""
+    if not exclusions:
+        return False
+    normalized_host: str | None = None
+    try:
+        parsed = httpx.URL(url if "://" in url else f"https://{url}")
+        normalized_host = parsed.raw_host.decode("ascii").lower().rstrip(".")
+    except (httpx.InvalidURL, UnicodeDecodeError):
+        pass
+    if not normalized_host:
+        return True
+    return any(
+        normalized_host == domain or normalized_host.endswith(f".{domain}") for domain in exclusions
+    )
+
+
+def _tavily_headers(api_key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {api_key}"}

--- a/apps/url4-cloud/src/url4_cloud/world_config.py
+++ b/apps/url4-cloud/src/url4_cloud/world_config.py
@@ -41,8 +41,19 @@ DEFAULT_CONFIG_PATH = "/etc/url4/url4.toml"
 """Where the declared world lives unless :data:`job_env.RUNNER_CONFIG` overrides it. Image-level
 wiring: the App never writes that variable — the file is baked into the image."""
 
-_AIGATEWAY_KEYS = frozenset({"base_url", "default_route", "models", "allow_outbound", "timeout_s"})
-_MODEL_KEYS = frozenset({"id", "web_tools"})
+DEFAULT_WEB_TOOL_MAX_ITERATIONS = 5
+
+_AIGATEWAY_KEYS = frozenset(
+    {
+        "base_url",
+        "default_route",
+        "models",
+        "allow_outbound",
+        "timeout_s",
+        "web_tool_max_iterations",
+    }
+)
+_MODEL_KEYS = frozenset({"id", "web_tools", "native_web_search"})
 _RESERVED_TABLES = frozenset({"data", "commands", "holdings", "identities"})
 _TOP_LEVEL_KEYS = frozenset({"aigateway"})
 _MODEL_ID_RE = re.compile(r"[A-Za-z0-9\-_.~]+(?:/[A-Za-z0-9\-_.~]+)*", re.ASCII)
@@ -70,6 +81,7 @@ class ModelSpec:
 
     id: str
     web_tools: bool = False
+    native_web_search: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -81,6 +93,7 @@ class AigatewaySection:
     models: tuple[ModelSpec, ...]
     allow_outbound: bool = True
     timeout_s: float = 60.0
+    web_tool_max_iterations: int = DEFAULT_WEB_TOOL_MAX_ITERATIONS
 
 
 @dataclass(frozen=True, slots=True)
@@ -160,6 +173,11 @@ def _parse_aigateway(table: Mapping[str, object], env: Mapping[str, str]) -> Aig
         models=models,
         allow_outbound=_bool(table, "allow_outbound", default=True),
         timeout_s=_float(table, "timeout_s", 60.0),
+        web_tool_max_iterations=_positive_int(
+            table,
+            "web_tool_max_iterations",
+            DEFAULT_WEB_TOOL_MAX_ITERATIONS,
+        ),
     )
     section = _apply_env(section, env)
     _require_declared(section.default_model, models)
@@ -228,12 +246,25 @@ def _model_table(table: Mapping[str, object]) -> ModelSpec:
     raw_id = table.get("id")
     if raw_id is None:
         raise WorldConfigError("[[aigateway.models]] entry is missing its `id`")
-    web_tools = table.get("web_tools", False)
-    if not isinstance(web_tools, bool):
+    web_tools = _model_flag(table, "web_tools")
+    native_web_search = _model_flag(table, "native_web_search")
+    if web_tools and native_web_search:
         raise WorldConfigError(
-            f"[[aigateway.models]] web_tools must be a boolean, got {web_tools!r}"
+            f"[[aigateway.models]] {raw_id!r} declares both web_tools and native_web_search — "
+            "a route serves one retrieval mechanism"
         )
-    return ModelSpec(id=_model_id(str(raw_id)), web_tools=web_tools)
+    return ModelSpec(
+        id=_model_id(str(raw_id)),
+        web_tools=web_tools,
+        native_web_search=native_web_search,
+    )
+
+
+def _model_flag(table: Mapping[str, object], key: str) -> bool:
+    value = table.get(key, False)
+    if not isinstance(value, bool):
+        raise WorldConfigError(f"[[aigateway.models]] {key} must be a boolean, got {value!r}")
+    return value
 
 
 def _model_id(model: str) -> str:
@@ -278,6 +309,13 @@ def _float(table: Mapping[str, object], key: str, default: float) -> float:
         return float(value)  # type: ignore[arg-type]
     except (TypeError, ValueError):
         raise WorldConfigError(f"[aigateway] {key} must be a number, got {value!r}") from None
+
+
+def _positive_int(table: Mapping[str, object], key: str, default: int) -> int:
+    value = table.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise WorldConfigError(f"[aigateway] {key} must be a positive integer, got {value!r}")
+    return value
 
 
 __all__ = [

--- a/apps/url4-cloud/tests/unit/benchmark_support.py
+++ b/apps/url4-cloud/tests/unit/benchmark_support.py
@@ -4,7 +4,8 @@ from collections.abc import Collection, Iterable
 from pathlib import Path
 
 from url4.peer.server import Url4Node
-from url4_cloud.benchmarks import BENCHMARKS, Benchmark, BenchmarkRegistry
+from url4_cloud.benchmarks import Benchmark, BenchmarkRegistry
+from url4_cloud.benchmarks.builtins import BUILTIN_BENCHMARKS
 from url4_cloud.benchmarks.candidate import install_candidate_invocation
 from url4_cloud.benchmarks.draco.definition import JUDGE_MODEL
 
@@ -26,7 +27,7 @@ def install_benchmarks(
         if route not in node.processor_routes():
             node.endpoint(route)(_unused_model)
     install_candidate_invocation(node)
-    registry = BENCHMARKS if benchmarks is None else BenchmarkRegistry(benchmarks)
+    registry = BUILTIN_BENCHMARKS if benchmarks is None else BenchmarkRegistry(benchmarks)
     registry.install(node, assets_root=root)
 
 

--- a/apps/url4-cloud/tests/unit/benchmark_support.py
+++ b/apps/url4-cloud/tests/unit/benchmark_support.py
@@ -1,0 +1,33 @@
+"""Test-only composition helper for an installed benchmark registry."""
+
+from collections.abc import Collection, Iterable
+from pathlib import Path
+
+from url4.peer.server import Url4Node
+from url4_cloud.benchmarks import BENCHMARKS, Benchmark, BenchmarkRegistry
+from url4_cloud.benchmarks.candidate import install_candidate_invocation
+from url4_cloud.benchmarks.draco.definition import JUDGE_MODEL
+
+_DEFAULT_MODEL_ROUTES = (f"/{JUDGE_MODEL}",)
+
+
+def _unused_model(_request: object) -> str:
+    raise AssertionError("the test did not provide a model implementation")
+
+
+def install_benchmarks(
+    node: Url4Node,
+    root: Path,
+    *,
+    model_routes: Collection[str] = (),
+    benchmarks: Iterable[Benchmark] | None = None,
+) -> None:
+    for route in dict.fromkeys((*_DEFAULT_MODEL_ROUTES, *model_routes)):
+        if route not in node.processor_routes():
+            node.endpoint(route)(_unused_model)
+    install_candidate_invocation(node)
+    registry = BENCHMARKS if benchmarks is None else BenchmarkRegistry(benchmarks)
+    registry.install(node, assets_root=root)
+
+
+__all__ = ["install_benchmarks"]

--- a/apps/url4-cloud/tests/unit/test_benchmark_foundation.py
+++ b/apps/url4-cloud/tests/unit/test_benchmark_foundation.py
@@ -36,8 +36,9 @@ from url4_cloud.model_outcomes import (
     capture_model_outcomes,
     record_model_outcome,
 )
-from url4_cloud.runner.connector import AigatewayConfig, _is_blocked, build_aigateway_world
+from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
 from url4_cloud.runner.main import build_executor
+from url4_cloud.runner.web_tools import _is_blocked
 from url4_cloud.testing import InMemoryEventStream
 from url4_cloud.world_config import AigatewaySection, ModelSpec, WorldConfig
 

--- a/apps/url4-cloud/tests/unit/test_draco_aggregate.py
+++ b/apps/url4-cloud/tests/unit/test_draco_aggregate.py
@@ -1,0 +1,406 @@
+"""DRACO aggregation — the paper's exact scoring math.
+
+FEATURE: the cross-row reducer of a Candidate benchmark run turns per-criterion Judge verdicts
+into a Candidate Result.
+STORY: as a researcher, the score I get back is the DRACO paper's `normalized_score`, not an
+approximation, so a leaderboard number means what the paper says it means.
+
+INVARIANT: the formulas here mirror `screamingface-benchmarks/benchmarking/graders/rubric.py`
+(arXiv:2602.11685 §4.2) exactly. Every expected value below is hand-computed from the rubric in
+`_RUBRIC`, so a drift in either implementation shows up as an arithmetic failure, not a vague
+"scores moved" regression.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from url4_cloud.benchmarks.draco import aggregate as agg
+from url4_cloud.benchmarks.draco.case_evaluation import (
+    bind_case_evaluation,
+    bind_criterion_evaluation,
+)
+from url4_cloud.benchmarks.draco.definition import REVISION as DRACO_REVISION
+from url4_cloud.benchmarks.draco.records import CASE_SCHEMA, CHECK_SCHEMA
+
+# Two sections, one negative criterion. Positive weights sum to 4 (a1=2, a2=1, b1=1).
+_RUBRIC = {
+    "sections": [
+        {
+            "id": "Factual Accuracy",
+            "criteria": [
+                {"id": "a1", "weight": 2, "requirement": "cites a source"},
+                {"id": "a2", "weight": 1, "requirement": "states the date"},
+                {"id": "a3", "weight": -3, "requirement": "invents a statistic"},
+            ],
+        },
+        {"id": "Presentation", "criteria": [{"id": "b1", "weight": 1, "requirement": "is terse"}]},
+    ]
+}
+
+
+def _selected_cases(*case_ids: int) -> list[dict[str, object]]:
+    return [{"id": case_id, "input": f"Question {case_id}"} for case_id in case_ids]
+
+
+def _verdict(cid: str, status: str, case: int = 1, sequence: int = 1) -> dict[str, object]:
+    raw = json.dumps({"explanation": "evidence", "criterion_status": status})
+    return {
+        "schema": "screamingface.criterion-verdict.v1",
+        "case_id": case,
+        "criterion_id": cid,
+        "sequence": sequence,
+        "producer_type": "model",
+        "producer_id": "fixture-judge",
+        "valid": True,
+        "explanation": "evidence",
+        "criterion_status": status,
+        "raw_output": raw,
+    }
+
+
+def _invalid(cid: str, reason: str, case: int = 1, sequence: int = 1) -> dict[str, object]:
+    return {
+        "schema": "screamingface.criterion-verdict.v1",
+        "case_id": case,
+        "criterion_id": cid,
+        "sequence": sequence,
+        "producer_type": "model",
+        "producer_id": "fixture-judge",
+        "valid": False,
+        "reason": reason,
+        "raw_output": "not json",
+    }
+
+
+def _case_row(
+    case: int,
+    *per_criterion: tuple[str, list[str]],
+    output: str | None = None,
+) -> dict[str, object]:
+    statuses = dict(per_criterion)
+    evidence = {
+        criterion_id: [
+            _verdict(criterion_id, status, case, sequence)
+            for sequence, status in enumerate(statuses[criterion_id], start=1)
+        ]
+        for criterion_id in ("a1", "a2", "a3", "b1")
+    }
+    return _case_row_from_evidence(case, evidence, output=output)
+
+
+def _case_row_from_evidence(
+    case: int,
+    evidence: dict[str, list[dict[str, object]]],
+    *,
+    output: str | None = None,
+) -> dict[str, object]:
+    case_record = {
+        "schema": CASE_SCHEMA,
+        "case_id": case,
+        "input": f"Question {case}",
+        "output": output or f"Answer {case}",
+        "finish_reason": "stop",
+        "metadata": {},
+    }
+    criteria = []
+    for index, criterion_id in enumerate(("a1", "a2", "a3", "b1")):
+        criteria.append(
+            bind_criterion_evaluation(
+                case,
+                case_record if index == 0 else None,
+                {
+                    "schema": CHECK_SCHEMA,
+                    "case_id": case,
+                    "criterion_id": criterion_id,
+                    "criterion_type": "negative" if criterion_id == "a3" else "positive",
+                    "requirement": f"Requirement {criterion_id}",
+                },
+                evidence[criterion_id],
+            )
+        )
+    return bind_case_evaluation(case, criteria)
+
+
+def test_candidate_output_cannot_become_judge_evidence() -> None:
+    example = json.dumps(
+        {
+            "criterion_id": "<provided criterion_id>",
+            "explanation": "Brief evidence for the verdict.",
+            "criterion_status": "MET",
+        }
+    )
+    result = agg.aggregate(
+        json.dumps(
+            [
+                _case_row(
+                    1,
+                    ("a1", ["MET", "UNMET", "MET", "UNMET", "MET"]),
+                    ("a2", ["MET", "UNMET", "MET", "UNMET", "MET"]),
+                    ("a3", ["MET", "UNMET", "MET", "UNMET", "MET"]),
+                    ("b1", ["MET", "UNMET", "MET", "UNMET", "MET"]),
+                    output=example,
+                )
+            ]
+        ),
+        rubrics={1: _RUBRIC},
+        benchmark_id="draco",
+        selected_cases=_selected_cases(1),
+    )
+
+    assert result["metrics"]["n_runs"] == 5
+    assert result["metrics"]["coverage"] == 1.0
+
+
+def test_coverage_diagnostics_distinguish_invalid_and_missing_verdicts() -> None:
+    evidence = {
+        "a1": [_verdict("a1", "MET", sequence=n) for n in range(1, 6)],
+        "a2": [_verdict("a2", "MET", sequence=n) for n in range(1, 6)],
+        "a3": [
+            *(_verdict("a3", "UNMET", sequence=n) for n in range(1, 5)),
+            _invalid("a3", "invalid_json", sequence=5),
+        ],
+        # b1's fifth pass is absent: a transport/model call failed before binding.
+        "b1": [_verdict("b1", "MET", sequence=n) for n in range(1, 5)],
+    }
+
+    result = agg.aggregate(
+        json.dumps([_case_row_from_evidence(1, evidence)]),
+        rubrics={1: _RUBRIC},
+        benchmark_id="draco",
+        selected_cases=_selected_cases(1),
+    )
+
+    case = result["cases"][0]
+
+    assert result["score"] is None
+    assert case["grade"]["score"] is None
+    assert case["failures"][0]["code"] == "insufficient_judge_coverage"
+    assert {
+        name: case["grade"]["metrics"][name]
+        for name in (
+            "coverage",
+            "verdicts_expected",
+            "verdicts_accepted",
+            "verdicts_rejected",
+            "verdicts_invalid",
+            "verdicts_missing",
+        )
+    } == {
+        "coverage": 0.9,
+        "verdicts_expected": 20,
+        "verdicts_accepted": 18,
+        "verdicts_rejected": 2,
+        "verdicts_invalid": 1,
+        "verdicts_missing": 1,
+    }
+
+
+def test_reference_coverage_floor_accepts_exactly_ninety_five_percent() -> None:
+    """The paper-compatible floor tolerates one rejected verdict out of twenty."""
+    evidence = {
+        "a1": [
+            *(_verdict("a1", "MET", sequence=n) for n in range(1, 5)),
+            _invalid("a1", "invalid_json", sequence=5),
+        ],
+        "a2": [_verdict("a2", "MET", sequence=n) for n in range(1, 6)],
+        "a3": [_verdict("a3", "UNMET", sequence=n) for n in range(1, 6)],
+        "b1": [_verdict("b1", "MET", sequence=n) for n in range(1, 6)],
+    }
+
+    result = agg.aggregate(
+        json.dumps([_case_row_from_evidence(1, evidence)]),
+        rubrics={1: _RUBRIC},
+        benchmark_id="draco",
+        selected_cases=_selected_cases(1),
+    )
+
+    assert result["score"] == 1.0
+    assert result["metrics"]["coverage"] == 0.95
+    assert result["cases"][0]["failures"] == []
+
+
+# --- the whole reduction ---------------------------------------------------------
+
+
+def test_aggregate_scores_the_official_nested_payload() -> None:
+    rows = json.dumps(
+        [
+            _case_row(
+                1,
+                ("a1", ["MET"] * 5),
+                ("a2", ["MET"] * 5),
+                ("a3", ["UNMET"] * 5),
+                ("b1", ["MET"] * 5),
+            ),
+            _case_row(
+                2,
+                ("a1", ["MET"] * 5),
+                ("a2", ["UNMET"] * 5),
+                ("a3", ["UNMET"] * 5),
+                ("b1", ["UNMET"] * 5),
+            ),
+        ]
+    )
+    result = agg.aggregate(
+        rows,
+        rubrics={1: _RUBRIC, 2: _RUBRIC},
+        benchmark_id="draco",
+        selected_cases=_selected_cases(1, 2),
+    )
+
+    assert result["case_count"] == 2
+    assert result["benchmark_revision"] == DRACO_REVISION
+    assert result["score"] == 0.75  # case 1 → 1.0 · case 2 → 0.5
+    assert "normalized_score" not in result["metrics"]
+    assert [c["case_id"] for c in result["cases"]] == [1, 2]
+    assert result["metrics"]["n_runs"] == 5
+    assert result["failures"] == []
+
+
+def test_extra_judge_pass_makes_the_case_unscored() -> None:
+    row = _case_row(
+        1,
+        ("a1", ["MET"] * 6),
+        ("a2", ["MET"] * 5),
+        ("a3", ["UNMET"] * 5),
+        ("b1", ["MET"] * 5),
+    )
+
+    result = agg.aggregate(
+        json.dumps([row]),
+        rubrics={1: _RUBRIC},
+        benchmark_id="draco",
+        selected_cases=_selected_cases(1),
+    )
+
+    assert result["score"] is None
+    assert result["cases"][0]["grade"] is None
+    failure = result["cases"][0]["failures"][0]
+    assert failure["code"] == "invalid_case_evaluation"
+    assert failure["metadata"]["reason"] == (
+        "a DRACO Check cannot carry more than 5 Judge Evidence records"
+    )
+
+
+def test_a_case_id_missing_from_evidence_makes_the_case_unscored() -> None:
+    """A scoreable verdict must carry the identity bound by the Engine after judging."""
+    row = _case_row(
+        1,
+        ("a1", ["MET"] * 5),
+        ("a2", ["MET"] * 5),
+        ("a3", ["UNMET"] * 5),
+        ("b1", ["MET"] * 5),
+    )
+    evidence = row["evidence"]
+    assert isinstance(evidence, list)
+    first_verdict = evidence[0]
+    assert isinstance(first_verdict, dict)
+    del first_verdict["case_id"]
+
+    result = agg.aggregate(
+        json.dumps([row]),
+        rubrics={1: _RUBRIC},
+        benchmark_id="draco",
+        selected_cases=_selected_cases(1),
+    )
+
+    assert result["score"] is None
+    assert result["cases"][0]["grade"] is None
+
+
+def test_a_row_with_no_verdicts_is_a_failure_not_a_zero() -> None:
+    rows = json.dumps(
+        [
+            _case_row(
+                1,
+                ("a1", ["MET"] * 5),
+                ("a2", ["MET"] * 5),
+                ("a3", ["UNMET"] * 5),
+                ("b1", ["MET"] * 5),
+            ),
+            "judge refused",
+        ]
+    )
+    result = agg.aggregate(
+        rows,
+        rubrics={1: _RUBRIC, 2: _RUBRIC},
+        benchmark_id="draco",
+        selected_cases=_selected_cases(1, 2),
+    )
+
+    assert result["case_count"] == 2
+    assert result["failures"] == []
+    assert result["cases"][1]["grade"] is None
+    assert len(result["cases"][1]["failures"]) == 1
+    assert result["cases"][0]["grade"]["score"] == 1.0
+    assert result["score"] is None
+    assert result["metrics"] == {}
+
+
+def test_no_rows_at_all_is_an_execution_failure() -> None:
+    """INVARIANT: a run with no evaluated Cases cannot report Candidate score zero."""
+    with pytest.raises(agg.AggregateError, match="no DRACO Case results"):
+        agg.aggregate(
+            "[]",
+            rubrics={1: _RUBRIC},
+            benchmark_id="draco",
+            selected_cases=_selected_cases(1),
+        )
+
+
+def test_all_failed_rows_retain_the_collected_execution_error() -> None:
+    rows = json.dumps(
+        [
+            {
+                "error": {
+                    "kind": "ResolutionError",
+                    "message": "aigateway returned neither answer content nor tool calls",
+                }
+            }
+        ]
+    )
+
+    result = agg.aggregate(
+        rows,
+        rubrics={1: _RUBRIC},
+        benchmark_id="draco",
+        selected_cases=_selected_cases(1),
+    )
+
+    assert result["score"] is None
+    assert result["cases"][0]["failures"][0]["message"] == (
+        "aigateway returned neither answer content nor tool calls"
+    )
+
+
+def test_a_valid_evaluated_case_may_legitimately_score_zero() -> None:
+    rows = json.dumps(
+        [
+            _case_row(
+                1,
+                ("a1", ["UNMET"] * 5),
+                ("a2", ["UNMET"] * 5),
+                ("a3", ["MET"] * 5),
+                ("b1", ["UNMET"] * 5),
+            )
+        ]
+    )
+
+    result = agg.aggregate(
+        rows,
+        rubrics={1: _RUBRIC},
+        benchmark_id="draco",
+        selected_cases=_selected_cases(1),
+    )
+
+    assert result["case_count"] == 1
+    assert result["score"] == 0.0
+    assert result["failures"] == []
+
+
+def test_a_malformed_top_level_payload_raises() -> None:
+    with pytest.raises(agg.AggregateError):
+        agg.aggregate("not json", rubrics={}, benchmark_id="draco", selected_cases=[])

--- a/apps/url4-cloud/tests/unit/test_draco_aggregate_case_mapping.py
+++ b/apps/url4-cloud/tests/unit/test_draco_aggregate_case_mapping.py
@@ -1,0 +1,210 @@
+"""The case -> rubric mapping must be PROVABLE, never guessed from row position.
+
+FEATURE: a DRACO run scores each case's answer against that case's rubric.
+STORY: as a researcher I need a published score to be the score of the cases I ran, not of
+whichever rubrics happened to sit at the same offsets.
+
+The Engine binds `case_id` onto every verdict after the Judge call. Aggregation requires that
+identity on every scoreable row and never infers it from row position. That remains correct for
+full, sliced, reordered, and partially failed iterations, while keeping orchestration identity
+out of the Judge's control.
+
+INVARIANT: every scoreable row carries exactly one unique Engine-bound `case_id`. An invalid
+or mismatched row is retained as an ungraded Case; the reducer never guesses or publishes a
+partial Candidate score.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from url4_cloud.benchmarks.draco import aggregate as agg
+from url4_cloud.benchmarks.draco.case_evaluation import (
+    bind_case_evaluation,
+    bind_criterion_evaluation,
+)
+from url4_cloud.benchmarks.draco.records import CASE_SCHEMA, CHECK_SCHEMA
+
+
+def _rubric(criterion: str) -> dict[str, object]:
+    return {
+        "sections": [
+            {"id": "Factual Accuracy", "criteria": [{"id": criterion, "weight": 1}]},
+        ]
+    }
+
+
+# Four declared cases, each with its OWN criterion id — so a mis-pairing cannot score by luck.
+_RUBRICS: dict[int, dict[str, object]] = {n: _rubric(f"c{n}") for n in (1, 2, 3, 4)}
+
+
+def _selected(*case_ids: int) -> list[dict[str, object]]:
+    return [{"id": case_id, "input": f"Question {case_id}"} for case_id in case_ids]
+
+
+def _row(criterion: str, *, case: int | None = None, status: str = "MET") -> object:
+    raw_output = json.dumps({"explanation": "fixture verdict", "criterion_status": status})
+    verdicts = [
+        {
+            "schema": agg.VERDICT_SCHEMA,
+            "criterion_id": criterion,
+            "sequence": sequence,
+            "producer_type": "model",
+            "producer_id": "fixture-judge",
+            "criterion_status": status,
+            "valid": True,
+            "explanation": "fixture verdict",
+            "raw_output": raw_output,
+        }
+        for sequence in range(1, 6)
+    ]
+    if case is not None:
+        for verdict in verdicts:
+            verdict["case_id"] = case
+        case_record = {
+            "schema": CASE_SCHEMA,
+            "case_id": case,
+            "input": f"Question {case}",
+            "output": f"Answer {case}",
+            "finish_reason": "stop",
+            "metadata": {},
+        }
+        check_record = {
+            "schema": CHECK_SCHEMA,
+            "case_id": case,
+            "criterion_id": criterion,
+            "criterion_type": "positive",
+            "requirement": f"Requirement {criterion}",
+        }
+        return bind_case_evaluation(
+            case,
+            [bind_criterion_evaluation(case, case_record, check_record, verdicts)],
+        )
+    return {"not": "a DRACO Case Evaluation", "verdicts": verdicts}
+
+
+# --- the guard ------------------------------------------------------------------
+
+
+def test_a_short_row_set_without_bound_case_evaluations_is_unscored() -> None:
+    """The `;iteration.slice=10:20` shape — two rows against four declared cases."""
+    rows = json.dumps([_row("c3"), _row("c4")])
+
+    result = agg.aggregate(
+        rows,
+        rubrics=_RUBRICS,
+        benchmark_id="draco",
+        selected_cases=_selected(3, 4),
+    )
+
+    assert result["score"] is None
+    assert [case["grade"] for case in result["cases"]] == [None, None]
+
+
+def test_the_failure_names_the_invalid_case_evaluation() -> None:
+    rows = json.dumps([_row("c3"), _row("c4")])
+
+    result = agg.aggregate(
+        rows,
+        rubrics=_RUBRICS,
+        benchmark_id="draco",
+        selected_cases=_selected(3, 4),
+    )
+
+    failure = result["cases"][0]["failures"][0]
+    assert failure["code"] == "invalid_case_evaluation"
+    assert failure["metadata"]["row_index"] == 0
+
+
+def test_a_mixed_row_set_retains_the_unverifiable_row() -> None:
+    """One echoed id does not vouch for a sibling that has none."""
+    rows = json.dumps([_row("c1", case=1), _row("c2")])
+
+    result = agg.aggregate(
+        rows,
+        rubrics=_RUBRICS,
+        benchmark_id="draco",
+        selected_cases=_selected(1, 2),
+    )
+
+    assert result["score"] is None
+    assert result["cases"][0]["grade"]["score"] == 1.0
+    assert result["cases"][1]["grade"] is None
+
+
+# --- what the guard must NOT catch ----------------------------------------------
+
+
+def test_a_short_row_set_with_bound_case_ids_scores_normally() -> None:
+    """INVARIANT: the guard targets an unprovable MAPPING, not a small run.
+
+    This is the shape a sliced run should take, and it must keep working — otherwise the fix
+    would forbid `;iteration.slice` outright rather than making it honest.
+    """
+    rows = json.dumps([_row("c3", case=3), _row("c4", case=4)])
+
+    result = agg.aggregate(
+        rows,
+        rubrics=_RUBRICS,
+        benchmark_id="draco",
+        selected_cases=_selected(3, 4),
+    )
+
+    assert result["case_count"] == 2
+    assert [c["case_id"] for c in result["cases"]] == [3, 4]
+    assert result["score"] == 1.0  # each row met ITS OWN case's criterion
+
+
+def test_rows_must_exactly_match_the_bound_selection() -> None:
+    """INVARIANT: a lost row cannot masquerade as an intentionally shorter prefix."""
+    rows = json.dumps([_row("c1", case=1)])
+
+    with pytest.raises(agg.AggregateError, match="exactly match"):
+        agg.aggregate(
+            rows,
+            rubrics=_RUBRICS,
+            benchmark_id="draco",
+            selected_cases=_selected(1, 2),
+        )
+
+
+def test_a_full_row_set_without_case_evaluations_is_still_unscored() -> None:
+    """Completeness does not make row position a durable Case identity."""
+    rows = json.dumps([_row(f"c{n}") for n in (1, 2, 3, 4)])
+
+    result = agg.aggregate(
+        rows,
+        rubrics=_RUBRICS,
+        benchmark_id="draco",
+        selected_cases=_selected(1, 2, 3, 4),
+    )
+
+    assert result["score"] is None
+
+
+def test_no_rows_at_all_fails_after_the_mapping_guard() -> None:
+    """An empty payload has no mapping error, but it still cannot produce a valid result."""
+    with pytest.raises(agg.AggregateError, match="no DRACO Case results"):
+        agg.aggregate("[]", rubrics=_RUBRICS, benchmark_id="draco", selected_cases=[])
+
+
+def test_rows_with_a_bound_case_but_no_verdict_become_failed_cases() -> None:
+    failed = _row("c2", case=2)
+    assert isinstance(failed, dict)
+    failed["evidence"][0]["schema"] = "not-a-verdict"
+    rows = json.dumps([_row("c1", case=1), failed])
+
+    result = agg.aggregate(
+        rows,
+        rubrics=_RUBRICS,
+        benchmark_id="draco",
+        selected_cases=_selected(1, 2),
+    )
+
+    assert result["case_count"] == 2
+    assert result["failures"] == []
+    assert result["cases"][1]["grade"] is None
+    assert len(result["cases"][1]["failures"]) == 1
+    assert result["score"] is None

--- a/apps/url4-cloud/tests/unit/test_draco_assets.py
+++ b/apps/url4-cloud/tests/unit/test_draco_assets.py
@@ -1,0 +1,31 @@
+"""DRACO private grading assets fail closed."""
+
+import json
+
+import pytest
+
+from url4_cloud.benchmarks.draco import aggregate as agg
+
+_RUBRIC = {
+    "sections": [
+        {"id": "accuracy", "criteria": [{"id": "a1", "weight": 1, "requirement": "correct"}]}
+    ]
+}
+
+
+def test_missing_rubrics_directory_raises_rather_than_scoring_nothing(tmp_path) -> None:
+    with pytest.raises(agg.AggregateError, match="no rubrics"):
+        agg.load_rubrics(tmp_path / "absent")
+
+
+def test_an_empty_rubrics_directory_raises(tmp_path) -> None:
+    (tmp_path / "rubrics").mkdir()
+
+    with pytest.raises(agg.AggregateError, match="no rubrics"):
+        agg.load_rubrics(tmp_path / "rubrics")
+
+
+def test_rubrics_load_keyed_by_case_id(tmp_path) -> None:
+    (tmp_path / "7.json").write_text(json.dumps(_RUBRIC), encoding="utf-8")
+
+    assert set(agg.load_rubrics(tmp_path)) == {7}

--- a/apps/url4-cloud/tests/unit/test_draco_blocklist_values.py
+++ b/apps/url4-cloud/tests/unit/test_draco_blocklist_values.py
@@ -1,0 +1,70 @@
+"""The blocklist VALUES — bare hosts only, because that is all a provider accepts.
+
+FEATURE: the DRACO retrieval policy keeps a candidate from reading the answer key.
+STORY: as a benchmark author, "the paper is blocked" must also mean the run still WORKS — a
+blocklist the provider rejects protects nothing, it just stops the benchmark.
+
+MEASURED 2026-08-02, straight to OpenRouter AND through the deployed gateway on a kind cluster:
+
+    exclude_domains: ["arxiv.org"]                 -> 200
+    exclude_domains: ["arxiv.org/abs/2602.11685"]  -> 400  "Invalid domain 'arxiv.org/abs/...'"
+    exclude_domains: ["*.substack.com"]            -> 400
+    exclude_domains: <the whole shipped list>      -> 400
+
+The path-shaped list this benchmark shipped therefore made EVERY native answering call a hard
+400: a run that finished in five seconds, reported `terminated: succeeded`, and scored nothing.
+It was invisible to every earlier test because those used a bare host in a PROBE policy — only
+the real expression carries the real list, and only a real Job run puts the two together.
+
+# AIDEV-NOTE: an earlier revision of this module asserted the OPPOSITE — one entry per URL form
+# (`/abs/`, `/pdf/`, `/html/`) and "never block a bare research host". That came from Tavily,
+# which does accept paths and match them partially. The provider side does not, and it is the
+# binding constraint. Both assertions were replaced the same day they were written.
+
+DECISION (owner, 2026-08-02): block whole SITES. The cost is real and belongs beside any published
+score — `arxiv.org` and `huggingface.co` are legitimate research sources, and removing them makes
+a candidate look worse at deep research than it is. The alternative under-blocks, which INFLATES
+scores, and an inflated score is the one nobody audits.
+"""
+
+from __future__ import annotations
+
+import json
+
+from url4_cloud.benchmarks.draco import prepare
+
+
+def test_every_entry_is_a_bare_host() -> None:
+    """INVARIANT: no path, no wildcard, no scheme. THE regression guard — one path-shaped entry
+    takes the whole benchmark down with a 400, and the failure presents as a successful run that
+    scored zero."""
+    for entry in prepare.EXCLUDED_DOMAINS:
+        assert "/" not in entry, f"{entry!r} has a path — the provider rejects the whole request"
+        assert "*" not in entry, f"{entry!r} is a wildcard — measured as a 400"
+        assert ":" not in entry, f"{entry!r} carries a scheme or port"
+        assert entry == entry.strip().lower(), f"{entry!r} is not normalised"
+
+
+def test_the_leak_sources_are_covered_at_host_level() -> None:
+    """Every host that actually served DRACO material in a live search."""
+    for host in ("arxiv.org", "huggingface.co", "openrouter.ai", "paperswithcode.com"):
+        assert host in prepare.EXCLUDED_DOMAINS
+
+
+def test_the_list_has_no_duplicates() -> None:
+    """Collapsing pages to hosts turns several old entries into the same host; a duplicate would
+    be sent to the provider twice and reads as sloppiness in a published artifact."""
+    entries = list(prepare.EXCLUDED_DOMAINS)
+
+    assert len(entries) == len(set(entries))
+
+
+def test_the_policy_artifact_carries_the_same_bare_hosts(tmp_path) -> None:
+    """What `prepare` WRITES is what a run sends. Asserting the constant alone would miss a
+    transform introduced between the constant and the file."""
+    prepare.write_policy(tmp_path)
+    policy = json.loads((tmp_path / "policy" / "retrieval.json").read_text(encoding="utf-8"))
+
+    assert policy["excluded_domains"]
+    for entry in policy["excluded_domains"]:
+        assert "/" not in entry and "*" not in entry

--- a/apps/url4-cloud/tests/unit/test_draco_case_artifacts.py
+++ b/apps/url4-cloud/tests/unit/test_draco_case_artifacts.py
@@ -16,8 +16,8 @@ from benchmark_support import install_benchmarks
 
 from url4 import Node, RelExpr, build, expr, render, src, text
 from url4_cloud.benchmarks.draco.definition import DRACO_SMOKE, JUDGE_MODEL
-from url4_cloud.world_config import ModelSpec
 from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+from url4_cloud.world_config import ModelSpec
 
 _QUESTION = "What is two plus two?"
 _ANSWER = "Four."

--- a/apps/url4-cloud/tests/unit/test_draco_case_artifacts.py
+++ b/apps/url4-cloud/tests/unit/test_draco_case_artifacts.py
@@ -1,0 +1,172 @@
+"""Complete DRACO Case evidence survives the public Candidate-result seam.
+
+FEATURE: OME-319 — a completed Evaluation remains auditable after its live stream ends.
+STORY: as a researcher, I can read exactly what was asked, what the Candidate answered, what the
+Judge returned, and why that reply produced its normalized criterion status.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+from benchmark_support import install_benchmarks
+
+from url4 import Node, RelExpr, build, expr, render, src, text
+from url4_cloud.benchmarks.draco.definition import DRACO_SMOKE, JUDGE_MODEL
+from url4_cloud.world_config import ModelSpec
+from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+
+_QUESTION = "What is two plus two?"
+_ANSWER = "Four."
+_EXPLANATION = "The response states that two plus two is four."
+_RAW_JUDGE_REPLY = json.dumps(
+    {"explanation": _EXPLANATION, "criterion_status": "MET"},
+    indent=2,
+)
+
+
+def _assets(root: Path) -> None:
+    (root / "criteria").mkdir(parents=True)
+    (root / "rubrics").mkdir()
+    (root / "cases.json").write_text(
+        json.dumps([{"id": 1, "input": _QUESTION, "domain": "Arithmetic"}]),
+        encoding="utf-8",
+    )
+    (root / "criteria" / "1.json").write_text(
+        json.dumps(
+            [
+                {
+                    "id": "answer-is-four",
+                    "requirement": "States that two plus two equals four.",
+                    "criterion_type": "positive",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (root / "rubrics" / "1.json").write_text(
+        json.dumps(
+            {
+                "sections": [
+                    {
+                        "id": "correctness",
+                        "criteria": [{"id": "answer-is-four", "weight": 3}],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _link(candidate: Node, benchmark: Node) -> str:
+    return render(
+        expr(
+            src(text(render(candidate)), name="candidate", weight=0.0),
+            benchmark,
+            intent=text(""),
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_draco_smoke_retains_complete_case_evidence(tmp_path: Path) -> None:
+    _assets(tmp_path / "draco")
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        model = json.loads(request.content)["model"]
+        content = _ANSWER if model == "provider/candidate" else _RAW_JUDGE_REPLY
+        return httpx.Response(
+            200,
+            json={
+                "choices": [{"message": {"content": content}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+            },
+        )
+
+    candidate = RelExpr(
+        path="/provider/candidate",
+        context="$input",
+        intent=text("Answer exactly."),
+    )
+    benchmark = DRACO_SMOKE.resource(1)["url4"]
+    assert isinstance(benchmark, str)
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(respond),
+        base_url="http://aigateway.test",
+    ) as client:
+        world = await build_aigateway_world(
+            AigatewayConfig(
+                default_model="provider/candidate",
+                models=(
+                    ModelSpec(id="provider/candidate", native_web_search=True),
+                    ModelSpec(id=JUDGE_MODEL),
+                ),
+            ),
+            client=client,
+        )
+        install_benchmarks(world.node, tmp_path, benchmarks=(DRACO_SMOKE,))
+        try:
+            result = await world.node.evaluate(_link(candidate, build(benchmark)))
+        finally:
+            await world.aclose()
+
+    decoded = json.loads(result.text)
+    assert decoded["cases"] == [
+        {
+            "case_id": 1,
+            "input": _QUESTION,
+            "output": _ANSWER,
+            "finish_reason": "stop",
+            "grade": {
+                "method": "rubric",
+                "score": 1.0,
+                "metrics": {
+                    "normalized_score_sd": 0.0,
+                    "pass_rate": 1.0,
+                    "pass_rate_sd": 0.0,
+                    "accuracy": 0.0,
+                    "accuracy_pass_rate": 0.0,
+                    "axis_scores": {"correctness": 1.0},
+                    "axis_pass_rates": {"correctness": 1.0},
+                    "coverage": 1.0,
+                    "coverage_sd": 0.0,
+                    "n_runs": 1,
+                    "verdicts_expected": 1,
+                    "verdicts_accepted": 1,
+                    "verdicts_rejected": 0,
+                    "verdicts_invalid": 0,
+                    "verdicts_missing": 0,
+                },
+                "checks": [
+                    {
+                        "type": "criterion",
+                        "id": "answer-is-four",
+                        "label": "States that two plus two equals four.",
+                        "evidence": [
+                            {
+                                "sequence": 1,
+                                "producer": {"type": "model", "id": JUDGE_MODEL},
+                                "valid": True,
+                                "outcome": "MET",
+                                "explanation": _EXPLANATION,
+                                "raw_output": _RAW_JUDGE_REPLY,
+                                "metadata": {},
+                            }
+                        ],
+                        "metadata": {
+                            "criterion_type": "positive",
+                            "weight": 3,
+                            "axis": "correctness",
+                        },
+                    }
+                ],
+            },
+            "failures": [],
+            "metadata": {"domain": "Arithmetic"},
+        }
+    ]

--- a/apps/url4-cloud/tests/unit/test_draco_case_artifacts.py
+++ b/apps/url4-cloud/tests/unit/test_draco_case_artifacts.py
@@ -129,8 +129,10 @@ async def test_draco_smoke_retains_complete_case_evidence(tmp_path: Path) -> Non
                     "normalized_score_sd": 0.0,
                     "pass_rate": 1.0,
                     "pass_rate_sd": 0.0,
-                    "accuracy": 0.0,
-                    "accuracy_pass_rate": 0.0,
+                    # This rubric has no Factual Accuracy axis, so accuracy is unknown rather
+                    # than zero — a scored-1.0 Case must not report "0% factually accurate".
+                    "accuracy": None,
+                    "accuracy_pass_rate": None,
                     "axis_scores": {"correctness": 1.0},
                     "axis_pass_rates": {"correctness": 1.0},
                     "coverage": 1.0,

--- a/apps/url4-cloud/tests/unit/test_draco_case_evaluation_route.py
+++ b/apps/url4-cloud/tests/unit/test_draco_case_evaluation_route.py
@@ -1,0 +1,172 @@
+"""DRACO emits one exact Case Evaluation before benchmark Aggregation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from url4 import RelExpr, Text, expr, render, src
+from url4.core.errors import ResolutionError
+from url4.peer.server import Url4Node
+from url4_cloud.benchmarks.draco import assets as draco_assets
+from url4_cloud.benchmarks.draco.case_evaluation import CASE_EVALUATION_SCHEMA
+from url4_cloud.benchmarks.draco.definition import (
+    CASE_EVALUATION_ROUTE,
+    CASES_ROUTE,
+    CRITERION_EVALUATION_ROUTE,
+    DRACO,
+    DRACO_LITE,
+    DRACO_SMOKE,
+    LITE_CASE_EVALUATION_ROUTE,
+    LITE_CRITERION_EVALUATION_ROUTE,
+    SMOKE_CASE_EVALUATION_ROUTE,
+    SMOKE_CASES_ROUTE,
+    SMOKE_CRITERION_EVALUATION_ROUTE,
+)
+from url4_cloud.benchmarks.draco.records import CASE_SCHEMA, CHECK_SCHEMA
+from url4_cloud.benchmarks.draco.runtime import install_canonical, install_smoke
+from url4_cloud.benchmarks.draco.verdict import SCHEMA as VERDICT_SCHEMA
+
+
+async def _call(node: Url4Node, path: str, context: object, intent: str) -> object:
+    expression = expr(
+        src(Text(json.dumps(context)), name="payload", weight=0.0),
+        src(
+            RelExpr(path=path, context="$payload", intent=Text(intent)),
+            name="result",
+            weight=0.0,
+        ),
+        intent=Text("$result"),
+    )
+    return json.loads((await node.evaluate(render(expression))).text)
+
+
+def _smoke_assets(root: Path) -> None:
+    (root / "criteria").mkdir(parents=True)
+    (root / "rubrics").mkdir()
+    (root / "cases.json").write_text('[{"id":1,"input":"Question 1"}]', encoding="utf-8")
+    (root / "criteria" / "1.json").write_text(
+        '[{"id":"c1","requirement":"Be correct","criterion_type":"positive"}]',
+        encoding="utf-8",
+    )
+    (root / "rubrics" / "1.json").write_text(
+        '{"sections":[{"id":"accuracy","criteria":[{"id":"c1","weight":1}]}]}',
+        encoding="utf-8",
+    )
+
+
+def test_every_draco_resource_builds_exact_criterion_and_case_evaluations() -> None:
+    profiles = (
+        (DRACO, CRITERION_EVALUATION_ROUTE, CASE_EVALUATION_ROUTE),
+        (DRACO_LITE, LITE_CRITERION_EVALUATION_ROUTE, LITE_CASE_EVALUATION_ROUTE),
+        (DRACO_SMOKE, SMOKE_CRITERION_EVALUATION_ROUTE, SMOKE_CASE_EVALUATION_ROUTE),
+    )
+
+    for benchmark, criterion_route, case_route in profiles:
+        url4 = benchmark.resource(1)["url4"]
+        assert isinstance(url4, str)
+        assert url4.count(criterion_route) == 1
+        assert url4.count(case_route) == 1
+
+
+@pytest.mark.asyncio
+async def test_runtime_packs_one_criterion_then_one_case_evaluation(tmp_path: Path) -> None:
+    _smoke_assets(tmp_path)
+    node = Url4Node("test")
+    install_smoke(node, tmp_path)
+    case = {
+        "schema": CASE_SCHEMA,
+        "case_id": 1,
+        "input": "Question 1",
+        "output": "Answer 1",
+        "finish_reason": "stop",
+        "metadata": {},
+    }
+    check = {
+        "schema": CHECK_SCHEMA,
+        "case_id": 1,
+        "criterion_id": "c1",
+        "criterion_type": "positive",
+        "requirement": "Be correct",
+    }
+    verdict = {
+        "schema": VERDICT_SCHEMA,
+        "case_id": 1,
+        "criterion_id": "c1",
+        "sequence": 1,
+        "producer_type": "model",
+        "producer_id": "fixture-judge",
+        "valid": True,
+        "explanation": "The requirement is met.",
+        "criterion_status": "MET",
+        "raw_output": '{"criterion_status":"MET"}',
+    }
+    criterion = await _call(
+        node,
+        SMOKE_CRITERION_EVALUATION_ROUTE,
+        {
+            "case": json.dumps(case),
+            "check": json.dumps(check),
+            "evidence_1": json.dumps(verdict),
+        },
+        "1",
+    )
+
+    result = await _call(node, SMOKE_CASE_EVALUATION_ROUTE, [criterion], "1")
+
+    assert result == {
+        "schema": CASE_EVALUATION_SCHEMA,
+        "case": case,
+        "checks": [check],
+        "evidence": [verdict],
+    }
+
+
+def test_install_fails_atomically_when_assets_are_missing(tmp_path: Path) -> None:
+    node = Url4Node("test")
+
+    with pytest.raises(ResolutionError, match="could not read DRACO cases"):
+        install_smoke(node, tmp_path)
+
+    assert SMOKE_CASES_ROUTE not in node.processor_routes()
+
+
+def test_canonical_install_rejects_a_truncated_case_set_atomically(tmp_path: Path) -> None:
+    _smoke_assets(tmp_path)
+    node = Url4Node("test")
+
+    with pytest.raises(ResolutionError, match="expected 100 DRACO cases"):
+        install_canonical(node, tmp_path)
+
+    assert CASES_ROUTE not in node.processor_routes()
+
+
+def test_asset_validation_rejects_duplicate_case_ids(tmp_path: Path) -> None:
+    _smoke_assets(tmp_path)
+    cases = [{"id": 1, "input": "Question"}, {"id": 1, "input": "Duplicate"}]
+
+    with pytest.raises(ValueError, match="repeats case_id 1"):
+        draco_assets.validate_protocol_assets(tmp_path, cases, None, "all")
+
+
+def test_asset_validation_rejects_empty_case_input(tmp_path: Path) -> None:
+    _smoke_assets(tmp_path)
+
+    with pytest.raises(ValueError, match="non-empty input"):
+        draco_assets.validate_protocol_assets(tmp_path, [{"id": 1, "input": ""}], None, "all")
+
+
+def test_asset_validation_rejects_an_empty_canonical_rubric(tmp_path: Path) -> None:
+    _smoke_assets(tmp_path)
+    (tmp_path / "criteria" / "1.json").write_text("[]", encoding="utf-8")
+    (tmp_path / "rubrics" / "1.json").write_text('{"sections":[]}', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="no DRACO rubric criteria"):
+        draco_assets.validate_protocol_assets(
+            tmp_path,
+            [{"id": 1, "input": "Question"}],
+            None,
+            "all",
+        )

--- a/apps/url4-cloud/tests/unit/test_draco_failure_integrity.py
+++ b/apps/url4-cloud/tests/unit/test_draco_failure_integrity.py
@@ -1,0 +1,249 @@
+"""DRACO partial results preserve the operational failure attached to each Case."""
+
+from __future__ import annotations
+
+import json
+
+from url4_cloud.benchmarks.draco import aggregate as agg
+from url4_cloud.benchmarks.draco.case_evaluation import (
+    bind_case_evaluation,
+    bind_criterion_evaluation,
+)
+from url4_cloud.benchmarks.draco.records import CASE_SCHEMA, CHECK_SCHEMA
+
+_RUBRIC = {
+    "sections": [
+        {"id": "correctness", "criteria": [{"id": "c1", "weight": 1}]},
+    ]
+}
+
+
+def _scored_row(case_id: int) -> dict[str, object]:
+    raw_output = json.dumps({"explanation": "fixture verdict", "criterion_status": "MET"})
+    records = [
+        {
+            "schema": CASE_SCHEMA,
+            "case_id": case_id,
+            "input": f"Question {case_id}",
+            "output": f"Answer {case_id}",
+            "finish_reason": "stop",
+            "metadata": {},
+        },
+        {
+            "schema": CHECK_SCHEMA,
+            "case_id": case_id,
+            "criterion_id": "c1",
+            "criterion_type": "positive",
+            "requirement": "Correct",
+        },
+        {
+            "schema": agg.VERDICT_SCHEMA,
+            "case_id": case_id,
+            "criterion_id": "c1",
+            "sequence": 1,
+            "producer_type": "model",
+            "producer_id": "fixture-judge",
+            "criterion_status": "MET",
+            "valid": True,
+            "explanation": "fixture verdict",
+            "raw_output": raw_output,
+        },
+    ]
+    return bind_case_evaluation(
+        case_id,
+        [bind_criterion_evaluation(case_id, records[0], records[1], [records[2]])],
+    )
+
+
+def _selected(*case_ids: int) -> list[dict[str, object]]:
+    return [{"id": case_id, "input": f"Question {case_id}"} for case_id in case_ids]
+
+
+def test_partial_result_preserves_the_collected_case_error() -> None:
+    rows = json.dumps(
+        [
+            _scored_row(1),
+            {
+                "error": {
+                    "kind": "ResolutionError",
+                    "code": "provider_refusal",
+                    "message": "provider refused the request",
+                }
+            },
+        ]
+    )
+
+    result = agg.aggregate(
+        rows,
+        {1: _RUBRIC, 2: _RUBRIC},
+        "draco",
+        selected_cases=_selected(1, 2),
+        judge_passes=1,
+    )
+
+    assert result["case_count"] == 2
+    assert result["score"] is None
+    assert result["metrics"] == {}
+    assert result["cases"][0]["grade"]["score"] == 1.0
+    expected_failure = [
+        {
+            "stage": "candidate",
+            "code": "provider_refusal",
+            "message": "provider refused the request",
+            "retryable": None,
+            "case_id": 2,
+            "metadata": {"row_index": 1, "error_kind": "ResolutionError"},
+        }
+    ]
+    assert result["failures"] == []
+    assert result["cases"][1] == {
+        "case_id": 2,
+        "input": "Question 2",
+        "output": None,
+        "finish_reason": None,
+        "grade": None,
+        "failures": expected_failure,
+        "metadata": {},
+    }
+
+
+def test_missing_selected_case_rubric_retains_the_case_and_invalidates_the_score() -> None:
+    result = agg.aggregate(
+        json.dumps([_scored_row(1), _scored_row(2)]),
+        {1: _RUBRIC},
+        "draco",
+        selected_cases=_selected(1, 2),
+        judge_passes=1,
+    )
+
+    assert result["case_count"] == 2
+    assert result["score"] is None
+    assert result["metrics"] == {}
+    assert result["cases"][0]["grade"]["score"] == 1.0
+    assert result["cases"][1] == {
+        "case_id": 2,
+        "input": "Question 2",
+        "output": "Answer 2",
+        "finish_reason": "stop",
+        "grade": None,
+        "failures": [
+            {
+                "stage": "grading",
+                "code": "missing_case_rubric",
+                "message": "the selected Case has no installed DRACO rubric",
+                "retryable": None,
+                "case_id": 2,
+                "metadata": {"row_index": 1},
+            }
+        ],
+        "metadata": {},
+    }
+
+
+def test_nested_draco_records_are_not_discovered_as_a_case_evaluation() -> None:
+    rows = json.dumps([{"nested": {"records": _scored_row(1)}}])
+
+    result = agg.aggregate(
+        rows,
+        {1: _RUBRIC},
+        "draco",
+        selected_cases=_selected(1),
+    )
+
+    assert result["score"] is None
+    assert result["cases"][0]["grade"] is None
+    failure = result["cases"][0]["failures"][0]
+    assert failure["code"] == "invalid_case_evaluation"
+    assert failure["metadata"]["reason"] == "invalid DRACO Case Evaluation envelope"
+
+
+def test_invalid_judge_evidence_is_retained_under_an_unscored_grade() -> None:
+    case = {
+        "schema": CASE_SCHEMA,
+        "case_id": 1,
+        "input": "Question 1",
+        "output": "Answer 1",
+        "finish_reason": "stop",
+        "metadata": {},
+    }
+    check = {
+        "schema": CHECK_SCHEMA,
+        "case_id": 1,
+        "criterion_id": "c1",
+        "criterion_type": "positive",
+        "requirement": "Correct",
+    }
+    invalid = {
+        "schema": agg.VERDICT_SCHEMA,
+        "case_id": 1,
+        "criterion_id": "c1",
+        "sequence": 1,
+        "producer_type": "model",
+        "producer_id": "fixture-judge",
+        "valid": False,
+        "reason": "invalid_json",
+        "raw_output": "not json",
+    }
+    row = bind_case_evaluation(
+        1,
+        [bind_criterion_evaluation(1, case, check, [invalid])],
+    )
+
+    result = agg.aggregate(
+        json.dumps([row]),
+        {1: _RUBRIC},
+        "draco",
+        selected_cases=_selected(1),
+        judge_passes=1,
+    )
+
+    grade = result["cases"][0]["grade"]
+    assert result["score"] is None
+    assert grade["score"] is None
+    assert grade["checks"][0]["evidence"] == [
+        {
+            "sequence": 1,
+            "producer": {"type": "model", "id": "fixture-judge"},
+            "valid": False,
+            "raw_output": "not json",
+            "metadata": {"rejection_reason": "invalid_json"},
+        }
+    ]
+    assert result["cases"][0]["failures"][0]["code"] == "no_valid_judge_verdict"
+
+
+def test_a_row_claiming_another_selected_case_is_retained_as_unscored() -> None:
+    rows = json.dumps([_scored_row(1), _scored_row(1)])
+
+    result = agg.aggregate(
+        rows,
+        {1: _RUBRIC, 2: _RUBRIC},
+        "draco",
+        selected_cases=_selected(1, 2),
+        judge_passes=1,
+    )
+
+    assert result["score"] is None
+    assert result["cases"][0]["grade"]["score"] == 1.0
+    assert result["cases"][1]["grade"] is None
+
+
+def test_one_row_cannot_mix_verdicts_from_different_cases() -> None:
+    row = _scored_row(1)
+    foreign = _scored_row(2)
+    evidence = row["evidence"]
+    foreign_evidence = foreign["evidence"]
+    assert isinstance(evidence, list)
+    assert isinstance(foreign_evidence, list)
+    evidence.append(foreign_evidence[0])
+    rows = json.dumps([row])
+
+    result = agg.aggregate(
+        rows,
+        {1: _RUBRIC, 2: _RUBRIC},
+        "draco",
+        selected_cases=_selected(1),
+    )
+
+    assert result["score"] is None
+    assert result["cases"][0]["grade"] is None

--- a/apps/url4-cloud/tests/unit/test_draco_lineup_declared.py
+++ b/apps/url4-cloud/tests/unit/test_draco_lineup_declared.py
@@ -1,0 +1,76 @@
+"""Every model the DRACO lineup answers with must have a declared route.
+
+FEATURE: a client can run any of DRACO's published configurations against this deployment.
+STORY: as a benchmark author, `budget_trio` is one of the paper's nine fusions, so its three
+panel members must be addressable — not a `ResolutionError` two minutes into a paid run.
+
+Routing is EXACT-MATCH with no wildcard form, so an undeclared model is not a degraded run: the
+expression fails to resolve. Before this guard existed, four of the eight lineup models were
+undeclared and nothing said so — the gap was invisible because the documented example expression
+only ever used the three that happened to be declared.
+
+INVARIANT: the lineup below is a HAND-COPY of
+`screamingface-benchmarks/benchmarks_config/draco.yaml`, and it duplicates that file ON PURPOSE.
+The two repos are not built together and this one cannot import the other, so a shared source is
+not available; the point of the copy is to FAIL when the lineup changes, which is exactly when a
+human needs to re-check both sides. A test that derived the list from url4.toml would assert
+nothing.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+_RUNNER_CONFIG = Path(__file__).resolve().parents[2] / "url4.toml"
+
+_GATEWAY_PREFIX = "openrouter/"
+"""DRACO runs every model through OpenRouter (`draco.yaml`: "calls go through OpenRouter,
+default for closed models"), so a route id is that prefix plus the paper's upstream slug."""
+
+# The 7 solos plus every distinct fusion panel member / synthesizer (draco.yaml §eval).
+# `qwen3.6-plus` is the one model that is NOT a solo — it appears only in `best_open_source`.
+DRACO_LINEUP = (
+    "anthropic/claude-fable-5",
+    "anthropic/claude-opus-4.8",
+    "openai/gpt-5.5",
+    "google/gemini-3.1-pro-preview",
+    "google/gemini-3-flash-preview",
+    "moonshotai/kimi-k2.6",
+    "deepseek/deepseek-v4-pro",
+    "qwen/qwen3.6-plus",
+)
+
+DRACO_JUDGE = "google/gemini-3.1-pro-preview"
+"""arXiv:2602.11685 §4.2 pins it. Also a solo candidate — see the dual-role test below."""
+
+
+def _routes() -> dict[str, dict]:
+    """Every declared model route, keyed by its gateway id."""
+    with _RUNNER_CONFIG.open("rb") as handle:
+        entries = tomllib.load(handle)["aigateway"]["models"]
+    return {e["id"]: e for e in entries if not isinstance(e, str)}
+
+
+@pytest.mark.parametrize("slug", DRACO_LINEUP)
+def test_every_lineup_model_has_a_declared_route(slug: str) -> None:
+    declared = _routes()
+    assert _GATEWAY_PREFIX + slug in declared, (
+        f"DRACO's lineup names {slug!r} but url4.toml declares no route for it. Routing is "
+        "exact-match, so every configuration using this model fails to resolve. Declare it here "
+        "AND seed it in aigateway's `_default_model_slugs()` — "
+        "`test_declared_models_match_aigateway.py` enforces the pair."
+    )
+
+
+def test_the_dual_role_judge_route_can_retrieve_as_a_candidate() -> None:
+    """The route declares capability; the Benchmark Judge call pins retrieval off in URL4."""
+
+    assert _routes()[_GATEWAY_PREFIX + DRACO_JUDGE].get("web_tools") is True
+
+
+def test_the_lineup_has_no_duplicate_entries() -> None:
+    """A duplicate would make the parametrized guard above silently weaker than it reads."""
+    assert len(set(DRACO_LINEUP)) == len(DRACO_LINEUP)

--- a/apps/url4-cloud/tests/unit/test_draco_lite_protocol.py
+++ b/apps/url4-cloud/tests/unit/test_draco_lite_protocol.py
@@ -15,7 +15,7 @@ from benchmark_support import install_benchmarks
 
 from url4 import RelExpr, Text, expr, render, src
 from url4.peer.server import Url4Node
-from url4_cloud.benchmarks import BENCHMARKS
+from url4_cloud.benchmarks.builtins import BUILTIN_BENCHMARKS
 from url4_cloud.benchmarks.contract import encode_candidate_invocation
 from url4_cloud.benchmarks.draco.case_evaluation import (
     bind_case_evaluation,
@@ -69,7 +69,7 @@ def _assets(root: Path) -> None:
 
 
 def test_lite_is_a_separate_noncanonical_benchmark() -> None:
-    assert BENCHMARKS.get("draco/lite") is DRACO_LITE
+    assert BUILTIN_BENCHMARKS.get("draco/lite") is DRACO_LITE
     assert DRACO_LITE.id == "draco/lite"
     assert DRACO_LITE.variant == "lite"
     assert DRACO_LITE.case_count == 2

--- a/apps/url4-cloud/tests/unit/test_draco_lite_protocol.py
+++ b/apps/url4-cloud/tests/unit/test_draco_lite_protocol.py
@@ -1,0 +1,245 @@
+"""DRACO lite is a bounded directional preview, not a smaller canonical score.
+
+FEATURE: OME-712 — researchers can compare Candidate plumbing and directional quality without
+paying for the complete 100-Case, five-pass Benchmark.
+STORY: as a researcher, I can run every rubric criterion over a pinned, reviewable Case subset.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from benchmark_support import install_benchmarks
+
+from url4 import RelExpr, Text, expr, render, src
+from url4.peer.server import Url4Node
+from url4_cloud.benchmarks import BENCHMARKS
+from url4_cloud.benchmarks.contract import encode_candidate_invocation
+from url4_cloud.benchmarks.draco.case_evaluation import (
+    bind_case_evaluation,
+    bind_criterion_evaluation,
+)
+from url4_cloud.benchmarks.draco.definition import (
+    DRACO,
+    DRACO_LITE,
+    DRACO_SMOKE,
+    JUDGE_MODEL,
+    LITE_AGGREGATE_ROUTE,
+    LITE_CASE_IDS,
+    LITE_CASES_ROUTE,
+    LITE_CRITERION_COUNT,
+    LITE_CRITERION_SELECTION,
+    LITE_TASKS_ROUTE,
+)
+from url4_cloud.benchmarks.draco.records import CASE_SCHEMA, CHECK_SCHEMA
+
+_EXPECTED_IDS = (2, 15)
+
+
+def _assets(root: Path) -> None:
+    root.mkdir(parents=True)
+    (root / "criteria").mkdir()
+    (root / "rubrics").mkdir()
+    cases = []
+    for case_id in range(1, 101):
+        cases.append({"id": case_id, "input": f"Question {case_id}", "domain": "test"})
+        criteria = [
+            {
+                "id": f"c{index}",
+                "requirement": f"Correct {index}",
+                "criterion_type": "positive",
+            }
+            for index in range(1, 13)
+        ]
+        (root / "criteria" / f"{case_id}.json").write_text(
+            json.dumps(criteria),
+            encoding="utf-8",
+        )
+        rubric_criteria = [
+            {"id": f"c{index}", "requirement": f"Correct {index}", "weight": 1}
+            for index in range(1, 13)
+        ]
+        (root / "rubrics" / f"{case_id}.json").write_text(
+            json.dumps({"sections": [{"id": "correctness", "criteria": rubric_criteria}]}),
+            encoding="utf-8",
+        )
+    (root / "cases.json").write_text(json.dumps(cases), encoding="utf-8")
+
+
+def test_lite_is_a_separate_noncanonical_benchmark() -> None:
+    assert BENCHMARKS.get("draco/lite") is DRACO_LITE
+    assert DRACO_LITE.id == "draco/lite"
+    assert DRACO_LITE.variant == "lite"
+    assert DRACO_LITE.case_count == 2
+    assert LITE_CASE_IDS == _EXPECTED_IDS
+    assert DRACO_LITE.revision not in {DRACO.revision, DRACO_SMOKE.revision}
+    assert "not comparable" in DRACO_LITE.description.lower()
+    assert LITE_CRITERION_SELECTION == "axis-balanced"
+    assert "axis-balanced" in DRACO_LITE.description.lower()
+
+
+def test_lite_caps_criteria_and_reduces_judge_repetition() -> None:
+    expression = render(DRACO_LITE.build(DRACO_LITE.case_count))
+
+    for route_fragment in ("/candidate", "/tasks", "/criterion-verdict", "/aggregate"):
+        assert route_fragment in expression
+    assert expression.count("/" + JUDGE_MODEL) == 1
+    assert f"iteration.slice=0:{LITE_CRITERION_COUNT}" in expression
+
+
+@pytest.mark.asyncio
+async def test_lite_private_cases_expose_the_ordered_pinned_subset(tmp_path: Path) -> None:
+    _assets(tmp_path / "draco")
+    node = Url4Node("test")
+    install_benchmarks(node, tmp_path)
+
+    cases = json.loads(await node.fetch(LITE_CASES_ROUTE, relative=True))
+
+    assert [case["id"] for case in cases] == list(_EXPECTED_IDS)
+
+
+@pytest.mark.asyncio
+async def test_lite_task_route_selects_criteria_across_axes(tmp_path: Path) -> None:
+    root = tmp_path / "draco"
+    _assets(root)
+    rubric = {
+        "sections": [
+            {
+                "id": axis,
+                "criteria": [
+                    {"id": f"{axis}{index}", "requirement": "Correct", "weight": 1}
+                    for index in range(1, 4)
+                ],
+            }
+            for axis in ("a", "b", "c", "d")
+        ]
+    }
+    criteria = [
+        {
+            "id": criterion["id"],
+            "requirement": criterion["requirement"],
+            "criterion_type": "positive",
+        }
+        for section in rubric["sections"]
+        for criterion in section["criteria"]
+    ]
+    (root / "rubrics" / "2.json").write_text(json.dumps(rubric), encoding="utf-8")
+    (root / "criteria" / "2.json").write_text(json.dumps(criteria), encoding="utf-8")
+    node = Url4Node("test")
+    install_benchmarks(node, tmp_path)
+
+    expression = expr(
+        src(
+            Text(encode_candidate_invocation("Answer", "stop", None)),
+            name="candidate_result",
+            weight=0.0,
+        ),
+        src(
+            RelExpr(
+                path=LITE_TASKS_ROUTE,
+                context="$candidate_result",
+                intent=Text("2"),
+            ),
+            name="criteria",
+            weight=0.0,
+        ),
+        intent=Text("$criteria"),
+    )
+    result = json.loads((await node.evaluate(render(expression))).text)
+
+    assert [criterion["criterion_id"] for criterion in result] == [
+        "a1",
+        "b1",
+        "c1",
+        "d1",
+        "a2",
+        "b2",
+        "c2",
+        "d2",
+        "a3",
+        "b3",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_lite_runtime_reports_its_own_identity_and_one_judge_pass(tmp_path: Path) -> None:
+    _assets(tmp_path / "draco")
+    rows = []
+    for case_id in _EXPECTED_IDS:
+        raw_output = json.dumps({"explanation": "evidence", "criterion_status": "MET"})
+        records = [
+            {
+                "schema": CASE_SCHEMA,
+                "case_id": case_id,
+                "input": f"Question {case_id}",
+                "output": f"Answer {case_id}",
+                "finish_reason": "stop",
+                "metadata": {"domain": "test"},
+            },
+        ]
+        for index in range(1, LITE_CRITERION_COUNT + 1):
+            records.extend(
+                (
+                    {
+                        "schema": CHECK_SCHEMA,
+                        "case_id": case_id,
+                        "criterion_id": f"c{index}",
+                        "criterion_type": "positive",
+                        "requirement": f"Correct {index}",
+                    },
+                    {
+                        "schema": "screamingface.criterion-verdict.v1",
+                        "case_id": case_id,
+                        "criterion_id": f"c{index}",
+                        "sequence": 1,
+                        "producer_type": "model",
+                        "producer_id": "fixture-judge",
+                        "valid": True,
+                        "explanation": "evidence",
+                        "criterion_status": "MET",
+                        "raw_output": raw_output,
+                    },
+                )
+            )
+        criteria = [
+            bind_criterion_evaluation(
+                case_id,
+                records[0] if index == 0 else None,
+                records[1 + index * 2],
+                [records[2 + index * 2]],
+            )
+            for index in range(LITE_CRITERION_COUNT)
+        ]
+        rows.append(bind_case_evaluation(case_id, criteria))
+    node = Url4Node("test")
+    install_benchmarks(node, tmp_path)
+
+    result = json.loads(
+        (
+            await node.evaluate(
+                render(
+                    expr(
+                        src(Text(json.dumps(rows)), name="rows", weight=0.0),
+                        src(
+                            RelExpr(
+                                path=LITE_AGGREGATE_ROUTE,
+                                context="$rows",
+                                intent=Text("aggregate:2"),
+                            ),
+                            name="result",
+                            weight=0.0,
+                        ),
+                        intent=Text("$result"),
+                    )
+                )
+            )
+        ).text
+    )
+
+    assert result["benchmark_id"] == DRACO_LITE.id
+    assert result["benchmark_revision"] == DRACO_LITE.revision
+    assert result["case_count"] == 2
+    assert result["metrics"]["n_runs"] == 1
+    assert result["metrics"]["coverage"] == 1.0

--- a/apps/url4-cloud/tests/unit/test_draco_prepare.py
+++ b/apps/url4-cloud/tests/unit/test_draco_prepare.py
@@ -1,0 +1,160 @@
+"""DRACO pinned-dataset preparation.
+
+FEATURE: a benchmark's declared world is generated from its dataset at image build.
+STORY: as a benchmark author, `prepare` turns `perplexity-ai/draco` into cases, private rubrics,
+and weight-free Judge criteria consumed by its installed runtime.
+
+The HF download itself is not exercised — `build()` takes rows, so every test here runs offline.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from url4_cloud.benchmarks.draco import prepare
+
+_RUBRIC = {
+    "sections": [
+        {"id": "Factual Accuracy", "criteria": [{"id": "a1", "weight": 2, "requirement": "x"}]}
+    ]
+}
+
+
+def _row(question: str = "What is X?", rubric: object | None = None) -> dict:
+    return {
+        "problem": question,
+        "answer": json.dumps(_RUBRIC) if rubric is None else rubric,
+        "domain": "finance",
+    }
+
+
+# --- artifacts ------------------------------------------------------------------
+
+
+def test_dataset_download_is_pinned_to_the_benchmark_revision(monkeypatch) -> None:
+    calls: list[tuple[str, str]] = []
+
+    class Datasets:
+        @staticmethod
+        def load_dataset(dataset: str, *, revision: str):
+            calls.append((dataset, revision))
+            return {"train": [_row()]}
+
+    monkeypatch.setattr(prepare.importlib, "import_module", lambda _name: Datasets)
+
+    assert len(prepare.load_rows()) == 1
+    assert calls == [(prepare.DATASET, prepare.DATASET_REVISION)]
+
+
+def test_cases_json_carries_id_and_input(tmp_path: Path) -> None:
+    prepare.build([_row("Q1"), _row("Q2")], tmp_path)
+
+    cases = json.loads((tmp_path / "cases.json").read_text())
+    assert cases[0]["id"] == 1
+    assert cases[0]["input"] == "Q1"
+    assert [c["id"] for c in cases] == [1, 2]
+
+
+def test_cases_json_never_carries_the_rubric(tmp_path: Path) -> None:
+    """INVARIANT: the privacy boundary of the whole design.
+
+    The client receives `cases.json`; the rubric stays in the image. Leaking it here would let a
+    Candidate be tuned against the answer key while every test still passed.
+    """
+    prepare.build([_row()], tmp_path)
+
+    body = (tmp_path / "cases.json").read_text()
+    assert "Factual Accuracy" not in body
+    assert "weight" not in body
+
+
+def test_each_rubric_is_written_to_its_own_file(tmp_path: Path) -> None:
+    prepare.build([_row(), _row()], tmp_path)
+
+    assert json.loads((tmp_path / "rubrics" / "1.json").read_text()) == _RUBRIC
+    assert (tmp_path / "rubrics" / "2.json").exists()
+
+
+def test_private_grading_artifacts_are_NOT_declared_as_routes(tmp_path: Path) -> None:
+    """INVARIANT: criteria and weights must be unreachable from an expression.
+
+    A declared `/draco/rubrics/N` could be fetched into a judge prompt, which is exactly the
+    leak `grading_mode: official` exists to prevent. The task builder reads weight-free criteria
+    and `aggregate.py` reads weighted rubrics directly from disk.
+    """
+    prepare.build([_row()], tmp_path)
+
+    assert not (tmp_path / "url4.data.toml").exists()
+
+
+def test_the_judge_facing_criteria_carry_no_weights(tmp_path: Path) -> None:
+    prepare.build([_row()], tmp_path)
+
+    criteria = json.loads((tmp_path / "criteria" / "1.json").read_text())
+    assert criteria == [{"id": "a1", "requirement": "x", "criterion_type": "positive"}]
+    assert "weight" not in json.dumps(criteria)
+
+
+def test_the_judge_facing_criteria_derive_negative_type_without_leaking_weight(
+    tmp_path: Path,
+) -> None:
+    rubric = json.dumps(
+        {
+            "sections": [
+                {
+                    "id": "quality",
+                    "criteria": [{"id": "bad", "weight": -2, "requirement": "makes an error"}],
+                }
+            ]
+        }
+    )
+    prepare.build([_row(rubric=rubric)], tmp_path)
+
+    criteria = json.loads((tmp_path / "criteria" / "1.json").read_text())
+    assert criteria == [
+        {"id": "bad", "requirement": "makes an error", "criterion_type": "negative"}
+    ]
+    assert "weight" not in json.dumps(criteria)
+
+
+# --- validation -----------------------------------------------------------------
+
+
+def test_an_empty_question_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(prepare.PrepareError, match="empty"):
+        prepare.build([_row("")], tmp_path)
+
+
+def test_a_rubric_with_no_sections_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(prepare.PrepareError, match="sections"):
+        prepare.build([_row(rubric=json.dumps([{"id": "a1"}]))], tmp_path)
+
+
+def test_a_rubric_that_flattens_to_zero_criteria_is_rejected(tmp_path: Path) -> None:
+    """It would score every answer 0.0 while looking like a successful run."""
+    with pytest.raises(prepare.PrepareError, match="0 criteria"):
+        prepare.build([_row(rubric=json.dumps({"sections": []}))], tmp_path)
+
+
+def test_a_full_build_must_match_the_declared_case_count(tmp_path: Path) -> None:
+    with pytest.raises(prepare.PrepareError, match="expected 100 DRACO cases"):
+        prepare.build([_row()], tmp_path, expected_count=100)
+
+    assert not any(tmp_path.iterdir())
+
+
+# --- the round trip -------------------------------------------------------------
+
+
+def test_prepared_rubrics_load_back_into_the_aggregator(tmp_path: Path) -> None:
+    """The two halves must agree on the on-disk shape — this is the seam between them."""
+    from url4_cloud.benchmarks.draco import aggregate, scoring
+
+    prepare.build([_row(), _row()], tmp_path)
+
+    rubrics = aggregate.load_rubrics(tmp_path / "rubrics")
+    assert set(rubrics) == {1, 2}
+    assert scoring.normalized_score(rubrics[1], {"a1": True}) == 1.0

--- a/apps/url4-cloud/tests/unit/test_draco_prepare_policy.py
+++ b/apps/url4-cloud/tests/unit/test_draco_prepare_policy.py
@@ -1,0 +1,48 @@
+"""The retrieval policy DRACO ships as one of its declared artifacts.
+
+FEATURE: a benchmark image carries its own blocklist at its own url4 address, so benchmarks that
+disagree about what to exclude share one set of model routes.
+STORY: as a researcher I need the guard that stops a candidate reading its own answer key to
+travel with the benchmark, and to be named in the expression so the score can be attributed.
+
+INVARIANT: `rubrics/` stays undeclared. The policy is safe to address because it names PUBLIC
+leak sources and carries no weight and no requirement text; the weighted rubric is neither.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from url4_cloud.benchmarks.draco import prepare
+
+
+def test_the_policy_is_written_as_an_addressable_artifact(tmp_path: Path) -> None:
+    written = prepare.write_policy(tmp_path)
+
+    document = json.loads(written.read_text(encoding="utf-8"))
+    assert written == tmp_path / "policy" / "retrieval.json"
+    assert document["id"] == prepare.RETRIEVAL_POLICY_ID
+    assert document["excluded_domains"] == list(prepare.EXCLUDED_DOMAINS)
+
+
+def test_the_policy_carries_the_draco_leak_sources(tmp_path: Path) -> None:
+    """The dataset card, the reproduction post and the paper are where the answer key lives."""
+    document = json.loads(prepare.write_policy(tmp_path).read_text(encoding="utf-8"))
+
+    joined = " ".join(document["excluded_domains"])
+    for source in ("huggingface.co", "openrouter.ai", "arxiv.org"):
+        assert source in joined
+
+
+def test_an_empty_policy_fails_the_BUILD(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """WHY here and not in the runner: the runner deliberately ACCEPTS an empty policy, because a
+    benchmark may declare unrestricted retrieval as an explicit, attributable statement. For DRACO
+    an empty list means the generator broke — and a generation bug belongs to the build, not to a
+    run that would score high and look clean."""
+    monkeypatch.setattr(prepare, "EXCLUDED_DOMAINS", ())
+
+    with pytest.raises(prepare.PrepareError, match="policy is empty"):
+        prepare.write_policy(tmp_path)

--- a/apps/url4-cloud/tests/unit/test_draco_scoring.py
+++ b/apps/url4-cloud/tests/unit/test_draco_scoring.py
@@ -1,0 +1,169 @@
+"""DRACO's exact per-case scoring arithmetic."""
+
+from url4_cloud.benchmarks.draco import aggregate as agg
+from url4_cloud.benchmarks.draco import scoring
+
+_RUBRIC = {
+    "sections": [
+        {
+            "id": "Factual Accuracy",
+            "criteria": [
+                {"id": "a1", "weight": 2, "requirement": "cites a source"},
+                {"id": "a2", "weight": 1, "requirement": "states the date"},
+                {"id": "a3", "weight": -3, "requirement": "invents a statistic"},
+            ],
+        },
+        {"id": "Presentation", "criteria": [{"id": "b1", "weight": 1, "requirement": "is terse"}]},
+    ]
+}
+
+
+def _verdicts(**kwargs: bool) -> dict[str, bool]:
+    return dict(kwargs)
+
+
+def test_perfect_answer_scores_one() -> None:
+    assert scoring.normalized_score(_RUBRIC, _verdicts(a1=True, a2=True, a3=False, b1=True)) == 1.0
+
+
+def test_a_met_negative_criterion_subtracts_from_the_numerator() -> None:
+    assert scoring.normalized_score(_RUBRIC, _verdicts(a1=True, a2=False, a3=True, b1=True)) == 0.0
+
+
+def test_the_score_is_clamped_at_zero_not_negative() -> None:
+    assert (
+        scoring.normalized_score(_RUBRIC, _verdicts(a1=False, a2=False, a3=True, b1=False)) == 0.0
+    )
+
+
+def test_partial_credit_is_weight_aware() -> None:
+    assert (
+        scoring.normalized_score(_RUBRIC, _verdicts(a1=True, a2=False, a3=False, b1=False)) == 0.5
+    )
+
+
+def test_all_negative_rubric_returns_zero_rather_than_dividing_by_zero() -> None:
+    rubric = {"sections": [{"id": "X", "criteria": [{"id": "n1", "weight": -1}]}]}
+
+    assert scoring.normalized_score(rubric, {"n1": False}) == 0.0
+
+
+def test_pass_rate_counts_avoided_negatives_as_correct() -> None:
+    assert scoring.pass_rate(_RUBRIC, _verdicts(a1=True, a2=True, a3=False, b1=True)) == 1.0
+
+
+def test_pass_rate_is_unweighted() -> None:
+    assert scoring.pass_rate(_RUBRIC, _verdicts(a1=True, a2=False, a3=True, b1=True)) == 0.5
+
+
+def test_axis_scores_are_per_section() -> None:
+    axes = scoring.axis_scores(_RUBRIC, _verdicts(a1=True, a2=False, a3=True, b1=True))
+
+    assert axes == {"Factual Accuracy": 0.0, "Presentation": 1.0}
+
+
+def test_axis_pass_rates_are_unweighted_per_section() -> None:
+    rates = scoring.axis_pass_rates(
+        _RUBRIC,
+        _verdicts(a1=True, a2=False, a3=False, b1=True),
+    )
+
+    assert rates == {"Factual Accuracy": 2 / 3, "Presentation": 1.0}
+
+
+def test_axis_balanced_selection_round_robins_across_rubric_sections() -> None:
+    rubric = {
+        "sections": [
+            {
+                "id": axis,
+                "criteria": [
+                    {"id": f"{axis}{index}", "weight": 1, "requirement": "x"}
+                    for index in range(1, 5)
+                ],
+            }
+            for axis in ("a", "b", "c", "d")
+        ]
+    }
+
+    selected = scoring.select_criteria(rubric, 10, "axis-balanced")
+
+    assert [criterion["id"] for criterion in selected] == [
+        "a1",
+        "b1",
+        "c1",
+        "d1",
+        "a2",
+        "b2",
+        "c2",
+        "d2",
+        "a3",
+        "b3",
+    ]
+    assert {axis: sum(criterion["axis"] == axis for criterion in selected) for axis in "abcd"} == {
+        "a": 3,
+        "b": 3,
+        "c": 2,
+        "d": 2,
+    }
+
+
+def test_an_unjudged_criterion_drops_out_of_both_numerator_and_denominator() -> None:
+    judged = {"a1": True, "a3": False, "b1": True}
+
+    assert scoring.score_case(_RUBRIC, [judged])["normalized_score"] == 1.0
+
+
+def test_coverage_reports_the_judged_fraction() -> None:
+    judged = {"a1": True, "a3": False, "b1": True}
+
+    assert scoring.score_case(_RUBRIC, [judged])["coverage"] == 0.75
+
+
+def test_runs_are_grouped_in_order_so_each_pass_scores_independently() -> None:
+    verdicts = [
+        {"case_id": 1, "criterion_id": "a1", "sequence": n, "criterion_status": status}
+        for n, status in enumerate(("MET", "UNMET", "MET"), start=1)
+    ]
+
+    assert agg.group_runs(verdicts) == [{"a1": True}, {"a1": False}, {"a1": True}]
+
+
+def test_a_criterion_with_fewer_passes_drops_out_of_the_missing_run() -> None:
+    verdicts = [
+        {"case_id": 1, "criterion_id": "a1", "sequence": 1, "criterion_status": "MET"},
+        {"case_id": 1, "criterion_id": "a1", "sequence": 2, "criterion_status": "MET"},
+        {"case_id": 1, "criterion_id": "a2", "sequence": 1, "criterion_status": "MET"},
+    ]
+
+    assert agg.group_runs(verdicts) == [{"a1": True, "a2": True}, {"a1": True}]
+
+
+def test_score_case_means_the_runs_and_reports_the_spread() -> None:
+    scored = scoring.score_case(
+        _RUBRIC,
+        [
+            {"a1": True, "a2": True, "a3": False, "b1": True},
+            {"a1": True, "a2": False, "a3": False, "b1": True},
+        ],
+    )
+
+    assert scored["normalized_score"] == 0.875
+    assert scored["normalized_score_sd"] == 0.1768
+    assert scored["pass_rate"] == 0.875
+    assert scored["pass_rate_sd"] == 0.1768
+    assert scored["accuracy"] == 0.8333
+    assert scored["accuracy_pass_rate"] == 0.8333
+    assert scored["axis_scores"] == {"Factual Accuracy": 0.8333, "Presentation": 1.0}
+    assert scored["axis_pass_rates"] == {
+        "Factual Accuracy": 0.8333,
+        "Presentation": 1.0,
+    }
+    assert scored["n_runs"] == 2
+
+
+def test_a_single_run_reports_zero_spread() -> None:
+    scored = scoring.score_case(_RUBRIC, [{"a1": True, "a2": True, "a3": False, "b1": True}])
+
+    assert scored["normalized_score"] == 1.0
+    assert scored["normalized_score_sd"] == 0.0
+    assert scored["n_runs"] == 1

--- a/apps/url4-cloud/tests/unit/test_draco_scoring.py
+++ b/apps/url4-cloud/tests/unit/test_draco_scoring.py
@@ -161,6 +161,30 @@ def test_score_case_means_the_runs_and_reports_the_spread() -> None:
     assert scored["n_runs"] == 2
 
 
+def test_a_rubric_without_a_factual_accuracy_axis_reports_unknown_not_zero() -> None:
+    """Absence must not render as 0.0 — that reads as "0% factually accurate" on a perfect run."""
+    rubric = {
+        "sections": [
+            {"id": "Presentation", "criteria": [{"id": "b1", "weight": 1, "requirement": "clear"}]}
+        ]
+    }
+
+    scored = scoring.score_case(rubric, [{"b1": True}])
+
+    assert scored["normalized_score"] == 1.0
+    assert scored["accuracy"] is None
+    assert scored["accuracy_pass_rate"] is None
+
+
+def test_a_case_missing_the_accuracy_axis_is_skipped_by_the_candidate_mean() -> None:
+    """A Case that never observed the axis must not drag the Candidate mean toward zero."""
+    with_axis = {"grade": {"metrics": {"accuracy": 0.8}}}
+    without_axis = {"grade": {"metrics": {"accuracy": None}}}
+
+    assert agg._mean_optional_grade_metrics([with_axis, without_axis], "accuracy") == 0.8
+    assert agg._mean_optional_grade_metrics([without_axis], "accuracy") is None
+
+
 def test_a_single_run_reports_zero_spread() -> None:
     scored = scoring.score_case(_RUBRIC, [{"a1": True, "a2": True, "a3": False, "b1": True}])
 

--- a/apps/url4-cloud/tests/unit/test_draco_smoke_protocol.py
+++ b/apps/url4-cloud/tests/unit/test_draco_smoke_protocol.py
@@ -1,0 +1,181 @@
+"""The safe DRACO smoke protocol is structurally faithful and explicitly non-canonical.
+
+FEATURE: OME-712 — notebooks can validate the DRACO execution path without accidentally
+launching the full paid Benchmark.
+STORY: as a researcher, I can test Model and Fusion plumbing cheaply without mistaking the
+diagnostic score for a publishable DRACO result.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from benchmark_support import install_benchmarks
+
+from url4 import RelExpr, Text, render
+from url4.peer.server import Url4Node
+from url4_cloud.benchmarks import BENCHMARKS
+from url4_cloud.benchmarks.draco.case_evaluation import (
+    bind_case_evaluation,
+    bind_criterion_evaluation,
+)
+from url4_cloud.benchmarks.draco.definition import (
+    DRACO,
+    DRACO_SMOKE,
+    JUDGE_MODEL,
+    SMOKE_AGGREGATE_ROUTE,
+    SMOKE_CASES_ROUTE,
+)
+from url4_cloud.benchmarks.draco.records import CASE_SCHEMA, CHECK_SCHEMA
+
+
+def test_smoke_is_a_separate_noncanonical_benchmark() -> None:
+    assert BENCHMARKS.get("draco/smoke") is DRACO_SMOKE
+    assert DRACO_SMOKE.id == "draco/smoke"
+    assert DRACO_SMOKE.variant == "smoke"
+    assert DRACO_SMOKE.case_count == 1
+    assert DRACO_SMOKE.revision != DRACO.revision
+    assert "not comparable" in DRACO_SMOKE.description.lower()
+
+
+def test_smoke_reduces_only_protocol_multiplicity() -> None:
+    # INVARIANT: both expressions cross the same Candidate/retrieval/verdict/reducer seams.
+    canonical = render(DRACO.build(1))
+    smoke = render(DRACO_SMOKE.build(1))
+
+    for route_fragment in ("/candidate", "/tasks", "/criterion-verdict", "/aggregate"):
+        assert route_fragment in canonical
+        assert route_fragment in smoke
+
+    judge_route = "/" + JUDGE_MODEL
+    assert canonical.count(judge_route) == 5
+    assert smoke.count(judge_route) == 1
+
+    # Canonical-one slices Cases only; smoke additionally slices the criterion collection.
+    assert canonical.count("iteration.slice=0:1") == 1
+    assert smoke.count("iteration.slice=0:1") == 2
+
+
+def test_canonical_draco_contract_is_unchanged() -> None:
+    assert DRACO.id == "draco"
+    assert DRACO.variant == "canonical"
+    assert DRACO.case_count == 100
+    assert render(DRACO.build(100)).count("/" + JUDGE_MODEL) == 5
+    assert "iteration.slice=0:1" not in render(DRACO.build(100))
+
+
+def test_canonical_judge_passes_have_stable_independent_cache_slots() -> None:
+    expression = render(DRACO.build(1))
+
+    assert expression.count("web_search=false") == 5
+    for seed in range(1, 6):
+        assert expression.count(f"&seed={seed}") == 1
+
+
+def _two_case_assets(root: Path) -> None:
+    root.mkdir(parents=True)
+    (root / "criteria").mkdir()
+    (root / "rubrics").mkdir()
+    (root / "cases.json").write_text(
+        json.dumps(
+            [
+                {"id": 1, "input": "First question", "domain": "Academic"},
+                {"id": 2, "input": "Second question", "domain": "Finance"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+    for case_id in (1, 2):
+        (root / "criteria" / f"{case_id}.json").write_text(
+            '[{"id":"c1","requirement":"Correct","criterion_type":"positive"}]',
+            encoding="utf-8",
+        )
+        (root / "rubrics" / f"{case_id}.json").write_text(
+            '{"sections":[{"id":"correctness","criteria":[{"id":"c1","weight":1}]}]}',
+            encoding="utf-8",
+        )
+
+
+@pytest.mark.asyncio
+async def test_smoke_private_cases_expose_only_the_pinned_case(tmp_path: Path) -> None:
+    _two_case_assets(tmp_path / "draco")
+    node = Url4Node("test")
+    install_benchmarks(node, tmp_path, benchmarks=(DRACO_SMOKE,))
+
+    cases = json.loads(await node.fetch(SMOKE_CASES_ROUTE, relative=True))
+
+    assert [case["id"] for case in cases] == [1]
+
+
+@pytest.mark.asyncio
+async def test_smoke_runtime_reports_its_own_identity_and_one_judge_pass(tmp_path: Path) -> None:
+    root = tmp_path / "draco"
+    (root / "criteria").mkdir(parents=True)
+    (root / "rubrics").mkdir()
+    (root / "cases.json").write_text('[{"id":1,"input":"Question"}]', encoding="utf-8")
+    (root / "criteria" / "1.json").write_text(
+        '[{"id":"c1","requirement":"Correct","criterion_type":"positive"},'
+        '{"id":"c2","requirement":"Complete","criterion_type":"positive"}]',
+        encoding="utf-8",
+    )
+    (root / "rubrics" / "1.json").write_text(
+        '{"sections":[{"id":"correctness","criteria":['
+        '{"id":"c1","weight":1},{"id":"c2","weight":1}]}]}',
+        encoding="utf-8",
+    )
+    raw_output = json.dumps({"explanation": "evidence", "criterion_status": "MET"})
+    case_record = {
+        "schema": CASE_SCHEMA,
+        "case_id": 1,
+        "input": "Question",
+        "output": "Answer",
+        "finish_reason": "stop",
+        "metadata": {},
+    }
+    check_record = {
+        "schema": CHECK_SCHEMA,
+        "case_id": 1,
+        "criterion_id": "c1",
+        "criterion_type": "positive",
+        "requirement": "Correct",
+    }
+    verdict = {
+        "schema": "screamingface.criterion-verdict.v1",
+        "case_id": 1,
+        "criterion_id": "c1",
+        "sequence": 1,
+        "producer_type": "model",
+        "producer_id": "fixture-judge",
+        "valid": True,
+        "explanation": "evidence",
+        "criterion_status": "MET",
+        "raw_output": raw_output,
+    }
+    row = bind_case_evaluation(
+        1,
+        [bind_criterion_evaluation(1, case_record, check_record, [verdict])],
+    )
+    node = Url4Node("test")
+    install_benchmarks(node, tmp_path, benchmarks=(DRACO_SMOKE,))
+
+    result = json.loads(
+        (
+            await node.evaluate(
+                render(
+                    RelExpr(
+                        path=SMOKE_AGGREGATE_ROUTE,
+                        context=json.dumps([row]),
+                        intent=Text("aggregate:1"),
+                    )
+                )
+            )
+        ).text
+    )
+
+    assert result["benchmark_id"] == DRACO_SMOKE.id
+    assert result["benchmark_revision"] == DRACO_SMOKE.revision
+    assert result["metrics"]["n_runs"] == 1
+    assert result["metrics"]["coverage"] == 1.0
+    assert result["metrics"]["verdicts_expected"] == 1

--- a/apps/url4-cloud/tests/unit/test_draco_smoke_protocol.py
+++ b/apps/url4-cloud/tests/unit/test_draco_smoke_protocol.py
@@ -16,7 +16,7 @@ from benchmark_support import install_benchmarks
 
 from url4 import RelExpr, Text, render
 from url4.peer.server import Url4Node
-from url4_cloud.benchmarks import BENCHMARKS
+from url4_cloud.benchmarks.builtins import BUILTIN_BENCHMARKS
 from url4_cloud.benchmarks.draco.case_evaluation import (
     bind_case_evaluation,
     bind_criterion_evaluation,
@@ -32,7 +32,7 @@ from url4_cloud.benchmarks.draco.records import CASE_SCHEMA, CHECK_SCHEMA
 
 
 def test_smoke_is_a_separate_noncanonical_benchmark() -> None:
-    assert BENCHMARKS.get("draco/smoke") is DRACO_SMOKE
+    assert BUILTIN_BENCHMARKS.get("draco/smoke") is DRACO_SMOKE
     assert DRACO_SMOKE.id == "draco/smoke"
     assert DRACO_SMOKE.variant == "smoke"
     assert DRACO_SMOKE.case_count == 1

--- a/apps/url4-cloud/tests/unit/test_draco_tasks.py
+++ b/apps/url4-cloud/tests/unit/test_draco_tasks.py
@@ -1,0 +1,54 @@
+"""DRACO's local case-to-criterion task preparation boundary."""
+
+from __future__ import annotations
+
+import pytest
+
+from url4_cloud.benchmarks.draco import tasks
+
+
+def test_build_tasks_combines_answer_with_weight_free_criteria() -> None:
+    criteria = [
+        {
+            "id": "correct",
+            "requirement": "The answer is four.",
+            "criterion_type": "positive",
+        },
+        {
+            "id": "wrong",
+            "requirement": "Claims the answer is five.",
+            "criterion_type": "negative",
+        },
+    ]
+
+    result = tasks.build_tasks(7, "What is two plus two?", "Four.", criteria)
+
+    assert result == [
+        {
+            "case_id": "7",
+            "question": "What is two plus two?",
+            "answer": "Four.",
+            "criterion_id": "correct",
+            "criterion": "The answer is four.",
+            "criterion_type": "positive",
+        },
+        {
+            "case_id": "7",
+            "question": "What is two plus two?",
+            "answer": "Four.",
+            "criterion_id": "wrong",
+            "criterion": "Claims the answer is five.",
+            "criterion_type": "negative",
+        },
+    ]
+    assert all("weight" not in task for task in result)
+
+
+def test_build_tasks_rejects_invalid_criterion_type() -> None:
+    with pytest.raises(tasks.TasksError, match="criterion_type"):
+        tasks.build_tasks(
+            1,
+            "Q",
+            "A",
+            [{"id": "c", "requirement": "R", "criterion_type": "unknown"}],
+        )

--- a/apps/url4-cloud/tests/unit/test_draco_validation.py
+++ b/apps/url4-cloud/tests/unit/test_draco_validation.py
@@ -1,0 +1,30 @@
+"""DRACO scalar records reject Python coercions that are not valid JSON field encodings."""
+
+import pytest
+
+from url4_cloud.benchmarks.draco.validation import (
+    has_text,
+    optional_integer,
+    require_positive_integer,
+    require_text,
+)
+
+
+@pytest.mark.parametrize("value", [True, False, 1.5, None, [], {}])
+def test_optional_integer_rejects_non_integer_json_shapes(value: object) -> None:
+    assert optional_integer(value) is None
+
+
+def test_integer_validation_accepts_integer_text_without_accepting_zero() -> None:
+    assert optional_integer("12") == 12
+    assert require_positive_integer(12, "case_id") == 12
+    with pytest.raises(ValueError, match="case_id must be a positive integer"):
+        require_positive_integer("0", "case_id")
+
+
+def test_text_validation_preserves_content_but_rejects_blank_text() -> None:
+    assert require_text("  answer  ", "answer") == "  answer  "
+    assert has_text("answer") is True
+    assert has_text("  ") is False
+    with pytest.raises(ValueError, match="answer must be non-empty text"):
+        require_text("  ", "answer")

--- a/apps/url4-cloud/tests/unit/test_draco_verdict.py
+++ b/apps/url4-cloud/tests/unit/test_draco_verdict.py
@@ -1,0 +1,93 @@
+"""DRACO criterion-verdict binding behavior."""
+
+from __future__ import annotations
+
+import json
+
+from url4_cloud.benchmarks.draco import verdict as criterion_verdict
+
+
+def _bind(raw: str, *, case_id: int, criterion_id: str) -> dict[str, object]:
+    return criterion_verdict.bind(
+        raw,
+        case_id=case_id,
+        criterion_id=criterion_id,
+        sequence=1,
+        producer_id="fixture-judge",
+    )
+
+
+def test_a_valid_reply_is_bound_to_the_engine_known_criterion() -> None:
+    raw = json.dumps(
+        {
+            "criterion_id": "model-invented-id",
+            "explanation": "The requirement is present.",
+            "criterion_status": "MET",
+        }
+    )
+    record = _bind(
+        raw,
+        case_id=7,
+        criterion_id="actual-id",
+    )
+
+    assert record == {
+        "schema": "screamingface.criterion-verdict.v1",
+        "case_id": 7,
+        "criterion_id": "actual-id",
+        "sequence": 1,
+        "producer_type": "model",
+        "producer_id": "fixture-judge",
+        "valid": True,
+        "explanation": "The requirement is present.",
+        "criterion_status": "MET",
+        "raw_output": raw,
+    }
+
+
+def test_fenced_or_prefixed_json_is_accepted_like_the_reference_harness() -> None:
+    record = _bind(
+        'Here is the verdict:\n```json\n{"explanation":"No error.",'
+        '"criterion_status":"UNMET"}\n```',
+        case_id=3,
+        criterion_id="negative-1",
+    )
+
+    assert record["valid"] is True
+    assert record["criterion_id"] == "negative-1"
+    assert record["criterion_status"] == "UNMET"
+
+
+def test_invalid_replies_become_diagnostic_records_instead_of_command_failures() -> None:
+    assert _bind("", case_id=1, criterion_id="a1") == {
+        "schema": "screamingface.criterion-verdict.v1",
+        "case_id": 1,
+        "criterion_id": "a1",
+        "sequence": 1,
+        "producer_type": "model",
+        "producer_id": "fixture-judge",
+        "valid": False,
+        "reason": "empty",
+        "raw_output": "",
+    }
+    assert _bind("not json", case_id=1, criterion_id="a1")["reason"] == "invalid_json"
+    assert (
+        _bind(
+            '{"explanation":"x","criterion_status":"MAYBE"}',
+            case_id=1,
+            criterion_id="a1",
+        )["reason"]
+        == "invalid_status"
+    )
+    assert (
+        _bind('{"criterion_status":"MET"}', case_id=1, criterion_id="a1")["reason"]
+        == "invalid_shape"
+    )
+
+
+def test_the_internal_binding_key_preserves_colons_in_criterion_ids() -> None:
+    assert criterion_verdict.binding_key("12:3:section:criterion") == (
+        12,
+        3,
+        "section:criterion",
+    )

--- a/apps/url4-cloud/tests/unit/test_model_params.py
+++ b/apps/url4-cloud/tests/unit/test_model_params.py
@@ -24,8 +24,8 @@ import httpx
 import pytest
 
 from url4.core.errors import ResolutionError
-from url4_cloud.world_config import ModelSpec
 from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+from url4_cloud.world_config import ModelSpec
 
 _MODEL = "openrouter/google/gemini-3.1-pro-preview"
 

--- a/apps/url4-cloud/tests/unit/test_model_params.py
+++ b/apps/url4-cloud/tests/unit/test_model_params.py
@@ -1,0 +1,234 @@
+"""Expression-level model parameters reaching the gateway request body.
+
+FEATURE: a url4 expression can pin a model call's sampling parameters —
+`/judge(…)!'grade';temperature=0.2;max_tokens=8192` — and they reach aigateway.
+STORY: as a benchmark author, the DRACO paper pins `judge_temperature: 0.2`
+(arXiv:2602.11685 §4.2), and a judge run at the provider's default temperature
+is a different benchmark from the one the paper defines.
+
+Before this, `_ModelEndpoint.__call__` read `path`/`context`/`intent` and never
+`params`, so every `;k=v` in an expression was parsed, carried to the endpoint, and
+silently dropped at the wire — the run still succeeded, at the wrong temperature.
+
+INVARIANT: the gateway is the AUTHORITY on which parameters exist and what values are
+legal (`core/standard_parameters.py` + each provider's rules, which fail closed on an
+unknown field). The runner keeps NO second allowlist — it rejects only the fields IT
+owns, and forwards the rest for the gateway to validate.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from url4.core.errors import ResolutionError
+from url4_cloud.world_config import ModelSpec
+from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+
+_MODEL = "openrouter/google/gemini-3.1-pro-preview"
+
+
+# Every probe expression carries `anchor:1.0:'a'` beside the model call: with the call as the
+# body's ONLY source, the all-calls rule fires the per-row reduce and `default_route` adds a
+# gateway hop these assertions do not expect. One data sibling degrades it to a join.
+async def _evaluate(expression: str, *, web_tools: bool = False, tavily: bool = False):
+    """Run one expression against a mock gateway; return the captured request bodies."""
+    bodies: list[dict] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        bodies.append(json.loads(request.content))
+        return httpx.Response(200, json={"choices": [{"message": {"content": "OK"}}], "usage": {}})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handle), base_url="http://aigateway.test"
+    ) as client:
+        world = await build_aigateway_world(
+            AigatewayConfig(
+                default_model=_MODEL, models=(ModelSpec(id=_MODEL, web_tools=web_tools),)
+            ),
+            client=client,
+            tavily_client=client if tavily else None,
+            tavily_api_key="tv-key" if tavily else None,
+        )
+        try:
+            await world.node.evaluate(expression)
+        finally:
+            await world.aclose()
+    return bodies
+
+
+# --- the parameters reach the wire, correctly typed ------------------------------
+
+
+@pytest.mark.asyncio
+async def test_temperature_reaches_the_request_body_as_a_number() -> None:
+    """INVARIANT: coerced, not passed through as text.
+
+    url4 hands params over as `Mapping[str, str]`, but the gateway's schemas are strictly
+    typed — `isinstance(v, (int, float)) and not isinstance(v, bool)` — so the string
+    "0.2" fails closed against `TEMPERATURE_SCHEMA`. A forwarded parameter that the
+    gateway then rejects is no better than a dropped one.
+    """
+    bodies = await _evaluate(
+        f"(v:1.0:/{_MODEL}(a:1.0:'x')!'grade';temperature=0.2,anchor:1.0:'a')!'go'"
+    )
+
+    assert bodies[0]["temperature"] == 0.2
+    assert isinstance(bodies[0]["temperature"], float)
+
+
+@pytest.mark.asyncio
+async def test_max_tokens_reaches_the_request_body_as_an_integer() -> None:
+    """Integer-valued URL4 parameters must remain integers at the Gateway boundary."""
+    bodies = await _evaluate(
+        f"(v:1.0:/{_MODEL}(a:1.0:'x')!'grade';max_tokens=8192,anchor:1.0:'a')!'go'"
+    )
+
+    assert bodies[0]["max_tokens"] == 8192
+    assert isinstance(bodies[0]["max_tokens"], int)
+
+
+@pytest.mark.asyncio
+async def test_an_enum_valued_parameter_stays_a_string() -> None:
+    """Coercion must not mangle a value the gateway expects as text: `stop` is a
+    `string | array[string]` union, and an enum ladder like `reasoning_effort` is a
+    plain string. Only JSON-shaped values become JSON."""
+    bodies = await _evaluate(f"(v:1.0:/{_MODEL}(a:1.0:'x')!'grade';stop=END,anchor:1.0:'a')!'go'")
+
+    assert bodies[0]["stop"] == "END"
+
+
+@pytest.mark.asyncio
+async def test_several_parameters_are_all_forwarded() -> None:
+    bodies = await _evaluate(
+        f"(v:1.0:/{_MODEL}(a:1.0:'x')!'grade';temperature=0.2;max_tokens=8192;seed=7,anchor:1.0:'a')!'go'"
+    )
+
+    assert bodies[0]["temperature"] == 0.2
+    assert bodies[0]["max_tokens"] == 8192
+    assert bodies[0]["seed"] == 7
+
+
+@pytest.mark.asyncio
+async def test_no_parameters_leaves_the_body_untouched() -> None:
+    """A call with no `;k=v` chain must send exactly what it always sent — no phantom
+    keys the gateway would then have to classify."""
+    bodies = await _evaluate(f"(v:1.0:/{_MODEL}(a:1.0:'x')!'grade',anchor:1.0:'a')!'go'")
+
+    assert set(bodies[0]) == {"model", "messages"}
+
+
+# --- the fields the RUNNER owns --------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["model", "messages", "tools", "tool_choice", "stream", "web_search_excluded_domains"],
+)
+@pytest.mark.asyncio
+async def test_a_runner_owned_field_is_rejected(field: str) -> None:
+    """INVARIANT: these are the runner's, not the caller's, and rejection is LOUD.
+
+    `model` would let an expression address one route and run another model, breaking the
+    "route path is exactly '/' + gateway id" invariant that `url4.toml` and
+    `test_declared_models_match_aigateway.py` exist to hold. `tools`/`tool_choice` would
+    bypass the per-route `web_tools` opt-in that keeps a configured Tavily key from
+    silently changing every model's payload. `stream` would break response parsing.
+
+    Dropping them silently would be worse than forwarding them: the expression would read
+    as though it had pinned something it had not.
+    """
+    with pytest.raises(ResolutionError, match=field):
+        await _evaluate(f"(v:1.0:/{_MODEL}(a:1.0:'x')!'grade';{field}=x,anchor:1.0:'a')!'go'")
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_parameter_is_forwarded_for_the_gateway_to_judge() -> None:
+    """The runner keeps no allowlist: enabling a parameter must stay a gateway-local edit.
+
+    The gateway fails closed on an unknown field ("unsupported chat parameters: …"), so a
+    typo surfaces there with a named 400 rather than being swallowed here — one authority,
+    no drift.
+    """
+    bodies = await _evaluate(
+        f"(v:1.0:/{_MODEL}(a:1.0:'x')!'grade';not_a_real_param=1,anchor:1.0:'a')!'go'"
+    )
+
+    assert bodies[0]["not_a_real_param"] == 1
+
+
+# --- interaction with the web-tool loop ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_web_tools_still_win_over_a_caller_supplied_payload() -> None:
+    """The route's declared tools must be what ships, on a route that opted in."""
+    bodies = await _evaluate(
+        f"(v:1.0:/{_MODEL}(a:1.0:'x')!'grade';temperature=0.2,anchor:1.0:'a')!'go'",
+        web_tools=True,
+        tavily=True,
+    )
+
+    assert bodies[0]["temperature"] == 0.2
+    assert bodies[0]["tool_choice"] == "auto"
+    assert isinstance(bodies[0]["tools"], list)
+
+
+@pytest.mark.asyncio
+async def test_parameters_apply_to_every_round_trip_of_the_tool_loop() -> None:
+    """A tool-calling turn re-posts; sampling parameters must hold on each hop, or the
+    answer is produced under different settings from the ones the expression pinned."""
+    calls: list[dict] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/v1/chat/completions"):
+            calls.append(json.loads(request.content))
+            if len(calls) == 1:
+                return httpx.Response(
+                    200,
+                    json={
+                        "choices": [
+                            {
+                                "message": {
+                                    "content": None,
+                                    "tool_calls": [
+                                        {
+                                            "id": "c1",
+                                            "type": "function",
+                                            "function": {
+                                                "name": "web_search",
+                                                "arguments": '{"query": "x"}',
+                                            },
+                                        }
+                                    ],
+                                }
+                            }
+                        ],
+                        "usage": {},
+                    },
+                )
+            return httpx.Response(
+                200, json={"choices": [{"message": {"content": "FINAL"}}], "usage": {}}
+            )
+        return httpx.Response(200, json={"results": []})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handle), base_url="http://aigateway.test"
+    ) as client:
+        world = await build_aigateway_world(
+            AigatewayConfig(default_model=_MODEL, models=(ModelSpec(id=_MODEL, web_tools=True),)),
+            client=client,
+            tavily_client=client,
+            tavily_api_key="tv-key",
+        )
+        try:
+            await world.node.evaluate(
+                f"(v:1.0:/{_MODEL}(a:1.0:'x')!'grade';temperature=0.2,anchor:1.0:'a')!'go'"
+            )
+        finally:
+            await world.aclose()
+
+    assert len(calls) == 2
+    assert [c["temperature"] for c in calls] == [0.2, 0.2]

--- a/apps/url4-cloud/tests/unit/test_native_web_search.py
+++ b/apps/url4-cloud/tests/unit/test_native_web_search.py
@@ -1,0 +1,206 @@
+"""Provider-side web search, and the expression-level toggle that selects it.
+
+FEATURE: a route whose provider runs search ITSELF declares `native_web_search`, and an
+expression turns retrieval on or off per call with `;web_search=`.
+STORY: as a benchmark author, a published score was produced on the provider's own server-side
+search — a client-side loop over a different backend is a different experiment, so I need the
+same surface, and I need to switch it off for the judge in the same expression.
+
+TWO MECHANISMS, one per route:
+  * `web_tools`         — the RUNNER declares OpenAI functions and executes them against Tavily.
+                          Kept for providers with no server-side search of their own.
+  * `native_web_search` — the PROVIDER executes the search and answers with it already done.
+                          The runner asks the GATEWAY for it (`web_search: true`) and never
+                          spells one provider's envelope itself.
+
+INVARIANT: never both on one route. The request would carry two tool populations and
+double-dispatch — searching twice per turn and billing for both.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from url4.core.errors import ResolutionError
+from url4_cloud.retrieval_policy import RetrievalPolicy, retrieval_scope
+from url4_cloud.world_config import ModelSpec, WorldConfigError, parse_config
+from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+
+_NATIVE = "openrouter/anthropic/claude-opus-4.8"
+_TAVILY = "claude-opus-4-8"
+_PLAIN = "claude-haiku-4-5"
+
+
+async def _bodies(expression: str, *, cfg: AigatewayConfig | None = None) -> list[dict]:
+    """Evaluate against a mock gateway; return every captured chat-completions body."""
+    captured: list[dict] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content))
+        return httpx.Response(200, json={"choices": [{"message": {"content": "OK"}}], "usage": {}})
+
+    config = cfg or AigatewayConfig(
+        default_model=_PLAIN,
+        models=(
+            ModelSpec(id=_NATIVE, native_web_search=True),
+            ModelSpec(id=_TAVILY, web_tools=True),
+            ModelSpec(id=_PLAIN),
+        ),
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handle), base_url="http://aigateway.test"
+    ) as client:
+        world = await build_aigateway_world(
+            config, client=client, tavily_client=client, tavily_api_key="tv-key"
+        )
+        try:
+            await world.node.evaluate(expression)
+        finally:
+            await world.aclose()
+    return captured
+
+
+def _call(route: str, chain: str = "") -> str:
+    # `anchor` keeps the all-calls rule from firing the per-row reduce onto default_route.
+    return f"(v:1.0:/{route}(a:1.0:'x')!'answer'{chain},anchor:1.0:'a')!'go'"
+
+
+# --- the native surface ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_native_route_asks_the_gateway_for_retrieval() -> None:
+    """INVARIANT: a provider-AGNOSTIC flag, not a provider payload.
+
+    The gateway owns which provider can retrieve and how its envelope is spelled (OpenRouter's
+    is `plugins: [{"id": "web"}]`, an extensibility envelope no caller may address). Building
+    that here would put provider knowledge in the runner and fork a contract the gateway
+    already owns.
+    """
+    body = (await _bodies(_call(_NATIVE)))[0]
+
+    assert body["web_search"] is True
+    assert "plugins" not in body
+    assert "tools" not in body
+
+
+@pytest.mark.asyncio
+async def test_a_native_route_sends_no_tool_choice() -> None:
+    """`tool_choice` is the OpenAI selection control and does not govern a provider-run
+    plugin; sending it would advertise a control the provider does not honor here."""
+    body = (await _bodies(_call(_NATIVE)))[0]
+
+    assert "tool_choice" not in body
+
+
+@pytest.mark.asyncio
+async def test_a_native_route_runs_no_client_side_loop() -> None:
+    """The provider answers with retrieval already done — one request, not a tool round trip."""
+    assert len(await _bodies(_call(_NATIVE))) == 1
+
+
+@pytest.mark.asyncio
+async def test_absent_operator_parameters_omit_the_field_entirely() -> None:
+    """An empty exclusion list must not be SENT as an empty list — that reads to the provider as
+    'exclude nothing' rather than 'use your default'."""
+    body = (await _bodies(_call(_NATIVE)))[0]
+
+    assert "web_search_excluded_domains" not in body
+
+
+@pytest.mark.asyncio
+async def test_benchmark_policy_enables_native_search_and_carries_its_exclusions() -> None:
+    with retrieval_scope(
+        RetrievalPolicy(web_search=True, excluded_domains=("rubric.test", "paper.test"))
+    ):
+        body = (await _bodies(_call(_NATIVE)))[0]
+
+    assert body["web_search"] is True
+    assert body["web_search_excluded_domains"] == ["paper.test", "rubric.test"]
+
+
+# --- the expression toggle -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_toggle_switches_a_native_route_off() -> None:
+    body = (await _bodies(_call(_NATIVE, ";web_search=false")))[0]
+
+    assert "web_search" not in body
+
+
+@pytest.mark.asyncio
+async def test_the_toggle_switches_a_tavily_route_off() -> None:
+    body = (await _bodies(_call(_TAVILY, ";web_search=false")))[0]
+
+    assert "tools" not in body
+
+
+@pytest.mark.asyncio
+async def test_a_tavily_route_still_declares_openai_functions() -> None:
+    """The client-side mechanism is unchanged — it is what a provider with no server-side
+    search of its own still needs."""
+    body = (await _bodies(_call(_TAVILY)))[0]
+
+    assert [t["function"]["name"] for t in body["tools"]] == ["web_search", "web_fetch"]
+    assert body["tool_choice"] == "auto"
+
+
+@pytest.mark.asyncio
+async def test_saying_nothing_keeps_the_routes_declared_behaviour() -> None:
+    """Absent means 'as declared', so every expression written before this toggle existed
+    behaves exactly as it did."""
+    assert "web_search" in (await _bodies(_call(_NATIVE)))[0]
+    assert "tools" in (await _bodies(_call(_TAVILY)))[0]
+    assert "tools" not in (await _bodies(_call(_PLAIN)))[0]
+    assert "web_search" not in (await _bodies(_call(_PLAIN)))[0]
+
+
+@pytest.mark.asyncio
+async def test_asking_a_route_with_no_mechanism_to_search_is_loud() -> None:
+    """The silent alternative is an expression that reads as though it retrieved and an answer
+    written from weights alone — indistinguishable in the result."""
+    with pytest.raises(ResolutionError, match="declares no web search"):
+        await _bodies(_call(_PLAIN, ";web_search=true"))
+
+
+@pytest.mark.asyncio
+async def test_the_toggle_is_consumed_and_never_reaches_the_gateway() -> None:
+    """The url4 toggle is consumed by `_wants_web_search`, never forwarded as a raw param — the
+    gateway field it produces is set by the connector, not copied from the expression."""
+    body = (await _bodies(_call(_NATIVE, ";web_search=true;temperature=0.2")))[0]
+
+    assert body["web_search"] is True
+    assert body["temperature"] == 0.2
+
+
+# --- the declared world ----------------------------------------------------------
+
+
+def test_declaring_both_mechanisms_is_a_config_error() -> None:
+    raw = {
+        "aigateway": {
+            "default_route": "/m",
+            "models": [{"id": "m", "web_tools": True, "native_web_search": True}],
+        }
+    }
+    with pytest.raises(WorldConfigError, match="one retrieval mechanism"):
+        parse_config(raw, {})
+
+
+def test_native_web_search_defaults_off() -> None:
+    raw = {"aigateway": {"default_route": "/m", "models": [{"id": "m"}]}}
+
+    section = parse_config(raw, {}).aigateway
+    assert section is not None
+    assert section.models[0].native_web_search is False
+
+
+def test_native_web_search_must_be_a_boolean() -> None:
+    raw = {"aigateway": {"default_route": "/m", "models": [{"id": "m", "native_web_search": 1}]}}
+
+    with pytest.raises(WorldConfigError, match="native_web_search must be a boolean"):
+        parse_config(raw, {})

--- a/apps/url4-cloud/tests/unit/test_native_web_search.py
+++ b/apps/url4-cloud/tests/unit/test_native_web_search.py
@@ -26,8 +26,8 @@ import pytest
 
 from url4.core.errors import ResolutionError
 from url4_cloud.retrieval_policy import RetrievalPolicy, retrieval_scope
-from url4_cloud.world_config import ModelSpec, WorldConfigError, parse_config
 from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+from url4_cloud.world_config import ModelSpec, WorldConfigError, parse_config
 
 _NATIVE = "openrouter/anthropic/claude-opus-4.8"
 _TAVILY = "claude-opus-4-8"

--- a/apps/url4-cloud/tests/unit/test_native_web_search.py
+++ b/apps/url4-cloud/tests/unit/test_native_web_search.py
@@ -27,6 +27,7 @@ import pytest
 from url4.core.errors import ResolutionError
 from url4_cloud.retrieval_policy import RetrievalPolicy, retrieval_scope
 from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+from url4_cloud.runner.web_tools import build_runtime
 from url4_cloud.world_config import ModelSpec, WorldConfigError, parse_config
 
 _NATIVE = "openrouter/anthropic/claude-opus-4.8"
@@ -204,3 +205,27 @@ def test_native_web_search_must_be_a_boolean() -> None:
 
     with pytest.raises(WorldConfigError, match="native_web_search must be a boolean"):
         parse_config(raw, {})
+
+
+@pytest.mark.asyncio
+async def test_a_default_on_search_route_still_honours_caller_exclusions() -> None:
+    """A `web_tools` route searches by DEFAULT, so a caller reaches the tool loop without ever
+    writing `web_search=true`. Their exclusion list must still bind: a silently ignored exclusion
+    is indistinguishable from an honoured one, which is the worst failure mode a privacy control
+    can have."""
+    client = httpx.AsyncClient(base_url="https://tavily.test")
+    try:
+        runtime = build_runtime(
+            spec=ModelSpec(id=_TAVILY, web_tools=True),
+            wants_search=True,
+            tavily_http=client,
+            tavily_api_key="key",
+            config=AigatewayConfig(),
+            policy=None,
+            params={"web_search_exclude": "evil.test"},
+        )
+    finally:
+        await client.aclose()
+
+    assert runtime is not None
+    assert runtime.excluded_domains == ("evil.test",)

--- a/apps/url4-cloud/url4.toml
+++ b/apps/url4-cloud/url4.toml
@@ -25,6 +25,8 @@
 [aigateway]
 base_url = "http://127.0.0.1:9105"
 default_route = "/claude-haiku-4-5"
+timeout_s = 600.0
+web_tool_max_iterations = 12
 
 # Absolute-URL sources (`https://…`) are a real url4 feature and a Url4Node world has always
 # been able to fetch them. Set false to hand the node a denying outbound layer instead.
@@ -98,14 +100,34 @@ id = "antigravity/gemini-3-flash"
 # web_tools: verified end-to-end through OpenRouter's OpenAI-shape tool calling.
 [[aigateway.models]]
 id = "openrouter/openai/gpt-5.5"
-web_tools = true
+native_web_search = true
 
 [[aigateway.models]]
 id = "openrouter/anthropic/claude-opus-4.8"
-web_tools = true
+native_web_search = true
 
 [[aigateway.models]]
 id = "openrouter/anthropic/claude-fable-5"
+native_web_search = true
+
+[[aigateway.models]]
+id = "openrouter/google/gemini-3.1-pro-preview"
+web_tools = true
+
+[[aigateway.models]]
+id = "openrouter/google/gemini-3-flash-preview"
+web_tools = true
+
+[[aigateway.models]]
+id = "openrouter/moonshotai/kimi-k2.6"
+web_tools = true
+
+[[aigateway.models]]
+id = "openrouter/deepseek/deepseek-v4-pro"
+web_tools = true
+
+[[aigateway.models]]
+id = "openrouter/qwen/qwen3.6-plus"
 web_tools = true
 
 # RESERVED — the format carries these (they are `url4 serve`'s tables) but the Runner does not

--- a/docs/plan/2026-08-07-OME-712-draco-protocol-deployment.md
+++ b/docs/plan/2026-08-07-OME-712-draco-protocol-deployment.md
@@ -1,0 +1,50 @@
+---
+title: OME-712 — DRACO protocol and deployment implementation plan
+status: completed
+created: 2026-08-07
+ticket: OME-712
+spec: docs/spec/2026-08-07-OME-712-draco-protocol-deployment.md
+---
+
+# DRACO protocol and deployment implementation plan
+
+## Goal
+
+Add the first scored protocol behind the generic Engine Benchmark interface without moving
+benchmark semantics into URL4, AI Gateway, or the ScreamingFace client.
+
+## Sequence
+
+1. Pin and prepare public Case inputs, private criteria, rubrics, retrieval policy, and revision
+   inputs in a separate benchmark image.
+2. Implement weight-free Judge tasks, schema-validated verdict binding, exact Case envelopes, and
+   lossless Case artifacts.
+3. Port the reference DRACO score arithmetic as deterministic pure functions and prove parity with
+   focused vectors.
+4. Build canonical, lite, and smoke URL4 protocols with exact ordered selection and stable seeded
+   Judge passes.
+5. Validate all selected assets and required routes when the Runner world is installed, before any
+   Candidate or Judge request.
+6. Add only the provider-neutral model parameters and retrieval mechanisms required by the
+   declared protocols.
+7. Publish the paired benchmark image and wire Runner Jobs to it without exposing rubrics to the
+   control plane.
+8. Verify failure integrity, privacy, artifacts, protocol rendering, Helm wiring, and the complete
+   URL4 Cloud quality gate.
+
+## Landing boundary
+
+- Modify URL4 Cloud, its benchmark image/deployment wiring, tests, and OME-712 artifacts.
+- Do not add DRACO behavior to URL4 grammar, AI Gateway, or the client.
+- Keep concrete DRACO registration in deployment composition; generic Benchmark modules remain
+  reusable by other Engine deployments.
+- Reconstruct the final PR directly from current `main` after the generic Benchmark foundation
+  lands; do not publish this dependency snapshot as a stacked PR.
+
+## Verification
+
+- Focused DRACO preparation, assets, tasks, verdict, envelope, aggregation, artifact, lite, and
+  smoke suites.
+- Runner parameter and retrieval-policy tests.
+- Ruff lint and formatting, Pyright, full URL4 Cloud tests, coverage, layering, image build, and
+  Helm rendering.

--- a/docs/spec/2026-08-07-OME-712-draco-protocol-deployment.md
+++ b/docs/spec/2026-08-07-OME-712-draco-protocol-deployment.md
@@ -1,0 +1,78 @@
+---
+title: OME-712 — DRACO protocol and deployment
+status: accepted
+created: 2026-08-07
+ticket: OME-712
+---
+
+# DRACO protocol and deployment
+
+## Purpose
+
+Install DRACO on the generic Engine Benchmark seam as ordinary URL4. The Engine owns Case
+selection, private rubrics, Judge calls, deterministic aggregation, and auditable result
+artifacts. The client supplies only a Candidate expression and never receives rubric content.
+
+## Installed resources
+
+- `draco` is the canonical 100-Case protocol with five independently seeded Judge passes per
+  criterion.
+- `draco/lite` selects two pinned Cases and ten axis-balanced criteria per Case with one Judge
+  pass. It is directional and not comparable with canonical DRACO.
+- `draco/smoke` selects one pinned Case and one criterion with one Judge pass. It proves wiring,
+  not model quality.
+- An explicit `limit=N` binds exactly the first `N` ordered Cases into the rendered URL4 and the
+  reducer validates that exact selection. Limits are never inferred from surviving rows.
+
+## Protocol invariants
+
+- Candidate answers run through the shared Candidate Invocation adapter with the Benchmark's
+  retrieval policy and exclusion list.
+- The Judge sees one weight-free criterion at a time, never sibling criteria or rubric weights.
+- Canonical Judge passes use stable seeds `1..5`, creating independent reusable cache slots;
+  lite and smoke use seed `1`.
+- Every Case is scored independently for each Judge pass and pass-level scores are averaged using
+  the reference DRACO arithmetic.
+- Missing, malformed, duplicated, misbound, under-covered, or failed Case evidence cannot publish
+  a numeric Candidate score.
+- A Case at the reference 95% valid-evidence threshold may score; lower coverage is unscored.
+- Case artifacts retain input, output, finish reason, Check metadata, accepted evidence, and
+  rejected raw Judge output.
+
+## Asset and privacy contract
+
+- `cases.json`, per-Case criteria, and per-Case rubrics are generated from a pinned dataset
+  revision during benchmark-image construction.
+- The Runner validates complete ordered Case/criteria/rubric alignment before registering any
+  DRACO route or issuing a paid request.
+- Rubrics and weights exist only in the benchmark Runner image. Control-plane discovery exposes
+  metadata and executable URL4, never private grading assets.
+- The benchmark image is version-coupled to the URL4 Cloud release and selected independently in
+  the Runner Job template.
+
+## Fidelity disclosure
+
+The public canonical description must state that this reproduction is not paper-identical. It
+uses the successor Judge model, provider-default reasoning, mixed native/Tavily retrieval, and a
+host-only approximation of the reference blocklist. These deviations are hashed into the
+Benchmark revision where they affect the executable protocol or prepared assets.
+
+## Ownership
+
+- `url4_cloud.benchmarks.draco` owns DRACO preparation, protocol construction, private runtime
+  routes, deterministic scoring, and artifacts.
+- The generic `url4_cloud.benchmarks` modules remain protocol-neutral.
+- A dedicated composition module selects the concrete Benchmarks installed by this deployment.
+- Runner retrieval and model-parameter extensions remain provider-neutral and contain no DRACO
+  scoring rule.
+
+## Acceptance
+
+- Canonical, lite, and smoke render and execute as ordinary URL4 Candidate Result producers.
+- Exact Case and criterion selections are deterministic and validated twice: at installation and
+  reduction.
+- Broken assets, missing Judge routes, and unavailable retrieval fail before model spend.
+- Reference score, pass-rate, accuracy, axis, coverage, and sample-deviation metrics match the
+  pinned reference implementation.
+- The complete URL4 Cloud quality gate and benchmark-image/Helm rendering checks pass from the
+  final non-stacked branch.

--- a/docs/spec/2026-08-07-OME-712-draco-protocol-deployment.md
+++ b/docs/spec/2026-08-07-OME-712-draco-protocol-deployment.md
@@ -39,16 +39,29 @@ artifacts. The client supplies only a Candidate expression and never receives ru
 - Case artifacts retain input, output, finish reason, Check metadata, accepted evidence, and
   rejected raw Judge output.
 
-## Asset and privacy contract
+## Asset contract
 
 - `cases.json`, per-Case criteria, and per-Case rubrics are generated from a pinned dataset
   revision during benchmark-image construction.
 - The Runner validates complete ordered Case/criteria/rubric alignment before registering any
   DRACO route or issuing a paid request.
-- Rubrics and weights exist only in the benchmark Runner image. Control-plane discovery exposes
-  metadata and executable URL4, never private grading assets.
+- Rubrics are PUBLIC. The upstream `perplexity-ai/draco` dataset downloads without credentials,
+  and each Case Result publishes the requirement text, weight, and axis of every graded criterion.
+  Grading assets ship in the benchmark Runner image for isolation of concerns — they change for
+  reasons unrelated to the engine and grow as Benchmarks are added — not as a secrecy boundary.
+  Control-plane discovery still exposes only metadata and executable URL4, because the control
+  plane has no reason to carry benchmark assets.
+- `cases.json` carries no rubric. That is a protocol boundary, not a secrecy one: the Candidate
+  must not be handed the criteria it is about to be graded against.
 - The benchmark image is version-coupled to the URL4 Cloud release and selected independently in
-  the Runner Job template.
+  the Runner Job template. A benchmark-only change therefore still rides an engine version bump;
+  independent Benchmark versioning needs an explicit tag plus a Runner compatibility check.
+
+## Not guaranteed
+
+- A Candidate Result is not an attestation. Nothing binds an executed expression to the published
+  protocol, so a submitted result document proves only its own internal consistency. Any consumer
+  that treats a score as verified must re-check it against the Engine's own run record.
 
 ## Fidelity disclosure
 

--- a/docs/work/2026-08-07-OME-712-draco-protocol-deployment.md
+++ b/docs/work/2026-08-07-OME-712-draco-protocol-deployment.md
@@ -1,0 +1,61 @@
+---
+ticket: OME-712
+stack: url4-cloud
+status: done
+started: 2026-08-07
+finished: 2026-08-07
+---
+
+# OME-712 — DRACO protocol and deployment
+
+## Intent
+
+Install the pinned DRACO benchmark as ordinary Engine-owned URL4, with deterministic scoring,
+auditable case evidence, inexpensive lite and smoke variants, and a separate Runner image that
+keeps private rubrics away from the control plane.
+
+## Planned changes
+
+- Add the DRACO definition, private runtime routes, preparation, scoring, verdict, and artifact
+  modules under `apps/url4-cloud/src/url4_cloud/benchmarks/draco/`.
+- Extend the Runner's declared model parameters and retrieval mechanisms only as required by the
+  DRACO candidate and Judge calls.
+- Build and publish a benchmark Runner image paired with the control-plane release; wire Helm to
+  schedule that image without exposing rubric assets from REST.
+- Install canonical `draco`, directional `draco/lite`, and structural `draco/smoke` resources.
+
+## Test plan
+
+- Prove pinned preparation, rubric privacy, exact Case and criterion selection, five independent
+  seeded Judge passes, official score arithmetic, failure integrity, and lossless artifacts.
+- Prove model parameters reach AI Gateway with correct types and native/Tavily retrieval remains
+  route-declared and fail-closed.
+- Prove missing or inconsistent assets fail installation before any model request.
+- Render the Helm chart and build both deployment images in CI.
+- Run URL4 Cloud formatting, lint, type, layering, full tests, and coverage gates.
+
+## Acceptance
+
+- Every installed DRACO expression runs as ordinary URL4 and returns a Candidate Result.
+- Empty, incomplete, misbound, or under-covered grading cannot publish a numeric score.
+- A resource specialized with `limit=N` binds and validates exactly N ordered Case results.
+- Canonical DRACO uses five stable seeded Judge cache slots; lite and smoke use one.
+- Rubrics exist only in the benchmark Runner image and are never addressable URL4 data.
+- Public descriptions disclose any deliberate differences from the paper protocol.
+
+## Outcome
+
+- **Actual files:** the DRACO definition/runtime/scoring/artifact modules, focused tests, required
+  Runner parameter and retrieval support, and the paired benchmark-image/Helm/release wiring.
+- **Commits:** this unit's commit (`Refs: OME-712`).
+- **Gates:** DRACO/runtime focused suites pass; Ruff, Pyright, and layering pass. The full suite is
+  652 passed / 5 skipped with two expected model-catalog failures until merged AI Gateway PR #520
+  is present in the branch ancestry.
+- **Deviations:**
+  - Public Case browsing was removed because the control plane does not carry benchmark assets;
+    it remains deferred to a dedicated public-case source.
+  - The public benchmark description discloses the successor Judge model, provider-default
+    reasoning, mixed native/Tavily retrieval, and host-only approximate blocklist, so results are
+    not presented as paper-identical.
+  - The reference 95% coverage floor is preserved: a Case at exactly 95% valid Judge evidence may
+    score, while lower coverage and every Candidate/Case execution failure remain unscored.


### PR DESCRIPTION
## Summary

- installs canonical `draco` plus explicit `draco/lite` and `draco/smoke` variants on the generic Engine Benchmark seam
- executes candidate retrieval and criterion-level judging as ordinary URL4 while keeping cases rubrics grading and aggregation Engine-owned
- preserves lossless case artifacts and fails closed when selected cases or judge evidence cannot be scored reliably
- adds a separately built benchmark Runner image and the matching Helm development and release wiring

## Protocol

- canonical DRACO: 100 cases and five independently seeded judge passes per criterion
- lite: two pinned cases ten axis-balanced criteria and one judge pass
- smoke: one pinned case one criterion and one judge pass
- exact `limit=N` selection is encoded into the fetched protocol and revalidated during reduction
- candidate retrieval uses the route's declared native-search or Tavily mechanism under the DRACO exclusion policy
- judge calls disable search and use stable seeds so the five canonical passes occupy distinct reusable cache entries

## Boundaries

- the generic Benchmark foundation remains protocol-neutral
- concrete DRACO registration is isolated in `benchmarks/builtins.py`
- private rubrics and weights exist only in the benchmark Runner image
- Runner extractions remain provider-neutral and contain no DRACO scoring rules
- no URL4 package AI Gateway or ScreamingFace client files are changed

## Fidelity disclosure

This reproduction preserves DRACO's grading arithmetic and five-pass structure but is not paper-identical. It uses the successor judge model provider-default reasoning mixed native/Tavily retrieval and a host-only approximation of the reference blocklist. Relevant protocol and asset choices are included in the benchmark revision.

## Verification

- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run pyright`
- full URL4 Cloud suite: 1116 passed and 5 skipped
- layering check passed
- Helm rendering was not run locally because Helm is unavailable on this macOS environment; Linux CI is authoritative

Linear: [OME-712](https://linear.app/openmined/issue/OME-712/run-draco-end-to-end-as-a-url4-expression-on-the-runner-path)
