### PR TITLE
fix(scoreboard): disable Kubernetes service links so they can't poison SCOREBOARD_ config

### DIFF
--- a/apps/scoreboard/charts/scoreboard/templates/deployment.yaml
+++ b/apps/scoreboard/charts/scoreboard/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      # These Pods read no Kubernetes service-link variables, and the injected
+      # SCOREBOARD_* names collide with this app's own SCOREBOARD_ config prefix.
+      enableServiceLinks: false
       serviceAccountName: {{ include "scoreboard.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/apps/scoreboard/charts/scoreboard/templates/job-migrate.yaml
+++ b/apps/scoreboard/charts/scoreboard/templates/job-migrate.yaml
@@ -21,6 +21,9 @@ spec:
         {{- include "scoreboard.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: migrate
     spec:
+      # See deployment.yaml — the injected SCOREBOARD_* service-link variables
+      # collide with this app's own SCOREBOARD_ config prefix.
+      enableServiceLinks: false
       restartPolicy: OnFailure
       serviceAccountName: {{ .Values.migration.serviceAccountName | quote }}
       {{- with .Values.imagePullSecrets }}

--- a/apps/scoreboard/charts/scoreboard/templates/job-seed-benchmarks.yaml
+++ b/apps/scoreboard/charts/scoreboard/templates/job-seed-benchmarks.yaml
@@ -21,6 +21,9 @@ spec:
         {{- include "scoreboard.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: seed-benchmarks
     spec:
+      # See deployment.yaml — this is the Pod the collision actually killed: it
+      # builds the Settings object, where migrate only reads the database URL.
+      enableServiceLinks: false
       restartPolicy: OnFailure
       serviceAccountName: {{ .Values.seedBenchmarks.serviceAccountName | quote }}
       {{- with .Values.imagePullSecrets }}


### PR DESCRIPTION
## Summary

Kubernetes injects a set of environment variables into every Pod for each Service in the same namespace, named after the Service. A Service named `scoreboard` produces `SCOREBOARD_PORT=tcp://10.0.48.109:9106`. The app reads its own configuration from variables with the prefix `SCOREBOARD_` and has a `port` setting — so that injected value lands directly on it, and startup fails:

```
seed.py: error: 1 validation error for Settings
port
  Input should be a valid integer, unable to parse string as an integer
  [type=int_parsing, input_value='tcp://10.0.48.109:9106', input_type=str]
```

This adds `enableServiceLinks: false` to the three Pod specs the chart owns, which turns that legacy injection off. Nothing in this chart or the app reads those variables.

## Why it hasn't bitten before

Two things hide it, which is what makes it worth fixing in the chart rather than in each deployment's values:

- **The server Pod is immune by accident.** Its `envFrom` ConfigMap sets `SCOREBOARD_PORT` explicitly, and an explicitly declared variable overrides an injected service link. So the API comes up fine and looks healthy.
- **`migrate` passes while `seed` fails.** Both hook Jobs get the poisoned value (neither has `envFrom`), but `migrate` only reads `SCOREBOARD_DATABASE_URL` and never constructs the `Settings` object. `seed` does, so it is the only one that ever validates the field.

The result is a deploy where the Service, the Deployment and the migration all succeed and only the post-install seed fails — which reads like a database or network problem rather than a configuration one. It took a fair amount of digging on our side to land on the real cause, which is the main reason we're sending this rather than just keeping our workaround.

## Why the obvious workaround isn't enough

We hit this because we set `fullnameOverride: scoreboard`, which made the Service name exactly equal to the config prefix. Your default naming (`<release>-scoreboard`) produces `DEV_SCOREBOARD_PORT` and doesn't collide, so **this is not a bug you would see with default values**.

We've already worked around it on our side by renaming the Service. But the collision depends only on a Service name uppercasing into the `SCOREBOARD_` prefix, so it returns for anyone who sets `fullnameOverride: scoreboard`, and it would return for us if a future Service in that namespace were named `scoreboard-something`. Turning the injection off removes the whole class rather than one instance of it.

## Components touched

`apps/scoreboard` — chart templates only. No app code, no values schema change, no new inputs, no behaviour change for anything that currently works.

## What the change is

One line in each of the three Pod specs, with a short comment so the reason survives:

```yaml
    spec:
      # These Pods read no Kubernetes service-link variables, and the injected
      # SCOREBOARD_* names collide with this app's own SCOREBOARD_ config prefix.
      enableServiceLinks: false
```

- `templates/deployment.yaml` — above `serviceAccountName`
- `templates/job-migrate.yaml` — above `restartPolicy`
- `templates/job-seed-benchmarks.yaml` — above `restartPolicy`

Total diff is +9 lines, no deletions.

## Test plan

- [x] `helm template` with default values → all three Pod specs carry `enableServiceLinks: false`; no other object changes (`git diff --stat` is 3 files, +9/-0)
- [x] `helm template --set fullnameOverride=scoreboard` → renders clean, Service is named `scoreboard`; this is exactly the configuration that produced the failure above
- [x] `helm lint` → 0 charts failed
- [ ] Not re-run on a live deploy: our cluster is currently on the renamed-Service workaround, so reproducing the original failure would mean deliberately breaking a running deployment. The failure and the fix are both evidenced from that incident — the seed Job's own container output is quoted above, and the same Job completed once the collision was removed.

## Cross-service notes

Disabling service links only removes the Docker-compatibility environment variables. **DNS is unaffected** — `scoreboard-db.<namespace>.svc` and every other Service name still resolve exactly as before, which is how this chart actually reaches its database. Nothing in the templates or the app reads a `*_SERVICE_HOST` / `*_PORT` variable.

If you'd rather make this a value than a fixed setting, we're happy either way — we suggested the fixed form because there's no configuration in which this app benefits from the injection, and a knob is one more thing to get wrong.

---

## Update 2026-09-09: the "future Service" case is no longer hypothetical

The section above says the collision would return for us "if a future Service in that namespace were named `scoreboard-something`". That has now happened. The namespace holds a `scoreboard-db` Service, and the running app Pod carries seven injected variables inside its own config prefix:

```
SCOREBOARD_DB_PORT=tcp://10.0.71.140:5432
SCOREBOARD_DB_PORT_5432_TCP=tcp://10.0.71.140:5432
SCOREBOARD_DB_PORT_5432_TCP_ADDR=10.0.71.140
SCOREBOARD_DB_PORT_5432_TCP_PORT=5432
SCOREBOARD_DB_PORT_5432_TCP_PROTO=tcp
SCOREBOARD_DB_SERVICE_HOST=10.0.71.140
SCOREBOARD_DB_SERVICE_PORT=5432
```

Nothing breaks today, because `Settings` is declared with `extra="ignore"` and no field is named `db_*`. That is the only thing standing between this and a repeat: adding any setting whose name starts with `db_` silently takes the service-link value instead of the intended one, and `SCOREBOARD_DB_PORT` is a URL string that fails integer coercion exactly as `port` did.

Renaming the Service fixed one instance. It cannot fix this one, because the prefix now collides through a second Service we need. That is the case for turning the injection off in the chart.

Verified on the pull-request head: all three Pod specs in the chart are covered, and `helm template` renders three `enableServiceLinks: false` lines with no other change.
