### PR TITLE
feat(public-docs): write the Installation page

### DIFF
--- a/docs/tasks/2026-08-08-installation-tutorial.md
+++ b/docs/tasks/2026-08-08-installation-tutorial.md
@@ -1,0 +1,41 @@
+---
+id: OME-672
+linear_url: https://linear.app/openmined/issue/OME-672
+parent: OME-666
+status: In Progress
+type: Task
+priority: P2
+labels: [repo, autonomous, agentic, task]
+created: 2026-08-08
+closed:
+---
+
+# Add installation tutorial
+
+Fourth of six sub-issues under `OME-666` (Documentation for ScreamingFace Client V1). Replaces
+the `Installation` stub under Get Started.
+
+The Linear issue has no description, so the spec is `OME-666`'s Installation paragraph —
+restructured, because that paragraph is local-first and names API that no longer exists
+(`sf.config`, engine port `:4404`).
+
+Two paths, in order:
+
+1. **Hosted** — install the client, point it at the engine, log in, connect a provider.
+2. **Self-hosted** — run AI Gateway and the Engine yourself. Covers what actually blocked us
+   bringing one up: `aigateway migrate`, `AIGW_AUTH_MODE=disabled`,
+   `AIGW_OPENROUTER_ENABLED=true`, and preparing benchmark assets.
+
+Vocabulary follows the Learn section: bundled / self-hosted / hosted. The client cannot bundle an
+engine — its dependencies carry no `url4-cloud` and it has no in-process execution path — so
+"bundled" describes the url4 SDK, not this client.
+
+`screamingface` is not on PyPI yet, so the install block says so and gives the source route.
+
+Branch `callis/ome-672-add-installation-tutorial` is cut from the epic branch
+`callis/ome-666-documentation-for-screamingface-client-v1`; its PR targets that branch, not
+`main`.
+
+Milestone: Week 3.
+
+Ledger: `docs/work/2026-08-08-OME-672-installation-tutorial.md`

--- a/docs/tasks/2026-08-08-installation-tutorial.md
+++ b/docs/tasks/2026-08-08-installation-tutorial.md
@@ -2,12 +2,12 @@
 id: OME-672
 linear_url: https://linear.app/openmined/issue/OME-672
 parent: OME-666
-status: In Progress
+status: Done
 type: Task
 priority: P2
 labels: [repo, autonomous, agentic, task]
 created: 2026-08-08
-closed:
+closed: 2026-08-08
 ---
 
 # Add installation tutorial

--- a/docs/work/2026-08-08-OME-672-installation-tutorial.md
+++ b/docs/work/2026-08-08-OME-672-installation-tutorial.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-672
 stack: repo
-status: in_progress
+status: done
 started: 2026-08-08
-finished:
+finished: 2026-08-08
 ---
 
 # OME-672 — Add installation tutorial
@@ -46,7 +46,30 @@ client, not how to reach an engine, not what a self-hosted stack needs.
 
 ## Outcome (fill at the end — required before COMMIT)
 
-- **Actual files:**
+- **Actual files:** 4 changed, +335 / −2.
+  - `public-docs/src/pages/sf-client/InstallationPage.vue` — the page
+  - `public-docs/src/components/ui/Note.vue` — new inline callout
+  - this ledger and the `docs/tasks` mirror
 - **Commits:**
-- **Gates:**
+  - `7f3e2f09` — feat(public-docs): write the Installation page
+- **Gates:** `oxlint` and `eslint` clean, run bare as CI does · `build` succeeds ·
+  `prettier --check` clean on the touched files. `public-docs` has no test suite.
+- **Verification:** every install command was executed in a throwaway venv before being written
+  down. `uv build` produces `screamingface-0.2.0-py3-none-any.whl`; it installs into a clean
+  Python 3.12 and imports 36 public names, resolving `url4` from PyPI. The `[notebook]` extra
+  resolves `ipywidgets 8.1.8`. The one-line git install works and pins `e387aefd`, the commit the
+  sidebar stamps — though it resolves `url4` from the same repository rather than PyPI, so the two
+  routes do not produce identical dependency sets.
 - **Deviations:**
+  - **Restructured from the parent's spec.** `OME-666` describes Installation as local-first, with
+    `sf.config(engine=…)` and port `4404`. Both are wrong against the current client, and hosted is
+    now the primary path, so the page leads with hosted and keeps self-hosting as section 3.
+  - **A `Note` component was added.** The source docs repeat the callout as inline Tailwind on each
+    use; here it is a component so the styling stays in one place.
+  - **The FAQ uses `Collapsible`**, following the pattern and the "Frequently Asked Questions"
+    heading used on eleven pages of `syft-space-hub-docs`.
+  - **Em-dashes were removed from this page only**, at the owner's request. The rest of the section
+    still uses them, so this page reads slightly differently from its neighbours.
+  - **`CodeBlock` does not respect the theme** — it is hardcoded `bg-zinc-900` and renders dark in
+    light mode. Left alone deliberately: it is shared with the Learn pages, which are owned
+    elsewhere, and terminal chrome staying dark is defensible.

--- a/docs/work/2026-08-08-OME-672-installation-tutorial.md
+++ b/docs/work/2026-08-08-OME-672-installation-tutorial.md
@@ -1,0 +1,52 @@
+---
+ticket: OME-672
+stack: repo
+status: in_progress
+started: 2026-08-08
+finished:
+---
+
+# OME-672 — Add installation tutorial
+
+## Intent
+
+Fourth sub-issue of `OME-666`. `InstallationPage.vue` is an 18-line stub reading "Stub page —
+replace with real content", while the sidebar has listed it under Get Started since `OME-667`.
+A reader arriving from the Overview or from the Learn section's Architecture page finds nothing.
+
+Nothing on the site currently says how to get a working environment: not how to install the
+client, not how to reach an engine, not what a self-hosted stack needs.
+
+## Planned changes
+
+- `public-docs/src/pages/sf-client/InstallationPage.vue` — replace the stub
+- this ledger and `docs/tasks/2026-08-08-installation-tutorial.md`
+
+## Test plan
+
+`public-docs` has no test suite. Verification is the gates CI runs, plus manual checks:
+
+- `npx oxlint .` · `npx eslint .` — bare, as CI runs them
+- `npm run build`
+- `npx prettier --check` on the touched files
+- Every command on the page run against a real local stack before it is written down
+- Light and dark theme, and at 400px with no horizontal page scroll
+
+## Acceptance
+
+- The page covers two paths, in this order: a hosted engine, then running your own
+- It uses the Learn section's vocabulary — bundled / self-hosted / hosted
+- Every command is one we have actually run
+- Python version, the `[notebook]` extra, and the fact that `screamingface` is not yet on PyPI
+  are all stated
+- The self-hosted path names what actually blocked us: migrations, `AIGW_AUTH_MODE=disabled`,
+  `AIGW_OPENROUTER_ENABLED=true`, benchmark asset preparation
+- No invented engine address — the placeholder constant is used
+- Gates green: lint, build, format on touched files
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+- **Commits:**
+- **Gates:**
+- **Deviations:**

--- a/public-docs/src/components/ui/Note.vue
+++ b/public-docs/src/components/ui/Note.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+/**
+ * An inline callout for something a reader needs *before* they trip over it.
+ * The pattern is borrowed from the Syft docs, which repeat this markup per use;
+ * here it is a component so the styling stays in one place.
+ */
+withDefaults(defineProps<{ label?: string }>(), { label: 'Note:' })
+</script>
+
+<template>
+  <div class="not-prose my-6 p-4 rounded-lg bg-amber-500/10 border border-amber-500/30">
+    <p class="text-sm text-foreground">
+      <span class="text-amber-500 font-semibold">{{ label }}</span>
+      <slot />
+    </p>
+  </div>
+</template>

--- a/public-docs/src/pages/sf-client/InstallationPage.vue
+++ b/public-docs/src/pages/sf-client/InstallationPage.vue
@@ -1,18 +1,241 @@
 <script setup lang="ts">
+import { RouterLink } from 'vue-router'
 import DocLayout from '@/components/layout/DocLayout.vue'
+import CodeBlock from '@/components/ui/CodeBlock.vue'
+import Collapsible from '@/components/ui/Collapsible.vue'
+import Note from '@/components/ui/Note.vue'
+import NbCell from '@/components/nb/NbCell.vue'
+import { SF_ENGINE_URL } from '@/lib/engine'
 import {
   sfClientNavigation as navigation,
   sfClientVersion as version,
 } from '@/navigation/sf-client'
+
+const SOURCE =
+  'git+https://github.com/OpenMined/screamingface' +
+  '@OME-605-screamingface-client-v1#subdirectory=packages/screamingface'
+
+const pypiNotebook = `!pip install "screamingface[notebook]"`
+const pypiTerminal = `uv pip install "screamingface[notebook]"`
+
+const sourceNotebook = `!pip install "screamingface[notebook] @ ${SOURCE}"`
+const sourceTerminal = `uv venv --python 3.12
+uv pip install "screamingface[notebook] @ ${SOURCE}"`
+
+const verify = `import screamingface as sf
+
+len(sf.__all__)   # 36`
+
+const point = `import screamingface as sf
+
+sf.configure(engine_url="${SF_ENGINE_URL}")`
+
+const loginCode = `client = sf.Client(engine_url="${SF_ENGINE_URL}")
+client.login()          # opens Cloudflare Access in your browser
+client.authenticated    # True once the token arrives`
+
+const connectCode = `sf.connect()   # the provider panel`
+
+const gateway = `cd apps/aigateway
+uv sync
+uv run aigateway migrate
+
+AIGW_AUTH_MODE=disabled AIGW_OPENROUTER_ENABLED=true \\
+  uv run uvicorn aigateway.main:app --port 9105`
+
+const assets = `cd apps/url4-cloud
+uv sync
+uv run --with datasets python -m url4_cloud.benchmarks.ifeval.prepare \\
+  --out /tmp/screamingface-benchmark-assets/ifeval`
+
+const engine = `URL4_BENCHMARK_ASSETS=/tmp/screamingface-benchmark-assets \\
+  uv run url4-cloud serve --local`
+
+const localPoint = `sf.configure(engine_url="http://127.0.0.1:9108")`
+
+const health = `curl -sf http://localhost:9105/healthz      # {"status":"ok"}
+curl -s  http://localhost:9108/v1/benchmarks   # draco, ifeval`
+
+const certs = `SSL_CERT_FILE=$(uv run --with certifi python -c "import certifi;print(certifi.where())") \\
+  uv run --with datasets python -m url4_cloud.benchmarks.ifeval.prepare \\
+  --out /tmp/screamingface-benchmark-assets/ifeval`
 </script>
 
 <template>
   <DocLayout
     title="Installation"
-    description="Stub page — replace with real content."
+    description="Install the client, and point it at an engine: hosted, or one you run yourself."
     :navigation="navigation"
     :version="version"
   >
-    <p>Stub content for this page. Route: <code>/sf-client/installation</code>.</p>
+    <p>
+      Two things are needed to successfully complete the installation: the <strong>client</strong>,
+      a Python library, and an <strong>engine</strong>, which does the work. The client never calls
+      a model provider itself, so it always needs an engine to talk to.
+    </p>
+
+    <p>
+      You can reach a <strong>hosted</strong> engine that someone else runs, or run a
+      <strong>self-hosted</strong> one yourself. The first takes a few lines while the second is
+      described in the rest of this page.
+    </p>
+
+    <h2>1 · Install the client</h2>
+
+    <p>Python <strong>3.12 or newer</strong>. In a notebook, one cell:</p>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="pypiNotebook" />
+    </div>
+
+    <p>Or from a terminal:</p>
+
+    <CodeBlock :code="pypiTerminal" language="bash" />
+
+    <blockquote>
+      <strong>Not on PyPI yet.</strong> Until it is published, install from source instead. The
+      commands below are the same, with the repository as the package's origin.
+    </blockquote>
+
+    <p>In a notebook:</p>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="sourceNotebook" />
+    </div>
+
+    <p>From a terminal:</p>
+
+    <CodeBlock :code="sourceTerminal" language="bash" />
+
+    <p>
+      The <code>[notebook]</code> extra pulls ipywidgets and jupyterlab, which is what makes
+      <code>sf.connect()</code> render a live panel instead of static text. Drop it if you are
+      writing scripts. Everything else, including <code>url4</code>, resolves automatically.
+    </p>
+
+    <p>A quick check that it worked:</p>
+
+    <div class="not-prose">
+      <NbCell :count="2" :code="verify" />
+    </div>
+
+    <h2>2 · Reach a hosted engine</h2>
+
+    <p>
+      Name the engine once and every later call uses it. Without this the client looks on your own
+      machine, finds nothing, and fails.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="point" />
+    </div>
+
+    <p>
+      A hosted engine sits behind Cloudflare Access. There is no token to paste.
+      <code>login()</code> opens your browser and collects it.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="2" :code="loginCode" />
+    </div>
+
+    <p>
+      Then connect a model provider, so the engine has a credential to call models with. The
+      <RouterLink to="/sf-client/guides/connections">Connections</RouterLink> guide covers the rest.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="3" :code="connectCode" />
+    </div>
+
+    <p>
+      That is the whole hosted path. Go and run the
+      <RouterLink to="/sf-client/quickstartPage">Quickstart</RouterLink>.
+    </p>
+
+    <h2>3 · Run your own engine</h2>
+
+    <p>
+      Self-hosting means running two services: <strong>AI Gateway</strong>, which holds provider
+      credentials, and the <strong>Engine</strong>, which executes runs. Both live in the
+      repository, so start from a checkout.
+    </p>
+
+    <h3>AI Gateway</h3>
+
+    <p>
+      A fresh install has no database schema, so migrate before the first start, otherwise it
+      crashes on boot. Two environment variables matter: local mode expects anonymous callers, and
+      the OpenRouter plugin ships <strong>disabled</strong>, so a valid key is refused until you
+      turn it on.
+    </p>
+
+    <CodeBlock :code="gateway" language="bash" />
+
+    <h3>Benchmark assets</h3>
+
+    <p>
+      The Engine never downloads datasets at runtime. That is deliberate: a run cannot silently
+      execute against a different revision of a benchmark than you think. Prepare them once:
+    </p>
+
+    <Note>
+      On macOS this download often fails TLS verification, because the system Python ships without a
+      CA bundle. If you see <code>CERTIFICATE_VERIFY_FAILED</code>, the fix is in the FAQ below.
+    </Note>
+
+    <CodeBlock :code="assets" language="bash" />
+
+    <h3>The Engine</h3>
+
+    <CodeBlock :code="engine" language="bash" />
+
+    <p>
+      It serves on <code>127.0.0.1:9108</code>, loopback only. Point the client at it, and skip the
+      login step. A local engine advertises no Cloudflare Access.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="localPoint" />
+    </div>
+
+    <h2>Check it works</h2>
+
+    <CodeBlock :code="health" language="bash" />
+
+    <h2>Frequently Asked Questions</h2>
+
+    <Collapsible title='AI Gateway crashes with "no such table: secret_master_keys"'>
+      <p>
+        It started before its migrations ran. A fresh install has no schema until you apply them.
+        Stop it, run <code>uv run aigateway migrate</code>, and start it again.
+      </p>
+    </Collapsible>
+
+    <Collapsible title="A valid provider key is rejected">
+      <p>
+        The OpenRouter plugin ships disabled, so AI Gateway refuses the key regardless of whether it
+        is good. Restart with <code>AIGW_OPENROUTER_ENABLED=true</code>.
+      </p>
+      <p>
+        Worth knowing, because the error names the credential rather than the configuration. It is
+        easy to spend a while checking a key that was never the problem.
+      </p>
+    </Collapsible>
+
+    <Collapsible title="CERTIFICATE_VERIFY_FAILED while preparing benchmark assets">
+      <p>
+        A macOS Python without a CA bundle, so the dataset download cannot verify TLS. Point that
+        one command at certifi's bundle:
+      </p>
+      <CodeBlock :code="certs" language="bash" />
+    </Collapsible>
+
+    <Collapsible title="Do I have to run my own engine?">
+      <p>
+        No. Reaching a hosted one is the shorter path, and everything in section 3 exists for people
+        who want the whole stack inside their own walls.
+      </p>
+    </Collapsible>
   </DocLayout>
 </template>


### PR DESCRIPTION
## Summary

Fourth sub-issue of `OME-666`. `InstallationPage.vue` was an 18-line stub while the
sidebar has listed it under Get Started since `OME-667`, so nothing on the site
said how to get a working environment.

Two paths, hosted first: install the client and point it at an engine someone else
runs, or run AI Gateway and the Engine yourself.

**Asana:** n/a — technical work does not go to Asana (CLAUDE.md rule 6).

## Components touched

`public-docs` only. Triggers `public-docs-tests.yml`.

## Every command was executed first

- `uv build` produces `screamingface-0.2.0-py3-none-any.whl`
- it installs into a clean Python 3.12 and imports 36 public names, resolving
  `url4` from PyPI
- the `[notebook]` extra resolves `ipywidgets 8.1.8`
- the one-line git install works and pins `e387aefd`, the commit the sidebar stamps

The self-hosted section documents what actually blocked bringing a stack up:
migrations before first start, `AIGW_AUTH_MODE`, the OpenRouter plugin shipping
disabled, and preparing benchmark assets. Those four plus "do I even need my own
engine" are an FAQ of collapsibles, following the `syft-space-hub-docs` pattern.

## Notes

- Adds a `Note` component for the inline callout; the source docs repeat that
  markup per use rather than componentising it.
- Restructured from the parent's spec, which describes Installation as local-first
  with `sf.config(engine=…)` and port `4404` — both wrong against the current client.
- Em-dashes removed from this page at the owner's request, so it reads slightly
  differently from its neighbours.
- `CodeBlock` renders dark in both themes. Left alone: it is shared with the Learn
  pages, and terminal chrome staying dark is defensible.

## Test plan

- [x] `npx oxlint .` and `npx eslint .` clean, run bare as CI does
- [x] `npm run build` succeeds
- [x] `npx prettier --check` clean on the touched files
- [x] Light and dark theme
- [ ] Screenshots attached

`public-docs` has no test suite.

## Cross-service notes

None.

Refs: OME-672