### PR TITLE
docs(public-docs): API reference for the core classes

### DIFF
--- a/docs/tasks/2026-08-08-api-reference-core-classes.md
+++ b/docs/tasks/2026-08-08-api-reference-core-classes.md
@@ -2,12 +2,12 @@
 id: OME-670
 linear_url: https://linear.app/openmined/issue/OME-670
 parent: OME-666
-status: In Progress
+status: Done
 type: Task
 priority: P2
 labels: [repo, autonomous, agentic, task]
 created: 2026-08-08
-closed:
+closed: 2026-08-09
 ---
 
 # Generate API reference for core classes
@@ -41,6 +41,10 @@ Modules, top-level functions, errors, warnings and event types belong to `OME-67
 own list is half-dead too (`sf.graders`, `sf.aggregators`, `sf.reducers`, `sf.tools` do not exist,
 and `sf.config` is `sf.configure`), so it gains `sf.events`, `sf.errors` and `sf.warnings`, which
 no ticket specified.
+
+A prose pass over the Overview and the six user guides was folded into this ticket at the owner's
+direction, so the whole SF Client section reads consistently. `QuickstartPage.vue` is excluded: its
+samples still target the pre-`OME-605` API and are due a rewrite that will cover its copy too.
 
 Branch `callis/ome-670-generate-api-reference-for-core-classes` is cut from the epic branch
 `callis/ome-666-documentation-for-screamingface-client-v1`; its PR targets that branch, not `main`.

--- a/docs/tasks/2026-08-08-api-reference-core-classes.md
+++ b/docs/tasks/2026-08-08-api-reference-core-classes.md
@@ -1,0 +1,50 @@
+---
+id: OME-670
+linear_url: https://linear.app/openmined/issue/OME-670
+parent: OME-666
+status: In Progress
+type: Task
+priority: P2
+labels: [repo, autonomous, agentic, task]
+created: 2026-08-08
+closed:
+---
+
+# Generate API reference for core classes
+
+Fifth of six sub-issues under `OME-666` (Documentation for ScreamingFace Client V1). Adds the API
+reference for the classes a reader constructs or reads.
+
+The Linear issue has no description, so the spec is `OME-666`'s API-reference paragraph. Its list
+of six core classes does not survive contact with the client: `sf.Case` is `CaseInfo` and carries
+only an id and a prompt, `sf.StudyReport` was merged into `Report`, and the paragraph omits most
+of the surface. Eighteen of the 36 names in `__all__` are class-shaped.
+
+Four pages, grouped by what a reader is doing, rather than one page per class — thirteen of the
+eighteen would be a single table:
+
+```
+API REFERENCE
+  ▸ Core classes
+      Recipes      Recipe · Model · Fusion · CorrectiveEnsemble
+      Benchmarks   Benchmark · BenchmarkInfo · CaseInfo · ModelInfo
+      Reports      Report · CandidateResult · MemberResult · OperationInfo · Usage · Failure
+      Clients      Client · AsyncClient · Connection · ConnectionPanel
+```
+
+Two depths. Eight classes you construct or call get a full entry: signature, what it is,
+parameters, returns, raises where the source raises, and one executed line. Ten you read but never
+construct get a field table, because a "runnable line" for `Failure` or `MemberResult` would be
+invented.
+
+Modules, top-level functions, errors, warnings and event types belong to `OME-671`. That ticket's
+own list is half-dead too (`sf.graders`, `sf.aggregators`, `sf.reducers`, `sf.tools` do not exist,
+and `sf.config` is `sf.configure`), so it gains `sf.events`, `sf.errors` and `sf.warnings`, which
+no ticket specified.
+
+Branch `callis/ome-670-generate-api-reference-for-core-classes` is cut from the epic branch
+`callis/ome-666-documentation-for-screamingface-client-v1`; its PR targets that branch, not `main`.
+
+Milestone: Week 3.
+
+Ledger: `docs/work/2026-08-08-OME-670-api-reference-core-classes.md`

--- a/docs/work/2026-08-08-OME-670-api-reference-core-classes.md
+++ b/docs/work/2026-08-08-OME-670-api-reference-core-classes.md
@@ -1,0 +1,62 @@
+---
+ticket: OME-670
+stack: repo
+status: in_progress
+started: 2026-08-08
+finished:
+---
+
+# OME-670 — API reference for core classes
+
+## Intent
+
+Fifth sub-issue of `OME-666`. The six user guides list their "Main APIs" as unlinked code because
+no reference exists to link to. This adds it for the classes a reader constructs or reads.
+
+The Linear issue has no description, so the spec is `OME-666`'s API-reference paragraph. That
+paragraph names six core classes; two of them do not exist (`sf.Case` is `CaseInfo`,
+`sf.StudyReport` was merged into `Report`) and it omits most of the surface. `__all__` exports 36
+names; the class-shaped ones are eighteen.
+
+## Planned changes
+
+- `public-docs/src/pages/sf-client/api/RecipesPage.vue` — Recipe, Model, Fusion,
+  CorrectiveEnsemble
+- `public-docs/src/pages/sf-client/api/BenchmarksPage.vue` — Benchmark, BenchmarkInfo, CaseInfo,
+  ModelInfo
+- `public-docs/src/pages/sf-client/api/ReportsPage.vue` — Report, CandidateResult, MemberResult,
+  OperationInfo, Usage, Failure
+- `public-docs/src/pages/sf-client/api/ClientsPage.vue` — Client, AsyncClient, Connection,
+  ConnectionPanel
+- `public-docs/src/navigation/sf-client.ts` — an `API Reference` group with a `Core classes`
+  subgroup
+- `public-docs/src/router/index.ts` — four routes under `/sf-client/api/`
+- `public-docs/CLAUDE.md` — routes and navigation tables
+- this ledger and `docs/tasks/2026-08-08-api-reference-core-classes.md`
+
+## Test plan
+
+`public-docs` has no test suite. Verification is the gates CI runs, plus:
+
+- Every signature copied from source at `e387aefd`, not reconstructed from memory
+- Every runnable line executed against a local engine before being written down
+- Constraints stated only where the source raises explicitly
+- `npx oxlint .` · `npx eslint .` · `npm run build` · `prettier --check` on touched files
+- Light and dark theme, and 400px with no horizontal page scroll
+
+## Acceptance
+
+- Eighteen classes documented across four pages, grouped by what a reader is doing
+- Eight full entries: signature, what it is, parameters, returns, raises where applicable, one
+  runnable line
+- Ten field tables: name, type, meaning, no invented examples
+- No name appears that is absent from `__all__` at `e387aefd`
+- Modules, top-level functions, errors, warnings and event types are absent; they are `OME-671`
+- Gates green: lint, build, format on touched files
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+- **Commits:**
+- **Gates:**
+- **Deviations:**

--- a/docs/work/2026-08-08-OME-670-api-reference-core-classes.md
+++ b/docs/work/2026-08-08-OME-670-api-reference-core-classes.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-670
 stack: repo
-status: in_progress
+status: done
 started: 2026-08-08
-finished:
+finished: 2026-08-09
 ---
 
 # OME-670 — API reference for core classes
@@ -56,7 +56,26 @@ names; the class-shaped ones are eighteen.
 
 ## Outcome (fill at the end — required before COMMIT)
 
-- **Actual files:**
+- **Actual files:** as planned, plus a prose pass over
+  `public-docs/src/pages/sf-client/Index.vue` and the six pages under
+  `public-docs/src/pages/sf-client/guides/`.
 - **Commits:**
-- **Gates:**
+  - `757baff0` — the four API reference pages, nav group, routes, `public-docs/CLAUDE.md`
+  - `0c0d45c9` — prose pass over the guides and Overview
+- **Gates:** `npx oxlint .`, `npx eslint .`, `npm run build` and
+  `prettier --check` all green. Sidebar nesting and long-repr wrapping confirmed
+  visually by the owner at three levels of navigation depth.
 - **Deviations:**
+  - The `OME-666` spec named six core classes, two of which do not exist
+    (`sf.Case` is `CaseInfo`; `sf.StudyReport` was merged into `Report`). The
+    page set follows `__all__` at `e387aefd` instead: eighteen class-shaped
+    names across four pages.
+  - `sf.MAX_ATTEMPTS` is exported from `corrective.py` but not re-exported at
+    package level, so the retry cap is stated as prose rather than referenced.
+  - Union types in tables use non-breaking spaces so a type cannot break across
+    lines.
+  - The prose pass over the guides and Overview was added to this ticket at the
+    owner's direction rather than filed separately. `QuickstartPage.vue` was
+    excluded: its samples still target the pre-`OME-605` API and are due a
+    rewrite that will cover its copy too.
+  - Work happened in the shared checkout rather than a per-unit worktree.

--- a/public-docs/CLAUDE.md
+++ b/public-docs/CLAUDE.md
@@ -59,7 +59,15 @@ There is no automated test setup in this project.
 | `/sf-client/guides/benchmarks` | `src/pages/sf-client/guides/BenchmarksPage.vue` |
 | `/sf-client/guides/running-an-evaluation` | `src/pages/sf-client/guides/EvaluationPage.vue` |
 | `/sf-client/guides/reproduce-and-share` | `src/pages/sf-client/guides/Url4Page.vue` |
+| `/sf-client/api/recipes` | `src/pages/sf-client/api/RecipesPage.vue` |
+| `/sf-client/api/benchmarks` | `src/pages/sf-client/api/BenchmarksPage.vue` |
+| `/sf-client/api/reports` | `src/pages/sf-client/api/ReportsPage.vue` |
+| `/sf-client/api/clients` | `src/pages/sf-client/api/ClientsPage.vue` |
 | `/sdk` | `src/pages/sdk/Index.vue` |
+
+Note that `BenchmarksPage.vue` exists twice — under `guides/` (how to choose a
+benchmark) and under `api/` (the `Benchmark` type). The route names
+disambiguate them.
 
 ### NotebookViewer
 
@@ -100,7 +108,7 @@ export const sfClientNavigation: NavEntry[] = [
 
 | File | Export | Used by | Entries |
 |---|---|---|---|
-| `src/navigation/sf-client.ts` | `sfClientNavigation`, `sfClientVersion` | All `/sf-client/*` pages | Overview, then **Get Started** and **User Guides** (with a nested **Compose** group) |
+| `src/navigation/sf-client.ts` | `sfClientNavigation`, `sfClientVersion` | All `/sf-client/*` pages | Overview, then **Get Started**, **User Guides** (with a nested **Compose** group) and **API Reference** (with a nested **Core classes** group) |
 | `src/navigation/sdk.ts` | `sdkNavigation` | All `/sdk/*` pages | **Getting Started**: Overview |
 
 **Versioning.** `sf-client.ts` also exports `sfClientVersion`

--- a/public-docs/src/navigation/sf-client.ts
+++ b/public-docs/src/navigation/sf-client.ts
@@ -39,4 +39,18 @@ export const sfClientNavigation: NavEntry[] = [
       { title: 'Reproduce & share (URL4)', path: '/sf-client/guides/reproduce-and-share' },
     ],
   },
+  {
+    title: 'API Reference',
+    children: [
+      {
+        title: 'Core classes',
+        children: [
+          { title: 'Recipes', path: '/sf-client/api/recipes' },
+          { title: 'Benchmarks', path: '/sf-client/api/benchmarks' },
+          { title: 'Reports', path: '/sf-client/api/reports' },
+          { title: 'Clients', path: '/sf-client/api/clients' },
+        ],
+      },
+    ],
+  },
 ]

--- a/public-docs/src/pages/sf-client/Index.vue
+++ b/public-docs/src/pages/sf-client/Index.vue
@@ -26,8 +26,8 @@ report = sf.evaluate([gpt, sf.Fusion([gpt, flash])], benchmark="ifeval", limit=3
     :version="version"
   >
     <p>
-      ScreamingFace is an open-source client for building <strong>fusions</strong> — several
-      frontier models answering the same question, combined into one — and measuring them against
+      ScreamingFace is an open-source client for building <strong>fusions</strong>, meaning several
+      frontier models answering the same question and combined into one, then measuring them against
       real benchmarks. It runs locally, and every run reproduces from a single <code>url4</code>
       expression you can share.
     </p>
@@ -36,8 +36,8 @@ report = sf.evaluate([gpt, sf.Fusion([gpt, flash])], benchmark="ifeval", limit=3
 
     <p>
       On <strong>DRACO</strong>, a 100-task deep-research benchmark, the strongest fusion scored
-      <strong>68.6%</strong> against <strong>60.2%</strong> for the best single model —
-      <strong>+8.4 points</strong>. Five separate fusions beat every individual model, so it is not
+      <strong>68.6%</strong> against <strong>60.2%</strong> for the best single model, a gain of
+      <strong>8.4 points</strong>. Five separate fusions beat every individual model, so it is not
       one lucky pairing, and a fusion of three cheaper models reached 58.5%, ahead of Claude Opus
       4.8 alone at 51.8%.
     </p>
@@ -59,8 +59,8 @@ report = sf.evaluate([gpt, sf.Fusion([gpt, flash])], benchmark="ifeval", limit=3
 
     <p>
       <code>score</code> is each candidate's accuracy on the same cases, and higher is always
-      better. There is no separate baseline or gain — the comparison <em>is</em> putting the solo
-      model and the fusion in one run and reading both numbers.
+      better. There is no separate baseline or gain field, because the comparison <em>is</em>
+      putting the solo model and the fusion in one run and reading both numbers.
     </p>
 
     <blockquote>
@@ -73,7 +73,7 @@ report = sf.evaluate([gpt, sf.Fusion([gpt, flash])], benchmark="ifeval", limit=3
     <h2>How it works</h2>
 
     <p>
-      The client talks only to the <strong>ScreamingFace Engine</strong> — never to model providers
+      The client talks only to the <strong>ScreamingFace Engine</strong>, never to model providers
       directly. Each evaluation compiles to one <strong>url4</strong> expression, and that
       expression is the contract between them: the engine resolves it, and anyone holding it can
       reproduce the run.

--- a/public-docs/src/pages/sf-client/api/BenchmarksPage.vue
+++ b/public-docs/src/pages/sf-client/api/BenchmarksPage.vue
@@ -1,0 +1,292 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import DocLayout from '@/components/layout/DocLayout.vue'
+import CodeBlock from '@/components/ui/CodeBlock.vue'
+import NbCell from '@/components/nb/NbCell.vue'
+import NbTextOut from '@/components/nb/NbTextOut.vue'
+import Note from '@/components/ui/Note.vue'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const listRun = `import screamingface as sf
+
+client = sf.Client()
+[(b.id, b.case_count) for b in client.benchmarks.list()]`
+const listRunOut = `[('draco', 100), ('ifeval', 541)]`
+
+const casesSig = `Benchmark.cases(limit: int = 50, offset: int = 0)`
+
+const casesRun = `ifeval = client.benchmarks.get("ifeval")
+ifeval.cases(limit=3)`
+const casesRunOut = `Cases(3 of 541, offset=0)`
+
+const caseRun = `case = ifeval.cases(limit=1)[0]
+case.id, case.input[:60]`
+const caseRunOut = `(1, 'Write a 300+ word summary of the wikipedia page "https://en.')`
+
+const modelsRun = `client.models.list()[0]`
+const modelsRunOut = `ModelInfo(id='anthropic/claude-opus-4-8', provider='anthropic')`
+</script>
+
+<template>
+  <DocLayout
+    title="Benchmarks"
+    description="Benchmark and the read-only values discovery returns."
+    :navigation="navigation"
+    :version="version"
+  >
+    <p>
+      A benchmark is a fixed set of cases, owned by the Engine and pinned by a revision. This page
+      covers <code>Benchmark</code> itself, alongside <code>CaseInfo</code> for a single case inside
+      it, <code>BenchmarkInfo</code> for the compact identity a report keeps of it, and
+      <code>ModelInfo</code> for the model routes the Engine can run it against. See the
+      <RouterLink to="/sf-client/guides/benchmarks">Benchmarks guide</RouterLink> for choosing which
+      benchmark to run.
+    </p>
+
+    <p>
+      A <RouterLink to="/sf-client/api/clients">Client</RouterLink> returns these values which are
+      all read-only and assigning to a field raises
+      <code>FrozenInstanceError: cannot assign to field 'provider'</code>. They also never refresh
+      themselves and the Client needs to be called again when current data is desired.
+    </p>
+
+    <h2>Benchmark</h2>
+
+    <p>
+      A <code>Benchmark</code> is the Engine's record of one benchmark, carrying its identity, its
+      size, and access to its public cases. <code>client.benchmarks.get(id)</code> returns a single
+      benchmark and <code>client.benchmarks.list()</code> returns every benchmark the Engine offers.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="listRun"><NbTextOut :text="listRunOut" /></NbCell>
+    </div>
+
+    <h3>Attributes</h3>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>id</code></td>
+          <td><code>str</code></td>
+          <td>
+            Stable identifier, such as <code>ifeval</code>. This is what you pass as
+            <code>benchmark=</code> when evaluating.
+          </td>
+        </tr>
+        <tr>
+          <td><code>title</code></td>
+          <td><code>str</code></td>
+          <td>Display name, such as <code>IFEval</code>.</td>
+        </tr>
+        <tr>
+          <td><code>description</code></td>
+          <td><code>str</code></td>
+          <td>
+            Prose describing what the benchmark measures. For benchmarks with more than one protocol
+            it also states which method is the default and how the alternatives differ.
+          </td>
+        </tr>
+        <tr>
+          <td><code>revision</code></td>
+          <td><code>str</code></td>
+          <td>
+            Opaque content hash of this benchmark's current state. Two reports are only comparable
+            when their revisions match.
+          </td>
+        </tr>
+        <tr>
+          <td><code>case_count</code></td>
+          <td><code>int</code></td>
+          <td>How many cases the benchmark holds in total.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>cases()</h3>
+
+    <CodeBlock :code="casesSig" language="python" />
+
+    <p>
+      This method fetches one page of the benchmark's public cases from the Engine and returns them
+      as a sequence of <code>CaseInfo</code> values supporting indexing, slicing, iteration and
+      <code>len()</code>. Within a notebook the sequence renders as a table, and as a searchable
+      table where the <code>notebook</code> extra is installed.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>limit</code></td>
+          <td><code>int</code></td>
+          <td>How many cases to fetch. Defaults to 50.</td>
+        </tr>
+        <tr>
+          <td><code>offset</code></td>
+          <td><code>int</code></td>
+          <td>How many cases to skip first. Defaults to 0.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="not-prose">
+      <NbCell :count="2" :code="casesRun"><NbTextOut :text="casesRunOut" /></NbCell>
+    </div>
+
+    <p>
+      This is a live call, so it raises <code>PlanningError</code> when the Engine cannot serve the
+      benchmark's case data.
+    </p>
+
+    <h2>CaseInfo</h2>
+
+    <p>
+      A <code>CaseInfo</code> is one public case from a benchmark, carrying its identifier and the
+      exact text a candidate receives. Nothing further crosses the Engine boundary: grading criteria
+      and rubrics remain on the Engine, so a case's answer key cannot be read through this value.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>id</code></td>
+          <td><code>int</code></td>
+          <td>Position within the benchmark, counting from 1.</td>
+        </tr>
+        <tr>
+          <td><code>input</code></td>
+          <td><code>str</code></td>
+          <td>The prompt text for this case.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="not-prose">
+      <NbCell :count="3" :code="caseRun"><NbTextOut :text="caseRunOut" /></NbCell>
+    </div>
+
+    <h2>BenchmarkInfo</h2>
+
+    <p>
+      A <code>BenchmarkInfo</code> is the pinned identity of a benchmark as it stood when a run took
+      place. It is the value embedded in a
+      <RouterLink to="/sf-client/api/reports">Report</RouterLink>, which is why it carries a
+      revision but no title or description: its purpose is to make a result reproducible rather than
+      to describe the benchmark.
+    </p>
+
+    <Note>
+      <code>BenchmarkInfo.case_count</code> is the benchmark's full size, not the number of cases a
+      run covered. The two differ: after evaluating with <code>limit=1</code>,
+      <code>report.case_count</code> is <code>1</code> while
+      <code>report.benchmark.case_count</code> remains <code>541</code>.
+    </Note>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>id</code></td>
+          <td><code>str</code></td>
+          <td>The benchmark identifier.</td>
+        </tr>
+        <tr>
+          <td><code>revision</code></td>
+          <td><code>str</code></td>
+          <td>The revision the run was executed against.</td>
+        </tr>
+        <tr>
+          <td><code>case_count</code></td>
+          <td><code>int</code></td>
+          <td>
+            The benchmark's full size. For what the run covered, read
+            <code>report.case_count</code>.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>ModelInfo</h2>
+
+    <p>
+      A <code>ModelInfo</code> is one model route the configured Engine can currently reach.
+      <code>client.models.list()</code> returns every addressable route, and consulting it before
+      naming a route in a <RouterLink to="/sf-client/api/recipes">Model</RouterLink> is worthwhile:
+      a route the Engine does not carry raises a <code>PlanningError</code> at evaluation time
+      rather than at construction time.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>id</code></td>
+          <td><code>str</code></td>
+          <td>The route, which is what you pass to <code>sf.Model()</code>.</td>
+        </tr>
+        <tr>
+          <td><code>provider</code></td>
+          <td><code>str</code></td>
+          <td>Which provider serves the route.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="not-prose">
+      <NbCell :count="4" :code="modelsRun"><NbTextOut :text="modelsRunOut" /></NbCell>
+    </div>
+
+    <h2>Validation</h2>
+
+    <p>
+      All four types validate their arguments on construction, so a malformed value cannot exist.
+      Blank strings raise <code>ValueError</code>, non-strings raise <code>TypeError</code>, and the
+      integer fields reject zero and negative values, which is why <code>case_count</code> and a
+      case <code>id</code> are always positive:
+    </p>
+
+    <CodeBlock
+      code="ValueError: Case id must be a positive integer
+ValueError: Case input must be a non-empty string
+ValueError: Benchmark case_count must be a positive integer
+ValueError: Model id must be a non-empty string"
+      language="text"
+    />
+  </DocLayout>
+</template>

--- a/public-docs/src/pages/sf-client/api/ClientsPage.vue
+++ b/public-docs/src/pages/sf-client/api/ClientsPage.vue
@@ -1,0 +1,409 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import DocLayout from '@/components/layout/DocLayout.vue'
+import CodeBlock from '@/components/ui/CodeBlock.vue'
+import NbCell from '@/components/nb/NbCell.vue'
+import NbTextOut from '@/components/nb/NbTextOut.vue'
+import Note from '@/components/ui/Note.vue'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const clientSig = `sf.Client(*, engine_url: str = "http://127.0.0.1:9108")`
+
+const basic = `import screamingface as sf
+
+client = sf.Client()
+client.engine_url, client.closed, client.authenticated`
+const basicOut = `('http://127.0.0.1:9108', False, False)`
+
+const evaluateSig = `Client.evaluate(
+    candidates: Recipe | Sequence[Recipe],
+    *,
+    benchmark: str,
+    limit: int | None = None,
+    method: str | None = None,
+    on_event: Callable[[Event], None] | None = None,
+    progress: bool | None = None,
+) -> Report`
+
+const withBlock = `with sf.Client() as client:
+    report = client.evaluate(
+        sf.Model("openrouter/anthropic/claude-haiku-4.5"),
+        benchmark="ifeval",
+        limit=1,
+        method="single_pass",
+    )`
+
+const closed = `client.close()
+client.connections.list()`
+const closedOut = `RuntimeError: ScreamingFace Client is closed`
+
+const asyncCode = `import asyncio
+import screamingface as sf
+
+async def main():
+    async with sf.AsyncClient() as client:
+        models = await client.models.list()
+        return len(models), client.engine_url
+
+asyncio.run(main())`
+const asyncOut = `(29, 'http://127.0.0.1:9108')`
+
+const connection = `client.connections.get("openrouter")`
+const connectionOut = `Connection(provider='openrouter', display_name='OpenRouter', auth_methods=('api_key',), status='connected', auth_method='api_key', account_label=None)`
+
+const panel = `client.connect()`
+const panelOut = `ConnectionPanel(engine='http://127.0.0.1:9108', openrouter=connected)`
+</script>
+
+<template>
+  <DocLayout
+    title="Clients"
+    description="Client, AsyncClient, and provider connections."
+    :navigation="navigation"
+    :version="version"
+  >
+    <p>
+      A <code>Client</code> is the connection to one Engine, and the object that every other page in
+      this reference depends on: recipes are passed to it, and benchmarks and reports come back from
+      it. This page covers <code>Client</code> itself, alongside <code>AsyncClient</code> for the
+      same interface over <code>await</code>, <code>Connection</code> for a provider's state on the
+      Engine, and <code>ConnectionPanel</code> for the interactive view that
+      <code>connect()</code> returns.
+    </p>
+
+    <h2>Client</h2>
+
+    <CodeBlock :code="clientSig" language="python" />
+
+    <p>
+      Creating a <code>Client</code> opens no connection and makes no request. The first call that
+      needs the Engine is the first one that talks to it.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="basic"><NbTextOut :text="basicOut" /></NbCell>
+    </div>
+
+    <Note>
+      The default <code>engine_url</code> points at a local Engine on port 9108. For a hosted
+      Engine, pass its address, or set <code>SCREAMINGFACE_ENGINE_URL</code> and use the
+      module-level functions.
+    </Note>
+
+    <h3>Properties</h3>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>engine_url</code></td>
+          <td><code>str</code></td>
+          <td>The Engine origin this Client was built for. Fixed for the Client's life.</td>
+        </tr>
+        <tr>
+          <td><code>closed</code></td>
+          <td><code>bool</code></td>
+          <td>Whether <code>close()</code> has run.</td>
+        </tr>
+        <tr>
+          <td><code>authenticated</code></td>
+          <td><code>bool</code></td>
+          <td>Whether this process currently holds hosted caller credentials.</td>
+        </tr>
+        <tr>
+          <td><code>authenticating</code></td>
+          <td><code>bool</code></td>
+          <td>Whether a login is in flight.</td>
+        </tr>
+        <tr>
+          <td><code>models</code></td>
+          <td>catalogue</td>
+          <td>
+            <code>models.list()</code> returns the
+            <RouterLink to="/sf-client/api/benchmarks">ModelInfo</RouterLink> routes this Engine can
+            reach.
+          </td>
+        </tr>
+        <tr>
+          <td><code>benchmarks</code></td>
+          <td>catalogue</td>
+          <td>
+            <code>benchmarks.list()</code>, <code>benchmarks.get(id)</code> and
+            <code>benchmarks.cases(id)</code>.
+          </td>
+        </tr>
+        <tr>
+          <td><code>connections</code></td>
+          <td>catalogue</td>
+          <td><code>connections.list()</code> and <code>connections.get(provider)</code>.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>evaluate()</h3>
+
+    <CodeBlock :code="evaluateSig" language="python" />
+
+    <p>
+      <code>evaluate()</code> runs one or more candidates against a benchmark and returns a
+      <RouterLink to="/sf-client/api/reports">Report</RouterLink>. This is the call that costs
+      money.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>candidates</code></td>
+          <td><code>Recipe</code> or sequence</td>
+          <td>
+            One <RouterLink to="/sf-client/api/recipes">recipe</RouterLink> or several. Several
+            candidates run independently and share one report.
+          </td>
+        </tr>
+        <tr>
+          <td><code>benchmark</code></td>
+          <td><code>str</code></td>
+          <td>The benchmark id, such as <code>ifeval</code>. Required keyword argument.</td>
+        </tr>
+        <tr>
+          <td><code>limit</code></td>
+          <td><code>int&nbsp;|&nbsp;None</code></td>
+          <td>
+            Run only this many cases. <code>None</code> runs the whole benchmark. Use a small limit
+            while you are still iterating.
+          </td>
+        </tr>
+        <tr>
+          <td><code>method</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>
+            Which protocol variant to run, such as ifeval's <code>single_pass</code>.
+            <code>None</code> runs the benchmark's default. This changes the pinned revision, so it
+            changes what the result is comparable to.
+          </td>
+        </tr>
+        <tr>
+          <td><code>on_event</code></td>
+          <td>callable</td>
+          <td>Called with each lifecycle event as the run proceeds.</td>
+        </tr>
+        <tr>
+          <td><code>progress</code></td>
+          <td><code>bool&nbsp;|&nbsp;None</code></td>
+          <td>Force the progress display on or off instead of letting it decide.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>connect() and disconnect()</h3>
+
+    <p>
+      <code>connect(provider, api_key=...)</code> stores a provider credential on the Engine and
+      returns the resulting <code>Connection</code>. <code>connect()</code> with no arguments
+      returns a <code>ConnectionPanel</code> instead. <code>disconnect(provider)</code> removes the
+      credential and is safe to call repeatedly.
+    </p>
+
+    <p>
+      Passing a key requires a secure origin: an <code>https</code> Engine, or a local one over
+      <code>http</code>. Supplying <code>api_key</code> without a provider raises
+      <code>TypeError</code>; a provider without <code>api_key</code> raises
+      <code>ValueError</code>.
+    </p>
+
+    <h3>Lifecycle</h3>
+
+    <p>
+      <code>close()</code> releases the Client's transports and is idempotent. Using a closed Client
+      raises:
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="2" :code="closed"><NbTextOut :text="closedOut" /></NbCell>
+    </div>
+
+    <p>
+      A <code>with</code> block closes it automatically, which is the form to prefer in a script:
+    </p>
+
+    <CodeBlock :code="withBlock" language="python" />
+
+    <p>
+      <code>login(timeout=300.0)</code> and <code>logout()</code> apply to hosted Engines that sit
+      behind browser-based access. A local Engine needs neither.
+    </p>
+
+    <h2>AsyncClient</h2>
+
+    <p>
+      An <code>AsyncClient</code> offers the same interface over <code>await</code> and returns the
+      same value types. It suits evaluations that run alongside other asynchronous work.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="3" :code="asyncCode"><NbTextOut :text="asyncOut" /></NbCell>
+    </div>
+
+    <p>Three differences are worth knowing:</p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Client</th>
+          <th>AsyncClient</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>close()</code></td>
+          <td><code>await aclose()</code></td>
+        </tr>
+        <tr>
+          <td><code>with</code></td>
+          <td><code>async with</code></td>
+        </tr>
+        <tr>
+          <td><code>connect()</code> may open a panel</td>
+          <td><code>connect(provider, api_key=...)</code> always requires both</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p>
+      <code>evaluate()</code>, <code>connect()</code>, <code>disconnect()</code>,
+      <code>login()</code> and <code>logout()</code> are all awaited. The properties
+      (<code>engine_url</code>, <code>closed</code>, <code>authenticated</code>) are not.
+    </p>
+
+    <h2>Connection</h2>
+
+    <p>
+      A <code>Connection</code> is sanitized provider state as the Engine reports it. It never
+      carries the credential itself, so an API key cannot be read back out of one.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="4" :code="connection"><NbTextOut :text="connectionOut" /></NbCell>
+    </div>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>provider</code></td>
+          <td><code>str</code></td>
+          <td>Identifier, such as <code>openrouter</code>.</td>
+        </tr>
+        <tr>
+          <td><code>display_name</code></td>
+          <td><code>str</code></td>
+          <td>Human-readable name, such as <code>OpenRouter</code>.</td>
+        </tr>
+        <tr>
+          <td><code>auth_methods</code></td>
+          <td><code>tuple[str, ...]</code></td>
+          <td>
+            What this provider supports: <code>api_key</code>, <code>oauth</code>, or both. Never
+            empty.
+          </td>
+        </tr>
+        <tr>
+          <td><code>status</code></td>
+          <td><code>str</code></td>
+          <td>
+            One of <code>not_connected</code>, <code>pending</code>, <code>connected</code>,
+            <code>needs_reauth</code> or <code>error</code>.
+          </td>
+        </tr>
+        <tr>
+          <td><code>auth_method</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>
+            Which method is in use, or <code>None</code> when not connected. Always one of
+            <code>auth_methods</code>.
+          </td>
+        </tr>
+        <tr>
+          <td><code>account_label</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>Which account, where the provider identifies one.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>ConnectionPanel</h2>
+
+    <p>
+      A <code>ConnectionPanel</code> is what <code>client.connect()</code> returns when called with
+      no arguments: a live view of every provider the Engine knows about. Within a notebook it
+      renders as an interactive widget, allowing a key to be pasted without placing it in a cell.
+      Outside a notebook it remains readable as a value.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="5" :code="panel"><NbTextOut :text="panelOut" /></NbCell>
+    </div>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Member</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>engine</code></td>
+          <td>The Engine origin this panel is bound to.</td>
+        </tr>
+        <tr>
+          <td><code>connections</code></td>
+          <td>The <code>Connection</code> values as of the last refresh.</td>
+        </tr>
+        <tr>
+          <td><code>authenticated</code> / <code>authenticating</code></td>
+          <td>Mirror the Client's login state.</td>
+        </tr>
+        <tr>
+          <td><code>refresh()</code></td>
+          <td>Re-read connections from the Engine and return them.</td>
+        </tr>
+        <tr>
+          <td><code>widget()</code></td>
+          <td>The notebook widget, when you want to place it yourself.</td>
+        </tr>
+        <tr>
+          <td><code>close()</code></td>
+          <td>Release the panel's background work. It does not close the Client.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p>
+      See the <RouterLink to="/sf-client/guides/connections">Connections guide</RouterLink> for
+      choosing between the panel and a direct <code>connect()</code> call.
+    </p>
+  </DocLayout>
+</template>

--- a/public-docs/src/pages/sf-client/api/RecipesPage.vue
+++ b/public-docs/src/pages/sf-client/api/RecipesPage.vue
@@ -1,0 +1,393 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import DocLayout from '@/components/layout/DocLayout.vue'
+import CodeBlock from '@/components/ui/CodeBlock.vue'
+import NbCell from '@/components/nb/NbCell.vue'
+import NbTextOut from '@/components/nb/NbTextOut.vue'
+import Note from '@/components/ui/Note.vue'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const modelSig = `sf.Model(
+    model: str,
+    *,
+    name: str | None = None,
+    prompt: str | None = None,
+    params: Mapping[str, str | int | float | bool] | None = None,
+)`
+
+const modelRun = `import screamingface as sf
+
+sf.Model("openrouter/openai/gpt-5.5", name="gpt-hot", params={"temperature": 0.9})`
+const modelRunOut = `Model('openrouter/openai/gpt-5.5', name='gpt-hot', params={'temperature': 0.9})`
+
+const fusionSig = `sf.Fusion(
+    members: Sequence[Recipe],
+    *,
+    name: str | None = None,
+    synthesizer: str | None = None,
+    prompt: str | None = None,
+    params: Mapping[str, str | int | float | bool] | None = None,
+)`
+
+const fusionRun = `opus = sf.Model("openrouter/anthropic/claude-opus-4.8")
+gpt = sf.Model("openrouter/openai/gpt-5.5", name="gpt-hot")
+
+sf.Fusion([opus, gpt], synthesizer="openrouter/openai/gpt-5.5")`
+const fusionRunOut = `Fusion(['claude-opus-4.8', 'gpt-hot'], synthesizer='openrouter/openai/gpt-5.5')`
+
+const correctiveSig = `sf.CorrectiveEnsemble(
+    members: Sequence[Model],
+    *,
+    judge: Model,
+    name: str | None = None,
+)`
+
+const correctiveRun = `sf.CorrectiveEnsemble([opus, gpt], judge=opus)`
+const correctiveRunOut = `CorrectiveEnsemble(['claude-opus-4.8', 'gpt-hot'], judge='claude-opus-4.8')`
+
+const identity = `sf.Model("openrouter/openai/gpt-5.5") == sf.Model("openrouter/openai/gpt-5.5")`
+const identityOut = `False`
+</script>
+
+<template>
+  <DocLayout
+    title="Recipes"
+    description="Recipe, Model, Fusion and CorrectiveEnsemble: the things you evaluate."
+    :navigation="navigation"
+    :version="version"
+  >
+    <p>
+      A recipe describes how to produce one answer, and is what a benchmark grades. This page covers
+      <code>Model</code> for a single model route, <code>Fusion</code> for several members combined
+      by a synthesizer, <code>CorrectiveEnsemble</code> for members that check their own drafts
+      against the benchmark's verifier, and <code>Recipe</code>, the abstract type the other three
+      satisfy.
+    </p>
+
+    <p>
+      All three constructible recipes are frozen and hold no client, so building one issues no
+      network request and can be done before connecting to anything.
+    </p>
+
+    <Note>
+      Recipes compare by identity, not by value. Two separately constructed recipes with identical
+      arguments are not equal, so they cannot be used interchangeably as dictionary keys or in sets.
+    </Note>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="identity"><NbTextOut :text="identityOut" /></NbCell>
+    </div>
+
+    <h2>Recipe</h2>
+
+    <p>
+      <code>Recipe</code> is the abstract base the other three inherit and cannot itself be
+      instantiated. It exists so that a parameter accepting any recipe can be annotated, and so that
+      a <code>Fusion</code> can hold a mixed sequence of members.
+    </p>
+
+    <p>Its only public attribute is <code>name</code>, a <code>str</code> every recipe carries.</p>
+
+    <p>Calling <code>sf.Recipe()</code> raises:</p>
+
+    <CodeBlock
+      code="TypeError: Can't instantiate abstract class Recipe without an implementation for abstract method '_recipe_marker'"
+      language="text"
+    />
+
+    <h2>Model</h2>
+
+    <p>
+      A <code>Model</code> is a single model route answering on its own. It is the simplest recipe,
+      and the baseline every other recipe is measured against. See the
+      <RouterLink to="/sf-client/guides/models">Models guide</RouterLink> for choosing a route.
+    </p>
+
+    <CodeBlock :code="modelSig" language="python" />
+
+    <h3>Parameters</h3>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>model</code></td>
+          <td><code>str</code></td>
+          <td>
+            The provider route, such as <code>openrouter/openai/gpt-5.5</code>. Required and
+            positional.
+          </td>
+        </tr>
+        <tr>
+          <td><code>name</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>
+            Label used in reports and on the leaderboard. Defaults to the segment of the route after
+            the last <code>/</code>, so <code>openrouter/openai/gpt-5.5</code> becomes
+            <code>gpt-5.5</code>.
+          </td>
+        </tr>
+        <tr>
+          <td><code>prompt</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>
+            The instruction given to the model alongside the case. When omitted the SDK supplies its
+            own default answer prompt, not the benchmark's.
+          </td>
+        </tr>
+        <tr>
+          <td><code>params</code></td>
+          <td><code>Mapping&nbsp;|&nbsp;None</code></td>
+          <td>
+            Generation overrides such as <code>temperature</code>. Values must be <code>str</code>,
+            <code>int</code>, <code>float</code> or <code>bool</code>, and floats must be finite. At
+            execution time these are merged over the SDK defaults <code>reasoning="low"</code> and
+            <code>max_output_tokens=4096</code>.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>Attributes</h3>
+
+    <p>
+      <code>model</code>, <code>name</code> and <code>prompt</code> read back what you passed.
+      <code>params</code> returns a <code>mappingproxy</code>, so the overrides cannot be mutated
+      after construction.
+    </p>
+
+    <h3>Raises</h3>
+
+    <table>
+      <thead>
+        <tr>
+          <th>When</th>
+          <th>Error</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>The route or name is not a string</td>
+          <td><code>TypeError</code></td>
+        </tr>
+        <tr>
+          <td>The route or name is empty or only whitespace</td>
+          <td><code>ValueError: model route must not be empty</code></td>
+        </tr>
+        <tr>
+          <td>The route or name contains control characters</td>
+          <td><code>ValueError</code></td>
+        </tr>
+        <tr>
+          <td>A <code>params</code> value is not a scalar, or a float is not finite</td>
+          <td><code>TypeError</code> / <code>ValueError</code></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="not-prose">
+      <NbCell :count="2" :code="modelRun"><NbTextOut :text="modelRunOut" /></NbCell>
+    </div>
+
+    <h2>Fusion</h2>
+
+    <p>
+      A <code>Fusion</code> combines two or more members: each answers, then a synthesizer model
+      reads their answers and writes the final one. That final answer is what the benchmark grades.
+      See the <RouterLink to="/sf-client/guides/fusions">Fusions guide</RouterLink> for the
+      reasoning behind the design.
+    </p>
+
+    <CodeBlock :code="fusionSig" language="python" />
+
+    <h3>Parameters</h3>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>members</code></td>
+          <td><code>Sequence[Recipe]</code></td>
+          <td>
+            At least two <code>Model</code> or <code>Fusion</code> values, in order. A
+            <code>Fusion</code> may hold another <code>Fusion</code>, so ensembles nest.
+          </td>
+        </tr>
+        <tr>
+          <td><code>name</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>
+            Defaults to the member names joined with <code>+</code>, for example
+            <code>claude-opus-4.8+gpt-hot</code>.
+          </td>
+        </tr>
+        <tr>
+          <td><code>synthesizer</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>
+            The route of the model that writes the final answer. Defaults to
+            <code>openrouter/anthropic/claude-haiku-4.5</code>.
+          </td>
+        </tr>
+        <tr>
+          <td><code>prompt</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>
+            The instruction for the synthesis turn, not for the members. When omitted the SDK
+            supplies its own default synthesis prompt.
+          </td>
+        </tr>
+        <tr>
+          <td><code>params</code></td>
+          <td><code>Mapping&nbsp;|&nbsp;None</code></td>
+          <td>Generation overrides for the synthesis turn. Same value rules as on a Model.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>Attributes</h3>
+
+    <p>
+      <code>members</code> is a <code>tuple</code> in the order you gave it. <code>name</code>,
+      <code>synthesizer</code>, <code>prompt</code> and <code>params</code> read back as on a Model.
+    </p>
+
+    <h3>Raises</h3>
+
+    <table>
+      <thead>
+        <tr>
+          <th>When</th>
+          <th>Error</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Fewer than two members</td>
+          <td><code>ValueError: a Fusion requires at least two members</code></td>
+        </tr>
+        <tr>
+          <td>Two members share a name</td>
+          <td><code>ValueError: duplicate Fusion member name '…'</code></td>
+        </tr>
+        <tr>
+          <td>
+            A member is not a <code>Model</code> or <code>Fusion</code>, including a
+            <code>CorrectiveEnsemble</code>
+          </td>
+          <td><code>TypeError: Fusion members must be sf.Model or sf.Fusion values</code></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="not-prose">
+      <NbCell :count="3" :code="fusionRun"><NbTextOut :text="fusionRunOut" /></NbCell>
+    </div>
+
+    <h2>CorrectiveEnsemble</h2>
+
+    <p>
+      A <code>CorrectiveEnsemble</code> runs its members in parallel and has the benchmark's own
+      verifier check every draft. Each member then gets a bounded number of retries against the
+      violations it caused, and a judge model picks between the drafts that passed. Nothing is
+      blended: the winning draft is returned verbatim.
+    </p>
+
+    <Note>
+      This recipe needs a benchmark that advertises <code>check</code>, <code>select</code> and
+      <code>finalize</code> verifier actions, such as <code>ifeval</code>. Evaluating it against any
+      other benchmark raises a <code>PlanningError</code> with code
+      <code>benchmark_without_verifier</code>. The retry cap is three attempts per member.
+    </Note>
+
+    <CodeBlock :code="correctiveSig" language="python" />
+
+    <h3>Parameters</h3>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>members</code></td>
+          <td><code>Sequence[Model]</code></td>
+          <td>
+            Two to four Models. <code>Fusion</code> is rejected, because the verifier grades each
+            member's raw draft and a synthesizer would hide those drafts.
+          </td>
+        </tr>
+        <tr>
+          <td><code>judge</code></td>
+          <td><code>Model</code></td>
+          <td>
+            Required keyword argument. The model that picks between drafts that passed the verifier.
+          </td>
+        </tr>
+        <tr>
+          <td><code>name</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>
+            Defaults to the member names joined with <code>+</code> followed by
+            <code>(corrective)</code>.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>Attributes</h3>
+
+    <p>
+      <code>members</code> is a <code>tuple[Model, ...]</code>, <code>judge</code> is the Model you
+      passed, and <code>name</code> is the resolved label.
+    </p>
+
+    <h3>Raises</h3>
+
+    <table>
+      <thead>
+        <tr>
+          <th>When</th>
+          <th>Error</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Fewer than two or more than four members</td>
+          <td><code>ValueError: CorrectiveEnsemble needs 2-4 members, got N</code></td>
+        </tr>
+        <tr>
+          <td>A member is not a <code>Model</code></td>
+          <td><code>TypeError: CorrectiveEnsemble members must be sf.Model values</code></td>
+        </tr>
+        <tr>
+          <td>The judge is not a <code>Model</code></td>
+          <td><code>TypeError: CorrectiveEnsemble judge must be an sf.Model</code></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="not-prose">
+      <NbCell :count="4" :code="correctiveRun"><NbTextOut :text="correctiveRunOut" /></NbCell>
+    </div>
+  </DocLayout>
+</template>

--- a/public-docs/src/pages/sf-client/api/ReportsPage.vue
+++ b/public-docs/src/pages/sf-client/api/ReportsPage.vue
@@ -1,0 +1,525 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import DocLayout from '@/components/layout/DocLayout.vue'
+import CodeBlock from '@/components/ui/CodeBlock.vue'
+import NbCell from '@/components/nb/NbCell.vue'
+import NbTextOut from '@/components/nb/NbTextOut.vue'
+import Note from '@/components/ui/Note.vue'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const runIt = `import screamingface as sf
+
+client = sf.Client()
+report = client.evaluate(
+    sf.Model("openrouter/anthropic/claude-haiku-4.5"),
+    benchmark="ifeval",
+    limit=1,
+    method="single_pass",
+)
+report`
+const runItOut = `Report(benchmark='ifeval', candidates=['claude-haiku-4.5'], ok=True)`
+
+const summary = `report.ok, report.case_count, report.duration_ms`
+const summaryOut = `(True, 1, 5248)`
+
+const usage = `report.usage`
+const usageOut = `Usage(input_tokens=103, output_tokens=398, cache_read_tokens=0, cache_creation_tokens=0, reasoning_tokens=0, cost_usd=Decimal('0'))`
+
+const only = `candidate = report.candidates.only
+candidate.name, candidate.kind, candidate.score`
+const onlyOut = `('claude-haiku-4.5', 'model', 1.0)`
+
+const byName = `report.candidates["claude-haiku-4.5"] is candidate`
+const byNameOut = `True`
+
+const metrics = `dict(candidate.metrics)`
+const metricsOut = `{'inst_level_strict_accuracy': 1.0, 'prompt_level_loose_accuracy': 1.0, 'inst_level_loose_accuracy': 1.0, 'cases_checked': 1.0, 'cases_fallback': 0.0}`
+
+const ops = `candidate.operations`
+const opsOut = `(OperationInfo(id='op_model_1', kind='model', label='claude-haiku-4.5 answer', depends_on=()),)`
+
+const dict = `sorted(report.to_dict())`
+const dictOut = `['benchmark', 'candidates', 'completed_at', 'schema', 'started_at', 'usage']`
+
+const bench = `report.benchmark`
+const benchOut = `BenchmarkInfo(id='ifeval', revision='047f1de449639c61', case_count=541)`
+</script>
+
+<template>
+  <DocLayout
+    title="Reports"
+    description="Report and everything it carries."
+    :navigation="navigation"
+    :version="version"
+  >
+    <p>
+      A <code>Report</code> is what an evaluation returns, and it is the only thing worth keeping:
+      it carries the scores, what was spent, what failed, and the exact expression that ran. This
+      page covers <code>Report</code> itself, alongside <code>CandidateResult</code> for one
+      candidate's outcome, <code>MemberResult</code> for one member of a fusion,
+      <code>OperationInfo</code> for a step that ran, <code>Usage</code> for token and cost
+      accounting, and <code>Failure</code> for anything that went wrong. See the
+      <RouterLink to="/sf-client/guides/running-an-evaluation">evaluation guide</RouterLink> for
+      running one.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="runIt"><NbTextOut :text="runItOut" /></NbCell>
+    </div>
+
+    <p>
+      Every example below reads from that report. The six types nest: a <code>Report</code> holds
+      <code>CandidateResult</code> values, each of which may hold <code>MemberResult</code> values,
+      while <code>OperationInfo</code>, <code>Usage</code> and <code>Failure</code> appear at more
+      than one level.
+    </p>
+
+    <h2>Report</h2>
+
+    <p>
+      A <code>Report</code> represents one evaluation. Its constructor is public, but in normal use
+      a <RouterLink to="/sf-client/api/clients">Client</RouterLink> returns it and it is never
+      constructed directly.
+    </p>
+
+    <h3>Attributes</h3>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>benchmark</code></td>
+          <td><code>BenchmarkInfo</code></td>
+          <td>Which benchmark, at which revision, this ran against.</td>
+        </tr>
+        <tr>
+          <td><code>case_count</code></td>
+          <td><code>int</code></td>
+          <td>How many cases this run actually covered.</td>
+        </tr>
+        <tr>
+          <td><code>candidates</code></td>
+          <td>sequence of <code>CandidateResult</code></td>
+          <td>One entry per candidate you evaluated, in the order you passed them.</td>
+        </tr>
+        <tr>
+          <td><code>ok</code></td>
+          <td><code>bool</code></td>
+          <td>
+            <code>True</code> when nothing failed anywhere in the run, at candidate or member level.
+          </td>
+        </tr>
+        <tr>
+          <td><code>failures</code></td>
+          <td><code>tuple[Failure, ...]</code></td>
+          <td>Every failure from every candidate and every member, flattened into one tuple.</td>
+        </tr>
+        <tr>
+          <td><code>usage</code></td>
+          <td><code>Usage</code></td>
+          <td>The whole run's accounting, summed across candidates.</td>
+        </tr>
+        <tr>
+          <td><code>started_at</code> / <code>completed_at</code></td>
+          <td><code>datetime</code></td>
+          <td>Earliest start and latest finish across candidates. Always timezone-aware.</td>
+        </tr>
+        <tr>
+          <td><code>duration_ms</code></td>
+          <td><code>int</code></td>
+          <td>Wall-clock milliseconds between those two.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="not-prose">
+      <NbCell :count="2" :code="summary"><NbTextOut :text="summaryOut" /></NbCell>
+    </div>
+
+    <Note>
+      <code>report.case_count</code> and <code>report.benchmark.case_count</code> are different
+      numbers. The first is what this run covered; the second is the benchmark's full size.
+    </Note>
+
+    <div class="not-prose">
+      <NbCell :count="3" :code="bench"><NbTextOut :text="benchOut" /></NbCell>
+    </div>
+
+    <p>
+      The revision depends on the method you ran. Evaluating <code>ifeval</code> with
+      <code>method="single_pass"</code> pins a different revision than its default protocol does, so
+      two reports are only comparable when both the id and the revision match.
+    </p>
+
+    <h3>candidates</h3>
+
+    <p>
+      <code>report.candidates</code> is a read-only sequence supporting iteration, positional
+      indexing and slicing. It also indexes by candidate name, and offers <code>.only</code> for the
+      common case of a single candidate.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="4" :code="only"><NbTextOut :text="onlyOut" /></NbCell>
+      <NbCell :count="5" :code="byName"><NbTextOut :text="byNameOut" /></NbCell>
+    </div>
+
+    <p>
+      <code>.only</code> raises <code>ValueError</code> when the report holds more than one
+      candidate, and indexing by an unknown name raises <code>KeyError</code>. Candidate names are
+      unique within a report.
+    </p>
+
+    <h3>Serialisation</h3>
+
+    <p>
+      <code>to_dict()</code> returns a plain JSON-compatible dictionary and
+      <code>to_json()</code> returns it as a compact string. Both carry a <code>schema</code> field,
+      <code>screamingface.report.v1</code>, so a consumer can tell what it is reading.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="6" :code="dict"><NbTextOut :text="dictOut" /></NbCell>
+    </div>
+
+    <h2>CandidateResult</h2>
+
+    <p>
+      A <code>CandidateResult</code> is one candidate's outcome. A higher <code>score</code> is
+      always better, whatever the benchmark measures.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>name</code></td>
+          <td><code>str</code></td>
+          <td>The recipe's name, unique within the report.</td>
+        </tr>
+        <tr>
+          <td><code>kind</code></td>
+          <td><code>str</code></td>
+          <td>One of <code>model</code>, <code>fusion</code> or <code>corrective</code>.</td>
+        </tr>
+        <tr>
+          <td><code>score</code></td>
+          <td><code>float&nbsp;|&nbsp;None</code></td>
+          <td>
+            The headline number, or <code>None</code> when the candidate failed or was not scored.
+          </td>
+        </tr>
+        <tr>
+          <td><code>metrics</code></td>
+          <td><code>Mapping[str, float]</code></td>
+          <td>
+            The benchmark's individual measures. Empty when <code>score</code> is <code>None</code>:
+            an unscored candidate cannot carry metrics.
+          </td>
+        </tr>
+        <tr>
+          <td><code>url4</code></td>
+          <td><code>str</code></td>
+          <td>
+            The complete expression that executed. See the
+            <RouterLink to="/sf-client/guides/reproduce-and-share">URL4 guide</RouterLink>.
+          </td>
+        </tr>
+        <tr>
+          <td><code>models</code></td>
+          <td><code>tuple[str, ...]</code></td>
+          <td>Every distinct model route this candidate used. Unique, and never empty.</td>
+        </tr>
+        <tr>
+          <td><code>operations</code></td>
+          <td><code>tuple[OperationInfo, ...]</code></td>
+          <td>The steps that ran, as an acyclic graph. Never empty.</td>
+        </tr>
+        <tr>
+          <td><code>members</code></td>
+          <td><code>tuple[MemberResult, ...]</code></td>
+          <td>
+            Direct members, for a fusion. Always empty for a <code>model</code> candidate, and at
+            least two entries for a fusion.
+          </td>
+        </tr>
+        <tr>
+          <td><code>failures</code></td>
+          <td><code>tuple[Failure, ...]</code></td>
+          <td>This candidate's own failures. Always empty when it has a score.</td>
+        </tr>
+        <tr>
+          <td><code>usage</code></td>
+          <td><code>Usage</code></td>
+          <td>This candidate's accounting.</td>
+        </tr>
+        <tr>
+          <td><code>run_id</code></td>
+          <td><code>str</code></td>
+          <td>Engine-assigned identifier for this candidate's execution.</td>
+        </tr>
+        <tr>
+          <td><code>started_at</code> / <code>completed_at</code> / <code>duration_ms</code></td>
+          <td><code>datetime</code> / <code>int</code></td>
+          <td>When it ran and for how long.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="not-prose">
+      <NbCell :count="7" :code="metrics"><NbTextOut :text="metricsOut" /></NbCell>
+    </div>
+
+    <h2>MemberResult</h2>
+
+    <p>
+      A <code>MemberResult</code> is one direct member of a fusion, held as a compact view: enough
+      to see what the member cost and whether it failed, without repeating the full candidate
+      structure. Members carry no score, because only the fusion's final answer is graded.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>name</code></td>
+          <td><code>str</code></td>
+          <td>The member recipe's name, unique among its siblings.</td>
+        </tr>
+        <tr>
+          <td><code>kind</code></td>
+          <td><code>str</code></td>
+          <td>One of <code>model</code>, <code>fusion</code> or <code>corrective</code>.</td>
+        </tr>
+        <tr>
+          <td><code>models</code></td>
+          <td><code>tuple[str, ...]</code></td>
+          <td>The routes this member used.</td>
+        </tr>
+        <tr>
+          <td><code>operation_id</code></td>
+          <td><code>str</code></td>
+          <td>Links this member to an entry in the candidate's <code>operations</code>.</td>
+        </tr>
+        <tr>
+          <td><code>failures</code></td>
+          <td><code>tuple[Failure, ...]</code></td>
+          <td>This member's failures, which also appear in <code>report.failures</code>.</td>
+        </tr>
+        <tr>
+          <td><code>duration_ms</code></td>
+          <td><code>int&nbsp;|&nbsp;None</code></td>
+          <td>How long the member took, when the Engine reported it.</td>
+        </tr>
+        <tr>
+          <td><code>usage</code></td>
+          <td><code>Usage</code></td>
+          <td>This member's accounting.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>OperationInfo</h2>
+
+    <p>
+      An <code>OperationInfo</code> is one step in a candidate's compiled graph. Reading
+      <code>operations</code> shows what actually ran and in what order, which is how a fusion's
+      members can be seen executing before its synthesis.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>id</code></td>
+          <td><code>str</code></td>
+          <td>Unique within the candidate. This is what <code>depends_on</code> refers to.</td>
+        </tr>
+        <tr>
+          <td><code>kind</code></td>
+          <td><code>str</code></td>
+          <td>What sort of step it was, for example <code>model</code>.</td>
+        </tr>
+        <tr>
+          <td><code>label</code></td>
+          <td><code>str</code></td>
+          <td>Human-readable description, such as <code>claude-haiku-4.5 answer</code>.</td>
+        </tr>
+        <tr>
+          <td><code>depends_on</code></td>
+          <td><code>tuple[str, ...]</code></td>
+          <td>
+            Ids of the steps that had to finish first. Empty for a step with no prerequisites.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="not-prose">
+      <NbCell :count="8" :code="ops"><NbTextOut :text="opsOut" /></NbCell>
+    </div>
+
+    <p>
+      The operations of a candidate form an acyclic graph: ids are unique, every dependency names a
+      step that exists, and no step can depend on itself.
+    </p>
+
+    <h2>Usage</h2>
+
+    <p>
+      A <code>Usage</code> holds the token and cost accounting for one subtree of a run. Every field
+      is optional, because a provider that does not report a number leaves it as
+      <code>None</code> rather than guessing zero.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>input_tokens</code></td>
+          <td><code>int&nbsp;|&nbsp;None</code></td>
+          <td>Tokens sent.</td>
+        </tr>
+        <tr>
+          <td><code>output_tokens</code></td>
+          <td><code>int&nbsp;|&nbsp;None</code></td>
+          <td>Tokens generated.</td>
+        </tr>
+        <tr>
+          <td><code>cache_read_tokens</code></td>
+          <td><code>int&nbsp;|&nbsp;None</code></td>
+          <td>Tokens served from a provider cache.</td>
+        </tr>
+        <tr>
+          <td><code>cache_creation_tokens</code></td>
+          <td><code>int&nbsp;|&nbsp;None</code></td>
+          <td>Tokens written into a provider cache.</td>
+        </tr>
+        <tr>
+          <td><code>reasoning_tokens</code></td>
+          <td><code>int&nbsp;|&nbsp;None</code></td>
+          <td>Tokens spent on reasoning, where the provider separates them.</td>
+        </tr>
+        <tr>
+          <td><code>cost_usd</code></td>
+          <td><code>Decimal&nbsp;|&nbsp;None</code></td>
+          <td>
+            Money, as a <code>Decimal</code> so it never loses precision. Accepts a string or a
+            <code>Decimal</code> on construction.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="not-prose">
+      <NbCell :count="9" :code="usage"><NbTextOut :text="usageOut" /></NbCell>
+    </div>
+
+    <p>
+      Summing follows a strict rule: <code>report.usage</code> adds a field across candidates only
+      when <em>every</em> candidate reported it. If one candidate leaves <code>cost_usd</code> as
+      <code>None</code>, the report's <code>cost_usd</code> is <code>None</code> too, rather than a
+      total that silently omits part of the run.
+    </p>
+
+    <p>
+      <code>to_dict()</code> drops fields that are <code>None</code> and renders
+      <code>cost_usd</code> as a string.
+    </p>
+
+    <h2>Failure</h2>
+
+    <p>
+      A <code>Failure</code> is one typed failure held inside an otherwise valid report. A report
+      with failures is still a report, so what succeeded can be read alongside what did not.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>stage</code></td>
+          <td><code>str</code></td>
+          <td>
+            Where it happened: <code>candidate</code>, <code>grading</code> or
+            <code>aggregation</code>.
+          </td>
+        </tr>
+        <tr>
+          <td><code>code</code></td>
+          <td><code>str</code></td>
+          <td>
+            Stable machine-readable identifier in lowercase snake_case, such as
+            <code>provider_timeout</code>. Match on this rather than on the message.
+          </td>
+        </tr>
+        <tr>
+          <td><code>message</code></td>
+          <td><code>str</code></td>
+          <td>Human-readable explanation. Not stable across versions.</td>
+        </tr>
+        <tr>
+          <td><code>retryable</code></td>
+          <td><code>bool</code></td>
+          <td>Whether running the same thing again could plausibly succeed.</td>
+        </tr>
+        <tr>
+          <td><code>operation_id</code></td>
+          <td><code>str</code></td>
+          <td>Which step failed, matching an <code>OperationInfo.id</code>.</td>
+        </tr>
+        <tr>
+          <td><code>case_id</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>Which case failed, when the failure was specific to one.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p>A failure reads like this:</p>
+
+    <CodeBlock
+      code="Failure(stage='candidate', code='provider_timeout', message='Upstream timed out', retryable=True, operation_id='op-1', case_id='7')"
+      language="python"
+    />
+  </DocLayout>
+</template>

--- a/public-docs/src/pages/sf-client/guides/BenchmarksPage.vue
+++ b/public-docs/src/pages/sf-client/guides/BenchmarksPage.vue
@@ -60,7 +60,7 @@ const casesOut = `1 | Write a 300+ word summary of the wikipedia page "https://e
 
     <ul>
       <li>List the benchmarks this engine publishes.</li>
-      <li>Read one's identity card — size, revision, and what it actually measures.</li>
+      <li>Read one's identity card: size, revision, and what it actually measures.</li>
       <li>Page its real prompts before spending anything.</li>
       <li>Select a protocol variant with <code>method</code>.</li>
     </ul>
@@ -68,18 +68,18 @@ const casesOut = `1 | Write a 300+ word summary of the wikipedia page "https://e
     <h2>Main APIs</h2>
 
     <ul>
-      <li><code>sf.benchmarks.list()</code> — every benchmark this engine publishes</li>
+      <li><code>sf.benchmarks.list()</code>: every benchmark this engine publishes</li>
       <li>
-        <code>sf.benchmarks.get(id, *, method=None)</code> — one benchmark's identity card, for a
+        <code>sf.benchmarks.get(id, *, method=None)</code>: one benchmark's identity card, for a
         chosen protocol
       </li>
       <li>
-        <code>sf.Benchmark</code> — that card: <code>.id</code> <code>.title</code>
+        <code>sf.Benchmark</code>, that card: <code>.id</code> <code>.title</code>
         <code>.description</code> <code>.revision</code> <code>.case_count</code>
         <code>.cases(limit, offset)</code>
       </li>
-      <li><code>sf.BenchmarkInfo</code> — the pinned subset a report carries</li>
-      <li><code>sf.CaseInfo</code> — one case's <code>id</code> and <code>input</code></li>
+      <li><code>sf.BenchmarkInfo</code>: the pinned subset a report carries</li>
+      <li><code>sf.CaseInfo</code>: one case's <code>id</code> and <code>input</code></li>
     </ul>
 
     <p>
@@ -100,7 +100,7 @@ const casesOut = `1 | Write a 300+ word summary of the wikipedia page "https://e
       Two benchmarks, and they differ in what grading costs. <strong>DRACO</strong> is 100
       deep-research tasks graded by a judge model
       (<code>openrouter/google/gemini-3.1-pro-preview</code>) with five independent passes per
-      criterion — the grading itself is the expensive part. <strong>IFEval</strong> is 541
+      criterion, so the grading itself is the expensive part. <strong>IFEval</strong> is 541
       instruction-following prompts checked by a deterministic verifier, so its grading is
       <strong>free</strong>: only the answers cost anything.
     </p>
@@ -120,8 +120,8 @@ const casesOut = `1 | Write a 300+ word summary of the wikipedia page "https://e
     <h3>Select a method</h3>
 
     <p>
-      Some benchmarks publish more than one protocol. IFEval's default is <code>corrective</code> —
-      a bounded three-attempt retry chain fed by the verifier's complaints.
+      Some benchmarks publish more than one protocol. IFEval's default is <code>corrective</code>, a
+      bounded three-attempt retry chain fed by the verifier's complaints.
       <code>single_pass</code> is one answer, one check, and it is the only variant comparable to
       published IFEval numbers.
     </p>
@@ -131,7 +131,7 @@ const casesOut = `1 | Write a 300+ word summary of the wikipedia page "https://e
     </div>
 
     <p>
-      Notice the revisions differ. A method is not a flag on one exam — it is a
+      Notice the revisions differ. A method is not a flag on one exam, but a
       <strong>different pinned protocol</strong>, with a different cost and a score that means
       something different. Comparing a corrective score against a single-pass one is a mistake the
       revisions let you catch.
@@ -141,8 +141,8 @@ const casesOut = `1 | Write a 300+ word summary of the wikipedia page "https://e
 
     <p>
       <code>cases()</code> pages the real prompts, 50 at a time by default. For IFEval this is worth
-      doing: each prompt carries its own constraints in its text — "300+ words", "no commas",
-      "highlight three sections" — which is exactly what makes it machine-checkable.
+      doing: each prompt carries its own constraints in its text, such as "300+ words", "no commas"
+      or "highlight three sections", which is exactly what makes it machine-checkable.
     </p>
 
     <div class="not-prose">
@@ -151,7 +151,7 @@ const casesOut = `1 | Write a 300+ word summary of the wikipedia page "https://e
 
     <p>
       A <code>CaseInfo</code> carries only its <code>id</code> and <code>input</code>. Prompts cross
-      the boundary to the models; grading criteria, rubrics and answer keys do not — and that
+      the boundary to the models; grading criteria, rubrics and answer keys do not, and that
       separation is what makes a verified result meaningful rather than self-reported.
     </p>
 
@@ -163,7 +163,7 @@ const casesOut = `1 | Write a 300+ word summary of the wikipedia page "https://e
           href="https://github.com/OpenMined/screamingface/blob/OME-605-screamingface-client-v1/packages/screamingface/examples/07_ifeval_e2e.ipynb"
           target="_blank"
           rel="noopener"
-          >Companion notebook — <code>07_ifeval_e2e.ipynb</code></a
+          >Companion notebook: <code>07_ifeval_e2e.ipynb</code></a
         >
       </li>
     </ul>

--- a/public-docs/src/pages/sf-client/guides/ConnectionsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/ConnectionsPage.vue
@@ -43,14 +43,14 @@ const remove = `sf.disconnect("openrouter")`
   >
     <p>
       A <strong>connection</strong> is a provider credential the engine holds on your behalf. The
-      client never talks to OpenRouter, Anthropic or any other provider directly — it sends your key
+      client never talks to OpenRouter, Anthropic or any other provider directly. It sends your key
       to the engine once, the engine passes it to AI Gateway to validate and store encrypted, and
       every later model call is dispatched there. Your notebook keeps no copy.
     </p>
 
     <p>
       Two steps get you there: log in to the engine, then connect a provider. Without a connection
-      the engine can still list benchmarks and models, but any evaluation fails — there is no
+      the engine can still list benchmarks and models, but any evaluation fails, because there is no
       credential to call a model with.
     </p>
 
@@ -69,15 +69,15 @@ const remove = `sf.disconnect("openrouter")`
     <h2>Main APIs</h2>
 
     <ul>
-      <li><code>sf.connect()</code> — open the interactive provider panel</li>
-      <li><code>sf.connect(provider, api_key=…)</code> — connect one provider directly</li>
-      <li><code>sf.connections.list()</code> — every provider this engine advertises</li>
-      <li><code>sf.connections.get(provider)</code> — one provider's current state</li>
-      <li><code>sf.disconnect(provider)</code> — remove a stored credential</li>
-      <li><code>sf.Connection</code> — the sanitised provider-state value</li>
-      <li><code>sf.ConnectionPanel</code> — the widget <code>sf.connect()</code> returns</li>
+      <li><code>sf.connect()</code>: open the interactive provider panel</li>
+      <li><code>sf.connect(provider, api_key=…)</code>: connect one provider directly</li>
+      <li><code>sf.connections.list()</code>: every provider this engine advertises</li>
+      <li><code>sf.connections.get(provider)</code>: one provider's current state</li>
+      <li><code>sf.disconnect(provider)</code>: remove a stored credential</li>
+      <li><code>sf.Connection</code>: the sanitised provider-state value</li>
+      <li><code>sf.ConnectionPanel</code>: the widget <code>sf.connect()</code> returns</li>
       <li>
-        <code>sf.Client.login()</code> · <code>sf.Client.logout()</code> — Cloudflare Access on a
+        <code>sf.Client.login()</code> · <code>sf.Client.logout()</code>: Cloudflare Access on a
         hosted engine
       </li>
     </ul>
@@ -98,14 +98,14 @@ const remove = `sf.disconnect("openrouter")`
     </div>
 
     <p>
-      In a notebook you rarely call this directly — the panel below handles it. A protected engine
-      shows a login row first and loads provider rows only once login succeeds.
+      In a notebook you rarely call this directly, since the panel below handles it. A protected
+      engine shows a login row first and loads provider rows only once login succeeds.
     </p>
 
     <h3>Connect from a notebook</h3>
 
     <p>
-      Called with no arguments, <code>sf.connect()</code> returns a <code>ConnectionPanel</code> — a
+      Called with no arguments, <code>sf.connect()</code> returns a <code>ConnectionPanel</code>, a
       live widget listing every provider the engine advertises, with a field for each one's
       supported auth method. The
       <RouterLink to="/sf-client/quickstartPage">Quickstart</RouterLink> steps through the whole
@@ -130,7 +130,7 @@ const remove = `sf.disconnect("openrouter")`
     <p>
       The two arguments go together. <code>sf.connect("openrouter")</code> without a key raises
       <code>ValueError</code>, and passing <code>api_key=</code> without a provider raises
-      <code>TypeError</code> — there is no partial form that silently does nothing.
+      <code>TypeError</code>. There is no partial form that silently does nothing.
     </p>
 
     <h3>Read the current state</h3>
@@ -142,9 +142,9 @@ const remove = `sf.disconnect("openrouter")`
     </div>
 
     <p>
-      Note the trailing comma — <code>list()</code> returns a <strong>tuple</strong>, not a list,
-      and this engine advertises exactly one provider. Fetch a single one by name when you only care
-      about its state:
+      Note the trailing comma, because <code>list()</code> returns a <strong>tuple</strong>, not a
+      list, and this engine advertises exactly one provider. Fetch a single one by name when you
+      only care about its state:
     </p>
 
     <div class="not-prose">
@@ -167,8 +167,9 @@ const remove = `sf.disconnect("openrouter")`
     <h3>A local engine</h3>
 
     <p>
-      If you run the engine yourself, point the client at it and skip the login step entirely — a
-      local engine advertises no Cloudflare Access, so the panel shows provider rows immediately.
+      If you run the engine yourself, point the client at it and skip the login step entirely,
+      because a local engine advertises no Cloudflare Access, so the panel shows provider rows
+      immediately.
     </p>
 
     <div class="not-prose">
@@ -178,22 +179,22 @@ const remove = `sf.disconnect("openrouter")`
     <h2>What a connection carries</h2>
 
     <p>
-      Every <code>Connection</code> is sanitised — the public provider name, its supported methods,
+      Every <code>Connection</code> is sanitised to the public provider name, its supported methods,
       and its state. AI Gateway account IDs, credential locators and upstream error bodies never
       cross this boundary.
     </p>
 
     <ul>
       <li>
-        <code>status</code> — one of <code>not_connected</code>, <code>pending</code>,
+        <code>status</code>: one of <code>not_connected</code>, <code>pending</code>,
         <code>connected</code>, <code>needs_reauth</code>, <code>error</code>
       </li>
       <li>
-        <code>auth_methods</code> — what the provider supports. The current engine advertises
+        <code>auth_methods</code>: what the provider supports. The current engine advertises
         <code>('api_key',)</code> for OpenRouter
       </li>
-      <li><code>auth_method</code> — which one is in use, or <code>None</code></li>
-      <li><code>account_label</code> — an optional display label</li>
+      <li><code>auth_method</code>: which one is in use, or <code>None</code></li>
+      <li><code>account_label</code>: an optional display label</li>
     </ul>
 
     <h2>When it fails</h2>
@@ -214,7 +215,7 @@ const remove = `sf.disconnect("openrouter")`
           href="https://github.com/OpenMined/screamingface/blob/OME-605-screamingface-client-v1/packages/screamingface/examples/00_quickstart.ipynb"
           target="_blank"
           rel="noopener"
-          >Companion notebook — <code>00_quickstart.ipynb</code></a
+          >Companion notebook: <code>00_quickstart.ipynb</code></a
         >
       </li>
     </ul>

--- a/public-docs/src/pages/sf-client/guides/EvaluationPage.vue
+++ b/public-docs/src/pages/sf-client/guides/EvaluationPage.vue
@@ -52,7 +52,7 @@ const watch = `def observe(event: sf.Event) -> None:
 
 sf.evaluate(haiku, benchmark="ifeval", limit=1, on_event=observe, progress=False)`
 
-const clients = `# once, at the top — every later sf.evaluate() call uses it
+const clients = `# once, at the top: every later sf.evaluate() call uses it
 sf.configure(engine_url="${SF_ENGINE_URL}")
 
 # or hold a client yourself
@@ -75,8 +75,8 @@ client.close()`
     </p>
 
     <p>
-      Everything expensive is on the far side of this call. Validation happens first and entirely —
-      an unknown benchmark, an unreachable route, a malformed candidate all fail
+      Everything expensive is on the far side of this call. Validation happens first and entirely,
+      so an unknown benchmark, an unreachable route, a malformed candidate all fail
       <strong>before the first paid request</strong>.
     </p>
 
@@ -97,15 +97,14 @@ client.close()`
         <code
           >sf.evaluate(candidates, *, benchmark, limit=None, method=None, on_event=None,
           progress=None)</code
-        >
-        — run candidates against a benchmark, returns <code>sf.Report</code>
+        >: run candidates against a benchmark, returns <code>sf.Report</code>
       </li>
       <li>
-        <code>sf.Client.evaluate(...)</code> · <code>await sf.AsyncClient.evaluate(...)</code> — the
+        <code>sf.Client.evaluate(...)</code> · <code>await sf.AsyncClient.evaluate(...)</code>: the
         same call on an explicit client
       </li>
-      <li><code>sf.configure(engine_url=…)</code> — repoint the shared client</li>
-      <li><code>sf.close()</code> — release the shared client</li>
+      <li><code>sf.configure(engine_url=…)</code>: repoint the shared client</li>
+      <li><code>sf.close()</code>: release the shared client</li>
     </ul>
 
     <h2>How to</h2>
@@ -113,7 +112,7 @@ client.close()`
     <h3>Evaluate one candidate</h3>
 
     <p>
-      The benchmark id is <strong>required</strong> — there is no default and no implicit choice.
+      The benchmark id is <strong>required</strong>, with no default and no implicit choice.
       <code>limit</code> caps the case count, and it is your main cost control.
     </p>
 
@@ -129,7 +128,8 @@ client.close()`
     <h3>Read the score</h3>
 
     <p>
-      Scores live on candidates, not on the report — a report may hold several. With one candidate,
+      Scores live on candidates, not on the report, because a report may hold several. With one
+      candidate,
       <code>.only</code> is the direct way to it.
     </p>
 
@@ -156,7 +156,7 @@ client.close()`
 
     <p>
       Pass a list. Every candidate runs against the same pinned exam in the same call, which is what
-      makes the comparison fair — and it is the only way to compare, because a report has no
+      makes the comparison fair, and it is the only way to compare, because a report has no
       "baseline" or "gain" field. You put the solo model and the fusion in one run and read both
       scores.
     </p>
@@ -183,9 +183,9 @@ client.close()`
 
     <p>
       An honest result: identical scores, <strong>3.2× the output tokens</strong>. On this slice the
-      retry loop bought nothing — <code>corrected_cases</code> above is <code>0.0</code>, meaning no
-      case failed first and passed later. That is what a three-case sample of a capable model looks
-      like, and it is the reason to run more cases before concluding anything.
+      retry loop bought nothing, since <code>corrected_cases</code> above is <code>0.0</code>,
+      meaning no case failed first and passed later. That is what a three-case sample of a capable
+      model looks like, and it is the reason to run more cases before concluding anything.
     </p>
 
     <h3>Read what it cost</h3>
@@ -196,7 +196,7 @@ client.close()`
 
     <p>
       <code>cost_usd</code> is <code>Decimal('0')</code> here because this engine has no pricing
-      data — a zero means "not reported", not "free". Token counts are the reliable measure. Any
+      data, so a zero means "not reported", not "free". Token counts are the reliable measure. Any
       field is <code>None</code> if even one candidate run failed to report it, rather than being
       silently summed as a partial total.
     </p>
@@ -217,7 +217,7 @@ client.close()`
 
     <p>
       <code>sf.evaluate()</code> never asks where the engine is, so it falls back to your own
-      machine — <code>http://127.0.0.1:9108</code>. Against a hosted engine that fails, so name it
+      machine at <code>http://127.0.0.1:9108</code>. Against a hosted engine that fails, so name it
       once with <code>sf.configure()</code> and every later call uses it.
     </p>
 
@@ -234,7 +234,7 @@ client.close()`
     <h2>When it fails</h2>
 
     <p>
-      <code>PlanningError</code> means the run never started — change the candidate, benchmark or
+      <code>PlanningError</code> means the run never started, so change the candidate, benchmark or
       configuration. <code>ExecutionError</code> means it reached the engine and ended without a
       valid report. <code>EngineUnavailableError</code> means the engine was not reachable at all.
       Each carries a stable <code>code</code> and a <code>hint</code>.
@@ -248,7 +248,7 @@ client.close()`
           href="https://github.com/OpenMined/screamingface/blob/OME-605-screamingface-client-v1/packages/screamingface/examples/05_draco_e2e.ipynb"
           target="_blank"
           rel="noopener"
-          >Companion notebook — <code>05_draco_e2e.ipynb</code></a
+          >Companion notebook: <code>05_draco_e2e.ipynb</code></a
         >
       </li>
     </ul>

--- a/public-docs/src/pages/sf-client/guides/FusionsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/FusionsPage.vue
@@ -41,8 +41,8 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
     :version="version"
   >
     <p>
-      A <strong>Fusion</strong> asks several members the same question and then has one more model —
-      the <strong>synthesizer</strong> — read their answers and produce a single final one. That
+      A <strong>Fusion</strong> asks several members the same question and then has one more model,
+      the <strong>synthesizer</strong>, read their answers and produce a single final one. That
       final answer is what the benchmark grades, so a Fusion competes in exactly the same column as
       a solo <RouterLink to="/sf-client/guides/models">Model</RouterLink>.
     </p>
@@ -52,7 +52,7 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
       score-merging. Members produce candidate answers, and a model decides.
     </p>
 
-    <p>Like a Model, a Fusion is immutable and network-free — building one makes no request.</p>
+    <p>Like a Model, a Fusion is immutable and network-free, so building one makes no request.</p>
 
     <h2>What you can do with it</h2>
 
@@ -67,14 +67,14 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
 
     <ul>
       <li>
-        <code>sf.Fusion(members, *, name=None, synthesizer=None, prompt=None, params=None)</code> —
+        <code>sf.Fusion(members, *, name=None, synthesizer=None, prompt=None, params=None)</code>:
         combine members behind a synthesizer
       </li>
       <li>
         <code>.name</code> · <code>.members</code> · <code>.synthesizer</code> ·
-        <code>.prompt</code> · <code>.params</code> — read back the resolved shape
+        <code>.prompt</code> · <code>.params</code>: read back the resolved shape
       </li>
-      <li><code>sf.Recipe</code> — the shared base type of every candidate kind</li>
+      <li><code>sf.Recipe</code>: the shared base type of every candidate kind</li>
     </ul>
 
     <h2>How to</h2>
@@ -92,7 +92,7 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
     </div>
 
     <p>
-      A Fusion needs <strong>at least two</strong> members and their names must be unique — one
+      A Fusion needs <strong>at least two</strong> members and their names must be unique: one
       member is not a fusion, and two identically named ones could not be told apart in a report.
       Both raise immediately, at construction.
     </p>
@@ -111,8 +111,8 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
     <h3>Choose the synthesizer</h3>
 
     <p>
-      The synthesizer is a <strong>model route string</strong>, not a Model object — it is the
-      engine that resolves it. Swapping it is the main lever a Fusion has: the same members with a
+      The synthesizer is a <strong>model route string</strong>, not a Model object, because the
+      engine resolves it. Swapping it is the main lever a Fusion has: the same members with a
       stronger synthesizer is a different candidate, and worth measuring as one.
     </p>
 
@@ -122,8 +122,8 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
 
     <p>
       <code>prompt</code> and <code>params</code> work the same way here as on a Model, but they
-      apply to the <em>synthesis</em> step — how the final answer is written, not how members
-      answer. Give a member its own prompt by setting it on that Model.
+      apply to the <em>synthesis</em> step, governing how the final answer is written rather than
+      how members answer. Give a member its own prompt by setting it on that Model.
     </p>
 
     <h3>Nest a fusion</h3>
@@ -138,8 +138,8 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
     </div>
 
     <p>
-      Members must be Models or Fusions. A corrective ensemble cannot be a member — it grades its
-      own members' raw drafts, which a surrounding synthesizer would have already replaced.
+      Members must be Models or Fusions. A corrective ensemble cannot be a member, because it grades
+      its own members' raw drafts, which a surrounding synthesizer would have already replaced.
     </p>
 
     <h2>Links</h2>
@@ -150,7 +150,7 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
           href="https://github.com/OpenMined/screamingface/blob/OME-605-screamingface-client-v1/packages/screamingface/examples/00_quickstart.ipynb"
           target="_blank"
           rel="noopener"
-          >Companion notebook — <code>00_quickstart.ipynb</code></a
+          >Companion notebook: <code>00_quickstart.ipynb</code></a
         >
       </li>
     </ul>

--- a/public-docs/src/pages/sf-client/guides/ModelsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/ModelsPage.vue
@@ -51,8 +51,8 @@ ModelInfo(id='openrouter/google/gemini-3.1-pro-preview', provider='openrouter')
 
     <p>
       A Model is <strong>immutable and network-free</strong>. Constructing one makes no request and
-      needs no connection — it is a value describing what to ask for. Nothing happens until you pass
-      it to an evaluation.
+      needs no connection, because it is only a value describing what to ask for. Nothing happens
+      until you pass it to an evaluation.
     </p>
 
     <h2>What you can do with it</h2>
@@ -68,15 +68,15 @@ ModelInfo(id='openrouter/google/gemini-3.1-pro-preview', provider='openrouter')
 
     <ul>
       <li>
-        <code>sf.Model(model, *, name=None, prompt=None, params=None)</code> — select a route,
+        <code>sf.Model(model, *, name=None, prompt=None, params=None)</code>: select a route,
         optionally with answer policy
       </li>
       <li>
-        <code>sf.models.list()</code> — routes this engine can reach, as <code>sf.ModelInfo</code>
+        <code>sf.models.list()</code>: routes this engine can reach, as <code>sf.ModelInfo</code>
       </li>
       <li>
-        <code>.name</code> · <code>.model</code> · <code>.prompt</code> · <code>.params</code> —
-        read back what a Model resolved to
+        <code>.name</code> · <code>.model</code> · <code>.prompt</code> · <code>.params</code>: read
+        back what a Model resolved to
       </li>
     </ul>
 
@@ -96,9 +96,10 @@ ModelInfo(id='openrouter/google/gemini-3.1-pro-preview', provider='openrouter')
     <h3>Name an independent sample</h3>
 
     <p>
-      Two Models on the same route with the same policy are the <em>same</em> candidate — the engine
-      deduplicates them by content inside one compiled graph. An explicit <code>name</code> is how
-      you say you meant two independent samples, and it is the name the report uses.
+      Two Models on the same route with the same policy are the <em>same</em> candidate, because the
+      engine deduplicates them by content inside one compiled graph. An explicit
+      <code>name</code> is how you say you meant two independent samples, and it is the name the
+      report uses.
     </p>
 
     <div class="not-prose">
@@ -131,8 +132,9 @@ ModelInfo(id='openrouter/google/gemini-3.1-pro-preview', provider='openrouter')
 
     <p>
       Two things to note. The catalogue spans <strong>every provider the engine knows</strong>, not
-      only the ones you have connected — a route you have no credential for will fail at evaluation,
-      not here. And ID shapes differ per provider: <code>anthropic/claude-opus-4-8</code> against
+      only the ones you have connected, so a route you have no credential for will fail at
+      evaluation rather than here. And ID shapes differ per provider:
+      <code>anthropic/claude-opus-4-8</code> against
       <code>openrouter/anthropic/claude-opus-4.8</code>. Copy the <code>id</code> rather than
       retyping it.
     </p>
@@ -145,7 +147,7 @@ ModelInfo(id='openrouter/google/gemini-3.1-pro-preview', provider='openrouter')
           href="https://github.com/OpenMined/screamingface/blob/OME-605-screamingface-client-v1/packages/screamingface/examples/00_quickstart.ipynb"
           target="_blank"
           rel="noopener"
-          >Companion notebook — <code>00_quickstart.ipynb</code></a
+          >Companion notebook: <code>00_quickstart.ipynb</code></a
         >
       </li>
     </ul>

--- a/public-docs/src/pages/sf-client/guides/Url4Page.vue
+++ b/public-docs/src/pages/sf-client/guides/Url4Page.vue
@@ -39,7 +39,7 @@ report.to_json()   # the same, as one string`
   >
     <p>
       Every candidate result carries a <code>url4</code> string: the complete expression the engine
-      executed. Not a summary of it, not a log of it — the plan itself, the thing that ran. Your
+      executed. Not a summary of it, not a log of it, but the plan itself, the thing that ran. Your
       candidate, the benchmark's routes, the retry prompts, and the pinned protocol revision, all in
       one line of text you can read, diff, and send to someone.
     </p>
@@ -61,15 +61,15 @@ report.to_json()   # the same, as one string`
     <h2>Main APIs</h2>
 
     <ul>
-      <li><code>CandidateResult.url4</code> — the expression that executed</li>
+      <li><code>CandidateResult.url4</code>: the expression that executed</li>
       <li>
-        <code>CandidateResult.operations</code> — the same plan as an
+        <code>CandidateResult.operations</code>: the same plan as an
         <code>sf.OperationInfo</code> DAG
       </li>
-      <li><code>CandidateResult.run_id</code> — the engine's identifier for this run</li>
-      <li><code>Report.benchmark.revision</code> — the pinned protocol the run used</li>
+      <li><code>CandidateResult.run_id</code>: the engine's identifier for this run</li>
+      <li><code>Report.benchmark.revision</code>: the pinned protocol the run used</li>
       <li>
-        <code>Report.to_dict()</code> · <code>Report.to_json()</code> — the whole report, serialised
+        <code>Report.to_dict()</code> · <code>Report.to_json()</code>: the whole report, serialised
       </li>
     </ul>
 
@@ -84,7 +84,7 @@ report.to_json()   # the same, as one string`
     <p>
       Fourteen hundred characters for a three-case run of one model. That length is the point: it
       spells out the resolved answer prompt, the generation parameters, every benchmark route, and
-      the retry chain — including everything the SDK filled in on your behalf.
+      the retry chain, including everything the SDK filled in on your behalf.
     </p>
 
     <h3>Audit it without reading all of it</h3>
@@ -97,7 +97,7 @@ report.to_json()   # the same, as one string`
 
     <p>
       Three candidate slots and three checker calls, from a run over three cases with IFEval's
-      corrective method — the retry chain is <em>unrolled</em> into the expression rather than being
+      corrective method. The retry chain is <em>unrolled</em> into the expression rather than being
       a loop the engine hides. Every attempt is visible before anything executes, which is also why
       every attempt is paid for even when the first one passes.
     </p>
@@ -111,7 +111,7 @@ report.to_json()   # the same, as one string`
     <h3>Inspect the operation graph</h3>
 
     <p>
-      <code>operations</code> is the same plan as structured data — a directed acyclic graph of
+      <code>operations</code> is the same plan as structured data: a directed acyclic graph of
       <code>OperationInfo</code> values, each with an <code>id</code>, a <code>kind</code>, a
       <code>label</code> and its <code>depends_on</code> edges.
     </p>
@@ -140,7 +140,7 @@ report.to_json()   # the same, as one string`
     </div>
 
     <p>
-      The dict carries a <code>schema</code> field — <code>screamingface.report.v1</code> — so a
+      The dict carries a <code>schema</code> field, <code>screamingface.report.v1</code>, so a
       consumer can tell what shape it is reading. Every candidate's <code>url4</code>, scores,
       metrics, usage and the pinned benchmark revision travel with it.
     </p>
@@ -149,8 +149,8 @@ report.to_json()   # the same, as one string`
 
     <p>
       A URL4 pins the run's <strong>definition</strong>, not its outputs. Re-executing the same
-      expression asks the same models the same questions under the same protocol — and models are
-      not deterministic, so the scores will move. What is reproducible is the experiment, not the
+      expression asks the same models the same questions under the same protocol, and models are not
+      deterministic, so the scores will move. What is reproducible is the experiment, not the
       number.
     </p>
 
@@ -168,7 +168,7 @@ report.to_json()   # the same, as one string`
           href="https://github.com/OpenMined/screamingface/blob/OME-605-screamingface-client-v1/packages/screamingface/examples/07_ifeval_e2e.ipynb"
           target="_blank"
           rel="noopener"
-          >Companion notebook — <code>07_ifeval_e2e.ipynb</code></a
+          >Companion notebook: <code>07_ifeval_e2e.ipynb</code></a
         >, which prints a full expression
       </li>
     </ul>

--- a/public-docs/src/router/index.ts
+++ b/public-docs/src/router/index.ts
@@ -54,6 +54,26 @@ const router = createRouter({
       component: () => import('@/pages/sf-client/guides/Url4Page.vue'),
     },
     {
+      path: '/sf-client/api/recipes',
+      name: 'sf-client-api-recipes',
+      component: () => import('@/pages/sf-client/api/RecipesPage.vue'),
+    },
+    {
+      path: '/sf-client/api/benchmarks',
+      name: 'sf-client-api-benchmarks',
+      component: () => import('@/pages/sf-client/api/BenchmarksPage.vue'),
+    },
+    {
+      path: '/sf-client/api/reports',
+      name: 'sf-client-api-reports',
+      component: () => import('@/pages/sf-client/api/ReportsPage.vue'),
+    },
+    {
+      path: '/sf-client/api/clients',
+      name: 'sf-client-api-clients',
+      component: () => import('@/pages/sf-client/api/ClientsPage.vue'),
+    },
+    {
       path: '/learn',
       name: 'learn',
       component: () => import('@/pages/learn/ArchitecturePage.vue'),


### PR DESCRIPTION
## Summary

Adds the API reference for the ScreamingFace client's core classes: eighteen class-shaped names from `__all__` at `e387aefd`, grouped across four pages under `/sf-client/api/`. Also reworks the prose on the Overview and the six user guides so the whole SF Client section reads consistently.

**Asana:** n/a (technical work, tracked as OME-670)

## Components touched

`public-docs` only. No app or package code.

## Test plan

`public-docs` has no test suite; verification was the gates plus manual checks.

- [x] `npx oxlint .`, `npx eslint .`, `npm run build`, `prettier --check` all green
- [x] Every signature copied from the client source at `e387aefd`, not reconstructed
- [x] Every example output executed against a local Engine and AI Gateway, including a real one-case `ifeval` run
- [x] Sidebar nesting checked at three levels (API Reference > Core classes > page)
- [x] Long reprs confirmed to wrap rather than scroll the page
- [ ] Screenshots attached

## Notes for review

Three things the ticket spec got wrong, corrected here against the source:

- `OME-666` names `sf.Case` and `sf.StudyReport`. Neither exists: `sf.Case` is `CaseInfo`, and `StudyReport` was merged into `Report`.
- `sf.MAX_ATTEMPTS` is in `corrective.py`'s `__all__` but is not re-exported at package level, so the retry cap is stated as prose.
- `BenchmarkInfo.case_count` is the benchmark's full size, not the run's coverage. After `limit=1` on `ifeval`, `report.case_count` is `1` while `report.benchmark.case_count` is `541`.

For `OME-671`, which inherits the rest of `__all__`: the remainder is 9 errors/warnings plus `Event`, 5 functions, and 4 modules (`benchmarks`, `connections`, `events`, `models` are modules, not functions). Note also that two distinct types are named `Usage`.

`QuickstartPage.vue` is deliberately untouched. Its samples still target the pre-`OME-605` API (`sf.config`, port `4404`, reducers), so it needs a content rewrite rather than a copy edit.

## Cross-service notes

None. Targets the `OME-666` epic branch, not `main`.

<img width="1468" height="836" alt="Screenshot 2026-08-09 at 15 15 00" src="https://github.com/user-attachments/assets/b71f9265-a8e2-4bda-a4ce-021522b43ef0" />
<img width="1468" height="836" alt="Screenshot 2026-08-09 at 15 14 40" src="https://github.com/user-attachments/assets/440be168-63f3-4594-b8a3-5088dbe68448" />
<img width="1468" height="836" alt="Screenshot 2026-08-09 at 15 14 46" src="https://github.com/user-attachments/assets/0a9a2446-b81e-47c2-b4f9-b20436af1334" />
<img width="1468" height="836" alt="Screenshot 2026-08-09 at 15 14 53" src="https://github.com/user-attachments/assets/306949b4-4140-429d-bb5c-8053aae8b352" />

