### PR TITLE
fix(ci): stamp dev images with the commit time so cached builds stay orderable

### DIFF
--- a/.github/workflows/dev-build-aigateway-ui.yml
+++ b/.github/workflows/dev-build-aigateway-ui.yml
@@ -38,7 +38,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - id: sha
-        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          echo "epoch=$(git log -1 --pretty=%ct)" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v4.6.0
         with:
@@ -56,6 +58,12 @@ jobs:
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - run: az acr login --name acropenmined
       - uses: docker/build-push-action@v7
+        env:
+          # Stamp the image's internal build date from the commit, not the build
+          # machine's clock. With the GHA cache, a content-identical rebuild
+          # otherwise inherits the PREVIOUS build's date, and downstream tooling
+          # that orders images by build date sees a tie and never deploys it.
+          SOURCE_DATE_EPOCH: ${{ steps.sha.outputs.epoch }}
         with:
           # Context is the repo root — matches the release workflows and this app's Dockerfile,
           # which COPYs apps/aigateway-ui/ from there.

--- a/.github/workflows/dev-build-aigateway.yml
+++ b/.github/workflows/dev-build-aigateway.yml
@@ -23,7 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - id: sha
-        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          echo "epoch=$(git log -1 --pretty=%ct)" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v4.6.0
         with:
@@ -41,6 +43,12 @@ jobs:
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - run: az acr login --name acropenmined
       - uses: docker/build-push-action@v7
+        env:
+          # Stamp the image's internal build date from the commit, not the build
+          # machine's clock. With the GHA cache, a content-identical rebuild
+          # otherwise inherits the PREVIOUS build's date, and downstream tooling
+          # that orders images by build date sees a tie and never deploys it.
+          SOURCE_DATE_EPOCH: ${{ steps.sha.outputs.epoch }}
         with:
           # Context is the repo root — matches the release workflows (url4-cloud's
           # Dockerfile COPYs packages/url4 from outside its own directory).

--- a/.github/workflows/dev-build-scoreboard.yml
+++ b/.github/workflows/dev-build-scoreboard.yml
@@ -23,7 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - id: sha
-        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          echo "epoch=$(git log -1 --pretty=%ct)" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v4.6.0
         with:
@@ -41,6 +43,12 @@ jobs:
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - run: az acr login --name acropenmined
       - uses: docker/build-push-action@v7
+        env:
+          # Stamp the image's internal build date from the commit, not the build
+          # machine's clock. With the GHA cache, a content-identical rebuild
+          # otherwise inherits the PREVIOUS build's date, and downstream tooling
+          # that orders images by build date sees a tie and never deploys it.
+          SOURCE_DATE_EPOCH: ${{ steps.sha.outputs.epoch }}
         with:
           # Context is the repo root — matches the release workflows (url4-cloud's
           # Dockerfile COPYs packages/url4 from outside its own directory).

--- a/.github/workflows/dev-build-url4-cloud.yml
+++ b/.github/workflows/dev-build-url4-cloud.yml
@@ -26,7 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - id: sha
-        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          echo "epoch=$(git log -1 --pretty=%ct)" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v4.6.0
         with:
@@ -44,6 +46,12 @@ jobs:
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - run: az acr login --name acropenmined
       - uses: docker/build-push-action@v7
+        env:
+          # Stamp the image's internal build date from the commit, not the build
+          # machine's clock. With the GHA cache, a content-identical rebuild
+          # otherwise inherits the PREVIOUS build's date, and downstream tooling
+          # that orders images by build date sees a tie and never deploys it.
+          SOURCE_DATE_EPOCH: ${{ steps.sha.outputs.epoch }}
         with:
           # Context is the repo root — matches the release workflows (url4-cloud's
           # Dockerfile COPYs packages/url4 from outside its own directory).
@@ -79,6 +87,12 @@ jobs:
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - run: az acr login --name acropenmined
       - uses: docker/build-push-action@v7
+        env:
+          # Stamp the image's internal build date from the commit, not the build
+          # machine's clock. With the GHA cache, a content-identical rebuild
+          # otherwise inherits the PREVIOUS build's date, and downstream tooling
+          # that orders images by build date sees a tie and never deploys it.
+          SOURCE_DATE_EPOCH: ${{ steps.sha.outputs.epoch }}
         with:
           context: .
           file: apps/url4-cloud/Dockerfile.benchmark


### PR DESCRIPTION
## Summary

Our deploy engine orders your dev images by the build date **inside** the image (the OCI `created` field). Your dev builds use the GitHub Actions build cache. On a merge that does not change the image content — for example the chart-only merge #536 — every layer is a cache hit, and the cached image configuration carries the **previous** build's date. Two different builds then claim the same build time (we verified both tags identical to the nanosecond), ordering ties, and the new build never deploys. That is why #536's chart fix sat undeployed for two days until we hand-pinned it on our side.

The fix: set `SOURCE_DATE_EPOCH` to the commit's timestamp in the four dev-build workflows. BuildKit then stamps the image with the commit time. Commit times always advance between merges, cache or no cache, so builds always stay orderable.

## The change (same shape in all four dev-build workflows)

```yaml
      - id: sha
        run: |
          echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
          echo "epoch=$(git log -1 --pretty=%ct)" >> "$GITHUB_OUTPUT"

      - uses: docker/build-push-action@v7
        env:
          SOURCE_DATE_EPOCH: ${{ steps.sha.outputs.epoch }}
        with:
          ...
```

`dev-build-url4-cloud.yml` has two build steps (engine and benchmark image); both are stamped so the pair stays consistent.

## What does not change

- Release workflows: untouched.
- Tags, labels, registries, cache configuration: untouched.
- Build speed: unchanged — the cache still works; only the stamped date changes.

## Test plan

- [x] All four workflows parse as valid YAML after the change.
- [ ] First dev build after merge: the image's internal date equals the commit time (`docker buildx imagetools inspect <tag>` → `created`).
- [ ] A later docs/chart-only merge: the new image's date still advances on a full cache hit — this is the case that previously produced the tie.

We can run the post-merge checks from our side and report back on this thread.