### PR TITLE
fix(url4-cloud): reclaim JetStream streams so runs stop failing with 10047

### DIFF
--- a/apps/url4-cloud/src/url4_cloud/adapters/jetstream.py
+++ b/apps/url4-cloud/src/url4_cloud/adapters/jetstream.py
@@ -4,27 +4,46 @@ between the Runner and the App. Subject and stream names are per-topic, derived 
 `url4_cloud.subjects.subject_for`/`stream_for` rather than reimplemented here."""
 
 import asyncio
+import logging
 from collections.abc import AsyncIterator
+from datetime import UTC, datetime
 
 import nats
 from nats.aio.client import Client
 from nats.js import JetStreamContext
-from nats.js.api import AckPolicy, ConsumerConfig, DeliverPolicy, DiscardPolicy
-from nats.js.errors import BadRequestError, NotFoundError
+from nats.js.api import AckPolicy, ConsumerConfig, DeliverPolicy, DiscardPolicy, StreamInfo
+from nats.js.errors import APIError, BadRequestError, NotFoundError
+from pydantic import ValidationError
 
 from url4.streaming.codec import decode, encode
 from url4.streaming.interfaces import EventConsumer, EventPublisher, validate_from_sequence
-from url4.streaming.protocol import OutboundFrame
-from url4_cloud.subjects import stream_for, subject_for
+from url4.streaming.protocol import OutboundFrame, TerminatedEvent
+from url4_cloud.subjects import owns_stream, stream_for, subject_for, topic_of
 
-# INVARIANT: a run's stream must outlive the run itself plus the window in which a client may
-# still attach and replay it. This is the ceiling for BOTH, and it is what stops an abandoned
-# run's frames from sitting in the filestore forever: `purge` deletes the stream on the normal
-# DELETE path, and `max_age` reclaims the ones no client ever gets around to deleting.
+logger = logging.getLogger(__name__)
+
+# INVARIANT: `max_age` bounds the BYTES a run's frames occupy. It does NOT reclaim the stream
+# object — JetStream expires messages and leaves the stream, its consumer state and its
+# filestore directory in place, still holding the whole `max_bytes` reservation. Reclaiming a
+# stream requires `delete_stream`, which is why reclamation is an explicit mechanism (the
+# runner's own teardown, plus `_sweep_orphans` below) and not a retention setting.
 DEFAULT_STREAM_MAX_AGE_S = 86_400.0
-# INVARIANT: bytes retained per run. JetStream's own default is unlimited, which makes one
-# runaway expression enough to fill the NATS filestore and take down every other run with it.
-DEFAULT_STREAM_MAX_BYTES = 256 * 1024 * 1024
+# INVARIANT: this is a RESERVATION, charged against the store the moment the stream is created
+# and held even while the stream is empty. It therefore sets the concurrency ceiling directly:
+# store_size / max_bytes. At the former 256 MiB against a 10Gi store that ceiling was 40 runs,
+# and the 41st `add_stream` failed with 10047 — the outage this value was cut to fix.
+DEFAULT_STREAM_MAX_BYTES = 50 * 1000 * 1000
+# JetStream's `JSInsufficientResourcesErr`: the store cannot place another stream.
+INSUFFICIENT_RESOURCES_ERR_CODE = 10047
+# How long a terminated run's stream is kept before the sweep may reclaim it, so a client still
+# draining the final frames is not cut off mid-read.
+DEFAULT_ORPHAN_GRACE_S = 60.0
+# How long an empty, unattached stream that NEVER received a message is kept before the sweep
+# treats it as a run that never started. Far above pod scheduling + image pull, because the cost
+# of being wrong is deleting a starting run's stream.
+DEFAULT_NEVER_STARTED_S = 1_800.0
+# Safety bound on the `streams_info` paging loop, far above any real broker's stream count.
+_MAX_STREAM_PAGES = 100
 # WHY bound the memo: it exists only to skip a round trip, so forgetting an entry costs one
 # `add_stream` call. Left unbounded it is a per-topic set that grows for the process's lifetime.
 _MAX_ENSURED_MEMO = 4096
@@ -64,10 +83,14 @@ class _JetStreamConnection:
         *,
         stream_max_age_s: float = DEFAULT_STREAM_MAX_AGE_S,
         stream_max_bytes: int = DEFAULT_STREAM_MAX_BYTES,
+        orphan_grace_s: float = DEFAULT_ORPHAN_GRACE_S,
+        never_started_s: float = DEFAULT_NEVER_STARTED_S,
     ) -> None:
         self._url = nats_url
         self._stream_max_age_s = stream_max_age_s
         self._stream_max_bytes = stream_max_bytes
+        self._orphan_grace_s = orphan_grace_s
+        self._never_started_s = never_started_s
         self._nc: Client | None = None
         self._js: JetStreamContext | None = None
         self._ensured: set[str] = set()
@@ -117,6 +140,25 @@ class _JetStreamConnection:
             return
         js = await self._jetstream()
         try:
+            await self._declare(js, topic)
+        except APIError as exc:
+            # WHY only this code: 10047 says the STORE is full, which a sweep can fix. Every other
+            # API failure is about this request and retrying it would just fail the same way.
+            if exc.err_code != INSUFFICIENT_RESOURCES_ERR_CODE:
+                raise
+            # INVARIANT: retry at most once, and only after the sweep actually freed something.
+            # Retrying a sweep that reclaimed nothing is an infinite loop against a full store —
+            # the caller has to see the real error instead of hanging.
+            if await self._sweep_orphans(js) == 0:
+                raise
+            await self._declare(js, topic)
+        if len(self._ensured) >= _MAX_ENSURED_MEMO:
+            self._ensured.clear()
+        self._ensured.add(topic)
+
+    async def _declare(self, js: JetStreamContext, topic: str) -> None:
+        """`add_stream`, tolerating a stream that is already declared."""
+        try:
             await js.add_stream(
                 name=stream_for(topic),
                 subjects=[subject_for(topic)],
@@ -126,9 +168,112 @@ class _JetStreamConnection:
             )
         except BadRequestError:
             pass
-        if len(self._ensured) >= _MAX_ENSURED_MEMO:
-            self._ensured.clear()
-        self._ensured.add(topic)
+
+    async def _sweep_orphans(self, js: JetStreamContext) -> int:
+        """Reclaim streams whose run is over, returning how many were freed.
+
+        WHY lazy rather than a background reaper: this runs only when the store is actually
+        exhausted, so it costs nothing in the normal case and needs no scheduler, no leader
+        election, and no extra RBAC. It is the backstop for runs whose pod died before its own
+        teardown could run — an OOMKill or an eviction skips the runner's `finally` entirely.
+        """
+        freed: list[str] = []
+        for info in await self._all_streams(js):
+            name = info.config.name
+            if name is None or not owns_stream(name):
+                continue
+            if not await self._is_orphan(js, info):
+                continue
+            try:
+                await js.delete_stream(name)
+            except NotFoundError:
+                # REGRESSION (I2): NOT `continue`. Sweeps race — every runner pod and every
+                # control-plane replica runs one — and this error means a CONCURRENT sweep
+                # already reclaimed this stream. Its space is free either way, so not counting
+                # it made the losing caller re-raise 10047 and fail a client for no reason.
+                pass
+            except APIError:
+                # One undeletable stream must not abort the sweep and mask the 10047 that
+                # triggered it; the remaining candidates are still worth trying.
+                logger.warning("could not reclaim stream %s", name, exc_info=True)
+                continue
+            # The memo must not outlive the stream it remembers, or a re-run of this topic would
+            # skip `add_stream` and publish into a stream that is no longer there.
+            self._ensured.discard(topic_of(name))
+            freed.append(name)
+        if freed:
+            # Name them: this is a destructive operation on a possibly shared broker, and this
+            # list is the only forensic record an operator gets.
+            logger.warning("reclaimed %d orphaned stream(s): %s", len(freed), ", ".join(freed))
+        return len(freed)
+
+    async def _all_streams(self, js: JetStreamContext) -> list[StreamInfo]:
+        """Every stream on the broker, across pages.
+
+        INVARIANT (REGRESSION I6): `streams_info()` is ONE request and the server caps a page at
+        256 entries. A single call silently examines a subset, so an orphan past the boundary is
+        invisible and the sweep reports nothing reclaimable while the store is full of it.
+        """
+        infos: list[StreamInfo] = []
+        for _ in range(_MAX_STREAM_PAGES):
+            page = await js.streams_info(offset=len(infos))
+            if not page:
+                break
+            infos.extend(page)
+        return infos
+
+    async def _is_orphan(self, js: JetStreamContext, info: StreamInfo) -> bool:
+        """Whether a stream is provably finished with, and so safe to delete.
+
+        INVARIANT: deleting a stream destroys its consumers with it, cutting off every attached
+        client. Both tests below therefore have to prove the run is OVER, never merely guess it.
+        """
+        state, name = info.state, info.config.name
+        if state.messages == 0:
+            # `max_age` emptied it, so there is nothing left to replay. `last_seq > 0` is
+            # load-bearing: a stream created microseconds ago also reports zero messages, and
+            # without this check the sweep would delete streams out from under starting runs.
+            return state.last_seq > 0 or self._never_started(info)
+        if name is None:
+            return False
+        return await self._terminated_before_grace(js, name)
+
+    def _never_started(self, info: StreamInfo) -> bool:
+        """Whether this stream's run never published anything and never will.
+
+        INVARIANT (REGRESSION C1): `messages == 0, last_seq == 0` is not only the state of a
+        stream created moments ago — it is the PERMANENT state of a topic whose runner never
+        published a frame. The control plane declares the stream when a client attaches, BEFORE
+        the Job is scheduled, so an ImagePullBackOff, a quota rejection, or a crash during world
+        resolution strands a stream holding its whole `max_bytes` reservation, which `max_age`
+        can never reclaim because there are no messages to expire. Treating that state as
+        permanently-not-orphan left the sweep unable to clear the very outage it exists for.
+
+        Two guards keep this off live runs: `created` is a SERVER-side timestamp (so no runner
+        clock is trusted), and a non-zero `consumer_count` means somebody is attached and waiting.
+        """
+        created = info.created
+        if created is None or info.state.consumer_count > 0:
+            return False
+        started = created if created.tzinfo is not None else created.replace(tzinfo=UTC)
+        return (datetime.now(UTC) - started).total_seconds() > self._never_started_s
+
+    async def _terminated_before_grace(self, js: JetStreamContext, name: str) -> bool:
+        """Whether this stream's last frame is a terminal one, old enough to be safe to drop.
+
+        This is what reclaims a run whose pod died between publishing its terminal frame and
+        running its own teardown — an OOMKill or an eviction during the drain grace.
+        """
+        try:
+            raw = await js.get_last_msg(name, subject_for(topic_of(name)))
+            frame = decode(raw.data or b"")
+        except (APIError, ValidationError):
+            # Unreadable means unprovable, and unprovable means keep it.
+            return False
+        if not isinstance(frame, TerminatedEvent) or frame.time is None:
+            return False
+        ended = frame.time if frame.time.tzinfo is not None else frame.time.replace(tzinfo=UTC)
+        return (datetime.now(UTC) - ended).total_seconds() > self._orphan_grace_s
 
     async def delete_stream(self, topic: str) -> None:
         """Drop a run's stream entirely, tolerating one that is already gone.

--- a/apps/url4-cloud/src/url4_cloud/adapters/k8s.py
+++ b/apps/url4-cloud/src/url4_cloud/adapters/k8s.py
@@ -22,6 +22,8 @@ from url4_cloud.ports import IdentityAwareJobRunner
 
 _CONFLICT = 409
 _NOT_FOUND = 404
+# Slack on top of the run deadline and the drain grace, covering the delete round trip itself.
+_TEARDOWN_MARGIN_S = 30
 
 RUNNER_LABELS = {
     "app.kubernetes.io/name": "url4-runner",
@@ -256,6 +258,7 @@ class K8sJobRunner(IdentityAwareJobRunner):
             {"name": job_env.TOPIC, "value": topic},
             {"name": job_env.EXPRESSION, "value": url4},
             {"name": job_env.JOB_DEADLINE_S, "value": str(deadline_s)},
+            {"name": job_env.STREAM_GRACE_S, "value": str(job_env.DEFAULT_STREAM_GRACE_S)},
         ]
         forwarded_traceparent = valid_traceparent(traceparent)
         if forwarded_traceparent is not None:
@@ -330,7 +333,14 @@ class K8sJobRunner(IdentityAwareJobRunner):
             container["resources"] = {k: dict(v) for k, v in self._resources.items()}
         spec: dict[str, object] = {
             "backoffLimit": 0,
-            "activeDeadlineSeconds": deadline_s,
+            # WHY this is NOT `deadline_s`: the run self-terminates at `JOB_DEADLINE_S`, publishes
+            # its terminal frame, then waits out `STREAM_GRACE_S` before deleting its own stream.
+            # Setting the pod's hard deadline to the same value SIGKILLed it mid-wait, so every
+            # timed-out run leaked a stream holding a full `max_bytes` reservation — the long runs
+            # with the fullest streams. The pod has to outlive the teardown it is asked to do.
+            "activeDeadlineSeconds": (
+                deadline_s + int(job_env.DEFAULT_STREAM_GRACE_S) + _TEARDOWN_MARGIN_S
+            ),
             "template": {
                 "metadata": {"labels": RUNNER_LABELS},
                 "spec": {

--- a/apps/url4-cloud/src/url4_cloud/job_env.py
+++ b/apps/url4-cloud/src/url4_cloud/job_env.py
@@ -180,6 +180,19 @@ TAVILY_API_KEY = "TAVILY_API_KEY"
 """Injected from the Tavily Secret by `envFrom`, so the Secret's KEY must be this exact name.
 Absent => web tools stay off."""
 
+STREAM_GRACE_S = "URL4_CLOUD_STREAM_GRACE_S"
+"""How long the Runner waits after its run ends before deleting the run's stream, so a client
+still draining the final frames is not cut off.
+
+WHY the App writes it rather than Helm: the App must ALSO widen the Job's
+``activeDeadlineSeconds`` to cover this wait, and two independently-set values would silently
+disagree — a grace longer than the deadline slack is a pod SIGKILLed mid-teardown, which is the
+leak this whole mechanism exists to close. One writer, one source of truth."""
+
+DEFAULT_STREAM_GRACE_S = 60.0
+"""Fallback for an unset :data:`STREAM_GRACE_S`, matching ``iat_window_s`` — the widest window in
+which any client can still hold a valid ticket and be attached to the run."""
+
 RUNNER_CONFIG = "URL4_RUNNER_CONFIG"
 """Path to the declared world (:mod:`url4_cloud.world_config`). Baked into the image; the App
 never writes it."""
@@ -211,6 +224,7 @@ WRITTEN_BY_APP = frozenset(
         TOPIC,
         EXPRESSION,
         JOB_DEADLINE_S,
+        STREAM_GRACE_S,
         TRACEPARENT,
         AIGATEWAY_PROFILE,
         CACHE_PARTICIPATE,
@@ -233,6 +247,7 @@ __all__ = [
     "CACHE_MAX_AGE_S",
     "CACHE_PARTICIPATE",
     "DEFAULT_NATS_URL",
+    "DEFAULT_STREAM_GRACE_S",
     "DEPLOY_TIME",
     "EXPRESSION",
     "IDENTITY_HEADER_ENV",
@@ -240,6 +255,7 @@ __all__ = [
     "NATS_URL",
     "REQUIRED",
     "RUNNER_CONFIG",
+    "STREAM_GRACE_S",
     "SECRET",
     "TAVILY_API_KEY",
     "TOPIC",

--- a/apps/url4-cloud/src/url4_cloud/runner/main.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/main.py
@@ -7,8 +7,9 @@ layering note in :mod:`url4_cloud.runner`.
 """
 
 import asyncio
+import logging
 import os
-from collections.abc import Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from pathlib import Path
@@ -25,9 +26,71 @@ from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
 from url4_cloud.runner.executor import Url4Executor, World, deny_by_default_world
 from url4_cloud.world_config import WorldConfig, WorldConfigError, load_config
 
+logger = logging.getLogger(__name__)
+
 
 class RunnerConfigError(ValueError):
     """The per-run Job environment is missing or malformed."""
+
+
+def stream_grace_s(env: Mapping[str, str]) -> float:
+    """The drain grace before a finished run's stream is reclaimed.
+
+    INVARIANT: never raises. A typo in this env var must not take down every Job at teardown —
+    the cost of the default being wrong is a slightly late reclamation, the cost of raising is
+    a leaked stream on every run.
+    """
+    raw = env.get(job_env.STREAM_GRACE_S)
+    if raw is None:
+        return job_env.DEFAULT_STREAM_GRACE_S
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("ignoring unparseable %s=%r", job_env.STREAM_GRACE_S, raw)
+        return job_env.DEFAULT_STREAM_GRACE_S
+
+
+async def run_and_reclaim(
+    publisher: JetStreamPublisher,
+    topic: str,
+    run_once: Callable[[], Awaitable[None]],
+    *,
+    grace_s: float = job_env.DEFAULT_STREAM_GRACE_S,
+    sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+) -> None:
+    """Drive one run, then reclaim its stream.
+
+    WHY the runner owns this: `DELETE /` is the only other path that reclaims a stream, and it
+    needs a capability token — those expire `iat_window_s` (60s) after minting and cannot be
+    re-issued for an existing topic, so any run longer than a minute could never tear its own
+    stream down. Every such run leaked a stream holding a full `max_bytes` reservation until the
+    store was full and every new run failed with 10047.
+
+    INVARIANT: the reclamation is in a `finally`. A run that raised is precisely the run whose
+    stream would otherwise be left behind.
+    """
+    try:
+        await run_once()
+    finally:
+        # WHY the delay: `delete_stream` destroys the stream AND its consumers. Deleting the
+        # instant the terminal frame is published races a client that has not drained yet, which
+        # would never see the terminal frame and would hang until its own timeout.
+        await sleep(grace_s)
+        try:
+            await publisher.delete_stream(topic)
+        except Exception:
+            # INVARIANT: nothing here may escape. Teardown is best-effort by design and
+            # `_sweep_orphans` is the stated backstop, so the cost of swallowing is a late
+            # reclamation. The cost of raising is far worse in BOTH directions: on the success
+            # path it reports a run that published `Terminated(succeeded)` as a Failed Job, and
+            # on the failure path a raise inside `finally` SUPERSEDES the exception already
+            # propagating, erasing the real cause of the failure from the Job's logs.
+            #
+            # WHY not `except APIError`: `delete_stream` connects lazily, so it also raises
+            # `NoServersError`, `ConnectionClosedError` and `nats.errors.TimeoutError` — none of
+            # which are `APIError`. A broker blip is exactly when reclamation fails, so the
+            # narrow clause missed the cases that actually happen.
+            logger.warning("could not reclaim stream for topic %s", topic, exc_info=True)
 
 
 @dataclass(frozen=True)
@@ -164,13 +227,19 @@ def main() -> None:  # pragma: no cover - real NATS + event loop (INFRA rule)
         params = params_from_env(os.environ)
         executor = build_executor(os.environ, benchmarks=BUILTIN_BENCHMARKS)
         traceparent = os.environ.get(job_env.TRACEPARENT)
-        await run(
-            JetStreamPublisher(params.nats_url),
-            executor,
+        publisher = JetStreamPublisher(params.nats_url)
+        await run_and_reclaim(
+            publisher,
             params.topic,
-            params.url4,
-            traceparent=traceparent,
-            deadline_s=params.deadline_s,
+            lambda: run(
+                publisher,
+                executor,
+                params.topic,
+                params.url4,
+                traceparent=traceparent,
+                deadline_s=params.deadline_s,
+            ),
+            grace_s=stream_grace_s(os.environ),
         )
 
     asyncio.run(_main())

--- a/apps/url4-cloud/src/url4_cloud/subjects.py
+++ b/apps/url4-cloud/src/url4_cloud/subjects.py
@@ -20,4 +20,18 @@ def stream_for(topic: str) -> str:
     return f"{PREFIX}_{topic}"
 
 
-__all__ = ["stream_for", "subject_for"]
+def owns_stream(stream_name: str) -> bool:
+    """Whether a stream on the broker is one of ours.
+
+    INVARIANT: the NATS store may be shared with other workloads. Reclamation enumerates every
+    stream the broker holds, so this is what keeps a sweep from deleting a stranger's data.
+    """
+    return stream_name.startswith(f"{PREFIX}_")
+
+
+def topic_of(stream_name: str) -> str:
+    """Inverse of :func:`stream_for`. Callers must check :func:`owns_stream` first."""
+    return stream_name.removeprefix(f"{PREFIX}_")
+
+
+__all__ = ["owns_stream", "stream_for", "subject_for", "topic_of"]

--- a/apps/url4-cloud/tests/unit/test_jetstream_reclamation.py
+++ b/apps/url4-cloud/tests/unit/test_jetstream_reclamation.py
@@ -1,0 +1,380 @@
+"""Stream reclamation: the leak that made every production run fail with 10047.
+
+Each run declares its own JetStream stream, and JetStream RESERVES `max_bytes` at creation —
+an empty stream still holds the whole reservation. With a 10Gi store and a 256 MiB reservation
+the ceiling was 40 streams, and nothing reclaimed them: `max_age` expires MESSAGES, never the
+stream object, and the only delete path needs a capability token that dies after 60s. These
+tests pin the reclamation that replaces that.
+"""
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from nats.js import JetStreamContext
+from nats.js.errors import BadRequestError, NotFoundError, ServerError
+
+from url4.streaming.codec import encode
+from url4.streaming.protocol import (
+    LogData,
+    LogEvent,
+    TerminatedData,
+    TerminatedEvent,
+    source_for,
+)
+from url4_cloud.adapters.jetstream import (
+    DEFAULT_STREAM_MAX_BYTES,
+    INSUFFICIENT_RESOURCES_ERR_CODE,
+    JetStreamConsumer,
+)
+from url4_cloud.subjects import stream_for, subject_for
+
+pytestmark = pytest.mark.asyncio
+
+
+def _exhausted() -> ServerError:
+    """The exact error production raised."""
+    return ServerError(
+        code=500,
+        err_code=INSUFFICIENT_RESOURCES_ERR_CODE,
+        description="insufficient storage resources available",
+    )
+
+
+def _info(
+    topic: str,
+    *,
+    messages: int,
+    last_seq: int,
+    created_age_s: float = 0.0,
+    consumer_count: int = 0,
+) -> Any:
+    return SimpleNamespace(
+        config=SimpleNamespace(name=stream_for(topic)),
+        created=datetime.now(UTC) - timedelta(seconds=created_age_s),
+        state=SimpleNamespace(messages=messages, last_seq=last_seq, consumer_count=consumer_count),
+    )
+
+
+def _raw(frame: Any) -> Any:
+    return SimpleNamespace(data=encode(frame))
+
+
+def _terminated(topic: str, *, age_s: float) -> Any:
+    return _raw(
+        TerminatedEvent(
+            id="t1",
+            source=source_for(topic),
+            subject=topic,
+            time=datetime.now(UTC) - timedelta(seconds=age_s),
+            data=TerminatedData(status="succeeded"),
+        )
+    )
+
+
+def _log(topic: str) -> Any:
+    return _raw(
+        LogEvent(
+            id="l1",
+            source=source_for(topic, "root"),
+            subject=topic,
+            time=datetime.now(UTC),
+            data=LogData.at("INFO", "still running"),
+        )
+    )
+
+
+class _FakeJetStream:
+    """A JetStream that can be out of storage, and can be freed by deleting streams."""
+
+    def __init__(
+        self,
+        *,
+        infos: list[Any] | None = None,
+        last_msgs: dict[str, Any] | None = None,
+        exhausted_until_freed: bool = False,
+    ) -> None:
+        self.added: list[dict[str, Any]] = []
+        self.deleted: list[str] = []
+        self._infos = infos or []
+        self._last_msgs = last_msgs or {}
+        self._exhausted_until_freed = exhausted_until_freed
+
+    async def add_stream(self, name: str, subjects: list[str], **kwargs: Any) -> object:
+        if self._exhausted_until_freed and not self.deleted:
+            raise _exhausted()
+        self.added.append({"name": name, "subjects": subjects, **kwargs})
+        return object()
+
+    async def streams_info(self, offset: int = 0) -> list[Any]:
+        # Honours `offset` like the real API: a paging caller must terminate.
+        return list(self._infos)[offset:]
+
+    async def get_last_msg(self, stream_name: str, subject: str, **kwargs: Any) -> Any:
+        if stream_name not in self._last_msgs:
+            raise NotFoundError
+        return self._last_msgs[stream_name]
+
+    async def delete_stream(self, name: str) -> bool:
+        self.deleted.append(name)
+        self._infos = [i for i in self._infos if i.config.name != name]
+        return True
+
+
+def _consumer(js: _FakeJetStream) -> JetStreamConsumer:
+    stream = JetStreamConsumer("nats://unused:4222")
+    stream._js = cast(JetStreamContext, js)  # noqa: SLF001
+    return stream
+
+
+async def test_insufficient_resources_is_not_a_bad_request() -> None:
+    """REGRESSION: this is why 10047 escaped as an unhandled 500 traceback in production.
+
+    `ensure_stream` caught `BadRequestError` to tolerate an already-declared stream. `ServerError`
+    (code 500) and `BadRequestError` (code 400) are SIBLINGS under `APIError`, not parent/child,
+    so the exhaustion error sailed straight past that arm.
+    """
+    assert not issubclass(ServerError, BadRequestError)
+    assert isinstance(_exhausted(), BadRequestError) is False
+
+
+async def test_streams_reserve_fifty_megabytes() -> None:
+    """INVARIANT: `max_bytes` is a RESERVATION charged at creation, so it sets the concurrency
+    ceiling: store_size / max_bytes. At 256 MiB against a 10Gi store that was 40 runs."""
+    assert DEFAULT_STREAM_MAX_BYTES == 50 * 1000 * 1000
+
+    js = _FakeJetStream()
+    await _consumer(js).ensure_stream("t")
+
+    assert js.added[0]["max_bytes"] == 50 * 1000 * 1000
+
+
+async def test_an_existing_stream_is_still_tolerated() -> None:
+    class _Exists(_FakeJetStream):
+        async def add_stream(self, name: str, subjects: list[str], **kwargs: Any) -> object:
+            raise BadRequestError(
+                code=400, err_code=10058, description="stream name already in use"
+            )
+
+    await _consumer(_Exists()).ensure_stream("t")  # must not raise
+
+
+async def test_exhaustion_sweeps_orphans_then_retries_once() -> None:
+    """The whole point: a run that hits an exhausted store reclaims dead streams and proceeds."""
+    js = _FakeJetStream(
+        infos=[_info("dead", messages=0, last_seq=42)],
+        exhausted_until_freed=True,
+    )
+
+    await _consumer(js).ensure_stream("fresh")
+
+    assert js.deleted == [stream_for("dead")]
+    assert [a["name"] for a in js.added] == [stream_for("fresh")]
+
+
+async def test_exhaustion_reraises_when_nothing_can_be_reclaimed() -> None:
+    """INVARIANT: the sweep must not become an infinite retry. With no orphan to free, the
+    caller has to see the real error rather than a hang."""
+    js = _FakeJetStream(infos=[], exhausted_until_freed=True)
+
+    with pytest.raises(ServerError) as exc:
+        await _consumer(js).ensure_stream("fresh")
+
+    assert exc.value.err_code == INSUFFICIENT_RESOURCES_ERR_CODE
+    assert js.deleted == []
+
+
+async def test_an_emptied_stream_is_an_orphan_but_a_fresh_one_is_never_swept() -> None:
+    """INVARIANT: `last_seq > 0` is load-bearing. A stream that `max_age` emptied and a stream
+    created microseconds ago BOTH report `messages == 0`; only the emptied one has ever held a
+    message. Without this test the sweep would delete streams out from under starting runs.
+    """
+    js = _FakeJetStream(
+        infos=[
+            _info("emptied", messages=0, last_seq=17),
+            _info("just-created", messages=0, last_seq=0),
+        ],
+        exhausted_until_freed=True,
+    )
+
+    await _consumer(js).ensure_stream("fresh")
+
+    assert js.deleted == [stream_for("emptied")]
+
+
+async def test_a_terminated_run_is_reclaimed_only_after_the_drain_grace() -> None:
+    """A pod killed during its own grace delay leaves a terminated-but-undeleted stream. Those
+    are reclaimable — but not instantly, or the sweep races a client draining the final frames.
+    """
+    js = _FakeJetStream(
+        infos=[
+            _info("long-done", messages=5, last_seq=5),
+            _info("just-finished", messages=5, last_seq=5),
+        ],
+        last_msgs={
+            stream_for("long-done"): _terminated("long-done", age_s=3600),
+            stream_for("just-finished"): _terminated("just-finished", age_s=1),
+        },
+        exhausted_until_freed=True,
+    )
+
+    await _consumer(js).ensure_stream("fresh")
+
+    assert js.deleted == [stream_for("long-done")]
+
+
+async def test_a_live_run_is_never_reclaimed() -> None:
+    """INVARIANT: a stream whose last frame is not terminal belongs to a run still in flight.
+    Deleting it destroys the stream AND its consumers, cutting off every attached client."""
+    js = _FakeJetStream(
+        infos=[_info("in-flight", messages=3, last_seq=3)],
+        last_msgs={stream_for("in-flight"): _log("in-flight")},
+        exhausted_until_freed=True,
+    )
+
+    with pytest.raises(ServerError):
+        await _consumer(js).ensure_stream("fresh")
+
+    assert js.deleted == []
+
+
+async def test_the_sweep_ignores_streams_this_deployment_does_not_own() -> None:
+    """INVARIANT: the store may be shared. Only `url4-cloud_*` streams are ours to reclaim."""
+    js = _FakeJetStream(
+        infos=[
+            SimpleNamespace(
+                config=SimpleNamespace(name="someone-elses-stream"),
+                state=SimpleNamespace(messages=0, last_seq=99),
+            )
+        ],
+        exhausted_until_freed=True,
+    )
+
+    with pytest.raises(ServerError):
+        await _consumer(js).ensure_stream("fresh")
+
+    assert js.deleted == []
+
+
+async def test_a_reclaimed_topic_can_be_declared_again() -> None:
+    """The memo must not outlive the stream it remembers, or a re-run of a swept topic would
+    skip `add_stream` and publish into a stream that no longer exists."""
+    js = _FakeJetStream(infos=[_info("dead", messages=0, last_seq=9)])
+    stream = _consumer(js)
+
+    await stream.ensure_stream("dead")
+    assert stream_for("dead") in [a["name"] for a in js.added]
+
+    await stream._sweep_orphans(cast(JetStreamContext, js))  # noqa: SLF001
+    js.added.clear()
+    await stream.ensure_stream("dead")
+
+    assert [a["name"] for a in js.added] == [stream_for("dead")]
+
+
+async def test_subject_naming_is_unchanged_by_reclamation() -> None:
+    js = _FakeJetStream()
+    await _consumer(js).ensure_stream("t")
+    assert js.added[0]["subjects"] == [subject_for("t")]
+
+
+async def test_a_stream_whose_run_never_published_is_reclaimed_once_it_is_old() -> None:
+    """REGRESSION (C1): `messages == 0, last_seq == 0` is not only the FRESH state — it is also
+    the PERMANENT state of a topic whose runner never published a frame.
+
+    The control plane creates the stream at attach time, before the Job runs, so an
+    ImagePullBackOff, a quota rejection, or a crash during world resolution leaves a stream that
+    reserves its full `max_bytes` and can never age out (`max_age` has no messages to expire).
+    Without this test the sweep is structurally unable to clear the very outage it exists for.
+    """
+    js = _FakeJetStream(
+        infos=[_info("never-ran", messages=0, last_seq=0, created_age_s=7200)],
+        exhausted_until_freed=True,
+    )
+
+    await _consumer(js).ensure_stream("fresh")
+
+    assert js.deleted == [stream_for("never-ran")]
+
+
+async def test_a_stream_created_moments_ago_is_still_never_reclaimed() -> None:
+    """INVARIANT: the C1 fix must not reopen the hole `last_seq > 0` was closing — a run that is
+    starting right now looks identical except for age."""
+    js = _FakeJetStream(
+        infos=[_info("starting", messages=0, last_seq=0, created_age_s=2)],
+        exhausted_until_freed=True,
+    )
+
+    with pytest.raises(ServerError):
+        await _consumer(js).ensure_stream("fresh")
+
+    assert js.deleted == []
+
+
+async def test_an_empty_stream_with_a_client_attached_is_never_reclaimed() -> None:
+    """INVARIANT: a live consumer is skew-free proof somebody is waiting on this run. Deleting
+    the stream destroys their consumer with it."""
+    js = _FakeJetStream(
+        infos=[_info("awaited", messages=0, last_seq=0, created_age_s=7200, consumer_count=1)],
+        exhausted_until_freed=True,
+    )
+
+    with pytest.raises(ServerError):
+        await _consumer(js).ensure_stream("fresh")
+
+    assert js.deleted == []
+
+
+async def test_a_stream_another_process_already_reclaimed_counts_as_freed() -> None:
+    """REGRESSION (I2): sweeps race — every runner pod and control-plane replica runs one.
+
+    Two callers hit 10047 and both sweep the same snapshot. The loser's `delete_stream` raises
+    NotFoundError because the winner already removed it. Treating that as "nothing reclaimed"
+    made the loser re-raise 10047 even though space HAD just been freed, failing a client for
+    no reason.
+    """
+
+    class _AlreadyGone(_FakeJetStream):
+        async def delete_stream(self, name: str) -> bool:
+            self.deleted.append(name)
+            self._infos = [i for i in self._infos if i.config.name != name]
+            raise NotFoundError
+
+    js = _AlreadyGone(
+        infos=[_info("raced", messages=0, last_seq=99)],
+        exhausted_until_freed=True,
+    )
+
+    await _consumer(js).ensure_stream("fresh")
+
+    assert [a["name"] for a in js.added] == [stream_for("fresh")]
+
+
+async def test_the_sweep_reads_every_page_of_streams() -> None:
+    """REGRESSION (I6): `streams_info(offset=0)` is ONE request and the server caps a page at
+    256. The reclaimable stream can sit past that boundary, and then the sweep frees nothing
+    while the store is full of orphans.
+    """
+    page_one = [_info(f"pad-{n}", messages=5, last_seq=5) for n in range(256)]
+    orphan = _info("beyond-the-page", messages=0, last_seq=3)
+
+    class _Paged(_FakeJetStream):
+        async def streams_info(self, offset: int = 0) -> list[Any]:
+            return list(self._infos)[offset : offset + 256]
+
+    js = _Paged(infos=[*page_one, orphan], exhausted_until_freed=True)
+
+    await _consumer(js).ensure_stream("fresh")
+
+    assert js.deleted == [stream_for("beyond-the-page")]
+
+
+async def test_the_retry_is_attempted_exactly_once() -> None:
+    """INVARIANT: pins termination structurally. `test_exhaustion_reraises_...` proves the raise
+    but would HANG rather than fail if the implementation looped, so count the attempts too."""
+    js = _FakeJetStream(infos=[_info("dead", messages=0, last_seq=4)], exhausted_until_freed=True)
+
+    await _consumer(js).ensure_stream("fresh")
+
+    assert len(js.added) == 1

--- a/apps/url4-cloud/tests/unit/test_runner_job_env_isolation.py
+++ b/apps/url4-cloud/tests/unit/test_runner_job_env_isolation.py
@@ -58,4 +58,14 @@ async def test_runner_job_env_is_exactly_what_the_app_set() -> None:
     )
 
     names = {e["name"] for e in _pod_spec(api)["containers"][0]["env"]}
-    assert names == {job_env.TOPIC, job_env.EXPRESSION, job_env.JOB_DEADLINE_S}
+    # STREAM_GRACE_S joined this set on 2026-08-10 (owner-approved): the App must write it
+    # BECAUSE it also widens `activeDeadlineSeconds` to cover the same wait, and two independently
+    # configured values would silently disagree — a grace longer than the deadline slack is a pod
+    # SIGKILLed mid-teardown. It is per-run by that argument, not deploy-time, so the invariant
+    # this test protects is unchanged and the assertion stays exact.
+    assert names == {
+        job_env.TOPIC,
+        job_env.EXPRESSION,
+        job_env.JOB_DEADLINE_S,
+        job_env.STREAM_GRACE_S,
+    }

--- a/apps/url4-cloud/tests/unit/test_runner_stream_reclamation.py
+++ b/apps/url4-cloud/tests/unit/test_runner_stream_reclamation.py
@@ -1,0 +1,151 @@
+"""The runner reclaims its own stream when the run ends.
+
+WHY the runner and not the control plane: `DELETE /` needs a capability token, and those expire
+`iat_window_s` (60s) after minting with no way to re-issue one for an existing topic — so any run
+longer than a minute could never tear its own stream down. That is the leak that filled the store.
+"""
+
+from typing import Any, cast
+
+import pytest
+from nats.errors import NoServersError
+from nats.js.errors import ServerError
+
+from url4_cloud import job_env
+from url4_cloud.adapters.jetstream import JetStreamPublisher
+from url4_cloud.runner.main import run_and_reclaim, stream_grace_s
+
+DEFAULT_STREAM_GRACE_S = job_env.DEFAULT_STREAM_GRACE_S
+
+pytestmark = pytest.mark.asyncio
+
+TOPIC = "run-topic"
+
+
+class _Recorder:
+    """Records teardown ordering: the grace delay must precede the delete."""
+
+    def __init__(self, *, delete_fails: bool = False) -> None:
+        self.events: list[str] = []
+        self._delete_fails = delete_fails
+        self.delete_error: Exception | None = None
+
+    async def sleep(self, seconds: float) -> None:
+        self.events.append(f"slept:{seconds}")
+
+    async def delete_stream(self, topic: str) -> None:
+        if self.delete_error is not None:
+            raise self.delete_error
+        if self._delete_fails:
+            raise ServerError(code=500, err_code=10047, description="still out of storage")
+        self.events.append(f"deleted:{topic}")
+
+
+def _publisher(rec: _Recorder) -> JetStreamPublisher:
+    return cast(JetStreamPublisher, cast(Any, rec))
+
+
+async def test_the_stream_is_reclaimed_after_a_successful_run() -> None:
+    rec = _Recorder()
+
+    async def _run() -> None:
+        rec.events.append("ran")
+
+    await run_and_reclaim(_publisher(rec), TOPIC, _run, grace_s=30.0, sleep=rec.sleep)
+
+    assert rec.events == ["ran", "slept:30.0", f"deleted:{TOPIC}"]
+
+
+async def test_the_stream_is_reclaimed_even_when_the_run_fails() -> None:
+    """INVARIANT: reclamation is in a `finally`. A run that raises is exactly the run whose
+    stream would otherwise linger, and every leaked stream holds its full reservation."""
+    rec = _Recorder()
+
+    async def _boom() -> None:
+        raise RuntimeError("execution blew up")
+
+    with pytest.raises(RuntimeError, match="execution blew up"):
+        await run_and_reclaim(_publisher(rec), TOPIC, _boom, grace_s=1.0, sleep=rec.sleep)
+
+    assert rec.events == ["slept:1.0", f"deleted:{TOPIC}"]
+
+
+async def test_the_grace_delay_precedes_the_delete() -> None:
+    """INVARIANT: `delete_stream` destroys the stream AND its consumers. Deleting the instant the
+    terminal frame is published races a client that has not drained yet — it would never receive
+    the terminal frame and would hang until its own timeout.
+    """
+    rec = _Recorder()
+
+    async def _run() -> None:
+        rec.events.append("ran")
+
+    await run_and_reclaim(_publisher(rec), TOPIC, _run, grace_s=60.0, sleep=rec.sleep)
+
+    assert rec.events.index("slept:60.0") < rec.events.index(f"deleted:{TOPIC}")
+
+
+async def test_a_failed_teardown_does_not_mask_the_run_outcome() -> None:
+    """A run that succeeded must not be reported as failed because reclamation could not finish;
+    the sweep will pick the stream up later."""
+    rec = _Recorder(delete_fails=True)
+
+    async def _run() -> None:
+        rec.events.append("ran")
+
+    await run_and_reclaim(_publisher(rec), TOPIC, _run, grace_s=0.0, sleep=rec.sleep)
+
+    assert "ran" in rec.events
+
+
+async def test_a_failed_teardown_does_not_swallow_the_run_failure() -> None:
+    rec = _Recorder(delete_fails=True)
+
+    async def _boom() -> None:
+        raise RuntimeError("the real failure")
+
+    with pytest.raises(RuntimeError, match="the real failure"):
+        await run_and_reclaim(_publisher(rec), TOPIC, _boom, grace_s=0.0, sleep=rec.sleep)
+
+
+async def test_a_broker_outage_during_teardown_does_not_fail_a_good_run() -> None:
+    """REGRESSION (I3): `delete_stream` connects lazily, so it can raise `NoServersError` /
+    `ConnectionClosedError` / `nats.errors.TimeoutError` — NONE of which are `APIError`.
+
+    A broker blip during a long run would otherwise turn a run that published
+    `Terminated(succeeded)` into a Job reported Failed.
+    """
+    rec = _Recorder()
+    rec.delete_error = NoServersError()
+
+    async def _run() -> None:
+        rec.events.append("ran")
+
+    await run_and_reclaim(_publisher(rec), TOPIC, _run, grace_s=0.0, sleep=rec.sleep)
+
+    assert "ran" in rec.events
+
+
+async def test_a_broker_outage_during_teardown_does_not_replace_the_run_failure() -> None:
+    """INVARIANT: a raise inside `finally` SUPERSEDES the exception already propagating, so a
+    teardown error would erase the real cause of a failed run from the Job's logs."""
+    rec = _Recorder()
+    rec.delete_error = NoServersError()
+
+    async def _boom() -> None:
+        raise RuntimeError("the real failure")
+
+    with pytest.raises(RuntimeError, match="the real failure"):
+        await run_and_reclaim(_publisher(rec), TOPIC, _boom, grace_s=0.0, sleep=rec.sleep)
+
+
+async def test_the_grace_window_is_configurable_and_defaults_to_the_attach_window() -> None:
+    """60s matches `iat_window_s` — the widest window in which any client can still be attached."""
+    assert DEFAULT_STREAM_GRACE_S == 60.0
+    assert stream_grace_s({}) == 60.0
+    assert stream_grace_s({job_env.STREAM_GRACE_S: "5"}) == 5.0
+
+
+async def test_an_unparseable_grace_falls_back_to_the_default() -> None:
+    """INVARIANT: a typo in the env must not crash every Job at teardown."""
+    assert stream_grace_s({job_env.STREAM_GRACE_S: "not-a-number"}) == DEFAULT_STREAM_GRACE_S

--- a/apps/url4-cloud/tests/unit/test_runners_k8s.py
+++ b/apps/url4-cloud/tests/unit/test_runners_k8s.py
@@ -94,7 +94,13 @@ async def test_schedule_builds_a_run_once_named_spec() -> None:
     assert manifest["metadata"]["name"] == name
     spec = manifest["spec"]
     assert spec["backoffLimit"] == 0
-    assert spec["activeDeadlineSeconds"] == 57600
+    # CONTRACT CHANGE (owner-approved 2026-08-10): this asserted `== 57600`, pinning
+    # `activeDeadlineSeconds == JOB_DEADLINE_S`. That equality was the defect: the run
+    # self-terminates at its own deadline, then waits out the drain grace before deleting its
+    # stream, so an identical pod deadline SIGKILLed it mid-teardown and every timed-out run
+    # leaked a stream. The run keeps its full requested budget; the POD outlives it by the
+    # teardown allowance.
+    assert spec["activeDeadlineSeconds"] > 57600 + job_env.DEFAULT_STREAM_GRACE_S
     pod = spec["template"]["spec"]
     assert pod["restartPolicy"] == "Never"
     container = pod["containers"][0]
@@ -378,3 +384,24 @@ async def test_stop_deletes_the_pod_too_not_just_the_job() -> None:
     await runner.stop(TOPIC)
 
     assert api.delete_policies == ["Background"]
+
+
+async def test_the_pod_outlives_its_own_stream_reclamation() -> None:
+    """REGRESSION: `activeDeadlineSeconds` used to equal `JOB_DEADLINE_S` exactly.
+
+    The runner self-terminates at its own deadline, publishes `Terminated(timed_out)`, then waits
+    out the drain grace before deleting its stream. With both deadlines identical, k8s killed the
+    pod during that wait, so EVERY timed-out run leaked a stream holding a full `max_bytes`
+    reservation — the long runs with the fullest streams, and exactly what the reclamation exists
+    to prevent. The Job's hard deadline must leave room for the teardown it is supposed to allow.
+    """
+    api = FakeBatchV1()
+    runner = K8sJobRunner(api, image="runner:test")
+    name = await runner.schedule(TOPIC, "/m('x')!'go'", 60)
+
+    spec = api.jobs[name]["spec"]
+    env = {e["name"]: e["value"] for e in spec["template"]["spec"]["containers"][0]["env"]}
+    grace = float(env[job_env.STREAM_GRACE_S])
+
+    assert float(env[job_env.JOB_DEADLINE_S]) == 60
+    assert spec["activeDeadlineSeconds"] > 60 + grace

--- a/docs/spec/2026-08-10-url4-cloud-jetstream-stream-reclamation.md
+++ b/docs/spec/2026-08-10-url4-cloud-jetstream-stream-reclamation.md
@@ -1,0 +1,180 @@
+# url4-cloud — JetStream stream reclamation
+
+Status: approved (owner, 2026-08-10) · Landing: `apps/url4-cloud` · No Linear item (owner
+directive: spec → implement only)
+
+## 1. Problem
+
+Production fails every run with:
+
+```
+nats.js.errors.ServerError: code=500 err_code=10047
+description='insufficient storage resources available'
+```
+
+`err_code=10047` is `JSInsufficientResourcesErr`. JetStream refuses to **place a new stream**
+because committed storage reservations already fill the store. It is not a per-message limit.
+
+The cause is a leak of stream *objects*, one per run:
+
+1. `ensure_stream()` creates one stream per topic with `max_bytes = 256 MiB`
+   (`adapters/jetstream.py:27`). JetStream **reserves** that amount at creation. An empty
+   stream still holds the full 256 MiB.
+2. The NATS PVC is `10Gi`, so the ceiling is `10240 / 256` = **40 streams**. The 41st
+   `add_stream` returns 10047.
+3. `max_age` (24 h) expires **messages**, never the stream object. The invariant comment at
+   `adapters/jetstream.py:20-23` claims it "reclaims the ones no client ever gets around to
+   deleting" — that claim is **false** and is the root defect.
+4. The only reclamation path is `DELETE /` → `delete_stream` (`rest/routes.py:485`), which
+   requires a capability token. `JwtCodec.sign` sets `exp = iat + iat_window_s` = **60 s**
+   (`auth/jwt.py:41-44`), and `POST /token` always mints a **fresh** topic
+   (`rest/routes.py:321`), so a token can never be re-issued for an existing topic.
+   **Any run longer than 60 s is structurally unable to delete its own stream.**
+5. `except BadRequestError` (`adapters/jetstream.py:127`) does **not** catch this: `ServerError`
+   (500) and `BadRequestError` (400) are siblings under `APIError`. The error escapes uncaught.
+
+Failure is monotonic and total: past ~40 leaked runs every subsequent run fails.
+
+## 2. Scope
+
+In scope: stream reclamation, stream sizing, and error surfacing. Out of scope: the
+shared-stream redesign (evaluated and deferred — it changes `sequence` semantics), token
+lifetime, and the replay-window contract.
+
+## 3. Design
+
+### 3.1 Reclamation is the runner's job (owner decision)
+
+The runner deletes its own stream at the end of its lifecycle. Reclamation is a deployment
+concern, not a protocol one, so it lives in the runner's composition root
+(`runner/main.py`) — **`packages/url4` is not modified**.
+
+`delete_stream` is declared on `EventConsumer`, not `EventPublisher`
+(`packages/url4/src/url4/streaming/interfaces/stream.py:35`), and the runner holds a
+`JetStreamPublisher`. It is **not** promoted to `EventPublisher`: `EventStream` inherits
+`(EventPublisher, EventConsumer)`, so a definition on `EventPublisher` would win the MRO and
+silently replace `EventConsumer`'s purge-delegating default — breaking local-mode teardown.
+The concrete `_JetStreamConnection` base already implements `delete_stream`, so the runner's
+composition root calls it directly on the concrete type.
+
+### 3.2 Grace delay before deletion
+
+`delete_stream` destroys the stream *and its consumers*. Deleting immediately after the
+terminal frame is published would race a client that has not drained yet, which loses the
+terminal frame and hangs the client. The runner therefore waits
+`URL4_RUNNER_STREAM_GRACE_S` (default **60 s**, matching `iat_window_s` — the widest window
+in which any client can still be attached) after `lifecycle.run` returns, then deletes.
+
+### 3.3 Lazy sweep backstop (crash-safety)
+
+A `finally` block does not run on OOMKill, eviction, node loss, or `activeDeadlineSeconds`.
+Those runs would leak exactly as today, so reclamation cannot rest on the runner alone.
+
+Rather than a background reaper (rejected: needs a loop, leader election, and RBAC), the
+sweep is **lazy** — it runs only when `ensure_stream` actually hits 10047, then retries once:
+
+```
+ensure_stream(topic):
+    try: add_stream(...)
+    except BadRequestError:  pass            # already exists
+    except APIError as e:
+        if e.err_code != 10047: raise
+        swept = sweep_orphans()
+        if swept == 0: raise                 # nothing reclaimable — surface it
+        add_stream(...)                      # retry exactly once
+```
+
+A stream is an orphan when either holds:
+
+- **Expired** — `state.messages == 0 and state.last_seq > 0`. Every message aged out, so
+  nothing is replayable. `last_seq > 0` is load-bearing: a freshly created stream that has
+  not been published to yet also has `messages == 0`, but `last_seq == 0`, so it is never
+  swept out from under a starting run.
+- **Terminated** — the last message decodes to `ai.url4.terminated` and its envelope `time`
+  is older than the grace window. The run is definitively over.
+
+- **Never started** — `messages == 0 and last_seq == 0`, `consumer_count == 0`, and
+  `StreamInfo.created` older than `never_started_s` (30 min). This case was **missed in the
+  first draft** and is the one that matters most: the control plane declares the stream when a
+  client attaches, *before* the Job is scheduled, so an `ImagePullBackOff`, a quota rejection,
+  or a crash during world resolution strands a stream that `max_age` can never reclaim (no
+  messages to expire). Treating it as permanently-not-orphan left the sweep structurally unable
+  to clear the outage it exists for.
+
+`StreamState` exposes no timestamp — but `StreamInfo.created` does, and it is a **server-side**
+value, so no runner clock is trusted. The earlier claim here that no timestamp was available at
+all was wrong and produced the gap above.
+
+The sweep costs one `streams_info()` plus at most one `get_last_msg` per candidate, and only
+on the rare exhaustion path.
+
+### 3.4 Sizing
+
+`DEFAULT_STREAM_MAX_BYTES`: 256 MiB → **50 MB** (owner directive). Ceiling rises from 40 to
+~200 concurrent runs.
+
+**Correction.** An earlier draft justified this as "safe" because per-run frame counts are
+bounded by the `_Bridge` caps. That is wrong: `_Bridge` bounds the *in-flight backlog*
+(`queue_cap=1024`), not the cumulative frames a 16-hour run publishes. With `DiscardPolicy.OLD`,
+a run exceeding `max_bytes` silently drops its **oldest** frames, and that threshold just fell
+5×. A heavy-log run can therefore lose early frames, breaking replay from sequence 1. The trade
+is still judged correct — 200 concurrent runs beats 40, and `result_cap` (1 MiB) bounds the one
+frame most likely to be large — but it is a trade, not a free win, and log-heavy runs are the
+exposure.
+
+`max_age` stays at 24 h as a byte-level bound; it is explicitly *not* a reclamation mechanism,
+and the false invariant comment is corrected.
+
+### 3.5 Error surfacing
+
+When the sweep cannot free space, 10047 must not escape as a raw 500 traceback:
+
+- Control plane: RFC 9457 problem, **503** `insufficient stream storage`.
+- Runner: the failure is already inside `lifecycle.run`'s outcome policy, which publishes
+  `TerminatedEvent(status="failed")` — but only if the stream exists. When `ensure_stream`
+  itself fails there is nowhere to publish, so the runner logs and exits non-zero rather than
+  dying on an unhandled traceback.
+
+## 4. Configuration
+
+| Setting | Default | Notes |
+|---|---|---|
+| `DEFAULT_STREAM_MAX_BYTES` | 50 MB | was 256 MiB |
+| `URL4_RUNNER_STREAM_GRACE_S` | 60 s | drain grace before self-delete |
+| `DEFAULT_STREAM_MAX_AGE_S` | 86 400 s | unchanged; byte bound only |
+
+## 5. Test plan
+
+RED first, per `sdlc-python`.
+
+1. `ensure_stream` sweeps and retries once on 10047; succeeds when the sweep frees a stream.
+2. `ensure_stream` re-raises when the sweep frees nothing (no infinite retry).
+3. `ensure_stream` still swallows `BadRequestError` (stream already exists).
+4. **Regression:** a `ServerError(500, err_code=10047)` is not caught by the `BadRequestError`
+   arm — pins the sibling-class bug that let this escape.
+5. Orphan test: `messages == 0, last_seq > 0` → swept; `messages == 0, last_seq == 0` (fresh)
+   → **not** swept.
+6. Orphan test: last frame `ai.url4.terminated` older than grace → swept; newer → not swept.
+7. Runner deletes its stream after `lifecycle.run` returns, and only after the grace delay.
+8. Runner still deletes on a failed/timed-out run (the `finally` path).
+9. `DEFAULT_STREAM_MAX_BYTES == 50 * 1000 * 1000` and is passed to `add_stream`.
+10. Local mode (`InMemoryEventStream`) teardown is unchanged — guards the MRO trap in §3.1.
+
+## 6. Operational note
+
+The fix is not retroactive. Streams already stranded in prod must be cleared once:
+
+```sh
+nats stream ls --names | grep '^url4-cloud_' | xargs -n1 nats stream rm -f
+```
+
+After deploy the lazy sweep reclaims stranded streams on its own, but only once storage is
+exhausted again — the manual pass restores headroom immediately.
+
+## 7. Known residual risk
+
+Runs killed before their `finally` block leak until the next exhaustion-triggered sweep.
+This is accepted: the sweep bounds the leak's consequence (a run fails, sweeps, and
+recovers) rather than eliminating the leak. The shared-stream redesign (one stream, subject
+per run, `max_msgs_per_subject`) removes the failure mode entirely and remains the
+recommended follow-up.

--- a/docs/work/2026-08-10-no-ticket-jetstream-stream-reclamation.md
+++ b/docs/work/2026-08-10-no-ticket-jetstream-stream-reclamation.md
@@ -1,0 +1,128 @@
+---
+ticket: none  # owner directive 2026-08-10: "No need to create new linear tickets, just spec/design/implement the fix"
+stack: url4-cloud
+status: done
+started: 2026-08-10
+finished: 2026-08-10
+---
+
+# Reclaim JetStream streams so runs stop failing with 10047
+
+## Intent
+
+Production fails every run with `err_code=10047 insufficient storage resources available`.
+Each run creates a JetStream stream reserving 256 MiB against a 10Gi store — a hard ceiling of
+40 streams — and nothing reclaims them: `max_age` expires messages but never the stream object,
+and the only delete path (`DELETE /`) needs a capability token that expires after 60 s, so any
+run longer than a minute can never tear its own stream down. This unit makes the runner reclaim
+its stream, adds a lazy sweep so crashed runs cannot leak indefinitely, and cuts the per-stream
+reservation to 50 MB (ceiling 40 → ~200).
+
+Spec: `docs/spec/2026-08-10-url4-cloud-jetstream-stream-reclamation.md`
+
+## Planned changes
+
+- `apps/url4-cloud/src/url4_cloud/adapters/jetstream.py` — `DEFAULT_STREAM_MAX_BYTES` 256 MiB →
+  50 MB; correct the false `max_age` invariant comment; catch `APIError` err_code 10047 in
+  `ensure_stream`, sweep orphans, retry once; add `_sweep_orphans`.
+- `apps/url4-cloud/src/url4_cloud/runner/main.py` — after `lifecycle.run`, wait
+  `URL4_RUNNER_STREAM_GRACE_S` (default 60 s) then `delete_stream`, in a `finally`.
+- `apps/url4-cloud/tests/unit/test_jetstream_reclamation.py` — new.
+- `apps/url4-cloud/tests/unit/` — runner teardown coverage.
+
+## Test plan
+
+Failing first, in this order:
+
+1. `ensure_stream` sweeps + retries once on 10047, succeeding when the sweep frees a stream.
+2. `ensure_stream` re-raises when the sweep frees nothing (no infinite retry).
+3. `ensure_stream` still swallows `BadRequestError` (stream already exists).
+4. Regression: `ServerError(500, err_code=10047)` is NOT caught by the `BadRequestError` arm.
+5. Orphan test — `messages == 0, last_seq > 0` swept; `last_seq == 0` (fresh) NOT swept.
+6. Orphan test — last frame `ai.url4.terminated` older than grace swept; newer NOT swept.
+7. Runner deletes its stream after the run, and only after the grace delay.
+8. Runner still deletes on a failed/timed-out run.
+9. `DEFAULT_STREAM_MAX_BYTES == 50_000_000` and reaches `add_stream`.
+10. Local-mode (`InMemoryEventStream`) teardown unchanged — guards the MRO trap.
+
+## Acceptance
+
+- All ten tests green; every pre-existing test unmodified and still green.
+- `run_gates.py url4-cloud` green (ruff, ruff format, pyright, layering, pytest ≥80% cov).
+- `packages/url4` untouched — reclamation policy stays in the app layer.
+
+## Outcome
+
+- **Actual files:**
+  - `apps/url4-cloud/src/url4_cloud/adapters/jetstream.py` — as planned, plus
+    `_declare`/`_terminated_before_grace` extracted (PLR0911 return-count gate).
+  - `apps/url4-cloud/src/url4_cloud/runner/main.py` — as planned; `run_and_reclaim` takes a
+    `run_once` thunk so the finally-path invariant is testable without an executor fake.
+  - `apps/url4-cloud/src/url4_cloud/subjects.py` — **unplanned**: added `owns_stream` /
+    `topic_of`. The sweep enumerates every stream on the broker, so it needs the inverse of
+    `stream_for` and an ownership test; keeping both in the naming module matches that
+    module's stated purpose rather than hand-formatting the prefix at the call site.
+  - `apps/url4-cloud/tests/unit/test_jetstream_reclamation.py` (11 tests) — new.
+  - `apps/url4-cloud/tests/unit/test_runner_stream_reclamation.py` (7 tests) — new.
+- **Commits:** not yet committed — awaiting owner go-ahead.
+- **Gates:** `run_gates.py url4-cloud` → ALL GATES GREEN (append-only check, ruff check, ruff
+  format --check, pyright, check_layering, pytest with `--cov-fail-under=80`). 18 new tests
+  pass; no pre-existing test modified (confirmed by the append-only gate).
+- **Deviations:**
+  1. `subjects.py` touched (above) — a shared leaf, additive only; layering gate green.
+  2. `URL4_RUNNER_STREAM_GRACE_S` is read from the Job env but **not plumbed through the Helm
+     chart**. The 60 s default is correct, so this only limits tuning; deliberately left out
+     of scope. Follow-up if operators need to tune it.
+  3. `packages/url4` untouched, as specified — reclamation policy stayed in the app layer and
+     `delete_stream` was NOT promoted to `EventPublisher` (MRO trap, spec §3.1).
+
+## Review round (2026-08-10)
+
+Two independent reviewers (senior + adversarial). Findings fixed in this unit:
+
+- **C1 — the backstop could not clear its own outage.** `messages == 0, last_seq == 0` is not
+  only the FRESH state; it is the PERMANENT state of a topic whose runner never published. The
+  control plane declares the stream at attach, before the Job runs, so an ImagePullBackOff or a
+  world-resolution crash stranded a stream `max_age` can never reclaim. Fixed with a third
+  orphan test on `StreamInfo.created` (server-side) + `consumer_count == 0`. **My spec §3.3 was
+  wrong** that no timestamp existed — corrected in the spec.
+- **I1 — `activeDeadlineSeconds == deadline_s`**, so k8s SIGKILLed the pod during the drain
+  grace and EVERY timed-out run leaked. Grace moved to `job_env` (one writer) and the pod
+  deadline widened by grace + 30 s margin.
+- **I2 — concurrent sweeps.** `NotFoundError` on delete means a racing sweep already freed the
+  space; not counting it made the loser re-raise 10047 and fail a client for nothing.
+- **I3 — `except APIError` too narrow.** `delete_stream` connects lazily, so `NoServersError` /
+  `ConnectionClosedError` / `nats.errors.TimeoutError` escaped — turning a good run into a
+  Failed Job, and on the failure path *replacing* the run's exception. Widened to `Exception`.
+- **I6 — `streams_info()` reads one page** (server caps at 256). Now paginated.
+- Sweep logging: only when something was reclaimed, and it names the streams.
+
+**Two prior tests changed (owner-approved — SDLC rule 5 Confidence Gate):**
+1. `test_runners_k8s.py::test_schedule_builds_a_run_once_named_spec` asserted
+   `activeDeadlineSeconds == 57600`, pinning the exact equality that was the defect. Owner chose
+   "widen the pod deadline" over "shrink the run budget", so the run keeps its full requested
+   budget and the pod outlives it by the teardown allowance.
+2. `test_runner_job_env_isolation.py` hardcoded the per-run env set; extended by
+   `STREAM_GRACE_S`. Intent (no deploy-time vars in `_env`) unchanged, assertion still exact.
+
+Gates were therefore run with the documented `--skip-append-only` flag.
+
+**Deferred, with owner agreement:**
+- **I4** — spec §3.5's RFC 9457 503 mapping is still not implemented; 10047 surfacing past the
+  sweep is a raw 500 on the REST path. Touches `rest/`, deliberately out of this diff.
+- I5 (`_ensured` not invalidated when another process deletes a stream — a replay/attach-path
+  defect, not data loss mid-run), M7 (runner-vs-control-plane clock skew on the terminated
+  test; `consumer_count` would be skew-free), M8 (no SIGTERM handler, so `stop` bypasses the
+  `finally` — though `DELETE /` covers that path today), M10 (two deployments sharing a broker
+  sweep each other).
+- Reviewer recommendation worth taking: every test runs against a hand-written `_FakeJetStream`,
+  which cannot catch a wrong assumption about JetStream itself — and two of the findings above
+  were exactly that. An integration test against the kind rig would close that class.
+
+## Notes for the next iteration
+
+- The fix is **not retroactive**: streams already stranded in production must be cleared once
+  by hand (spec §6). The lazy sweep only fires once the store is exhausted again.
+- Residual risk stands: a pod killed before its `finally` still leaks until the next sweep.
+  The shared-stream redesign (one stream, subject per run, `max_msgs_per_subject`) removes
+  the failure mode outright and remains the recommended follow-up.

--- a/docs/work/2026-08-10-no-ticket-jetstream-stream-reclamation.md
+++ b/docs/work/2026-08-10-no-ticket-jetstream-stream-reclamation.md
@@ -64,7 +64,8 @@ Failing first, in this order:
     module's stated purpose rather than hand-formatting the prefix at the call site.
   - `apps/url4-cloud/tests/unit/test_jetstream_reclamation.py` (11 tests) — new.
   - `apps/url4-cloud/tests/unit/test_runner_stream_reclamation.py` (7 tests) — new.
-- **Commits:** not yet committed — awaiting owner go-ahead.
+- **Commits:** `a78cab5d` — fix(url4-cloud): reclaim JetStream streams so runs stop failing
+  with 10047. (This ledger's own sha lands in the follow-up doc commit; the branch squash-merges.)
 - **Gates:** `run_gates.py url4-cloud` → ALL GATES GREEN (append-only check, ruff check, ruff
   format --check, pyright, check_layering, pytest with `--cov-fail-under=80`). 18 new tests
   pass; no pre-existing test modified (confirmed by the append-only gate).


### PR DESCRIPTION
## Summary

Production `url4-cloud` failed **every** run with `err_code=10047 insufficient storage resources available`.

Each run declared its own JetStream stream reserving **256 MiB** against a 10Gi store — a hard ceiling of **40 streams** — and nothing reclaimed them:

- `max_age` expires **messages**, never the stream object, so an empty stream keeps its full reservation. The invariant comment in `jetstream.py` claimed the opposite, and that false belief is why nothing reclaimed anything.
- The only delete path (`DELETE /`) needs a capability token, and `JwtCodec.sign` sets `exp = iat + iat_window_s` (**60 s**) while `POST /token` always mints a *fresh* topic — so a token can never be re-issued for an existing topic. **Any run longer than a minute was structurally unable to tear its own stream down.**
- `except BadRequestError` never caught it: `ServerError` (500) and `BadRequestError` (400) are siblings under `APIError`, so 10047 escaped as an unhandled 500.

Failure was monotonic and total: past ~40 leaked runs, every subsequent run failed.

## What changed

- **The runner reclaims its own stream** after a drain grace (`run_and_reclaim`), in a `finally` so a failed run reclaims too. The grace exists because `delete_stream` destroys the stream *and its consumers* — deleting on the terminal frame would race a draining client.
- **Lazy sweep on 10047**, retried exactly once, covering runs whose pod died before teardown. No background reaper, no leader election, no extra RBAC. An orphan is *proven*, never guessed: emptied by `max_age`, terminated past the grace, or created long ago with nothing published and nobody attached.
- **`max_bytes` 256 MiB → 50 MB** — ceiling 40 → ~200.
- **`activeDeadlineSeconds` now outlives the teardown it must allow.** It previously equalled the run deadline *exactly*, so k8s killed the pod during the drain grace and every timed-out run leaked.
- **Teardown failures never escape.** `delete_stream` connects lazily, so a broker blip raises outside `APIError` — which would report a good run as Failed, or (inside `finally`) *replace* a failed run's real exception.

`packages/url4` is untouched: `delete_stream` was deliberately **not** promoted to `EventPublisher`, since `EventStream(EventPublisher, EventConsumer)` would resolve to it and silently break local-mode teardown.

## Test plan

`uv run .claude/scripts/run_gates.py url4-cloud` → **all green** (ruff, format, pyright, layering, pytest ≥80% cov). 1147 tests pass; 26 new across two files.

Two prior tests changed under the SDLC Confidence Gate, both owner-approved:
1. `test_schedule_builds_a_run_once_named_spec` pinned `activeDeadlineSeconds == deadline_s` — the exact equality that was the defect.
2. `test_runner_job_env_isolation` enumerated the per-run env set; extended by `STREAM_GRACE_S`. Intent unchanged, assertion still exact.

Gates therefore ran with the documented `--skip-append-only`.

## Reviewer notes

Two review passes (senior + adversarial) ran against this branch. They caught a **critical** hole in the first draft: `messages == 0, last_seq == 0` is not only the *fresh* state but the *permanent* state of a topic whose runner never published — reachable via `ImagePullBackOff`, quota rejection, or a world-resolution crash — which made the sweep unable to clear the very outage it exists for. Fixed via `StreamInfo.created` (server-side, so no runner clock is trusted) + `consumer_count == 0`.

**Deliberately deferred** (recorded in the ledger): spec §3.5's RFC 9457 **503** mapping, so a 10047 surviving the sweep is still a raw 500 on the REST path; plus `_ensured` invalidation on out-of-process deletion, clock-skew on the terminated test, a SIGTERM handler, and multi-deployment brokers.

## Not retroactive — one manual step before this helps

Streams already stranded in production must be cleared once; the lazy sweep only fires once the store fills again:

```sh
nats stream ls --names | grep '^url4-cloud_' | xargs -n1 nats stream rm -f
```

## Known residual risk

A pod killed before its `finally` still leaks until the next sweep. The sweep bounds the *consequence* (a run fails, sweeps, recovers) rather than eliminating the leak. The shared-stream redesign — one stream, subject per run, `max_msgs_per_subject` — removes the failure mode outright and remains the recommended follow-up.

Also note: every test runs against a hand-written `_FakeJetStream`, which cannot catch a wrong assumption about JetStream itself — and two of the confirmed review findings were exactly that class of bug. An integration test against the kind rig would close it.

No Linear item — owner directive to spec and implement directly.
Spec: `docs/spec/2026-08-10-url4-cloud-jetstream-stream-reclamation.md`
Ledger: `docs/work/2026-08-10-no-ticket-jetstream-stream-reclamation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)