### PR TITLE
docs: additively refresh repo READMEs — product framing + doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,109 @@
-# ScreamingFace
+# 😱 ScreamingFace
 
-An AI ensemble system that routes coding CLI prompts through multiple models (Claude, Gemini,
-Codex, Ollama) to beat SOTA benchmarks. Built by OpenMined — [screamingface.ai](https://screamingface.ai).
+> **Build model fusions, measure them honestly, and reproduce any run from a single line of text.**
 
-## Monorepo Layout
+ScreamingFace is a toolkit for composing **fusions**, several models answering the same question and
+reduced to a single answer, and scoring them against real benchmarks. Concretely, it is three pieces:
 
+- **An open protocol, `url4`.** Every fusion and its benchmark run compile to one short,
+  human-readable line. Sharing a result is sharing that string, and `sf.from_url4(...)` reproduces
+  the exact run in a single call. **A result is only worth as much as your ability to rerun it.**
+- **A shared cache.** Every model call is cached and shared across the community, so reproducing a
+  run is both **faithful and nearly free**. Verifying someone's work costs minutes, not budgets, and
+  the more people run, the cheaper it gets for everyone.
+- **A small toolkit.** A Python library where composing a fusion, evaluating it, and reading the
+  scores takes **a few lines, not an infrastructure project** to stand up first.
+
+We built this because the same pattern kept showing up: a fusion beat the best single model inside
+it, and the result was nearly impossible to reproduce or check. Two datapoints: reproducing DRACO,
+our best fusion scored **68.6%** vs **60.2%** for the top single model (**+8.4**,
+[write-up](https://andrewtrask.substack.com/p/6-weeks-ago-frontier-ai-labs-lost)); and small-model
+ensembles beat their best member in _Beyond Leaderboards_ (Skurikhin et al., Los Alamos).
+
+It is early, and rough in places. If you find something wrong, good: every result here is meant to
+be rerun and picked apart.
+
+📚 [docs.screamingface.ai](https://docs.screamingface.ai) ·
+🏆 [leaderboard.screamingface.ai](https://leaderboard.screamingface.ai) ·
+⚖️ [Apache-2.0](LICENSE)
+
+## What it gives you
+
+- **One interface, every provider.** Bring your own keys and compose across open and closed models,
+  API and local. The client never calls a provider directly; your keys go to an engine that holds
+  them.
+- **Evaluation you can defend.** A benchmark is pinned and lives engine-side: the cases, the judge,
+  the rubric, the answer keys. Your candidate only ever sees the prompt. That separation is the
+  whole reason a "verified gain" means anything.
+- **Start from the frontier.** Pull a published run's `url4`, change one thing, and measure the
+  difference, so the next person starts where the last one finished.
+- **Shared cache, and subsidized compute.** Model calls are cached and shared across the
+  community, and we sponsor compute for researchers on a discretionary basis. A BYOK path is also
+  available, and we are happy to extend the providers we support — just open an issue.
+
+And it only really works as a community: no one team can measure every model, on every benchmark,
+across every domain. **We are looking for talented people to join this early community and help
+demonstrate it at a bigger scale.**
+
+Right now this is single-turn evaluation. No multi-turn or tool-using agent loops yet.
+
+## Quickstart
+
+```bash
+pip install "screamingface[notebook]"   # once it is on PyPI; until then, install from source (see the docs)
 ```
-apps/
-  aigateway/   LiteLLM-based AI Gateway — provider OAuth + encrypted credentials (Python, uv)
-  scoreboard/  Public benchmark scoreboard service + demo portal (Python, uv)
-packages/
-  url4/        url4 expression protocol — grammar, parser, AST, interpreter (Python, uv)
-docs/          SDLC artifacts — spec/ plan/ tasks/ work/ diagrams/ (see docs/README.md)
+
+```python
+import screamingface as sf
+
+sf.configure(engine_url="http://127.0.0.1:9108")   # your own engine, or a hosted one
+
+gpt = sf.Model("openrouter/openai/gpt-5.5")
+flash = sf.Model("openrouter/google/gemini-3-flash-preview")
+fusion = sf.Fusion([gpt, flash])
+
+# score the solo model beside the fusion, on the same cases
+report = sf.evaluate([gpt, fusion], benchmark="ifeval", limit=3)
+{c.name: c.score for c in report.candidates}
 ```
 
-> **Repo re-foundation (July 2026).** The legacy desktop app and plugin server were deprecated
-> and removed; the full pre-teardown tree is preserved at the git tag
-> **`legacy-monorepo-2026-07-08`**. New, separately-lifecycled packages (pure-Electron desktop
-> app, Python CLI on PyPI) are being built — names are being finalized. The public website
-> lives in the separate `screamingface-web` repo; this monorepo does not publish GitHub Pages.
+Full walkthrough in the [Quickstart](https://docs.screamingface.ai/sf-client/quickstartPage).
 
 ## Prerequisites
 
-| Tool | Version | Install |
-|------|---------|---------|
-| uv | latest | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
-| Python | ≥ 3.12 | `uv` installs and pins it for you |
+You need the **client** (a Python library) and an **engine** (the runtime that actually does the
+work). Two ways to get an engine:
 
-## Quickstart
+- **Run your own:** your machine, your keys, nothing in the middle on the local path.
+- **Use a hosted one:** an engine we operate, with the shared cache and, for some cohorts, subsidized
+  compute.
+
+Same client code either way; only the engine URL changes. The
+[Installation guide](https://docs.screamingface.ai) has both.
+
+| Tool   | Version | Notes                                                                        |
+| ------ | ------- | ---------------------------------------------------------------------------- |
+| Python | ≥ 3.12  | for the client                                                               |
+| uv     | latest  | for working in this repo: `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
+
+## Monorepo layout
+
+```
+apps/
+  aigateway/      AI gateway: holds provider keys (encrypted), one endpoint to every provider
+  url4-cloud/     the Engine: turns a url4 expression into a graded result
+  scoreboard/     the public Leaderboard service
+packages/
+  screamingface/  the Client: `pip install screamingface` (Python SDK)
+  url4/           the url4 protocol: grammar, parser, AST, DAG executor
+public-docs/      the documentation site (docs.screamingface.ai)
+docs/             SDLC artifacts: spec/ plan/ tasks/ work/ diagrams/ (see docs/README.md)
+```
+
+> Legacy code (the old desktop app, plugin server, and url4 engine) is preserved read-only at the
+> git tag **`legacy-monorepo-2026-07-08`**.
+
+## Working in this repo
 
 ```bash
 git clone https://github.com/OpenMined/screamingface.git
@@ -35,17 +111,23 @@ cd screamingface
 git config core.hooksPath .githooks     # pre-commit guard (blocks commits to main)
 ```
 
-Run an app:
+Run a service:
 
 ```bash
-# AI Gateway (port 9105)
+# AI gateway (port 9105)
 cd apps/aigateway && uv sync && uv run uvicorn aigateway.main:app --port 9105 --reload
 
 # Scoreboard (port 9106)
 cd apps/scoreboard && uv sync && uv run scoreboard
 ```
 
-Check a stack — lint, format, typecheck, tests, and coverage in one command:
+Run the docs site:
+
+```bash
+cd public-docs && npm install && npm run dev
+```
+
+Check a stack (lint, format, typecheck, tests, and coverage) in one command:
 
 ```bash
 uv run .claude/scripts/run_gates.py <stack>   # aigateway | scoreboard | url4
@@ -53,9 +135,14 @@ uv run .claude/scripts/run_gates.py <stack>   # aigateway | scoreboard | url4
 
 ## More
 
+- **Docs** (quickstart, guides, concepts) → [docs.screamingface.ai](https://docs.screamingface.ai)
 - **Developing / git workflow** → [`CONTRIBUTING.md`](CONTRIBUTING.md)
-- **Gateway internals** → [`apps/aigateway/README.md`](apps/aigateway/README.md)
+- **AI gateway internals** → [`apps/aigateway/README.md`](apps/aigateway/README.md)
 - **Scoreboard internals** → [`apps/scoreboard/README.md`](apps/scoreboard/README.md)
-- **url4 SDK** → [`packages/url4/README.md`](packages/url4/README.md)
+- **url4 protocol** → [`packages/url4/README.md`](packages/url4/README.md)
 - **Repo guide** (skills, agents, cards, process) → [`.claude/README.md`](.claude/README.md)
-- **Legacy code** (desktop app, plugin server, url4 engine, marketing site, infra) → `git checkout legacy-monorepo-2026-07-08`
+- **Legacy code** → `git checkout legacy-monorepo-2026-07-08`
+
+## License
+
+[Apache-2.0](LICENSE). Open to whoever shows up to measure the next slice.

--- a/apps/aigateway/README.md
+++ b/apps/aigateway/README.md
@@ -1,16 +1,26 @@
 # aigateway
 
-LiteLLM-compatible AI gateway. Exposes an OpenAI-shape `/v1/chat/completions`
-endpoint and dispatches through registered provider plugins via
+The AI gateway: the component the ScreamingFace Engine calls to reach model
+providers, and the place provider credentials live. It is LiteLLM-based and
+exposes one OpenAI-shaped `/v1/chat/completions` endpoint to every provider,
+dispatching through registered provider plugins via
 [LiteLLM](https://github.com/BerriAI/litellm). The registered providers are
 Anthropic, Antigravity, Codex, Gemini CLI, Hugging Face, Ollama and OpenRouter.
+Concept page: https://docs.screamingface.ai/learn/ai-gateway
+
+The AI gateway is the system's credential boundary: the Engine and Client never
+see raw keys. Keys are stored encrypted at rest (see Secrets at rest below), and
+the master key `AIGATEWAY_SECRET_KEY` is never stored with the data or logged;
+there is no OS keychain.
 
 The request *shape* is OpenAI-compatible; the provider set is not. Codex targets
 its own ChatGPT subscription backend, which is distinct from the OpenAI Platform
-API — AIGateway does not currently include a first-class OpenAI Platform
-provider. Provider concerns — OAuth tokens, refresh, response shaping — live in
-self-contained plugins under `src/aigateway/plugins/`; every direct subpackage
-exposing a `PLUGIN` attribute is discovered automatically.
+API: AIGateway does not currently include a first-class OpenAI Platform
+provider. Providers are plugins, enabled per deployment (for example the
+OpenRouter plugin ships disabled until `AIGW_OPENROUTER_ENABLED=true`). Provider
+concerns, OAuth tokens, refresh, response shaping, live in self-contained
+plugins under `src/aigateway/plugins/`; every direct subpackage exposing a
+`PLUGIN` attribute is discovered automatically.
 
 Local development uses SQLite at `sqlite://./aigateway.sqlite3` by default.
 Hosted deployments should set `AIGATEWAY_DATABASE_URL` to Postgres.

--- a/apps/scoreboard/README.md
+++ b/apps/scoreboard/README.md
@@ -1,6 +1,8 @@
 # scoreboard
 
-Public benchmark scoreboard service for ScreamingFace clients. It now provides the runnable service shell, health route, settings, Tortoise database wiring, score-domain models, the initial migration, and the persistence/query store. HTTP ingestion and leaderboard routes land in follow-up tickets.
+This service powers the ScreamingFace Leaderboard, the public surface where fusion results are ranked and verified by re-run, not just claimed. Every entry carries its `url4` and can be re-run; results are cached so building on prior work is cheap. It is fed by the Client and Studio through the Engine. Public site: https://leaderboard.screamingface.ai. Docs: https://docs.screamingface.ai.
+
+It now provides the runnable service shell, health route, settings, Tortoise database wiring, score-domain models, the initial migration, and the persistence/query store. HTTP ingestion and leaderboard routes land in follow-up tickets.
 
 ## Quick Start
 

--- a/apps/url4-cloud/README.md
+++ b/apps/url4-cloud/README.md
@@ -1,5 +1,15 @@
 # url4-cloud
 
+The ScreamingFace Engine: the runtime that turns a `url4` expression into a
+graded benchmark result. The Client talks only to an Engine, never to providers
+directly. It is a demand-driven, memoized DAG executor and streams usage as it
+runs. It runs bundled, self-hosted, or hosted; the local default is
+http://127.0.0.1:9108. Concept page: https://docs.screamingface.ai/learn/engine
+
+The Engine is the trust boundary: it holds provider credentials (via the AI
+gateway), the benchmark answer keys, and the grading. Prompts cross to the
+models; answer keys and rubrics do not.
+
 REST + WebSocket url4 execution runner (k8s Jobs + NATS). Design: `docs/spec/2026-07-21-url4-cloud.md`
 · epic OME-513.
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -6,12 +6,14 @@ to a registry. Deployable integration code belongs under root `apps/` or in its 
 
 Apps must never import another app's internals — shared code moves here.
 
+Docs: https://docs.screamingface.ai
+
 ## Current residents
 
 - **`url4`** — the Python URL4 grammar/parser, builders, DAG executor, I/O layers, `Url4Node`,
-  raw ASGI surface, and `url4 serve` / `url4 eval` CLI.
-- **`screamingface`** — the Python Fusion and benchmark SDK. It compiles work to URL4 and calls
-  only a configured ScreamingFace URL4 engine; benchmark data loading, grading, aggregation,
-  model dispatch, and tools are engine responsibilities.
+  raw ASGI surface, and `url4 serve` / `url4 eval` CLI. Publishes to PyPI as `url4`.
+- **`screamingface`** — the Python Fusion and benchmark SDK (`pip install screamingface`). It
+  compiles work to URL4 and calls only a configured ScreamingFace URL4 engine; benchmark data
+  loading, grading, aggregation, model dispatch, and tools are engine responsibilities.
 
 A Node SDK may be added later under a separately approved package and release contract.

--- a/packages/url4/README.md
+++ b/packages/url4/README.md
@@ -1,13 +1,19 @@
 # url4
 
-**A standalone, framework-free core library for the url4 expression protocol.**
+**A standalone, framework-free core library for url4: a grammar and a protocol for saying
+"given these sources, do this".**
 
-url4 expresses multi-source computation as `(sources)!intent` — *"given this data, do
-this"* — recursively, with `$name` / `$N` references resolved through a lexical scope. An
-expression compiles into an executable **DAG** of typed nodes: each node owns its own logic
-behind a small protocol, independent nodes run in parallel, and nested fragments parse
-lazily inside the node that owns them. All I/O is inverted behind an `IOLayer` port, so the
-core is deterministic and testable.
+The shape is `(sources)!intent`: sources in parentheses, an intent after the bang. A source
+can itself be another url4, so expressions are recursive and compose into an arbitrary DAG,
+with `$name` / `$N` references resolved through a lexical scope. url4 compiles from text to a
+frozen **AST** and lowers to a typed **DAG** of nodes: each node owns its own logic behind a
+small protocol, independent nodes run in parallel, and nested fragments parse lazily inside
+the node that owns them. Rendering a tree back to text is the lossless inverse of parsing, so
+`url4.build(url4.render(node))` round-trips. All I/O is inverted behind an `IOLayer` port, so
+the core is deterministic and testable. The name is always lowercase.
+
+Concept pages: https://docs.screamingface.ai/learn/url4 and
+https://docs.screamingface.ai/learn/url4-sdk
 
 Part of [ScreamingFace](https://screamingface.ai) by [OpenMined](https://openmined.org).
 
@@ -43,28 +49,28 @@ async with Client(io) as client:
     print(res.request)  # the canonical url4 text that ran
 ```
 
-The execution engine — DAG compilation, executor, lowering — lives one level down:
+The execution engine (DAG compilation, executor, lowering) lives one level down:
 `from url4.dag import compile_expression, run`.
 
 ## Features
 
-- **Expression-as-computation** — `(sources)!intent` with recursive fan-out and `$name`/`$N`
+- **Expression-as-computation**: `(sources)!intent` with recursive fan-out and `$name`/`$N`
   lexical references.
-- **Typed DAG** — expressions compile to a graph of typed nodes; independent nodes execute
+- **Typed DAG**: expressions compile to a graph of typed nodes; independent nodes execute
   concurrently.
-- **Inverted I/O** — all side effects go through the `IOLayer` port (`StaticIOLayer` for
+- **Inverted I/O**: all side effects go through the `IOLayer` port (`StaticIOLayer` for
   tests/offline, HTTP for real fetches), keeping the core pure and deterministic.
-- **Fully typed** — passes `pyright`; type hints ship to consumers.
+- **Fully typed**: passes `pyright`; type hints ship to consumers.
 
-## The `url4` CLI — serve a node
+## The `url4` CLI: serve a node
 
 A url4 expression *is* the address. `(/upper(hello)!'go')` names a route, a context, and an
 intent in one string; the engine compiles it to a DAG, fans out, and reduces. Nodes speak
 GET, and any leaf can be a local command. The `url4` console script runs the engine as an
-HTTP node (`url4 serve`) or evaluates an expression locally (`url4 eval`) — `serve` needs the
+HTTP node (`url4 serve`) or evaluates an expression locally (`url4 eval`): `serve` needs the
 `url4[server]` extra above.
 
-### Configure — `url4.toml`
+### Configure: `url4.toml`
 
 One file declares the node's whole surface: what it can **do** (`[commands]`) and what it can
 **read** (`[data]`, `[holdings]`, `[identities]`).
@@ -78,17 +84,17 @@ default_route = "/model"   # reduce route for fan-out; defaults to first command
 
 [commands]
 "/upper" = ["tr", "a-z", "A-Z"]
-"/bash"  = "bash -lc {intent}"   # arbitrary local exec — 127.0.0.1 only
+"/bash"  = "bash -lc {intent}"   # arbitrary local exec, 127.0.0.1 only
 "/model" = "python gateway.py --temp {param:temperature}"   # your own LLM backend
 ```
 
 > **Picking `default_route`.** A fan-out `(a, b)!'pick'` reduces by calling this route with
 > the per-source results **merged into its `{intent}`, and empty stdin**. So a reduce backend
-> must consume `{intent}` — a stdin-only command like `["tr", "a-z", "A-Z"]` reads nothing and
+> must consume `{intent}`: a stdin-only command like `["tr", "a-z", "A-Z"]` reads nothing and
 > returns an empty `200`. Unset, `default_route` is the first declared command, which is only
 > a sensible reduce backend by coincidence; name one deliberately.
 
-#### Commands — what the node can do
+#### Commands: what the node can do
 
 `[commands]` maps a route path to an argv template. The template sees everything a Python
 handler would, each substituted as a **single token** (never re-split):
@@ -96,14 +102,14 @@ handler would, each substituted as a **single token** (never re-split):
 | Token | Value |
 |---|---|
 | `{intent}` | the resolved intent |
-| `{context}` | the resolved context — also piped to the command's **stdin** |
+| `{context}` | the resolved context, also piped to the command's **stdin** |
 | `{param:<name>}` | one query param (`/model?temperature=0.7`); `""` if absent |
 | `{params}` | all params as JSON |
 
 **stdout** is the result. Substitution happens in one pass over *your* template, so
-token-shaped text in a caller's input stays literal — it never expands.
+token-shaped text in a caller's input stays literal: it never expands.
 
-#### Reads — what the node can see
+#### Reads: what the node can see
 
 Without these, a served node has no sources: `(/rubrics/42)` has nothing to resolve against
 and `@` fails. Each entry is an inline string, or a table with **exactly one** of
@@ -112,10 +118,10 @@ and `@` fails. Each entry is an inline string, or a table with **exactly one** o
 ```toml
 [data]                                    # bare relative URIs in an expression
 "/rubrics/42" = "score 1-5 on clarity"
-"/corpus"     = { file = "corpus.md" }    # re-read per request — edit, no restart
+"/corpus"     = { file = "corpus.md" }    # re-read per request, edit with no restart
 "/rows"       = { command = ["./rows.sh"], media_type = "application/json" }
 
-[holdings]                                # `@` — this node's own holdings
+[holdings]                                # `@`, this node's own holdings
 default = "my working notes"              # the unqualified shelf
 science = { file = "shelves/science.md" }
 
@@ -127,12 +133,12 @@ notes   = { file = "emily/notes.md" }
 - A `file` provider is read **per request**, so edits land without a restart.
 - A `command` provider runs your argv (no shell, empty stdin) and uses its stdout;
   `{collection}` substitutes the requested holdings collection.
-- `media_type` works on `[data]` only, and decides how a collection parses — a one-line JSON
+- `media_type` works on `[data]` only, and decides how a collection parses: a one-line JSON
   array served as `text/plain` would collapse to a single element.
 - The key `default` means the unqualified shelf, so a collection can't be *named* `"default"`.
 
 **Addressing a shelf.** A bare `@` is your `default` shelf. To pick another, qualify the eval
-path — per the URL4 spec a bare `@` takes no collection suffix (`@/science` is a parse error),
+path: per the url4 spec a bare `@` takes no collection suffix (`@/science` is a parse error),
 so the collection travels in the path:
 
 ```bash
@@ -141,7 +147,7 @@ curl 'http://127.0.0.1:4404/v1/science?q=(@)!%27%27'      # the "science" shelf
 curl 'http://127.0.0.1:4404/v1/drafts/2026?q=(@)!%27%27'  # segments join with "/"
 ```
 
-An unknown qualifier falls back to `default`. The qualifier scopes *your* shelves only —
+An unknown qualifier falls back to `default`. The qualifier scopes *your* shelves only,
 `@emily/notes` keeps its own collection either way. Because `{eval_path}/…` is reserved for
 this, declaring a command or data route under it is a config error.
 
@@ -153,19 +159,19 @@ uv run --extra server url4 serve --config url4.toml
 
 Flags override env vars (`URL4_HOST`, `URL4_PORT`, `URL4_DEFAULT_ROUTE`, `URL4_EVAL_PATH`,
 `URL4_CONFIG`, ...) which override the TOML file, which overrides built-in defaults. An
-**empty** env var counts as unset — `URL4_HOST=` in a `.env`/compose file falls through to the
+**empty** env var counts as unset: `URL4_HOST=` in a `.env`/compose file falls through to the
 TOML value, then the default, exactly as an absent variable would.
 
 ### Binding & exposure
 
-A command route is **arbitrary local execution reachable over HTTP** — that is the point of
+A command route is **arbitrary local execution reachable over HTTP**, and that is the point of
 the feature, and it is why the node binds `127.0.0.1` by default.
 
 - Loopback is exactly `127.0.0.1`, `::1`, `localhost`. Anything else prints a loud warning,
   plus a second one naming the command routes now remotely reachable.
 - To bind every interface, write `0.0.0.0` explicitly (it warns). An **empty** host is
   rejected outright: it would bind `0.0.0.0` *and* `::` while reading as "unset".
-- Config problems fail fast **before** the bind, with exit code 2 — an undeclared
+- Config problems fail fast **before** the bind, with exit code 2: an undeclared
   `default_route`, an empty `[commands]`, an `eval_path` that is not a `/path` or collides
   with `/healthz`, a `[data]` path clashing with a command or reserved route, an invalid
   identity name, or a provider declaring zero or several of `value`/`file`/`command`.
@@ -179,16 +185,16 @@ authn/authz of its own.
 # liveness
 curl http://127.0.0.1:4404/healthz
 
-# eval — dispatch to the /upper command
+# eval: dispatch to the /upper command
 curl 'http://127.0.0.1:4404/v1?q=(/upper(hello world)!%27go%27)'
 
-# fan-out + reduce — both results reach default_route as its {intent}
+# fan-out + reduce: both results reach default_route as its {intent}
 curl 'http://127.0.0.1:4404/v1?q=(/upper(a)!%27go%27,+/upper(b)!%27go%27)!%27choose+the+best%27'
 
 # read a [data] route as a bare relative URI
 curl 'http://127.0.0.1:4404/v1?q=(/rubrics/42)!%27%27'
 
-# holdings — the node's own `@`, and a named identity's shelf
+# holdings: the node's own `@`, and a named identity's shelf
 curl 'http://127.0.0.1:4404/v1?q=(@)!%27%27'
 curl 'http://127.0.0.1:4404/v1?q=(@emily/notes)!%27%27'
 ```
@@ -213,4 +219,4 @@ uv run url4 eval "(/upper(hi)!'go')"
 
 ## License
 
-Apache-2.0 — see [LICENSE](LICENSE).
+Apache-2.0, see [LICENSE](LICENSE).

--- a/public-docs/README.md
+++ b/public-docs/README.md
@@ -1,6 +1,9 @@
 # screamingface-docs
 
-Documentation site for ScreamingFace — a Vue 3 + TypeScript + Vite single-page app.
+The ScreamingFace docs site, a Vue 3 + TypeScript + Vite single-page app served at
+[https://docs.screamingface.ai](https://docs.screamingface.ai). It covers the ScreamingFace
+Client (install, quickstart, and guides) alongside the url4, Engine, AI gateway, and caching
+concepts.
 
 ## Stack
 


### PR DESCRIPTION
## Summary

Refreshes the root and component READMEs with product framing and links to `docs.screamingface.ai`. Purely **additive** — reconstructed on top of `origin/main` so nothing already on main is reverted.

- **Root `README.md`** — fusion / `url4` / shared-cache framing, quickstart, updated monorepo layout, license note.
- **`apps/aigateway`** — credential-boundary framing + concept-page link.
- **`apps/url4-cloud`** — "ScreamingFace Engine" intro + trust-boundary note (main's model-catalog / cache-policy / connections sections left intact).
- **`apps/scoreboard`** — Leaderboard intro (main's `SCOREBOARD_SUBMISSION_API_KEY` settings docs left intact).
- **`packages/`** — docs link + PyPI / `pip install` specifics on top of main's descriptions.
- **`packages/url4`** — protocol description + round-trip / concept-page notes.
- **`public-docs`** — docs-site description + coverage.

## Why reconstructed

The source edits were sitting uncommitted on the already-merged `callis/ome-666-…` branch (PR #530), whose base was ~89 commits behind `origin/main`. In the meantime `origin/main` further rewrote `scoreboard`, `url4-cloud`, and `packages` READMEs. Committing the working tree verbatim would have reverted that newer work (notably ~130 lines of `url4-cloud` cache-policy / provider-connections docs), so only the additive parts were re-applied here.

## Test plan

- Docs-only change; no code touched.
- `git diff origin/main` confirmed additive: no content removed from `url4-cloud` / `scoreboard` / `packages` beyond replaced/reflowed lines.

## Follow-up

Linear work item (`repo` / docs task) to be filed and linked — Linear MCP was not authenticated at commit time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)