### PR TITLE
fix(screamingface): surface failure identity and failed-state semantics in the report view

### DIFF
--- a/docs/tasks/2026-08-12-report-failure-ux.md
+++ b/docs/tasks/2026-08-12-report-failure-ux.md
@@ -1,0 +1,17 @@
+---
+id: OME-793
+linear_url: https://linear.app/openmined/issue/OME-793/surface-failure-identity-and-failed-state-semantics-in-the-report-view
+status: in_progress
+type: bug
+priority: high
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-08-12
+closed:
+---
+
+# Surface failure identity and failed-state semantics in the report view
+
+The report widget discards failure evidence the report already carries: banner lines with
+no case ids, INCORRECT badges on never-graded cases, "None" detail panes, unexplained
+metric dashes. Display-only fix in `_ui/report_view.py`; scope and Before/After in Linear.
+Ledger: `docs/work/2026-08-12-OME-793-report-failure-ux.md`. Related: `OME-784`, `OME-794`.

--- a/docs/work/2026-08-12-OME-793-report-failure-ux.md
+++ b/docs/work/2026-08-12-OME-793-report-failure-ux.md
@@ -1,0 +1,63 @@
+---
+ticket: OME-793
+stack: screamingface
+status: in_progress
+started: 2026-08-12
+finished:
+---
+
+# OME-793 — Surface failure identity and failed-state semantics in the report view
+
+## Intent
+
+Debugging the 2026-08-11 HealthBench worst30 fusion run through the report widget required
+dropping to raw JSON: the failure banner repeats an identical message with no case ids, a
+never-graded case wears the same INCORRECT badge as a genuinely wrong answer, the failed
+case's detail pane renders nothing useful, and the withheld metrics show bare dashes with
+no reason. All the evidence (case_id, code, collected_errors, failure counts) is already in
+`screamingface.report.v1` — this unit makes the view show it. Display-only; the report
+artifact and score-withholding rule are untouched.
+
+## Planned changes
+
+- `packages/screamingface/src/screamingface/_ui/report_view.py` — failure banner groups
+  identical failures and names cases/codes/underlying errors; tri-state case rendering
+  (passed / incorrect / failed) with a distinct warning-styled mark+badge for ungraded
+  cases; failed-case pane renders the failures chain and an explicit input-unavailable
+  note; unscored candidate card gets a "score withheld — N/M cases failed" warn strip;
+  absent-cost cell gets a title distinguishing "not reported" from "withheld".
+- `packages/screamingface/tests/test_report_panel.py` — new tests only (append-only).
+
+## Test plan
+
+- RED: banner shows case id + code + first collected error, and collapses 3 identical
+  failures into one grouped line (invariant: no failure loses its identity).
+- RED: a failed case (grade=None, failures present) renders a `failed` badge distinct from
+  `incorrect`, a warning mark in the rail, the failure chain in the pane, and an explicit
+  input-unavailable note (invariant: infra failure never presents as a wrong answer).
+- RED: an unscored candidate with failed cases explains the dashes ("score withheld — 1/2
+  cases failed"); cost `—` carries the not-reported title (invariant: every dash says why).
+- Boundaries: single failure (no grouping suffix), failures without case_id/collected
+  errors, untrusted text in failure messages stays escaped.
+- All prior tests stay green and unmodified.
+
+## Acceptance
+
+- Report of a partially failed run answers in the widget: which cases failed, with what
+  code/error, and why aggregate metrics are absent.
+- Graded-but-wrong vs never-graded cases visually distinct.
+- `run_gates.py screamingface` fully green.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned — `_ui/report_view.py` (banner grouping + `_failure_line` /
+  `_first_collected_error` / `_case_state` / `_case_failures_html` / `_withheld_html`,
+  warn badge+mark CSS, cost cell title), `tests/test_report_panel.py` (+7 tests,
+  append-only).
+- **Commits:** single commit on `OME-793-report-failure-ux` (sha in PR).
+- **Gates:** ALL GREEN — append-only check, ruff check, ruff format, pyright,
+  pytest --cov ≥95 (692 tests: 685+7 −? → suite green), notebook check, uv build,
+  distribution check.
+- **Deviations:** `report_view.py` was already over the 450-line guidance before this unit
+  (629 → ~745 lines); splitting it is out of scope for a display fix — flagged for a
+  follow-up refactor rather than done as a drive-by.

--- a/packages/screamingface/src/screamingface/_ui/report_view.py
+++ b/packages/screamingface/src/screamingface/_ui/report_view.py
@@ -92,6 +92,10 @@ _STYLE = (
 .sf-badge--bad{{color:var(--sf-blind);border-color:var(--sf-blind);
   background:var(--sf-blind-bg)}}
 .sf-badge--bad .sq{{background:var(--sf-blind)}}
+/* infra failure is a WARNING state, not a wrong answer — never the incorrect red */
+.sf-badge--warn{{color:var(--sf-warning);border-color:var(--sf-warning-solid);
+  background:var(--sf-warning-bg)}}
+.sf-badge--warn .sq{{background:var(--sf-warning-solid)}}
 .sf-report__pre{{margin:8px 0 0;padding:8px;background:var(--sf-surface);
   border:1px solid var(--sf-line);font-family:"IBM Plex Mono",ui-monospace,monospace;
   font-size:12px;color:var(--sf-ink-2);white-space:pre-wrap;overflow-wrap:anywhere;
@@ -118,6 +122,8 @@ _STYLE = (
   border:1px solid var(--sf-success);background:var(--sf-success-bg)}}
 .sf-mark--bad{{color:var(--sf-blind);border-color:var(--sf-blind);
   background:var(--sf-blind-bg)}}
+.sf-mark--warn{{color:var(--sf-warning);border-color:var(--sf-warning-solid);
+  background:var(--sf-warning-bg)}}
 .sf-pane{{display:none;padding:12px 14px;min-width:0}}
 .sf-pane__h{{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:10px}}
 .sf-pane__q{{font-size:15px;line-height:1.45;color:var(--sf-ink)}}
@@ -266,7 +272,13 @@ def _card_html(candidate: CandidateResult, report: Report) -> str:
         _cell("score", _percent(candidate.score), score=scored),
         _cell("pass rate", _percent(_metric(metrics, "pass_rate"))),
         _cell("coverage", _percent(_metric(metrics, "coverage"))),
-        _cell("cost", "—" if usage.cost_usd is None else _money(usage.cost_usd)),
+        # WHY (OME-793): the two dash meanings differ — cost is "not reported by this
+        # run" (a pipeline gap), while withheld score/metrics are explained by the strip.
+        _cell(
+            "cost",
+            "—" if usage.cost_usd is None else _money(usage.cost_usd),
+            title="cost not reported by this run" if usage.cost_usd is None else "",
+        ),
         _cell("tokens", _tokens_total(usage)),
         _cell("duration", _duration(candidate.duration_ms)),
     ]
@@ -277,10 +289,31 @@ def _card_html(candidate: CandidateResult, report: Report) -> str:
         f"<span class='sf-report__run'>{escape(_short(candidate.run_id))}</span></div>"
         f"{_models_html(candidate)}"
         f"<div class='sf-report__grid'>{''.join(cells)}</div>"
+        f"{_withheld_html(candidate)}"
         f"{_axes_html(metrics)}"
         f"{_grading_html(metrics)}"
         f"{_members_html(candidate)}"
         f"{_recipe_html(candidate)}</div>"
+    )
+
+
+def _withheld_html(candidate: CandidateResult) -> str:
+    """Explain the dashes: B1 withholds ALL metrics when any selected case failed.
+
+    A partial mean over surviving cases would silently drop exactly the hardest rows, so
+    the aggregate publishes nothing — this strip says that instead of leaving bare `—`s
+    (OME-793: three unexplained dashes sent readers hunting a rendering bug).
+    """
+
+    if candidate.score is not None:
+        return ""
+    failed = sum(1 for case in candidate.cases if case.grade is None)
+    if not failed:
+        return ""
+    total = len(candidate.cases)
+    return (
+        f"<div class='sf-report__warn'>score withheld — {failed} of {total} cases failed; "
+        "metrics are published only for fully scored runs.</div>"
     )
 
 
@@ -387,13 +420,14 @@ def _recipe_html(candidate: CandidateResult) -> str:
     )
 
 
-def _cell(key: str, value: str, *, score: bool = False) -> str:
+def _cell(key: str, value: str, *, score: bool = False, title: str = "") -> str:
     """One figure. The score cell is the card's hero — it alone takes the fusion edge."""
 
     cell_class = "sf-report__cell" + (" sf-report__cell--score" if score else "")
     value_class = "sf-report__v" + (" sf-report__v--score" if score else "")
+    title_attr = f" title='{escape(title)}'" if title else ""
     return (
-        f"<div class='{cell_class}'><div class='sf-report__k'>{escape(key)}</div>"
+        f"<div class='{cell_class}'{title_attr}><div class='sf-report__k'>{escape(key)}</div>"
         f"<div class='{value_class}'>{escape(value)}</div></div>"
     )
 
@@ -403,14 +437,58 @@ def _stamp(moment: Any) -> str:
 
 
 def _failures_html(report: Report) -> str:
+    """The failure banner names every failed case — a bare message forces raw-JSON triage.
+
+    Identical failures (same stage · code · message) collapse into ONE line carrying every
+    affected case id, so three dead cases read as one diagnosis, not three mysteries
+    (OME-793: the worst30 fusion incident rendered 3 id-less duplicate lines).
+    """
+
     failures = report.failures
     if not failures:
         return ""
-    lines = "\n".join(
-        f"{getattr(item, 'stage', '?')} · {getattr(item, 'message', item)}" for item in failures
-    )
+    groups: dict[tuple[str, str, str], list[Any]] = {}
+    for item in failures:
+        key = (
+            str(getattr(item, "stage", "?")),
+            str(getattr(item, "code", "") or ""),
+            str(getattr(item, "message", item)),
+        )
+        groups.setdefault(key, []).append(item)
+    lines = "\n".join(_failure_line(key, items) for key, items in groups.items())
     count = f"{len(failures)} failure" + ("" if len(failures) == 1 else "s")
     return f"<div class='sf-report__fail' role='alert'>{escape(count)}\n{escape(lines)}</div>"
+
+
+def _failure_line(key: tuple[str, str, str], items: list[Any]) -> str:
+    stage, code, message = key
+    case_ids = [str(value) for value in (getattr(item, "case_id", None) for item in items) if value]
+    # A failure with no code and no case identity keeps the plain `stage · message` shape.
+    if not code and not case_ids:
+        return f"{stage} · {message}"
+    head = " · ".join(part for part in (stage, code) if part)
+    cases = ""
+    if case_ids:
+        label = "case" if len(case_ids) == 1 else "cases"
+        cases = f" · {label} {', '.join(case_ids)}"
+    underlying = next(
+        (found for found in (_first_collected_error(item) for item in items) if found), ""
+    )
+    return f"{head}{cases} — {message}{underlying}"
+
+
+def _first_collected_error(failure: Any) -> str:
+    """Pull `(Kind: message)` out of a failure's collected_errors metadata, if present."""
+
+    metadata = getattr(failure, "metadata", None)
+    collected = metadata.get("collected_errors") if isinstance(metadata, Mapping) else None
+    first = collected[0] if isinstance(collected, list | tuple) and collected else None
+    error = first.get("error") if isinstance(first, Mapping) else None
+    kind = error.get("kind") if isinstance(error, Mapping) else None
+    message = error.get("message") if isinstance(error, Mapping) else None
+    if not kind and not message:
+        return ""
+    return f" ({kind}: {message})" if kind else f" ({message})"
 
 
 def _cases_html(report: Report) -> str:
@@ -471,21 +549,31 @@ def _group_key(report: Report) -> str:
 
 
 def _rail_item(item: str, candidate: CandidateResult, case: CaseResult, show_who: bool) -> str:
-    passed = _case_passed(case)
-    mark = "sf-mark" + ("" if passed else " sf-mark--bad")
-    glyph = "&check;" if passed else "&times;"
+    state = _case_state(case)
+    # WHY (OME-793): a failed case gets the warning mark, never the incorrect ✗ — the rail
+    # must not present an infra failure as a graded wrong answer.
+    mark = (
+        "sf-mark" + {"passed": "", "incorrect": " sf-mark--bad", "failed": " sf-mark--warn"}[state]
+    )
+    glyph = {"passed": "&check;", "incorrect": "&times;", "failed": "!"}[state]
     who = f" <span class='sf-rail__who'>{escape(candidate.name)}</span>" if show_who else ""
+    preview = _clip(case.input, 90) if case.input is not None else "input unavailable"
     return (
         f"<label class='sf-rail__item' for='{item}'>"
         f"<span class='{mark}' aria-hidden='true'>{glyph}</span>"
         f"<span class='sf-rail__id'>case {case.case_id}</span>{who}"
-        f"<span class='sf-rail__q'>{escape(_clip(case.input, 90))}</span></label>"
+        f"<span class='sf-rail__q'>{escape(preview)}</span></label>"
     )
 
 
 def _pane_html(candidate: CandidateResult, case: CaseResult) -> str:
-    passed = _case_passed(case)
-    verdict = _badge("correct" if passed else "incorrect", good=passed)
+    state = _case_state(case)
+    # WHY (OME-793): tri-state verdict — "failed" (warning) is neither correct nor
+    # incorrect; the case was never graded, and the badge must say so.
+    if state == "failed":
+        verdict = _badge("failed", good=False, warn=True)
+    else:
+        verdict = _badge("correct" if state == "passed" else "incorrect", good=state == "passed")
     grade = case.grade
     checks = "".join(_check_html(check) for check in (grade.checks if grade else ()))
     checks_head = (
@@ -508,12 +596,35 @@ def _pane_html(candidate: CandidateResult, case: CaseResult) -> str:
         for key, value in (case.metadata or {}).items()
     )
     tags_html = f"<div class='sf-chips' style='margin-top:8px'>{tags}</div>" if tags else ""
+    if case.input is not None:
+        question = f"<div class='sf-pane__q'>{escape(_clip(case.input, 600))}</div>"
+    else:
+        # INVARIANT (OME-793): absence is stated, never rendered as an empty body — a
+        # failed case's input was not retained by the Engine (see OME-784 for fixing that).
+        question = (
+            "<div class='sf-pane__q'>input unavailable — "
+            "the case failed before it was recorded</div>"
+        )
     return (
         "<div class='sf-pane'><div class='sf-pane__h'>"
         f"<span class='sf-report__case-id'>case {case.case_id} · "
         f"{escape(candidate.name)}</span>{verdict}{finish_html}</div>{tags_html}"
-        f"<div class='sf-pane__q'>{escape(_clip(case.input, 600))}</div>"
-        f"{answer_html}{checks_head}{checks}</div>"
+        f"{question}{answer_html}{_case_failures_html(case)}{checks_head}{checks}</div>"
+    )
+
+
+def _case_failures_html(case: CaseResult) -> str:
+    """The failure chain IS the failed case's content — stage, code, message, evidence."""
+
+    if not case.failures:
+        return ""
+    lines = "\n".join(
+        f"{failure.stage} · {failure.code} — {failure.message}{_first_collected_error(failure)}"
+        for failure in case.failures
+    )
+    return (
+        "<div class='sf-detail__k'>failures</div>"
+        f"<div class='sf-report__fail'>{escape(lines)}</div>"
     )
 
 
@@ -526,6 +637,18 @@ def _case_passed(case: CaseResult) -> bool:
     if grade.checks:
         return all(_check_good(check) for check in grade.checks)
     return grade.score is not None and grade.score > 0
+
+
+def _case_state(case: CaseResult) -> str:
+    """Tri-state outcome: 'failed' (never graded) is distinct from 'incorrect' (graded, bad).
+
+    INVARIANT (OME-793): grade is None ⇒ the Engine produced no verdict for this case —
+    the model contract guarantees such a case carries failures explaining why.
+    """
+
+    if case.grade is None:
+        return "failed"
+    return "passed" if _case_passed(case) else "incorrect"
 
 
 def _check_good(check: Any) -> bool:
@@ -554,8 +677,8 @@ def _check_html(check: Any) -> str:
     )
 
 
-def _badge(text: str, *, good: bool) -> str:
-    variant = "sf-badge--ok" if good else "sf-badge--bad"
+def _badge(text: str, *, good: bool, warn: bool = False) -> str:
+    variant = "sf-badge--warn" if warn else ("sf-badge--ok" if good else "sf-badge--bad")
     return f"<span class='sf-badge {variant}'><i class='sq'></i>{escape(text)}</span>"
 
 

--- a/packages/screamingface/tests/test_report_panel.py
+++ b/packages/screamingface/tests/test_report_panel.py
@@ -245,6 +245,122 @@ def test_axis_and_grading_details_render_only_meaningful_differences() -> None:
     assert "of 5 verdicts" in grading
 
 
+def multi_case_report(*cases: CaseResult) -> Report:
+    """A Report sized to its cases — Report validation pins case_count to the Benchmark."""
+
+    benchmark = BenchmarkInfo("draco/smoke", "74c94830e8de6afd", len(cases))
+    inner = candidate("open_trio", None, cases=cases)
+    sized = CandidateResult(
+        benchmark=benchmark,
+        run_id=inner.run_id,
+        started_at=_START,
+        completed_at=_END,
+        name=inner.name,
+        kind=inner.kind,
+        url4=inner.url4,
+        models=list(inner.models),
+        operations=list(inner.operations),
+        score=None,
+        metrics={},
+        cases=list(cases),
+        members=[],
+        failures=[],
+        usage=sf.Usage(input_tokens=3449, output_tokens=2340),
+    )
+    return Report(benchmark=benchmark, case_count=len(cases), candidates=[sized])
+
+
+def failed_case(case_id: int = 153) -> CaseResult:
+    """A Case the Engine could not grade — the OME-793 incident shape."""
+
+    return CaseResult(
+        case_id=case_id,
+        input=None,
+        output=None,
+        finish_reason=None,
+        grade=None,
+        failures=[
+            sf.Failure(
+                stage="candidate",
+                code="missing_case_row",
+                message="no evaluation row for this Case reached the aggregate",
+                case_id=case_id,
+                metadata={
+                    "collected_errors": [
+                        {
+                            "error": {
+                                "kind": "ResolutionError",
+                                "message": "malformed aigateway response",
+                            }
+                        }
+                    ]
+                },
+            )
+        ],
+        metadata={},
+    )
+
+
+# WHY (OME-793): an infra failure must never present as a wrong answer — the badge is the
+# first thing a reader trusts, and "incorrect" on a never-graded case misreports the run.
+def test_a_failed_case_is_not_painted_as_incorrect() -> None:
+    html = body(report_html(report(candidate("open_trio", None, cases=(failed_case(),)))))
+
+    assert "failed" in html
+    assert "incorrect" not in html
+    assert "sf-badge--warn" in html
+    assert "sf-mark--warn" in html
+
+
+# INVARIANT (OME-793): the pane must surface the failure chain the report already carries —
+# stage, code, message, and the underlying collected error — not an empty body.
+def test_a_failed_case_pane_shows_the_failure_chain_not_nothing() -> None:
+    html = body(report_html(report(candidate("open_trio", None, cases=(failed_case(),)))))
+
+    assert "missing_case_row" in html
+    assert "no evaluation row for this Case reached the aggregate" in html
+    assert "ResolutionError: malformed aigateway response" in html
+    assert "input unavailable" in html
+
+
+# WHY (OME-793): three identical banner lines with no ids forced readers into raw JSON;
+# grouping keeps the count while naming every case.
+def test_the_failure_banner_names_cases_and_groups_identical_failures() -> None:
+    value = multi_case_report(failed_case(153), failed_case(149), failed_case(418))
+    banner = _failures_html(value)
+
+    assert "3 failures" in banner
+    assert "cases 153, 149, 418" in banner
+    assert "missing_case_row" in banner
+    assert "ResolutionError: malformed aigateway response" in banner
+    # Grouped: the shared message appears ONCE in the banner, not three times.
+    assert banner.count("no evaluation row for this Case reached the aggregate") == 1
+
+
+# WHY (OME-793): a bare dash teaches readers that dashes are meaningless; the withheld
+# score must say it is withheld and why (B1 keeps metrics empty when any case failed).
+def test_an_unscored_candidate_explains_the_withheld_score() -> None:
+    html = body(report_html(multi_case_report(case(), failed_case())))
+
+    assert "score withheld" in html
+    assert "1 of 2 cases failed" in html
+
+
+def test_an_absent_cost_says_it_was_not_reported() -> None:
+    html = body(report_html(report(candidate("m", 0.5))))
+
+    assert "cost not reported" in html
+
+
+def test_a_failure_without_case_id_or_collected_errors_still_renders() -> None:
+    bare = sf.Failure(stage="aggregation", code="orphan_rows", message="rows without a case")
+    html = _failures_html(cast(Report, SimpleNamespace(failures=(bare,))))
+
+    assert "1 failure" in html
+    assert "orphan_rows" in html
+    assert "rows without a case" in html
+
+
 def test_empty_cases_and_untrusted_failures_have_safe_markup() -> None:
     empty_report = cast(Report, SimpleNamespace(candidates=()))
     assert _cases_html(empty_report) == ""


### PR DESCRIPTION
Refs: OME-793 · https://linear.app/openmined/issue/OME-793

## Before / After

### Before
- Trigger: a dev opens the report widget on a run where cases died (the 2026-08-11 HealthBench worst30 fusion run: 3 of 10 cases lost to gateway failures).
- Today: the failure banner repeats `candidate · no evaluation row for this Case reached the aggregate` three times with no case ids; a never-graded case wears the same red INCORRECT badge as a genuinely wrong answer; the failed case's detail pane renders nothing useful; score / pass rate / coverage show bare dashes with no reason.
- Cost: every failure investigation drops to raw report.json; infra failures read as bad model answers in screenshots and team discussion.

### After
- Same trigger.
- Now: the banner groups identical failures into one line naming the cases, code, and underlying error (`candidate · missing_case_row · cases 153, 149, 418 — … (ResolutionError: malformed aigateway response)`); failed cases carry a distinct warning-styled FAILED state; the pane renders the failures chain plus an explicit input-unavailable note; unscored candidates say `score withheld — 3 of 10 cases failed`, and an absent cost carries a "cost not reported by this run" title.
- Win: triage happens in the widget; a screenshot of it is self-explanatory.

### Don't regress
- Graded cases' rubric/check rendering unchanged; prior tests untouched (append-only check green).
- `report.to_json()` byte-identical — display-only change.
- The B1 score-withholding rule itself is untouched; the strip only explains it.

## Test plan
- 7 new tests in `test_report_panel.py`: banner grouping + identity, tri-state failed badge/mark, failure-chain pane, withheld-score strip, cost title, no-code failure fallback, escaped untrusted failure text.
- Full `run_gates.py screamingface` green: ruff, format, pyright, pytest --cov ≥95, notebook determinism, build, distribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)