### PR TITLE
fix(url4-cloud): make local mode reach a successful run out of the box

### DIFF
--- a/apps/url4-cloud/src/url4_cloud/local.py
+++ b/apps/url4-cloud/src/url4_cloud/local.py
@@ -33,7 +33,7 @@ from url4_cloud import job_env
 from url4_cloud.adapters.inprocess import InProcessJobRunner
 from url4_cloud.adapters.memory import InMemoryEventStream
 from url4_cloud.app import create_app
-from url4_cloud.benchmarks import BenchmarkRegistry
+from url4_cloud.benchmarks import BENCHMARK_ASSETS_ENV, EMPTY_BENCHMARKS, BenchmarkRegistry
 from url4_cloud.benchmarks.builtins import BUILTIN_BENCHMARKS
 from url4_cloud.catalog import build_executable_catalog_service
 from url4_cloud.config import INSECURE_DEFAULT_JWT_SECRET, Settings
@@ -87,11 +87,40 @@ def _with_runner_config(env: Mapping[str, str]) -> Mapping[str, str]:
     return {**env, job_env.RUNNER_CONFIG: str(candidate)}
 
 
+def _local_benchmarks(env: Mapping[str, str]) -> BenchmarkRegistry:
+    """The Benchmarks a local run installs: the builtins only where assets were declared.
+
+    WHY not the builtins unconditionally (which is what this used to be): `benchmarks.install()`
+    runs while the WORLD is built — before, and independent of, what the expression addresses —
+    so a Benchmark whose assets are absent fails EVERY run, including one that references no
+    Benchmark at all. DRACO's cases live at ``/opt/benchmarks/draco/cases.json``, a path the
+    Dockerfile creates and a source checkout does not, so the default was guaranteed to fail
+    exactly where local mode is meant to be usable (OME-795).
+
+    INVARIANT: naming an asset root is the operator asserting the assets exist. Local mode takes
+    that at face value and installs, so a wrong path fails loudly rather than silently serving a
+    Benchmark-less Engine. Absence of the variable is the only "install nothing" signal.
+    """
+    return BUILTIN_BENCHMARKS if BENCHMARK_ASSETS_ENV in env else EMPTY_BENCHMARKS
+
+
+def _with_local_gateway(settings: Settings) -> Settings:
+    """Substitute the loopback default into the ONE address the whole App resolves.
+
+    INVARIANT: `aigateway_base_url` still wins when stated — the local value is a fallback, not
+    an override, so a developer who names a gateway never has half the App quietly talk to a
+    different one.
+    """
+    if settings.aigateway_base_url is not None:
+        return settings
+    return settings.model_copy(update={"aigateway_base_url": settings.local_aigateway_base_url})
+
+
 def create_local_app(
     settings: Settings | None = None,
     *,
     env: Mapping[str, str] | None = None,
-    benchmarks: BenchmarkRegistry = BUILTIN_BENCHMARKS,
+    benchmarks: BenchmarkRegistry | None = None,
 ) -> FastAPI:
     """Build the local-mode App: in-process runner, in-memory stream, real everything else.
 
@@ -114,6 +143,8 @@ def create_local_app(
     from url4_cloud.runner.main import build_executor
 
     run_env = _with_runner_config(env if env is not None else os.environ)
+    if benchmarks is None:
+        benchmarks = _local_benchmarks(run_env)
     job_runner = InProcessJobRunner(
         stream,
         partial(build_executor, benchmarks=benchmarks),
@@ -121,13 +152,15 @@ def create_local_app(
         max_concurrent_runs=settings.local_max_concurrent_runs,
         max_history=settings.local_max_run_history,
     )
+    # INVARIANT: the local default is substituted ONCE, here, before anything reads the address —
+    # so discovery and connections resolve the same gateway by construction rather than by two
+    # call sites agreeing. This substitution used to sit BELOW the catalog and feed only
+    # `build_connections`, which left `/v1/models` answering 503 "not configured" on the one
+    # deployment shape whose address is known in advance, while `/v1/connections` on that very
+    # address answered 200 (OME-795).
+    settings = _with_local_gateway(settings)
     catalog = build_executable_catalog_service(settings, run_env)
-    connection_settings = settings
-    if connection_settings.aigateway_base_url is None:
-        connection_settings = connection_settings.model_copy(
-            update={"aigateway_base_url": settings.local_aigateway_base_url}
-        )
-    connections = build_connections(connection_settings)
+    connections = build_connections(settings)
     app = create_app(
         settings,
         stream=stream,

--- a/apps/url4-cloud/tests/unit/test_declared_models_match_aigateway.py
+++ b/apps/url4-cloud/tests/unit/test_declared_models_match_aigateway.py
@@ -31,21 +31,47 @@ _REPO_ROOT = Path(__file__).resolve().parents[4]
 _PLUGINS = _REPO_ROOT / "apps/aigateway/src/aigateway/plugins"
 _RUNNER_CONFIG = _REPO_ROOT / "apps/url4-cloud/url4.toml"
 
-# (source file, the assigned name holding the slug list, the gateway's id prefix).
-# WHY anthropic has no prefix: its ModelEntry.model_name is the BARE slug — the `anthropic/`
-# prefix appears only in litellm_params, so `/v1/models` advertises `claude-haiku-4-5`.
+# (source file, the assigned name holding the slug list, the plugin's `custom_llm_provider`).
+#
+# INVARIANT: the third field is the PROVIDER NAME, never a pre-computed prefix string. The
+# gateway derives every public id through one universal rule (`canonical_model_id`), mirrored
+# below in `_canonical` — so this table states only what the rule needs as input.
+#
+# AIDEV-NOTE: this used to carry a hand-written prefix per provider, with anthropic's set to ""
+# on the belief that `/v1/models` advertised bare `claude-haiku-4-5`. `canonical_model_id` has
+# no such exemption — it prefixes unless the slug already starts with `<provider>/` — so the
+# gateway served `anthropic/claude-haiku-4-5` while url4.toml declared the bare form, all five
+# Anthropic routes silently dropped out of the projected catalog, and the declared default_route
+# failed with `model must be provider-prefixed`. Twenty-six tests passed throughout (OME-795).
+# Do not reintroduce a per-provider prefix column: four independent guesses drift, one rule
+# cannot.
 _SLUG_SOURCES = (
-    ("anthropic_provider/settings.py", "names", ""),
-    ("codex_provider/models.py", "_MODEL_SLUGS", "codex/"),
-    ("gemini_provider/models.py", "_MODEL_SLUGS", "gemini-cli/"),
-    ("antigravity_provider/settings.py", "names", "antigravity/"),
+    ("anthropic_provider/settings.py", "names", "anthropic"),
+    ("codex_provider/models.py", "_MODEL_SLUGS", "codex"),
+    ("gemini_provider/models.py", "_MODEL_SLUGS", "gemini-cli"),
+    ("antigravity_provider/settings.py", "names", "antigravity"),
 )
 
-# (source file, the function whose `return [...]` holds the slugs, the gateway's id prefix).
+# (source file, the function whose `return [...]` holds the slugs, the `custom_llm_provider`).
 # WHY a separate table: these slugs are returned by a default-factory function rather than
-# bound to a module-level name, so the assignment scan below cannot see them. WHY the prefix is
-# empty: OpenRouter's seeds are already spelled as full gateway ids (`openrouter/<author>/…`).
-_RETURNED_SLUG_SOURCES = (("openrouter_provider/settings.py", "_default_model_slugs", ""),)
+# bound to a module-level name, so the assignment scan below cannot see them. OpenRouter's seeds
+# are already spelled as full gateway ids (`openrouter/<author>/…`), which is precisely the
+# already-prefixed case `_canonical` leaves alone.
+_RETURNED_SLUG_SOURCES = (
+    ("openrouter_provider/settings.py", "_default_model_slugs", "openrouter"),
+)
+
+
+def _canonical(provider: str, slug: str) -> str:
+    """The public id aigateway advertises for ``slug``, by aigateway's own rule.
+
+    INVARIANT: mirrors `aigateway.core.model_capabilities.canonical_model_id` — keep the slug
+    when it already begins with ``<provider>/``, otherwise prefix it. aigateway is a separate uv
+    project and is NOT installed here, so this is a mirror rather than an import; it is one line
+    of one rule, which is the smallest surface that can go stale.
+    """
+    prefix = f"{provider}/"
+    return slug if slug.startswith(prefix) else f"{prefix}{slug}"
 
 
 def _string_list_assigned_to(source: Path, name: str) -> tuple[str, ...]:
@@ -87,15 +113,21 @@ def _string_list_returned_by(source: Path, name: str) -> tuple[str, ...]:
 
 def _aigateway_model_ids() -> set[str]:
     ids: set[str] = set()
-    for relative, name, prefix in _SLUG_SOURCES:
+    for relative, name, provider in _SLUG_SOURCES:
         source = _PLUGINS / relative
         assert source.is_file(), f"{source} moved — update _SLUG_SOURCES"
-        ids.update(prefix + slug for slug in _string_list_assigned_to(source, name))
-    for relative, name, prefix in _RETURNED_SLUG_SOURCES:
+        ids.update(_canonical(provider, slug) for slug in _string_list_assigned_to(source, name))
+    for relative, name, provider in _RETURNED_SLUG_SOURCES:
         source = _PLUGINS / relative
         assert source.is_file(), f"{source} moved — update _RETURNED_SLUG_SOURCES"
-        ids.update(prefix + slug for slug in _string_list_returned_by(source, name))
+        ids.update(_canonical(provider, slug) for slug in _string_list_returned_by(source, name))
     return ids
+
+
+def _declared_default_route() -> str:
+    """The `default_route` url4.toml names, without its leading slash."""
+    with _RUNNER_CONFIG.open("rb") as handle:
+        return str(tomllib.load(handle)["aigateway"]["default_route"]).lstrip("/")
 
 
 def _declared_models() -> tuple[str, ...]:
@@ -115,10 +147,28 @@ def test_the_guard_actually_finds_the_plugin_registries() -> None:
     ids = _aigateway_model_ids()
 
     assert len(ids) >= 10
-    assert "claude-haiku-4-5" in ids
+    # Anthropic is prefixed like every other provider — `canonical_model_id` has no exemption.
+    assert "anthropic/claude-haiku-4-5" in ids
     assert "codex/gpt-5.5" in ids
     # The returned-list extractor is the one that would silently contribute nothing.
     assert "openrouter/openai/gpt-5.5" in ids
+
+
+def test_the_canonical_rule_prefixes_once_and_only_once() -> None:
+    # INVARIANT: the mirrored rule is idempotent — an already-qualified slug (OpenRouter's
+    # seeds) must survive untouched, or every OpenRouter id would gain a second prefix.
+    assert _canonical("anthropic", "claude-haiku-4-5") == "anthropic/claude-haiku-4-5"
+    assert _canonical("openrouter", "openrouter/openai/gpt-5.5") == "openrouter/openai/gpt-5.5"
+    assert _canonical("codex", _canonical("codex", "gpt-5.5")) == "codex/gpt-5.5"
+
+
+def test_the_declared_default_route_is_a_declared_model() -> None:
+    """INVARIANT: the fan-out reduce dispatches here, so it must name a route that resolves.
+
+    A default_route that no `[[aigateway.models]]` entry declares is unreachable: it fails at
+    the gateway inside a user's expression rather than at boot (OME-795).
+    """
+    assert _declared_default_route() in set(_declared_models())
 
 
 def test_every_declared_model_exists_in_aigateway() -> None:

--- a/apps/url4-cloud/tests/unit/test_local_aigateway_connection.py
+++ b/apps/url4-cloud/tests/unit/test_local_aigateway_connection.py
@@ -17,7 +17,12 @@ def test_local_app_automatically_wires_the_loopback_aigateway() -> None:
 
     assert isinstance(app.state.connections, AigatewayConnections)
     assert str(app.state.connections._client.base_url) == LOCAL_AIGATEWAY_BASE_URL  # noqa: SLF001
-    assert app.state.catalog is None
+    # INVARIANT: ONE local default, honoured by BOTH consumers. This used to assert the catalog
+    # was None — the fallback was computed after the catalog had already been built from the
+    # unsubstituted settings, so `/v1/models` answered 503 on the one deployment shape whose
+    # address is known in advance, while `/v1/connections` on the same address answered 200
+    # (OME-795).
+    assert app.state.catalog is not None
 
 
 def test_local_app_preserves_an_explicit_aigateway_url() -> None:
@@ -57,6 +62,19 @@ def test_an_explicit_aigateway_url_outranks_the_local_default() -> None:
         local_aigateway_base_url="http://sidecar.test:9105",
     )
 
+    assert isinstance(app.state.connections, AigatewayConnections)
+    assert str(app.state.connections._client.base_url) == "http://gateway.test:9876"  # noqa: SLF001
+
+
+def test_an_explicit_url_points_the_catalog_at_the_same_gateway_as_connections() -> None:
+    """INVARIANT: the two consumers never diverge onto different gateways.
+
+    The bug OME-795 fixed was exactly this divergence in the DEFAULT case; this pins the
+    explicit case too, so a future refactor cannot restore the split from the other side.
+    """
+    app = _app(aigateway_base_url="http://gateway.test:9876")
+
+    assert app.state.catalog is not None
     assert isinstance(app.state.connections, AigatewayConnections)
     assert str(app.state.connections._client.base_url) == "http://gateway.test:9876"  # noqa: SLF001
 

--- a/apps/url4-cloud/tests/unit/test_local_benchmarks.py
+++ b/apps/url4-cloud/tests/unit/test_local_benchmarks.py
@@ -1,0 +1,58 @@
+"""Local mode installs Benchmarks only where their assets were declared.
+
+FEATURE: local bring-up — `url4-cloud serve --local` on a clean checkout.
+STORY: as a developer with a fresh clone, I evaluate a single-model expression without first
+obtaining the 100-case DRACO asset bundle that exists only inside the deployed image.
+
+WHY this is worth a guard: `benchmarks.install()` runs while the WORLD is built, before and
+independent of what the expression addresses, so a benchmark whose assets are absent fails EVERY
+run — including runs that reference no benchmark at all. The failure surfaces as
+`benchmark_unavailable`, which reads like a benchmark problem and is really a packaging one.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from fastapi import FastAPI
+
+from url4_cloud.benchmarks import EMPTY_BENCHMARKS
+from url4_cloud.benchmarks.builtins import BUILTIN_BENCHMARKS
+from url4_cloud.benchmarks.registry import BENCHMARK_ASSETS_ENV
+from url4_cloud.config import Settings
+from url4_cloud.local import create_local_app
+
+
+def _app(env: Mapping[str, str], **kwargs: object) -> FastAPI:
+    return create_local_app(Settings(jwt_secret="s" * 32, **kwargs), env=env)  # type: ignore[arg-type]
+
+
+def _installed(app: FastAPI):
+    """The registry the App handed the executor factory — what a run would install."""
+    return app.state.job_runner._factory.keywords["benchmarks"]  # noqa: SLF001
+
+
+def test_a_checkout_that_declares_no_asset_root_installs_no_benchmarks() -> None:
+    # INVARIANT: local mode never installs a Benchmark whose assets it was not pointed at.
+    # This is what keeps an unrelated expression from dying on a missing DRACO case file.
+    assert len(_installed(_app({}))) == 0
+
+
+def test_declaring_an_asset_root_opts_back_into_the_builtins() -> None:
+    # WHY the env var is the switch: naming an asset root is the operator stating the assets
+    # exist. Local mode takes them at their word and installs — so a bogus path fails loudly
+    # rather than silently serving a Benchmark-less Engine.
+    installed = _installed(_app({BENCHMARK_ASSETS_ENV: "/opt/benchmarks"}))
+
+    assert installed is BUILTIN_BENCHMARKS
+
+
+def test_an_explicitly_passed_registry_outranks_the_env_default() -> None:
+    # INVARIANT: the parameter is the caller's decision; the env only fills its absence.
+    app = create_local_app(
+        Settings(jwt_secret="s" * 32),
+        env={BENCHMARK_ASSETS_ENV: "/opt/benchmarks"},
+        benchmarks=EMPTY_BENCHMARKS,
+    )
+
+    assert _installed(app) is EMPTY_BENCHMARKS

--- a/apps/url4-cloud/url4.toml
+++ b/apps/url4-cloud/url4.toml
@@ -5,10 +5,17 @@
 # exist; env supplies only per-Job values (the token, and optional base_url / model overrides).
 #
 # INVARIANT: a route path is exactly "/" + the gateway id. No renaming, no aliases. `id`
-# entries must match aigateway's `/v1/models` ids EXACTLY — note that Anthropic's ids are
-# UNPREFIXED (`claude-haiku-4-5`), the `anthropic/` prefix appearing only in litellm_params,
-# while every other provider prefixes. `tests/unit/test_declared_models_match_aigateway.py`
-# fails if this list drifts from the plugins' MODELS.
+# entries must match aigateway's `/v1/models` ids EXACTLY, and that id is ALWAYS
+# `<custom_llm_provider>/<slug>` — `canonical_model_id` prefixes every provider's slug unless it
+# already carries the prefix, with no exemption for any of them. Anthropic included: the served
+# id is `anthropic/claude-haiku-4-5`. `tests/unit/test_declared_models_match_aigateway.py`
+# derives the expected ids through that same rule and fails if this list drifts from the
+# plugins' MODELS.
+#
+# AIDEV-NOTE: this block used to claim Anthropic's ids were UNPREFIXED, and the five routes below
+# were declared bare to match. They were therefore served by nothing: the projection dropped all
+# five from `/v1/models`, and `default_route` failed with "model must be provider-prefixed"
+# inside a user's expression (OME-795).
 #
 # Adding a model is a deliberate, reviewable edit: these paths are a public naming surface that
 # url4 expressions depend on.
@@ -32,7 +39,7 @@
 
 [aigateway]
 base_url = "http://127.0.0.1:9105"
-default_route = "/claude-haiku-4-5"
+default_route = "/anthropic/claude-haiku-4-5"
 timeout_s = 600.0
 web_tool_max_iterations = 12
 
@@ -40,26 +47,26 @@ web_tool_max_iterations = 12
 # been able to fetch them. Set false to hand the node a denying outbound layer instead.
 allow_outbound = true
 
-# --- anthropic — unprefixed ids -----------------------------------------------------------
+# --- anthropic ------------------------------------------------------------------------------
 # These take the Tavily loop: `anthropic` is not in WEB_SEARCH_NATIVE_PROVIDERS, because
 # aigateway's Anthropic plugin declares no web-search parameter. The plugin dispatches
 # OpenAI-shape tool calls through litellm, which IS the shape `_WEB_TOOLS` declares, so the
 # loop is expected to round-trip — not yet verified end-to-end against a live Anthropic
 # credential (OME-797 defers that check; a deployment with no TAVILY_API_KEY is unaffected).
 [[aigateway.models]]
-id = "claude-opus-4-8"
+id = "anthropic/claude-opus-4-8"
 
 [[aigateway.models]]
-id = "claude-opus-4-7"
+id = "anthropic/claude-opus-4-7"
 
 [[aigateway.models]]
-id = "claude-sonnet-4-6"
+id = "anthropic/claude-sonnet-4-6"
 
 [[aigateway.models]]
-id = "claude-sonnet-4-5"
+id = "anthropic/claude-sonnet-4-5"
 
 [[aigateway.models]]
-id = "claude-haiku-4-5"
+id = "anthropic/claude-haiku-4-5"
 
 # --- codex ---------------------------------------------------------------------------------
 # Tavily loop as well. These dispatch through the Codex OAuth backend, not litellm's stock

--- a/docs/tasks/2026-08-12-OME-795-local-mode-bringup.md
+++ b/docs/tasks/2026-08-12-OME-795-local-mode-bringup.md
@@ -1,0 +1,27 @@
+---
+id: OME-795
+linear_url: https://linear.app/openmined/issue/OME-795/make-url4-cloud-local-mode-reach-a-successful-run-out-of-the-box
+status: In Progress
+type: Bug
+priority: P1
+labels: [url4-cloud, agentic, autonomous]
+created: 2026-08-12
+closed:
+---
+
+# Make url4-cloud local mode reach a successful run out of the box
+
+Three stacked defects stopped `url4-cloud serve --local` from completing any run on a clean
+checkout, each reporting a cause that was not the cause:
+
+1. The local gateway-address fallback was applied after the catalog was built and only to
+   connections, so `/v1/models` answered 503 while `/v1/connections` answered 200 on the same
+   default address.
+2. Local mode installed the builtin Benchmarks unconditionally, and DRACO's install reads an
+   image-only asset path — failing *every* run with `benchmark_unavailable`, including runs that
+   address no Benchmark.
+3. `url4.toml` declared the five Anthropic ids unprefixed while aigateway serves them prefixed,
+   dropping all five from discovery and breaking the declared `default_route`. The pinning test
+   could not see this: it AST-parsed aigateway's source and applied a hardcoded prefix table.
+
+Ledger: `docs/work/2026-08-12-OME-795-local-mode-bringup.md`

--- a/docs/work/2026-08-12-OME-795-local-mode-bringup.md
+++ b/docs/work/2026-08-12-OME-795-local-mode-bringup.md
@@ -1,0 +1,103 @@
+---
+ticket: OME-795
+stack: url4-cloud
+status: done
+started: 2026-08-12
+finished: 2026-08-12
+---
+
+# OME-795 — Make url4-cloud local mode reach a successful run out of the box
+
+## Intent
+
+`url4-cloud serve --local` against a loopback aigateway (auth disabled) cannot complete a run on a
+clean checkout. Three independent defects stack, each producing an error that names the wrong
+cause. This unit removes all three so that "clone → run two commands → evaluate an expression"
+works without bespoke factory modules or hand-patched config, which is the premise local mode
+exists to serve.
+
+Full reproduction evidence, including the frame traces, is in `OME-795`.
+
+## Planned changes
+
+- `src/url4_cloud/local.py` — apply the `local_aigateway_base_url` fallback BEFORE the catalog is
+  built, so discovery and connections resolve the same address. Decide the local benchmark default
+  (see Design forks).
+- `url4.toml` — prefix the five Anthropic model ids with `anthropic/` and update `default_route`.
+- `tests/unit/test_declared_models_match_aigateway.py` — derive the expected id from aigateway's
+  real `canonical_model_id` rule instead of a hardcoded per-provider prefix table.
+- New/extended tests under `tests/unit/` for each defect (see Test plan).
+
+## Design forks — resolved with the owner before coding
+
+1. **Local benchmark default** → **(a)**: `create_local_app(benchmarks=None)` resolves to the
+   builtins only when `URL4_BENCHMARK_ASSETS` is present in the run env, else `EMPTY_BENCHMARKS`.
+   Naming an asset root is the operator asserting the assets exist, so a wrong path still fails
+   loudly rather than silently serving a Benchmark-less Engine.
+2. **How the pinning test learns the real prefix rule** → **(a)**: the per-provider prefix table
+   is replaced by the provider NAME plus one mirrored rule (`_canonical`). aigateway is a separate
+   uv project and cannot be imported, so this mirrors one rule rather than four assumptions.
+3. **Prior test that had to change** (asked separately) → update
+   `test_local_app_automatically_wires_the_loopback_aigateway`'s `assert app.state.catalog is None`
+   to `is not None`. That assertion pinned the defect itself.
+
+## Test plan (RED first, append-only)
+
+- Local composition builds a catalog when only the local default address applies — currently fails
+  (catalog is `None`), pins defect 1.
+- A local App with no benchmark assets present can still build an executor and run a
+  non-benchmark expression — pins defect 2.
+- Every id declared in `url4.toml` satisfies aigateway's canonical prefix rule, and the declared
+  `default_route` names a declared model — pins defect 3 and would have caught the drift.
+- Boundary/error: an explicit `URL4_CLOUD_AIGATEWAY_BASE_URL` still wins over the local default;
+  a declared world whose ids do not match still degrades (503) rather than raising at composition.
+
+## Acceptance
+
+- On a clean checkout with a loopback aigateway (auth disabled) and no extra env:
+  `GET /v1/models` returns the full declared catalog (not 503), and a single-model expression
+  reaches `terminated: succeeded` without a custom factory or a patched `url4.toml`.
+- The declared-models test fails if either side's prefix rule changes.
+- All card gates green for the `url4-cloud` stack; no prior test weakened, skipped or deleted
+  (two were modified under explicit owner approval — see Design forks 2–3 and Deviations 1).
+
+## Outcome
+
+- **Actual files** (as planned, plus one not foreseen):
+  - `src/url4_cloud/local.py` — added `_local_benchmarks()` and `_with_local_gateway()`; the local
+    address is now substituted ONCE, above the catalog, and feeds both consumers.
+  - `url4.toml` — five Anthropic ids prefixed, `default_route` updated, and the header INVARIANT
+    comment corrected (it asserted the opposite rule and is what the declarations followed).
+  - `tests/unit/test_declared_models_match_aigateway.py` — prefix table → provider name +
+    `_canonical`; added `test_the_canonical_rule_prefixes_once_and_only_once` and
+    `test_the_declared_default_route_is_a_declared_model`.
+  - `tests/unit/test_local_benchmarks.py` — NEW, three cases for the benchmark decision.
+  - `tests/unit/test_local_aigateway_connection.py` — flipped the one authorized assertion; added
+    `test_an_explicit_url_points_the_catalog_at_the_same_gateway_as_connections`.
+- **Gates:** `ALL GATES GREEN` — ruff check · ruff format --check · pyright · check_layering.py ·
+  pytest with coverage (`1152 passed, 5 skipped`; coverage gate ≥80 met).
+- **Acceptance verified against live services**, not just tests: with the fixed code, a plain
+  `uv run url4-cloud serve --local` and **no env vars at all** returned `/v1/models` = 200 with 23
+  models (previously 503), and `/openrouter/openai/gpt-5.5('What is 7+5?')` reached
+  `terminated: succeeded` with body `12`. `/anthropic/claude-haiku-4-5` now fails with
+  `profile_not_found` (no credential connected) instead of `aigateway_http_400`
+  ("model must be provider-prefixed") — the id resolves; only the credential is absent.
+
+### Deviations
+
+1. **`run_gates.py --skip-append-only` was used.** The append-only check flags ANY `M` on a path
+   matching `test_globs`, and this unit necessarily modified two prior test files. Both changes
+   were put to the owner as Confidence-Gate decisions and approved BEFORE coding: the derived
+   prefix rule (which cannot be done without editing `_SLUG_SOURCES` and its guard assertion) and
+   the single `catalog is None` assertion that pinned defect 1. No prior test was weakened,
+   skipped, or deleted — the suite grew from 1147 to 1152 passing.
+2. **`url4.toml`'s header comment was corrected**, which the plan did not list. It stated the
+   inverse rule ("Anthropic's ids are UNPREFIXED") and is the reason the declarations were wrong;
+   fixing the ids while leaving the comment would have re-created the drift at the next edit.
+3. **The `/v1/benchmarks` honesty problem is NOT fixed here.** Discovery still lists DRACO on a
+   box where no assets are installed, so it advertises what execution would refuse. The chosen
+   fork makes local mode install nothing by default, which removes the run failure but leaves
+   discovery over-promising. Worth its own item.
+4. **`create_local_app`'s `benchmarks` default changed** from `BUILTIN_BENCHMARKS` to `None`
+   (resolved from the env). No in-repo caller passes the parameter, so this is source-compatible;
+   an external caller relying on the implicit builtins would now need `URL4_BENCHMARK_ASSETS`.


### PR DESCRIPTION
Local mode couldn't complete a single run on a fresh clone. Now it can.

Closes OME-795.

## The problem

Three separate bugs, stacked. Each one reported a cause that wasn't the cause, so you fix the error you're shown and hit the next one.

**Ask it what models exist → 503 "not configured". Ask it what providers are connected → 200, works fine.** Same process, same gateway address, two different answers. The loopback default (`127.0.0.1:9105`) was being filled in one step too late: the model catalog was built first, saw no address, and disabled itself; the connection code got the default a moment later and was fine. So discovery was broken on the exact setup whose address we already know in advance.

**Every run died on a benchmark, including runs with no benchmark in them.** DRACO's 100 test cases live in a file that only exists inside the Docker image. Local mode installed all the builtin benchmarks while setting up the world — before looking at what you actually asked for — so a missing file for a benchmark you weren't using killed your run. The error said `benchmark_unavailable`, which sounds like a benchmark problem and is really a packaging one.

**Every Claude model was unreachable.** The gateway serves them as `anthropic/claude-haiku-4-5`. Our config file declared them as `claude-haiku-4-5`, and named one of them as the default route. Nothing errored at startup — the five just quietly vanished from the model list (10 served where 15 were declared), and using the default route failed inside your expression with "model must be provider-prefixed".

**There is a test whose entire job is catching that last one. It passed.** It can't see the gateway, so it reads the gateway's source and applies a lookup table of prefixes — one hand-written entry per provider. Anthropic's was set to empty string, with a comment explaining that Anthropic is the special case that doesn't get a prefix. The comment was wrong. The gateway prefixes everything, no exceptions. So 26 tests agreed with a wrong comment while the real thing was broken.

## The fix

**The address** is now filled in once, before anything reads it, so discovery and connections can't disagree. An explicitly configured address still wins — the local value only fills a gap.

**Benchmarks** now install only if you've pointed at an asset directory (`URL4_BENCHMARK_ASSETS`). Setting that variable is you saying the files exist, so a wrong path still fails loudly rather than silently giving you a benchmark-less engine. Worth noting the runner's own default was already "install nothing" — local mode was the odd one out.

**The model ids** are prefixed, along with the default route and the comment at the top of the file that claimed the opposite rule. That comment is why the ids were wrong in the first place; fixing the ids alone would let the next person re-create the drift.

**The test** no longer keeps a table of prefixes. It keeps the provider's *name* and applies the one rule the gateway applies. Four independent guesses became one rule that can't drift out of sync.

## Things I deliberately didn't do

- **`/v1/benchmarks` still advertises DRACO on a machine with no DRACO files.** This PR stops that from breaking your run, but discovery still promises something execution would refuse. That's a real inconsistency and it wants its own ticket.
- **Didn't touch the four-step dance needed to run an expression** (mint a token → open a websocket → send an attach frame → make the request). It works as designed, but it's undiscoverable: the header it needs is `URL4-Capability`, which isn't in the OpenAPI spec, and the 401 you get is deliberately vague. That's a docs problem, not a code one.
- **Didn't make the test talk to a live gateway.** It would catch more, but it needs a running gateway, so it wouldn't run in normal CI and would mostly sit there not running.

## Please look at this

**I changed 2 existing tests, and the guard that normally catches that was switched off.** I used `--skip-append-only` on the gate runner. Everything else ran normally and passed.

| File | What changed |
|---|---|
| `test_declared_models_match_aigateway.py` | the prefix table → provider name + the real rule. Bug 3 can't be fixed without editing this — it's where the wrong assumption lived. |
| `test_local_aigateway_connection.py` | one line: `assert app.state.catalog is None` → `is not None`. That assertion was pinning bug 1 in place. |

Both were run past the owner before I wrote any code. Nothing was weakened, skipped or deleted, and the suite grew rather than shrank — but nothing except me has reviewed those two diffs.

One knock-on worth knowing: `create_local_app`'s `benchmarks` argument now defaults to `None` (resolved from the environment) instead of the builtins. No caller in the repo passes it.

## Testing

- `run_gates.py url4-cloud` — green (ruff, format, pyright, layering, pytest + coverage)
- 1147 → 1152 tests passing
- New: `test_local_benchmarks.py` (3), plus a rule-is-idempotent test and a default-route-exists test
- The declared-models test was genuinely red on the bare ids before I fixed the config — it catches the real bug now

I also ran it for real against a live gateway rather than trusting the tests. With the fix, no environment variables at all:

- `GET /v1/models` → 200, 23 models. Was 503.
- `/openrouter/openai/gpt-5.5('What is 7+5?')!'Answer with just the number.'` → `12`, `succeeded`.
- `/anthropic/claude-haiku-4-5(…)` → now fails with `profile_not_found`, i.e. "you haven't connected an Anthropic account" — the correct complaint. Before, it never got that far.

## What you get

Clone the repo, start the gateway, run `uv run url4-cloud serve --local`, evaluate an expression. No environment variables, no hand-patched config file, no custom Python module to work around the benchmark loader.

That was the whole point of local mode, and it hadn't worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
