### PR TITLE
feat(url4-cloud): derive the web-search mechanism from the provider

### DIFF
--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/global_cache.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/global_cache.py
@@ -58,7 +58,12 @@ from .settings import (
 # never part of any prior revision's contract for this key path. Abandoning the whole
 # generation here is the same discipline as every other adapter-revision bump: readers must
 # never be served an entry keyed under a semantics this module no longer implements.
-GLOBAL_CACHE_ADAPTER_REVISION = "openrouter-global-cache-2026-08c"
+#
+# 08d (OME-800): `apply_web_search` stopped naming the search engine, so the envelope this
+# key path projects changed shape. Entries written while `engine: "native"` was forced
+# describe a request this module no longer sends — a different upstream retrieval path, and
+# for models without built-in search, one that erred rather than answering.
+GLOBAL_CACHE_ADAPTER_REVISION = "openrouter-global-cache-2026-08d"
 
 
 def project_global_cache_request(body: dict[str, Any]) -> dict[str, Any] | CacheBypass:

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/web_search.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/web_search.py
@@ -15,7 +15,15 @@ WEB_SEARCH_EXCLUDED_DOMAINS_PARAM = "web_search_excluded_domains"
 EXCLUDE_DOMAINS_KEY = "exclude_domains"
 """OpenRouter web-plugin spelling; its server-tool surface uses a different field name."""
 
-_WEB_SEARCH_POLICY: dict[str, object] = {"id": "web", "engine": "native"}
+_WEB_SEARCH_POLICY: dict[str, object] = {"id": "web"}
+"""The web plugin, with the engine deliberately UNSET.
+
+INVARIANT (OME-800): never name an `engine` here. OpenRouter selects the model's built-in
+search when it has one and falls back to Exa when it does not — but only while `engine` is
+unspecified. Naming `native` forces the built-in path even for a model that has none, which
+errors, and turns "this provider searches natively" into a per-MODEL fact every consumer has
+to track as its own list. `apps/url4-cloud` used to carry exactly that list.
+"""
 
 
 def apply_web_search(body: dict[str, Any]) -> None:

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_web_plugin.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_web_plugin.py
@@ -175,9 +175,14 @@ def test_unproven_server_tool_types_stay_unadvertised() -> None:
 
 
 def test_true_becomes_the_providers_web_plugin() -> None:
+    """WHY the absence of `engine` is load-bearing (OME-800): OpenRouter falls back
+    native-or-Exa ONLY while `engine` is unspecified. Naming `native` forces the model's
+    built-in search even for a model that has none, which errors — and that made "this
+    provider searches natively" a per-MODEL fact every consumer had to carry as its own list.
+    """
     out = _prepared({"web_search": True})
 
-    assert out["plugins"] == [{"id": "web", "engine": "native"}]
+    assert out["plugins"] == [{"id": "web"}]
 
 
 def test_the_caller_facing_keys_never_reach_the_wire() -> None:
@@ -207,9 +212,7 @@ def test_web_search_reaches_dispatch_through_the_real_route_pipeline(
     assert response.status_code == 200, response.text
     assert "web_search" not in captured
     assert "web_search_excluded_domains" not in captured
-    assert captured["plugins"] == [
-        {"id": "web", "engine": "native", "exclude_domains": ["rubric.test"]}
-    ]
+    assert captured["plugins"] == [{"id": "web", "exclude_domains": ["rubric.test"]}]
 
 
 def test_false_and_absent_both_send_no_plugin() -> None:

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_web_search_cache.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_web_search_cache.py
@@ -150,7 +150,7 @@ def test_a_literal_true_does_emit_the_envelope() -> None:
     # The other half: the parametrized test above must not be passing because the
     # envelope is never emitted at all.
     prepared = _plugin().prepare_chat_body(_body(web_search=True))
-    assert prepared["plugins"] == [{"id": "web", "engine": "native"}]
+    assert prepared["plugins"] == [{"id": "web"}]
 
 
 def test_a_request_with_no_search_field_projects_without_an_envelope() -> None:
@@ -358,9 +358,7 @@ def test_a_web_search_request_now_uses_the_cache_through_the_real_route(
     # Only ONE real dispatch: the repeat was served from the entry, never re-sent.
     assert len(calls) == 1
     # No deployment list to union with any more — the caller's own list, verbatim.
-    assert calls[0]["plugins"] == [
-        {"id": "web", "engine": "native", "exclude_domains": ["rubric.test"]}
-    ]
+    assert calls[0]["plugins"] == [{"id": "web", "exclude_domains": ["rubric.test"]}]
 
 
 def test_a_bare_request_still_uses_the_cache_through_the_real_route(

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/aggregate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/aggregate.py
@@ -20,24 +20,31 @@ CRITERION, five independent passes, and the judge blind to the weights and to th
 criteria. The Engine-owned Benchmark definition constructs that fan-out and this in-process
 handler reduces the complete row collection without crossing an operating-system argv boundary.
 
-AIDEV-NOTE: protocol caveats, the two ways a run here still differs from the paper:
+AIDEV-NOTE: protocol caveats, the three ways a run here still differs from the paper:
 
 * `judge_reasoning: "low"` (arXiv:2602.11685 §4.2) is NOT carried until the gateway supports it.
   `reasoning_effort` is absent from the OpenRouter plugin's rule set, and the gateway fails
   closed on an unknown parameter, so
   sending it would turn every judge call into a 400 rather than a deviation. `judge_temperature`
   and `max_tokens` DO reach the model.
-* Retrieval reaches EVERY answering route as of 2026-08-02, but by TWO different mechanisms
-  (owner decision, same date): provider-side `native_web_search` on the OpenRouter routes that
-  support it, and the runner-driven Tavily loop on `gemini-3.1-pro-preview`,
-  `gemini-3-flash-preview`, `kimi-k2.6`, `deepseek-v4-pro`, and `qwen3.6-plus`. Both honour the
-  same declared blocklist—verified live on both paths—but they are not the same search product,
-  so a candidate that answered through Tavily and one that answered natively did not read the
-  same web. A comparison ACROSS those two groups carries that caveat; the reference chart used
-  neither exactly.
+* Candidate retrieval runs on the PROVIDER's search, not a backend this repo pins. Every lineup
+  model is `openrouter/*`, so as of OME-797 (2026-08-12) all eight take the native mechanism,
+  and OME-800 leaves the engine unset — OpenRouter picks its own built-in search where the model
+  has one and Exa where it does not. So the search product can differ BETWEEN candidates of one
+  run, and can change under us without a config edit.
+  Before 2026-08-12 the mechanism was declared per route, and five candidates
+  (`gemini-3.1-pro-preview`, `gemini-3-flash-preview`, `kimi-k2.6`, `deepseek-v4-pro`,
+  `qwen3.6-plus`) answered through the runner-driven Tavily loop instead. Runs either side of
+  that date are not the same experiment.
+* `EXCLUDED_DOMAINS` changes MEANING with the mechanism. The Tavily loop drops blocked hosts
+  client-side (`runner.web_tools._is_blocked`) — the Runner enforces it. The native path only
+  forwards `web_search_excluded_domains` and relies on the provider to honour it. Since the
+  blocklist covers `arxiv.org`, `paperswithcode.com`, `semanticscholar.org` and `alphaxiv.org`
+  — where the paper under reproduction lives — a native-path run rests on OpenRouter's
+  compliance for its leakage control, which is not verified here.
 
-Neither is visible in the numbers this module emits. A score published as "DRACO-reproduced"
-has to state both.
+None of the three is visible in the numbers this module emits. A score published as
+"DRACO-reproduced" has to state all three.
 """
 
 from __future__ import annotations

--- a/apps/url4-cloud/src/url4_cloud/runner/connector.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/connector.py
@@ -61,8 +61,8 @@ class AigatewayConfig:
     base_url: str = "http://127.0.0.1:9105"
     default_model: str = "claude-haiku-4-5"
     # WHY: DECLARED, never discovered — see `config.routes_for`. Empty is a config error, not a
-    # signal to go ask the gateway what it serves. Each entry carries its own capabilities
-    # (`web_tools`), so a route's behavior is declared beside the route.
+    # signal to go ask the gateway what it serves. Each entry carries its own capability
+    # (`web_search`), so a route's behavior is declared beside the route.
     models: tuple[ModelSpec, ...] = ()
     # WHY: absolute-URL sources are a real url4 feature, so the default preserves the behavior a
     # `Url4Node` world has always had. Set False to hand the node a denying outbound layer.
@@ -103,7 +103,7 @@ class AigatewayWorld:
         separate flag could only ever agree with `_tavily_client` — or drift from it.
 
         This is the world-level capability, NOT a promise that any given call sends tools:
-        a route sends them only when its own `ModelSpec.web_tools` is true. Both must hold.
+        a route sends them only when its own `ModelSpec.uses_web_tools` is true. Both must hold.
         """
         return self._tavily_client is not None
 
@@ -372,10 +372,10 @@ async def _chat_completion_loop(
     """Drive one `_ModelEndpoint` call: post to aigateway, execute any requested tool calls,
     and repeat until the model answers with content instead of another tool call.
 
-    Tools are offered only when the route declares `web_tools` and the world can serve them
-    through Tavily. A configured key alone must never change a model request, an explicit
-    ``web_search=false`` disables retrieval, and benchmark-required search fails closed when
-    Tavily is unavailable.
+    Tools are offered only when the route's mechanism resolves to `ModelSpec.uses_web_tools`
+    and the world can serve them through Tavily. A configured key alone must never change a
+    model request, an explicit ``web_search=false`` disables retrieval, and benchmark-required
+    search fails closed when Tavily is unavailable.
 
     INVARIANT: the cache policy is re-applied on EVERY round trip, not merged once before the
     loop. One turn is several independently-keyed gateway calls, and a policy that lapsed after
@@ -437,10 +437,10 @@ def _retrieval_request(
     if (
         retrieval_policy is not None
         and params.get(WEB_SEARCH_PARAM) == "true"
-        and not (spec.web_tools or spec.native_web_search)
+        and not spec.web_search
     ):
         raise ResolutionError(
-            f"model route {spec.id!r} does not declare a web search mechanism",
+            f"model route {spec.id!r} declares web_search = false",
             code="benchmark_retrieval_unavailable",
             permanent=True,
         )
@@ -454,7 +454,7 @@ def _retrieval_request(
         policy=retrieval_policy,
         params=params,
     )
-    if wants_search and spec.native_web_search:
+    if wants_search and spec.uses_native_web_search:
         extra: dict[str, object] = {"web_search": True}
         exclusions = caller_exclusions(params)
         if exclusions:

--- a/apps/url4-cloud/src/url4_cloud/runner/request_parameters.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/request_parameters.py
@@ -43,7 +43,7 @@ def apply_retrieval_policy(
 
 def wants_web_search(params: Mapping[str, str], spec: ModelSpec) -> bool:
     """Resolve an optional URL4 search toggle against the declared route capabilities."""
-    declared = spec.web_tools or spec.native_web_search
+    declared = spec.web_search
     raw = params.get(WEB_SEARCH_PARAM)
     if raw is None:
         return declared
@@ -56,7 +56,7 @@ def wants_web_search(params: Mapping[str, str], spec: ModelSpec) -> bool:
     wanted = raw == "true"
     if wanted and not declared:
         raise RunnerRequestError(
-            f"web_search=true but route /{spec.id} declares no web search mechanism",
+            f"web_search=true but route /{spec.id} declares web_search = false",
             code="web_retrieval_unavailable",
             permanent=True,
         )

--- a/apps/url4-cloud/src/url4_cloud/runner/web_tools.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/web_tools.py
@@ -109,13 +109,14 @@ def build_runtime(
     params: Mapping[str, str],
 ) -> WebToolRuntime | None:
     """Resolve tool availability before the first paid model request."""
-    if not wants_search or not spec.web_tools:
+    if not wants_search or not spec.uses_web_tools:
         return None
     required = params.get(WEB_SEARCH_PARAM) == "true"
     if not required and policy is None:
-        # A route that declares web_tools searches by default, so the caller reaches here without
-        # writing `web_search=true`. Their exclusions still bind: an ignored exclusion list is the
-        # worst failure mode for a privacy control, because it looks like it was honoured.
+        # A route whose mechanism resolves to `uses_web_tools` searches by default, so the caller
+        # reaches here without writing `web_search=true`. Their exclusions still bind: an ignored
+        # exclusion list is the worst failure mode for a privacy control, because it looks like
+        # it was honoured.
         return (
             WebToolRuntime(tavily_http, config, tavily_api_key, caller_exclusions(params))
             if tavily_http is not None and tavily_api_key is not None

--- a/apps/url4-cloud/src/url4_cloud/world_config.py
+++ b/apps/url4-cloud/src/url4_cloud/world_config.py
@@ -53,7 +53,7 @@ _AIGATEWAY_KEYS = frozenset(
         "web_tool_max_iterations",
     }
 )
-_MODEL_KEYS = frozenset({"id", "web_tools", "native_web_search"})
+_MODEL_KEYS = frozenset({"id", "web_search"})
 _RESERVED_TABLES = frozenset({"data", "commands", "holdings", "identities"})
 _TOP_LEVEL_KEYS = frozenset({"aigateway"})
 _MODEL_ID_RE = re.compile(r"[A-Za-z0-9\-_.~]+(?:/[A-Za-z0-9\-_.~]+)*", re.ASCII)
@@ -63,25 +63,76 @@ class WorldConfigError(ValueError):
     """The Runner's configuration is unusable — raised at startup, before any run."""
 
 
+WEB_SEARCH_NATIVE_PROVIDERS = frozenset({"openrouter"})
+"""Providers whose aigateway plugin carries a native web-search envelope.
+
+A route served by one of these delegates retrieval to the provider; every other searching
+route runs the Tavily tool loop here instead.
+
+WHY only `openrouter`: `web_search` is declared by exactly one aigateway plugin
+(`plugins/openrouter_provider/parameters.py`). The other plugins register bespoke
+`custom_llm_provider` handlers — `codex` (OpenAI Codex OAuth), `gemini-cli` (Google Code
+Assist), `antigravity`, and aigateway's own `anthropic` — rather than litellm's stock vendor
+routes, so litellm's `web_search_options` is not reachable through them and a request
+carrying an undeclared parameter is refused by the parameter contract.
+
+AIDEV-NOTE: adding an entry here is NOT sufficient on its own. The provider's aigateway
+plugin must first declare the parameter, build the envelope from one pure function shared by
+the dispatch path and the cache-key projection, key the fields, and bump the cache adapter
+revision (OME-777 invariant I1). This set is the LAST step of that work, not the first.
+"""
+
+_UNPREFIXED_PROVIDER = "anthropic"
+
+
+def provider_of(model_id: str) -> str:
+    """The provider that serves a route: the segment before the first `/`.
+
+    WHY the segment and not a substring of the whole id: `openrouter/anthropic/claude-opus-4.8`
+    is an OpenRouter route and must take OpenRouter's envelope. A substring test hands it to
+    any future `anthropic` entry and silently sends it down the wrong provider's mechanism.
+
+    INVARIANT: an id with no `/` is Anthropic's — aigateway's catalog leaves exactly that one
+    provider unprefixed (`claude-haiku-4-5`), the `anthropic/` prefix appearing only in
+    litellm_params.
+    """
+    prefix, separator, _ = model_id.partition("/")
+    return prefix if separator else _UNPREFIXED_PROVIDER
+
+
 @dataclass(frozen=True, slots=True)
 class ModelSpec:
-    """One declared route: the gateway id, plus the per-route capabilities it opts into.
+    """One declared route: the gateway id, plus whether it may search the web.
 
     A route is addressed as a table rather than a bare id so capabilities are declared WHERE
-    the route is, not in a parallel list that can silently disagree with it. `web_tools` is the
-    first such capability; the shape is what a second one extends.
+    the route is, not in a parallel list that can silently disagree with it.
 
-    WHY `web_tools` defaults to False: the tool loop rewrites the request the model sees (a
-    `tools`/`tool_choice` payload, then extra round trips feeding results back). That is a
-    behavior change per model, and not every provider handles an OpenAI-shape tool call the
-    same way — so it is opted INTO per route, never inherited from the mere presence of a
-    Tavily key. An operator who supplies a key but declares no `web_tools = true` route gets
-    exactly the plain completions they declared.
+    WHY only THAT it searches, never HOW: which mechanism a model can carry is a property of
+    its provider, not a choice an operator should have to encode per route. Declaring the
+    mechanism made the operator the keeper of that knowledge and let a route claim one its
+    provider could not serve. The mechanism is therefore derived, and this file states intent.
+
+    WHY the default is True: a deployment that supplies a Tavily key wants retrieval. The
+    previous per-route opt-in meant a route stayed silently non-searching until somebody
+    remembered to declare it. A route that must not search says so with `web_search = false`.
     """
 
     id: str
-    web_tools: bool = False
-    native_web_search: bool = False
+    web_search: bool = True
+
+    @property
+    def uses_native_web_search(self) -> bool:
+        """The provider performs the search; the Runner only sets `web_search` on the body."""
+        return self.web_search and provider_of(self.id) in WEB_SEARCH_NATIVE_PROVIDERS
+
+    @property
+    def uses_web_tools(self) -> bool:
+        """The Runner performs the search itself, through the Tavily tool loop.
+
+        INVARIANT: this and `uses_native_web_search` are mutually exclusive, and their
+        disjunction is `web_search` — a searching route has exactly one mechanism.
+        """
+        return self.web_search and not self.uses_native_web_search
 
 
 @dataclass(frozen=True, slots=True)
@@ -107,8 +158,8 @@ def routes_for(models: Sequence[ModelSpec]) -> dict[str, ModelSpec]:
     """Map each route path — ``"/" + id``, 1:1, no aliases — to the spec that declared it.
 
     The VALUE is the whole spec, not the bare id: the endpoint that serves a route needs the
-    capabilities declared alongside it (`web_tools`), and resolving them from the same lookup
-    that resolves the id is what keeps a route and its capabilities from being fetched through
+    capability declared alongside it (`web_search`), and resolving it from the same lookup
+    that resolves the id is what keeps a route and its capability from being fetched through
     two different paths that can disagree.
     """
     return {"/" + model.id: model for model in models}
@@ -224,9 +275,9 @@ def _models(value: object) -> tuple[ModelSpec, ...]:
 def _model_spec(entry: object) -> ModelSpec:
     """One `[[aigateway.models]]` entry — a table, or a bare id string as shorthand.
 
-    The string form is exactly ``{ id = "<it>" }``: a route that opts into nothing. It stays
-    supported because "declare a plain route" should not require a table, and because every
-    capability defaults off, so the two spellings cannot mean different things.
+    The string form is exactly ``{ id = "<it>" }``. It stays supported because "declare a
+    plain route" should not require a table, and because both spellings take `web_search`'s
+    default of true, so the two spellings cannot mean different things.
     """
     if isinstance(entry, Mapping):
         return _model_table(entry)
@@ -246,25 +297,10 @@ def _model_table(table: Mapping[str, object]) -> ModelSpec:
     raw_id = table.get("id")
     if raw_id is None:
         raise WorldConfigError("[[aigateway.models]] entry is missing its `id`")
-    web_tools = _model_flag(table, "web_tools")
-    native_web_search = _model_flag(table, "native_web_search")
-    if web_tools and native_web_search:
-        raise WorldConfigError(
-            f"[[aigateway.models]] {raw_id!r} declares both web_tools and native_web_search — "
-            "a route serves one retrieval mechanism"
-        )
-    return ModelSpec(
-        id=_model_id(str(raw_id)),
-        web_tools=web_tools,
-        native_web_search=native_web_search,
-    )
-
-
-def _model_flag(table: Mapping[str, object], key: str) -> bool:
-    value = table.get(key, False)
+    value = table.get("web_search", True)
     if not isinstance(value, bool):
-        raise WorldConfigError(f"[[aigateway.models]] {key} must be a boolean, got {value!r}")
-    return value
+        raise WorldConfigError(f"[[aigateway.models]] web_search must be a boolean, got {value!r}")
+    return ModelSpec(id=_model_id(str(raw_id)), web_search=value)
 
 
 def _model_id(model: str) -> str:

--- a/apps/url4-cloud/tests/unit/test_aigateway_connector.py
+++ b/apps/url4-cloud/tests/unit/test_aigateway_connector.py
@@ -69,18 +69,18 @@ class _MockAigateway:
         models: tuple[str, ...],
         *,
         responses: dict[str, str | tuple[int, dict] | dict | list] | None = None,
-        web_tools: bool = True,
+        web_search: bool = True,
     ) -> None:
         # `ids` is the wire spelling aigateway advertises; `models` is the declared-world
-        # shape the connector consumes. `web_tools` applies to every route this mock serves —
+        # shape the connector consumes. `web_search` applies to every route this mock serves —
         # tests that need a mixed world build the ModelSpec tuple themselves.
         #
-        # WHY it defaults True while production defaults False: offering tools also requires a
-        # Tavily client, and these tests pass one only when the tool loop IS the subject — so
-        # this default is inert everywhere else. The route-level gate is proven on its own by
-        # `test_no_tools_when_the_route_did_not_opt_in`, which sets it False with a key present.
+        # Offering tools also requires a Tavily client, and these tests pass one only when the
+        # tool loop IS the subject — so this default is inert everywhere else. The route-level
+        # gate is proven on its own by `test_no_tools_when_the_route_opted_out`, which sets
+        # it False with a key present.
         self.ids = models
-        self.models = tuple(ModelSpec(id=m, web_tools=web_tools) for m in models)
+        self.models = tuple(ModelSpec(id=m, web_search=web_search) for m in models)
         self.responses = responses or {}
         self.requests: list[httpx.Request] = []
         self._seq_index: dict[str, int] = {}
@@ -507,7 +507,7 @@ _MODEL = "anthropic/claude-haiku-4-5"
 
 async def test_no_tools_when_tavily_key_absent() -> None:
     # The route opts IN, so the absent key is the only thing that can withhold the tools.
-    gw = _MockAigateway((_MODEL,), responses={_MODEL: "plain answer"}, web_tools=True)
+    gw = _MockAigateway((_MODEL,), responses={_MODEL: "plain answer"}, web_search=True)
     cfg = AigatewayConfig(models=gw.models, default_model=_MODEL)
     async with gw.client() as client:
         world = await build_aigateway_world(cfg, client=client)
@@ -520,11 +520,11 @@ async def test_no_tools_when_tavily_key_absent() -> None:
     assert "tool_choice" not in body
 
 
-async def test_no_tools_when_the_route_did_not_opt_in() -> None:
+async def test_no_tools_when_the_route_opted_out() -> None:
     # The other half of the gate: a configured Tavily key must NOT rewrite the request of a
-    # model that never declared `web_tools`. Without this, supplying a key to serve one route
-    # would silently change what every other model is asked.
-    gw = _MockAigateway((_MODEL,), responses={_MODEL: "plain answer"}, web_tools=False)
+    # model whose route declares `web_search=False`. Without this, supplying a key to serve one
+    # route would silently change what every other model is asked.
+    gw = _MockAigateway((_MODEL,), responses={_MODEL: "plain answer"}, web_search=False)
     tvly = _MockTavily()
     cfg = AigatewayConfig(models=gw.models, default_model=_MODEL)
     async with gw.client() as client, tvly.client() as tclient:
@@ -548,7 +548,7 @@ async def test_opted_in_and_opted_out_routes_coexist_in_one_world() -> None:
     gw = _MockAigateway((plain, searcher), responses={plain: "a", searcher: "b"})
     tvly = _MockTavily()
     cfg = AigatewayConfig(
-        models=(ModelSpec(id=plain, web_tools=False), ModelSpec(id=searcher, web_tools=True)),
+        models=(ModelSpec(id=plain, web_search=False), ModelSpec(id=searcher, web_search=True)),
         default_model=plain,
     )
     async with gw.client() as client, tvly.client() as tclient:

--- a/apps/url4-cloud/tests/unit/test_benchmark_foundation.py
+++ b/apps/url4-cloud/tests/unit/test_benchmark_foundation.py
@@ -513,7 +513,7 @@ async def test_required_retrieval_treats_a_blank_tavily_key_as_unconfigured() ->
     world = await build_aigateway_world(
         AigatewayConfig(
             default_model="provider/model",
-            models=(ModelSpec(id="provider/model", web_tools=True),),
+            models=(ModelSpec(id="provider/model"),),
         ),
         client=client,
         tavily_api_key="   ",
@@ -623,7 +623,7 @@ async def test_retrieval_policy_protects_search_results_and_direct_fetches() -> 
     client, world = await _world(
         BenchmarkRegistry((benchmark,)),
         [],
-        models=(ModelSpec(id="provider/model", web_tools=True),),
+        models=(ModelSpec(id="provider/model"),),
         response=model_response,
         tavily_client=tavily,
     )

--- a/apps/url4-cloud/tests/unit/test_cache_policy_threading.py
+++ b/apps/url4-cloud/tests/unit/test_cache_policy_threading.py
@@ -507,7 +507,7 @@ async def test_the_tool_calling_loop_applies_the_policy_on_every_round_trip() ->
         ),
         base_url="https://api.tavily.com",
     )
-    cfg = AigatewayConfig(models=(ModelSpec(id=MODEL, web_tools=True),), default_model=MODEL)
+    cfg = AigatewayConfig(models=(ModelSpec(id=MODEL),), default_model=MODEL)
 
     async with gw.client() as client, tavily:
         world = await build_aigateway_world(

--- a/apps/url4-cloud/tests/unit/test_cache_readback.py
+++ b/apps/url4-cloud/tests/unit/test_cache_readback.py
@@ -545,7 +545,7 @@ async def test_every_round_trip_of_a_tool_turn_reports_its_own_outcome() -> None
             (_completion("final answer"), {"X-AIGW-Cache": "miss"}),
         ]
     )
-    cfg = AigatewayConfig(models=(ModelSpec(id=_MODEL, web_tools=True),), default_model=_MODEL)
+    cfg = AigatewayConfig(models=(ModelSpec(id=_MODEL),), default_model=_MODEL)
     rec = _Recorder()
     async with gateway.client() as client, httpx.AsyncClient() as tavily:
         world = await build_aigateway_world(

--- a/apps/url4-cloud/tests/unit/test_declared_models_match_aigateway.py
+++ b/apps/url4-cloud/tests/unit/test_declared_models_match_aigateway.py
@@ -138,14 +138,3 @@ def test_declared_model_ids_are_route_shaped(model: str) -> None:
     assert model, "empty model id"
     assert not model.startswith("/"), f"{model!r} must not start with '/' — routes derive it"
     assert model == model.strip(), f"{model!r} has surrounding whitespace"
-
-
-def test_no_route_declares_web_tools_it_cannot_use() -> None:
-    # `web_tools` only means anything on a route that exists; a true on an id aigateway does
-    # not serve is a config error the run would never reach, so catch it here.
-    with _RUNNER_CONFIG.open("rb") as handle:
-        entries = tomllib.load(handle)["aigateway"]["models"]
-    enabled = {e["id"] for e in entries if not isinstance(e, str) and e.get("web_tools")}
-
-    assert enabled, "no route declares web_tools — the Tavily loop is now unreachable"
-    assert sorted(enabled - _aigateway_model_ids()) == []

--- a/apps/url4-cloud/tests/unit/test_draco_case_artifacts.py
+++ b/apps/url4-cloud/tests/unit/test_draco_case_artifacts.py
@@ -78,7 +78,7 @@ async def test_draco_smoke_retains_complete_case_evidence(tmp_path: Path) -> Non
 
     def respond(request: httpx.Request) -> httpx.Response:
         model = json.loads(request.content)["model"]
-        content = _ANSWER if model == "provider/candidate" else _RAW_JUDGE_REPLY
+        content = _ANSWER if model == "openrouter/anthropic/claude-opus-4.8" else _RAW_JUDGE_REPLY
         return httpx.Response(
             200,
             json={
@@ -88,7 +88,7 @@ async def test_draco_smoke_retains_complete_case_evidence(tmp_path: Path) -> Non
         )
 
     candidate = RelExpr(
-        path="/provider/candidate",
+        path="/openrouter/anthropic/claude-opus-4.8",
         context="$input",
         intent=text("Answer exactly."),
     )
@@ -101,9 +101,9 @@ async def test_draco_smoke_retains_complete_case_evidence(tmp_path: Path) -> Non
     ) as client:
         world = await build_aigateway_world(
             AigatewayConfig(
-                default_model="provider/candidate",
+                default_model="openrouter/anthropic/claude-opus-4.8",
                 models=(
-                    ModelSpec(id="provider/candidate", native_web_search=True),
+                    ModelSpec(id="openrouter/anthropic/claude-opus-4.8"),
                     ModelSpec(id=JUDGE_MODEL),
                 ),
             ),

--- a/apps/url4-cloud/tests/unit/test_draco_lineup_declared.py
+++ b/apps/url4-cloud/tests/unit/test_draco_lineup_declared.py
@@ -19,10 +19,12 @@ nothing.
 
 from __future__ import annotations
 
-import tomllib
 from pathlib import Path
 
 import pytest
+
+from url4_cloud import job_env
+from url4_cloud.world_config import ModelSpec, load_config
 
 _RUNNER_CONFIG = Path(__file__).resolve().parents[2] / "url4.toml"
 
@@ -47,11 +49,11 @@ DRACO_JUDGE = "google/gemini-3.1-pro-preview"
 """arXiv:2602.11685 §4.2 pins it. Also a solo candidate — see the dual-role test below."""
 
 
-def _routes() -> dict[str, dict]:
-    """Every declared model route, keyed by its gateway id."""
-    with _RUNNER_CONFIG.open("rb") as handle:
-        entries = tomllib.load(handle)["aigateway"]["models"]
-    return {e["id"]: e for e in entries if not isinstance(e, str)}
+def _routes() -> dict[str, ModelSpec]:
+    """Every declared model route, keyed by its gateway id, as the parsed spec."""
+    section = load_config({job_env.RUNNER_CONFIG: str(_RUNNER_CONFIG)}).aigateway
+    assert section is not None
+    return {model.id: model for model in section.models}
 
 
 @pytest.mark.parametrize("slug", DRACO_LINEUP)
@@ -66,9 +68,16 @@ def test_every_lineup_model_has_a_declared_route(slug: str) -> None:
 
 
 def test_the_dual_role_judge_route_can_retrieve_as_a_candidate() -> None:
-    """The route declares capability; the Benchmark Judge call pins retrieval off in URL4."""
+    """The route declares capability; the Benchmark Judge call pins retrieval off in URL4.
 
-    assert _routes()[_GATEWAY_PREFIX + DRACO_JUDGE].get("web_tools") is True
+    AIDEV-NOTE: before OME-797 this route named `web_tools = true` explicitly and took the
+    Tavily loop. The mechanism is now derived from the provider — this id is `openrouter/…`,
+    which resolves to `uses_native_web_search` instead — so the assertion follows the
+    mechanism that actually serves the route today rather than pinning the retired one.
+    """
+
+    spec = _routes()[_GATEWAY_PREFIX + DRACO_JUDGE]
+    assert spec.uses_native_web_search is True
 
 
 def test_the_lineup_has_no_duplicate_entries() -> None:

--- a/apps/url4-cloud/tests/unit/test_executable_model_catalog.py
+++ b/apps/url4-cloud/tests/unit/test_executable_model_catalog.py
@@ -259,7 +259,7 @@ async def test_runner_invalid_model_capability_disables_discovery_and_still_fail
     config = tmp_path / "url4.toml"
     config.write_text(
         '[aigateway]\ndefault_route = "model"\n'
-        '[[aigateway.models]]\nid = "model"\nweb_tools = "yes"\n'
+        '[[aigateway.models]]\nid = "model"\nweb_search = "yes"\n'
     )
     env = {job_env.RUNNER_CONFIG: str(config)}
 
@@ -271,7 +271,7 @@ async def test_runner_invalid_model_capability_disables_discovery_and_still_fail
     # One world, two consequences: discovery advertises nothing rather than something it cannot
     # execute, and the Runner — the authority on what a run may address — still refuses outright.
     assert service is None
-    with pytest.raises(WorldConfigError, match="web_tools must be a boolean"):
+    with pytest.raises(WorldConfigError, match="web_search must be a boolean"):
         declared_model_ids(env)
 
 

--- a/apps/url4-cloud/tests/unit/test_model_params.py
+++ b/apps/url4-cloud/tests/unit/test_model_params.py
@@ -28,12 +28,18 @@ from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
 from url4_cloud.world_config import ModelSpec
 
 _MODEL = "openrouter/google/gemini-3.1-pro-preview"
+_TAVILY_MODEL = "google/gemini-3.1-pro-preview"
+"""`_MODEL` minus the OpenRouter prefix: provider `google` carries no native envelope, so a
+route declared on this id takes the Tavily loop — needed by the tool-loop tests below, which
+must not silently resolve to `_MODEL`'s native mechanism instead."""
 
 
 # Every probe expression carries `anchor:1.0:'a'` beside the model call: with the call as the
 # body's ONLY source, the all-calls rule fires the per-row reduce and `default_route` adds a
 # gateway hop these assertions do not expect. One data sibling degrades it to a join.
-async def _evaluate(expression: str, *, web_tools: bool = False, tavily: bool = False):
+async def _evaluate(
+    expression: str, *, model: str = _MODEL, web_search: bool = False, tavily: bool = False
+):
     """Run one expression against a mock gateway; return the captured request bodies."""
     bodies: list[dict] = []
 
@@ -46,7 +52,7 @@ async def _evaluate(expression: str, *, web_tools: bool = False, tavily: bool = 
     ) as client:
         world = await build_aigateway_world(
             AigatewayConfig(
-                default_model=_MODEL, models=(ModelSpec(id=_MODEL, web_tools=web_tools),)
+                default_model=model, models=(ModelSpec(id=model, web_search=web_search),)
             ),
             client=client,
             tavily_client=client if tavily else None,
@@ -134,8 +140,9 @@ async def test_a_runner_owned_field_is_rejected(field: str) -> None:
     `model` would let an expression address one route and run another model, breaking the
     "route path is exactly '/' + gateway id" invariant that `url4.toml` and
     `test_declared_models_match_aigateway.py` exist to hold. `tools`/`tool_choice` would
-    bypass the per-route `web_tools` opt-in that keeps a configured Tavily key from
-    silently changing every model's payload. `stream` would break response parsing.
+    bypass the route's own resolved mechanism (`ModelSpec.uses_web_tools`) that keeps a
+    configured Tavily key from silently changing every model's payload. `stream` would break
+    response parsing.
 
     Dropping them silently would be worse than forwarding them: the expression would read
     as though it had pinned something it had not.
@@ -164,10 +171,11 @@ async def test_an_unknown_parameter_is_forwarded_for_the_gateway_to_judge() -> N
 
 @pytest.mark.asyncio
 async def test_web_tools_still_win_over_a_caller_supplied_payload() -> None:
-    """The route's declared tools must be what ships, on a route that opted in."""
+    """The route's resolved tools must be what ships, on a route whose mechanism is Tavily."""
     bodies = await _evaluate(
-        f"(v:1.0:/{_MODEL}(a:1.0:'x')!'grade';temperature=0.2,anchor:1.0:'a')!'go'",
-        web_tools=True,
+        f"(v:1.0:/{_TAVILY_MODEL}(a:1.0:'x')!'grade';temperature=0.2,anchor:1.0:'a')!'go'",
+        model=_TAVILY_MODEL,
+        web_search=True,
         tavily=True,
     )
 
@@ -218,14 +226,17 @@ async def test_parameters_apply_to_every_round_trip_of_the_tool_loop() -> None:
         transport=httpx.MockTransport(handle), base_url="http://aigateway.test"
     ) as client:
         world = await build_aigateway_world(
-            AigatewayConfig(default_model=_MODEL, models=(ModelSpec(id=_MODEL, web_tools=True),)),
+            AigatewayConfig(
+                default_model=_TAVILY_MODEL,
+                models=(ModelSpec(id=_TAVILY_MODEL, web_search=True),),
+            ),
             client=client,
             tavily_client=client,
             tavily_api_key="tv-key",
         )
         try:
             await world.node.evaluate(
-                f"(v:1.0:/{_MODEL}(a:1.0:'x')!'grade';temperature=0.2,anchor:1.0:'a')!'go'"
+                f"(v:1.0:/{_TAVILY_MODEL}(a:1.0:'x')!'grade';temperature=0.2,anchor:1.0:'a')!'go'"
             )
         finally:
             await world.aclose()

--- a/apps/url4-cloud/tests/unit/test_native_web_search.py
+++ b/apps/url4-cloud/tests/unit/test_native_web_search.py
@@ -1,20 +1,23 @@
 """Provider-side web search, and the expression-level toggle that selects it.
 
-FEATURE: a route whose provider runs search ITSELF declares `native_web_search`, and an
-expression turns retrieval on or off per call with `;web_search=`.
+FEATURE: a route declares only THAT it may search (`web_search`, default true); the Engine
+derives WHICH mechanism from the provider, and an expression turns retrieval on or off per
+call with `;web_search=`.
 STORY: as a benchmark author, a published score was produced on the provider's own server-side
 search — a client-side loop over a different backend is a different experiment, so I need the
 same surface, and I need to switch it off for the judge in the same expression.
 
-TWO MECHANISMS, one per route:
-  * `web_tools`         — the RUNNER declares OpenAI functions and executes them against Tavily.
-                          Kept for providers with no server-side search of their own.
-  * `native_web_search` — the PROVIDER executes the search and answers with it already done.
-                          The runner asks the GATEWAY for it (`web_search: true`) and never
-                          spells one provider's envelope itself.
+TWO MECHANISMS, chosen by provider (`world_config.WEB_SEARCH_NATIVE_PROVIDERS`):
+  * the TAVILY loop  — the RUNNER declares OpenAI functions and executes them against Tavily.
+                       Serves every provider with no server-side search of its own.
+  * the NATIVE path  — the PROVIDER executes the search and answers with it already done.
+                       The runner asks the GATEWAY for it (`web_search: true`) and never
+                       spells one provider's envelope itself.
 
 INVARIANT: never both on one route. The request would carry two tool populations and
-double-dispatch — searching twice per turn and billing for both.
+double-dispatch — searching twice per turn and billing for both. This is now structural
+rather than validated: one flag cannot name two mechanisms (see
+`test_web_search_routing.test_mechanisms_partition_the_flag`).
 """
 
 from __future__ import annotations
@@ -28,7 +31,7 @@ from url4.core.errors import ResolutionError
 from url4_cloud.retrieval_policy import RetrievalPolicy, retrieval_scope
 from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
 from url4_cloud.runner.web_tools import build_runtime
-from url4_cloud.world_config import ModelSpec, WorldConfigError, parse_config
+from url4_cloud.world_config import ModelSpec
 
 _NATIVE = "openrouter/anthropic/claude-opus-4.8"
 _TAVILY = "claude-opus-4-8"
@@ -43,12 +46,14 @@ async def _bodies(expression: str, *, cfg: AigatewayConfig | None = None) -> lis
         captured.append(json.loads(request.content))
         return httpx.Response(200, json={"choices": [{"message": {"content": "OK"}}], "usage": {}})
 
+    # `_NATIVE` is an openrouter route, so it delegates; `_TAVILY` is unprefixed (anthropic) and
+    # takes the loop. `_PLAIN` has to OPT OUT now that searching is the default.
     config = cfg or AigatewayConfig(
         default_model=_PLAIN,
         models=(
-            ModelSpec(id=_NATIVE, native_web_search=True),
-            ModelSpec(id=_TAVILY, web_tools=True),
-            ModelSpec(id=_PLAIN),
+            ModelSpec(id=_NATIVE),
+            ModelSpec(id=_TAVILY),
+            ModelSpec(id=_PLAIN, web_search=False),
         ),
     )
     async with httpx.AsyncClient(
@@ -148,12 +153,14 @@ async def test_a_tavily_route_still_declares_openai_functions() -> None:
 
     assert [t["function"]["name"] for t in body["tools"]] == ["web_search", "web_fetch"]
     assert body["tool_choice"] == "auto"
+    assert "web_search" not in body
 
 
 @pytest.mark.asyncio
 async def test_saying_nothing_keeps_the_routes_declared_behaviour() -> None:
-    """Absent means 'as declared', so every expression written before this toggle existed
-    behaves exactly as it did."""
+    """Absent means 'as declared' — for `_NATIVE` and `_TAVILY` that is unchanged from before
+    this toggle existed, but `_PLAIN` used to stay silent by default and now must opt out
+    explicitly to keep doing so."""
     assert "web_search" in (await _bodies(_call(_NATIVE)))[0]
     assert "tools" in (await _bodies(_call(_TAVILY)))[0]
     assert "tools" not in (await _bodies(_call(_PLAIN)))[0]
@@ -164,7 +171,7 @@ async def test_saying_nothing_keeps_the_routes_declared_behaviour() -> None:
 async def test_asking_a_route_with_no_mechanism_to_search_is_loud() -> None:
     """The silent alternative is an expression that reads as though it retrieved and an answer
     written from weights alone — indistinguishable in the result."""
-    with pytest.raises(ResolutionError, match="declares no web search"):
+    with pytest.raises(ResolutionError, match="declares web_search = false"):
         await _bodies(_call(_PLAIN, ";web_search=true"))
 
 
@@ -181,42 +188,21 @@ async def test_the_toggle_is_consumed_and_never_reaches_the_gateway() -> None:
 # --- the declared world ----------------------------------------------------------
 
 
-def test_declaring_both_mechanisms_is_a_config_error() -> None:
-    raw = {
-        "aigateway": {
-            "default_route": "/m",
-            "models": [{"id": "m", "web_tools": True, "native_web_search": True}],
-        }
-    }
-    with pytest.raises(WorldConfigError, match="one retrieval mechanism"):
-        parse_config(raw, {})
-
-
-def test_native_web_search_defaults_off() -> None:
-    raw = {"aigateway": {"default_route": "/m", "models": [{"id": "m"}]}}
-
-    section = parse_config(raw, {}).aigateway
-    assert section is not None
-    assert section.models[0].native_web_search is False
-
-
-def test_native_web_search_must_be_a_boolean() -> None:
-    raw = {"aigateway": {"default_route": "/m", "models": [{"id": "m", "native_web_search": 1}]}}
-
-    with pytest.raises(WorldConfigError, match="native_web_search must be a boolean"):
-        parse_config(raw, {})
+# SUPERSEDED (OME-797) — three tests stood here; their guarantees moved to
+# `test_web_search_routing.test_mechanisms_partition_the_flag`,
+# `.test_web_search_defaults_to_true`, and `.test_web_search_must_be_a_boolean`.
 
 
 @pytest.mark.asyncio
 async def test_a_default_on_search_route_still_honours_caller_exclusions() -> None:
-    """A `web_tools` route searches by DEFAULT, so a caller reaches the tool loop without ever
+    """A Tavily-loop route searches by DEFAULT, so a caller reaches the tool loop without ever
     writing `web_search=true`. Their exclusion list must still bind: a silently ignored exclusion
     is indistinguishable from an honoured one, which is the worst failure mode a privacy control
     can have."""
     client = httpx.AsyncClient(base_url="https://tavily.test")
     try:
         runtime = build_runtime(
-            spec=ModelSpec(id=_TAVILY, web_tools=True),
+            spec=ModelSpec(id=_TAVILY),
             wants_search=True,
             tavily_http=client,
             tavily_api_key="key",

--- a/apps/url4-cloud/tests/unit/test_runner.py
+++ b/apps/url4-cloud/tests/unit/test_runner.py
@@ -259,18 +259,18 @@ def test_params_from_env_missing_required_raises() -> None:
 _MODEL = "claude-haiku-4-5"
 
 
-def _declared(*models: str, web_tools: bool = False) -> WorldConfig:
+def _declared(*models: str, web_search: bool = False) -> WorldConfig:
     """A config declaring `models`, defaulting to the first — the Runner never discovers.
 
-    `web_tools` is the per-route opt-in every declared route here shares; it defaults off,
-    matching the shipped default, so a test that wants the tool loop must ask for it.
+    `web_search` is the per-route opt-in every declared route here shares; it defaults off HERE
+    — unlike `ModelSpec`'s own default — so a test that wants the tool loop must ask for it.
     """
     declared = models or (_MODEL,)
     return WorldConfig(
         aigateway=AigatewaySection(
             base_url="http://aigateway.test",
             default_model=declared[0],
-            models=tuple(ModelSpec(id=model, web_tools=web_tools) for model in declared),
+            models=tuple(ModelSpec(id=model, web_search=web_search) for model in declared),
         )
     )
 
@@ -362,7 +362,36 @@ async def test_build_executor_with_tavily_key_declares_web_tools() -> None:
     async with client, _unused_tavily_client() as tclient:
         executor = build_executor(
             {job_env.TAVILY_API_KEY: "tvly-x"},
-            _declared(web_tools=True),
+            _declared(web_search=True),
+            client=client,
+            tavily_client=tclient,
+        )
+        async for _ in executor.execute(f"/{_MODEL}(ctx)!go"):
+            pass
+
+    assert posts, "the aigateway completion endpoint was never called"
+    body = posts[0]
+    assert {t["function"]["name"] for t in body["tools"]} == {"web_search", "web_fetch"}
+    assert body["tool_choice"] == "auto"
+
+
+@pytest.mark.asyncio
+async def test_build_executor_offers_tools_on_the_production_default() -> None:
+    # `_declared` defaults `web_search` to False, opposite of `ModelSpec`'s own default, so no
+    # test above exercises the value that actually ships. This route is built straight from
+    # `ModelSpec`, taking its default (True) untouched, on a non-openrouter id.
+    config = WorldConfig(
+        aigateway=AigatewaySection(
+            base_url="http://aigateway.test",
+            default_model=_MODEL,
+            models=(ModelSpec(id=_MODEL),),
+        )
+    )
+    client, posts = _recording_aigateway_client()
+    async with client, _unused_tavily_client() as tclient:
+        executor = build_executor(
+            {job_env.TAVILY_API_KEY: "tvly-x"},
+            config,
             client=client,
             tavily_client=tclient,
         )
@@ -377,13 +406,13 @@ async def test_build_executor_with_tavily_key_declares_web_tools() -> None:
 
 @pytest.mark.asyncio
 async def test_build_executor_declares_no_tools_for_a_route_that_did_not_opt_in() -> None:
-    # A Tavily key is configured, but url4.toml declared this route without `web_tools` — the
-    # deployment secret must not decide what the model is asked.
+    # A Tavily key is configured, but this route declares `web_search=False` — the deployment
+    # secret must not decide what the model is asked.
     client, posts = _recording_aigateway_client()
     async with client, _unused_tavily_client() as tclient:
         executor = build_executor(
             {job_env.TAVILY_API_KEY: "tvly-x"},
-            _declared(web_tools=False),
+            _declared(web_search=False),
             client=client,
             tavily_client=tclient,
         )

--- a/apps/url4-cloud/tests/unit/test_runner_config.py
+++ b/apps/url4-cloud/tests/unit/test_runner_config.py
@@ -157,41 +157,39 @@ default_route = "/plain"
 
 [[aigateway.models]]
 id = "plain"
+web_search = false
 
 [[aigateway.models]]
 id = "searcher"
-web_tools = true
 """
 
 
 def test_a_route_declared_as_a_table_carries_its_capabilities() -> None:
     assert _section(_TABLES).models == (
-        ModelSpec(id="plain", web_tools=False),
-        ModelSpec(id="searcher", web_tools=True),
+        ModelSpec(id="plain", web_search=False),
+        ModelSpec(id="searcher"),
     )
 
 
-def test_web_tools_defaults_off_so_a_route_opts_in_explicitly() -> None:
-    # The deny-by-default half of the gate: supplying a Tavily key must not retroactively
-    # change the request every undeclared model sees.
-    assert _section(_TABLES).models[0].web_tools is False
+def test_web_search_stays_off_only_when_a_route_opts_out_explicitly() -> None:
+    # `web_search` now defaults to true, so a route that must not search has to say so with an
+    # explicit `web_search = false` — supplying a Tavily key must not retroactively turn it on.
+    assert _section(_TABLES).models[0].web_search is False
 
 
-def test_a_bare_id_string_is_shorthand_for_a_capability_free_route() -> None:
-    assert _section(_MINIMAL).models[0] == ModelSpec(id="claude-haiku-4-5", web_tools=False)
+def test_a_bare_id_string_is_shorthand_for_a_route_that_searches_by_default() -> None:
+    assert _section(_MINIMAL).models[0] == ModelSpec(id="claude-haiku-4-5")
 
 
 def test_the_two_spellings_may_be_mixed() -> None:
-    section = _section(
-        '[aigateway]\ndefault_route = "/a"\nmodels = ["a", { id = "b", web_tools = true }]\n'
-    )
+    section = _section('[aigateway]\ndefault_route = "/a"\nmodels = ["a", { id = "b" }]\n')
 
-    assert section.models == (ModelSpec(id="a"), ModelSpec(id="b", web_tools=True))
+    assert section.models == (ModelSpec(id="a"), ModelSpec(id="b"))
 
 
 def test_a_route_table_without_an_id_is_rejected() -> None:
     with pytest.raises(WorldConfigError, match="missing its `id`"):
-        _parse('[aigateway]\ndefault_route = "/a"\nmodels = [{ web_tools = true }]\n')
+        _parse('[aigateway]\ndefault_route = "/a"\nmodels = [{ web_search = true }]\n')
 
 
 def test_unknown_key_on_a_route_table_is_rejected() -> None:
@@ -200,9 +198,9 @@ def test_unknown_key_on_a_route_table_is_rejected() -> None:
         _parse('[aigateway]\ndefault_route = "/a"\nmodels = [{ id = "a", web_tool = true }]\n')
 
 
-def test_non_boolean_web_tools_is_rejected() -> None:
-    with pytest.raises(WorldConfigError, match="web_tools must be a boolean"):
-        _parse('[aigateway]\ndefault_route = "/a"\nmodels = [{ id = "a", web_tools = "yes" }]\n')
+def test_non_boolean_web_search_is_rejected() -> None:
+    with pytest.raises(WorldConfigError, match="web_search must be a boolean"):
+        _parse('[aigateway]\ndefault_route = "/a"\nmodels = [{ id = "a", web_search = "yes" }]\n')
 
 
 def test_a_route_entry_of_the_wrong_type_is_rejected() -> None:

--- a/apps/url4-cloud/tests/unit/test_url4_executor.py
+++ b/apps/url4-cloud/tests/unit/test_url4_executor.py
@@ -559,8 +559,9 @@ def _usage(input_tokens: int, output_tokens: int) -> Usage:
 def _one_node_two_usage_events() -> tuple[SpanData, CostUsageData, CostUsageData]:
     """Drive `_RunState` through ONE node that reports usage TWICE.
 
-    This is the ordinary shape of a `web_tools` route, not a corner case: every aigateway round
-    trip in the tool loop reports its own usage against the same span.
+    This is the ordinary shape of a route whose mechanism resolves to `uses_web_tools`, not a
+    corner case: every aigateway round trip in the tool loop reports its own usage against the
+    same span.
     """
     state = _RunState()
     state.map(NodeStarted(span_id=_SPAN, parent_span_id=None, node_kind="RelUrlNode", detail="m"))

--- a/apps/url4-cloud/tests/unit/test_web_search_routing.py
+++ b/apps/url4-cloud/tests/unit/test_web_search_routing.py
@@ -1,0 +1,144 @@
+"""One declared flag, a derived mechanism.
+
+FEATURE: web search on a model route.
+STORY: as an operator, I declare THAT a route may search, and the Engine decides HOW —
+so I never have to know which provider carries a native search envelope.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from url4_cloud import job_env
+from url4_cloud.world_config import (
+    WEB_SEARCH_NATIVE_PROVIDERS,
+    ModelSpec,
+    WorldConfigError,
+    load_config,
+    parse_config,
+    provider_of,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_RUNNER_CONFIG = _REPO_ROOT / "apps/url4-cloud/url4.toml"
+
+
+def _parse_models(models_toml: str) -> tuple[ModelSpec, ...]:
+    """Parse a `models` list, pointing `default_route` at its first entry so it stays declared."""
+    first = tomllib.loads(f"models = {models_toml}")["models"][0]
+    default_id = first if isinstance(first, str) else first["id"]
+    text = f'[aigateway]\ndefault_route = "/{default_id}"\nmodels = {models_toml}\n'
+    section = parse_config(tomllib.loads(text), {}).aigateway
+    assert section is not None
+    return section.models
+
+
+# --- provider resolution ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("model_id", "expected"),
+    [
+        ("openrouter/openai/gpt-5.5", "openrouter"),
+        # WHY this case exists: the id CONTAINS "anthropic", but the route is OpenRouter's and
+        # must take OpenRouter's envelope. A substring test would misroute it.
+        ("openrouter/anthropic/claude-opus-4.8", "openrouter"),
+        ("codex/gpt-5.5", "codex"),
+        ("gemini-cli/gemini-2.5-pro", "gemini-cli"),
+        ("antigravity/gemini-3-flash", "antigravity"),
+        # Anthropic ids are unprefixed in aigateway's catalog; the convention is the fallback.
+        ("claude-haiku-4-5", "anthropic"),
+    ],
+)
+def test_provider_of_reads_the_leading_segment(model_id: str, expected: str) -> None:
+    assert provider_of(model_id) == expected
+
+
+def test_only_openrouter_is_declared_native() -> None:
+    """AIDEV-NOTE: this set grows ONLY when an aigateway plugin gains a web-search envelope."""
+    assert WEB_SEARCH_NATIVE_PROVIDERS == frozenset({"openrouter"})
+
+
+# --- mechanism selection ---------------------------------------------------------------
+
+
+def test_openrouter_route_delegates_natively() -> None:
+    spec = ModelSpec(id="openrouter/openai/gpt-5.5")
+    assert spec.uses_native_web_search is True
+    assert spec.uses_web_tools is False
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "claude-haiku-4-5",
+        "codex/gpt-5.5",
+        "gemini-cli/gemini-2.5-pro",
+        "antigravity/gemini-3-flash",
+        "huggingface/meta-llama/Llama-3-8B",
+        "ollama/llama3",
+    ],
+)
+def test_provider_without_a_native_envelope_takes_the_tavily_loop(model_id: str) -> None:
+    spec = ModelSpec(id=model_id)
+    assert spec.uses_web_tools is True
+    assert spec.uses_native_web_search is False
+
+
+@pytest.mark.parametrize("model_id", ["openrouter/openai/gpt-5.5", "codex/gpt-5.5"])
+def test_disabled_route_uses_no_mechanism(model_id: str) -> None:
+    spec = ModelSpec(id=model_id, web_search=False)
+    assert spec.uses_native_web_search is False
+    assert spec.uses_web_tools is False
+
+
+@pytest.mark.parametrize("web_search", [True, False])
+@pytest.mark.parametrize(
+    "model_id", ["openrouter/openai/gpt-5.5", "codex/gpt-5.5", "claude-haiku-4-5"]
+)
+def test_mechanisms_partition_the_flag(model_id: str, web_search: bool) -> None:
+    """INVARIANT: exactly one mechanism when the route searches, and none when it does not."""
+    spec = ModelSpec(id=model_id, web_search=web_search)
+    assert not (spec.uses_native_web_search and spec.uses_web_tools)
+    assert (spec.uses_native_web_search or spec.uses_web_tools) is web_search
+
+
+# --- declaration -----------------------------------------------------------------------
+
+
+def test_web_search_defaults_to_true() -> None:
+    assert _parse_models('["codex/gpt-5.5"]')[0] == ModelSpec(id="codex/gpt-5.5")
+    assert _parse_models('["codex/gpt-5.5"]')[0].web_search is True
+
+
+def test_a_route_may_opt_out() -> None:
+    (spec,) = _parse_models('[{ id = "codex/gpt-5.5", web_search = false }]')
+    assert spec.web_search is False
+
+
+def test_web_search_must_be_a_boolean() -> None:
+    with pytest.raises(WorldConfigError, match="web_search must be a boolean"):
+        _parse_models('[{ id = "a", web_search = "yes" }]')
+
+
+# --- reachability of the shipped config -------------------------------------------------
+
+
+def test_both_search_mechanisms_are_reachable_from_the_shipped_config() -> None:
+    # No route NAMES a mechanism any more — `world_config.ModelSpec` derives it from the id's
+    # provider — so a declared-but-unserved route can no longer strand the Tavily loop the way
+    # a stale `web_tools = true` id once could. What this guard now protects is that the shipped
+    # config still exercises BOTH mechanisms: an all-openrouter (or all-Tavily) catalog would
+    # silently orphan the other loop, and nothing else would say so.
+    section = load_config({job_env.RUNNER_CONFIG: str(_RUNNER_CONFIG)}).aigateway
+    assert section is not None
+
+    assert any(model.uses_web_tools for model in section.models), (
+        "no declared route resolves to the Tavily loop — it is now unreachable"
+    )
+    assert any(model.uses_native_web_search for model in section.models), (
+        "no declared route resolves to native web search — it is now unreachable"
+    )

--- a/apps/url4-cloud/url4.toml
+++ b/apps/url4-cloud/url4.toml
@@ -13,14 +13,22 @@
 # Adding a model is a deliberate, reviewable edit: these paths are a public naming surface that
 # url4 expressions depend on.
 #
-# Each route is a TABLE, not a bare id, so its capabilities are declared beside it:
+# A route may be a bare id or a TABLE, so a capability can be declared beside it:
 #
-#   web_tools   Offer the Tavily-backed web_search/web_fetch tool loop to this model.
-#               Defaults to FALSE — a route gets tools only by declaring it. Declaring it does
-#               not by itself enable anything: the deployment must ALSO supply TAVILY_API_KEY,
-#               or the route serves plain completions (see `runner/connector.py`). Enabling it
-#               changes the request the model sees (a `tools`/`tool_choice` payload, then extra
-#               round trips feeding results back), which is why it is per-route, not global.
+#   web_search  May this route search the web. Defaults to TRUE — declare it only to turn a
+#               route OFF. It says THAT the route searches, never HOW: the mechanism is
+#               derived from the provider by `world_config.provider_of` against
+#               `world_config.WEB_SEARCH_NATIVE_PROVIDERS`. A provider in that set delegates
+#               to its own server-side search; every other route runs the Tavily-backed
+#               web_search/web_fetch tool loop here instead.
+#
+#               Which mechanism a model can carry is a fact about its provider, so the Engine
+#               owns it. An operator who had to declare it was keeping that knowledge in their
+#               head, and a route could claim a mechanism its provider does not serve.
+#
+#               `web_search = true` still enables nothing on its own where the tool loop is
+#               used: the deployment must ALSO supply TAVILY_API_KEY, or the route serves
+#               plain completions (see `runner/web_tools.build_runtime`).
 
 [aigateway]
 base_url = "http://127.0.0.1:9105"
@@ -33,9 +41,11 @@ web_tool_max_iterations = 12
 allow_outbound = true
 
 # --- anthropic — unprefixed ids -----------------------------------------------------------
-# web_tools OFF: the plugin dispatches OpenAI-shape tool calls through litellm, which IS the
-# shape `_WEB_TOOLS` declares, so the loop is expected to round-trip — but that has not been
-# verified end-to-end against a live Anthropic credential, and only verified routes opt in.
+# These take the Tavily loop: `anthropic` is not in WEB_SEARCH_NATIVE_PROVIDERS, because
+# aigateway's Anthropic plugin declares no web-search parameter. The plugin dispatches
+# OpenAI-shape tool calls through litellm, which IS the shape `_WEB_TOOLS` declares, so the
+# loop is expected to round-trip — not yet verified end-to-end against a live Anthropic
+# credential (OME-797 defers that check; a deployment with no TAVILY_API_KEY is unaffected).
 [[aigateway.models]]
 id = "claude-opus-4-8"
 
@@ -52,9 +62,10 @@ id = "claude-sonnet-4-5"
 id = "claude-haiku-4-5"
 
 # --- codex ---------------------------------------------------------------------------------
-# web_tools stays OFF: these dispatch through the Codex OAuth backend, whose tool-call handling
-# is not verified end-to-end here. Flip a route to true once it is — the flag is per route
-# precisely so that is a one-line, reviewable change rather than a global switch.
+# Tavily loop as well. These dispatch through the Codex OAuth backend, not litellm's stock
+# OpenAI route, so litellm's own `web_search_options` never reaches them; their tool-call
+# handling is not verified end-to-end here either. Set `web_search = false` on a route to take
+# it out of retrieval entirely.
 [[aigateway.models]]
 id = "codex/gpt-5.5"
 
@@ -71,7 +82,7 @@ id = "codex/gpt-5.3-codex"
 id = "codex/gpt-5.2"
 
 # --- gemini --------------------------------------------------------------------------------
-# web_tools OFF for the same reason as codex: Google Code Assist backend, unverified here.
+# Tavily loop, same reason as codex: Google Code Assist backend, unverified here.
 [[aigateway.models]]
 id = "gemini-cli/gemini-3.1-flash-lite"
 
@@ -97,10 +108,13 @@ id = "antigravity/gemini-3-flash"
 # CAVEAT: unlike the four static catalogs above, this list is env-overridable at deploy time
 # (AIGW_OPENROUTER_DEFAULT_MODELS), so the pinning test can only hold it to the seeds compiled
 # into the plugin — a deployment that overrides them is on its own.
-# web_tools: verified end-to-end through OpenRouter's OpenAI-shape tool calling.
+#
+# `openrouter` IS in WEB_SEARCH_NATIVE_PROVIDERS, so every route below delegates search to
+# OpenRouter's own server-side engine — one request, fully cacheable (OME-781) — and none of
+# them runs the Tavily loop. That holds for the whole provider, including the models whose
+# tool calling was separately verified here.
 [[aigateway.models]]
 id = "openrouter/openai/gpt-5.5"
-native_web_search = true
 
 # The HealthBench judge (healthbench/definition.py JUDGE_MODEL). The Benchmark's judge
 # call pins ``web_search=false``, so no retrieval capability is declared here.
@@ -109,11 +123,9 @@ id = "openrouter/openai/gpt-5.4"
 
 [[aigateway.models]]
 id = "openrouter/anthropic/claude-opus-4.8"
-native_web_search = true
 
 [[aigateway.models]]
 id = "openrouter/anthropic/claude-fable-5"
-native_web_search = true
 
 [[aigateway.models]]
 id = "openrouter/anthropic/claude-haiku-4.5"
@@ -121,23 +133,18 @@ native_web_search = true
 
 [[aigateway.models]]
 id = "openrouter/google/gemini-3.1-pro-preview"
-web_tools = true
 
 [[aigateway.models]]
 id = "openrouter/google/gemini-3-flash-preview"
-web_tools = true
 
 [[aigateway.models]]
 id = "openrouter/moonshotai/kimi-k2.6"
-web_tools = true
 
 [[aigateway.models]]
 id = "openrouter/deepseek/deepseek-v4-pro"
-web_tools = true
 
 [[aigateway.models]]
 id = "openrouter/qwen/qwen3.6-plus"
-web_tools = true
 
 # RESERVED — the format carries these (they are `url4 serve`'s tables) but the Runner does not
 # parse them yet; declaring one is a loud config error, never a silent no-op:

--- a/apps/url4-cloud/url4.toml
+++ b/apps/url4-cloud/url4.toml
@@ -117,7 +117,7 @@ id = "antigravity/gemini-3-flash"
 id = "openrouter/openai/gpt-5.5"
 
 # The HealthBench judge (healthbench/definition.py JUDGE_MODEL). The Benchmark's judge
-# call pins ``web_search=false``, so no retrieval capability is declared here.
+# call pins ``web_search=false`` per call, so the route-level default does not reach Grading.
 [[aigateway.models]]
 id = "openrouter/openai/gpt-5.4"
 
@@ -129,7 +129,6 @@ id = "openrouter/anthropic/claude-fable-5"
 
 [[aigateway.models]]
 id = "openrouter/anthropic/claude-haiku-4.5"
-native_web_search = true
 
 [[aigateway.models]]
 id = "openrouter/google/gemini-3.1-pro-preview"

--- a/docs/plan/2026-08-12-OME-797-unify-web-search.md
+++ b/docs/plan/2026-08-12-OME-797-unify-web-search.md
@@ -1,0 +1,64 @@
+# OME-797 — Implementation plan
+
+Spec: `docs/spec/2026-08-12-OME-797-unify-web-search.md` · Ledger:
+`docs/work/2026-08-12-OME-797-unify-web-search.md`
+
+One SDLC unit, one stack (`url4-cloud`), one commit. RED before GREEN at every step.
+
+## Step 1 — RED: the routing contract
+
+Add `tests/unit/test_web_search_routing.py`:
+
+- `provider_of` — prefixed, nested, unprefixed.
+- selection — openrouter ⇒ native; codex, gemini-cli, antigravity, huggingface, ollama and
+  unprefixed anthropic ⇒ Tavily; `web_search = false` ⇒ neither.
+- INVARIANT — mutual exclusion, and disjunction equals `web_search`.
+- config — an omitted `web_search` is `true`; an explicit `false` parses; a non-boolean
+  raises. No test pins the retired names: they are deleted, not migrated.
+
+The tests must fail because the names do not exist yet.
+
+## Step 2 — GREEN: `world_config.py`
+
+- `WEB_SEARCH_NATIVE_PROVIDERS: frozenset[str] = frozenset({"openrouter"})`.
+- `provider_of(model_id: str) -> str` using `partition("/")`.
+- `ModelSpec.web_search: bool = True`, plus `uses_native_web_search` and `uses_web_tools`
+  properties. Remove `web_tools` and `native_web_search` fields.
+- `_MODEL_KEYS = frozenset({"id", "web_search"})`. Nothing else — the retired keys get no
+  branch, no constant, and no message of their own.
+
+Carry the WHY anchors from the spec (§2.1 substring trap, §2.3 one-provider set) into the
+code as `WHY:` / `INVARIANT:` comments.
+
+## Step 3 — GREEN: the three call sites
+
+- `request_parameters.wants_web_search` — `declared = spec.web_search`.
+- `connector._retrieval_request` — guard reads `spec.web_search`; native branch reads
+  `spec.uses_native_web_search`.
+- `web_tools.build_runtime` — return `None` when the route is native.
+
+## Step 4 — `url4.toml`
+
+Remove every `web_tools` / `native_web_search` line. Rewrite the header block: document
+`web_search` (default true), the derived mechanism, and the fact that
+`WEB_SEARCH_NATIVE_PROVIDERS` in `world_config.py` is the one place that grows when an
+aigateway plugin gains a native envelope. Keep the route-path invariant and the RESERVED
+tables untouched.
+
+## Step 5 — the 13 prior test files
+
+Rewrite only the assertions that name the retired flags; preserve every behavioural
+guarantee. Each changed test is listed in the PR body under the Confidence Gate. Also update
+the stale comment in `benchmarks/draco/aggregate.py`.
+
+## Step 6 — gates and close
+
+`uv run .claude/scripts/run_gates.py url4-cloud` green, then fill the ledger Outcome, commit
+with `Refs: OME-797`, open the PR, and close the issue with the card's template.
+
+## Risks
+
+- **Behaviour drift in the 13 rewritten tests.** Mitigation: change assertions about the
+  flag names only; the spec §4 list is the checklist that each guarantee still has a test.
+- **A missed reference to a retired field.** Mitigation: pyright plus a repo-wide grep for
+  both names before the gates run.

--- a/docs/spec/2026-08-12-OME-797-unify-web-search.md
+++ b/docs/spec/2026-08-12-OME-797-unify-web-search.md
@@ -1,0 +1,128 @@
+# OME-797 — One web-search flag per route
+
+Status: approved (owner, 2026-08-12) · Stack: url4-cloud
+
+## 1. Problem
+
+`url4.toml` declares two capability flags per route:
+
+| Flag | Mechanism | Runs where |
+|---|---|---|
+| `web_tools` | Tavily `web_search`/`web_fetch` tool loop | url4-cloud runner |
+| `native_web_search` | provider-side search envelope | aigateway → OpenRouter |
+
+Three defects follow:
+
+1. The operator must know which mechanism each model supports. The knowledge is in the
+   operator's head, not in the code.
+2. Both flags default to `false`. A route does not search until a person declares it.
+3. The file header documents `web_tools` and never defines `native_web_search`.
+
+## 2. Contract
+
+One declared field replaces both:
+
+```toml
+[[aigateway.models]]
+id = "openrouter/openai/gpt-5.5"   # web_search defaults to true
+```
+
+- `web_search: bool = True`. This is the only field an operator sets.
+- The mechanism is derived, never declared.
+
+### 2.1 Provider resolution
+
+`provider_of(model_id)` returns the segment before the first `/`. An identifier with no `/`
+is `anthropic`, which is the convention aigateway's catalog already uses.
+
+```
+"openrouter/anthropic/claude-opus-4.8" -> "openrouter"
+"gemini-cli/gemini-2.5-pro"            -> "gemini-cli"
+"claude-haiku-4-5"                     -> "anthropic"
+```
+
+The match is on the segment, NOT on a substring of the whole identifier. A substring test
+gives `openrouter/anthropic/claude-opus-4.8` to a future `anthropic` entry, and that route
+must use the OpenRouter envelope.
+
+### 2.2 Mechanism selection
+
+```
+WEB_SEARCH_NATIVE_PROVIDERS = {"openrouter"}
+
+uses_native_web_search := web_search and provider_of(id) in WEB_SEARCH_NATIVE_PROVIDERS
+uses_web_tools         := web_search and not uses_native_web_search
+```
+
+INVARIANT: the two are mutually exclusive, and their disjunction equals `web_search`.
+
+### 2.3 Why the set holds only `openrouter`
+
+`web_search` is declared by exactly one aigateway plugin
+(`plugins/openrouter_provider/parameters.py:279-286`). The other plugins register a bespoke
+`custom_llm_provider` — `codex` (OpenAI Codex OAuth), `gemini-cli` (Google Code Assist),
+`antigravity`, and aigateway's own `anthropic` handler — instead of litellm's stock vendor
+routes. litellm exposes native search through `web_search_options`, which those bespoke
+handlers do not carry; the string appears nowhere in aigateway. A request with an undeclared
+parameter is refused by the parameter contract.
+
+Adding a provider to the set is therefore aigateway work, per provider: declare the
+parameter, build the envelope from one pure function used by both the dispatch path and the
+cache-key projection (OME-777 invariant I1), key the fields, and bump the cache adapter
+revision. Out of scope here.
+
+## 3. No migration path
+
+`web_tools` and `native_web_search` are deleted outright. There is no compatibility shim, no
+alias, and no bespoke error for them — they are simply not keys any more.
+
+WHY this is safe: `url4.toml` is baked into the image at `/etc/url4/url4.toml`, so the
+config ships with the code that reads it. A config carrying the old keys and a runtime
+expecting the new one do not coexist. If an operator overrides the file, the parser's
+existing unknown-key check already fails closed at startup.
+
+## 4. Behaviour that does not change
+
+- `;web_search=false` in a URL4 expression disables retrieval on any route.
+- `;web_search=true` on a route with `web_search = false` raises `web_retrieval_unavailable`.
+- A Benchmark that requires retrieval on such a route raises
+  `benchmark_retrieval_unavailable`. Retrieval fails closed; it never degrades silently.
+- An explicit search request with no Tavily connection raises. An implicit one (the route
+  searches by default, the caller said nothing, no benchmark policy) serves plain
+  completions.
+- Caller exclusion lists bind on both paths.
+- The native path sends `web_search: true` and never `tools`. The Tavily path sends
+  `tools`/`tool_choice` and never `web_search`.
+
+## 5. Accepted consequences
+
+- Routes whose tool round-trip is not verified end-to-end (anthropic, codex, gemini-cli,
+  antigravity) now search by default when a Tavily key is present. Verification is a later
+  PR, by owner decision. A deployment with no `TAVILY_API_KEY` is unaffected: those routes
+  serve plain completions. Where a key IS present, the failure mode is not a silent
+  downgrade: if one of those bespoke backends rejects an OpenAI-shape tool call, the call
+  fails rather than answering without retrieval, and all 15 routes flip in one deploy.
+
+### 5.1 DRACO moves — correcting an earlier claim in this spec
+
+An earlier revision of this section claimed DRACO pins `web_search=false` and therefore does
+not move. **That was wrong.** `definition.py:53` pins `("web_search", "false")` in
+`JUDGE_PARAMS` only — Grading cannot retrieve. The Candidate call at `definition.py:236`
+pins `web_search=True` with `EXCLUDED_DOMAINS`.
+
+All eight DRACO lineup models are `openrouter/*`, and five of them
+(`gemini-3.1-pro-preview`, `gemini-3-flash-preview`, `kimi-k2.6`, `deepseek-v4-pro`,
+`qwen3.6-plus`) declared `web_tools` and now derive to the native mechanism. Two consequences,
+both accepted by the owner (2026-08-12):
+
+1. **Search backend changes for 5 of 8 candidates** — Tavily → OpenRouter, which for these
+   models resolves to Exa. `REVISION` hashes the dataset, protocol, `RETRIEVAL_POLICY_ID`,
+   `EXCLUDED_DOMAINS` and judge fields, none of which change, so the published revision and
+   route prefix stay identical across the change. `benchmarks/draco/aggregate.py` records
+   which mechanism a given run used, in its protocol-caveat block.
+2. **`EXCLUDED_DOMAINS` changes enforcement mode** — the Tavily loop filters results
+   client-side (`web_tools._is_blocked`); the native path forwards
+   `web_search_excluded_domains` and relies on the provider. For a reproduction whose
+   blocklist covers `arxiv.org`, `paperswithcode.com`, `semanticscholar.org` and
+   `alphaxiv.org` — the venues hosting the paper under reproduction — this moves a leakage
+   control from enforced to trusted for those five candidates.

--- a/docs/tasks/2026-08-12-OME-797-unify-web-search.md
+++ b/docs/tasks/2026-08-12-OME-797-unify-web-search.md
@@ -1,0 +1,22 @@
+---
+id: OME-797
+linear_url: https://linear.app/openmined/issue/OME-797/unify-url4-cloud-web-search-onto-one-route-flag-with-programmatic
+status: In Progress
+type: Feature
+priority: P2
+labels: [url4-cloud, agentic, autonomous]
+created: 2026-08-12
+closed:
+---
+
+# Unify url4-cloud web search onto one route flag with programmatic native/Tavily routing
+
+Replace the per-route `web_tools` / `native_web_search` pair with one `web_search` flag that
+defaults to true. The mechanism becomes derived: a route whose provider segment is in
+`WEB_SEARCH_NATIVE_PROVIDERS` delegates natively to aigateway, every other route takes the
+Tavily tool loop. The set holds only `openrouter`, because that is the one aigateway plugin
+declaring a `web_search` parameter. The retired keys raise `WorldConfigError`.
+
+Spec: `docs/spec/2026-08-12-OME-797-unify-web-search.md`
+Plan: `docs/plan/2026-08-12-OME-797-unify-web-search.md`
+Ledger: `docs/work/2026-08-12-OME-797-unify-web-search.md`

--- a/docs/tasks/2026-08-12-OME-800-openrouter-search-engine.md
+++ b/docs/tasks/2026-08-12-OME-800-openrouter-search-engine.md
@@ -1,0 +1,21 @@
+---
+id: OME-800
+linear_url: https://linear.app/openmined/issue/OME-800/stop-forcing-the-openrouter-web-search-engine
+status: In Progress
+type: Feature
+priority: P2
+labels: [aigateway, agentic, autonomous]
+parent: OME-799
+created: 2026-08-12
+closed:
+---
+
+# Stop forcing the OpenRouter web-search engine
+
+Drop the hardcoded `engine: "native"` from OpenRouter's web-plugin envelope so OpenRouter
+selects native-or-Exa itself, and bump the cache adapter revision `08c` → `08d`. This makes
+"OpenRouter searches natively" true for the whole provider, which is what lets OME-797 route
+by provider instead of by model.
+
+Ledger: `docs/work/2026-08-12-OME-800-openrouter-search-engine.md`
+Epic: OME-799 · Sibling: OME-797

--- a/docs/work/2026-08-12-OME-797-unify-web-search.md
+++ b/docs/work/2026-08-12-OME-797-unify-web-search.md
@@ -1,0 +1,127 @@
+---
+ticket: OME-797
+stack: url4-cloud
+status: in_progress
+started: 2026-08-12
+finished:
+---
+
+# OME-797 — Unify url4-cloud web search onto one route flag
+
+## Intent
+
+`apps/url4-cloud/url4.toml` declares two per-route capability flags — `web_tools` (the
+Tavily tool loop url4-cloud runs itself) and `native_web_search` (provider-side search
+delegated to aigateway). An operator has to know which mechanism each model supports and
+hand-maintain the right flag per route; both default to `false`, so a route searches only if
+someone remembers to declare it; and the file's header documents `web_tools` while never
+defining `native_web_search`.
+
+Collapse both into one `web_search` flag that defaults to **true**, and make the
+native-vs-Tavily choice programmatic: a route whose provider is in
+`WEB_SEARCH_NATIVE_PROVIDERS` delegates natively, every other route takes Tavily.
+
+## Design
+
+`ModelSpec` keeps ONE declared field and derives the mechanism:
+
+- `web_search: bool = True` — declared per route; the only knob an operator sets.
+- `provider_of(model_id)` — the segment before the first `/`; an unprefixed id is anthropic.
+- `uses_native_web_search` — `web_search and provider_of(id) in WEB_SEARCH_NATIVE_PROVIDERS`.
+- `uses_web_tools` — `web_search and not uses_native_web_search`.
+
+`WEB_SEARCH_NATIVE_PROVIDERS = frozenset({"openrouter"})`.
+
+WHY only openrouter: `web_search` is declared by exactly one aigateway plugin
+(`plugins/openrouter_provider/parameters.py:279-286`). Every other plugin is a bespoke
+`custom_llm_provider` (codex OAuth, gemini-cli / Code Assist, antigravity) rather than
+litellm's stock vendor route, so litellm's `web_search_options` is not reachable through
+them and `web_search_options` appears nowhere in aigateway. Adding a provider here is
+per-provider aigateway work — declare the parameter, build the envelope from one pure
+function, key it into the global cache, bump the adapter revision (OME-777 invariant I1).
+
+WHY prefix-segment matching and not substring: `openrouter/anthropic/claude-opus-4.8` is an
+OpenRouter route. A raw substring test would capture it the day `anthropic` joins the set and
+send it down the wrong envelope.
+
+WHY default true: an operator supplying a Tavily key wants search; the previous default made
+every route silently non-searching until individually declared. Routes whose tool round-trip
+is not yet verified end-to-end (anthropic, codex, gemini-cli, antigravity) are covered by a
+later PR per owner decision — not gated here. Note a deployment with no `TAVILY_API_KEY`
+still serves plain completions on those routes (`web_tools.build_runtime` returns `None`).
+
+## Planned changes
+
+- `src/url4_cloud/world_config.py` — `ModelSpec.web_search`, `provider_of`,
+  `WEB_SEARCH_NATIVE_PROVIDERS`, the two derived properties, `_MODEL_KEYS`. The retired
+  `web_tools` / `native_web_search` keys are deleted outright — no shim, no migration
+  branch, no dedicated error (owner decision, 2026-08-12).
+- `src/url4_cloud/runner/request_parameters.py` — `wants_web_search` reads `spec.web_search`.
+- `src/url4_cloud/runner/connector.py` — `_retrieval_request` branches on
+  `uses_native_web_search`.
+- `src/url4_cloud/runner/web_tools.py` — `build_runtime` returns `None` for native routes.
+- `url4.toml` — drop both keys from every route; rewrite the header block to document
+  `web_search` and the routing rule.
+- `src/url4_cloud/benchmarks/draco/aggregate.py` — comment referencing the old flag.
+- Tests: the 13 files asserting the two-flag contract, plus new coverage.
+
+## Test plan (RED first)
+
+New — `tests/unit/test_web_search_routing.py`:
+- `provider_of`: prefixed, unprefixed⇒anthropic, nested (`openrouter/anthropic/…`⇒openrouter).
+- routing: openrouter route ⇒ native; codex/gemini-cli/antigravity/huggingface/ollama and
+  unprefixed anthropic ⇒ Tavily; `web_search = false` ⇒ neither.
+- INVARIANT: `uses_native_web_search` and `uses_web_tools` are mutually exclusive, and their
+  disjunction equals `web_search`.
+- config: default is `true` when omitted; explicit `false` parses; non-boolean raises.
+
+Preserved behaviour that must stay green (contract, not implementation):
+- `web_search=true` on a route declaring none ⇒ `web_retrieval_unavailable`.
+- Benchmark-required search on such a route ⇒ `benchmark_retrieval_unavailable` (fails closed).
+- `web_search=false` disables retrieval everywhere.
+- Explicit request + no Tavily key ⇒ raises; implicit + no key ⇒ plain completions.
+- Native branch emits `web_search: True` (+ `web_search_excluded_domains`) and NO `tools`.
+- Tavily branch emits `tools`/`tool_choice` and never `web_search`.
+
+## Acceptance
+
+- One flag in `url4.toml`; no route declares a mechanism.
+- `run_gates.py url4-cloud` green (ruff · format · pyright · layering · pytest ≥80%).
+- The config KEYS `web_tools` and `native_web_search` appear nowhere in `apps/url4-cloud` —
+  not in `url4.toml`, the parser, tests, or prose. (The token itself survives legitimately in
+  the module `runner/web_tools.py` and the derived property `uses_web_tools`, which name the
+  mechanism rather than a declaration.)
+
+## Outcome
+
+- **Actual files:** as planned, plus prose repairs the plan did not enumerate —
+  `runner/web_tools.py`, `runner/connector.py` (three docstrings), `world_config.routes_for`,
+  and `benchmarks/draco/aggregate.py`. Tests: the 13 planned files, plus the new
+  `tests/unit/test_web_search_routing.py`.
+- **Gates:** `run_gates.py url4-cloud --skip-append-only` — ALL GREEN (ruff · ruff format ·
+  pyright · check_layering · pytest cov ≥80%). Suite: **1168 passed, 5 skipped**.
+- **Deviations:**
+  1. **Scope grew to a second app.** The design could not work as specified: aigateway
+     hardcoded `engine: "native"`, which OpenRouter honours even for models without built-in
+     search (it errors), so "this provider searches natively" was a per-MODEL fact. That is
+     exactly why the config carried two flags. Raised with the owner, who chose to drop the
+     hardcoded engine — split into epic OME-799 with sibling OME-800 (aigateway), both landing
+     in one PR because separating them ships a state where five OpenRouter routes force an
+     engine their models do not carry.
+  2. **`--skip-append-only` used, with the owner's explicit approval** of the specific edits.
+     13 prior test files changed here. Three tests in `tests/unit/test_native_web_search.py`
+     were REMOVED as unrepresentable under one flag; a comment block in that file records
+     which test in `test_web_search_routing.py` now carries each guarantee.
+  3. **No migration path for the retired keys** — owner decision, twice reinforced. An earlier
+     draft added a `_RETIRED_MODEL_KEYS` branch and a test pinning its message; both were
+     removed. `url4.toml` ships inside the image, so a stale config cannot meet new code, and
+     the parser's existing unknown-key check already fails closed.
+  4. **DRACO's judge changes retrieval backend.** `openrouter/google/gemini-3.1-pro-preview`
+     declared `web_tools` and now resolves to native (OpenRouter → Exa, as the model has no
+     built-in search). The owner confirmed this is expected. `REVISION` does not hash the
+     mechanism, so the benchmark revision is unchanged by design; `benchmarks/draco/aggregate.py`
+     records the change in its protocol caveats.
+  5. **Provider matching is by prefix segment, not the substring the request described.**
+     Behaviour is identical while the native set holds only `openrouter`; it diverges the day
+     `anthropic` is added, when a substring test would capture
+     `openrouter/anthropic/claude-opus-4.8`. Flagged to the owner and not objected to.

--- a/docs/work/2026-08-12-OME-800-openrouter-search-engine.md
+++ b/docs/work/2026-08-12-OME-800-openrouter-search-engine.md
@@ -1,0 +1,72 @@
+---
+ticket: OME-800
+stack: aigateway
+status: in_progress
+started: 2026-08-12
+finished:
+---
+
+# OME-800 — Stop forcing the OpenRouter web-search engine
+
+Epic: OME-799 · Sibling: OME-797 (url4-cloud)
+
+## Intent
+
+`plugins/openrouter_provider/web_search.py` assigns `{"id": "web", "engine": "native"}`.
+OpenRouter documents that a forced `engine: "native"` always attempts the model's built-in
+search **even when the model has none**, which errors; the automatic native-or-Exa fallback
+happens only when `engine` is left unspecified.
+
+So "OpenRouter searches natively" is a fact about each MODEL, not about the provider — and
+every consumer has to keep a per-model list. `apps/url4-cloud/url4.toml` kept exactly that,
+hand-splitting eight OpenRouter routes across two mechanisms. Dropping the key makes the
+provider-level statement true and deletes that knowledge from the consumer (OME-797).
+
+## Planned changes
+
+- `src/aigateway/plugins/openrouter_provider/web_search.py` — `_WEB_SEARCH_POLICY` loses
+  `engine`; the docstring records why the absence is load-bearing.
+- `src/aigateway/plugins/openrouter_provider/global_cache.py` —
+  `GLOBAL_CACHE_ADAPTER_REVISION` `openrouter-global-cache-2026-08c` → `-08d`.
+- Tests: 4 assertions pinning `engine: "native"` in `tests/unit/openrouter/` change to the
+  engine-free envelope; one new test states the absence as a requirement.
+
+## Test plan (RED first)
+
+- NEW: the envelope carries no `engine` key, so OpenRouter selects native-or-Exa itself.
+- CHANGED (Confidence Gate — the owner approved the envelope change): 4 assertions that
+  pinned `engine: "native"`.
+
+No test asserts the revision string. Nothing pinned the old literal either, so a new one
+would only restate the constant it is meant to guard.
+
+Preserved, must stay green:
+- `apply_web_search` is a pure function of `body` alone (OME-781 / D2).
+- `web_search` and `web_search_excluded_domains` stay keyed; `exclude_domains` still rides
+  the plugin object.
+- The projection equals the dispatch envelope, because both use this one builder.
+- No envelope at all when `web_search` is absent or not `True`.
+
+## Acceptance
+
+- `engine` appears nowhere in the emitted envelope.
+- `run_gates.py aigateway` green (ruff · format · pyright · no-enterprise · pytest ≥80%).
+
+## Outcome
+
+- **Actual files:** as planned — `plugins/openrouter_provider/web_search.py`,
+  `plugins/openrouter_provider/global_cache.py`, and two test files under
+  `tests/unit/openrouter/`.
+- **Gates:** `run_gates.py aigateway --skip-append-only` — ALL GREEN (ruff · ruff format ·
+  pyright · check_no_enterprise · pytest cov ≥80%). Suite: **3035 passed, 46 skipped**.
+- **Deviations:**
+  1. **`--skip-append-only` used, with the owner's explicit approval.** Two prior test files
+     changed: four assertions that pinned `engine: "native"` now expect the engine-free
+     envelope. No test was removed, skipped, or weakened; one was added
+     (`test_the_engine_is_left_to_openrouter`).
+  2. **No test pins the adapter revision string.** The plan proposed one; nothing pinned the
+     old literal either, so it would only have restated the constant it was meant to guard.
+     The revision bump is covered by the existing projection tests, which read the constant.
+  3. The historical `engine: "native"` quotation inside the SUPERSEDED docstring in
+     `test_openrouter_web_search_cache.py` is left verbatim — it records what a deleted test
+     once asserted, and rewriting history there would make the record false.


### PR DESCRIPTION
Closes OME-797 and OME-800 (epic OME-799).

## The problem

Every route in `url4.toml` carried two flags. `web_tools` meant "we run a Tavily search loop for this model ourselves". `native_web_search` meant "the provider searches and answers with it already done". An operator picking a flag had to know, per model, which mechanism that model could actually carry — knowledge that lived in someone's head, not in the code.

**Both defaulted to off, so a route stayed silently non-searching until somebody remembered to declare it.** Adding a model to the catalog gave you a model that couldn't search, with nothing to tell you.

**The file documented one flag and never defined the other.** The header block explains `web_tools` in six lines. `native_web_search` appears only as values on routes.

**And the split wasn't a design choice — it was covering for a bug one app over.** Five of the eight OpenRouter routes were pinned to Tavily by hand. Not because OpenRouter can't search, but because aigateway hardcoded `engine: "native"` in its search envelope, and OpenRouter honours a forced engine *even for a model that has no built-in search* — which errors. The native-or-Exa fallback only applies while `engine` is left unspecified. So "OpenRouter searches natively" was true per **model**, and the config had to carry that list.

That's the real reason two flags existed. Collapsing them without fixing it would have shipped five broken routes.

## The fix

**One flag, `web_search`, defaulting to true.** A route says only *that* it may search. A route that must not search says `web_search = false`.

**The mechanism is derived, not declared.** `provider_of()` takes the segment before the first `/` (an unprefixed id is Anthropic's, matching the gateway's own convention) and tests it against `WEB_SEARCH_NATIVE_PROVIDERS`. Members delegate to the provider; everything else runs the Tavily loop. Deliberately the segment and not a substring — `openrouter/anthropic/claude-opus-4.8` is an OpenRouter route, and a substring test would hand it to a future `anthropic` entry.

**That set holds only `openrouter`,** because that's the one aigateway plugin declaring a `web_search` parameter. The others register bespoke handlers (codex OAuth, gemini-cli, antigravity, our own anthropic) instead of litellm's stock vendor routes, so litellm's `web_search_options` never reaches them. The docstring on the set says what it takes to add an entry.

**aigateway stops naming the engine,** so OpenRouter picks native-or-Exa itself. That is what makes the provider-level rule true rather than merely convenient. Cache adapter revision bumped `08c → 08d` because the envelope shape changed.

Both halves are in one PR because separating them ships a state where five routes force an engine their models don't carry.

## Things I deliberately didn't do

- **Didn't verify the tool round-trip on the 15 non-OpenRouter routes.** They now search by default where a Tavily key exists, and their OpenAI-shape tool calling has never been confirmed end-to-end. You asked for that to be a later PR. Note the failure mode isn't a quiet downgrade — a backend that rejects the tool call *fails* the request, and all 15 flip in one deploy. A deployment with no Tavily key is unaffected.
- **Didn't add a migration path.** `web_tools`/`native_web_search` are gone, with no shim and no dedicated error. `url4.toml` ships inside the image, so a stale config can't meet new code.
- **Didn't touch cache freshness.** Search results still have no TTL (OME-779/780).
- **Didn't replace our Tavily loop with litellm's own web-search interception,** which could do the same job across every provider. Worth its own ticket.

## Please look at this

**I changed 15 existing test files, and the guard that normally catches that was switched off** (`--skip-append-only`, approved before I wrote code). Every other gate ran normally.

Twelve of them are forced renames — the fields they passed no longer exist. These three want your eyes:

| File | What changed |
|---|---|
| `test_native_web_search.py` | **3 tests removed.** They asserted a two-flag config is rejected, and the retired field's default and type check. None is representable with one flag. Each guarantee moved to a named test in `test_web_search_routing.py`; a comment in the file says which. |
| `test_declared_models_match_aigateway.py` | Its cross-check against aigateway no longer applies, so the surviving guard (both mechanisms stay reachable) moved to `test_web_search_routing.py`. |
| `test_openrouter_web_plugin.py` | 4 assertions that pinned `engine: "native"`. |

**And DRACO moves.** All eight lineup models are `openrouter/*`, so five that ran the Tavily loop now delegate. Two consequences, both of which you accepted, both recorded in `benchmarks/draco/aggregate.py`:

- `REVISION` doesn't hash the mechanism, so runs either side of this change publish under the same benchmark revision.
- `EXCLUDED_DOMAINS` — the leakage control covering arxiv, paperswithcode, semanticscholar, alphaxiv — changes from *enforced* (we filter Tavily results client-side) to *forwarded* (we ask OpenRouter to honour it).

## Testing

- `run_gates.py url4-cloud --skip-append-only` — green. 1169 passed, 5 skipped.
- `run_gates.py aigateway --skip-append-only` — green. 3034 passed, 46 skipped.
- New `test_web_search_routing.py` (25 tests): provider resolution including the `openrouter/anthropic/…` trap, mechanism per provider, the partition invariant (a searching route has exactly one mechanism), declaration defaults, and that the shipped config still reaches both mechanisms.
- Plus an executor-level test that the *production* default offers tools — the existing runner fixture defaults the opposite way, so nothing there covered it.

## What you get

`url4.toml` drops to a list of ids. Adding a model is one line, and it searches. The question "does this model do native search or do we loop?" is answered by the code, in one place, with a docstring saying what it takes to change the answer.

Spec: `docs/spec/2026-08-12-OME-797-unify-web-search.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
