### PR TITLE
feat(screamingface): add recursive pipeline recipes

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,6 +1,6 @@
 # ScreamingFace
 
-ScreamingFace evaluates candidate Models and Fusions against reproducible research benchmarks.
+ScreamingFace evaluates Candidate Recipes against reproducible research benchmarks.
 
 ## Language
 
@@ -19,8 +19,32 @@ own identity and revision even when it shares Cases or Grading material with the
 _Avoid_: Method, mode, option
 
 **Candidate**:
-A Model or Fusion submitted to a Benchmark for evaluation.
-_Avoid_: Ensemble when referring to both Models and Fusions
+A complete Recipe submitted to a Benchmark for evaluation. Model, Fusion, and Pipeline are the
+public Candidate kinds.
+_Avoid_: Ensemble when referring to all Candidate kinds
+
+**Recipe**:
+An immutable, network-free description of Candidate-owned answer production. Model, Fusion, and
+Pipeline are the public Recipe values and may compose recursively.
+_Avoid_: Candidate when the Recipe is nested inside another Recipe
+
+**Complete Recipe**:
+A Recipe that accepts one input and produces one final answer. Every constructible public Model,
+Fusion, and Pipeline is complete; Fusion therefore always requires a synthesizer.
+_Avoid_: Valid Recipe
+
+**Model**:
+One atomic model-backed Recipe.
+_Avoid_: Solo Fusion
+
+**Fusion**:
+An ordered parallel collection of Recipe members followed by one synthesizer Recipe.
+_Avoid_: Pipeline, fan-out when referring to the complete synthesized Candidate
+
+**Pipeline**:
+An ordered serial Recipe. Its first stage receives the Pipeline input and every later stage
+receives only the immediately preceding stage's final answer.
+_Avoid_: Cascade, because Pipeline does not imply conditional routing or early exit
 
 **Candidate Result**:
 The outcome of evaluating one Candidate against one Benchmark, including its score, Candidate
@@ -94,10 +118,10 @@ changes the Candidate rather than the Benchmark.
 _Avoid_: Benchmark dependency, pinned Judge
 
 **Fusion Synthesizer**:
-The Candidate-owned Model configured for a Fusion's synthesizer role. A whole-Candidate invocation
-uses its Candidate-owned prompt to produce the final answer. A structural Benchmark may instead
-invoke its route and parameters under Benchmark-owned selection or coaching instructions; that
-adaptation does not make it a Benchmark-owned grading Judge.
+The Candidate-owned complete Recipe configured for a Fusion's synthesizer role. A Fusion
+invocation passes its input and parallel member answers to it to produce one final answer.
+It is part of the complete Candidate Recipe and remains distinct from a Benchmark-owned grading
+Judge.
 _Avoid_: Fusion member, grading Judge
 
 **Cost Estimate**:

--- a/docs/plan/2026-08-12-OME-786-pipeline-composition.md
+++ b/docs/plan/2026-08-12-OME-786-pipeline-composition.md
@@ -1,0 +1,44 @@
+---
+title: Implement serial Pipeline and recursive Candidate composition
+ticket: OME-786
+status: approved
+date: 2026-08-12
+spec: ../spec/2026-08-12-OME-786-pipeline-composition.md
+---
+
+# Implement serial Pipeline and recursive Candidate composition
+
+1. Add public-interface tests for immutable, structurally equal `Pipeline` construction,
+   one-or-more-stage validation, route-string normalization, naming, and exact
+   `Recipe.then(...)` shorthand; implement only enough value behavior to make them pass.
+2. Add compiler tests for a two-stage Model Pipeline, then generalize Candidate compilation around
+   a Recipe bound to an input expression so serial dependencies are explicit and reuse remains
+   input-sensitive.
+3. Add recursive-composition tests for Fusions inside Pipelines, Pipelines inside Fusions, and
+   Recipe synthesizers; require complete Fusions with one-or-more members and extend compilation
+   around one canonical versioned Recipe descriptor.
+4. Remove content/identity deduplication across graph placements and prove repeated equal or reused
+   Recipes compile as distinct logical invocations under both equal and different inputs.
+5. Replace prose Fusion input formatting with URL4-native canonical structured context, proving
+   runtime-safe answer substitution, stable ordering, display-name independence, and consistent
+   Model/Pipeline synthesizer input.
+6. Remove the SDK-owned `max_tokens=4096` generation default and prove parameter-free Models emit
+   no generation parameters while explicit values remain preflighted and reconstructable.
+7. Add no-spend shape and preflight tests for routes, explicit parameters, cycles, sealed Recipe
+   variants, structural validity, and all-before-any behavior. Keep Engine-owned compatibility and
+   execution limits out of Client constructors.
+8. Extend typed results, exports, URL4-to-Python reconstruction, and operation projections for a
+   `pipeline` root while preserving existing Model/Fusion contracts.
+9. Add the SFDS v2 Pipeline notebook card and verify its light/dark output through public
+   representation tests.
+10. Update the repository domain glossary and Client documentation to define Pipeline, complete
+   Recipe, and recursive Fusion synthesis without embedding Benchmark protocol logic.
+11. Run focused tests after every red-green slice, then the complete screamingface test suite and
+   `uv run .claude/scripts/run_gates.py screamingface` from the repository root.
+12. Review `origin/main...HEAD` for speculative control-flow behavior, accidental Engine coupling,
+   legacy/fallback paths, altered prior tests, and only the two intentional Model/Fusion URL4
+   changes: no universal generation parameters and structured Fusion context.
+
+If the existing URL4 public AST cannot encode an input-bound serial graph, stop and split the
+required `packages/url4` capability into its own landing ticket rather than adding a Client-local
+protocol workaround.

--- a/docs/spec/2026-08-12-OME-786-pipeline-composition.md
+++ b/docs/spec/2026-08-12-OME-786-pipeline-composition.md
@@ -1,0 +1,216 @@
+---
+title: Serial Pipeline and recursive Candidate composition
+ticket: OME-786
+status: approved
+date: 2026-08-12
+---
+
+# Serial Pipeline and recursive Candidate composition
+
+## Outcome
+
+Researchers can express serial model pipelines and arbitrarily nest the Client's serial and
+parallel composition structures without authoring raw URL4 or moving benchmark protocols into the
+Client.
+
+`sf.Pipeline([...])` is the canonical serial value. `Recipe.then(...)` is immutable shorthand for
+constructing that same value. `sf.Fusion([...], synthesizer=...)` remains the explicit parallel
+fan-out-and-synthesis value.
+
+## Domain model
+
+- A **Recipe** is an immutable, network-free description of Candidate-owned answer production.
+- A **Model** is one atomic model-backed Recipe.
+- A **Pipeline** is an ordered serial Recipe whose stages are Recipes.
+- A **Fusion** is an ordered parallel collection of Recipe members followed by a synthesizer.
+- A **complete Recipe** accepts one input and produces one final answer.
+- Every public Recipe is complete. A bare multi-output fan-out is not a Recipe.
+- A **Candidate** is the complete root Recipe selected for evaluation; nested values remain Recipes.
+
+The root public type determines the Candidate kind: `model`, `fusion`, or `pipeline`. Nested
+topology remains visible through ordered operations rather than being flattened into a misleading
+kind.
+
+## Public interface
+
+```python
+pipeline = sf.Pipeline(
+    [model_a, model_b, model_c],
+    name="draft-review-final",
+)
+
+candidate = sf.Fusion(
+    [
+        model_d,
+        pipeline,
+        sf.Fusion([model_e, model_f], synthesizer=model_g),
+    ],
+    synthesizer=sf.Pipeline([judge, writer]),
+)
+
+chained = model_a.then(model_b).then(model_c)
+constructed = sf.Pipeline([model_a, model_b, model_c])
+assert chained.stages == constructed.stages
+```
+
+The value interfaces are:
+
+```python
+Pipeline(stages: Sequence[str | Recipe], *, name: str | None = None)
+
+Fusion(
+    members: Sequence[str | Recipe],
+    *,
+    name: str | None = None,
+    synthesizer: str | Recipe,
+)
+
+Recipe.then(next_recipe: str | Recipe) -> Pipeline
+```
+
+A route string normalizes immediately to `Model(route)` anywhere a Recipe is expected. Explicit
+`Model(...)` remains available for prompts, parameters, and names. `.then()` accepts exactly one
+complete Recipe or route string and never accepts a list, performs network access, or executes
+work. Lists acquire meaning only inside the explicit `Fusion([...])` and `Pipeline([...])`
+constructors. There is no fluent `.Fusion(...)` method whose meaning changes between scalar and
+list arguments.
+
+Recipes are immutable configuration values with structural equality. Names participate in value
+equality and provenance but never alter executable model requests. Graph position, rather than
+Python object identity or equality, defines one logical invocation.
+
+## Serial semantics
+
+- A Pipeline contains at least one stage.
+- The first stage receives the Pipeline input.
+- Every later stage receives only the immediately preceding stage's final answer.
+- No original input or accumulated stage history is injected implicitly.
+- A failed stage prevents downstream stages from executing.
+- Pipelines flatten only where doing so is behaviorally and representationally lossless; an
+  explicitly named nested Pipeline retains its grouping.
+
+Original-input or history carrying is a future explicit context capability, not hidden Pipeline
+behavior.
+
+## Recursive composition
+
+Models, Fusions, and Pipelines may be Pipeline stages, Fusion members, or Fusion synthesizers.
+Consequently a Pipeline may contain a Fusion, a Fusion may contain Pipelines, and a Fusion may use
+a Pipeline or Fusion to synthesize its member answers. A Fusion contains at least one member and
+always requires its explicit `synthesizer=` keyword.
+
+Structural Benchmark protocols do not obtain incomplete Fusion internals from the Client.
+Benchmark-independent strategies such as a corrective loop become their own complete Recipe types
+and pass through the same `$candidate` seam. Canonical Benchmarks consuming the whole `$candidate`
+accept any complete Recipe. Genuine input/output incompatibilities fail during authoritative
+Engine preflight before spend.
+
+## Compilation invariants
+
+- Compilation emits ordinary Engine-executable URL4 and uses the existing `sf.evaluate(...)`
+  lifecycle; Pipeline introduces no execution endpoint or second protocol.
+- Fusion member order and Pipeline stage order are stable.
+- Operation dependencies faithfully distinguish serial edges from parallel fan-out and synthesis.
+- Every graph placement creates a distinct logical invocation, even when the same Recipe object or
+  an equal Recipe value appears more than once. The compiler never merges placements. Engine cache
+  policy may reuse the result of each stable invocation across replays but cannot collapse two
+  declared positions into one invocation.
+- Every reachable model route and explicitly supplied parameter set participates in all-before-any
+  no-spend preflight. The SDK emits no universal generation parameter defaults; a parameter-free
+  Model delegates parameter defaults to its provider/model contract.
+- Cycles and malformed local structure fail without network access. Engine-owned facts such as
+  route availability, parameter support, credentials, Benchmark compatibility, capabilities, and
+  execution limits are validated authoritatively by the Engine before paid execution.
+- Every complete Recipe URL4 carries one root `_sf_recipe` descriptor using the
+  `screamingface.recipe.v1` schema. Replay and Python reconstruction require that canonical
+  descriptor; there is no call-graph inference fallback.
+
+## Fusion semantics
+
+- Every Fusion member receives the same Fusion input and executes as an independent parallel
+  branch.
+- Any member failure fails the Fusion and prevents synthesis. Partial panels, quorum behavior, and
+  fallback are separate future Recipes.
+- The synthesizer receives one URL4-native canonical JSON object containing the original input and
+  ordered outputs:
+
+  ```json
+  {
+    "input": "original request",
+    "outputs": {
+      "member_1": "first answer",
+      "member_2": "second answer"
+    }
+  }
+  ```
+
+  URL4 performs runtime substitution and JSON escaping. Display names are excluded from this
+  executable context.
+- A Pipeline used as synthesizer receives that context at its first stage; later stages retain
+  normal previous-output-only Pipeline semantics.
+- Fusion carries no prompt or generation defaults. Configuration belongs to its Model Recipes.
+  No parameters propagate implicitly through nested Recipes.
+
+## Prompt and parameter policy
+
+- The SDK retains documented answer and synthesis prompts for route-string convenience.
+- A Model in an ordinary answer position uses the answer default when no prompt is supplied.
+- A direct Model synthesizer, or the first stage of a synthesizer Pipeline, uses the synthesis
+  default when no prompt is supplied. Later Pipeline stages use the ordinary answer default.
+- An explicit prompt completely replaces the role default; no hidden text is appended or merged.
+- The SDK no longer injects `max_tokens=4096`, `web_search=false`, or any other model/request
+  parameter. Every model-call parameter emitted by the SDK represents an explicit user choice.
+  An omitted parameter, including `web_search`, uses the Engine's configured default. A Benchmark
+  may still impose an explicit execution policy in its own URL4 protocol.
+- URL4-to-Python reconstruction omits an effective prompt only when it equals the applicable SDK
+  role default. It preserves every parameter present in executable URL4, including an explicit
+  `max_tokens=4096`.
+
+## Validation and limits
+
+- Constructors are network-free and validate local type, non-empty collection, required
+  synthesizer, cycle, and structural invariants.
+- The Client does not invent expression-byte, operation-count, Recipe-node, or public nesting-depth
+  limits. URL4 Cloud owns and reports real execution limits. Untrusted topology decoding uses safe
+  traversal and converts malformed or resource-exhausting inputs into clear errors without
+  presenting parser safeguards as product limits.
+- Recipe is a sealed public interface in v1. Unknown subclasses fail clearly until a deliberate
+  compilation-extension interface exists.
+
+## Results and representation
+
+Pipeline roots report `kind="pipeline"`. Ordered operation metadata, failures, usage, export,
+notebook representation, and supported URL4-to-Python reconstruction preserve serial structure.
+The notebook card follows SFDS v2 in both light and dark themes and represents serial flow without
+using colour as the only encoding.
+
+`Url4.to_python()` reconstructs semantic Recipe configuration rather than the caller's original
+Python spelling. It preserves routes, explicit parameters, non-default prompts, names, named
+Pipeline groups, topology, and ordering; shorthand, comments, and variable names are not
+recoverable. The executable URL4 remains the effective-behavior source of truth, while
+`screamingface.recipe.v1` records topology only and is checked against executable dependencies.
+
+## Exclusions
+
+- Arbitrary DAG or raw URL4 Candidate authoring.
+- Bare multi-output fan-out without synthesis.
+- Routing, cascading, retry loops, boosting, voting, early exit, or other control-flow policies.
+- `MajorityVote`, `ChooseBest`, `CorrectiveLoop`, presets, routers, or placeholder interfaces for
+  those future complete Recipes.
+- Hidden original-input/history propagation.
+- Generalizing Engine Benchmark checking or aggregation.
+- A fluent `.Fusion(...)` builder.
+
+## Compatibility
+
+This is the clean v1 interface and intentionally provides no legacy aliases or fallback compiler:
+
+- incomplete Fusion construction is rejected;
+- `models=`, `steps=`, and other constructor aliases are not accepted;
+- old URL4 without `screamingface.recipe.v1` is not reconstructable through `to_python()`;
+- the removed generation default is not emulated; and
+- explicitly configured existing parameters remain stable, while parameter-free Model/Fusion URL4
+  intentionally stops carrying `max_tokens=4096` and Fusion URL4 intentionally adopts structured
+  synthesis context.
+
+Those capabilities may later compose with Recipe, but this unit does not guess their interfaces.

--- a/docs/tasks/2026-08-11-ome-786-pipeline-composition.md
+++ b/docs/tasks/2026-08-11-ome-786-pipeline-composition.md
@@ -1,0 +1,26 @@
+---
+id: OME-786
+linear_url: https://linear.app/openmined/issue/OME-786/support-serial-pipelines-and-recursively-composed-candidates-in-the
+status: In Progress
+type: Feature
+priority: P1
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-08-11
+closed:
+---
+
+# Support serial Pipelines and recursively composed Candidates in the Python Client
+
+Add an immutable `sf.Pipeline` Recipe for serial Candidate composition, make Models, Fusions, and
+Pipelines recursively composable complete Recipes, and provide `Recipe.then(...)` as exact
+immutable Pipeline shorthand. Require explicit Fusion synthesis, normalize route strings anywhere
+a Recipe is accepted, preserve distinct invocation positions, remove the universal generation
+parameter default, and use URL4-native structured synthesis context. The Client continues compiling
+one complete URL4 expression and evaluating it through the existing Engine lifecycle.
+
+Related work: OME-607 defines Model/Fusion values; OME-609 defines Candidate compilation and
+preflight; OME-614 owns the Engine contracts; OME-408 separately tracks importing shared raw URL4.
+
+Spec: `docs/spec/2026-08-12-OME-786-pipeline-composition.md`
+Plan: `docs/plan/2026-08-12-OME-786-pipeline-composition.md`
+Ledger: `docs/work/2026-08-12-OME-786-pipeline-composition.md`

--- a/docs/work/2026-08-12-OME-786-pipeline-composition.md
+++ b/docs/work/2026-08-12-OME-786-pipeline-composition.md
@@ -1,0 +1,75 @@
+---
+ticket: OME-786
+stack: screamingface
+status: in_progress
+started: 2026-08-12
+finished:
+---
+
+# OME-786 — serial Pipeline and recursive Candidate composition
+
+## Intent
+
+Add the missing serial composition primitive to the public Client while keeping URL4 as the sole
+executable representation and preserving the distinction between serial Pipeline and parallel
+Fusion.
+
+## Planned changes
+
+- `packages/screamingface/src/screamingface/pipeline.py`, `recipe.py`, `fusion.py`, and public exports
+- Candidate compilation, linking, operation projection, result/report, and URL4-to-Python modules
+- Pipeline notebook representation under `packages/screamingface/src/screamingface/_ui/`
+- new append-only public-interface, compilation, integration, representation, and UI tests
+- `CONTEXT.md` and focused Client documentation
+- this unit's task mirror, specification, plan, and ledger
+
+## Test plan
+
+- Construct, name, compare, represent, and reject malformed immutable Pipelines.
+- Prove `.then()` is exact Pipeline shorthand across Models, Fusions, Pipelines, and model-route
+  strings, and rejects ambiguous list arguments.
+- Compile serial Model stages and verify exact URL4 data flow and ordered operation dependencies.
+- Compile Pipelines nested in Fusion members and synthesizers, and Fusions nested in Pipelines.
+- Preserve distinct invocations when one Recipe is rebound to different Pipeline inputs.
+- Reject cycles, unsupported Recipe extensions, and obsolete structural Benchmark bindings before
+  spend.
+- Emit one canonical `screamingface.recipe.v1` descriptor for every complete Recipe URL4 and
+  preserve all-before-any preflight.
+- Decode/report/export/reconstruct a Pipeline Candidate without relabeling it as a Fusion.
+- Render accessible SFDS v2 Pipeline cards in light and dark themes.
+
+## Acceptance
+
+- Researchers can evaluate `sf.Pipeline([...])` against a canonical Benchmark.
+- Any complete Recipe can occupy serial stages, parallel members, and the synthesis role.
+- `a.then(b).then(c)` constructs the same serial graph as `sf.Pipeline([a, b, c])`.
+- Invalid or incomplete graphs fail with clear typed no-spend errors.
+- Model, Fusion, and Pipeline use the same required Recipe descriptor with no inference fallback.
+- The complete screamingface gate is green without modifying or weakening prior tests.
+
+## Outcome
+
+- **Actual files:** `CONTEXT.md`; `packages/screamingface/README.md`;
+  `src/screamingface/{pipeline,recipe,fusion,report,url4}.py`; public exports; Candidate
+  compilation/model/replay/topology modules; notebook cards/styles; focused Pipeline, replay,
+  preflight, report, and display tests; this unit's spec, plan, task mirror, and ledger.
+- **Commits:** pending
+- **Gates:** `uv run .claude/scripts/run_gates.py screamingface --skip-append-only` → ALL GATES
+  GREEN: Ruff check/format, Pyright, 95% coverage suite, deterministic notebooks, wheel/sdist
+  build, and distribution check. Direct package suite before the final focused reconstruction fix:
+  688 passed / 1 skipped; the repository gate reran the complete suite after that fix.
+- **Deviations:** The owner explicitly selected a clean v1 contract with no compatibility path.
+  Existing tests for incomplete Fusions, structural member/synthesizer Benchmark projections,
+  Client-side content deduplication, two-member minimums, prose synthesis context, and injected
+  generation defaults were therefore replaced with assertions for the new contract. The public
+  surface assertion adds `Pipeline`. The sanctioned `--skip-append-only` flag covers these
+  intentional Confidence-Gate changes; no production fallback was added to preserve the removed
+  behavior.
+
+## Design resolution
+
+Every complete compiled Recipe carries exactly one root `_sf_recipe` source with schema
+`screamingface.recipe.v1`. This is the sole authoring-structure contract for replay reporting and
+`Url4.to_python()`; neither operation falls back to guessing Model/Fusion/Pipeline topology from the
+executable call graph. Nested Recipes live inside that single descriptor rather than adding a
+descriptor per nested node.

--- a/packages/screamingface/README.md
+++ b/packages/screamingface/README.md
@@ -1,8 +1,8 @@
 # screamingface
 
-Evaluate Models and Fusions against URL4-native research Benchmarks.
+Evaluate composable Candidate Recipes against URL4-native research Benchmarks.
 
-> **Development status:** immutable Model/Fusion authoring, Engine-backed discovery, the direct
+> **Development status:** immutable Model/Fusion/Pipeline authoring, Engine-backed discovery, the direct
 > evaluation API, and the confirmed `url4-cloud` lifecycle are
 > implemented. The current MVP Engine publishes canonical `draco` plus the non-comparable
 > `draco/lite` and `draco/smoke` development protocols as independently revisioned Benchmark
@@ -51,11 +51,17 @@ editable_python = score.url4.to_python()
 replayed_report = sf.evaluate(score.url4)
 ```
 
-`Url4.to_python()` is local and no-spend: it produces an editable `sf.Model` or `sf.Fusion` plus
+`Url4.to_python()` is local and no-spend: it produces an editable `sf.Model`, `sf.Fusion`, or
+`sf.Pipeline` plus
 the recovered Benchmark call. Raw URL4 evaluation does not accept `benchmark=` or `limit=`
 because either would imply
 recompiling an already-complete expression. Replay starts a new, potentially paid Run; identical
 URL4 does not guarantee identical model output.
+
+Every Client-compiled Candidate URL4 contains exactly one inert `_sf_recipe` source with the
+versioned `screamingface.recipe.v1` descriptor. It preserves the public Recipe structure and names
+for exact replay reporting and `to_python()` reconstruction. These operations require that
+descriptor; the Client does not guess authoring structure from an executable call graph.
 
 The installed `draco` definition always refers to the complete official 100-task Benchmark;
 `limit=1` merely runs one Case. Grading uses five independent Judge passes per criterion. The
@@ -103,24 +109,63 @@ constraint_aware = sf.Fusion(
 ```
 
 These overrides never alter Benchmark-owned Cases, fixed Judge models or prompts, Grading, or
-Aggregation. Prompt defaults and explicit overrides are embedded in each final URL4. A Fusion may
-be authored without `synthesizer=`, but planning rejects it before spend whenever the selected
-Benchmark invokes the whole Fusion or its synthesizer. When a Benchmark binds the synthesizer as a
-separate structural component, the model route and `params` remain Candidate-owned while the
-Benchmark owns that role's instructions; an ordinary whole-Fusion blending prompt is not reused as
-a Judge prompt. The Benchmark sets the retrieval ceiling on `/candidate`; ordinary Model and
-Fusion-member calls inherit it, while the SDK compiler always pins whole-Fusion synthesis to
-`web_search=false`. Users cannot override retrieval through Candidate `params`. DRACO can therefore
-offer guarded web access to answer producers without silently giving synthesis a stronger
-experiment than the published protocol.
+Aggregation. Prompt defaults and explicit overrides are embedded in each final URL4. Every Fusion
+requires an explicit `synthesizer=` and always produces one answer. Model-call parameters are never
+invented by the SDK: a parameter-free Model emits no sampling or retrieval parameters and therefore
+uses the Engine's configured defaults. Benchmarks may still impose explicit execution policy in
+their own URL4 protocol. Transport, routing, tool, and Benchmark-policy fields remain unavailable
+through Candidate `params`.
+
+### Serial and recursive composition
+
+Every complete `Recipe` accepts one input and returns one final answer. `Model` is atomic,
+`Fusion` runs members in parallel and passes their answers to a synthesizer, and `Pipeline` passes
+one answer through ordered serial stages:
+
+```python
+draft = sf.Model("openrouter/openai/gpt-5.5")
+review = sf.Model(
+    "openrouter/anthropic/claude-opus-4.8",
+    prompt="Review the previous answer and return a corrected answer.",
+)
+final = sf.Model(
+    "openrouter/openai/gpt-5.5",
+    prompt="Polish the previous answer without adding unsupported claims.",
+)
+
+review_chain = sf.Pipeline([draft, review, final], name="review-chain")
+same_chain = draft.then(review).then(final)
+```
+
+The first Pipeline stage receives the Candidate input; each later stage receives only the previous
+stage's answer. No original input or accumulated history is injected implicitly. Pipelines and
+complete Fusions compose recursively, including in the synthesis role:
+
+```python
+judge = sf.Model("openrouter/anthropic/claude-opus-4.8")
+writer = sf.Model("openrouter/openai/gpt-5.5")
+
+candidate = sf.Fusion(
+    [
+        review_chain,
+        sf.Model("openrouter/google/gemini-3.1-pro-preview"),
+    ],
+    synthesizer=sf.Pipeline([judge, writer]),
+)
+```
+
+`Pipeline([...])` is the canonical serial representation; `.then(...)` is immutable shorthand and
+never executes work. Every Recipe-valued position also accepts a model-route string as shorthand
+for `sf.Model(...)`. Shape mismatches, cycles, invalid models, and invalid parameters fail before
+spend.
 
 Each flat Benchmark resource uses `screamingface.benchmark.v1` and carries one canonical `url4`
-plus an opaque immutable `revision`. The SDK fetches the requested id, compiles a Model or Fusion
-into an expression accepting `$input`, and links only the universal bindings referenced by that
-Benchmark (`$candidate`, direct members, or an explicit synthesizer). A Benchmark invokes a bound
-expression through `/candidate`; that route evaluates it inside the same Engine job, not through
-an additional Client or control-plane request. Unsupported Candidate shapes fail with typed errors
-instead of falling back to Client-side execution.
+plus an opaque immutable `revision`. The SDK fetches the requested id, compiles a Recipe
+into an expression accepting `$input`, and links it through the single universal `$candidate`
+binding. A Benchmark invokes that bound expression through `/candidate`; that route evaluates it
+inside the same Engine job, not through an additional Client or control-plane request. Old
+structural member/synthesizer bindings fail with a typed planning error rather than invoking a
+second Client compilation path.
 
 The Candidate input is normally plain text. Engine-owned Benchmarks that require native chat
 history wrap structured turns in the versioned Candidate-input envelope; the Runner preserves
@@ -340,15 +385,16 @@ model providers, Tavily, or Benchmark datasets directly. Local and hosted Engine
 Client-visible contract; in-memory channels, NATS, workers, and deployment topology are Engine
 details.
 
-Models and Fusions are immutable, Client-independent, and network-free. Models select routes and
-optional answer policy; Fusions declare topology and optional synthesis policy. The SDK resolves
-their defaults and compiles the Candidate expression. Benchmarks are immutable Engine protocols
+Models, Fusions, and Pipelines are immutable, structurally comparable, Client-independent, and
+network-free. Models select routes and optional answer policy; Fusions declare parallel topology
+and an explicit synthesizer; Pipelines declare serial topology. Every placement compiles to a
+distinct logical invocation, even when two Recipe values are equal or reused. The SDK compiles the
+complete Recipe into one Candidate expression. Benchmarks are immutable Engine protocols
 that own Cases, Candidate Invocation order, fixed Judge configuration, Grading, Aggregation,
 and execution policy. Reports record the exact Engine-pinned Benchmark revision.
 
-Equivalent resolved Model calls deduplicate by content inside a compiled Candidate graph.
-Explicit Model names identify intentional independent samples. Durable reuse across Candidates,
-retries, and resumed Evaluations belongs to the Engine's provenance-aware response cache.
+Durable reuse across graph positions, Candidates, retries, and resumed Evaluations belongs to the
+Engine's provenance-aware response cache; Client compilation never merges authored positions.
 
 ## Discovery
 

--- a/packages/screamingface/src/screamingface/__init__.py
+++ b/packages/screamingface/src/screamingface/__init__.py
@@ -1,4 +1,4 @@
-"""ScreamingFace — evaluate Models and Fusions on research Benchmarks."""
+"""ScreamingFace — evaluate composable Candidate Recipes on research Benchmarks."""
 
 from screamingface import benchmarks, connections, events, leaderboards, models
 from screamingface._default_client import close, configure, connect, disconnect, evaluate
@@ -34,6 +34,7 @@ from screamingface.leaderboard import (
 )
 from screamingface.model import Model
 from screamingface.operation import OperationInfo
+from screamingface.pipeline import Pipeline
 from screamingface.recipe import Recipe
 from screamingface.report import (
     CandidateResult,
@@ -94,6 +95,7 @@ __all__ = [
     "OperationInfo",
     "OAuthFlow",
     "PlanningError",
+    "Pipeline",
     "ProviderConnectionError",
     "Recipe",
     "Report",

--- a/packages/screamingface/src/screamingface/_evaluation/candidate.py
+++ b/packages/screamingface/src/screamingface/_evaluation/candidate.py
@@ -1,4 +1,4 @@
-"""Compile benchmark-agnostic Model and Fusion values into Candidate URL4."""
+"""Compile benchmark-agnostic Recipe values into Candidate URL4."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Literal
 
-from url4 import Node, RelExpr, RenderError, Text, expr, render, src
+from url4 import Node, RelExpr, RenderError, Text, expr, render, src, struct
 
 from screamingface._evaluation.model import (
     _compiled_operation,
@@ -21,44 +21,26 @@ from screamingface._evaluation.policy import (
     DEFAULT_SYNTHESIS_PROMPT,
     resolved_params,
 )
+from screamingface._evaluation.topology import (
+    _RecipeTopology,
+    _topology_source,
+)
 from screamingface.errors import PlanningError
 from screamingface.fusion import Fusion
 from screamingface.model import Model
 from screamingface.operation import OperationInfo
+from screamingface.pipeline import Pipeline
 from screamingface.recipe import Recipe
 
 
 @dataclass(frozen=True, slots=True)
 class _CompiledCandidate:
-    kind: Literal["model", "fusion"]
-    url4: str | None
+    kind: Literal["model", "fusion", "pipeline"]
+    url4: str
     models: tuple[str, ...]
     operations: tuple[OperationInfo, ...]
     members: tuple[_MemberProjection, ...]
-    member_expressions: tuple[_MemberExpression, ...]
     parameter_assignments: tuple[_ModelParameterAssignment, ...]
-    # WHY: a structural Benchmark may bind this component separately through
-    # `$candidate_synthesizer`; a solo Model has no such component.
-    synthesizer: _SynthesizerExpression | None
-
-
-@dataclass(frozen=True, slots=True)
-class _MemberExpression:
-    """One direct Fusion member exposed through the universal binding contract."""
-
-    name: str
-    kind: Literal["model", "fusion"]
-    url4: str | None
-
-
-@dataclass(frozen=True, slots=True)
-class _SynthesizerExpression:
-    """The explicit Fusion component exposed by `$candidate_synthesizer`."""
-
-    model: str
-    operation: OperationInfo
-    parameter_assignment: _ModelParameterAssignment | None
-    url4: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -66,12 +48,14 @@ class _ResolvedRecipe:
     reference: str
     operation_id: str
     name: str
-    kind: Literal["model", "fusion"]
+    kind: Literal["model", "fusion", "pipeline"]
     models: tuple[str, ...]
+    topology: _RecipeTopology
+    members: tuple[_ResolvedRecipe, ...] = ()
 
 
 def compile_candidate(recipe: Recipe) -> _CompiledCandidate:
-    """Compile a Candidate, retaining structural members when a Fusion is incomplete."""
+    """Compile one complete, benchmark-independent Recipe into Candidate URL4."""
 
     try:
         return _CandidateCompiler().compile(recipe)
@@ -85,87 +69,38 @@ def compile_candidate(recipe: Recipe) -> _CompiledCandidate:
 
 
 class _CandidateCompiler:
-    """Flatten one immutable Recipe into a shared, content-deduplicated URL4 DAG."""
+    """Compile one immutable Recipe while preserving every declared invocation position."""
 
     def __init__(self) -> None:
         self._sources: list[Node] = []
         self._operations: list[OperationInfo] = []
         self._parameter_assignments: list[_ModelParameterAssignment] = []
-        self._resolved: dict[int, _ResolvedRecipe] = {}
-        self._models_by_content: dict[tuple[object, ...], _ResolvedRecipe] = {}
         self._active: set[int] = set()
         self._model_count = 0
         self._synthesis_count = 0
 
     def compile(self, recipe: Recipe, *, synthesis_root: bool = False) -> _CompiledCandidate:
         root = self._recipe(recipe, synthesis=synthesis_root)
-        members: tuple[_MemberProjection, ...] = ()
-        if isinstance(recipe, Fusion):
-            members = tuple(
-                _member_projection(
-                    operation_id=self._resolved[id(member)].operation_id,
-                    name=member.name,
-                    kind=self._resolved[id(member)].kind,
-                    models=self._resolved[id(member)].models,
-                )
-                for member in recipe.members
-            )
-        member_expressions = (
+        members = (
             tuple(
-                _MemberExpression(
+                _member_projection(
+                    operation_id=resolved.operation_id,
                     name=member.name,
-                    kind="model" if isinstance(member, Model) else "fusion",
-                    url4=compile_candidate(member).url4,
+                    kind=resolved.kind,
+                    models=resolved.models,
                 )
-                for member in recipe.members
+                for member, resolved in zip(recipe.members, root.members, strict=True)
             )
             if isinstance(recipe, Fusion)
             else ()
         )
-        synthesizer = None
-        if isinstance(recipe, Fusion) and recipe.synthesizer is not None:
-            synthesizer_model = _canonical_model(recipe.synthesizer.model)
-            # INVARIANT: structural Benchmarks own their Judge instructions, while the
-            # Candidate still owns the selected model's generation parameters. Reusing
-            # the Model's synthesis prompt here would leak ordinary blending policy into a
-            # different Benchmark role; dropping its params would silently change the system.
-            expression = _CandidateCompiler().compile(
-                Model(synthesizer_model, params=recipe.synthesizer.params),
-                synthesis_root=True,
-            )
-            assert expression.url4 is not None
-            operation_id = "op_candidate_synthesizer"
-            synthesizer = _SynthesizerExpression(
-                model=synthesizer_model,
-                operation=_compiled_operation(
-                    id=operation_id,
-                    kind="synthesis",
-                    label=f"{recipe.name} synthesizer",
-                    depends_on=(),
-                ),
-                parameter_assignment=(
-                    _model_parameter_assignment(
-                        operation_id=operation_id,
-                        model=synthesizer_model,
-                        params=recipe.synthesizer.params,
-                    )
-                    if recipe.synthesizer.params
-                    else None
-                ),
-                url4=expression.url4,
-            )
+        sources = [*self._sources, _topology_source(root.topology)]
         return _CompiledCandidate(
             kind=root.kind,
-            url4=(
-                render(expr(*self._sources, intent=Text(root.reference)))
-                if root.reference
-                else None
-            ),
+            url4=render(expr(*sources, intent=Text(root.reference))),
             models=root.models,
             operations=tuple(self._operations),
             members=members,
-            member_expressions=member_expressions,
-            synthesizer=synthesizer,
             parameter_assignments=tuple(self._parameter_assignments),
         )
 
@@ -173,41 +108,55 @@ class _CandidateCompiler:
         self,
         recipe: Recipe,
         *,
+        input_context: str = "$input",
+        input_dependencies: tuple[str, ...] = (),
         synthesis: bool = False,
     ) -> _ResolvedRecipe:
         identity = id(recipe)
-        if resolved := self._resolved.get(identity):
-            return resolved
         if identity in self._active:
             raise ValueError(f"Candidate graph contains a cycle at {recipe.name!r}")
         self._active.add(identity)
-        if isinstance(recipe, Model):
-            resolved = self._model(recipe, synthesis=synthesis)
-        elif isinstance(recipe, Fusion):
-            resolved = self._fusion(
-                recipe,
-                tuple(self._recipe(member) for member in recipe.members),
-            )
-        else:  # pragma: no cover - the public validation seals Recipe variants
-            raise TypeError("candidate must be an sf.Model or sf.Fusion")
-        self._active.remove(identity)
-        self._resolved[identity] = resolved
-        return resolved
+        try:
+            if isinstance(recipe, Model):
+                return self._model(
+                    recipe,
+                    input_context=input_context,
+                    input_dependencies=input_dependencies,
+                    synthesis=synthesis,
+                )
+            if isinstance(recipe, Fusion):
+                members = tuple(
+                    self._recipe(
+                        member,
+                        input_context=input_context,
+                        input_dependencies=input_dependencies,
+                    )
+                    for member in recipe.members
+                )
+                return self._fusion(recipe, members, input_context=input_context)
+            if isinstance(recipe, Pipeline):
+                return self._pipeline(
+                    recipe,
+                    input_context=input_context,
+                    input_dependencies=input_dependencies,
+                    synthesis=synthesis,
+                )
+            raise TypeError("candidate must be an sf.Model, sf.Fusion, or sf.Pipeline")
+        finally:
+            self._active.remove(identity)
 
     def _model(
         self,
         model: Model,
         *,
+        input_context: str,
+        input_dependencies: tuple[str, ...],
         synthesis: bool,
     ) -> _ResolvedRecipe:
-        prompt = model.prompt or DEFAULT_ANSWER_PROMPT
-        params = _synthesis_params(model.params) if synthesis else resolved_params(model.params)
+        default_prompt = DEFAULT_SYNTHESIS_PROMPT if synthesis else DEFAULT_ANSWER_PROMPT
+        prompt = model.prompt or default_prompt
+        params = resolved_params(model.params)
         route = _canonical_model(model.model)
-        content = (route, model._sample_id, prompt, params)
-        if resolved := self._models_by_content.get(content):
-            self._record_parameter_assignment(resolved.operation_id, route, model.params)
-            return resolved
-
         self._model_count += 1
         binding = f"model_{self._model_count}"
         operation_id = f"op_{binding}"
@@ -215,7 +164,7 @@ class _CandidateCompiler:
             src(
                 RelExpr(
                     path=_model_route(route),
-                    context="$input",
+                    context=input_context,
                     intent=Text(_url4_text(prompt)),
                     params=params,
                 ),
@@ -226,74 +175,154 @@ class _CandidateCompiler:
         self._operations.append(
             _compiled_operation(
                 id=operation_id,
-                kind="model",
-                label=f"{model.name} answer",
-                depends_on=(),
+                kind="synthesis" if synthesis else "model",
+                label=f"{model.name} {'synthesis' if synthesis else 'answer'}",
+                depends_on=input_dependencies,
             )
         )
         self._record_parameter_assignment(operation_id, route, model.params)
-        resolved = _ResolvedRecipe(
+        return _ResolvedRecipe(
             reference=f"${binding}",
             operation_id=operation_id,
             name=model.name,
             kind="model",
             models=(route,),
+            topology=_RecipeTopology(
+                kind="model",
+                name=model.name,
+                binding=binding,
+                named=model._sample_id is not None,
+                role="synthesis" if synthesis else "model",
+            ),
         )
-        self._models_by_content[content] = resolved
-        return resolved
 
     def _fusion(
         self,
         fusion: Fusion,
         members: tuple[_ResolvedRecipe, ...],
+        *,
+        input_context: str,
     ) -> _ResolvedRecipe:
         self._synthesis_count += 1
         binding = f"synthesis_{self._synthesis_count}"
         operation_id = f"op_{binding}"
         models = tuple(model for member in members for model in member.models)
-        if fusion.synthesizer is None or any(not member.reference for member in members):
-            return _ResolvedRecipe(
-                reference="",
+        context = _fusion_context(input_context, members)
+        dependencies = tuple(member.operation_id for member in members)
+        if isinstance(fusion.synthesizer, Model):
+            synthesizer = _canonical_model(fusion.synthesizer.model)
+            prompt = fusion.synthesizer.prompt or DEFAULT_SYNTHESIS_PROMPT
+            self._sources.append(
+                src(
+                    RelExpr(
+                        path=_model_route(synthesizer),
+                        context=context,
+                        intent=Text(_url4_text(prompt)),
+                        params=resolved_params(fusion.synthesizer.params),
+                    ),
+                    name=binding,
+                    weight=0.0,
+                )
+            )
+            self._operations.append(
+                _compiled_operation(
+                    id=operation_id,
+                    kind="synthesis",
+                    label=f"{fusion.name} synthesis",
+                    depends_on=dependencies,
+                )
+            )
+            self._record_parameter_assignment(
+                operation_id,
+                synthesizer,
+                fusion.synthesizer.params,
+            )
+            result = _ResolvedRecipe(
+                reference=f"${binding}",
                 operation_id=operation_id,
                 name=fusion.name,
                 kind="fusion",
-                models=_ordered_unique(models),
-            )
-        synthesizer = _canonical_model(fusion.synthesizer.model)
-        prompt = fusion.synthesizer.prompt or DEFAULT_SYNTHESIS_PROMPT
-        member_names: list[str] = []
-        for member in members:
-            # Keep labels out of raw URL4 syntax. Names are user-visible text and may contain
-            # characters that would be problematic in an expression context, including `(` and `)`.
-            # Normalize them so label rendering remains readable without affecting URL4 parsing.
-            member_names.append(_context_text(member.name))
-        self._sources.append(
-            src(
-                RelExpr(
-                    path=_model_route(synthesizer),
-                    context=_fusion_context(members, tuple(member_names)),
-                    intent=Text(_url4_text(prompt)),
-                    params=_synthesis_params(fusion.synthesizer.params),
+                models=_ordered_unique((*models, synthesizer)),
+                topology=_RecipeTopology(
+                    kind="fusion",
+                    name=fusion.name,
+                    binding=binding,
+                    members=tuple(_required_topology(member) for member in members),
+                    synthesizer=_RecipeTopology(
+                        kind="model",
+                        name=fusion.synthesizer.name,
+                        binding=binding,
+                        named=fusion.synthesizer._sample_id is not None,
+                        role="synthesis",
+                    ),
                 ),
-                name=binding,
-                weight=0.0,
+                members=members,
             )
+            return result
+
+        # WHY: a complete Recipe used as the synthesizer receives the same explicit
+        # question-and-panel value as a direct Model synthesizer. Its internal serial or
+        # parallel topology remains ordinary Recipe compilation rather than a special path.
+        resolved_synthesizer = self._recipe(
+            fusion.synthesizer,
+            input_context=context,
+            input_dependencies=dependencies,
+            synthesis=True,
         )
-        self._operations.append(
-            _compiled_operation(
-                id=operation_id,
-                kind="synthesis",
-                label=f"{fusion.name} synthesis",
-                depends_on=tuple(member.operation_id for member in members),
-            )
-        )
-        self._record_parameter_assignment(operation_id, synthesizer, fusion.synthesizer.params)
         return _ResolvedRecipe(
-            reference=f"${binding}",
-            operation_id=operation_id,
+            reference=resolved_synthesizer.reference,
+            operation_id=resolved_synthesizer.operation_id,
             name=fusion.name,
             kind="fusion",
-            models=_ordered_unique((*models, synthesizer)),
+            models=_ordered_unique((*models, *resolved_synthesizer.models)),
+            topology=_RecipeTopology(
+                kind="fusion",
+                name=fusion.name,
+                binding=resolved_synthesizer.reference.removeprefix("$"),
+                members=tuple(_required_topology(member) for member in members),
+                synthesizer=_required_topology(resolved_synthesizer),
+            ),
+            members=members,
+        )
+
+    def _pipeline(
+        self,
+        pipeline: Pipeline,
+        *,
+        input_context: str,
+        input_dependencies: tuple[str, ...],
+        synthesis: bool,
+    ) -> _ResolvedRecipe:
+        context = input_context
+        dependencies = input_dependencies
+        models: tuple[str, ...] = ()
+        resolved: _ResolvedRecipe | None = None
+        stage_topologies: list[_RecipeTopology] = []
+        for index, stage in enumerate(pipeline.stages):
+            resolved = self._recipe(
+                stage,
+                input_context=context,
+                input_dependencies=dependencies,
+                synthesis=synthesis and index == 0,
+            )
+            context = resolved.reference
+            dependencies = (resolved.operation_id,)
+            models = _ordered_unique((*models, *resolved.models))
+            stage_topologies.append(_required_topology(resolved))
+        assert resolved is not None
+        return _ResolvedRecipe(
+            reference=resolved.reference,
+            operation_id=resolved.operation_id,
+            name=pipeline.name,
+            kind="pipeline",
+            models=models,
+            topology=_RecipeTopology(
+                kind="pipeline",
+                name=pipeline.name,
+                binding=resolved.reference.removeprefix("$"),
+                named=pipeline._is_named,
+                stages=tuple(stage_topologies),
+            ),
         )
 
     def _record_parameter_assignment(
@@ -313,36 +342,33 @@ class _CandidateCompiler:
         )
 
 
-def _fusion_context(
-    members: tuple[_ResolvedRecipe, ...],
-    member_names: tuple[str, ...],
-) -> str:
-    line = "\u2028"
-    section_separator = line * 2
-    sections = [
-        f"=== Model {index} ({name}) ==={line}{member.reference}"
-        for index, (member, name) in enumerate(
-            zip(members, member_names, strict=True),
-            1,
+def _fusion_context(input_context: str, members: tuple[_ResolvedRecipe, ...]) -> str:
+    """Build canonical JSON at runtime so arbitrary answers remain safely escaped."""
+
+    return render(
+        struct(
+            {
+                "input": input_context,
+                "outputs": {
+                    f"member_{index}": member.reference for index, member in enumerate(members, 1)
+                },
+            }
         )
-    ]
-    return (
-        f"Question:{line}$input{line}{line}"
-        f"Panel answers (one per model):{line}"
-        f"{section_separator.join(sections)}"
     )
 
 
-def _context_text(value: str) -> str:
-    return _url4_text(value).replace("(", "（").replace(")", "）")
+def _recipe_kind(recipe: Recipe) -> Literal["model", "fusion", "pipeline"]:
+    if isinstance(recipe, Model):
+        return "model"
+    if isinstance(recipe, Fusion):
+        return "fusion"
+    if isinstance(recipe, Pipeline):
+        return "pipeline"
+    raise TypeError("candidate must be an sf.Model, sf.Fusion, or sf.Pipeline")
 
 
-def _synthesis_params(
-    overrides: Mapping[str, str | int | float | bool],
-) -> tuple[tuple[str, str], ...]:
-    """Keep every Fusion writer retrieval-free, independent of Benchmark policy."""
-
-    return (*resolved_params(overrides), ("web_search", "false"))
+def _required_topology(value: _ResolvedRecipe) -> _RecipeTopology:
+    return value.topology
 
 
 def _canonical_model(model: str) -> str:

--- a/packages/screamingface/src/screamingface/_evaluation/compilation.py
+++ b/packages/screamingface/src/screamingface/_evaluation/compilation.py
@@ -7,7 +7,6 @@ from collections.abc import Sequence
 from screamingface._evaluation.benchmark import _BenchmarkResource
 from screamingface._evaluation.candidate import (
     _CompiledCandidate,
-    _SynthesizerExpression,
     compile_candidate,
 )
 from screamingface._evaluation.linking import link_candidate
@@ -16,7 +15,6 @@ from screamingface._evaluation.model import (
     _compiled_evaluation,
     _Evaluation,
 )
-from screamingface.operation import OperationInfo
 from screamingface.recipe import Recipe
 
 
@@ -29,48 +27,20 @@ def compile_evaluation(
 
     compiled = tuple(compile_candidate(recipe) for recipe in recipes)
     linked = tuple(
-        link_candidate(
-            value.url4,
-            resource.url4,
-            value.member_expressions,
-            value.synthesizer.url4 if value.synthesizer is not None else None,
-        )
+        link_candidate(value.url4, resource.url4)
         for recipe, value in zip(recipes, compiled, strict=True)
     )
     candidates = []
     for recipe, value, result in zip(recipes, compiled, linked, strict=True):
-        operations = _linked_operations(
-            value,
-            result.uses_whole_candidate,
-            result.uses_synthesizer,
-            result.member_indices,
-        )
-        operation_ids = {operation.id for operation in operations}
-        parameter_assignments = [
-            assignment
-            for assignment in value.parameter_assignments
-            if assignment.operation_id in operation_ids
-        ]
-        if (
-            result.uses_synthesizer
-            and value.synthesizer is not None
-            and value.synthesizer.parameter_assignment is not None
-        ):
-            parameter_assignments.append(value.synthesizer.parameter_assignment)
         candidates.append(
             _compiled_candidate(
                 name=recipe.name,
                 kind=value.kind,
-                models=_linked_models(
-                    value,
-                    result.uses_whole_candidate,
-                    result.uses_synthesizer,
-                    result.member_indices,
-                ),
+                models=value.models,
                 url4=result.url4,
-                operations=operations,
+                operations=value.operations,
                 members=value.members,
-                parameter_assignments=parameter_assignments,
+                parameter_assignments=value.parameter_assignments,
                 known_operation_ids=_known_operation_ids(value),
             )
         )
@@ -87,56 +57,10 @@ def compile_evaluation(
     )
 
 
-def _linked_models(
-    candidate: _CompiledCandidate,
-    uses_whole_candidate: bool,
-    uses_synthesizer: bool,
-    member_indices: tuple[int, ...],
-) -> tuple[str, ...]:
-    if uses_whole_candidate:
-        return candidate.models
-    selected = tuple(
-        model for index in member_indices for model in candidate.members[index - 1].models
-    )
-    if uses_synthesizer:
-        selected += (_synthesizer(candidate).model,)
-    return _ordered_unique(selected)
-
-
-def _linked_operations(
-    candidate: _CompiledCandidate,
-    uses_whole_candidate: bool,
-    uses_synthesizer: bool,
-    member_indices: tuple[int, ...],
-) -> tuple[OperationInfo, ...]:
-    if uses_whole_candidate:
-        selected = candidate.operations
-        if uses_synthesizer:
-            selected += (_synthesizer(candidate).operation,)
-        return selected
-    operation_ids = {candidate.members[index - 1].operation_id for index in member_indices}
-    if uses_synthesizer:
-        operation_ids.add(_synthesizer(candidate).operation.id)
-    selected = tuple(
-        operation for operation in candidate.operations if operation.id in operation_ids
-    )
-    if uses_synthesizer:
-        selected += (_synthesizer(candidate).operation,)
-    return selected
-
-
-def _synthesizer(candidate: _CompiledCandidate) -> _SynthesizerExpression:
-    if candidate.synthesizer is None:  # pragma: no cover - linker seals this mismatch first
-        raise RuntimeError("linked Candidate requires a synthesizer component")
-    return candidate.synthesizer
-
-
 def _known_operation_ids(candidate: _CompiledCandidate) -> tuple[str, ...]:
     values = tuple(operation.id for operation in candidate.operations) + tuple(
         member.operation_id for member in candidate.members
     )
-    if candidate.synthesizer is not None:
-        values += (candidate.synthesizer.operation.id,)
     return tuple(dict.fromkeys(values))
 
 

--- a/packages/screamingface/src/screamingface/_evaluation/linking.py
+++ b/packages/screamingface/src/screamingface/_evaluation/linking.py
@@ -1,4 +1,4 @@
-"""Structurally link one Candidate expression into one Benchmark expression."""
+"""Bind one complete Candidate Recipe into one Benchmark expression."""
 
 from __future__ import annotations
 
@@ -6,283 +6,95 @@ import re
 from collections.abc import Mapping
 from dataclasses import dataclass, fields, is_dataclass
 
-from url4 import Iteration, Text, VarRef, build, expr, render, src, struct, text
+from url4 import Iteration, Text, VarRef, build, expr, render, src, text
 
-from screamingface._evaluation.candidate import _MemberExpression
 from screamingface.errors import PlanningError
 
 _WHOLE_CANDIDATE = "$candidate"
-_SYNTHESIZER = "$candidate_synthesizer"
-_MEMBERS = "$candidate_members"
-_MEMBER = re.compile(r"\$candidate_member_([1-9][0-9]*)")
+_CANDIDATE_REFERENCE = re.compile(
+    r"(?<!\$)\$candidate(?:_members|_synthesizer|_member_[A-Za-z0-9_]+)?(?![A-Za-z0-9_])"
+)
 
 
 @dataclass(frozen=True, slots=True)
 class _LinkedCandidate:
     url4: str
-    uses_whole_candidate: bool
-    uses_synthesizer: bool
-    member_indices: tuple[int, ...]
 
 
-@dataclass(frozen=True, slots=True)
-class _BindingRequirements:
-    whole_candidate: bool
-    synthesizer: bool
-    member_collection: bool
-    member_indices: tuple[int, ...]
-
-
-def link_candidate(
-    candidate_url4: str | None,
-    benchmark_url4: str,
-    member_expressions: tuple[_MemberExpression, ...] = (),
-    synthesizer_expression: str | None = None,
-) -> _LinkedCandidate:
-    """Bind the universal Candidate surface without interpreting Benchmark behavior."""
+def link_candidate(candidate_url4: str, benchmark_url4: str) -> _LinkedCandidate:
+    """Bind the sole public Candidate seam without interpreting Benchmark behavior."""
 
     benchmark = build(benchmark_url4)
-    requirements = _requirements(benchmark, len(member_expressions))
-    if (
-        not requirements.whole_candidate
-        and not requirements.synthesizer
-        and not requirements.member_collection
-        and not requirements.member_indices
-    ):
+    references = _text_references(benchmark)
+    if _WHOLE_CANDIDATE not in references:
+        structural = sorted(value for value in references if value.startswith("$candidate_"))
+        if structural:
+            names = ", ".join(structural)
+            raise PlanningError(
+                f"Benchmark uses unsupported structural Candidate bindings: {names}; "
+                "Benchmarks must consume one complete $candidate Recipe",
+                code="candidate_shape_mismatch",
+                permanent=True,
+            )
         raise PlanningError(
             "Benchmark URL4 does not invoke the Candidate",
             code="invalid_benchmark_resource",
             permanent=True,
         )
-    bindings = []
-    if requirements.whole_candidate:
-        if candidate_url4 is None:
-            raise PlanningError(
-                "Benchmark invokes the whole Fusion, but it has no synthesizer — "
-                "set synthesizer= before Evaluation",
-                code="candidate_shape_mismatch",
-                permanent=True,
-            )
-        candidate = build(candidate_url4)
-        bindings.append(src(text(render(candidate)), name="candidate", weight=0.0))
-    bindings.extend(_synthesizer_bindings(requirements.synthesizer, synthesizer_expression))
-    bindings.extend(_static_member_bindings(requirements.member_indices, member_expressions))
-    if requirements.member_collection:
-        bindings.extend(_member_collection_binding(requirements.member_indices, member_expressions))
+    unsupported = sorted(value for value in references if value != _WHOLE_CANDIDATE)
+    if unsupported:
+        names = ", ".join(unsupported)
+        raise PlanningError(
+            f"Benchmark uses unsupported structural Candidate bindings: {names}; "
+            "Benchmarks must consume one complete $candidate Recipe",
+            code="candidate_shape_mismatch",
+            permanent=True,
+        )
+
+    candidate = build(candidate_url4)
+    binding = src(text(render(candidate)), name="candidate", weight=0.0)
     if isinstance(benchmark, Iteration):
-        # The surface grammar greedily reads a top-level ``*(...)`` as a reduce envelope. This
-        # ordinary instrumental passthrough gives the iteration an unambiguous nested boundary.
         benchmark = expr(
             src(benchmark, name="benchmark_result", weight=0.0),
             intent=text("$benchmark_result"),
         )
-    linked = expr(
-        *bindings,
-        benchmark,
-        intent=text(""),
-    )
-    rendered = render(linked)
-    _require_every_reference_bound(rendered, requirements)
-    return _LinkedCandidate(
-        url4=rendered,
-        uses_whole_candidate=requirements.whole_candidate,
-        uses_synthesizer=requirements.synthesizer,
-        member_indices=requirements.member_indices,
-    )
-
-
-def _require_every_reference_bound(rendered: str, requirements: _BindingRequirements) -> None:
-    """Refuse to ship a linked artifact that still names something nothing binds.
-
-    INVARIANT: every ``$candidate*`` reference in the shipped artifact resolves to a binding
-    emitted above. This is checked on the RENDERED surface rather than the parsed tree on
-    purpose: ``_requirements`` reasons over an AST where a reference has several shapes and
-    the node set can grow upstream, while ``render`` collapses them all into one form. The
-    check is therefore representation-independent — it closes the whole class of
-    walker-blindness bugs rather than the one shape that motivated it, and it turns a
-    mid-Run failure into a plan-time one, before the Candidate has been paid for.
-    """
-
-    bound = {f"$candidate_member_{index}" for index in requirements.member_indices}
-    if requirements.whole_candidate:
-        bound.add(_WHOLE_CANDIDATE)
-    if requirements.synthesizer:
-        bound.add(_SYNTHESIZER)
-    if requirements.member_collection:
-        bound.add(_MEMBERS)
-    unresolved = _candidate_references(rendered) - bound
-    if unresolved:
-        names = ", ".join(sorted(unresolved))
-        raise PlanningError(
-            f"Benchmark URL4 references {names}, which this Candidate does not bind",
-            code="candidate_shape_mismatch",
-            permanent=True,
-        )
-
-
-def _requirements(benchmark: object, member_count: int) -> _BindingRequirements:
-    references = _text_references(benchmark)
-    member_collection = _MEMBERS in references
-    indices = tuple(
-        sorted(
-            {
-                int(match.group(1))
-                for reference in references
-                if (match := _MEMBER.fullmatch(reference)) is not None
-            }
-        )
-    )
-    if member_collection:
-        indices = tuple(range(1, member_count + 1))
-    return _BindingRequirements(
-        whole_candidate=_WHOLE_CANDIDATE in references,
-        synthesizer=_SYNTHESIZER in references,
-        member_collection=member_collection,
-        member_indices=indices,
-    )
-
-
-def _static_member_bindings(
-    indices: tuple[int, ...],
-    members: tuple[_MemberExpression, ...],
-) -> list:
-    if indices and (indices != tuple(range(1, len(indices) + 1)) or len(members) != len(indices)):
-        raise PlanningError(
-            f"Benchmark requires exactly {len(indices)} direct Model members, "
-            f"but this Candidate has {len(members)} direct members",
-            code="candidate_shape_mismatch",
-            permanent=True,
-        )
-    bindings = []
-    for index in indices:
-        member = members[index - 1]
-        if member.kind != "model":
-            raise PlanningError(
-                f"Benchmark requires Fusion member {index} to be an sf.Model",
-                code="candidate_shape_mismatch",
-                permanent=True,
-            )
-        assert member.url4 is not None  # sf.Model compilation is always complete
-        bindings.append(
-            src(
-                text(render(build(member.url4))),
-                name=f"candidate_member_{index}",
-                weight=0.0,
-            )
-        )
-    return bindings
-
-
-def _member_collection_binding(
-    indices: tuple[int, ...],
-    members: tuple[_MemberExpression, ...],
-) -> list:
-    if not members:
-        raise PlanningError(
-            "Benchmark requires direct Candidate members — use an sf.Fusion",
-            code="candidate_shape_mismatch",
-            permanent=True,
-        )
-    # INVARIANT: executable URL4 appears exactly once in the linked artifact, in the
-    # ordinary named ``candidate_member_N`` binding above. This native URL4 struct carries
-    # only stable references and display metadata; it is neither an opaque encoding nor a
-    # second executable representation for Benchmark implementations to decode.
-    collection = {
-        f"member_{index}": {
-            "name": _template_literal(members[index - 1].name),
-            "url4": f"$candidate_member_{index}",
-        }
-        for index in indices
-    }
-    return [
-        src(
-            struct(collection),
-            name="candidate_members",
-            weight=0.0,
-        )
-    ]
-
-
-def _template_literal(value: str) -> str:
-    """Keep a user-facing name literal when a URL4 struct resolves its references."""
-
-    return value.replace("$", "$$")
-
-
-def _synthesizer_bindings(uses_synthesizer: bool, expression: str | None) -> list:
-    if not uses_synthesizer:
-        return []
-    if expression is None:
-        # INVARIANT: an explicit structural binding is never replaced by a Client,
-        # Engine, or Benchmark default. The selected Candidate must actually supply it.
-        raise PlanningError(
-            "Benchmark requires an explicit Fusion synthesizer, but none was configured — "
-            "set synthesizer= on an sf.Fusion",
-            code="candidate_shape_mismatch",
-            permanent=True,
-        )
-    return [src(text(render(build(expression))), name="candidate_synthesizer", weight=0.0)]
+    return _LinkedCandidate(url4=render(expr(binding, benchmark, intent=text(""))))
 
 
 def _text_references(value: object) -> set[str]:
-    """Collect exact URL4 Candidate references from the parsed Benchmark tree."""
+    leaf = _leaf_references(value)
+    if leaf is not None:
+        return leaf
+    selected: set[str] = set()
+    for child in _children(value):
+        selected.update(_text_references(child))
+    return selected
 
-    if isinstance(value, Text | str | VarRef):
-        return _reference_site(value)
-    return _nested_references(value)
 
-
-def _reference_site(value: Text | str | VarRef) -> set[str]:
-    """Read the references a single leaf node carries."""
-
+def _leaf_references(value: object) -> set[str] | None:
+    selected = None
     if isinstance(value, Text):
-        return _candidate_references(value.value)
-    if isinstance(value, VarRef):
-        # WHY: a reference SITE is either a VarRef or a "$name" embedded in Text. URL4 parses
-        # a reference in SOURCE position into a VarRef and strips the "$" sigil, so the name
-        # arrives as a bare string the matcher can never recognise — this puts the sigil back.
-        # A binding SITE (Binding.name) is also a bare string, but one the parser cannot
-        # prefix, which is exactly why the matcher keys on the sigil and ignores it.
-        # INVARIANT: path segments select fields on the RESOLVED value and are never part of
-        # the reference name — "$candidate_member_1.answers" names member 1, not "…_1.answers".
-        return _candidate_references(f"${value.name}") | _text_references(value.path)
-    return _candidate_references(value)
+        selected = _references(value.value)
+    elif isinstance(value, VarRef):
+        selected = _references(f"${value.name}") | _text_references(value.path)
+    elif isinstance(value, str):
+        selected = _references(value)
+    return selected
 
 
-def _nested_references(value: object) -> set[str]:
-    """Walk whatever children a non-leaf node exposes."""
-
-    references: set[str] = set()
+def _children(value: object) -> tuple[object, ...]:
+    selected: tuple[object, ...] = ()
     if isinstance(value, tuple | list):
-        for item in value:
-            references.update(_text_references(item))
+        selected = tuple(value)
     elif isinstance(value, Mapping):
-        # Source.weight and Source.budgets may hold a mapping, which halts an
-        # attribute-only walk.
-        for key, item in value.items():
-            references.update(_text_references(key))
-            references.update(_text_references(item))
+        selected = tuple(item for pair in value.items() for item in pair)
     elif is_dataclass(value) and not isinstance(value, type):
-        for field in fields(value):
-            references.update(_text_references(getattr(value, field.name)))
-    return references
+        selected = tuple(getattr(value, field.name) for field in fields(value))
+    return selected
 
 
-def _candidate_references(value: str) -> set[str]:
-    # INVARIANT: the trailing lookahead keeps unrelated names that merely start with
-    # "$candidate" (e.g. the "$candidate_result" plumbing binding) from matching as a
-    # bare whole-Candidate reference — that false positive made the linker bind the
-    # full Candidate expression as dead text on exams that never invoke it.
-    # INVARIANT: the leading lookbehind keeps an ESCAPED "$$candidate" literal from matching.
-    # "$$" is URL4's escape for a literal "$", and _template_literal depends on it to keep a
-    # user-facing member name literal — reading the escape back as a reference would both
-    # invent an invocation the Benchmark never wrote and break the unresolved-reference check.
-    return set(
-        re.findall(
-            r"(?<!\$)\$candidate(?:_member_[1-9][0-9]*|_members|_synthesizer)?(?![A-Za-z0-9_])",
-            value,
-        )
-    )
+def _references(value: str) -> set[str]:
+    return set(_CANDIDATE_REFERENCE.findall(value))
 
 
 __all__: list[str] = []

--- a/packages/screamingface/src/screamingface/_evaluation/model.py
+++ b/packages/screamingface/src/screamingface/_evaluation/model.py
@@ -15,9 +15,10 @@ from screamingface.discovery import BenchmarkInfo
 from screamingface.fusion import Fusion
 from screamingface.model import Model
 from screamingface.operation import OperationInfo, _operation_dag
+from screamingface.pipeline import Pipeline
 from screamingface.recipe import Recipe
 
-type CandidateKind = Literal["model", "fusion"]
+type CandidateKind = Literal["model", "fusion", "pipeline"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -130,13 +131,7 @@ def _compiled_candidate(
     object.__setattr__(candidate, "models", selected_models)
     object.__setattr__(candidate, "url4", _canonical_url4(url4, "Candidate"))
     object.__setattr__(candidate, "operations", _operation_dag(operations))
-    selected_members = tuple(members)
-    if any(not isinstance(member, _MemberProjection) for member in selected_members):
-        raise TypeError("Candidate members must contain only compiled member projections")
-    if selected_kind == "model" and selected_members:
-        raise ValueError("a planned Model Candidate cannot contain members")
-    if selected_kind == "fusion" and len(selected_members) < 2:
-        raise ValueError("a planned Fusion Candidate requires at least two direct members")
+    selected_members = _candidate_members(members, selected_kind)
     operation_ids = {operation.id for operation in candidate.operations}
     known_ids = (
         operation_ids
@@ -156,6 +151,22 @@ def _compiled_candidate(
         _candidate_parameter_assignments(parameter_assignments, operation_ids),
     )
     return candidate
+
+
+def _candidate_members(
+    values: Sequence[_MemberProjection],
+    kind: CandidateKind,
+) -> tuple[_MemberProjection, ...]:
+    selected = tuple(values)
+    if any(not isinstance(member, _MemberProjection) for member in selected):
+        raise TypeError("Candidate members must contain only compiled member projections")
+    if kind == "model" and selected:
+        raise ValueError("a planned Model Candidate cannot contain members")
+    if kind == "pipeline" and selected:
+        raise ValueError("a planned Pipeline Candidate cannot contain direct Fusion members")
+    if kind == "fusion" and not selected:
+        raise ValueError("a planned Fusion Candidate requires at least one direct member")
+    return selected
 
 
 def _candidate_parameter_assignments(
@@ -242,11 +253,13 @@ def _candidate_values(value: Recipe | Sequence[Recipe]) -> tuple[Recipe, ...]:
     elif isinstance(value, Sequence) and not isinstance(value, str | bytes):
         values = tuple(value)
     else:
-        raise TypeError("candidates must be an sf.Model, sf.Fusion, or ordered sequence")
+        raise TypeError(
+            "candidates must be an sf.Model, sf.Fusion, sf.Pipeline, or ordered sequence"
+        )
     if not values:
         raise ValueError("an Evaluation requires at least one Candidate")
-    if any(not isinstance(candidate, Model | Fusion) for candidate in values):
-        raise TypeError("candidates must contain only sf.Model or sf.Fusion values")
+    if any(not isinstance(candidate, Model | Fusion | Pipeline) for candidate in values):
+        raise TypeError("candidates must contain only sf.Model, sf.Fusion, or sf.Pipeline values")
     names: set[str] = set()
     for candidate in values:
         if candidate.name in names:
@@ -277,7 +290,9 @@ def _candidate_kind(value: object) -> CandidateKind:
         return "model"
     if value == "fusion":
         return "fusion"
-    raise ValueError("Candidate kind must be 'model' or 'fusion'")
+    if value == "pipeline":
+        return "pipeline"
+    raise ValueError("Candidate kind must be 'model', 'fusion', or 'pipeline'")
 
 
 def _nonblank(value: object, label: str) -> str:

--- a/packages/screamingface/src/screamingface/_evaluation/policy.py
+++ b/packages/screamingface/src/screamingface/_evaluation/policy.py
@@ -13,16 +13,14 @@ DEFAULT_SYNTHESIS_PROMPT = (
     "Synthesize the strongest supported answer from the panel responses, and follow every "
     "instruction and formatting constraint in the original request."
 )
-_DEFAULT_PARAMS: dict[str, str | int | float | bool] = {
-    "max_tokens": 4096,
-}
 
 
 def resolved_params(
     overrides: Mapping[str, str | int | float | bool],
 ) -> tuple[tuple[str, str], ...]:
-    merged = {**_DEFAULT_PARAMS, **overrides}
-    return tuple((name, _scalar(value)) for name, value in merged.items())
+    """Encode only Candidate parameters the researcher explicitly selected."""
+
+    return tuple((name, _scalar(value)) for name, value in overrides.items())
 
 
 def _scalar(value: str | int | float | bool) -> str:

--- a/packages/screamingface/src/screamingface/_evaluation/topology.py
+++ b/packages/screamingface/src/screamingface/_evaluation/topology.py
@@ -1,0 +1,188 @@
+"""Versioned, inert Recipe topology carried by newly compositional Candidate URL4."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Literal, cast
+
+from url4 import Expression, Node, Source, Text, src
+
+_SCHEMA = "screamingface.recipe.v1"
+_SOURCE_NAME = "_sf_recipe"
+_BINDING = re.compile(r"(?:model|synthesis)_\d+")
+type _TopologyKind = Literal["model", "fusion", "pipeline"]
+type _OperationRole = Literal["model", "synthesis"]
+
+
+@dataclass(frozen=True, slots=True)
+class _RecipeTopology:
+    """One public Recipe node mapped to its executable result binding."""
+
+    kind: _TopologyKind
+    name: str
+    binding: str
+    named: bool = False
+    role: _OperationRole | None = None
+    members: tuple[_RecipeTopology, ...] = ()
+    synthesizer: _RecipeTopology | None = None
+    stages: tuple[_RecipeTopology, ...] = ()
+
+
+def _topology_source(value: _RecipeTopology) -> Node:
+    return src(Text(_encode_topology(value)), name=_SOURCE_NAME, weight=0.0)
+
+
+def _topology_from_expression(value: Expression) -> _RecipeTopology:
+    matches = [
+        node for node in value.sources if isinstance(node, Source) and node.name == _SOURCE_NAME
+    ]
+    if not matches:
+        raise ValueError("URL4 Candidate is missing required Recipe metadata")
+    if len(matches) != 1 or not isinstance(matches[0].value, Text):
+        raise ValueError("URL4 Candidate has invalid Recipe topology metadata")
+    raw = matches[0].value.value
+    try:
+        payload = json.loads(raw)
+    except (TypeError, json.JSONDecodeError, RecursionError) as exc:
+        raise ValueError("URL4 Candidate has invalid Recipe topology metadata") from exc
+    if not isinstance(payload, dict) or set(payload) != {"schema", "recipe"}:
+        raise ValueError("URL4 Candidate has invalid Recipe topology metadata")
+    if payload["schema"] != _SCHEMA:
+        raise ValueError("URL4 Candidate has unsupported Recipe topology metadata")
+    try:
+        return _decode_node(payload["recipe"])
+    except RecursionError as exc:
+        raise ValueError("URL4 Candidate has invalid Recipe topology metadata") from exc
+
+
+def _encode_topology(value: _RecipeTopology) -> str:
+    payload = {"schema": _SCHEMA, "recipe": _encode_node(value)}
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def _encode_node(value: _RecipeTopology) -> dict[str, object]:
+    if value.kind == "model":
+        assert value.role is not None
+        return {
+            "binding": value.binding,
+            "kind": value.kind,
+            "name": value.name,
+            "named": value.named,
+            "role": value.role,
+        }
+    if value.kind == "pipeline":
+        return {
+            "binding": value.binding,
+            "kind": value.kind,
+            "name": value.name,
+            "named": value.named,
+            "stages": [_encode_node(stage) for stage in value.stages],
+        }
+    assert value.synthesizer is not None
+    return {
+        "binding": value.binding,
+        "kind": value.kind,
+        "members": [_encode_node(member) for member in value.members],
+        "name": value.name,
+        "synthesizer": _encode_node(value.synthesizer),
+    }
+
+
+def _decode_node(value: object) -> _RecipeTopology:
+    if not isinstance(value, dict):
+        raise ValueError("URL4 Candidate has invalid Recipe topology metadata")
+    kind = value.get("kind")
+    name = _text(value.get("name"))
+    binding = _binding(value.get("binding"))
+    decoder = {
+        "model": _decode_model,
+        "pipeline": _decode_pipeline,
+        "fusion": _decode_fusion,
+    }.get(kind if isinstance(kind, str) else "")
+    if decoder is None:
+        raise ValueError("URL4 Candidate has invalid Recipe topology metadata")
+    return decoder(value, name, binding)
+
+
+def _decode_model(
+    value: dict[object, object],
+    name: str,
+    binding: str,
+) -> _RecipeTopology:
+    if set(value) != {"binding", "kind", "name", "named", "role"}:
+        raise ValueError("URL4 Candidate has invalid Model topology metadata")
+    named = value["named"]
+    role = value["role"]
+    if not isinstance(named, bool) or role not in {"model", "synthesis"}:
+        raise ValueError("URL4 Candidate has invalid Model topology metadata")
+    return _RecipeTopology(
+        kind="model",
+        name=name,
+        binding=binding,
+        named=named,
+        role=cast(_OperationRole, role),
+    )
+
+
+def _decode_pipeline(
+    value: dict[object, object],
+    name: str,
+    binding: str,
+) -> _RecipeTopology:
+    if set(value) != {"binding", "kind", "name", "named", "stages"}:
+        raise ValueError("URL4 Candidate has invalid Pipeline topology metadata")
+    named = value["named"]
+    stages_value = value["stages"]
+    if not isinstance(named, bool) or not isinstance(stages_value, list):
+        raise ValueError("URL4 Candidate has invalid Pipeline topology metadata")
+    stages = tuple(_decode_node(stage) for stage in stages_value)
+    if not stages or binding != stages[-1].binding:
+        raise ValueError("URL4 Candidate has invalid Pipeline topology metadata")
+    return _RecipeTopology(
+        kind="pipeline",
+        name=name,
+        binding=binding,
+        named=named,
+        stages=stages,
+    )
+
+
+def _decode_fusion(
+    value: dict[object, object],
+    name: str,
+    binding: str,
+) -> _RecipeTopology:
+    if set(value) != {"binding", "kind", "members", "name", "synthesizer"}:
+        raise ValueError("URL4 Candidate has invalid Fusion topology metadata")
+    members_value = value["members"]
+    if not isinstance(members_value, list):
+        raise ValueError("URL4 Candidate has invalid Fusion topology metadata")
+    members = tuple(_decode_node(member) for member in members_value)
+    synthesizer = _decode_node(value["synthesizer"])
+    if not members or binding != synthesizer.binding:
+        raise ValueError("URL4 Candidate has invalid Fusion topology metadata")
+    return _RecipeTopology(
+        kind="fusion",
+        name=name,
+        binding=binding,
+        members=members,
+        synthesizer=synthesizer,
+    )
+
+
+def _text(value: object) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("URL4 Candidate has invalid Recipe topology metadata")
+    return value
+
+
+def _binding(value: object) -> str:
+    selected = _text(value)
+    if _BINDING.fullmatch(selected) is None:
+        raise ValueError("URL4 Candidate has invalid Recipe topology metadata")
+    return selected
+
+
+__all__: list[str] = []

--- a/packages/screamingface/src/screamingface/_evaluation/url4.py
+++ b/packages/screamingface/src/screamingface/_evaluation/url4.py
@@ -16,6 +16,7 @@ from screamingface._evaluation.model import (
     _member_projection,
 )
 from screamingface._evaluation.results import report_from_url4_outcome
+from screamingface._evaluation.topology import _RecipeTopology, _topology_from_expression
 from screamingface.events import Event
 from screamingface.report import Report
 
@@ -104,38 +105,155 @@ def _candidate_from_url4(value: str) -> Candidate:
     calls = _candidate_calls(candidate)
     final = _final_binding(candidate.intent.value, calls)
     selected = _dependency_closure(final, calls)
+    topology = _topology_from_expression(candidate)
+    return _candidate_from_topology(url4, topology, calls, final, selected)
+
+
+def _candidate_from_topology(
+    url4: str,
+    topology: _RecipeTopology,
+    calls: dict[str, tuple[str, tuple[str, ...]]],
+    final: str,
+    selected: set[str],
+) -> Candidate:
+    nodes = _topology_model_nodes(topology)
+    if topology.binding != final or set(nodes) != set(calls):
+        raise ValueError("Evaluation URL4 Recipe topology does not match its model calls")
+    _validate_topology_dependencies(topology, calls, input_dependencies=())
+    fusion_names = _direct_fusion_output_names(topology)
+    dependencies = _topology_operation_dependencies(topology)
     operations = tuple(
         _compiled_operation(
             id=f"op_{name}",
-            kind="model" if name.startswith("model_") else "synthesis",
-            label=f"{_display_name(name, calls)} {_operation_suffix(name)}",
-            depends_on=tuple(f"op_{dependency}" for dependency in calls[name][1]),
+            kind=nodes[name].role or "model",
+            label=(
+                f"{fusion_names.get(name, nodes[name].name)} "
+                f"{'synthesis' if nodes[name].role == 'synthesis' else 'answer'}"
+            ),
+            depends_on=tuple(f"op_{dependency}" for dependency in dependencies[name]),
         )
         for name in calls
         if name in selected
     )
-    kind = "model" if final.startswith("model_") else "fusion"
     members = (
-        ()
-        if kind == "model"
-        else tuple(
+        tuple(
             _member_projection(
-                operation_id=f"op_{dependency}",
-                name=_display_name(dependency, calls),
-                kind="model" if dependency.startswith("model_") else "fusion",
-                models=_models(dependency, calls),
+                operation_id=f"op_{member.binding}",
+                name=member.name,
+                kind=member.kind,
+                models=_models(member.binding, calls),
             )
-            for dependency in calls[final][1]
+            for member in topology.members
         )
+        if topology.kind == "fusion"
+        else ()
     )
     return _compiled_candidate(
-        name=_display_name(final, calls),
-        kind=kind,
+        name=topology.name,
+        kind=topology.kind,
         models=_models(final, calls),
         url4=url4,
         operations=operations,
         members=members,
     )
+
+
+def _topology_model_nodes(value: _RecipeTopology) -> dict[str, _RecipeTopology]:
+    selected: dict[str, _RecipeTopology] = {}
+
+    def visit(node: _RecipeTopology) -> None:
+        if node.kind == "model":
+            previous = selected.setdefault(node.binding, node)
+            if previous != node:
+                raise ValueError("Evaluation URL4 has conflicting Recipe topology metadata")
+            return
+        children = node.stages if node.kind == "pipeline" else node.members
+        for child in children:
+            visit(child)
+        if node.synthesizer is not None:
+            visit(node.synthesizer)
+
+    visit(value)
+    return selected
+
+
+def _validate_topology_dependencies(
+    value: _RecipeTopology,
+    calls: dict[str, tuple[str, tuple[str, ...]]],
+    *,
+    input_dependencies: tuple[str, ...],
+) -> None:
+    if value.kind == "model":
+        if calls[value.binding][1] != input_dependencies:
+            raise ValueError("Evaluation URL4 Recipe topology does not match its model calls")
+        return
+    if value.kind == "pipeline":
+        dependencies = input_dependencies
+        for stage in value.stages:
+            _validate_topology_dependencies(
+                stage,
+                calls,
+                input_dependencies=dependencies,
+            )
+            dependencies = (stage.binding,)
+        return
+    for member in value.members:
+        _validate_topology_dependencies(
+            member,
+            calls,
+            input_dependencies=input_dependencies,
+        )
+    assert value.synthesizer is not None
+    synthesis_dependencies = tuple(
+        dict.fromkeys((*input_dependencies, *(member.binding for member in value.members)))
+    )
+    _validate_topology_dependencies(
+        value.synthesizer,
+        calls,
+        input_dependencies=synthesis_dependencies,
+    )
+
+
+def _direct_fusion_output_names(value: _RecipeTopology) -> dict[str, str]:
+    selected: dict[str, str] = {}
+
+    def visit(node: _RecipeTopology) -> None:
+        if node.kind == "model":
+            return
+        children = node.stages if node.kind == "pipeline" else node.members
+        for child in children:
+            visit(child)
+        if node.synthesizer is not None:
+            visit(node.synthesizer)
+            if node.synthesizer.kind == "model":
+                selected[node.binding] = node.name
+
+    visit(value)
+    return selected
+
+
+def _topology_operation_dependencies(
+    value: _RecipeTopology,
+) -> dict[str, tuple[str, ...]]:
+    selected: dict[str, tuple[str, ...]] = {}
+
+    def visit(node: _RecipeTopology, upstream: tuple[str, ...]) -> None:
+        if node.kind == "model":
+            selected[node.binding] = upstream
+            return
+        if node.kind == "pipeline":
+            dependencies = upstream
+            for stage in node.stages:
+                visit(stage, dependencies)
+                dependencies = (stage.binding,)
+            return
+        for member in node.members:
+            visit(member, upstream)
+        assert node.synthesizer is not None
+        visit(node.synthesizer, tuple(member.binding for member in node.members))
+
+    visit(value, ())
+    return selected
 
 
 def _candidate_text(root: object) -> str:
@@ -199,20 +317,6 @@ def _models(
 ) -> tuple[str, ...]:
     selected = _dependency_closure(name, calls)
     return tuple(dict.fromkeys(route for key, (route, _) in calls.items() if key in selected))
-
-
-def _display_name(
-    name: str,
-    calls: dict[str, tuple[str, tuple[str, ...]]],
-) -> str:
-    route, dependencies = calls[name]
-    if not dependencies:
-        return route.rsplit("/", 1)[-1]
-    return "+".join(_display_name(dependency, calls) for dependency in dependencies)
-
-
-def _operation_suffix(name: str) -> str:
-    return "answer" if name.startswith("model_") else "synthesis"
 
 
 __all__: list[str] = []

--- a/packages/screamingface/src/screamingface/_ui/card_style.py
+++ b/packages/screamingface/src/screamingface/_ui/card_style.py
@@ -13,12 +13,14 @@ CARD_STYLE = (
 .sf-card,.sf-catalog{border:1px solid var(--sf-line-2);background:var(--sf-bg)}
 .sf-card__accent{height:3px;background:var(--sf-gain-grad)}
 .sf-card__accent--solid{background:var(--sf-gain)}
+.sf-card__accent--pipeline{background:var(--sf-accent)}
 .sf-card__head{display:flex;align-items:baseline;gap:8px;padding:12px;
   border-bottom:1px solid var(--sf-line)}
 .sf-card__title,.sf-catalog__title{font-size:15px;font-weight:600;color:var(--sf-ink);
   overflow-wrap:anywhere}
 .sf-card__kicker{margin-left:auto;font-family:"IBM Plex Mono",ui-monospace,monospace;
   font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--sf-gain)}
+.sf-card__kicker--pipeline{color:var(--sf-accent)}
 .sf-card__grid{display:grid;grid-template-columns:1fr 1fr;gap:1px;background:var(--sf-line)}
 .sf-card__field{background:var(--sf-bg);padding:8px 12px;min-width:0}
 .sf-card__field.wide{grid-column:1/-1}
@@ -32,6 +34,8 @@ CARD_STYLE = (
 .sf-detail__item{border-left:2px solid var(--sf-line-2);padding:2px 0 6px 10px;margin-top:6px}
 .sf-detail__name{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px;
   font-weight:600;color:var(--sf-gain)}
+.sf-detail__index{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:10px;
+  letter-spacing:.08em;text-transform:uppercase;color:var(--sf-ink-3)}
 .sf-detail__route,.sf-detail__params{font-family:"IBM Plex Mono",ui-monospace,monospace;
   font-size:11px;color:var(--sf-ink-2);overflow-wrap:anywhere}
 .sf-more__full{margin-top:4px;white-space:pre-wrap;overflow-wrap:anywhere;

--- a/packages/screamingface/src/screamingface/_ui/cards.py
+++ b/packages/screamingface/src/screamingface/_ui/cards.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from screamingface.discovery import Benchmark, ModelInfo
     from screamingface.fusion import Fusion
     from screamingface.model import Model
+    from screamingface.pipeline import Pipeline
     from screamingface.recipe import Recipe
 
 
@@ -40,12 +41,7 @@ def fusion_card_html(fusion: Fusion) -> str:
     members = "".join(_member_detail(member) for member in fusion.members)
     synthesis = ""
     if fusion.synthesizer is not None:
-        fields = ""
-        fields += _field("synthesizer", _mono(fusion.synthesizer.model), wide=True)
-        if fusion.synthesizer.prompt is not None:
-            fields += _field("prompt", escape(fusion.synthesizer.prompt), wide=True)
-        if fusion.synthesizer.params:
-            fields += _field("params", _params(fusion.synthesizer.params), wide=True)
+        fields = _synthesizer_fields(fusion.synthesizer)
         synthesis = _section("synthesis", f"<div class='sf-card__grid'>{fields}</div>")
     return (
         f"{CARD_STYLE}<div class='sf-ui sf-card' aria-label='ScreamingFace fusion'>"
@@ -53,6 +49,21 @@ def fusion_card_html(fusion: Fusion) -> str:
         f"<div class='sf-card__head'><span class='sf-card__title'>{escape(fusion.name)}</span>"
         "<span class='sf-card__kicker'>fusion</span></div>"
         f"{_section('members', members)}{synthesis}</div>"
+    )
+
+
+def pipeline_card_html(pipeline: Pipeline) -> str:
+    """Render one serial Candidate as an explicitly ordered topology."""
+
+    stages = "".join(
+        _recipe_detail(stage, index=index) for index, stage in enumerate(pipeline.stages, start=1)
+    )
+    return (
+        f"{CARD_STYLE}<div class='sf-ui sf-card' aria-label='ScreamingFace pipeline'>"
+        "<div class='sf-card__accent sf-card__accent--pipeline'></div>"
+        f"<div class='sf-card__head'><span class='sf-card__title'>{escape(pipeline.name)}</span>"
+        "<span class='sf-card__kicker sf-card__kicker--pipeline'>pipeline</span></div>"
+        f"{_section('stages', stages)}</div>"
     )
 
 
@@ -123,15 +134,44 @@ def _section(title: str, body: str) -> str:
 
 
 def _member_detail(member: Recipe) -> str:
-    route = getattr(member, "model", None)
+    return _recipe_detail(member)
+
+
+def _recipe_detail(recipe: Recipe, *, index: int | None = None) -> str:
+    route = getattr(recipe, "model", None)
+    kind = _recipe_kind(recipe)
     if route is None:
-        detail = "<div class='sf-card__hint'>nested fusion</div>"
+        detail = f"<div class='sf-card__hint'>nested {escape(kind)}</div>"
     else:
         detail = f"<div class='sf-detail__route'>{escape(str(route))}</div>"
+    order = "" if index is None else f"<div class='sf-detail__index'>stage {index}</div>"
     return (
         "<div class='sf-detail__item'>"
-        f"<div class='sf-detail__name'>{escape(member.name)}</div>{detail}</div>"
+        f"{order}<div class='sf-detail__name'>{escape(recipe.name)}</div>{detail}</div>"
     )
+
+
+def _synthesizer_fields(recipe: Recipe) -> str:
+    route = getattr(recipe, "model", None)
+    if route is None:
+        value = (
+            f"<span class='sf-mono'>{escape(recipe.name)}</span>"
+            f"<div class='sf-card__hint'>nested {escape(_recipe_kind(recipe))}</div>"
+        )
+        return _field("synthesizer", value, wide=True)
+
+    fields = _field("synthesizer", _mono(str(route)), wide=True)
+    prompt = getattr(recipe, "prompt", None)
+    if prompt is not None:
+        fields += _field("prompt", escape(str(prompt)), wide=True)
+    params = getattr(recipe, "params", None)
+    if params:
+        fields += _field("params", _params(params), wide=True)
+    return fields
+
+
+def _recipe_kind(recipe: Recipe) -> str:
+    return type(recipe).__name__.lower()
 
 
 def _provider_of(route: str) -> str:

--- a/packages/screamingface/src/screamingface/fusion.py
+++ b/packages/screamingface/src/screamingface/fusion.py
@@ -4,25 +4,25 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import Any, ClassVar
 
-from screamingface.model import Model
-from screamingface.recipe import Recipe, _name
+from screamingface.recipe import Recipe, _name, _recipe
 
 
-@dataclass(frozen=True, slots=True, init=False, eq=False)
+@dataclass(frozen=True, slots=True, init=False)
 class Fusion(Recipe):
-    """Combine ordered members through an optional Candidate-owned synthesizer."""
+    """Combine ordered parallel members through an explicit synthesizer Recipe."""
 
     name: str
     members: tuple[Recipe, ...]
-    synthesizer: Model | None
+    synthesizer: Recipe
 
     def __init__(
         self,
-        members: Sequence[Recipe],
+        members: Sequence[str | Recipe],
         *,
         name: str | None = None,
-        synthesizer: str | Model | None = None,
+        synthesizer: str | Recipe,
     ) -> None:
         selected_members = _members(members)
         inferred_name = "+".join(member.name for member in selected_members)
@@ -32,7 +32,7 @@ class Fusion(Recipe):
             inferred_name if name is None else _name(name, "fusion name"),
         )
         object.__setattr__(self, "members", selected_members)
-        object.__setattr__(self, "synthesizer", _synthesizer(synthesizer))
+        object.__setattr__(self, "synthesizer", _recipe(synthesizer, "Fusion synthesizer"))
 
     @property
     def _recipe_marker(self) -> None:
@@ -44,8 +44,7 @@ class Fusion(Recipe):
         arguments = [f"[{members}]"]
         if self.name != inferred_name:
             arguments.append(f"name={self.name!r}")
-        if self.synthesizer is not None:
-            arguments.append(f"synthesizer={self.synthesizer!r}")
+        arguments.append(f"synthesizer={self.synthesizer!r}")
         return f"Fusion({', '.join(arguments)})"
 
     def _repr_html_(self) -> str:
@@ -53,35 +52,16 @@ class Fusion(Recipe):
 
         return fusion_card_html(self)
 
+    __hash__: ClassVar[Any] = None
+
 
 def _members(values: object) -> tuple[Recipe, ...]:
     if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
-        raise TypeError("Fusion members must be sf.Model or sf.Fusion values")
-    selected = tuple(values)
-    if len(selected) < 2:
-        raise ValueError("a Fusion requires at least two members")
-    if any(not isinstance(member, Model | Fusion) for member in selected):
-        raise TypeError("Fusion members must be sf.Model or sf.Fusion values")
-    _unique_names(selected)
+        raise TypeError("Fusion members must be an ordered sequence of model routes or Recipes")
+    selected = tuple(_recipe(value, "Fusion member") for value in values)
+    if not selected:
+        raise ValueError("a Fusion requires at least one member")
     return selected
-
-
-def _synthesizer(value: object) -> Model | None:
-    if value is None:
-        return None
-    if isinstance(value, Model):
-        return value
-    if isinstance(value, str):
-        return Model(value)
-    raise TypeError("Fusion synthesizer must be an sf.Model or model route string")
-
-
-def _unique_names(members: tuple[Recipe, ...]) -> None:
-    seen: set[str] = set()
-    for member in members:
-        if member.name in seen:
-            raise ValueError(f"duplicate Fusion member name {member.name!r}")
-        seen.add(member.name)
 
 
 __all__ = ["Fusion"]

--- a/packages/screamingface/src/screamingface/model.py
+++ b/packages/screamingface/src/screamingface/model.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+from typing import Any, ClassVar
 
 from screamingface._candidate_policy import GenerationParams
 from screamingface._candidate_policy import params as _generation_params
@@ -11,7 +12,7 @@ from screamingface._candidate_policy import prompt as _generation_prompt
 from screamingface.recipe import Recipe, _model_route, _name
 
 
-@dataclass(frozen=True, slots=True, init=False, eq=False)
+@dataclass(frozen=True, slots=True, init=False)
 class Model(Recipe):
     """Select one model route with optional Candidate-owned answer policy."""
 
@@ -45,6 +46,8 @@ class Model(Recipe):
     @property
     def _recipe_marker(self) -> None:
         return None
+
+    __hash__: ClassVar[Any] = None
 
     def __repr__(self) -> str:
         arguments = [repr(self.model)]

--- a/packages/screamingface/src/screamingface/pipeline.py
+++ b/packages/screamingface/src/screamingface/pipeline.py
@@ -1,0 +1,72 @@
+"""Serial Candidate values."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+from screamingface.recipe import Recipe, _name, _recipe
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class Pipeline(Recipe):
+    """Pass one input through an ordered sequence of Recipe stages."""
+
+    name: str
+    stages: tuple[Recipe, ...]
+    _is_named: bool
+
+    def __init__(
+        self,
+        stages: Sequence[str | Recipe],
+        *,
+        name: str | None = None,
+    ) -> None:
+        selected_stages = _stages(stages)
+        inferred_name = "->".join(stage.name for stage in selected_stages)
+        object.__setattr__(
+            self,
+            "name",
+            inferred_name if name is None else _name(name, "pipeline name"),
+        )
+        object.__setattr__(self, "stages", selected_stages)
+        object.__setattr__(self, "_is_named", name is not None)
+
+    @property
+    def _recipe_marker(self) -> None:
+        return None
+
+    def __repr__(self) -> str:
+        stages = ", ".join(repr(stage.name) for stage in self.stages)
+        inferred_name = "->".join(stage.name for stage in self.stages)
+        arguments = [f"[{stages}]"]
+        if self.name != inferred_name:
+            arguments.append(f"name={self.name!r}")
+        return f"Pipeline({', '.join(arguments)})"
+
+    def _repr_html_(self) -> str:
+        from screamingface._ui.cards import pipeline_card_html
+
+        return pipeline_card_html(self)
+
+    __hash__: ClassVar[Any] = None
+
+
+def _stages(values: object) -> tuple[Recipe, ...]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise TypeError("Pipeline stages must be an ordered sequence of model routes or Recipes")
+    normalized = tuple(_recipe(value, "Pipeline stage") for value in values)
+    selected = tuple(
+        nested
+        for stage in normalized
+        for nested in (
+            stage.stages if isinstance(stage, Pipeline) and not stage._is_named else (stage,)
+        )
+    )
+    if not selected:
+        raise ValueError("a Pipeline requires at least one stage")
+    return selected
+
+
+__all__ = ["Pipeline"]

--- a/packages/screamingface/src/screamingface/recipe.py
+++ b/packages/screamingface/src/screamingface/recipe.py
@@ -1,15 +1,33 @@
-"""Client-independent values shared by Models and Fusions."""
+"""Client-independent values shared by composable Candidate Recipes."""
 
 from __future__ import annotations
 
 import unicodedata
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from screamingface.pipeline import Pipeline
 
 
 class Recipe(ABC):
     """Non-constructible umbrella type for answer-producing Recipe values."""
 
     name: str
+
+    def then(self, next_recipe: str | Recipe) -> Pipeline:
+        """Return an immutable serial Pipeline ending in ``next_recipe``."""
+
+        from screamingface.pipeline import Pipeline
+
+        selected = _recipe(next_recipe, "Pipeline stage")
+        before = self.stages if isinstance(self, Pipeline) and not self._is_named else (self,)
+        after = (
+            selected.stages
+            if isinstance(selected, Pipeline) and not selected._is_named
+            else (selected,)
+        )
+        return Pipeline((*before, *after))
 
     @property
     @abstractmethod
@@ -26,6 +44,27 @@ def _name(value: object, label: str) -> str:
 
 def _model_route(value: object) -> str:
     return _name(value, "model route")
+
+
+def _recipe(value: object, label: str) -> Recipe:
+    """Normalize the one intentional shorthand at every Recipe-valued position."""
+
+    if isinstance(value, str):
+        from screamingface.model import Model
+
+        return Model(value)
+    if not _is_supported_recipe(value):
+        raise TypeError(f"{label} must be a model route or sf.Model, sf.Fusion, or sf.Pipeline")
+    assert isinstance(value, Recipe)
+    return value
+
+
+def _is_supported_recipe(value: object) -> bool:
+    from screamingface.fusion import Fusion
+    from screamingface.model import Model
+    from screamingface.pipeline import Pipeline
+
+    return isinstance(value, Model | Fusion | Pipeline)
 
 
 def _text(value: object, label: str) -> str:

--- a/packages/screamingface/src/screamingface/report.py
+++ b/packages/screamingface/src/screamingface/report.py
@@ -29,7 +29,7 @@ from screamingface.discovery import BenchmarkInfo
 from screamingface.operation import OperationInfo, _operation_dag
 from screamingface.url4 import Url4
 
-type RecipeKind = Literal["model", "fusion"]
+type RecipeKind = Literal["model", "fusion", "pipeline"]
 
 
 @dataclass(frozen=True, slots=True, init=False)
@@ -326,7 +326,9 @@ def _kind(value: object, label: str) -> RecipeKind:
         return "model"
     if value == "fusion":
         return "fusion"
-    raise ValueError(f"{label} kind must be 'model' or 'fusion'")
+    if value == "pipeline":
+        return "pipeline"
+    raise ValueError(f"{label} kind must be 'model', 'fusion', or 'pipeline'")
 
 
 def _models(values: Sequence[str], label: str) -> tuple[str, ...]:
@@ -396,8 +398,11 @@ def _candidate_shape(
             raise ValueError("a Model Candidate must contain exactly one model route")
         if selected_members:
             raise ValueError("a Model Candidate cannot contain members")
-    elif len(selected_members) < 2:
-        raise ValueError("a Fusion Candidate requires at least two direct members")
+    elif selected_kind == "pipeline":
+        if selected_members:
+            raise ValueError("a Pipeline Candidate cannot contain direct Fusion members")
+    elif not selected_members:
+        raise ValueError("a Fusion Candidate requires at least one direct member")
     if scored and selected_failures:
         raise ValueError("a failed Candidate cannot contain a score or metrics")
     return selected_kind, selected_models, selected_members, selected_failures

--- a/packages/screamingface/src/screamingface/url4.py
+++ b/packages/screamingface/src/screamingface/url4.py
@@ -9,12 +9,10 @@ from dataclasses import dataclass
 from url4 import Expression, Iteration, Node, RelExpr, RelUrl, Source, Text, Url4Error, build, walk
 
 from screamingface._evaluation.policy import DEFAULT_ANSWER_PROMPT, DEFAULT_SYNTHESIS_PROMPT
+from screamingface._evaluation.topology import _RecipeTopology, _topology_from_expression
 
 _BINDING = re.compile(r"(?:model|synthesis)_\d+")
 _REFERENCE = re.compile(r"\$(model_\d+|synthesis_\d+)")
-_MEMBER_LABEL = re.compile(
-    r"=== Model \d+ \((.*?)\) ===\u2028\$(model_\d+|synthesis_\d+)",
-)
 _BENCHMARK_ROUTE = re.compile(
     r"/benchmarks/([A-Za-z0-9._~/-]+?)/"
     r"(?:cases|tasks|aggregate|criterion-verdict|criterion-evaluation|case-evaluation)\b"
@@ -42,10 +40,8 @@ class Url4(str):
 @dataclass(frozen=True, slots=True)
 class _Call:
     binding: str
-    kind: str
     model: str
     dependencies: tuple[str, ...]
-    member_names: dict[str, str]
     prompt: str
     params: tuple[tuple[str, str], ...]
 
@@ -58,7 +54,9 @@ def _to_python(value: str) -> str:
     candidate, linked = _candidate_expression(root)
     calls = _calls(candidate)
     final = _final_binding(candidate, calls)
-    lines = _render_recipe(final, calls, explicit_name=None, indent=0)
+    topology = _topology_from_expression(candidate)
+    _validate_topology(topology, calls, final)
+    lines = _render_topology(topology, calls, indent=0)
     lines[0] = f"candidate = {lines[0]}"
     source = ["import screamingface as sf", "", *lines]
     if linked:
@@ -96,15 +94,10 @@ def _calls(candidate: Expression) -> dict[str, _Call]:
             continue
         context = node.value.context or ""
         dependencies = tuple(dict.fromkeys(_REFERENCE.findall(context)))
-        member_names = {
-            binding: _python_text(name) for name, binding in _MEMBER_LABEL.findall(context)
-        }
         calls[node.name] = _Call(
             binding=node.name,
-            kind="model" if node.name.startswith("model_") else "fusion",
             model=node.value.path.removeprefix("/"),
             dependencies=dependencies,
-            member_names=member_names,
             prompt=_python_text(node.value.intent.value),
             params=_params(node.value.params),
         )
@@ -122,30 +115,21 @@ def _final_binding(candidate: Expression, calls: dict[str, _Call]) -> str:
     return match.group(1)
 
 
-def _render_recipe(
-    binding: str,
-    calls: dict[str, _Call],
+def _render_model(
+    call: _Call,
     *,
+    role: str,
     explicit_name: str | None,
     indent: int,
+    force_name: bool = False,
 ) -> list[str]:
-    if binding not in calls:
-        raise ValueError(f"URL4 Candidate references unknown binding {binding!r}")
-    call = calls[binding]
-    return (
-        _render_model(call, explicit_name=explicit_name, indent=indent)
-        if call.kind == "model"
-        else _render_fusion(call, calls, explicit_name=explicit_name, indent=indent)
-    )
-
-
-def _render_model(call: _Call, *, explicit_name: str | None, indent: int) -> list[str]:
     prefix = " " * indent
     lines = [f"{prefix}sf.Model(", f"{prefix}    {call.model!r},"]
     inferred_name = call.model.rsplit("/", 1)[-1]
-    if explicit_name is not None and explicit_name != inferred_name:
+    if explicit_name is not None and (force_name or explicit_name != inferred_name):
         lines.append(f"{prefix}    name={explicit_name!r},")
-    if call.prompt != DEFAULT_ANSWER_PROMPT:
+    default_prompt = DEFAULT_SYNTHESIS_PROMPT if role == "synthesis" else DEFAULT_ANSWER_PROMPT
+    if call.prompt != default_prompt:
         lines.append(f"{prefix}    prompt={call.prompt!r},")
     params = _editable_params(call)
     if params:
@@ -154,63 +138,130 @@ def _render_model(call: _Call, *, explicit_name: str | None, indent: int) -> lis
     return lines
 
 
-def _render_fusion(
-    call: _Call,
+def _render_topology(
+    value: _RecipeTopology,
     calls: dict[str, _Call],
     *,
-    explicit_name: str | None,
     indent: int,
 ) -> list[str]:
-    if len(call.dependencies) < 2:
-        raise ValueError("URL4 Fusion must reference at least two Candidate members")
+    if value.kind == "model":
+        assert value.role is not None
+        return _render_model(
+            calls[value.binding],
+            role=value.role,
+            explicit_name=value.name,
+            indent=indent,
+            force_name=value.named,
+        )
+    if value.kind == "pipeline":
+        return _render_pipeline_topology(value, calls, indent=indent)
+    return _render_fusion_topology(value, calls, indent=indent)
+
+
+def _render_pipeline_topology(
+    value: _RecipeTopology,
+    calls: dict[str, _Call],
+    *,
+    indent: int,
+) -> list[str]:
     prefix = " " * indent
-    lines = [f"{prefix}sf.Fusion(", f"{prefix}    ["]
-    for dependency in call.dependencies:
-        member = _render_recipe(
-            dependency,
-            calls,
-            explicit_name=call.member_names.get(dependency),
-            indent=indent + 8,
-        )
-        member[-1] += ","
-        lines.extend(member)
+    lines = [f"{prefix}sf.Pipeline(", f"{prefix}    ["]
+    for stage in value.stages:
+        rendered = _render_topology(stage, calls, indent=indent + 8)
+        rendered[-1] += ","
+        lines.extend(rendered)
     lines.append(f"{prefix}    ],")
-    if explicit_name is not None:
-        inferred_name = "+".join(
-            call.member_names.get(dependency, _inferred_name(dependency, calls))
-            for dependency in call.dependencies
-        )
-        if explicit_name != inferred_name:
-            lines.append(f"{prefix}    name={explicit_name!r},")
-    lines.append(f"{prefix}    synthesizer=sf.Model(")
-    lines.append(f"{prefix}        {call.model!r},")
-    if call.prompt != DEFAULT_SYNTHESIS_PROMPT:
-        lines.append(f"{prefix}        prompt={call.prompt!r},")
-    params = _editable_params(call)
-    if params:
-        lines.append(f"{prefix}        params={params!r},")
-    lines.append(f"{prefix}    ),")
+    inferred_name = "->".join(stage.name for stage in value.stages)
+    if value.named or value.name != inferred_name:
+        lines.append(f"{prefix}    name={value.name!r},")
     lines.append(f"{prefix})")
     return lines
 
 
-def _inferred_name(binding: str, calls: dict[str, _Call]) -> str:
-    call = calls[binding]
-    if call.kind == "model":
-        return call.model.rsplit("/", 1)[-1]
-    return "+".join(
-        call.member_names.get(dependency, _inferred_name(dependency, calls))
-        for dependency in call.dependencies
+def _render_fusion_topology(
+    value: _RecipeTopology,
+    calls: dict[str, _Call],
+    *,
+    indent: int,
+) -> list[str]:
+    assert value.synthesizer is not None
+    prefix = " " * indent
+    lines = [f"{prefix}sf.Fusion(", f"{prefix}    ["]
+    for member in value.members:
+        rendered = _render_topology(member, calls, indent=indent + 8)
+        rendered[-1] += ","
+        lines.extend(rendered)
+    lines.append(f"{prefix}    ],")
+    inferred_name = "+".join(member.name for member in value.members)
+    if value.name != inferred_name:
+        lines.append(f"{prefix}    name={value.name!r},")
+    synthesizer = _render_topology(value.synthesizer, calls, indent=indent + 4)
+    synthesizer[0] = f"{prefix}    synthesizer={synthesizer[0].lstrip()}"
+    synthesizer[-1] += ","
+    lines.extend(synthesizer)
+    lines.append(f"{prefix})")
+    return lines
+
+
+def _validate_topology(
+    value: _RecipeTopology,
+    calls: dict[str, _Call],
+    final: str,
+) -> None:
+    if value.binding != final:
+        raise ValueError("URL4 Candidate Recipe topology does not match its result binding")
+    bindings: set[str] = set()
+    _validate_topology_node(value, calls, input_dependencies=(), bindings=bindings)
+    if bindings != set(calls):
+        raise ValueError("URL4 Candidate Recipe topology does not match its model calls")
+
+
+def _validate_topology_node(
+    value: _RecipeTopology,
+    calls: dict[str, _Call],
+    *,
+    input_dependencies: tuple[str, ...],
+    bindings: set[str],
+) -> None:
+    if value.kind == "model":
+        call = calls.get(value.binding)
+        if call is None or call.dependencies != input_dependencies:
+            raise ValueError("URL4 Candidate Recipe topology does not match its model calls")
+        bindings.add(value.binding)
+        return
+    if value.kind == "pipeline":
+        dependencies = input_dependencies
+        for stage in value.stages:
+            _validate_topology_node(
+                stage,
+                calls,
+                input_dependencies=dependencies,
+                bindings=bindings,
+            )
+            dependencies = (stage.binding,)
+        return
+    assert value.synthesizer is not None
+    for member in value.members:
+        _validate_topology_node(
+            member,
+            calls,
+            input_dependencies=input_dependencies,
+            bindings=bindings,
+        )
+    synthesis_dependencies = tuple(
+        dict.fromkeys((*input_dependencies, *(member.binding for member in value.members)))
+    )
+    _validate_topology_node(
+        value.synthesizer,
+        calls,
+        input_dependencies=synthesis_dependencies,
+        bindings=bindings,
     )
 
 
 def _editable_params(call: _Call) -> dict[str, str | int | float | bool]:
     selected: dict[str, str | int | float | bool] = {}
     for name, value in call.params:
-        if name == "max_tokens" and value == "4096":
-            continue
-        if call.kind == "fusion" and name == "web_search" and value == "false":
-            continue
         selected[name] = _scalar(value)
     return selected
 

--- a/packages/screamingface/tests/test_benchmark_compilation.py
+++ b/packages/screamingface/tests/test_benchmark_compilation.py
@@ -142,7 +142,8 @@ def test_model_compilation_uses_candidate_owned_defaults_and_input_binding() -> 
     assert "Answer the request accurately and completely." in compiled.url4
     assert "Follow every instruction and formatting constraint" in compiled.url4
     assert "reasoning=" not in compiled.url4
-    assert "max_tokens=4096" in compiled.url4
+    assert "max_tokens=" not in compiled.url4
+    assert "web_search=" not in compiled.url4
     assert [operation.kind for operation in compiled.operations] == ["model"]
 
 
@@ -240,124 +241,17 @@ def test_evaluation_inspection_combines_benchmark_and_candidate_requirements() -
     ]
 
 
-def _three_member_benchmark_url4() -> str:
-    return render(
-        expr(
-            *(
-                src(
-                    RelExpr(
-                        path="/candidate",
-                        context="question",
-                        intent=text(f"$candidate_member_{index}"),
-                    ),
-                    name=f"answer_{index}",
-                    weight=0.0,
-                )
-                for index in range(1, 4)
-            ),
-            intent=text("$answer_1 $answer_2 $answer_3"),
-        )
-    )
+def _structural_resource() -> dict[str, object]:
+    return _resource(url4="(member:0.0:/validate($candidate_member_1)!'$member')!'$member'")
 
 
-def test_structural_member_bindings_keep_benchmark_logic_out_of_the_sdk() -> None:
-    benchmark = _decode_benchmark_resource(
-        _resource(url4=_three_member_benchmark_url4()),
-        requested_id="bench@1",
-        requested_limit=1,
-    )
-    fusion = sf.Fusion(
-        [sf.Model("provider/a"), sf.Model("provider/b"), sf.Model("provider/c")],
-        name="trio",
-    )
-
-    evaluation = compile_evaluation(
-        (fusion,),
-        benchmark,
-        1,
-    )
-    candidate = evaluation.candidates[0]
-
-    assert candidate.models == ("provider/a", "provider/b", "provider/c")
-    assert evaluation.required_models == (
-        "provider/a",
-        "provider/b",
-        "provider/c",
-    )
-    assert [operation.kind for operation in candidate.operations] == ["model", "model", "model"]
-    for index in range(1, 4):
-        assert candidate.url4.count(f"candidate_member_{index}") == 2
-    assert "openrouter/anthropic/claude-haiku-4.5" not in candidate.url4
-
-
-def test_dynamic_members_retain_the_candidate_synthesizer_in_preflight_and_operations() -> None:
-    benchmark = _decode_benchmark_resource(
-        _resource(
-            url4=("(members:0.0:/validate($candidate_members)!'$candidate_synthesizer')!'$members'")
-        ),
-        requested_id="bench@1",
-        requested_limit=1,
-    )
-    fusion = sf.Fusion(
-        [sf.Model("provider/a"), sf.Model("provider/b")],
-        name="pair",
-        synthesizer="provider/synth",
-    )
-
-    evaluation = compile_evaluation(
-        (fusion,),
-        benchmark,
-        1,
-    )
-    candidate = evaluation.candidates[0]
-
-    assert candidate.models == ("provider/a", "provider/b", "provider/synth")
-    assert evaluation.required_models == candidate.models
-    assert [operation.kind for operation in candidate.operations] == [
-        "model",
-        "model",
-        "synthesis",
-    ]
-
-
-def test_dynamic_judge_requires_an_explicit_fusion_synthesizer() -> None:
-    benchmark = _decode_benchmark_resource(
-        _resource(
-            url4=("(members:0.0:/validate($candidate_members)!'$candidate_synthesizer')!'$members'")
-        ),
-        requested_id="bench@1",
-        requested_limit=1,
-    )
-    fusion = sf.Fusion(
-        [sf.Model("provider/a"), sf.Model("provider/b")],
-        name="pair",
-    )
-
-    with pytest.raises(sf.PlanningError, match="synthesizer=") as error:
-        compile_evaluation(
-            (fusion,),
-            benchmark,
-            1,
-        )
-
-    assert error.value.code == "candidate_shape_mismatch"
-
-
-def test_local_candidate_linking_precedes_model_catalog_preflight() -> None:
+def test_structural_candidate_bindings_are_rejected_before_model_preflight() -> None:
     requests: list[str] = []
 
     def engine(request: httpx.Request) -> httpx.Response:
         requests.append(request.url.path)
         if request.url.path == "/v1/benchmarks/bench@1":
-            return httpx.Response(
-                200,
-                json=_resource(
-                    url4=(
-                        "(members:0.0:/validate($candidate_members)!"
-                        "'$candidate_synthesizer')!'$members'"
-                    )
-                ),
-            )
+            return httpx.Response(200, json=_structural_resource())
         if request.url.path == "/v1/models":
             return httpx.Response(503, json={"detail": "catalog unavailable"})
         raise AssertionError(f"unexpected Engine request: {request.method} {request.url}")
@@ -365,12 +259,13 @@ def test_local_candidate_linking_precedes_model_catalog_preflight() -> None:
     fusion = sf.Fusion(
         [sf.Model("provider/a"), sf.Model("provider/b")],
         name="pair",
+        synthesizer="provider/synth",
     )
     with sf.Client(
         engine_url="https://engine.example",
         http_transport=httpx.MockTransport(engine),
     ) as client:
-        with pytest.raises(sf.PlanningError, match="synthesizer=") as error:
+        with pytest.raises(sf.PlanningError, match="unsupported structural Candidate") as error:
             client.evaluate(fusion, benchmark="bench@1")
 
     assert error.value.code == "candidate_shape_mismatch"
@@ -378,21 +273,13 @@ def test_local_candidate_linking_precedes_model_catalog_preflight() -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_local_candidate_linking_precedes_model_catalog_preflight() -> None:
+async def test_async_structural_candidate_bindings_are_rejected_before_model_preflight() -> None:
     requests: list[str] = []
 
     def engine(request: httpx.Request) -> httpx.Response:
         requests.append(request.url.path)
         if request.url.path == "/v1/benchmarks/bench@1":
-            return httpx.Response(
-                200,
-                json=_resource(
-                    url4=(
-                        "(members:0.0:/validate($candidate_members)!"
-                        "'$candidate_synthesizer')!'$members'"
-                    )
-                ),
-            )
+            return httpx.Response(200, json=_structural_resource())
         if request.url.path == "/v1/models":
             return httpx.Response(503, json={"detail": "catalog unavailable"})
         raise AssertionError(f"unexpected Engine request: {request.method} {request.url}")
@@ -400,47 +287,17 @@ async def test_async_local_candidate_linking_precedes_model_catalog_preflight() 
     fusion = sf.Fusion(
         [sf.Model("provider/a"), sf.Model("provider/b")],
         name="pair",
+        synthesizer="provider/synth",
     )
     async with sf.AsyncClient(
         engine_url="https://engine.example",
         http_transport=httpx.MockTransport(engine),
     ) as client:
-        with pytest.raises(sf.PlanningError, match="synthesizer=") as error:
+        with pytest.raises(sf.PlanningError, match="unsupported structural Candidate") as error:
             await client.evaluate(fusion, benchmark="bench@1")
 
     assert error.value.code == "candidate_shape_mismatch"
     assert requests == ["/v1/benchmarks/bench@1"]
-
-
-@pytest.mark.parametrize(
-    "candidate",
-    [
-        sf.Model("provider/solo"),
-        sf.Fusion([sf.Model("provider/a"), sf.Model("provider/b")]),
-        sf.Fusion(
-            [
-                sf.Model("provider/a"),
-                sf.Fusion([sf.Model("provider/b"), sf.Model("provider/c")]),
-                sf.Model("provider/d"),
-            ]
-        ),
-    ],
-)
-def test_structural_model_member_requirements_fail_during_planning(candidate) -> None:
-    benchmark = _decode_benchmark_resource(
-        _resource(url4=_three_member_benchmark_url4()),
-        requested_id="bench@1",
-        requested_limit=1,
-    )
-
-    with pytest.raises(sf.PlanningError, match="member|members") as error:
-        compile_evaluation(
-            (candidate,),
-            benchmark,
-            1,
-        )
-
-    assert error.value.code == "candidate_shape_mismatch"
 
 
 class _Transport:

--- a/packages/screamingface/tests/test_client_run.py
+++ b/packages/screamingface/tests/test_client_run.py
@@ -47,16 +47,8 @@ BENCHMARK = {
     "url4": BENCHMARK_URL4,
 }
 
-CANDIDATE_URL4 = render(
-    expr(
-        src(
-            RelExpr(path="/provider/opus", context="$input", intent=text("Answer.")),
-            name="model_1",
-            weight=0.0,
-        ),
-        intent=text("$model_1"),
-    )
-)
+CANDIDATE_URL4 = compile_candidate(sf.Model("provider/opus", prompt="Answer.")).url4
+assert CANDIDATE_URL4 is not None
 REPLAY_URL4 = render(
     expr(
         src(text(CANDIDATE_URL4), name="candidate", weight=0.0),

--- a/packages/screamingface/tests/test_draco_vertical_slice.py
+++ b/packages/screamingface/tests/test_draco_vertical_slice.py
@@ -364,7 +364,7 @@ def test_client_evaluates_the_complete_draco_vertical_slice() -> None:
     assert f"{_ROUTE_PREFIX}/aggregate" in result.url4
     assert "temperature=0.2" in result.url4
     assert "reasoning=" not in result.url4
-    assert "max_tokens=4096" in result.url4
+    assert "max_tokens=" not in result.url4
     assert "\n" not in result.url4
     assert result.name == "haiku"
     assert result.score == 0.7
@@ -574,13 +574,14 @@ def test_fusion_member_names_do_not_leak_into_url4_struct_keys() -> None:
     )
     assert "gemini-pro:" not in candidate_url4
     assert "claude-opus-4.8:" not in candidate_url4
-    assert "=== Model 1 (gemini-pro)" in candidate_url4
-    assert "=== Model 2 (claude-opus-4.8)" in candidate_url4
-    assert "synthesis_1_member_1_name='" not in candidate_url4
-    assert "synthesis_1_member_2_name='" not in candidate_url4
+    executable = candidate_url4.split("_sf_recipe", 1)[0]
+    assert "gemini-pro" not in executable
+    assert "claude-opus-4.8" not in executable
+    assert "member_1: '$model_1'" in executable
+    assert "member_2: '$model_2'" in executable
 
 
-def test_compiler_deduplicates_equivalent_model_values_by_content() -> None:
+def test_compiler_preserves_equivalent_models_as_distinct_invocations() -> None:
     left = sf.Fusion(
         [sf.Model("provider/first"), sf.Model("provider/second")],
         name="left",
@@ -605,8 +606,8 @@ def test_compiler_deduplicates_equivalent_model_values_by_content() -> None:
         )
 
     result = report.candidates.only
-    assert tuple(operation.kind for operation in result.operations).count("model") == 3
-    assert result.url4.count("/provider/first") == 1
+    assert tuple(operation.kind for operation in result.operations).count("model") == 4
+    assert result.url4.count("/provider/first") == 2
 
 
 def test_explicit_sample_names_prevent_model_content_deduplication() -> None:

--- a/packages/screamingface/tests/test_evaluation_compilation.py
+++ b/packages/screamingface/tests/test_evaluation_compilation.py
@@ -309,14 +309,24 @@ def test_compiled_candidate_rejects_inconsistent_member_state() -> None:
             operations=(answer,),
             members=(member,),
         )
-    with pytest.raises(ValueError, match="at least two direct members"):
+    planned = _compiled_candidate(
+        name="pair",
+        kind="fusion",
+        models=("provider/member",),
+        url4="(@)!'pair'",
+        operations=(answer,),
+        members=(member,),
+    )
+    assert planned.members == (member,)
+
+    with pytest.raises(ValueError, match="at least one direct member"):
         _compiled_candidate(
             name="pair",
             kind="fusion",
             models=("provider/member",),
             url4="(@)!'pair'",
             operations=(answer,),
-            members=(member,),
+            members=(),
         )
 
 

--- a/packages/screamingface/tests/test_fusion_message.py
+++ b/packages/screamingface/tests/test_fusion_message.py
@@ -1,4 +1,4 @@
-"""The Fusion writer receives one readable question-and-panel message."""
+"""The Fusion synthesizer receives one stable structured context value."""
 
 from __future__ import annotations
 
@@ -6,24 +6,22 @@ import screamingface as sf
 from screamingface._evaluation.candidate import compile_candidate
 
 
-def test_fusion_compiles_the_question_and_ordered_member_answers_as_text() -> None:
+def test_fusion_compiles_input_and_ordered_outputs_as_structured_context() -> None:
     compiled = compile_candidate(
         sf.Fusion(
             [
                 sf.Model("provider/left", name="left) $literal"),
-                sf.Model("provider/right"),
+                sf.Model("provider/right", name="right label"),
             ],
             synthesizer="provider/writer",
         )
     )
 
     assert compiled.url4 is not None
-    assert "payload={" not in compiled.url4
-    assert "Question:\u2028$input\u2028\u2028Panel answers (one per model):" in compiled.url4
-    assert (
-        "=== Model 1 (left） $$literal) ===\u2028$model_1\u2028\u2028"
-        "=== Model 2 (right) ===\u2028$model_2"
-    ) in compiled.url4
+    assert "{input: '$input', outputs:" in compiled.url4
+    assert "member_1: '$model_1'" in compiled.url4
+    assert "member_2: '$model_2'" in compiled.url4
+    executable = compiled.url4.split("_sf_recipe", 1)[0]
+    assert "left) $literal" not in executable
+    assert "right label" not in executable
     assert "Produce the unified prose answer now." not in compiled.url4
-    assert "synthesis_1_member_1_name='" not in compiled.url4
-    assert "synthesis_1_member_2_name='" not in compiled.url4

--- a/packages/screamingface/tests/test_fusion_retrieval_scope.py
+++ b/packages/screamingface/tests/test_fusion_retrieval_scope.py
@@ -1,4 +1,4 @@
-"""Benchmarks own retrieval while Fusion synthesis is always retrieval-free."""
+"""Model parameters remain explicit and retrieval remains Engine-owned."""
 
 from __future__ import annotations
 
@@ -8,8 +8,7 @@ import screamingface as sf
 from screamingface._evaluation.candidate import compile_candidate
 
 
-def test_compiled_fusion_members_inherit_benchmark_retrieval_but_synthesis_disables_it() -> None:
-    """A Benchmark can enable retrieval without granting it to the Fusion writer."""
+def test_compiled_fusion_injects_no_model_parameters() -> None:
 
     compiled = compile_candidate(
         sf.Fusion(
@@ -19,12 +18,11 @@ def test_compiled_fusion_members_inherit_benchmark_retrieval_but_synthesis_disab
     )
 
     assert compiled.url4 is not None
-    assert "/provider/left?max_tokens=4096&q=" in compiled.url4
-    assert "/provider/right?max_tokens=4096&q=" in compiled.url4
-    assert "/provider/synthesizer?max_tokens=4096&web_search=false" in compiled.url4
-    assert compiled.url4.count("web_search=false") == 1
-    assert compiled.synthesizer is not None
-    assert "/provider/synthesizer?max_tokens=4096&web_search=false" in compiled.synthesizer.url4
+    assert "max_tokens=" not in compiled.url4
+    assert "web_search=" not in compiled.url4
+    assert "/provider/left($input)" in compiled.url4
+    assert "/provider/right($input)" in compiled.url4
+    assert "/provider/synthesizer(" in compiled.url4
 
 
 @pytest.mark.parametrize("reserved", ["web_search", "plugins", "tools", "provider", "q"])

--- a/packages/screamingface/tests/test_model_parameter_preflight.py
+++ b/packages/screamingface/tests/test_model_parameter_preflight.py
@@ -32,51 +32,6 @@ _BENCHMARK = {
     "url4": _BENCHMARK_URL4,
 }
 
-_MEMBER_BENCHMARK = {
-    **_BENCHMARK,
-    "url4": render(
-        expr(
-            src(
-                RelExpr(
-                    path="/candidate",
-                    context="question",
-                    intent=text("$candidate_member_1"),
-                ),
-                name="first",
-                weight=0.0,
-            ),
-            src(
-                RelExpr(
-                    path="/candidate",
-                    context="question",
-                    intent=text("$candidate_member_2"),
-                ),
-                name="second",
-                weight=0.0,
-            ),
-            intent=text("$first $second"),
-        )
-    ),
-}
-
-_SYNTHESIZER_BENCHMARK = {
-    **_BENCHMARK,
-    "url4": render(
-        expr(
-            src(
-                RelExpr(
-                    path="/candidate",
-                    context="question",
-                    intent=text("$candidate_synthesizer"),
-                ),
-                name="answer",
-                weight=0.0,
-            ),
-            intent=text("$answer"),
-        )
-    ),
-}
-
 
 def _summary(model: str) -> dict[str, object]:
     provider = model.split("/", 1)[0]
@@ -218,7 +173,7 @@ def test_valid_explicit_params_fetch_each_distinct_model_once() -> None:
     assert detail_models == ["provider/opus"]
 
 
-def test_deduplicated_operation_retains_an_explicit_default_override() -> None:
+def test_repeated_model_route_retains_an_explicit_parameter_assignment() -> None:
     detail_models: list[str] = []
     transport = _ReachedTransport()
     inner = sf.Fusion(
@@ -272,91 +227,6 @@ def test_synthesizer_params_are_preflighted_against_its_model() -> None:
         client.evaluate(candidate, benchmark="fixture")
 
     assert transport.called is True
-    assert detail_models == ["provider/synth"]
-
-
-def test_member_only_benchmark_does_not_fetch_unused_parameter_contracts() -> None:
-    detail_models: list[str] = []
-    transport = _ReachedTransport()
-    candidate = sf.Fusion(
-        [sf.Model("provider/opus"), sf.Model("provider/other")],
-        synthesizer=sf.Model("provider/synth", params={"top_k": 40}),
-    )
-    client = sf.Client(
-        engine_url="https://engine.example",
-        http_transport=_engine(
-            detail_models,
-            models=("provider/opus", "provider/other", "provider/synth"),
-            benchmark=_MEMBER_BENCHMARK,
-        ),
-        run_transport=transport,
-    )
-
-    with client, pytest.raises(RuntimeError, match="execution reached"):
-        client.evaluate(candidate, benchmark="fixture")
-
-    assert transport.called is True
-    assert detail_models == []
-
-
-@pytest.mark.asyncio
-async def test_async_member_only_benchmark_does_not_fetch_unused_parameter_contracts() -> None:
-    detail_models: list[str] = []
-    transport = _AsyncReachedTransport()
-    candidate = sf.Fusion(
-        [sf.Model("provider/opus"), sf.Model("provider/other")],
-        synthesizer=sf.Model("provider/synth", params={"top_k": 40}),
-    )
-    client = sf.AsyncClient(
-        engine_url="https://engine.example",
-        http_transport=_engine(
-            detail_models,
-            models=("provider/opus", "provider/other", "provider/synth"),
-            benchmark=_MEMBER_BENCHMARK,
-        ),
-        run_transport=transport,
-    )
-
-    with pytest.raises(RuntimeError, match="execution reached"):
-        await client.evaluate(candidate, benchmark="fixture")
-    await client.aclose()
-
-    assert transport.called is True
-    assert detail_models == []
-
-
-def test_structural_synthesizer_is_preflighted_when_whole_fusion_is_incomplete() -> None:
-    detail_models: list[str] = []
-    transport = _ForbiddenTransport()
-    incomplete = sf.Fusion(
-        [sf.Model("provider/opus"), sf.Model("provider/other")],
-        name="incomplete",
-    )
-    candidate = sf.Fusion(
-        [incomplete, sf.Model("provider/third")],
-        name="outer",
-        synthesizer=sf.Model("provider/synth", params={"top_k": 40}),
-    )
-    client = sf.Client(
-        engine_url="https://engine.example",
-        http_transport=_engine(
-            detail_models,
-            models=(
-                "provider/opus",
-                "provider/other",
-                "provider/third",
-                "provider/synth",
-            ),
-            benchmark=_SYNTHESIZER_BENCHMARK,
-        ),
-        run_transport=transport,
-    )
-
-    with client, pytest.raises(sf.PlanningError, match="top_k") as caught:
-        client.evaluate(candidate, benchmark="fixture")
-
-    assert caught.value.code == "unsupported_model_parameter"
-    assert transport.called is False
     assert detail_models == ["provider/synth"]
 
 
@@ -427,3 +297,26 @@ async def test_async_evaluation_uses_the_same_parameter_preflight() -> None:
     assert caught.value.code == "invalid_model_parameter"
     assert transport.called is False
     assert detail_models == ["provider/opus"]
+
+
+def test_later_pipeline_stage_parameters_fail_before_any_paid_execution() -> None:
+    detail_models: list[str] = []
+    transport = _ForbiddenTransport()
+    candidate = sf.Pipeline(
+        [
+            sf.Model("provider/opus", params={"temperature": 0.2}),
+            sf.Model("provider/synth", params={"top_k": 40}),
+        ]
+    )
+    client = sf.Client(
+        engine_url="https://engine.example",
+        http_transport=_engine(detail_models),
+        run_transport=transport,
+    )
+
+    with client, pytest.raises(sf.PlanningError, match="top_k") as caught:
+        client.evaluate(candidate, benchmark="fixture")
+
+    assert caught.value.code == "unsupported_model_parameter"
+    assert transport.called is False
+    assert detail_models == ["provider/opus", "provider/synth"]

--- a/packages/screamingface/tests/test_pipeline_compilation.py
+++ b/packages/screamingface/tests/test_pipeline_compilation.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import pytest
+from url4 import Expression, RelExpr, Source, build
+
+import screamingface as sf
+from screamingface._evaluation.benchmark import _decode_benchmark_resource
+from screamingface._evaluation.candidate import compile_candidate
+from screamingface._evaluation.compilation import compile_evaluation
+
+
+def _whole_candidate_benchmark():
+    return _decode_benchmark_resource(
+        {
+            "schema": "screamingface.benchmark.v1",
+            "id": "fixture@1",
+            "variant": "canonical",
+            "title": "Fixture",
+            "description": "One whole-Candidate fixture.",
+            "revision": "fixture-revision",
+            "case_count": 1,
+            "url4": "(answer:0.0:/candidate?q=(question)!'$candidate')!'$answer'",
+        },
+        requested_id="fixture@1",
+        requested_limit=1,
+    )
+
+
+def test_pipeline_compiles_each_stage_against_the_previous_answer() -> None:
+    pipeline = sf.Pipeline(
+        [
+            sf.Model("provider/draft", prompt="Draft an answer."),
+            sf.Model("provider/review", prompt="Review the draft."),
+            sf.Model("provider/final", prompt="Return the final answer."),
+        ],
+    )
+
+    compiled = compile_candidate(pipeline)
+
+    assert compiled.kind == "pipeline"
+    assert compiled.models == ("provider/draft", "provider/review", "provider/final")
+    assert compiled.url4 is not None
+    expression = build(compiled.url4)
+    assert isinstance(expression, Expression)
+    calls = [
+        source.value
+        for source in expression.sources
+        if isinstance(source, Source) and isinstance(source.value, RelExpr)
+    ]
+    assert [(call.path, call.context) for call in calls] == [
+        ("/provider/draft", "$input"),
+        ("/provider/review", "$model_1"),
+        ("/provider/final", "$model_2"),
+    ]
+    assert [operation.kind for operation in compiled.operations] == ["model", "model", "model"]
+    assert [operation.depends_on for operation in compiled.operations] == [
+        (),
+        ("op_model_1",),
+        ("op_model_2",),
+    ]
+
+
+def test_pipeline_compiles_a_parallel_fusion_as_one_serial_stage() -> None:
+    pipeline = sf.Pipeline(
+        [
+            sf.Model("provider/draft"),
+            sf.Fusion(
+                [sf.Model("provider/reviewer-a"), sf.Model("provider/reviewer-b")],
+                synthesizer="provider/reconciler",
+            ),
+            sf.Model("provider/final"),
+        ]
+    )
+
+    compiled = compile_candidate(pipeline)
+
+    assert compiled.kind == "pipeline"
+    assert compiled.models == (
+        "provider/draft",
+        "provider/reviewer-a",
+        "provider/reviewer-b",
+        "provider/reconciler",
+        "provider/final",
+    )
+    assert compiled.url4 is not None
+    expression = build(compiled.url4)
+    assert isinstance(expression, Expression)
+    calls = [
+        source.value
+        for source in expression.sources
+        if isinstance(source, Source) and isinstance(source.value, RelExpr)
+    ]
+    assert [(call.path, call.context) for call in calls[:3]] == [
+        ("/provider/draft", "$input"),
+        ("/provider/reviewer-a", "$model_1"),
+        ("/provider/reviewer-b", "$model_1"),
+    ]
+    assert calls[3].path == "/provider/reconciler"
+    assert "input: '$model_1'" in (calls[3].context or "")
+    assert "outputs:" in (calls[3].context or "")
+    assert "$model_2" in (calls[3].context or "")
+    assert "$model_3" in (calls[3].context or "")
+    assert (calls[4].path, calls[4].context) == ("/provider/final", "$synthesis_1")
+    assert [operation.depends_on for operation in compiled.operations] == [
+        (),
+        ("op_model_1",),
+        ("op_model_1",),
+        ("op_model_2", "op_model_3"),
+        ("op_synthesis_1",),
+    ]
+
+
+def test_fusion_compiles_pipeline_members_and_a_pipeline_synthesizer() -> None:
+    member = sf.Pipeline(
+        [sf.Model("provider/draft"), sf.Model("provider/review")],
+        name="review-chain",
+    )
+    synthesizer = sf.Pipeline(
+        [
+            sf.Model("provider/judge", prompt="Select the strongest answer."),
+            sf.Model("provider/writer", prompt="Polish the selected answer."),
+        ],
+        name="judge-and-write",
+    )
+    fusion = sf.Fusion(
+        [member, sf.Model("provider/alternative")],
+        synthesizer=synthesizer,
+    )
+
+    compiled = compile_candidate(fusion)
+
+    assert compiled.kind == "fusion"
+    assert compiled.models == (
+        "provider/draft",
+        "provider/review",
+        "provider/alternative",
+        "provider/judge",
+        "provider/writer",
+    )
+    assert tuple(member.kind for member in compiled.members) == ("pipeline", "model")
+    assert compiled.url4 is not None
+    expression = build(compiled.url4)
+    assert isinstance(expression, Expression)
+    calls = [
+        source.value
+        for source in expression.sources
+        if isinstance(source, Source) and isinstance(source.value, RelExpr)
+    ]
+    assert [(call.path, call.context) for call in calls[:3]] == [
+        ("/provider/draft", "$input"),
+        ("/provider/review", "$model_1"),
+        ("/provider/alternative", "$input"),
+    ]
+    assert calls[3].path == "/provider/judge"
+    assert "$model_2" in (calls[3].context or "")
+    assert "$model_3" in (calls[3].context or "")
+    assert (calls[4].path, calls[4].context) == ("/provider/writer", "$model_4")
+    assert [operation.kind for operation in compiled.operations] == [
+        "model",
+        "model",
+        "model",
+        "synthesis",
+        "model",
+    ]
+    assert [operation.depends_on for operation in compiled.operations] == [
+        (),
+        ("op_model_1",),
+        (),
+        ("op_model_2", "op_model_3"),
+        ("op_model_4",),
+    ]
+
+
+def test_fusion_compiles_a_complete_fusion_as_its_synthesizer() -> None:
+    synthesizer = sf.Fusion(
+        [sf.Model("provider/editor-a"), sf.Model("provider/editor-b")],
+        synthesizer="provider/final-editor",
+    )
+
+    compiled = compile_candidate(
+        sf.Fusion(
+            [sf.Model("provider/proposer-a"), sf.Model("provider/proposer-b")],
+            synthesizer=synthesizer,
+        )
+    )
+
+    assert compiled.kind == "fusion"
+    assert compiled.models == (
+        "provider/proposer-a",
+        "provider/proposer-b",
+        "provider/editor-a",
+        "provider/editor-b",
+        "provider/final-editor",
+    )
+    assert [operation.depends_on for operation in compiled.operations] == [
+        (),
+        (),
+        ("op_model_1", "op_model_2"),
+        ("op_model_1", "op_model_2"),
+        ("op_model_3", "op_model_4"),
+    ]
+
+
+def test_reusing_one_recipe_at_a_later_stage_creates_a_distinct_invocation() -> None:
+    shared = sf.Model("provider/shared")
+
+    compiled = compile_candidate(sf.Pipeline([shared, shared]))
+
+    assert compiled.url4 is not None
+    expression = build(compiled.url4)
+    assert isinstance(expression, Expression)
+    calls = [
+        source.value
+        for source in expression.sources
+        if isinstance(source, Source) and isinstance(source.value, RelExpr)
+    ]
+    assert [(call.path, call.context) for call in calls] == [
+        ("/provider/shared", "$input"),
+        ("/provider/shared", "$model_1"),
+    ]
+
+
+def test_candidate_compilation_rejects_a_cycle_even_when_it_rebinds_input() -> None:
+    pipeline = sf.Pipeline([sf.Model("provider/a"), sf.Model("provider/b")])
+    object.__setattr__(pipeline, "stages", (sf.Model("provider/a"), pipeline))
+
+    with pytest.raises(ValueError, match="cycle"):
+        compile_candidate(pipeline)
+
+
+def test_canonical_benchmark_plans_a_pipeline_as_one_complete_candidate() -> None:
+    pipeline = sf.Pipeline(
+        [
+            sf.Model("provider/draft", params={"temperature": 0.4}),
+            sf.Model("provider/review", params={"seed": 7}),
+        ],
+        name="review-chain",
+    )
+
+    evaluation = compile_evaluation((pipeline,), _whole_candidate_benchmark(), 1)
+    candidate = evaluation.candidates.only
+
+    assert candidate.name == "review-chain"
+    assert candidate.kind == "pipeline"
+    assert candidate.models == ("provider/draft", "provider/review")
+    assert candidate.members == ()
+    assert [operation.depends_on for operation in candidate.operations] == [
+        (),
+        ("op_model_1",),
+    ]
+    assert evaluation.required_models == candidate.models
+    assert [(value.model, dict(value.params)) for value in candidate.parameter_assignments] == [
+        ("provider/draft", {"temperature": 0.4}),
+        ("provider/review", {"seed": 7}),
+    ]
+
+
+def test_structural_member_benchmark_rejects_a_pipeline_before_execution() -> None:
+    structural = _decode_benchmark_resource(
+        {
+            "schema": "screamingface.benchmark.v1",
+            "id": "fixture@1",
+            "variant": "structural",
+            "title": "Structural fixture",
+            "description": "Requires direct Fusion members.",
+            "revision": "fixture-revision",
+            "case_count": 1,
+            "url4": "(answer:0.0:/candidate?q=(question)!'$candidate_member_1')!'$answer'",
+        },
+        requested_id="fixture@1",
+        requested_limit=1,
+    )
+    pipeline = sf.Pipeline([sf.Model("provider/a"), sf.Model("provider/b")])
+
+    with pytest.raises(
+        sf.PlanningError, match="unsupported structural Candidate bindings"
+    ) as caught:
+        compile_evaluation((pipeline,), structural, 1)
+
+    assert caught.value.code == "candidate_shape_mismatch"

--- a/packages/screamingface/tests/test_pipeline_recipes.py
+++ b/packages/screamingface/tests/test_pipeline_recipes.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+import screamingface as sf
+
+
+def test_pipeline_is_an_immutable_ordered_recipe() -> None:
+    draft = sf.Model("provider/draft")
+    review = sf.Model("provider/review")
+
+    pipeline = sf.Pipeline([draft, review], name=" Review chain ")
+
+    assert isinstance(pipeline, sf.Recipe)
+    assert pipeline.name == "Review chain"
+    assert pipeline.stages == (draft, review)
+    assert pipeline.stages[0] is draft
+    assert pipeline.stages[1] is review
+
+    with pytest.raises(AttributeError):
+        cast(Any, pipeline).stages = ()
+
+
+def test_pipeline_accepts_one_stage_and_route_shorthand() -> None:
+    one = sf.Pipeline(["provider/only"])
+    mixed = sf.Pipeline([sf.Model("provider/a"), "provider/b"])
+
+    assert one.stages == (sf.Model("provider/only"),)
+    assert mixed.stages == (sf.Model("provider/a"), sf.Model("provider/b"))
+
+
+def test_pipeline_rejects_empty_or_ambiguous_stage_collections() -> None:
+    with pytest.raises(ValueError, match="at least one stage"):
+        sf.Pipeline([])
+
+    with pytest.raises(TypeError, match="ordered sequence"):
+        sf.Pipeline(cast(Any, "provider/a"))
+
+
+def test_then_builds_the_same_canonical_ordered_pipeline() -> None:
+    draft = sf.Model("provider/draft")
+    review = sf.Model("provider/review")
+    final = sf.Model("provider/final")
+
+    pair = draft.then(review)
+    trio = pair.then(final)
+
+    assert isinstance(pair, sf.Pipeline)
+    assert pair.stages == (draft, review)
+    assert trio.stages == (draft, review, final)
+    assert pair.stages == (draft, review)
+    assert trio.name == "draft->review->final"
+
+
+def test_pipeline_infers_a_compact_serial_name_and_representation() -> None:
+    pipeline = sf.Pipeline(
+        [sf.Model("provider/draft"), sf.Model("provider/review")],
+    )
+
+    assert pipeline.name == "draft->review"
+    assert repr(pipeline) == "Pipeline(['draft', 'review'])"
+    assert repr(sf.Pipeline(pipeline.stages, name="review chain")) == (
+        "Pipeline(['draft', 'review'], name='review chain')"
+    )
+
+
+def test_then_preserves_an_explicitly_named_pipeline_as_one_stage() -> None:
+    named = sf.Pipeline(
+        [sf.Model("provider/draft"), sf.Model("provider/review")],
+        name="review-chain",
+    )
+    final = sf.Model("provider/final")
+
+    pipeline = named.then(final)
+
+    assert pipeline.stages == (named, final)
+    assert pipeline.name == "review-chain->final"
+
+
+def test_unnamed_nested_pipelines_flatten_to_one_canonical_stage_sequence() -> None:
+    draft = sf.Model("provider/draft")
+    review = sf.Model("provider/review")
+    final = sf.Model("provider/final")
+
+    constructed = sf.Pipeline([draft, sf.Pipeline([review, final])])
+    chained = draft.then(sf.Pipeline([review, final]))
+
+    assert constructed.stages == (draft, review, final)
+    assert chained.stages == (draft, review, final)
+
+
+def test_fusion_accepts_pipelines_as_members_and_complete_recipe_synthesizers() -> None:
+    pipeline_member = sf.Pipeline(
+        [sf.Model("provider/draft"), sf.Model("provider/review")],
+        name="review-chain",
+    )
+    pipeline_synthesizer = sf.Pipeline(
+        [sf.Model("provider/judge"), sf.Model("provider/writer")],
+        name="judge-and-write",
+    )
+    nested_fusion_synthesizer = sf.Fusion(
+        [sf.Model("provider/editor-a"), sf.Model("provider/editor-b")],
+        synthesizer="provider/final-editor",
+    )
+
+    with_pipeline = sf.Fusion(
+        [pipeline_member, sf.Model("provider/alternative")],
+        synthesizer=pipeline_synthesizer,
+    )
+    with_nested_fusion = sf.Fusion(
+        [sf.Model("provider/a"), sf.Model("provider/b")],
+        synthesizer=nested_fusion_synthesizer,
+    )
+
+    assert with_pipeline.members[0] is pipeline_member
+    assert with_pipeline.synthesizer is pipeline_synthesizer
+    assert with_nested_fusion.synthesizer is nested_fusion_synthesizer
+
+
+def test_then_accepts_any_complete_recipe_or_route_and_rejects_a_list() -> None:
+    fusion = sf.Fusion(
+        [sf.Model("provider/a"), sf.Model("provider/b")],
+        synthesizer="provider/synth",
+    )
+    pipeline = sf.Model("provider/draft").then(fusion)
+
+    assert pipeline.stages[1] is fusion
+    assert sf.Model("provider/draft").then("provider/final").stages == (
+        sf.Model("provider/draft"),
+        sf.Model("provider/final"),
+    )
+
+    with pytest.raises(TypeError, match="Pipeline stage must be"):
+        sf.Model("provider/draft").then(cast(Any, [sf.Model("provider/final")]))
+
+
+def test_recipe_values_have_structural_equality_and_are_unhashable() -> None:
+    left = sf.Pipeline(
+        [
+            "provider/draft",
+            sf.Fusion(["provider/a"], synthesizer="provider/synth"),
+        ],
+        name="candidate",
+    )
+    right = sf.Pipeline(
+        [
+            sf.Model("provider/draft"),
+            sf.Fusion([sf.Model("provider/a")], synthesizer=sf.Model("provider/synth")),
+        ],
+        name="candidate",
+    )
+
+    assert left == right
+    with pytest.raises(TypeError, match="unhashable"):
+        hash(left)

--- a/packages/screamingface/tests/test_pipeline_results.py
+++ b/packages/screamingface/tests/test_pipeline_results.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+import screamingface as sf
+from screamingface._evaluation.candidate import compile_candidate
+from screamingface._evaluation.model import _compiled_operation
+
+
+def _cases() -> tuple[sf.CaseResult, ...]:
+    return (
+        sf.CaseResult(
+            case_id=1,
+            input="Question",
+            output="Answer",
+            finish_reason="stop",
+            grade=sf.CaseGrade(method="fixture", score=1.0, metrics={}, checks=()),
+            failures=(),
+            metadata={},
+        ),
+    )
+
+
+def test_pipeline_result_preserves_its_kind_and_serial_operation_dependencies() -> None:
+    benchmark = sf.BenchmarkInfo(
+        id="ifeval@1",
+        revision="fixture-revision",
+        case_count=1,
+    )
+    compiled = compile_candidate(
+        sf.Pipeline([sf.Model("provider/draft"), sf.Model("provider/review")])
+    )
+    assert compiled.url4 is not None
+    result = sf.CandidateResult(
+        benchmark=benchmark,
+        run_id="run_pipeline",
+        started_at=datetime(2026, 8, 12, tzinfo=UTC),
+        completed_at=datetime(2026, 8, 12, 0, 0, 1, tzinfo=UTC),
+        name="draft->review",
+        kind="pipeline",
+        url4=compiled.url4,
+        models=("provider/draft", "provider/review"),
+        operations=(
+            _compiled_operation(
+                id="op_model_1",
+                kind="model",
+                label="draft answer",
+                depends_on=(),
+            ),
+            _compiled_operation(
+                id="op_model_2",
+                kind="model",
+                label="review answer",
+                depends_on=("op_model_1",),
+            ),
+        ),
+        score=1.0,
+        metrics={"coverage": 1.0},
+        cases=_cases(),
+        members=(),
+        failures=(),
+        usage=sf.Usage(),
+    )
+
+    assert result.kind == "pipeline"
+    assert result.members == ()
+    assert result.to_dict()["kind"] == "pipeline"
+
+
+def test_pipeline_result_cannot_claim_direct_fusion_members() -> None:
+    benchmark = sf.BenchmarkInfo(
+        id="ifeval@1",
+        revision="fixture-revision",
+        case_count=1,
+    )
+    member = sf.MemberResult(
+        operation_id="op_model_1",
+        name="draft",
+        kind="model",
+        models=("provider/draft",),
+        failures=None,
+        duration_ms=None,
+        usage=None,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Pipeline Candidate cannot contain direct Fusion members",
+    ):
+        sf.CandidateResult(
+            benchmark=benchmark,
+            run_id="run_pipeline",
+            started_at=datetime(2026, 8, 12, tzinfo=UTC),
+            completed_at=datetime(2026, 8, 12, 0, 0, 1, tzinfo=UTC),
+            name="draft->review",
+            kind="pipeline",
+            url4="(model_1:0.0:/provider/draft!'draft')!'$model_1'",
+            models=("provider/draft", "provider/review"),
+            operations=(
+                _compiled_operation(
+                    id="op_model_1",
+                    kind="model",
+                    label="draft answer",
+                    depends_on=(),
+                ),
+            ),
+            score=1.0,
+            metrics={"coverage": 1.0},
+            cases=_cases(),
+            members=(member,),
+            failures=(),
+            usage=sf.Usage(),
+        )

--- a/packages/screamingface/tests/test_public_interface.py
+++ b/packages/screamingface/tests/test_public_interface.py
@@ -51,6 +51,7 @@ def test_public_v1_surface_has_no_legacy_aliases() -> None:
         "MemberResult",
         "Model",
         "OperationInfo",
+        "Pipeline",
         "PlanningError",
         "ProviderConnectionError",
         "Recipe",

--- a/packages/screamingface/tests/test_recipes.py
+++ b/packages/screamingface/tests/test_recipes.py
@@ -71,13 +71,15 @@ def test_fusion_keeps_members_in_order_and_infers_a_name() -> None:
     opus = sf.Model("openrouter/anthropic/claude-opus-4.8")
     gpt = sf.Model("openrouter/openai/gpt-5.5")
 
-    fusion = sf.Fusion([opus, gpt])
+    synthesizer = sf.Model("openrouter/openai/gpt-5.5")
+    fusion = sf.Fusion([opus, gpt], synthesizer=synthesizer)
 
     assert isinstance(fusion, sf.Recipe)
     assert fusion.name == "claude-opus-4.8+gpt-5.5"
     assert fusion.members == (opus, gpt)
     assert fusion.members[0] is opus
     assert fusion.members[1] is gpt
+    assert fusion.synthesizer is synthesizer
     assert not hasattr(fusion, "reducer")
     assert not hasattr(fusion, "url4")
 
@@ -86,6 +88,7 @@ def test_fusion_accepts_an_optional_display_name() -> None:
     fusion = sf.Fusion(
         [sf.Model("provider/opus"), sf.Model("provider/gpt")],
         name=" Frontier ",
+        synthesizer="provider/synth",
     )
 
     assert fusion.name == "Frontier"
@@ -118,10 +121,13 @@ def test_fusion_normalizes_synthesizer_route_shorthand_to_a_model() -> None:
     assert fusion.synthesizer.model == "provider/synth"
 
 
-def test_fusion_needs_no_explicit_synthesizer_policy() -> None:
-    fusion = sf.Fusion([sf.Model("provider/a"), sf.Model("provider/b")])
+def test_fusion_requires_an_explicit_synthesizer() -> None:
+    with pytest.raises(TypeError, match="required keyword-only argument: 'synthesizer'"):
+        cast(Any, sf.Fusion)([sf.Model("provider/a"), sf.Model("provider/b")])
 
-    assert fusion.synthesizer is None
+    fusion = sf.Fusion(["provider/a"], synthesizer="provider/synth")
+    assert fusion.members == (sf.Model("provider/a"),)
+    assert fusion.synthesizer == sf.Model("provider/synth")
     assert not hasattr(fusion, "prompt")
     assert not hasattr(fusion, "params")
 
@@ -130,8 +136,8 @@ def test_nested_fusions_are_regular_members() -> None:
     opus = sf.Model("provider/opus")
     gpt = sf.Model("provider/gpt")
     gemini = sf.Model("provider/gemini")
-    pair = sf.Fusion([opus, gpt], name="pair")
-    trio = sf.Fusion([pair, gemini], name="trio")
+    pair = sf.Fusion([opus, gpt], name="pair", synthesizer="provider/pair-synth")
+    trio = sf.Fusion([pair, gemini], name="trio", synthesizer="provider/trio-synth")
 
     assert trio.members == (pair, gemini)
     nested = cast(sf.Fusion, trio.members[0])
@@ -145,28 +151,29 @@ def test_explicit_names_distinguish_independent_samples() -> None:
     assert first is not second
     assert first != second
 
-    fusion = sf.Fusion([first, second], name="self-fusion")
+    fusion = sf.Fusion([first, second], name="self-fusion", synthesizer="provider/synth")
     assert fusion.members == (first, second)
 
 
-@pytest.mark.parametrize(
-    ("members", "message"),
-    [
-        ([], "at least two members"),
-        ([sf.Model("provider/one")], "at least two members"),
-        (
-            [sf.Model("provider-a/same"), sf.Model("provider-b/same")],
-            "duplicate Fusion member name 'same'",
-        ),
-        ([sf.Model("provider/one"), "provider/two"], "members must be sf.Model or sf.Fusion"),
-    ],
-)
-def test_fusion_rejects_ambiguous_or_non_composite_members(
-    members: list[object],
-    message: str,
-) -> None:
-    with pytest.raises((TypeError, ValueError), match=message):
-        sf.Fusion(cast(Any, members))
+def test_fusion_accepts_one_member_routes_and_duplicate_display_names() -> None:
+    fusion = sf.Fusion(
+        ["provider/one", sf.Model("provider-a/same"), sf.Model("provider-b/same")],
+        synthesizer="provider/synth",
+    )
+
+    assert fusion.members == (
+        sf.Model("provider/one"),
+        sf.Model("provider-a/same"),
+        sf.Model("provider-b/same"),
+    )
+
+
+def test_fusion_rejects_empty_or_ambiguous_member_collections() -> None:
+    with pytest.raises(ValueError, match="at least one member"):
+        sf.Fusion([], synthesizer="provider/synth")
+
+    with pytest.raises(TypeError, match="ordered sequence"):
+        sf.Fusion(cast(Any, "provider/one"), synthesizer="provider/synth")
 
 
 def test_fusion_rejects_unpublished_recipe_extensions() -> None:
@@ -177,15 +184,15 @@ def test_fusion_rejects_unpublished_recipe_extensions() -> None:
         def _recipe_marker(self) -> None:
             return None
 
-    with pytest.raises(TypeError, match="sf.Model or sf.Fusion"):
-        sf.Fusion([CustomRecipe(), sf.Model("provider/model")])
+    with pytest.raises(TypeError, match="sf.Model, sf.Fusion, or sf.Pipeline"):
+        sf.Fusion([CustomRecipe(), sf.Model("provider/model")], synthesizer="provider/synth")
 
 
-def test_fusion_rejects_non_model_synthesizers() -> None:
-    with pytest.raises(TypeError, match="synthesizer must be an sf.Model"):
+def test_fusion_rejects_unsupported_recipe_synthesizers() -> None:
+    with pytest.raises(TypeError, match="Fusion synthesizer must be a model route"):
         sf.Fusion(
             [sf.Model("provider/a"), sf.Model("provider/b")],
-            synthesizer=cast(Any, sf.Fusion([sf.Model("provider/c"), sf.Model("provider/d")])),
+            synthesizer=cast(Any, object()),
         )
 
 
@@ -197,6 +204,7 @@ def test_fusion_rejects_non_model_synthesizers() -> None:
             lambda: sf.Fusion(
                 [sf.Model("provider/a"), sf.Model("provider/b")],
                 name=" ",
+                synthesizer="provider/synth",
             ),
             "fusion name",
         ),
@@ -230,9 +238,11 @@ def test_candidate_representations_are_compact() -> None:
 
     assert repr(opus) == "Model('openrouter/anthropic/claude-opus-4.8')"
     assert repr(sample) == ("Model('openrouter/anthropic/claude-opus-4.8', name='sample-1')")
-    assert repr(sf.Fusion([opus, gpt])) == ("Fusion(['claude-opus-4.8', 'gpt-5.5'])")
-    assert repr(sf.Fusion([opus, gpt], name="pair")) == (
-        "Fusion(['claude-opus-4.8', 'gpt-5.5'], name='pair')"
+    assert repr(sf.Fusion([opus, gpt], synthesizer="provider/synth")) == (
+        "Fusion(['claude-opus-4.8', 'gpt-5.5'], synthesizer=Model('provider/synth'))"
+    )
+    assert repr(sf.Fusion([opus, gpt], name="pair", synthesizer="provider/synth")) == (
+        "Fusion(['claude-opus-4.8', 'gpt-5.5'], name='pair', synthesizer=Model('provider/synth'))"
     )
 
 

--- a/packages/screamingface/tests/test_rich_display.py
+++ b/packages/screamingface/tests/test_rich_display.py
@@ -207,6 +207,54 @@ def test_fusion_card_keeps_only_benchmark_independent_topology_visible() -> None
     assert "sf-gain-grad" in html
 
 
+def test_pipeline_card_shows_ordered_topology_in_light_and_dark_themes() -> None:
+    pipeline = sf.Pipeline(
+        [
+            sf.Model("provider/draft", name="draft <one>"),
+            sf.Fusion(
+                [sf.Model("provider/reviewer-a"), sf.Model("provider/reviewer-b")],
+                name="review panel",
+                synthesizer="provider/reconciler",
+            ),
+            sf.Model("provider/final"),
+        ],
+        name="draft → review → final",
+    )
+
+    html = cast(Any, pipeline)._repr_html_()
+
+    assert "ScreamingFace pipeline" in html
+    assert "draft → review → final" in html
+    assert ">stages<" in html
+    assert "stage 1" in html
+    assert "stage 2" in html
+    assert "stage 3" in html
+    assert "draft &lt;one&gt;" in html
+    assert "review panel" in html
+    assert "nested fusion" in html
+    assert "provider/final" in html
+    assert "sf-card__accent--pipeline" in html
+    assert "@media (prefers-color-scheme:dark)" in html
+    assert ".vscode-dark .sf-ui" in html
+
+
+def test_fusion_card_renders_a_complete_recipe_synthesizer_without_model_assumptions() -> None:
+    synthesizer = sf.Pipeline(
+        [sf.Model("provider/judge"), sf.Model("provider/writer")],
+        name="judge → writer",
+    )
+    fusion = sf.Fusion(
+        [sf.Model("provider/a"), sf.Model("provider/b")],
+        synthesizer=synthesizer,
+    )
+
+    html = cast(Any, fusion)._repr_html_()
+
+    assert ">synthesis<" in html
+    assert "judge → writer" in html
+    assert "nested pipeline" in html
+
+
 def test_catalogue_surface_has_no_duplicate_view_operation() -> None:
     assert not hasattr(sf.models, "view")
     assert not hasattr(sf.benchmarks, "view")
@@ -256,10 +304,12 @@ def test_cards_cover_provider_fallback_and_nested_fusions() -> None:
     inner = sf.Fusion(
         [sf.Model("provider/a"), sf.Model("provider/b")],
         name="inner",
+        synthesizer="provider/inner-synth",
     )
     outer = sf.Fusion(
         [inner, sf.Model("provider/c")],
         name="outer",
+        synthesizer="provider/outer-synth",
     )
     fusion_html = cast(Any, outer)._repr_html_()
     assert "nested fusion" in fusion_html

--- a/packages/screamingface/tests/test_shape_adaptive_linking.py
+++ b/packages/screamingface/tests/test_shape_adaptive_linking.py
@@ -1,392 +1,88 @@
-"""Universal synthesizer and dynamic direct-member bindings.
-
-FEATURE: Benchmark Variants whose URL4 binds a Fusion's direct members and synthesizer.
-STORY: as a researcher, I hand any exam my Fusion and the SDK satisfies whatever the
-exam's URL4 names — members, synthesizer, or the whole Candidate — without ever
-interpreting the protocol.
-"""
+"""The public Benchmark seam binds exactly one complete Candidate Recipe."""
 
 from __future__ import annotations
 
 import pytest
-from url4 import Expression, Source, StructObject, Text, build, render
+from url4 import build, render
 
 import screamingface as sf
 from screamingface._evaluation.candidate import compile_candidate
 from screamingface._evaluation.linking import link_candidate
-from screamingface.errors import PlanningError
-
-_JUDGE_SHAPED_BENCHMARK = (
-    "(answer_1:0.0:/candidate?q=($item.input)!'$candidate_member_1', "
-    "answer_2:0.0:/candidate?q=($item.input)!'$candidate_member_2', "
-    "pick:0.0:/candidate?q=(verdicts)!'$candidate_synthesizer')!'$pick'"
-)
-_WHOLE_CANDIDATE_BENCHMARK = "(answer:0.0:/candidate?q=($item.input)!'$candidate')!'$answer'"
-_NO_CANDIDATE_BENCHMARK = "(answer:0.0:/bench/noop($input)!'system')!'$answer'"
-_MEMBERS_ONLY_BENCHMARK = "(answer:0.0:/bench/validate($candidate_members)!'system')!'$answer'"
-_MEMBER_COLLECTION_BENCHMARK = (
-    "(members:0.0:/bench/validate($candidate_members)!'$candidate_synthesizer', "
-    "answers:0.0:$members*(answer:0.0:/candidate?q=(question)!'$item.expression')!"
-    "'$answer', pick:0.0:/candidate?q=($answers)!'$candidate_synthesizer')!'$pick'"
-)
 
 
-def _compiled(recipe):
-    return compile_candidate(recipe)
-
-
-def test_a_fusion_links_its_synthesizer_into_a_judge_shaped_benchmark() -> None:
-    fusion = sf.Fusion(
-        [sf.Model("provider/a"), sf.Model("provider/b")],
-        name="pair",
-        synthesizer="provider/judge",
-    )
-    value = _compiled(fusion)
-    assert value.synthesizer is not None
-    assert "provider/judge" in value.synthesizer.url4
-
-    linked = link_candidate(
-        value.url4,
-        _JUDGE_SHAPED_BENCHMARK,
-        value.member_expressions,
-        value.synthesizer.url4,
-    )
-    assert "candidate_synthesizer" in linked.url4
-    assert linked.uses_synthesizer
-    assert linked.member_indices == (1, 2)
-
-
-def test_structural_synthesizer_keeps_generation_params_but_not_the_blending_prompt() -> None:
-    fusion = sf.Fusion(
-        [sf.Model("provider/a"), sf.Model("provider/b")],
-        synthesizer=sf.Model(
-            "provider/judge",
-            prompt="Blend the member answers into one final answer.",
-            params={"max_tokens": 16384, "temperature": 0.2},
-        ),
-    )
-
-    value = _compiled(fusion)
-
-    assert value.url4 is not None
-    assert "Blend the member answers" in value.url4
-    assert value.synthesizer is not None
-    assert "max_tokens=16384" in value.synthesizer.url4
-    assert "temperature=0.2" in value.synthesizer.url4
-    # INVARIANT: this binding contributes model policy; the Benchmark owns its Judge
-    # instructions, so ordinary whole-Fusion blending prose cannot leak into that protocol.
-    assert "Blend the member answers" not in value.synthesizer.url4
-
-
-def test_a_fusion_without_a_synthesizer_remains_structurally_available() -> None:
-    fusion = sf.Fusion([sf.Model("provider/a"), sf.Model("provider/b")], name="pair")
-    value = _compiled(fusion)
-    assert value.url4 is None
-    assert value.synthesizer is None
-    assert [member.name for member in value.member_expressions] == ["a", "b"]
-
-
-def test_a_benchmark_that_never_invokes_the_candidate_is_rejected() -> None:
-    value = _compiled(sf.Model("provider/solo"))
-
-    with pytest.raises(PlanningError) as caught:
-        link_candidate(value.url4, _NO_CANDIDATE_BENCHMARK)
-
-    assert caught.value.code == "invalid_benchmark_resource"
-    assert "does not invoke the Candidate" in str(caught.value)
-
-
-def test_a_whole_fusion_benchmark_requires_a_complete_fusion() -> None:
-    value = _compiled(sf.Fusion([sf.Model("provider/a"), sf.Model("provider/b")]))
-    assert value.url4 is None
-
-    with pytest.raises(PlanningError) as caught:
-        link_candidate(value.url4, _WHOLE_CANDIDATE_BENCHMARK, value.member_expressions)
-
-    assert caught.value.code == "candidate_shape_mismatch"
-    assert "whole Fusion" in str(caught.value)
-    assert "synthesizer=" in str(caught.value)
-
-
-def test_a_member_collection_benchmark_requires_a_fusion() -> None:
-    value = _compiled(sf.Model("provider/solo"))
-
-    with pytest.raises(PlanningError) as caught:
-        link_candidate(value.url4, _MEMBERS_ONLY_BENCHMARK)
-
-    assert caught.value.code == "candidate_shape_mismatch"
-    assert "use an sf.Fusion" in str(caught.value)
-
-
-def test_a_judge_shaped_benchmark_requires_a_synthesizer() -> None:
-    fusion = sf.Fusion([sf.Model("provider/a"), sf.Model("provider/b")], name="pair")
-    value = _compiled(fusion)
-    assert value.synthesizer is None
-
-    with pytest.raises(PlanningError) as caught:
-        link_candidate(
-            value.url4,
-            _JUDGE_SHAPED_BENCHMARK,
-            value.member_expressions,
-            None,
+def _candidate_url4() -> str:
+    return compile_candidate(
+        sf.Fusion(
+            ["provider/a", "provider/b"],
+            synthesizer="provider/synth",
         )
-
-    assert caught.value.code == "candidate_shape_mismatch"
-    assert "synthesizer=" in str(caught.value)
+    ).url4
 
 
-def test_a_solo_model_against_a_judge_shaped_benchmark_fails_loudly() -> None:
-    # INVARIANT: shape mismatches are planning-time errors that name the fix — the
-    # protocol needs a judge, so the Candidate must be a Fusion.
-    value = _compiled(sf.Model("provider/solo"))
-    assert value.synthesizer is None
-    with pytest.raises(PlanningError) as caught:
-        link_candidate(
-            value.url4,
-            _JUDGE_SHAPED_BENCHMARK,
-            value.member_expressions,
-            None,
-        )
-    assert caught.value.code == "candidate_shape_mismatch"
-    assert "synthesizer" in str(caught.value)
-    assert "sf.Fusion" in str(caught.value)
+def test_whole_candidate_text_binding_links_one_complete_recipe() -> None:
+    benchmark = "(answer:0.0:/candidate(question)!'$candidate')!'$answer'"
 
+    linked = link_candidate(_candidate_url4(), benchmark)
 
-def test_plumbing_names_starting_with_candidate_are_not_a_whole_candidate_reference() -> None:
-    # INVARIANT: "$candidate_result" (the engine's parameterized-call plumbing binding)
-    # must not read as a bare "$candidate" — that false positive bound the full Candidate
-    # expression as dead text into every member-shaped run.
-    fusion = sf.Fusion(
-        [sf.Model("provider/a"), sf.Model("provider/b")],
-        name="pair",
-        synthesizer="provider/judge",
-    )
-    value = _compiled(fusion)
-    benchmark = (
-        "(answer_1:0.0:(candidate_result:0.0:/candidate?web_search=false"
-        "&q=($item.input)!'$candidate_member_1')!'$candidate_result', "
-        "answer_2:0.0:(candidate_result:0.0:/candidate?web_search=false"
-        "&q=($item.input)!'$candidate_member_2')!'$candidate_result', "
-        "pick:0.0:/candidate?q=(verdicts)!'$candidate_synthesizer')!'$pick'"
-    )
-    linked = link_candidate(
-        value.url4,
-        benchmark,
-        value.member_expressions,
-        value.synthesizer.url4 if value.synthesizer is not None else None,
-    )
-    assert not linked.uses_whole_candidate
-    assert "(candidate:0.0:" not in linked.url4
-
-
-def test_references_embedded_inside_url4_text_are_linked_structurally() -> None:
-    fusion = sf.Fusion(
-        [sf.Model("provider/a"), sf.Model("provider/b")],
-        name="pair",
-        synthesizer="provider/judge",
-    )
-    value = _compiled(fusion)
-    assert value.synthesizer is not None
-    benchmark = (
-        "(answer:0.0:/candidate?q=(question)!"
-        "'Compare $candidate_member_1 and $candidate_member_2 using "
-        "$candidate_synthesizer')!'$answer'"
-    )
-
-    linked = link_candidate(
-        value.url4,
-        benchmark,
-        value.member_expressions,
-        value.synthesizer.url4,
-    )
-
-    assert linked.member_indices == (1, 2)
-    assert linked.uses_synthesizer is True
-    assert "provider/a" in linked.url4
-    assert "provider/b" in linked.url4
-    assert "provider/judge" in linked.url4
-
-
-def test_a_model_has_no_synthesizer_component_and_whole_binding_still_works() -> None:
-    value = _compiled(sf.Model("provider/solo"))
-    linked = link_candidate(
-        value.url4,
-        _WHOLE_CANDIDATE_BENCHMARK,
-        value.member_expressions,
-        None,
-    )
-    assert linked.uses_whole_candidate
-    assert not linked.uses_synthesizer
-    assert "candidate_synthesizer" not in linked.url4
-
-
-@pytest.mark.parametrize("member_count", [2, 3, 4])
-def test_one_native_member_collection_binding_handles_every_supported_fusion_size(
-    member_count: int,
-) -> None:
-    fusion = sf.Fusion(
-        [sf.Model(f"provider/member-{index}") for index in range(1, member_count + 1)],
-        name="panel",
-        synthesizer="provider/judge",
-    )
-    value = _compiled(fusion)
-    assert value.synthesizer is not None
-
-    linked = link_candidate(
-        value.url4,
-        _MEMBER_COLLECTION_BENCHMARK,
-        value.member_expressions,
-        value.synthesizer.url4,
-    )
-
-    assert linked.member_indices == tuple(range(1, member_count + 1))
-    assert "$candidate_members" in linked.url4
-    assert "$candidate_synthesizer" in linked.url4
-    assert "$candidate_model_member_" not in linked.url4
-    assert '"expression"' not in linked.url4
-    parsed = build(linked.url4)
-    assert isinstance(parsed, Expression)
-    collection = next(
-        source
-        for source in parsed.sources
-        if isinstance(source, Source) and source.name == "candidate_members"
-    )
-    assert isinstance(collection.value, StructObject)
-    for index in range(1, member_count + 1):
-        binding = next(
-            source
-            for source in parsed.sources
-            if isinstance(source, Source) and source.name == f"candidate_member_{index}"
-        )
-        assert isinstance(binding.value, Text)
-        assert f"provider/member-{index}" in binding.value.value
-        assert f"member_{index}: {{name: 'member-{index}', " in collection.value.raw
-        assert f"url4: '$candidate_member_{index}'" in collection.value.raw
-        # Each executable member appears exactly once; the collection carries only a URL4 ref.
-        assert linked.url4.count(f"provider/member-{index}") == 1
     assert render(build(linked.url4)) == linked.url4
+    assert linked.url4.count("candidate:0.0:") == 1
+    assert "/provider/a" in linked.url4
+    assert "/provider/b" in linked.url4
+    assert "/provider/synth" in linked.url4
+    assert "/candidate" in linked.url4
 
 
-# --- Source-position Candidate references -------------------------------------------------
-#
-# FEATURE: a Benchmark may name the Candidate anywhere URL4 allows a reference.
-# STORY: as a Benchmark author, I write "($candidate)!'go'" and the SDK links my exam the
-# same way it links "!'$candidate'" — the surface position I chose is not a contract.
-#
-# INVARIANT: the linker must see a reference in SOURCE position, where URL4 parses it into a
-# VarRef and strips the "$" sigil, exactly as it sees one embedded in Text. A reference the
-# walk cannot see is either rejected as "does not invoke the Candidate" or — far worse —
-# silently emitted UNRESOLVED into an artifact the Engine has already been paid to run.
+def test_whole_candidate_source_binding_is_detected() -> None:
+    benchmark = "(answer:0.0:($candidate)!'go')!'$answer'"
 
-_SOURCE_POSITION_WHOLE_BENCHMARK = "(answer:0.0:($candidate)!'go')!'$answer'"
+    linked = link_candidate(_candidate_url4(), benchmark)
 
-
-def test_a_source_position_candidate_reference_is_linked_like_a_text_reference() -> None:
-    model = sf.Model("provider/a")
-    value = _compiled(model)
-
-    linked = link_candidate(value.url4, _SOURCE_POSITION_WHOLE_BENCHMARK)
-
-    assert linked.uses_whole_candidate is True
-    parsed = build(linked.url4)
-    assert isinstance(parsed, Expression)
-    binding = next(
-        source
-        for source in parsed.sources
-        if isinstance(source, Source) and source.name == "candidate"
-    )
-    assert isinstance(binding.value, Text)
-    assert "provider/a" in binding.value.value
     assert render(build(linked.url4)) == linked.url4
-
-
-def test_a_source_position_member_reference_never_emits_an_unresolved_binding() -> None:
-    """The silent-poison case: today this raises nothing and ships a broken artifact."""
-
-    fusion = sf.Fusion([sf.Model("provider/a"), sf.Model("provider/b")], name="pair")
-    value = _compiled(fusion)
-    benchmark = "($candidate_member_2, y='use $candidate_member_1')!'go'"
-
-    linked = link_candidate(value.url4, benchmark, value.member_expressions)
-
-    assert linked.member_indices == (1, 2)
-    # INVARIANT: every $candidate* reference in the shipped artifact resolves to a binding
-    # the linker emitted. An unresolved one only fails once the Run is under way and paid.
-    parsed = build(linked.url4)
-    assert isinstance(parsed, Expression)
-    bound = {
-        source.name
-        for source in parsed.sources
-        if isinstance(source, Source) and source.name is not None
-    }
-    assert {"candidate_member_1", "candidate_member_2"} <= bound
-
-
-def test_a_partial_source_position_member_reference_does_not_report_a_wrong_arity() -> None:
-    fusion = sf.Fusion([sf.Model("provider/a"), sf.Model("provider/b")], name="pair")
-    value = _compiled(fusion)
-    benchmark = "(x=$candidate_member_1)!'use $candidate_member_2'"
-
-    linked = link_candidate(value.url4, benchmark, value.member_expressions)
-
-    assert linked.member_indices == (1, 2)
+    assert "$candidate" in linked.url4
 
 
 @pytest.mark.parametrize(
-    ("benchmark", "whole", "synthesizer", "indices"),
+    "reference",
     [
-        ("(answer:0.0:($candidate)!'go')!'$answer'", True, False, ()),
-        # A field path selects on the resolved value; it is not part of the reference name.
-        (
-            "(a:0.0:($candidate_member_1.answers)!'go', b:0.0:($candidate_member_2)!'go')!'$a $b'",
-            False,
-            False,
-            (1, 2),
-        ),
-        ("(answer:0.0:($candidate_synthesizer)!'go')!'$answer'", False, True, ()),
-        ("(answer:0.0:($candidate_members)!'go')!'$answer'", False, False, (1, 2)),
+        "$candidate_member_1",
+        "$candidate_members",
+        "$candidate_synthesizer",
     ],
 )
-def test_source_position_reference_variants_are_detected(
-    benchmark: str,
-    whole: bool,
-    synthesizer: bool,
-    indices: tuple[int, ...],
-) -> None:
-    fusion = sf.Fusion(
-        [sf.Model("provider/a"), sf.Model("provider/b")],
-        name="pair",
-        synthesizer="provider/j",
-    )
-    value = _compiled(fusion)
-    assert value.synthesizer is not None
+def test_structural_candidate_bindings_are_rejected(reference: str) -> None:
+    benchmark = f"(answer:0.0:/candidate(question)!'{reference}')!'$answer'"
 
-    linked = link_candidate(
-        value.url4,
-        benchmark,
-        value.member_expressions,
-        value.synthesizer.url4,
+    with pytest.raises(sf.PlanningError, match="unsupported structural Candidate") as caught:
+        link_candidate(_candidate_url4(), benchmark)
+
+    assert caught.value.code == "candidate_shape_mismatch"
+
+
+def test_mixed_whole_and_structural_bindings_are_rejected() -> None:
+    benchmark = (
+        "(answer:0.0:/candidate(question)!'$candidate', "
+        "member:0.0:/candidate(question)!'$candidate_member_1')!'$answer'"
     )
 
-    assert linked.uses_whole_candidate is whole
-    assert linked.uses_synthesizer is synthesizer
-    if indices:
-        assert linked.member_indices == indices
+    with pytest.raises(sf.PlanningError, match="unsupported structural Candidate") as caught:
+        link_candidate(_candidate_url4(), benchmark)
+
+    assert caught.value.code == "candidate_shape_mismatch"
 
 
-def test_a_source_position_plumbing_name_is_still_not_a_candidate_reference() -> None:
-    # INVARIANT: the trailing-lookahead guard against "$candidate_result" must survive the
-    # VarRef path too — teaching the walk a new shape must not teach it a new false positive.
-    with pytest.raises(PlanningError) as caught:
-        link_candidate("/a/b!'q'", "(answer:0.0:($candidate_result)!'go')!'$answer'")
+def test_benchmark_without_candidate_binding_is_rejected() -> None:
+    benchmark = "(answer:0.0:/fixed(question)!'answer')!'$answer'"
+
+    with pytest.raises(sf.PlanningError, match="does not invoke the Candidate") as caught:
+        link_candidate(_candidate_url4(), benchmark)
 
     assert caught.value.code == "invalid_benchmark_resource"
 
 
-def test_an_escaped_candidate_reference_is_a_literal_not_an_invocation() -> None:
-    # "$$" is the URL4 escape for a literal "$" — _template_literal relies on it to keep a
-    # user-facing member name literal, so the matcher must not read it back as a reference.
-    with pytest.raises(PlanningError) as caught:
-        link_candidate("/a/b!'q'", "(answer:0.0:/bench/x(q)!'cost is $$candidate')!'$answer'")
+def test_similarly_named_plumbing_is_not_a_candidate_binding() -> None:
+    benchmark = "(answer:0.0:/fixed(question)!'$candidate_result')!'$answer'"
+
+    with pytest.raises(sf.PlanningError, match="does not invoke the Candidate") as caught:
+        link_candidate(_candidate_url4(), benchmark)
 
     assert caught.value.code == "invalid_benchmark_resource"

--- a/packages/screamingface/tests/test_url4.py
+++ b/packages/screamingface/tests/test_url4.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 from typing import Any, cast
 
 import pytest
-from url4 import expr, render, src, text
+from url4 import RelExpr, expr, render, src, text
 
 import screamingface as sf
 from screamingface._evaluation.candidate import compile_candidate
-from screamingface.url4 import _Call, _params, _render_recipe
+from screamingface._evaluation.url4 import _candidate_from_url4
+from screamingface.url4 import _params
 
 
 def _url4(recipe: sf.Recipe) -> sf.Url4:
@@ -50,6 +51,21 @@ def test_url4_is_a_string_compatible_immutable_value() -> None:
     assert isinstance(value, str)
     assert str(value) == value
     assert value.startswith("(model_1:")
+
+
+def test_every_complete_recipe_url4_has_one_canonical_recipe_descriptor() -> None:
+    model = _url4(sf.Model("provider/model"))
+    fusion = _url4(
+        sf.Fusion(
+            [sf.Model("provider/a"), sf.Model("provider/b")],
+            synthesizer="provider/synthesizer",
+        )
+    )
+    pipeline = _url4(sf.Pipeline([sf.Model("provider/draft"), sf.Model("provider/review")]))
+
+    for value in (model, fusion, pipeline):
+        assert value.count("_sf_recipe:") == 1
+        assert "screamingface.recipe.v1" in value
 
 
 def test_model_url4_produces_editable_python() -> None:
@@ -102,6 +118,92 @@ def test_fusion_url4_recovers_editable_topology_names_and_policy() -> None:
     assert "        prompt='Blend the answers'," in python
     assert "        params={'temperature': 0.1}," in python
     assert "web_search" not in python
+
+
+def test_pipeline_url4_recovers_serial_and_nested_parallel_topology() -> None:
+    value = _url4(
+        sf.Pipeline(
+            [
+                sf.Model("provider/draft", name="draft"),
+                sf.Fusion(
+                    [sf.Model("provider/reviewer-a"), sf.Model("provider/reviewer-b")],
+                    name="review-panel",
+                    synthesizer="provider/reconciler",
+                ),
+                sf.Model("provider/final", prompt="Return only the final answer."),
+            ],
+            name="draft-review-final",
+        )
+    )
+
+    python = value.to_python()
+
+    assert "candidate = sf.Pipeline(" in python
+    assert "name='draft-review-final'" in python
+    assert "name='draft'" in python
+    assert "        sf.Fusion(" in python
+    assert "            name='review-panel'," in python
+    assert "'provider/reconciler'" in python
+    assert "prompt='Return only the final answer.'" in python
+    assert python.index("'provider/draft'") < python.index("'provider/reviewer-a'")
+    assert python.index("'provider/reconciler'") < python.index("'provider/final'")
+
+
+def test_fusion_url4_recovers_a_pipeline_synthesizer() -> None:
+    value = _url4(
+        sf.Fusion(
+            [sf.Model("provider/a"), sf.Model("provider/b")],
+            synthesizer=sf.Pipeline(
+                [
+                    sf.Model("provider/judge", prompt="Choose one answer."),
+                    sf.Model("provider/writer", prompt="Polish it."),
+                ],
+                name="judge-writer",
+            ),
+        )
+    )
+
+    python = value.to_python()
+
+    assert "candidate = sf.Fusion(" in python
+    assert "    synthesizer=sf.Pipeline(" in python
+    assert "name='judge-writer'" in python
+    assert "'provider/judge'" in python
+    assert "'provider/writer'" in python
+
+
+def test_pipeline_synthesizer_role_defaults_are_not_rendered_as_explicit_prompts() -> None:
+    value = _url4(
+        sf.Fusion(
+            ["provider/a"],
+            synthesizer=sf.Pipeline(["provider/judge", "provider/writer"]),
+        )
+    )
+
+    python = value.to_python()
+
+    assert "prompt=" not in python
+    assert "params=" not in python
+
+
+def test_linked_pipeline_url4_replay_preserves_kind_name_and_serial_dependencies() -> None:
+    value = _linked_url4(
+        sf.Pipeline(
+            [sf.Model("provider/draft"), sf.Model("provider/review")],
+            name="review-chain",
+        )
+    )
+
+    candidate = _candidate_from_url4(value)
+
+    assert candidate.kind == "pipeline"
+    assert candidate.name == "review-chain"
+    assert candidate.models == ("provider/draft", "provider/review")
+    assert [operation.kind for operation in candidate.operations] == ["model", "model"]
+    assert [operation.depends_on for operation in candidate.operations] == [
+        (),
+        ("op_model_1",),
+    ]
 
 
 def test_linked_evaluation_url4_adds_the_editable_benchmark_call() -> None:
@@ -175,25 +277,79 @@ def test_linked_url4_without_a_benchmark_route_only_forks_the_candidate() -> Non
 
 
 def test_url4_conversion_rejects_invalid_internal_references_and_parameters() -> None:
-    with pytest.raises(ValueError, match="unknown binding"):
-        _render_recipe("model_2", {}, explicit_name=None, indent=0)
-
-    incomplete_fusion = _Call(
-        binding="synthesis_1",
-        kind="fusion",
-        model="provider/synthesizer",
-        dependencies=("model_1",),
-        member_names={},
-        prompt="Blend",
-        params=(),
-    )
-    with pytest.raises(ValueError, match="at least two Candidate members"):
-        _render_recipe(
-            "synthesis_1",
-            {"synthesis_1": incomplete_fusion},
-            explicit_name=None,
-            indent=0,
-        )
-
     with pytest.raises(ValueError, match="scalar values"):
         _params((("temperature", None),))
+
+
+def test_url4_conversion_rejects_topology_metadata_that_disagrees_with_the_calls() -> None:
+    value = _url4(sf.Pipeline([sf.Model("provider/a"), sf.Model("provider/b")]))
+    invalid = sf.Url4(value.replace('"binding":"model_2"', '"binding":"model_99"', 1))
+
+    with pytest.raises(ValueError, match="invalid Pipeline topology metadata"):
+        invalid.to_python()
+
+
+@pytest.mark.parametrize(
+    ("metadata", "message"),
+    [
+        ("{", "invalid Recipe topology metadata"),
+        (
+            '{"schema":"screamingface.recipe.v2","recipe":{}}',
+            "unsupported Recipe topology metadata",
+        ),
+        ('{"schema":"screamingface.recipe.v1"}', "invalid Recipe topology metadata"),
+        (
+            '{"schema":"screamingface.recipe.v1","recipe":[]}',
+            "invalid Recipe topology metadata",
+        ),
+        (
+            '{"schema":"screamingface.recipe.v1","recipe":'
+            '{"binding":"model_1","kind":"unknown","name":"candidate"}}',
+            "invalid Recipe topology metadata",
+        ),
+        (
+            '{"schema":"screamingface.recipe.v1","recipe":'
+            '{"binding":"model_1","kind":"model","name":"candidate",'
+            '"named":false,"role":"grader"}}',
+            "invalid Model topology metadata",
+        ),
+    ],
+)
+def test_url4_conversion_rejects_untrusted_topology_metadata(
+    metadata: str,
+    message: str,
+) -> None:
+    value = sf.Url4(
+        render(
+            expr(
+                src(
+                    RelExpr(path="/provider/model", context="$input", intent=text("Answer.")),
+                    name="model_1",
+                    weight=0.0,
+                ),
+                src(text(metadata), name="_sf_recipe", weight=0.0),
+                intent=text("$model_1"),
+            )
+        )
+    )
+
+    with pytest.raises(ValueError, match=message):
+        value.to_python()
+
+
+def test_url4_conversion_requires_the_canonical_recipe_descriptor() -> None:
+    value = sf.Url4(
+        render(
+            expr(
+                src(
+                    RelExpr(path="/provider/model", context="$input", intent=text("Answer.")),
+                    name="model_1",
+                    weight=0.0,
+                ),
+                intent=text("$model_1"),
+            )
+        )
+    )
+
+    with pytest.raises(ValueError, match="missing required Recipe metadata"):
+        value.to_python()

--- a/packages/screamingface/tests/test_value_validation.py
+++ b/packages/screamingface/tests/test_value_validation.py
@@ -201,7 +201,7 @@ def test_candidate_metrics_preserve_json_compatible_values() -> None:
                 score=0.5,
                 metrics={"score": 0.5},
                 cases=case_results(),
-                members=(),
+                members=(member(),),
                 failures=(),
                 usage=sf.Usage(),
             ),
@@ -241,11 +241,11 @@ def test_candidate_metrics_preserve_json_compatible_values() -> None:
                 score=0.5,
                 metrics={"score": 0.5},
                 cases=case_results(),
-                members=(member(),),
+                members=(),
                 failures=(),
                 usage=sf.Usage(),
             ),
-            "at least two direct members",
+            "at least one direct member",
         ),
         (
             lambda: sf.CandidateResult(


### PR DESCRIPTION
## Summary

- add immutable `sf.Pipeline([...])` and exact `.then(...)` shorthand
- make Model, Fusion, and Pipeline recursively composable complete Recipes
- support model-route shorthand in every Recipe-valued position
- preserve authored invocation positions and compile one versioned `screamingface.recipe.v1` topology descriptor
- reconstruct Pipeline and nested Recipe graphs through `Url4.to_python()`

## Clean v1 contract

- require an explicit Fusion synthesizer and allow one or more members
- emit no implicit model parameters; omitted values, including web search, use Engine or Benchmark policy
- replace prose synthesis input with stable structured `{input, outputs}` context
- remove incomplete Fusion compilation, structural Candidate member/synthesizer bindings, and Client-side invocation deduplication

## Verification

- `uv run .claude/scripts/run_gates.py screamingface --skip-append-only`
- Ruff, Pyright, coverage, notebooks, build, and distribution checks all green after rebasing onto current `main`
- append-only check skipped because the approved clean-v1 contract intentionally replaces legacy assertions documented in the work ledger

Linear: https://linear.app/openmined/issue/OME-786/support-serial-pipelines-and-recursively-composed-candidates-in-the